### PR TITLE
RN: Trim Leading Slash in DevServerHelper

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.java
@@ -404,6 +404,11 @@ public class DevServerHelper {
   }
 
   private static String createResourceURL(String host, String resourcePath) {
+    // This is what we get for not using a proper URI library.
+    if (resourcePath.startsWith("/")) {
+      FLog.w(ReactConstants.TAG, "Resource path should not begin with `/`, removing it.");
+      resourcePath = resourcePath.substring(1);
+    }
     return String.format(Locale.US, "http://%s/%s", host, resourcePath);
   }
 


### PR DESCRIPTION
Summary:
Currently, `DevServerHelper` will fetch malformed URLs if the supplied `resourcePath` has a leading slash.

This diff adds a warning and automatically trims the leading slash when this happens.

Changelog:
[Android][Changed] - Leading slash supplied to `DevServerHelper.downloadBundleResourceFromUrlSync` will now be trimmed and emit a warning.

Differential Revision: D71333088


