### PR TITLE
[RN][iOS][Releases] Bump Podfile.lock automatically

### DIFF
--- a/.github/workflows/bump-podfile-lock.yml
+++ b/.github/workflows/bump-podfile-lock.yml
@@ -1,0 +1,41 @@
+name: Bump Podfile.lock
+
+on:
+  workflow_call: # this directive allow us to call this workflow from other workflows
+
+jobs:
+  bump-podfile-lock:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Install dependencies
+        uses: ./.github/actions/yarn-install
+      - name: Configure git
+        run: |
+          git config --local user.email "bot@reactnative.dev"
+          git config --local user.name "React Native Bot"
+      - name: Extract branch name
+        run: |
+          TAG="${{ github.ref_name }}";
+          BRANCH_NAME=$(echo "$TAG" | sed -E 's/v([0-9]+\.[0-9]+)\.[0-9]+(-rc\.[0-9]+)?/\1-stable/')
+          echo "Branch Name is $BRANCH_NAME"
+          echo "BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_ENV
+      - name: Checkout release branch
+        run: |
+          git checkout "$BRANCH_NAME"
+          git fetch
+          git pull origin "$BRANCH_NAME"
+      - name: Bump podfile.lock
+        run: |
+          cd packages/rn-tester
+          bundle install
+          bundle exec pod update hermes-engine --no-repo-update
+      - name: Commit changes
+        run: |
+          git add packages/rn-tester/Podfile.lock
+          git commit -m "[LOCAL] Bump Podfile.lock"
+          git push origin "$BRANCH_NAME"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -238,7 +238,12 @@ jobs:
             const version = "${{ github.ref_name }}";
             await verifyArtifactsAreOnMaven(version);
 
-  create_changelog:
+  generate_changelog:
     needs: build_npm_package
     uses: ./.github/workflows/generate-changelog.yml
+    secrets: inherit
+
+  bump-podfile-lock:
+    needs: build_npm_package
+    uses: ./.github/workflows/bump-podfile-lock.yml
     secrets: inherit


### PR DESCRIPTION
## Summary:
This workflow bumps the Podfile.lock automatically when a new release happens.
I decided not to use a js script in this case because all the commands are bash commands for git or cocoapods, therefore wrapping them all in a JS file would have added little to no benefit and only overheads.

## Changelog:
[Internal] - Bumps podfile.lock automatically

## Test Plan:
GHA - tested as a separate workflow first, hardcoding the latest RC
https://github.com/facebook/react-native/actions/runs/14127895380/job/39581024861?pr=50345

The flow correctly fails as the Podfile.lock has already been bumped in the release branch.
