### PR TITLE
[iOS][prebuild] change header structure rn deps in XCFrameworks

### DIFF
--- a/packages/react-native/scripts/cocoapods/rndependencies.rb
+++ b/packages/react-native/scripts/cocoapods/rndependencies.rb
@@ -11,6 +11,7 @@ require_relative './utils.rb'
 
 ## There are two environment variables that is related to ReactNativeDependencies:
 ## - RCT_USE_RN_DEP: If set to 1, it will use the release tarball from Maven instead of building from source.
+## - RCT_USE_LOCAL_RN_DEP: **TEST ONLY** If set, it will use a local tarball of ReactNativeDependencies if it exists.
 ## - RCT_DEPS_VERSION: **TEST ONLY** If set, it will override the version of ReactNativeDependencies to be used.
 
 ### Adds ReactNativeDependencies as a dependency to the given podspec if we're not

--- a/packages/react-native/third-party-podspecs/ReactNativeDependencies.podspec
+++ b/packages/react-native/third-party-podspecs/ReactNativeDependencies.podspec
@@ -41,16 +41,19 @@ Pod::Spec.new do |spec|
   spec.vendored_frameworks  = 'framework/packages/react-native/ReactNativeDependencies.xcframework'
   spec.header_mappings_dir  = 'Headers'
   spec.source_files         = 'Headers/**/*.{h,hpp}'
+
+  # We need to make sure that the headers are copied to the right place - local tar.gz has a different structure
+  # than the one from the maven repo
   spec.prepare_command    = <<-CMD
-    pwd
     CURRENT_PATH=$(pwd)
     mkdir -p Headers
-    BASE_PATH=$(find "$CURRENT_PATH" -type d -name "ios-arm64")
-    rsync -a "$BASE_PATH/ReactNativeDependencies.framework/Headers/" Headers
+    XCFRAMEWORK_PATH=$(find "$CURRENT_PATH" -type d -name "ReactNativeDependencies.xcframework")
+    HEADERS_PATH=$(find "$XCFRAMEWORK_PATH" -type d -name "Headers" | head -n 1)
+    rsync -a "$HEADERS_PATH/" Headers
     mkdir -p framework/packages/react-native
-    rsync -a --remove-source-files "$BASE_PATH/../.." framework/packages/react-native/
+    rsync -a --remove-source-files "$XCFRAMEWORK_PATH/.." framework/packages/react-native/
     find "$CURRENT_PATH" -type d -empty -delete
-  CMD
+    CMD
 
   # If we are passing a local tarball, we don't want to switch between Debug and Release
   if !ENV["RCT_USE_LOCAL_RN_DEP"]

--- a/scripts/releases/ios-prebuild/compose-framework.js
+++ b/scripts/releases/ios-prebuild/compose-framework.js
@@ -113,6 +113,7 @@ function copyBundles(
             targetArchFolder,
             `${scheme}.framework`,
             'Resources',
+            bundleName,
           );
           if (
             !fs.existsSync(path.join(targetArchFolder, `${scheme}.framework`))
@@ -123,7 +124,8 @@ function copyBundles(
             console.warn("Source bundle doesn't exist", sourceBundlePath);
           }
           // A bundle is a directory, so we need to copy the whole directory
-          execSync(`cp -r ${sourceBundlePath} ${targetBundlePath}`);
+          execSync(`mkdir -p "${targetBundlePath}"`);
+          execSync(`cp -r "${sourceBundlePath}/" "${targetBundlePath}"`);
         });
       } else {
         console.warn(`Bundle ${sourceBundlePath} not found`);

--- a/scripts/releases/ios-prebuild/compose-framework.js
+++ b/scripts/releases/ios-prebuild/compose-framework.js
@@ -9,13 +9,13 @@
  * @oncall react_native
  */
 
+const {HEADERS_FOLDER, TARGET_FOLDER} = require('./constants');
 const {execSync} = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
 /*::
 import type { Dependency, Platform } from './types';
-import {exec} from "child_process";
 */
 
 /**
@@ -64,6 +64,9 @@ async function createFramework(
   // Copy bundles into the framework
   copyBundles(scheme, dependencies, output, frameworkPaths);
 
+  // Copy headers to the framework - start by building the Header folder
+  await copyHeaders(scheme, dependencies, rootFolder);
+
   // Copy Symbols to symbols folder
   const symbolPaths = frameworkPaths.map(framework =>
     path.join(framework, `${scheme}.framework.dSYM`),
@@ -76,6 +79,40 @@ async function createFramework(
   if (identity) {
     signXCFramework(identity, output);
   }
+}
+
+/**
+ * Copies headers needed from the package to a Header folder that we'll pass to
+ * each framework arch type
+ */
+async function copyHeaders(
+  scheme /*: string */,
+  dependencies /*: $ReadOnlyArray<Dependency> */,
+  rootFolder /*: string */,
+) {
+  console.log('Copying header files for dependencies...');
+
+  // Create and clean the header folder
+  const headeDestinationFolder = path.join(
+    rootFolder,
+    `${scheme}.xcframework`,
+    'Headers',
+  );
+  fs.rmSync(headeDestinationFolder, {force: true, recursive: true});
+  fs.mkdirSync(headeDestinationFolder, {recursive: true});
+
+  // Now we can go through all dependencies and copy header files for each depencendy
+  dependencies.forEach(dep => {
+    const depHeaders = path.join(
+      rootFolder,
+      dep.name,
+      TARGET_FOLDER,
+      HEADERS_FOLDER,
+    );
+
+    // Copy all header files from the dependency to headerTempFolder
+    execSync(`cp -r ${depHeaders}/* ${headeDestinationFolder}/`);
+  });
 }
 
 /**

--- a/scripts/releases/ios-prebuild/configuration.js
+++ b/scripts/releases/ios-prebuild/configuration.js
@@ -54,7 +54,8 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
     settings: {
       publicHeaderFiles: './headers',
       headerSearchPaths: ['src'],
-      compilerFlags: ['-Wno-shorten-64-to-32', '-Wno-everything'],
+      cCompilerFlags: ['-Wno-shorten-64-to-32', '-Wno-everything'],
+      cxxCompilerFlags: ['-Wno-shorten-64-to-32', '-Wno-everything'],
       defines: [
         {name: 'DEFINES_MODULE', value: 'YES'},
         {name: 'USE_HEADERMAP', value: 'NO'},
@@ -76,7 +77,8 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
     settings: {
       publicHeaderFiles: './headers',
       headerSearchPaths: ['src'],
-      compilerFlags: ['-Wno-everything'],
+      cCompilerFlags: ['-Wno-everything'],
+      cxxCompilerFlags: ['-Wno-everything'],
     },
   },
   {
@@ -94,8 +96,8 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
       publicHeaderFiles: './include',
       headerSearchPaths: ['include'],
       linkedLibraries: ['c++'],
-      compilerFlags: ['-Wno-everything'],
-      cppVersion: CPP_STANDARD,
+      cCompilerFlags: ['-Wno-everything'],
+      cxxCompilerFlags: ['-Wno-everything', `-std=${CPP_STANDARD}`],
     },
   },
   {
@@ -113,7 +115,8 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
     settings: {
       publicHeaderFiles: './',
       headerSearchPaths: ['./'],
-      compilerFlags: ['-Wno-everything', '-Wno-documentation'],
+      cCompilerFlags: ['-Wno-everything', '-Wno-documentation'],
+      cxxCompilerFlags: ['-Wno-everything', '-Wno-documentation'],
     },
   },
   {
@@ -131,8 +134,8 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
     settings: {
       publicHeaderFiles: './include',
       headerSearchPaths: ['include'],
-      compilerFlags: ['-Wno-everything'],
-      cppVersion: CPP_STANDARD,
+      cCompilerFlags: ['-Wno-everything'],
+      cxxCompilerFlags: ['-Wno-everything', `-std=${CPP_STANDARD}`],
       linkedLibraries: ['c++'],
     },
   },
@@ -160,7 +163,8 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
         'SocketRocket/Internal/Security',
         'SocketRocket/Internal/Utilities',
       ],
-      compilerFlags: ['-Wno-everything'],
+      cCompilerFlags: ['-Wno-everything'],
+      cxxCompilerFlags: ['-Wno-everything'],
     },
   },
   {
@@ -260,13 +264,19 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
     settings: {
       publicHeaderFiles: './',
       headerSearchPaths: ['./'],
-      compilerFlags: [
+      cCompilerFlags: [
         '-Wno-everything',
         '-faligned-new',
         '-Wno-shorten-64-to-32',
         '-Wno-comma',
       ],
-      cppVersion: CPP_STANDARD,
+      cxxCompilerFlags: [
+        '-Wno-everything',
+        '-faligned-new',
+        '-Wno-shorten-64-to-32',
+        '-Wno-comma',
+        `-std=${CPP_STANDARD}`,
+      ],
       defines: [
         {name: 'USE_HEADERMAP', value: 'NO'},
         {name: 'DEFINES_MODULE', value: 'YES'},

--- a/scripts/releases/ios-prebuild/configuration.js
+++ b/scripts/releases/ios-prebuild/configuration.js
@@ -48,7 +48,7 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
         'src/vlog_is_on.cc',
       ],
       headers: ['src/glog/*.h'],
-      // resources: ['../third-party-podspecs/glog/PrivacyInfo.xcprivacy'],
+      resources: ['../third-party-podspecs/glog/PrivacyInfo.xcprivacy'],
       headerSkipFolderNames: 'src',
     },
     settings: {
@@ -94,7 +94,8 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
       publicHeaderFiles: './include',
       headerSearchPaths: ['include'],
       linkedLibraries: ['c++'],
-      compilerFlags: ['-Wno-everything', `-std=${CPP_STANDARD}`],
+      compilerFlags: ['-Wno-everything'],
+      cppVersion: CPP_STANDARD,
     },
   },
   {
@@ -107,7 +108,7 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
     files: {
       sources: ['boost/**/*.hpp', 'dummy.cc'],
       headers: ['boost/**/*.hpp'],
-      // resources: ['../third-party-podspecs/boost/PrivacyInfo.xcprivacy'],
+      resources: ['../third-party-podspecs/boost/PrivacyInfo.xcprivacy'],
     },
     settings: {
       publicHeaderFiles: './',
@@ -130,7 +131,8 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
     settings: {
       publicHeaderFiles: './include',
       headerSearchPaths: ['include'],
-      compilerFlags: ['-Wno-everything', `-std=${CPP_STANDARD}`],
+      compilerFlags: ['-Wno-everything'],
+      cppVersion: CPP_STANDARD,
       linkedLibraries: ['c++'],
     },
   },
@@ -245,8 +247,7 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
         'folly/portability/*.h',
         'folly/system/*.h',
       ],
-      // TODO: When including this we get "failed to scan dependencies" error
-      // resources: ['../third-party-podspecs/RCT-Folly/PrivacyInfo.xcprivacy'],
+      resources: ['../third-party-podspecs/RCT-Folly/PrivacyInfo.xcprivacy'],
     },
     dependencies: [
       'glog',
@@ -261,11 +262,11 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
       headerSearchPaths: ['./'],
       compilerFlags: [
         '-Wno-everything',
-        `-std=${CPP_STANDARD}`,
         '-faligned-new',
         '-Wno-shorten-64-to-32',
         '-Wno-comma',
       ],
+      cppVersion: CPP_STANDARD,
       defines: [
         {name: 'USE_HEADERMAP', value: 'NO'},
         {name: 'DEFINES_MODULE', value: 'YES'},

--- a/scripts/releases/ios-prebuild/configuration.js
+++ b/scripts/releases/ios-prebuild/configuration.js
@@ -54,8 +54,8 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
     settings: {
       publicHeaderFiles: './headers',
       headerSearchPaths: ['src'],
-      cCompilerFlags: ['-Wno-shorten-64-to-32', '-Wno-everything'],
-      cxxCompilerFlags: ['-Wno-shorten-64-to-32', '-Wno-everything'],
+      cCompilerFlags: ['-Wno-shorten-64-to-32'],
+      cxxCompilerFlags: ['-Wno-shorten-64-to-32', `-std=${CPP_STANDARD}`],
       defines: [
         {name: 'DEFINES_MODULE', value: 'YES'},
         {name: 'USE_HEADERMAP', value: 'NO'},
@@ -77,8 +77,6 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
     settings: {
       publicHeaderFiles: './headers',
       headerSearchPaths: ['src'],
-      cCompilerFlags: ['-Wno-everything'],
-      cxxCompilerFlags: ['-Wno-everything'],
     },
   },
   {
@@ -96,8 +94,7 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
       publicHeaderFiles: './include',
       headerSearchPaths: ['include'],
       linkedLibraries: ['c++'],
-      cCompilerFlags: ['-Wno-everything'],
-      cxxCompilerFlags: ['-Wno-everything', `-std=${CPP_STANDARD}`],
+      cxxCompilerFlags: [`-std=${CPP_STANDARD}`],
     },
   },
   {
@@ -115,8 +112,8 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
     settings: {
       publicHeaderFiles: './',
       headerSearchPaths: ['./'],
-      cCompilerFlags: ['-Wno-everything', '-Wno-documentation'],
-      cxxCompilerFlags: ['-Wno-everything', '-Wno-documentation'],
+      cCompilerFlags: ['-Wno-documentation'],
+      cxxCompilerFlags: ['-Wno-documentation', `-std=${CPP_STANDARD}`],
     },
   },
   {
@@ -134,8 +131,7 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
     settings: {
       publicHeaderFiles: './include',
       headerSearchPaths: ['include'],
-      cCompilerFlags: ['-Wno-everything'],
-      cxxCompilerFlags: ['-Wno-everything', `-std=${CPP_STANDARD}`],
+      cxxCompilerFlags: [`-std=${CPP_STANDARD}`],
       linkedLibraries: ['c++'],
     },
   },
@@ -163,8 +159,6 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
         'SocketRocket/Internal/Security',
         'SocketRocket/Internal/Utilities',
       ],
-      cCompilerFlags: ['-Wno-everything'],
-      cxxCompilerFlags: ['-Wno-everything'],
     },
   },
   {
@@ -264,14 +258,8 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
     settings: {
       publicHeaderFiles: './',
       headerSearchPaths: ['./'],
-      cCompilerFlags: [
-        '-Wno-everything',
-        '-faligned-new',
-        '-Wno-shorten-64-to-32',
-        '-Wno-comma',
-      ],
+      cCompilerFlags: ['-faligned-new', '-Wno-shorten-64-to-32', '-Wno-comma'],
       cxxCompilerFlags: [
-        '-Wno-everything',
         '-faligned-new',
         '-Wno-shorten-64-to-32',
         '-Wno-comma',

--- a/scripts/releases/ios-prebuild/swift-package.js
+++ b/scripts/releases/ios-prebuild/swift-package.js
@@ -73,6 +73,12 @@ function createSwiftTarget(dependency /*  :Dependency */) {
     unsafeCAndCxxSettings = `.unsafeFlags([${dependency.settings.compilerFlags.map(flag => `"${flag}"`).join(', ')}]),`;
   }
 
+  // Add c++ version to c++ settings if provided
+  let unsafeCxxSettings = '';
+  if (dependency.settings.cppVersion != null) {
+    unsafeCxxSettings = `.unsafeFlags(["-std=${dependency.settings.cppVersion}"]),`;
+  }
+
   // Setup defines
   let defines = '';
   if (dependency.settings.defines != null) {
@@ -127,6 +133,7 @@ function createSwiftTarget(dependency /*  :Dependency */) {
                 ${headerSearchPaths}
                 ${unsafeCAndCxxSettings}
                 ${defines}
+                ${unsafeCxxSettings}
               ],
               linkerSettings: [
                 ${linkedLibraries}

--- a/scripts/releases/ios-prebuild/swift-package.js
+++ b/scripts/releases/ios-prebuild/swift-package.js
@@ -68,15 +68,15 @@ ${dependencies.map(d => createSwiftTarget(d)).join('')}
  */
 function createSwiftTarget(dependency /*  :Dependency */) {
   // Setup unsafe flags
-  let unsafeCAndCxxSettings = '';
-  if (dependency.settings.compilerFlags != null) {
-    unsafeCAndCxxSettings = `.unsafeFlags([${dependency.settings.compilerFlags.map(flag => `"${flag}"`).join(', ')}]),`;
+  let unsafeCSettings = '';
+  if (dependency.settings.cCompilerFlags != null) {
+    unsafeCSettings = `.unsafeFlags([${dependency.settings.cCompilerFlags.map(flag => `"${flag}"`).join(', ')}]),`;
   }
 
   // Add c++ version to c++ settings if provided
   let unsafeCxxSettings = '';
-  if (dependency.settings.cppVersion != null) {
-    unsafeCxxSettings = `.unsafeFlags(["-std=${dependency.settings.cppVersion}"]),`;
+  if (dependency.settings.cxxCompilerFlags != null) {
+    unsafeCxxSettings = `.unsafeFlags([${dependency.settings.cxxCompilerFlags.map(flag => `"${flag}"`).join(', ')}]),`;
   }
 
   // Setup defines
@@ -126,14 +126,13 @@ function createSwiftTarget(dependency /*  :Dependency */) {
               publicHeadersPath: "${dependency.settings.publicHeaderFiles}",
               cSettings: [
                 ${headerSearchPaths}
-                ${unsafeCAndCxxSettings}
+                ${unsafeCSettings}
                 ${defines}
               ],
               cxxSettings: [
                 ${headerSearchPaths}
-                ${unsafeCAndCxxSettings}
-                ${defines}
                 ${unsafeCxxSettings}
+                ${defines}
               ],
               linkerSettings: [
                 ${linkedLibraries}

--- a/scripts/releases/ios-prebuild/types.js
+++ b/scripts/releases/ios-prebuild/types.js
@@ -32,6 +32,7 @@ export type Settings = $ReadOnly<{
   headerSearchPaths?: $ReadOnlyArray<string>,
   defines?: $ReadOnlyArray<Define>,
   compilerFlags?: $ReadOnlyArray<string>,
+  cppVersion?: string,
   linkedLibraries?: $ReadOnlyArray<string>,
   publicHeaderFiles: string,
   linkerSettings?: $ReadOnlyArray<string>

--- a/scripts/releases/ios-prebuild/types.js
+++ b/scripts/releases/ios-prebuild/types.js
@@ -31,8 +31,8 @@ export type Define = $ReadOnly<{
 export type Settings = $ReadOnly<{
   headerSearchPaths?: $ReadOnlyArray<string>,
   defines?: $ReadOnlyArray<Define>,
-  compilerFlags?: $ReadOnlyArray<string>,
-  cppVersion?: string,
+  cCompilerFlags?: $ReadOnlyArray<string>,
+  cxxCompilerFlags?: $ReadOnlyArray<string>,
   linkedLibraries?: $ReadOnlyArray<string>,
   publicHeaderFiles: string,
   linkerSettings?: $ReadOnlyArray<string>


### PR DESCRIPTION
## Summary:

Headers are currently copied into each arch in the final xcframework. This is not necessary and will cause a lot of duplication since these files are the same for all archs.

This commit fixes this by only copying headers when we build the final XCFramework:

- ReactNativeDependencies.podspec: Changed the prepare script to be more resilient to different header structs, since we have multiple ways of packaging our tarballs locally and on the servers
- build.js: Removed copying headers when building frameworks
- compose-framework.js: Added copying headers once to the root of the XCFramework.
- rndependencies.rb: updated docs with correct ENV vars

## Changelog:

[INTERNAL] - Changes the header structure in our XCFramework to avoid duplication

## Test Plan:

Run RNTester with RCT_USE_RN_DEPS=1 to use prebuilt RN Deps.
