### PR TITLE
Configure prod version of NetworkReporter

### DIFF
--- a/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.h
+++ b/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+/**
+ * [Experimental] An interface for reporting network events to the modern
+ * debugger server and Web Performance APIs.
+ *
+ * This is a helper class wrapping
+ * `facebook::react::jsinspector_modern::NetworkReporter`.
+ */
+@interface RCTInspectorNetworkReporter : NSObject
+
++ (void)reportRequestStart:(NSNumber *)requestId
+                   request:(NSURLRequest *)request
+         encodedDataLength:(int)encodedDataLength;
++ (void)reportResponseStart:(NSNumber *)requestId
+                   response:(NSURLResponse *)response
+                 statusCode:(int)statusCode
+                    headers:(NSDictionary<NSString *, NSString *> *)headers;
++ (void)reportResponseEnd:(NSNumber *)requestId encodedDataLength:(int)encodedDataLength;
+
+@end

--- a/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.mm
+++ b/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.mm
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTInspectorNetworkReporter.h"
+
+#import <jsinspector-modern/network/NetworkReporter.h>
+
+namespace {
+
+using namespace facebook::react::jsinspector_modern;
+
+Headers convertNSDictionaryToHeaders(const NSDictionary<NSString *, NSString *> *headers)
+{
+  Headers responseHeaders;
+  for (NSString *key in headers) {
+    responseHeaders[[key UTF8String]] = [headers[key] UTF8String];
+  }
+  return responseHeaders;
+}
+
+} // namespace
+
+@implementation RCTInspectorNetworkReporter {
+}
+
++ (void)reportRequestStart:(NSNumber *)requestId
+                   request:(NSURLRequest *)request
+         encodedDataLength:(int)encodedDataLength
+{
+  RequestInfo requestInfo;
+  requestInfo.url = [request.URL absoluteString].UTF8String;
+  requestInfo.httpMethod = [request.HTTPMethod UTF8String];
+  requestInfo.headers = convertNSDictionaryToHeaders(request.allHTTPHeaderFields);
+  requestInfo.httpBody = std::string((const char *)request.HTTPBody.bytes, request.HTTPBody.length);
+
+  NetworkReporter::getInstance().reportRequestStart(
+      requestId.stringValue.UTF8String, requestInfo, encodedDataLength, std::nullopt);
+}
+
++ (void)reportResponseStart:(NSNumber *)requestId
+                   response:(NSURLResponse *)response
+                 statusCode:(int)statusCode
+                    headers:(NSDictionary<NSString *, NSString *> *)headers
+{
+  ResponseInfo responseInfo;
+  responseInfo.url = response.URL.absoluteString.UTF8String;
+  responseInfo.statusCode = statusCode;
+  responseInfo.headers = convertNSDictionaryToHeaders(headers);
+
+  NetworkReporter::getInstance().reportResponseStart(
+      requestId.stringValue.UTF8String, responseInfo, response.expectedContentLength);
+}
+
++ (void)reportResponseEnd:(NSNumber *)requestId encodedDataLength:(int)encodedDataLength
+{
+  NetworkReporter::getInstance().reportResponseEnd(requestId.stringValue.UTF8String, encodedDataLength);
+}
+
+@end

--- a/packages/react-native/Libraries/Network/React-RCTNetwork.podspec
+++ b/packages/react-native/Libraries/Network/React-RCTNetwork.podspec
@@ -46,6 +46,8 @@ Pod::Spec.new do |s|
 
   add_dependency(s, "React-RCTFBReactNativeSpec")
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
+  add_dependency(s, "React-jsinspectorcdp", :framework_name => 'jsinspector_moderncdp')
+  add_dependency(s, "React-jsinspectornetwork", :framework_name => 'jsinspector_modernnetwork')
   add_dependency(s, "React-NativeModulesApple", :additional_framework_paths => ["build/generated/ios"])
 
   add_rn_third_party_dependencies(s)

--- a/packages/react-native/React/React-RCTFabric.podspec
+++ b/packages/react-native/React/React-RCTFabric.podspec
@@ -86,6 +86,7 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-RCTAnimation", :framework_name => 'RCTAnimation')
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
   add_dependency(s, "React-jsinspectorcdp", :framework_name => 'jsinspector_moderncdp')
+  add_dependency(s, "React-jsinspectornetwork", :framework_name => 'jsinspector_modernnetwork')
   add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')
   add_dependency(s, "React-renderercss")
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/NetworkIOAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/NetworkIOAgent.cpp
@@ -271,16 +271,19 @@ bool NetworkIOAgent::handleRequest(
   }
 
   if (InspectorFlags::getInstance().getNetworkInspectionEnabled()) {
+    auto& networkReporter = NetworkReporter::getInstance();
+
     // @cdp Network.enable support is experimental.
     if (req.method == "Network.enable") {
-      NetworkReporter::getInstance().enableDebugging();
+      networkReporter.setFrontendChannel(frontendChannel_);
+      networkReporter.enableDebugging();
       frontendChannel_(cdp::jsonResult(req.id));
       return true;
     }
 
     // @cdp Network.disable support is experimental.
     if (req.method == "Network.disable") {
-      NetworkReporter::getInstance().disableDebugging();
+      networkReporter.disableDebugging();
       frontendChannel_(cdp::jsonResult(req.id));
       return true;
     }

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/CMakeLists.txt
@@ -23,6 +23,5 @@ target_include_directories(jsinspector_network PUBLIC ${REACT_COMMON_DIR})
 
 target_link_libraries(jsinspector_network
         folly_runtime
-        glog
         jsinspector_cdp
 )

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/CMakeLists.txt
@@ -24,4 +24,5 @@ target_include_directories(jsinspector_network PUBLIC ${REACT_COMMON_DIR})
 target_link_libraries(jsinspector_network
         folly_runtime
         glog
+        jsinspector_cdp
 )

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/CdpNetwork.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/CdpNetwork.cpp
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "CdpNetwork.h"
+
+#include "HttpUtils.h"
+
+namespace facebook::react::jsinspector_modern::cdp::network {
+
+namespace {
+
+folly::dynamic headersToDynamic(const std::optional<Headers>& headers) {
+  folly::dynamic result = folly::dynamic::object;
+
+  if (headers) {
+    for (const auto& [key, value] : *headers) {
+      result[key] = value;
+    }
+  }
+
+  return result;
+}
+
+} // namespace
+
+/* static */ Request Request::fromInputParams(const RequestInfo& requestInfo) {
+  return {
+      .url = requestInfo.url,
+      .method = requestInfo.httpMethod,
+      .headers = requestInfo.headers,
+      .postData = requestInfo.httpBody,
+  };
+}
+
+folly::dynamic Request::toDynamic() const {
+  folly::dynamic result = folly::dynamic::object;
+
+  result["url"] = url;
+  result["method"] = method;
+  result["headers"] = headersToDynamic(headers);
+  result["postData"] = postData.value_or("");
+
+  return result;
+}
+
+/* static */ Response Response::fromInputParams(
+    const ResponseInfo& responseInfo,
+    int encodedDataLength) {
+  auto headers = responseInfo.headers.value_or(Headers());
+
+  return {
+      .url = responseInfo.url,
+      .status = responseInfo.statusCode,
+      .statusText = "",
+      .headers = headers,
+      .mimeType = mimeTypeFromHeaders(headers),
+      .encodedDataLength = encodedDataLength,
+  };
+}
+
+folly::dynamic Response::toDynamic() const {
+  folly::dynamic result = folly::dynamic::object;
+
+  result["url"] = url;
+  result["status"] = status;
+  result["statusText"] = statusText;
+  result["headers"] = headersToDynamic(headers);
+  result["mimeType"] = mimeType;
+  result["encodedDataLength"] = encodedDataLength;
+
+  return result;
+}
+
+folly::dynamic RequestWillBeSentParams::toDynamic() const {
+  folly::dynamic params = folly::dynamic::object;
+
+  params["requestId"] = requestId;
+  params["loaderId"] = loaderId;
+  params["documentURL"] = documentURL;
+  params["request"] = request.toDynamic();
+  params["timestamp"] = timestamp;
+  params["wallTime"] = wallTime;
+  params["initiator"] = initiator;
+  params["redirectHasExtraInfo"] = redirectResponse.has_value();
+
+  if (redirectResponse.has_value()) {
+    params["redirectResponse"] = redirectResponse->toDynamic();
+  }
+
+  return params;
+}
+
+folly::dynamic ResponseReceivedParams::toDynamic() const {
+  folly::dynamic params = folly::dynamic::object;
+
+  params["requestId"] = requestId;
+  params["loaderId"] = loaderId;
+  params["timestamp"] = timestamp;
+  params["type"] = type;
+  params["response"] = response.toDynamic();
+  params["hasExtraInfo"] = hasExtraInfo;
+
+  return params;
+}
+
+folly::dynamic LoadingFinishedParams::toDynamic() const {
+  folly::dynamic params = folly::dynamic::object;
+
+  params["requestId"] = requestId;
+  params["timestamp"] = timestamp;
+  params["encodedDataLength"] = encodedDataLength;
+
+  return params;
+}
+
+std::string resourceTypeFromMimeType(const std::string& mimeType) {
+  if (mimeType.find("image/") == 0) {
+    return "Image";
+  }
+
+  if (mimeType.find("video/") == 0 || mimeType.find("audio/") == 0) {
+    return "Media";
+  }
+
+  if (mimeType == "application/javascript" || mimeType == "text/javascript" ||
+      mimeType == "application/x-javascript") {
+    return "Script";
+  }
+
+  if (mimeType == "application/json" || mimeType.find("application/xml") == 0 ||
+      mimeType == "text/xml") {
+    // Assume XHR for JSON/XML types
+    return "XHR";
+  }
+
+  return "Other";
+}
+
+} // namespace facebook::react::jsinspector_modern::cdp::network

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/CdpNetwork.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/CdpNetwork.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "NetworkTypes.h"
+
+#include <folly/dynamic.h>
+
+#include <string>
+
+// Data containers for CDP Network domain types, supporting serialization to
+// folly::dynamic objects.
+
+namespace facebook::react::jsinspector_modern::cdp::network {
+
+/**
+ * https://chromedevtools.github.io/devtools-protocol/tot/Network/#type-Request
+ */
+struct Request {
+  std::string url;
+  std::string method;
+  std::optional<Headers> headers;
+  std::optional<std::string> postData;
+
+  /**
+   * Convenience function to construct a `Request` from the generic
+   * `RequestInfo` input object.
+   */
+  static Request fromInputParams(const RequestInfo& requestInfo);
+
+  folly::dynamic toDynamic() const;
+};
+
+/**
+ * https://chromedevtools.github.io/devtools-protocol/tot/Network/#type-Response
+ */
+struct Response {
+  std::string url;
+  uint16_t status;
+  std::string statusText;
+  std::optional<Headers> headers;
+  std::string mimeType;
+  int encodedDataLength;
+
+  /**
+   * Convenience function to construct a `Response` from the generic
+   * `ResponseInfo` input object.
+   */
+  static Response fromInputParams(
+      const ResponseInfo& responseInfo,
+      int encodedDataLength);
+
+  folly::dynamic toDynamic() const;
+};
+
+/**
+ * https://chromedevtools.github.io/devtools-protocol/tot/Network/#event-requestWillBeSent
+ */
+struct RequestWillBeSentParams {
+  std::string requestId;
+  std::string loaderId;
+  std::string documentURL;
+  Request request;
+  double timestamp;
+  double wallTime;
+  folly::dynamic initiator;
+  bool redirectHasExtraInfo;
+  std::optional<Response> redirectResponse;
+
+  folly::dynamic toDynamic() const;
+};
+
+/**
+ * https://chromedevtools.github.io/devtools-protocol/tot/Network/#event-responseReceived
+ */
+struct ResponseReceivedParams {
+  std::string requestId;
+  std::string loaderId;
+  double timestamp;
+  std::string type;
+  Response response;
+  bool hasExtraInfo;
+
+  folly::dynamic toDynamic() const;
+};
+
+/**
+ * https://chromedevtools.github.io/devtools-protocol/tot/Network/#event-loadingFinished
+ */
+struct LoadingFinishedParams {
+  std::string requestId;
+  double timestamp;
+  int encodedDataLength;
+
+  folly::dynamic toDynamic() const;
+};
+
+/**
+ * Get the CDP `ResourceType` for a given MIME type.
+ *
+ * https://chromedevtools.github.io/devtools-protocol/tot/Network/#type-ResourceType
+ */
+std::string resourceTypeFromMimeType(const std::string& mimeType);
+
+} // namespace facebook::react::jsinspector_modern::cdp::network

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/HttpUtils.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/HttpUtils.cpp
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "HttpUtils.h"
+
+namespace facebook::react::jsinspector_modern {
+
+std::string mimeTypeFromHeaders(const Headers& headers) {
+  std::string mimeType = "application/octet-stream";
+
+  if (headers.find("Content-Type") != headers.end()) {
+    mimeType = headers.at("Content-Type");
+  }
+
+  return mimeType;
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/HttpUtils.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/HttpUtils.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "NetworkTypes.h"
+
+#include <string>
+
+namespace facebook::react::jsinspector_modern {
+
+/**
+ * Get the MIME type for a response based on the 'Content-Type' header. If
+ * the header is not present, returns 'application/octet-stream'.
+ */
+std::string mimeTypeFromHeaders(const Headers& headers);
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkReporter.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkReporter.cpp
@@ -8,14 +8,108 @@
 #include "NetworkReporter.h"
 
 #include <glog/logging.h>
+#include <jsinspector-modern/cdp/CdpJson.h>
 
 #include <stdexcept>
 
 namespace facebook::react::jsinspector_modern {
 
+namespace {
+
+/**
+ * Get the CDP `ResourceType` for a given MIME type.
+ *
+ * https://chromedevtools.github.io/devtools-protocol/tot/Network/#type-ResourceType
+ */
+std::string mimeTypeToResourceType(const std::string& mimeType) {
+  if (mimeType.find("image/") == 0) {
+    return "Image";
+  }
+
+  if (mimeType.find("video/") == 0 || mimeType.find("audio/") == 0) {
+    return "Media";
+  }
+
+  if (mimeType == "application/javascript" || mimeType == "text/javascript" ||
+      mimeType == "application/x-javascript") {
+    return "Script";
+  }
+
+  if (mimeType == "application/json" || mimeType.find("application/xml") == 0 ||
+      mimeType == "text/xml") {
+    // Assume XHR for JSON/XML types
+    return "XHR";
+  }
+
+  return "Other";
+}
+
+folly::dynamic headersToDynamic(const std::optional<Headers>& headers) {
+  folly::dynamic result = folly::dynamic::object;
+
+  if (headers) {
+    for (const auto& [key, value] : *headers) {
+      result[key] = value;
+    }
+  }
+
+  return result;
+}
+
+folly::dynamic requestToCdpParams(const RequestInfo& request) {
+  folly::dynamic result = folly::dynamic::object;
+  result["url"] = request.url;
+  result["method"] = request.httpMethod;
+  result["headers"] = headersToDynamic(request.headers);
+  result["postData"] = request.httpBody.value();
+
+  return result;
+}
+
+folly::dynamic responseToCdpParams(
+    const ResponseInfo& response,
+    int encodedDataLength) {
+  auto headers = response.headers.value_or(Headers());
+  std::string mimeType = "Other";
+
+  if (headers.find("Content-Type") != headers.end()) {
+    mimeType = mimeTypeToResourceType(headers.at("Content-Type"));
+  }
+
+  folly::dynamic result = folly::dynamic::object;
+  result["url"] = response.url;
+  result["status"] = response.statusCode;
+  result["statusText"] = "";
+  result["headers"] = headersToDynamic(response.headers);
+  result["mimeType"] = mimeType;
+  result["encodedDataLength"] = encodedDataLength;
+
+  return result;
+}
+
+/**
+ * Get the current Unix timestamp in seconds (µs precision).
+ */
+double getCurrentUnixTimestampSeconds() {
+  auto now = std::chrono::system_clock::now().time_since_epoch();
+  auto seconds = std::chrono::duration_cast<std::chrono::seconds>(now).count();
+  auto micros =
+      std::chrono::duration_cast<std::chrono::microseconds>(now).count() %
+      1000000;
+
+  return static_cast<double>(seconds) +
+      (static_cast<double>(micros) / 1000000.0);
+}
+
+} // namespace
+
 NetworkReporter& NetworkReporter::getInstance() {
   static NetworkReporter tracer;
   return tracer;
+}
+
+void NetworkReporter::setFrontendChannel(FrontendChannel frontendChannel) {
+  frontendChannel_ = std::move(frontendChannel);
 }
 
 bool NetworkReporter::enableDebugging() {
@@ -38,13 +132,34 @@ bool NetworkReporter::disableDebugging() {
   return true;
 }
 
-void NetworkReporter::reportRequestStart(const std::string& /*requestId*/) {
+void NetworkReporter::reportRequestStart(
+    const std::string& requestId,
+    const RequestInfo& requestInfo,
+    int encodedDataLength,
+    const std::optional<ResponseInfo>& redirectResponse) {
   if (!debuggingEnabled_.load(std::memory_order_relaxed)) {
     return;
   }
 
-  // TODO(T216933356)
-  throw std::runtime_error("Not implemented");
+  double timestamp = getCurrentUnixTimestampSeconds();
+
+  folly::dynamic params = folly::dynamic::object;
+  params["requestId"] = requestId;
+  params["loaderId"] = "";
+  params["documentURL"] = "mobile";
+  params["request"] = requestToCdpParams(requestInfo);
+  // NOTE: timestamp and wallTime share the same time unit and precision,
+  // except wallTime is from an arbitrary epoch - use the Unix epoch for both.
+  params["timestamp"] = timestamp;
+  params["wallTime"] = timestamp;
+  params["initiator"] = folly::dynamic::object("type", "script");
+  params["redirectHasExtraInfo"] = redirectResponse.has_value();
+  if (redirectResponse.has_value()) {
+    params["redirectResponse"] =
+        responseToCdpParams(redirectResponse.value(), encodedDataLength);
+  }
+
+  frontendChannel_(cdp::jsonNotification("Network.requestWillBeSent", params));
 }
 
 void NetworkReporter::reportConnectionTiming(const std::string& /*requestId*/) {
@@ -65,13 +180,26 @@ void NetworkReporter::reportRequestFailed(const std::string& /*requestId*/) {
   throw std::runtime_error("Not implemented");
 }
 
-void NetworkReporter::reportResponseStart(const std::string& /*requestId*/) {
+void NetworkReporter::reportResponseStart(
+    const std::string& requestId,
+    const ResponseInfo& responseInfo,
+    int encodedDataLength) {
   if (!debuggingEnabled_.load(std::memory_order_relaxed)) {
     return;
   }
 
-  // TODO(T216933356)
-  throw std::runtime_error("Not implemented");
+  folly::dynamic responseParams =
+      responseToCdpParams(responseInfo, encodedDataLength);
+
+  folly::dynamic params = folly::dynamic::object;
+  params["requestId"] = requestId;
+  params["loaderId"] = "";
+  params["timestamp"] = getCurrentUnixTimestampSeconds();
+  params["type"] = responseParams["mimeType"];
+  params["response"] = responseParams;
+  params["hasExtraInfo"] = false;
+
+  frontendChannel_(cdp::jsonNotification("Network.responseReceived", params));
 }
 
 void NetworkReporter::reportDataReceived(const std::string& /*requestId*/) {
@@ -83,13 +211,19 @@ void NetworkReporter::reportDataReceived(const std::string& /*requestId*/) {
   throw std::runtime_error("Not implemented");
 }
 
-void NetworkReporter::reportResponseEnd(const std::string& /*requestId*/) {
+void NetworkReporter::reportResponseEnd(
+    const std::string& requestId,
+    int encodedDataLength) {
   if (!debuggingEnabled_.load(std::memory_order_relaxed)) {
     return;
   }
 
-  // TODO(T216933356)
-  throw std::runtime_error("Not implemented");
+  folly::dynamic params = folly::dynamic::object;
+  params["requestId"] = requestId;
+  params["timestamp"] = getCurrentUnixTimestampSeconds();
+  params["encodedDataLength"] = encodedDataLength;
+
+  frontendChannel_(cdp::jsonNotification("Network.loadingFinished", params));
 }
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkReporter.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkReporter.cpp
@@ -7,85 +7,17 @@
 
 #include "NetworkReporter.h"
 
-#include <glog/logging.h>
+#include "CdpNetwork.h"
+
+#include <folly/dynamic.h>
 #include <jsinspector-modern/cdp/CdpJson.h>
 
+#include <chrono>
 #include <stdexcept>
 
 namespace facebook::react::jsinspector_modern {
 
 namespace {
-
-/**
- * Get the CDP `ResourceType` for a given MIME type.
- *
- * https://chromedevtools.github.io/devtools-protocol/tot/Network/#type-ResourceType
- */
-std::string mimeTypeToResourceType(const std::string& mimeType) {
-  if (mimeType.find("image/") == 0) {
-    return "Image";
-  }
-
-  if (mimeType.find("video/") == 0 || mimeType.find("audio/") == 0) {
-    return "Media";
-  }
-
-  if (mimeType == "application/javascript" || mimeType == "text/javascript" ||
-      mimeType == "application/x-javascript") {
-    return "Script";
-  }
-
-  if (mimeType == "application/json" || mimeType.find("application/xml") == 0 ||
-      mimeType == "text/xml") {
-    // Assume XHR for JSON/XML types
-    return "XHR";
-  }
-
-  return "Other";
-}
-
-folly::dynamic headersToDynamic(const std::optional<Headers>& headers) {
-  folly::dynamic result = folly::dynamic::object;
-
-  if (headers) {
-    for (const auto& [key, value] : *headers) {
-      result[key] = value;
-    }
-  }
-
-  return result;
-}
-
-folly::dynamic requestToCdpParams(const RequestInfo& request) {
-  folly::dynamic result = folly::dynamic::object;
-  result["url"] = request.url;
-  result["method"] = request.httpMethod;
-  result["headers"] = headersToDynamic(request.headers);
-  result["postData"] = request.httpBody.value();
-
-  return result;
-}
-
-folly::dynamic responseToCdpParams(
-    const ResponseInfo& response,
-    int encodedDataLength) {
-  auto headers = response.headers.value_or(Headers());
-  std::string mimeType = "Other";
-
-  if (headers.find("Content-Type") != headers.end()) {
-    mimeType = mimeTypeToResourceType(headers.at("Content-Type"));
-  }
-
-  folly::dynamic result = folly::dynamic::object;
-  result["url"] = response.url;
-  result["status"] = response.statusCode;
-  result["statusText"] = "";
-  result["headers"] = headersToDynamic(response.headers);
-  result["mimeType"] = mimeType;
-  result["encodedDataLength"] = encodedDataLength;
-
-  return result;
-}
 
 /**
  * Get the current Unix timestamp in seconds (µs precision).
@@ -104,8 +36,8 @@ double getCurrentUnixTimestampSeconds() {
 } // namespace
 
 NetworkReporter& NetworkReporter::getInstance() {
-  static NetworkReporter tracer;
-  return tracer;
+  static NetworkReporter instance;
+  return instance;
 }
 
 void NetworkReporter::setFrontendChannel(FrontendChannel frontendChannel) {
@@ -118,7 +50,6 @@ bool NetworkReporter::enableDebugging() {
   }
 
   debuggingEnabled_.store(true, std::memory_order_release);
-  LOG(INFO) << "Network debugging enabled" << std::endl;
   return true;
 }
 
@@ -128,7 +59,6 @@ bool NetworkReporter::disableDebugging() {
   }
 
   debuggingEnabled_.store(false, std::memory_order_release);
-  LOG(INFO) << "Network debugging disabled" << std::endl;
   return true;
 }
 
@@ -136,34 +66,39 @@ void NetworkReporter::reportRequestStart(
     const std::string& requestId,
     const RequestInfo& requestInfo,
     int encodedDataLength,
-    const std::optional<ResponseInfo>& redirectResponse) {
-  if (!debuggingEnabled_.load(std::memory_order_relaxed)) {
+    const std::optional<ResponseInfo>& redirectResponse) const {
+  if (!isDebuggingEnabledNoSync()) {
     return;
   }
 
   double timestamp = getCurrentUnixTimestampSeconds();
+  auto request = cdp::network::Request::fromInputParams(requestInfo);
+  auto params = cdp::network::RequestWillBeSentParams{
+      .requestId = requestId,
+      .loaderId = "",
+      .documentURL = "mobile",
+      .request = std::move(request),
+      // NOTE: Both timestamp and wallTime use the same unit, however wallTime
+      // is relative to an "arbitrary epoch". In our implementation, use the
+      // Unix epoch for both.
+      .timestamp = timestamp,
+      .wallTime = timestamp,
+      .initiator = folly::dynamic::object("type", "script"),
+      .redirectHasExtraInfo = redirectResponse.has_value(),
+  };
 
-  folly::dynamic params = folly::dynamic::object;
-  params["requestId"] = requestId;
-  params["loaderId"] = "";
-  params["documentURL"] = "mobile";
-  params["request"] = requestToCdpParams(requestInfo);
-  // NOTE: timestamp and wallTime share the same time unit and precision,
-  // except wallTime is from an arbitrary epoch - use the Unix epoch for both.
-  params["timestamp"] = timestamp;
-  params["wallTime"] = timestamp;
-  params["initiator"] = folly::dynamic::object("type", "script");
-  params["redirectHasExtraInfo"] = redirectResponse.has_value();
   if (redirectResponse.has_value()) {
-    params["redirectResponse"] =
-        responseToCdpParams(redirectResponse.value(), encodedDataLength);
+    params.redirectResponse = cdp::network::Response::fromInputParams(
+        redirectResponse.value(), encodedDataLength);
   }
 
-  frontendChannel_(cdp::jsonNotification("Network.requestWillBeSent", params));
+  frontendChannel_(
+      cdp::jsonNotification("Network.requestWillBeSent", params.toDynamic()));
 }
 
-void NetworkReporter::reportConnectionTiming(const std::string& /*requestId*/) {
-  if (!debuggingEnabled_.load(std::memory_order_relaxed)) {
+void NetworkReporter::reportConnectionTiming(
+    const std::string& /*requestId*/) const {
+  if (!isDebuggingEnabledNoSync()) {
     return;
   }
 
@@ -171,8 +106,9 @@ void NetworkReporter::reportConnectionTiming(const std::string& /*requestId*/) {
   throw std::runtime_error("Not implemented");
 }
 
-void NetworkReporter::reportRequestFailed(const std::string& /*requestId*/) {
-  if (!debuggingEnabled_.load(std::memory_order_relaxed)) {
+void NetworkReporter::reportRequestFailed(
+    const std::string& /*requestId*/) const {
+  if (!isDebuggingEnabledNoSync()) {
     return;
   }
 
@@ -183,27 +119,29 @@ void NetworkReporter::reportRequestFailed(const std::string& /*requestId*/) {
 void NetworkReporter::reportResponseStart(
     const std::string& requestId,
     const ResponseInfo& responseInfo,
-    int encodedDataLength) {
-  if (!debuggingEnabled_.load(std::memory_order_relaxed)) {
+    int encodedDataLength) const {
+  if (!isDebuggingEnabledNoSync()) {
     return;
   }
 
-  folly::dynamic responseParams =
-      responseToCdpParams(responseInfo, encodedDataLength);
+  auto response =
+      cdp::network::Response::fromInputParams(responseInfo, encodedDataLength);
+  auto params = cdp::network::ResponseReceivedParams{
+      .requestId = requestId,
+      .loaderId = "",
+      .timestamp = getCurrentUnixTimestampSeconds(),
+      .type = cdp::network::resourceTypeFromMimeType(response.mimeType),
+      .response = response,
+      .hasExtraInfo = false,
+  };
 
-  folly::dynamic params = folly::dynamic::object;
-  params["requestId"] = requestId;
-  params["loaderId"] = "";
-  params["timestamp"] = getCurrentUnixTimestampSeconds();
-  params["type"] = responseParams["mimeType"];
-  params["response"] = responseParams;
-  params["hasExtraInfo"] = false;
-
-  frontendChannel_(cdp::jsonNotification("Network.responseReceived", params));
+  frontendChannel_(
+      cdp::jsonNotification("Network.responseReceived", params.toDynamic()));
 }
 
-void NetworkReporter::reportDataReceived(const std::string& /*requestId*/) {
-  if (!debuggingEnabled_.load(std::memory_order_relaxed)) {
+void NetworkReporter::reportDataReceived(
+    const std::string& /*requestId*/) const {
+  if (!isDebuggingEnabledNoSync()) {
     return;
   }
 
@@ -213,17 +151,19 @@ void NetworkReporter::reportDataReceived(const std::string& /*requestId*/) {
 
 void NetworkReporter::reportResponseEnd(
     const std::string& requestId,
-    int encodedDataLength) {
-  if (!debuggingEnabled_.load(std::memory_order_relaxed)) {
+    int encodedDataLength) const {
+  if (!isDebuggingEnabledNoSync()) {
     return;
   }
 
-  folly::dynamic params = folly::dynamic::object;
-  params["requestId"] = requestId;
-  params["timestamp"] = getCurrentUnixTimestampSeconds();
-  params["encodedDataLength"] = encodedDataLength;
+  auto params = cdp::network::LoadingFinishedParams{
+      .requestId = requestId,
+      .timestamp = getCurrentUnixTimestampSeconds(),
+      .encodedDataLength = encodedDataLength,
+  };
 
-  frontendChannel_(cdp::jsonNotification("Network.loadingFinished", params));
+  frontendChannel_(
+      cdp::jsonNotification("Network.loadingFinished", params.toDynamic()));
 }
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkReporter.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkReporter.cpp
@@ -7,16 +7,23 @@
 
 #include "NetworkReporter.h"
 
+#ifdef REACT_NATIVE_DEBUGGER_ENABLED
 #include "CdpNetwork.h"
+#endif
 
+#ifdef REACT_NATIVE_DEBUGGER_ENABLED
 #include <folly/dynamic.h>
 #include <jsinspector-modern/cdp/CdpJson.h>
+#endif
 
+#ifdef REACT_NATIVE_DEBUGGER_ENABLED
 #include <chrono>
+#endif
 #include <stdexcept>
 
 namespace facebook::react::jsinspector_modern {
 
+#ifdef REACT_NATIVE_DEBUGGER_ENABLED
 namespace {
 
 /**
@@ -34,6 +41,7 @@ double getCurrentUnixTimestampSeconds() {
 }
 
 } // namespace
+#endif
 
 NetworkReporter& NetworkReporter::getInstance() {
   static NetworkReporter instance;
@@ -67,6 +75,8 @@ void NetworkReporter::reportRequestStart(
     const RequestInfo& requestInfo,
     int encodedDataLength,
     const std::optional<ResponseInfo>& redirectResponse) const {
+#ifdef REACT_NATIVE_DEBUGGER_ENABLED
+  // Debug build: CDP event handling
   if (!isDebuggingEnabledNoSync()) {
     return;
   }
@@ -94,32 +104,41 @@ void NetworkReporter::reportRequestStart(
 
   frontendChannel_(
       cdp::jsonNotification("Network.requestWillBeSent", params.toDynamic()));
+#endif
 }
 
 void NetworkReporter::reportConnectionTiming(
     const std::string& /*requestId*/) const {
+#ifdef REACT_NATIVE_DEBUGGER_ENABLED
+  // Debug build: CDP event handling
   if (!isDebuggingEnabledNoSync()) {
     return;
   }
 
   // TODO(T218236597)
   throw std::runtime_error("Not implemented");
+#endif
 }
 
 void NetworkReporter::reportRequestFailed(
     const std::string& /*requestId*/) const {
+#ifdef REACT_NATIVE_DEBUGGER_ENABLED
+  // Debug build: CDP event handling
   if (!isDebuggingEnabledNoSync()) {
     return;
   }
 
   // TODO(T218236855)
   throw std::runtime_error("Not implemented");
+#endif
 }
 
 void NetworkReporter::reportResponseStart(
     const std::string& requestId,
     const ResponseInfo& responseInfo,
     int encodedDataLength) const {
+#ifdef REACT_NATIVE_DEBUGGER_ENABLED
+  // Debug build: CDP event handling
   if (!isDebuggingEnabledNoSync()) {
     return;
   }
@@ -137,21 +156,27 @@ void NetworkReporter::reportResponseStart(
 
   frontendChannel_(
       cdp::jsonNotification("Network.responseReceived", params.toDynamic()));
+#endif
 }
 
 void NetworkReporter::reportDataReceived(
     const std::string& /*requestId*/) const {
+#ifdef REACT_NATIVE_DEBUGGER_ENABLED
+  // Debug build: CDP event handling
   if (!isDebuggingEnabledNoSync()) {
     return;
   }
 
   // TODO(T218236266)
   throw std::runtime_error("Not implemented");
+#endif
 }
 
 void NetworkReporter::reportResponseEnd(
     const std::string& requestId,
     int encodedDataLength) const {
+#ifdef REACT_NATIVE_DEBUGGER_ENABLED
+  // Debug build: CDP event handling
   if (!isDebuggingEnabledNoSync()) {
     return;
   }
@@ -164,6 +189,7 @@ void NetworkReporter::reportResponseEnd(
 
   frontendChannel_(
       cdp::jsonNotification("Network.loadingFinished", params.toDynamic()));
+#endif
 }
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkReporter.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkReporter.h
@@ -25,6 +25,8 @@ using FrontendChannel = std::function<void(std::string_view messageJson)>;
 /**
  * [Experimental] An interface for reporting network events to the modern
  * debugger server and Web Performance APIs.
+ *
+ * In a production (non dev or profiling) build, CDP reporting is disabled.
  */
 class NetworkReporter {
  public:

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkReporter.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkReporter.h
@@ -7,10 +7,10 @@
 
 #pragma once
 
+#include "NetworkTypes.h"
+
 #include <atomic>
 #include <functional>
-#include <map>
-#include <optional>
 #include <string>
 
 namespace facebook::react::jsinspector_modern {
@@ -21,27 +21,6 @@ namespace facebook::react::jsinspector_modern {
  * The callback may be called from any thread.
  */
 using FrontendChannel = std::function<void(std::string_view messageJson)>;
-
-using Headers = std::map<std::string, std::string>;
-
-/**
- * Request info from the request caller.
- */
-struct RequestInfo {
-  std::string url;
-  std::string httpMethod;
-  std::optional<Headers> headers;
-  std::optional<std::string> httpBody;
-};
-
-/**
- * Response info from the request caller.
- */
-struct ResponseInfo {
-  std::string url;
-  uint16_t statusCode;
-  std::optional<Headers> headers;
-};
 
 /**
  * [Experimental] An interface for reporting network events to the modern
@@ -86,7 +65,7 @@ class NetworkReporter {
       const std::string& requestId,
       const RequestInfo& requestInfo,
       int encodedDataLength,
-      const std::optional<ResponseInfo>& redirectResponse);
+      const std::optional<ResponseInfo>& redirectResponse) const;
 
   /**
    * Report detailed timing info, such as DNS lookup, when a request has
@@ -98,14 +77,14 @@ class NetworkReporter {
    *
    * https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-connectstart
    */
-  void reportConnectionTiming(const std::string& requestId);
+  void reportConnectionTiming(const std::string& requestId) const;
 
   /**
    * Report when a network request has failed.
    *
    * Corresponds to `Network.loadingFailed` in CDP.
    */
-  void reportRequestFailed(const std::string& requestId);
+  void reportRequestFailed(const std::string& requestId) const;
 
   /**
    * Report when HTTP response headers have been received, corresponding to
@@ -119,14 +98,14 @@ class NetworkReporter {
   void reportResponseStart(
       const std::string& requestId,
       const ResponseInfo& responseInfo,
-      int encodedDataLength);
+      int encodedDataLength) const;
 
   /**
    * Report when additional chunks of the response body have been received.
    *
    * Corresponds to `Network.dataReceived` in CDP.
    */
-  void reportDataReceived(const std::string& requestId);
+  void reportDataReceived(const std::string& requestId) const;
 
   /**
    * Report when a network request is complete and we are no longer receiving
@@ -137,7 +116,8 @@ class NetworkReporter {
    *
    * https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-responseend
    */
-  void reportResponseEnd(const std::string& requestId, int encodedDataLength);
+  void reportResponseEnd(const std::string& requestId, int encodedDataLength)
+      const;
 
  private:
   FrontendChannel frontendChannel_;
@@ -148,6 +128,10 @@ class NetworkReporter {
   ~NetworkReporter() = default;
 
   std::atomic<bool> debuggingEnabled_{false};
+
+  inline bool isDebuggingEnabledNoSync() const {
+    return debuggingEnabled_.load(std::memory_order_relaxed);
+  }
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkTypes.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkTypes.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <map>
+#include <optional>
+#include <string>
+
+// Defines generic input object types for NetworkReporter.
+
+namespace facebook::react::jsinspector_modern {
+
+/**
+ * A collection of parsed HTTP headers.
+ */
+using Headers = std::map<std::string, std::string>;
+
+/**
+ * Request info from the request caller.
+ */
+struct RequestInfo {
+  std::string url;
+  std::string httpMethod;
+  std::optional<Headers> headers;
+  std::optional<std::string> httpBody;
+};
+
+/**
+ * Response info from the request caller.
+ */
+struct ResponseInfo {
+  std::string url;
+  uint16_t statusCode;
+  std::optional<Headers> headers;
+};
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/React-jsinspectornetwork.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/React-jsinspectornetwork.podspec
@@ -46,5 +46,7 @@ Pod::Spec.new do |s|
     s.header_mappings_dir = "../.."
   end
 
+  add_dependency(s, "React-jsinspectorcdp", :framework_name => 'jsinspector_moderncdp')
+
   add_rn_third_party_dependencies(s)
 end

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -1706,6 +1706,7 @@ PODS:
     - glog
     - RCT-Folly
     - RCT-Folly/Fabric
+    - React-jsinspectorcdp
     - SocketRocket
   - React-jsinspectortracing (1000.0.0):
     - boost
@@ -1903,6 +1904,7 @@ PODS:
     - React-jsi
     - React-jsinspector
     - React-jsinspectorcdp
+    - React-jsinspectornetwork
     - React-jsinspectortracing
     - React-performancetimeline
     - React-RCTAnimation
@@ -1967,6 +1969,8 @@ PODS:
     - RCTTypeSafety
     - React-Core/RCTNetworkHeaders
     - React-jsi
+    - React-jsinspectorcdp
+    - React-jsinspectornetwork
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
@@ -2594,7 +2598,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 569425f7cd2c3e005a17e5211843e541c11d6916
   React-jsinspector: 885e8180e898f07e4d7df29e2681a89e69d736d3
   React-jsinspectorcdp: 5fb266e5f23d3a2819ba848e9d4d0b6b00f95934
-  React-jsinspectornetwork: 79fbc86b7c308aeb29e883177b8573d953f6b5e2
+  React-jsinspectornetwork: 207422b56a7918e83c94c207570849f83ab9052a
   React-jsinspectortracing: 80e9418ac67630c76f15ef06534087037a822330
   React-jsitooling: b1af12acbfcb039bf87f8f2a82bde3a79c2ddade
   React-jsitracing: ce443686f52538d1033ce7db1e7d643e866262f0
@@ -2609,11 +2613,11 @@ SPEC CHECKSUMS:
   React-RCTAnimation: 263593e66c89bf810604b1ace15dfa382a1ca2df
   React-RCTAppDelegate: 3d35d7226338009b22d1cf9621eaa827acb8fd1d
   React-RCTBlob: 7b76230c53fe87d305eeeb250b0aae031bb6cbae
-  React-RCTFabric: b3746cb91560703c95028002fb6db618aebb3b61
+  React-RCTFabric: 78b6aec5985ef438a9c088032c0e89d2bd77b3ba
   React-RCTFBReactNativeSpec: 503491a0584dc29f03ef9f8ed366794604cd59ef
   React-RCTImage: de404b6b0ebe53976a97e3a0dee819c83e12977b
   React-RCTLinking: 06742cfad41c506091403a414370743a4ed75af3
-  React-RCTNetwork: 091d9c4c3e24f0800d782d0c2a0077419b478d66
+  React-RCTNetwork: f8f7ac330958ac85300827267390bc8decc06ba0
   React-RCTPushNotification: ea11178d499696516e0ff9ae335edbe99b06f94b
   React-RCTRuntime: 07b41aed797e8d950ada851c6363ecf931335663
   React-RCTSettings: d3c2dd305ec81f7faf42762ec598d57f07fd43be


### PR DESCRIPTION
Summary:
Configures a thinner version of `NetworkReporter.cpp` (the entry point to `jsinspector_network`) in production builds (i.e. dev or profiling build, as gated by `REACT_NATIVE_DEBUGGER_ENABLED`).

Even though enabling the CDP Network domain isn't reachable in prod, this will reduce the compiled code footprint of `jsinspector_network`.

We also don't need `glog` here any more — remove dep.

**Implementation notes**

The reason to gate the logic within each method, with inline `#ifdefs`, rather than swapping between complete implementation files, is because each `report*` function will also have load-bearing logic (for the Performance API) in all prod builds. Therefore, this will reduce duplication (and file switching) down the line — and can be understood at a glance with this pattern.

Changelog: [Internal]

Reviewed By: robhogan

Differential Revision: D71636694


