### PR TITLE
Change Animated re-export to generate correct namespace in TS

### DIFF
--- a/packages/react-native/Libraries/Animated/Animated.js.flow
+++ b/packages/react-native/Libraries/Animated/Animated.js.flow
@@ -9,7 +9,5 @@
  * @oncall react_native
  */
 
-import * as Animated from './AnimatedExports';
-
+export * as default from './AnimatedExports';
 export type {CompositeAnimation, Numeric} from './AnimatedImplementation';
-export default Animated;

--- a/packages/react-native/Libraries/Animated/components/AnimatedScrollView.js
+++ b/packages/react-native/Libraries/Animated/components/AnimatedScrollView.js
@@ -46,11 +46,12 @@ const AnimatedScrollView: AnimatedComponentType<Props, Instance> =
         props.style != null
       ) {
         return (
-          // $FlowFixMe[prop-missing]
+          // $FlowFixMe - It should return an Animated ScrollView but it returns a ScrollView with Animated props applied.
           <AnimatedScrollViewWithInvertedRefreshControl
             scrollEventThrottle={0.0001}
             {...props}
             ref={forwardedRef}
+            // $FlowFixMe[incompatible-type]
             refreshControl={props.refreshControl}
           />
         );

--- a/packages/react-native/Libraries/Animated/createAnimatedComponent.js
+++ b/packages/react-native/Libraries/Animated/createAnimatedComponent.js
@@ -17,14 +17,17 @@ import useMergeRefs from '../Utilities/useMergeRefs';
 import * as React from 'react';
 import {useMemo} from 'react';
 
+type Nullable = void | null;
+type Builtin = (...$ReadOnlyArray<empty>) => mixed | Date | Error | RegExp;
+
+export type WithAnimatedValue<+T> = T extends Builtin | Nullable ? T : any;
+
 export type AnimatedProps<Props: {...}> = {
-  // eslint-disable-next-line no-unused-vars
-  +[_K in keyof (Props &
-      $ReadOnly<{
-        passthroughAnimatedPropExplicitValues?: React.ElementConfig<
-          typeof View,
-        >,
-      }>)]: any,
+  +[K in keyof Props]: WithAnimatedValue<Props[K]>,
+} & {
+  passthroughAnimatedPropExplicitValues?: React.ElementConfig<
+    typeof View,
+  > | null,
 };
 
 // We could use a mapped type here to introduce acceptable Animated variants
@@ -53,7 +56,10 @@ export default function createAnimatedComponent<
   $ReadOnly<React.ElementProps<TInstance>>,
   React.ElementRef<TInstance>,
 > {
-  return unstable_createAnimatedComponentWithAllowlist(Component, null);
+  return unstable_createAnimatedComponentWithAllowlist(
+    Component,
+    null,
+  ) as $FlowFixMe;
 }
 
 export function unstable_createAnimatedComponentWithAllowlist<

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedValueXY.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedValueXY.js
@@ -214,7 +214,9 @@ export default class AnimatedValueXY extends AnimatedWithChildren {
    *
    * See https://reactnative.dev/docs/animatedvaluexy#gettranslatetransform
    */
-  getTranslateTransform(): Array<{[key: string]: AnimatedValue, ...}> {
+  getTranslateTransform(): Array<
+    {translateX: AnimatedValue} | {translateY: AnimatedValue},
+  > {
     return [{translateX: this.x}, {translateY: this.y}];
   }
 

--- a/packages/react-native/Libraries/Components/Touchable/TouchableBounce.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableBounce.js
@@ -173,7 +173,8 @@ class TouchableBounce extends React.Component<Props, State> {
         importantForAccessibility={
           this.props['aria-hidden'] === true
             ? 'no-hide-descendants'
-            : this.props.importantForAccessibility
+            : // $FlowFixMe[incompatible-type] - AnimatedProps types were made more strict and need refining at this call site
+              this.props.importantForAccessibility
         }
         accessibilityViewIsModal={
           this.props['aria-modal'] ?? this.props.accessibilityViewIsModal

--- a/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
@@ -308,7 +308,8 @@ class TouchableOpacity extends React.Component<TouchableOpacityProps, State> {
         importantForAccessibility={
           this.props['aria-hidden'] === true
             ? 'no-hide-descendants'
-            : this.props.importantForAccessibility
+            : // $FlowFixMe[incompatible-type] - AnimatedProps types were made more strict and need refining at this call site
+              this.props.importantForAccessibility
         }
         accessibilityViewIsModal={
           this.props['aria-modal'] ?? this.props.accessibilityViewIsModal

--- a/packages/react-native/Libraries/Components/View/ViewAccessibility.js
+++ b/packages/react-native/Libraries/Components/View/ViewAccessibility.js
@@ -53,7 +53,8 @@ export type AccessibilityRole =
   | 'webview'
   | 'drawerlayout'
   | 'slidingdrawer'
-  | 'iconmenu';
+  | 'iconmenu'
+  | string;
 
 // Role types for web
 export type Role =

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -118,8 +118,8 @@ declare export default typeof Animated;
 `;
 
 exports[`public API should not change unintentionally Libraries/Animated/Animated.js.flow 1`] = `
-"export type { CompositeAnimation, Numeric } from \\"./AnimatedImplementation\\";
-declare export default typeof Animated;
+"export * as default from \\"./AnimatedExports\\";
+export type { CompositeAnimation, Numeric } from \\"./AnimatedImplementation\\";
 "
 `;
 

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -644,13 +644,15 @@ exports[`public API should not change unintentionally Libraries/Animated/compone
 `;
 
 exports[`public API should not change unintentionally Libraries/Animated/createAnimatedComponent.js 1`] = `
-"export type AnimatedProps<Props: { ... }> = {
-  +[_K in keyof (Props &
-      $ReadOnly<{
-        passthroughAnimatedPropExplicitValues?: React.ElementConfig<
-          typeof View,
-        >,
-      }>)]: any,
+"type Nullable = void | null;
+type Builtin = (...$ReadOnlyArray<empty>) => mixed | Date | Error | RegExp;
+export type WithAnimatedValue<+T> = T extends Builtin | Nullable ? T : any;
+export type AnimatedProps<Props: { ... }> = {
+  +[K in keyof Props]: WithAnimatedValue<Props[K]>,
+} & {
+  passthroughAnimatedPropExplicitValues?: React.ElementConfig<
+    typeof View,
+  > | null,
 };
 export type StrictAnimatedProps<Props: { ... }> = $ReadOnly<{
   ...$Exact<Props>,

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -645,14 +645,41 @@ exports[`public API should not change unintentionally Libraries/Animated/compone
 
 exports[`public API should not change unintentionally Libraries/Animated/createAnimatedComponent.js 1`] = `
 "type Nullable = void | null;
+type Primitive = string | number | boolean | symbol | void;
 type Builtin = (...$ReadOnlyArray<empty>) => mixed | Date | Error | RegExp;
-export type WithAnimatedValue<+T> = T extends Builtin | Nullable ? T : any;
-export type AnimatedProps<Props: { ... }> = {
-  +[K in keyof Props]: WithAnimatedValue<Props[K]>,
-} & {
+export type WithAnimatedValue<+T> = T extends Builtin | Nullable
+  ? T
+  : T extends Primitive
+    ?
+        | T
+        | AnimatedNode
+        | AnimatedAddition
+        | AnimatedSubtraction
+        | AnimatedDivision
+        | AnimatedMultiplication
+        | AnimatedModulo
+        | AnimatedDiffClamp
+        | AnimatedValue
+        | AnimatedInterpolation<number | string>
+        | AnimatedInterpolation<number>
+        | AnimatedInterpolation<string>
+    : T extends $ReadOnlyArray<infer P>
+      ? $ReadOnlyArray<WithAnimatedValue<P>>
+      : T extends { ... }
+        ? { +[K in keyof T]: WithAnimatedValue<T[K]> }
+        : T;
+type NonAnimatedProps = \\"ref\\" | \\"innerViewRef\\" | \\"scrollViewRef\\";
+type PassThroughProps = $ReadOnly<{
   passthroughAnimatedPropExplicitValues?: React.ElementConfig<
     typeof View,
   > | null,
+}>;
+export type AnimatedProps<Props: { ... }> = {
+  [K in keyof (Props & PassThroughProps)]: K extends $Keys<PassThroughProps>
+    ? PassThroughProps[K]
+    : K extends NonAnimatedProps
+      ? Props[K]
+      : WithAnimatedValue<Props[K]>,
 };
 export type StrictAnimatedProps<Props: { ... }> = $ReadOnly<{
   ...$Exact<Props>,
@@ -998,7 +1025,9 @@ declare export default class AnimatedValueXY extends AnimatedWithChildren {
   removeListener(id: string): void;
   removeAllListeners(): void;
   getLayout(): { [key: string]: AnimatedValue, ... };
-  getTranslateTransform(): Array<{ [key: string]: AnimatedValue, ... }>;
+  getTranslateTransform(): Array<
+    { translateX: AnimatedValue } | { translateY: AnimatedValue },
+  >;
 }
 "
 `;
@@ -3800,7 +3829,8 @@ exports[`public API should not change unintentionally Libraries/Components/View/
   | \\"webview\\"
   | \\"drawerlayout\\"
   | \\"slidingdrawer\\"
-  | \\"iconmenu\\";
+  | \\"iconmenu\\"
+  | string;
 export type Role =
   | \\"alert\\"
   | \\"alertdialog\\"

--- a/packages/rn-tester/js/examples/Animated/TransformStylesExample.js
+++ b/packages/rn-tester/js/examples/Animated/TransformStylesExample.js
@@ -70,6 +70,7 @@ function AnimatedView({
         Apply Selected Transforms
       </RNTesterButton>
       <Animated.View
+        // $FlowFixMe[incompatible-type] - properties are not exact
         style={[styles.animatedView, {transform: transformStyles}]}
       />
     </>

--- a/packages/rn-tester/js/examples/SectionList/SectionList-scrollable.js
+++ b/packages/rn-tester/js/examples/SectionList/SectionList-scrollable.js
@@ -318,6 +318,7 @@ export function SectionList_scrollable(Props: {...}): React.MixedElement {
           )
         }
         onEndReachedThreshold={0}
+        // $FlowFixMe[incompatible-type] - incompatible redenerItem type
         sections={filteredSectionData}
         style={styles.list}
         viewabilityConfig={VIEWABILITY_CONFIG}

--- a/packages/rn-tester/js/examples/SectionList/SectionList-scrollable.js
+++ b/packages/rn-tester/js/examples/SectionList/SectionList-scrollable.js
@@ -143,8 +143,9 @@ const renderItemComponent =
 
 const onScrollToIndexFailed = (info: {
   index: number,
-  c: number,
+  highestMeasuredFrameIndex: number,
   averageItemLength: number,
+  ...
 }) => {
   console.warn('onScrollToIndexFailed. See comment in callback', info);
   /**


### PR DESCRIPTION
Summary:
The flow-api-translator will generate 

```ts
export * as default from './AnimatedExports';
```

in TS which preserves the namespace. Previous import, export translated to:

```ts
declare const $$EXPORT_DEFAULT_DECLARATION$$: typeof Animated;
declare type $$EXPORT_DEFAULT_DECLARATION$$ =
  typeof $$EXPORT_DEFAULT_DECLARATION$$;
export default $$EXPORT_DEFAULT_DECLARATION$$;
```

which dropped the `Animated` namespace.

Changelog:
[Internal]

Differential Revision: D71737199


