### PR TITLE
RN/Relay: Upgrade to `eslint-plugin-react-hooks@5.2.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "eslint-plugin-jsx-a11y": "^6.6.0",
     "eslint-plugin-lint": "^1.0.0",
     "eslint-plugin-react": "^7.30.1",
-    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-native": "^4.0.0",
     "eslint-plugin-redundant-undefined": "^0.4.0",
     "eslint-plugin-relay": "^1.8.3",

--- a/packages/eslint-config-react-native/package.json
+++ b/packages/eslint-config-react-native/package.json
@@ -30,7 +30,7 @@
     "eslint-plugin-ft-flow": "^2.0.1",
     "eslint-plugin-jest": "^27.9.0",
     "eslint-plugin-react": "^7.30.1",
-    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-native": "^4.0.0"
   },
   "peerDependencies": {

--- a/packages/react-native/types/__typetests__/index.tsx
+++ b/packages/react-native/types/__typetests__/index.tsx
@@ -429,8 +429,8 @@ class CustomView extends React.Component {
 class Welcome extends React.Component<
   ElementProps<View> & {color: string; bgColor?: null | undefined | string}
 > {
-  rootViewRef = React.useRef<View>(null);
-  customViewRef = React.useRef<CustomView>(null);
+  rootViewRef = React.createRef<View>();
+  customViewRef = React.createRef<CustomView>();
 
   testNativeMethods() {
     if (this.rootViewRef.current != null) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3943,10 +3943,10 @@ eslint-plugin-lint@^1.0.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-lint/-/eslint-plugin-lint-1.0.0.tgz#bfc98ad0d1b5ea437b0072ec735c459df4d084b5"
   integrity sha512-hYl6F/lYLjycZmHYnpTk3dlliNxjy9breG/9URhdQmPZibmENjM378EPKvSdIDBOV+Zw/Z0d3EaJhLTjcWTovA==
 
-eslint-plugin-react-hooks@^4.6.0:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz#c829eb06c0e6f484b3fbb85a97e57784f328c596"
-  integrity sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==
+eslint-plugin-react-hooks@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz#1be0080901e6ac31ce7971beed3d3ec0a423d9e3"
+  integrity sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==
 
 eslint-plugin-react-native-globals@^0.1.1:
   version "0.1.2"


### PR DESCRIPTION
Summary:
Upgrades React Native and Relay to `eslint-plugin-react-hooks` from v4.6.0 to v5.2.0. ([CHANGELOG](https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/CHANGELOG.md))

Changelog:
[General][Breaking] Updated `eslint-config-react-native` to depend on `eslint-plugin-react-hooks` v5.2.0 from v4.6.0. This includes a breaking change in which ESLint will no longer recognize component names that start with 1 or more underscores followed by a capital letter. (https://github.com/facebook/react/pull/25162)

Reviewed By: captbaritone

Differential Revision: D71483664


