### PR TITLE
Adding onPressMove to Pressable

### DIFF
--- a/packages/react-native/Libraries/Components/Pressable/Pressable.js
+++ b/packages/react-native/Libraries/Components/Pressable/Pressable.js
@@ -105,6 +105,10 @@ type PressableBaseProps = $ReadOnly<{
    * Called when a touch is engaged before `onPress`.
    */
   onPressIn?: ?(event: GestureResponderEvent) => mixed,
+  /**
+   * Called when the press location moves.
+   */
+  onPressMove?: ?(event: GestureResponderEvent) => mixed,
 
   /**
    * Called when a touch is released before `onPress`.
@@ -185,6 +189,7 @@ function Pressable(
     onLongPress,
     onPress,
     onPressIn,
+    onPressMove,
     onPressOut,
     pressRetentionOffset,
     style,
@@ -263,7 +268,12 @@ function Pressable(
           onPressIn(event);
         }
       },
-      onPressMove: android_rippleConfig?.onPressMove,
+      onPressMove(event: GestureResponderEvent): void {
+        android_rippleConfig?.onPressMove(event);
+        if (onPressMove != null) {
+          onPressMove(event);
+        }
+      },
       onPressOut(event: GestureResponderEvent): void {
         if (android_rippleConfig != null) {
           android_rippleConfig.onPressOut(event);
@@ -288,6 +298,7 @@ function Pressable(
       onLongPress,
       onPress,
       onPressIn,
+      onPressMove,
       onPressOut,
       pressRetentionOffset,
       setPressed,

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -1719,6 +1719,7 @@ type PressableBaseProps = $ReadOnly<{
   onLongPress?: ?(event: GestureResponderEvent) => mixed,
   onPress?: ?(event: GestureResponderEvent) => mixed,
   onPressIn?: ?(event: GestureResponderEvent) => mixed,
+  onPressMove?: ?(event: GestureResponderEvent) => mixed,
   onPressOut?: ?(event: GestureResponderEvent) => mixed,
   style?:
     | ViewStyleProp


### PR DESCRIPTION
Summary: adding this event to Pressable because it is going to be consumed after to track if pressable location is moved

Differential Revision: D71429258


