### PR TITLE
Fix several tests and grouping in Fantom-itest

### DIFF
--- a/packages/react-native-fantom/runtime/patchWeakRef.js
+++ b/packages/react-native-fantom/runtime/patchWeakRef.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import * as Fantom from '@react-native/fantom';
+
+let initialized = false;
+
+/**
+ * This method modifies the built-in `WeakRef.prototype.deref` method to make
+ * sure it is always called within the Event Loop in Fantom tests.
+ *
+ * Calling it outside the Event Loop can lead to inconsistent and confusing
+ * behavior as WeakRefs semantics are tied to the task + microtasks lifecycle.
+ */
+export default function patchWeakRef(): void {
+  if (initialized) {
+    return;
+  }
+
+  initialized = true;
+
+  // $FlowExpectedError[method-unbinding]
+  const originalDeref = WeakRef.prototype.deref;
+
+  // $FlowExpectedError[cannot-write]
+  WeakRef.prototype.deref = function patchedDeref<T>(this: WeakRef<T>): T {
+    if (!Fantom.isInWorkLoop()) {
+      throw new Error(
+        'Unexpected call to `WeakRef.deref()` outside of the Event Loop. Please use this method within `Fantom.runTask()`.',
+      );
+    }
+
+    return originalDeref.call(this);
+  };
+
+  const OriginalWeakRef = WeakRef;
+
+  global.WeakRef = function WeakRef(...args) {
+    if (!Fantom.isInWorkLoop()) {
+      throw new Error(
+        'Unexpected instantiation of `WeakRef` outside of the Event Loop. Please create the instance within `Fantom.runTask()`.',
+      );
+    }
+
+    return new OriginalWeakRef(...args);
+  };
+}

--- a/packages/react-native-fantom/runtime/setup.js
+++ b/packages/react-native-fantom/runtime/setup.js
@@ -13,6 +13,7 @@ import type {SnapshotConfig, TestSnapshotResults} from './snapshotContext';
 
 import expect from './expect';
 import {createMockFunction} from './mocks';
+import patchWeakRef from './patchWeakRef';
 import {setupSnapshotConfig, snapshotContext} from './snapshotContext';
 import NativeFantom from 'react-native/src/private/testing/fantom/specs/NativeFantom';
 
@@ -408,3 +409,5 @@ export function registerTest(
     setUpTest();
   });
 }
+
+patchWeakRef();

--- a/packages/react-native-fantom/src/__tests__/Fantom-itest.js
+++ b/packages/react-native-fantom/src/__tests__/Fantom-itest.js
@@ -37,6 +37,38 @@ function getActualViewportDimensions(root: Root): {
 }
 
 describe('Fantom', () => {
+  describe('scheduleTask', () => {
+    it('does not run task immediately', () => {
+      let didRun = false;
+
+      Fantom.scheduleTask(() => {
+        didRun = true;
+      });
+
+      expect(didRun).toBe(false);
+
+      Fantom.runWorkLoop();
+
+      expect(didRun).toBe(true);
+    });
+
+    it('can be scheduled from within another task', () => {
+      let didInnerTaskRun = false;
+
+      Fantom.scheduleTask(() => {
+        Fantom.scheduleTask(() => {
+          didInnerTaskRun = true;
+        });
+      });
+
+      expect(didInnerTaskRun).toBe(false);
+
+      Fantom.runWorkLoop();
+
+      expect(didInnerTaskRun).toBe(true);
+    });
+  });
+
   describe('runTask', () => {
     it('should run a task synchronously', () => {
       const task = jest.fn();
@@ -419,90 +451,90 @@ describe('Fantom', () => {
 
       expect(focusEvent).toHaveBeenCalledTimes(1);
     });
-  });
 
-  it('sends event with payload', () => {
-    const root = Fantom.createRoot();
-    let maybeNode;
-    const onChange = jest.fn();
+    it('sends event with payload', () => {
+      const root = Fantom.createRoot();
+      let maybeNode;
+      const onChange = jest.fn();
 
-    Fantom.runTask(() => {
-      root.render(
-        <TextInput
-          onChange={event => {
-            onChange(event.nativeEvent);
-          }}
-          ref={node => {
-            maybeNode = node;
-          }}
-        />,
-      );
-    });
-
-    const element = ensureInstance(maybeNode, ReactNativeElement);
-
-    Fantom.runOnUIThread(() => {
-      Fantom.enqueueNativeEvent(element, 'change', {
-        text: 'Hello World',
+      Fantom.runTask(() => {
+        root.render(
+          <TextInput
+            onChange={event => {
+              onChange(event.nativeEvent);
+            }}
+            ref={node => {
+              maybeNode = node;
+            }}
+          />,
+        );
       });
-    });
 
-    Fantom.runWorkLoop();
+      const element = ensureInstance(maybeNode, ReactNativeElement);
 
-    expect(onChange).toHaveBeenCalledTimes(1);
-    const [entry] = onChange.mock.lastCall;
-    expect(entry.text).toEqual('Hello World');
-  });
-
-  it('it batches events with isUnique option', () => {
-    const root = Fantom.createRoot();
-    let maybeNode;
-    const onScroll = jest.fn();
-
-    Fantom.runTask(() => {
-      root.render(
-        <ScrollView
-          onScroll={event => {
-            onScroll(event.nativeEvent);
-          }}
-          ref={node => {
-            maybeNode = node;
-          }}
-        />,
-      );
-    });
-
-    const element = ensureInstance(maybeNode, ReactNativeElement);
-
-    Fantom.runOnUIThread(() => {
-      Fantom.enqueueNativeEvent(element, 'scroll', {
-        contentOffset: {
-          x: 0,
-          y: 1,
-        },
+      Fantom.runOnUIThread(() => {
+        Fantom.enqueueNativeEvent(element, 'change', {
+          text: 'Hello World',
+        });
       });
-      Fantom.enqueueNativeEvent(
-        element,
-        'scroll',
-        {
+
+      Fantom.runWorkLoop();
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      const [entry] = onChange.mock.lastCall;
+      expect(entry.text).toEqual('Hello World');
+    });
+
+    it('it batches events with isUnique option', () => {
+      const root = Fantom.createRoot();
+      let maybeNode;
+      const onScroll = jest.fn();
+
+      Fantom.runTask(() => {
+        root.render(
+          <ScrollView
+            onScroll={event => {
+              onScroll(event.nativeEvent);
+            }}
+            ref={node => {
+              maybeNode = node;
+            }}
+          />,
+        );
+      });
+
+      const element = ensureInstance(maybeNode, ReactNativeElement);
+
+      Fantom.runOnUIThread(() => {
+        Fantom.enqueueNativeEvent(element, 'scroll', {
           contentOffset: {
             x: 0,
-            y: 2,
+            y: 1,
           },
-        },
-        {
-          isUnique: true,
-        },
-      );
-    });
+        });
+        Fantom.enqueueNativeEvent(
+          element,
+          'scroll',
+          {
+            contentOffset: {
+              x: 0,
+              y: 2,
+            },
+          },
+          {
+            isUnique: true,
+          },
+        );
+      });
 
-    Fantom.runWorkLoop();
+      Fantom.runWorkLoop();
 
-    expect(onScroll).toHaveBeenCalledTimes(1);
-    const [entry] = onScroll.mock.lastCall;
-    expect(entry.contentOffset).toEqual({
-      x: 0,
-      y: 2,
+      expect(onScroll).toHaveBeenCalledTimes(1);
+      const [entry] = onScroll.mock.lastCall;
+      expect(entry.contentOffset).toEqual({
+        x: 0,
+        y: 2,
+      });
     });
   });
 
@@ -534,7 +566,7 @@ describe('Fantom', () => {
     });
   });
 
-  describe('scrollTo', () => {
+  describe('enqueueScrollEvent', () => {
     it('throws error if called on node that is not scroll view', () => {
       const root = Fantom.createRoot();
       let maybeNode;
@@ -656,11 +688,9 @@ describe('Fantom', () => {
       const element = ensureInstance(maybeNode, ReactNativeElement);
 
       expect(() => {
-        Fantom.runOnUIThread(() => {
-          Fantom.enqueueScrollEvent(element, {
-            x: 0,
-            y: 1,
-          });
+        Fantom.scrollTo(element, {
+          x: 0,
+          y: 1,
         });
       }).toThrow(
         'Exception in HostFunction: enqueueScrollEvent() can only be called on <ScrollView />',
@@ -760,6 +790,7 @@ describe('Fantom', () => {
       expect(onLayout).toHaveBeenCalledTimes(1);
     });
   });
+
   describe('enqueueModalSizeUpdate', () => {
     it('throws error if called on node that is not <Modal />', () => {
       const root = Fantom.createRoot();
@@ -827,37 +858,5 @@ describe('Fantom', () => {
       expect(boundingClientRect.height).toBe(25);
       expect(boundingClientRect.width).toBe(50);
     });
-  });
-});
-
-describe('scheduleTask', () => {
-  it('does not run task immediately', () => {
-    let didRun = false;
-
-    Fantom.scheduleTask(() => {
-      didRun = true;
-    });
-
-    expect(didRun).toBe(false);
-
-    Fantom.runWorkLoop();
-
-    expect(didRun).toBe(true);
-  });
-
-  it('can be scheduled from within another task', () => {
-    let didInnerTaskRun = false;
-
-    Fantom.scheduleTask(() => {
-      Fantom.scheduleTask(() => {
-        didInnerTaskRun = true;
-      });
-    });
-
-    expect(didInnerTaskRun).toBe(false);
-
-    Fantom.runWorkLoop();
-
-    expect(didInnerTaskRun).toBe(true);
   });
 });

--- a/packages/react-native-fantom/src/__tests__/FantomWeakRefs-itest.js
+++ b/packages/react-native-fantom/src/__tests__/FantomWeakRefs-itest.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import 'react-native/Libraries/Core/InitializeCore';
+
+import * as Fantom from '@react-native/fantom';
+
+describe('WeakRefs in Fantom', () => {
+  it('cannot be created outside tasks', () => {
+    expect(() => {
+      // eslint-disable-next-line no-new
+      new WeakRef({});
+    }).toThrow(
+      'Unexpected instantiation of `WeakRef` outside of the Event Loop. Please create the instance within `Fantom.runTask()`.',
+    );
+
+    const task = jest.fn(() => {
+      // eslint-disable-next-line no-new
+      new WeakRef({});
+    });
+
+    Fantom.runTask(task);
+
+    // TODO replace with expect(task).toHaveReturned() when available in Fantom.
+    expect(task.mock.results[0].isThrow).toBe(false);
+  });
+
+  it('cannot be dereferenced outside tasks', () => {
+    let weakRef;
+
+    Fantom.runTask(() => {
+      weakRef = new WeakRef({});
+    });
+
+    expect(() => {
+      weakRef.deref();
+    }).toThrow(
+      'Unexpected call to `WeakRef.deref()` outside of the Event Loop. Please use this method within `Fantom.runTask()`.',
+    );
+
+    const task = jest.fn(() => {
+      weakRef.deref();
+    });
+
+    Fantom.runTask(task);
+
+    // TODO replace with expect(task).toHaveReturned() when available in Fantom.
+    expect(task.mock.results[0].isThrow).toBe(false);
+  });
+});

--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -243,6 +243,25 @@ export function runWorkLoop(): void {
 }
 
 /**
+ * Indicates if the current function is being executed within the Event Loop
+ * (as a task or microtask).
+ *
+ * @example
+ * ```
+ * Fantom.isInWorkLoop(); // false
+ *
+ * Fantom.runTask(() => {
+ *   Fantom.isInWorkLoop(); // true
+ * });
+ *
+ * Fantom.isInWorkLoop(); // false
+ * ```
+ */
+export function isInWorkLoop(): boolean {
+  return flushingQueue;
+}
+
+/**
  * Create a Root that can render a React component tree.
  *
  * Accepts an optional RootConfig with the following optional options:


### PR DESCRIPTION
Summary:
Changelog: [internal]

Minor reordering of tests in `Fantom-itest`, fix of describe block for  `enqueueScrollEvent` and fix incorrect usage of `enqueueScrollEvent` instead of `scrollTo` in `scrollTo` tests.

Differential Revision: D71820977


