### PR TITLE
Use intersection of AnimatedProps and PassThroughProps to generate correct TS type

### DIFF
--- a/packages/react-native/Libraries/Animated/createAnimatedComponent.js
+++ b/packages/react-native/Libraries/Animated/createAnimatedComponent.js
@@ -66,12 +66,10 @@ type PassThroughProps = $ReadOnly<{
 }>;
 
 export type AnimatedProps<Props: {...}> = {
-  [K in keyof (Props & PassThroughProps)]: K extends $Keys<PassThroughProps>
-    ? PassThroughProps[K]
-    : K extends NonAnimatedProps
-      ? Props[K]
-      : WithAnimatedValue<Props[K]>,
-};
+  [K in keyof Props]: K extends NonAnimatedProps
+    ? Props[K]
+    : WithAnimatedValue<Props[K]>,
+} & PassThroughProps;
 
 export type AnimatedBaseProps<Props: {...}> = {
   [K in keyof Props]: K extends NonAnimatedProps

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -681,12 +681,10 @@ type PassThroughProps = $ReadOnly<{
   > | null,
 }>;
 export type AnimatedProps<Props: { ... }> = {
-  [K in keyof (Props & PassThroughProps)]: K extends $Keys<PassThroughProps>
-    ? PassThroughProps[K]
-    : K extends NonAnimatedProps
-      ? Props[K]
-      : WithAnimatedValue<Props[K]>,
-};
+  [K in keyof Props]: K extends NonAnimatedProps
+    ? Props[K]
+    : WithAnimatedValue<Props[K]>,
+} & PassThroughProps;
 export type AnimatedBaseProps<Props: { ... }> = {
   [K in keyof Props]: K extends NonAnimatedProps
     ? Props[K]


### PR DESCRIPTION
Summary:
Using keys intersection to iterate over Props and PassThroughProps is not legal in TS. The issue can be mitigated by using intersection of AnimatedProps and PassThroughProps.

Changelog:
[Internal]

Differential Revision: D71898246


