### PR TITLE
Add missing `folly` header

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/tests/TestComponent.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/TestComponent.h
@@ -18,10 +18,6 @@
 #include <react/renderer/core/RawProps.h>
 #include <react/renderer/core/ShadowNode.h>
 
-#ifdef ANDROID
-#include <folly/dynamic.h>
-#endif
-
 /**
  * This defines a set of TestComponent classes: Props, ShadowNode,
  * ComponentDescriptor. To be used for testing purpose.

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceHandler.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceHandler.h
@@ -10,6 +10,7 @@
 #include <memory>
 #include <shared_mutex>
 
+#include <folly/dynamic.h>
 #include <react/renderer/core/LayoutConstraints.h>
 #include <react/renderer/core/LayoutContext.h>
 #include <react/renderer/core/ReactPrimitives.h>


### PR DESCRIPTION
Summary:
## Changelog
[General] [Fixed] – Add explicit `folly/dynamic.h` include where it is actually used

## Internal
This symbol is used in the file, so ensure we actually declare it. That way we do not need to depend on some other header to provide the symbol

Reviewed By: NickGerleman

Differential Revision: D71910330


