### PR TITLE
[Fabric] iOS: Fixes Switch component incorrectly renders as toggled on even though value prop is hardcoded to false

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Switch/RCTSwitchComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Switch/RCTSwitchComponentView.mm
@@ -47,9 +47,6 @@ using namespace facebook::react;
 {
   [super prepareForRecycle];
   _isInitialValueSet = NO;
-
-  const auto &switchProps = static_cast<const SwitchProps &>(*_props);
-  _switchView.on = switchProps.value;
 }
 
 + (ComponentDescriptorProvider)componentDescriptorProvider
@@ -63,7 +60,7 @@ using namespace facebook::react;
   const auto &newSwitchProps = static_cast<const SwitchProps &>(*props);
 
   // `value`
-  if (oldSwitchProps.value != newSwitchProps.value) {
+  if (!_isInitialValueSet || oldSwitchProps.value != newSwitchProps.value) {
     BOOL shouldAnimate = _isInitialValueSet == YES;
     [_switchView setOn:newSwitchProps.value animated:shouldAnimate];
   }

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Switch/RCTSwitchComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Switch/RCTSwitchComponentView.mm
@@ -47,6 +47,9 @@ using namespace facebook::react;
 {
   [super prepareForRecycle];
   _isInitialValueSet = NO;
+
+  const auto &switchProps = static_cast<const SwitchProps &>(*_props);
+  _switchView.on = switchProps.value;
 }
 
 + (ComponentDescriptorProvider)componentDescriptorProvider


### PR DESCRIPTION
## Summary:

Fixes #50026

## Changelog:

[IOS] [FIXED] - [Fabric] iOS: Fixes Switch component incorrectly renders as toggled on even though value prop is hardcoded to false

## Test Plan:

Repro please see #50026.
