### PR TITLE
Automate checking for artifacts on Maven

### DIFF
--- a/.github/workflow-scripts/__tests__/verifyArtifactsAreOnMaven-test.js
+++ b/.github/workflow-scripts/__tests__/verifyArtifactsAreOnMaven-test.js
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+const {verifyArtifactsAreOnMaven} = require('../verifyArtifactsAreOnMaven');
+
+const mockSleep = jest.fn();
+const silence = () => {};
+const mockFetch = jest.fn();
+const mockExit = jest.fn();
+
+jest.mock('../utils.js', () => ({
+  log: silence,
+  sleep: mockSleep,
+}));
+
+process.exit = mockExit;
+global.fetch = mockFetch;
+
+describe('#verifyArtifactsAreOnMaven', () => {
+  beforeEach(jest.clearAllMocks);
+
+  it('waits for the packages to be published on maven when version has no v', async () => {
+    mockSleep.mockReturnValueOnce(Promise.resolve()).mockImplementation(() => {
+      throw new Error('Should not be called again!');
+    });
+    mockFetch
+      .mockReturnValueOnce(Promise.resolve({status: 404}))
+      .mockReturnValueOnce(Promise.resolve({status: 200}));
+
+    const version = '0.78.1';
+    await verifyArtifactsAreOnMaven(version);
+
+    expect(mockSleep).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.78.1',
+    );
+  });
+
+  it('waits for the packages to be published on maven, when version starts with v', async () => {
+    mockSleep.mockReturnValueOnce(Promise.resolve()).mockImplementation(() => {
+      throw new Error('Should not be called again!');
+    });
+    mockFetch
+      .mockReturnValueOnce(Promise.resolve({status: 404}))
+      .mockReturnValueOnce(Promise.resolve({status: 200}));
+
+    const version = 'v0.78.1';
+    await verifyArtifactsAreOnMaven(version);
+
+    expect(mockSleep).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.78.1',
+    );
+  });
+
+  it('passes immediately if packages are already on Maven', async () => {
+    mockFetch.mockReturnValueOnce(Promise.resolve({status: 200}));
+
+    const version = '0.78.1';
+    await verifyArtifactsAreOnMaven(version);
+
+    expect(mockSleep).toHaveBeenCalledTimes(0);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.78.1',
+    );
+  });
+
+  it('tries 90 times and then exits', async () => {
+    mockSleep.mockReturnValue(Promise.resolve());
+    mockFetch.mockReturnValue(Promise.resolve({status: 404}));
+
+    const version = '0.78.1';
+    await verifyArtifactsAreOnMaven(version);
+
+    expect(mockSleep).toHaveBeenCalledTimes(90);
+    expect(mockExit).toHaveBeenCalledWith(1);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.78.1',
+    );
+  });
+});

--- a/.github/workflow-scripts/verifyArtifactsAreOnMaven.js
+++ b/.github/workflow-scripts/verifyArtifactsAreOnMaven.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+const {log, sleep} = require('./utils');
+
+const SLEEP_S = 60; // 1 minute
+const MAX_RETRIES = 90; // 90 attempts. Waiting between attempt: 1 min. Total time: 90 min.
+const ARTIFACT_URL =
+  'https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/';
+
+async function verifyArtifactsAreOnMaven(version, retries = MAX_RETRIES) {
+  if (version.startsWith('v')) {
+    version = version.substring(1);
+  }
+
+  const artifactUrl = `${ARTIFACT_URL}${version}`;
+  for (let currentAttempt = 1; currentAttempt <= retries; currentAttempt++) {
+    const response = await fetch(artifactUrl);
+
+    if (response.status !== 200) {
+      log(
+        `${currentAttempt}) Artifact's for version ${version} are not on maven yet.\nURL: ${artifactUrl}\nLet's wait a minute and try again.\n`,
+      );
+      await sleep(SLEEP_S);
+    } else {
+      return;
+    }
+  }
+
+  log(
+    `We waited 90 minutes for the artifacts to be on Maven. Check https://status.maven.org/ if there are issues wth the service.`,
+  );
+  process.exit(1);
+}
+
+module.exports = {verifyArtifactsAreOnMaven};

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -230,3 +230,10 @@ jobs:
             const {isLatest} = require('./.github/workflow-scripts/publishTemplate.js');
             const version = "${{ github.ref_name }}";
             await verifyReleaseOnNpm(version, isLatest());
+      - name: Verify that artifacts are on Maven
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const {verifyArtifactsAreOnMaven} = require('./.github/workflow-scripts/verifyArtifactsAreOnMaven.js');
+            const version = "${{ github.ref_name }}";
+            await verifyArtifactsAreOnMaven(version);


### PR DESCRIPTION
Summary:
This change adds a check to automate a step in the release process: https://github.com/reactwg/react-native-releases/blob/main/docs/guide-release-process.md#verify-assets-have-been-uploaded-to-maven

The script will poll maven for 90 minutes and return when the artifacts are available. If, after 90 minutes, artifacts are not available, it exits with code 1 that should fail the Release workflow. The Release Crew should have a look at what's happened.

## Changelog:
[Internal] - Automate the check for artifacts being on Maven

Differential Revision: D71825014


