### PR TITLE
Add nullptr checks for findNextFocusableView

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
@@ -226,8 +226,17 @@ jfloatArray FabricUIManagerBinding::findNextFocusableElementMetrics(
   std::shared_ptr<UIManager> uimanager = getScheduler()->getUIManager();
 
   parentShadowNode = uimanager->findShadowNodeByTag_DEPRECATED(parentTag);
+
+  if (parentShadowNode == nullptr) {
+    return nullptr;
+  }
+
   focusedShadowNode = FocusOrderingHelper::findShadowNodeByTagRecursively(
       parentShadowNode, focusedTag);
+
+  if (focusedShadowNode == nullptr) {
+    return nullptr;
+  }
 
   LayoutMetrics childLayoutMetrics = uimanager->getRelativeLayoutMetrics(
       *focusedShadowNode, parentShadowNode.get(), {.includeTransform = true});


### PR DESCRIPTION
Summary:
We were missing some null checks that could cause a crash.

There seems to be some cases where either the parent or the currently focused View are present on Android's hierarchy but not present on the Shadow Tree, in this cases we can just return a nullptr to fall back to default focusing behavior on Android.

Reviewed By: joevilches

Differential Revision: D71050870


