### PR TITLE
Minimize operations in InspectorNetworkReporter in prod

### DIFF
--- a/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.h
+++ b/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+/**
+ * [Experimental] An interface for reporting network events to the modern
+ * debugger server and Web Performance APIs.
+ *
+ * This is a helper class wrapping
+ * `facebook::react::jsinspector_modern::NetworkReporter`.
+ */
+@interface RCTInspectorNetworkReporter : NSObject
+
++ (void)reportRequestStart:(NSNumber *)requestId
+                   request:(NSURLRequest *)request
+         encodedDataLength:(int)encodedDataLength;
++ (void)reportResponseStart:(NSNumber *)requestId
+                   response:(NSURLResponse *)response
+                 statusCode:(int)statusCode
+                    headers:(NSDictionary<NSString *, NSString *> *)headers;
++ (void)reportResponseEnd:(NSNumber *)requestId encodedDataLength:(int)encodedDataLength;
+
+@end

--- a/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.h
+++ b/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.h
@@ -13,6 +13,8 @@
  * [Experimental] An interface for reporting network events to the modern
  * debugger server and Web Performance APIs.
  *
+ * In a production (non dev or profiling) build, CDP reporting is disabled.
+ *
  * This is a helper class wrapping
  * `facebook::react::jsinspector_modern::NetworkReporter`.
  */

--- a/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.mm
+++ b/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.mm
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTInspectorNetworkReporter.h"
+
+#import <jsinspector-modern/network/NetworkReporter.h>
+
+namespace {
+
+using namespace facebook::react::jsinspector_modern;
+
+Headers convertNSDictionaryToHeaders(const NSDictionary<NSString *, NSString *> *headers)
+{
+  Headers responseHeaders;
+  for (NSString *key in headers) {
+    responseHeaders[[key UTF8String]] = [headers[key] UTF8String];
+  }
+  return responseHeaders;
+}
+
+} // namespace
+
+@implementation RCTInspectorNetworkReporter {
+}
+
++ (void)reportRequestStart:(NSNumber *)requestId
+                   request:(NSURLRequest *)request
+         encodedDataLength:(int)encodedDataLength
+{
+  RequestInfo requestInfo;
+  requestInfo.url = [request.URL absoluteString].UTF8String;
+  requestInfo.httpMethod = [request.HTTPMethod UTF8String];
+  requestInfo.headers = convertNSDictionaryToHeaders(request.allHTTPHeaderFields);
+  requestInfo.httpBody = std::string((const char *)request.HTTPBody.bytes, request.HTTPBody.length);
+
+  NetworkReporter::getInstance().reportRequestStart(
+      requestId.stringValue.UTF8String, requestInfo, encodedDataLength, std::nullopt);
+}
+
++ (void)reportResponseStart:(NSNumber *)requestId
+                   response:(NSURLResponse *)response
+                 statusCode:(int)statusCode
+                    headers:(NSDictionary<NSString *, NSString *> *)headers
+{
+  ResponseInfo responseInfo;
+  responseInfo.url = response.URL.absoluteString.UTF8String;
+  responseInfo.statusCode = statusCode;
+  responseInfo.headers = convertNSDictionaryToHeaders(headers);
+
+  NetworkReporter::getInstance().reportResponseStart(
+      requestId.stringValue.UTF8String, responseInfo, response.expectedContentLength);
+}
+
++ (void)reportResponseEnd:(NSNumber *)requestId encodedDataLength:(int)encodedDataLength
+{
+  NetworkReporter::getInstance().reportResponseEnd(requestId.stringValue.UTF8String, encodedDataLength);
+}
+
+@end

--- a/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.mm
+++ b/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.mm
@@ -9,9 +9,10 @@
 
 #import <jsinspector-modern/network/NetworkReporter.h>
 
-namespace {
-
 using namespace facebook::react::jsinspector_modern;
+
+#ifdef REACT_NATIVE_DEBUGGER_ENABLED
+namespace {
 
 Headers convertNSDictionaryToHeaders(const NSDictionary<NSString *, NSString *> *headers)
 {
@@ -23,6 +24,7 @@ Headers convertNSDictionaryToHeaders(const NSDictionary<NSString *, NSString *> 
 }
 
 } // namespace
+#endif
 
 @implementation RCTInspectorNetworkReporter {
 }
@@ -34,8 +36,11 @@ Headers convertNSDictionaryToHeaders(const NSDictionary<NSString *, NSString *> 
   RequestInfo requestInfo;
   requestInfo.url = [request.URL absoluteString].UTF8String;
   requestInfo.httpMethod = [request.HTTPMethod UTF8String];
+#ifdef REACT_NATIVE_DEBUGGER_ENABLED
+  // Debug build: Process additional request info for CDP reporting
   requestInfo.headers = convertNSDictionaryToHeaders(request.allHTTPHeaderFields);
   requestInfo.httpBody = std::string((const char *)request.HTTPBody.bytes, request.HTTPBody.length);
+#endif
 
   NetworkReporter::getInstance().reportRequestStart(
       requestId.stringValue.UTF8String, requestInfo, encodedDataLength, std::nullopt);
@@ -49,7 +54,11 @@ Headers convertNSDictionaryToHeaders(const NSDictionary<NSString *, NSString *> 
   ResponseInfo responseInfo;
   responseInfo.url = response.URL.absoluteString.UTF8String;
   responseInfo.statusCode = statusCode;
+
+#ifdef REACT_NATIVE_DEBUGGER_ENABLED
+  // Debug build: Process additional request info for CDP reporting
   responseInfo.headers = convertNSDictionaryToHeaders(headers);
+#endif
 
   NetworkReporter::getInstance().reportResponseStart(
       requestId.stringValue.UTF8String, responseInfo, response.expectedContentLength);

--- a/packages/react-native/Libraries/Network/React-RCTNetwork.podspec
+++ b/packages/react-native/Libraries/Network/React-RCTNetwork.podspec
@@ -46,6 +46,8 @@ Pod::Spec.new do |s|
 
   add_dependency(s, "React-RCTFBReactNativeSpec")
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
+  add_dependency(s, "React-jsinspectorcdp", :framework_name => 'jsinspector_moderncdp')
+  add_dependency(s, "React-jsinspectornetwork", :framework_name => 'jsinspector_modernnetwork')
   add_dependency(s, "React-NativeModulesApple", :additional_framework_paths => ["build/generated/ios"])
 
   add_rn_third_party_dependencies(s)

--- a/packages/react-native/React/React-RCTFabric.podspec
+++ b/packages/react-native/React/React-RCTFabric.podspec
@@ -86,6 +86,7 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-RCTAnimation", :framework_name => 'RCTAnimation')
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
   add_dependency(s, "React-jsinspectorcdp", :framework_name => 'jsinspector_moderncdp')
+  add_dependency(s, "React-jsinspectornetwork", :framework_name => 'jsinspector_modernnetwork')
   add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')
   add_dependency(s, "React-renderercss")
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/NetworkIOAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/NetworkIOAgent.cpp
@@ -271,16 +271,19 @@ bool NetworkIOAgent::handleRequest(
   }
 
   if (InspectorFlags::getInstance().getNetworkInspectionEnabled()) {
+    auto& networkReporter = NetworkReporter::getInstance();
+
     // @cdp Network.enable support is experimental.
     if (req.method == "Network.enable") {
-      NetworkReporter::getInstance().enableDebugging();
+      networkReporter.setFrontendChannel(frontendChannel_);
+      networkReporter.enableDebugging();
       frontendChannel_(cdp::jsonResult(req.id));
       return true;
     }
 
     // @cdp Network.disable support is experimental.
     if (req.method == "Network.disable") {
-      NetworkReporter::getInstance().disableDebugging();
+      networkReporter.disableDebugging();
       frontendChannel_(cdp::jsonResult(req.id));
       return true;
     }

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/CMakeLists.txt
@@ -24,4 +24,5 @@ target_include_directories(jsinspector_network PUBLIC ${REACT_COMMON_DIR})
 target_link_libraries(jsinspector_network
         folly_runtime
         glog
+        jsinspector_cdp
 )

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkReporter.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkReporter.cpp
@@ -8,14 +8,108 @@
 #include "NetworkReporter.h"
 
 #include <glog/logging.h>
+#include <jsinspector-modern/cdp/CdpJson.h>
 
 #include <stdexcept>
 
 namespace facebook::react::jsinspector_modern {
 
+namespace {
+
+/**
+ * Get the CDP `ResourceType` for a given MIME type.
+ *
+ * https://chromedevtools.github.io/devtools-protocol/tot/Network/#type-ResourceType
+ */
+std::string mimeTypeToResourceType(const std::string& mimeType) {
+  if (mimeType.find("image/") == 0) {
+    return "Image";
+  }
+
+  if (mimeType.find("video/") == 0 || mimeType.find("audio/") == 0) {
+    return "Media";
+  }
+
+  if (mimeType == "application/javascript" || mimeType == "text/javascript" ||
+      mimeType == "application/x-javascript") {
+    return "Script";
+  }
+
+  if (mimeType == "application/json" || mimeType.find("application/xml") == 0 ||
+      mimeType == "text/xml") {
+    // Assume XHR for JSON/XML types
+    return "XHR";
+  }
+
+  return "Other";
+}
+
+folly::dynamic headersToDynamic(const std::optional<Headers>& headers) {
+  folly::dynamic result = folly::dynamic::object;
+
+  if (headers) {
+    for (const auto& [key, value] : *headers) {
+      result[key] = value;
+    }
+  }
+
+  return result;
+}
+
+folly::dynamic requestToCdpParams(const RequestInfo& request) {
+  folly::dynamic result = folly::dynamic::object;
+  result["url"] = request.url;
+  result["method"] = request.httpMethod;
+  result["headers"] = headersToDynamic(request.headers);
+  result["postData"] = request.httpBody.value();
+
+  return result;
+}
+
+folly::dynamic responseToCdpParams(
+    const ResponseInfo& response,
+    int encodedDataLength) {
+  auto headers = response.headers.value_or(Headers());
+  std::string mimeType = "Other";
+
+  if (headers.find("Content-Type") != headers.end()) {
+    mimeType = mimeTypeToResourceType(headers.at("Content-Type"));
+  }
+
+  folly::dynamic result = folly::dynamic::object;
+  result["url"] = response.url;
+  result["status"] = response.statusCode;
+  result["statusText"] = "";
+  result["headers"] = headersToDynamic(response.headers);
+  result["mimeType"] = mimeType;
+  result["encodedDataLength"] = encodedDataLength;
+
+  return result;
+}
+
+/**
+ * Get the current Unix timestamp in seconds (µs precision).
+ */
+double getCurrentUnixTimestampSeconds() {
+  auto now = std::chrono::system_clock::now().time_since_epoch();
+  auto seconds = std::chrono::duration_cast<std::chrono::seconds>(now).count();
+  auto micros =
+      std::chrono::duration_cast<std::chrono::microseconds>(now).count() %
+      1000000;
+
+  return static_cast<double>(seconds) +
+      (static_cast<double>(micros) / 1000000.0);
+}
+
+} // namespace
+
 NetworkReporter& NetworkReporter::getInstance() {
   static NetworkReporter tracer;
   return tracer;
+}
+
+void NetworkReporter::setFrontendChannel(FrontendChannel frontendChannel) {
+  frontendChannel_ = std::move(frontendChannel);
 }
 
 bool NetworkReporter::enableDebugging() {
@@ -38,13 +132,34 @@ bool NetworkReporter::disableDebugging() {
   return true;
 }
 
-void NetworkReporter::reportRequestStart(const std::string& /*requestId*/) {
+void NetworkReporter::reportRequestStart(
+    const std::string& requestId,
+    const RequestInfo& requestInfo,
+    int encodedDataLength,
+    const std::optional<ResponseInfo>& redirectResponse) {
   if (!debuggingEnabled_.load(std::memory_order_relaxed)) {
     return;
   }
 
-  // TODO(T216933356)
-  throw std::runtime_error("Not implemented");
+  double timestamp = getCurrentUnixTimestampSeconds();
+
+  folly::dynamic params = folly::dynamic::object;
+  params["requestId"] = requestId;
+  params["loaderId"] = "";
+  params["documentURL"] = "mobile";
+  params["request"] = requestToCdpParams(requestInfo);
+  // NOTE: timestamp and wallTime share the same time unit and precision,
+  // except wallTime is from an arbitrary epoch - use the Unix epoch for both.
+  params["timestamp"] = timestamp;
+  params["wallTime"] = timestamp;
+  params["initiator"] = folly::dynamic::object("type", "script");
+  params["redirectHasExtraInfo"] = redirectResponse.has_value();
+  if (redirectResponse.has_value()) {
+    params["redirectResponse"] =
+        responseToCdpParams(redirectResponse.value(), encodedDataLength);
+  }
+
+  frontendChannel_(cdp::jsonNotification("Network.requestWillBeSent", params));
 }
 
 void NetworkReporter::reportConnectionTiming(const std::string& /*requestId*/) {
@@ -65,13 +180,26 @@ void NetworkReporter::reportRequestFailed(const std::string& /*requestId*/) {
   throw std::runtime_error("Not implemented");
 }
 
-void NetworkReporter::reportResponseStart(const std::string& /*requestId*/) {
+void NetworkReporter::reportResponseStart(
+    const std::string& requestId,
+    const ResponseInfo& responseInfo,
+    int encodedDataLength) {
   if (!debuggingEnabled_.load(std::memory_order_relaxed)) {
     return;
   }
 
-  // TODO(T216933356)
-  throw std::runtime_error("Not implemented");
+  folly::dynamic responseParams =
+      responseToCdpParams(responseInfo, encodedDataLength);
+
+  folly::dynamic params = folly::dynamic::object;
+  params["requestId"] = requestId;
+  params["loaderId"] = "";
+  params["timestamp"] = getCurrentUnixTimestampSeconds();
+  params["type"] = responseParams["mimeType"];
+  params["response"] = responseParams;
+  params["hasExtraInfo"] = false;
+
+  frontendChannel_(cdp::jsonNotification("Network.responseReceived", params));
 }
 
 void NetworkReporter::reportDataReceived(const std::string& /*requestId*/) {
@@ -83,13 +211,19 @@ void NetworkReporter::reportDataReceived(const std::string& /*requestId*/) {
   throw std::runtime_error("Not implemented");
 }
 
-void NetworkReporter::reportResponseEnd(const std::string& /*requestId*/) {
+void NetworkReporter::reportResponseEnd(
+    const std::string& requestId,
+    int encodedDataLength) {
   if (!debuggingEnabled_.load(std::memory_order_relaxed)) {
     return;
   }
 
-  // TODO(T216933356)
-  throw std::runtime_error("Not implemented");
+  folly::dynamic params = folly::dynamic::object;
+  params["requestId"] = requestId;
+  params["timestamp"] = getCurrentUnixTimestampSeconds();
+  params["encodedDataLength"] = encodedDataLength;
+
+  frontendChannel_(cdp::jsonNotification("Network.loadingFinished", params));
 }
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/React-jsinspectornetwork.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/React-jsinspectornetwork.podspec
@@ -46,5 +46,7 @@ Pod::Spec.new do |s|
     s.header_mappings_dir = "../.."
   end
 
+  add_dependency(s, "React-jsinspectorcdp", :framework_name => 'jsinspector_moderncdp')
+
   add_rn_third_party_dependencies(s)
 end

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -51,7 +51,9 @@ class ReactNativePodsUtils
 
     def self.set_gcc_preprocessor_definition_for_debugger(installer)
         self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "REACT_NATIVE_DEBUGGER_ENABLED=1", "React-jsinspector", :debug)
+        self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "REACT_NATIVE_DEBUGGER_ENABLED=1", "React-RCTNetwork", :debug)
         self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "REACT_NATIVE_DEBUGGER_ENABLED_DEVONLY=1", "React-jsinspector", :debug)
+        self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "REACT_NATIVE_DEBUGGER_ENABLED_DEVONLY=1", "React-RCTNetwork", :debug)
     end
 
     def self.turn_off_resource_bundle_react_core(installer)

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -1703,6 +1703,7 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
+    - React-jsinspectorcdp
     - SocketRocket
   - React-jsinspectortracing (1000.0.0):
     - boost
@@ -1900,6 +1901,7 @@ PODS:
     - React-jsi
     - React-jsinspector
     - React-jsinspectorcdp
+    - React-jsinspectornetwork
     - React-jsinspectortracing
     - React-performancetimeline
     - React-RCTAnimation
@@ -1964,6 +1966,8 @@ PODS:
     - RCTTypeSafety
     - React-Core/RCTNetworkHeaders
     - React-jsi
+    - React-jsinspectorcdp
+    - React-jsinspectornetwork
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
@@ -2590,7 +2594,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 569425f7cd2c3e005a17e5211843e541c11d6916
   React-jsinspector: 885e8180e898f07e4d7df29e2681a89e69d736d3
   React-jsinspectorcdp: 5fb266e5f23d3a2819ba848e9d4d0b6b00f95934
-  React-jsinspectornetwork: 79fbc86b7c308aeb29e883177b8573d953f6b5e2
+  React-jsinspectornetwork: 207422b56a7918e83c94c207570849f83ab9052a
   React-jsinspectortracing: 80e9418ac67630c76f15ef06534087037a822330
   React-jsitooling: b1af12acbfcb039bf87f8f2a82bde3a79c2ddade
   React-jsitracing: ce443686f52538d1033ce7db1e7d643e866262f0
@@ -2605,11 +2609,11 @@ SPEC CHECKSUMS:
   React-RCTAnimation: 263593e66c89bf810604b1ace15dfa382a1ca2df
   React-RCTAppDelegate: 3d35d7226338009b22d1cf9621eaa827acb8fd1d
   React-RCTBlob: 7b76230c53fe87d305eeeb250b0aae031bb6cbae
-  React-RCTFabric: b3746cb91560703c95028002fb6db618aebb3b61
+  React-RCTFabric: 78b6aec5985ef438a9c088032c0e89d2bd77b3ba
   React-RCTFBReactNativeSpec: 503491a0584dc29f03ef9f8ed366794604cd59ef
   React-RCTImage: de404b6b0ebe53976a97e3a0dee819c83e12977b
   React-RCTLinking: 06742cfad41c506091403a414370743a4ed75af3
-  React-RCTNetwork: 091d9c4c3e24f0800d782d0c2a0077419b478d66
+  React-RCTNetwork: f8f7ac330958ac85300827267390bc8decc06ba0
   React-RCTPushNotification: ea11178d499696516e0ff9ae335edbe99b06f94b
   React-RCTRuntime: 07b41aed797e8d950ada851c6363ecf931335663
   React-RCTSettings: d3c2dd305ec81f7faf42762ec598d57f07fd43be


### PR DESCRIPTION
Summary:
Similar to D71636694, adds conditional compile to `InspectorNetworkReporter.mm` to minimize code size and operations performed in production builds.

Specifically:

- Expensive copy of `httpBody` is eliminated.
- Other optional fields that are only mapped when CDP support is enabled are also omitted.

Changelog: [Internal]

Differential Revision: D71637716


