### PR TITLE
Simplify event emitter layering

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -5249,11 +5249,8 @@ public abstract interface class com/facebook/react/uimanager/events/EventDispatc
 	public abstract fun dispatchAllEvents ()V
 	public abstract fun dispatchEvent (Lcom/facebook/react/uimanager/events/Event;)V
 	public abstract fun onCatalystInstanceDestroyed ()V
-	public abstract fun registerEventEmitter (ILcom/facebook/react/uimanager/events/RCTEventEmitter;)V
-	public abstract fun registerEventEmitter (ILcom/facebook/react/uimanager/events/RCTModernEventEmitter;)V
 	public abstract fun removeBatchEventDispatchedListener (Lcom/facebook/react/uimanager/events/BatchEventDispatchedListener;)V
 	public abstract fun removeListener (Lcom/facebook/react/uimanager/events/EventDispatcherListener;)V
-	public abstract fun unregisterEventEmitter (I)V
 }
 
 public class com/facebook/react/uimanager/events/EventDispatcherImpl : com/facebook/react/bridge/LifecycleEventListener, com/facebook/react/uimanager/events/EventDispatcher {
@@ -5266,11 +5263,8 @@ public class com/facebook/react/uimanager/events/EventDispatcherImpl : com/faceb
 	public fun onHostDestroy ()V
 	public fun onHostPause ()V
 	public fun onHostResume ()V
-	public fun registerEventEmitter (ILcom/facebook/react/uimanager/events/RCTEventEmitter;)V
-	public fun registerEventEmitter (ILcom/facebook/react/uimanager/events/RCTModernEventEmitter;)V
 	public fun removeBatchEventDispatchedListener (Lcom/facebook/react/uimanager/events/BatchEventDispatchedListener;)V
 	public fun removeListener (Lcom/facebook/react/uimanager/events/EventDispatcherListener;)V
-	public fun unregisterEventEmitter (I)V
 }
 
 public abstract interface class com/facebook/react/uimanager/events/EventDispatcherListener {
@@ -5279,23 +5273,6 @@ public abstract interface class com/facebook/react/uimanager/events/EventDispatc
 
 public abstract interface class com/facebook/react/uimanager/events/EventDispatcherProvider {
 	public abstract fun getEventDispatcher ()Lcom/facebook/react/uimanager/events/EventDispatcher;
-}
-
-public class com/facebook/react/uimanager/events/FabricEventDispatcher : com/facebook/react/bridge/LifecycleEventListener, com/facebook/react/uimanager/events/EventDispatcher {
-	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;)V
-	public fun addBatchEventDispatchedListener (Lcom/facebook/react/uimanager/events/BatchEventDispatchedListener;)V
-	public fun addListener (Lcom/facebook/react/uimanager/events/EventDispatcherListener;)V
-	public fun dispatchAllEvents ()V
-	public fun dispatchEvent (Lcom/facebook/react/uimanager/events/Event;)V
-	public fun onCatalystInstanceDestroyed ()V
-	public fun onHostDestroy ()V
-	public fun onHostPause ()V
-	public fun onHostResume ()V
-	public fun registerEventEmitter (ILcom/facebook/react/uimanager/events/RCTEventEmitter;)V
-	public fun registerEventEmitter (ILcom/facebook/react/uimanager/events/RCTModernEventEmitter;)V
-	public fun removeBatchEventDispatchedListener (Lcom/facebook/react/uimanager/events/BatchEventDispatchedListener;)V
-	public fun removeListener (Lcom/facebook/react/uimanager/events/EventDispatcherListener;)V
-	public fun unregisterEventEmitter (I)V
 }
 
 public final class com/facebook/react/uimanager/events/NativeGestureUtil {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -664,7 +664,7 @@ public class ReactHostImpl implements ReactHost {
   /* package */ EventDispatcher getEventDispatcher() {
     final ReactInstance reactInstance = mReactInstance;
     if (reactInstance == null) {
-      return BlackHoleEventDispatcher.get();
+      return BlackHoleEventDispatcher.INSTANCE;
     }
 
     return reactInstance.getEventDispatcher();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
@@ -184,8 +184,6 @@ public class UIManagerModule extends ReactContextBaseJavaModule
   public void initialize() {
     getReactApplicationContext().registerComponentCallbacks(mMemoryTrimCallback);
     getReactApplicationContext().registerComponentCallbacks(mViewManagerRegistry);
-    mEventDispatcher.registerEventEmitter(
-        LEGACY, getReactApplicationContext().getJSModule(RCTEventEmitter.class));
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/BlackHoleEventDispatcher.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/BlackHoleEventDispatcher.kt
@@ -13,7 +13,7 @@ import com.facebook.common.logging.FLog
  * A singleton class that overrides [EventDispatcher] with no-op methods, to be used by callers that
  * expect an EventDispatcher when the instance doesn't exist.
  */
-internal class BlackHoleEventDispatcher private constructor() : EventDispatcher {
+internal object BlackHoleEventDispatcher : EventDispatcher {
   override fun dispatchEvent(event: Event<*>) {
     FLog.d(
         "BlackHoleEventDispatcher",
@@ -31,20 +31,6 @@ internal class BlackHoleEventDispatcher private constructor() : EventDispatcher 
   override fun removeBatchEventDispatchedListener(listener: BatchEventDispatchedListener): Unit =
       Unit
 
-  @Deprecated("Deprecated in Java")
-  @Suppress("DEPRECATION")
-  override fun registerEventEmitter(uiManagerType: Int, eventEmitter: RCTEventEmitter): Unit = Unit
-
-  override fun registerEventEmitter(uiManagerType: Int, eventEmitter: RCTModernEventEmitter): Unit =
-      Unit
-
-  override fun unregisterEventEmitter(uiManagerType: Int): Unit = Unit
-
+  @Deprecated("Private API, should only be used when the concrete implementation is known.")
   override fun onCatalystInstanceDestroyed(): Unit = Unit
-
-  companion object {
-    private val eventDispatcher: EventDispatcher = BlackHoleEventDispatcher()
-
-    @JvmStatic fun get(): EventDispatcher = eventDispatcher
-  }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/EventDispatcher.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/EventDispatcher.kt
@@ -7,8 +7,6 @@
 
 package com.facebook.react.uimanager.events
 
-import com.facebook.react.uimanager.common.UIManagerType
-
 public interface EventDispatcher {
   /** Sends the given Event to JS, coalescing eligible events if JS is backed up. */
   public fun dispatchEvent(event: Event<*>)
@@ -25,16 +23,6 @@ public interface EventDispatcher {
 
   public fun removeBatchEventDispatchedListener(listener: BatchEventDispatchedListener)
 
-  @Deprecated("Use the modern version with RCTModernEventEmitter")
-  @Suppress("DEPRECATION")
-  public fun registerEventEmitter(@UIManagerType uiManagerType: Int, eventEmitter: RCTEventEmitter)
-
-  public fun registerEventEmitter(
-      @UIManagerType uiManagerType: Int,
-      eventEmitter: RCTModernEventEmitter
-  )
-
-  public fun unregisterEventEmitter(@UIManagerType uiManagerType: Int)
-
+  @Deprecated("Private API, should only be used when the concrete implementation is known.")
   public fun onCatalystInstanceDestroyed()
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/EventDispatcherImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/EventDispatcherImpl.java
@@ -16,7 +16,6 @@ import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.UiThreadUtil;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.modules.core.ReactChoreographer;
-import com.facebook.react.uimanager.common.UIManagerType;
 import com.facebook.systrace.Systrace;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -100,14 +99,14 @@ public class EventDispatcherImpl implements EventDispatcher, LifecycleEventListe
 
   private Event[] mEventsToDispatch = new Event[16];
   private int mEventsToDispatchSize = 0;
-  private volatile ReactEventEmitter mReactEventEmitter;
+  private final EventEmitterImpl mReactEventEmitter;
   private short mNextEventTypeId = 0;
   private volatile boolean mHasDispatchScheduled = false;
 
   public EventDispatcherImpl(ReactApplicationContext reactContext) {
     mReactContext = reactContext;
     mReactContext.addLifecycleEventListener(this);
-    mReactEventEmitter = new ReactEventEmitter(mReactContext);
+    mReactEventEmitter = new EventEmitterImpl(mReactContext);
   }
 
   /** Sends the given Event to JS, coalescing eligible events if JS is backed up. */
@@ -131,16 +130,7 @@ public class EventDispatcherImpl implements EventDispatcher, LifecycleEventListe
   }
 
   private void maybePostFrameCallbackFromNonUI() {
-    if (mReactEventEmitter != null) {
-      // If the host activity is paused, the frame callback may not be currently
-      // posted. Ensure that it is so that this event gets delivered promptly.
-      mCurrentFrameCallback.maybePostFromNonUI();
-    } else {
-      // No JS application has started yet, or resumed. This can happen when a ReactRootView is
-      // added to view hierarchy, but ReactContext creation has not completed yet. In this case, any
-      // touch event dispatch will hit this codepath, and we simply queue them so that they
-      // are dispatched once ReactContext creation completes and JS app is running.
-    }
+    mCurrentFrameCallback.maybePostFromNonUI();
   }
 
   /** Add a listener to this EventDispatcher. */
@@ -176,14 +166,10 @@ public class EventDispatcherImpl implements EventDispatcher, LifecycleEventListe
     stopFrameCallback();
   }
 
+  @Override
+  @Deprecated
   public void onCatalystInstanceDestroyed() {
-    UiThreadUtil.runOnUiThread(
-        new Runnable() {
-          @Override
-          public void run() {
-            stopFrameCallback();
-          }
-        });
+    UiThreadUtil.runOnUiThread(this::stopFrameCallback);
   }
 
   private void stopFrameCallback() {
@@ -259,19 +245,6 @@ public class EventDispatcherImpl implements EventDispatcher, LifecycleEventListe
     return viewTag
         | (((long) eventTypeId) & 0xffff) << 32
         | (((long) coalescingKey) & 0xffff) << 48;
-  }
-
-  public void registerEventEmitter(@UIManagerType int uiManagerType, RCTEventEmitter eventEmitter) {
-    mReactEventEmitter.register(uiManagerType, eventEmitter);
-  }
-
-  public void registerEventEmitter(
-      @UIManagerType int uiManagerType, RCTModernEventEmitter eventEmitter) {
-    mReactEventEmitter.register(uiManagerType, eventEmitter);
-  }
-
-  public void unregisterEventEmitter(@UIManagerType int uiManagerType) {
-    mReactEventEmitter.unregister(uiManagerType);
   }
 
   private class ScheduleDispatchFrameCallback implements Choreographer.FrameCallback {
@@ -352,7 +325,6 @@ public class EventDispatcherImpl implements EventDispatcher, LifecycleEventListe
             "ScheduleDispatchFrameCallback",
             mHasDispatchScheduledCount.getAndIncrement());
         mHasDispatchScheduled = false;
-        Assertions.assertNotNull(mReactEventEmitter);
         synchronized (mEventsToDispatchLock) {
           if (mEventsToDispatchSize > 0) {
             // We avoid allocating an array and iterator, and "sorting" if we don't need to.

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/fabric/events/TouchEventDispatchTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/fabric/events/TouchEventDispatchTest.kt
@@ -18,16 +18,14 @@ import com.facebook.react.bridge.ReactTestHelper
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.WritableArray
 import com.facebook.react.bridge.WritableMap
-import com.facebook.react.fabric.FabricUIManager
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsForTests
 import com.facebook.react.modules.core.ReactChoreographer
 import com.facebook.react.uimanager.DisplayMetricsHolder
-import com.facebook.react.uimanager.ViewManagerRegistry
 import com.facebook.react.uimanager.events.EventDispatcher
+import com.facebook.react.uimanager.events.FabricEventDispatcher
 import com.facebook.react.uimanager.events.TouchEvent
 import com.facebook.react.uimanager.events.TouchEventCoalescingKeyHelper
 import com.facebook.react.uimanager.events.TouchEventType
-import com.facebook.testutils.fakes.FakeBatchEventDispatchedListener
 import com.facebook.testutils.shadows.ShadowSoLoader
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
@@ -37,11 +35,10 @@ import org.junit.runner.RunWith
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.*
 import org.mockito.MockedStatic
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.mockStatic
-import org.mockito.Mockito.spy
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
+import org.mockito.kotlin.mock
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
@@ -462,7 +459,7 @@ class TouchEventDispatchTest {
                       buildGesture(SURFACE_ID, TARGET_VIEW_ID, 2f, 1f, GESTURE_START_TIME, 1))))
 
   private lateinit var eventDispatcher: EventDispatcher
-  private lateinit var uiManager: FabricUIManager
+  private lateinit var eventEmitter: FabricEventEmitter
   private lateinit var arguments: MockedStatic<Arguments>
   private var reactChoreographerOriginal: ReactChoreographer? = null
 
@@ -479,19 +476,13 @@ class TouchEventDispatchTest {
     metrics.density = 1f
     DisplayMetricsHolder.setWindowDisplayMetrics(metrics)
 
-    // We use a real FabricUIManager here as it's harder to mock with both static and non-static
-    // methods.
     val reactContext = ReactTestHelper.createCatalystContextForTest()
-    val viewManagerRegistry = ViewManagerRegistry(emptyList())
-    val batchEventDispatchedListener = FakeBatchEventDispatchedListener()
-    uiManager =
-        spy(FabricUIManager(reactContext, viewManagerRegistry, batchEventDispatchedListener))
-    uiManager.initialize()
 
-    eventDispatcher = uiManager.eventDispatcher
+    eventEmitter = mock()
+    eventDispatcher = FabricEventDispatcher(reactContext, eventEmitter)
 
     // Ignore scheduled choreographer work
-    val reactChoreographerMock = mock(ReactChoreographer::class.java)
+    val reactChoreographerMock: ReactChoreographer = mock()
     reactChoreographerOriginal = ReactChoreographer.overrideInstanceForTest(reactChoreographerMock)
   }
 
@@ -507,8 +498,9 @@ class TouchEventDispatchTest {
       eventDispatcher.dispatchEvent(event)
     }
     val argument = ArgumentCaptor.forClass(WritableMap::class.java)
-    verify(uiManager, times(4))
-        .receiveEvent(anyInt(), anyInt(), anyString(), anyBoolean(), argument.capture(), anyInt())
+    verify(eventEmitter, times(4))
+        .receiveEvent(
+            anyInt(), anyInt(), anyString(), anyBoolean(), anyInt(), argument.capture(), anyInt())
     assertThat(startMoveEndExpectedSequence).isEqualTo(argument.allValues)
   }
 
@@ -518,8 +510,9 @@ class TouchEventDispatchTest {
       eventDispatcher.dispatchEvent(event)
     }
     val argument = ArgumentCaptor.forClass(WritableMap::class.java)
-    verify(uiManager, times(6))
-        .receiveEvent(anyInt(), anyInt(), anyString(), anyBoolean(), argument.capture(), anyInt())
+    verify(eventEmitter, times(6))
+        .receiveEvent(
+            anyInt(), anyInt(), anyString(), anyBoolean(), anyInt(), argument.capture(), anyInt())
     assertThat(startMoveCancelExpectedSequence).isEqualTo(argument.allValues)
   }
 
@@ -529,8 +522,9 @@ class TouchEventDispatchTest {
       eventDispatcher.dispatchEvent(event)
     }
     val argument = ArgumentCaptor.forClass(WritableMap::class.java)
-    verify(uiManager, times(6))
-        .receiveEvent(anyInt(), anyInt(), anyString(), anyBoolean(), argument.capture(), anyInt())
+    verify(eventEmitter, times(6))
+        .receiveEvent(
+            anyInt(), anyInt(), anyString(), anyBoolean(), anyInt(), argument.capture(), anyInt())
     assertThat(startPointerMoveUpExpectedSequence).isEqualTo(argument.allValues)
   }
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/fakes/FakeEventDispatcher.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/fakes/FakeEventDispatcher.kt
@@ -13,8 +13,6 @@ import com.facebook.react.uimanager.events.BatchEventDispatchedListener
 import com.facebook.react.uimanager.events.Event
 import com.facebook.react.uimanager.events.EventDispatcher
 import com.facebook.react.uimanager.events.EventDispatcherListener
-import com.facebook.react.uimanager.events.RCTEventEmitter
-import com.facebook.react.uimanager.events.RCTModernEventEmitter
 
 @SuppressWarnings("rawtypes")
 class FakeEventDispatcher : EventDispatcher {
@@ -38,12 +36,6 @@ class FakeEventDispatcher : EventDispatcher {
 
   override fun removeBatchEventDispatchedListener(listener: BatchEventDispatchedListener) = Unit
 
-  @Deprecated("Deprecated in Java")
-  override fun registerEventEmitter(uiManagerType: Int, eventEmitter: RCTEventEmitter) = Unit
-
-  override fun registerEventEmitter(uiManagerType: Int, eventEmitter: RCTModernEventEmitter) = Unit
-
-  override fun unregisterEventEmitter(uiManagerType: Int) = Unit
-
+  @Deprecated("Private API, should only be used when the concrete implementation is known.")
   override fun onCatalystInstanceDestroyed() = Unit
 }


### PR DESCRIPTION
Summary:
* Make FabricEventDispatcher private, we already have a public EventDispatcher interface
* Rename ReactEventEmitter to EventEmitterImpl, to make it clearer it aligned with EventDispatcherImpl
* Update docs to make it clearer what's part of the old architecture

Changelog:

[Android][Removed] Removed FabricEventDispatcher from public Android API
[Android][Removed] Removed (un)registerEventEmitter from EventDispatcher interface

Differential Revision: D71735505
