### PR TITLE
Makes TouchesHelper internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -5437,13 +5437,6 @@ public final class com/facebook/react/uimanager/events/TouchEventType$Companion 
 	public final fun getJSEventName (Lcom/facebook/react/uimanager/events/TouchEventType;)Ljava/lang/String;
 }
 
-public final class com/facebook/react/uimanager/events/TouchesHelper {
-	public static final field INSTANCE Lcom/facebook/react/uimanager/events/TouchesHelper;
-	public static final field TARGET_KEY Ljava/lang/String;
-	public static final fun sendTouchEvent (Lcom/facebook/react/uimanager/events/RCTModernEventEmitter;Lcom/facebook/react/uimanager/events/TouchEvent;)V
-	public static final fun sendTouchesLegacy (Lcom/facebook/react/uimanager/events/RCTEventEmitter;Lcom/facebook/react/uimanager/events/TouchEvent;)V
-}
-
 public class com/facebook/react/uimanager/layoutanimation/LayoutAnimationController {
 	public fun <init> ()V
 	public fun applyLayoutUpdate (Landroid/view/View;IIII)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/ReactEventEmitter.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/ReactEventEmitter.kt
@@ -59,7 +59,7 @@ internal class ReactEventEmitter(private val reactContext: ReactApplicationConte
     receiveEvent(surfaceId, targetTag, eventName, false, 0, params, EventCategoryDef.UNSPECIFIED)
   }
 
-  @Deprecated("Please use RCTModernEventEmitter")
+  @Deprecated("Dispatch the TouchEvent using [EventDispatcher] instead")
   override fun receiveTouches(
       eventName: String,
       touches: WritableArray,
@@ -78,7 +78,7 @@ internal class ReactEventEmitter(private val reactContext: ReactApplicationConte
     }
   }
 
-  @Deprecated("Please use RCTModernEventEmitter")
+  @Deprecated("Dispatch the TouchEvent using [EventDispatcher] instead")
   override fun receiveTouches(event: TouchEvent) {
     @UIManagerType val uiManagerType = getUIManagerType(event.viewTag, event.surfaceId)
     if (uiManagerType == UIManagerType.FABRIC) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/TouchesHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/TouchesHelper.kt
@@ -15,7 +15,7 @@ import com.facebook.react.uimanager.events.TouchEventType.Companion.getJSEventNa
 import com.facebook.systrace.Systrace
 
 /** Class responsible for generating catalyst touch events based on android [MotionEvent]. */
-public object TouchesHelper {
+internal object TouchesHelper {
   @JvmField @Deprecated("Not used in New Architecture") public val TARGET_KEY: String = "target"
 
   private const val TARGET_SURFACE_KEY = "targetSurface"


### PR DESCRIPTION
Summary:
This was unintentionally made public during the Kotlin migration (D67791375), revert back to internal visibility, and update some of the deprecation comments.

Changelog: [Android][Removed] TouchesHelper is no longer part of the public API

Reviewed By: Abbondanzo

Differential Revision: D71114176


