### PR TITLE
Define "exports" field on main package

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -26,7 +26,25 @@
   "bin": {
     "react-native": "cli.js"
   },
+  "main": "./index.js",
   "types": "types",
+  "exports": {
+    ".": "./index.js",
+    "./*": "./*.js",
+    "./*.js": "./*.js",
+    "./Libraries/*.d.ts": "./Libraries/*.d.ts",
+    "./types/*.d.ts": "./types/*.d.ts",
+    "./gradle/*": null,
+    "./React/*": null,
+    "./ReactAndroid/*": null,
+    "./ReactApple/*": null,
+    "./ReactCommon/*": null,
+    "./sdks/*": null,
+    "./src/*": null,
+    "./third-party-podspecs/*": null,
+    "./types/*": null,
+    "./package.json": "./package.json"
+  },
   "jest-junit": {
     "outputDirectory": "reports/junit",
     "outputName": "js-test-results.xml"
@@ -84,11 +102,6 @@
     "sdks/hermesc",
     "settings.gradle.kts",
     "src",
-    "template.config.js",
-    "template",
-    "!template/node_modules",
-    "!template/package-lock.json",
-    "!template/yarn.lock",
     "third-party-podspecs",
     "types"
   ],


### PR DESCRIPTION
Summary:
Define `"exports"` field on the main `react-native` package.

**Notes**

Module resolution should be equivalent to the previous implicit `"main"` field (backwards compatible).

- Exports all module subpaths to JavaScript (Flow) source files, with and without `.js` suffix (unchanged ✅)
    - These are restricted to the `flow/` and `Libraries/` subdirectories (ℹ️ this should be unchanged, matching any JS imports apps may have today)
        - Still includes 3P integration scripts such as `./jest-preset.js` and `./rn-get-polyfills.js` (unchanged ✅)
- Exports `./package.json` (unchanged ✅)
- TypeScript should:
    - fall back to the `"types"` field (unchanged ✅)
    - OR to `"."`,`"./*"` when Package Exports support is enabled via `compilerOptions`, and use the *adjacent `.d.ts` file* (unchanged ✅)

Changelog:
[General][Breaking] - The `react-native` package now defines package.json `"exports"`.
- While these expose existing JavaScript and TypeScript modules, this change may affect deep imports of non-JS files via Node in third party tools.
- Imports from `src/` and `src/private/` directories are disallowed.

Differential Revision: D71968187


