### PR TITLE
Deprecate UIManagerType.DEFAULT and introduce UIManagerType.LEGACY

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -5167,11 +5167,13 @@ public abstract interface annotation class com/facebook/react/uimanager/common/U
 	public static final field Companion Lcom/facebook/react/uimanager/common/UIManagerType$Companion;
 	public static final field DEFAULT I
 	public static final field FABRIC I
+	public static final field LEGACY I
 }
 
 public final class com/facebook/react/uimanager/common/UIManagerType$Companion {
 	public static final field DEFAULT I
 	public static final field FABRIC I
+	public static final field LEGACY I
 }
 
 public final class com/facebook/react/uimanager/common/ViewUtil {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/DebugCorePackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/DebugCorePackage.java
@@ -12,10 +12,10 @@ import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.ModuleSpec;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.UIManager;
 import com.facebook.react.module.annotations.ReactModuleList;
 import com.facebook.react.module.model.ReactModuleInfo;
 import com.facebook.react.module.model.ReactModuleInfoProvider;
-import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.ViewManager;
 import com.facebook.react.views.debuggingoverlay.DebuggingOverlayManager;
 import java.util.ArrayList;
@@ -54,7 +54,7 @@ public class DebugCorePackage extends BaseReactPackage implements ViewManagerOnD
   }
 
   /**
-   * @return a map of view managers that should be registered with {@link UIManagerModule}
+   * @return a map of view managers that should be registered with {@link UIManager}
    */
   private Map<String, ModuleSpec> getViewManagersMap() {
     if (mViewManagers == null) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackage.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackage.kt
@@ -9,9 +9,9 @@ package com.facebook.react
 
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.UIManager
 import com.facebook.react.common.annotations.DeprecatedInNewArchitecture
 import com.facebook.react.common.annotations.StableReactNativeAPI
-import com.facebook.react.uimanager.UIManagerModule
 import com.facebook.react.uimanager.ViewManager
 
 /**
@@ -37,7 +37,7 @@ public interface ReactPackage {
   @DeprecatedInNewArchitecture(message = "Migrate to BaseReactPackage and implement getModule")
   public fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule>
 
-  /** @return a list of view managers that should be registered with [UIManagerModule] */
+  /** @return a list of view managers that should be registered with [UIManager] */
   public fun createViewManagers(
       reactContext: ReactApplicationContext
   ): List<ViewManager<in Nothing, in Nothing>>

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -9,8 +9,8 @@ package com.facebook.react;
 
 import static com.facebook.infer.annotation.ThreadConfined.UI;
 import static com.facebook.react.uimanager.BlendModeHelper.needsIsolatedLayer;
-import static com.facebook.react.uimanager.common.UIManagerType.DEFAULT;
 import static com.facebook.react.uimanager.common.UIManagerType.FABRIC;
+import static com.facebook.react.uimanager.common.UIManagerType.LEGACY;
 import static com.facebook.systrace.Systrace.TRACE_TAG_REACT_JAVA_BRIDGE;
 
 import android.content.Context;
@@ -114,7 +114,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
   private int mLastHeight = 0;
   private int mLastOffsetX = Integer.MIN_VALUE;
   private int mLastOffsetY = Integer.MIN_VALUE;
-  private @UIManagerType int mUIManagerType = DEFAULT;
+  private @UIManagerType int mUIManagerType = LEGACY;
   private final AtomicInteger mState = new AtomicInteger(STATE_STOPPED);
 
   public ReactRootView(Context context) {
@@ -817,7 +817,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
   }
 
   public void setIsFabric(boolean isFabric) {
-    mUIManagerType = isFabric ? FABRIC : DEFAULT;
+    mUIManagerType = isFabric ? FABRIC : LEGACY;
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.java
@@ -232,7 +232,7 @@ public class NativeAnimatedModule extends NativeAnimatedModuleSpec
   private boolean mInitializedForFabric = false;
   private boolean mInitializedForNonFabric = false;
   private boolean mEnqueuedAnimationOnFrame = false;
-  private @UIManagerType int mUIManagerType = UIManagerType.DEFAULT;
+  private @UIManagerType int mUIManagerType = UIManagerType.LEGACY;
   private int mNumFabricAnimations = 0;
   private int mNumNonFabricAnimations = 0;
 
@@ -542,8 +542,8 @@ public class NativeAnimatedModule extends NativeAnimatedModuleSpec
       mUIManagerType = UIManagerType.FABRIC;
     } else if (mNumFabricAnimations == 0
         && mNumNonFabricAnimations > 0
-        && mUIManagerType != UIManagerType.DEFAULT) {
-      mUIManagerType = UIManagerType.DEFAULT;
+        && mUIManagerType != UIManagerType.LEGACY) {
+      mUIManagerType = UIManagerType.LEGACY;
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/ReactChoreographer.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/ReactChoreographer.kt
@@ -26,7 +26,7 @@ public class ReactChoreographer private constructor(choreographerProvider: Chore
   public enum class CallbackType(internal val order: Int) {
     /** For use by perf markers that need to happen immediately after draw */
     PERF_MARKERS(0),
-    /** For use by [com.facebook.react.uimanager.UIManagerModule] */
+    /** For use by [com.facebook.react.bridge.UIManager] */
     DISPATCH_UI(1),
     /** For use by [com.facebook.react.animated.NativeAnimatedModule] */
     NATIVE_ANIMATED_MODULE(2),

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/touch/JSResponderHandler.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/touch/JSResponderHandler.kt
@@ -12,7 +12,7 @@ import android.view.ViewGroup
 import android.view.ViewParent
 
 /**
- * This class coordinates JSResponder commands for [UIManagerModule]. It should be set as
+ * This class coordinates JSResponder commands for [UIManager]. It should be set as
  * OnInterceptTouchEventListener for all newly created native views that implements [ ] and thanks
  * to the information whether JSResponder is set and to which view it will correctly coordinate the
  * return values of [OnInterceptTouchEventListener] such that touch events will be dispatched to the

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerHelper.java
@@ -181,7 +181,7 @@ public class UIManagerHelper {
     int reactTag = view.getId();
 
     // In non-Fabric we don't have (or use) SurfaceId
-    if (getUIManagerType(reactTag) == UIManagerType.DEFAULT) {
+    if (getUIManagerType(reactTag) == UIManagerType.LEGACY) {
       return -1;
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
@@ -9,8 +9,8 @@ package com.facebook.react.uimanager;
 
 import static com.facebook.react.bridge.ReactMarkerConstants.CREATE_UI_MANAGER_MODULE_CONSTANTS_END;
 import static com.facebook.react.bridge.ReactMarkerConstants.CREATE_UI_MANAGER_MODULE_CONSTANTS_START;
-import static com.facebook.react.uimanager.common.UIManagerType.DEFAULT;
 import static com.facebook.react.uimanager.common.UIManagerType.FABRIC;
+import static com.facebook.react.uimanager.common.UIManagerType.LEGACY;
 
 import android.content.ComponentCallbacks2;
 import android.content.res.Configuration;
@@ -185,7 +185,7 @@ public class UIManagerModule extends ReactContextBaseJavaModule
     getReactApplicationContext().registerComponentCallbacks(mMemoryTrimCallback);
     getReactApplicationContext().registerComponentCallbacks(mViewManagerRegistry);
     mEventDispatcher.registerEventEmitter(
-        DEFAULT, getReactApplicationContext().getJSModule(RCTEventEmitter.class));
+        LEGACY, getReactApplicationContext().getJSModule(RCTEventEmitter.class));
   }
 
   @Override
@@ -851,7 +851,7 @@ public class UIManagerModule extends ReactContextBaseJavaModule
   @Override
   public void receiveEvent(
       int surfaceId, int reactTag, String eventName, @Nullable WritableMap event) {
-    assert ViewUtil.getUIManagerType(reactTag) == DEFAULT;
+    assert ViewUtil.getUIManagerType(reactTag) == LEGACY;
     getReactApplicationContext()
         .getJSModule(RCTEventEmitter.class)
         .receiveEvent(reactTag, eventName, event);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/common/UIManagerType.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/common/UIManagerType.kt
@@ -11,11 +11,15 @@ import androidx.annotation.IntDef
 import com.facebook.react.common.annotations.DeprecatedInNewArchitecture
 
 @Retention(AnnotationRetention.SOURCE)
-@IntDef(UIManagerType.DEFAULT, UIManagerType.FABRIC)
+@Suppress("DEPRECATION")
+@IntDef(UIManagerType.DEFAULT, UIManagerType.LEGACY, UIManagerType.FABRIC)
 @DeprecatedInNewArchitecture
 public annotation class UIManagerType {
   public companion object {
+    @Deprecated(
+        "UIManagerType.DEFAULT will be deleted in the next release of React Native. Use [LEGACY] instead.")
     public const val DEFAULT: Int = 1
+    public const val LEGACY: Int = 1
     public const val FABRIC: Int = 2
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/common/ViewUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/common/ViewUtil.kt
@@ -25,7 +25,7 @@ public object ViewUtil {
       if (viewTag % 2 == 0) {
         UIManagerType.FABRIC
       } else {
-        UIManagerType.DEFAULT
+        UIManagerType.LEGACY
       }
 
   /**
@@ -55,8 +55,8 @@ public object ViewUtil {
     // by RN and is essentially a random number.
     // At some point it would be great to pass the SurfaceContext here instead.
     @UIManagerType
-    val uiManagerType = if (surfaceId == -1) UIManagerType.DEFAULT else UIManagerType.FABRIC
-    if (uiManagerType == UIManagerType.DEFAULT && !isRootTag(viewTag)) {
+    val uiManagerType = if (surfaceId == -1) UIManagerType.LEGACY else UIManagerType.FABRIC
+    if (uiManagerType == UIManagerType.LEGACY && !isRootTag(viewTag)) {
       // TODO (T123064648): Some events for Fabric still didn't have the surfaceId set, so if it's
       // not a React RootView, double check if the tag belongs to Fabric.
       if (viewTag % 2 == 0) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/ReactEventEmitter.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/ReactEventEmitter.kt
@@ -32,12 +32,12 @@ internal class ReactEventEmitter(private val reactContext: ReactApplicationConte
   }
 
   fun register(@UIManagerType uiManagerType: Int, eventEmitter: RCTEventEmitter?) {
-    check(uiManagerType == UIManagerType.DEFAULT)
+    check(uiManagerType == UIManagerType.LEGACY)
     defaultEventEmitter = eventEmitter
   }
 
   fun unregister(@UIManagerType uiManagerType: Int) {
-    if (uiManagerType == UIManagerType.DEFAULT) {
+    if (uiManagerType == UIManagerType.LEGACY) {
       defaultEventEmitter = null
     } else {
       fabricEventEmitter = null
@@ -73,7 +73,7 @@ internal class ReactEventEmitter(private val reactContext: ReactApplicationConte
 
     val reactTag = touches.getMap(0)?.getInt(TouchesHelper.TARGET_KEY) ?: 0
     @UIManagerType val uiManagerType = getUIManagerType(reactTag)
-    if (uiManagerType == UIManagerType.DEFAULT) {
+    if (uiManagerType == UIManagerType.LEGACY) {
       ensureDefaultEventEmitter()?.receiveTouches(eventName, touches, changedIndices)
     }
   }
@@ -83,7 +83,7 @@ internal class ReactEventEmitter(private val reactContext: ReactApplicationConte
     @UIManagerType val uiManagerType = getUIManagerType(event.viewTag, event.surfaceId)
     if (uiManagerType == UIManagerType.FABRIC) {
       fabricEventEmitter?.let { TouchesHelper.sendTouchEvent(it, event) }
-    } else if (uiManagerType == UIManagerType.DEFAULT) {
+    } else if (uiManagerType == UIManagerType.LEGACY) {
       ensureDefaultEventEmitter()?.let { TouchesHelper.sendTouchesLegacy(it, event) }
     }
   }
@@ -119,7 +119,7 @@ internal class ReactEventEmitter(private val reactContext: ReactApplicationConte
     if (uiManagerType == UIManagerType.FABRIC) {
       fabricEventEmitter?.receiveEvent(
           surfaceId, targetTag, eventName, canCoalesceEvent, customCoalesceKey, params, category)
-    } else if (uiManagerType == UIManagerType.DEFAULT) {
+    } else if (uiManagerType == UIManagerType.LEGACY) {
       ensureDefaultEventEmitter()?.receiveEvent(targetTag, eventName, params)
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
@@ -312,7 +312,7 @@ public object ReactScrollViewHelper {
       FLog.i(
           TAG, "updateFabricScrollState[%d] scrollX %d scrollY %d", scrollView.id, scrollX, scrollY)
     }
-    if (ViewUtil.getUIManagerType(scrollView.id) == UIManagerType.DEFAULT) {
+    if (ViewUtil.getUIManagerType(scrollView.id) == UIManagerType.LEGACY) {
       return
     }
     // NOTE: if the state wrapper is null, we shouldn't even update

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -34,16 +34,18 @@ import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.UIManager;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.common.ReactConstants;
+import com.facebook.react.common.build.ReactBuildConfig;
 import com.facebook.react.internal.SystraceSection;
 import com.facebook.react.uimanager.BackgroundStyleApplicator;
 import com.facebook.react.uimanager.LengthPercentage;
 import com.facebook.react.uimanager.LengthPercentageType;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ReactCompoundView;
-import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.uimanager.UIManagerHelper;
 import com.facebook.react.uimanager.ViewDefaults;
 import com.facebook.react.uimanager.common.UIManagerType;
 import com.facebook.react.uimanager.common.ViewUtil;
@@ -195,7 +197,8 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
     // TODO T62882314: Delete this method when Fabric is fully released in OSS
     int reactTag = getId();
     if (!(getText() instanceof Spanned)
-        || ViewUtil.getUIManagerType(reactTag) == UIManagerType.FABRIC) {
+        || ViewUtil.getUIManagerType(reactTag) == UIManagerType.FABRIC
+        || ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE) {
       /**
        * In general, {@link #setText} is called via {@link ReactTextViewManager#updateExtraData}
        * before we are laid out. This ordering is a requirement because we utilize the data from
@@ -213,8 +216,8 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
     }
 
     ReactContext reactContext = getReactContext();
-    UIManagerModule uiManager =
-        Assertions.assertNotNull(reactContext.getNativeModule(UIManagerModule.class));
+    UIManager uiManager =
+        Assertions.assertNotNull(UIManagerHelper.getUIManager(reactContext, UIManagerType.DEFAULT));
 
     Spanned text = (Spanned) getText();
     Layout layout = getLayout();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -217,7 +217,7 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
 
     ReactContext reactContext = getReactContext();
     UIManager uiManager =
-        Assertions.assertNotNull(UIManagerHelper.getUIManager(reactContext, UIManagerType.DEFAULT));
+        Assertions.assertNotNull(UIManagerHelper.getUIManager(reactContext, UIManagerType.LEGACY));
 
     Spanned text = (Spanned) getText();
     Layout layout = getLayout();


### PR DESCRIPTION
Summary:
UIManagerType.DEFAULT is becoming confusings As we are expanding the usage of the New architecture everywhere.

That's why I'm depreacting this constant and introducing UIManagerType.LEGACY.

changelog: [Android][Deprecated] Deprecate UIManagerType.DEFAULT, replaced by UIManagerType.LEGACY

Reviewed By: alanleedev

Differential Revision: D70738948
