### PR TITLE
fix(ios): selection range not respected when changing text or selection when selection is forced

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -547,6 +547,10 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
   if (startPosition && endPosition) {
     UITextRange *range = [_backedTextInputView textRangeFromPosition:startPosition toPosition:endPosition];
     [_backedTextInputView setSelectedTextRange:range notifyDelegate:NO];
+    // ensure we scroll to the selected position
+    NSInteger offsetEnd = [_backedTextInputView offsetFromPosition:_backedTextInputView.beginningOfDocument
+                                                                  toPosition:range.end];
+    [_backedTextInputView scrollRangeToVisible:NSMakeRange(offsetEnd, 0)];
   }
   _comingFromJS = NO;
 }
@@ -721,18 +725,17 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
   // Updating the UITextView attributedText, for example changing the lineHeight, the color or adding
   // a new paragraph with \n, causes the cursor to move to the end of the Text and scroll.
   // This is fixed by restoring the cursor position and scrolling to that position (iOS issue 652653).
-  if (selectedRange.empty) {
-    // Maintaining a cursor position relative to the end of the old text.
-    NSInteger offsetStart = [_backedTextInputView offsetFromPosition:_backedTextInputView.beginningOfDocument
-                                                          toPosition:selectedRange.start];
-    NSInteger offsetFromEnd = oldTextLength - offsetStart;
-    NSInteger newOffset = attributedString.string.length - offsetFromEnd;
-    UITextPosition *position = [_backedTextInputView positionFromPosition:_backedTextInputView.beginningOfDocument
-                                                                   offset:newOffset];
-    [_backedTextInputView setSelectedTextRange:[_backedTextInputView textRangeFromPosition:position toPosition:position]
-                                notifyDelegate:YES];
-    [_backedTextInputView scrollRangeToVisible:NSMakeRange(offsetStart, 0)];
-  }
+  // Maintaining a cursor position relative to the end of the old text.
+  NSInteger offsetStart = [_backedTextInputView offsetFromPosition:_backedTextInputView.beginningOfDocument
+                                                        toPosition:selectedRange.start];
+  NSInteger offsetFromEnd = oldTextLength - offsetStart;
+  NSInteger newOffset = attributedString.string.length - offsetFromEnd;
+  UITextPosition *position = [_backedTextInputView positionFromPosition:_backedTextInputView.beginningOfDocument
+                                                                  offset:newOffset];
+  [_backedTextInputView setSelectedTextRange:[_backedTextInputView textRangeFromPosition:position toPosition:position]
+                              notifyDelegate:YES];
+  [_backedTextInputView scrollRangeToVisible:NSMakeRange(offsetStart, 0)];
+
   [self _restoreTextSelection];
   [self _updateTypingAttributes];
   _lastStringStateWasUpdatedWith = attributedString;


### PR DESCRIPTION
## Summary:

fix: https://github.com/facebook/react-native/issues/50132
The goal of this PR is to ensure selected TextInput scrolls to the selected range when text or selection change.
The background of this feature check is to implement a rich text editor.

## Changelog:

[IOS][FIXED] - Selection range not respected when changing text or selection when selection is forced

## Test Plan:

Tested with the sample linked to this pull request.
As TextInput is a controlled component 

Here is a video of the sample with the patch: https://drive.google.com/file/d/1lS9_70quNqND_E8MjLFcRG6HoHcDkfmv/view?usp=drive_link

First TextInput shows the initial issue reported in the ticket.
Second TextInput shows the global behavior of the controlled component, the 2 buttons allows to force focus and the force text values

I have also backport this part on 0.77.1 and test it in my app, it works fine for me (let's see if I have QA feedback)