### PR TITLE
Add Jest E2E Tests for S462299

### DIFF
--- a/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
@@ -866,6 +866,7 @@ function DynamicContentWidth() {
     <View>
       <RNTesterText>Uncontrolled:</RNTesterText>
       <TextInput
+        testID="dynamic-width-uncontrolled-textinput"
         placeholder="Type..."
         style={{
           fontSize: 16,
@@ -875,6 +876,7 @@ function DynamicContentWidth() {
       />
       <RNTesterText>Controlled:</RNTesterText>
       <TextInput
+        testID="dynamic-width-controlled-textinput"
         placeholder="..."
         value={text}
         onChangeText={setText}


### PR DESCRIPTION
Summary:
This adds some tests that verify that controlled textinput, via text prop, or children creating attributedstring, does not jumble text, so long as JS side does not mutate underlying text content.

The rewriting/max length example does still run into problems here.

Changelog: [Internal]

Reviewed By: joevilches

Differential Revision: D71076703


