### PR TITLE
Remove deprecated RCTModernEventEmitter.receiveTouches

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2462,7 +2462,6 @@ public final class com/facebook/react/fabric/events/FabricEventEmitter : com/fac
 	public fun receiveEvent (IILjava/lang/String;Lcom/facebook/react/bridge/WritableMap;)V
 	public fun receiveEvent (IILjava/lang/String;ZILcom/facebook/react/bridge/WritableMap;I)V
 	public fun receiveEvent (ILjava/lang/String;Lcom/facebook/react/bridge/WritableMap;)V
-	public fun receiveTouches (Lcom/facebook/react/uimanager/events/TouchEvent;)V
 	public fun receiveTouches (Ljava/lang/String;Lcom/facebook/react/bridge/WritableArray;Lcom/facebook/react/bridge/WritableArray;)V
 }
 
@@ -5389,7 +5388,6 @@ public abstract interface class com/facebook/react/uimanager/events/RCTEventEmit
 public abstract interface class com/facebook/react/uimanager/events/RCTModernEventEmitter : com/facebook/react/uimanager/events/RCTEventEmitter {
 	public abstract fun receiveEvent (IILjava/lang/String;Lcom/facebook/react/bridge/WritableMap;)V
 	public abstract fun receiveEvent (IILjava/lang/String;ZILcom/facebook/react/bridge/WritableMap;I)V
-	public abstract fun receiveTouches (Lcom/facebook/react/uimanager/events/TouchEvent;)V
 }
 
 public final class com/facebook/react/uimanager/events/TouchEvent : com/facebook/react/uimanager/events/Event {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/EventAnimationDriver.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/EventAnimationDriver.kt
@@ -15,7 +15,6 @@ import com.facebook.react.bridge.WritableArray
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.EventCategoryDef
 import com.facebook.react.uimanager.events.RCTModernEventEmitter
-import com.facebook.react.uimanager.events.TouchEvent
 
 /** Handles updating a [ValueAnimatedNode] when an event gets dispatched. */
 internal class EventAnimationDriver(
@@ -43,11 +42,6 @@ internal class EventAnimationDriver(
       touches: WritableArray,
       changedIndices: WritableArray
   ) {
-    throw UnsupportedOperationException("receiveTouches is not support by native animated events")
-  }
-
-  @Deprecated("Deprecated in Java")
-  override fun receiveTouches(event: TouchEvent) {
     throw UnsupportedOperationException("receiveTouches is not support by native animated events")
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/events/FabricEventEmitter.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/events/FabricEventEmitter.kt
@@ -13,7 +13,6 @@ import com.facebook.react.fabric.FabricUIManager
 import com.facebook.react.uimanager.common.ViewUtil
 import com.facebook.react.uimanager.events.EventCategoryDef
 import com.facebook.react.uimanager.events.RCTModernEventEmitter
-import com.facebook.react.uimanager.events.TouchEvent
 import com.facebook.systrace.Systrace
 
 public class FabricEventEmitter(private val uiManager: FabricUIManager) : RCTModernEventEmitter {
@@ -56,12 +55,6 @@ public class FabricEventEmitter(private val uiManager: FabricUIManager) : RCTMod
       touches: WritableArray,
       changedIndices: WritableArray
   ): Unit {
-    throw UnsupportedOperationException("EventEmitter#receiveTouches is not supported by Fabric")
-  }
-
-  @Deprecated("Deprecated in Java")
-  public override fun receiveTouches(event: TouchEvent): Unit {
-    // Calls are expected to go via TouchesHelper
     throw UnsupportedOperationException("EventEmitter#receiveTouches is not supported by Fabric")
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/RCTModernEventEmitter.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/RCTModernEventEmitter.kt
@@ -31,7 +31,4 @@ public interface RCTModernEventEmitter : RCTEventEmitter {
       params: WritableMap?,
       @EventCategoryDef category: Int
   )
-
-  @Deprecated("Dispatch the TouchEvent using [EventDispatcher] instead")
-  public fun receiveTouches(event: TouchEvent)
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/ReactEventEmitter.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/ReactEventEmitter.kt
@@ -18,6 +18,12 @@ import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.common.UIManagerType
 import com.facebook.react.uimanager.common.ViewUtil.getUIManagerType
 
+/**
+ * This class handles event emitting across the legacy and Fabric event emitting mechanisms. Based
+ * on the surfaceId and targetTag, it will route the event to the appropriate event emitter.
+ *
+ * This class is constructed both by Paper's EventDispatcherImpl and the FabricEventDispatcher.
+ */
 internal class ReactEventEmitter(private val reactContext: ReactApplicationContext) :
     RCTModernEventEmitter {
   /** Corresponds to [com.facebook.react.fabric.events.FabricEventEmitter] */
@@ -59,32 +65,21 @@ internal class ReactEventEmitter(private val reactContext: ReactApplicationConte
     receiveEvent(surfaceId, targetTag, eventName, false, 0, params, EventCategoryDef.UNSPECIFIED)
   }
 
+  /*
+   * This method should be unused by Fabric event processing pipeline, but leaving it here to make sure
+   * that any custom code using it in legacy renderer is compatible
+   */
   @Deprecated("Dispatch the TouchEvent using [EventDispatcher] instead")
   override fun receiveTouches(
       eventName: String,
       touches: WritableArray,
       changedIndices: WritableArray
   ) {
-    /*
-     * This method should be unused by default processing pipeline, but leaving it here to make sure
-     * that any custom code using it in legacy renderer is compatible
-     */
     check(touches.size() > 0)
-
     val reactTag = touches.getMap(0)?.getInt(TouchesHelper.TARGET_KEY) ?: 0
     @UIManagerType val uiManagerType = getUIManagerType(reactTag)
     if (uiManagerType == UIManagerType.LEGACY) {
       ensureDefaultEventEmitter()?.receiveTouches(eventName, touches, changedIndices)
-    }
-  }
-
-  @Deprecated("Dispatch the TouchEvent using [EventDispatcher] instead")
-  override fun receiveTouches(event: TouchEvent) {
-    @UIManagerType val uiManagerType = getUIManagerType(event.viewTag, event.surfaceId)
-    if (uiManagerType == UIManagerType.FABRIC) {
-      fabricEventEmitter?.let { TouchesHelper.sendTouchEvent(it, event) }
-    } else if (uiManagerType == UIManagerType.LEGACY) {
-      ensureDefaultEventEmitter()?.let { TouchesHelper.sendTouchesLegacy(it, event) }
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/TouchEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/TouchEvent.kt
@@ -14,6 +14,8 @@ import androidx.core.util.Pools.SynchronizedPool
 import com.facebook.infer.annotation.Assertions
 import com.facebook.react.bridge.ReactSoftExceptionLogger
 import com.facebook.react.bridge.SoftAssertions
+import com.facebook.react.uimanager.common.UIManagerType
+import com.facebook.react.uimanager.common.ViewUtil.getUIManagerType
 import com.facebook.react.uimanager.events.TouchEventType.Companion.getJSEventName
 
 /**
@@ -118,12 +120,17 @@ public class TouchEvent private constructor() : Event<TouchEvent>() {
     }
   }
 
-  override fun dispatchModern(rctEventEmitter: RCTModernEventEmitter) {
-    if (verifyMotionEvent()) {
+  override fun dispatchModern(eventEmitter: RCTModernEventEmitter) {
+    if (!verifyMotionEvent()) {
+      return
+    }
+
+    @UIManagerType val uiManagerType = getUIManagerType(viewTag, surfaceId)
+    if (uiManagerType == UIManagerType.FABRIC) {
       // TouchesHelper.sendTouchEvent can be inlined here post Fabric rollout
-      // For now, we go via the event emitter, which will decide whether the legacy or modern
-      // event path is required
-      rctEventEmitter.receiveTouches(this)
+      TouchesHelper.sendTouchEvent(eventEmitter, this)
+    } else if (uiManagerType == UIManagerType.LEGACY) {
+      TouchesHelper.sendTouchesLegacy(eventEmitter, this)
     }
   }
 


### PR DESCRIPTION
Summary:
Call TouchesHelper directly from TouchEvent and remove the need for `RCTModernEventEmitter.receiveTouches`. This enables `Animated.Event` to process these events too, since they are now being delivered just like any other event.

Changelog:
[Android][Fixed] Enables Animated.Event to be used with onTouchMove in the new architecture.
[Android][Removed] Removed deprecated EventDispatcher#receiveTouches

Differential Revision: D71114177


