### PR TITLE
Have react-hermes and React-renderercss define modules

### DIFF
--- a/packages/react-native/ReactCommon/hermes/React-hermes.podspec
+++ b/packages/react-native/ReactCommon/hermes/React-hermes.podspec
@@ -31,7 +31,8 @@ Pod::Spec.new do |s|
   s.public_header_files    = "executor/HermesExecutorFactory.h"
   s.pod_target_xcconfig    = {
                                "HEADER_SEARCH_PATHS" => "\"${PODS_ROOT}/hermes-engine/destroot/include\" \"$(PODS_TARGET_SRCROOT)/..\"",
-                               "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard()
+                               "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
+                               "DEFINES_MODULE" => "YES",
                              }
   s.header_dir             = "reacthermes"
   s.dependency "React-cxxreact", version

--- a/packages/react-native/ReactCommon/react/renderer/css/React-renderercss.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/css/React-renderercss.podspec
@@ -36,7 +36,9 @@ Pod::Spec.new do |s|
   s.exclude_files          = "tests"
   s.pod_target_xcconfig    = {
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
-    "HEADER_SEARCH_PATHS" => header_search_paths.join(' ')}
+    "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),
+    "DEFINES_MODULE" => "YES",
+  }
 
   if ENV['USE_FRAMEWORKS']
     s.module_name            = "React_renderercss"

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -37,6 +37,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -65,6 +66,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -94,6 +96,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2293,6 +2296,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
+    - React-renderercss
     - React-rendererdebug
     - React-utils
     - ReactCodegen
@@ -2559,11 +2563,11 @@ SPEC CHECKSUMS:
   FBLazyVector: d3c2dd739a63c1a124e775df075dc7c517a719cb
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
-  hermes-engine: 477e4c78f1a55c9f8b9c4b1494f1f2f5354cd36e
-  MyNativeView: 6d4a0932b08dbc9221b2755ee13f2b048858cebf
-  NativeCxxModuleExample: 27047b890cb16e941c0e7640a353fdbc9c02f451
+  hermes-engine: 4be07099027e1372268b255c29525480cddcd356
+  MyNativeView: 649cc955b283053e5832e8d45c2a20597daa94cd
+  NativeCxxModuleExample: d9bac8e847a427f0a40b0c9fb066ab102b3aefd0
   OCMock: 589f2c84dacb1f5aaf6e4cec1f292551fe748e74
-  OSSLibraryExample: 57a905a52e6160873c56d7184e488f2b0ea97649
+  OSSLibraryExample: 9264008f6ba6a068cb2db3765ffdf519c9c0f6a4
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: 3808e36294137f9ee5668f4df2e73dc079cd1dcf
   RCTRequired: a00614e2da5344c2cda3d287050b6cee00e21dc6
@@ -2582,7 +2586,7 @@ SPEC CHECKSUMS:
   React-featureflags: 595651ea13c63a9f77f06d9a1973b665b4a28b7e
   React-featureflagsnativemodule: f5f69151bc4c2945003fc502ebaecee7fda02c42
   React-graphics: 38cc9ba3336bd50960e6052648374f3591abc7a6
-  React-hermes: 04a2c6e899f5afbd8fe5abfc1a38bda44d209830
+  React-hermes: 34666bbd8d6b585e290f000d4d31c2182ece8940
   React-idlecallbacksnativemodule: b66d99ffb2ff765e1bd952b6bc6bf4ba3d5204d3
   React-ImageManager: a6833445e17879933378b7c0ba45ee42115c14bc
   React-jserrorhandler: bec134a192c50338193544404d45df24fb8a19ca
@@ -2617,7 +2621,7 @@ SPEC CHECKSUMS:
   React-RCTText: e416825b80c530647040ef91d23ffd35ccc87981
   React-RCTVibration: 1837a27fc16eeffc9509779c3334fde54c012bcc
   React-rendererconsistency: 777c894edc43dde01499189917ac54ee76ae6a6a
-  React-renderercss: 0cb3a3a38ea18d0479928fe116d1a8e2824e829d
+  React-renderercss: a9cb6ba7f49a80dc4b4f7008bae1590d12f27049
   React-rendererdebug: fea8bde927403a198742b2d940a5f1cd8230c0b4
   React-rncore: 4a81ce7b8e47448973a6b29c765b07e01715921e
   React-RuntimeApple: 97755a0b9f6adff1e1911ef4894cb0c5a9e40c77
@@ -2631,7 +2635,7 @@ SPEC CHECKSUMS:
   ReactCodegen: 0c8d830ce35b1b48f8b674b0d00e532abc448470
   ReactCommon: a53973ab35d399560ace331ec9e2b26db0592cec
   ReactCommon-Samples: 3dd174c775b04ab7d59a1b3c1a832e04377c9538
-  ScreenshotManager: 4d1dbc8e85d32e89a54e4531f5bf0ad02442f5ca
+  ScreenshotManager: 8687f6358b007230590842b03505606e905c3ce9
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 59290f2ce3fc5c34797a21244288cad99b357b63
 


### PR DESCRIPTION
Summary:
In OSS we have some libraries written in Swift, like Flashlist, that depends on these pods.

However, if a pod is not configured to define modules, those pods cannot be imported by Swift. Therefore, the libraries above will failed to be installed in a project.

This change adds the defines_modules directive to those pods and make the library work again.

This fixes https://github.com/facebook/react-native/issues/50246

## Changelog
[Internal] - Make React-hermes and React-renderercss defines modules

Differential Revision: D71892679


