### PR TITLE
Fix Nullsafe FIXMES for MountingManager.java and mark nullsafe

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountItemDispatcher.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountItemDispatcher.java
@@ -12,10 +12,11 @@ import static com.facebook.react.fabric.FabricUIManager.IS_DEVELOPMENT_ENVIRONME
 
 import android.os.SystemClock;
 import android.view.View;
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 import com.facebook.common.logging.FLog;
+import com.facebook.infer.annotation.Assertions;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.infer.annotation.ThreadConfined;
 import com.facebook.react.bridge.ReactIgnorableMountingException;
 import com.facebook.react.bridge.ReactNoCrashSoftException;
@@ -30,6 +31,7 @@ import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class MountItemDispatcher {
 
   private static final String TAG = "MountItemDispatcher";
@@ -39,14 +41,11 @@ public class MountItemDispatcher {
   private final MountingManager mMountingManager;
   private final ItemDispatchListener mItemDispatchListener;
 
-  @NonNull
   private final ConcurrentLinkedQueue<DispatchCommandMountItem> mViewCommandMountItems =
       new ConcurrentLinkedQueue<>();
 
-  @NonNull
   private final ConcurrentLinkedQueue<MountItem> mMountItems = new ConcurrentLinkedQueue<>();
 
-  @NonNull
   private final ConcurrentLinkedQueue<MountItem> mPreMountItems = new ConcurrentLinkedQueue<>();
 
   private boolean mInDispatch = false;
@@ -122,8 +121,8 @@ public class MountItemDispatcher {
   public void dispatchMountItems(Queue<MountItem> mountItems) {
     while (!mountItems.isEmpty()) {
       MountItem item = mountItems.poll();
+      Assertions.assertNotNull(item);
       try {
-        // NULLSAFE_FIXME[Nullable Dereference]
         item.execute(mMountingManager);
       } catch (RetryableMountingLayerException e) {
         if (item instanceof DispatchCommandMountItem) {
@@ -138,7 +137,6 @@ public class MountItemDispatcher {
           }
         } else {
           printMountItem(
-              // NULLSAFE_FIXME[Parameter Not Nullable]
               item, "dispatchExternalMountItems: mounting failed with " + e.getMessage());
         }
       }
@@ -345,8 +343,8 @@ public class MountItemDispatcher {
             item.getSurfaceId());
       }
       SurfaceMountingManager surfaceMountingManager =
-          mMountingManager.getSurfaceManager(item.getSurfaceId());
-      // NULLSAFE_FIXME[Nullable Dereference]
+          mMountingManager.getSurfaceManagerEnforced(
+              item.getSurfaceId(), "MountItemDispatcher::executeOrEnqueue");
       surfaceMountingManager.scheduleMountItemOnViewAttach(item);
     } else {
       item.execute(mMountingManager);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountItemDispatcher.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountItemDispatcher.java
@@ -123,6 +123,7 @@ public class MountItemDispatcher {
     while (!mountItems.isEmpty()) {
       MountItem item = mountItems.poll();
       try {
+        // NULLSAFE_FIXME[Nullable Dereference]
         item.execute(mMountingManager);
       } catch (RetryableMountingLayerException e) {
         if (item instanceof DispatchCommandMountItem) {
@@ -137,6 +138,7 @@ public class MountItemDispatcher {
           }
         } else {
           printMountItem(
+              // NULLSAFE_FIXME[Parameter Not Nullable]
               item, "dispatchExternalMountItems: mounting failed with " + e.getMessage());
         }
       }
@@ -344,6 +346,7 @@ public class MountItemDispatcher {
       }
       SurfaceMountingManager surfaceMountingManager =
           mMountingManager.getSurfaceManager(item.getSurfaceId());
+      // NULLSAFE_FIXME[Nullable Dereference]
       surfaceMountingManager.scheduleMountItemOnViewAttach(item);
     } else {
       item.execute(mMountingManager);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountingManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountingManager.java
@@ -12,10 +12,11 @@ import static com.facebook.infer.annotation.ThreadConfined.UI;
 
 import android.view.View;
 import androidx.annotation.AnyThread;
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 import com.facebook.common.logging.FLog;
+import com.facebook.infer.annotation.Assertions;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.infer.annotation.ThreadConfined;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactSoftExceptionLogger;
@@ -45,11 +46,11 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * Class responsible for actually dispatching view updates enqueued via {@link
  * FabricUIManager#scheduleMountItem} on the UI thread.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class MountingManager {
   public static final String TAG = MountingManager.class.getSimpleName();
   private static final int MAX_STOPPED_SURFACE_IDS_LENGTH = 15;
 
-  @NonNull
   private final ConcurrentHashMap<Integer, SurfaceMountingManager> mSurfaceIdToManager =
       new ConcurrentHashMap<>(); // any thread
 
@@ -58,10 +59,10 @@ public class MountingManager {
   @Nullable private SurfaceMountingManager mMostRecentSurfaceMountingManager;
   @Nullable private SurfaceMountingManager mLastQueriedSurfaceMountingManager;
 
-  @NonNull private final JSResponderHandler mJSResponderHandler = new JSResponderHandler();
-  @NonNull private final ViewManagerRegistry mViewManagerRegistry;
-  @NonNull private final MountItemExecutor mMountItemExecutor;
-  @NonNull private final RootViewManager mRootViewManager = new RootViewManager();
+  private final JSResponderHandler mJSResponderHandler = new JSResponderHandler();
+  private final ViewManagerRegistry mViewManagerRegistry;
+  private final MountItemExecutor mMountItemExecutor;
+  private final RootViewManager mRootViewManager = new RootViewManager();
 
   public interface MountItemExecutor {
     @UiThread
@@ -70,8 +71,7 @@ public class MountingManager {
   }
 
   public MountingManager(
-      @NonNull ViewManagerRegistry viewManagerRegistry,
-      @NonNull MountItemExecutor mountItemExecutor) {
+      ViewManagerRegistry viewManagerRegistry, MountItemExecutor mountItemExecutor) {
     mViewManagerRegistry = viewManagerRegistry;
     mMountItemExecutor = mountItemExecutor;
   }
@@ -116,7 +116,7 @@ public class MountingManager {
 
   @AnyThread
   public void attachRootView(
-      final int surfaceId, @NonNull final View rootView, ThemedReactContext themedReactContext) {
+      final int surfaceId, final View rootView, ThemedReactContext themedReactContext) {
     SurfaceMountingManager surfaceMountingManager =
         getSurfaceManagerEnforced(surfaceId, "attachView");
 
@@ -136,10 +136,9 @@ public class MountingManager {
       // Maximum number of stopped surfaces to keep track of
       while (mStoppedSurfaceIds.size() >= MAX_STOPPED_SURFACE_IDS_LENGTH) {
         Integer staleStoppedId = mStoppedSurfaceIds.get(0);
-        // NULLSAFE_FIXME[Nullable Dereference]
+        Assertions.assertNotNull(staleStoppedId);
         mSurfaceIdToManager.remove(staleStoppedId.intValue());
         mStoppedSurfaceIds.remove(staleStoppedId);
-        // NULLSAFE_FIXME[Nullable Dereference]
         FLog.d(TAG, "Removing stale SurfaceMountingManager: [%d]", staleStoppedId.intValue());
       }
       mStoppedSurfaceIds.add(surfaceId);
@@ -177,7 +176,6 @@ public class MountingManager {
     return surfaceMountingManager;
   }
 
-  @NonNull
   public SurfaceMountingManager getSurfaceManagerEnforced(int surfaceId, String context) {
     SurfaceMountingManager surfaceMountingManager = getSurfaceManager(surfaceId);
 
@@ -252,7 +250,6 @@ public class MountingManager {
     return null;
   }
 
-  @NonNull
   @AnyThread
   public SurfaceMountingManager getSurfaceManagerForViewEnforced(int reactTag) {
     SurfaceMountingManager surfaceMountingManager = getSurfaceManagerForView(reactTag);
@@ -278,7 +275,7 @@ public class MountingManager {
   }
 
   public void receiveCommand(
-      int surfaceId, int reactTag, @NonNull String commandId, @Nullable ReadableArray commandArgs) {
+      int surfaceId, int reactTag, String commandId, @Nullable ReadableArray commandArgs) {
     UiThreadUtil.assertOnUiThread();
     getSurfaceManagerEnforced(surfaceId, "receiveCommand:string")
         .receiveCommand(reactTag, commandId, commandArgs);
@@ -359,15 +356,15 @@ public class MountingManager {
    */
   @AnyThread
   public long measure(
-      @NonNull ReactContext context,
-      @NonNull String componentName,
-      @NonNull ReadableMap localData,
-      @NonNull ReadableMap props,
-      @NonNull ReadableMap state,
+      ReactContext context,
+      String componentName,
+      ReadableMap localData,
+      ReadableMap props,
+      ReadableMap state,
       float width,
-      @NonNull YogaMeasureMode widthMode,
+      YogaMeasureMode widthMode,
       float height,
-      @NonNull YogaMeasureMode heightMode,
+      YogaMeasureMode heightMode,
       @Nullable float[] attachmentsPositions) {
 
     return mViewManagerRegistry
@@ -402,15 +399,15 @@ public class MountingManager {
    */
   @AnyThread
   public long measureMapBuffer(
-      @NonNull ReactContext context,
-      @NonNull String componentName,
-      @NonNull MapBuffer localData,
-      @NonNull MapBuffer props,
+      ReactContext context,
+      String componentName,
+      MapBuffer localData,
+      MapBuffer props,
       @Nullable MapBuffer state,
       float width,
-      @NonNull YogaMeasureMode widthMode,
+      YogaMeasureMode widthMode,
       float height,
-      @NonNull YogaMeasureMode heightMode,
+      YogaMeasureMode heightMode,
       @Nullable float[] attachmentsPositions) {
 
     return mViewManagerRegistry

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountingManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountingManager.java
@@ -136,8 +136,10 @@ public class MountingManager {
       // Maximum number of stopped surfaces to keep track of
       while (mStoppedSurfaceIds.size() >= MAX_STOPPED_SURFACE_IDS_LENGTH) {
         Integer staleStoppedId = mStoppedSurfaceIds.get(0);
+        // NULLSAFE_FIXME[Nullable Dereference]
         mSurfaceIdToManager.remove(staleStoppedId.intValue());
         mStoppedSurfaceIds.remove(staleStoppedId);
+        // NULLSAFE_FIXME[Nullable Dereference]
         FLog.d(TAG, "Removing stale SurfaceMountingManager: [%d]", staleStoppedId.intValue());
       }
       mStoppedSurfaceIds.add(surfaceId);


### PR DESCRIPTION
Summary:
Gone trough all the FIXMEs added in the previous diff by the nullsafe tool, marked the class as nullsafe and ensured no remaining violations.
Changelog: [Android][Fixed] Made MountingManager.java nullsafe

Differential Revision: D71979607
