### PR TITLE
Rename ReactBridge to BridgeSoLoader

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BridgeSoLoader.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BridgeSoLoader.kt
@@ -7,7 +7,6 @@
 
 package com.facebook.react.bridge
 
-import android.os.SystemClock
 import com.facebook.react.common.annotations.internal.LegacyArchitecture
 import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
 import com.facebook.soloader.SoLoader
@@ -15,41 +14,28 @@ import com.facebook.systrace.Systrace
 import com.facebook.systrace.Systrace.TRACE_TAG_REACT_JAVA_BRIDGE
 
 @LegacyArchitecture
-internal object ReactBridge {
+internal object BridgeSoLoader {
   init {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled("ReactBridge")
+    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled("BridgeSoLoader")
   }
-
-  @Volatile private var _loadStartTime: Long = 0
-  @Volatile private var _loadEndTime: Long = 0
-  @Volatile private var _didInit: Boolean = false
 
   @JvmStatic
   @Synchronized
   fun staticInit() {
-    if (_didInit) {
+    if (initialized) {
       return
     }
-    _loadStartTime = SystemClock.uptimeMillis()
-    Systrace.beginSection(
-        TRACE_TAG_REACT_JAVA_BRIDGE, "ReactBridge.staticInit::load:reactnativejni")
+    Systrace.beginSection(TRACE_TAG_REACT_JAVA_BRIDGE, "BridgeSoLoader")
     ReactMarker.logMarker(ReactMarkerConstants.LOAD_REACT_NATIVE_SO_FILE_START)
     SoLoader.loadLibrary("reactnativejni")
     ReactMarker.logMarker(ReactMarkerConstants.LOAD_REACT_NATIVE_SO_FILE_END)
     Systrace.endSection(TRACE_TAG_REACT_JAVA_BRIDGE)
-    _loadEndTime = SystemClock.uptimeMillis()
-    _didInit = true
+    initialized = true
   }
 
-  @JvmStatic
-  val loadStartTime: Long
-    get() = _loadStartTime
-
-  @JvmStatic
-  val loadEndTime: Long
-    get() = _loadEndTime
-
-  @JvmStatic
-  val initialized: Boolean
-    @JvmName("isInitialized") get() = _didInit
+  @get:JvmStatic
+  @get:JvmName("isInitialized")
+  @Volatile
+  var initialized: Boolean = false
+    private set
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
@@ -50,7 +50,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 @LegacyArchitecture
 public class CatalystInstanceImpl implements CatalystInstance {
   static {
-    ReactBridge.staticInit();
+    BridgeSoLoader.staticInit();
     LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
         "CatalystInstanceImpl", LegacyArchitectureLogLevel.WARNING);
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CxxModuleWrapperBase.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CxxModuleWrapperBase.kt
@@ -48,7 +48,7 @@ protected constructor(
 
   private companion object {
     init {
-      ReactBridge.staticInit()
+      BridgeSoLoader.staticInit()
       LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
           "CxxModuleWrapperBase", LegacyArchitectureLogLevel.WARNING)
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/Inspector.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/Inspector.java
@@ -18,7 +18,7 @@ import java.util.List;
 @DoNotStrip
 public class Inspector {
   static {
-    ReactBridge.staticInit();
+    BridgeSoLoader.staticInit();
   }
 
   private final HybridData mHybridData;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeArray.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeArray.kt
@@ -19,7 +19,7 @@ public abstract class NativeArray protected constructor() :
 
   private companion object {
     init {
-      ReactBridge.staticInit()
+      BridgeSoLoader.staticInit()
     }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeMap.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeMap.kt
@@ -17,7 +17,7 @@ public abstract class NativeMap : HybridClassBase() {
 
   private companion object {
     init {
-      ReactBridge.staticInit()
+      BridgeSoLoader.staticInit()
     }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactInstanceManagerInspectorTarget.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactInstanceManagerInspectorTarget.java
@@ -70,6 +70,6 @@ public class ReactInstanceManagerInspectorTarget implements AutoCloseable {
   static {
     LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
         "ReactInstanceManagerInspectorTarget", LegacyArchitectureLogLevel.WARNING);
-    ReactBridge.staticInit();
+    BridgeSoLoader.staticInit();
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactMarker.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactMarker.java
@@ -211,7 +211,7 @@ public class ReactMarker {
       now = SystemClock.uptimeMillis();
     }
 
-    if (ReactBridge.isInitialized()) {
+    if (BridgeSoLoader.isInitialized()) {
       // First send the current marker
       nativeLogMarker(name.name(), now);
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultSoLoader.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultSoLoader.kt
@@ -9,18 +9,16 @@ package com.facebook.react.defaults
 
 import com.facebook.soloader.SoLoader
 
-internal class DefaultSoLoader {
-  companion object {
-    @Synchronized
-    @JvmStatic
-    fun maybeLoadSoLibrary() {
-      SoLoader.loadLibrary("react_newarchdefaults")
-      try {
-        SoLoader.loadLibrary("appmodules")
-      } catch (e: UnsatisfiedLinkError) {
-        // ignore: DefaultTurboModuleManagerDelegate is still used in apps that don't have
-        // appmodules.so
-      }
+internal object DefaultSoLoader {
+  @Synchronized
+  @JvmStatic
+  fun maybeLoadSoLibrary() {
+    SoLoader.loadLibrary("react_newarchdefaults")
+    try {
+      SoLoader.loadLibrary("appmodules")
+    } catch (e: UnsatisfiedLinkError) {
+      // ignore: DefaultTurboModuleManagerDelegate is still used in apps that don't have
+      // appmodules.so
     }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricSoLoader.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricSoLoader.kt
@@ -20,8 +20,7 @@ public object FabricSoLoader {
     if (didInit) {
       return
     }
-    Systrace.beginSection(
-        Systrace.TRACE_TAG_REACT_JAVA_BRIDGE, "FabricSoLoader.staticInit::load:fabricjni")
+    Systrace.beginSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE, "FabricSoLoader")
     ReactMarker.logMarker(ReactMarkerConstants.LOAD_REACT_NATIVE_SO_FILE_START)
     SoLoader.loadLibrary("fabricjni")
     ReactMarker.logMarker(ReactMarkerConstants.LOAD_REACT_NATIVE_SO_FILE_END)


### PR DESCRIPTION
Summary:
Make it clearer that the only purpose of this class is to manage the soloading of the core bridge so file.

Changelog: [Internal]

Differential Revision: D71965759
