### PR TITLE
Remove `__REACT_DEVTOOLS_GLOBAL_HOOK__ ` from react-native libdef

### DIFF
--- a/packages/react-native/Libraries/Debugging/DebuggingOverlayRegistry.js
+++ b/packages/react-native/Libraries/Debugging/DebuggingOverlayRegistry.js
@@ -35,8 +35,8 @@ import processColor from '../StyleSheet/processColor';
 
 // TODO(T171193075): __REACT_DEVTOOLS_GLOBAL_HOOK__ is always injected in dev-bundles,
 // but it is not mocked in some Jest tests. We should update Jest tests setup, so it would be the same as expected testing environment.
-const reactDevToolsHook: ?ReactDevToolsGlobalHook =
-  window.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+const reactDevToolsHook: ?ReactDevToolsGlobalHook = (window: $FlowFixMe)
+  .__REACT_DEVTOOLS_GLOBAL_HOOK__;
 
 export type DebuggingOverlayRegistrySubscriberProtocol = {
   rootViewRef: AppContainerRootViewRef,

--- a/packages/react-native/Libraries/ReactNative/AppContainer-dev.js
+++ b/packages/react-native/Libraries/ReactNative/AppContainer-dev.js
@@ -27,8 +27,8 @@ import * as React from 'react';
 
 const {useEffect, useState, useCallback} = React;
 
-const reactDevToolsHook: ReactDevToolsGlobalHook =
-  window.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+const reactDevToolsHook: ReactDevToolsGlobalHook = (window: $FlowFixMe)
+  .__REACT_DEVTOOLS_GLOBAL_HOOK__;
 
 // Required for React DevTools to view / edit React Native styles in Flipper.
 // Flipper doesn't inject these values when initializing DevTools.

--- a/packages/react-native/interface.js
+++ b/packages/react-native/interface.js
@@ -19,7 +19,3 @@
 /* eslint-disable no-unused-vars */
 
 declare var __DEV__: boolean;
-
-declare var __REACT_DEVTOOLS_GLOBAL_HOOK__: any; /*?{
-  inject: ?((stuff: Object) => void)
-};*/

--- a/packages/react-native/src/private/inspector/getInspectorDataForViewAtPoint.js
+++ b/packages/react-native/src/private/inspector/getInspectorDataForViewAtPoint.js
@@ -26,14 +26,14 @@ export type ReactRenderer = {
 };
 type AttachedRendererEventPayload = {id: number, renderer: ReactRenderer};
 
-const reactDevToolsHook = window.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+const reactDevToolsHook = (window: any).__REACT_DEVTOOLS_GLOBAL_HOOK__;
 invariant(
   Boolean(reactDevToolsHook),
   'getInspectorDataForViewAtPoint should not be used if React DevTools hook is not injected',
 );
 
 const renderers: Array<ReactRenderer> = Array.from(
-  window.__REACT_DEVTOOLS_GLOBAL_HOOK__.renderers.values(),
+  (window: any).__REACT_DEVTOOLS_GLOBAL_HOOK__.renderers.values(),
 );
 
 const appendRenderer = ({renderer}: AttachedRendererEventPayload) =>


### PR DESCRIPTION
Summary:
This is an implementation detail of React and better not make it leak everywhere. It's not used quite often even in react-native codebase, so it's better to just suppress the error on each call site. Currently it's typed as any, so there is not much type safety lost anyways.

Changelog: [Internal]

Differential Revision: D71687426


