### PR TITLE
Allow link role to be announced if its set on entire text in nested text

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentAccessibilityProvider.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentAccessibilityProvider.mm
@@ -81,11 +81,16 @@ using namespace facebook::react;
                            enumerateAttribute:RCTTextAttributesAccessibilityRoleAttributeName
                                         frame:_frame
                                    usingBlock:^(CGRect fragmentRect, NSString *_Nonnull fragmentText, NSString *value) {
-                                     if ([fragmentText isEqualToString:firstElement.accessibilityLabel]) {
-                                       // The fragment is the entire paragraph. This is handled as `firstElement`.
+                                     if ((![value isEqualToString:@"button"] && ![value isEqualToString:@"link"])) {
                                        return;
                                      }
-                                     if ((![value isEqualToString:@"button"] && ![value isEqualToString:@"link"])) {
+                                     if ([fragmentText isEqualToString:firstElement.accessibilityLabel]) {
+                                       if ([value isEqualToString:@"link"]) {
+                                         firstElement.accessibilityTraits |= UIAccessibilityTraitLink;
+                                       } else if ([value isEqualToString:@"button"]) {
+                                         firstElement.accessibilityTraits |= UIAccessibilityTraitButton;
+                                       }
+                                       // The fragment is the entire paragraph. This is handled as `firstElement`.
                                        return;
                                      }
                                      if ([value isEqualToString:@"button"] &&


### PR DESCRIPTION
Summary:
If you do something like

```
<Text>
  <Text accessibilityRole="link">
    I am a link!
  </Text>
</Text>
```

we do not announce "link". 

We skip any sort of spans on the entire text on iOS, which I feel like is not ideal. This case would be common enough, and users may not have access to the top level text component.

Note Android correctly handles this already.

Changelog: [iOS] [Fixed] - Correctly announce "link" on nested text if its the entire text element

Differential Revision: D71770798


