### PR TITLE
Animated: Avoid Invalidation of Ref Callback

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -67,6 +67,8 @@ module.name_mapper='^react-native/\(.*\)$' -> '<PROJECT_ROOT>/packages/react-nat
 module.name_mapper='^@react-native/dev-middleware$' -> '<PROJECT_ROOT>/packages/dev-middleware'
 module.name_mapper='^@?[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|webp\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|aac\|aiff\|caf\|m4a\|mp3\|wav\|html\|pdf\|xml\)$' -> '<PROJECT_ROOT>/packages/react-native/Libraries/Image/RelativeImageStub'
 
+react.runtime=automatic
+
 suppress_type=$FlowIssue
 suppress_type=$FlowFixMe
 suppress_type=$FlowFixMeProps

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js
@@ -141,6 +141,22 @@ export default class AnimatedProps extends AnimatedNode {
     return props;
   }
 
+  __getNativeAnimatedEventTuples(): $ReadOnlyArray<[string, AnimatedEvent]> {
+    const tuples = [];
+
+    const keys = Object.keys(this.#props);
+    for (let ii = 0, length = keys.length; ii < length; ii++) {
+      const key = keys[ii];
+      const value = this.#props[key];
+
+      if (value instanceof AnimatedEvent && value.__isNative) {
+        tuples.push([key, value]);
+      }
+    }
+
+    return tuples;
+  }
+
   __getAnimatedValue(): Object {
     const props: {[string]: mixed} = {};
 

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -518,6 +518,17 @@ const definitions: FeatureFlagDefinitions = {
       },
       ossReleaseStage: 'none',
     },
+    avoidAnimatedRefInvalidation: {
+      defaultValue: false,
+      metadata: {
+        dateAdded: '2025-03-12',
+        description:
+          'Changes `useAnimatedProps` to avoid invalidating the callback ref whenever `props` changes.',
+        expectedReleaseValue: true,
+        purpose: 'experimentation',
+      },
+      ossReleaseStage: 'none',
+    },
     avoidStateUpdateInAnimatedPropsMemo: {
       defaultValue: false,
       metadata: {

--- a/packages/react-native/src/private/animated/__tests__/AnimatedNative-test.js
+++ b/packages/react-native/src/private/animated/__tests__/AnimatedNative-test.js
@@ -23,9 +23,6 @@ describe('Native Animated', () => {
       get NativeAnimatedHelper() {
         return require('../NativeAnimatedHelper').default;
       },
-      get ReactNativeFeatureFlags() {
-        return require('../../featureflags/ReactNativeFeatureFlags');
-      },
     };
   }
 

--- a/packages/react-native/src/private/animated/__tests__/createAnimatedPropsHook-test.js
+++ b/packages/react-native/src/private/animated/__tests__/createAnimatedPropsHook-test.js
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {ReactNativeFeatureFlagsJsOnlyOverrides} from '../../featureflags/ReactNativeFeatureFlags';
+
+import {create, update} from '../../../../jest/renderer';
+import {useLayoutEffect} from 'react';
+
+describe('useAnimatedProps', () => {
+  function importModules(overrides: ReactNativeFeatureFlagsJsOnlyOverrides) {
+    const ReactNativeFeatureFlags = require('../../featureflags/ReactNativeFeatureFlags');
+
+    // Make sure to setup overrides before importing any modules.
+    ReactNativeFeatureFlags.override(overrides);
+
+    return {
+      // $FlowIgnore[unsafe-getters-setters]
+      get AnimatedEvent() {
+        return require('../../../../Libraries/Animated/AnimatedEvent')
+          .AnimatedEvent;
+      },
+      // $FlowIgnore[unsafe-getters-setters]
+      get createAnimatedPropsHook() {
+        return require('../createAnimatedPropsHook').default;
+      },
+    };
+  }
+
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('returns a new ref callback when `props` changes', async () => {
+    const {createAnimatedPropsHook} = importModules({
+      avoidAnimatedRefInvalidation: () => false,
+    });
+    const useAnimatedProps = createAnimatedPropsHook(null);
+
+    const refs = [];
+    function Sentinel(props: {[string]: mixed}): React.Node {
+      const [, ref] = useAnimatedProps<{[string]: mixed}, mixed>(props);
+      useLayoutEffect(() => {
+        refs.push(ref);
+      }, [ref]);
+      return null;
+    }
+
+    const root = await create(<Sentinel foo={1} />);
+    expect(refs.length).toBe(1);
+    expect(refs[0]).toBeInstanceOf(Function);
+
+    await update(root, <Sentinel foo={2} />);
+    expect(refs.length).toBe(2);
+    expect(refs[1]).toBeInstanceOf(Function);
+
+    expect(refs[0]).not.toBe(refs[1]);
+  });
+
+  it('returns the same ref callback when `props` changes', async () => {
+    const {createAnimatedPropsHook} = importModules({
+      avoidAnimatedRefInvalidation: () => true,
+    });
+    const useAnimatedProps = createAnimatedPropsHook(null);
+
+    const refs = [];
+    function Sentinel(props: {[string]: mixed}): React.Node {
+      const [, ref] = useAnimatedProps<{[string]: mixed}, mixed>(props);
+      useLayoutEffect(() => {
+        refs.push(ref);
+      }, [ref]);
+      return null;
+    }
+
+    const root = await create(<Sentinel foo={1} />);
+    expect(refs.length).toBe(1);
+    expect(refs[0]).toBeInstanceOf(Function);
+
+    await update(root, <Sentinel foo={2} />);
+    expect(refs.length).toBe(1);
+  });
+
+  it('returns the same ref callback when `AnimatedEvent` is the same', async () => {
+    const {AnimatedEvent, createAnimatedPropsHook} = importModules({
+      avoidAnimatedRefInvalidation: () => true,
+    });
+    const useAnimatedProps = createAnimatedPropsHook(null);
+
+    const refs = [];
+    function Sentinel(props: {[string]: mixed}): React.Node {
+      const [, ref] = useAnimatedProps<{[string]: mixed}, mixed>(props);
+      useLayoutEffect(() => {
+        refs.push(ref);
+      }, [ref]);
+      return null;
+    }
+
+    const event = new AnimatedEvent([{}], {useNativeDriver: true});
+
+    const root = await create(<Sentinel foo={event} />);
+    expect(refs.length).toBe(1);
+    expect(refs[0]).toBeInstanceOf(Function);
+
+    await update(root, <Sentinel foo={event} />);
+    expect(refs.length).toBe(1);
+  });
+
+  it('returns a new ref callback when `AnimatedEvent` changes', async () => {
+    const {AnimatedEvent, createAnimatedPropsHook} = importModules({
+      avoidAnimatedRefInvalidation: () => true,
+    });
+    const useAnimatedProps = createAnimatedPropsHook(null);
+
+    const refs = [];
+    function Sentinel(props: {[string]: mixed}): React.Node {
+      const [, ref] = useAnimatedProps<{[string]: mixed}, mixed>(props);
+      useLayoutEffect(() => {
+        refs.push(ref);
+      }, [ref]);
+      return null;
+    }
+
+    const eventA = new AnimatedEvent([{}], {useNativeDriver: true});
+    const eventB = new AnimatedEvent([{}], {useNativeDriver: true});
+
+    const root = await create(<Sentinel foo={eventA} />);
+    expect(refs.length).toBe(1);
+    expect(refs[0]).toBeInstanceOf(Function);
+
+    await update(root, <Sentinel foo={eventB} />);
+    expect(refs.length).toBe(2);
+    expect(refs[1]).toBeInstanceOf(Function);
+
+    expect(refs[0]).not.toBe(refs[1]);
+  });
+});

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<99bbe1c87a7620b6381705db9795fd77>>
+ * @generated SignedSource<<69857a5037b853d3a868ac29d67ab9e7>>
  * @flow strict
  */
 
@@ -30,6 +30,7 @@ export type ReactNativeFeatureFlagsJsOnly = $ReadOnly<{
   jsOnlyTestFlag: Getter<boolean>,
   animatedShouldDebounceQueueFlush: Getter<boolean>,
   animatedShouldUseSingleOp: Getter<boolean>,
+  avoidAnimatedRefInvalidation: Getter<boolean>,
   avoidStateUpdateInAnimatedPropsMemo: Getter<boolean>,
   disableInteractionManager: Getter<boolean>,
   enableAccessToHostTreeInFabric: Getter<boolean>,
@@ -106,6 +107,11 @@ export const animatedShouldDebounceQueueFlush: Getter<boolean> = createJavaScrip
  * Enables an experimental mega-operation for Animated.js that replaces many calls to native with a single call into native, to reduce JSI/JNI traffic.
  */
 export const animatedShouldUseSingleOp: Getter<boolean> = createJavaScriptFlagGetter('animatedShouldUseSingleOp', false);
+
+/**
+ * Changes `useAnimatedProps` to avoid invalidating the callback ref whenever `props` changes.
+ */
+export const avoidAnimatedRefInvalidation: Getter<boolean> = createJavaScriptFlagGetter('avoidAnimatedRefInvalidation', false);
 
 /**
  * Changes `useAnimatedPropsMemo` to avoid state updates to invalidate the cached `AnimatedProps`.


### PR DESCRIPTION
Summary:
Creates a new feature flag, `avoidAnimatedRefInvalidation`, to experiment with changing `useAnimatedProps`, so that the returned ref callback is no longer invalidated when `props` changes.

When we introduced `useAnimatedPropsMemo` and stabilized `AnimatedProps` (which is only invalidated when `AnimatedValue` and shallow `AnimatedEvent` instances are changed in an update), we should have also made this change. It was an oversight that we did not do this.

Avoiding unnecessary invalidation of the ref callback is important to reduce extra work and unpredictable semantics associated with unnecessary detaching and re-attaching of refs.

Changelog:
[Internal]

Reviewed By: lunaleaps

Differential Revision: D71074781


