### PR TITLE
[0.77] community-cli-plugin: resolve cli-server-api via peer dependency on cli

### DIFF
--- a/packages/community-cli-plugin/package.json
+++ b/packages/community-cli-plugin/package.json
@@ -37,10 +37,10 @@
     "metro-resolver": "^0.81.0"
   },
   "peerDependencies": {
-    "@react-native-community/cli-server-api": "*"
+    "@react-native-community/cli": "*"
   },
   "peerDependenciesMeta": {
-    "@react-native-community/cli-server-api": {
+    "@react-native-community/cli": {
       "optional": true
     }
   },

--- a/packages/community-cli-plugin/src/commands/start/middleware.js
+++ b/packages/community-cli-plugin/src/commands/start/middleware.js
@@ -9,6 +9,7 @@
  * @oncall react_native
  */
 
+import typeof * as CLIServerAPI from '@react-native-community/cli-server-api';
 import type {NextHandleFunction, Server} from 'connect';
 import type {TerminalReportableEvent} from 'metro/src/lib/TerminalReporter';
 
@@ -65,11 +66,26 @@ const communityMiddlewareFallback = {
 // Attempt to use the community middleware if it exists, but fallback to
 // the stubs if it doesn't.
 try {
-  const community = require('@react-native-community/cli-server-api');
-  communityMiddlewareFallback.indexPageMiddleware =
-    community.indexPageMiddleware;
+  // `@react-native-community/cli` is an optional peer dependency of this
+  // package, and should be a dev dependency of the host project (via the
+  // community template's package.json).
+  const communityCliPath = require.resolve('@react-native-community/cli');
+
+  // `@react-native-community/cli-server-api` is a dependency of
+  // `@react-native-community/cli`, but is not re-exported by it, so we need
+  // to resolve the former through the latter.
+  const communityCliServerApiPath = require.resolve(
+    '@react-native-community/cli-server-api',
+    {paths: [communityCliPath]},
+  );
+  // $FlowIgnore[unsupported-syntax] dynamic import
+  const communityCliServerApi: CLIServerAPI = require(
+    communityCliServerApiPath,
+  );
   communityMiddlewareFallback.createDevServerMiddleware =
-    community.createDevServerMiddleware;
+    communityCliServerApi.createDevServerMiddleware;
+  communityMiddlewareFallback.indexPageMiddleware =
+    communityCliServerApi.indexPageMiddleware;
 } catch {
   debug(`⚠️ Unable to find @react-native-community/cli-server-api
 Starting the server without the community middleware.`);

--- a/packages/react-native/react-native.config.js
+++ b/packages/react-native/react-native.config.js
@@ -44,27 +44,11 @@ try {
 
 const commands = [];
 
-try {
-  const {
-    bundleCommand,
-    startCommand,
-  } = require('@react-native/community-cli-plugin');
-  commands.push(bundleCommand, startCommand);
-} catch (e) {
-  const known =
-    e.code === 'MODULE_NOT_FOUND' &&
-    e.message.includes('@react-native-community/cli-server-api');
-
-  if (!known) {
-    throw e;
-  }
-
-  if (verbose) {
-    console.warn(
-      '@react-native-community/cli-server-api not found, the react-native.config.js may be unusable.',
-    );
-  }
-}
+const {
+  bundleCommand,
+  startCommand,
+} = require('@react-native/community-cli-plugin');
+commands.push(bundleCommand, startCommand);
 
 const codegenCommand = {
   name: 'codegen',


### PR DESCRIPTION
## Summary:

Picks: https://github.com/facebook/react-native/pull/49518

## Changelog:

[GENERAL][FIXED] Fix registering of `start` and `bundle` commands with community CLI and isolated node_modules.

## Test Plan:

As in main - eg testing with RN 0.79-rc.2:

<img width="1673" alt="image" src="https://github.com/user-attachments/assets/8b4eb541-be12-433f-b199-d8fe1b6ea478" />
