### PR TITLE
Add warning when a module tries to invoke a method using the interop layer

### DIFF
--- a/packages/react-native/React/Base/RCTBridge.h
+++ b/packages/react-native/React/Base/RCTBridge.h
@@ -39,6 +39,11 @@ RCT_EXTERN_C_BEGIN
 NSString *RCTBridgeModuleNameForClass(Class bridgeModuleClass);
 
 /**
+ * This function returns the list of modules that have been registered using the Old Architecture mechanism.
+ */
+NSMutableArray<NSString *> *getModulesLoadedWithOldArch(void);
+
+/**
  * Experimental.
  * Check/set if JSI-bound NativeModule is enabled. By default it's off.
  */

--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -42,6 +42,97 @@ NSArray<Class> *RCTGetModuleClasses(void)
   return result;
 }
 
+NSSet<NSString *> *getCoreModuleClasses(void);
+NSSet<NSString *> *getCoreModuleClasses(void)
+{
+  static NSSet<NSString *> *coreModuleClasses = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    coreModuleClasses = [NSSet setWithArray:@[
+      @"RCTViewManager",
+      @"RCTActivityIndicatorViewManager",
+      @"RCTDebuggingOverlayManager",
+      @"RCTModalHostViewManager",
+      @"RCTModalManager",
+      @"RCTRefreshControlManager",
+      @"RCTSafeAreaViewManager",
+      @"RCTScrollContentViewManager",
+      @"RCTScrollViewManager",
+      @"RCTSwitchManager",
+      @"RCTUIManager",
+      @"RCTAccessibilityManager",
+      @"RCTActionSheetManager",
+      @"RCTAlertManager",
+      @"RCTAppearance",
+      @"RCTAppState",
+      @"RCTClipboard",
+      @"RCTDeviceInfo",
+      @"RCTDevLoadingView",
+      @"RCTDevMenu",
+      @"RCTDevSettings",
+      @"RCTDevToolsRuntimeSettingsModule",
+      @"RCTEventDispatcher",
+      @"RCTExceptionsManager",
+      @"RCTI18nManager",
+      @"RCTKeyboardObserver",
+      @"RCTLogBox",
+      @"RCTPerfMonitor",
+      @"RCTPlatform",
+      @"RCTRedBox",
+      @"RCTSourceCode",
+      @"RCTStatusBarManager",
+      @"RCTTiming",
+      @"RCTWebSocketModule",
+      @"RCTNativeAnimatedModule",
+      @"RCTNativeAnimatedTurboModule",
+      @"RCTBlobManager",
+      @"RCTFileReaderModule",
+      @"RCTBundleAssetImageLoader",
+      @"RCTGIFImageDecoder",
+      @"RCTImageEditingManager",
+      @"RCTImageLoader",
+      @"RCTImageStoreManager",
+      @"RCTImageViewManager",
+      @"RCTLocalAssetImageLoader",
+      @"RCTLinkingManager",
+      @"RCTDataRequestHandler",
+      @"RCTFileRequestHandler",
+      @"RCTHTTPRequestHandler",
+      @"RCTNetworking",
+      @"RCTPushNotificationManager",
+      @"RCTSettingsManager",
+      @"RCTBaseTextViewManager",
+      @"RCTBaseTextInputViewManager",
+      @"RCTInputAccessoryViewManager",
+      @"RCTMultilineTextInputViewManager",
+      @"RCTRawTextViewManager",
+      @"RCTSinglelineTextInputViewManager",
+      @"RCTTextViewManager",
+      @"RCTVirtualTextViewManager",
+      @"RCTVibration",
+    ]];
+  });
+
+  return coreModuleClasses;
+}
+
+static NSMutableArray<NSString *> *modulesLoadedWithOldArch;
+void addModuleLoadedWithOldArch(NSString *);
+void addModuleLoadedWithOldArch(NSString *moduleName)
+{
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    modulesLoadedWithOldArch = [NSMutableArray new];
+  });
+
+  [modulesLoadedWithOldArch addObject:moduleName];
+}
+
+NSMutableArray<NSString *> *getModulesLoadedWithOldArch(void)
+{
+  return modulesLoadedWithOldArch;
+}
+
 /**
  * Register the given class as a bridge module. All modules must be registered
  * prior to the first bridge initialization.
@@ -50,6 +141,9 @@ NSArray<Class> *RCTGetModuleClasses(void)
 void RCTRegisterModule(Class);
 void RCTRegisterModule(Class moduleClass)
 {
+  if (RCTIsNewArchEnabled() && ![getCoreModuleClasses() containsObject:[moduleClass description]]) {
+    addModuleLoadedWithOldArch([moduleClass description]);
+  }
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
     RCTModuleClasses = [NSMutableArray new];

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTInteropTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTInteropTurboModule.h
@@ -86,9 +86,12 @@ class JSI_EXPORT ObjCInteropTurboModule : public ObjCTurboModule {
   std::vector<MethodDescriptor> methodDescriptors_;
   NSDictionary<NSString *, NSArray<NSString *> *> *methodArgumentTypeNames_;
   jsi::Value constantsCache_;
+  std::unordered_set<std::string> warnedModuleInvocation_;
 
   const jsi::Value &getConstants(jsi::Runtime &runtime);
   bool exportsConstants();
+
+  void _logLegacyArchitectureWarning(NSString *moduleName, const std::string &methodName);
 };
 
 } // namespace react

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTInteropTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTInteropTurboModule.mm
@@ -268,12 +268,15 @@ jsi::Value ObjCInteropTurboModule::create(jsi::Runtime &runtime, const jsi::Prop
               if (!this->constantsCache_.isUndefined()) {
                 return jsi::Value(rt, this->constantsCache_);
               }
+              const std::string &methodName = this->methodDescriptors_[i].methodName;
+              NSString *moduleName = [[this->instance_ class] description];
+              this->_logLegacyArchitectureWarning(moduleName, methodName);
 
               // TODO: Dispatch getConstants to the main queue, if the module requires main queue setup
               jsi::Value ret = this->invokeObjCMethod(
                   rt,
                   this->methodDescriptors_[i].jsReturnKind,
-                  this->methodDescriptors_[i].methodName,
+                  methodName,
                   this->methodDescriptors_[i].selector,
                   args,
                   count);
@@ -305,10 +308,14 @@ jsi::Value ObjCInteropTurboModule::create(jsi::Runtime &runtime, const jsi::Prop
           propName,
           static_cast<unsigned int>(methodDescriptors_[i].jsArgCount),
           [this, i](jsi::Runtime &rt, const jsi::Value &thisVal, const jsi::Value *args, size_t count) {
+            const std::string &methodName = this->methodDescriptors_[i].methodName;
+            NSString *moduleName = [[this->instance_ class] description];
+            this->_logLegacyArchitectureWarning(moduleName, methodName);
+
             return this->invokeObjCMethod(
                 rt,
                 this->methodDescriptors_[i].jsReturnKind,
-                this->methodDescriptors_[i].methodName,
+                methodName,
                 this->methodDescriptors_[i].selector,
                 args,
                 count);
@@ -325,6 +332,22 @@ jsi::Value ObjCInteropTurboModule::create(jsi::Runtime &runtime, const jsi::Prop
   }
 
   return constant;
+}
+
+void ObjCInteropTurboModule::_logLegacyArchitectureWarning(NSString *moduleName, const std::string &methodName)
+{
+  std::string separator = std::string(".");
+
+  std::string moduleInvocation = [moduleName cStringUsingEncoding:NSUTF8StringEncoding] + separator + methodName;
+  if (warnedModuleInvocation_.find(moduleInvocation) == warnedModuleInvocation_.end()) {
+    RCTLogWarn(
+        @"The `%@` module is invoking the `%s` method using the TurboModule interop layer. This is part of the compatibility layer with the Legacy Architecture. If `%@` is a local module, please migrate it to be a Native Module as described at https://reactnative.dev/docs/next/turbo-native-modules-introduction. If `%@` is a third party dependency, please open an issue in the library repository.",
+        moduleName,
+        methodName.c_str(),
+        moduleName,
+        moduleName);
+    warnedModuleInvocation_.insert(moduleInvocation);
+  }
 }
 
 void ObjCInteropTurboModule::setInvocationArg(

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -512,7 +512,24 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
         // Set up hot module reloading in Dev only.
         [strongSelf->_performanceLogger markStopForTag:RCTPLScriptDownload];
         [devSettings setupHMRClientWithBundleURL:sourceURL];
+
+        [strongSelf _logOldArchitectureWarnings];
       }];
+}
+
+- (void)_logOldArchitectureWarnings
+{
+  NSMutableArray<NSString *> *modulesInOldArchMode = getModulesLoadedWithOldArch();
+  if (modulesInOldArchMode.count > 0) {
+    NSMutableString *moduleList = [NSMutableString new];
+    for (NSString *moduleName in modulesInOldArchMode) {
+      [moduleList appendFormat:@"- %@\n", moduleName];
+    }
+    RCTLogWarn(
+        @"The following modules have been registered using a RCT_EXPORT_MODULE. That's a Legacy Architecture API. Please migrate to the new approach as described in the https://reactnative.dev/docs/next/turbo-native-modules-introduction#register-the-native-module-in-your-app website or open a PR in the library repository:\n%@",
+        moduleList);
+    [modulesInOldArchMode removeAllObjects];
+  }
 }
 
 - (void)_loadScriptFromSource:(RCTSource *)source


### PR DESCRIPTION
Summary:
This change logs warning in the RN Dev Tools and in the Xcode console when a legacy module is used through the interop layer.

The `moduleName.methodName` warning is logged only once per usage not to flood the users with Warnings.

## Changelog:
[iOS][Added] - Add warnings when a legacy module is used in the Interop Layer.

Differential Revision: D71561348


