### PR TITLE
Avoid generating `<appname>,` folders when running pod install

### DIFF
--- a/packages/react-native/scripts/codegen/__tests__/__snapshots__/generate-artifacts-executor-test.js.snap
+++ b/packages/react-native/scripts/codegen/__tests__/__snapshots__/generate-artifacts-executor-test.js.snap
@@ -434,9 +434,9 @@ RCT_SCRIPT_POD_INSTALLATION_ROOT=$(pwd)
 popd >/dev/null
 
 export RCT_SCRIPT_RN_DIR=\\"$RCT_SCRIPT_POD_INSTALLATION_ROOT/../../../../..\\"
-export RCT_SCRIPT_APP_PATH=\\"$RCT_SCRIPT_POD_INSTALLATION_ROOT/..\\",
-export RCT_SCRIPT_OUTPUT_DIR=\\"$RCT_SCRIPT_POD_INSTALLATION_ROOT\\",
-export RCT_SCRIPT_TYPE=\\"withCodegenDiscovery\\",
+export RCT_SCRIPT_APP_PATH=\\"$RCT_SCRIPT_POD_INSTALLATION_ROOT/..\\"
+export RCT_SCRIPT_OUTPUT_DIR=\\"$RCT_SCRIPT_POD_INSTALLATION_ROOT\\"
+export RCT_SCRIPT_TYPE=\\"withCodegenDiscovery\\"
 
 SCRIPT_PHASES_SCRIPT=\\"$RCT_SCRIPT_RN_DIR/scripts/react_native_pods_utils/script_phases.sh\\"
 WITH_ENVIRONMENT=\\"$RCT_SCRIPT_RN_DIR/scripts/xcode/with-environment.sh\\"

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/generateReactCodegenPodspec.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/generateReactCodegenPodspec.js
@@ -78,9 +78,9 @@ RCT_SCRIPT_POD_INSTALLATION_ROOT=$(pwd)
 popd >/dev/null
 
 export RCT_SCRIPT_RN_DIR="$RCT_SCRIPT_POD_INSTALLATION_ROOT/${path.relative(outputPath, REACT_NATIVE_PACKAGE_ROOT_FOLDER)}"
-export RCT_SCRIPT_APP_PATH="$RCT_SCRIPT_POD_INSTALLATION_ROOT/${relativeAppPath.length === 0 ? '.' : relativeAppPath}",
-export RCT_SCRIPT_OUTPUT_DIR="$RCT_SCRIPT_POD_INSTALLATION_ROOT",
-export RCT_SCRIPT_TYPE="withCodegenDiscovery",
+export RCT_SCRIPT_APP_PATH="$RCT_SCRIPT_POD_INSTALLATION_ROOT/${relativeAppPath.length === 0 ? '.' : relativeAppPath}"
+export RCT_SCRIPT_OUTPUT_DIR="$RCT_SCRIPT_POD_INSTALLATION_ROOT"
+export RCT_SCRIPT_TYPE="withCodegenDiscovery"
 
 SCRIPT_PHASES_SCRIPT="$RCT_SCRIPT_RN_DIR/scripts/react_native_pods_utils/script_phases.sh"
 WITH_ENVIRONMENT="$RCT_SCRIPT_RN_DIR/scripts/xcode/with-environment.sh"


### PR DESCRIPTION
Summary:
While moving the generation of `ReactCodegen.podspec` from Cocoapods to Codegen, we wrongly copied some parts of the script and now it is generating folders with a `,` as a suffix.

This change fixes the problem and prevent the generation of such folders.

## Changelog:
[Internal] -  Avoid generating `ios,` folders

Differential Revision: D71395049


