### PR TITLE
Shim `$PropertyType` in react-native for now

### DIFF
--- a/packages/react-native/flow/global.js
+++ b/packages/react-native/flow/global.js
@@ -86,3 +86,5 @@ declare var global: {
   // Undeclared properties are implicitly `any`.
   [string | symbol]: any,
 };
+
+type $PropertyType<T, K> = T[K];


### PR DESCRIPTION
Summary:
In the next version of Flow, support for `$PropertyType` will be removed in favor of indexed access types. The final 2 usages in react-native is in `ReactNativeTypes`, which is synced from upstream react. Sync of https://github.com/facebook/react/pull/32733 is currently blocked by test failures, so I will add the temporary shim to unblock releases.

Changelog: [Internal]

Reviewed By: panagosg7

Differential Revision: D71849353


