### PR TITLE
Update TS docs for contentInsetAdjustmentBehavior

### DIFF
--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.d.ts
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.d.ts
@@ -405,7 +405,7 @@ export interface ScrollViewPropsIOS {
 
   /**
    * This property specifies how the safe area insets are used to modify the content area of the scroll view.
-   * The default value of this property must be 'automatic'. But the default value is 'never' until RN@0.51.
+   * The default value of this property is "never". Available on iOS 11 and later.
    */
   contentInsetAdjustmentBehavior?:
     | 'automatic'

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.d.ts
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.d.ts
@@ -405,7 +405,7 @@ export interface ScrollViewPropsIOS {
 
   /**
    * This property specifies how the safe area insets are used to modify the content area of the scroll view.
-   * The default value of this property is "never". Available on iOS 11 and later.
+   * The default value of this property is "never".
    */
   contentInsetAdjustmentBehavior?:
     | 'automatic'

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
@@ -303,7 +303,7 @@ export type ScrollViewPropsIOS = $ReadOnly<{
   /**
    * This property specifies how the safe area insets are used to modify the
    * content area of the scroll view. The default value of this property is
-   * "never". Available on iOS 11 and later.
+   * "never".
    * @platform ios
    */
   contentInsetAdjustmentBehavior?: ?(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Update the TS docs to reflect the default value for `contentInsetAdjustmentBehavior`. The TS docs suggest it will be `automatic` however it's actually `never`.

The default behaviour is correctly specified in the JS docs: https://github.com/facebook/react-native/blob/850760ab6112d1f38a5a9014282ae5186ab814d6/packages/react-native/Libraries/Components/ScrollView/ScrollView.js#L306

It's also documented as the default in the native module: https://github.com/facebook/react-native/blob/main/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTEnhancedScrollView.mm#L34

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[General] [Fixed] - Fix TS docs for `contentInsetAdjustmentBehavior`

<!-- Help reviewers and the release process by writing your own changelog entry.