### PR TITLE
Verify built types in Github CI

### DIFF
--- a/.github/actions/build-npm-package/action.yml
+++ b/.github/actions/build-npm-package/action.yml
@@ -121,6 +121,9 @@ runs:
     - name: Build packages
       shell: bash
       run: yarn build
+    - name: Build types
+      shell: bash
+      run: yarn build-types
     # Continue with publish steps
     - name: Set npm credentials
       if: ${{ inputs.release-type == 'release' ||

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -38,6 +38,12 @@ runs:
     - name: Run typescript check
       shell: bash
       run: yarn test-typescript
+    - name: Build types
+      shell: bash
+      run: yarn build-types
+    - name: Run typescript check of generated types
+      shell: bash
+      run: yarn test-generated-typescript
     - name: Check license
       shell: bash
       run: ./.github/workflow-scripts/check_license.sh

--- a/.github/workflows/publish-bumped-packages.yml
+++ b/.github/workflows/publish-bumped-packages.yml
@@ -20,6 +20,8 @@ jobs:
         uses: ./.github/actions/yarn-install
       - name: Build packages
         run: yarn build
+      - name: Build types
+        run: yarn build-types
       - name: Set NPM auth token
         run: echo "//registry.npmjs.org/:_authToken=$GHA_NPM_TOKEN" > ~/.npmrc
       - name: Find and publish all bumped packages

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test-ios": "./scripts/objc-test.sh test",
     "test-typescript-offline": "dtslint --localTs node_modules/typescript/lib  packages/react-native/types",
     "test-typescript": "dtslint packages/react-native/types",
+    "test-generated-typescript": "tsc -p packages/react-native/types_generated/tsconfig.test.json",
     "test": "jest",
     "fantom": "JS_DIR='..' yarn jest --config packages/react-native-fantom/config/jest.config.js",
     "trigger-react-native-release": "node ./scripts/releases-local/trigger-react-native-release.js",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -29,8 +29,16 @@
   "main": "./index.js",
   "types": "types",
   "exports": {
-    ".": "./index.js",
-    "./*": "./*.js",
+    ".": {
+      "react-native-strict-api": "./types_generated/index.d.ts",
+      "react-native-strict-api-UNSAFE-ALLOW-SUBPATHS": "./types_generated/index.d.ts",
+      "default": "./index.js"
+    },
+    "./*": {
+      "react-native-strict-api": null,
+      "react-native-strict-api-UNSAFE-ALLOW-SUBPATHS": "./types_generated/*.d.ts",
+      "default": "./*.js"
+    },
     "./*.js": "./*.js",
     "./Libraries/*.d.ts": "./Libraries/*.d.ts",
     "./types/*.d.ts": "./types/*.d.ts",
@@ -103,7 +111,8 @@
     "settings.gradle.kts",
     "src",
     "third-party-podspecs",
-    "types"
+    "types",
+    "types_generated"
   ],
   "scripts": {
     "prepack": "node ./scripts/prepack.js",

--- a/packages/virtualized-lists/package.json
+++ b/packages/virtualized-lists/package.json
@@ -19,6 +19,13 @@
   "engines": {
     "node": ">=18"
   },
+  "exports": {
+    ".": {
+      "types": "./types_generated/index.d.ts",
+      "default": "./index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "dependencies": {
     "invariant": "^2.2.4",
     "nullthrows": "^1.1.1"

--- a/scripts/build/build-types/buildTypes.js
+++ b/scripts/build/build-types/buildTypes.js
@@ -61,10 +61,16 @@ async function buildTypes(): Promise<void> {
     }
   }
 
-  await fs.copyFile(
-    path.join(__dirname, 'templates/tsconfig.json'),
-    path.join(PACKAGES_DIR, 'react-native', OUTPUT_DIR, 'tsconfig.json'),
-  );
+  await Promise.all([
+    fs.copyFile(
+      path.join(__dirname, 'templates/tsconfig.json'),
+      path.join(PACKAGES_DIR, 'react-native', OUTPUT_DIR, 'tsconfig.json'),
+    ),
+    fs.copyFile(
+      path.join(__dirname, 'templates/tsconfig.test.json'),
+      path.join(PACKAGES_DIR, 'react-native', OUTPUT_DIR, 'tsconfig.test.json'),
+    ),
+  ]);
 }
 
 type DependencyEdges = Array<[string, string]>;

--- a/scripts/build/build-types/templates/tsconfig.test.json
+++ b/scripts/build/build-types/templates/tsconfig.test.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "module": "ES2015",
+    "moduleResolution": "bundler",
+    "customConditions": ["react-native-strict-api"]
+  },
+  "include": ["./src/**/*.d.ts", "../types/__typetests__/**/*"]
+}


### PR DESCRIPTION
Summary:
## This diff
Generates types via `yarn build-types` and verifies them on the basis of react-native/types/__typetests.

Changelog: [Internal]

Differential Revision: D71902007


