### PR TITLE
Finish adding accessibilityOrder to ReactNative

### DIFF
--- a/packages/react-native/Libraries/Components/View/ViewAccessibility.js
+++ b/packages/react-native/Libraries/Components/View/ViewAccessibility.js
@@ -326,6 +326,11 @@ export type AccessibilityProps = $ReadOnly<{
   ...AccessibilityPropsAndroid,
   ...AccessibilityPropsIOS,
   /**
+   * Array which specifies the order in which the children of a view will be focused by the accessibility service.
+   */
+  accessibilityOrder?: $ReadOnlyArray<string>,
+
+  /**
    * When `true`, indicates that the view is an accessibility element.
    * By default, all the touchable elements are accessible.
    *

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -3945,6 +3945,7 @@ export type AccessibilityPropsIOS = $ReadOnly<{
 export type AccessibilityProps = $ReadOnly<{
   ...AccessibilityPropsAndroid,
   ...AccessibilityPropsIOS,
+  accessibilityOrder?: $ReadOnlyArray<string>,
   accessible?: ?boolean,
   accessibilityLabel?: ?Stringish,
   accessibilityHint?: ?Stringish,

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
@@ -823,6 +823,14 @@ folly::dynamic HostPlatformViewProps::getDiffProps(
     result["accessibilityLabelledBy"] = accessibilityLabelledByValues;
   }
 
+  if (accessibilityOrder != oldProps->accessibilityOrder) {
+    auto accessibilityChildrenIds = folly::dynamic::array();
+    for (const auto& accessibilityChildId : accessibilityOrder) {
+      accessibilityChildrenIds.push_back(accessibilityChildId);
+    }
+    result["accessibilityElements"] = accessibilityChildrenIds;
+  }
+
   if (accessibilityLiveRegion != oldProps->accessibilityLiveRegion) {
     switch (accessibilityLiveRegion) {
       case AccessibilityLiveRegion::Assertive:


### PR DESCRIPTION
Summary:
Few details where missing for fully enabling accessibilityOrder on ReactNative

Changelog: [Added][General] Add accessibilityOrder to iOS and Android

Differential Revision: D71420768


