### PR TITLE
Migrate modules off lazy main queue setup

### DIFF
--- a/packages/react-native/React/CoreModules/RCTAppearance.mm
+++ b/packages/react-native/React/CoreModules/RCTAppearance.mm
@@ -18,8 +18,6 @@ using namespace facebook::react;
 NSString *const RCTAppearanceColorSchemeLight = @"light";
 NSString *const RCTAppearanceColorSchemeDark = @"dark";
 
-static BOOL sIsAppearancePreferenceSet = NO;
-
 static BOOL sAppearancePreferenceEnabled = YES;
 void RCTEnableAppearancePreference(BOOL enabled)
 {
@@ -62,11 +60,6 @@ NSString *RCTColorSchemePreference(UITraitCollection *traitCollection)
   if (!sAppearancePreferenceEnabled) {
     // Return the default if the app doesn't allow different color schemes.
     return RCTAppearanceColorSchemeLight;
-  }
-
-  if (appearances[@(traitCollection.userInterfaceStyle)]) {
-    sIsAppearancePreferenceSet = YES;
-    return appearances[@(traitCollection.userInterfaceStyle)];
   }
 
   if (!traitCollection) {
@@ -131,13 +124,6 @@ RCT_EXPORT_METHOD(setColorScheme : (NSString *)style)
 
 RCT_EXPORT_SYNCHRONOUS_TYPED_METHOD(NSString *, getColorScheme)
 {
-  if (!sIsAppearancePreferenceSet) {
-    __block UITraitCollection *traitCollection = nil;
-    RCTUnsafeExecuteOnMainQueueSync(^{
-      traitCollection = RCTKeyWindow().traitCollection;
-    });
-    _currentColorScheme = RCTColorSchemePreference(traitCollection);
-  }
   return _currentColorScheme;
 }
 

--- a/packages/react-native/React/CoreModules/RCTLogBox.mm
+++ b/packages/react-native/React/CoreModules/RCTLogBox.mm
@@ -31,7 +31,7 @@ RCT_EXPORT_MODULE()
 
 + (BOOL)requiresMainQueueSetup
 {
-  return YES;
+  return NO;
 }
 
 - (void)setSurfacePresenter:(id<RCTSurfacePresenterStub>)surfacePresenter

--- a/packages/react-native/React/CoreModules/RCTPerfMonitor.mm
+++ b/packages/react-native/React/CoreModules/RCTPerfMonitor.mm
@@ -118,7 +118,7 @@ RCT_EXPORT_MODULE()
 
 + (BOOL)requiresMainQueueSetup
 {
-  return YES;
+  return NO;
 }
 
 - (dispatch_queue_t)methodQueue

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -154,6 +154,9 @@
             "AccessibilityManager": {
               "unstableRequiresMainQueueSetup": true
             },
+            "Appearance": {
+              "unstableRequiresMainQueueSetup": true
+            },
             "AppState": {
               "unstableRequiresMainQueueSetup": true
             },


### PR DESCRIPTION
Summary:
These modules don't actually use ui things in their setup. So, they don't need to be set up on the main queue.

Changelog: [Internal]

Differential Revision: D71849447


