### PR TITLE
Compile-out UIManagerModule from FpsDebugFrameCallback

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -4805,6 +4805,8 @@ public abstract interface class com/facebook/react/uimanager/UIManagerModule$Cus
 
 public class com/facebook/react/uimanager/UIManagerModuleConstantsHelper {
 	public fun <init> ()V
+	public static fun createConstants (Ljava/util/List;Ljava/util/Map;Ljava/util/Map;)Ljava/util/Map;
+	public static fun createConstantsForViewManager (Lcom/facebook/react/uimanager/ViewManager;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)Ljava/util/Map;
 	public static fun getDefaultExportableEventTypes ()Ljava/util/Map;
 }
 

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -5167,11 +5167,13 @@ public abstract interface annotation class com/facebook/react/uimanager/common/U
 	public static final field Companion Lcom/facebook/react/uimanager/common/UIManagerType$Companion;
 	public static final field DEFAULT I
 	public static final field FABRIC I
+	public static final field LEGACY I
 }
 
 public final class com/facebook/react/uimanager/common/UIManagerType$Companion {
 	public static final field DEFAULT I
 	public static final field FABRIC I
+	public static final field LEGACY I
 }
 
 public final class com/facebook/react/uimanager/common/ViewUtil {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/DebugCorePackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/DebugCorePackage.java
@@ -12,10 +12,10 @@ import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.ModuleSpec;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.UIManager;
 import com.facebook.react.module.annotations.ReactModuleList;
 import com.facebook.react.module.model.ReactModuleInfo;
 import com.facebook.react.module.model.ReactModuleInfoProvider;
-import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.ViewManager;
 import com.facebook.react.views.debuggingoverlay.DebuggingOverlayManager;
 import java.util.ArrayList;
@@ -54,7 +54,7 @@ public class DebugCorePackage extends BaseReactPackage implements ViewManagerOnD
   }
 
   /**
-   * @return a map of view managers that should be registered with {@link UIManagerModule}
+   * @return a map of view managers that should be registered with {@link UIManager}
    */
   private Map<String, ModuleSpec> getViewManagersMap() {
     if (mViewManagers == null) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackage.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackage.kt
@@ -9,9 +9,9 @@ package com.facebook.react
 
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.UIManager
 import com.facebook.react.common.annotations.DeprecatedInNewArchitecture
 import com.facebook.react.common.annotations.StableReactNativeAPI
-import com.facebook.react.uimanager.UIManagerModule
 import com.facebook.react.uimanager.ViewManager
 
 /**
@@ -37,7 +37,7 @@ public interface ReactPackage {
   @DeprecatedInNewArchitecture(message = "Migrate to BaseReactPackage and implement getModule")
   public fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule>
 
-  /** @return a list of view managers that should be registered with [UIManagerModule] */
+  /** @return a list of view managers that should be registered with [UIManager] */
   public fun createViewManagers(
       reactContext: ReactApplicationContext
   ): List<ViewManager<in Nothing, in Nothing>>

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -9,8 +9,8 @@ package com.facebook.react;
 
 import static com.facebook.infer.annotation.ThreadConfined.UI;
 import static com.facebook.react.uimanager.BlendModeHelper.needsIsolatedLayer;
-import static com.facebook.react.uimanager.common.UIManagerType.DEFAULT;
 import static com.facebook.react.uimanager.common.UIManagerType.FABRIC;
+import static com.facebook.react.uimanager.common.UIManagerType.LEGACY;
 import static com.facebook.systrace.Systrace.TRACE_TAG_REACT_JAVA_BRIDGE;
 
 import android.content.Context;
@@ -114,7 +114,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
   private int mLastHeight = 0;
   private int mLastOffsetX = Integer.MIN_VALUE;
   private int mLastOffsetY = Integer.MIN_VALUE;
-  private @UIManagerType int mUIManagerType = DEFAULT;
+  private @UIManagerType int mUIManagerType = LEGACY;
   private final AtomicInteger mState = new AtomicInteger(STATE_STOPPED);
 
   public ReactRootView(Context context) {
@@ -817,7 +817,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
   }
 
   public void setIsFabric(boolean isFabric) {
-    mUIManagerType = isFabric ? FABRIC : DEFAULT;
+    mUIManagerType = isFabric ? FABRIC : LEGACY;
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.java
@@ -27,6 +27,7 @@ import com.facebook.react.bridge.UIManagerListener;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.common.annotations.VisibleForTesting;
+import com.facebook.react.common.build.ReactBuildConfig;
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.modules.core.ReactChoreographer;
@@ -387,9 +388,13 @@ public class NativeAnimatedModule extends NativeAnimatedModuleSpec
     if (mOperations.isEmpty() && mPreOperations.isEmpty()) {
       return;
     }
-    if (mUIManagerType == UIManagerType.FABRIC) {
+    if (mUIManagerType == UIManagerType.FABRIC
+        || ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE) {
       return;
     }
+    // The following code ONLY executes for non-fabric
+    // When ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE is true, the folowing code
+    // might be stripped out.
 
     final long frameNo = mCurrentBatchNumber++;
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.java
@@ -232,7 +232,7 @@ public class NativeAnimatedModule extends NativeAnimatedModuleSpec
   private boolean mInitializedForFabric = false;
   private boolean mInitializedForNonFabric = false;
   private boolean mEnqueuedAnimationOnFrame = false;
-  private @UIManagerType int mUIManagerType = UIManagerType.DEFAULT;
+  private @UIManagerType int mUIManagerType = UIManagerType.LEGACY;
   private int mNumFabricAnimations = 0;
   private int mNumNonFabricAnimations = 0;
 
@@ -542,8 +542,8 @@ public class NativeAnimatedModule extends NativeAnimatedModuleSpec
       mUIManagerType = UIManagerType.FABRIC;
     } else if (mNumFabricAnimations == 0
         && mNumNonFabricAnimations > 0
-        && mUIManagerType != UIManagerType.DEFAULT) {
-      mUIManagerType = UIManagerType.DEFAULT;
+        && mUIManagerType != UIManagerType.LEGACY) {
+      mUIManagerType = UIManagerType.LEGACY;
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeModuleRegistry.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeModuleRegistry.java
@@ -8,6 +8,8 @@
 package com.facebook.react.bridge;
 
 import com.facebook.infer.annotation.Assertions;
+import com.facebook.react.common.annotations.internal.LegacyArchitectureLogLevel;
+import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.systrace.Systrace;
 import java.util.ArrayList;
@@ -113,6 +115,8 @@ public class NativeModuleRegistry {
     // short-circuit
     // the search, and simply call OnBatchComplete on the UI Manager.
     // With Fabric, UIManager would no longer be a NativeModule, so this call would simply go away
+    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+        "NativeModuleRegistry.onBatchComplete()", LegacyArchitectureLogLevel.ERROR);
     ModuleHolder moduleHolder = mModules.get("UIManager");
     if (moduleHolder != null && moduleHolder.hasInstance()) {
       ((OnBatchCompleteListener) moduleHolder.getModule()).onBatchComplete();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/ReactChoreographer.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/ReactChoreographer.kt
@@ -26,7 +26,7 @@ public class ReactChoreographer private constructor(choreographerProvider: Chore
   public enum class CallbackType(internal val order: Int) {
     /** For use by perf markers that need to happen immediately after draw */
     PERF_MARKERS(0),
-    /** For use by [com.facebook.react.uimanager.UIManagerModule] */
+    /** For use by [com.facebook.react.bridge.UIManager] */
     DISPATCH_UI(1),
     /** For use by [com.facebook.react.animated.NativeAnimatedModule] */
     NATIVE_ANIMATED_MODULE(2),

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/DidJSUpdateUiDuringFrameDetector.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/DidJSUpdateUiDuringFrameDetector.kt
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 @file:Suppress(
     "DEPRECATION") // Suppressing deprecation of NotThreadSafeViewHierarchyUpdateDebugListener
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/FpsDebugFrameCallback.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/FpsDebugFrameCallback.kt
@@ -11,6 +11,7 @@ import android.view.Choreographer
 import com.facebook.infer.annotation.Assertions
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.UiThreadUtil
+import com.facebook.react.common.build.ReactBuildConfig
 import com.facebook.react.uimanager.UIManagerModule
 import java.util.TreeMap
 
@@ -37,8 +38,6 @@ public class FpsDebugFrameCallback(private val reactContext: ReactContext) :
   )
 
   private var choreographer: Choreographer? = null
-  private val uiManagerModule: UIManagerModule? =
-      reactContext.getNativeModule(UIManagerModule::class.java)
   private val didJSUpdateUiDuringFrameDetector: DidJSUpdateUiDuringFrameDetector =
       DidJSUpdateUiDuringFrameDetector()
   private var firstFrameTime: Long = -1
@@ -88,10 +87,13 @@ public class FpsDebugFrameCallback(private val reactContext: ReactContext) :
     // T172641976: re-think if we need to implement addBridgeIdleDebugListener and
     // removeBridgeIdleDebugListener for Bridgeless
     @Suppress("DEPRECATION")
-    if (!reactContext.isBridgeless) {
-      reactContext.catalystInstance.addBridgeIdleDebugListener(didJSUpdateUiDuringFrameDetector)
+    if (!ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE) {
+      val uiManagerModule = reactContext.getNativeModule(UIManagerModule::class.java)
+      if (!reactContext.isBridgeless) {
+        reactContext.catalystInstance.addBridgeIdleDebugListener(didJSUpdateUiDuringFrameDetector)
+      }
+      uiManagerModule?.setViewHierarchyUpdateDebugListener(didJSUpdateUiDuringFrameDetector)
     }
-    uiManagerModule?.setViewHierarchyUpdateDebugListener(didJSUpdateUiDuringFrameDetector)
     this.targetFps = targetFps
     UiThreadUtil.runOnUiThread {
       choreographer = Choreographer.getInstance()
@@ -107,10 +109,14 @@ public class FpsDebugFrameCallback(private val reactContext: ReactContext) :
 
   public fun stop() {
     @Suppress("DEPRECATION")
-    if (!reactContext.isBridgeless) {
-      reactContext.catalystInstance.removeBridgeIdleDebugListener(didJSUpdateUiDuringFrameDetector)
+    if (!ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE) {
+      val uiManagerModule = reactContext.getNativeModule(UIManagerModule::class.java)
+      if (!reactContext.isBridgeless) {
+        reactContext.catalystInstance.removeBridgeIdleDebugListener(
+            didJSUpdateUiDuringFrameDetector)
+      }
+      uiManagerModule?.setViewHierarchyUpdateDebugListener(null)
     }
-    uiManagerModule?.setViewHierarchyUpdateDebugListener(null)
     UiThreadUtil.runOnUiThread {
       choreographer = Choreographer.getInstance()
       choreographer?.removeFrameCallback(this)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -699,7 +699,9 @@ public class ReactHostImpl implements ReactHost {
   /* package */
   @Nullable
   <T extends NativeModule> T getNativeModule(Class<T> nativeModuleInterface) {
-    if (nativeModuleInterface == UIManagerModule.class) {
+    if (!ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE
+        && nativeModuleInterface == UIManagerModule.class) {
+
       ReactSoftExceptionLogger.logSoftExceptionVerbose(
           TAG,
           new ReactNoCrashBridgeNotAllowedSoftException(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/touch/JSResponderHandler.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/touch/JSResponderHandler.kt
@@ -12,7 +12,7 @@ import android.view.ViewGroup
 import android.view.ViewParent
 
 /**
- * This class coordinates JSResponder commands for [UIManagerModule]. It should be set as
+ * This class coordinates JSResponder commands for [UIManager]. It should be set as
  * OnInterceptTouchEventListener for all newly created native views that implements [ ] and thanks
  * to the information whether JSResponder is set and to which view it will correctly coordinate the
  * return values of [OnInterceptTouchEventListener] such that touch events will be dispatched to the

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerHelper.java
@@ -22,6 +22,8 @@ import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactNoCrashSoftException;
 import com.facebook.react.bridge.ReactSoftExceptionLogger;
 import com.facebook.react.bridge.UIManager;
+import com.facebook.react.common.annotations.internal.LegacyArchitectureLogLevel;
+import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger;
 import com.facebook.react.uimanager.common.UIManagerType;
 import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.react.uimanager.events.EventDispatcherProvider;
@@ -69,6 +71,14 @@ public class UIManagerHelper {
       return uiManager;
     }
 
+    // The following code is compiled-out when `context.isBridgeless() == true &&
+    // ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE == true ` because:
+    // - BridgelessReactContext.isBridgeless() is set to true statically
+    // - BridgeReactContext is compiled-out when UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE == true
+    //
+    // To detect a potential regression we add the following assertion ERROR
+    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+        "UIManagerHelper.getUIManager(context, uiManagerType)", LegacyArchitectureLogLevel.ERROR);
     if (!context.hasCatalystInstance()) {
       ReactSoftExceptionLogger.logSoftException(
           TAG,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerHelper.java
@@ -181,7 +181,7 @@ public class UIManagerHelper {
     int reactTag = view.getId();
 
     // In non-Fabric we don't have (or use) SurfaceId
-    if (getUIManagerType(reactTag) == UIManagerType.DEFAULT) {
+    if (getUIManagerType(reactTag) == UIManagerType.LEGACY) {
       return -1;
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
@@ -9,8 +9,8 @@ package com.facebook.react.uimanager;
 
 import static com.facebook.react.bridge.ReactMarkerConstants.CREATE_UI_MANAGER_MODULE_CONSTANTS_END;
 import static com.facebook.react.bridge.ReactMarkerConstants.CREATE_UI_MANAGER_MODULE_CONSTANTS_START;
-import static com.facebook.react.uimanager.common.UIManagerType.DEFAULT;
 import static com.facebook.react.uimanager.common.UIManagerType.FABRIC;
+import static com.facebook.react.uimanager.common.UIManagerType.LEGACY;
 
 import android.content.ComponentCallbacks2;
 import android.content.res.Configuration;
@@ -185,7 +185,7 @@ public class UIManagerModule extends ReactContextBaseJavaModule
     getReactApplicationContext().registerComponentCallbacks(mMemoryTrimCallback);
     getReactApplicationContext().registerComponentCallbacks(mViewManagerRegistry);
     mEventDispatcher.registerEventEmitter(
-        DEFAULT, getReactApplicationContext().getJSModule(RCTEventEmitter.class));
+        LEGACY, getReactApplicationContext().getJSModule(RCTEventEmitter.class));
   }
 
   @Override
@@ -851,7 +851,7 @@ public class UIManagerModule extends ReactContextBaseJavaModule
   @Override
   public void receiveEvent(
       int surfaceId, int reactTag, String eventName, @Nullable WritableMap event) {
-    assert ViewUtil.getUIManagerType(reactTag) == DEFAULT;
+    assert ViewUtil.getUIManagerType(reactTag) == LEGACY;
     getReactApplicationContext()
         .getJSModule(RCTEventEmitter.class)
         .receiveEvent(reactTag, eventName, event);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelper.java
@@ -86,7 +86,9 @@ public class UIManagerModuleConstantsHelper {
    * into the map of {@link UIManagerModule} base constants that is stored in {@link
    * UIManagerModuleConstants}. TODO(6845124): Create a test for this
    */
-  /* package */ static Map<String, Object> createConstants(
+  // NOTE: When converted to Kotlin this method should be `internal` due to
+  // visibility restriction for `ReactInstance`
+  public static Map<String, Object> createConstants(
       List<ViewManager> viewManagers,
       @Nullable Map<String, Object> allBubblingEventTypes,
       @Nullable Map<String, Object> allDirectEventTypes) {
@@ -124,7 +126,9 @@ public class UIManagerModuleConstantsHelper {
     return constants;
   }
 
-  /* package */ static Map<String, Object> createConstantsForViewManager(
+  // NOTE: When converted to Kotlin this method should be `internal` due to
+  // visibility restriction for `ReactInstance`
+  public static Map<String, Object> createConstantsForViewManager(
       ViewManager viewManager,
       @Nullable Map defaultBubblingEvents,
       @Nullable Map defaultDirectEvents,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/common/UIManagerType.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/common/UIManagerType.kt
@@ -11,11 +11,15 @@ import androidx.annotation.IntDef
 import com.facebook.react.common.annotations.DeprecatedInNewArchitecture
 
 @Retention(AnnotationRetention.SOURCE)
-@IntDef(UIManagerType.DEFAULT, UIManagerType.FABRIC)
+@Suppress("DEPRECATION")
+@IntDef(UIManagerType.DEFAULT, UIManagerType.LEGACY, UIManagerType.FABRIC)
 @DeprecatedInNewArchitecture
 public annotation class UIManagerType {
   public companion object {
+    @Deprecated(
+        "UIManagerType.DEFAULT will be deleted in the next release of React Native. Use [LEGACY] instead.")
     public const val DEFAULT: Int = 1
+    public const val LEGACY: Int = 1
     public const val FABRIC: Int = 2
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/common/ViewUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/common/ViewUtil.kt
@@ -25,7 +25,7 @@ public object ViewUtil {
       if (viewTag % 2 == 0) {
         UIManagerType.FABRIC
       } else {
-        UIManagerType.DEFAULT
+        UIManagerType.LEGACY
       }
 
   /**
@@ -55,8 +55,8 @@ public object ViewUtil {
     // by RN and is essentially a random number.
     // At some point it would be great to pass the SurfaceContext here instead.
     @UIManagerType
-    val uiManagerType = if (surfaceId == -1) UIManagerType.DEFAULT else UIManagerType.FABRIC
-    if (uiManagerType == UIManagerType.DEFAULT && !isRootTag(viewTag)) {
+    val uiManagerType = if (surfaceId == -1) UIManagerType.LEGACY else UIManagerType.FABRIC
+    if (uiManagerType == UIManagerType.LEGACY && !isRootTag(viewTag)) {
       // TODO (T123064648): Some events for Fabric still didn't have the surfaceId set, so if it's
       // not a React RootView, double check if the tag belongs to Fabric.
       if (viewTag % 2 == 0) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/ReactEventEmitter.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/ReactEventEmitter.kt
@@ -32,12 +32,12 @@ internal class ReactEventEmitter(private val reactContext: ReactApplicationConte
   }
 
   fun register(@UIManagerType uiManagerType: Int, eventEmitter: RCTEventEmitter?) {
-    check(uiManagerType == UIManagerType.DEFAULT)
+    check(uiManagerType == UIManagerType.LEGACY)
     defaultEventEmitter = eventEmitter
   }
 
   fun unregister(@UIManagerType uiManagerType: Int) {
-    if (uiManagerType == UIManagerType.DEFAULT) {
+    if (uiManagerType == UIManagerType.LEGACY) {
       defaultEventEmitter = null
     } else {
       fabricEventEmitter = null
@@ -73,7 +73,7 @@ internal class ReactEventEmitter(private val reactContext: ReactApplicationConte
 
     val reactTag = touches.getMap(0)?.getInt(TouchesHelper.TARGET_KEY) ?: 0
     @UIManagerType val uiManagerType = getUIManagerType(reactTag)
-    if (uiManagerType == UIManagerType.DEFAULT) {
+    if (uiManagerType == UIManagerType.LEGACY) {
       ensureDefaultEventEmitter()?.receiveTouches(eventName, touches, changedIndices)
     }
   }
@@ -83,7 +83,7 @@ internal class ReactEventEmitter(private val reactContext: ReactApplicationConte
     @UIManagerType val uiManagerType = getUIManagerType(event.viewTag, event.surfaceId)
     if (uiManagerType == UIManagerType.FABRIC) {
       fabricEventEmitter?.let { TouchesHelper.sendTouchEvent(it, event) }
-    } else if (uiManagerType == UIManagerType.DEFAULT) {
+    } else if (uiManagerType == UIManagerType.LEGACY) {
       ensureDefaultEventEmitter()?.let { TouchesHelper.sendTouchesLegacy(it, event) }
     }
   }
@@ -119,7 +119,7 @@ internal class ReactEventEmitter(private val reactContext: ReactApplicationConte
     if (uiManagerType == UIManagerType.FABRIC) {
       fabricEventEmitter?.receiveEvent(
           surfaceId, targetTag, eventName, canCoalesceEvent, customCoalesceKey, params, category)
-    } else if (uiManagerType == UIManagerType.DEFAULT) {
+    } else if (uiManagerType == UIManagerType.LEGACY) {
       ensureDefaultEventEmitter()?.receiveEvent(targetTag, eventName, params)
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/safeareaview/ReactSafeAreaView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/safeareaview/ReactSafeAreaView.kt
@@ -15,6 +15,7 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsCompat.CONSUMED
 import com.facebook.react.bridge.GuardedRunnable
 import com.facebook.react.bridge.WritableNativeMap
+import com.facebook.react.common.build.ReactBuildConfig
 import com.facebook.react.uimanager.PixelUtil.pxToDp
 import com.facebook.react.uimanager.StateWrapper
 import com.facebook.react.uimanager.ThemedReactContext
@@ -40,25 +41,26 @@ internal class ReactSafeAreaView(val reactContext: ThemedReactContext) : ViewGro
 
   @UiThread
   private fun updateState(insets: Insets) {
-    stateWrapper?.let { stateWrapper ->
-      // fabric
+    val sw = stateWrapper
+    if (sw != null) {
       WritableNativeMap().apply {
         putDouble("left", insets.left.toFloat().pxToDp().toDouble())
         putDouble("top", insets.top.toFloat().pxToDp().toDouble())
         putDouble("bottom", insets.bottom.toFloat().pxToDp().toDouble())
         putDouble("right", insets.right.toFloat().pxToDp().toDouble())
 
-        stateWrapper.updateState(this)
+        sw.updateState(this)
       }
+    } else if (!ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE) {
+      // paper
+      reactContext.runOnNativeModulesQueueThread(
+          object : GuardedRunnable(reactContext) {
+            override fun runGuarded() {
+              this@ReactSafeAreaView.reactContext.reactApplicationContext
+                  .getNativeModule(UIManagerModule::class.java)
+                  ?.updateInsetsPadding(id, insets.top, insets.left, insets.bottom, insets.right)
+            }
+          })
     }
-        // paper
-        ?: reactContext.runOnNativeModulesQueueThread(
-            object : GuardedRunnable(reactContext) {
-              override fun runGuarded() {
-                this@ReactSafeAreaView.reactContext.reactApplicationContext
-                    .getNativeModule(UIManagerModule::class.java)
-                    ?.updateInsetsPadding(id, insets.top, insets.left, insets.bottom, insets.right)
-              }
-            })
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/MaintainVisibleScrollPositionHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/MaintainVisibleScrollPositionHelper.java
@@ -77,7 +77,7 @@ class MaintainVisibleScrollPositionHelper<ScrollViewT extends ViewGroup & HasSmo
       return;
     }
     mListening = true;
-    getUIManagerModule().addUIManagerEventListener(this);
+    getUIManager().addUIManagerEventListener(this);
   }
 
   /** Stop listening to view hierarchy updates. Should be called before this is destroyed. */
@@ -86,7 +86,7 @@ class MaintainVisibleScrollPositionHelper<ScrollViewT extends ViewGroup & HasSmo
       return;
     }
     mListening = false;
-    getUIManagerModule().removeUIManagerEventListener(this);
+    getUIManager().removeUIManagerEventListener(this);
   }
 
   /**
@@ -143,7 +143,7 @@ class MaintainVisibleScrollPositionHelper<ScrollViewT extends ViewGroup & HasSmo
     return (ReactViewGroup) mScrollView.getChildAt(0);
   }
 
-  private UIManager getUIManagerModule() {
+  private UIManager getUIManager() {
     return Assertions.assertNotNull(
         UIManagerHelper.getUIManager(
             (ReactContext) mScrollView.getContext(),

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
@@ -312,7 +312,7 @@ public object ReactScrollViewHelper {
       FLog.i(
           TAG, "updateFabricScrollState[%d] scrollX %d scrollY %d", scrollView.id, scrollX, scrollY)
     }
-    if (ViewUtil.getUIManagerType(scrollView.id) == UIManagerType.DEFAULT) {
+    if (ViewUtil.getUIManagerType(scrollView.id) == UIManagerType.LEGACY) {
       return
     }
     // NOTE: if the state wrapper is null, we shouldn't even update

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -34,16 +34,18 @@ import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.UIManager;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.common.ReactConstants;
+import com.facebook.react.common.build.ReactBuildConfig;
 import com.facebook.react.internal.SystraceSection;
 import com.facebook.react.uimanager.BackgroundStyleApplicator;
 import com.facebook.react.uimanager.LengthPercentage;
 import com.facebook.react.uimanager.LengthPercentageType;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ReactCompoundView;
-import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.uimanager.UIManagerHelper;
 import com.facebook.react.uimanager.ViewDefaults;
 import com.facebook.react.uimanager.common.UIManagerType;
 import com.facebook.react.uimanager.common.ViewUtil;
@@ -195,7 +197,8 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
     // TODO T62882314: Delete this method when Fabric is fully released in OSS
     int reactTag = getId();
     if (!(getText() instanceof Spanned)
-        || ViewUtil.getUIManagerType(reactTag) == UIManagerType.FABRIC) {
+        || ViewUtil.getUIManagerType(reactTag) == UIManagerType.FABRIC
+        || ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE) {
       /**
        * In general, {@link #setText} is called via {@link ReactTextViewManager#updateExtraData}
        * before we are laid out. This ordering is a requirement because we utilize the data from
@@ -213,8 +216,8 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
     }
 
     ReactContext reactContext = getReactContext();
-    UIManagerModule uiManager =
-        Assertions.assertNotNull(reactContext.getNativeModule(UIManagerModule.class));
+    UIManager uiManager =
+        Assertions.assertNotNull(UIManagerHelper.getUIManager(reactContext, UIManagerType.DEFAULT));
 
     Spanned text = (Spanned) getText();
     Layout layout = getLayout();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -217,7 +217,7 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
 
     ReactContext reactContext = getReactContext();
     UIManager uiManager =
-        Assertions.assertNotNull(UIManagerHelper.getUIManager(reactContext, UIManagerType.DEFAULT));
+        Assertions.assertNotNull(UIManagerHelper.getUIManager(reactContext, UIManagerType.LEGACY));
 
     Spanned text = (Spanned) getText();
     Layout layout = getLayout();


### PR DESCRIPTION
Summary:
Compile-out UIManagerModule from FpsDebugFrameCallback

The setViewHierarchyUpdateDebugListener does not exists on Bridgeless and NotThreadSafeViewHierarchyUpdateDebugListener is deprecated and marked for deletion on the new architecture.

The new architecture exposes a different API called ItemDispatchListener that's a sort of replacement for NotThreadSafeViewHierarchyUpdateDebugListener. Although it's not the same.

FpsView is broken in old/new arch and needs to be rebuild, I believe this behavior needs to be rethinked in the future. For now I'm excluding usages of NotThreadSafeViewHierarchyUpdateDebugListener and setViewHierarchyUpdateDebugListener for apps running on the new arch enabled by default.

changelog: [internal] internal

Reviewed By: rshest

Differential Revision: D71050642
