### PR TITLE
Add OnHierarchyChangeListener to accessibilityOrder parent to track changes in hierarchy

### DIFF
--- a/packages/react-native/Libraries/Components/View/ViewAccessibility.js
+++ b/packages/react-native/Libraries/Components/View/ViewAccessibility.js
@@ -326,6 +326,11 @@ export type AccessibilityProps = $ReadOnly<{
   ...AccessibilityPropsAndroid,
   ...AccessibilityPropsIOS,
   /**
+   * Array which specifies the order in which the children of a view will be focused by the accessibility service.
+   */
+  accessibilityOrder?: $ReadOnlyArray<string>,
+
+  /**
    * When `true`, indicates that the view is an accessibility element.
    * By default, all the touchable elements are accessible.
    *

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -3945,6 +3945,7 @@ export type AccessibilityPropsIOS = $ReadOnly<{
 export type AccessibilityProps = $ReadOnly<{
   ...AccessibilityPropsAndroid,
   ...AccessibilityPropsIOS,
+  accessibilityOrder?: $ReadOnlyArray<string>,
   accessible?: ?boolean,
   accessibilityLabel?: ?Stringish,
   accessibilityHint?: ?Stringish,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -307,6 +307,31 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
     view.setTag(R.id.accessibility_order, nativeIds);
     view.setTag(R.id.accessibility_order_dirty, true);
 
+    if (view instanceof ViewGroup) {
+      ((ViewGroup) view)
+          .setOnHierarchyChangeListener(
+              new ViewGroup.OnHierarchyChangeListener() {
+                @Override
+                public void onChildViewAdded(View parent, View child) {
+                  view.setTag(R.id.accessibility_order_dirty, true);
+
+                  // We also want to listen to changes on the hierarchy of nested ViewGroups
+                  if (child instanceof ViewGroup) {
+                    ViewGroup childGroup = (ViewGroup) child;
+                    childGroup.setOnHierarchyChangeListener(this);
+                    for (int i = 0; i < childGroup.getChildCount(); i++) {
+                      onChildViewAdded(childGroup, childGroup.getChildAt(i));
+                    }
+                  }
+                }
+
+                @Override
+                public void onChildViewRemoved(View parent, View child) {
+                  view.setTag(R.id.accessibility_order_dirty, true);
+                }
+              });
+    }
+
     ReactAxOrderHelper.unsetAccessibilityOrder(view);
     ((ViewGroup) view)
         .notifySubtreeAccessibilityStateChanged(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.java
@@ -142,7 +142,7 @@ public class ReactAccessibilityDelegate extends ExploreByTouchHelper {
       boolean isAxOrderDirty = (boolean) host.getTag(R.id.accessibility_order_dirty);
       if (isAxOrderDirty) {
         ReactAxOrderHelper.setCustomAccessibilityFocusOrder(host);
-        host.setTag(R.id.accessibility_order_dirty);
+        host.setTag(R.id.accessibility_order_dirty, false);
       }
     }
 

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values/ids.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values/ids.xml
@@ -9,7 +9,7 @@
   <!-- tag is used to store the accessibleElements tag -->
   <item type="id" name="accessibility_order"/>
 
-  <!-- tag is used to store the accessibleElements tag -->
+  <!-- tag is used to store the current state of the accessibility order tree-->
   <item type="id" name="accessibility_order_dirty"/>
 
   <!-- tag is used to store the accessibleElements parent View tag -->

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
@@ -823,6 +823,14 @@ folly::dynamic HostPlatformViewProps::getDiffProps(
     result["accessibilityLabelledBy"] = accessibilityLabelledByValues;
   }
 
+  if (accessibilityOrder != oldProps->accessibilityOrder) {
+    auto accessibilityChildrenIds = folly::dynamic::array();
+    for (const auto& accessibilityChildId : accessibilityOrder) {
+      accessibilityChildrenIds.push_back(accessibilityChildId);
+    }
+    result["accessibilityElements"] = accessibilityChildrenIds;
+  }
+
   if (accessibilityLiveRegion != oldProps->accessibilityLiveRegion) {
     switch (accessibilityLiveRegion) {
       case AccessibilityLiveRegion::Assertive:


### PR DESCRIPTION
Summary:
Since now we have the optimization of only running the custom accessibility order when we define the tree as dirty we need to add a hierarchy change listener on all ViewGroups within the parent to notify accessibility services of potential changes in hierarchy and so mark the subtree as dirty.

Changelog: [Internal]

Differential Revision: D71821636


