### PR TITLE
Scaffold NetworkReporter methods

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<cbe1d77424b561149b0bda39955dffac>>
+ * @generated SignedSource<<0d1442e18cb4deba17719c8b5462b82d>>
  */
 
 /**
@@ -81,7 +81,7 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
 
   override fun fuseboxEnabledRelease(): Boolean = false
 
-  override fun fuseboxNetworkInspectionEnabled(): Boolean = false
+  override fun fuseboxNetworkInspectionEnabled(): Boolean = true
 
   override fun lazyAnimationCallbacks(): Boolean = false
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/NetworkIOAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/NetworkIOAgent.cpp
@@ -284,6 +284,12 @@ bool NetworkIOAgent::handleRequest(
       frontendChannel_(cdp::jsonResult(req.id));
       return true;
     }
+
+    // @cdp Network.getResponseBody support is experimental.
+    if (req.method == "Network.getResponseBody") {
+      // TODO(T218468200)
+      return false;
+    }
   }
 
   return false;

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkReporter.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkReporter.cpp
@@ -9,6 +9,8 @@
 
 #include <glog/logging.h>
 
+#include <stdexcept>
+
 namespace facebook::react::jsinspector_modern {
 
 NetworkReporter& NetworkReporter::getInstance() {
@@ -17,25 +19,77 @@ NetworkReporter& NetworkReporter::getInstance() {
 }
 
 bool NetworkReporter::enableDebugging() {
-  std::lock_guard lock(mutex_);
-  if (enabled_) {
+  if (debuggingEnabled_.load(std::memory_order_acquire)) {
     return false;
   }
 
-  enabled_ = true;
+  debuggingEnabled_.store(true, std::memory_order_release);
   LOG(INFO) << "Network debugging enabled" << std::endl;
   return true;
 }
 
 bool NetworkReporter::disableDebugging() {
-  std::lock_guard lock(mutex_);
-  if (!enabled_) {
+  if (!debuggingEnabled_.load(std::memory_order_acquire)) {
     return false;
   }
 
-  enabled_ = false;
+  debuggingEnabled_.store(false, std::memory_order_release);
   LOG(INFO) << "Network debugging disabled" << std::endl;
   return true;
+}
+
+void NetworkReporter::reportRequestStart(const std::string& /*requestId*/) {
+  if (!debuggingEnabled_.load(std::memory_order_relaxed)) {
+    return;
+  }
+
+  // TODO(T216933356)
+  throw std::runtime_error("Not implemented");
+}
+
+void NetworkReporter::reportConnectionTiming(const std::string& /*requestId*/) {
+  if (!debuggingEnabled_.load(std::memory_order_relaxed)) {
+    return;
+  }
+
+  // TODO(T218236597)
+  throw std::runtime_error("Not implemented");
+}
+
+void NetworkReporter::reportRequestFailed(const std::string& /*requestId*/) {
+  if (!debuggingEnabled_.load(std::memory_order_relaxed)) {
+    return;
+  }
+
+  // TODO(T218236855)
+  throw std::runtime_error("Not implemented");
+}
+
+void NetworkReporter::reportResponseStart(const std::string& /*requestId*/) {
+  if (!debuggingEnabled_.load(std::memory_order_relaxed)) {
+    return;
+  }
+
+  // TODO(T216933356)
+  throw std::runtime_error("Not implemented");
+}
+
+void NetworkReporter::reportDataReceived(const std::string& /*requestId*/) {
+  if (!debuggingEnabled_.load(std::memory_order_relaxed)) {
+    return;
+  }
+
+  // TODO(T218236266)
+  throw std::runtime_error("Not implemented");
+}
+
+void NetworkReporter::reportResponseEnd(const std::string& /*requestId*/) {
+  if (!debuggingEnabled_.load(std::memory_order_relaxed)) {
+    return;
+  }
+
+  // TODO(T216933356)
+  throw std::runtime_error("Not implemented");
 }
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkReporter.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkReporter.h
@@ -7,7 +7,8 @@
 
 #pragma once
 
-#include <mutex>
+#include <atomic>
+#include <string>
 
 namespace facebook::react::jsinspector_modern {
 
@@ -23,7 +24,7 @@ class NetworkReporter {
    * Enable network tracking over CDP. Once enabled, network events will be
    * sent to the debugger client. Returns `false` if already enabled.
    *
-   * Corresponds to @cdp `Network.enable`.
+   * Corresponds to `Network.enable` in CDP.
    */
   bool enableDebugging();
 
@@ -31,9 +32,68 @@ class NetworkReporter {
    * Disable network tracking over CDP, preventing network events from being
    * sent to the debugger client. Returns `false` if not initially enabled.
    *
-   * Corresponds to @cdp `Network.disable`.
+   * Corresponds to `Network.disable` in CDP.
    */
   bool disableDebugging();
+
+  /**
+   * Report a network request that is about to be sent.
+   *
+   * - Corresponds to `Network.requestWillBeSent` in CDP.
+   * - Corresponds to `PerformanceResourceTiming.requestStart` (specifically,
+   *   marking when the native request was initiated).
+   *
+   * https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-requeststart
+   */
+  void reportRequestStart(const std::string& requestId);
+
+  /**
+   * Report detailed timing info, such as DNS lookup, when a request has
+   * started.
+   *
+   * - Corresponds to `Network.requestWillBeSentExtraInfo` in CDP.
+   * - Corresponds to `PerformanceResourceTiming.domainLookupStart`,
+   * `PerformanceResourceTiming.connectStart`.
+   *
+   * https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-connectstart
+   */
+  void reportConnectionTiming(const std::string& requestId);
+
+  /**
+   * Report when a network request has failed.
+   *
+   * Corresponds to `Network.loadingFailed` in CDP.
+   */
+  void reportRequestFailed(const std::string& requestId);
+
+  /**
+   * Report when HTTP response headers have been received, corresponding to
+   * when the first byte of the response is available.
+   *
+   * - Corresponds to `Network.responseReceived` in CDP.
+   * - Corresponds to `PerformanceResourceTiming.responseStart`.
+   *
+   * https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-responsestart
+   */
+  void reportResponseStart(const std::string& requestId);
+
+  /**
+   * Report when additional chunks of the response body have been received.
+   *
+   * Corresponds to `Network.dataReceived` in CDP.
+   */
+  void reportDataReceived(const std::string& requestId);
+
+  /**
+   * Report when a network request is complete and we are no longer receiving
+   * response data.
+   *
+   * - Corresponds to `Network.loadingFinished` in CDP.
+   * - Corresponds to `PerformanceResourceTiming.responseEnd`.
+   *
+   * https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-responseend
+   */
+  void reportResponseEnd(const std::string& requestId);
 
  private:
   NetworkReporter() = default;
@@ -41,8 +101,7 @@ class NetworkReporter {
   NetworkReporter& operator=(const NetworkReporter&) = delete;
   ~NetworkReporter() = default;
 
-  bool enabled_{false};
-  std::mutex mutex_;
+  std::atomic<bool> debuggingEnabled_{false};
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<140e6580100dab5806194e780610f122>>
+ * @generated SignedSource<<c8250a91144dfdce6bef3b1769d69dbe>>
  */
 
 /**
@@ -144,7 +144,7 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool fuseboxNetworkInspectionEnabled() override {
-    return false;
+    return true;
   }
 
   bool lazyAnimationCallbacks() override {

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -354,7 +354,7 @@ const definitions: FeatureFlagDefinitions = {
       ossReleaseStage: 'none',
     },
     fuseboxNetworkInspectionEnabled: {
-      defaultValue: false,
+      defaultValue: true,
       metadata: {
         dateAdded: '2024-01-31',
         description:

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<e76d584cb67e2feae209795beb2009d6>>
+ * @generated SignedSource<<27cb33482957fbf8bcb6ce930ca4e489>>
  * @flow strict
  */
 
@@ -279,7 +279,7 @@ export const fuseboxEnabledRelease: Getter<boolean> = createNativeFlagGetter('fu
 /**
  * Enable network inspection support in the React Native DevTools CDP backend. Requires `enableBridgelessArchitecture`. This flag is global and should not be changed across React Host lifetimes.
  */
-export const fuseboxNetworkInspectionEnabled: Getter<boolean> = createNativeFlagGetter('fuseboxNetworkInspectionEnabled', false);
+export const fuseboxNetworkInspectionEnabled: Getter<boolean> = createNativeFlagGetter('fuseboxNetworkInspectionEnabled', true);
 /**
  * Only enqueue Choreographer calls if there is an ongoing animation, instead of enqueueing every frame.
  */


### PR DESCRIPTION
Summary:
Outlines and stubs methods on the `NetworkReporter` class, and the `Network.getResponseBody` CDP request on `NetworkIOAgent`. Together, these form the APIs to implement for CDP network debugging.

Also updates internal mutex use to `std::atomic<bool>`.

Changelog: [Internal]

Differential Revision: D70708526


