### PR TITLE
Fix nullsafe FIXMEs for TurboModuleInteropUtils and mark nullsafe

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleInteropUtils.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleInteropUtils.java
@@ -8,6 +8,8 @@
 package com.facebook.react.internal.turbomodule.core;
 
 import androidx.annotation.Nullable;
+import com.facebook.infer.annotation.Assertions;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.Dynamic;
@@ -26,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+@Nullsafe(Nullsafe.Mode.LOCAL)
 class TurboModuleInteropUtils {
 
   static class MethodDescriptor {
@@ -117,14 +120,12 @@ class TurboModuleInteropUtils {
     Class<? extends NativeModule> classForMethods = module.getClass();
     Class<? extends NativeModule> superClass =
         (Class<? extends NativeModule>) classForMethods.getSuperclass();
-    // NULLSAFE_FIXME[Parameter Not Nullable]
-    if (TurboModule.class.isAssignableFrom(superClass)) {
+    if (superClass != null && TurboModule.class.isAssignableFrom(superClass)) {
       // For java module that is based on generated flow-type spec, inspect the
       // spec abstract class instead, which is the super class of the given java
       // module.
       classForMethods = superClass;
     }
-    // NULLSAFE_FIXME[Nullable Dereference]
     return classForMethods.getDeclaredMethods();
   }
 
@@ -218,8 +219,9 @@ class TurboModuleInteropUtils {
   }
 
   private static String convertClassToJniType(Class<?> cls) {
-    // NULLSAFE_FIXME[Nullable Dereference]
-    return 'L' + cls.getCanonicalName().replace('.', '/') + ';';
+    String canonicalName = cls.getCanonicalName();
+    Assertions.assertNotNull(canonicalName, "Class must have a canonical name");
+    return 'L' + canonicalName.replace('.', '/') + ';';
   }
 
   private static int getJsArgCount(String moduleName, String methodName, Class<?>[] paramClasses) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleInteropUtils.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleInteropUtils.java
@@ -94,7 +94,9 @@ class TurboModuleInteropUtils {
         if (returnType != Map.class) {
           // TODO(T145105887) Output error. getConstants must always have a return type of Map
         }
+        // NULLSAFE_FIXME[Nullable Dereference]
       } else if (annotation.isBlockingSynchronousMethod() && returnType == void.class
+          // NULLSAFE_FIXME[Nullable Dereference]
           || !annotation.isBlockingSynchronousMethod() && returnType != void.class) {
         // TODO(T145105887): Output error. TurboModule system assumes returnType == void iff the
         // method is synchronous.
@@ -115,12 +117,14 @@ class TurboModuleInteropUtils {
     Class<? extends NativeModule> classForMethods = module.getClass();
     Class<? extends NativeModule> superClass =
         (Class<? extends NativeModule>) classForMethods.getSuperclass();
+    // NULLSAFE_FIXME[Parameter Not Nullable]
     if (TurboModule.class.isAssignableFrom(superClass)) {
       // For java module that is based on generated flow-type spec, inspect the
       // spec abstract class instead, which is the super class of the given java
       // module.
       classForMethods = superClass;
     }
+    // NULLSAFE_FIXME[Nullable Dereference]
     return classForMethods.getDeclaredMethods();
   }
 
@@ -214,6 +218,7 @@ class TurboModuleInteropUtils {
   }
 
   private static String convertClassToJniType(Class<?> cls) {
+    // NULLSAFE_FIXME[Nullable Dereference]
     return 'L' + cls.getCanonicalName().replace('.', '/') + ';';
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleInteropUtils.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleInteropUtils.java
@@ -92,14 +92,14 @@ class TurboModuleInteropUtils {
 
       if ("getConstants".equals(methodName)) {
         if (returnType != Map.class) {
-          // TODO(T145105887) Output error. getConstants must always have a return type of Map
+          throw new ParsingException(moduleName, "getConstants must return a Map");
         }
-        // NULLSAFE_FIXME[Nullable Dereference]
-      } else if (annotation.isBlockingSynchronousMethod() && returnType == void.class
-          // NULLSAFE_FIXME[Nullable Dereference]
-          || !annotation.isBlockingSynchronousMethod() && returnType != void.class) {
-        // TODO(T145105887): Output error. TurboModule system assumes returnType == void iff the
-        // method is synchronous.
+      } else if (annotation != null
+          && (annotation.isBlockingSynchronousMethod() && returnType == void.class
+              || !annotation.isBlockingSynchronousMethod() && returnType != void.class)) {
+        throw new ParsingException(
+            moduleName,
+            "TurboModule system assumes returnType == void iff the method is synchronous.");
       }
 
       methodDescriptors.add(


### PR DESCRIPTION
Summary:
Gone trough all the FIXMEs added in the previous diff by the nullsafe tool, marked the class as nullsafe and ensured no remaining violations.
Changelog: [Android][Fixed] Made TurboModuleInteropUtils.java nullsafe

Differential Revision: D71979599
