### PR TITLE
Add experimental prop to accessibilityOrder

### DIFF
--- a/packages/react-native/Libraries/Components/View/ViewAccessibility.js
+++ b/packages/react-native/Libraries/Components/View/ViewAccessibility.js
@@ -326,11 +326,6 @@ export type AccessibilityProps = $ReadOnly<{
   ...AccessibilityPropsAndroid,
   ...AccessibilityPropsIOS,
   /**
-   * Array which specifies the order in which the children of a view will be focused by the accessibility service.
-   */
-  accessibilityOrder?: $ReadOnlyArray<string>,
-
-  /**
    * When `true`, indicates that the view is an accessibility element.
    * By default, all the touchable elements are accessible.
    *

--- a/packages/react-native/Libraries/NativeComponent/BaseViewConfig.android.js
+++ b/packages/react-native/Libraries/NativeComponent/BaseViewConfig.android.js
@@ -203,7 +203,7 @@ const validAttributesForNonEventProps = {
   accessibilityState: true,
   accessibilityActions: true,
   accessibilityValue: true,
-  accessibilityOrder: true,
+  experimental_accessibilityOrder: true,
   importantForAccessibility: true,
   role: true,
   rotation: true,

--- a/packages/react-native/Libraries/NativeComponent/BaseViewConfig.ios.js
+++ b/packages/react-native/Libraries/NativeComponent/BaseViewConfig.ios.js
@@ -197,7 +197,7 @@ const validAttributesForNonEventProps = {
   accessibilityIgnoresInvertColors: true,
   accessibilityShowsLargeContentViewer: true,
   accessibilityLargeContentTitle: true,
-  accessibilityOrder: true,
+  experimental_accessibilityOrder: true,
   testID: true,
   backgroundColor: {process: require('../StyleSheet/processColor').default},
   backfaceVisibility: true,

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -3946,7 +3946,6 @@ export type AccessibilityPropsIOS = $ReadOnly<{
 export type AccessibilityProps = $ReadOnly<{
   ...AccessibilityPropsAndroid,
   ...AccessibilityPropsIOS,
-  accessibilityOrder?: $ReadOnlyArray<string>,
   accessible?: ?boolean,
   accessibilityLabel?: ?Stringish,
   accessibilityHint?: ?Stringish,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.kt
@@ -157,7 +157,7 @@ public object ViewProps {
   public const val ACCESSIBILITY_ACTIONS: String = "accessibilityActions"
   public const val ACCESSIBILITY_VALUE: String = "accessibilityValue"
   public const val ACCESSIBILITY_LABELLED_BY: String = "accessibilityLabelledBy"
-  public const val ACCESSIBILITY_ORDER: String = "accessibilityOrder"
+  public const val ACCESSIBILITY_ORDER: String = "experimental_accessibilityOrder"
   public const val IMPORTANT_FOR_ACCESSIBILITY: String = "importantForAccessibility"
   public const val ROLE: String = "role"
   // DEPRECATED

--- a/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.cpp
@@ -52,7 +52,7 @@ AccessibilityProps::AccessibilityProps(
               : convertRawProp(
                     context,
                     rawProps,
-                    "accessibilityOrder",
+                    "experimental_accessibilityOrder",
                     sourceProps.accessibilityOrder,
                     {})),
       accessibilityLabelledBy(

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
@@ -823,14 +823,6 @@ folly::dynamic HostPlatformViewProps::getDiffProps(
     result["accessibilityLabelledBy"] = accessibilityLabelledByValues;
   }
 
-  if (accessibilityOrder != oldProps->accessibilityOrder) {
-    auto accessibilityChildrenIds = folly::dynamic::array();
-    for (const auto& accessibilityChildId : accessibilityOrder) {
-      accessibilityChildrenIds.push_back(accessibilityChildId);
-    }
-    result["accessibilityElements"] = accessibilityChildrenIds;
-  }
-
   if (accessibilityLiveRegion != oldProps->accessibilityLiveRegion) {
     switch (accessibilityLiveRegion) {
       case AccessibilityLiveRegion::Assertive:


### PR DESCRIPTION
Summary:
We are going to initially expose this with the `experimental_` prefix to indicate that it has not been battle tested yet.

Changelog: [Internal]

Differential Revision: D71939365


