### PR TITLE
Remove ANDROID ifdefs from TextShadowNode

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/text/TextShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/TextShadowNode.h
@@ -6,9 +6,6 @@
  */
 
 #pragma once
-
-#include <limits>
-
 #include <react/renderer/components/text/BaseTextShadowNode.h>
 #include <react/renderer/components/text/TextProps.h>
 #include <react/renderer/components/view/ViewEventEmitter.h>
@@ -27,31 +24,7 @@ class TextShadowNode : public ConcreteShadowNode<
                            TextEventEmitter>,
                        public BaseTextShadowNode {
  public:
-  static ShadowNodeTraits BaseTraits() {
-    auto traits = ConcreteShadowNode::BaseTraits();
-#ifdef ANDROID
-    traits.set(ShadowNodeTraits::Trait::FormsView);
-#endif
-    return traits;
-  }
-
   using ConcreteShadowNode::ConcreteShadowNode;
-
-#ifdef ANDROID
-  using BaseShadowNode = ConcreteShadowNode<
-      TextComponentName,
-      ShadowNode,
-      TextProps,
-      TextEventEmitter>;
-
-  TextShadowNode(
-      const ShadowNodeFragment& fragment,
-      const ShadowNodeFamily::Shared& family,
-      ShadowNodeTraits traits)
-      : BaseShadowNode(fragment, family, traits), BaseTextShadowNode() {
-    orderIndex_ = std::numeric_limits<decltype(orderIndex_)>::max();
-  }
-#endif
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
Noticed this logic from early Fabric, and it seems suppper funky in the context of how the rest of the systems work today. `Text` doesn't form a view (compared to `Paragraph`), and Differentiator will treat non-layoutable, or shadownodes with empty layout metrics as virtual, so I can't think of why this would do anything. Let's clean it up.

Changelog: [Internal]

Differential Revision: D71941993


