### PR TITLE
RN: Set `react.runtime=automatic` in Flow Config

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -67,6 +67,8 @@ module.name_mapper='^react-native/\(.*\)$' -> '<PROJECT_ROOT>/packages/react-nat
 module.name_mapper='^@react-native/dev-middleware$' -> '<PROJECT_ROOT>/packages/dev-middleware'
 module.name_mapper='^@?[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|webp\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|aac\|aiff\|caf\|m4a\|mp3\|wav\|html\|pdf\|xml\)$' -> '<PROJECT_ROOT>/packages/react-native/Libraries/Image/RelativeImageStub'
 
+react.runtime=automatic
+
 suppress_type=$FlowIssue
 suppress_type=$FlowFixMe
 suppress_type=$FlowFixMeProps


### PR DESCRIPTION
Summary:
Updates `react-native/.flowconfig` with the following option:

```
react.runtime=automatic
```

This adjusts Flow to model the current behavior of React and JSX, relaxing the requirement that JSX elements have `React` within scope.

Changelog:
[General][Changed] - Changed Flow for the React Native monorepo, so that `React` no longer has to be in scope when using JSX.

Differential Revision: D71096283


