### PR TITLE
Add SyncAccessibilityInfo TM, SyncAccessibilityManager TM and useIsScreenReaderEnabled hook

### DIFF
--- a/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
+++ b/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
@@ -11,6 +11,8 @@
 import type {HostInstance} from '../../../src/private/types/HostInstance';
 import type {EventSubscription} from '../../vendor/emitter/EventEmitter';
 
+import NativeAccessibilityInfoSyncAndroid from '../../../src/private/accessibility/NativeAccessibilityInfoSync';
+import NativeAccessibilityManagerSyncIOS from '../../../src/private/accessibility/NativeAccessibilityManagerSync';
 import RCTDeviceEventEmitter from '../../EventEmitter/RCTDeviceEventEmitter';
 import {sendAccessibilityEvent} from '../../ReactNative/RendererProxy';
 import Platform from '../../Utilities/Platform';
@@ -296,12 +298,16 @@ const AccessibilityInfo = {
   },
 
   /**
-   * Query whether a screen reader is currently enabled.
+   * Cross-platform asynchronous API to query whether a screen reader is currently enabled.
    *
    * Returns a promise which resolves to a boolean.
    * The result is `true` when a screen reader is enabled and `false` otherwise.
    *
    * See https://reactnative.dev/docs/accessibilityinfo#isScreenReaderEnabled
+   *
+   * @deprecated this API is asynchronous, please use a synchronous alternative like
+   * useIsScreenReaderEnabled hook for cross-platform and isTouchExplorationEnabled for
+   * Android or getCurrentVoiceOverState for iOS.
    */
   isScreenReaderEnabled(): Promise<boolean> {
     return new Promise((resolve, reject) => {
@@ -322,6 +328,42 @@ const AccessibilityInfo = {
         }
       }
     });
+  },
+
+  /**
+   * Android only. Synchronous. Query whether TalkBack is currently enabled.
+   *
+   * Returns a boolean boolean.
+   * The result is `true` when TalkBack is enabled and `false` otherwise.
+   *
+   * See https://reactnative.dev/docs/accessibilityinfo#isScreenReaderEnabled
+   */
+  isTouchExplorationEnabled(): boolean {
+    if (Platform.OS === 'android') {
+      return (
+        NativeAccessibilityInfoSyncAndroid?.isTouchExplorationEnabled() || false
+      );
+    } else {
+      return false;
+    }
+  },
+
+  /**
+   * iOS only. Synchronous. Query whether VoiceOver is currently enabled.
+   *
+   * Returns a boolean.
+   * The result is `true` when VoiceOver is enabled and `false` otherwise.
+   *
+   * See https://reactnative.dev/docs/accessibilityinfo#isScreenReaderEnabled
+   */
+  getCurrentVoiceOverState(): boolean {
+    if (Platform.OS === 'android') {
+      return false;
+    } else {
+      return (
+        NativeAccessibilityManagerSyncIOS?.getCurrentVoiceOverState() || false
+      );
+    }
   },
 
   /**

--- a/packages/react-native/Libraries/Utilities/Accessibility.d.ts
+++ b/packages/react-native/Libraries/Utilities/Accessibility.d.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+export function experimental_useIsScreenReaderEnabled(): boolean;

--- a/packages/react-native/Libraries/Utilities/useIsScreenReaderEnabled.js
+++ b/packages/react-native/Libraries/Utilities/useIsScreenReaderEnabled.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import AccessibilityInfo from '../Components/AccessibilityInfo/AccessibilityInfo';
+import Platform from './Platform';
+import {useEffect, useState} from 'react';
+
+function getCurrentVoiceAssistantState(): boolean {
+  if (Platform.OS === 'android') {
+    return AccessibilityInfo.isTouchExplorationEnabled();
+  } else if (Platform.OS === 'ios') {
+    return AccessibilityInfo.getCurrentVoiceOverState();
+  }
+  return false;
+}
+
+export default function useIsScreenReaderEnabled(): boolean {
+  const [isScreenReaderEnabled, setIsScreenReaderEnabled] = useState(
+    getCurrentVoiceAssistantState(),
+  );
+
+  useEffect(() => {
+    const currentStatus = getCurrentVoiceAssistantState();
+
+    // Update state if current status differs from stored state
+    if (currentStatus !== isScreenReaderEnabled) {
+      setIsScreenReaderEnabled(currentStatus);
+    }
+
+    const subscription = AccessibilityInfo.addEventListener(
+      'screenReaderChanged',
+      setIsScreenReaderEnabled,
+    );
+
+    return () => subscription.remove();
+  }, [isScreenReaderEnabled]);
+
+  return isScreenReaderEnabled;
+}

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -1398,6 +1398,8 @@ declare const AccessibilityInfo: {
   prefersCrossFadeTransitions(): Promise<boolean>,
   isReduceTransparencyEnabled(): Promise<boolean>,
   isScreenReaderEnabled(): Promise<boolean>,
+  isTouchExplorationEnabled(): boolean,
+  getCurrentVoiceOverState(): boolean,
   isAccessibilityServiceEnabled(): Promise<boolean>,
   addEventListener<K: $Keys<AccessibilityEventDefinitions>>(
     eventName: K,
@@ -9049,6 +9051,11 @@ exports[`public API should not change unintentionally Libraries/Utilities/useCol
 "
 `;
 
+exports[`public API should not change unintentionally Libraries/Utilities/useIsScreenReaderEnabled.js 1`] = `
+"declare export default function useIsScreenReaderEnabled(): boolean;
+"
+`;
+
 exports[`public API should not change unintentionally Libraries/Utilities/useMergeRefs.js 1`] = `
 "declare export default function useMergeRefs<Instance>(
   ...refs: $ReadOnlyArray<?React.RefSetter<Instance>>
@@ -9395,6 +9402,7 @@ export { unstable_batchedUpdates } from \\"./Libraries/ReactNative/RendererProxy
 export { default as useAnimatedValue } from \\"./Libraries/Animated/useAnimatedValue\\";
 export { default as useColorScheme } from \\"./Libraries/Utilities/useColorScheme\\";
 export { default as useWindowDimensions } from \\"./Libraries/Utilities/useWindowDimensions\\";
+export { default as experimental_useIsScreenReaderEnabled } from \\"./Libraries/Utilities/useIsScreenReaderEnabled\\";
 export { default as UTFSequence } from \\"./Libraries/UTFSequence\\";
 export { default as Vibration } from \\"./Libraries/Vibration/Vibration\\";
 "

--- a/packages/react-native/React/CoreModules/RCTAccessibilityManagerSync.h
+++ b/packages/react-native/React/CoreModules/RCTAccessibilityManagerSync.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import <React/RCTBridge.h>
+#import <React/RCTBridgeModule.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RCTAccessibilityManagerSync : NSObject <RCTBridgeModule>
+
+@property (nonatomic, assign) BOOL isVoiceOverEnabled;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native/React/CoreModules/RCTAccessibilityManagerSync.mm
+++ b/packages/react-native/React/CoreModules/RCTAccessibilityManagerSync.mm
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTAccessibilityManagerSync.h"
+
+#import <FBReactNativeSpec/FBReactNativeSpec.h>
+#import <React/RCTEventDispatcherProtocol.h>
+
+#import "CoreModulesPlugins.h"
+
+using namespace facebook::react;
+
+@interface RCTAccessibilityManagerSync () <NativeAccessibilityManagerSyncSpec>
+@end
+
+@implementation RCTAccessibilityManagerSync
+
+@synthesize moduleRegistry = _moduleRegistry;
+
+RCT_EXPORT_MODULE()
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(voiceVoiceOverStatusDidChange:)
+                                                 name:UIAccessibilityVoiceOverStatusDidChangeNotification
+                                               object:nil];
+
+    _isVoiceOverEnabled = UIAccessibilityIsVoiceOverRunning();
+    ;
+  }
+  return self;
+}
+
+- (void)voiceVoiceOverStatusDidChange:(__unused NSNotification *)notification
+{
+  NSNumber *isVoiceOverEnabled = UIAccessibilityIsVoiceOverRunning() ? @1 : @0;
+  [self _setIsVoiceOverEnabled:isVoiceOverEnabled];
+}
+
+- (void)_setIsVoiceOverEnabled:(BOOL)isVoiceOverEnabled
+{
+  if (_isVoiceOverEnabled != isVoiceOverEnabled) {
+    _isVoiceOverEnabled = isVoiceOverEnabled;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    [[_moduleRegistry moduleForName:"EventDispatcher"] sendDeviceEventWithName:@"screenReaderChanged"
+                                                                          body:@(_isVoiceOverEnabled)];
+#pragma clang diagnostic pop
+  }
+}
+
+RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSNumber *, getCurrentVoiceOverState)
+{
+  return _isVoiceOverEnabled ? @1 : @0;
+}
+
+- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:
+    (const facebook::react::ObjCTurboModule::InitParams &)params
+{
+  return std::make_shared<facebook::react::NativeAccessibilityManagerSyncSpecJSI>(params);
+}
+
+@end
+
+Class RCTAccessibilityManagerSyncCls(void)
+{
+  return RCTAccessibilityManagerSync.class;
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfosync/AccessibilityInfoModuleSync.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfosync/AccessibilityInfoModuleSync.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.modules.accessibilityinfosync
+
+import android.annotation.TargetApi
+import android.content.Context
+import android.os.Build
+import android.view.accessibility.AccessibilityManager
+import com.facebook.fbreact.specs.NativeAccessibilityInfoSyncSpec
+import com.facebook.react.bridge.LifecycleEventListener
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.module.annotations.ReactModule
+
+@ReactModule(name = NativeAccessibilityInfoSyncSpec.NAME)
+internal class AccessibilityInfoModuleSync(context: ReactApplicationContext) :
+    NativeAccessibilityInfoSyncSpec(context), LifecycleEventListener {
+  private inner class ReactTouchExplorationStateChangeListener :
+      AccessibilityManager.TouchExplorationStateChangeListener {
+    override fun onTouchExplorationStateChanged(enabled: Boolean) {
+      updateAndSendTouchExplorationChangeEvent(enabled)
+    }
+  }
+
+  // Android can listen for accessibility service enable with `accessibilityStateChange`, but
+  // `accessibilityState` conflicts with React Native props and confuses developers. Therefore, the
+  // name `accessibilityServiceChange` is used here instead.
+  @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+  private inner class ReactAccessibilityServiceChangeListener :
+      AccessibilityManager.AccessibilityStateChangeListener {
+    override fun onAccessibilityStateChanged(enabled: Boolean) {
+      updateAndSendAccessibilityServiceChangeEvent(enabled)
+    }
+  }
+
+  private fun updateAndSendAccessibilityServiceChangeEvent(enabled: Boolean) {
+    if (accessibilityServiceEnabled != enabled) {
+      accessibilityServiceEnabled = enabled
+      val reactApplicationContext = getReactApplicationContextIfActiveOrWarn()
+      if (reactApplicationContext != null) {
+        getReactApplicationContext()
+            .emitDeviceEvent(ACCESSIBILITY_SERVICE_EVENT_NAME, accessibilityServiceEnabled)
+      }
+    }
+  }
+
+  private fun updateAndSendTouchExplorationChangeEvent(enabled: Boolean) {
+    if (touchExplorationEnabled != enabled) {
+      touchExplorationEnabled = enabled
+      val reactApplicationContext = getReactApplicationContextIfActiveOrWarn()
+      if (reactApplicationContext != null) {
+        getReactApplicationContext()
+            .emitDeviceEvent(TOUCH_EXPLORATION_EVENT_NAME, touchExplorationEnabled)
+      }
+    }
+  }
+
+  private val accessibilityManager: AccessibilityManager
+  private val touchExplorationStateChangeListener: ReactTouchExplorationStateChangeListener =
+      ReactTouchExplorationStateChangeListener()
+  private val accessibilityServiceChangeListener: ReactAccessibilityServiceChangeListener =
+      ReactAccessibilityServiceChangeListener()
+
+  private var touchExplorationEnabled = false
+  private var accessibilityServiceEnabled = false
+
+  init {
+    val appContext = context.applicationContext
+    accessibilityManager =
+        appContext.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager
+    touchExplorationEnabled = accessibilityManager.isTouchExplorationEnabled
+  }
+
+  override fun isTouchExplorationEnabled(): Boolean {
+    return accessibilityManager.isTouchExplorationEnabled
+  }
+
+  @TargetApi(Build.VERSION_CODES.LOLLIPOP)
+  override fun onHostResume() {
+    accessibilityManager.addTouchExplorationStateChangeListener(touchExplorationStateChangeListener)
+    updateAndSendTouchExplorationChangeEvent(accessibilityManager.isTouchExplorationEnabled)
+  }
+
+  override fun onHostPause() {
+    accessibilityManager.removeTouchExplorationStateChangeListener(
+        touchExplorationStateChangeListener)
+    accessibilityManager.removeAccessibilityStateChangeListener(accessibilityServiceChangeListener)
+  }
+
+  override fun onHostDestroy(): Unit = Unit
+
+  override fun invalidate() {
+    getReactApplicationContext().removeLifecycleEventListener(this)
+    super.invalidate()
+  }
+
+  override fun initialize() {
+    getReactApplicationContext().addLifecycleEventListener(this)
+    updateAndSendTouchExplorationChangeEvent(accessibilityManager.isTouchExplorationEnabled)
+    updateAndSendAccessibilityServiceChangeEvent(accessibilityManager.isEnabled)
+  }
+
+  companion object {
+    const val NAME: String = NativeAccessibilityInfoSyncSpec.NAME
+    private const val TOUCH_EXPLORATION_EVENT_NAME = "touchExplorationDidChange"
+    private const val ACCESSIBILITY_SERVICE_EVENT_NAME = "accessibilityServiceDidChange"
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.kt
@@ -21,6 +21,7 @@ import com.facebook.react.module.model.ReactModuleInfo
 import com.facebook.react.module.model.ReactModuleInfo.Companion.classIsTurboModule
 import com.facebook.react.module.model.ReactModuleInfoProvider
 import com.facebook.react.modules.accessibilityinfo.AccessibilityInfoModule
+import com.facebook.react.modules.accessibilityinfosync.AccessibilityInfoModuleSync
 import com.facebook.react.modules.appearance.AppearanceModule
 import com.facebook.react.modules.appstate.AppStateModule
 import com.facebook.react.modules.blob.BlobModule
@@ -71,6 +72,7 @@ import com.facebook.react.views.view.ReactViewManager
     nativeModules =
         [
             AccessibilityInfoModule::class,
+            AccessibilityInfoModuleSync::class,
             AppearanceModule::class,
             AppStateModule::class,
             BlobModule::class,
@@ -103,6 +105,7 @@ constructor(private val config: MainPackageConfig? = null) :
   override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule? =
       when (name) {
         AccessibilityInfoModule.NAME -> AccessibilityInfoModule(reactContext)
+        AccessibilityInfoModuleSync.NAME -> AccessibilityInfoModuleSync(reactContext)
         AppearanceModule.NAME -> AppearanceModule(reactContext)
         AppStateModule.NAME -> AppStateModule(reactContext)
         BlobModule.NAME -> BlobModule(reactContext)
@@ -229,6 +232,7 @@ constructor(private val config: MainPackageConfig? = null) :
     val moduleList: Array<Class<*>> =
         arrayOf(
             AccessibilityInfoModule::class.java,
+            AccessibilityInfoModuleSync::class.java,
             AppearanceModule::class.java,
             AppStateModule::class.java,
             BlobModule::class.java,

--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -307,6 +307,9 @@ module.exports = {
   get useWindowDimensions() {
     return require('./Libraries/Utilities/useWindowDimensions').default;
   },
+  get experimental_useIsScreenReaderEnabled() {
+    return require('./Libraries/Utilities/useIsScreenReaderEnabled').default;
+  },
   get UTFSequence() {
     return require('./Libraries/UTFSequence').default;
   },

--- a/packages/react-native/index.js.flow
+++ b/packages/react-native/index.js.flow
@@ -114,6 +114,7 @@ export {unstable_batchedUpdates} from './Libraries/ReactNative/RendererProxy';
 export {default as useAnimatedValue} from './Libraries/Animated/useAnimatedValue';
 export {default as useColorScheme} from './Libraries/Utilities/useColorScheme';
 export {default as useWindowDimensions} from './Libraries/Utilities/useWindowDimensions';
+export {default as experimental_useIsScreenReaderEnabled} from './Libraries/Utilities/useIsScreenReaderEnabled';
 export {default as UTFSequence} from './Libraries/UTFSequence';
 export {default as Vibration} from './Libraries/Vibration/Vibration';
 

--- a/packages/react-native/src/private/accessibility/NativeAccessibilityInfoSync.js
+++ b/packages/react-native/src/private/accessibility/NativeAccessibilityInfoSync.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ */
+
+import type {TurboModule} from '../../../Libraries/TurboModule/RCTExport';
+
+import * as TurboModuleRegistry from '../../../Libraries/TurboModule/TurboModuleRegistry';
+
+export interface Spec extends TurboModule {
+  +isTouchExplorationEnabled: () => boolean;
+}
+
+export default (TurboModuleRegistry.get<Spec>('AccessibilityInfoSync'): ?Spec);

--- a/packages/react-native/src/private/accessibility/NativeAccessibilityManagerSync.js
+++ b/packages/react-native/src/private/accessibility/NativeAccessibilityManagerSync.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ */
+
+import type {TurboModule} from '../../../Libraries/TurboModule/RCTExport';
+
+import * as TurboModuleRegistry from '../../../Libraries/TurboModule/TurboModuleRegistry';
+
+export interface Spec extends TurboModule {
+  +getCurrentVoiceOverState: () => boolean;
+}
+
+export default (TurboModuleRegistry.get<Spec>(
+  'AccessibilityManagerSync',
+): ?Spec);

--- a/packages/react-native/types/__typetests__/index.tsx
+++ b/packages/react-native/types/__typetests__/index.tsx
@@ -122,6 +122,7 @@ import {
   LayoutAnimation,
   processColor,
   experimental_LayoutConformance as LayoutConformance,
+  experimental_useIsScreenReaderEnabled as useIsScreenReaderEnabled,
 } from 'react-native';
 
 declare module 'react-native' {
@@ -743,6 +744,7 @@ const AppStateExample = () => {
     appState.current,
   );
   const appStateIsAvailable = AppState.isAvailable;
+  const isScreenReaderEnabled = useIsScreenReaderEnabled();
 
   React.useEffect(() => {
     const subscription = AppState.addEventListener('change', nextAppState => {
@@ -767,6 +769,7 @@ const AppStateExample = () => {
     <View style={styles.container}>
       <Text>Current state is: {appStateVisible}</Text>
       <Text>Available: {appStateIsAvailable}</Text>
+      <Text>Is screen reader enabled: {isScreenReaderEnabled}</Text>
     </View>
   );
 };

--- a/packages/react-native/types/index.d.ts
+++ b/packages/react-native/types/index.d.ts
@@ -147,6 +147,7 @@ export * from '../src/private/devmenu/DevMenu';
 export * from '../Libraries/Utilities/DevSettings';
 export * from '../Libraries/Utilities/Dimensions';
 export * from '../Libraries/Utilities/PixelRatio';
+export * from '../Libraries/Utilities/Accessibility';
 export * from '../Libraries/Utilities/Platform';
 export * from '../Libraries/Vibration/Vibration';
 export * from '../Libraries/vendor/core/ErrorUtils';


### PR DESCRIPTION
Summary:
This diff implements two new Turbo Modules to enabled the synchronous query of Accessibility information from both Android and iOS.

As a first step this also implements a new hook `useIsScreenReaderEnabled` this would the the first hook in the series of accessibility hooks to enabled synchronous fetching of accessibility information from native.

These hooks will allow you to subscribe to the accessibility information triggering automatic re-renders with the new information if subscribed.

For example:
```
const isScreenReaderEnabled = useIsScreenReaderEnabled()
```
will subscribe to the state of the screen reader and update the value of it accordingly if the state changes at any point.

Also added a feature flag `enableAccessibilityHooks` to gate this feature during development

Differential Revision: D70917330
