### PR TITLE
Fix issues in react-native ahead of making `React.ComponentType` an alias of `component(...Props)`

### DIFF
--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
@@ -829,11 +829,11 @@ class ScrollView extends React.Component<ScrollViewProps, State> {
   };
 
   getScrollableNode: () => ?number = () => {
-    return findNodeHandle(this.getNativeScrollRef());
+    return findNodeHandle<$FlowFixMe>(this.getNativeScrollRef());
   };
 
   getInnerViewNode: () => ?number = () => {
-    return findNodeHandle(this._innerView.nativeInstance);
+    return findNodeHandle<$FlowFixMe>(this._innerView.nativeInstance);
   };
 
   getInnerViewRef: () => InnerViewInstance | null = () => {
@@ -941,7 +941,7 @@ class ScrollView extends React.Component<ScrollViewProps, State> {
     if (typeof nodeHandle === 'number') {
       UIManager.measureLayout(
         nodeHandle,
-        nullthrows(findNodeHandle(this)),
+        nullthrows(findNodeHandle<$FlowFixMe>(this)),
         // $FlowFixMe[method-unbinding] added when improving typing for this parameters
         this._textInputFocusError,
         this._inputMeasureAndScrollToKeyboard,

--- a/packages/react-native/Libraries/Components/TextInput/TextInputState.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInputState.js
@@ -38,7 +38,7 @@ function currentlyFocusedField(): ?number {
     );
   }
 
-  return findNodeHandle(currentlyFocusedInputRef);
+  return findNodeHandle<$FlowFixMe>(currentlyFocusedInputRef);
 }
 
 function focusInput(textField: ?HostInstance): void {

--- a/packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js
@@ -253,7 +253,7 @@ class TouchableNativeFeedback extends React.Component<
 
   _dispatchPressedStateChange(pressed: boolean): void {
     if (Platform.OS === 'android') {
-      const hostComponentRef = findHostInstance_DEPRECATED(this);
+      const hostComponentRef = findHostInstance_DEPRECATED<$FlowFixMe>(this);
       if (hostComponentRef == null) {
         console.warn(
           'Touchable: Unable to find HostComponent instance. ' +
@@ -268,7 +268,7 @@ class TouchableNativeFeedback extends React.Component<
   _dispatchHotspotUpdate(event: GestureResponderEvent): void {
     if (Platform.OS === 'android') {
       const {locationX, locationY} = event.nativeEvent;
-      const hostComponentRef = findHostInstance_DEPRECATED(this);
+      const hostComponentRef = findHostInstance_DEPRECATED<$FlowFixMe>(this);
       if (hostComponentRef == null) {
         console.warn(
           'Touchable: Unable to find HostComponent instance. ' +

--- a/packages/react-native/Libraries/Debugging/DebuggingOverlayRegistry.js
+++ b/packages/react-native/Libraries/Debugging/DebuggingOverlayRegistry.js
@@ -226,7 +226,7 @@ class DebuggingOverlayRegistry {
         return;
       }
 
-      const instanceReactTag = findNodeHandle(node);
+      const instanceReactTag = findNodeHandle<$FlowFixMe>(node);
       if (instanceReactTag == null) {
         return;
       }

--- a/packages/rn-tester/NativeComponentExample/js/MyLegacyViewNativeComponent.js
+++ b/packages/rn-tester/NativeComponentExample/js/MyLegacyViewNativeComponent.js
@@ -43,7 +43,7 @@ export function callNativeMethodToChangeBackgroundColor(
     console.log('viewRef is null');
     return;
   }
-  const reactTag = ReactNative.findNodeHandle(viewRef);
+  const reactTag = ReactNative.findNodeHandle<$FlowFixMe>(viewRef);
   if (reactTag == null) {
     console.log('reactTag is null');
     return;
@@ -64,7 +64,7 @@ export function callNativeMethodToAddOverlays(
     console.log('viewRef is null');
     return;
   }
-  const reactTag = ReactNative.findNodeHandle(viewRef);
+  const reactTag = ReactNative.findNodeHandle<$FlowFixMe>(viewRef);
   if (reactTag == null) {
     console.log('reactTag is null');
     return;
@@ -85,7 +85,7 @@ export function callNativeMethodToRemoveOverlays(
     console.log('viewRef is null');
     return;
   }
-  const reactTag = ReactNative.findNodeHandle(viewRef);
+  const reactTag = ReactNative.findNodeHandle<$FlowFixMe>(viewRef);
   if (reactTag == null) {
     console.log('reactTag is null');
     return;

--- a/packages/rn-tester/js/examples/ActionSheetIOS/ActionSheetIOSExample.js
+++ b/packages/rn-tester/js/examples/ActionSheetIOS/ActionSheetIOSExample.js
@@ -241,7 +241,7 @@ class ActionSheetAnchorExample extends React.Component<
         cancelButtonIndex: CANCEL_INDEX,
         destructiveButtonIndex: DESTRUCTIVE_INDEX,
         anchor: this.anchorRef.current
-          ? findNodeHandle(this.anchorRef.current)
+          ? findNodeHandle<$FlowFixMe>(this.anchorRef.current)
           : undefined,
       },
       buttonIndex => {
@@ -471,7 +471,7 @@ class ShareScreenshotAnchorExample extends React.Component<
             url: uri,
             excludedActivityTypes: ['com.apple.UIKit.activity.PostToTwitter'],
             anchor: this.anchorRef.current
-              ? findNodeHandle(this.anchorRef.current)
+              ? findNodeHandle<$FlowFixMe>(this.anchorRef.current)
               : undefined,
           },
           error => Alert.alert('Error', error?.message),

--- a/packages/virtualized-lists/Lists/VirtualizedList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedList.js
@@ -315,7 +315,7 @@ class VirtualizedList extends StateSafePureComponent<
     if (this._scrollRef && this._scrollRef.getScrollableNode) {
       return this._scrollRef.getScrollableNode();
     } else {
-      return findNodeHandle(this._scrollRef);
+      return findNodeHandle<$FlowFixMe>(this._scrollRef);
     }
   }
 


### PR DESCRIPTION
Summary:
Prepare for the change that makes `React.ComponentType` an alias of `component(...Props)`, which comes with stricter checking and making the props automatically readonly.

Changelog: [Internal]

Differential Revision: D71566900


