### PR TITLE
add tests for Fantom.scheduleTask

### DIFF
--- a/packages/react-native-fantom/src/__tests__/Fantom-itest.js
+++ b/packages/react-native-fantom/src/__tests__/Fantom-itest.js
@@ -829,3 +829,35 @@ describe('Fantom', () => {
     });
   });
 });
+
+describe('scheduleTask', () => {
+  it('does not run task immediately', () => {
+    let didRun = false;
+
+    Fantom.scheduleTask(() => {
+      didRun = true;
+    });
+
+    expect(didRun).toBe(false);
+
+    Fantom.runWorkLoop();
+
+    expect(didRun).toBe(true);
+  });
+
+  it('can be scheduled from within another task', () => {
+    let didInnerTaskRun = false;
+
+    Fantom.scheduleTask(() => {
+      Fantom.scheduleTask(() => {
+        didInnerTaskRun = true;
+      });
+    });
+
+    expect(didInnerTaskRun).toBe(false);
+
+    Fantom.runWorkLoop();
+
+    expect(didInnerTaskRun).toBe(true);
+  });
+});


### PR DESCRIPTION
Summary:
changelog: [internal]

All public APIs should be covered with tests, this diff adds tests for Fantom.scheduleTask.

Reviewed By: rubennorte

Differential Revision: D71195921


