### PR TITLE
Enforce that WeakRef.deref() is always called within the event loop

### DIFF
--- a/packages/react-native-fantom/runtime/patchWeakRef.js
+++ b/packages/react-native-fantom/runtime/patchWeakRef.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import * as Fantom from '@react-native/fantom';
+
+let initialized = false;
+
+/**
+ * This method modifies the built-in `WeakRef.prototype.deref` method to make
+ * sure it is always called within the Event Loop in Fantom tests.
+ *
+ * Calling it outside the Event Loop can lead to inconsistent and confusing
+ * behavior as WeakRefs semantics are tied to the task + microtasks lifecycle.
+ */
+export default function patchWeakRef(): void {
+  if (initialized) {
+    return;
+  }
+
+  initialized = true;
+
+  // $FlowExpectedError[method-unbinding]
+  const originalDeref = WeakRef.prototype.deref;
+
+  // $FlowExpectedError[cannot-write]
+  WeakRef.prototype.deref = function patchedDeref<T>(this: WeakRef<T>): T {
+    if (!Fantom.isInWorkLoop()) {
+      throw new Error(
+        'Unexpected call to `WeakRef.deref()` outside of the Event Loop. Please use this method within `Fantom.runTask()`.',
+      );
+    }
+
+    return originalDeref.call(this);
+  };
+
+  const OriginalWeakRef = WeakRef;
+
+  global.WeakRef = function WeakRef(...args) {
+    if (!Fantom.isInWorkLoop()) {
+      throw new Error(
+        'Unexpected instantiation of `WeakRef` outside of the Event Loop. Please create the instance within `Fantom.runTask()`.',
+      );
+    }
+
+    return new OriginalWeakRef(...args);
+  };
+}

--- a/packages/react-native-fantom/runtime/setup.js
+++ b/packages/react-native-fantom/runtime/setup.js
@@ -13,6 +13,7 @@ import type {SnapshotConfig, TestSnapshotResults} from './snapshotContext';
 
 import expect from './expect';
 import {createMockFunction} from './mocks';
+import patchWeakRef from './patchWeakRef';
 import {setupSnapshotConfig, snapshotContext} from './snapshotContext';
 import NativeFantom from 'react-native/src/private/testing/fantom/specs/NativeFantom';
 
@@ -408,3 +409,5 @@ export function registerTest(
     setUpTest();
   });
 }
+
+patchWeakRef();

--- a/packages/react-native-fantom/src/__tests__/FantomWeakRefs-itest.js
+++ b/packages/react-native-fantom/src/__tests__/FantomWeakRefs-itest.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import 'react-native/Libraries/Core/InitializeCore';
+
+import * as Fantom from '@react-native/fantom';
+
+describe('WeakRefs in Fantom', () => {
+  it('cannot be created outside tasks', () => {
+    expect(() => {
+      // eslint-disable-next-line no-new
+      new WeakRef({});
+    }).toThrow(
+      'Unexpected instantiation of `WeakRef` outside of the Event Loop. Please create the instance within `Fantom.runTask()`.',
+    );
+
+    const task = jest.fn(() => {
+      // eslint-disable-next-line no-new
+      new WeakRef({});
+    });
+
+    Fantom.runTask(task);
+
+    // TODO replace with expect(task).toHaveReturned() when available in Fantom.
+    expect(task.mock.results[0].isThrow).toBe(false);
+  });
+
+  it('cannot be dereferenced outside tasks', () => {
+    let weakRef;
+
+    Fantom.runTask(() => {
+      weakRef = new WeakRef({});
+    });
+
+    expect(() => {
+      weakRef.deref();
+    }).toThrow(
+      'Unexpected call to `WeakRef.deref()` outside of the Event Loop. Please use this method within `Fantom.runTask()`.',
+    );
+
+    const task = jest.fn(() => {
+      weakRef.deref();
+    });
+
+    Fantom.runTask(task);
+
+    // TODO replace with expect(task).toHaveReturned() when available in Fantom.
+    expect(task.mock.results[0].isThrow).toBe(false);
+  });
+});

--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -243,6 +243,25 @@ export function runWorkLoop(): void {
 }
 
 /**
+ * Indicates if the current function is being executed within the Event Loop
+ * (as a task or microtask).
+ *
+ * @example
+ * ```
+ * Fantom.isInWorkLoop(); // false
+ *
+ * Fantom.runTask(() => {
+ *   Fantom.isInWorkLoop(); // true
+ * });
+ *
+ * Fantom.isInWorkLoop(); // false
+ * ```
+ */
+export function isInWorkLoop(): boolean {
+  return flushingQueue;
+}
+
+/**
  * Create a Root that can render a React component tree.
  *
  * Accepts an optional RootConfig with the following optional options:


### PR DESCRIPTION
Summary:
Changelog: [internal]

## Context

We have some tests that make sure certain objects are deallocated/released at the right times, but those are generally hard to get right. The main reason is that WeakRefs semantics are tied to the tasks and microtasks in JS, but we handle them both inside and outside the Event Loop in Fantom tests.

This leads to some surprising behavior where things we expect to have been deallocated weren't because of some innocent looking code.

## Changes

This introduces a safety mechanism in Fantom to enforce that WeakRefs are always dereferenced inside the Event Loop, by patching the method in `WeakRef` and checking if we're in the Event Loop using Fantom APIs.

It also updates the existing test using WeakRefs to fix the new errors thrown by this patch, and to serve as a "good example" on how to use WeakRefs to do memory testing.

Reviewed By: yungsters

Differential Revision: D71815397


