### PR TITLE
Remove all the data classes from React Native

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3859,16 +3859,10 @@ public final class com/facebook/react/uimanager/LengthPercentage {
 	public static final field Companion Lcom/facebook/react/uimanager/LengthPercentage$Companion;
 	public fun <init> ()V
 	public fun <init> (FLcom/facebook/react/uimanager/LengthPercentageType;)V
-	public final fun component2 ()Lcom/facebook/react/uimanager/LengthPercentageType;
-	public final fun copy (FLcom/facebook/react/uimanager/LengthPercentageType;)Lcom/facebook/react/uimanager/LengthPercentage;
-	public static synthetic fun copy$default (Lcom/facebook/react/uimanager/LengthPercentage;FLcom/facebook/react/uimanager/LengthPercentageType;ILjava/lang/Object;)Lcom/facebook/react/uimanager/LengthPercentage;
-	public fun equals (Ljava/lang/Object;)Z
 	public final fun getType ()Lcom/facebook/react/uimanager/LengthPercentageType;
-	public fun hashCode ()I
 	public final fun resolve (F)F
 	public final fun resolve (FF)Lcom/facebook/react/uimanager/style/CornerRadii;
 	public static final fun setFromDynamic (Lcom/facebook/react/bridge/Dynamic;)Lcom/facebook/react/uimanager/LengthPercentage;
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/facebook/react/uimanager/LengthPercentage$Companion {
@@ -5491,24 +5485,13 @@ public final class com/facebook/react/uimanager/style/BoxShadow {
 	public static final field Companion Lcom/facebook/react/uimanager/style/BoxShadow$Companion;
 	public fun <init> (FFLjava/lang/Integer;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;)V
 	public synthetic fun <init> (FFLjava/lang/Integer;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()F
-	public final fun component2 ()F
-	public final fun component3 ()Ljava/lang/Integer;
-	public final fun component4 ()Ljava/lang/Float;
-	public final fun component5 ()Ljava/lang/Float;
-	public final fun component6 ()Ljava/lang/Boolean;
-	public final fun copy (FFLjava/lang/Integer;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;)Lcom/facebook/react/uimanager/style/BoxShadow;
-	public static synthetic fun copy$default (Lcom/facebook/react/uimanager/style/BoxShadow;FFLjava/lang/Integer;Ljava/lang/Float;Ljava/lang/Float;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/facebook/react/uimanager/style/BoxShadow;
-	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBlurRadius ()Ljava/lang/Float;
 	public final fun getColor ()Ljava/lang/Integer;
 	public final fun getInset ()Ljava/lang/Boolean;
 	public final fun getOffsetX ()F
 	public final fun getOffsetY ()F
 	public final fun getSpreadDistance ()Ljava/lang/Float;
-	public fun hashCode ()I
 	public static final fun parse (Lcom/facebook/react/bridge/ReadableMap;Landroid/content/Context;)Lcom/facebook/react/uimanager/style/BoxShadow;
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/facebook/react/uimanager/style/BoxShadow$Companion {
@@ -5518,22 +5501,13 @@ public final class com/facebook/react/uimanager/style/BoxShadow$Companion {
 public final class com/facebook/react/uimanager/style/ComputedBorderRadius {
 	public fun <init> ()V
 	public fun <init> (Lcom/facebook/react/uimanager/style/CornerRadii;Lcom/facebook/react/uimanager/style/CornerRadii;Lcom/facebook/react/uimanager/style/CornerRadii;Lcom/facebook/react/uimanager/style/CornerRadii;)V
-	public final fun component1 ()Lcom/facebook/react/uimanager/style/CornerRadii;
-	public final fun component2 ()Lcom/facebook/react/uimanager/style/CornerRadii;
-	public final fun component3 ()Lcom/facebook/react/uimanager/style/CornerRadii;
-	public final fun component4 ()Lcom/facebook/react/uimanager/style/CornerRadii;
-	public final fun copy (Lcom/facebook/react/uimanager/style/CornerRadii;Lcom/facebook/react/uimanager/style/CornerRadii;Lcom/facebook/react/uimanager/style/CornerRadii;Lcom/facebook/react/uimanager/style/CornerRadii;)Lcom/facebook/react/uimanager/style/ComputedBorderRadius;
-	public static synthetic fun copy$default (Lcom/facebook/react/uimanager/style/ComputedBorderRadius;Lcom/facebook/react/uimanager/style/CornerRadii;Lcom/facebook/react/uimanager/style/CornerRadii;Lcom/facebook/react/uimanager/style/CornerRadii;Lcom/facebook/react/uimanager/style/CornerRadii;ILjava/lang/Object;)Lcom/facebook/react/uimanager/style/ComputedBorderRadius;
-	public fun equals (Ljava/lang/Object;)Z
 	public final fun get (Lcom/facebook/react/uimanager/style/ComputedBorderRadiusProp;)Lcom/facebook/react/uimanager/style/CornerRadii;
 	public final fun getBottomLeft ()Lcom/facebook/react/uimanager/style/CornerRadii;
 	public final fun getBottomRight ()Lcom/facebook/react/uimanager/style/CornerRadii;
 	public final fun getTopLeft ()Lcom/facebook/react/uimanager/style/CornerRadii;
 	public final fun getTopRight ()Lcom/facebook/react/uimanager/style/CornerRadii;
 	public final fun hasRoundedBorders ()Z
-	public fun hashCode ()I
 	public final fun isUniform ()Z
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class com/facebook/react/uimanager/style/ComputedBorderRadiusProp : java/lang/Enum {
@@ -5550,16 +5524,9 @@ public final class com/facebook/react/uimanager/style/CornerRadii {
 	public fun <init> ()V
 	public fun <init> (FF)V
 	public synthetic fun <init> (FFILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()F
-	public final fun component2 ()F
-	public final fun copy (FF)Lcom/facebook/react/uimanager/style/CornerRadii;
-	public static synthetic fun copy$default (Lcom/facebook/react/uimanager/style/CornerRadii;FFILjava/lang/Object;)Lcom/facebook/react/uimanager/style/CornerRadii;
-	public fun equals (Ljava/lang/Object;)Z
 	public final fun getHorizontal ()F
 	public final fun getVertical ()F
-	public fun hashCode ()I
 	public final fun toPixelFromDIP ()Lcom/facebook/react/uimanager/style/CornerRadii;
-	public fun toString ()Ljava/lang/String;
 }
 
 public abstract class com/facebook/react/uimanager/style/LogicalEdge : java/lang/Enum {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/SpringAnimation.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/SpringAnimation.kt
@@ -17,7 +17,7 @@ import kotlin.math.*
  */
 internal class SpringAnimation(config: ReadableMap) : AnimationDriver() {
   // storage for the current and prior physics state while integration is occurring
-  private data class PhysicsState(var position: Double = 0.0, var velocity: Double = 0.0)
+  private class PhysicsState(var position: Double = 0.0, var velocity: Double = 0.0)
 
   private var lastTime: Long = 0
   private var springStarted = false

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/SynchronousEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/SynchronousEvent.kt
@@ -7,12 +7,30 @@
 
 package com.facebook.react.fabric
 
+import java.util.Objects
+
 /**
  * Represents the identifying criteria of a synchronous event that was sent directly on the main
  * thread. Used to determine if subsequent events are duplicates and should not be emitted.
  */
-internal data class SynchronousEvent(
+internal class SynchronousEvent(
     val surfaceId: Int,
     val viewTag: Int,
     val eventName: String,
-)
+) {
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) {
+      return true
+    }
+    if (javaClass != other?.javaClass) {
+      return false
+    }
+    other as SynchronousEvent
+    return (surfaceId == other.surfaceId &&
+        viewTag == other.viewTag &&
+        eventName == other.eventName)
+  }
+
+  override fun hashCode(): Int = Objects.hash(surfaceId, viewTag, eventName)
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/interfaces/exceptionmanager/ReactJsExceptionHandler.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/interfaces/exceptionmanager/ReactJsExceptionHandler.kt
@@ -37,7 +37,7 @@ public fun interface ReactJsExceptionHandler {
   }
 
   @DoNotStripAny
-  private data class ProcessedErrorStackFrameImpl(
+  private class ProcessedErrorStackFrameImpl(
       override val file: String?,
       override val methodName: String,
       override val lineNumber: Int?,
@@ -45,7 +45,7 @@ public fun interface ReactJsExceptionHandler {
   ) : ProcessedError.StackFrame
 
   @DoNotStripAny
-  private data class ProcessedErrorImpl(
+  private class ProcessedErrorImpl(
       override val message: String,
       override val originalMessage: String?,
       override val name: String?,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LengthPercentage.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LengthPercentage.kt
@@ -19,7 +19,7 @@ public enum class LengthPercentageType {
   PERCENT,
 }
 
-public data class LengthPercentage(
+public class LengthPercentage(
     private val value: Float,
     public val type: LengthPercentageType,
 ) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/BorderColors.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/BorderColors.kt
@@ -13,7 +13,7 @@ import android.util.LayoutDirection
 import androidx.annotation.ColorInt
 import com.facebook.react.modules.i18nmanager.I18nUtil
 
-internal data class ColorEdges(
+internal class ColorEdges(
     @ColorInt val left: Int = Color.BLACK,
     @ColorInt val top: Int = Color.BLACK,
     @ColorInt val right: Int = Color.BLACK,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/BorderRadiusStyle.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/BorderRadiusStyle.kt
@@ -30,7 +30,7 @@ public enum class BorderRadiusProp {
 }
 
 /** Represents all logical properties and shorthands for border radius. */
-internal data class BorderRadiusStyle(
+internal class BorderRadiusStyle(
     var uniform: LengthPercentage? = null,
     var topLeft: LengthPercentage? = null,
     var topRight: LengthPercentage? = null,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/BoxShadow.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/BoxShadow.kt
@@ -15,13 +15,13 @@ import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.ReadableType
 
 /** Represents all logical properties and shorthands for border radius. */
-public data class BoxShadow(
-    val offsetX: Float,
-    val offsetY: Float,
-    @ColorInt val color: Int? = null,
-    val blurRadius: Float? = null,
-    val spreadDistance: Float? = null,
-    val inset: Boolean? = null,
+public class BoxShadow(
+    public val offsetX: Float,
+    public val offsetY: Float,
+    @ColorInt public val color: Int? = null,
+    public val blurRadius: Float? = null,
+    public val spreadDistance: Float? = null,
+    public val inset: Boolean? = null,
 ) {
   public companion object {
     @JvmStatic

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/ComputedBorderRadius.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/ComputedBorderRadius.kt
@@ -16,11 +16,11 @@ public enum class ComputedBorderRadiusProp {
 }
 
 /** Physical edge lengths (in DIPs) for a border-radius. */
-public data class ComputedBorderRadius(
-    val topLeft: CornerRadii,
-    val topRight: CornerRadii,
-    val bottomLeft: CornerRadii,
-    val bottomRight: CornerRadii,
+public class ComputedBorderRadius(
+    public val topLeft: CornerRadii,
+    public val topRight: CornerRadii,
+    public val bottomLeft: CornerRadii,
+    public val bottomRight: CornerRadii,
 ) {
   public fun hasRoundedBorders(): Boolean {
     return topLeft.horizontal > 0f ||

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/CornerRadii.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/CornerRadii.kt
@@ -7,13 +7,33 @@
 
 package com.facebook.react.uimanager.style
 
+import com.facebook.common.internal.Objects
 import com.facebook.react.uimanager.PixelUtil
 
-public data class CornerRadii(
-    val horizontal: Float = 0f,
-    val vertical: Float = 0f,
+public class CornerRadii(
+    public val horizontal: Float = 0f,
+    public val vertical: Float = 0f,
 ) {
   public fun toPixelFromDIP(): CornerRadii {
     return CornerRadii(PixelUtil.toPixelFromDIP(horizontal), PixelUtil.toPixelFromDIP(vertical))
   }
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) {
+      return true
+    }
+    if (javaClass != other?.javaClass) {
+      return false
+    }
+    other as CornerRadii
+    if (horizontal != other.horizontal) {
+      return false
+    }
+    if (vertical != other.vertical) {
+      return false
+    }
+    return true
+  }
+
+  override fun hashCode(): Int = Objects.hashCode(horizontal, vertical)
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/LinearGradient.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/LinearGradient.kt
@@ -24,9 +24,9 @@ import kotlin.math.ln
 import kotlin.math.sqrt
 import kotlin.math.tan
 
-private data class ColorStop(var color: Int? = null, val position: LengthPercentage? = null)
+private class ColorStop(var color: Int? = null, val position: LengthPercentage? = null)
 
-private data class ProcessedColorStop(var color: Int? = null, val position: Float? = null)
+private class ProcessedColorStop(var color: Int? = null, val position: Float? = null)
 
 internal class LinearGradient(
     directionMap: ReadableMap,
@@ -34,7 +34,7 @@ internal class LinearGradient(
     private val context: Context
 ) {
   private sealed class Direction {
-    data class Angle(val value: Double) : Direction()
+    class Angle(val value: Double) : Direction()
 
     enum class Keywords {
       TO_TOP_RIGHT,
@@ -43,7 +43,7 @@ internal class LinearGradient(
       TO_BOTTOM_LEFT
     }
 
-    data class Keyword(val value: Keywords) : Direction()
+    class Keyword(val value: Keywords) : Direction()
   }
 
   private val direction: Direction =

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactTextPaintHolderSpan.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactTextPaintHolderSpan.kt
@@ -10,4 +10,4 @@ package com.facebook.react.views.text.internal.span
 import android.text.TextPaint
 
 /** Associates a TextPaint instance with a Spannable for convenience */
-public data class ReactTextPaintHolderSpan(public val textPaint: TextPaint) : ReactSpan
+public class ReactTextPaintHolderSpan(public val textPaint: TextPaint) : ReactSpan


### PR DESCRIPTION
Summary:
Those classes are marked as data classes while they should not as we're not effectively using them as data classes. This just increases the apk size so we can clean this up.

Changelog:
[Android] [Changed] - Remove all the data classes from React Native

Differential Revision: D71554367


