### PR TITLE
Do not crash when event is emitted when ReactInstance is reloaded

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/EventEmitterImpl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/EventEmitterImpl.kt
@@ -83,7 +83,7 @@ internal class EventEmitterImpl(
         logSoftException(
             TAG,
             ReactNoCrashSoftException(
-                "Cannot get RCTEventEmitter from Context, no active Catalyst instance!"))
+                "Cannot get RCTEventEmitter without active Catalyst instance!"))
       }
     }
     return legacyEventEmitter
@@ -100,15 +100,15 @@ internal class EventEmitterImpl(
   ) {
     @UIManagerType val uiManagerType = getUIManagerType(targetTag, surfaceId)
     if (uiManagerType == UIManagerType.FABRIC) {
-      checkNotNull(fabricEventEmitter)
-          .receiveEvent(
-              surfaceId,
-              targetTag,
-              eventName,
-              canCoalesceEvent,
-              customCoalesceKey,
-              params,
-              category)
+      val fabricEventEmitter = fabricEventEmitter
+      if (fabricEventEmitter == null) {
+        logSoftException(
+            TAG,
+            ReactNoCrashSoftException("No fabricEventEmitter registered, cannot dispatch event"))
+      } else {
+        fabricEventEmitter.receiveEvent(
+            surfaceId, targetTag, eventName, canCoalesceEvent, customCoalesceKey, params, category)
+      }
     } else if (uiManagerType == UIManagerType.LEGACY) {
       ensureLegacyEventEmitter()?.receiveEvent(targetTag, eventName, params)
     }


### PR DESCRIPTION
Summary:
Regression introduced in recent refactor where I tried to ensure fabricEventEmitter was always non-null. Instead log a soft error when this happens, so we don't drop the event silently.

Changelog: [Android][Fixed] Fixed crash when event is emitted after instance is shutdown

Differential Revision: D71967092


