### PR TITLE
Move CornerRadii resolution logic out of LengthPercentage

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3871,7 +3871,6 @@ public final class com/facebook/react/uimanager/LengthPercentage {
 	public final fun getType ()Lcom/facebook/react/uimanager/LengthPercentageType;
 	public fun hashCode ()I
 	public final fun resolve (F)F
-	public final fun resolve (FF)Lcom/facebook/react/uimanager/style/CornerRadii;
 	public static final fun setFromDynamic (Lcom/facebook/react/bridge/Dynamic;)Lcom/facebook/react/uimanager/LengthPercentage;
 	public fun toString ()Ljava/lang/String;
 }
@@ -5536,6 +5535,7 @@ public final class com/facebook/react/uimanager/style/CornerRadii {
 	public fun <init> ()V
 	public fun <init> (FF)V
 	public synthetic fun <init> (FFILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/facebook/react/uimanager/LengthPercentage;FF)V
 	public final fun component1 ()F
 	public final fun component2 ()F
 	public final fun copy (FF)Lcom/facebook/react/uimanager/style/CornerRadii;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LengthPercentage.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LengthPercentage.kt
@@ -11,7 +11,6 @@ import com.facebook.common.logging.FLog
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReadableType
 import com.facebook.react.common.ReactConstants
-import com.facebook.react.uimanager.style.CornerRadii
 import java.lang.NumberFormatException
 
 public enum class LengthPercentageType {
@@ -60,14 +59,6 @@ public data class LengthPercentage(
         }
       }
     }
-  }
-
-  public fun resolve(width: Float, height: Float): CornerRadii {
-    if (type == LengthPercentageType.PERCENT) {
-      return CornerRadii((value / 100) * width, (value / 100) * height)
-    }
-
-    return CornerRadii(value, value)
   }
 
   public fun resolve(referenceLength: Float): Float {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/BorderRadiusStyle.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/BorderRadiusStyle.kt
@@ -113,16 +113,21 @@ internal data class BorderRadiusStyle(
       LayoutDirection.LTR ->
           ensureNoOverlap(
               topLeft =
-                  (startStart ?: topStart ?: topLeft ?: uniform)?.resolve(width, height)
-                      ?: zeroRadii,
+                  (startStart ?: topStart ?: topLeft ?: uniform)?.let {
+                    CornerRadii(it, width, height)
+                  } ?: zeroRadii,
               topRight =
-                  (endStart ?: topEnd ?: topRight ?: uniform)?.resolve(width, height) ?: zeroRadii,
+                  (endStart ?: topEnd ?: topRight ?: uniform)?.let {
+                    CornerRadii(it, width, height)
+                  } ?: zeroRadii,
               bottomLeft =
-                  (startEnd ?: bottomStart ?: bottomLeft ?: uniform)?.resolve(width, height)
-                      ?: zeroRadii,
+                  (startEnd ?: bottomStart ?: bottomLeft ?: uniform)?.let {
+                    CornerRadii(it, width, height)
+                  } ?: zeroRadii,
               bottomRight =
-                  (endEnd ?: bottomEnd ?: bottomRight ?: uniform)?.resolve(width, height)
-                      ?: zeroRadii,
+                  (endEnd ?: bottomEnd ?: bottomRight ?: uniform)?.let {
+                    CornerRadii(it, width, height)
+                  } ?: zeroRadii,
               width = width,
               height = height,
           )
@@ -130,33 +135,42 @@ internal data class BorderRadiusStyle(
           if (I18nUtil.instance.doLeftAndRightSwapInRTL(context)) {
             ensureNoOverlap(
                 topLeft =
-                    (endStart ?: topEnd ?: topRight ?: uniform)?.resolve(width, height)
-                        ?: zeroRadii,
+                    (endStart ?: topEnd ?: topRight ?: uniform)?.let {
+                      CornerRadii(it, width, height)
+                    } ?: zeroRadii,
                 topRight =
-                    (startStart ?: topStart ?: topLeft ?: uniform)?.resolve(width, height)
-                        ?: zeroRadii,
+                    (startStart ?: topStart ?: topLeft ?: uniform)?.let {
+                      CornerRadii(it, width, height)
+                    } ?: zeroRadii,
                 bottomLeft =
-                    (endEnd ?: bottomStart ?: bottomRight ?: uniform)?.resolve(width, height)
-                        ?: zeroRadii,
+                    (endEnd ?: bottomStart ?: bottomRight ?: uniform)?.let {
+                      CornerRadii(it, width, height)
+                    } ?: zeroRadii,
                 bottomRight =
-                    (startEnd ?: bottomEnd ?: bottomLeft ?: uniform)?.resolve(width, height)
-                        ?: zeroRadii,
+                    (startEnd ?: bottomEnd ?: bottomLeft ?: uniform)?.let {
+                      CornerRadii(it, width, height)
+                    } ?: zeroRadii,
                 width = width,
                 height = height,
             )
           } else {
             ensureNoOverlap(
                 topLeft =
-                    (endStart ?: topEnd ?: topLeft ?: uniform)?.resolve(width, height) ?: zeroRadii,
+                    (endStart ?: topEnd ?: topLeft ?: uniform)?.let {
+                      CornerRadii(it, width, height)
+                    } ?: zeroRadii,
                 topRight =
-                    (startStart ?: topStart ?: topRight ?: uniform)?.resolve(width, height)
-                        ?: zeroRadii,
+                    (startStart ?: topStart ?: topRight ?: uniform)?.let {
+                      CornerRadii(it, width, height)
+                    } ?: zeroRadii,
                 bottomLeft =
-                    (endEnd ?: bottomStart ?: bottomLeft ?: uniform)?.resolve(width, height)
-                        ?: zeroRadii,
+                    (endEnd ?: bottomStart ?: bottomLeft ?: uniform)?.let {
+                      CornerRadii(it, width, height)
+                    } ?: zeroRadii,
                 bottomRight =
-                    (startEnd ?: bottomEnd ?: bottomRight ?: uniform)?.resolve(width, height)
-                        ?: zeroRadii,
+                    (startEnd ?: bottomEnd ?: bottomRight ?: uniform)?.let {
+                      CornerRadii(it, width, height)
+                    } ?: zeroRadii,
                 width = width,
                 height = height,
             )

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/CornerRadii.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/CornerRadii.kt
@@ -7,12 +7,20 @@
 
 package com.facebook.react.uimanager.style
 
+import com.facebook.react.uimanager.LengthPercentage
 import com.facebook.react.uimanager.PixelUtil
 
+/** Represents the resolved horizontal and vertical radii of the ellipse representing a corner. */
 public data class CornerRadii(
     val horizontal: Float = 0f,
     val vertical: Float = 0f,
 ) {
+  public constructor(
+      length: LengthPercentage,
+      referenceWidth: Float,
+      referenceHeight: Float
+  ) : this(horizontal = length.resolve(referenceWidth), vertical = length.resolve(referenceHeight))
+
   public fun toPixelFromDIP(): CornerRadii {
     return CornerRadii(PixelUtil.toPixelFromDIP(horizontal), PixelUtil.toPixelFromDIP(vertical))
   }


### PR DESCRIPTION
Summary:
`LengthPercentage` is a class representing a length, or a percentage of a reference length.

Having a function on it, specific to resolving asymetrical corner radius is the wrong organization. Let's move it to where it belongs.

Very technically breaking, but I would be shocked if anyone is using this API.

Changelog: [Internal]

Reviewed By: jorge-cab

Differential Revision: D71922893


