### PR TITLE
rename fantom.scrollTo to fantom.enqueueScrollEvent

### DIFF
--- a/packages/react-native-fantom/src/__tests__/Fantom-itest.js
+++ b/packages/react-native-fantom/src/__tests__/Fantom-itest.js
@@ -553,13 +553,13 @@ describe('Fantom', () => {
 
       expect(() => {
         Fantom.runOnUIThread(() => {
-          Fantom.scrollTo(element, {
+          Fantom.enqueueScrollEvent(element, {
             x: 0,
             y: 1,
           });
         });
       }).toThrow(
-        'Exception in HostFunction: scrollTo() can only be called on <ScrollView />',
+        'Exception in HostFunction: enqueueScrollEvent() can only be called on <ScrollView />',
       );
     });
 
@@ -594,7 +594,7 @@ describe('Fantom', () => {
       );
 
       Fantom.runOnUIThread(() => {
-        Fantom.scrollTo(scrollViewElement, {
+        Fantom.enqueueScrollEvent(scrollViewElement, {
           x: 0,
           y: 1,
         });

--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -229,12 +229,12 @@ function dispatchNativeEvent(
   runWorkLoop();
 }
 
-function scrollTo(
+function enqueueScrollEvent(
   node: ReactNativeElement,
   options: {x: number, y: number, zoomScale?: number},
 ) {
   const shadowNode = getNativeNodeReference(node);
-  NativeFantom.scrollTo(shadowNode, options);
+  NativeFantom.enqueueScrollEvent(shadowNode, options);
 }
 
 function enqueueModalSizeUpdate(
@@ -346,6 +346,6 @@ export default {
   flushAllNativeEvents,
   enqueueModalSizeUpdate,
   unstable_benchmark: Benchmark,
-  scrollTo,
+  enqueueScrollEvent,
   saveJSMemoryHeapSnapshot,
 };

--- a/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-viewCulling-itest.js
+++ b/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-viewCulling-itest.js
@@ -50,7 +50,7 @@ test('basic culling', () => {
   const element = ensureInstance(maybeNode, ReactNativeElement);
 
   Fantom.runOnUIThread(() => {
-    Fantom.scrollTo(element, {
+    Fantom.enqueueScrollEvent(element, {
       x: 0,
       y: 60,
     });
@@ -66,7 +66,7 @@ test('basic culling', () => {
   ]);
 
   Fantom.runOnUIThread(() => {
-    Fantom.scrollTo(element, {
+    Fantom.enqueueScrollEvent(element, {
       x: 0,
       y: 0,
     });
@@ -133,7 +133,7 @@ test('recursive culling', () => {
 
   // === Scroll down to the edge of child AA ===
   Fantom.runOnUIThread(() => {
-    Fantom.scrollTo(element, {
+    Fantom.enqueueScrollEvent(element, {
       x: 0,
       y: 30,
     });
@@ -146,7 +146,7 @@ test('recursive culling', () => {
 
   // === Scroll down past child AA ===
   Fantom.runOnUIThread(() => {
-    Fantom.scrollTo(element, {
+    Fantom.enqueueScrollEvent(element, {
       x: 0,
       y: 36,
     });
@@ -161,7 +161,7 @@ test('recursive culling', () => {
 
   // === Scroll down past child AB ===
   Fantom.runOnUIThread(() => {
-    Fantom.scrollTo(element, {
+    Fantom.enqueueScrollEvent(element, {
       x: 0,
       y: 51,
     });
@@ -176,7 +176,7 @@ test('recursive culling', () => {
 
   // === Scroll down past element A ===
   Fantom.runOnUIThread(() => {
-    Fantom.scrollTo(element, {
+    Fantom.enqueueScrollEvent(element, {
       x: 0,
       y: 56,
     });
@@ -191,7 +191,7 @@ test('recursive culling', () => {
 
   // Scroll element B into viewport. Just child BA should be created.
   Fantom.runOnUIThread(() => {
-    Fantom.scrollTo(element, {
+    Fantom.enqueueScrollEvent(element, {
       x: 0,
       y: 155,
     });
@@ -208,7 +208,7 @@ test('recursive culling', () => {
 
   // Scroll child BA into viewport.
   Fantom.runOnUIThread(() => {
-    Fantom.scrollTo(element, {
+    Fantom.enqueueScrollEvent(element, {
       x: 0,
       y: 165,
     });
@@ -223,7 +223,7 @@ test('recursive culling', () => {
 
   // Scroll back to start
   Fantom.runOnUIThread(() => {
-    Fantom.scrollTo(element, {
+    Fantom.enqueueScrollEvent(element, {
       x: 0,
       y: 0,
     });
@@ -248,7 +248,7 @@ test('recursive culling', () => {
 
   // Scroll past element A
   Fantom.runOnUIThread(() => {
-    Fantom.scrollTo(element, {
+    Fantom.enqueueScrollEvent(element, {
       x: 0,
       y: 85,
     });
@@ -304,7 +304,7 @@ test('recursive culling when initial offset is negative', () => {
   const element = ensureInstance(maybeNode, ReactNativeElement);
 
   Fantom.runOnUIThread(() => {
-    Fantom.scrollTo(element, {
+    Fantom.enqueueScrollEvent(element, {
       x: 0,
       y: 0,
     });
@@ -374,7 +374,7 @@ test('deep nesting', () => {
   const element = ensureInstance(maybeNode, ReactNativeElement);
 
   Fantom.runOnUIThread(() => {
-    Fantom.scrollTo(element, {
+    Fantom.enqueueScrollEvent(element, {
       x: 0,
       y: 40,
     });
@@ -392,7 +392,7 @@ test('deep nesting', () => {
   ]);
 
   Fantom.runOnUIThread(() => {
-    Fantom.scrollTo(element, {
+    Fantom.enqueueScrollEvent(element, {
       x: 0,
       y: 150,
     });
@@ -543,7 +543,7 @@ test('initial render', () => {
   const element = ensureInstance(maybeNode, ReactNativeElement);
 
   Fantom.runOnUIThread(() => {
-    Fantom.scrollTo(element, {
+    Fantom.enqueueScrollEvent(element, {
       x: 0,
       y: 100,
     });
@@ -622,7 +622,7 @@ test('basic culling smaller ScrollView', () => {
   const element = ensureInstance(maybeNode, ReactNativeElement);
 
   Fantom.runOnUIThread(() => {
-    Fantom.scrollTo(element, {
+    Fantom.enqueueScrollEvent(element, {
       x: 0,
       y: 11,
     });
@@ -692,7 +692,7 @@ test('culling with transform move', () => {
   const element = ensureInstance(maybeNode, ReactNativeElement);
 
   Fantom.runOnUIThread(() => {
-    Fantom.scrollTo(element, {
+    Fantom.enqueueScrollEvent(element, {
       x: 0,
       y: 1,
     });
@@ -744,7 +744,7 @@ test('culling with recursive transform move', () => {
   const element = ensureInstance(maybeNode, ReactNativeElement);
 
   Fantom.runOnUIThread(() => {
-    Fantom.scrollTo(element, {
+    Fantom.enqueueScrollEvent(element, {
       x: 0,
       y: 1,
     });
@@ -795,7 +795,7 @@ test('culling with transform scale', () => {
   const element = ensureInstance(maybeNode, ReactNativeElement);
 
   Fantom.runOnUIThread(() => {
-    Fantom.scrollTo(element, {
+    Fantom.enqueueScrollEvent(element, {
       x: 0,
       y: 121,
     });
@@ -875,7 +875,7 @@ test('view flattening with culling', () => {
   const element = ensureInstance(maybeNode, ReactNativeElement);
 
   Fantom.runOnUIThread(() => {
-    Fantom.scrollTo(element, {
+    Fantom.enqueueScrollEvent(element, {
       x: 0,
       y: 60,
     });

--- a/packages/react-native/src/private/renderer/consistency/__tests__/UIConsistency-itest.js
+++ b/packages/react-native/src/private/renderer/consistency/__tests__/UIConsistency-itest.js
@@ -49,7 +49,7 @@ describe('UIConsistency', () => {
       expect(scrollViewNode.scrollTop).toBe(0);
 
       Fantom.runOnUIThread(() => {
-        Fantom.scrollTo(scrollViewNode, {x: 0, y: 100});
+        Fantom.enqueueScrollEvent(scrollViewNode, {x: 0, y: 100});
       });
 
       expect(scrollViewNode.scrollTop).toBe(0);
@@ -84,7 +84,7 @@ describe('UIConsistency', () => {
       // We never accessed the tree before the state update
 
       Fantom.runOnUIThread(() => {
-        Fantom.scrollTo(scrollViewNode, {x: 0, y: 100});
+        Fantom.enqueueScrollEvent(scrollViewNode, {x: 0, y: 100});
       });
 
       // The value is up-to-date immediately
@@ -142,7 +142,7 @@ describe('UIConsistency', () => {
               expect(scrollViewNode.scrollTop).toBe(0);
 
               Fantom.runOnUIThread(() => {
-                Fantom.scrollTo(scrollViewNode, {x: 0, y: 100});
+                Fantom.enqueueScrollEvent(scrollViewNode, {x: 0, y: 100});
               });
 
               expect(scrollViewNode.scrollTop).toBe(0);

--- a/packages/react-native/src/private/testing/fantom/specs/NativeFantom.js
+++ b/packages/react-native/src/private/testing/fantom/specs/NativeFantom.js
@@ -72,7 +72,7 @@ interface Spec extends TurboModule {
     category?: NativeEventCategory,
     isUnique?: boolean,
   ) => void;
-  scrollTo: (
+  enqueueScrollEvent: (
     shadowNode: mixed /* ShadowNode */,
     options: ScrollOptions,
   ) => void;


### PR DESCRIPTION
Summary:
changelog: [internal]

rename method `scrollTo` to `enqueueOnScrollEvent` to make it obvious that event is only enqueued and not executed.

Reviewed By: rubennorte

Differential Revision: D71027761


