### PR TITLE
improve error reporting when a debugger for an unknown device is opened

### DIFF
--- a/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
+++ b/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
@@ -520,7 +520,9 @@ export default class InspectorProxy implements InspectorProxyQueries {
         }
 
         if (device == null) {
-          throw new Error('Unknown device with ID ' + deviceId);
+          throw new Error(
+            'Debugger connection attempted for a non registered device',
+          );
         }
 
         this.#logger?.info(
@@ -616,9 +618,10 @@ export default class InspectorProxy implements InspectorProxyQueries {
         });
       } catch (error) {
         this.#logger?.error(
-          "Connection failed to be established with DevTools for app='%s' on device='%s' with error:",
+          "Connection failed to be established with DevTools for app='%s' on device='%s' and device id='%s' with error:",
           device?.getApp() || 'unknown',
           device?.getName() || 'unknown',
+          deviceId,
           error,
         );
         socket.close(INTERNAL_ERROR_CODE, error?.toString() ?? 'Unknown error');


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Make the error reported when a debugger is created for a device that does not exist generic, and not including any specific details to make them easier to aggregate

Differential Revision: D71979796


