### PR TITLE
Add flag to turn off legacy warning

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
@@ -50,6 +50,7 @@ using namespace facebook::react;
 {
   if (self = [super init]) {
     self.delegate = delegate;
+    RCTNewArchitectureSetMinValidationLevel(RCTNotAllowedInFabricWithoutLegacy);
     [self _setUpFeatureFlags:releaseLevel];
 
     auto newArchEnabled = [self newArchEnabled];

--- a/packages/react-native/React/Base/RCTAssert.m
+++ b/packages/react-native/React/Base/RCTAssert.m
@@ -310,6 +310,9 @@ newArchitectureValidationInternal(RCTLogLevel level, RCTNotAllowedValidation typ
       case RCTLogLevelFatal:
         RCTAssert(0, @"%@", msg);
         break;
+      case RCTLogLevelWarning:
+        RCTLogWarn(@"%@", msg);
+        break;
       default:
         RCTAssert(0, @"New architecture validation is only for info, error, and fatal levels.");
     }
@@ -334,7 +337,7 @@ void RCTErrorNewArchitectureValidation(RCTNotAllowedValidation type, id context,
 
 void RCTLogNewArchitectureValidation(RCTNotAllowedValidation type, id context, NSString *extra)
 {
-  newArchitectureValidationInternal(RCTLogLevelInfo, type, context, extra);
+  newArchitectureValidationInternal(RCTLogLevelWarning, type, context, extra);
 }
 
 void RCTNewArchitectureValidationPlaceholder(RCTNotAllowedValidation type, id context, NSString *extra)

--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -141,7 +141,8 @@ NSMutableArray<NSString *> *getModulesLoadedWithOldArch(void)
 void RCTRegisterModule(Class);
 void RCTRegisterModule(Class moduleClass)
 {
-  if (RCTIsNewArchEnabled() && ![getCoreModuleClasses() containsObject:[moduleClass description]]) {
+  if (RCTAreLegacyLogsEnabled() && RCTIsNewArchEnabled() &&
+      ![getCoreModuleClasses() containsObject:[moduleClass description]]) {
     addModuleLoadedWithOldArch([moduleClass description]);
   }
   static dispatch_once_t onceToken;

--- a/packages/react-native/React/Base/RCTUtils.h
+++ b/packages/react-native/React/Base/RCTUtils.h
@@ -22,6 +22,10 @@ RCT_EXTERN void RCTSetNewArchEnabled(BOOL enabled) __attribute__((deprecated(
     "This function is now no-op. You need to modify the Info.plist adding a RCTNewArchEnabled bool property to control whether the New Arch is enabled or not")));
 ;
 
+// Whether React native should output logs for modules and components used
+// through the interop layers
+RCT_EXTERN BOOL RCTAreLegacyLogsEnabled(void);
+
 // JSON serialization/deserialization
 RCT_EXTERN NSString *__nullable RCTJSONStringify(id __nullable jsonObject, NSError **error);
 RCT_EXTERN id __nullable RCTJSONParse(NSString *__nullable jsonString, NSError **error);

--- a/packages/react-native/React/Base/RCTUtils.m
+++ b/packages/react-native/React/Base/RCTUtils.m
@@ -51,6 +51,18 @@ void RCTSetNewArchEnabled(BOOL enabled)
   // whether the New Arch is enabled or not.
 }
 
+static BOOL _legacyWarningEnabled = true;
+BOOL RCTAreLegacyLogsEnabled(void)
+{
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    NSNumber *rctNewArchEnabled =
+        (NSNumber *)[[NSBundle mainBundle] objectForInfoDictionaryKey:@"RCTLegacyWarningsEnabled"];
+    _legacyWarningEnabled = rctNewArchEnabled == nil || rctNewArchEnabled.boolValue;
+  });
+  return _legacyWarningEnabled;
+}
+
 static NSString *__nullable _RCTJSONStringifyNoRetry(id __nullable jsonObject, NSError **error)
 {
   if (!jsonObject) {

--- a/packages/react-native/React/Fabric/Mounting/RCTComponentViewFactory.mm
+++ b/packages/react-native/React/Fabric/Mounting/RCTComponentViewFactory.mm
@@ -141,11 +141,13 @@ static Class<RCTComponentViewProtocol> RCTComponentViewClassWithName(const char 
   // TODO(T174674274): Implement lazy loading of legacy view managers in the new architecture.
   if (RCTFabricInteropLayerEnabled() && [RCTLegacyViewManagerInteropComponentView isSupported:componentNameString]) {
     RCTLogNewArchitectureValidation(
-        RCTNotAllowedInBridgeless,
+        RCTNotAllowedInFabricWithoutLegacy,
         self,
         [NSString
             stringWithFormat:
-                @"Legacy ViewManagers should be migrated to Fabric ComponentViews in the new architecture to reduce risk. Component using interop layer: %@",
+                @"The `%@` component is loaded in the app using the Fabric Interop layer. This is part of the compatibility layer with the Legacy Architecture. If `%@` is a local component, please migrate it to be a Native Component as described at https://reactnative.dev/docs/next/fabric-native-components-introduction. If `%@` is a third party dependency, please open an issue in the library repository.",
+                componentNameString,
+                componentNameString,
                 componentNameString]);
 
     auto flavor = std::make_shared<const std::string>(name);

--- a/packages/react-native/React/Fabric/Mounting/RCTComponentViewFactory.mm
+++ b/packages/react-native/React/Fabric/Mounting/RCTComponentViewFactory.mm
@@ -141,7 +141,7 @@ static Class<RCTComponentViewProtocol> RCTComponentViewClassWithName(const char 
   // TODO(T174674274): Implement lazy loading of legacy view managers in the new architecture.
   if (RCTFabricInteropLayerEnabled() && [RCTLegacyViewManagerInteropComponentView isSupported:componentNameString]) {
     RCTLogNewArchitectureValidation(
-        RCTNotAllowedInFabricWithoutLegacy,
+        RCTAreLegacyLogsEnabled() ? RCTNotAllowedInFabricWithoutLegacy : RCTNotAllowedInBridgeless,
         self,
         [NSString
             stringWithFormat:

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTInteropTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTInteropTurboModule.mm
@@ -336,6 +336,10 @@ jsi::Value ObjCInteropTurboModule::create(jsi::Runtime &runtime, const jsi::Prop
 
 void ObjCInteropTurboModule::_logLegacyArchitectureWarning(NSString *moduleName, const std::string &methodName)
 {
+  if (!RCTAreLegacyLogsEnabled()) {
+    return;
+  }
+
   std::string separator = std::string(".");
 
   std::string moduleInvocation = [moduleName cStringUsingEncoding:NSUTF8StringEncoding] + separator + methodName;


### PR DESCRIPTION
Summary:
This change introduces a flag to turn off the legacy architecture warning if they become too annoying.

The flag can be set in the Info.plist of the React Native architecture and it is controlled by the key: `RCTLegacyWarningsEnabled`.

* If the key is missing or with a value of `YES`, logs are enabled
* If the key has a value of `NO`, react native will not output any log.

We decided to use the Info.plist file to configure the logs because in that way it will work also with React Native prebuilds.

## Changelog:
[iOS][Added] - Add flag to enable or disable legacy warning.

Differential Revision: D71814001


