### PR TITLE
Make Appearance use main queue setup

### DIFF
--- a/packages/react-native/React/CoreModules/RCTAppearance.mm
+++ b/packages/react-native/React/CoreModules/RCTAppearance.mm
@@ -18,8 +18,6 @@ using namespace facebook::react;
 NSString *const RCTAppearanceColorSchemeLight = @"light";
 NSString *const RCTAppearanceColorSchemeDark = @"dark";
 
-static BOOL sIsAppearancePreferenceSet = NO;
-
 static BOOL sAppearancePreferenceEnabled = YES;
 void RCTEnableAppearancePreference(BOOL enabled)
 {
@@ -62,11 +60,6 @@ NSString *RCTColorSchemePreference(UITraitCollection *traitCollection)
   if (!sAppearancePreferenceEnabled) {
     // Return the default if the app doesn't allow different color schemes.
     return RCTAppearanceColorSchemeLight;
-  }
-
-  if (appearances[@(traitCollection.userInterfaceStyle)]) {
-    sIsAppearancePreferenceSet = YES;
-    return appearances[@(traitCollection.userInterfaceStyle)];
   }
 
   if (!traitCollection) {
@@ -131,13 +124,6 @@ RCT_EXPORT_METHOD(setColorScheme : (NSString *)style)
 
 RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSString *, getColorScheme)
 {
-  if (!sIsAppearancePreferenceSet) {
-    __block UITraitCollection *traitCollection = nil;
-    RCTUnsafeExecuteOnMainQueueSync(^{
-      traitCollection = RCTKeyWindow().traitCollection;
-    });
-    _currentColorScheme = RCTColorSchemePreference(traitCollection);
-  }
   return _currentColorScheme;
 }
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -154,6 +154,9 @@
             "AccessibilityManager": {
               "unstableRequiresMainQueueSetup": true
             },
+            "Appearance": {
+              "unstableRequiresMainQueueSetup": true
+            },
             "AppState": {
               "unstableRequiresMainQueueSetup": true
             },


### PR DESCRIPTION
Summary:
## Rationale
Rendering can now include main -> js sync calls.

If we allow js -> main sync calls during rendering, react native can deadlock.

So, this diff moves the js -> main sync calls to "main queue module setup", which occurs before rendering.

Changelog: [Internal]

Differential Revision: D71347452
