### PR TITLE
Rename accessibilityElements to accessibilityOrder for iOS

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -391,9 +391,9 @@ const CGFloat BACKGROUND_COLOR_ZPOSITION = -1024.0f;
     }
   }
 
-  if (oldViewProps.accessibilityElements != newViewProps.accessibilityElements) {
+  if (oldViewProps.accessibilityOrder != newViewProps.accessibilityOrder) {
     _accessibleElementsNativeIds = [NSMutableArray new];
-    for (const std::string &childId : newViewProps.accessibilityElements) {
+    for (const std::string &childId : newViewProps.accessibilityOrder) {
       [_accessibleElementsNativeIds addObject:RCTNSStringFromString(childId)];
     }
   }

--- a/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.cpp
@@ -46,14 +46,14 @@ AccessibilityProps::AccessibilityProps(
                     "accessibilityLabel",
                     sourceProps.accessibilityLabel,
                     "")),
-      accessibilityElements(
+      accessibilityOrder(
           ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
-              ? sourceProps.accessibilityElements
+              ? sourceProps.accessibilityOrder
               : convertRawProp(
                     context,
                     rawProps,
-                    "accessibilityElements",
-                    sourceProps.accessibilityElements,
+                    "accessibilityOrder",
+                    sourceProps.accessibilityOrder,
                     {})),
       accessibilityLabelledBy(
           ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
@@ -255,7 +255,7 @@ void AccessibilityProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(accessible);
     RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityState);
     RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityLabel);
-    RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityElements);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityOrder);
     RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityLabelledBy);
     RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityHint);
     RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityLanguage);

--- a/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.h
@@ -34,7 +34,7 @@ class AccessibilityProps {
   bool accessible{false};
   std::optional<AccessibilityState> accessibilityState{std::nullopt};
   std::string accessibilityLabel{""};
-  std::vector<std::string> accessibilityElements{};
+  std::vector<std::string> accessibilityOrder{};
   AccessibilityLabelledBy accessibilityLabelledBy{};
   AccessibilityLiveRegion accessibilityLiveRegion{
       AccessibilityLiveRegion::None};

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.cpp
@@ -63,7 +63,7 @@ void ViewShadowNode::initialize() noexcept {
       viewProps.mixBlendMode != BlendMode::Normal ||
       viewProps.isolation == Isolation::Isolate ||
       HostPlatformViewTraitsInitializer::formsStackingContext(viewProps) ||
-      !viewProps.accessibilityElements.empty();
+      !viewProps.accessibilityOrder.empty();
 
   bool formsView = formsStackingContext ||
       isColorMeaningful(viewProps.backgroundColor) || hasBorder() ||


### PR DESCRIPTION
Summary:
We settled on a different name here so gotta change some code with the old name. This is not exposed yet so this change is chill

Changelog: [Internal]

Differential Revision: D71471884


