### PR TITLE
Allow union changes when the new element is in the middle of the union

### DIFF
--- a/packages/react-native-compatibility-check/src/__tests__/TypeDiffing-test.js
+++ b/packages/react-native-compatibility-check/src/__tests__/TypeDiffing-test.js
@@ -1010,7 +1010,16 @@ describe('compareTypes on string literal unions', () => {
         nativeTypeDiffingTypesAliases,
         nativeTypeDiffingTypesAliases,
       ),
-    ).toHaveErrorWithMessage('Subtype of union at position 1 did not match');
+    ).toEqual(
+      expect.objectContaining({
+        status: 'positionalTypeChange',
+        changeLog: expect.objectContaining({
+          typeKind: 'stringUnion',
+          addedElements: expect.arrayContaining([expect.any(Array)]),
+          removedElements: expect.arrayContaining([expect.any(Array)]),
+        }),
+      }),
+    );
   });
 });
 

--- a/packages/react-native-compatibility-check/src/__tests__/__fixtures__/native-component-with-props-union-added/NativeComponent.js.flow
+++ b/packages/react-native-compatibility-check/src/__tests__/__fixtures__/native-component-with-props-union-added/NativeComponent.js.flow
@@ -16,7 +16,7 @@ import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNati
 
 export type Props = $ReadOnly<{
   ...ViewProps,
-  size?: WithDefault<'small' | 'large' | 'huge', 'small'>,
+  size?: WithDefault<'small' | 'huge' | 'large', 'small'>,
 }>;
 
 export default (codegenNativeComponent<Props>(

--- a/packages/react-native-compatibility-check/src/__tests__/__snapshots__/ErrorFormatting-test.js.snap
+++ b/packages/react-native-compatibility-check/src/__tests__/__snapshots__/ErrorFormatting-test.js.snap
@@ -196,7 +196,7 @@ Object {
         Object {
           "errorCode": "addedUnionCases",
           "message": "NativeComponent.sizes: Union added items, but native will not expect/support them
-  -- position 3 huge",
+  -- position 2 huge",
         },
       ],
     },
@@ -237,7 +237,7 @@ Object {
         Object {
           "errorCode": "addedUnionCases",
           "message": "NativeComponent.size: Union added items, but native will not expect/support them
-  -- position 3 huge",
+  -- position 1 huge",
         },
       ],
     },
@@ -709,7 +709,7 @@ Object {
         Object {
           "errorCode": "addedUnionCases",
           "message": "NativeModuleTest.exampleFunction parameter 0: Union added items, but native will not expect/support them
-  -- position 4 d",
+  -- position 3 d",
         },
       ],
     },
@@ -725,20 +725,10 @@ Object {
       "framework": "ReactNative",
       "incompatibleSpecs": Array [
         Object {
-          "errorCode": "incompatibleTypes",
-          "message": "NativeModuleTest: Object contained a property with a type mismatch
-  -- exampleFunction: has conflicting type changes
-      --new: (a: (a | b | c), b: number)=>void
-      --old: (a: (a | '0' | '1' | 'a long string'), b: number)=>void
-      Parameter at index 0 did not match
-          --new: (a: (a | b | c), b: number)=>void
-          --old: (a: (a | '0' | '1' | 'a long string'), b: number)=>void
-          Subtype of union at position 1 did not match
-              --new: (a | b | c)
-              --old: (a | '0' | '1' | 'a long string')
-              String literals are not equal
-                  --new: b
-                  --old: '0'",
+          "errorCode": "addedUnionCases",
+          "message": "NativeModuleTest.exampleFunction parameter 0: Union added items, but native will not expect/support them
+  -- position 1 b
+  -- position 2 c",
         },
       ],
     },
@@ -756,7 +746,7 @@ Object {
         Object {
           "errorCode": "removedUnionCases",
           "message": "NativeModuleTest.getConstants.exampleConstant: Union removed items, but native may still provide them
-  -- position 4 d",
+  -- position 3 d",
         },
       ],
     },


### PR DESCRIPTION
Summary:
D70870978 failed the compat check because it modified a union by removing an element in the middle:

```
'global' | 'self'
```

from
```
'global' | 'application' | 'self'
```

This caused the compat check to complain that index 1 in both unions: `self` didn't match `application` and thus it was a type incompatibility.

We should have been comparing these as an unsorted array of options, which first sorts, then treats differences as added/removed elements instead of incompatbile elements.

If in the example above the removed element was the last one from the union, it would have been fine.

Once these are classified as added/removed, the VersionDiffer is able to check whether that change is allowed in fromNative or toNative.

Changelog: [General][Fixed] Compatibility Check: Allow union changes when the new element is in the middle of the union

Reviewed By: makovkastar

Differential Revision: D71433054


