### PR TITLE
Ignore unexisting nativeIDs on accessibilityOrder

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAxOrderHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAxOrderHelper.kt
@@ -33,14 +33,14 @@ private object ReactAxOrderHelper {
       }
     }
 
-    val axOrderViews = processAxOrderTree(host, axOrderIdsList, axOrderSet)
+    val axOrderViews = processAxOrderTree(host, axOrderIdsList, axOrderSet).filterNotNull()
 
     // Set up traversal order between views
     for (i in 0 until axOrderViews.size - 1) {
       val currentView = axOrderViews[i]
       val flowToView = axOrderViews[i + 1]
 
-      currentView?.setTag(R.id.accessibility_order_flow_to, flowToView)
+      currentView.setTag(R.id.accessibility_order_flow_to, flowToView)
     }
   }
 


### PR DESCRIPTION
Summary: axOrderViews is an optimization I came up with so that we could find and queue all the views on a single tree traversal. It initializes the array with the size of the accessibilityOrder array and places each view where its nativeID is. If there is no view corresponding to the nativeID then that axOrderViews element will be null. So to fully ignore nativeIDs that don't correspond to any View we can just filter the nulls

Differential Revision: D71977739


