### PR TITLE
Enable useFabricInterop for Stable in OSS

### DIFF
--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSStable.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSStable.h
@@ -26,5 +26,8 @@ class ReactNativeFeatureFlagsOverridesOSSStable
   bool useNativeViewConfigsInBridgelessMode() override {
     return true;
   }
+  bool useFabricInterop() override {
+    return true;
+  }
 };
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
Enabling `useFabricInterop` for Stable in OSS just as done in Android here:

https://github.com/facebook/react-native/blob/26ca802e8462e978282180e6cfd65e644d67bbc7/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android.kt#L15

**Changelog:**
[iOS][Added]  Enabled `useFabricInterop` by default in OSS

Differential Revision: D71751048


