### PR TITLE
fix fetch of content scheme urls failing on Android

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java
@@ -286,6 +286,8 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
       for (UriHandler handler : mUriHandlers) {
         if (handler.supports(uri, responseType)) {
           WritableMap res = handler.fetch(uri);
+          //fix: UriHandlers which are not using file:// scheme fail in whatwg-fetch at this line  https://github.com/JakeChampion/fetch/blob/main/fetch.js#L547
+          ResponseUtil.onResponseReceived(reactApplicationContext, requestId, 200, Arguments.createMap(), url);
           ResponseUtil.onDataReceived(reactApplicationContext, requestId, res);
           ResponseUtil.onRequestSuccess(reactApplicationContext, requestId);
           return;

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/ImagePickerAndroid.kt
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/android/ImagePickerAndroid.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.fbreact.specs
+
+import android.net.Uri
+import android.os.Build
+import android.util.DisplayMetrics
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResultRegistry 
+import androidx.activity.result.ActivityResultCallback
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.result.ActivityResultLauncher
+import com.facebook.proguard.annotations.DoNotStrip
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.Callback
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.WritableArray
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.bridge.WritableNativeArray
+import com.facebook.react.bridge.WritableNativeMap
+import com.facebook.react.module.annotations.ReactModule
+import com.facebook.react.turbomodule.core.interfaces.BindingsInstallerHolder
+import com.facebook.react.turbomodule.core.interfaces.TurboModuleWithJSIBindings
+import java.util.UUID
+
+
+//https://stackoverflow.com/questions/64476827/how-to-resolve-the-error-lifecycleowners-must-call-register-before-they-are-sta
+public fun <I, O> ComponentActivity.registerActivityResultLauncher(
+    contract: ActivityResultContract<I, O>,
+    callback: ActivityResultCallback<O>
+): ActivityResultLauncher<I> {
+    val key = UUID.randomUUID().toString()
+    return activityResultRegistry.register(key, contract, callback)
+}
+
+@DoNotStrip
+@ReactModule(name = ImagePickerAndroid.NAME)
+public class ImagePickerAndroid(private val context: ReactApplicationContext) :
+    NativeImagePickerAndroidSpec(context) {
+
+  @DoNotStrip
+  @Suppress("unused")
+  override fun getImageUrl(promise: Promise?) {
+    val activity = context.getCurrentActivity() as? ComponentActivity
+    if(context.hasCurrentActivity() && activity!=null){
+      val launcher  = activity.registerActivityResultLauncher(ActivityResultContracts.GetContent(), { uri: Uri? ->
+        if(uri != null){
+          promise?.resolve(uri.toString())
+        }else{
+          promise?.resolve(null)
+        }
+      })
+      launcher.launch("image/*")
+    }else{
+      promise?.reject("code1","Unable to obtain an image uri. No Current Activity.")
+    }
+  }
+
+  override fun getName(): String {
+    return NAME
+  }
+
+  public companion object {
+    public const val NAME: String = "ImagePickerAndroid"
+  }
+}
+

--- a/packages/react-native/src/private/specs_DEPRECATED/modules/NativeImagePickerAndroid.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/modules/NativeImagePickerAndroid.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';
+
+import * as TurboModuleRegistry from '../../../../Libraries/TurboModule/TurboModuleRegistry';
+
+export interface Spec extends TurboModule {
+  +getImageUrl: () => Promise<string | null>;
+}
+
+export default (TurboModuleRegistry.getEnforcing<Spec>(
+  'ImagePickerAndroid',
+): Spec);

--- a/packages/rn-tester/ImagePickerModule/ImagePickerAndroid.js
+++ b/packages/rn-tester/ImagePickerModule/ImagePickerAndroid.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
+
+import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';
+
+export interface Spec extends TurboModule {
+  getImageUrl: () => Promise<string | null>;
+}
+
+const NativeModule = TurboModuleRegistry.get<Spec>('ImagePickerAndroid');
+export function getImageUrl(): Promise<string | null> {
+  if (NativeModule != null) {
+    return NativeModule.getImageUrl();
+  } else {
+    return Promise.reject('NativeModule is null');
+  }
+}

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.kt
@@ -10,6 +10,7 @@ package com.facebook.react.uiapp
 import android.app.Application
 import com.facebook.fbreact.specs.SampleLegacyModule
 import com.facebook.fbreact.specs.SampleTurboModule
+import com.facebook.fbreact.specs.ImagePickerAndroid
 import com.facebook.react.BaseReactPackage
 import com.facebook.react.ReactApplication
 import com.facebook.react.ReactHost
@@ -63,6 +64,9 @@ internal class RNTesterApplication : Application(), ReactApplication {
                 if (SampleLegacyModule.NAME == name) {
                   return SampleLegacyModule(reactContext)
                 }
+                if (ImagePickerAndroid.NAME == name) {
+                  return ImagePickerAndroid(reactContext)
+                }
                 return null
               }
 
@@ -88,7 +92,15 @@ internal class RNTesterApplication : Application(), ReactApplication {
                                   canOverrideExistingModule = false,
                                   needsEagerInit = false,
                                   isCxxModule = false,
-                                  isTurboModule = false))
+                                  isTurboModule = false),
+                          ImagePickerAndroid.NAME to
+                              ReactModuleInfo(
+                                  ImagePickerAndroid.NAME,
+                                  "ImagePickerAndroid",
+                                  canOverrideExistingModule = false,
+                                  needsEagerInit = false,
+                                  isCxxModule = false,
+                                  isTurboModule = true))
                     } else {
                       emptyMap()
                     }

--- a/packages/rn-tester/js/examples/ContentURLAndroid/ContentURLAndroid.js
+++ b/packages/rn-tester/js/examples/ContentURLAndroid/ContentURLAndroid.js
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict-local
+ */
+
+'use strict';
+
+import RNTesterBlock from '../../components/RNTesterBlock';
+import RNTesterPage from '../../components/RNTesterPage';
+import RNTesterText from '../../components/RNTesterText';
+import React from 'react';
+import {
+  Platform,
+  StyleSheet,
+  ToastAndroid,
+  TouchableOpacity,
+  View,
+  Image,
+} from 'react-native';
+
+function blobToBase64(blob: Blob) {
+  return new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      var result = reader.result;
+      if (typeof result === 'string') {
+        resolve(result);
+      } else {
+        reject('error: incompatible types');
+      }
+    };
+    reader.readAsDataURL(blob);
+  });
+}
+
+const ImagePicker = require('../../../ImagePickerModule/ImagePickerAndroid');
+
+const ContentSelector = (): React.Node => {
+  const [base64Image, setBase64Image] = React.useState('');
+  const imageSelector = React.useCallback(async () => {
+    try {
+      const uri = await ImagePicker.getImageUrl();
+      if (uri !== null) {
+        const response = await fetch(uri);
+        const blob = await response.blob();
+        setBase64Image(await blobToBase64(blob));
+      }
+    } catch (e) {
+      ToastAndroid.show('' + e, ToastAndroid.LONG);
+    }
+  }, []);
+
+  return (
+    <>
+      <TouchableOpacity onPress={imageSelector}>
+        <View style={[styles.button, styles.buttonIntent]}>
+          <RNTesterText>Select Image</RNTesterText>
+        </View>
+      </TouchableOpacity>
+      {base64Image !== '' && (
+        <Image style={styles.image} source={{uri: base64Image}} />
+      )}
+    </>
+  );
+};
+
+class ContentURLAndroidExample extends React.Component<{}, {}> {
+  render(): React.Node {
+    return (
+      <RNTesterPage title={'fetch content:// scheme urls on Android as a Blob'}>
+        {Platform.OS === 'android' && (
+          <RNTesterBlock title="Content fetch">
+            <RNTesterText style={styles.textSeparator}>
+              Choose content to fetch.
+            </RNTesterText>
+            <ContentSelector />
+          </RNTesterBlock>
+        )}
+      </RNTesterPage>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  textSeparator: {
+    paddingBottom: 8,
+  },
+  button: {
+    padding: 10,
+    backgroundColor: '#3B5998',
+    marginBottom: 10,
+  },
+  buttonIntent: {
+    backgroundColor: '#009688',
+  },
+  image: {
+    width: '100%',
+    resizeMode: 'cover',
+    height: '300',
+  },
+});
+
+exports.title = 'ContentURLAndroid';
+exports.description = 'Android specific fetch content:// scheme urls as blob.';
+exports.examples = [
+  {
+    title: 'fetch content:// urls as blob',
+    render(): React.MixedElement {
+      return <ContentURLAndroidExample />;
+    },
+  },
+];

--- a/packages/rn-tester/js/utils/RNTesterList.android.js
+++ b/packages/rn-tester/js/utils/RNTesterList.android.js
@@ -188,6 +188,11 @@ const APIs: Array<RNTesterModuleInfo> = ([
     module: require('../examples/AppState/AppStateExample'),
   },
   {
+    key: 'ContentURLAndroid',
+    category: 'Android',
+    module: require('../examples/ContentURLAndroid/ContentURLAndroid'),
+  },
+  {
     key: 'URLExample',
     category: 'Basic',
     module: require('../examples/Urls/UrlExample'),


### PR DESCRIPTION
## Summary:

This PR fixes https://github.com/facebook/react-native/issues/48762
- fix creating Blobs from Android 'content://' scheme urls was failing on the js side due to [this check](https://github.com/JakeChampion/fetch/blob/ba5cf1ed2e02ebb96fa1e60b4fd2eb04071b60e4/fetch.js#L547)

## Changelog:
[ANDROID] [FIXED] - fix fetch of content scheme uris failing on Android.

## Test Plan:
Used the App here to test Android Blob creation. https://github.com/giantslogik/blob-large-file-fetch.

EDIT: Added tester to RNTester
