### PR TITLE
[RN][iOS][CI] Bump cache keys for Xcode which was restoring an old Pods folder

### DIFF
--- a/.github/actions/setup-xcode-build-cache/action.yml
+++ b/.github/actions/setup-xcode-build-cache/action.yml
@@ -30,9 +30,9 @@ runs:
       uses: actions/cache@v4
       with:
         path: packages/rn-tester/Podfile.lock
-        key: v12-podfilelock-${{ github.job }}-${{ inputs.architecture }}-${{ inputs.jsengine }}-${{ inputs.flavor }}-${{ inputs.use-frameworks }}-${{ inputs.ruby-version }}-${{ hashfiles('packages/rn-tester/Podfile') }}-${{ inputs.hermes-version }}
+        key: v13-podfilelock-${{ github.job }}-${{ inputs.architecture }}-${{ inputs.jsengine }}-${{ inputs.flavor }}-${{ inputs.use-frameworks }}-${{ inputs.ruby-version }}-${{ hashfiles('packages/rn-tester/Podfile') }}-${{ inputs.hermes-version }}
     - name: Cache cocoapods
       uses: actions/cache@v4
       with:
         path: packages/rn-tester/Pods
-        key: v14-cocoapods-${{ github.job }}-${{ inputs.architecture }}-${{ inputs.jsengine }}-${{ inputs.flavor }}-${{ inputs.use-frameworks }}-${{ inputs.ruby-version }}-${{ hashfiles('packages/rn-tester/Podfile.lock') }}-${{ hashfiles('packages/rn-tester/Podfile') }}-${{ inputs.hermes-version}}
+        key: v15-cocoapods-${{ github.job }}-${{ inputs.architecture }}-${{ inputs.jsengine }}-${{ inputs.flavor }}-${{ inputs.use-frameworks }}-${{ inputs.ruby-version }}-${{ hashfiles('packages/rn-tester/Podfile.lock') }}-${{ hashfiles('packages/rn-tester/Podfile') }}-${{ inputs.hermes-version}}


### PR DESCRIPTION
## Summary:
Bump the xcode keys to make sure that we use the newly created artifacts

## Changelog:
[Internal] - bump keys to use the right artifacts

## Test Plan:
GHA - Verified that CI passes the critical point in https://github.com/facebook/react-native/actions/runs/13948665701/job/39044363180?pr=50134