### PR TITLE
Do not warn for JSC deprecation on react-native-github

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/TaskConfiguration.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/TaskConfiguration.kt
@@ -54,7 +54,9 @@ internal fun Project.configureReactTasks(variant: Variant, config: ReactExtensio
 
   configureNewArchPackagingOptions(project, config, variant)
   configureJsEnginePackagingOptions(config, variant, isHermesEnabledInThisVariant, useThirdPartyJSC)
-  if (!isHermesEnabledInThisVariant && !useThirdPartyJSC) {
+  if (!isHermesEnabledInThisVariant &&
+      !useThirdPartyJSC &&
+      rootProject.name != "react-native-github") {
     showJSCRemovalMessage(project)
   }
 


### PR DESCRIPTION
Summary:
This specific warning is only for React Native users.

We don't need this warning on console for RNtester so I'm excluding react-native-github
project from the list of project where this warning gets fired.

Changelog:
[Internal] [Changed] - Do not warn for JSC deprecation on react-native-github

Reviewed By: mdvacca

Differential Revision: D71556035


