### PR TITLE
Define root README.md for technical docs

### DIFF
--- a/__docs__/DOCS.md
+++ b/__docs__/DOCS.md
@@ -1,0 +1,61 @@
+# React Native Technical Documentation
+
+The React Native technical documentation describes how React Native works internally, the subsystems it is composed of, how they work and how they interact with each other.
+
+The intended audience is people who want to learn about the internals of React Native and contribute to it. **End users of React Native are meant to use the [public website](https://reactnative.dev) instead** (its code can be found [here](https://github.com/facebook/react-native-website)).
+
+## Motivation
+
+The goals of this documentation are:
+1. To make it easier for people to understand and contribute to the React Native architecture.
+2. To ensure the architecture is easy to maintain, with clearly scoped subsystems that are easy to reason about and change.
+
+## Strategy
+
+Our documentation supports the following use cases:
+1. [Exploration based] I want to understand how React Native works and learn about its different parts. I want to explore.
+2. [Goal based] I want to solve a problem and change something specific, so I want to understand what I should change and how the system I need to change works. I need to understand how other systems depend on this.
+
+To support the first case, we provide a single entrypoint for the whole documentation, which will be the first step in a tree of docs with links to parents and children:
+- `<root>/__docs__/README.md` (with links to subsystems 1, 2, etc.)
+  - `Subsystem 1/__docs__/README.md` (with links to root and subsystems 1.1, 1.2, etc.)
+    - `Subsystem 1.1/__docs__/README.md` (with links to subsystem 1 and subsystems 1.1.1, 1.1.2, etc.)
+    - `Subsystem 1.2/__docs__/README.md`
+  - `Subsystem 2/__docs__/README.md`
+
+This structure will make it possible for the user to navigate across the documentation organically, just following links within the documents themselves.
+
+To support the second use case, focusing on a specific subsystem, we will describe what are the relationships between that subsystem and others, to make sure that changes to its API are understood, and that usages of other subsystems are considered.
+
+The use of the `__docs__` directory (inspired by Python) has 2 goals:
+1. Make the documentation easy to find in the directory, by generally appearing at the top of the directory (similar to `__tests__`).
+2. Grouping the documentation itself and its assets (images, diagrams, etc.).
+
+## Guidelines
+
+### Content
+
+Use [this template](./README-template.md) to write the documentation for a subsystem, adding the appropriate subsections depending on what that documentation requires. Only diverge from this structure if it is strictly necessary (removing unnecessary or empty sections is fine).
+
+Include supporting images and diagrams in the documentation. Those assets should be placed in the same `__docs__` directory as the `README.md` file. Use relative paths to link to the assets in those directories.
+
+If you include Excalidraw diagrams, make sure to export an SVG image from the website using the "Embedded scene" option, so the original diagram is included in the file and can be re-uploaded to Excalidraw for future modifications. Use the extension `.excalidraw.svg` to signal this.
+
+### Granularity
+
+The level of granularity in the definition of the subsystems should be enough to correctly describe how React Native works, but not so detailed that any changes in the code require changes in the documentation.
+
+Examples:
+- Requires updating the docs:
+  - Adding a new major feature or API.
+  - Adding a new relevant dependency. Adding a dependency to helper functions does not count as relevant.
+- Does NOT require updating the docs:
+  - Internal implementation details that do not change how the system works or interacts with others.
+  - Making a minor API or feature change.
+  - Internal refactors, even if they create new modules or introduce dependencies to external helpers.
+
+### Location
+
+When a specific subsystem exists in multiple directories (e.g.: platform-specific ones, C++, JavaScript, etc.):
+  1. Choose one of them to place the canonical documentation (in order of preference, JavaScript -> C++ -> platform).
+  2. Create specific files in the rest linking to the canonical one.

--- a/__docs__/README-template.md
+++ b/__docs__/README-template.md
@@ -1,0 +1,31 @@
+# _Subsystem name_
+
+* [Main doc](../__docs__/README.md)
+
+_Description of the subsystem with the necessary context._
+
+## Usage
+
+_Explanation of how the subsystem is used._
+
+## Design
+
+_Explain how the subsystem is designed, relevant implementation details, etc. Ideally include an Excalidraw diagram._
+
+## Relationship with other systems
+
+### Part of
+
+- _A single bullet for the parent subsystem. Link to the documentation of that subsystem if it exists._
+
+### Part of this
+
+- _One bullet point for each subsystem that is part of this one. Link to the documentation of those subsystems if it exists._
+
+### Used by this
+
+- _One bullet point for each subsystem used by this one, explaining why it uses it and how. Link to the documentation of those subsystems if it exists._
+
+### Uses this
+
+- _One bullet point for each subsystem using this one, explaining why it uses it and how. Link to the documentation of those subsystems if it exists._

--- a/__docs__/README.md
+++ b/__docs__/README.md
@@ -1,0 +1,36 @@
+# React Native Documentation
+
+This is the internal technical documentation for React Native. It is not intended for end users of the platform.
+
+For information on our documentation strategy and structure, see [DOCS.md](./DOCS.md).
+
+## Usage
+
+This repository is not meant to be consumed directly by end users. Instead, it creates several packages that are published to the NPM registry for direct consumption by end users and frameworks.
+
+This repository uses a monorepo approach, and public packages can be found in the [`packages`](../packages/) directory (the ones that do not contain `"private": true` in their `package.json` file).
+
+The most important package is the [`react-native`](https://www.npmjs.com/package/react-native) package, located in [`packages/react-native`](../packages/react-native), which contains the public JavaScript API.
+
+This repository provides the Android and iOS versions of React Native. Versions for other platforms are maintained in their own  repositories.
+
+## Design
+
+TODO: Explain the different components of React Native at a high level.
+
+## Relationship with other systems
+
+### Part of this
+
+(TODO)
+
+### Used by this
+
+This repository has many different types of dependencies: build systems, external packages to be used during development, external packages used at runtime, etc.
+
+### Uses this
+
+The main use cases for this repository are:
+1. Developing React Native itself.
+2. Testing and releasing React Native.
+3. Synchronizing forks like `react-native-windows` and `react-native-macos`.


### PR DESCRIPTION
Summary:
Changelog: [internal]

This defines a placeholder for the main entrypoint for the React Native internal technical documentation.

Reviewed By: javache, rshest

Differential Revision: D71889755


