### PR TITLE
fatalWithMessage() - added warning suppression: unused 'message' argument

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/debug/AssertFatal.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/debug/AssertFatal.cpp
@@ -19,6 +19,7 @@ namespace facebook::yoga {
 #if defined(__cpp_exceptions)
   throw std::logic_error(message);
 #else
+  static_cast<void>(message); // Unused
   std::terminate();
 #endif
 }


### PR DESCRIPTION
Summary:
## Changelog:

[Internal] - suppression: unused 'message' argument

X-link: https://github.com/facebook/yoga/pull/1803

Reviewed By: NickGerleman

Differential Revision: D71492528

Pulled By: lunaleaps


