### PR TITLE
TurboModuleWithJSIBindings

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.cpp
@@ -20,6 +20,7 @@
 #include <ReactCommon/TurboCxxModule.h>
 #include <ReactCommon/TurboModuleBinding.h>
 #include <ReactCommon/TurboModulePerfLogger.h>
+#include <ReactCommon/TurboModuleWithJSIBindings.h>
 #include <react/jni/CxxModuleWrapper.h>
 
 namespace facebook::react {
@@ -165,6 +166,7 @@ std::shared_ptr<TurboModule> TurboModuleManager::getTurboModule(
 
   auto cxxModule = cxxDelegate->getTurboModule(name, jsCallInvoker_);
   if (cxxModule) {
+    TurboModuleWithJSIBindings::installJSIBindings(cxxModule, runtime);
     turboModuleCache_.insert({name, cxxModule});
     return cxxModule;
   }

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleWithJSIBindings.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleWithJSIBindings.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "TurboModuleWithJSIBindings.h"
+
+#include <ReactCommon/TurboModule.h>
+
+namespace facebook::react {
+
+/* static */ void TurboModuleWithJSIBindings::installJSIBindings(
+    const std::shared_ptr<TurboModule>& cxxModule,
+    jsi::Runtime& runtime) {
+  if (auto* cxxModuleWithJSIBindings =
+          dynamic_cast<TurboModuleWithJSIBindings*>(cxxModule.get())) {
+    cxxModuleWithJSIBindings->installJSIBindingsWithRuntime(runtime);
+  }
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleWithJSIBindings.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleWithJSIBindings.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <ReactCommon/CallInvoker.h>
+#include <jsi/jsi.h>
+
+namespace facebook::react {
+
+class TurboModule;
+
+class TurboModuleWithJSIBindings {
+ public:
+  virtual ~TurboModuleWithJSIBindings() = default;
+
+  static void installJSIBindings(
+      const std::shared_ptr<TurboModule>& cxxModule,
+      jsi::Runtime& runtime);
+
+ private:
+  virtual void installJSIBindingsWithRuntime(jsi::Runtime& runtime) = 0;
+};
+
+} // namespace facebook::react


### PR DESCRIPTION
Summary:
## Changelog:

[General] [Added] - Create TurboModuleWithJSIBindings interface

So c++ TurboModules can initialize some private members with reference to `jsi::Runtime`

Differential Revision: D71396842


