### PR TITLE
Use UIDevice systemName for inspector metadata

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
@@ -48,12 +48,17 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
   jsinspector_modern::HostTargetMetadata getMetadata() override
   {
     auto metadata = [RCTInspectorUtils getHostMetadata];
+#if TARGET_OS_IPHONE
+    NSString *osName = [[UIDevice currentDevice] systemName];
+#else
+    NSString *osName = @"macOS";
+#endif
 
     return {
         .appDisplayName = [metadata.appDisplayName UTF8String],
         .appIdentifier = [metadata.appIdentifier UTF8String],
         .deviceName = [metadata.deviceName UTF8String],
-        .integrationName = [[NSString stringWithFormat:@"%@ Bridgeless (RCTHost)", metadata.platform] UTF8String],
+        .integrationName = [[NSString stringWithFormat:@"%@ Bridgeless (RCTHost)", osName] UTF8String],
         .platform = [metadata.platform UTF8String],
         .reactNativeVersion = [metadata.reactNativeVersion UTF8String],
     };


### PR DESCRIPTION
Summary:
Follows D69867335, but uses the system `[[UIDevice currentDevice] systemName]` API to get the case sensitive OS name (as opposed to the `RCTPlatformName` concept, which is lowercase "ios").

Ultimately, this value is displayed as a user facing label in the debugger.

Changelog: [Internal]

Differential Revision: D71809427


