### PR TITLE
Correctly compare oldProps in RCTPullToRefreshViewComponentView

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
@@ -76,7 +76,7 @@ using namespace facebook::react;
     return;
   }
 
-  const auto &oldConcreteProps = static_cast<const PullToRefreshViewProps &>(*oldProps);
+  const auto &oldConcreteProps = static_cast<const PullToRefreshViewProps &>(*_props);
   const auto &newConcreteProps = static_cast<const PullToRefreshViewProps &>(*props);
 
   if (newConcreteProps.tintColor != oldConcreteProps.tintColor) {


### PR DESCRIPTION
Summary:
`oldProps` can be null, so this is an unsafe dereference. We also typically compare with `_props`, which represents the previous state of the component.

Changelog: [General][Fixed] Fixed crash in RCTPullToRefreshViewComponentView#updateProps

Differential Revision: D71388015


