### PR TITLE
Add type exports to index.js.flow

### DIFF
--- a/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
@@ -58,7 +58,7 @@ type TouchableHighlightBaseProps = $ReadOnly<{
   hostRef: React.RefSetter<React.ElementRef<typeof View>>,
 }>;
 
-type TouchableHighlightProps = $ReadOnly<{
+export type TouchableHighlightProps = $ReadOnly<{
   ...TouchableWithoutFeedbackProps,
   ...AndroidProps,
   ...IOSProps,

--- a/packages/react-native/Libraries/Components/View/ViewPropTypes.js
+++ b/packages/react-native/Libraries/Components/View/ViewPropTypes.js
@@ -346,6 +346,51 @@ export type ViewPropsAndroid = $ReadOnly<{
   onClick?: ?(event: GestureResponderEvent) => mixed,
 }>;
 
+export type TVViewPropsIOS = $ReadOnly<{
+  /**
+   * *(Apple TV only)* When set to true, this view will be focusable
+   * and navigable using the Apple TV remote.
+   *
+   * @platform ios
+   */
+  isTVSelectable?: boolean,
+
+  /**
+   * *(Apple TV only)* May be set to true to force the Apple TV focus engine to move focus to this view.
+   *
+   * @platform ios
+   */
+  hasTVPreferredFocus?: boolean,
+
+  /**
+   * *(Apple TV only)* May be used to change the appearance of the Apple TV parallax effect when this view goes in or out of focus.  Defaults to 2.0.
+   *
+   * @platform ios
+   */
+  tvParallaxShiftDistanceX?: number,
+
+  /**
+   * *(Apple TV only)* May be used to change the appearance of the Apple TV parallax effect when this view goes in or out of focus.  Defaults to 2.0.
+   *
+   * @platform ios
+   */
+  tvParallaxShiftDistanceY?: number,
+
+  /**
+   * *(Apple TV only)* May be used to change the appearance of the Apple TV parallax effect when this view goes in or out of focus.  Defaults to 0.05.
+   *
+   * @platform ios
+   */
+  tvParallaxTiltAngle?: number,
+
+  /**
+   * *(Apple TV only)* May be used to change the appearance of the Apple TV parallax effect when this view goes in or out of focus.  Defaults to 1.0.
+   *
+   * @platform ios
+   */
+  tvParallaxMagnification?: number,
+}>;
+
 export type ViewPropsIOS = $ReadOnly<{
   /**
    * Whether this `View` should be rendered as a bitmap before compositing.

--- a/packages/react-native/Libraries/Image/ImageBackground.js
+++ b/packages/react-native/Libraries/Image/ImageBackground.js
@@ -17,6 +17,8 @@ import StyleSheet from '../StyleSheet/StyleSheet';
 import Image from './Image';
 import * as React from 'react';
 
+export type {ImageBackgroundProps} from './ImageProps';
+
 /**
  * Very simple drop-in replacement for <Image> which supports nesting views.
  *

--- a/packages/react-native/Libraries/Lists/VirtualizedList.js
+++ b/packages/react-native/Libraries/Lists/VirtualizedList.js
@@ -19,5 +19,6 @@ export type {
   ListRenderItemInfo,
   ListRenderItem,
   Separators,
+  VirtualizedListProps,
 } from '@react-native/virtualized-lists';
 export default VirtualizedList;

--- a/packages/react-native/Libraries/Lists/VirtualizedSectionList.js
+++ b/packages/react-native/Libraries/Lists/VirtualizedSectionList.js
@@ -20,5 +20,6 @@ const VirtualizedSectionList: VirtualizedSectionListType =
 export type {
   SectionBase,
   ScrollToLocationParamsType,
+  VirtualizedSectionListProps,
 } from '@react-native/virtualized-lists';
 export default VirtualizedSectionList;

--- a/packages/react-native/Libraries/Utilities/DeviceInfo.js
+++ b/packages/react-native/Libraries/Utilities/DeviceInfo.js
@@ -8,6 +8,8 @@
  * @flow strict-local
  */
 
+export type {DeviceInfoConstants} from './NativeDeviceInfo';
+
 import NativeDeviceInfo from './NativeDeviceInfo';
 
 export default NativeDeviceInfo;

--- a/packages/react-native/Libraries/Utilities/Dimensions.js
+++ b/packages/react-native/Libraries/Utilities/Dimensions.js
@@ -19,7 +19,7 @@ import NativeDeviceInfo, {
 } from './NativeDeviceInfo';
 import invariant from 'invariant';
 
-export type {DisplayMetrics, DisplayMetricsAndroid};
+export type {DimensionsPayload, DisplayMetrics, DisplayMetricsAndroid};
 
 /** @deprecated Use DisplayMetrics */
 export type ScaledSize = DisplayMetrics;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -3564,7 +3564,7 @@ type TouchableHighlightBaseProps = $ReadOnly<{
   testOnly_pressed?: ?boolean,
   hostRef: React.RefSetter<React.ElementRef<typeof View>>,
 }>;
-type TouchableHighlightProps = $ReadOnly<{
+export type TouchableHighlightProps = $ReadOnly<{
   ...TouchableWithoutFeedbackProps,
   ...AndroidProps,
   ...IOSProps,
@@ -4074,6 +4074,14 @@ export type ViewPropsAndroid = $ReadOnly<{
   focusable?: ?boolean,
   tabIndex?: 0 | -1,
   onClick?: ?(event: GestureResponderEvent) => mixed,
+}>;
+export type TVViewPropsIOS = $ReadOnly<{
+  isTVSelectable?: boolean,
+  hasTVPreferredFocus?: boolean,
+  tvParallaxShiftDistanceX?: number,
+  tvParallaxShiftDistanceY?: number,
+  tvParallaxTiltAngle?: number,
+  tvParallaxMagnification?: number,
 }>;
 export type ViewPropsIOS = $ReadOnly<{
   shouldRasterizeIOS?: ?boolean,
@@ -4612,7 +4620,8 @@ declare export default typeof Context;
 `;
 
 exports[`public API should not change unintentionally Libraries/Image/ImageBackground.js 1`] = `
-"declare class ImageBackground extends React.Component<ImageBackgroundProps> {
+"export type { ImageBackgroundProps } from \\"./ImageProps\\";
+declare class ImageBackground extends React.Component<ImageBackgroundProps> {
   setNativeProps(props: { ... }): void;
   render(): React.Node;
 }
@@ -5461,6 +5470,7 @@ export type {
   ListRenderItemInfo,
   ListRenderItem,
   Separators,
+  VirtualizedListProps,
 } from \\"@react-native/virtualized-lists\\";
 declare export default typeof VirtualizedList;
 "
@@ -5480,6 +5490,7 @@ declare const VirtualizedSectionList: VirtualizedSectionListType;
 export type {
   SectionBase,
   ScrollToLocationParamsType,
+  VirtualizedSectionListProps,
 } from \\"@react-native/virtualized-lists\\";
 declare export default typeof VirtualizedSectionList;
 "
@@ -8540,12 +8551,13 @@ declare export default typeof DevSettings;
 `;
 
 exports[`public API should not change unintentionally Libraries/Utilities/DeviceInfo.js 1`] = `
-"declare export default typeof NativeDeviceInfo;
+"export type { DeviceInfoConstants } from \\"./NativeDeviceInfo\\";
+declare export default typeof NativeDeviceInfo;
 "
 `;
 
 exports[`public API should not change unintentionally Libraries/Utilities/Dimensions.js 1`] = `
-"export type { DisplayMetrics, DisplayMetricsAndroid };
+"export type { DimensionsPayload, DisplayMetrics, DisplayMetricsAndroid };
 export type ScaledSize = DisplayMetrics;
 declare class Dimensions {
   static get(dim: string): DisplayMetrics | DisplayMetricsAndroid;
@@ -9342,87 +9354,283 @@ declare export default class EventEmitter<
 `;
 
 exports[`public API should not change unintentionally index.js.flow 1`] = `
-"export { default as ActivityIndicator } from \\"./Libraries/Components/ActivityIndicator/ActivityIndicator\\";
+"export type { ActivityIndicatorProps } from \\"./Libraries/Components/ActivityIndicator/ActivityIndicator\\";
+export { default as ActivityIndicator } from \\"./Libraries/Components/ActivityIndicator/ActivityIndicator\\";
+export type { ButtonProps } from \\"./Libraries/Components/Button\\";
 export { default as Button } from \\"./Libraries/Components/Button\\";
+export type {
+  DrawerLayoutAndroidProps,
+  DrawerSlideEvent,
+} from \\"./Libraries/Components/DrawerAndroid/DrawerLayoutAndroid\\";
 export { default as DrawerLayoutAndroid } from \\"./Libraries/Components/DrawerAndroid/DrawerLayoutAndroid\\";
+export type { FlatListProps } from \\"./Libraries/Lists/FlatList\\";
 export { default as FlatList } from \\"./Libraries/Lists/FlatList\\";
+export type {
+  ImageBackgroundProps,
+  ImageErrorEvent,
+  ImageLoadEvent,
+  ImageProgressEventIOS,
+  ImageProps,
+  ImagePropsAndroid,
+  ImagePropsBase,
+  ImagePropsIOS,
+  ImageResolvedAssetSource,
+  ImageSize,
+  ImageSourcePropType,
+} from \\"./Libraries/Image/Image\\";
+export type {
+  ImageSource,
+  ImageURISource,
+} from \\"./Libraries/Image/ImageSource\\";
 export { default as Image } from \\"./Libraries/Image/Image\\";
 export { default as ImageBackground } from \\"./Libraries/Image/ImageBackground\\";
+export type { InputAccessoryViewProps } from \\"./Libraries/Components/TextInput/InputAccessoryView\\";
 export { default as InputAccessoryView } from \\"./Libraries/Components/TextInput/InputAccessoryView\\";
+export type { KeyboardAvoidingViewProps } from \\"./Libraries/Components/Keyboard/KeyboardAvoidingView\\";
 export { default as KeyboardAvoidingView } from \\"./Libraries/Components/Keyboard/KeyboardAvoidingView\\";
+export type { LayoutConformanceProps } from \\"./Libraries/Components/LayoutConformance/LayoutConformance\\";
 export { default as experimental_LayoutConformance } from \\"./Libraries/Components/LayoutConformance/LayoutConformance\\";
+export type {
+  ModalBaseProps,
+  ModalProps,
+  ModalPropsAndroid,
+  ModalPropsIOS,
+} from \\"./Libraries/Modal/Modal\\";
 export { default as Modal } from \\"./Libraries/Modal/Modal\\";
+export type {
+  PressableProps,
+  PressableStateCallbackType,
+} from \\"./Libraries/Components/Pressable/Pressable\\";
 export { default as Pressable } from \\"./Libraries/Components/Pressable/Pressable\\";
+export type { ProgressBarAndroidProps } from \\"./Libraries/Components/ProgressBarAndroid/ProgressBarAndroid\\";
 export { default as ProgressBarAndroid } from \\"./Libraries/Components/ProgressBarAndroid/ProgressBarAndroid\\";
+export type {
+  RefreshControlProps,
+  RefreshControlPropsAndroid,
+  RefreshControlPropsIOS,
+} from \\"./Libraries/Components/RefreshControl/RefreshControl\\";
 export { default as RefreshControl } from \\"./Libraries/Components/RefreshControl/RefreshControl\\";
 export { default as SafeAreaView } from \\"./Libraries/Components/SafeAreaView/SafeAreaView\\";
+export type {
+  ScrollViewProps,
+  ScrollViewPropsAndroid,
+  ScrollViewPropsIOS,
+} from \\"./Libraries/Components/ScrollView/ScrollView\\";
 export { default as ScrollView } from \\"./Libraries/Components/ScrollView/ScrollView\\";
+export type {
+  SectionListProps,
+  SectionListRenderItem,
+  SectionListRenderItemInfo,
+} from \\"./Libraries/Lists/SectionList\\";
 export { default as SectionList } from \\"./Libraries/Lists/SectionList\\";
+export type {
+  StatusBarAnimation,
+  StatusBarProps,
+  StatusBarStyle,
+} from \\"./Libraries/Components/StatusBar/StatusBar\\";
 export { default as StatusBar } from \\"./Libraries/Components/StatusBar/StatusBar\\";
+export type {
+  SwitchChangeEvent,
+  SwitchProps,
+} from \\"./Libraries/Components/Switch/Switch\\";
 export { default as Switch } from \\"./Libraries/Components/Switch/Switch\\";
+export type { TextProps } from \\"./Libraries/Text/Text\\";
 export { default as Text } from \\"./Libraries/Text/Text\\";
+export type {
+  AutoCapitalize,
+  EnterKeyHintTypeOptions,
+  KeyboardTypeOptions,
+  InputModeOptions,
+  TextContentType,
+  TextInputAndroidProps,
+  TextInputIOSProps,
+  TextInputProps,
+  TextInputChangeEvent,
+  TextInputContentSizeChangeEvent,
+  TextInputEndEditingEvent,
+  TextInputFocusEvent,
+  TextInputKeyPressEvent,
+  TextInputScrollEvent,
+  TextInputSelectionChangeEvent,
+  TextInputSubmitEditingEvent,
+  ReturnKeyTypeOptions,
+  SubmitBehavior,
+} from \\"./Libraries/Components/TextInput/TextInput\\";
 export { default as TextInput } from \\"./Libraries/Components/TextInput/TextInput\\";
 export { default as Touchable } from \\"./Libraries/Components/Touchable/Touchable\\";
+export type { TouchableHighlightProps } from \\"./Libraries/Components/Touchable/TouchableHighlight\\";
 export { default as TouchableHighlight } from \\"./Libraries/Components/Touchable/TouchableHighlight\\";
+export type { TouchableNativeFeedbackProps } from \\"./Libraries/Components/Touchable/TouchableNativeFeedback\\";
 export { default as TouchableNativeFeedback } from \\"./Libraries/Components/Touchable/TouchableNativeFeedback\\";
+export type { TouchableOpacityProps } from \\"./Libraries/Components/Touchable/TouchableOpacity\\";
 export { default as TouchableOpacity } from \\"./Libraries/Components/Touchable/TouchableOpacity\\";
+export type { TouchableWithoutFeedbackProps } from \\"./Libraries/Components/Touchable/TouchableWithoutFeedback\\";
 export { default as TouchableWithoutFeedback } from \\"./Libraries/Components/Touchable/TouchableWithoutFeedback\\";
-export { default as View } from \\"./Libraries/Components/View/View\\";
-export { default as VirtualizedList } from \\"./Libraries/Lists/VirtualizedList\\";
-export { default as VirtualizedSectionList } from \\"./Libraries/Lists/VirtualizedSectionList\\";
-export type * from \\"./Libraries/Types/CodegenTypesNamespace\\";
-export type { ViewProps } from \\"./Libraries/Components/View/ViewPropTypes\\";
-export type { ImageSource } from \\"react-native/Libraries/Image/ImageSource\\";
-export type { ColorValue } from \\"react-native/Libraries/StyleSheet/StyleSheet\\";
 export type {
-  DimensionValue,
-  EdgeInsetsValue,
-  PointValue,
-} from \\"react-native/Libraries/StyleSheet/StyleSheetTypes\\";
+  GestureResponderHandlers,
+  TVViewPropsIOS,
+  ViewProps,
+  ViewPropsAndroid,
+  ViewPropsIOS,
+} from \\"./Libraries/Components/View/ViewPropTypes\\";
+export { default as View } from \\"./Libraries/Components/View/View\\";
+export type {
+  ListRenderItemInfo,
+  ListRenderItem,
+  Separators,
+  VirtualizedListProps,
+} from \\"./Libraries/Lists/VirtualizedList\\";
+export { default as VirtualizedList } from \\"./Libraries/Lists/VirtualizedList\\";
+export type {
+  ScrollToLocationParamsType,
+  SectionBase,
+  VirtualizedSectionListProps,
+} from \\"./Libraries/Lists/VirtualizedSectionList\\";
+export { default as VirtualizedSectionList } from \\"./Libraries/Lists/VirtualizedSectionList\\";
 export { default as AccessibilityInfo } from \\"./Libraries/Components/AccessibilityInfo/AccessibilityInfo\\";
+export type {
+  ActionSheetIOSOptions,
+  ShareActionSheetIOSOptions,
+  ShareActionSheetError,
+} from \\"./Libraries/ActionSheetIOS/ActionSheetIOS\\";
 export { default as ActionSheetIOS } from \\"./Libraries/ActionSheetIOS/ActionSheetIOS\\";
+export type {
+  AlertType,
+  AlertButtonStyle,
+  AlertButton,
+  AlertOptions,
+} from \\"./Libraries/Alert/Alert\\";
 export { default as Alert } from \\"./Libraries/Alert/Alert\\";
 export { default as Animated } from \\"./Libraries/Animated/Animated\\";
 export * as Appearance from \\"./Libraries/Utilities/Appearance\\";
+export type {
+  TaskProvider,
+  ComponentProvider,
+  ComponentProviderInstrumentationHook,
+  AppConfig,
+  Runnable,
+  Runnables,
+  Registry,
+  WrapperComponentProvider,
+  RootViewStyleProvider,
+} from \\"./Libraries/ReactNative/AppRegistry\\";
 export { AppRegistry } from \\"./Libraries/ReactNative/AppRegistry\\";
+export type {
+  AppStateStatus,
+  AppStateEvent,
+} from \\"./Libraries/AppState/AppState\\";
 export { default as AppState } from \\"./Libraries/AppState/AppState\\";
+export type { BackPressEventName } from \\"./Libraries/Utilities/BackHandler\\";
 export { default as BackHandler } from \\"./Libraries/Utilities/BackHandler\\";
 export { default as Clipboard } from \\"./Libraries/Components/Clipboard/Clipboard\\";
 export { default as codegenNativeComponent } from \\"./Libraries/Utilities/codegenNativeComponent\\";
 export { default as codegenNativeCommands } from \\"./Libraries/Utilities/codegenNativeCommands\\";
 export { default as DeviceEventEmitter } from \\"./Libraries/EventEmitter/RCTDeviceEventEmitter\\";
+export type { DeviceInfoConstants } from \\"./Libraries/Utilities/DeviceInfo\\";
 export { default as DeviceInfo } from \\"./Libraries/Utilities/DeviceInfo\\";
 export { default as DevMenu } from \\"./src/private/devmenu/DevMenu\\";
 export { default as DevSettings } from \\"./Libraries/Utilities/DevSettings\\";
+export type {
+  DimensionsPayload,
+  DisplayMetrics,
+  DisplayMetricsAndroid,
+  ScaledSize,
+} from \\"./Libraries/Utilities/Dimensions\\";
 export { default as Dimensions } from \\"./Libraries/Utilities/Dimensions\\";
+export type { DynamicColorIOSTuple } from \\"./Libraries/StyleSheet/PlatformColorValueTypesIOS\\";
 export { DynamicColorIOS } from \\"./Libraries/StyleSheet/PlatformColorValueTypesIOS\\";
+export type { EasingFunction } from \\"./Libraries/Animated/Easing\\";
 export { default as Easing } from \\"./Libraries/Animated/Easing\\";
 export { findNodeHandle } from \\"./Libraries/ReactNative/RendererProxy\\";
-export type { HostInstance } from \\"./src/private/types/HostInstance\\";
-export type { HostComponent } from \\"./src/private/types/HostComponent\\";
 export { default as I18nManager } from \\"./Libraries/ReactNative/I18nManager\\";
+export type {
+  Handle,
+  PromiseTask,
+  SimpleTask,
+} from \\"./Libraries/Interaction/InteractionManager\\";
 export { default as InteractionManager } from \\"./Libraries/Interaction/InteractionManager\\";
+export type {
+  AndroidKeyboardEvent,
+  IOSKeyboardEvent,
+  KeyboardEvent,
+  KeyboardEventEasing,
+  KeyboardEventName,
+  KeyboardMetrics,
+} from \\"./Libraries/Components/Keyboard/Keyboard\\";
 export { default as Keyboard } from \\"./Libraries/Components/Keyboard/Keyboard\\";
+export type {
+  LayoutAnimationAnim,
+  LayoutAnimationConfig,
+  LayoutAnimationProperties,
+  LayoutAnimationProperty,
+  LayoutAnimationType,
+  LayoutAnimationTypes,
+} from \\"./Libraries/LayoutAnimation/LayoutAnimation\\";
 export { default as LayoutAnimation } from \\"./Libraries/LayoutAnimation/LayoutAnimation\\";
 export { default as Linking } from \\"./Libraries/Linking/Linking\\";
+export type {
+  ExtendedExceptionData,
+  IgnorePattern,
+  LogData,
+} from \\"./Libraries/LogBox/LogBox\\";
 export { default as LogBox } from \\"./Libraries/LogBox/LogBox\\";
 export { default as NativeAppEventEmitter } from \\"./Libraries/EventEmitter/RCTNativeAppEventEmitter\\";
 export { default as NativeDialogManagerAndroid } from \\"./Libraries/NativeModules/specs/NativeDialogManagerAndroid\\";
 export { default as NativeEventEmitter } from \\"./Libraries/EventEmitter/NativeEventEmitter\\";
 export { default as NativeModules } from \\"./Libraries/BatchedBridge/NativeModules\\";
 export { default as Networking } from \\"./Libraries/Network/RCTNetworking\\";
+export type {
+  PanResponderCallbacks,
+  PanResponderGestureState,
+  PanResponderInstance,
+} from \\"./Libraries/Interaction/PanResponder\\";
 export { default as PanResponder } from \\"./Libraries/Interaction/PanResponder\\";
+export type {
+  Permission,
+  PermissionStatus,
+  Rationale,
+} from \\"./Libraries/PermissionsAndroid/PermissionsAndroid\\";
 export { default as PermissionsAndroid } from \\"./Libraries/PermissionsAndroid/PermissionsAndroid\\";
 export { default as PixelRatio } from \\"./Libraries/Utilities/PixelRatio\\";
+export type {
+  PlatformOSType,
+  PlatformSelectSpec,
+} from \\"./Libraries/Utilities/PlatformTypes\\";
 export { default as Platform } from \\"./Libraries/Utilities/Platform\\";
 export { PlatformColor } from \\"./Libraries/StyleSheet/PlatformColorValueTypes\\";
+export type {
+  PushNotificationEventName,
+  PushNotificationPermissions,
+} from \\"./Libraries/PushNotificationIOS/PushNotificationIOS\\";
 export { default as PushNotificationIOS } from \\"./Libraries/PushNotificationIOS/PushNotificationIOS\\";
+export type { ProcessedColorValue } from \\"./Libraries/StyleSheet/processColor\\";
 export { default as processColor } from \\"./Libraries/StyleSheet/processColor\\";
 export { default as registerCallableModule } from \\"./Libraries/Core/registerCallableModule\\";
 export { default as requireNativeComponent } from \\"./Libraries/ReactNative/requireNativeComponent\\";
+export type { RootTag } from \\"./Libraries/ReactNative/RootTag\\";
 export { RootTagContext } from \\"./Libraries/ReactNative/RootTag\\";
 export { default as Settings } from \\"./Libraries/Settings/Settings\\";
+export type {
+  ShareAction,
+  ShareContent,
+  ShareOptions,
+} from \\"./Libraries/Share/Share\\";
 export { default as Share } from \\"./Libraries/Share/Share\\";
+export type {
+  ColorValue,
+  ImageStyle,
+  StyleProp,
+  TextStyle,
+  ViewStyle,
+} from \\"./Libraries/StyleSheet/StyleSheet\\";
+export type {
+  BoxShadowValue,
+  CursorValue,
+  DimensionValue,
+  DropShadowValue,
+  EdgeInsetsValue,
+  PointValue,
+} from \\"./Libraries/StyleSheet/StyleSheetTypes\\";
 export { default as StyleSheet } from \\"./Libraries/StyleSheet/StyleSheet\\";
 export * as Systrace from \\"./Libraries/Performance/Systrace\\";
 export { default as ToastAndroid } from \\"./Libraries/Components/ToastAndroid/ToastAndroid\\";
@@ -9434,6 +9642,31 @@ export { default as useColorScheme } from \\"./Libraries/Utilities/useColorSchem
 export { default as useWindowDimensions } from \\"./Libraries/Utilities/useWindowDimensions\\";
 export { default as UTFSequence } from \\"./Libraries/UTFSequence\\";
 export { default as Vibration } from \\"./Libraries/Vibration/Vibration\\";
+export type {
+  BlurEvent,
+  FocusEvent,
+  GestureResponderEvent,
+  LayoutChangeEvent,
+  LayoutRectangle,
+  MouseEvent,
+  NativeMouseEvent,
+  NativePointerEvent,
+  NativeSyntheticEvent,
+  NativeTouchEvent,
+  NativeUIEvent,
+  ResponderSyntheticEvent,
+  ScrollEvent,
+  TargetedEvent,
+  TextLayoutEvent,
+} from \\"./Libraries/Types/CoreEventTypes\\";
+export type * from \\"./Libraries/Types/CodegenTypesNamespace\\";
+export type {
+  HostInstance,
+  MeasureInWindowOnSuccessCallback,
+  MeasureLayoutOnSuccessCallback,
+  MeasureOnSuccessCallback,
+} from \\"./src/private/types/HostInstance\\";
+export type { HostComponent } from \\"./src/private/types/HostComponent\\";
 "
 `;
 

--- a/packages/react-native/index.js.flow
+++ b/packages/react-native/index.js.flow
@@ -11,6 +11,9 @@
 // ----------------------------------------------------------------------------
 // Types entry point for react-native.
 //
+// Exports of this module define the public API for React Native at development
+// time, and are automatically translated to TypeScript when we publish to npm.
+//
 // IMPORTANT: Keep this file in sync with index.js. Test your changes whenever
 // updating React Native's public API.
 // ----------------------------------------------------------------------------
@@ -19,93 +22,349 @@
 
 // #region Components
 
+export type {ActivityIndicatorProps} from './Libraries/Components/ActivityIndicator/ActivityIndicator';
 export {default as ActivityIndicator} from './Libraries/Components/ActivityIndicator/ActivityIndicator';
+
+export type {ButtonProps} from './Libraries/Components/Button';
 export {default as Button} from './Libraries/Components/Button';
+
+export type {
+  DrawerLayoutAndroidProps,
+  DrawerSlideEvent,
+} from './Libraries/Components/DrawerAndroid/DrawerLayoutAndroid';
 export {default as DrawerLayoutAndroid} from './Libraries/Components/DrawerAndroid/DrawerLayoutAndroid';
+
+export type {FlatListProps} from './Libraries/Lists/FlatList';
 export {default as FlatList} from './Libraries/Lists/FlatList';
+
+export type {
+  ImageBackgroundProps,
+  ImageErrorEvent,
+  ImageLoadEvent,
+  ImageProgressEventIOS,
+  ImageProps,
+  ImagePropsAndroid,
+  ImagePropsBase,
+  ImagePropsIOS,
+  ImageResolvedAssetSource,
+  ImageSize,
+  ImageSourcePropType,
+} from './Libraries/Image/Image';
+export type {ImageSource, ImageURISource} from './Libraries/Image/ImageSource';
 export {default as Image} from './Libraries/Image/Image';
 export {default as ImageBackground} from './Libraries/Image/ImageBackground';
+
+export type {InputAccessoryViewProps} from './Libraries/Components/TextInput/InputAccessoryView';
 export {default as InputAccessoryView} from './Libraries/Components/TextInput/InputAccessoryView';
+
+export type {KeyboardAvoidingViewProps} from './Libraries/Components/Keyboard/KeyboardAvoidingView';
 export {default as KeyboardAvoidingView} from './Libraries/Components/Keyboard/KeyboardAvoidingView';
+
+export type {LayoutConformanceProps} from './Libraries/Components/LayoutConformance/LayoutConformance';
 export {default as experimental_LayoutConformance} from './Libraries/Components/LayoutConformance/LayoutConformance';
+
+export type {
+  ModalBaseProps,
+  ModalProps,
+  ModalPropsAndroid,
+  ModalPropsIOS,
+} from './Libraries/Modal/Modal';
 export {default as Modal} from './Libraries/Modal/Modal';
+
+export type {
+  PressableProps,
+  PressableStateCallbackType,
+} from './Libraries/Components/Pressable/Pressable';
 export {default as Pressable} from './Libraries/Components/Pressable/Pressable';
+
+export type {ProgressBarAndroidProps} from './Libraries/Components/ProgressBarAndroid/ProgressBarAndroid';
 export {default as ProgressBarAndroid} from './Libraries/Components/ProgressBarAndroid/ProgressBarAndroid';
+
+export type {
+  RefreshControlProps,
+  RefreshControlPropsAndroid,
+  RefreshControlPropsIOS,
+} from './Libraries/Components/RefreshControl/RefreshControl';
 export {default as RefreshControl} from './Libraries/Components/RefreshControl/RefreshControl';
+
 export {default as SafeAreaView} from './Libraries/Components/SafeAreaView/SafeAreaView';
+
+export type {
+  ScrollViewProps,
+  ScrollViewPropsAndroid,
+  ScrollViewPropsIOS,
+} from './Libraries/Components/ScrollView/ScrollView';
 export {default as ScrollView} from './Libraries/Components/ScrollView/ScrollView';
+
+export type {
+  SectionListProps,
+  SectionListRenderItem,
+  SectionListRenderItemInfo,
+} from './Libraries/Lists/SectionList';
 export {default as SectionList} from './Libraries/Lists/SectionList';
+
+export type {
+  StatusBarAnimation,
+  StatusBarProps,
+  StatusBarStyle,
+} from './Libraries/Components/StatusBar/StatusBar';
 export {default as StatusBar} from './Libraries/Components/StatusBar/StatusBar';
+
+export type {
+  SwitchChangeEvent,
+  SwitchProps,
+} from './Libraries/Components/Switch/Switch';
 export {default as Switch} from './Libraries/Components/Switch/Switch';
+
+export type {TextProps} from './Libraries/Text/Text';
 export {default as Text} from './Libraries/Text/Text';
+
+export type {
+  AutoCapitalize,
+  EnterKeyHintTypeOptions,
+  KeyboardTypeOptions,
+  InputModeOptions,
+  TextContentType,
+  TextInputAndroidProps,
+  TextInputIOSProps,
+  TextInputProps,
+  TextInputChangeEvent,
+  TextInputContentSizeChangeEvent,
+  TextInputEndEditingEvent,
+  TextInputFocusEvent,
+  TextInputKeyPressEvent,
+  TextInputScrollEvent,
+  TextInputSelectionChangeEvent,
+  TextInputSubmitEditingEvent,
+  ReturnKeyTypeOptions,
+  SubmitBehavior,
+} from './Libraries/Components/TextInput/TextInput';
 export {default as TextInput} from './Libraries/Components/TextInput/TextInput';
+
 export {default as Touchable} from './Libraries/Components/Touchable/Touchable';
+
+export type {TouchableHighlightProps} from './Libraries/Components/Touchable/TouchableHighlight';
 export {default as TouchableHighlight} from './Libraries/Components/Touchable/TouchableHighlight';
+
+export type {TouchableNativeFeedbackProps} from './Libraries/Components/Touchable/TouchableNativeFeedback';
 export {default as TouchableNativeFeedback} from './Libraries/Components/Touchable/TouchableNativeFeedback';
+
+export type {TouchableOpacityProps} from './Libraries/Components/Touchable/TouchableOpacity';
 export {default as TouchableOpacity} from './Libraries/Components/Touchable/TouchableOpacity';
+
+export type {TouchableWithoutFeedbackProps} from './Libraries/Components/Touchable/TouchableWithoutFeedback';
 export {default as TouchableWithoutFeedback} from './Libraries/Components/Touchable/TouchableWithoutFeedback';
+
+export type {
+  GestureResponderHandlers,
+  TVViewPropsIOS,
+  ViewProps,
+  ViewPropsAndroid,
+  ViewPropsIOS,
+} from './Libraries/Components/View/ViewPropTypes';
 export {default as View} from './Libraries/Components/View/View';
+
+export type {
+  ListRenderItemInfo,
+  ListRenderItem,
+  Separators,
+  VirtualizedListProps,
+} from './Libraries/Lists/VirtualizedList';
 export {default as VirtualizedList} from './Libraries/Lists/VirtualizedList';
+
+export type {
+  ScrollToLocationParamsType,
+  SectionBase,
+  VirtualizedSectionListProps,
+} from './Libraries/Lists/VirtualizedSectionList';
 export {default as VirtualizedSectionList} from './Libraries/Lists/VirtualizedSectionList';
 
 // #endregion
 // #region APIs
 
-export type * from './Libraries/Types/CodegenTypesNamespace';
-export type {ViewProps} from './Libraries/Components/View/ViewPropTypes';
-export type {ImageSource} from 'react-native/Libraries/Image/ImageSource';
-export type {ColorValue} from 'react-native/Libraries/StyleSheet/StyleSheet';
-export type {
-  DimensionValue,
-  EdgeInsetsValue,
-  PointValue,
-} from 'react-native/Libraries/StyleSheet/StyleSheetTypes';
-
 export {default as AccessibilityInfo} from './Libraries/Components/AccessibilityInfo/AccessibilityInfo';
+
+export type {
+  ActionSheetIOSOptions,
+  ShareActionSheetIOSOptions,
+  ShareActionSheetError,
+} from './Libraries/ActionSheetIOS/ActionSheetIOS';
 export {default as ActionSheetIOS} from './Libraries/ActionSheetIOS/ActionSheetIOS';
+
+export type {
+  AlertType,
+  AlertButtonStyle,
+  AlertButton,
+  AlertOptions,
+} from './Libraries/Alert/Alert';
 export {default as Alert} from './Libraries/Alert/Alert';
+
 export {default as Animated} from './Libraries/Animated/Animated';
+
 export * as Appearance from './Libraries/Utilities/Appearance';
+
+export type {
+  TaskProvider,
+  ComponentProvider,
+  ComponentProviderInstrumentationHook,
+  AppConfig,
+  Runnable,
+  Runnables,
+  Registry,
+  WrapperComponentProvider,
+  RootViewStyleProvider,
+} from './Libraries/ReactNative/AppRegistry';
 export {AppRegistry} from './Libraries/ReactNative/AppRegistry';
+
+export type {
+  AppStateStatus,
+  AppStateEvent,
+} from './Libraries/AppState/AppState';
 export {default as AppState} from './Libraries/AppState/AppState';
+
+export type {BackPressEventName} from './Libraries/Utilities/BackHandler';
 export {default as BackHandler} from './Libraries/Utilities/BackHandler';
+
 export {default as Clipboard} from './Libraries/Components/Clipboard/Clipboard';
+
 export {default as codegenNativeComponent} from './Libraries/Utilities/codegenNativeComponent';
 export {default as codegenNativeCommands} from './Libraries/Utilities/codegenNativeCommands';
+
 export {default as DeviceEventEmitter} from './Libraries/EventEmitter/RCTDeviceEventEmitter';
+
+export type {DeviceInfoConstants} from './Libraries/Utilities/DeviceInfo';
 export {default as DeviceInfo} from './Libraries/Utilities/DeviceInfo';
+
 export {default as DevMenu} from './src/private/devmenu/DevMenu';
 export {default as DevSettings} from './Libraries/Utilities/DevSettings';
+
+export type {
+  DimensionsPayload,
+  DisplayMetrics,
+  DisplayMetricsAndroid,
+  ScaledSize,
+} from './Libraries/Utilities/Dimensions';
 export {default as Dimensions} from './Libraries/Utilities/Dimensions';
+
+export type {DynamicColorIOSTuple} from './Libraries/StyleSheet/PlatformColorValueTypesIOS';
 export {DynamicColorIOS} from './Libraries/StyleSheet/PlatformColorValueTypesIOS';
+
+export type {EasingFunction} from './Libraries/Animated/Easing';
 export {default as Easing} from './Libraries/Animated/Easing';
+
 export {findNodeHandle} from './Libraries/ReactNative/RendererProxy';
-export type {HostInstance} from './src/private/types/HostInstance';
-export type {HostComponent} from './src/private/types/HostComponent';
+
 export {default as I18nManager} from './Libraries/ReactNative/I18nManager';
+
+export type {
+  Handle,
+  PromiseTask,
+  SimpleTask,
+} from './Libraries/Interaction/InteractionManager';
 export {default as InteractionManager} from './Libraries/Interaction/InteractionManager';
+
+export type {
+  AndroidKeyboardEvent,
+  IOSKeyboardEvent,
+  KeyboardEvent,
+  KeyboardEventEasing,
+  KeyboardEventName,
+  KeyboardMetrics,
+} from './Libraries/Components/Keyboard/Keyboard';
 export {default as Keyboard} from './Libraries/Components/Keyboard/Keyboard';
+
+export type {
+  LayoutAnimationAnim,
+  LayoutAnimationConfig,
+  LayoutAnimationProperties,
+  LayoutAnimationProperty,
+  LayoutAnimationType,
+  LayoutAnimationTypes,
+} from './Libraries/LayoutAnimation/LayoutAnimation';
 export {default as LayoutAnimation} from './Libraries/LayoutAnimation/LayoutAnimation';
+
 export {default as Linking} from './Libraries/Linking/Linking';
+
+export type {
+  ExtendedExceptionData,
+  IgnorePattern,
+  LogData,
+} from './Libraries/LogBox/LogBox';
 export {default as LogBox} from './Libraries/LogBox/LogBox';
+
 export {default as NativeAppEventEmitter} from './Libraries/EventEmitter/RCTNativeAppEventEmitter';
+
 export {default as NativeDialogManagerAndroid} from './Libraries/NativeModules/specs/NativeDialogManagerAndroid';
 export {default as NativeEventEmitter} from './Libraries/EventEmitter/NativeEventEmitter';
 export {default as NativeModules} from './Libraries/BatchedBridge/NativeModules';
 export {default as Networking} from './Libraries/Network/RCTNetworking';
+
+export type {
+  PanResponderCallbacks,
+  PanResponderGestureState,
+  PanResponderInstance,
+} from './Libraries/Interaction/PanResponder';
 export {default as PanResponder} from './Libraries/Interaction/PanResponder';
+
+export type {
+  Permission,
+  PermissionStatus,
+  Rationale,
+} from './Libraries/PermissionsAndroid/PermissionsAndroid';
 export {default as PermissionsAndroid} from './Libraries/PermissionsAndroid/PermissionsAndroid';
+
 export {default as PixelRatio} from './Libraries/Utilities/PixelRatio';
+
+export type {
+  PlatformOSType,
+  PlatformSelectSpec,
+} from './Libraries/Utilities/PlatformTypes';
 export {default as Platform} from './Libraries/Utilities/Platform';
+
 export {PlatformColor} from './Libraries/StyleSheet/PlatformColorValueTypes';
+
+export type {
+  PushNotificationEventName,
+  PushNotificationPermissions,
+} from './Libraries/PushNotificationIOS/PushNotificationIOS';
 export {default as PushNotificationIOS} from './Libraries/PushNotificationIOS/PushNotificationIOS';
+
+export type {ProcessedColorValue} from './Libraries/StyleSheet/processColor';
 export {default as processColor} from './Libraries/StyleSheet/processColor';
+
 export {default as registerCallableModule} from './Libraries/Core/registerCallableModule';
 export {default as requireNativeComponent} from './Libraries/ReactNative/requireNativeComponent';
+
+export type {RootTag} from './Libraries/ReactNative/RootTag';
 export {RootTagContext} from './Libraries/ReactNative/RootTag';
+
 export {default as Settings} from './Libraries/Settings/Settings';
+
+export type {
+  ShareAction,
+  ShareContent,
+  ShareOptions,
+} from './Libraries/Share/Share';
 export {default as Share} from './Libraries/Share/Share';
+
+// TODO(T210505449): StyleSheet/StyleSheetTypes exports are incomplete - review
+export type {
+  ColorValue,
+  ImageStyle,
+  StyleProp,
+  TextStyle,
+  ViewStyle,
+} from './Libraries/StyleSheet/StyleSheet';
+export type {
+  BoxShadowValue,
+  CursorValue,
+  DimensionValue,
+  DropShadowValue,
+  EdgeInsetsValue,
+  PointValue,
+} from './Libraries/StyleSheet/StyleSheetTypes';
 export {default as StyleSheet} from './Libraries/StyleSheet/StyleSheet';
+
 export * as Systrace from './Libraries/Performance/Systrace';
 export {default as ToastAndroid} from './Libraries/Components/ToastAndroid/ToastAndroid';
 export * as TurboModuleRegistry from './Libraries/TurboModule/TurboModuleRegistry';
@@ -116,5 +375,36 @@ export {default as useColorScheme} from './Libraries/Utilities/useColorScheme';
 export {default as useWindowDimensions} from './Libraries/Utilities/useWindowDimensions';
 export {default as UTFSequence} from './Libraries/UTFSequence';
 export {default as Vibration} from './Libraries/Vibration/Vibration';
+
+// #endregion
+// #region APIs (types only)
+
+export type {
+  BlurEvent,
+  FocusEvent,
+  GestureResponderEvent,
+  LayoutChangeEvent,
+  LayoutRectangle,
+  MouseEvent,
+  NativeMouseEvent,
+  NativePointerEvent,
+  NativeSyntheticEvent,
+  NativeTouchEvent,
+  NativeUIEvent,
+  ResponderSyntheticEvent,
+  ScrollEvent,
+  TargetedEvent,
+  TextLayoutEvent,
+} from './Libraries/Types/CoreEventTypes';
+
+export type * from './Libraries/Types/CodegenTypesNamespace';
+
+export type {
+  HostInstance,
+  MeasureInWindowOnSuccessCallback,
+  MeasureLayoutOnSuccessCallback,
+  MeasureOnSuccessCallback,
+} from './src/private/types/HostInstance';
+export type {HostComponent} from './src/private/types/HostComponent';
 
 // #endregion

--- a/packages/virtualized-lists/index.js
+++ b/packages/virtualized-lists/index.js
@@ -29,6 +29,7 @@ export type {
   ListRenderItemInfo,
   ListRenderItem,
   Separators,
+  VirtualizedListProps,
 } from './Lists/VirtualizedListProps';
 export type {
   VirtualizedSectionListProps,


### PR DESCRIPTION
Summary:
Updates `index.js.flow` to export (what should be) all public types for `react-native`, closely matching the resolved exported types of `types/index.d.ts` (current manual TS defs).

- Note that this first pass doesn't have to be exhaustive (not yet load bearing) — however, I've done a best-effort scan, which passes our current `__typetests__` fixtures.

**Approach: Explicit type imports in `index.js.flow`**

We have a number of options for how we organise and re-export values and types from the new index file — for now, we're opting for explicitly exporting each symbol here.

- While this clutters the index file somewhat, it also provides a single scannable source of truth — without introducing / altering each contributing module's type exports (we might want to do this eventually, but we're far from having strong organisation denoting the public API boundary). It's self-documenting that the index file contains all root exports by name.
- At the same time, we currently have some exceptions that use `export [type] *` to line up with TypeScript `namespace`s. We aim to review and update these within this release cycle, to enforce the above system.

Changelog: [Internal] - The `react-native` package now exports all public types in Flow (fbsource)

Differential Revision: D71741575
