### PR TITLE
[ios][prebuild] fixed inclusion of resources in swift package

### DIFF
--- a/scripts/releases/ios-prebuild/compose-framework.js
+++ b/scripts/releases/ios-prebuild/compose-framework.js
@@ -113,6 +113,7 @@ function copyBundles(
             targetArchFolder,
             `${scheme}.framework`,
             'Resources',
+            bundleName,
           );
           if (
             !fs.existsSync(path.join(targetArchFolder, `${scheme}.framework`))
@@ -123,7 +124,8 @@ function copyBundles(
             console.warn("Source bundle doesn't exist", sourceBundlePath);
           }
           // A bundle is a directory, so we need to copy the whole directory
-          execSync(`cp -r ${sourceBundlePath} ${targetBundlePath}`);
+          execSync(`mkdir -p "${targetBundlePath}"`);
+          execSync(`cp -r "${sourceBundlePath}/" "${targetBundlePath}"`);
         });
       } else {
         console.warn(`Bundle ${sourceBundlePath} not found`);

--- a/scripts/releases/ios-prebuild/configuration.js
+++ b/scripts/releases/ios-prebuild/configuration.js
@@ -48,7 +48,7 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
         'src/vlog_is_on.cc',
       ],
       headers: ['src/glog/*.h'],
-      // resources: ['../third-party-podspecs/glog/PrivacyInfo.xcprivacy'],
+      resources: ['../third-party-podspecs/glog/PrivacyInfo.xcprivacy'],
       headerSkipFolderNames: 'src',
     },
     settings: {
@@ -94,7 +94,8 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
       publicHeaderFiles: './include',
       headerSearchPaths: ['include'],
       linkedLibraries: ['c++'],
-      compilerFlags: ['-Wno-everything', `-std=${CPP_STANDARD}`],
+      compilerFlags: ['-Wno-everything'],
+      cppVersion: CPP_STANDARD,
     },
   },
   {
@@ -107,7 +108,7 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
     files: {
       sources: ['boost/**/*.hpp', 'dummy.cc'],
       headers: ['boost/**/*.hpp'],
-      // resources: ['../third-party-podspecs/boost/PrivacyInfo.xcprivacy'],
+      resources: ['../third-party-podspecs/boost/PrivacyInfo.xcprivacy'],
     },
     settings: {
       publicHeaderFiles: './',
@@ -130,7 +131,8 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
     settings: {
       publicHeaderFiles: './include',
       headerSearchPaths: ['include'],
-      compilerFlags: ['-Wno-everything', `-std=${CPP_STANDARD}`],
+      compilerFlags: ['-Wno-everything'],
+      cppVersion: CPP_STANDARD,
       linkedLibraries: ['c++'],
     },
   },
@@ -245,8 +247,7 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
         'folly/portability/*.h',
         'folly/system/*.h',
       ],
-      // TODO: When including this we get "failed to scan dependencies" error
-      // resources: ['../third-party-podspecs/RCT-Folly/PrivacyInfo.xcprivacy'],
+      resources: ['../third-party-podspecs/RCT-Folly/PrivacyInfo.xcprivacy'],
     },
     dependencies: [
       'glog',
@@ -261,11 +262,11 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
       headerSearchPaths: ['./'],
       compilerFlags: [
         '-Wno-everything',
-        `-std=${CPP_STANDARD}`,
         '-faligned-new',
         '-Wno-shorten-64-to-32',
         '-Wno-comma',
       ],
+      cppVersion: CPP_STANDARD,
       defines: [
         {name: 'USE_HEADERMAP', value: 'NO'},
         {name: 'DEFINES_MODULE', value: 'YES'},

--- a/scripts/releases/ios-prebuild/swift-package.js
+++ b/scripts/releases/ios-prebuild/swift-package.js
@@ -73,6 +73,12 @@ function createSwiftTarget(dependency /*  :Dependency */) {
     unsafeCAndCxxSettings = `.unsafeFlags([${dependency.settings.compilerFlags.map(flag => `"${flag}"`).join(', ')}]),`;
   }
 
+  // Add c++ version to c++ settings if provided
+  let unsafeCxxSettings = '';
+  if (dependency.settings.cppVersion != null) {
+    unsafeCxxSettings = `.unsafeFlags(["-std=${dependency.settings.cppVersion}"]),`;
+  }
+
   // Setup defines
   let defines = '';
   if (dependency.settings.defines != null) {
@@ -127,6 +133,7 @@ function createSwiftTarget(dependency /*  :Dependency */) {
                 ${headerSearchPaths}
                 ${unsafeCAndCxxSettings}
                 ${defines}
+                ${unsafeCxxSettings}
               ],
               linkerSettings: [
                 ${linkedLibraries}

--- a/scripts/releases/ios-prebuild/types.js
+++ b/scripts/releases/ios-prebuild/types.js
@@ -32,6 +32,7 @@ export type Settings = $ReadOnly<{
   headerSearchPaths?: $ReadOnlyArray<string>,
   defines?: $ReadOnlyArray<Define>,
   compilerFlags?: $ReadOnlyArray<string>,
+  cppVersion?: string,
   linkedLibraries?: $ReadOnlyArray<string>,
   publicHeaderFiles: string,
   linkerSettings?: $ReadOnlyArray<string>


### PR DESCRIPTION
## Summary:

We had some issues with the Swift package build step where we saw an error message when we included resources and couldn't find out why this was happening.

After systematically going through the generated swift package file and looking for a reason I found a mistake.

When we generate the Package.swift file we pass all compilerFlags from the configuration of the target to both cpp/c flags - which in the case of the folly target ends up being passed to the dependency scanner which isn't too happy about this c++ flag.

The solution is to break out the c++ stdlib version as a separate setting in the configuration and pass it only to the `cxxSettings` section in our final Package.swift file.

This commit fixes this by:
- Adding a new field in the dependency settings struct called `cppVersion`
- Updated configuration with correct resources and cppVersion for relevant targets
- Now emits the correct cppVersion to the cxxSettings section
- Fixed issue with the copy bundles step that didn't copy the directory in some cases.



<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[INTERNAL]  - Fixed processing resources in the generated swift package for the RN Dependencies/prebuild
