### PR TITLE
Add UUID struct to JSI

### DIFF
--- a/packages/react-native/ReactCommon/jsi/jsi/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsi/jsi/CMakeLists.txt
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_library(jsi


### PR DESCRIPTION
Summary:
Add UUID struct to JSI. This will be used in the incoming changes, such
as identifying JSI interfaces and storing custom runtime data.

Changelog: [Internal]

Differential Revision: D71826382


