### PR TITLE
Animated: Omit `allowlist` in `avoidStateUpdateInAnimatedPropsMemo` Experiment

### DIFF
--- a/packages/react-native/src/private/animated/createAnimatedPropsMemoHook.js
+++ b/packages/react-native/src/private/animated/createAnimatedPropsMemoHook.js
@@ -91,8 +91,7 @@ export function createAnimatedPropsMemoHook(
     const prev = prevRef.current;
 
     const next =
-      prev != null &&
-      areCompositeKeysEqual(prev.compositeKey, compositeKey, allowlist)
+      prev != null && areCompositeKeysEqual(prev.compositeKey, compositeKey)
         ? prev
         : {
             compositeKey,


### PR DESCRIPTION
Summary:
While reviewing the `avoidStateUpdateInAnimatedPropsMemo` experiment, I noticed that the control and test groups were invoking `areCompositeKeysEqual` differently:

- Test group was passing in `allowlist`.
- Control group was not passing in `allowlist`.

Passing it in is technically more correct, but let's restore the control group behavior for now to isolate the tested changes.

Changelog:
[Internal]

Differential Revision: D71746745


