### PR TITLE
Internalize classes exposed for TextInputEventsTestCase

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextUpdate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextUpdate.kt
@@ -12,8 +12,7 @@ import android.text.Spannable
 import com.facebook.react.common.ReactConstants
 
 /**
- * Class that contains the data needed for a text update. Used by both <Text/> and <TextInput/>
- * VisibleForTesting from [TextInputEventsTestCase].
+ * Class that contains the data needed for a text update. Used by both <Text/> and <TextInput/>.
  */
 public class ReactTextUpdate(
     public val text: Spannable,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactContentSizeChangedEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactContentSizeChangedEvent.kt
@@ -13,7 +13,7 @@ import com.facebook.react.uimanager.common.ViewUtil
 import com.facebook.react.uimanager.events.Event
 
 /** Event emitted by EditText native view when content size changes. */
-public class ReactContentSizeChangedEvent(
+internal class ReactContentSizeChangedEvent(
     surfaceId: Int,
     viewId: Int,
     private val contentWidth: Float,
@@ -23,7 +23,7 @@ public class ReactContentSizeChangedEvent(
       "Use the constructor with surfaceId instead",
       ReplaceWith(
           "ReactContentSizeChangedEvent(surfaceId, viewId, contentSizeWidth, contentSizeHeight)"))
-  public constructor(
+  constructor(
       viewId: Int,
       contentSizeWidth: Float,
       contentSizeHeight: Float
@@ -44,7 +44,7 @@ public class ReactContentSizeChangedEvent(
     }
   }
 
-  public companion object {
-    public const val EVENT_NAME: String = "topContentSizeChange"
+  companion object {
+    const val EVENT_NAME: String = "topContentSizeChange"
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -93,7 +93,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
  *
  * <p>The wrapper stops the EditText from triggering *TextChanged events, in the case where JS has
  * called this explicitly. This is the default behavior on other platforms as well.
- * VisibleForTesting from {@link TextInputEventsTestCase}.
  */
 public class ReactEditText extends AppCompatEditText {
 
@@ -654,7 +653,6 @@ public class ReactEditText extends AppCompatEditText {
     }
   }
 
-  // VisibleForTesting from {@link TextInputEventsTestCase}.
   public void requestFocusFromJS() {
     if (ReactNativeFeatureFlags.useEditTextStockAndroidFocusBehavior()) {
       requestFocusProgramatically();
@@ -667,7 +665,6 @@ public class ReactEditText extends AppCompatEditText {
     clearFocus();
   }
 
-  // VisibleForTesting from {@link TextInputEventsTestCase}.
   public int incrementAndGetEventCounter() {
     return ++mNativeEventCount;
   }
@@ -688,8 +685,7 @@ public class ReactEditText extends AppCompatEditText {
     return eventCounter >= mNativeEventCount;
   }
 
-  // VisibleForTesting from {@link TextInputEventsTestCase}.
-  public void maybeSetText(ReactTextUpdate reactTextUpdate) {
+  private void maybeSetText(ReactTextUpdate reactTextUpdate) {
     if (isSecureText() && TextUtils.equals(getText(), reactTextUpdate.getText())) {
       return;
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextChangedEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextChangedEvent.kt
@@ -12,11 +12,8 @@ import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.common.ViewUtil
 import com.facebook.react.uimanager.events.Event
 
-/**
- * Event emitted by EditText native view when text changes. VisibleForTesting from
- * [TextInputEventsTestCase].
- */
-public class ReactTextChangedEvent(
+/** Event emitted by EditText native view when text changes. */
+internal class ReactTextChangedEvent(
     surfaceId: Int,
     viewId: Int,
     private val text: String,
@@ -25,7 +22,7 @@ public class ReactTextChangedEvent(
   @Deprecated(
       "Use the constructor with surfaceId instead",
       ReplaceWith("ReactTextChangedEvent(surfaceId, viewId, text, eventCount)"))
-  public constructor(
+  constructor(
       viewId: Int,
       text: String,
       eventCount: Int
@@ -41,7 +38,7 @@ public class ReactTextChangedEvent(
     }
   }
 
-  public companion object {
-    public const val EVENT_NAME: String = "topChange"
+  companion object {
+    const val EVENT_NAME: String = "topChange"
   }
 }


### PR DESCRIPTION
## Summary:

TextInputEventsTestCase is a test that no longer exists; it seems like in the past, some classes/methods were made public to allow this file to use them. We can clean this up by removing its reference from the codebase and internalizing what's not used in OSS.

Internalized classes:
- [ReactContentSizeChangedEvent](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.views.textinput.ReactContentSizeChangedEvent)
- [ReactTextChangedEvent](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.views.textinput.ReactTextChangedEvent)

Both classes above are used only in gutenberg aztec (archived repo)

Internalized methods:
- ReactEditText.maybeSetText (method only used within the class itself)

## Changelog:

[INTERNAL] - Internalize classes exposed for TextInputEventsTestCase

## Test Plan:

```sh
yarn test-android
yarn android
```