### PR TITLE
Allow value extraction from folly::dynamic events

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollEvent.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollEvent.cpp
@@ -72,6 +72,21 @@ folly::dynamic ScrollEvent::asDynamic() const {
   return metrics;
 };
 
+std::optional<double> ScrollEvent::extractValue(
+    const std::vector<std::string>& path) const {
+  if (path.size() == 1 && path[0] == "zoomScale") {
+    return zoomScale;
+  } else if (path.size() == 2 && path[0] == "contentOffset") {
+    if (path[1] == "x") {
+      return contentOffset.x;
+    } else if (path[1] == "y") {
+      return contentOffset.y;
+    }
+  }
+
+  return EventPayload::extractValue(path);
+}
+
 EventPayloadType ScrollEvent::getType() const {
   return EventPayloadType::ScrollEvent;
 }

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollEvent.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollEvent.h
@@ -36,6 +36,9 @@ struct ScrollEvent : public EventPayload {
    */
   jsi::Value asJSIValue(jsi::Runtime& runtime) const override;
   EventPayloadType getType() const override;
+
+  std::optional<double> extractValue(
+      const std::vector<std::string>& path) const override;
 };
 
 struct ScrollEndDragEvent : public ScrollEvent {

--- a/packages/react-native/ReactCommon/react/renderer/core/DynamicEventPayload.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/DynamicEventPayload.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "DynamicEventPayload.h"
+
+#include <jsi/JSIDynamic.h>
+
+namespace facebook::react {
+
+DynamicEventPayload::DynamicEventPayload(folly::dynamic&& payload)
+    : payload_(std::move(payload)) {}
+
+jsi::Value DynamicEventPayload::asJSIValue(jsi::Runtime& runtime) const {
+  return jsi::valueFromDynamic(runtime, payload_);
+}
+
+EventPayloadType DynamicEventPayload::getType() const {
+  return EventPayloadType::ValueFactory;
+}
+
+std::optional<double> DynamicEventPayload::extractValue(
+    const std::vector<std::string>& path) const {
+  auto dynamic = payload_;
+  for (auto& key : path) {
+    auto type = dynamic.type();
+    if ((type == folly::dynamic::Type::OBJECT ||
+         type == folly::dynamic::Type::ARRAY) &&
+        !dynamic.empty()) {
+      dynamic = folly::dynamic(dynamic[key]);
+    }
+  }
+  if (dynamic.type() == folly::dynamic::Type::DOUBLE) {
+    return dynamic.asDouble();
+  } else if (dynamic.type() == folly::dynamic::Type::INT64) {
+    return dynamic.asInt();
+  }
+  return std::nullopt;
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/DynamicEventPayload.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/DynamicEventPayload.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/dynamic.h>
+#include <react/renderer/core/EventPayload.h>
+
+namespace facebook::react {
+
+struct DynamicEventPayload : public EventPayload {
+  explicit DynamicEventPayload(folly::dynamic&& payload);
+
+  /*
+   * EventPayload implementations
+   */
+  jsi::Value asJSIValue(jsi::Runtime& runtime) const override;
+  EventPayloadType getType() const override;
+  std::optional<double> extractValue(
+      const std::vector<std::string>& path) const override;
+
+ private:
+  folly::dynamic payload_;
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.cpp
@@ -9,9 +9,9 @@
 
 #include <cxxreact/TraceSection.h>
 #include <folly/dynamic.h>
-#include <jsi/JSIDynamic.h>
 #include <jsi/jsi.h>
 
+#include "DynamicEventPayload.h"
 #include "RawEvent.h"
 
 namespace facebook::react {
@@ -61,18 +61,16 @@ void EventEmitter::dispatchEvent(
     RawEvent::Category category) const {
   dispatchEvent(
       std::move(type),
-      [payload](jsi::Runtime& runtime) {
-        return valueFromDynamic(runtime, payload);
-      },
+      std::make_shared<DynamicEventPayload>(folly::dynamic(payload)),
       category);
 }
 
 void EventEmitter::dispatchUniqueEvent(
     std::string type,
     const folly::dynamic& payload) const {
-  dispatchUniqueEvent(std::move(type), [payload](jsi::Runtime& runtime) {
-    return valueFromDynamic(runtime, payload);
-  });
+  dispatchUniqueEvent(
+      std::move(type),
+      std::make_shared<DynamicEventPayload>(folly::dynamic(payload)));
 }
 
 void EventEmitter::dispatchEvent(

--- a/packages/react-native/ReactCommon/react/renderer/core/EventPayload.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventPayload.h
@@ -10,6 +10,8 @@
 #include <jsi/jsi.h>
 
 #include <react/renderer/core/EventPayloadType.h>
+#include <optional>
+#include <vector>
 
 namespace facebook::react {
 
@@ -33,6 +35,17 @@ struct EventPayload {
    * in `EventPayloadType` and return it from its overriden `getType()` method.
    */
   virtual EventPayloadType getType() const = 0;
+
+  /**
+   * Used to extract numeric values from the event payload based on
+   * property path names as they will exist in JavaScript. This can
+   * be used in conjunction with listeners on EventEmitters to do
+   * things like drive native animations.
+   */
+  virtual std::optional<double> extractValue(
+      const std::vector<std::string>& /* path */) const {
+    return std::nullopt;
+  }
 };
 
 using SharedEventPayload = std::shared_ptr<const EventPayload>;


### PR DESCRIPTION
Summary:
In the new architecture, Android dispatches all events with folly::dynamic payloads. Various other callsites in some host platforms similarly dispatch events with folly::dynamic payloads.

Events disptached with folly::dynamic payloads have alignment with the `EventPayload::extractValue` method, added for integration with other capabilities like native animations.

When combined with a general pupose synchronous listener on facebook::react::EventEmitter, this should allow easier integration with host platform native event animation drivers.

## Changelog

[Internal]

Differential Revision: D71198197


