### PR TITLE
Animated: Type `#animatedView` in `AnimatedProps`

### DIFF
--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -858,6 +858,7 @@ exports[`public API should not change unintentionally Libraries/Animated/nodes/A
   style?: ?AnimatedStyleAllowlist,
   [string]: true,
 }>;
+type TargetViewInstance = React.ElementRef<React.ElementType>;
 declare export default class AnimatedProps extends AnimatedNode {
   constructor(
     inputProps: { [string]: mixed },
@@ -866,7 +867,7 @@ declare export default class AnimatedProps extends AnimatedNode {
     config?: ?AnimatedNodeConfig
   ): void;
   update(): void;
-  setNativeView(animatedView: any): void;
+  setNativeView(targetInstance: TargetViewInstance): void;
 }
 "
 `;


### PR DESCRIPTION
Summary:
Properly annotate the type of `#animatedView` in `AnimatedProps` and rename it to `#targetInstance`.

Otherwise, no runtime behavior change.

Changelog:
[Internal]

Differential Revision: D71739606


