### PR TITLE
Add `asDynamic` to EventPayload

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollEvent.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollEvent.cpp
@@ -72,6 +72,21 @@ folly::dynamic ScrollEvent::asDynamic() const {
   return metrics;
 };
 
+std::optional<double> ScrollEvent::extractValue(
+    const std::vector<std::string>& path) const {
+  if (path.size() == 1 && path[0] == "zoomScale") {
+    return zoomScale;
+  } else if (path.size() == 2 && path[0] == "contentOffset") {
+    if (path[1] == "x") {
+      return contentOffset.x;
+    } else if (path[1] == "y") {
+      return contentOffset.y;
+    }
+  }
+
+  return EventPayload::extractValue(path);
+}
+
 EventPayloadType ScrollEvent::getType() const {
   return EventPayloadType::ScrollEvent;
 }

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollEvent.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollEvent.h
@@ -36,6 +36,9 @@ struct ScrollEvent : public EventPayload {
    */
   jsi::Value asJSIValue(jsi::Runtime& runtime) const override;
   EventPayloadType getType() const override;
+
+  std::optional<double> extractValue(
+      const std::vector<std::string>& path) const override;
 };
 
 struct ScrollEndDragEvent : public ScrollEvent {

--- a/packages/react-native/ReactCommon/react/renderer/core/EventPayload.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventPayload.h
@@ -10,6 +10,8 @@
 #include <jsi/jsi.h>
 
 #include <react/renderer/core/EventPayloadType.h>
+#include <optional>
+#include <vector>
 
 namespace facebook::react {
 
@@ -33,6 +35,17 @@ struct EventPayload {
    * in `EventPayloadType` and return it from its overriden `getType()` method.
    */
   virtual EventPayloadType getType() const = 0;
+
+  /**
+   * Used to extract numeric values from the event payload based on
+   * property path names as they will exist in JavaScript. This can
+   * be used in conjunction with listeners on EventEmitters to do
+   * things like drive native animations.
+   */
+  virtual std::optional<double> extractValue(
+      const std::vector<std::string>& /* path */) const {
+    return std::nullopt;
+  }
 };
 
 using SharedEventPayload = std::shared_ptr<const EventPayload>;


### PR DESCRIPTION
Summary:
NativeAnimated currently depends on folly::dynamic event payloads for event-driven animations. While some events (e.g., ScrollEvent.h) have an `asDynamic` implementation, not all events do. Having the ability to convert an EventPayload to a folly::dynamic defined on the EventPayload implementations precludes generalized event handling in NativeAnimated.

This change moves the `asDynamic` method from `ScrollEvent` to the base `EventPayload` interface, defaulting the implemention to returning a null value.

## Changelog

[Internal]

Differential Revision: D71046682


