### PR TITLE
[iOS] Fixes crash when Blob module returns nil

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
@@ -106,12 +106,11 @@ id<RCTTurboModule> RCTAppSetupDefaultModuleFromClass(Class moduleClass, id<RCTDe
         initWithHandlersProvider:^NSArray<id<RCTURLRequestHandler>> *(RCTModuleRegistry *moduleRegistry) {
           NSArray *URLRequestHandlerModules =
               extractModuleConformingToProtocol(moduleRegistry, @protocol(RCTURLRequestHandler));
-          return [@[
-            [RCTHTTPRequestHandler new],
-            [RCTDataRequestHandler new],
-            [RCTFileRequestHandler new],
-            [moduleRegistry moduleForName:"BlobModule"],
-          ] arrayByAddingObjectsFromArray:URLRequestHandlerModules];
+          return [[NSArray arrayWithObjects:[RCTHTTPRequestHandler new],
+                                            [RCTDataRequestHandler new],
+                                            [RCTFileRequestHandler new],
+                                            [moduleRegistry moduleForName:"BlobModule"],
+                                            nil] arrayByAddingObjectsFromArray:URLRequestHandlerModules];
         }];
   }
   // No custom initializer here.


### PR DESCRIPTION
## Summary:

Fixes #50210 . We changed from https://github.com/facebook/react-native/pull/42923/files#diff-91dbe299fbfe3e18882740ec5adb85f3402b6a77500fe2a9ee3ec983f3377c4a. 

## Changelog:

[IOS] [FIXED] -  Fixes crash when Blob module returns nil

## Test Plan:

Let ` [moduleRegistry moduleForName:"BlobModule"]` returns nil and should not crash.
