### PR TITLE
fix globals types (__DEV__ is incorrectly exposed and unrecognized, as well as others var)

### DIFF
--- a/packages/react-native/src/types/globals.d.ts
+++ b/packages/react-native/src/types/globals.d.ts
@@ -43,19 +43,19 @@ declare global {
    *
    * @see https://github.com/facebook/react-native/issues/934
    */
-  const originalXMLHttpRequest: any;
+  var originalXMLHttpRequest: any;
 
-  const __BUNDLE_START_TIME__: number;
-  const ErrorUtils: ErrorUtils;
+  var __BUNDLE_START_TIME__: number;
+  var ErrorUtils: ErrorUtils;
 
   /**
    * This variable is set to true when react-native is running in Dev mode
    * @example
    * if (__DEV__) console.log('Running in dev mode')
    */
-  const __DEV__: boolean;
+  var __DEV__: boolean;
 
-  const HermesInternal: null | {};
+  var HermesInternal: null | {};
 
   // #region Timer Functions
 


### PR DESCRIPTION
## Summary:

I am sharing code with the web using Next.js. Turbopack doesn't allow easy injection (yet?) for `__DEV__` that's why I detected this issue when trying to inject this way:

```ts
globalThis.__DEV__ = process.env.NODE_ENV !== "production";
```

This code is currently throwing this error (with ts 5.8):

```
Property '__DEV__' does not exist on type 'typeof globalThis'.ts(2339)
```

Currently some exported types use `const` keywords.  But this doesn't look right as explained in TypeScript 3.4 changelog.

> Note that global variables declared with let and const don’t show up on globalThis.

https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#type-checking-for-globalthis

This means **with current `const` declaration, this defined types are not accessible, _which defeat the purpose_**.

## Changelog:

[GENERAL] [FIXED] - globalThis now properly expose global vars

## Test Plan:

This PR should fix this problem (currently works for me using patch-package).

Before this change

<img width="748" alt="image" src="https://github.com/user-attachments/assets/500be4f3-a746-4b11-bf31-e7fb55adf6ca" />

After this change

<img width="622" alt="image" src="https://github.com/user-attachments/assets/4a21fc0b-42ed-47d5-ad65-70860271b1bb" />
