### PR TITLE
[0.76][github] Fix upload-artifact version on maestro android

### DIFF
--- a/.github/actions/maestro-android/action.yml
+++ b/.github/actions/maestro-android/action.yml
@@ -56,7 +56,7 @@ runs:
           echo "Stop recording. Saving to screen.mp4"
           adb pull /sdcard/screen.mp4
     - name: Store tests result
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4.3.4
       with:
         name: e2e_android_${{ inputs.app-id }}_report_${{ inputs.jsengine }}
         path: |


### PR DESCRIPTION
## Summary:

Android E2E maestro tests are failing on 0.76-stable because `actions/upload-artifact` v3 has been deprecated.
https://github.com/facebook/react-native/actions/runs/14044976491/job/39325684374

## Changelog:

[INTERNAL] [FIXED] - Bump `actions/upload-artifact` version on Android E2E maestro tests

## Test Plan:

Android E2E maestro tests should be green 
