### PR TITLE
track situations where devices are not reporting a valid debug page

### DIFF
--- a/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
+++ b/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
@@ -176,6 +176,10 @@ export default class InspectorProxy implements InspectorProxyQueries {
 
         this.#eventReporter?.logEvent({
           type: 'no_debug_pages_for_device',
+          appId: device.getApp(),
+          deviceName: device.getName(),
+          deviceId: deviceId,
+          pageId: null,
         });
       }
 

--- a/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
+++ b/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
@@ -166,9 +166,10 @@ export default class InspectorProxy implements InspectorProxyQueries {
         this.#logger?.warn(
           `Waiting for a DevTools connection to app='%s' on device='%s'.
     Try again when it's established. If no connection occurs, try to:
-    - Restart the app
-    - Ensure a stable connection to the device
-    - Ensure that the app is built in a mode that supports debugging`,
+    - Restart the app. For Android, force stopping the app first might be required.
+    - Ensure a stable connection to the device.
+    - Ensure that the app is built in a mode that supports debugging.
+    - Take the app out of running in the background.`,
           device.getApp(),
           device.getName(),
         );

--- a/packages/dev-middleware/src/types/EventReporter.js
+++ b/packages/dev-middleware/src/types/EventReporter.js
@@ -91,6 +91,7 @@ export type ReportableEvent =
     }
   | {
       type: 'no_debug_pages_for_device',
+      ...DebuggerSessionIDs,
     }
   | {
       type: 'proxy_error',


### PR DESCRIPTION
Summary:
Changelog:
[General][Internal] track situations where devices are not reporting a valid debug page

Reviewed By: robhogan

Differential Revision: D71898522


