### PR TITLE
[0.78] community-cli-plugin: resolve cli-server-api via peer dependency on cli

### DIFF
--- a/packages/community-cli-plugin/package.json
+++ b/packages/community-cli-plugin/package.json
@@ -37,10 +37,10 @@
     "metro-resolver": "^0.81.0"
   },
   "peerDependencies": {
-    "@react-native-community/cli-server-api": "*"
+    "@react-native-community/cli": "*"
   },
   "peerDependenciesMeta": {
-    "@react-native-community/cli-server-api": {
+    "@react-native-community/cli": {
       "optional": true
     }
   },

--- a/packages/react-native/react-native.config.js
+++ b/packages/react-native/react-native.config.js
@@ -44,27 +44,11 @@ try {
 
 const commands = [];
 
-try {
-  const {
-    bundleCommand,
-    startCommand,
-  } = require('@react-native/community-cli-plugin');
-  commands.push(bundleCommand, startCommand);
-} catch (e) {
-  const known =
-    e.code === 'MODULE_NOT_FOUND' &&
-    e.message.includes('@react-native-community/cli-server-api');
-
-  if (!known) {
-    throw e;
-  }
-
-  if (verbose) {
-    console.warn(
-      '@react-native-community/cli-server-api not found, the react-native.config.js may be unusable.',
-    );
-  }
-}
+const {
+  bundleCommand,
+  startCommand,
+} = require('@react-native/community-cli-plugin');
+commands.push(bundleCommand, startCommand);
 
 const codegenCommand = {
   name: 'codegen',


### PR DESCRIPTION
## Summary:

Picks: https://github.com/facebook/react-native/pull/49518

## Changelog:

[GENERAL][FIXED] Fix registering of `start` and `bundle` commands with community CLI and isolated node_modules.

## Test Plan:

As in main