### PR TITLE
Pass down jsi::Runtime to getModule()

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultTurboModuleManagerDelegate.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultTurboModuleManagerDelegate.cpp
@@ -54,11 +54,12 @@ void DefaultTurboModuleManagerDelegate::registerNatives() {
 
 std::shared_ptr<TurboModule> DefaultTurboModuleManagerDelegate::getTurboModule(
     const std::string& name,
-    const std::shared_ptr<CallInvoker>& jsInvoker) {
+    const std::shared_ptr<CallInvoker>& jsInvoker,
+    jsi::Runtime& runtime) {
   for (const auto& cxxReactPackage : cxxReactPackages_) {
     auto cppPart = cxxReactPackage->cthis();
     if (cppPart) {
-      auto module = cppPart->getModule(name, jsInvoker);
+      auto module = cppPart->getModule(name, jsInvoker, runtime);
       if (module) {
         return module;
       }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultTurboModuleManagerDelegate.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultTurboModuleManagerDelegate.h
@@ -42,7 +42,8 @@ class DefaultTurboModuleManagerDelegate : public jni::HybridClass<
 
   std::shared_ptr<TurboModule> getTurboModule(
       const std::string& name,
-      const std::shared_ptr<CallInvoker>& jsInvoker) override;
+      const std::shared_ptr<CallInvoker>& jsInvoker,
+      jsi::Runtime& runtime) override;
   std::shared_ptr<TurboModule> getTurboModule(
       const std::string& name,
       const JavaTurboModule::InitParams& params) override;

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/cxxreactpackage/ReactCommon/CxxReactPackage.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/cxxreactpackage/ReactCommon/CxxReactPackage.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <fbjni/fbjni.h>
+#include <jsi/jsi.h>
 #include <memory>
 
 namespace facebook::react {
@@ -22,7 +23,8 @@ class CxxReactPackage : public jni::HybridClass<CxxReactPackage> {
 
   virtual std::shared_ptr<TurboModule> getModule(
       const std::string& name,
-      const std::shared_ptr<CallInvoker>& jsInvoker) = 0;
+      const std::shared_ptr<CallInvoker>& jsInvoker,
+      jsi::Runtime& runtime) = 0;
 
  private:
   friend HybridBase;

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.cpp
@@ -163,7 +163,7 @@ std::shared_ptr<TurboModule> TurboModuleManager::getTurboModule(
 
   auto cxxDelegate = delegate_->cthis();
 
-  auto cxxModule = cxxDelegate->getTurboModule(name, jsCallInvoker_);
+  auto cxxModule = cxxDelegate->getTurboModule(name, jsCallInvoker_, runtime);
   if (cxxModule) {
     turboModuleCache_.insert({name, cxxModule});
     return cxxModule;

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManagerDelegate.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManagerDelegate.h
@@ -26,7 +26,8 @@ class TurboModuleManagerDelegate
       const JavaTurboModule::InitParams& params) = 0;
   virtual std::shared_ptr<TurboModule> getTurboModule(
       const std::string& name,
-      const std::shared_ptr<CallInvoker>& jsInvoker) = 0;
+      const std::shared_ptr<CallInvoker>& jsInvoker,
+      jsi::Runtime& runtime) = 0;
 
  private:
   friend HybridBase;


### PR DESCRIPTION
Summary: Changelog: [Internal] add `jsi::Runtime& runtime` arg to `CxxReactPackage::getModule`

Differential Revision:
D71155216

Privacy Context Container: L1295364


