### PR TITLE
Eliminate $PropertyType and `$ElementType` in react-native

### DIFF
--- a/packages/react-native-codegen/src/generators/components/GeneratePropsJavaPojo/PojoCollector.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsJavaPojo/PojoCollector.js
@@ -112,10 +112,8 @@ class PojoCollector {
       }
       case 'ArrayTypeAnnotation': {
         const arrayTypeAnnotation = typeAnnotation;
-        const elementType: $PropertyType<
-          ComponentArrayTypeAnnotation,
-          'elementType',
-        > = arrayTypeAnnotation.elementType;
+        const elementType: ComponentArrayTypeAnnotation['elementType'] =
+          arrayTypeAnnotation.elementType;
 
         const pojoElementType = (() => {
           switch (elementType.type) {

--- a/packages/react-native/Libraries/AppState/AppState.js
+++ b/packages/react-native/Libraries/AppState/AppState.js
@@ -107,7 +107,7 @@ class AppStateImpl {
    */
   addEventListener<K: AppStateEvent>(
     type: K,
-    handler: (...$ElementType<AppStateEventDefinitions, K>) => void,
+    handler: (...AppStateEventDefinitions[K]) => void,
   ): EventSubscription {
     const emitter = this._emitter;
     if (emitter == null) {

--- a/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
+++ b/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
@@ -397,7 +397,7 @@ const AccessibilityInfo = {
   addEventListener<K: $Keys<AccessibilityEventDefinitions>>(
     eventName: K,
     // $FlowIssue[incompatible-type] - Flow bug with unions and generics (T128099423)
-    handler: (...$ElementType<AccessibilityEventDefinitions, K>) => void,
+    handler: (...AccessibilityEventDefinitions[K]) => void,
   ): EventSubscription {
     const deviceEventName = EventNames.get(eventName);
     return deviceEventName == null

--- a/packages/react-native/Libraries/Components/Keyboard/Keyboard.js
+++ b/packages/react-native/Libraries/Components/Keyboard/Keyboard.js
@@ -148,7 +148,7 @@ class Keyboard {
    */
   addListener<K: $Keys<KeyboardEventDefinitions>>(
     eventType: K,
-    listener: (...$ElementType<KeyboardEventDefinitions, K>) => mixed,
+    listener: (...KeyboardEventDefinitions[K]) => mixed,
     context?: mixed,
   ): EventSubscription {
     return this._emitter.addListener(eventType, listener);

--- a/packages/react-native/Libraries/Components/Pressable/Pressable.js
+++ b/packages/react-native/Libraries/Components/Pressable/Pressable.js
@@ -26,7 +26,7 @@ import useAndroidRippleForView, {
 import * as React from 'react';
 import {useMemo, useRef, useState} from 'react';
 
-type ViewStyleProp = $ElementType<React.ElementConfig<typeof View>, 'style'>;
+type ViewStyleProp = React.ElementConfig<typeof View>['style'];
 
 export type PressableStateCallbackType = $ReadOnly<{
   pressed: boolean,

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
@@ -134,19 +134,16 @@ export interface ScrollViewScrollToOptions {
 
 // Public methods for ScrollView
 export interface ScrollViewImperativeMethods {
-  +getScrollResponder: $PropertyType<ScrollView, 'getScrollResponder'>;
-  +getScrollableNode: $PropertyType<ScrollView, 'getScrollableNode'>;
-  +getInnerViewNode: $PropertyType<ScrollView, 'getInnerViewNode'>;
-  +getInnerViewRef: $PropertyType<ScrollView, 'getInnerViewRef'>;
-  +getNativeScrollRef: $PropertyType<ScrollView, 'getNativeScrollRef'>;
-  +scrollTo: $PropertyType<ScrollView, 'scrollTo'>;
-  +scrollToEnd: $PropertyType<ScrollView, 'scrollToEnd'>;
-  +flashScrollIndicators: $PropertyType<ScrollView, 'flashScrollIndicators'>;
-  +scrollResponderZoomTo: $PropertyType<ScrollView, 'scrollResponderZoomTo'>;
-  +scrollResponderScrollNativeHandleToKeyboard: $PropertyType<
-    ScrollView,
-    'scrollResponderScrollNativeHandleToKeyboard',
-  >;
+  +getScrollResponder: ScrollView['getScrollResponder'];
+  +getScrollableNode: ScrollView['getScrollableNode'];
+  +getInnerViewNode: ScrollView['getInnerViewNode'];
+  +getInnerViewRef: ScrollView['getInnerViewRef'];
+  +getNativeScrollRef: ScrollView['getNativeScrollRef'];
+  +scrollTo: ScrollView['scrollTo'];
+  +scrollToEnd: ScrollView['scrollToEnd'];
+  +flashScrollIndicators: ScrollView['flashScrollIndicators'];
+  +scrollResponderZoomTo: ScrollView['scrollResponderZoomTo'];
+  +scrollResponderScrollNativeHandleToKeyboard: ScrollView['scrollResponderScrollNativeHandleToKeyboard'];
 }
 
 export type DecelerationRateType = 'fast' | 'normal' | number;

--- a/packages/react-native/Libraries/EventEmitter/NativeEventEmitter.js
+++ b/packages/react-native/Libraries/EventEmitter/NativeEventEmitter.js
@@ -80,7 +80,7 @@ export default class NativeEventEmitter<
 
   addListener<TEvent: $Keys<TEventToArgsMap>>(
     eventType: TEvent,
-    listener: (...args: $ElementType<TEventToArgsMap, TEvent>) => mixed,
+    listener: (...args: TEventToArgsMap[TEvent]) => mixed,
     context?: mixed,
   ): EventSubscription {
     this._nativeModule?.addListener(eventType);
@@ -104,7 +104,7 @@ export default class NativeEventEmitter<
 
   emit<TEvent: $Keys<TEventToArgsMap>>(
     eventType: TEvent,
-    ...args: $ElementType<TEventToArgsMap, TEvent>
+    ...args: TEventToArgsMap[TEvent]
   ): void {
     // Generally, `RCTDeviceEventEmitter` is directly invoked. But this is
     // included for completeness.

--- a/packages/react-native/Libraries/EventEmitter/__mocks__/NativeEventEmitter.js
+++ b/packages/react-native/Libraries/EventEmitter/__mocks__/NativeEventEmitter.js
@@ -24,7 +24,7 @@ export default class NativeEventEmitter<
 {
   addListener<TEvent: $Keys<TEventToArgsMap>>(
     eventType: TEvent,
-    listener: (...args: $ElementType<TEventToArgsMap, TEvent>) => mixed,
+    listener: (...args: TEventToArgsMap[TEvent]) => mixed,
     context?: mixed,
   ): EventSubscription {
     return RCTDeviceEventEmitter.addListener(eventType, listener, context);
@@ -32,7 +32,7 @@ export default class NativeEventEmitter<
 
   emit<TEvent: $Keys<TEventToArgsMap>>(
     eventType: TEvent,
-    ...args: $ElementType<TEventToArgsMap, TEvent>
+    ...args: TEventToArgsMap[TEvent]
   ): void {
     RCTDeviceEventEmitter.emit(eventType, ...args);
   }

--- a/packages/react-native/Libraries/Interaction/PanResponder.js
+++ b/packages/react-native/Libraries/Interaction/PanResponder.js
@@ -333,7 +333,7 @@ const PanResponder = {
    */
   _updateGestureStateOnMove(
     gestureState: PanResponderGestureState,
-    touchHistory: $PropertyType<GestureResponderEvent, 'touchHistory'>,
+    touchHistory: GestureResponderEvent['touchHistory'],
   ) {
     gestureState.numberActiveTouches = touchHistory.numberActiveTouches;
     gestureState.moveX = currentCentroidXOfTouchesChangedAfter(

--- a/packages/react-native/Libraries/Linking/Linking.js
+++ b/packages/react-native/Libraries/Linking/Linking.js
@@ -34,7 +34,7 @@ class LinkingImpl extends NativeEventEmitter<LinkingEventDefinitions> {
    */
   addEventListener<K: $Keys<LinkingEventDefinitions>>(
     eventType: K,
-    listener: (...$ElementType<LinkingEventDefinitions, K>) => mixed,
+    listener: (...LinkingEventDefinitions[K]) => mixed,
   ): EventSubscription {
     return this.addListener(eventType, listener);
   }

--- a/packages/react-native/Libraries/Lists/FlatList.js
+++ b/packages/react-native/Libraries/Lists/FlatList.js
@@ -184,17 +184,14 @@ type FlatListBaseProps<ItemT> = {
 type VirtualizedListProps = React.ElementConfig<typeof VirtualizedList>;
 
 export type FlatListProps<ItemT> = {
-  ...$Diff<
+  ...Omit<
     VirtualizedListProps,
-    {
-      data: $PropertyType<VirtualizedListProps, 'data'>,
-      getItem: $PropertyType<VirtualizedListProps, 'getItem'>,
-      getItemCount: $PropertyType<VirtualizedListProps, 'getItemCount'>,
-      getItemLayout: $PropertyType<VirtualizedListProps, 'getItemLayout'>,
-      renderItem: $PropertyType<VirtualizedListProps, 'renderItem'>,
-      keyExtractor: $PropertyType<VirtualizedListProps, 'keyExtractor'>,
-      ...
-    },
+    | 'data'
+    | 'getItem'
+    | 'getItemCount'
+    | 'getItemLayout'
+    | 'renderItem'
+    | 'keyExtractor',
   >,
   ...FlatListBaseProps<ItemT>,
   ...

--- a/packages/react-native/Libraries/Lists/SectionList.js
+++ b/packages/react-native/Libraries/Lists/SectionList.js
@@ -106,27 +106,9 @@ type OptionalProps<ItemT, SectionT = DefaultSectionT> = {
 };
 
 export type SectionListProps<ItemT, SectionT = DefaultSectionT> = {
-  ...$Diff<
+  ...Omit<
     VirtualizedSectionListProps<ItemT, SectionT>,
-    {
-      getItem: $PropertyType<
-        VirtualizedSectionListProps<ItemT, SectionT>,
-        'getItem',
-      >,
-      getItemCount: $PropertyType<
-        VirtualizedSectionListProps<ItemT, SectionT>,
-        'getItemCount',
-      >,
-      renderItem: $PropertyType<
-        VirtualizedSectionListProps<ItemT, SectionT>,
-        'renderItem',
-      >,
-      keyExtractor: $PropertyType<
-        VirtualizedSectionListProps<ItemT, SectionT>,
-        'keyExtractor',
-      >,
-      ...
-    },
+    'getItem' | 'getItemCount' | 'renderItem' | 'keyExtractor',
   >,
   ...RequiredProps<ItemT, SectionT>,
   ...OptionalProps<ItemT, SectionT>,

--- a/packages/react-native/Libraries/Lists/SectionListModern.js
+++ b/packages/react-native/Libraries/Lists/SectionListModern.js
@@ -102,27 +102,9 @@ type OptionalProps<ItemT, SectionT = DefaultSectionT> = {
 };
 
 export type Props<ItemT, SectionT = DefaultSectionT> = $ReadOnly<{
-  ...$Diff<
+  ...Omit<
     VirtualizedSectionListProps<ItemT, SectionT>,
-    {
-      getItem: $PropertyType<
-        VirtualizedSectionListProps<ItemT, SectionT>,
-        'getItem',
-      >,
-      getItemCount: $PropertyType<
-        VirtualizedSectionListProps<ItemT, SectionT>,
-        'getItemCount',
-      >,
-      renderItem: $PropertyType<
-        VirtualizedSectionListProps<ItemT, SectionT>,
-        'renderItem',
-      >,
-      keyExtractor: $PropertyType<
-        VirtualizedSectionListProps<ItemT, SectionT>,
-        'keyExtractor',
-      >,
-      ...
-    },
+    'getItem' | 'getItemCount' | 'renderItem' | 'keyExtractor',
   >,
   ...RequiredProps<ItemT, SectionT>,
   ...OptionalProps<ItemT, SectionT>,

--- a/packages/react-native/Libraries/Network/RCTNetworking.android.js
+++ b/packages/react-native/Libraries/Network/RCTNetworking.android.js
@@ -50,7 +50,7 @@ const emitter = new NativeEventEmitter<$FlowFixMe>(
 const RCTNetworking = {
   addListener<K: $Keys<RCTNetworkingEventDefinitions>>(
     eventType: K,
-    listener: (...$ElementType<RCTNetworkingEventDefinitions, K>) => mixed,
+    listener: (...RCTNetworkingEventDefinitions[K]) => mixed,
     context?: mixed,
   ): EventSubscription {
     // $FlowFixMe[incompatible-call]

--- a/packages/react-native/Libraries/Network/RCTNetworking.ios.js
+++ b/packages/react-native/Libraries/Network/RCTNetworking.ios.js
@@ -20,7 +20,7 @@ import {type NativeResponseType} from './XMLHttpRequest';
 const RCTNetworking = {
   addListener<K: $Keys<RCTNetworkingEventDefinitions>>(
     eventType: K,
-    listener: (...$ElementType<RCTNetworkingEventDefinitions, K>) => mixed,
+    listener: (...RCTNetworkingEventDefinitions[K]) => mixed,
     context?: mixed,
   ): EventSubscription {
     // $FlowFixMe[incompatible-call]

--- a/packages/react-native/Libraries/Network/RCTNetworking.js.flow
+++ b/packages/react-native/Libraries/Network/RCTNetworking.js.flow
@@ -19,7 +19,7 @@ declare const RCTNetworking: interface {
   addListener<K: $Keys<RCTNetworkingEventDefinitions>>(
     eventType: K,
     // $FlowFixMe[invalid-computed-prop]
-    listener: (...$ElementType<RCTNetworkingEventDefinitions, K>) => mixed,
+    listener: (...RCTNetworkingEventDefinitions[K]) => mixed,
     context?: mixed,
   ): EventSubscription,
 

--- a/packages/react-native/Libraries/Pressability/Pressability.js
+++ b/packages/react-native/Libraries/Pressability/Pressability.js
@@ -829,7 +829,7 @@ export default class Pressability {
   };
 
   _isTouchWithinResponderRegion(
-    touch: $PropertyType<GestureResponderEvent, 'nativeEvent'>,
+    touch: GestureResponderEvent['nativeEvent'],
     responderRegion: $ReadOnly<{
       bottom: number,
       left: number,

--- a/packages/react-native/Libraries/StyleSheet/StyleSheet.js
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheet.js
@@ -118,7 +118,7 @@ export type DangerouslyImpreciseStyleProp =
  */
 export type TypeForStyleKey<
   +key: $Keys<____DangerouslyImpreciseStyle_Internal>,
-> = $ElementType<____DangerouslyImpreciseStyle_Internal, key>;
+> = ____DangerouslyImpreciseStyle_Internal[key];
 
 /**
  * This type is an object of the different possible style

--- a/packages/react-native/Libraries/StyleSheet/StyleSheet.js.flow
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheet.js.flow
@@ -120,7 +120,7 @@ export type DangerouslyImpreciseStyleProp =
  */
 export type TypeForStyleKey<
   +key: $Keys<____DangerouslyImpreciseStyle_Internal>,
-> = $ElementType<____DangerouslyImpreciseStyle_Internal, key>;
+> = ____DangerouslyImpreciseStyle_Internal[key];
 
 /**
  * This type is an object of the different possible style

--- a/packages/react-native/Libraries/Utilities/ReactNativeTestTools.js
+++ b/packages/react-native/Libraries/Utilities/ReactNativeTestTools.js
@@ -22,7 +22,7 @@ const View = require('../Components/View/View').default;
 const Text = require('../Text/Text').default;
 const {VirtualizedList} = require('@react-native/virtualized-lists').default;
 
-export type ReactTestInstance = $PropertyType<ReactTestRendererType, 'root'>;
+export type ReactTestInstance = ReactTestRendererType['root'];
 export type Predicate = (node: ReactTestInstance) => boolean;
 /* $FlowFixMe[value-as-type] (>=0.125.1 site=react_native_fb) This comment
  * suppresses an error found when Flow v0.125.1 was deployed. To see the error,

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -1076,7 +1076,7 @@ declare class AppStateImpl {
   constructor(): void;
   addEventListener<K: AppStateEvent>(
     type: K,
-    handler: (...$ElementType<AppStateEventDefinitions, K>) => void
+    handler: (...AppStateEventDefinitions[K]) => void
   ): EventSubscription;
 }
 declare const AppState: AppStateImpl;
@@ -1432,7 +1432,7 @@ declare const AccessibilityInfo: {
   isAccessibilityServiceEnabled(): Promise<boolean>,
   addEventListener<K: $Keys<AccessibilityEventDefinitions>>(
     eventName: K,
-    handler: (...$ElementType<AccessibilityEventDefinitions, K>) => void
+    handler: (...AccessibilityEventDefinitions[K]) => void
   ): EventSubscription,
   setAccessibilityFocus(reactTag: number): void,
   sendAccessibilityEvent(
@@ -1667,7 +1667,7 @@ declare class Keyboard {
   constructor(): void;
   addListener<K: $Keys<KeyboardEventDefinitions>>(
     eventType: K,
-    listener: (...$ElementType<KeyboardEventDefinitions, K>) => mixed,
+    listener: (...KeyboardEventDefinitions[K]) => mixed,
     context?: mixed
   ): EventSubscription;
   removeAllListeners<K: $Keys<KeyboardEventDefinitions>>(eventType: ?K): void;
@@ -1731,7 +1731,7 @@ declare export default typeof LayoutConformanceNativeComponent;
 `;
 
 exports[`public API should not change unintentionally Libraries/Components/Pressable/Pressable.js 1`] = `
-"type ViewStyleProp = $ElementType<React.ElementConfig<typeof View>, \\"style\\">;
+"type ViewStyleProp = React.ElementConfig<typeof View>[\\"style\\"];
 export type PressableStateCallbackType = $ReadOnly<{
   pressed: boolean,
 }>;
@@ -1930,19 +1930,16 @@ exports[`public API should not change unintentionally Libraries/Components/Scrol
   animated?: boolean;
 }
 export interface ScrollViewImperativeMethods {
-  +getScrollResponder: $PropertyType<ScrollView, \\"getScrollResponder\\">;
-  +getScrollableNode: $PropertyType<ScrollView, \\"getScrollableNode\\">;
-  +getInnerViewNode: $PropertyType<ScrollView, \\"getInnerViewNode\\">;
-  +getInnerViewRef: $PropertyType<ScrollView, \\"getInnerViewRef\\">;
-  +getNativeScrollRef: $PropertyType<ScrollView, \\"getNativeScrollRef\\">;
-  +scrollTo: $PropertyType<ScrollView, \\"scrollTo\\">;
-  +scrollToEnd: $PropertyType<ScrollView, \\"scrollToEnd\\">;
-  +flashScrollIndicators: $PropertyType<ScrollView, \\"flashScrollIndicators\\">;
-  +scrollResponderZoomTo: $PropertyType<ScrollView, \\"scrollResponderZoomTo\\">;
-  +scrollResponderScrollNativeHandleToKeyboard: $PropertyType<
-    ScrollView,
-    \\"scrollResponderScrollNativeHandleToKeyboard\\",
-  >;
+  +getScrollResponder: ScrollView[\\"getScrollResponder\\"];
+  +getScrollableNode: ScrollView[\\"getScrollableNode\\"];
+  +getInnerViewNode: ScrollView[\\"getInnerViewNode\\"];
+  +getInnerViewRef: ScrollView[\\"getInnerViewRef\\"];
+  +getNativeScrollRef: ScrollView[\\"getNativeScrollRef\\"];
+  +scrollTo: ScrollView[\\"scrollTo\\"];
+  +scrollToEnd: ScrollView[\\"scrollToEnd\\"];
+  +flashScrollIndicators: ScrollView[\\"flashScrollIndicators\\"];
+  +scrollResponderZoomTo: ScrollView[\\"scrollResponderZoomTo\\"];
+  +scrollResponderScrollNativeHandleToKeyboard: ScrollView[\\"scrollResponderScrollNativeHandleToKeyboard\\"];
 }
 export type DecelerationRateType = \\"fast\\" | \\"normal\\" | number;
 export type ScrollResponderType = ScrollViewImperativeMethods;
@@ -4426,12 +4423,12 @@ declare export default class NativeEventEmitter<
   constructor(nativeModule: ?NativeModule): void;
   addListener<TEvent: $Keys<TEventToArgsMap>>(
     eventType: TEvent,
-    listener: (...args: $ElementType<TEventToArgsMap, TEvent>) => mixed,
+    listener: (...args: TEventToArgsMap[TEvent]) => mixed,
     context?: mixed
   ): EventSubscription;
   emit<TEvent: $Keys<TEventToArgsMap>>(
     eventType: TEvent,
-    ...args: $ElementType<TEventToArgsMap, TEvent>
+    ...args: TEventToArgsMap[TEvent]
   ): void;
   removeAllListeners<TEvent: $Keys<TEventToArgsMap>>(eventType?: ?TEvent): void;
   listenerCount<TEvent: $Keys<TEventToArgsMap>>(eventType: TEvent): number;
@@ -5208,7 +5205,7 @@ declare class LinkingImpl extends NativeEventEmitter<LinkingEventDefinitions> {
   constructor(): void;
   addEventListener<K: $Keys<LinkingEventDefinitions>>(
     eventType: K,
-    listener: (...$ElementType<LinkingEventDefinitions, K>) => mixed
+    listener: (...LinkingEventDefinitions[K]) => mixed
   ): EventSubscription;
   openURL(url: string): Promise<void>;
   canOpenURL(url: string): Promise<boolean>;
@@ -5282,17 +5279,14 @@ type FlatListBaseProps<ItemT> = {
 };
 type VirtualizedListProps = React.ElementConfig<typeof VirtualizedList>;
 export type FlatListProps<ItemT> = {
-  ...$Diff<
+  ...Omit<
     VirtualizedListProps,
-    {
-      data: $PropertyType<VirtualizedListProps, \\"data\\">,
-      getItem: $PropertyType<VirtualizedListProps, \\"getItem\\">,
-      getItemCount: $PropertyType<VirtualizedListProps, \\"getItemCount\\">,
-      getItemLayout: $PropertyType<VirtualizedListProps, \\"getItemLayout\\">,
-      renderItem: $PropertyType<VirtualizedListProps, \\"renderItem\\">,
-      keyExtractor: $PropertyType<VirtualizedListProps, \\"keyExtractor\\">,
-      ...
-    },
+    | \\"data\\"
+    | \\"getItem\\"
+    | \\"getItemCount\\"
+    | \\"getItemLayout\\"
+    | \\"renderItem\\"
+    | \\"keyExtractor\\",
   >,
   ...FlatListBaseProps<ItemT>,
   ...
@@ -5366,27 +5360,9 @@ type OptionalProps<ItemT, SectionT = DefaultSectionT> = {
   removeClippedSubviews?: boolean,
 };
 export type SectionListProps<ItemT, SectionT = DefaultSectionT> = {
-  ...$Diff<
+  ...Omit<
     VirtualizedSectionListProps<ItemT, SectionT>,
-    {
-      getItem: $PropertyType<
-        VirtualizedSectionListProps<ItemT, SectionT>,
-        \\"getItem\\",
-      >,
-      getItemCount: $PropertyType<
-        VirtualizedSectionListProps<ItemT, SectionT>,
-        \\"getItemCount\\",
-      >,
-      renderItem: $PropertyType<
-        VirtualizedSectionListProps<ItemT, SectionT>,
-        \\"renderItem\\",
-      >,
-      keyExtractor: $PropertyType<
-        VirtualizedSectionListProps<ItemT, SectionT>,
-        \\"keyExtractor\\",
-      >,
-      ...
-    },
+    \\"getItem\\" | \\"getItemCount\\" | \\"renderItem\\" | \\"keyExtractor\\",
   >,
   ...RequiredProps<ItemT, SectionT>,
   ...OptionalProps<ItemT, SectionT>,
@@ -5438,27 +5414,9 @@ type OptionalProps<ItemT, SectionT = DefaultSectionT> = {
   removeClippedSubviews?: boolean,
 };
 export type Props<ItemT, SectionT = DefaultSectionT> = $ReadOnly<{
-  ...$Diff<
+  ...Omit<
     VirtualizedSectionListProps<ItemT, SectionT>,
-    {
-      getItem: $PropertyType<
-        VirtualizedSectionListProps<ItemT, SectionT>,
-        \\"getItem\\",
-      >,
-      getItemCount: $PropertyType<
-        VirtualizedSectionListProps<ItemT, SectionT>,
-        \\"getItemCount\\",
-      >,
-      renderItem: $PropertyType<
-        VirtualizedSectionListProps<ItemT, SectionT>,
-        \\"renderItem\\",
-      >,
-      keyExtractor: $PropertyType<
-        VirtualizedSectionListProps<ItemT, SectionT>,
-        \\"keyExtractor\\",
-      >,
-      ...
-    },
+    \\"getItem\\" | \\"getItemCount\\" | \\"renderItem\\" | \\"keyExtractor\\",
   >,
   ...RequiredProps<ItemT, SectionT>,
   ...OptionalProps<ItemT, SectionT>,
@@ -6242,7 +6200,7 @@ exports[`public API should not change unintentionally Libraries/Network/RCTNetwo
 "declare const RCTNetworking: interface {
   addListener<K: $Keys<RCTNetworkingEventDefinitions>>(
     eventType: K,
-    listener: (...$ElementType<RCTNetworkingEventDefinitions, K>) => mixed,
+    listener: (...RCTNetworkingEventDefinitions[K]) => mixed,
     context?: mixed
   ): EventSubscription,
   sendRequest(
@@ -7435,7 +7393,7 @@ export type DangerouslyImpreciseStyleProp =
   ____DangerouslyImpreciseStyleProp_Internal;
 export type TypeForStyleKey<
   +key: $Keys<____DangerouslyImpreciseStyle_Internal>,
-> = $ElementType<____DangerouslyImpreciseStyle_Internal, key>;
+> = ____DangerouslyImpreciseStyle_Internal[key];
 export type ViewStyle = ____ViewStyle_Internal;
 export type TextStyle = ____TextStyle_Internal;
 export type ImageStyle = ____ImageStyle_Internal;
@@ -7467,7 +7425,7 @@ export type DangerouslyImpreciseStyleProp =
   ____DangerouslyImpreciseStyleProp_Internal;
 export type TypeForStyleKey<
   +key: $Keys<____DangerouslyImpreciseStyle_Internal>,
-> = $ElementType<____DangerouslyImpreciseStyle_Internal, key>;
+> = ____DangerouslyImpreciseStyle_Internal[key];
 export type ViewStyle = ____ViewStyle_Internal;
 export type TextStyle = ____TextStyle_Internal;
 export type ImageStyle = ____ImageStyle_Internal;
@@ -8894,7 +8852,7 @@ declare export default typeof RCTLog;
 `;
 
 exports[`public API should not change unintentionally Libraries/Utilities/ReactNativeTestTools.js 1`] = `
-"export type ReactTestInstance = $PropertyType<ReactTestRendererType, \\"root\\">;
+"export type ReactTestInstance = ReactTestRendererType[\\"root\\"];
 export type Predicate = (node: ReactTestInstance) => boolean;
 export type ReactTestRendererJSON = ReturnType<ReactTestRenderer.create.toJSON>;
 declare function byClickable(): Predicate;

--- a/packages/rn-tester/js/components/RNTPressableRow.js
+++ b/packages/rn-tester/js/components/RNTPressableRow.js
@@ -13,7 +13,7 @@ import {RNTesterThemeContext} from './RNTesterTheme';
 import * as React from 'react';
 import {Pressable, StyleSheet, Text, View} from 'react-native';
 
-type ViewStyleProp = $ElementType<React.ElementConfig<typeof View>, 'style'>;
+type ViewStyleProp = React.ElementConfig<typeof View>['style'];
 type Props = {
   accessibilityLabel?: ?string,
   testID?: ?string,

--- a/packages/rn-tester/js/examples/Animated/utils/ToggleNativeDriver.js
+++ b/packages/rn-tester/js/examples/Animated/utils/ToggleNativeDriver.js
@@ -12,14 +12,11 @@ import {RNTesterThemeContext} from '../../../components/RNTesterTheme';
 import * as React from 'react';
 import {StyleSheet, Switch, Text, View} from 'react-native';
 
-type ViewStyleProp = $ElementType<React.ElementConfig<typeof View>, 'style'>;
+type ViewStyleProp = React.ElementConfig<typeof View>['style'];
 
 type Props = {
   value: boolean,
-  onValueChange: $ElementType<
-    React.ElementConfig<typeof Switch>,
-    'onValueChange',
-  >,
+  onValueChange: React.ElementConfig<typeof Switch>['onValueChange'],
   style?: ?ViewStyleProp,
 };
 

--- a/packages/rn-tester/js/examples/FlatList/FlatList-BaseOnViewableItemsChanged.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatList-BaseOnViewableItemsChanged.js
@@ -17,7 +17,7 @@ import * as React from 'react';
 import {FlatList, StyleSheet, View} from 'react-native';
 
 type FlatListProps = React.ElementProps<typeof FlatList>;
-type ViewabilityConfig = $PropertyType<FlatListProps, 'viewabilityConfig'>;
+type ViewabilityConfig = FlatListProps['viewabilityConfig'];
 
 const BASE_VIEWABILITY_CONFIG = {
   minimumViewTime: 1000,

--- a/packages/rn-tester/js/examples/SectionList/SectionList-BaseOnViewableItemsChanged.js
+++ b/packages/rn-tester/js/examples/SectionList/SectionList-BaseOnViewableItemsChanged.js
@@ -15,7 +15,7 @@ import * as React from 'react';
 import {SectionList, StyleSheet, View} from 'react-native';
 
 type SectionListProps = React.ElementProps<typeof SectionList>;
-type ViewabilityConfig = $PropertyType<SectionListProps, 'viewabilityConfig'>;
+type ViewabilityConfig = SectionListProps['viewabilityConfig'];
 
 const BASE_VIEWABILITY_CONFIG = {
   minimumViewTime: 1000,

--- a/packages/virtualized-lists/Lists/VirtualizedSectionList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedSectionList.js
@@ -102,14 +102,7 @@ type VirtualizedListProps = React.ElementConfig<typeof VirtualizedList>;
 export type VirtualizedSectionListProps<ItemT, SectionT = DefaultSectionT> = {
   ...RequiredProps<ItemT, SectionT>,
   ...OptionalProps<ItemT, SectionT>,
-  ...$Diff<
-    VirtualizedListProps,
-    {
-      renderItem: $PropertyType<VirtualizedListProps, 'renderItem'>,
-      data: $PropertyType<VirtualizedListProps, 'data'>,
-      ...
-    },
-  >,
+  ...Omit<VirtualizedListProps, 'data' | 'renderItem'>,
 };
 export type ScrollToLocationParamsType = {
   animated?: ?boolean,


### PR DESCRIPTION
Summary:
Prepare for their removal in Flow

Changelog: [Internal]

Reviewed By: gkz

Differential Revision: D71823860


