### PR TITLE
[iOS] Fabric: Fixes color hash type to prevent bits truncation

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/HostPlatformColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/HostPlatformColor.h
@@ -24,9 +24,9 @@ struct Color {
   Color(int32_t color);
   Color(const DynamicColor& dynamicColor);
   Color(const ColorComponents& components);
-  Color() : uiColor_(nullptr){};
+  Color() : uiColor_(nullptr) {};
   int32_t getColor() const;
-  int32_t getUIColorHash() const;
+  std::size_t getUIColorHash() const;
 
   static Color createSemanticColor(std::vector<std::string>& semanticItems);
 
@@ -54,7 +54,7 @@ struct Color {
  private:
   Color(std::shared_ptr<void> uiColor);
   std::shared_ptr<void> uiColor_;
-  int32_t uiColorHashValue_;
+  std::size_t uiColorHashValue_;
 };
 
 namespace HostPlatformColor {

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/HostPlatformColor.mm
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/HostPlatformColor.mm
@@ -132,7 +132,7 @@ UIColor *_Nullable UIColorFromComponentsColor(const facebook::react::ColorCompon
   return uiColor;
 }
 
-int32_t hashFromUIColor(const std::shared_ptr<void> &uiColor)
+std::size_t hashFromUIColor(const std::shared_ptr<void> &uiColor)
 {
   if (uiColor == nullptr) {
     return 0;
@@ -229,7 +229,7 @@ float Color::getChannel(int channelId) const
   return static_cast<float>(rgba[channelId]);
 }
 
-int32_t Color::getUIColorHash() const
+std::size_t Color::getUIColorHash() const
 {
   return uiColorHashValue_;
 }


### PR DESCRIPTION
## Summary:

I made a mistake before, it seems we should use std::size_t to prevent bits truncation.

## Changelog:

[IOS] [FIXED] - Fabric: Fixes color hash type to prevent bits truncation

## Test Plan:

N/A
