### PR TITLE
Fix multiple modal issue on React Native 0.76

### DIFF
--- a/packages/react-native/React/Views/RCTModalHostViewManager.m
+++ b/packages/react-native/React/Views/RCTModalHostViewManager.m
@@ -64,9 +64,9 @@ RCT_EXPORT_MODULE()
     if (self->_presentationBlock) {
       self->_presentationBlock([modalHostView reactViewController], viewController, animated, completionBlock);
     } else {
-      [[self _topMostViewControllerFrom:[modalHostView reactViewController]] presentViewController:viewController
-                                                                                          animated:animated
-                                                                                        completion:completionBlock];
+      [[modalHostView reactViewController] presentViewController:viewController
+                                                        animated:animated
+                                                      completion:completionBlock];
     }
   });
 }
@@ -105,26 +105,6 @@ RCT_EXPORT_MODULE()
     [hostView invalidate];
   }
   _hostViews = nil;
-}
-
-#pragma mark - Private
-
-- (UIViewController *)_topMostViewControllerFrom:(UIViewController *)rootViewController
-{
-  UIViewController *topController = rootViewController;
-  while (topController.presentedViewController) {
-    topController = topController.presentedViewController;
-  }
-  if ([topController isKindOfClass:[UINavigationController class]]) {
-    UINavigationController *navigationController = (UINavigationController *)topController;
-    topController = navigationController.visibleViewController;
-    return [self _topMostViewControllerFrom:topController];
-  } else if ([topController isKindOfClass:[UITabBarController class]]) {
-    UITabBarController *tabBarController = (UITabBarController *)topController;
-    topController = tabBarController.selectedViewController;
-    return [self _topMostViewControllerFrom:topController];
-  }
-  return topController;
 }
 
 RCT_EXPORT_VIEW_PROPERTY(animationType, NSString)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Fixes: https://github.com/facebook/react-native/issues/48611

Which is caused by the changes from: https://github.com/facebook/react-native/commit/f1031be3e2cc4d2af2973787b6afdf825ad8fa0c (included in 0.76).
The commit was backed out, but didn't land on 0.76: https://github.com/facebook/react-native/commit/080c82e70f0e9976ee7f7811ff6770baff546785

The current Expo version (52) is still using 0.76, so I would imagine it's worth applying this and closing the issue.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[IOS] [FIXED] - Multiple modals on old architecture

## Test Plan:

```
import { Button, Modal, Text, View } from "react-native";
import { useState } from "react";

export const App = (): JSX.Element => {
  const [aVisible, setAVisible] = useState(true);
  const [bVisible, setBVisible] = useState(false);

  return (
    <View>
      <Modal visible={aVisible} animationType="slide">
        <View style={{ flex: 1, margin: 100 }}>
          <Text>A</Text>
          <Button
            title="Close"
            onPress={() => {
              setAVisible(false);
              setBVisible(true);
            }}
          />
        </View>
      </Modal>
      <Modal visible={bVisible} animationType="slide">
        <View style={{ flex: 1, margin: 100 }}>
          <Text>B</Text>
          <Button
            title="Close"
            onPress={() => {
              setBVisible(false);
              setAVisible(true);
            }}
          />
        </View>
      </Modal>
    </View>
  );
};

export default App;
```
