### PR TITLE
Rename LongTask as LongTasks in test

### DIFF
--- a/packages/react-native/src/private/webapis/performance/__tests__/LongTasksAPI-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/LongTasksAPI-itest.js
@@ -42,7 +42,7 @@ function ensurePerformanceLongTaskTiming(
   return value;
 }
 
-describe('LongTask API', () => {
+describe('LongTasks API', () => {
   it('does NOT report short tasks (under 50ms)', () => {
     const callback = jest.fn();
 


### PR DESCRIPTION
Summary:
Changelog: [internal]

Small rename as the official name of the API is LongTasks.

Differential Revision: D71734777
