### PR TITLE
chore: add jest-config to monorepo dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "hermes-transform": "0.25.1",
     "inquirer": "^7.1.0",
     "jest": "^29.7.0",
+    "jest-config": "^29.7.0",
     "jest-diff": "^29.7.0",
     "jest-junit": "^10.0.0",
     "jest-snapshot": "^29.7.0",


### PR DESCRIPTION
## Summary:

The React Native monorepo depends on `jest-config` in `jest.config.js` but does not specify it as a dependency. This means we got it as a phantom / transitive dependency. In React Native macOS, I am testing using Yarn 4 with pnpm layout to protect against such dependencies (See https://github.com/microsoft/react-native-macos/pull/2366). The simplest way to fix this is to just declare it as a dependency. 

## Changelog:

[INTERNAL] [FIXED] - Add jest-config as a dependency

## Test Plan:

This change should be a no-op in React Native, we already had the package in our lock. 