### PR TITLE
RN/Metro: Set `reactRuntimeTarget` w/ Hermes Parser

### DIFF
--- a/packages/react-native-codegen/src/parsers/flow/parseFlowAndThrowErrors.js
+++ b/packages/react-native-codegen/src/parsers/flow/parseFlowAndThrowErrors.js
@@ -25,6 +25,7 @@ function parseFlowAndThrowErrors(
       babel: false,
       // Parse Flow without a pragma
       flow: 'all',
+      reactRuntimeTarget: '18',
       ...(options.filename != null ? {sourceFilename: options.filename} : {}),
     });
   } catch (e) {


### PR DESCRIPTION
Summary:
Explicitly sets the default `reactRuntimeTarget` when invoking `require('hermes-parser').parse` so that it'll be easier to find these configurations when upgrading to `'19'`.

Changelog:
[Internal]

Differential Revision: D72006705


