### PR TITLE
Apply Nullsafe FIXMEs for xplat/js/react-native-github/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountItemDispatcher.java

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountItemDispatcher.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountItemDispatcher.java
@@ -123,6 +123,7 @@ public class MountItemDispatcher {
     while (!mountItems.isEmpty()) {
       MountItem item = mountItems.poll();
       try {
+        // NULLSAFE_FIXME[Nullable Dereference]
         item.execute(mMountingManager);
       } catch (RetryableMountingLayerException e) {
         if (item instanceof DispatchCommandMountItem) {
@@ -137,6 +138,7 @@ public class MountItemDispatcher {
           }
         } else {
           printMountItem(
+              // NULLSAFE_FIXME[Parameter Not Nullable]
               item, "dispatchExternalMountItems: mounting failed with " + e.getMessage());
         }
       }
@@ -344,6 +346,7 @@ public class MountItemDispatcher {
       }
       SurfaceMountingManager surfaceMountingManager =
           mMountingManager.getSurfaceManager(item.getSurfaceId());
+      // NULLSAFE_FIXME[Nullable Dereference]
       surfaceMountingManager.scheduleMountItemOnViewAttach(item);
     } else {
       item.execute(mMountingManager);


### PR DESCRIPTION
Summary:
Added nullsafe FIXMEs for easier reviewing of next diff, where we fix them

Changelog: [Internal]

Differential Revision: D71979596
