### PR TITLE
Send Profile in smaller chunk to prevent WebSocket disconnections on android

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.cpp
@@ -20,6 +20,15 @@ namespace {
  */
 const uint16_t TRACE_EVENT_CHUNK_SIZE = 1000;
 
+/**
+ * The maximum number of ProfileChunk trace events
+ * that will be sent in a single CDP Tracing.dataCollected message.
+ * TODO(T219394401): Increase the size once we manage the queue on OkHTTP side
+ * properly and avoid WebSocket disconnections when sending a message larger
+ * than 16MB.
+ */
+const uint16_t PROFILE_TRACE_EVENT_CHUNK_SIZE = 1;
+
 } // namespace
 
 bool TracingAgent::handleRequest(const cdp::PreparsedRequest& req) {
@@ -89,7 +98,7 @@ bool TracingAgent::handleRequest(const cdp::PreparsedRequest& req) {
         instanceAgent_->collectTracingProfile().getRuntimeSamplingProfile(),
         instanceTracingStartTimestamp_,
         dataCollectedCallback,
-        TRACE_EVENT_CHUNK_SIZE);
+        PROFILE_TRACE_EVENT_CHUNK_SIZE);
 
     frontendChannel_(cdp::jsonNotification(
         "Tracing.tracingComplete",

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.h
@@ -20,6 +20,19 @@ class RuntimeSamplingProfileTraceEventSerializer {
  public:
   RuntimeSamplingProfileTraceEventSerializer() = delete;
 
+  /**
+   * \param performanceTracer A reference to PerformanceTracer instance.
+   * \param profile What we will be serializing.
+   * \param tracingStartTime A timestamp of when tracing of an
+   * Instance started, will be used as a starting reference point of JavaScript
+   * samples recording.
+   * \param notificationCallback A callback, which is called
+   * when a chunk of trace events is ready to be sent.
+   * \param traceEventChunkSize The maximum number of ProfileChunk trace events
+   * that can be sent in a single CDP Tracing.dataCollected message.
+   * \param profileChunkSize The maximum number of ProfileChunk trace events
+   * that can be sent in a single ProfileChunk trace event.
+   */
   static void serializeAndNotify(
       PerformanceTracer& performanceTracer,
       const RuntimeSamplingProfile& profile,
@@ -27,7 +40,7 @@ class RuntimeSamplingProfileTraceEventSerializer {
       const std::function<void(const folly::dynamic& traceEventsChunk)>&
           notificationCallback,
       uint16_t traceEventChunkSize,
-      uint16_t profileChunkSize = 100);
+      uint16_t profileChunkSize = 10);
 };
 
 } // namespace facebook::react::jsinspector_modern::tracing


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

This should not have any functional changes, it only prevents the WebSocket from being killed on Android, when we are sending Profile-related Trace Events.

For large traces, a single message could be more than 16MB, because we send a unique string url for every call frame.

Differential Revision: D71993748


