### PR TITLE
Fix animated images missing from offscreen render

### DIFF
--- a/packages/react-native/Libraries/Image/RCTUIImageViewAnimated.mm
+++ b/packages/react-native/Libraries/Image/RCTUIImageViewAnimated.mm
@@ -123,11 +123,9 @@ static NSUInteger RCTDeviceFreeMemory(void)
     if ([self paused]) {
       [self start];
     }
-
-    [self.layer setNeedsDisplay];
-  } else {
-    super.image = image;
   }
+
+  super.image = image;
 }
 
 #pragma mark - Private


### PR DESCRIPTION
Summary:
D70668516 broke some SSTs, where asset that previously was black, showed up as clear.

I was assuming that was because we fixed a separate bug where assets could erroneously show as black layer, but these tests were actually just using a black asset.

Real bug here, is that the change led to only setting image when we have a displayLink, ie showing on screen, where before, we set image (implicitly at first frame) as layer content.

This change fixes that behavior, so first frame is rendered as part of off-screen view rendering, for images considered animatable.

Changelog:
[iOS][Fixed] - Fix animated images missing from offscreen render

Differential Revision: D71590856


