### PR TITLE
Build JSI, React-Debug and React-logger with SPM

### DIFF
--- a/packages/react-native/Package.swift
+++ b/packages/react-native/Package.swift
@@ -1,0 +1,111 @@
+// swift-tools-version: 6.0
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import PackageDescription
+
+let react = "React"
+
+let cxxRNDepHeaderSearchPath: (Int) -> CXXSetting = {
+  let prefix = (0..<$0).map { _ in "../" } .joined(separator: "")
+  return .headerSearchPath("\(prefix)third-party/ReactNativeDependencies.xcframework/Headers")
+}
+let cRNDepHeaderSearchPath: (Int) -> CSetting = {
+  let prefix = (0..<$0).map { _ in "../" } .joined(separator: "")
+  return .headerSearchPath("\(prefix)third-party/ReactNativeDependencies.xcframework/Headers")
+}
+
+let package = Package(
+  name: react,
+  products: [
+    .library(
+      name: react,
+      type: .dynamic,
+      targets: [.reactDebug, .jsi, .logger, .mapbuffer]
+    ),
+  ],
+  targets: [
+    .reactNativeTarget(
+      name: .reactDebug,
+      dependencies: [.reactNativeDependencies],
+      path: "ReactCommon/react/debug",
+      publicHeadersPath: "."
+    ),
+    .reactNativeTarget(
+      name: .jsi,
+      dependencies: [.reactNativeDependencies],
+      path: "ReactCommon/jsi",
+      extraExcludes: ["jsi/CMakeLists.txt", "jsi/test/testlib.h", "jsi/test/testlib.cpp"],
+      sources: ["jsi"],
+      publicHeadersPath: "jsi/",
+      extraCSettings: [.headerSearchPath(".")],
+      extraCxxSettings: [.headerSearchPath(".")]
+    ),
+    .reactNativeTarget(
+      name: .logger,
+      dependencies: [.reactNativeDependencies, .jsi],
+      path: "ReactCommon/logger",
+      publicHeadersPath: "."
+    ),
+    .reactNativeTarget(
+      name: .mapbuffer,
+      dependencies: [.reactNativeDependencies, .reactDebug],
+      path: "ReactCommon/react/renderer/mapbuffer",
+      extraExcludes: ["tests/MapBufferTest.cpp"],
+      publicHeadersPath: ".",
+      extraCSettings: [.headerSearchPath("../../..")],
+      extraCxxSettings: [.headerSearchPath("../../..")]
+    ),
+    .binaryTarget(
+      name: .reactNativeDependencies,
+      path: "third-party/ReactNativeDependencies.xcframework"
+    ),
+  ]
+)
+
+extension String {
+  static let reactDebug = "React-debug"
+  static let jsi = "React-jsi"
+  static let logger = "React-logger"
+  static let mapbuffer = "React-Mapbuffer"
+
+  static let reactNativeDependencies = "ReactNativeDependencies"
+}
+
+func defaultExcludeFor(module: String) -> [String] {
+  return ["BUCK", "CMakeLists.txt", "\(module).podspec"]
+}
+
+extension Target {
+  static func reactNativeTarget(
+    name: String,
+    dependencies: [String],
+    path: String,
+    extraExcludes: [String] = [],
+    sources: [String]? = nil,
+    publicHeadersPath: String? = nil,
+    extraCSettings: [CSetting] = [],
+    extraCxxSettings: [CXXSetting] = []
+  ) -> Target {
+    let dependencies = dependencies.map { Dependency.byNameItem(name: $0, condition: nil) }
+    let excludes = defaultExcludeFor(module: .logger) + extraExcludes
+    let numOfSlash = path.count { $0 == "/" }
+    let cSettings = [cRNDepHeaderSearchPath(numOfSlash + 1)] + extraCSettings
+    let cxxSettings = [cxxRNDepHeaderSearchPath(numOfSlash + 1), .unsafeFlags(["-std=c++20"])] + extraCxxSettings
+
+    return .target(
+      name: name,
+      dependencies: dependencies,
+      path: path,
+      exclude: excludes,
+      sources: sources,
+      publicHeadersPath: publicHeadersPath,
+      cSettings: cSettings,
+      cxxSettings: cxxSettings
+    )
+  }
+}


### PR DESCRIPTION
Summary:
This is an exploratory change to see how it will look like to build core from SPM.

In this change we are building three pieces of React native (using the Podspec names for simplicity):
- React-jsi
- React-debug
- React-logger

They depends on a local ReactNativeDependency.xcframework we can build using the prebuild-io script.

## CHANGELOG:
[INTERNAL] - set up initial Swift PM configuration

Differential Revision: D70567840

## Test Plan:

You can build the Swift PM project with the command:
```
# Build the dependencies locally
node scripts/releases/prebuild-ios -p ios ios-simulator

# Copy the header in the root of the xcframework folder
cp -R \
  packages/react-native/third-party/reactNativeDependencies.xcframework/ios-arm64/Headers \
  packages/react-native/third-party/reactNativeDependencies.xcframework/Headers

# Build the package.swift file
xcodebuild -scheme React -destination "generic/platform=iOS" -derivedDataPath ~/Desktop/React.build/ -configuration Debug
```

The last instruction will create a build folder on the Desktop.

The content of the build folder is the following:

<img width="799" alt="Screenshot 2025-03-17 at 15 44 36" src="https://github.com/user-attachments/assets/9e9e3e6a-3567-4f50-b1c8-d1767c10903d" />

You can see that it contains the react frmaework plus all the `.o` files for the three target we are building.



