### PR TITLE
Call RCTScreenSize early

### DIFF
--- a/packages/react-native/React/Base/UIKitProxies/RCTInitializeUIKitProxies.mm
+++ b/packages/react-native/React/Base/UIKitProxies/RCTInitializeUIKitProxies.mm
@@ -6,6 +6,7 @@
  */
 
 #import "RCTInitializeUIKitProxies.h"
+#import <React/RCTUtils.h>
 #import "RCTInitialAccessibilityValuesProxy.h"
 #import "RCTKeyWindowValuesProxy.h"
 #import "RCTTraitCollectionProxy.h"
@@ -19,5 +20,7 @@ void RCTInitializeUIKitProxies(void)
     [[RCTTraitCollectionProxy sharedInstance] startObservingTraitCollection];
     [[RCTInitialAccessibilityValuesProxy sharedInstance] recordAccessibilityValues];
     [[RCTKeyWindowValuesProxy sharedInstance] startObservingWindowSizeIfNecessary];
+    // Early cache size of screen to avoid main thread contention
+    RCTScreenSize();
   });
 }


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Early initialize call to RCTScreenSize which is used by Modal and will read screen size off the UI Thread to avoid main thread deadlocks

Reviewed By: sammy-SC

Differential Revision: D70999156


