### PR TITLE
Add support for triple-slash directives in generated .d.ts files

### DIFF
--- a/scripts/build/build-types/buildTypes.js
+++ b/scripts/build/build-types/buildTypes.js
@@ -90,6 +90,7 @@ async function translateSourceFiles(
           translatedModuleTemplate({
             originalFileName: path.relative(REPO_ROOT, file),
             source: stripDocblock(typescriptDef),
+            tripleSlashDirectives: extractTripleSlashDirectives(source),
           }),
         );
       } catch (e) {
@@ -126,6 +127,16 @@ function getBuildPath(file: string): string {
 
 function stripDocblock(source: string): string {
   return source.replace(/\/\*\*[\s\S]*?\*\/\n/, '');
+}
+
+function extractTripleSlashDirectives(source: string): Array<string> {
+  const directives = source.match(/^\/\/\/.*$/gm);
+
+  if (directives == null) {
+    return [];
+  }
+
+  return directives.map(directive => directive.replace(/^\/\/\//g, '').trim());
 }
 
 module.exports = buildTypes;

--- a/scripts/build/build-types/templates/translatedModule.d.ts-template.js
+++ b/scripts/build/build-types/templates/translatedModule.d.ts-template.js
@@ -14,9 +14,11 @@ const signedsource = require('signedsource');
 function translatedModuleTemplate({
   source,
   originalFileName,
+  tripleSlashDirectives,
 }: {
   source: string,
   originalFileName: string,
+  tripleSlashDirectives: $ReadOnlyArray<string>,
 }): string {
   return signedsource.signFile(
     `/**
@@ -30,7 +32,7 @@ function translatedModuleTemplate({
  * This file was translated from Flow by scripts/build/build-types.js.
  * Original file: ${originalFileName}
  */
-${source}
+${tripleSlashDirectives.length > 0 ? '\n/// ' + tripleSlashDirectives.join('\n/// ') + '\n\n' : ''}${source}
 `,
   );
 }


### PR DESCRIPTION
Summary:
The diff adds extraction of triple-slash directives using regex to match and retrieve following reference.

Changelog:
[internal] - Added support for triple-slash directives in generated .d.ts files

Differential Revision: D71113674


