### PR TITLE
Fix Nullsafe FIXMEs for DevSupportManagerBase.java

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/BundleDownloader.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/BundleDownloader.java
@@ -141,8 +141,10 @@ public class BundleDownloader {
               // Make sure the result is a multipart response and parse the boundary.
               String contentType = response.header("content-type");
               Pattern regex = Pattern.compile("multipart/mixed;.*boundary=\"([^\"]+)\"");
+              // NULLSAFE_FIXME[Parameter Not Nullable]
               Matcher match = regex.matcher(contentType);
               if (match.find()) {
+                // NULLSAFE_FIXME[Parameter Not Nullable]
                 processMultipartResponse(url, r, match.group(1), outputFile, bundleInfo, callback);
               } else {
                 // In case the server doesn't support multipart/mixed responses, fallback to normal
@@ -152,8 +154,10 @@ public class BundleDownloader {
                       url,
                       r.code(),
                       r.headers(),
+                      // NULLSAFE_FIXME[Nullable Dereference]
                       r.body().source(),
                       outputFile,
+                      // NULLSAFE_FIXME[Parameter Not Nullable]
                       bundleInfo,
                       callback);
                 }
@@ -173,6 +177,7 @@ public class BundleDownloader {
       throws IOException {
 
     MultipartStreamReader bodyReader =
+        // NULLSAFE_FIXME[Nullable Dereference]
         new MultipartStreamReader(response.body().source(), boundary);
     boolean completed =
         bodyReader.readAllParts(
@@ -192,6 +197,7 @@ public class BundleDownloader {
                     status = Integer.parseInt(headers.get("X-Http-Status"));
                   }
                   processBundleResult(
+                      // NULLSAFE_FIXME[Parameter Not Nullable]
                       url, status, Headers.of(headers), body, outputFile, bundleInfo, callback);
                 } else {
                   if (!headers.containsKey("Content-Type")

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/BundleDownloader.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/BundleDownloader.java
@@ -10,6 +10,7 @@ package com.facebook.react.devsupport;
 import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.common.DebugServerException;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener;
@@ -32,6 +33,7 @@ import okio.Sink;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class BundleDownloader {
   private static final String TAG = "BundleDownloader";
 
@@ -140,26 +142,29 @@ public class BundleDownloader {
               final String url = response.request().url().toString();
               // Make sure the result is a multipart response and parse the boundary.
               String contentType = response.header("content-type");
+              if (contentType == null) {
+                // fallback to empty string for nullability
+                contentType = "";
+              }
               Pattern regex = Pattern.compile("multipart/mixed;.*boundary=\"([^\"]+)\"");
-              // NULLSAFE_FIXME[Parameter Not Nullable]
               Matcher match = regex.matcher(contentType);
-              if (match.find()) {
-                // NULLSAFE_FIXME[Parameter Not Nullable]
-                processMultipartResponse(url, r, match.group(1), outputFile, bundleInfo, callback);
+              if (!contentType.isEmpty() && match.find()) {
+                String boundary = Assertions.assertNotNull(match.group(1));
+                processMultipartResponse(url, r, boundary, outputFile, bundleInfo, callback);
               } else {
                 // In case the server doesn't support multipart/mixed responses, fallback to normal
                 // download.
                 try (ResponseBody body = r.body()) {
-                  processBundleResult(
-                      url,
-                      r.code(),
-                      r.headers(),
-                      // NULLSAFE_FIXME[Nullable Dereference]
-                      r.body().source(),
-                      outputFile,
-                      // NULLSAFE_FIXME[Parameter Not Nullable]
-                      bundleInfo,
-                      callback);
+                  if (body != null) {
+                    processBundleResult(
+                        url,
+                        r.code(),
+                        r.headers(),
+                        body.source(),
+                        outputFile,
+                        bundleInfo,
+                        callback);
+                  }
                 }
               }
             }
@@ -175,9 +180,18 @@ public class BundleDownloader {
       @Nullable final BundleInfo bundleInfo,
       final DevBundleDownloadListener callback)
       throws IOException {
-
+    if (response.body() == null) {
+      callback.onFailure(
+          new DebugServerException(
+              "Error while reading multipart response.\n\nResponse body was empty: "
+                  + response.code()
+                  + "\n\n"
+                  + "URL: "
+                  + url.toString()
+                  + "\n\n"));
+      return;
+    }
     MultipartStreamReader bodyReader =
-        // NULLSAFE_FIXME[Nullable Dereference]
         new MultipartStreamReader(response.body().source(), boundary);
     boolean completed =
         bodyReader.readAllParts(
@@ -197,7 +211,6 @@ public class BundleDownloader {
                     status = Integer.parseInt(headers.get("X-Http-Status"));
                   }
                   processBundleResult(
-                      // NULLSAFE_FIXME[Parameter Not Nullable]
                       url, status, Headers.of(headers), body, outputFile, bundleInfo, callback);
                 } else {
                   if (!headers.containsKey("Content-Type")
@@ -249,7 +262,7 @@ public class BundleDownloader {
       Headers headers,
       BufferedSource body,
       File outputFile,
-      BundleInfo bundleInfo,
+      @Nullable BundleInfo bundleInfo,
       DevBundleDownloadListener callback)
       throws IOException {
     // Check for server errors. If the server error has the expected form, fail with more info.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/CxxInspectorPackagerConnection.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/CxxInspectorPackagerConnection.java
@@ -10,6 +10,7 @@ package com.facebook.react.devsupport;
 import android.os.Handler;
 import android.os.Looper;
 import androidx.annotation.Nullable;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
 import java.io.Closeable;
@@ -21,7 +22,8 @@ import okhttp3.WebSocket;
 import okhttp3.WebSocketListener;
 
 /** Java wrapper around a C++ InspectorPackagerConnection. */
-/* package */ class CxxInspectorPackagerConnection implements IInspectorPackagerConnection {
+/* package */ @Nullsafe(Nullsafe.Mode.LOCAL)
+class CxxInspectorPackagerConnection implements IInspectorPackagerConnection {
   static {
     DevSupportSoLoader.staticInit();
   }
@@ -39,8 +41,7 @@ import okhttp3.WebSocketListener;
 
   public native void closeQuietly();
 
-  // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
-  public native void sendEventToAllConnections(String event);
+  public native void sendEventToAllConnections(@Nullable String event);
 
   /** Java wrapper around a C++ IWebSocketDelegate, allowing us to call the interface from Java. */
   @DoNotStrip

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/CxxInspectorPackagerConnection.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/CxxInspectorPackagerConnection.java
@@ -39,6 +39,7 @@ import okhttp3.WebSocketListener;
 
   public native void closeQuietly();
 
+  // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
   public native void sendEventToAllConnections(String event);
 
   /** Java wrapper around a C++ IWebSocketDelegate, allowing us to call the interface from Java. */

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DebugOverlayController.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DebugOverlayController.java
@@ -18,6 +18,7 @@ import android.view.WindowManager;
 import android.widget.FrameLayout;
 import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.common.ReactConstants;
@@ -26,7 +27,8 @@ import com.facebook.react.common.ReactConstants;
  * Helper class for controlling overlay view with FPS and JS FPS info that gets added directly
  * to @{link WindowManager} instance.
  */
-/* package */ class DebugOverlayController {
+/* package */ @Nullsafe(Nullsafe.Mode.LOCAL)
+class DebugOverlayController {
 
   public static void requestPermission(Context context) {
     // Get permission to show debug overlay in dev builds.
@@ -74,8 +76,7 @@ import com.facebook.react.common.ReactConstants;
 
   private static boolean canHandleIntent(Context context, Intent intent) {
     PackageManager packageManager = context.getPackageManager();
-    // NULLSAFE_FIXME[Parameter Not Nullable]
-    return intent.resolveActivity(packageManager) != null;
+    return packageManager != null && intent.resolveActivity(packageManager) != null;
   }
 
   private final WindowManager mWindowManager;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DebugOverlayController.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DebugOverlayController.java
@@ -57,6 +57,7 @@ import com.facebook.react.common.ReactConstants;
       PackageInfo info =
           context
               .getPackageManager()
+              // NULLSAFE_FIXME[Nullable Dereference]
               .getPackageInfo(context.getPackageName(), PackageManager.GET_PERMISSIONS);
       if (info.requestedPermissions != null) {
         for (String p : info.requestedPermissions) {
@@ -73,6 +74,7 @@ import com.facebook.react.common.ReactConstants;
 
   private static boolean canHandleIntent(Context context, Intent intent) {
     PackageManager packageManager = context.getPackageManager();
+    // NULLSAFE_FIXME[Parameter Not Nullable]
     return intent.resolveActivity(packageManager) != null;
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
@@ -327,7 +327,7 @@ public class DevServerHelper {
       DevBundleDownloadListener callback,
       File outputFile,
       String bundleURL,
-      BundleDownloader.BundleInfo bundleInfo) {
+      @Nullable BundleDownloader.BundleInfo bundleInfo) {
     mBundleDownloader.downloadBundleFromURL(callback, outputFile, bundleURL, bundleInfo);
   }
 
@@ -335,7 +335,7 @@ public class DevServerHelper {
       DevBundleDownloadListener callback,
       File outputFile,
       String bundleURL,
-      BundleDownloader.BundleInfo bundleInfo,
+      @Nullable BundleDownloader.BundleInfo bundleInfo,
       Request.Builder requestBuilder) {
     mBundleDownloader.downloadBundleFromURL(
         callback, outputFile, bundleURL, bundleInfo, requestBuilder);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
@@ -208,6 +208,7 @@ public class DevServerHelper {
 
         mInspectorPackagerConnection =
             new CxxInspectorPackagerConnection(
+                // NULLSAFE_FIXME[Parameter Not Nullable]
                 getInspectorDeviceUrl(), metadata.get("deviceName"), mPackageName);
         mInspectorPackagerConnection.connect();
         return null;
@@ -452,6 +453,7 @@ public class DevServerHelper {
       }
 
       try (Sink output = Okio.sink(outputFile)) {
+        // NULLSAFE_FIXME[Nullable Dereference]
         Okio.buffer(response.body().source()).readAll(output);
       }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.java
@@ -223,6 +223,7 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
     if (e instanceof JavascriptException) {
       FLog.e(ReactConstants.TAG, "Exception in native call from JS", e);
       showNewError(
+          // NULLSAFE_FIXME[Nullable Dereference]
           e.getMessage().toString(), new StackFrame[] {}, JSEXCEPTION_ERROR_COOKIE, ErrorType.JS);
     } else {
       showNewJavaError(message.toString(), e);
@@ -230,6 +231,7 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
   }
 
   @Override
+  // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
   public void showNewJavaError(@Nullable String message, Throwable e) {
     FLog.e(ReactConstants.TAG, "Exception in native call", e);
     showNewError(
@@ -242,16 +244,19 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
    * called.
    */
   @Override
+  // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
   public void addCustomDevOption(String optionName, DevOptionHandler optionHandler) {
     mCustomDevOptions.put(optionName, optionHandler);
   }
 
   @Override
+  // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
   public void showNewJSError(String message, ReadableArray details, int errorCookie) {
     showNewError(message, StackTraceHelper.convertJsStackTrace(details), errorCookie, ErrorType.JS);
   }
 
   @Override
+  // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
   public void registerErrorCustomizer(ErrorCustomizer errorCustomizer) {
     if (mErrorCustomizers == null) {
       mErrorCustomizers = new ArrayList<>();
@@ -260,6 +265,7 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
   }
 
   @Override
+  // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
   public Pair<String, StackFrame[]> processErrorCustomizers(Pair<String, StackFrame[]> errorInfo) {
     if (mErrorCustomizers != null) {
       for (ErrorCustomizer errorCustomizer : mErrorCustomizers) {
@@ -281,10 +287,12 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
     mRedBoxSurfaceDelegate.hide();
   }
 
+  // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
   public @Nullable View createRootView(String appKey) {
     return mReactInstanceDevHelper.createRootView(appKey);
   }
 
+  // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
   public void destroyRootView(View rootView) {
     mReactInstanceDevHelper.destroyRootView(rootView);
   }
@@ -518,12 +526,14 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
     mDevOptionsDialog =
         new AlertDialog.Builder(context)
             .setCustomTitle(header)
+            // NULLSAFE_FIXME[Not Vetted Third-Party]
             .setAdapter(
                 adapter,
                 (dialog, which) -> {
                   optionHandlers[which].onOptionSelected();
                   mDevOptionsDialog = null;
                 })
+            // NULLSAFE_FIXME[Not Vetted Third-Party]
             .setOnCancelListener(dialog -> mDevOptionsDialog = null)
             .create();
     mDevOptionsDialog.show();
@@ -538,6 +548,7 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
     try {
       return getReactInstanceDevHelper().getJavaScriptExecutorFactory().toString();
     } catch (IllegalStateException e) {
+      // NULLSAFE_FIXME[Return Not Nullable]
       return null;
     }
   }
@@ -624,6 +635,7 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
       try {
         String packageName = mApplicationContext.getPackageName();
         PackageInfo thisPackage =
+            // NULLSAFE_FIXME[Nullable Dereference]
             mApplicationContext.getPackageManager().getPackageInfo(packageName, 0);
         if (mJSBundleDownloadedFile.lastModified() > thisPackage.lastUpdateTime) {
           // Base APK has not been updated since we downloaded JS, but if app is using exopackage
@@ -663,6 +675,7 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
     if (mCurrentReactContext != null) {
       try {
         URL sourceUrl = new URL(getSourceUrl());
+        // NULLSAFE_FIXME[Nullable Dereference]
         String path = sourceUrl.getPath().substring(1); // strip initial slash in path
         String host = sourceUrl.getHost();
         String scheme = sourceUrl.getProtocol();
@@ -785,6 +798,7 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
                 }
 
                 @Override
+                // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
                 public void onFailure(Exception cause) {
                   UiThreadUtil.runOnUiThread(
                       DevSupportManagerBase.this::hideSplitBundleDevLoadingView);
@@ -793,6 +807,7 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
               },
               bundleFile,
               bundleUrl,
+              // NULLSAFE_FIXME[Parameter Not Nullable]
               null);
         });
   }
@@ -821,6 +836,7 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
   }
 
   @Override
+  // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
   public @Nullable File downloadBundleResourceFromUrlSync(
       final String resourceURL, final File outputFile) {
     return mDevServerHelper.downloadBundleResourceFromUrlSync(resourceURL, outputFile);
@@ -888,6 +904,7 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
           }
 
           @Override
+          // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
           public void onFailure(final Exception cause) {
             hideDevLoadingView();
             if (mBundleDownloadListener != null) {
@@ -975,6 +992,7 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
       // start shake gesture detector
       if (!mIsShakeDetectorStarted) {
         mShakeDetector.start(
+            // NULLSAFE_FIXME[Parameter Not Nullable]
             (SensorManager) mApplicationContext.getSystemService(Context.SENSOR_SERVICE));
         mIsShakeDetectorStarted = true;
       }
@@ -1060,6 +1078,7 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
   }
 
   @Override
+  // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
   public void setPackagerLocationCustomizer(
       DevSupportManager.PackagerLocationCustomizer packagerLocationCustomizer) {
     mPackagerLocationCustomizer = packagerLocationCustomizer;
@@ -1071,6 +1090,7 @@ public abstract class DevSupportManagerBase implements DevSupportManager {
   }
 
   @Override
+  // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
   public @Nullable SurfaceDelegate createSurfaceDelegate(String moduleName) {
     if (mSurfaceDelegateFactory == null) {
       return null;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/JSDebuggerWebSocketClient.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/JSDebuggerWebSocketClient.java
@@ -13,6 +13,7 @@ import android.util.JsonWriter;
 import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.common.JavascriptException;
 import com.facebook.react.common.annotations.VisibleForTesting;
 import java.io.IOException;
@@ -29,6 +30,7 @@ import okhttp3.WebSocket;
 import okhttp3.WebSocketListener;
 
 /** A wrapper around WebSocketClient that recognizes RN debugging message format. */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 class JSDebuggerWebSocketClient extends WebSocketListener {
 
   private static final String TAG = "JSDebuggerWebSocketClient";
@@ -210,8 +212,7 @@ class JSDebuggerWebSocketClient extends WebSocketListener {
   }
 
   @Override
-  // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
-  public void onFailure(WebSocket webSocket, Throwable t, Response response) {
+  public void onFailure(@Nullable WebSocket webSocket, Throwable t, @Nullable Response response) {
     abort("Websocket exception", t);
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/JSDebuggerWebSocketClient.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/JSDebuggerWebSocketClient.java
@@ -210,6 +210,7 @@ class JSDebuggerWebSocketClient extends WebSocketListener {
   }
 
   @Override
+  // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
   public void onFailure(WebSocket webSocket, Throwable t, Response response) {
     abort("Websocket exception", t);
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/MultipartStreamReader.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/MultipartStreamReader.java
@@ -60,6 +60,7 @@ class MultipartStreamReader {
     ByteString marker = ByteString.encodeUtf8(CRLF + CRLF);
     long indexOfMarker = chunk.indexOf(marker);
     if (indexOfMarker == -1) {
+      // NULLSAFE_FIXME[Parameter Not Nullable]
       listener.onChunkComplete(null, chunk, done);
     } else {
       Buffer headers = new Buffer();
@@ -148,6 +149,7 @@ class MultipartStreamReader {
         Buffer chunk = new Buffer();
         content.skip(chunkStart);
         content.read(chunk, length);
+        // NULLSAFE_FIXME[Parameter Not Nullable]
         emitProgress(currentHeaders, chunk.size() - currentHeadersLength, true, listener);
         emitChunk(chunk, isCloseDelimiter, listener);
         currentHeaders = null;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/MultipartStreamReader.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/MultipartStreamReader.java
@@ -7,7 +7,9 @@
 
 package com.facebook.react.devsupport;
 
+import com.facebook.infer.annotation.Nullsafe;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import okio.Buffer;
@@ -15,6 +17,7 @@ import okio.BufferedSource;
 import okio.ByteString;
 
 /** Utility class to parse the body of a response of type multipart/mixed. */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 class MultipartStreamReader {
   // Standard line separator for HTTP.
   private static final String CRLF = "\r\n";
@@ -60,8 +63,7 @@ class MultipartStreamReader {
     ByteString marker = ByteString.encodeUtf8(CRLF + CRLF);
     long indexOfMarker = chunk.indexOf(marker);
     if (indexOfMarker == -1) {
-      // NULLSAFE_FIXME[Parameter Not Nullable]
-      listener.onChunkComplete(null, chunk, done);
+      listener.onChunkComplete(Collections.emptyMap(), chunk, done);
     } else {
       Buffer headers = new Buffer();
       Buffer body = new Buffer();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/ReleaseDevSupportManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/ReleaseDevSupportManager.kt
@@ -36,11 +36,11 @@ public open class ReleaseDevSupportManager : DevSupportManager {
 
   private val defaultJSExceptionHandler: DefaultJSExceptionHandler = DefaultJSExceptionHandler()
 
-  public override fun showNewJavaError(message: String?, e: Throwable?): Unit = Unit
+  public override fun showNewJavaError(message: String?, e: Throwable): Unit = Unit
 
   public override fun addCustomDevOption(
-      optionName: String?,
-      optionHandler: DevOptionHandler?
+      optionName: String,
+      optionHandler: DevOptionHandler
   ): Unit = Unit
 
   public override fun showNewJSError(
@@ -49,7 +49,7 @@ public open class ReleaseDevSupportManager : DevSupportManager {
       errorCookie: Int
   ): Unit = Unit
 
-  public override fun createRootView(appKey: String?): View? = null
+  public override fun createRootView(appKey: String): View? = null
 
   public override fun destroyRootView(rootView: View?): Unit = Unit
 
@@ -111,7 +111,7 @@ public open class ReleaseDevSupportManager : DevSupportManager {
 
   public override fun downloadBundleResourceFromUrlSync(
       resourceURL: String,
-      outputFile: File?
+      outputFile: File
   ): File? = null
 
   public override val lastErrorTitle: String?
@@ -125,14 +125,14 @@ public open class ReleaseDevSupportManager : DevSupportManager {
 
   public override val lastErrorCookie: Int = 0
 
-  public override fun registerErrorCustomizer(errorCustomizer: ErrorCustomizer?): Unit = Unit
+  public override fun registerErrorCustomizer(errorCustomizer: ErrorCustomizer): Unit = Unit
 
   public override fun processErrorCustomizers(
-      errorInfo: Pair<String, Array<StackFrame>>?
-  ): Pair<String, Array<StackFrame>>? = errorInfo
+      errorInfo: Pair<String, Array<StackFrame>>
+  ): Pair<String, Array<StackFrame>> = errorInfo
 
   public override fun setPackagerLocationCustomizer(
-      packagerLocationCustomizer: PackagerLocationCustomizer?
+      packagerLocationCustomizer: PackagerLocationCustomizer
   ): Unit = Unit
 
   public override fun handleException(e: Exception) {
@@ -145,7 +145,7 @@ public open class ReleaseDevSupportManager : DevSupportManager {
   public override val currentReactContext: ReactContext?
     get() = null
 
-  public override fun createSurfaceDelegate(moduleName: String?): SurfaceDelegate? = null
+  public override fun createSurfaceDelegate(moduleName: String): SurfaceDelegate? = null
 
   public override fun openDebugger(): Unit = Unit
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/StackTraceHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/StackTraceHelper.java
@@ -8,6 +8,8 @@
 package com.facebook.react.devsupport;
 
 import androidx.annotation.Nullable;
+import com.facebook.infer.annotation.Assertions;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.JavaOnlyArray;
 import com.facebook.react.bridge.JavaOnlyMap;
 import com.facebook.react.bridge.ReadableArray;
@@ -26,6 +28,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 /** Helper class converting JS and Java stack traces into arrays of {@link StackFrame} objects. */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class StackTraceHelper {
 
   public static final String COLUMN_KEY = "column";
@@ -49,27 +52,29 @@ public class StackTraceHelper {
 
   /** Represents a generic entry in a stack trace, be it originally from JS or Java. */
   public static class StackFrameImpl implements StackFrame {
-    private final String mFile;
+    @Nullable private final String mFile;
     private final String mMethod;
     private final int mLine;
     private final int mColumn;
-    private final String mFileName;
+    @Nullable private final String mFileName;
     private final boolean mIsCollapsed;
 
-    private StackFrameImpl(String file, String method, int line, int column, boolean isCollapsed) {
+    private StackFrameImpl(
+        @Nullable String file, String method, int line, int column, boolean isCollapsed) {
       mFile = file;
       mMethod = method;
       mLine = line;
       mColumn = column;
-      mFileName = file != null ? new File(file).getName() : "";
+      mFileName = file != null ? new File(file).getName() : null;
       mIsCollapsed = isCollapsed;
     }
 
-    private StackFrameImpl(String file, String method, int line, int column) {
+    private StackFrameImpl(@Nullable String file, String method, int line, int column) {
       this(file, method, line, column, false);
     }
 
-    private StackFrameImpl(String file, String fileName, String method, int line, int column) {
+    private StackFrameImpl(
+        @Nullable String file, @Nullable String fileName, String method, int line, int column) {
       mFile = file;
       mFileName = fileName;
       mMethod = method;
@@ -84,7 +89,8 @@ public class StackTraceHelper {
      * <p>JS traces return the full path to the file here, while Java traces only return the file
      * name (the path is not known).
      */
-    public String getFile() {
+    @Override
+    public @Nullable String getFile() {
       return mFile;
     }
 
@@ -109,7 +115,8 @@ public class StackTraceHelper {
      * <p>For JS traces this is different from {@link #getFile()} in that it only returns the file
      * name, not the full path. For Java traces there is no difference.
      */
-    public String getFileName() {
+    @Override
+    public @Nullable String getFileName() {
       return mFileName;
     }
 
@@ -119,9 +126,10 @@ public class StackTraceHelper {
 
     /** Convert the stack frame to a JSON representation. */
     public JSONObject toJSON() {
+      String file = getFile();
       return new JSONObject(
           MapBuilder.of(
-              "file", getFile(),
+              "file", (file == null) ? "" : file,
               "methodName", getMethod(),
               "lineNumber", getLine(),
               "column", getColumn(),
@@ -136,36 +144,33 @@ public class StackTraceHelper {
   public static StackFrame[] convertJsStackTrace(@Nullable ReadableArray stack) {
     int size = stack != null ? stack.size() : 0;
     StackFrame[] result = new StackFrame[size];
-    for (int i = 0; i < size; i++) {
-      // NULLSAFE_FIXME[Nullable Dereference]
-      ReadableType type = stack.getType(i);
-      if (type == ReadableType.Map) {
-        // NULLSAFE_FIXME[Nullable Dereference]
-        ReadableMap frame = stack.getMap(i);
-        // NULLSAFE_FIXME[Nullable Dereference]
-        String methodName = frame.getString("methodName");
-        // NULLSAFE_FIXME[Nullable Dereference]
-        String fileName = frame.getString("file");
-        boolean collapse =
-            // NULLSAFE_FIXME[Nullable Dereference]
-            frame.hasKey("collapse") && !frame.isNull("collapse") && frame.getBoolean("collapse");
-        int lineNumber = -1;
-        // NULLSAFE_FIXME[Nullable Dereference]
-        if (frame.hasKey(LINE_NUMBER_KEY) && !frame.isNull(LINE_NUMBER_KEY)) {
-          // NULLSAFE_FIXME[Nullable Dereference]
-          lineNumber = frame.getInt(LINE_NUMBER_KEY);
+    if (stack != null) {
+      for (int i = 0; i < size; i++) {
+        ReadableType type = stack.getType(i);
+        if (type == ReadableType.Map) {
+          ReadableMap frame = stack.getMap(i);
+          Assertions.assertNotNull(frame);
+          String methodName = frame.getString("methodName");
+          String fileName = frame.getString("file");
+          Assertions.assertNotNull(fileName);
+          Assertions.assertNotNull(methodName);
+          boolean collapse =
+              frame.hasKey("collapse") && !frame.isNull("collapse") && frame.getBoolean("collapse");
+          int lineNumber = -1;
+          if (frame.hasKey(LINE_NUMBER_KEY) && !frame.isNull(LINE_NUMBER_KEY)) {
+            lineNumber = frame.getInt(LINE_NUMBER_KEY);
+          }
+          int columnNumber = -1;
+          if (frame.hasKey(COLUMN_KEY) && !frame.isNull(COLUMN_KEY)) {
+            columnNumber = frame.getInt(COLUMN_KEY);
+          }
+          result[i] = new StackFrameImpl(fileName, methodName, lineNumber, columnNumber, collapse);
+        } else if (type == ReadableType.String) {
+          String stackFrame = stack.getString(i);
+          if (stackFrame != null) {
+            result[i] = new StackFrameImpl(null, stackFrame, -1, -1);
+          }
         }
-        int columnNumber = -1;
-        // NULLSAFE_FIXME[Nullable Dereference]
-        if (frame.hasKey(COLUMN_KEY) && !frame.isNull(COLUMN_KEY)) {
-          // NULLSAFE_FIXME[Nullable Dereference]
-          columnNumber = frame.getInt(COLUMN_KEY);
-        }
-        // NULLSAFE_FIXME[Parameter Not Nullable]
-        result[i] = new StackFrameImpl(fileName, methodName, lineNumber, columnNumber, collapse);
-      } else if (type == ReadableType.String) {
-        // NULLSAFE_FIXME[Parameter Not Nullable, Nullable Dereference]
-        result[i] = new StackFrameImpl(null, stack.getString(i), -1, -1);
       }
     }
     return result;
@@ -214,19 +219,22 @@ public class StackTraceHelper {
       } else if (matcher1.find()) {
         matcher = matcher1;
       } else {
-        // NULLSAFE_FIXME[Parameter Not Nullable]
-        result[i] = new StackFrameImpl(null, stackTrace[i], -1, -1);
+        String unmatchedStackFrame = stackTrace[i];
+        if (unmatchedStackFrame != null) {
+          result[i] = new StackFrameImpl(null, unmatchedStackFrame, -1, -1);
+        }
+        continue;
+      }
+      String fileName = matcher.group(2);
+      String methodName = matcher.group(1) == null ? "(unknown)" : matcher.group(1);
+      String lineString = matcher.group(3);
+      String columnString = matcher.group(4);
+      if (methodName == null || fileName == null || lineString == null || columnString == null) {
         continue;
       }
       result[i] =
           new StackFrameImpl(
-              // NULLSAFE_FIXME[Parameter Not Nullable]
-              matcher.group(2),
-              matcher.group(1) == null ? "(unknown)" : matcher.group(1),
-              // NULLSAFE_FIXME[Parameter Not Nullable]
-              Integer.parseInt(matcher.group(3)),
-              // NULLSAFE_FIXME[Parameter Not Nullable]
-              Integer.parseInt(matcher.group(4)));
+              fileName, methodName, Integer.parseInt(lineString), Integer.parseInt(columnString));
     }
     return result;
   }
@@ -239,7 +247,6 @@ public class StackTraceHelper {
       result[i] =
           new StackFrameImpl(
               stackTrace[i].getClassName(),
-              // NULLSAFE_FIXME[Parameter Not Nullable]
               stackTrace[i].getFileName(),
               stackTrace[i].getMethodName(),
               stackTrace[i].getLineNumber(),

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/StackTraceHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/StackTraceHelper.java
@@ -137,23 +137,34 @@ public class StackTraceHelper {
     int size = stack != null ? stack.size() : 0;
     StackFrame[] result = new StackFrame[size];
     for (int i = 0; i < size; i++) {
+      // NULLSAFE_FIXME[Nullable Dereference]
       ReadableType type = stack.getType(i);
       if (type == ReadableType.Map) {
+        // NULLSAFE_FIXME[Nullable Dereference]
         ReadableMap frame = stack.getMap(i);
+        // NULLSAFE_FIXME[Nullable Dereference]
         String methodName = frame.getString("methodName");
+        // NULLSAFE_FIXME[Nullable Dereference]
         String fileName = frame.getString("file");
         boolean collapse =
+            // NULLSAFE_FIXME[Nullable Dereference]
             frame.hasKey("collapse") && !frame.isNull("collapse") && frame.getBoolean("collapse");
         int lineNumber = -1;
+        // NULLSAFE_FIXME[Nullable Dereference]
         if (frame.hasKey(LINE_NUMBER_KEY) && !frame.isNull(LINE_NUMBER_KEY)) {
+          // NULLSAFE_FIXME[Nullable Dereference]
           lineNumber = frame.getInt(LINE_NUMBER_KEY);
         }
         int columnNumber = -1;
+        // NULLSAFE_FIXME[Nullable Dereference]
         if (frame.hasKey(COLUMN_KEY) && !frame.isNull(COLUMN_KEY)) {
+          // NULLSAFE_FIXME[Nullable Dereference]
           columnNumber = frame.getInt(COLUMN_KEY);
         }
+        // NULLSAFE_FIXME[Parameter Not Nullable]
         result[i] = new StackFrameImpl(fileName, methodName, lineNumber, columnNumber, collapse);
       } else if (type == ReadableType.String) {
+        // NULLSAFE_FIXME[Parameter Not Nullable, Nullable Dereference]
         result[i] = new StackFrameImpl(null, stack.getString(i), -1, -1);
       }
     }
@@ -203,14 +214,18 @@ public class StackTraceHelper {
       } else if (matcher1.find()) {
         matcher = matcher1;
       } else {
+        // NULLSAFE_FIXME[Parameter Not Nullable]
         result[i] = new StackFrameImpl(null, stackTrace[i], -1, -1);
         continue;
       }
       result[i] =
           new StackFrameImpl(
+              // NULLSAFE_FIXME[Parameter Not Nullable]
               matcher.group(2),
               matcher.group(1) == null ? "(unknown)" : matcher.group(1),
+              // NULLSAFE_FIXME[Parameter Not Nullable]
               Integer.parseInt(matcher.group(3)),
+              // NULLSAFE_FIXME[Parameter Not Nullable]
               Integer.parseInt(matcher.group(4)));
     }
     return result;
@@ -224,6 +239,7 @@ public class StackTraceHelper {
       result[i] =
           new StackFrameImpl(
               stackTrace[i].getClassName(),
+              // NULLSAFE_FIXME[Parameter Not Nullable]
               stackTrace[i].getFileName(),
               stackTrace[i].getMethodName(),
               stackTrace[i].getLineNumber(),

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevBundleDownloadListener.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevBundleDownloadListener.kt
@@ -12,5 +12,5 @@ public interface DevBundleDownloadListener {
 
   public fun onProgress(status: String?, done: Int?, total: Int?)
 
-  public fun onFailure(cause: Exception?)
+  public fun onFailure(cause: Exception)
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.kt
@@ -38,11 +38,11 @@ public interface DevSupportManager : JSExceptionHandler {
 
   public var devSupportEnabled: Boolean
 
-  public fun showNewJavaError(message: String?, e: Throwable?)
+  public fun showNewJavaError(message: String?, e: Throwable)
 
-  public fun addCustomDevOption(optionName: String?, optionHandler: DevOptionHandler?)
+  public fun addCustomDevOption(optionName: String, optionHandler: DevOptionHandler)
 
-  public fun createRootView(appKey: String?): View?
+  public fun createRootView(appKey: String): View?
 
   public fun destroyRootView(rootView: View?)
 
@@ -78,15 +78,15 @@ public interface DevSupportManager : JSExceptionHandler {
 
   public fun toggleElementInspector()
 
-  public fun downloadBundleResourceFromUrlSync(resourceURL: String, outputFile: File?): File?
+  public fun downloadBundleResourceFromUrlSync(resourceURL: String, outputFile: File): File?
 
-  public fun registerErrorCustomizer(errorCustomizer: ErrorCustomizer?)
+  public fun registerErrorCustomizer(errorCustomizer: ErrorCustomizer)
 
   public fun processErrorCustomizers(
-      errorInfo: Pair<String, Array<StackFrame>>?
-  ): Pair<String, Array<StackFrame>>?
+      errorInfo: Pair<String, Array<StackFrame>>
+  ): Pair<String, Array<StackFrame>>
 
-  public fun setPackagerLocationCustomizer(packagerLocationCustomizer: PackagerLocationCustomizer?)
+  public fun setPackagerLocationCustomizer(packagerLocationCustomizer: PackagerLocationCustomizer)
 
   /**
    * Create the surface delegate that the provided module should use to interact with
@@ -94,7 +94,7 @@ public interface DevSupportManager : JSExceptionHandler {
    * @param moduleName the module name that helps decide which surface it should interact with
    * @return a [SurfaceDelegate] instance
    */
-  public fun createSurfaceDelegate(moduleName: String?): SurfaceDelegate?
+  public fun createSurfaceDelegate(moduleName: String): SurfaceDelegate?
 
   /** Attempt to open the JS debugger on the host machine. */
   public fun openDebugger()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/StackFrame.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/StackFrame.kt
@@ -20,7 +20,7 @@ public interface StackFrame {
   public val file: String?
 
   /** Get the name of the method this frame points to. */
-  public val method: String?
+  public val method: String
 
   /** Get the line number this frame points to in the file returned by [.getFile]. */
   public val line: Int
@@ -40,5 +40,5 @@ public interface StackFrame {
   public val isCollapsed: Boolean
 
   /** Convert the stack frame to a JSON representation. */
-  public fun toJSON(): JSONObject?
+  public fun toJSON(): JSONObject
 }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/devsupport/JSDebuggerWebSocketClientTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/devsupport/JSDebuggerWebSocketClientTest.kt
@@ -41,7 +41,7 @@ class JSDebuggerWebSocketClientTest {
     val client = spy(JSDebuggerWebSocketClient())
     val injectedObjects = mapOf("key1" to "value1", "key2" to "value2")
     client.loadBundle(
-        "http://localhost:8080/index.js", injectedObjects as HashMap<String, String>?, cb)
+        "http://localhost:8080/index.js", injectedObjects as HashMap<String, String>, cb)
     verify(client)
         .sendMessage(
             0,

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/devsupport/MultipartStreamReaderTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/devsupport/MultipartStreamReaderTest.kt
@@ -33,7 +33,7 @@ class MultipartStreamReaderTest {
 
     val callback: CallCountTrackingChunkCallback =
         object : CallCountTrackingChunkCallback() {
-          override fun onChunkComplete(headers: Map<String, String>?, body: Buffer, done: Boolean) {
+          override fun onChunkComplete(headers: Map<String, String>, body: Buffer, done: Boolean) {
             super.onChunkComplete(headers, body, done)
 
             assertThat(done).isTrue
@@ -68,7 +68,7 @@ class MultipartStreamReaderTest {
 
     val callback: CallCountTrackingChunkCallback =
         object : CallCountTrackingChunkCallback() {
-          override fun onChunkComplete(headers: Map<String, String>?, body: Buffer, done: Boolean) {
+          override fun onChunkComplete(headers: Map<String, String>, body: Buffer, done: Boolean) {
             super.onChunkComplete(headers, body, done)
 
             assertThat(done).isEqualTo(callCount == 3)
@@ -125,7 +125,7 @@ class MultipartStreamReaderTest {
     var callCount = 0
       private set
 
-    override fun onChunkComplete(headers: Map<String, String>?, body: Buffer, done: Boolean) {
+    override fun onChunkComplete(headers: Map<String, String>, body: Buffer, done: Boolean) {
       callCount++
     }
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/devsupport/StackTraceHelperTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/devsupport/StackTraceHelperTest.kt
@@ -47,7 +47,7 @@ class StackTraceHelperTest {
   fun testParseStackFrameWithInvalidFrame() {
     val frame = StackTraceHelper.convertJsStackTrace("Test.bundle:ten:twenty").get(0)
     assertThat(frame.method).isEqualTo("Test.bundle:ten:twenty")
-    assertThat(frame.fileName).isEqualTo("")
+    assertThat(frame.fileName).isEqualTo(null)
     assertThat(frame.line).isEqualTo(-1)
     assertThat(frame.column).isEqualTo(-1)
   }
@@ -56,7 +56,7 @@ class StackTraceHelperTest {
   fun testParseStackFrameWithNativeCodeFrame() {
     val frame = StackTraceHelper.convertJsStackTrace("forEach@[native code]").get(0)
     assertThat(frame.method).isEqualTo("forEach@[native code]")
-    assertThat(frame.fileName).isEqualTo("")
+    assertThat(frame.fileName).isEqualTo(null)
     assertThat(frame.line).isEqualTo(-1)
     assertThat(frame.column).isEqualTo(-1)
   }


### PR DESCRIPTION
Summary:
Note: this involved tightening up some signatures in Kotlin files

Gone trough all the FIXMEs added in the previous diff by the nullsafe tool, marked the class as nullsafe and ensured no remaining violations.

Changelog: [Android][Fixed] Made DevSupportManagerBase.java nullsafe

Reviewed By: mdvacca

Differential Revision: D71126381


