### PR TITLE
[RN][CI][Releases] Remove the v prefix from the version passed by GHA to the script

### DIFF
--- a/.github/workflow-scripts/publishTemplate.js
+++ b/.github/workflow-scripts/publishTemplate.js
@@ -68,6 +68,10 @@ module.exports.verifyPublishedTemplate = async (
   latest = false,
   retries = MAX_RETRIES,
 ) => {
+  if (version.startsWith('v')) {
+    version = version.slice(1);
+  }
+
   log(`🔍 Is ${TEMPLATE_NPM_PKG}@${version} on npm?`);
 
   let count = retries;


### PR DESCRIPTION
## Summary:
GHA passes the version to the script using the tag, therefore, the version we receive is something like `v0.X.Y`.

The script, instead, expect the version to be `0.X.Y`, with no leading `v`.

This change fixes the script removing the `v` if present. It also mimic a fix we already have on main.

An example of a failing job is [here](https://github.com/facebook/react-native/actions/runs/13944332034/job/39031068356)

## Changelog:
[Internal] - Fix release script by dropping the passed `v`.

## Test Plan:
Next release.