### PR TITLE
Fix nullsafe FIXMES for ReconnectingWebSocket.java and mark nullsafe

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountItemDispatcher.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountItemDispatcher.java
@@ -12,10 +12,11 @@ import static com.facebook.react.fabric.FabricUIManager.IS_DEVELOPMENT_ENVIRONME
 
 import android.os.SystemClock;
 import android.view.View;
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 import com.facebook.common.logging.FLog;
+import com.facebook.infer.annotation.Assertions;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.infer.annotation.ThreadConfined;
 import com.facebook.react.bridge.ReactIgnorableMountingException;
 import com.facebook.react.bridge.ReactNoCrashSoftException;
@@ -30,6 +31,7 @@ import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class MountItemDispatcher {
 
   private static final String TAG = "MountItemDispatcher";
@@ -39,14 +41,11 @@ public class MountItemDispatcher {
   private final MountingManager mMountingManager;
   private final ItemDispatchListener mItemDispatchListener;
 
-  @NonNull
   private final ConcurrentLinkedQueue<DispatchCommandMountItem> mViewCommandMountItems =
       new ConcurrentLinkedQueue<>();
 
-  @NonNull
   private final ConcurrentLinkedQueue<MountItem> mMountItems = new ConcurrentLinkedQueue<>();
 
-  @NonNull
   private final ConcurrentLinkedQueue<MountItem> mPreMountItems = new ConcurrentLinkedQueue<>();
 
   private boolean mInDispatch = false;
@@ -122,8 +121,8 @@ public class MountItemDispatcher {
   public void dispatchMountItems(Queue<MountItem> mountItems) {
     while (!mountItems.isEmpty()) {
       MountItem item = mountItems.poll();
+      Assertions.assertNotNull(item);
       try {
-        // NULLSAFE_FIXME[Nullable Dereference]
         item.execute(mMountingManager);
       } catch (RetryableMountingLayerException e) {
         if (item instanceof DispatchCommandMountItem) {
@@ -138,7 +137,6 @@ public class MountItemDispatcher {
           }
         } else {
           printMountItem(
-              // NULLSAFE_FIXME[Parameter Not Nullable]
               item, "dispatchExternalMountItems: mounting failed with " + e.getMessage());
         }
       }
@@ -345,8 +343,8 @@ public class MountItemDispatcher {
             item.getSurfaceId());
       }
       SurfaceMountingManager surfaceMountingManager =
-          mMountingManager.getSurfaceManager(item.getSurfaceId());
-      // NULLSAFE_FIXME[Nullable Dereference]
+          mMountingManager.getSurfaceManagerEnforced(
+              item.getSurfaceId(), "MountItemDispatcher::executeOrEnqueue");
       surfaceMountingManager.scheduleMountItemOnViewAttach(item);
     } else {
       item.execute(mMountingManager);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountItemDispatcher.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountItemDispatcher.java
@@ -123,6 +123,7 @@ public class MountItemDispatcher {
     while (!mountItems.isEmpty()) {
       MountItem item = mountItems.poll();
       try {
+        // NULLSAFE_FIXME[Nullable Dereference]
         item.execute(mMountingManager);
       } catch (RetryableMountingLayerException e) {
         if (item instanceof DispatchCommandMountItem) {
@@ -137,6 +138,7 @@ public class MountItemDispatcher {
           }
         } else {
           printMountItem(
+              // NULLSAFE_FIXME[Parameter Not Nullable]
               item, "dispatchExternalMountItems: mounting failed with " + e.getMessage());
         }
       }
@@ -344,6 +346,7 @@ public class MountItemDispatcher {
       }
       SurfaceMountingManager surfaceMountingManager =
           mMountingManager.getSurfaceManager(item.getSurfaceId());
+      // NULLSAFE_FIXME[Nullable Dereference]
       surfaceMountingManager.scheduleMountItemOnViewAttach(item);
     } else {
       item.execute(mMountingManager);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountingManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountingManager.java
@@ -12,10 +12,11 @@ import static com.facebook.infer.annotation.ThreadConfined.UI;
 
 import android.view.View;
 import androidx.annotation.AnyThread;
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 import com.facebook.common.logging.FLog;
+import com.facebook.infer.annotation.Assertions;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.infer.annotation.ThreadConfined;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactSoftExceptionLogger;
@@ -45,11 +46,11 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * Class responsible for actually dispatching view updates enqueued via {@link
  * FabricUIManager#scheduleMountItem} on the UI thread.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class MountingManager {
   public static final String TAG = MountingManager.class.getSimpleName();
   private static final int MAX_STOPPED_SURFACE_IDS_LENGTH = 15;
 
-  @NonNull
   private final ConcurrentHashMap<Integer, SurfaceMountingManager> mSurfaceIdToManager =
       new ConcurrentHashMap<>(); // any thread
 
@@ -58,10 +59,10 @@ public class MountingManager {
   @Nullable private SurfaceMountingManager mMostRecentSurfaceMountingManager;
   @Nullable private SurfaceMountingManager mLastQueriedSurfaceMountingManager;
 
-  @NonNull private final JSResponderHandler mJSResponderHandler = new JSResponderHandler();
-  @NonNull private final ViewManagerRegistry mViewManagerRegistry;
-  @NonNull private final MountItemExecutor mMountItemExecutor;
-  @NonNull private final RootViewManager mRootViewManager = new RootViewManager();
+  private final JSResponderHandler mJSResponderHandler = new JSResponderHandler();
+  private final ViewManagerRegistry mViewManagerRegistry;
+  private final MountItemExecutor mMountItemExecutor;
+  private final RootViewManager mRootViewManager = new RootViewManager();
 
   public interface MountItemExecutor {
     @UiThread
@@ -70,8 +71,7 @@ public class MountingManager {
   }
 
   public MountingManager(
-      @NonNull ViewManagerRegistry viewManagerRegistry,
-      @NonNull MountItemExecutor mountItemExecutor) {
+      ViewManagerRegistry viewManagerRegistry, MountItemExecutor mountItemExecutor) {
     mViewManagerRegistry = viewManagerRegistry;
     mMountItemExecutor = mountItemExecutor;
   }
@@ -116,7 +116,7 @@ public class MountingManager {
 
   @AnyThread
   public void attachRootView(
-      final int surfaceId, @NonNull final View rootView, ThemedReactContext themedReactContext) {
+      final int surfaceId, final View rootView, ThemedReactContext themedReactContext) {
     SurfaceMountingManager surfaceMountingManager =
         getSurfaceManagerEnforced(surfaceId, "attachView");
 
@@ -136,10 +136,9 @@ public class MountingManager {
       // Maximum number of stopped surfaces to keep track of
       while (mStoppedSurfaceIds.size() >= MAX_STOPPED_SURFACE_IDS_LENGTH) {
         Integer staleStoppedId = mStoppedSurfaceIds.get(0);
-        // NULLSAFE_FIXME[Nullable Dereference]
+        Assertions.assertNotNull(staleStoppedId);
         mSurfaceIdToManager.remove(staleStoppedId.intValue());
         mStoppedSurfaceIds.remove(staleStoppedId);
-        // NULLSAFE_FIXME[Nullable Dereference]
         FLog.d(TAG, "Removing stale SurfaceMountingManager: [%d]", staleStoppedId.intValue());
       }
       mStoppedSurfaceIds.add(surfaceId);
@@ -177,7 +176,6 @@ public class MountingManager {
     return surfaceMountingManager;
   }
 
-  @NonNull
   public SurfaceMountingManager getSurfaceManagerEnforced(int surfaceId, String context) {
     SurfaceMountingManager surfaceMountingManager = getSurfaceManager(surfaceId);
 
@@ -252,7 +250,6 @@ public class MountingManager {
     return null;
   }
 
-  @NonNull
   @AnyThread
   public SurfaceMountingManager getSurfaceManagerForViewEnforced(int reactTag) {
     SurfaceMountingManager surfaceMountingManager = getSurfaceManagerForView(reactTag);
@@ -278,7 +275,7 @@ public class MountingManager {
   }
 
   public void receiveCommand(
-      int surfaceId, int reactTag, @NonNull String commandId, @Nullable ReadableArray commandArgs) {
+      int surfaceId, int reactTag, String commandId, @Nullable ReadableArray commandArgs) {
     UiThreadUtil.assertOnUiThread();
     getSurfaceManagerEnforced(surfaceId, "receiveCommand:string")
         .receiveCommand(reactTag, commandId, commandArgs);
@@ -359,15 +356,15 @@ public class MountingManager {
    */
   @AnyThread
   public long measure(
-      @NonNull ReactContext context,
-      @NonNull String componentName,
-      @NonNull ReadableMap localData,
-      @NonNull ReadableMap props,
-      @NonNull ReadableMap state,
+      ReactContext context,
+      String componentName,
+      ReadableMap localData,
+      ReadableMap props,
+      ReadableMap state,
       float width,
-      @NonNull YogaMeasureMode widthMode,
+      YogaMeasureMode widthMode,
       float height,
-      @NonNull YogaMeasureMode heightMode,
+      YogaMeasureMode heightMode,
       @Nullable float[] attachmentsPositions) {
 
     return mViewManagerRegistry
@@ -402,15 +399,15 @@ public class MountingManager {
    */
   @AnyThread
   public long measureMapBuffer(
-      @NonNull ReactContext context,
-      @NonNull String componentName,
-      @NonNull MapBuffer localData,
-      @NonNull MapBuffer props,
+      ReactContext context,
+      String componentName,
+      MapBuffer localData,
+      MapBuffer props,
       @Nullable MapBuffer state,
       float width,
-      @NonNull YogaMeasureMode widthMode,
+      YogaMeasureMode widthMode,
       float height,
-      @NonNull YogaMeasureMode heightMode,
+      YogaMeasureMode heightMode,
       @Nullable float[] attachmentsPositions) {
 
     return mViewManagerRegistry

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountingManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountingManager.java
@@ -136,8 +136,10 @@ public class MountingManager {
       // Maximum number of stopped surfaces to keep track of
       while (mStoppedSurfaceIds.size() >= MAX_STOPPED_SURFACE_IDS_LENGTH) {
         Integer staleStoppedId = mStoppedSurfaceIds.get(0);
+        // NULLSAFE_FIXME[Nullable Dereference]
         mSurfaceIdToManager.remove(staleStoppedId.intValue());
         mStoppedSurfaceIds.remove(staleStoppedId);
+        // NULLSAFE_FIXME[Nullable Dereference]
         FLog.d(TAG, "Removing stale SurfaceMountingManager: [%d]", staleStoppedId.intValue());
       }
       mStoppedSurfaceIds.add(surfaceId);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobProvider.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobProvider.java
@@ -14,6 +14,7 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.os.ParcelFileDescriptor;
 import androidx.annotation.Nullable;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.bridge.ReactContext;
@@ -23,6 +24,7 @@ import java.io.OutputStream;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public final class BlobProvider extends ContentProvider {
 
   private static final int PIPE_CAPACITY = 65536;
@@ -72,7 +74,9 @@ public final class BlobProvider extends ContentProvider {
     if (context instanceof ReactApplication) {
       ReactNativeHost host = ((ReactApplication) context).getReactNativeHost();
       ReactContext reactContext = host.getReactInstanceManager().getCurrentReactContext();
-      // NULLSAFE_FIXME[Nullable Dereference]
+      if (reactContext == null) {
+        throw new RuntimeException("No ReactContext associated with BlobProvider");
+      }
       blobModule = reactContext.getNativeModule(BlobModule.class);
     }
 
@@ -87,7 +91,6 @@ public final class BlobProvider extends ContentProvider {
 
     ParcelFileDescriptor[] pipe;
     try {
-      // NULLSAFE_FIXME[Not Vetted Third-Party]
       pipe = ParcelFileDescriptor.createPipe();
     } catch (IOException exception) {
       return null;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobProvider.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobProvider.java
@@ -72,6 +72,7 @@ public final class BlobProvider extends ContentProvider {
     if (context instanceof ReactApplication) {
       ReactNativeHost host = ((ReactApplication) context).getReactNativeHost();
       ReactContext reactContext = host.getReactInstanceManager().getCurrentReactContext();
+      // NULLSAFE_FIXME[Nullable Dereference]
       blobModule = reactContext.getNativeModule(BlobModule.class);
     }
 
@@ -86,6 +87,7 @@ public final class BlobProvider extends ContentProvider {
 
     ParcelFileDescriptor[] pipe;
     try {
+      // NULLSAFE_FIXME[Not Vetted Third-Party]
       pipe = ParcelFileDescriptor.createPipe();
     } catch (IOException exception) {
       return null;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/blob/FileReaderModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/blob/FileReaderModule.java
@@ -27,9 +27,11 @@ public class FileReaderModule extends NativeFileReaderModuleSpec {
     ReactApplicationContext reactApplicationContext = getReactApplicationContextIfActiveOrWarn();
 
     if (reactApplicationContext != null) {
+      // NULLSAFE_FIXME[Return Not Nullable]
       return reactApplicationContext.getNativeModule(BlobModule.class);
     }
 
+    // NULLSAFE_FIXME[Return Not Nullable]
     return null;
   }
 
@@ -47,6 +49,7 @@ public class FileReaderModule extends NativeFileReaderModuleSpec {
     }
 
     byte[] bytes =
+        // NULLSAFE_FIXME[Parameter Not Nullable]
         blobModule.resolve(blob.getString("blobId"), blob.getInt("offset"), blob.getInt("size"));
 
     if (bytes == null) {
@@ -75,6 +78,7 @@ public class FileReaderModule extends NativeFileReaderModuleSpec {
     }
 
     byte[] bytes =
+        // NULLSAFE_FIXME[Parameter Not Nullable]
         blobModule.resolve(blob.getString("blobId"), blob.getInt("offset"), blob.getInt("size"));
 
     if (bytes == null) {
@@ -86,6 +90,7 @@ public class FileReaderModule extends NativeFileReaderModuleSpec {
       StringBuilder sb = new StringBuilder();
       sb.append("data:");
 
+      // NULLSAFE_FIXME[Nullable Dereference]
       if (blob.hasKey("type") && !blob.getString("type").isEmpty()) {
         sb.append(blob.getString("type"));
       } else {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/blob/FileReaderModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/blob/FileReaderModule.java
@@ -8,12 +8,15 @@
 package com.facebook.react.modules.blob;
 
 import android.util.Base64;
+import androidx.annotation.Nullable;
 import com.facebook.fbreact.specs.NativeFileReaderModuleSpec;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.module.annotations.ReactModule;
 
+@Nullsafe(Nullsafe.Mode.LOCAL)
 @ReactModule(name = NativeFileReaderModuleSpec.NAME)
 public class FileReaderModule extends NativeFileReaderModuleSpec {
 
@@ -23,15 +26,13 @@ public class FileReaderModule extends NativeFileReaderModuleSpec {
     super(reactContext);
   }
 
-  private BlobModule getBlobModule(String reason) {
+  private @Nullable BlobModule getBlobModule(String reason) {
     ReactApplicationContext reactApplicationContext = getReactApplicationContextIfActiveOrWarn();
 
     if (reactApplicationContext != null) {
-      // NULLSAFE_FIXME[Return Not Nullable]
       return reactApplicationContext.getNativeModule(BlobModule.class);
     }
 
-    // NULLSAFE_FIXME[Return Not Nullable]
     return null;
   }
 
@@ -48,9 +49,13 @@ public class FileReaderModule extends NativeFileReaderModuleSpec {
       return;
     }
 
-    byte[] bytes =
-        // NULLSAFE_FIXME[Parameter Not Nullable]
-        blobModule.resolve(blob.getString("blobId"), blob.getInt("offset"), blob.getInt("size"));
+    String blobId = blob.getString("blobId");
+    if (blobId == null) {
+      promise.reject(ERROR_INVALID_BLOB, "The specified blob does not contain a blobId");
+      return;
+    }
+
+    byte[] bytes = blobModule.resolve(blobId, blob.getInt("offset"), blob.getInt("size"));
 
     if (bytes == null) {
       promise.reject(ERROR_INVALID_BLOB, "The specified blob is invalid");
@@ -77,9 +82,13 @@ public class FileReaderModule extends NativeFileReaderModuleSpec {
       return;
     }
 
-    byte[] bytes =
-        // NULLSAFE_FIXME[Parameter Not Nullable]
-        blobModule.resolve(blob.getString("blobId"), blob.getInt("offset"), blob.getInt("size"));
+    String blobId = blob.getString("blobId");
+    if (blobId == null) {
+      promise.reject(ERROR_INVALID_BLOB, "The specified blob does not contain a blobId");
+      return;
+    }
+
+    byte[] bytes = blobModule.resolve(blobId, blob.getInt("offset"), blob.getInt("size"));
 
     if (bytes == null) {
       promise.reject(ERROR_INVALID_BLOB, "The specified blob is invalid");
@@ -90,8 +99,9 @@ public class FileReaderModule extends NativeFileReaderModuleSpec {
       StringBuilder sb = new StringBuilder();
       sb.append("data:");
 
-      // NULLSAFE_FIXME[Nullable Dereference]
-      if (blob.hasKey("type") && !blob.getString("type").isEmpty()) {
+      if (blob.hasKey("type")
+          && blob.getString("type") != null
+          && !blob.getString("type").isEmpty()) {
         sb.append(blob.getString("type"));
       } else {
         sb.append("application/octet-stream");

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/DialogModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/DialogModule.java
@@ -130,6 +130,7 @@ public class DialogModule extends NativeDialogManagerAndroidSpec implements Life
     }
 
     @Override
+    // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
     public void onDismiss(DialogInterface dialog) {
       if (!mCallbackConsumed) {
         if (getReactApplicationContext().hasActiveReactInstance()) {
@@ -198,8 +199,11 @@ public class DialogModule extends NativeDialogManagerAndroidSpec implements Life
     }
     if (options.hasKey(KEY_ITEMS)) {
       ReadableArray items = options.getArray(KEY_ITEMS);
+      // NULLSAFE_FIXME[Nullable Dereference]
       CharSequence[] itemsArray = new CharSequence[items.size()];
+      // NULLSAFE_FIXME[Nullable Dereference]
       for (int i = 0; i < items.size(); i++) {
+        // NULLSAFE_FIXME[Nullable Dereference]
         itemsArray[i] = items.getString(i);
       }
       args.putCharSequenceArray(AlertFragment.ARG_ITEMS, itemsArray);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/DialogModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/DialogModule.java
@@ -12,12 +12,13 @@ import android.content.DialogInterface;
 import android.content.DialogInterface.OnClickListener;
 import android.content.DialogInterface.OnDismissListener;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 import com.facebook.common.logging.FLog;
 import com.facebook.fbreact.specs.NativeDialogManagerAndroidSpec;
+import com.facebook.infer.annotation.Assertions;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -29,6 +30,7 @@ import com.facebook.react.common.MapBuilder;
 import com.facebook.react.module.annotations.ReactModule;
 import java.util.Map;
 
+@Nullsafe(Nullsafe.Mode.LOCAL)
 @ReactModule(name = NativeDialogManagerAndroidSpec.NAME)
 public class DialogModule extends NativeDialogManagerAndroidSpec implements LifecycleEventListener {
 
@@ -59,12 +61,13 @@ public class DialogModule extends NativeDialogManagerAndroidSpec implements Life
     super(reactContext);
   }
 
+  @Nullsafe(Nullsafe.Mode.LOCAL)
   private class FragmentManagerHelper {
-    private final @NonNull FragmentManager mFragmentManager;
+    private final FragmentManager mFragmentManager;
 
     private @Nullable Object mFragmentToShow;
 
-    public FragmentManagerHelper(@NonNull FragmentManager fragmentManager) {
+    public FragmentManagerHelper(FragmentManager fragmentManager) {
       mFragmentManager = fragmentManager;
     }
 
@@ -110,6 +113,7 @@ public class DialogModule extends NativeDialogManagerAndroidSpec implements Life
     }
   }
 
+  @Nullsafe(Nullsafe.Mode.LOCAL)
   /* package */ class AlertFragmentListener implements OnClickListener, OnDismissListener {
 
     private final Callback mCallback;
@@ -130,8 +134,7 @@ public class DialogModule extends NativeDialogManagerAndroidSpec implements Life
     }
 
     @Override
-    // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
-    public void onDismiss(DialogInterface dialog) {
+    public void onDismiss(@Nullable DialogInterface dialog) {
       if (!mCallbackConsumed) {
         if (getReactApplicationContext().hasActiveReactInstance()) {
           mCallback.invoke(ACTION_DISMISSED);
@@ -199,11 +202,9 @@ public class DialogModule extends NativeDialogManagerAndroidSpec implements Life
     }
     if (options.hasKey(KEY_ITEMS)) {
       ReadableArray items = options.getArray(KEY_ITEMS);
-      // NULLSAFE_FIXME[Nullable Dereference]
+      Assertions.assertNotNull(items);
       CharSequence[] itemsArray = new CharSequence[items.size()];
-      // NULLSAFE_FIXME[Nullable Dereference]
       for (int i = 0; i < items.size(); i++) {
-        // NULLSAFE_FIXME[Nullable Dereference]
         itemsArray[i] = items.getString(i);
       }
       args.putCharSequenceArray(AlertFragment.ARG_ITEMS, itemsArray);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/ReconnectingWebSocket.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/ReconnectingWebSocket.java
@@ -138,6 +138,7 @@ public final class ReconnectingWebSocket extends WebSocketListener {
   }
 
   @Override
+  // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
   public synchronized void onFailure(WebSocket webSocket, Throwable t, Response response) {
     if (mWebSocket != null) {
       abort("Websocket exception", t);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/ReconnectingWebSocket.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/ReconnectingWebSocket.java
@@ -11,6 +11,7 @@ import android.os.Handler;
 import android.os.Looper;
 import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
+import com.facebook.infer.annotation.Nullsafe;
 import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.TimeUnit;
@@ -22,6 +23,7 @@ import okhttp3.WebSocketListener;
 import okio.ByteString;
 
 /** A wrapper around WebSocketClient that reconnects automatically */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public final class ReconnectingWebSocket extends WebSocketListener {
   private static final String TAG = ReconnectingWebSocket.class.getSimpleName();
 
@@ -138,8 +140,8 @@ public final class ReconnectingWebSocket extends WebSocketListener {
   }
 
   @Override
-  // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
-  public synchronized void onFailure(WebSocket webSocket, Throwable t, Response response) {
+  public synchronized void onFailure(
+      @Nullable WebSocket webSocket, Throwable t, @Nullable Response response) {
     if (mWebSocket != null) {
       abort("Websocket exception", t);
     }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/dialog/DialogModuleTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/dialog/DialogModuleTest.kt
@@ -67,7 +67,7 @@ class DialogModuleTest {
           putBoolean("cancelable", false)
         }
 
-    dialogModule.showAlert(options, null, null)
+    dialogModule.showAlert(options, SimpleCallback(), SimpleCallback())
     shadowOf(getMainLooper()).idle()
 
     val fragment = getFragment()
@@ -85,14 +85,16 @@ class DialogModuleTest {
   fun testCallbackPositive() {
     val options = JavaOnlyMap().apply { putString("buttonPositive", "OK") }
 
+    val errorCallback = SimpleCallback()
     val actionCallback = SimpleCallback()
-    dialogModule.showAlert(options, null, actionCallback)
+    dialogModule.showAlert(options, errorCallback, actionCallback)
     shadowOf(getMainLooper()).idle()
 
     val dialog = getFragment().dialog as AlertDialog
     dialog.getButton(DialogInterface.BUTTON_POSITIVE).performClick()
     shadowOf(getMainLooper()).idle()
 
+    assertThat(errorCallback.calls).isEqualTo(0)
     assertThat(actionCallback.calls).isEqualTo(1)
     assertThat(actionCallback.args?.get(0)).isEqualTo(DialogModule.ACTION_BUTTON_CLICKED)
     assertThat(actionCallback.args?.get(1)).isEqualTo(DialogInterface.BUTTON_POSITIVE)
@@ -102,14 +104,16 @@ class DialogModuleTest {
   fun testCallbackNegative() {
     val options = JavaOnlyMap().apply { putString("buttonNegative", "Cancel") }
 
+    val errorCallback = SimpleCallback()
     val actionCallback = SimpleCallback()
-    dialogModule.showAlert(options, null, actionCallback)
+    dialogModule.showAlert(options, errorCallback, actionCallback)
     shadowOf(getMainLooper()).idle()
 
     val dialog = getFragment().dialog as AlertDialog
     dialog.getButton(DialogInterface.BUTTON_NEGATIVE).performClick()
     shadowOf(getMainLooper()).idle()
 
+    assertThat(errorCallback.calls).isEqualTo(0)
     assertThat(actionCallback.calls).isEqualTo(1)
     assertThat(actionCallback.args?.get(0)).isEqualTo(DialogModule.ACTION_BUTTON_CLICKED)
     assertThat(actionCallback.args?.get(1)).isEqualTo(DialogInterface.BUTTON_NEGATIVE)
@@ -119,14 +123,16 @@ class DialogModuleTest {
   fun testCallbackNeutral() {
     val options = JavaOnlyMap().apply { putString("buttonNeutral", "Later") }
 
+    val errorCallback = SimpleCallback()
     val actionCallback = SimpleCallback()
-    dialogModule.showAlert(options, null, actionCallback)
+    dialogModule.showAlert(options, errorCallback, actionCallback)
     shadowOf(getMainLooper()).idle()
 
     val dialog = getFragment().dialog as AlertDialog
     dialog.getButton(DialogInterface.BUTTON_NEUTRAL).performClick()
     shadowOf(getMainLooper()).idle()
 
+    assertThat(errorCallback.calls).isEqualTo(0)
     assertThat(actionCallback.calls).isEqualTo(1)
     assertThat(actionCallback.args?.get(0)).isEqualTo(DialogModule.ACTION_BUTTON_CLICKED)
     assertThat(actionCallback.args?.get(1)).isEqualTo(DialogInterface.BUTTON_NEUTRAL)
@@ -136,13 +142,15 @@ class DialogModuleTest {
   fun testCallbackDismiss() {
     val options = JavaOnlyMap()
 
+    val errorCallback = SimpleCallback()
     val actionCallback = SimpleCallback()
-    dialogModule.showAlert(options, null, actionCallback)
+    dialogModule.showAlert(options, errorCallback, actionCallback)
     shadowOf(getMainLooper()).idle()
 
     getFragment().dialog?.dismiss()
     shadowOf(getMainLooper()).idle()
 
+    assertThat(errorCallback.calls).isEqualTo(0)
     assertThat(actionCallback.calls).isEqualTo(1)
     assertThat(actionCallback.args?.get(0)).isEqualTo(DialogModule.ACTION_DISMISSED)
   }
@@ -153,13 +161,15 @@ class DialogModuleTest {
 
     val options = JavaOnlyMap()
 
+    val errorCallback = SimpleCallback()
     val actionCallback = SimpleCallback()
-    dialogModule.showAlert(options, null, actionCallback)
+    dialogModule.showAlert(options, errorCallback, actionCallback)
     shadowOf(getMainLooper()).idle()
 
     getFragment().dialog?.dismiss()
     shadowOf(getMainLooper()).idle()
 
+    assertThat(errorCallback.calls).isEqualTo(0)
     assertThat(actionCallback.calls).isEqualTo(1)
     assertThat(actionCallback.args?.get(0)).isEqualTo(DialogModule.ACTION_DISMISSED)
   }


### PR DESCRIPTION
Summary:
Gone trough all the FIXMEs added in the previous diff by the nullsafe tool, marked the class as nullsafe and ensured no remaining violations.
Changelog: [Android][Fixed] Made ReconnectingWebSocket.java nullsafe

Differential Revision: D71979606
