### PR TITLE
Animated: Manually Manage Connected `viewTag`

### DIFF
--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -897,7 +897,7 @@ declare export default class AnimatedProps extends AnimatedNode {
     config?: ?AnimatedNodeConfig
   ): void;
   update(): void;
-  setNativeView(targetInstance: TargetViewInstance): void;
+  setNativeView(instance: TargetViewInstance): void;
 }
 "
 `;

--- a/packages/react-native/src/private/animated/__tests__/AnimatedProps-itest.js
+++ b/packages/react-native/src/private/animated/__tests__/AnimatedProps-itest.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import 'react-native/Libraries/Core/InitializeCore';
+
+import NativeAnimatedHelper from '../NativeAnimatedHelper';
+import * as Fantom from '@react-native/fantom';
+import * as React from 'react';
+import {Animated} from 'react-native';
+
+function mockNativeAnimatedHelperAPI() {
+  const mocks = {
+    connectAnimatedNodeToView: jest.fn(),
+    disconnectAnimatedNodeFromView: jest.fn(),
+  };
+  // $FlowFixMe[cannot-write] - Switch to `jest.spyOn` when supported.
+  Object.assign(NativeAnimatedHelper.API, mocks);
+  return mocks;
+}
+
+test('connects and disconnects views', () => {
+  const mocks = mockNativeAnimatedHelperAPI();
+  const opacity = new Animated.Value(0);
+
+  const root = Fantom.createRoot();
+
+  Fantom.runTask(() => {
+    root.render(<Animated.View style={{opacity}} />);
+  });
+  expect(mocks.connectAnimatedNodeToView).not.toBeCalled();
+  expect(mocks.disconnectAnimatedNodeFromView).not.toBeCalled();
+
+  Fantom.runTask(() => {
+    Animated.timing(opacity, {
+      toValue: 1,
+      duration: 1000,
+      useNativeDriver: true,
+    }).start();
+  });
+  expect(mocks.connectAnimatedNodeToView).toBeCalledTimes(1);
+  expect(mocks.disconnectAnimatedNodeFromView).not.toBeCalled();
+
+  Fantom.runTask(() => {
+    root.destroy();
+  });
+
+  expect(mocks.connectAnimatedNodeToView).toBeCalledTimes(1);
+  expect(mocks.disconnectAnimatedNodeFromView).toBeCalledTimes(1);
+});


### PR DESCRIPTION
Summary:
Currently, `AnimatedProps` invokes `findNodeHandle` to both connect and disconnect the native `AnimatedNode` instances to corresponding `viewTag`s.

Not only is this slow and wasteful (because `findNodeHandle` requires traversing the fiber tree), but it prevents deferring disconnection to after the fiber tree has been unmounted.

Disconnecting after unmount is necessary when the `scheduleAnimatedCleanupInMicrotask` feature flag is enabled, which is necessary to avoid invoking animation completion callbacks in the commit phase that unmounts animated views.

I have verified that `disconnectAnimatedNodeFromView` is needed and handles being called after fibers are unmounted.

Changelog:
[Internal]

Differential Revision: D71745805


