### PR TITLE
[Genernal] Added slash of alpha support using rgb()

### DIFF
--- a/packages/normalize-color/__tests__/normalizeColor-test.js
+++ b/packages/normalize-color/__tests__/normalizeColor-test.js
@@ -85,6 +85,8 @@ it('handles rgb properly', () => {
   expect(normalizeColor('rgb(256, 256, 256)')).toBe(0xffffffff);
   expect(normalizeColor('rgb(0  0  0)')).toBe(0x000000ff);
   expect(normalizeColor('rgb(0 0 255)')).toBe(0x0000ffff);
+  expect(normalizeColor('rgb(0 0 0 / 0.5)')).toBe(0x00000080);
+  expect(normalizeColor('rgb(0 0 0 / 1)')).toBe(0x000000ff);
 });
 
 it('handles rgba properly', () => {

--- a/packages/normalize-color/__tests__/normalizeColor-test.js
+++ b/packages/normalize-color/__tests__/normalizeColor-test.js
@@ -87,6 +87,7 @@ it('handles rgb properly', () => {
   expect(normalizeColor('rgb(0 0 255)')).toBe(0x0000ffff);
   expect(normalizeColor('rgb(0 0 0 / 0.5)')).toBe(0x00000080);
   expect(normalizeColor('rgb(0 0 0 / 1)')).toBe(0x000000ff);
+  expect(normalizeColor('rgb(0, 0, 0, 0.5)')).toBe(0x00000080);
 });
 
 it('handles rgba properly', () => {
@@ -100,6 +101,7 @@ it('handles rgba properly', () => {
   expect(normalizeColor('rgba(0  0  0 / 0.0)')).toBe(0x00000000);
   expect(normalizeColor('rgba(0 0 0 / 1)')).toBe(0x000000ff);
   expect(normalizeColor('rgba(100 15 69 / 0.5)')).toBe(0x640f4580);
+  expect(normalizeColor('rgba(0, 0, 0)')).toBe(0x000000ff);
 });
 
 it('handles hsl properly', () => {

--- a/packages/normalize-color/index.js
+++ b/packages/normalize-color/index.js
@@ -48,7 +48,7 @@ function normalizeColor(color) {
         0
       );
     }
-    // // rgb(R, G, B, A) / rgba(R, G, B, A) notation
+    // rgb(R, G, B, A) / rgba(R, G, B, A) notation
     else if (match[5] !== undefined) {
       return (
         ((parse255(match[5]) << 24) | // r

--- a/packages/normalize-color/index.js
+++ b/packages/normalize-color/index.js
@@ -38,10 +38,22 @@ function normalizeColor(color) {
   }
 
   if ((match = matchers.rgb.exec(color))) {
+    // rgb(R G B / A) notation
+    if (match[5] !== undefined) {
+      return (
+        ((parse255(match[5]) << 24) | // r
+          (parse255(match[6]) << 16) | // g
+          (parse255(match[7]) << 8) | // b
+          parse1(match[8])) >>> // a
+        0
+      );
+    }
+
+    // rgb(R, G, B) notation
     return (
-      ((parse255(match[1]) << 24) | // r
-        (parse255(match[2]) << 16) | // g
-        (parse255(match[3]) << 8) | // b
+      ((parse255(match[2]) << 24) | // r
+        (parse255(match[3]) << 16) | // g
+        (parse255(match[4]) << 8) | // b
         0x000000ff) >>> // a
       0
     );
@@ -239,7 +251,13 @@ let cachedMatchers;
 function getMatchers() {
   if (cachedMatchers === undefined) {
     cachedMatchers = {
-      rgb: new RegExp('rgb' + call(NUMBER, NUMBER, NUMBER)),
+      rgb: new RegExp(
+        'rgb(' +
+          call(NUMBER, NUMBER, NUMBER) +
+          '|' +
+          callWithSlashSeparator(NUMBER, NUMBER, NUMBER, NUMBER) +
+          ')',
+      ),
       rgba: new RegExp(
         'rgba(' +
           commaSeparatedCall(NUMBER, NUMBER, NUMBER, NUMBER) +


### PR DESCRIPTION
## Summary:

Fixes https://github.com/facebook/react-native/issues/50207

Added slash alpha support like `rgb(255 122 127 / 0.2);`, currently seems we don't support it.

## Changelog:

[GENERAL] [ADDED] - Added slash of alpha support using rgb()

## Test Plan:

`rgb(255 122 127 / 0.2)` can shows correctly.
