### PR TITLE
move Fantom's API to regular functions

### DIFF
--- a/packages/react-native-fantom/runner/getFantomTestConfig.js
+++ b/packages/react-native-fantom/runner/getFantomTestConfig.js
@@ -54,7 +54,8 @@ const DEFAULT_MODE: FantomTestConfigMode =
 const FANTOM_FLAG_FORMAT = /^(\w+):(\w+)$/;
 
 const FANTOM_BENCHMARK_FILENAME_RE = /[Bb]enchmark-itest\./g;
-const FANTOM_BENCHMARK_SUITE_RE = /\nFantom\.unstable_benchmark(\s*)\.suite\(/g;
+const FANTOM_BENCHMARK_SUITE_RE =
+  /\n(Fantom\.)?unstable_benchmark(\s*)\.suite\(/g;
 
 /**
  * Extracts the Fantom configuration from the test file, specified as part of

--- a/packages/react-native-fantom/src/__tests__/Fantom-itest.js
+++ b/packages/react-native-fantom/src/__tests__/Fantom-itest.js
@@ -13,7 +13,7 @@ import 'react-native/Libraries/Core/InitializeCore';
 
 import type {Root} from '@react-native/fantom';
 
-import Fantom from '@react-native/fantom';
+import * as Fantom from '@react-native/fantom';
 import * as React from 'react';
 import {Modal, ScrollView, Text, TextInput, View} from 'react-native';
 import NativeFantom from 'react-native/src/private/testing/fantom/specs/NativeFantom';

--- a/packages/react-native-fantom/src/__tests__/benchmarks/BenchmarkTests-testMode-benchmark-itest.js
+++ b/packages/react-native-fantom/src/__tests__/benchmarks/BenchmarkTests-testMode-benchmark-itest.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import Fantom from '@react-native/fantom';
+import * as Fantom from '@react-native/fantom';
 
 let runs = 0;
 

--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -130,7 +130,7 @@ const DEFAULT_TASK_PRIORITY = schedulerPriorityImmediate;
  * If the work loop is running, it will be executed according to its priority.
  * Otherwise, it will wait in the queue until the work loop runs.
  */
-function scheduleTask(task: () => void | Promise<void>) {
+export function scheduleTask(task: () => void | Promise<void>) {
   nativeRuntimeScheduler.unstable_scheduleCallback(DEFAULT_TASK_PRIORITY, task);
 }
 
@@ -141,7 +141,7 @@ let flushingQueue = false;
  *
  * React must run inside of event loop to ensure scheduling environment is closer to production.
  */
-function runTask(task: () => void | Promise<void>) {
+export function runTask(task: () => void | Promise<void>) {
   if (flushingQueue) {
     throw new Error(
       'Nested `runTask` calls are not allowed. If you want to schedule a task from inside another task, use `scheduleTask` instead.',
@@ -155,7 +155,7 @@ function runTask(task: () => void | Promise<void>) {
 /*
  * Simmulates running a task on the UI thread and forces side effect to drain the event queue, scheduling events to be dispatched to JavaScript.
  */
-function runOnUIThread(task: () => void) {
+export function runOnUIThread(task: () => void) {
   task();
   NativeFantom.flushEventQueue();
 }
@@ -164,7 +164,7 @@ function runOnUIThread(task: () => void) {
  * Runs a side effect to drain the event queue and dispatches events to JavaScript.
  * Useful to flash out all tasks.
  */
-function flushAllNativeEvents() {
+export function flushAllNativeEvents() {
   NativeFantom.flushEventQueue();
   runWorkLoop();
 }
@@ -172,7 +172,7 @@ function flushAllNativeEvents() {
 /**
  * Runs the event loop until all tasks are executed.
  */
-function runWorkLoop(): void {
+export function runWorkLoop(): void {
   if (flushingQueue) {
     throw new Error(
       'Cannot start the work loop because it is already running. If you want to schedule a task from inside another task, use `scheduleTask` instead.',
@@ -189,7 +189,7 @@ function runWorkLoop(): void {
 
 // TODO: Add option to define surface props and pass it to startSurface
 // Surfacep rops: concurrentRoot, surfaceWidth, surfaceHeight, layoutDirection, pointScaleFactor.
-function createRoot(rootConfig?: RootConfig): Root {
+export function createRoot(rootConfig?: RootConfig): Root {
   return new Root(rootConfig);
 }
 
@@ -200,7 +200,7 @@ function createRoot(rootConfig?: RootConfig): Root {
  *
  * For a higher level API, use `dispatchNativeEvent`.
  */
-function enqueueNativeEvent(
+export function enqueueNativeEvent(
   node: ReactNativeElement,
   type: string,
   payload?: {[key: string]: mixed},
@@ -216,7 +216,7 @@ function enqueueNativeEvent(
   );
 }
 
-function dispatchNativeEvent(
+export function dispatchNativeEvent(
   node: ReactNativeElement,
   type: string,
   payload?: {[key: string]: mixed},
@@ -235,7 +235,7 @@ export type ScrollEventOptions = {
   zoomScale?: number,
 };
 
-function enqueueScrollEvent(
+export function enqueueScrollEvent(
   node: ReactNativeElement,
   options: ScrollEventOptions,
 ) {
@@ -271,7 +271,10 @@ function enqueueScrollEvent(
  * // Assert that changes from Fantom.scrollTo are in effect.
  * ```
  */
-function scrollTo(node: ReactNativeElement, options: ScrollEventOptions) {
+export function scrollTo(
+  node: ReactNativeElement,
+  options: ScrollEventOptions,
+) {
   runOnUIThread(() => {
     enqueueScrollEvent(node, options);
   });
@@ -279,7 +282,7 @@ function scrollTo(node: ReactNativeElement, options: ScrollEventOptions) {
   runWorkLoop();
 }
 
-function enqueueModalSizeUpdate(
+export function enqueueModalSizeUpdate(
   node: ReactNativeElement,
   size: {width: number, height: number},
 ) {
@@ -369,26 +372,10 @@ if (typeof global.EventTarget === 'undefined') {
   );
 }
 
-function saveJSMemoryHeapSnapshot(filePath: string): void {
+export function saveJSMemoryHeapSnapshot(filePath: string): void {
   if (getConstants().isRunningFromCI) {
     throw new Error('Unexpected call to `saveJSMemoryHeapSnapshot` from CI');
   }
 
   NativeFantom.saveJSMemoryHeapSnapshot(filePath);
 }
-
-export default {
-  scheduleTask,
-  runTask,
-  runOnUIThread,
-  runWorkLoop,
-  createRoot,
-  dispatchNativeEvent,
-  enqueueNativeEvent,
-  flushAllNativeEvents,
-  enqueueModalSizeUpdate,
-  unstable_benchmark: Benchmark,
-  enqueueScrollEvent,
-  scrollTo,
-  saveJSMemoryHeapSnapshot,
-};

--- a/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-itest.js
+++ b/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-itest.js
@@ -11,7 +11,7 @@
 
 import 'react-native/Libraries/Core/InitializeCore';
 
-import Fantom from '@react-native/fantom';
+import * as Fantom from '@react-native/fantom';
 import * as React from 'react';
 import {ScrollView} from 'react-native';
 import ensureInstance from 'react-native/src/private/utilities/ensureInstance';

--- a/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-viewCulling-itest.js
+++ b/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-viewCulling-itest.js
@@ -12,7 +12,7 @@
  */
 
 import 'react-native/Libraries/Core/InitializeCore.js';
-import Fantom from '@react-native/fantom';
+import * as Fantom from '@react-native/fantom';
 import * as React from 'react';
 import {Modal, ScrollView, View} from 'react-native';
 import ensureInstance from 'react-native/src/private/utilities/ensureInstance';

--- a/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-itest.js
+++ b/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-itest.js
@@ -11,7 +11,7 @@
 
 import 'react-native/Libraries/Core/InitializeCore';
 
-import Fantom from '@react-native/fantom';
+import * as Fantom from '@react-native/fantom';
 import * as React from 'react';
 import {useEffect, useLayoutEffect, useRef} from 'react';
 import {TextInput} from 'react-native';

--- a/packages/react-native/Libraries/Components/View/__tests__/View-benchmark-itest.js
+++ b/packages/react-native/Libraries/Components/View/__tests__/View-benchmark-itest.js
@@ -11,7 +11,7 @@
 
 import 'react-native/Libraries/Core/InitializeCore';
 
-import Fantom from '@react-native/fantom';
+import * as Fantom from '@react-native/fantom';
 import * as React from 'react';
 import {View} from 'react-native';
 

--- a/packages/react-native/Libraries/Components/View/__tests__/View-itest.js
+++ b/packages/react-native/Libraries/Components/View/__tests__/View-itest.js
@@ -11,7 +11,7 @@
 
 import 'react-native/Libraries/Core/InitializeCore';
 
-import Fantom from '@react-native/fantom';
+import * as Fantom from '@react-native/fantom';
 import * as React from 'react';
 import {View} from 'react-native';
 

--- a/packages/react-native/Libraries/LogBox/__tests__/LogBox-itest.js
+++ b/packages/react-native/Libraries/LogBox/__tests__/LogBox-itest.js
@@ -12,7 +12,7 @@
 import 'react-native/Libraries/Core/InitializeCore';
 
 import {renderLogBox} from './fantomHelpers';
-import Fantom from '@react-native/fantom';
+import * as Fantom from '@react-native/fantom';
 import * as React from 'react';
 import {useEffect} from 'react';
 import {LogBox, Text, View} from 'react-native';

--- a/packages/react-native/Libraries/LogBox/__tests__/fantomHelpers.js
+++ b/packages/react-native/Libraries/LogBox/__tests__/fantomHelpers.js
@@ -14,7 +14,7 @@ import ReadOnlyElement from '../../../src/private/webapis/dom/nodes/ReadOnlyElem
 import View from '../../Components/View/View';
 import AppContainer from '../../ReactNative/AppContainer';
 import LogBoxInspectorContainer from '../LogBoxInspectorContainer';
-import Fantom from '@react-native/fantom';
+import * as Fantom from '@react-native/fantom';
 import nullthrows from 'nullthrows';
 import * as React from 'react';
 

--- a/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/ReactFabricPublicInstance-benchmark-itest.js
+++ b/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/ReactFabricPublicInstance-benchmark-itest.js
@@ -17,7 +17,7 @@ import type {
 } from 'react-native/Libraries/Renderer/shims/ReactNativeTypes';
 import type ReactNativeDocument from 'react-native/src/private/webapis/dom/nodes/ReactNativeDocument';
 
-import Fantom from '@react-native/fantom';
+import * as Fantom from '@react-native/fantom';
 import ReactFabricHostComponent from 'react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricHostComponent';
 import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 

--- a/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/setUpReactFabricPublicInstanceFantomTests.js
+++ b/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/setUpReactFabricPublicInstanceFantomTests.js
@@ -15,7 +15,7 @@ import ReactNativeElement from '../../../../src/private/webapis/dom/nodes/ReactN
 import TextInputState from '../../../Components/TextInput/TextInputState';
 import View from '../../../Components/View/View';
 import ReactFabricHostComponent from '../ReactFabricHostComponent';
-import Fantom from '@react-native/fantom';
+import * as Fantom from '@react-native/fantom';
 import nullthrows from 'nullthrows';
 import * as React from 'react';
 

--- a/packages/react-native/Libraries/ReactNative/__tests__/InterruptibleRendering-itest.js
+++ b/packages/react-native/Libraries/ReactNative/__tests__/InterruptibleRendering-itest.js
@@ -11,7 +11,7 @@
 
 import 'react-native/Libraries/Core/InitializeCore';
 
-import Fantom from '@react-native/fantom';
+import * as Fantom from '@react-native/fantom';
 import * as React from 'react';
 import {startTransition, useDeferredValue, useEffect, useState} from 'react';
 import {Text, TextInput} from 'react-native';

--- a/packages/react-native/Libraries/ReactNative/__tests__/ReactFabric-Suspense-itest.js
+++ b/packages/react-native/Libraries/ReactNative/__tests__/ReactFabric-Suspense-itest.js
@@ -11,7 +11,7 @@
 
 import 'react-native/Libraries/Core/InitializeCore';
 
-import Fantom from '@react-native/fantom';
+import * as Fantom from '@react-native/fantom';
 import * as React from 'react';
 import {Suspense, startTransition} from 'react';
 import {View} from 'react-native';

--- a/packages/react-native/src/private/renderer/consistency/__tests__/UIConsistency-itest.js
+++ b/packages/react-native/src/private/renderer/consistency/__tests__/UIConsistency-itest.js
@@ -14,7 +14,7 @@
 
 import 'react-native/Libraries/Core/InitializeCore';
 
-import Fantom from '@react-native/fantom';
+import * as Fantom from '@react-native/fantom';
 import * as React from 'react';
 import {useLayoutEffect} from 'react';
 import {ScrollView, Text} from 'react-native';

--- a/packages/react-native/src/private/renderer/mounting/__tests__/Mounting-itest.js
+++ b/packages/react-native/src/private/renderer/mounting/__tests__/Mounting-itest.js
@@ -11,7 +11,7 @@
 
 import 'react-native/Libraries/Core/InitializeCore';
 
-import Fantom from '@react-native/fantom';
+import * as Fantom from '@react-native/fantom';
 import * as React from 'react';
 import {View} from 'react-native';
 

--- a/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeDocument-itest.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeDocument-itest.js
@@ -11,7 +11,7 @@
 
 import 'react-native/Libraries/Core/InitializeCore';
 
-import Fantom from '@react-native/fantom';
+import * as Fantom from '@react-native/fantom';
 import nullthrows from 'nullthrows';
 import * as React from 'react';
 import {View} from 'react-native';

--- a/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeElement-itest.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeElement-itest.js
@@ -11,7 +11,7 @@
 
 import 'react-native/Libraries/Core/InitializeCore';
 
-import Fantom from '@react-native/fantom';
+import * as Fantom from '@react-native/fantom';
 import * as React from 'react';
 import {ScrollView, View} from 'react-native';
 import {

--- a/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReadOnlyText-itest.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReadOnlyText-itest.js
@@ -11,7 +11,7 @@
 
 import 'react-native/Libraries/Core/InitializeCore';
 
-import Fantom from '@react-native/fantom';
+import * as Fantom from '@react-native/fantom';
 import invariant from 'invariant';
 import * as React from 'react';
 import {NativeText} from 'react-native/Libraries/Text/TextNativeComponent';

--- a/packages/react-native/src/private/webapis/idlecallbacks/__tests__/requestIdleCallback-itest.js
+++ b/packages/react-native/src/private/webapis/idlecallbacks/__tests__/requestIdleCallback-itest.js
@@ -11,7 +11,7 @@
 
 import 'react-native/Libraries/Core/InitializeCore';
 
-import Fantom from '@react-native/fantom';
+import * as Fantom from '@react-native/fantom';
 
 interface IdleDeadline {
   +didTimeout: boolean;

--- a/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-itest.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-itest.js
@@ -13,7 +13,7 @@ import 'react-native/Libraries/Core/InitializeCore';
 
 import type IntersectionObserverType from 'react-native/src/private/webapis/intersectionobserver/IntersectionObserver';
 
-import Fantom from '@react-native/fantom';
+import * as Fantom from '@react-native/fantom';
 import * as React from 'react';
 import {ScrollView, View} from 'react-native';
 import setUpIntersectionObserver from 'react-native/src/private/setup/setUpIntersectionObserver';

--- a/packages/react-native/src/private/webapis/mutationobserver/__tests__/MutationObserver-itest.js
+++ b/packages/react-native/src/private/webapis/mutationobserver/__tests__/MutationObserver-itest.js
@@ -14,7 +14,7 @@ import 'react-native/Libraries/Core/InitializeCore';
 import type MutationObserverType from 'react-native/src/private/webapis/mutationobserver/MutationObserver';
 import type MutationRecordType from 'react-native/src/private/webapis/mutationobserver/MutationRecord';
 
-import Fantom from '@react-native/fantom';
+import * as Fantom from '@react-native/fantom';
 import nullthrows from 'nullthrows';
 import * as React from 'react';
 import {View} from 'react-native';

--- a/packages/react-native/src/private/webapis/performance/__tests__/LongTaskAPI-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/LongTaskAPI-itest.js
@@ -17,7 +17,7 @@ import type {
   PerformanceObserverEntryList,
 } from 'react-native/src/private/webapis/performance/PerformanceObserver';
 
-import Fantom from '@react-native/fantom';
+import * as Fantom from '@react-native/fantom';
 import nullthrows from 'nullthrows';
 import setUpPerformanceObserver from 'react-native/src/private/setup/setUpPerformanceObserver';
 import {PerformanceLongTaskTiming} from 'react-native/src/private/webapis/performance/LongTasks';

--- a/packages/react-native/src/private/webapis/performance/__tests__/Performance-benchmark-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/Performance-benchmark-itest.js
@@ -14,7 +14,7 @@ import 'react-native/Libraries/Core/InitializeCore';
 
 import type Performance from 'react-native/src/private/webapis/performance/Performance';
 
-import Fantom from '@react-native/fantom';
+import * as Fantom from '@react-native/fantom';
 
 declare var performance: Performance;
 

--- a/packages/react-native/src/private/webapis/performance/__tests__/UserTimingAPI-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/UserTimingAPI-itest.js
@@ -14,7 +14,7 @@ import 'react-native/Libraries/Core/InitializeCore';
 
 import type Performance from 'react-native/src/private/webapis/performance/Performance';
 
-import Fantom from '@react-native/fantom';
+import * as Fantom from '@react-native/fantom';
 import setUpPerformanceObserver from 'react-native/src/private/setup/setUpPerformanceObserver';
 import ensureInstance from 'react-native/src/private/utilities/ensureInstance';
 import {PerformanceObserver} from 'react-native/src/private/webapis/performance/PerformanceObserver';


### PR DESCRIPTION
Summary:
changelog: [internal]

to make it easier to write JSDocs, let's export functions directly from index.js instead of using proxy object.

Reviewed By: rubennorte

Differential Revision: D71200977


