### PR TITLE
Remove RCTUnsafeExecuteOnMainQueueSync from sample modules

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleLegacyModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleLegacyModule.mm
@@ -39,16 +39,11 @@ RCT_EXPORT_MODULE()
 
 - (NSDictionary *)getConstants
 {
-  __block NSDictionary *constants;
-  RCTUnsafeExecuteOnMainQueueSync(^{
-    constants = @{
-      @"const1" : @YES,
-      @"const2" : @(390),
-      @"const3" : @"something",
-    };
-  });
-
-  return constants;
+  return @{
+    @"const1" : @YES,
+    @"const2" : @(390),
+    @"const3" : @"something",
+  };
 }
 
 // TODO: Remove once fully migrated to TurboModule.

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleTurboModule.mm
@@ -9,16 +9,19 @@
 #import "RCTSampleTurboModulePlugin.h"
 
 #import <React/RCTAssert.h>
+#import <React/RCTInitializing.h>
 #import <React/RCTUtils.h>
 #import <ReactCommon/RCTTurboModuleWithJSIBindings.h>
 #import <UIKit/UIKit.h>
 
 using namespace facebook::react;
 
-@interface RCTSampleTurboModule () <RCTTurboModuleWithJSIBindings>
+@interface RCTSampleTurboModule () <RCTTurboModuleWithJSIBindings, RCTInitializing>
 @end
 
-@implementation RCTSampleTurboModule
+@implementation RCTSampleTurboModule {
+  NSDictionary *_constants;
+}
 
 // Backward-compatible export
 RCT_EXPORT_MODULE()
@@ -27,6 +30,18 @@ RCT_EXPORT_MODULE()
 + (BOOL)requiresMainQueueSetup
 {
   return YES;
+}
+
+- (void)initialize
+{
+  UIScreen *mainScreen = UIScreen.mainScreen;
+  CGSize screenSize = mainScreen.bounds.size;
+
+  _constants = @{
+    @"const1" : @YES,
+    @"const2" : @(screenSize.width),
+    @"const3" : @"something",
+  };
 }
 
 - (dispatch_queue_t)methodQueue
@@ -49,19 +64,7 @@ RCT_EXPORT_MODULE()
 
 - (NSDictionary *)getConstants
 {
-  __block NSDictionary *constants;
-  RCTUnsafeExecuteOnMainQueueSync(^{
-    UIScreen *mainScreen = UIScreen.mainScreen;
-    CGSize screenSize = mainScreen.bounds.size;
-
-    constants = @{
-      @"const1" : @YES,
-      @"const2" : @(screenSize.width),
-      @"const3" : @"something",
-    };
-  });
-
-  return constants;
+  return _constants;
 }
 
 // TODO: Remove once fully migrated to TurboModule.

--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -44,8 +44,15 @@
       "javaPackageName": "com.facebook.fbreact.specs"
     },
     "ios": {
-      "componentProvider": {
-        "RNTMyNativeView": "RNTMyNativeViewComponentView"
+      "modules": {
+        "SampleTurboModule": {
+          "unstableRequiresMainQueueSetup": true
+        }
+      },
+      "components": {
+        "RNTMyNativeView": {
+          "className": "RNTMyNativeViewComponentView"
+        }
       }
     }
   },


### PR DESCRIPTION
Summary:
Let's just remove RCTUnsafeExecuteOnMainQueueSync from the examples.

That way, people don't copy-paste it, thinking it's okay to use.

Changelog: [Internal]

Differential Revision: D71505823
