### PR TITLE
RN: Ship `disableInteractionManager`

### DIFF
--- a/packages/react-native/Libraries/Interaction/InteractionManager.d.ts
+++ b/packages/react-native/Libraries/Interaction/InteractionManager.d.ts
@@ -20,6 +20,9 @@ export type PromiseTask = {
   gen: () => Promise<any>;
 };
 
+/**
+ * @deprecated
+ */
 export interface InteractionManagerStatic {
   Events: {
     interactionStart: string;
@@ -36,6 +39,8 @@ export interface InteractionManagerStatic {
    *   emitted
    * @param context - Optional context object to use when invoking the
    *   listener
+   *
+   * @deprecated
    */
   addListener(
     eventType: string,
@@ -46,6 +51,8 @@ export interface InteractionManagerStatic {
   /**
    * Schedule a function to run after all interactions have completed.
    * Returns a cancellable
+   *
+   * @deprecated
    */
   runAfterInteractions(task?: (() => any) | SimpleTask | PromiseTask): {
     then: (onfulfilled?: () => any, onrejected?: () => any) => Promise<any>;
@@ -55,11 +62,15 @@ export interface InteractionManagerStatic {
 
   /**
    * Notify manager that an interaction has started.
+   *
+   * @deprecated
    */
   createInteractionHandle(): Handle;
 
   /**
    * Notify manager that an interaction has completed.
+   *
+   * @deprecated
    */
   clearInteractionHandle(handle: Handle): void;
 
@@ -67,6 +78,8 @@ export interface InteractionManagerStatic {
    * A positive number will use setTimeout to schedule any tasks after
    * the eventLoopRunningTime hits the deadline value, otherwise all
    * tasks will be executed in one setImmediate batch (default).
+   *
+   * @deprecated
    */
   setDeadline(deadline: number): void;
 }

--- a/packages/react-native/Libraries/Interaction/__tests__/InteractionManager-test.js
+++ b/packages/react-native/Libraries/Interaction/__tests__/InteractionManager-test.js
@@ -10,15 +10,32 @@
 
 'use strict';
 
-const BatchedBridge = require('../../BatchedBridge/BatchedBridge').default;
+import type {ReactNativeFeatureFlagsJsOnlyOverrides} from '../../../src/private/featureflags/ReactNativeFeatureFlags';
 
-jest.mock('../../vendor/core/ErrorUtils');
-jest.mock('../../BatchedBridge/BatchedBridge');
+function importModules(overrides: ReactNativeFeatureFlagsJsOnlyOverrides) {
+  const ReactNativeFeatureFlags = require('../../../src/private/featureflags/ReactNativeFeatureFlags');
+
+  // Make sure to setup overrides before importing any modules.
+  ReactNativeFeatureFlags.override(overrides);
+
+  const BatchedBridge = require('../../BatchedBridge/BatchedBridge').default;
+  const InteractionManager = require('../InteractionManager').default;
+
+  jest.mock('../../vendor/core/ErrorUtils');
+  jest.mock('../../BatchedBridge/BatchedBridge');
+
+  return {
+    BatchedBridge,
+    InteractionManager,
+  };
+}
 
 const isWindows = process.platform === 'win32';
-const itif = condition => (condition ? it : it.skip);
+const itif = (condition: boolean) => (condition ? it : it.skip);
 
-function expectToBeCalledOnce(fn) {
+function expectToBeCalledOnce(
+  fn: JestMockFn<$ReadOnlyArray<mixed>, mixed>,
+): void {
   expect(fn.mock.calls.length).toBe(1);
 }
 
@@ -29,7 +46,9 @@ describe('InteractionManager', () => {
 
   beforeEach(() => {
     jest.resetModules();
-    InteractionManager = require('../InteractionManager').default;
+    ({InteractionManager} = importModules({
+      disableInteractionManager: () => false,
+    }));
 
     interactionStart = jest.fn();
     interactionComplete = jest.fn();
@@ -45,6 +64,7 @@ describe('InteractionManager', () => {
   });
 
   it('throws when clearing an undefined handle', () => {
+    // $FlowExpectedError[incompatible-call]
     expect(() => InteractionManager.clearInteractionHandle()).toThrow();
   });
 
@@ -157,16 +177,23 @@ describe('InteractionManager', () => {
 });
 
 describe('promise tasks', () => {
+  let BatchedBridge;
   let InteractionManager;
   let sequenceId;
-  function createSequenceTask(expectedSequenceId) {
+
+  function createSequenceTask(expectedSequenceId: number) {
     return jest.fn(() => {
       expect(++sequenceId).toBe(expectedSequenceId);
     });
   }
+
   beforeEach(() => {
     jest.resetModules();
-    InteractionManager = require('../InteractionManager').default;
+
+    ({BatchedBridge, InteractionManager} = importModules({
+      disableInteractionManager: () => false,
+    }));
+
     sequenceId = 0;
   });
 

--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -204,6 +204,9 @@ module.exports = {
   get I18nManager() {
     return require('./Libraries/ReactNative/I18nManager').default;
   },
+  /**
+   * @deprecated
+   */
   get InteractionManager() {
     return require('./Libraries/Interaction/InteractionManager').default;
   },

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -541,13 +541,12 @@ const definitions: FeatureFlagDefinitions = {
       ossReleaseStage: 'none',
     },
     disableInteractionManager: {
-      defaultValue: false,
+      defaultValue: true,
       metadata: {
-        dateAdded: '2024-11-06',
         description:
           'Disables InteractionManager and replaces its scheduler with `setImmediate`.',
         expectedReleaseValue: true,
-        purpose: 'experimentation',
+        purpose: 'release',
       },
       ossReleaseStage: 'none',
     },

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<bb1c3b4c3d3d20ab463e4d0131efc3d9>>
+ * @generated SignedSource<<cfb93f77067ecb7b6729bfe388949737>>
  * @flow strict
  */
 
@@ -119,7 +119,7 @@ export const avoidStateUpdateInAnimatedPropsMemo: Getter<boolean> = createJavaSc
 /**
  * Disables InteractionManager and replaces its scheduler with `setImmediate`.
  */
-export const disableInteractionManager: Getter<boolean> = createJavaScriptFlagGetter('disableInteractionManager', false);
+export const disableInteractionManager: Getter<boolean> = createJavaScriptFlagGetter('disableInteractionManager', true);
 
 /**
  * Enables access to the host tree in Fabric using DOM-compatible APIs.


### PR DESCRIPTION
Summary:
Ships the `disableInteractionManager` feature flag, which disables `InteractionManager` and replaces its scheduler with `setImmediate`.

Changelog:
[General][Changed] - InteractionManager is deprecated and will be removed in a future release. Its behavior has been changed to be the same as `setImmediate`, and callers should migrate off of it.

Differential Revision: D71766877


