### PR TITLE
fix: make `requestIdleCallback` handle type a number

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/idlecallbacks/NativeIdleCallbacks.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/idlecallbacks/NativeIdleCallbacks.h
@@ -14,10 +14,13 @@
 #else
 #include <FBReactNativeSpec/FBReactNativeSpecJSI.h>
 #endif
+#include <unordered_map>
 
 namespace facebook::react {
 
-using CallbackHandle = jsi::Object;
+struct Task;
+
+using CallbackHandle = double;
 
 using NativeRequestIdleCallbackOptions =
     NativeIdleCallbacksRequestIdleCallbackOptions<std::optional<double>>;
@@ -36,7 +39,11 @@ class NativeIdleCallbacks
       jsi::Runtime& runtime,
       SyncCallback<void(jsi::Object)>&& callback,
       std::optional<NativeRequestIdleCallbackOptions> options);
-  void cancelIdleCallback(jsi::Runtime& runtime, jsi::Object handle);
+  void cancelIdleCallback(jsi::Runtime& runtime, CallbackHandle handle);
+
+ private:
+  std::unordered_map<double, std::shared_ptr<Task>> taskMap_;
+  double counter_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/src/private/webapis/idlecallbacks/specs/NativeIdleCallbacks.js
+++ b/packages/react-native/src/private/webapis/idlecallbacks/specs/NativeIdleCallbacks.js
@@ -25,8 +25,8 @@ export interface Spec extends TurboModule {
   +requestIdleCallback: (
     callback: (idleDeadline: IdleDeadline) => mixed,
     options?: RequestIdleCallbackOptions,
-  ) => mixed;
-  +cancelIdleCallback: (handle: mixed) => void;
+  ) => number;
+  +cancelIdleCallback: (handle: number) => void;
 }
 
 export default (TurboModuleRegistry.getEnforcing<Spec>(


### PR DESCRIPTION
## Summary:

This PR changes the return value of `requestIdleCallback` and parameter type of `cancelIdleCallback` from opaque object with NativeState into number to further match WebAPI.

Fixes #49684 

## Changelog:

[GENERAL] [FIXED] - Fixed `requestIdleCallback` handle type

## Test Plan:

