### PR TITLE
Remove CGFLOAT_IS_DOUBLE macro

### DIFF
--- a/packages/react-native/Libraries/Text/Text/RCTDynamicTypeRamp.mm
+++ b/packages/react-native/Libraries/Text/Text/RCTDynamicTypeRamp.mm
@@ -78,5 +78,5 @@ CGFloat RCTBaseSizeForDynamicTypeRamp(RCTDynamicTypeRamp dynamicTypeRamp)
 
   NSNumber *baseSize =
       mapping[@(dynamicTypeRamp)] ?: @17; // Default to body size if we don't recognize the specified ramp
-  return CGFLOAT_IS_DOUBLE ? [baseSize doubleValue] : [baseSize floatValue];
+  return [baseSize doubleValue];
 }

--- a/packages/react-native/React/Views/RCTFont.mm
+++ b/packages/react-native/React/Views/RCTFont.mm
@@ -94,11 +94,7 @@ BOOL RCTHasFontHandlerSet()
 // which one we actually have.
 static inline BOOL CompareFontWeights(UIFontWeight firstWeight, UIFontWeight secondWeight)
 {
-#if CGFLOAT_IS_DOUBLE
   return fabs(firstWeight - secondWeight) < 0.01;
-#else
-  return fabsf(firstWeight - secondWeight) < 0.01;
-#endif
 }
 
 static NSString *FontWeightDescriptionFromUIFontWeight(UIFontWeight fontWeight)


### PR DESCRIPTION
Summary:
[From iOS 11 onwards and from MacOS 10.15](https://developer.apple.com/documentation/uikit/updating-your-app-from-32-bit-to-64-bit-architecture?language=objc), Apple only supports 64 bit architectures.

Hence, [`CGFloat` is now always mapped to a Double](https://developer.apple.com/documentation/corefoundation/cgfloat-swift.struct?language=objc#overview) and it is now safe to remove the macro.

## Changelog
[Internal] - Remove usages of `CGFLOAT_IS_DOUBLE`

Differential Revision: D71128583


