### PR TITLE
Expose TextInputState API at root

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/TextInputState.d.ts
+++ b/packages/react-native/Libraries/Components/TextInput/TextInputState.d.ts
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+import type {HostInstance} from '../../../types/public/ReactNativeTypes';
+
+declare function currentlyFocusedInput(): null | undefined | HostInstance;
+
+/**
+ * Returns the ID of the currently focused text field, if one exists
+ * If no text field is focused it returns null
+ */
+declare function currentlyFocusedField(): null | undefined | number;
+
+declare function focusInput(textField: null | undefined | HostInstance): void;
+declare function blurInput(textField: null | undefined | HostInstance): void;
+declare function focusField(textFieldID: null | undefined | number): void;
+declare function blurField(textFieldID: null | undefined | number): void;
+
+/**
+ * @param {number} TextInputID id of the text field to focus
+ * Focuses the specified text field
+ * noop if the text field was already focused or if the field is not editable
+ */
+declare function focusTextInput(
+  textField: null | undefined | HostInstance,
+): void;
+
+/**
+ * @param {number} textFieldID id of the text field to unfocus
+ * Unfocuses the specified text field
+ * noop if it wasn't focused
+ */
+declare function blurTextInput(
+  textField: null | undefined | HostInstance,
+): void;
+
+declare function registerInput(textField: HostInstance): void;
+declare function unregisterInput(textField: HostInstance): void;
+declare function isTextInput(textField: HostInstance): boolean;
+
+/**
+ * Responsible for coordinating the "focused" state for text inputs. All calls
+ * relating to the keyboard should be funneled through here.
+ */
+declare const TextInputState: {
+  currentlyFocusedInput: typeof currentlyFocusedInput;
+  focusInput: typeof focusInput;
+  blurInput: typeof blurInput;
+  currentlyFocusedField: typeof currentlyFocusedField;
+  focusField: typeof focusField;
+  blurField: typeof blurField;
+  focusTextInput: typeof focusTextInput;
+  blurTextInput: typeof blurTextInput;
+  registerInput: typeof registerInput;
+  unregisterInput: typeof unregisterInput;
+  isTextInput: typeof isTextInput;
+};
+
+declare const $$EXPORT_DEFAULT_DECLARATION$$: typeof TextInputState;
+export default $$EXPORT_DEFAULT_DECLARATION$$;

--- a/packages/react-native/Libraries/Components/TextInput/TextInputState.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInputState.js
@@ -8,10 +8,6 @@
  * @flow strict-local
  */
 
-// This class is responsible for coordinating the "focused" state for
-// TextInputs. All calls relating to the keyboard should be funneled
-// through here.
-
 import type {HostInstance} from '../../../src/private/types/HostInstance';
 
 import {Commands as AndroidTextInputCommands} from '../../Components/TextInput/AndroidTextInputNativeComponent';
@@ -180,11 +176,14 @@ function isTextInput(textField: HostInstance): boolean {
   return inputs.has(textField);
 }
 
+/**
+ * Responsible for coordinating the "focused" state for text inputs. All calls
+ * relating to the keyboard should be funneled through here.
+ */
 const TextInputState = {
   currentlyFocusedInput,
   focusInput,
   blurInput,
-
   currentlyFocusedField,
   focusField,
   blurField,

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -9631,6 +9631,7 @@ export type {
 } from \\"./Libraries/StyleSheet/StyleSheetTypes\\";
 export { default as StyleSheet } from \\"./Libraries/StyleSheet/StyleSheet\\";
 export * as Systrace from \\"./Libraries/Performance/Systrace\\";
+export { default as TextInputState } from \\"./Libraries/Components/TextInput/TextInputState\\";
 export { default as ToastAndroid } from \\"./Libraries/Components/ToastAndroid/ToastAndroid\\";
 export * as TurboModuleRegistry from \\"./Libraries/TurboModule/TurboModuleRegistry\\";
 export { default as UIManager } from \\"./Libraries/ReactNative/UIManager\\";

--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -288,6 +288,9 @@ module.exports = {
   get Systrace() {
     return require('./Libraries/Performance/Systrace');
   },
+  get TextInputState() {
+    return require('./Libraries/Components/TextInput/TextInputState').default;
+  },
   get ToastAndroid() {
     return require('./Libraries/Components/ToastAndroid/ToastAndroid').default;
   },

--- a/packages/react-native/index.js.flow
+++ b/packages/react-native/index.js.flow
@@ -366,6 +366,7 @@ export type {
 export {default as StyleSheet} from './Libraries/StyleSheet/StyleSheet';
 
 export * as Systrace from './Libraries/Performance/Systrace';
+export {default as TextInputState} from './Libraries/Components/TextInput/TextInputState';
 export {default as ToastAndroid} from './Libraries/Components/ToastAndroid/ToastAndroid';
 export * as TurboModuleRegistry from './Libraries/TurboModule/TurboModuleRegistry';
 export {default as UIManager} from './Libraries/ReactNative/UIManager';

--- a/packages/react-native/types/index.d.ts
+++ b/packages/react-native/types/index.d.ts
@@ -94,6 +94,7 @@ export * from '../Libraries/Components/StatusBar/StatusBar';
 export * from '../Libraries/Components/Switch/Switch';
 export * from '../Libraries/Components/TextInput/InputAccessoryView';
 export * from '../Libraries/Components/TextInput/TextInput';
+export {default as TextInputState} from '../Libraries/Components/TextInput/TextInputState';
 export * from '../Libraries/Components/ToastAndroid/ToastAndroid';
 export * from '../Libraries/Components/Touchable/Touchable';
 export * from '../Libraries/Components/Touchable/TouchableHighlight';


### PR DESCRIPTION
Summary:
Promotes `TextInputState` to a main export of `react-native`, and adds missing TypeScript API.

**Motivation**: This is a public runtime API depended on by several active third party packages.

- [stripe-react-native](https://github.com/stripe/stripe-react-native/blob/5f920e3d4a745cca1b7ca0f6675362aed9171ac0/src/helpers.ts#L6)
- [react-native-keyboard-avoiding-scrollview](https://github.com/alkafinance/react-native-keyboard-avoiding-scroll-view/blob/a6cf6f29bc6900cc14a531e8b034a702115b98d8/src/utils/hijackTextInputEvents.ts#L2)
- [react-native-paste-input](https://github.com/mattermost/react-native-paste-input/blob/f260447edc645a817ab1ba7b46d8341d84dba8e9/src/module.d.ts#L1)

This follows up recently being touched externally as part of the 0.79 `export` syntax migration (https://github.com/stripe/stripe-react-native/pull/1865/files#r1996803240). Moving this to a root export will prevent future breaking changes.

Changelog:
[General][Added] - `TextInputState` is now a root export of `react-native`

Differential Revision: D71211458


