### PR TITLE
Add warning when a component is loaded with the interop layer

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
@@ -50,6 +50,7 @@ using namespace facebook::react;
 {
   if (self = [super init]) {
     self.delegate = delegate;
+    RCTNewArchitectureSetMinValidationLevel(RCTNotAllowedInFabricWithoutLegacy);
     [self _setUpFeatureFlags:releaseLevel];
 
     auto newArchEnabled = [self newArchEnabled];

--- a/packages/react-native/React/Base/RCTAssert.m
+++ b/packages/react-native/React/Base/RCTAssert.m
@@ -310,6 +310,9 @@ newArchitectureValidationInternal(RCTLogLevel level, RCTNotAllowedValidation typ
       case RCTLogLevelFatal:
         RCTAssert(0, @"%@", msg);
         break;
+      case RCTLogLevelWarning:
+        RCTLogWarn(@"%@", msg);
+        break;
       default:
         RCTAssert(0, @"New architecture validation is only for info, error, and fatal levels.");
     }
@@ -334,7 +337,7 @@ void RCTErrorNewArchitectureValidation(RCTNotAllowedValidation type, id context,
 
 void RCTLogNewArchitectureValidation(RCTNotAllowedValidation type, id context, NSString *extra)
 {
-  newArchitectureValidationInternal(RCTLogLevelInfo, type, context, extra);
+  newArchitectureValidationInternal(RCTLogLevelWarning, type, context, extra);
 }
 
 void RCTNewArchitectureValidationPlaceholder(RCTNotAllowedValidation type, id context, NSString *extra)

--- a/packages/react-native/React/Fabric/Mounting/RCTComponentViewFactory.mm
+++ b/packages/react-native/React/Fabric/Mounting/RCTComponentViewFactory.mm
@@ -141,11 +141,13 @@ static Class<RCTComponentViewProtocol> RCTComponentViewClassWithName(const char 
   // TODO(T174674274): Implement lazy loading of legacy view managers in the new architecture.
   if (RCTFabricInteropLayerEnabled() && [RCTLegacyViewManagerInteropComponentView isSupported:componentNameString]) {
     RCTLogNewArchitectureValidation(
-        RCTNotAllowedInBridgeless,
+        RCTNotAllowedInFabricWithoutLegacy,
         self,
         [NSString
             stringWithFormat:
-                @"Legacy ViewManagers should be migrated to Fabric ComponentViews in the new architecture to reduce risk. Component using interop layer: %@",
+                @"The `%@` component is loaded in the app using the Fabric Interop layer. This is part of the compatibility layer with the Legacy Architecture. If `%@` is a local component, please migrate it to be a Native Component as described at https://reactnative.dev/docs/next/fabric-native-components-introduction. If `%@` is a third party dependency, please open an issue in the library repository.",
+                componentNameString,
+                componentNameString,
                 componentNameString]);
 
     auto flavor = std::make_shared<const std::string>(name);


### PR DESCRIPTION
Summary:
This change adds warning to React Native whenever a component is loaded using the interop layer.

The warning is emitted only once per component.

## Changelog:
[iOS][Added] - Add warnings when components are loaded using the interop layer.

Differential Revision: D71808323


