### PR TITLE
Animated: Pass Target into `{dis,}connectAnimatedView`

### DIFF
--- a/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js
@@ -183,7 +183,7 @@ export default class AnimatedProps extends AnimatedNode {
 
   __detach(): void {
     if (this.__isNative && this.#targetInstance != null) {
-      this.__disconnectAnimatedView();
+      this.#disconnectAnimatedView(this.#targetInstance);
     }
     this.#targetInstance = null;
 
@@ -211,12 +211,12 @@ export default class AnimatedProps extends AnimatedNode {
       this.__isNative = true;
 
       // Since this does not call the super.__makeNative, we need to store the
-      // supplied platformConfig here, before calling __connectAnimatedView
+      // supplied platformConfig here, before calling #connectAnimatedView
       // where it will be needed to traverse the graph of attached values.
       super.__setPlatformConfig(platformConfig);
 
       if (this.#targetInstance != null) {
-        this.__connectAnimatedView();
+        this.#connectAnimatedView(this.#targetInstance);
       }
     }
   }
@@ -227,13 +227,13 @@ export default class AnimatedProps extends AnimatedNode {
     }
     this.#targetInstance = targetInstance;
     if (this.__isNative) {
-      this.__connectAnimatedView();
+      this.#connectAnimatedView(this.#targetInstance);
     }
   }
 
-  __connectAnimatedView(): void {
+  #connectAnimatedView(targetInstance: TargetViewInstance): void {
     invariant(this.__isNative, 'Expected node to be marked as "native"');
-    let nativeViewTag: ?number = findNodeHandle(this.#targetInstance);
+    let nativeViewTag: ?number = findNodeHandle(targetInstance);
     if (nativeViewTag == null) {
       if (process.env.NODE_ENV === 'test') {
         nativeViewTag = -1;
@@ -247,9 +247,9 @@ export default class AnimatedProps extends AnimatedNode {
     );
   }
 
-  __disconnectAnimatedView(): void {
+  #disconnectAnimatedView(targetInstance: TargetViewInstance): void {
     invariant(this.__isNative, 'Expected node to be marked as "native"');
-    let nativeViewTag: ?number = findNodeHandle(this.#targetInstance);
+    let nativeViewTag: ?number = findNodeHandle(targetInstance);
     if (nativeViewTag == null) {
       if (process.env.NODE_ENV === 'test') {
         nativeViewTag = -1;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -858,6 +858,7 @@ exports[`public API should not change unintentionally Libraries/Animated/nodes/A
   style?: ?AnimatedStyleAllowlist,
   [string]: true,
 }>;
+type TargetViewInstance = React.ElementRef<React.ElementType>;
 declare export default class AnimatedProps extends AnimatedNode {
   constructor(
     inputProps: { [string]: mixed },
@@ -866,7 +867,7 @@ declare export default class AnimatedProps extends AnimatedNode {
     config?: ?AnimatedNodeConfig
   ): void;
   update(): void;
-  setNativeView(animatedView: any): void;
+  setNativeView(targetInstance: TargetViewInstance): void;
 }
 "
 `;


### PR DESCRIPTION
Summary:
Makes a few internal improvements to `AnimatedProps`:

- Change `__connectAnimatedView` and `__disconnectAnimatedView` to be private methods, so that we can confidently change their type signatures.
- Pass `#targetInstance` into those methods, so that the responsibility of verifying `#targetInstance`'s non-nullability is hoisted to the call sites.

There should be no observable runtime behavior change.

Changelog:
[Internal]

Differential Revision: D71740601


