### PR TITLE
raise event when trying to open the debugger on opt builds

### DIFF
--- a/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
+++ b/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
@@ -172,6 +172,10 @@ export default class InspectorProxy implements InspectorProxyQueries {
           device.getApp(),
           device.getName(),
         );
+
+        this.#eventReporter?.logEvent({
+          type: 'no_debug_pages_for_device',
+        });
       }
 
       result = result.concat(devicePages);

--- a/packages/dev-middleware/src/types/EventReporter.js
+++ b/packages/dev-middleware/src/types/EventReporter.js
@@ -90,6 +90,9 @@ export type ReportableEvent =
       type: 'fusebox_console_notice',
     }
   | {
+      type: 'no_debug_pages_for_device',
+    }
+  | {
       type: 'proxy_error',
       status: 'error',
       messageOrigin: 'debugger' | 'device',


### PR DESCRIPTION
Summary:
Changelog:
[General][Internal] raises an event report when an attempt to open the debugger for not supported apps is made

Differential Revision: D71398802


