### PR TITLE
Add React-renderercss dependency for 3p libs

### DIFF
--- a/packages/react-native/scripts/cocoapods/new_architecture.rb
+++ b/packages/react-native/scripts/cocoapods/new_architecture.rb
@@ -92,6 +92,7 @@ class NewArchitectureHelper
                 .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-debug", "React_debug", []))
                 .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-ImageManager", "React_ImageManager", []))
                 .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-rendererdebug", "React_rendererdebug", []))
+                .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-renderercss", "React_renderercss", []))
                 .each { |search_path|
                     header_search_paths << "\"#{search_path}\""
                 }
@@ -127,6 +128,7 @@ class NewArchitectureHelper
         spec.dependency "React-ImageManager"
         spec.dependency "React-rendererdebug"
         spec.dependency 'React-jsi'
+        spec.dependency 'React-renderercss'
 
         depend_on_js_engine(spec)
         add_rn_third_party_dependencies(spec)

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -291,7 +291,8 @@ class ReactNativePodsUtils
     # Add a new dependency to an existing spec, configuring also the headers search paths
     def self.add_dependency(spec, dependency_name, base_folder_for_frameworks, framework_name, additional_paths: [], version: nil, subspec_dependency: nil)
         # Update Search Path
-        optional_current_search_path = spec.to_hash["pod_target_xcconfig"]["HEADER_SEARCH_PATHS"]
+        current_pod_target_xcconfig = spec.to_hash["pod_target_xcconfig"] ? spec.to_hash["pod_target_xcconfig"] : {}
+        optional_current_search_path = current_pod_target_xcconfig["HEADER_SEARCH_PATHS"]
         current_search_paths = (optional_current_search_path != nil ? optional_current_search_path : "")
             .split(" ")
         create_header_search_path_for_frameworks(base_folder_for_frameworks, dependency_name, framework_name, additional_paths)
@@ -299,7 +300,6 @@ class ReactNativePodsUtils
                 wrapped_path = "\"#{path}\""
                 current_search_paths << wrapped_path
             }
-        current_pod_target_xcconfig = spec.to_hash["pod_target_xcconfig"]
         current_pod_target_xcconfig["HEADER_SEARCH_PATHS"] = current_search_paths.join(" ")
         spec.pod_target_xcconfig = current_pod_target_xcconfig
 


### PR DESCRIPTION
Summary:
Third party libraries depend transitively agains the React-renderercss modules because it is imported by Fabric.
Without this change, the use_frameworks on iOS does not works when a 3P library is imported.

This changes fix the behavior and we need to cherry pick them in 0.79.

## Changelog:
[iOS][Fixed] - Make sure 3p libraries depends on React-renderercss to work with use_frameworks

Differential Revision: D71618395


