### PR TITLE
fix nullsafe FIXMEs for FabicUIManager.java and mark nullsafe

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/UIManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/UIManager.kt
@@ -20,14 +20,14 @@ public interface UIManager : PerformanceCounter {
   @UiThread
   @ThreadConfined(ThreadConfined.UI)
   @Deprecated("")
-  public fun <T : View?> addRootView(rootView: T, initialProps: WritableMap?): Int
+  public fun <T : View?> addRootView(rootView: T, initialProps: WritableMap): Int
 
   /** Registers a new root view with width and height. */
   @AnyThread
   public fun <T : View?> startSurface(
       rootView: T,
       moduleName: String,
-      initialProps: WritableMap?,
+      initialProps: WritableMap,
       widthMeasureSpec: Int,
       heightMeasureSpec: Int
   ): Int
@@ -92,7 +92,7 @@ public interface UIManager : PerformanceCounter {
    */
   @UiThread
   @ThreadConfined(ThreadConfined.UI)
-  public fun synchronouslyUpdateViewOnUIThread(reactTag: Int, props: ReadableMap?)
+  public fun synchronouslyUpdateViewOnUIThread(reactTag: Int, props: ReadableMap)
 
   /**
    * Dispatch an accessibility event to a view asynchronously.
@@ -109,14 +109,14 @@ public interface UIManager : PerformanceCounter {
    *
    * @param listener
    */
-  public fun addUIManagerEventListener(listener: UIManagerListener?)
+  public fun addUIManagerEventListener(listener: UIManagerListener)
 
   /**
    * Unregister a [UIManagerListener] from this UIManager to stop receiving lifecycle callbacks.
    *
    * @param listener
    */
-  public fun removeUIManagerEventListener(listener: UIManagerListener?)
+  public fun removeUIManagerEventListener(listener: UIManagerListener)
 
   /**
    * Resolves a view based on its reactTag. Do not mutate properties on this view that are already

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -25,10 +25,11 @@ import android.os.SystemClock;
 import android.view.View;
 import android.view.accessibility.AccessibilityEvent;
 import androidx.annotation.AnyThread;
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 import com.facebook.common.logging.FLog;
+import com.facebook.infer.annotation.Assertions;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.infer.annotation.ThreadConfined;
 import com.facebook.proguard.annotations.DoNotStripAny;
 import com.facebook.react.bridge.ColorPropConverter;
@@ -98,6 +99,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * We instruct ProGuard not to strip out any fields or methods, because many of these methods are
  * only called through the JNI from Cxx so it appears that most of this class is "unused".
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 @SuppressLint("MissingNativeLoadLibrary")
 @DoNotStripAny
 public class FabricUIManager
@@ -107,8 +109,7 @@ public class FabricUIManager
   // The IS_DEVELOPMENT_ENVIRONMENT variable is used to log extra data when running fabric in a
   // development environment. DO NOT ENABLE THIS ON PRODUCTION OR YOU WILL BE FIRED!
   public static final boolean IS_DEVELOPMENT_ENVIRONMENT = false && ReactBuildConfig.DEBUG;
-  // NULLSAFE_FIXME[Field Not Initialized]
-  public DevToolsReactPerfLogger mDevToolsReactPerfLogger;
+  public @Nullable DevToolsReactPerfLogger mDevToolsReactPerfLogger;
 
   private static final DevToolsReactPerfLogger.DevToolsReactPerfLoggerListener FABRIC_PERF_LOGGER =
       commitPoint -> {
@@ -161,27 +162,24 @@ public class FabricUIManager
   }
 
   @Nullable private FabricUIManagerBinding mBinding;
-  @NonNull private final ReactApplicationContext mReactApplicationContext;
-  @NonNull private final MountingManager mMountingManager;
-  @NonNull private final FabricEventDispatcher mEventDispatcher;
-  @NonNull private final MountItemDispatcher mMountItemDispatcher;
-  @NonNull private final ViewManagerRegistry mViewManagerRegistry;
+  private final ReactApplicationContext mReactApplicationContext;
+  private final MountingManager mMountingManager;
+  private final FabricEventDispatcher mEventDispatcher;
+  private final MountItemDispatcher mMountItemDispatcher;
+  private final ViewManagerRegistry mViewManagerRegistry;
 
-  @NonNull private final BatchEventDispatchedListener mBatchEventDispatchedListener;
+  private final BatchEventDispatchedListener mBatchEventDispatchedListener;
 
-  @NonNull
   private final CopyOnWriteArrayList<UIManagerListener> mListeners = new CopyOnWriteArrayList<>();
 
   private boolean mMountNotificationScheduled = false;
   private List<Integer> mSurfaceIdsWithPendingMountNotification = new ArrayList<>();
 
   @ThreadConfined(UI)
-  @NonNull
   private final DispatchUIFrameCallback mDispatchUIFrameCallback;
 
   /** Set of events sent synchronously during the current frame render. Cleared after each frame. */
   @ThreadConfined(UI)
-  @NonNull
   private final Set<SynchronousEvent> mSynchronousEvents = new HashSet<>();
 
   /**
@@ -219,9 +217,9 @@ public class FabricUIManager
   @Nullable private InteropUIBlockListener mInteropUIBlockListener;
 
   public FabricUIManager(
-      @NonNull ReactApplicationContext reactContext,
-      @NonNull ViewManagerRegistry viewManagerRegistry,
-      @NonNull BatchEventDispatchedListener batchEventDispatchedListener) {
+      ReactApplicationContext reactContext,
+      ViewManagerRegistry viewManagerRegistry,
+      BatchEventDispatchedListener batchEventDispatchedListener) {
     mDispatchUIFrameCallback = new DispatchUIFrameCallback(reactContext);
     mReactApplicationContext = reactContext;
     mMountingManager = new MountingManager(viewManagerRegistry, mMountItemExecutor);
@@ -239,7 +237,6 @@ public class FabricUIManager
   @UiThread
   @ThreadConfined(UI)
   @Deprecated
-  // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
   public <T extends View> int addRootView(final T rootView, final WritableMap initialProps) {
     ReactSoftExceptionLogger.logSoftException(
         TAG,
@@ -257,7 +254,7 @@ public class FabricUIManager
     if (ReactNativeFeatureFlags.enableFabricLogs()) {
       FLog.d(TAG, "Starting surface for module: %s and reactTag: %d", moduleName, rootTag);
     }
-    // NULLSAFE_FIXME[Nullable Dereference]
+    Assertions.assertNotNull(mBinding, "Binding in FabricUIManager is null");
     mBinding.startSurface(rootTag, moduleName, (NativeMap) initialProps);
     return rootTag;
   }
@@ -265,7 +262,6 @@ public class FabricUIManager
   @Override
   @AnyThread
   @ThreadConfined(ANY)
-  // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
   public <T extends View> int startSurface(
       final T rootView,
       final String moduleName,
@@ -288,7 +284,7 @@ public class FabricUIManager
     Point viewportOffset =
         UiThreadUtil.isOnUiThread() ? RootViewUtil.getViewportOffset(rootView) : new Point(0, 0);
 
-    // NULLSAFE_FIXME[Nullable Dereference]
+    Assertions.assertNotNull(mBinding, "Binding in FabricUIManager is null");
     mBinding.startSurfaceWithConstraints(
         rootTag,
         moduleName,
@@ -316,7 +312,7 @@ public class FabricUIManager
     if (!(surfaceHandler instanceof SurfaceHandlerBinding)) {
       throw new IllegalArgumentException("Invalid SurfaceHandler");
     }
-    // NULLSAFE_FIXME[Nullable Dereference]
+    Assertions.assertNotNull(mBinding, "Binding in FabricUIManager is null");
     mBinding.startSurfaceWithSurfaceHandler(
         rootTag, (SurfaceHandlerBinding) surfaceHandler, rootView != null);
   }
@@ -345,7 +341,7 @@ public class FabricUIManager
     if (!(surfaceHandler instanceof SurfaceHandlerBinding)) {
       throw new IllegalArgumentException("Invalid SurfaceHandler");
     }
-    // NULLSAFE_FIXME[Nullable Dereference]
+    Assertions.assertNotNull(mBinding, "Binding in FabricUIManager is null");
     mBinding.stopSurfaceWithSurfaceHandler((SurfaceHandlerBinding) surfaceHandler);
   }
 
@@ -362,10 +358,10 @@ public class FabricUIManager
     // Mark surfaceId as dead, stop executing mounting instructions
     mMountingManager.stopSurface(surfaceID);
 
+    Assertions.assertNotNull(mBinding, "Binding in FabricUIManager is null");
     // Communicate stopSurface to Cxx - causes an empty ShadowTree to be committed,
     // but all mounting instructions will be ignored because stopSurface was called
     // on the MountingManager
-    // NULLSAFE_FIXME[Nullable Dereference]
     mBinding.stopSurface(surfaceID);
   }
 
@@ -416,8 +412,9 @@ public class FabricUIManager
     mReactApplicationContext.removeLifecycleEventListener(this);
     onHostPause();
 
-    // NULLSAFE_FIXME[Nullable Dereference]
-    mBinding.unregister();
+    if (mBinding != null) {
+      mBinding.unregister();
+    }
     mBinding = null;
 
     ViewManagerPropertyUpdater.clear();
@@ -461,7 +458,6 @@ public class FabricUIManager
     }
   }
 
-  @NonNull
   private InteropUIBlockListener getInteropUIBlockListener() {
     if (mInteropUIBlockListener == null) {
       mInteropUIBlockListener = new InteropUIBlockListener();
@@ -548,12 +544,13 @@ public class FabricUIManager
         return 0;
       }
       context = surfaceMountingManager.getContext();
+      Assertions.assertNotNull(
+          context, "Context in SurfaceMountingManager is null. surfaceId: " + surfaceId);
     } else {
       context = mReactApplicationContext;
     }
 
     return mMountingManager.measure(
-        // NULLSAFE_FIXME[Parameter Not Nullable]
         context,
         componentName,
         localData,
@@ -587,13 +584,14 @@ public class FabricUIManager
         return 0;
       }
       context = surfaceMountingManager.getContext();
+      Assertions.assertNotNull(
+          context, "Context in SurfaceMountingManager is null. surfaceId: " + surfaceId);
     } else {
       context = mReactApplicationContext;
     }
 
     // TODO: replace ReadableNativeMap -> ReadableMapBuffer
     return mMountingManager.measureMapBuffer(
-        // NULLSAFE_FIXME[Parameter Not Nullable]
         context,
         componentName,
         localData,
@@ -630,13 +628,11 @@ public class FabricUIManager
   }
 
   @Override
-  // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
   public void addUIManagerEventListener(UIManagerListener listener) {
     mListeners.add(listener);
   }
 
   @Override
-  // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
   public void removeUIManagerEventListener(UIManagerListener listener) {
     mListeners.remove(listener);
   }
@@ -644,9 +640,7 @@ public class FabricUIManager
   @Override
   @UiThread
   @ThreadConfined(UI)
-  // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
-  public void synchronouslyUpdateViewOnUIThread(
-      final int reactTag, @NonNull final ReadableMap props) {
+  public void synchronouslyUpdateViewOnUIThread(final int reactTag, final ReadableMap props) {
     UiThreadUtil.assertOnUiThread();
 
     int commitNumber = mCurrentSynchronousCommitNumber++;
@@ -677,7 +671,7 @@ public class FabricUIManager
     MountItem synchronousMountItem =
         new MountItem() {
           @Override
-          public void execute(@NonNull MountingManager mountingManager) {
+          public void execute(MountingManager mountingManager) {
             try {
               mountingManager.updateProps(reactTag, props);
             } catch (Exception ex) {
@@ -695,7 +689,6 @@ public class FabricUIManager
             return View.NO_ID;
           }
 
-          @NonNull
           @Override
           public String toString() {
             String propsString =
@@ -800,11 +793,14 @@ public class FabricUIManager
     // calls scheduleMountItems with a BatchMountItem.
     long scheduleMountItemStartTime = SystemClock.uptimeMillis();
     boolean isBatchMountItem = mountItem instanceof BatchMountItem;
-    boolean shouldSchedule =
-        // NULLSAFE_FIXME[Nullable Dereference]
-        (isBatchMountItem && !((BatchMountItem) mountItem).isBatchEmpty())
-            || (!isBatchMountItem && mountItem != null);
-
+    boolean shouldSchedule = false;
+    if (isBatchMountItem) {
+      BatchMountItem batchMountItem = (BatchMountItem) mountItem;
+      Assertions.assertNotNull(batchMountItem, "BatchMountItem is null");
+      shouldSchedule = batchMountItem.isBatchEmpty();
+    } else {
+      shouldSchedule = mountItem != null;
+    }
     // In case of sync rendering, this could be called on the UI thread. Otherwise,
     // it should ~always be called on the JS thread.
     for (UIManagerListener listener : mListeners) {
@@ -820,7 +816,7 @@ public class FabricUIManager
     }
 
     if (shouldSchedule) {
-      // NULLSAFE_FIXME[Parameter Not Nullable]
+      Assertions.assertNotNull(mountItem, "MountItem is null");
       mMountItemDispatcher.addMountItem(mountItem);
       Runnable runnable =
           new GuardedRunnable(mReactApplicationContext) {
@@ -917,7 +913,7 @@ public class FabricUIManager
       doLeftAndRightSwapInRTL = I18nUtil.getInstance().doLeftAndRightSwapInRTL(context);
     }
 
-    // NULLSAFE_FIXME[Nullable Dereference]
+    Assertions.assertNotNull(mBinding, "Binding in FabricUIManager is null");
     mBinding.setConstraints(
         surfaceId,
         getMinSize(widthMeasureSpec),
@@ -931,11 +927,10 @@ public class FabricUIManager
   }
 
   @Override
-  public View resolveView(int reactTag) {
+  public @Nullable View resolveView(int reactTag) {
     UiThreadUtil.assertOnUiThread();
 
     SurfaceMountingManager surfaceManager = mMountingManager.getSurfaceManagerForView(reactTag);
-    // NULLSAFE_FIXME[Return Not Nullable]
     return surfaceManager == null ? null : surfaceManager.getView(reactTag);
   }
 
@@ -978,7 +973,7 @@ public class FabricUIManager
   public void receiveEvent(
       int surfaceId,
       int reactTag,
-      @NonNull String eventName,
+      String eventName,
       boolean canCoalesceEvent,
       @Nullable WritableMap params,
       @EventCategoryDef int eventCategory,
@@ -1031,7 +1026,6 @@ public class FabricUIManager
   }
 
   @Override
-  @NonNull
   public EventDispatcher getEventDispatcher() {
     return mEventDispatcher;
   }
@@ -1144,7 +1138,7 @@ public class FabricUIManager
     mMountItemDispatcher.addMountItem(
         new MountItem() {
           @Override
-          public void execute(@NonNull MountingManager mountingManager) {
+          public void execute(MountingManager mountingManager) {
             SurfaceMountingManager surfaceMountingManager =
                 mountingManager.getSurfaceManager(surfaceId);
             if (surfaceMountingManager != null) {
@@ -1161,7 +1155,6 @@ public class FabricUIManager
             return surfaceId;
           }
 
-          @NonNull
           @SuppressLint("DefaultLocale")
           @Override
           public String toString() {
@@ -1178,7 +1171,7 @@ public class FabricUIManager
     mMountItemDispatcher.addMountItem(
         new MountItem() {
           @Override
-          public void execute(@NonNull MountingManager mountingManager) {
+          public void execute(MountingManager mountingManager) {
             mountingManager.clearJSResponder();
           }
 
@@ -1187,7 +1180,6 @@ public class FabricUIManager
             return View.NO_ID;
           }
 
-          @NonNull
           @Override
           public String toString() {
             return "CLEAR_JS_RESPONDER";
@@ -1336,7 +1328,7 @@ public class FabricUIManager
     @ThreadConfined(UI)
     private boolean mIsScheduled = false;
 
-    private DispatchUIFrameCallback(@NonNull ReactContext reactContext) {
+    private DispatchUIFrameCallback(ReactContext reactContext) {
       super(reactContext);
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -107,6 +107,7 @@ public class FabricUIManager
   // The IS_DEVELOPMENT_ENVIRONMENT variable is used to log extra data when running fabric in a
   // development environment. DO NOT ENABLE THIS ON PRODUCTION OR YOU WILL BE FIRED!
   public static final boolean IS_DEVELOPMENT_ENVIRONMENT = false && ReactBuildConfig.DEBUG;
+  // NULLSAFE_FIXME[Field Not Initialized]
   public DevToolsReactPerfLogger mDevToolsReactPerfLogger;
 
   private static final DevToolsReactPerfLogger.DevToolsReactPerfLoggerListener FABRIC_PERF_LOGGER =
@@ -238,6 +239,7 @@ public class FabricUIManager
   @UiThread
   @ThreadConfined(UI)
   @Deprecated
+  // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
   public <T extends View> int addRootView(final T rootView, final WritableMap initialProps) {
     ReactSoftExceptionLogger.logSoftException(
         TAG,
@@ -255,6 +257,7 @@ public class FabricUIManager
     if (ReactNativeFeatureFlags.enableFabricLogs()) {
       FLog.d(TAG, "Starting surface for module: %s and reactTag: %d", moduleName, rootTag);
     }
+    // NULLSAFE_FIXME[Nullable Dereference]
     mBinding.startSurface(rootTag, moduleName, (NativeMap) initialProps);
     return rootTag;
   }
@@ -262,6 +265,7 @@ public class FabricUIManager
   @Override
   @AnyThread
   @ThreadConfined(ANY)
+  // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
   public <T extends View> int startSurface(
       final T rootView,
       final String moduleName,
@@ -284,6 +288,7 @@ public class FabricUIManager
     Point viewportOffset =
         UiThreadUtil.isOnUiThread() ? RootViewUtil.getViewportOffset(rootView) : new Point(0, 0);
 
+    // NULLSAFE_FIXME[Nullable Dereference]
     mBinding.startSurfaceWithConstraints(
         rootTag,
         moduleName,
@@ -311,6 +316,7 @@ public class FabricUIManager
     if (!(surfaceHandler instanceof SurfaceHandlerBinding)) {
       throw new IllegalArgumentException("Invalid SurfaceHandler");
     }
+    // NULLSAFE_FIXME[Nullable Dereference]
     mBinding.startSurfaceWithSurfaceHandler(
         rootTag, (SurfaceHandlerBinding) surfaceHandler, rootView != null);
   }
@@ -339,6 +345,7 @@ public class FabricUIManager
     if (!(surfaceHandler instanceof SurfaceHandlerBinding)) {
       throw new IllegalArgumentException("Invalid SurfaceHandler");
     }
+    // NULLSAFE_FIXME[Nullable Dereference]
     mBinding.stopSurfaceWithSurfaceHandler((SurfaceHandlerBinding) surfaceHandler);
   }
 
@@ -358,6 +365,7 @@ public class FabricUIManager
     // Communicate stopSurface to Cxx - causes an empty ShadowTree to be committed,
     // but all mounting instructions will be ignored because stopSurface was called
     // on the MountingManager
+    // NULLSAFE_FIXME[Nullable Dereference]
     mBinding.stopSurface(surfaceID);
   }
 
@@ -408,6 +416,7 @@ public class FabricUIManager
     mReactApplicationContext.removeLifecycleEventListener(this);
     onHostPause();
 
+    // NULLSAFE_FIXME[Nullable Dereference]
     mBinding.unregister();
     mBinding = null;
 
@@ -544,6 +553,7 @@ public class FabricUIManager
     }
 
     return mMountingManager.measure(
+        // NULLSAFE_FIXME[Parameter Not Nullable]
         context,
         componentName,
         localData,
@@ -583,6 +593,7 @@ public class FabricUIManager
 
     // TODO: replace ReadableNativeMap -> ReadableMapBuffer
     return mMountingManager.measureMapBuffer(
+        // NULLSAFE_FIXME[Parameter Not Nullable]
         context,
         componentName,
         localData,
@@ -619,11 +630,13 @@ public class FabricUIManager
   }
 
   @Override
+  // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
   public void addUIManagerEventListener(UIManagerListener listener) {
     mListeners.add(listener);
   }
 
   @Override
+  // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
   public void removeUIManagerEventListener(UIManagerListener listener) {
     mListeners.remove(listener);
   }
@@ -631,6 +644,7 @@ public class FabricUIManager
   @Override
   @UiThread
   @ThreadConfined(UI)
+  // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
   public void synchronouslyUpdateViewOnUIThread(
       final int reactTag, @NonNull final ReadableMap props) {
     UiThreadUtil.assertOnUiThread();
@@ -787,6 +801,7 @@ public class FabricUIManager
     long scheduleMountItemStartTime = SystemClock.uptimeMillis();
     boolean isBatchMountItem = mountItem instanceof BatchMountItem;
     boolean shouldSchedule =
+        // NULLSAFE_FIXME[Nullable Dereference]
         (isBatchMountItem && !((BatchMountItem) mountItem).isBatchEmpty())
             || (!isBatchMountItem && mountItem != null);
 
@@ -805,6 +820,7 @@ public class FabricUIManager
     }
 
     if (shouldSchedule) {
+      // NULLSAFE_FIXME[Parameter Not Nullable]
       mMountItemDispatcher.addMountItem(mountItem);
       Runnable runnable =
           new GuardedRunnable(mReactApplicationContext) {
@@ -901,6 +917,7 @@ public class FabricUIManager
       doLeftAndRightSwapInRTL = I18nUtil.getInstance().doLeftAndRightSwapInRTL(context);
     }
 
+    // NULLSAFE_FIXME[Nullable Dereference]
     mBinding.setConstraints(
         surfaceId,
         getMinSize(widthMeasureSpec),
@@ -918,6 +935,7 @@ public class FabricUIManager
     UiThreadUtil.assertOnUiThread();
 
     SurfaceMountingManager surfaceManager = mMountingManager.getSurfaceManagerForView(reactTag);
+    // NULLSAFE_FIXME[Return Not Nullable]
     return surfaceManager == null ? null : surfaceManager.getView(reactTag);
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountItemDispatcher.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountItemDispatcher.java
@@ -12,10 +12,11 @@ import static com.facebook.react.fabric.FabricUIManager.IS_DEVELOPMENT_ENVIRONME
 
 import android.os.SystemClock;
 import android.view.View;
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 import com.facebook.common.logging.FLog;
+import com.facebook.infer.annotation.Assertions;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.infer.annotation.ThreadConfined;
 import com.facebook.react.bridge.ReactIgnorableMountingException;
 import com.facebook.react.bridge.ReactNoCrashSoftException;
@@ -30,6 +31,7 @@ import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class MountItemDispatcher {
 
   private static final String TAG = "MountItemDispatcher";
@@ -39,14 +41,11 @@ public class MountItemDispatcher {
   private final MountingManager mMountingManager;
   private final ItemDispatchListener mItemDispatchListener;
 
-  @NonNull
   private final ConcurrentLinkedQueue<DispatchCommandMountItem> mViewCommandMountItems =
       new ConcurrentLinkedQueue<>();
 
-  @NonNull
   private final ConcurrentLinkedQueue<MountItem> mMountItems = new ConcurrentLinkedQueue<>();
 
-  @NonNull
   private final ConcurrentLinkedQueue<MountItem> mPreMountItems = new ConcurrentLinkedQueue<>();
 
   private boolean mInDispatch = false;
@@ -122,8 +121,8 @@ public class MountItemDispatcher {
   public void dispatchMountItems(Queue<MountItem> mountItems) {
     while (!mountItems.isEmpty()) {
       MountItem item = mountItems.poll();
+      Assertions.assertNotNull(item);
       try {
-        // NULLSAFE_FIXME[Nullable Dereference]
         item.execute(mMountingManager);
       } catch (RetryableMountingLayerException e) {
         if (item instanceof DispatchCommandMountItem) {
@@ -138,7 +137,6 @@ public class MountItemDispatcher {
           }
         } else {
           printMountItem(
-              // NULLSAFE_FIXME[Parameter Not Nullable]
               item, "dispatchExternalMountItems: mounting failed with " + e.getMessage());
         }
       }
@@ -345,8 +343,8 @@ public class MountItemDispatcher {
             item.getSurfaceId());
       }
       SurfaceMountingManager surfaceMountingManager =
-          mMountingManager.getSurfaceManager(item.getSurfaceId());
-      // NULLSAFE_FIXME[Nullable Dereference]
+          mMountingManager.getSurfaceManagerEnforced(
+              item.getSurfaceId(), "MountItemDispatcher::executeOrEnqueue");
       surfaceMountingManager.scheduleMountItemOnViewAttach(item);
     } else {
       item.execute(mMountingManager);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountItemDispatcher.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountItemDispatcher.java
@@ -123,6 +123,7 @@ public class MountItemDispatcher {
     while (!mountItems.isEmpty()) {
       MountItem item = mountItems.poll();
       try {
+        // NULLSAFE_FIXME[Nullable Dereference]
         item.execute(mMountingManager);
       } catch (RetryableMountingLayerException e) {
         if (item instanceof DispatchCommandMountItem) {
@@ -137,6 +138,7 @@ public class MountItemDispatcher {
           }
         } else {
           printMountItem(
+              // NULLSAFE_FIXME[Parameter Not Nullable]
               item, "dispatchExternalMountItems: mounting failed with " + e.getMessage());
         }
       }
@@ -344,6 +346,7 @@ public class MountItemDispatcher {
       }
       SurfaceMountingManager surfaceMountingManager =
           mMountingManager.getSurfaceManager(item.getSurfaceId());
+      // NULLSAFE_FIXME[Nullable Dereference]
       surfaceMountingManager.scheduleMountItemOnViewAttach(item);
     } else {
       item.execute(mMountingManager);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountingManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountingManager.java
@@ -12,10 +12,11 @@ import static com.facebook.infer.annotation.ThreadConfined.UI;
 
 import android.view.View;
 import androidx.annotation.AnyThread;
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 import com.facebook.common.logging.FLog;
+import com.facebook.infer.annotation.Assertions;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.infer.annotation.ThreadConfined;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactSoftExceptionLogger;
@@ -45,11 +46,11 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * Class responsible for actually dispatching view updates enqueued via {@link
  * FabricUIManager#scheduleMountItem} on the UI thread.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class MountingManager {
   public static final String TAG = MountingManager.class.getSimpleName();
   private static final int MAX_STOPPED_SURFACE_IDS_LENGTH = 15;
 
-  @NonNull
   private final ConcurrentHashMap<Integer, SurfaceMountingManager> mSurfaceIdToManager =
       new ConcurrentHashMap<>(); // any thread
 
@@ -58,10 +59,10 @@ public class MountingManager {
   @Nullable private SurfaceMountingManager mMostRecentSurfaceMountingManager;
   @Nullable private SurfaceMountingManager mLastQueriedSurfaceMountingManager;
 
-  @NonNull private final JSResponderHandler mJSResponderHandler = new JSResponderHandler();
-  @NonNull private final ViewManagerRegistry mViewManagerRegistry;
-  @NonNull private final MountItemExecutor mMountItemExecutor;
-  @NonNull private final RootViewManager mRootViewManager = new RootViewManager();
+  private final JSResponderHandler mJSResponderHandler = new JSResponderHandler();
+  private final ViewManagerRegistry mViewManagerRegistry;
+  private final MountItemExecutor mMountItemExecutor;
+  private final RootViewManager mRootViewManager = new RootViewManager();
 
   public interface MountItemExecutor {
     @UiThread
@@ -70,8 +71,7 @@ public class MountingManager {
   }
 
   public MountingManager(
-      @NonNull ViewManagerRegistry viewManagerRegistry,
-      @NonNull MountItemExecutor mountItemExecutor) {
+      ViewManagerRegistry viewManagerRegistry, MountItemExecutor mountItemExecutor) {
     mViewManagerRegistry = viewManagerRegistry;
     mMountItemExecutor = mountItemExecutor;
   }
@@ -116,7 +116,7 @@ public class MountingManager {
 
   @AnyThread
   public void attachRootView(
-      final int surfaceId, @NonNull final View rootView, ThemedReactContext themedReactContext) {
+      final int surfaceId, final View rootView, ThemedReactContext themedReactContext) {
     SurfaceMountingManager surfaceMountingManager =
         getSurfaceManagerEnforced(surfaceId, "attachView");
 
@@ -136,10 +136,9 @@ public class MountingManager {
       // Maximum number of stopped surfaces to keep track of
       while (mStoppedSurfaceIds.size() >= MAX_STOPPED_SURFACE_IDS_LENGTH) {
         Integer staleStoppedId = mStoppedSurfaceIds.get(0);
-        // NULLSAFE_FIXME[Nullable Dereference]
+        Assertions.assertNotNull(staleStoppedId);
         mSurfaceIdToManager.remove(staleStoppedId.intValue());
         mStoppedSurfaceIds.remove(staleStoppedId);
-        // NULLSAFE_FIXME[Nullable Dereference]
         FLog.d(TAG, "Removing stale SurfaceMountingManager: [%d]", staleStoppedId.intValue());
       }
       mStoppedSurfaceIds.add(surfaceId);
@@ -177,7 +176,6 @@ public class MountingManager {
     return surfaceMountingManager;
   }
 
-  @NonNull
   public SurfaceMountingManager getSurfaceManagerEnforced(int surfaceId, String context) {
     SurfaceMountingManager surfaceMountingManager = getSurfaceManager(surfaceId);
 
@@ -252,7 +250,6 @@ public class MountingManager {
     return null;
   }
 
-  @NonNull
   @AnyThread
   public SurfaceMountingManager getSurfaceManagerForViewEnforced(int reactTag) {
     SurfaceMountingManager surfaceMountingManager = getSurfaceManagerForView(reactTag);
@@ -278,7 +275,7 @@ public class MountingManager {
   }
 
   public void receiveCommand(
-      int surfaceId, int reactTag, @NonNull String commandId, @Nullable ReadableArray commandArgs) {
+      int surfaceId, int reactTag, String commandId, @Nullable ReadableArray commandArgs) {
     UiThreadUtil.assertOnUiThread();
     getSurfaceManagerEnforced(surfaceId, "receiveCommand:string")
         .receiveCommand(reactTag, commandId, commandArgs);
@@ -359,15 +356,15 @@ public class MountingManager {
    */
   @AnyThread
   public long measure(
-      @NonNull ReactContext context,
-      @NonNull String componentName,
-      @NonNull ReadableMap localData,
-      @NonNull ReadableMap props,
-      @NonNull ReadableMap state,
+      ReactContext context,
+      String componentName,
+      ReadableMap localData,
+      ReadableMap props,
+      ReadableMap state,
       float width,
-      @NonNull YogaMeasureMode widthMode,
+      YogaMeasureMode widthMode,
       float height,
-      @NonNull YogaMeasureMode heightMode,
+      YogaMeasureMode heightMode,
       @Nullable float[] attachmentsPositions) {
 
     return mViewManagerRegistry
@@ -402,15 +399,15 @@ public class MountingManager {
    */
   @AnyThread
   public long measureMapBuffer(
-      @NonNull ReactContext context,
-      @NonNull String componentName,
-      @NonNull MapBuffer localData,
-      @NonNull MapBuffer props,
+      ReactContext context,
+      String componentName,
+      MapBuffer localData,
+      MapBuffer props,
       @Nullable MapBuffer state,
       float width,
-      @NonNull YogaMeasureMode widthMode,
+      YogaMeasureMode widthMode,
       float height,
-      @NonNull YogaMeasureMode heightMode,
+      YogaMeasureMode heightMode,
       @Nullable float[] attachmentsPositions) {
 
     return mViewManagerRegistry

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountingManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountingManager.java
@@ -136,8 +136,10 @@ public class MountingManager {
       // Maximum number of stopped surfaces to keep track of
       while (mStoppedSurfaceIds.size() >= MAX_STOPPED_SURFACE_IDS_LENGTH) {
         Integer staleStoppedId = mStoppedSurfaceIds.get(0);
+        // NULLSAFE_FIXME[Nullable Dereference]
         mSurfaceIdToManager.remove(staleStoppedId.intValue());
         mStoppedSurfaceIds.remove(staleStoppedId);
+        // NULLSAFE_FIXME[Nullable Dereference]
         FLog.d(TAG, "Removing stale SurfaceMountingManager: [%d]", staleStoppedId.intValue());
       }
       mStoppedSurfaceIds.add(surfaceId);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleInteropUtils.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleInteropUtils.java
@@ -94,7 +94,9 @@ class TurboModuleInteropUtils {
         if (returnType != Map.class) {
           // TODO(T145105887) Output error. getConstants must always have a return type of Map
         }
+        // NULLSAFE_FIXME[Nullable Dereference]
       } else if (annotation.isBlockingSynchronousMethod() && returnType == void.class
+          // NULLSAFE_FIXME[Nullable Dereference]
           || !annotation.isBlockingSynchronousMethod() && returnType != void.class) {
         // TODO(T145105887): Output error. TurboModule system assumes returnType == void iff the
         // method is synchronous.
@@ -115,12 +117,14 @@ class TurboModuleInteropUtils {
     Class<? extends NativeModule> classForMethods = module.getClass();
     Class<? extends NativeModule> superClass =
         (Class<? extends NativeModule>) classForMethods.getSuperclass();
+    // NULLSAFE_FIXME[Parameter Not Nullable]
     if (TurboModule.class.isAssignableFrom(superClass)) {
       // For java module that is based on generated flow-type spec, inspect the
       // spec abstract class instead, which is the super class of the given java
       // module.
       classForMethods = superClass;
     }
+    // NULLSAFE_FIXME[Nullable Dereference]
     return classForMethods.getDeclaredMethods();
   }
 
@@ -214,6 +218,7 @@ class TurboModuleInteropUtils {
   }
 
   private static String convertClassToJniType(Class<?> cls) {
+    // NULLSAFE_FIXME[Nullable Dereference]
     return 'L' + cls.getCanonicalName().replace('.', '/') + ';';
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleInteropUtils.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleInteropUtils.java
@@ -8,6 +8,8 @@
 package com.facebook.react.internal.turbomodule.core;
 
 import androidx.annotation.Nullable;
+import com.facebook.infer.annotation.Assertions;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.Dynamic;
@@ -26,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+@Nullsafe(Nullsafe.Mode.LOCAL)
 class TurboModuleInteropUtils {
 
   static class MethodDescriptor {
@@ -90,18 +93,6 @@ class TurboModuleInteropUtils {
       Class<?>[] paramClasses = method.getParameterTypes();
       Class<?> returnType = method.getReturnType();
 
-      if ("getConstants".equals(methodName)) {
-        if (returnType != Map.class) {
-          // TODO(T145105887) Output error. getConstants must always have a return type of Map
-        }
-        // NULLSAFE_FIXME[Nullable Dereference]
-      } else if (annotation.isBlockingSynchronousMethod() && returnType == void.class
-          // NULLSAFE_FIXME[Nullable Dereference]
-          || !annotation.isBlockingSynchronousMethod() && returnType != void.class) {
-        // TODO(T145105887): Output error. TurboModule system assumes returnType == void iff the
-        // method is synchronous.
-      }
-
       methodDescriptors.add(
           new MethodDescriptor(
               methodName,
@@ -117,14 +108,12 @@ class TurboModuleInteropUtils {
     Class<? extends NativeModule> classForMethods = module.getClass();
     Class<? extends NativeModule> superClass =
         (Class<? extends NativeModule>) classForMethods.getSuperclass();
-    // NULLSAFE_FIXME[Parameter Not Nullable]
-    if (TurboModule.class.isAssignableFrom(superClass)) {
+    if (superClass != null && TurboModule.class.isAssignableFrom(superClass)) {
       // For java module that is based on generated flow-type spec, inspect the
       // spec abstract class instead, which is the super class of the given java
       // module.
       classForMethods = superClass;
     }
-    // NULLSAFE_FIXME[Nullable Dereference]
     return classForMethods.getDeclaredMethods();
   }
 
@@ -218,8 +207,9 @@ class TurboModuleInteropUtils {
   }
 
   private static String convertClassToJniType(Class<?> cls) {
-    // NULLSAFE_FIXME[Nullable Dereference]
-    return 'L' + cls.getCanonicalName().replace('.', '/') + ';';
+    String canonicalName = cls.getCanonicalName();
+    Assertions.assertNotNull(canonicalName, "Class must have a canonical name");
+    return 'L' + canonicalName.replace('.', '/') + ';';
   }
 
   private static int getJsArgCount(String moduleName, String methodName, Class<?>[] paramClasses) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleManager.java
@@ -66,12 +66,14 @@ public class TurboModuleManager implements TurboModuleRegistry {
       @Nullable final TurboModuleManagerDelegate delegate,
       CallInvokerHolder jsCallInvokerHolder,
       NativeMethodCallInvokerHolder nativeMethodCallInvokerHolder) {
+    // NULLSAFE_FIXME[Field Not Nullable]
     mDelegate = delegate;
     mHybridData =
         initHybrid(
             runtimeExecutor,
             (CallInvokerHolderImpl) jsCallInvokerHolder,
             (NativeMethodCallInvokerHolderImpl) nativeMethodCallInvokerHolder,
+            // NULLSAFE_FIXME[Parameter Not Nullable]
             delegate);
     installJSIBindings(shouldEnableLegacyModuleInterop());
 
@@ -239,12 +241,16 @@ public class TurboModuleManager implements TurboModuleRegistry {
       moduleHolder = mModuleHolders.get(moduleName);
     }
 
+    // NULLSAFE_FIXME[Nullable Dereference]
     TurboModulePerfLogger.moduleCreateStart(moduleName, moduleHolder.getModuleId());
+    // NULLSAFE_FIXME[Parameter Not Nullable]
     NativeModule module = getOrCreateModule(moduleName, moduleHolder, true);
 
     if (module != null) {
+      // NULLSAFE_FIXME[Nullable Dereference]
       TurboModulePerfLogger.moduleCreateEnd(moduleName, moduleHolder.getModuleId());
     } else {
+      // NULLSAFE_FIXME[Nullable Dereference]
       TurboModulePerfLogger.moduleCreateFail(moduleName, moduleHolder.getModuleId());
     }
 
@@ -425,6 +431,7 @@ public class TurboModuleManager implements TurboModuleRegistry {
   }
 
   private static class ModuleHolder {
+    // NULLSAFE_FIXME[Field Not Nullable]
     private volatile NativeModule mModule = null;
     private volatile boolean mIsTryingToCreate = false;
     private volatile boolean mIsDoneCreatingModule = false;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobModule.java
@@ -106,6 +106,7 @@ public class BlobModule extends NativeBlobModuleSpec {
         @Override
         public RequestBody toRequestBody(ReadableMap data, String contentType) {
           String type = contentType;
+          // NULLSAFE_FIXME[Nullable Dereference]
           if (data.hasKey("type") && !data.getString("type").isEmpty()) {
             type = data.getString("type");
           }
@@ -113,7 +114,9 @@ public class BlobModule extends NativeBlobModuleSpec {
             type = "application/octet-stream";
           }
           ReadableMap blob = data.getMap("blob");
+          // NULLSAFE_FIXME[Nullable Dereference]
           String blobId = blob.getString("blobId");
+          // NULLSAFE_FIXME[Parameter Not Nullable, Nullable Dereference]
           byte[] bytes = resolve(blobId, blob.getInt("offset"), blob.getInt("size"));
 
           return RequestBody.create(MediaType.parse(type), bytes);
@@ -148,6 +151,7 @@ public class BlobModule extends NativeBlobModuleSpec {
   }
 
   @Override
+  // NULLSAFE_FIXME[Inconsistent Subclass Return Annotation]
   public @Nullable Map<String, Object> getTypedExportedConstants() {
     // The application can register BlobProvider as a ContentProvider so that blobs are resolvable.
     // If it does, it needs to tell us what authority was used via this string resource.
@@ -201,6 +205,7 @@ public class BlobModule extends NativeBlobModuleSpec {
     if (sizeParam != null) {
       size = Integer.parseInt(sizeParam, 10);
     }
+    // NULLSAFE_FIXME[Parameter Not Nullable]
     return resolve(blobId, offset, size);
   }
 
@@ -221,6 +226,7 @@ public class BlobModule extends NativeBlobModuleSpec {
   }
 
   public @Nullable byte[] resolve(ReadableMap blob) {
+    // NULLSAFE_FIXME[Parameter Not Nullable]
     return resolve(blob.getString("blobId"), blob.getInt("offset"), blob.getInt("size"));
   }
 
@@ -269,6 +275,7 @@ public class BlobModule extends NativeBlobModuleSpec {
 
   private String getNameFromUri(Uri contentUri) {
     if ("file".equals(contentUri.getScheme())) {
+      // NULLSAFE_FIXME[Return Not Nullable]
       return contentUri.getLastPathSegment();
     }
     String[] projection = {MediaStore.MediaColumns.DISPLAY_NAME};
@@ -279,12 +286,14 @@ public class BlobModule extends NativeBlobModuleSpec {
     if (metaCursor != null) {
       try {
         if (metaCursor.moveToFirst()) {
+          // NULLSAFE_FIXME[Return Not Nullable]
           return metaCursor.getString(0);
         }
       } finally {
         metaCursor.close();
       }
     }
+    // NULLSAFE_FIXME[Return Not Nullable]
     return contentUri.getLastPathSegment();
   }
 
@@ -316,9 +325,11 @@ public class BlobModule extends NativeBlobModuleSpec {
     ReactApplicationContext reactApplicationContext = getReactApplicationContextIfActiveOrWarn();
 
     if (reactApplicationContext != null) {
+      // NULLSAFE_FIXME[Return Not Nullable]
       return reactApplicationContext.getNativeModule(WebSocketModule.class);
     }
 
+    // NULLSAFE_FIXME[Return Not Nullable]
     return null;
   }
 
@@ -329,8 +340,11 @@ public class BlobModule extends NativeBlobModuleSpec {
     if (reactApplicationContext != null) {
       NetworkingModule networkingModule =
           reactApplicationContext.getNativeModule(NetworkingModule.class);
+      // NULLSAFE_FIXME[Nullable Dereference]
       networkingModule.addUriHandler(mNetworkingUriHandler);
+      // NULLSAFE_FIXME[Nullable Dereference]
       networkingModule.addRequestBodyHandler(mNetworkingRequestBodyHandler);
+      // NULLSAFE_FIXME[Nullable Dereference]
       networkingModule.addResponseHandler(mNetworkingResponseHandler);
     }
   }
@@ -364,11 +378,13 @@ public class BlobModule extends NativeBlobModuleSpec {
     WebSocketModule webSocketModule = getWebSocketModule("sendOverSocket");
 
     if (webSocketModule != null) {
+      // NULLSAFE_FIXME[Parameter Not Nullable]
       byte[] data = resolve(blob.getString("blobId"), blob.getInt("offset"), blob.getInt("size"));
 
       if (data != null) {
         webSocketModule.sendBinary(ByteString.of(data), id);
       } else {
+        // NULLSAFE_FIXME[Parameter Not Nullable]
         webSocketModule.sendBinary((ByteString) null, id);
       }
     }
@@ -380,18 +396,24 @@ public class BlobModule extends NativeBlobModuleSpec {
     ArrayList<byte[]> partList = new ArrayList<>(parts.size());
     for (int i = 0; i < parts.size(); i++) {
       ReadableMap part = parts.getMap(i);
+      // NULLSAFE_FIXME[Nullable Dereference]
       switch (part.getString("type")) {
         case "blob":
+          // NULLSAFE_FIXME[Nullable Dereference]
           ReadableMap blob = part.getMap("data");
+          // NULLSAFE_FIXME[Nullable Dereference]
           totalBlobSize += blob.getInt("size");
+          // NULLSAFE_FIXME[Parameter Not Nullable]
           partList.add(i, resolve(blob));
           break;
         case "string":
+          // NULLSAFE_FIXME[Nullable Dereference]
           byte[] bytes = part.getString("data").getBytes(Charset.forName("UTF-8"));
           totalBlobSize += bytes.length;
           partList.add(i, bytes);
           break;
         default:
+          // NULLSAFE_FIXME[Nullable Dereference]
           throw new IllegalArgumentException("Invalid type for blob: " + part.getString("type"));
       }
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobProvider.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobProvider.java
@@ -14,6 +14,7 @@ import android.database.Cursor;
 import android.net.Uri;
 import android.os.ParcelFileDescriptor;
 import androidx.annotation.Nullable;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.bridge.ReactContext;
@@ -23,6 +24,7 @@ import java.io.OutputStream;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public final class BlobProvider extends ContentProvider {
 
   private static final int PIPE_CAPACITY = 65536;
@@ -72,7 +74,9 @@ public final class BlobProvider extends ContentProvider {
     if (context instanceof ReactApplication) {
       ReactNativeHost host = ((ReactApplication) context).getReactNativeHost();
       ReactContext reactContext = host.getReactInstanceManager().getCurrentReactContext();
-      // NULLSAFE_FIXME[Nullable Dereference]
+      if (reactContext == null) {
+        throw new RuntimeException("No ReactContext associated with BlobProvider");
+      }
       blobModule = reactContext.getNativeModule(BlobModule.class);
     }
 
@@ -87,7 +91,6 @@ public final class BlobProvider extends ContentProvider {
 
     ParcelFileDescriptor[] pipe;
     try {
-      // NULLSAFE_FIXME[Not Vetted Third-Party]
       pipe = ParcelFileDescriptor.createPipe();
     } catch (IOException exception) {
       return null;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobProvider.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobProvider.java
@@ -72,6 +72,7 @@ public final class BlobProvider extends ContentProvider {
     if (context instanceof ReactApplication) {
       ReactNativeHost host = ((ReactApplication) context).getReactNativeHost();
       ReactContext reactContext = host.getReactInstanceManager().getCurrentReactContext();
+      // NULLSAFE_FIXME[Nullable Dereference]
       blobModule = reactContext.getNativeModule(BlobModule.class);
     }
 
@@ -86,6 +87,7 @@ public final class BlobProvider extends ContentProvider {
 
     ParcelFileDescriptor[] pipe;
     try {
+      // NULLSAFE_FIXME[Not Vetted Third-Party]
       pipe = ParcelFileDescriptor.createPipe();
     } catch (IOException exception) {
       return null;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/blob/FileReaderModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/blob/FileReaderModule.java
@@ -27,9 +27,11 @@ public class FileReaderModule extends NativeFileReaderModuleSpec {
     ReactApplicationContext reactApplicationContext = getReactApplicationContextIfActiveOrWarn();
 
     if (reactApplicationContext != null) {
+      // NULLSAFE_FIXME[Return Not Nullable]
       return reactApplicationContext.getNativeModule(BlobModule.class);
     }
 
+    // NULLSAFE_FIXME[Return Not Nullable]
     return null;
   }
 
@@ -47,6 +49,7 @@ public class FileReaderModule extends NativeFileReaderModuleSpec {
     }
 
     byte[] bytes =
+        // NULLSAFE_FIXME[Parameter Not Nullable]
         blobModule.resolve(blob.getString("blobId"), blob.getInt("offset"), blob.getInt("size"));
 
     if (bytes == null) {
@@ -75,6 +78,7 @@ public class FileReaderModule extends NativeFileReaderModuleSpec {
     }
 
     byte[] bytes =
+        // NULLSAFE_FIXME[Parameter Not Nullable]
         blobModule.resolve(blob.getString("blobId"), blob.getInt("offset"), blob.getInt("size"));
 
     if (bytes == null) {
@@ -86,6 +90,7 @@ public class FileReaderModule extends NativeFileReaderModuleSpec {
       StringBuilder sb = new StringBuilder();
       sb.append("data:");
 
+      // NULLSAFE_FIXME[Nullable Dereference]
       if (blob.hasKey("type") && !blob.getString("type").isEmpty()) {
         sb.append(blob.getString("type"));
       } else {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/blob/FileReaderModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/blob/FileReaderModule.java
@@ -8,12 +8,15 @@
 package com.facebook.react.modules.blob;
 
 import android.util.Base64;
+import androidx.annotation.Nullable;
 import com.facebook.fbreact.specs.NativeFileReaderModuleSpec;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.module.annotations.ReactModule;
 
+@Nullsafe(Nullsafe.Mode.LOCAL)
 @ReactModule(name = NativeFileReaderModuleSpec.NAME)
 public class FileReaderModule extends NativeFileReaderModuleSpec {
 
@@ -23,15 +26,13 @@ public class FileReaderModule extends NativeFileReaderModuleSpec {
     super(reactContext);
   }
 
-  private BlobModule getBlobModule(String reason) {
+  private @Nullable BlobModule getBlobModule(String reason) {
     ReactApplicationContext reactApplicationContext = getReactApplicationContextIfActiveOrWarn();
 
     if (reactApplicationContext != null) {
-      // NULLSAFE_FIXME[Return Not Nullable]
       return reactApplicationContext.getNativeModule(BlobModule.class);
     }
 
-    // NULLSAFE_FIXME[Return Not Nullable]
     return null;
   }
 
@@ -48,9 +49,13 @@ public class FileReaderModule extends NativeFileReaderModuleSpec {
       return;
     }
 
-    byte[] bytes =
-        // NULLSAFE_FIXME[Parameter Not Nullable]
-        blobModule.resolve(blob.getString("blobId"), blob.getInt("offset"), blob.getInt("size"));
+    String blobId = blob.getString("blobId");
+    if (blobId == null) {
+      promise.reject(ERROR_INVALID_BLOB, "The specified blob does not contain a blobId");
+      return;
+    }
+
+    byte[] bytes = blobModule.resolve(blobId, blob.getInt("offset"), blob.getInt("size"));
 
     if (bytes == null) {
       promise.reject(ERROR_INVALID_BLOB, "The specified blob is invalid");
@@ -77,9 +82,13 @@ public class FileReaderModule extends NativeFileReaderModuleSpec {
       return;
     }
 
-    byte[] bytes =
-        // NULLSAFE_FIXME[Parameter Not Nullable]
-        blobModule.resolve(blob.getString("blobId"), blob.getInt("offset"), blob.getInt("size"));
+    String blobId = blob.getString("blobId");
+    if (blobId == null) {
+      promise.reject(ERROR_INVALID_BLOB, "The specified blob does not contain a blobId");
+      return;
+    }
+
+    byte[] bytes = blobModule.resolve(blobId, blob.getInt("offset"), blob.getInt("size"));
 
     if (bytes == null) {
       promise.reject(ERROR_INVALID_BLOB, "The specified blob is invalid");
@@ -90,8 +99,9 @@ public class FileReaderModule extends NativeFileReaderModuleSpec {
       StringBuilder sb = new StringBuilder();
       sb.append("data:");
 
-      // NULLSAFE_FIXME[Nullable Dereference]
-      if (blob.hasKey("type") && !blob.getString("type").isEmpty()) {
+      if (blob.hasKey("type")
+          && blob.getString("type") != null
+          && !blob.getString("type").isEmpty()) {
         sb.append(blob.getString("type"));
       } else {
         sb.append("application/octet-stream");

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/DialogModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/DialogModule.java
@@ -130,6 +130,7 @@ public class DialogModule extends NativeDialogManagerAndroidSpec implements Life
     }
 
     @Override
+    // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
     public void onDismiss(DialogInterface dialog) {
       if (!mCallbackConsumed) {
         if (getReactApplicationContext().hasActiveReactInstance()) {
@@ -198,8 +199,11 @@ public class DialogModule extends NativeDialogManagerAndroidSpec implements Life
     }
     if (options.hasKey(KEY_ITEMS)) {
       ReadableArray items = options.getArray(KEY_ITEMS);
+      // NULLSAFE_FIXME[Nullable Dereference]
       CharSequence[] itemsArray = new CharSequence[items.size()];
+      // NULLSAFE_FIXME[Nullable Dereference]
       for (int i = 0; i < items.size(); i++) {
+        // NULLSAFE_FIXME[Nullable Dereference]
         itemsArray[i] = items.getString(i);
       }
       args.putCharSequenceArray(AlertFragment.ARG_ITEMS, itemsArray);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/DialogModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/DialogModule.java
@@ -12,12 +12,13 @@ import android.content.DialogInterface;
 import android.content.DialogInterface.OnClickListener;
 import android.content.DialogInterface.OnDismissListener;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
 import com.facebook.common.logging.FLog;
 import com.facebook.fbreact.specs.NativeDialogManagerAndroidSpec;
+import com.facebook.infer.annotation.Assertions;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -29,6 +30,7 @@ import com.facebook.react.common.MapBuilder;
 import com.facebook.react.module.annotations.ReactModule;
 import java.util.Map;
 
+@Nullsafe(Nullsafe.Mode.LOCAL)
 @ReactModule(name = NativeDialogManagerAndroidSpec.NAME)
 public class DialogModule extends NativeDialogManagerAndroidSpec implements LifecycleEventListener {
 
@@ -59,12 +61,13 @@ public class DialogModule extends NativeDialogManagerAndroidSpec implements Life
     super(reactContext);
   }
 
+  @Nullsafe(Nullsafe.Mode.LOCAL)
   private class FragmentManagerHelper {
-    private final @NonNull FragmentManager mFragmentManager;
+    private final FragmentManager mFragmentManager;
 
     private @Nullable Object mFragmentToShow;
 
-    public FragmentManagerHelper(@NonNull FragmentManager fragmentManager) {
+    public FragmentManagerHelper(FragmentManager fragmentManager) {
       mFragmentManager = fragmentManager;
     }
 
@@ -110,6 +113,7 @@ public class DialogModule extends NativeDialogManagerAndroidSpec implements Life
     }
   }
 
+  @Nullsafe(Nullsafe.Mode.LOCAL)
   /* package */ class AlertFragmentListener implements OnClickListener, OnDismissListener {
 
     private final Callback mCallback;
@@ -130,8 +134,7 @@ public class DialogModule extends NativeDialogManagerAndroidSpec implements Life
     }
 
     @Override
-    // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
-    public void onDismiss(DialogInterface dialog) {
+    public void onDismiss(@Nullable DialogInterface dialog) {
       if (!mCallbackConsumed) {
         if (getReactApplicationContext().hasActiveReactInstance()) {
           mCallback.invoke(ACTION_DISMISSED);
@@ -199,11 +202,9 @@ public class DialogModule extends NativeDialogManagerAndroidSpec implements Life
     }
     if (options.hasKey(KEY_ITEMS)) {
       ReadableArray items = options.getArray(KEY_ITEMS);
-      // NULLSAFE_FIXME[Nullable Dereference]
+      Assertions.assertNotNull(items);
       CharSequence[] itemsArray = new CharSequence[items.size()];
-      // NULLSAFE_FIXME[Nullable Dereference]
       for (int i = 0; i < items.size(); i++) {
-        // NULLSAFE_FIXME[Nullable Dereference]
         itemsArray[i] = items.getString(i);
       }
       args.putCharSequenceArray(AlertFragment.ARG_ITEMS, itemsArray);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java
@@ -324,6 +324,7 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
             Response originalResponse = chain.proceed(chain.request());
             ProgressResponseBody responseBody =
                 new ProgressResponseBody(
+                    // NULLSAFE_FIXME[Parameter Not Nullable]
                     originalResponse.body(),
                     new ProgressListener() {
                       long last = System.nanoTime();
@@ -385,6 +386,7 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
         || method.toLowerCase(Locale.ROOT).equals("head")) {
       requestBody = RequestBodyUtil.getEmptyBody(method);
     } else if (handler != null) {
+      // NULLSAFE_FIXME[Parameter Not Nullable]
       requestBody = handler.toRequestBody(data, contentType);
     } else if (data.hasKey(REQUEST_BODY_KEY_STRING)) {
       if (contentType == null) {
@@ -398,6 +400,7 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
       String body = data.getString(REQUEST_BODY_KEY_STRING);
       MediaType contentMediaType = MediaType.parse(contentType);
       if (RequestBodyUtil.isGzipEncoding(contentEncoding)) {
+        // NULLSAFE_FIXME[Parameter Not Nullable]
         requestBody = RequestBodyUtil.createGzip(contentMediaType, body);
         if (requestBody == null) {
           ResponseUtil.onRequestError(
@@ -412,6 +415,7 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
             contentMediaType == null
                 ? StandardCharsets.UTF_8
                 : contentMediaType.charset(StandardCharsets.UTF_8);
+        // NULLSAFE_FIXME[Parameter Not Nullable, Nullable Dereference]
         requestBody = RequestBody.create(contentMediaType, body.getBytes(charset));
       }
     } else if (data.hasKey(REQUEST_BODY_KEY_BASE64)) {
@@ -425,6 +429,7 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
       }
       String base64String = data.getString(REQUEST_BODY_KEY_BASE64);
       MediaType contentMediaType = MediaType.parse(contentType);
+      // NULLSAFE_FIXME[Parameter Not Nullable]
       requestBody = RequestBody.create(contentMediaType, ByteString.decodeBase64(base64String));
     } else if (data.hasKey(REQUEST_BODY_KEY_URI)) {
       if (contentType == null) {
@@ -437,6 +442,7 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
       }
       String uri = data.getString(REQUEST_BODY_KEY_URI);
       InputStream fileInputStream =
+          // NULLSAFE_FIXME[Parameter Not Nullable]
           RequestBodyUtil.getFileInputStream(getReactApplicationContext(), uri);
       if (fileInputStream == null) {
         ResponseUtil.onRequestError(
@@ -450,6 +456,7 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
       }
       ReadableArray parts = data.getArray(REQUEST_BODY_KEY_FORMDATA);
       MultipartBody.Builder multipartBuilder =
+          // NULLSAFE_FIXME[Parameter Not Nullable]
           constructMultipartBody(parts, contentType, requestId);
       if (multipartBuilder == null) {
         return;
@@ -460,6 +467,7 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
       requestBody = RequestBodyUtil.getEmptyBody(method);
     }
 
+    // NULLSAFE_FIXME[Parameter Not Nullable]
     requestBuilder.method(method, wrapRequestBodyWithProgressEmitter(requestBody, requestId));
 
     addRequest(requestId);
@@ -524,6 +532,7 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
                   // Check if a handler is registered
                   for (ResponseHandler handler : mResponseHandlers) {
                     if (handler.supports(responseType)) {
+                      // NULLSAFE_FIXME[Parameter Not Nullable]
                       WritableMap res = handler.toResponseData(responseBody);
                       ResponseUtil.onDataReceived(reactApplicationContext, requestId, res);
                       ResponseUtil.onRequestSuccess(reactApplicationContext, requestId);
@@ -535,6 +544,7 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
                   // response,
                   // periodically send response data updates to JS.
                   if (useIncrementalUpdates && responseType.equals("text")) {
+                    // NULLSAFE_FIXME[Parameter Not Nullable]
                     readWithProgress(requestId, responseBody);
                     ResponseUtil.onRequestSuccess(reactApplicationContext, requestId);
                     return;
@@ -544,6 +554,7 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
                   String responseString = "";
                   if (responseType.equals("text")) {
                     try {
+                      // NULLSAFE_FIXME[Nullable Dereference]
                       responseString = responseBody.string();
                     } catch (IOException e) {
                       if (response.request().method().equalsIgnoreCase("HEAD")) {
@@ -558,6 +569,7 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
                       }
                     }
                   } else if (responseType.equals("base64")) {
+                    // NULLSAFE_FIXME[Nullable Dereference]
                     responseString = Base64.encodeToString(responseBody.bytes(), Base64.NO_WRAP);
                   }
                   ResponseUtil.onDataReceived(reactApplicationContext, requestId, responseString);
@@ -573,6 +585,7 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
   private RequestBody wrapRequestBodyWithProgressEmitter(
       final RequestBody requestBody, final int requestId) {
     if (requestBody == null) {
+      // NULLSAFE_FIXME[Return Not Nullable]
       return null;
     }
     final ReactApplicationContext reactApplicationContext =
@@ -610,6 +623,7 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
             ? StandardCharsets.UTF_8
             : responseBody.contentType().charset(StandardCharsets.UTF_8);
 
+    // NULLSAFE_FIXME[Parameter Not Nullable]
     ProgressiveStringDecoder streamDecoder = new ProgressiveStringDecoder(charset);
     InputStream inputStream = responseBody.byteStream();
     try {
@@ -689,6 +703,7 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
   private @Nullable MultipartBody.Builder constructMultipartBody(
       ReadableArray body, String contentType, int requestId) {
     MultipartBody.Builder multipartBuilder = new MultipartBody.Builder();
+    // NULLSAFE_FIXME[Parameter Not Nullable]
     multipartBuilder.setType(MediaType.parse(contentType));
 
     final ReactApplicationContext reactApplicationContext =
@@ -698,6 +713,7 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
       ReadableMap bodyPart = body.getMap(i);
 
       // Determine part's content type.
+      // NULLSAFE_FIXME[Nullable Dereference]
       ReadableArray headersArray = bodyPart.getArray("headers");
       Headers headers = extractHeaders(headersArray, null);
       if (headers == null) {
@@ -717,9 +733,13 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
         headers = headers.newBuilder().removeAll(CONTENT_TYPE_HEADER_NAME).build();
       }
 
+      // NULLSAFE_FIXME[Nullable Dereference]
       if (bodyPart.hasKey(REQUEST_BODY_KEY_STRING)) {
+        // NULLSAFE_FIXME[Nullable Dereference]
         String bodyValue = bodyPart.getString(REQUEST_BODY_KEY_STRING);
+        // NULLSAFE_FIXME[Parameter Not Nullable]
         multipartBuilder.addPart(headers, RequestBody.create(partContentType, bodyValue));
+        // NULLSAFE_FIXME[Nullable Dereference]
       } else if (bodyPart.hasKey(REQUEST_BODY_KEY_URI)) {
         if (partContentType == null) {
           ResponseUtil.onRequestError(
@@ -729,8 +749,10 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
               null);
           return null;
         }
+        // NULLSAFE_FIXME[Nullable Dereference]
         String fileContentUriStr = bodyPart.getString(REQUEST_BODY_KEY_URI);
         InputStream fileInputStream =
+            // NULLSAFE_FIXME[Parameter Not Nullable]
             RequestBodyUtil.getFileInputStream(getReactApplicationContext(), fileContentUriStr);
         if (fileInputStream == null) {
           ResponseUtil.onRequestError(
@@ -763,6 +785,7 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
       if (header == null || header.size() != 2) {
         return null;
       }
+      // NULLSAFE_FIXME[Parameter Not Nullable]
       String headerName = HeaderUtil.stripHeaderName(header.getString(0));
       String headerValue = header.getString(1);
       if (headerName == null || headerValue == null) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.java
@@ -13,6 +13,8 @@ import android.util.Base64;
 import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
 import com.facebook.fbreact.specs.NativeNetworkingAndroidSpec;
+import com.facebook.infer.annotation.Assertions;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactMethod;
@@ -48,6 +50,7 @@ import okio.GzipSource;
 import okio.Okio;
 
 /** Implements the XMLHttpRequest JavaScript interface. */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 @ReactModule(name = NativeNetworkingAndroidSpec.NAME)
 public final class NetworkingModule extends NativeNetworkingAndroidSpec {
 
@@ -69,7 +72,7 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
     boolean supports(ReadableMap map);
 
     /** Returns the {@link RequestBody} for the JS body payload. */
-    RequestBody toRequestBody(ReadableMap map, String contentType);
+    RequestBody toRequestBody(ReadableMap map, @Nullable String contentType);
   }
 
   /** Allows adding custom handling to build the JS body payload from the {@link ResponseBody}. */
@@ -238,7 +241,7 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
       String url,
       double requestIdAsDouble,
       ReadableArray headers,
-      ReadableMap data,
+      @Nullable ReadableMap data,
       String responseType,
       boolean useIncrementalUpdates,
       double timeoutAsDouble,
@@ -272,7 +275,7 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
       String url,
       final int requestId,
       ReadableArray headers,
-      ReadableMap data,
+      @Nullable ReadableMap data,
       final String responseType,
       final boolean useIncrementalUpdates,
       int timeout,
@@ -322,10 +325,11 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
       clientBuilder.addNetworkInterceptor(
           chain -> {
             Response originalResponse = chain.proceed(chain.request());
+            ResponseBody originalResponseBody = originalResponse.body();
+            Assertions.assertNotNull(originalResponseBody);
             ProgressResponseBody responseBody =
                 new ProgressResponseBody(
-                    // NULLSAFE_FIXME[Parameter Not Nullable]
-                    originalResponse.body(),
+                    originalResponseBody,
                     new ProgressListener() {
                       long last = System.nanoTime();
 
@@ -386,7 +390,6 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
         || method.toLowerCase(Locale.ROOT).equals("head")) {
       requestBody = RequestBodyUtil.getEmptyBody(method);
     } else if (handler != null) {
-      // NULLSAFE_FIXME[Parameter Not Nullable]
       requestBody = handler.toRequestBody(data, contentType);
     } else if (data.hasKey(REQUEST_BODY_KEY_STRING)) {
       if (contentType == null) {
@@ -400,8 +403,10 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
       String body = data.getString(REQUEST_BODY_KEY_STRING);
       MediaType contentMediaType = MediaType.parse(contentType);
       if (RequestBodyUtil.isGzipEncoding(contentEncoding)) {
-        // NULLSAFE_FIXME[Parameter Not Nullable]
-        requestBody = RequestBodyUtil.createGzip(contentMediaType, body);
+        requestBody = null;
+        if (contentMediaType != null && body != null) {
+          requestBody = RequestBodyUtil.createGzip(contentMediaType, body);
+        }
         if (requestBody == null) {
           ResponseUtil.onRequestError(
               reactApplicationContext, requestId, "Failed to gzip request body", null);
@@ -415,7 +420,12 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
             contentMediaType == null
                 ? StandardCharsets.UTF_8
                 : contentMediaType.charset(StandardCharsets.UTF_8);
-        // NULLSAFE_FIXME[Parameter Not Nullable, Nullable Dereference]
+        Assertions.assertNotNull(charset);
+        if (body == null) {
+          ResponseUtil.onRequestError(
+              reactApplicationContext, requestId, "Received request but body was empty", null);
+          return;
+        }
         requestBody = RequestBody.create(contentMediaType, body.getBytes(charset));
       }
     } else if (data.hasKey(REQUEST_BODY_KEY_BASE64)) {
@@ -428,9 +438,24 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
         return;
       }
       String base64String = data.getString(REQUEST_BODY_KEY_BASE64);
+      Assertions.assertNotNull(base64String);
+
       MediaType contentMediaType = MediaType.parse(contentType);
-      // NULLSAFE_FIXME[Parameter Not Nullable]
-      requestBody = RequestBody.create(contentMediaType, ByteString.decodeBase64(base64String));
+      if (contentMediaType == null) {
+        ResponseUtil.onRequestError(
+            reactApplicationContext,
+            requestId,
+            "Invalid content type specified: " + contentType,
+            null);
+        return;
+      }
+      ByteString base64DecodedString = ByteString.decodeBase64(base64String);
+      if (base64DecodedString == null) {
+        ResponseUtil.onRequestError(
+            reactApplicationContext, requestId, "Request body base64 string was invalid", null);
+        return;
+      }
+      requestBody = RequestBody.create(contentMediaType, base64DecodedString);
     } else if (data.hasKey(REQUEST_BODY_KEY_URI)) {
       if (contentType == null) {
         ResponseUtil.onRequestError(
@@ -441,8 +466,12 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
         return;
       }
       String uri = data.getString(REQUEST_BODY_KEY_URI);
+      if (uri == null) {
+        ResponseUtil.onRequestError(
+            reactApplicationContext, requestId, "Request body URI field was set but null", null);
+        return;
+      }
       InputStream fileInputStream =
-          // NULLSAFE_FIXME[Parameter Not Nullable]
           RequestBodyUtil.getFileInputStream(getReactApplicationContext(), uri);
       if (fileInputStream == null) {
         ResponseUtil.onRequestError(
@@ -455,8 +484,12 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
         contentType = "multipart/form-data";
       }
       ReadableArray parts = data.getArray(REQUEST_BODY_KEY_FORMDATA);
+      if (parts == null) {
+        ResponseUtil.onRequestError(
+            reactApplicationContext, requestId, "Received request but form data was empty", null);
+        return;
+      }
       MultipartBody.Builder multipartBuilder =
-          // NULLSAFE_FIXME[Parameter Not Nullable]
           constructMultipartBody(parts, contentType, requestId);
       if (multipartBuilder == null) {
         return;
@@ -467,7 +500,6 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
       requestBody = RequestBodyUtil.getEmptyBody(method);
     }
 
-    // NULLSAFE_FIXME[Parameter Not Nullable]
     requestBuilder.method(method, wrapRequestBodyWithProgressEmitter(requestBody, requestId));
 
     addRequest(requestId);
@@ -518,8 +550,12 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
                   // See
                   // https://github.com/square/okhttp/blob/5b37cda9e00626f43acf354df145fd452c3031f1/okhttp/src/main/java/okhttp3/internal/http/BridgeInterceptor.java#L76-L111
                   ResponseBody responseBody = response.body();
-                  if ("gzip".equalsIgnoreCase(response.header("Content-Encoding"))
-                      && responseBody != null) {
+                  if (responseBody == null) {
+                    ResponseUtil.onRequestError(
+                        reactApplicationContext, requestId, "Response body is null", null);
+                    return;
+                  }
+                  if ("gzip".equalsIgnoreCase(response.header("Content-Encoding"))) {
                     GzipSource gzipSource = new GzipSource(responseBody.source());
                     String contentType = response.header("Content-Type");
                     responseBody =
@@ -532,7 +568,6 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
                   // Check if a handler is registered
                   for (ResponseHandler handler : mResponseHandlers) {
                     if (handler.supports(responseType)) {
-                      // NULLSAFE_FIXME[Parameter Not Nullable]
                       WritableMap res = handler.toResponseData(responseBody);
                       ResponseUtil.onDataReceived(reactApplicationContext, requestId, res);
                       ResponseUtil.onRequestSuccess(reactApplicationContext, requestId);
@@ -544,7 +579,6 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
                   // response,
                   // periodically send response data updates to JS.
                   if (useIncrementalUpdates && responseType.equals("text")) {
-                    // NULLSAFE_FIXME[Parameter Not Nullable]
                     readWithProgress(requestId, responseBody);
                     ResponseUtil.onRequestSuccess(reactApplicationContext, requestId);
                     return;
@@ -554,7 +588,6 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
                   String responseString = "";
                   if (responseType.equals("text")) {
                     try {
-                      // NULLSAFE_FIXME[Nullable Dereference]
                       responseString = responseBody.string();
                     } catch (IOException e) {
                       if (response.request().method().equalsIgnoreCase("HEAD")) {
@@ -569,7 +602,6 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
                       }
                     }
                   } else if (responseType.equals("base64")) {
-                    // NULLSAFE_FIXME[Nullable Dereference]
                     responseString = Base64.encodeToString(responseBody.bytes(), Base64.NO_WRAP);
                   }
                   ResponseUtil.onDataReceived(reactApplicationContext, requestId, responseString);
@@ -582,10 +614,9 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
             });
   }
 
-  private RequestBody wrapRequestBodyWithProgressEmitter(
-      final RequestBody requestBody, final int requestId) {
+  private @Nullable RequestBody wrapRequestBodyWithProgressEmitter(
+      @Nullable final RequestBody requestBody, final int requestId) {
     if (requestBody == null) {
-      // NULLSAFE_FIXME[Return Not Nullable]
       return null;
     }
     final ReactApplicationContext reactApplicationContext =
@@ -622,8 +653,9 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
         responseBody.contentType() == null
             ? StandardCharsets.UTF_8
             : responseBody.contentType().charset(StandardCharsets.UTF_8);
+    Assertions.assertNotNull(
+        charset, "Null character set for Content-Type: " + responseBody.contentType());
 
-    // NULLSAFE_FIXME[Parameter Not Nullable]
     ProgressiveStringDecoder streamDecoder = new ProgressiveStringDecoder(charset);
     InputStream inputStream = responseBody.byteStream();
     try {
@@ -702,18 +734,25 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
 
   private @Nullable MultipartBody.Builder constructMultipartBody(
       ReadableArray body, String contentType, int requestId) {
-    MultipartBody.Builder multipartBuilder = new MultipartBody.Builder();
-    // NULLSAFE_FIXME[Parameter Not Nullable]
-    multipartBuilder.setType(MediaType.parse(contentType));
-
     final ReactApplicationContext reactApplicationContext =
         getReactApplicationContextIfActiveOrWarn();
+    MultipartBody.Builder multipartBuilder = new MultipartBody.Builder();
+    MediaType mediaType = MediaType.parse(contentType);
+    if (mediaType == null) {
+      ResponseUtil.onRequestError(reactApplicationContext, requestId, "Invalid media type.", null);
+      return null;
+    }
+    multipartBuilder.setType(mediaType);
 
     for (int i = 0, size = body.size(); i < size; i++) {
       ReadableMap bodyPart = body.getMap(i);
+      if (bodyPart == null) {
+        ResponseUtil.onRequestError(
+            reactApplicationContext, requestId, "Unrecognized FormData part.", null);
+        return null;
+      }
 
       // Determine part's content type.
-      // NULLSAFE_FIXME[Nullable Dereference]
       ReadableArray headersArray = bodyPart.getArray("headers");
       Headers headers = extractHeaders(headersArray, null);
       if (headers == null) {
@@ -733,14 +772,12 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
         headers = headers.newBuilder().removeAll(CONTENT_TYPE_HEADER_NAME).build();
       }
 
-      // NULLSAFE_FIXME[Nullable Dereference]
-      if (bodyPart.hasKey(REQUEST_BODY_KEY_STRING)) {
-        // NULLSAFE_FIXME[Nullable Dereference]
+      if (bodyPart.hasKey(REQUEST_BODY_KEY_STRING)
+          && bodyPart.getString(REQUEST_BODY_KEY_STRING) != null) {
         String bodyValue = bodyPart.getString(REQUEST_BODY_KEY_STRING);
-        // NULLSAFE_FIXME[Parameter Not Nullable]
         multipartBuilder.addPart(headers, RequestBody.create(partContentType, bodyValue));
-        // NULLSAFE_FIXME[Nullable Dereference]
-      } else if (bodyPart.hasKey(REQUEST_BODY_KEY_URI)) {
+      } else if (bodyPart.hasKey(REQUEST_BODY_KEY_URI)
+          && bodyPart.getString(REQUEST_BODY_KEY_URI) != null) {
         if (partContentType == null) {
           ResponseUtil.onRequestError(
               reactApplicationContext,
@@ -749,10 +786,8 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
               null);
           return null;
         }
-        // NULLSAFE_FIXME[Nullable Dereference]
         String fileContentUriStr = bodyPart.getString(REQUEST_BODY_KEY_URI);
         InputStream fileInputStream =
-            // NULLSAFE_FIXME[Parameter Not Nullable]
             RequestBodyUtil.getFileInputStream(getReactApplicationContext(), fileContentUriStr);
         if (fileInputStream == null) {
           ResponseUtil.onRequestError(
@@ -785,8 +820,10 @@ public final class NetworkingModule extends NativeNetworkingAndroidSpec {
       if (header == null || header.size() != 2) {
         return null;
       }
-      // NULLSAFE_FIXME[Parameter Not Nullable]
-      String headerName = HeaderUtil.stripHeaderName(header.getString(0));
+      String headerName = null;
+      if (header.getString(0) != null) {
+        headerName = HeaderUtil.stripHeaderName(header.getString(0));
+      }
       String headerValue = header.getString(1);
       if (headerName == null || headerValue == null) {
         return null;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/ReconnectingWebSocket.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/ReconnectingWebSocket.java
@@ -138,6 +138,7 @@ public final class ReconnectingWebSocket extends WebSocketListener {
   }
 
   @Override
+  // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
   public synchronized void onFailure(WebSocket webSocket, Throwable t, Response response) {
     if (mWebSocket != null) {
       abort("Websocket exception", t);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/ReconnectingWebSocket.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/ReconnectingWebSocket.java
@@ -11,6 +11,7 @@ import android.os.Handler;
 import android.os.Looper;
 import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
+import com.facebook.infer.annotation.Nullsafe;
 import java.io.IOException;
 import java.nio.channels.ClosedChannelException;
 import java.util.concurrent.TimeUnit;
@@ -22,6 +23,7 @@ import okhttp3.WebSocketListener;
 import okio.ByteString;
 
 /** A wrapper around WebSocketClient that reconnects automatically */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public final class ReconnectingWebSocket extends WebSocketListener {
   private static final String TAG = ReconnectingWebSocket.class.getSimpleName();
 
@@ -138,8 +140,8 @@ public final class ReconnectingWebSocket extends WebSocketListener {
   }
 
   @Override
-  // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
-  public synchronized void onFailure(WebSocket webSocket, Throwable t, Response response) {
+  public synchronized void onFailure(
+      @Nullable WebSocket webSocket, Throwable t, @Nullable Response response) {
     if (mWebSocket != null) {
       abort("Websocket exception", t);
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/Task.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/Task.java
@@ -8,6 +8,8 @@
 package com.facebook.react.runtime.internal.bolts;
 
 import androidx.annotation.Nullable;
+import com.facebook.infer.annotation.Assertions;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.interfaces.TaskInterface;
 import java.util.ArrayList;
 import java.util.List;
@@ -21,6 +23,7 @@ import java.util.concurrent.TimeUnit;
  *
  * @param <TResult> The type of the result of the task.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class Task<TResult> implements TaskInterface<TResult> {
   /**
    * An {@link java.util.concurrent.Executor} that executes tasks in the current thread unless the
@@ -75,18 +78,16 @@ public class Task<TResult> implements TaskInterface<TResult> {
   private final Object lock = new Object();
   private boolean complete;
   private boolean cancelled;
-  // NULLSAFE_FIXME[Field Not Initialized]
-  private TResult result;
-  // NULLSAFE_FIXME[Field Not Initialized]
-  private Exception error;
+
+  private @Nullable TResult result;
+  private @Nullable Exception error;
   private boolean errorHasBeenObserved;
-  // NULLSAFE_FIXME[Field Not Initialized]
-  private UnobservedErrorNotifier unobservedErrorNotifier;
-  private List<Continuation<TResult, Void>> continuations = new ArrayList<>();
+  private @Nullable UnobservedErrorNotifier unobservedErrorNotifier;
+  private @Nullable List<Continuation<TResult, Void>> continuations = new ArrayList<>();
 
   /* package */ Task() {}
 
-  private Task(TResult result) {
+  private Task(@Nullable TResult result) {
     trySetResult(result);
   }
 
@@ -94,7 +95,6 @@ public class Task<TResult> implements TaskInterface<TResult> {
     if (cancelled) {
       trySetCancelled();
     } else {
-      // NULLSAFE_FIXME[Parameter Not Nullable]
       trySetResult(null);
     }
   }
@@ -139,7 +139,7 @@ public class Task<TResult> implements TaskInterface<TResult> {
    * @return The result of the task, if set. {@code null} otherwise.
    */
   @Override
-  public TResult getResult() {
+  public @Nullable TResult getResult() {
     synchronized (lock) {
       return result;
     }
@@ -149,13 +149,12 @@ public class Task<TResult> implements TaskInterface<TResult> {
    * @return The error for the task, if set. {@code null} otherwise.
    */
   @Override
-  public Exception getError() {
+  public @Nullable Exception getError() {
     synchronized (lock) {
       if (error != null) {
         errorHasBeenObserved = true;
         if (unobservedErrorNotifier != null) {
           unobservedErrorNotifier.setObserved();
-          // NULLSAFE_FIXME[Field Not Nullable]
           unobservedErrorNotifier = null;
         }
       }
@@ -180,10 +179,10 @@ public class Task<TResult> implements TaskInterface<TResult> {
    *     false} otherwise.
    */
   @Override
-  // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
-  public boolean waitForCompletion(long duration, TimeUnit timeUnit) throws InterruptedException {
+  public boolean waitForCompletion(long duration, @Nullable TimeUnit timeUnit)
+      throws InterruptedException {
     synchronized (lock) {
-      if (!isCompleted()) {
+      if (!isCompleted() && timeUnit != null) {
         lock.wait(timeUnit.toMillis(duration));
       }
       return isCompleted();
@@ -227,6 +226,7 @@ public class Task<TResult> implements TaskInterface<TResult> {
               return Task.cancelled();
             }
             if (task.isFaulted()) {
+              Assertions.assertNotNull(task.getError());
               return Task.forError(task.getError());
             }
             return Task.forResult(null);
@@ -270,6 +270,7 @@ public class Task<TResult> implements TaskInterface<TResult> {
     synchronized (lock) {
       completed = this.isCompleted();
       if (!completed) {
+        Assertions.assertNotNull(continuations);
         continuations.add(
             new Continuation<TResult, Void>() {
               @Override
@@ -307,6 +308,7 @@ public class Task<TResult> implements TaskInterface<TResult> {
     synchronized (lock) {
       completed = this.isCompleted();
       if (!completed) {
+        Assertions.assertNotNull(continuations);
         continuations.add(
             new Continuation<TResult, Void>() {
               @Override
@@ -343,6 +345,7 @@ public class Task<TResult> implements TaskInterface<TResult> {
           @Override
           public Task<TContinuationResult> then(Task<TResult> task) {
             if (task.isFaulted()) {
+              Assertions.assertNotNull(task.getError());
               return Task.forError(task.getError());
             } else if (task.isCancelled()) {
               return Task.cancelled();
@@ -374,6 +377,7 @@ public class Task<TResult> implements TaskInterface<TResult> {
           @Override
           public Task<TContinuationResult> then(Task<TResult> task) {
             if (task.isFaulted()) {
+              Assertions.assertNotNull(task.getError());
               return Task.forError(task.getError());
             } else if (task.isCancelled()) {
               return Task.cancelled();
@@ -464,6 +468,7 @@ public class Task<TResult> implements TaskInterface<TResult> {
                           if (task.isCancelled()) {
                             tcs.setCancelled();
                           } else if (task.isFaulted()) {
+                            Assertions.assertNotNull(task.getError());
                             tcs.setError(task.getError());
                           } else {
                             tcs.setResult(task.getResult());
@@ -486,6 +491,7 @@ public class Task<TResult> implements TaskInterface<TResult> {
 
   private void runContinuations() {
     synchronized (lock) {
+      Assertions.assertNotNull(continuations);
       for (Continuation<TResult, ?> continuation : continuations) {
         try {
           continuation.then(this);
@@ -495,7 +501,7 @@ public class Task<TResult> implements TaskInterface<TResult> {
           throw new RuntimeException(e);
         }
       }
-      // NULLSAFE_FIXME[Field Not Nullable]
+      // only setting continuations to null in siutations where complete is set to true
       continuations = null;
     }
   }
@@ -515,7 +521,7 @@ public class Task<TResult> implements TaskInterface<TResult> {
   }
 
   /** Sets the result on the Task if the Task hasn't already been completed. */
-  /* package */ boolean trySetResult(TResult result) {
+  /* package */ boolean trySetResult(@Nullable TResult result) {
     synchronized (lock) {
       if (complete) {
         return false;
@@ -545,7 +551,6 @@ public class Task<TResult> implements TaskInterface<TResult> {
     }
   }
 
-  // NULLSAFE_FIXME[Parameter Not Nullable]
   private static Task<?> TASK_NULL = new Task<>(null);
   private static Task<Boolean> TASK_TRUE = new Task<>((Boolean) true);
   private static Task<Boolean> TASK_FALSE = new Task<>((Boolean) false);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/Task.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/Task.java
@@ -75,9 +75,12 @@ public class Task<TResult> implements TaskInterface<TResult> {
   private final Object lock = new Object();
   private boolean complete;
   private boolean cancelled;
+  // NULLSAFE_FIXME[Field Not Initialized]
   private TResult result;
+  // NULLSAFE_FIXME[Field Not Initialized]
   private Exception error;
   private boolean errorHasBeenObserved;
+  // NULLSAFE_FIXME[Field Not Initialized]
   private UnobservedErrorNotifier unobservedErrorNotifier;
   private List<Continuation<TResult, Void>> continuations = new ArrayList<>();
 
@@ -91,6 +94,7 @@ public class Task<TResult> implements TaskInterface<TResult> {
     if (cancelled) {
       trySetCancelled();
     } else {
+      // NULLSAFE_FIXME[Parameter Not Nullable]
       trySetResult(null);
     }
   }
@@ -151,6 +155,7 @@ public class Task<TResult> implements TaskInterface<TResult> {
         errorHasBeenObserved = true;
         if (unobservedErrorNotifier != null) {
           unobservedErrorNotifier.setObserved();
+          // NULLSAFE_FIXME[Field Not Nullable]
           unobservedErrorNotifier = null;
         }
       }
@@ -175,6 +180,7 @@ public class Task<TResult> implements TaskInterface<TResult> {
    *     false} otherwise.
    */
   @Override
+  // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
   public boolean waitForCompletion(long duration, TimeUnit timeUnit) throws InterruptedException {
     synchronized (lock) {
       if (!isCompleted()) {
@@ -489,6 +495,7 @@ public class Task<TResult> implements TaskInterface<TResult> {
           throw new RuntimeException(e);
         }
       }
+      // NULLSAFE_FIXME[Field Not Nullable]
       continuations = null;
     }
   }
@@ -538,6 +545,7 @@ public class Task<TResult> implements TaskInterface<TResult> {
     }
   }
 
+  // NULLSAFE_FIXME[Parameter Not Nullable]
   private static Task<?> TASK_NULL = new Task<>(null);
   private static Task<Boolean> TASK_TRUE = new Task<>((Boolean) true);
   private static Task<Boolean> TASK_FALSE = new Task<>((Boolean) false);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/TaskCompletionSource.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/TaskCompletionSource.kt
@@ -25,7 +25,7 @@ internal class TaskCompletionSource<TResult>() {
   fun trySetResult(result: TResult?): Boolean = task.trySetResult(result)
 
   /** Sets the error on the Task if the Task hasn't already been completed. */
-  fun trySetError(error: Exception?): Boolean = task.trySetError(error)
+  fun trySetError(error: Exception): Boolean = task.trySetError(error)
 
   /** Sets the cancelled flag on the task, throwing if the Task has already been completed. */
   fun setCancelled(): Unit {
@@ -42,7 +42,7 @@ internal class TaskCompletionSource<TResult>() {
   }
 
   /** Sets the error of the Task, throwing if the Task has already been completed. */
-  fun setError(error: Exception?): Unit {
+  fun setError(error: Exception): Unit {
     if (!trySetError(error)) {
       throw IllegalStateException("Cannot set the error on a completed task.")
     }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/dialog/DialogModuleTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/dialog/DialogModuleTest.kt
@@ -67,7 +67,7 @@ class DialogModuleTest {
           putBoolean("cancelable", false)
         }
 
-    dialogModule.showAlert(options, null, null)
+    dialogModule.showAlert(options, SimpleCallback(), SimpleCallback())
     shadowOf(getMainLooper()).idle()
 
     val fragment = getFragment()
@@ -85,14 +85,16 @@ class DialogModuleTest {
   fun testCallbackPositive() {
     val options = JavaOnlyMap().apply { putString("buttonPositive", "OK") }
 
+    val errorCallback = SimpleCallback()
     val actionCallback = SimpleCallback()
-    dialogModule.showAlert(options, null, actionCallback)
+    dialogModule.showAlert(options, errorCallback, actionCallback)
     shadowOf(getMainLooper()).idle()
 
     val dialog = getFragment().dialog as AlertDialog
     dialog.getButton(DialogInterface.BUTTON_POSITIVE).performClick()
     shadowOf(getMainLooper()).idle()
 
+    assertThat(errorCallback.calls).isEqualTo(0)
     assertThat(actionCallback.calls).isEqualTo(1)
     assertThat(actionCallback.args?.get(0)).isEqualTo(DialogModule.ACTION_BUTTON_CLICKED)
     assertThat(actionCallback.args?.get(1)).isEqualTo(DialogInterface.BUTTON_POSITIVE)
@@ -102,14 +104,16 @@ class DialogModuleTest {
   fun testCallbackNegative() {
     val options = JavaOnlyMap().apply { putString("buttonNegative", "Cancel") }
 
+    val errorCallback = SimpleCallback()
     val actionCallback = SimpleCallback()
-    dialogModule.showAlert(options, null, actionCallback)
+    dialogModule.showAlert(options, errorCallback, actionCallback)
     shadowOf(getMainLooper()).idle()
 
     val dialog = getFragment().dialog as AlertDialog
     dialog.getButton(DialogInterface.BUTTON_NEGATIVE).performClick()
     shadowOf(getMainLooper()).idle()
 
+    assertThat(errorCallback.calls).isEqualTo(0)
     assertThat(actionCallback.calls).isEqualTo(1)
     assertThat(actionCallback.args?.get(0)).isEqualTo(DialogModule.ACTION_BUTTON_CLICKED)
     assertThat(actionCallback.args?.get(1)).isEqualTo(DialogInterface.BUTTON_NEGATIVE)
@@ -119,14 +123,16 @@ class DialogModuleTest {
   fun testCallbackNeutral() {
     val options = JavaOnlyMap().apply { putString("buttonNeutral", "Later") }
 
+    val errorCallback = SimpleCallback()
     val actionCallback = SimpleCallback()
-    dialogModule.showAlert(options, null, actionCallback)
+    dialogModule.showAlert(options, errorCallback, actionCallback)
     shadowOf(getMainLooper()).idle()
 
     val dialog = getFragment().dialog as AlertDialog
     dialog.getButton(DialogInterface.BUTTON_NEUTRAL).performClick()
     shadowOf(getMainLooper()).idle()
 
+    assertThat(errorCallback.calls).isEqualTo(0)
     assertThat(actionCallback.calls).isEqualTo(1)
     assertThat(actionCallback.args?.get(0)).isEqualTo(DialogModule.ACTION_BUTTON_CLICKED)
     assertThat(actionCallback.args?.get(1)).isEqualTo(DialogInterface.BUTTON_NEUTRAL)
@@ -136,13 +142,15 @@ class DialogModuleTest {
   fun testCallbackDismiss() {
     val options = JavaOnlyMap()
 
+    val errorCallback = SimpleCallback()
     val actionCallback = SimpleCallback()
-    dialogModule.showAlert(options, null, actionCallback)
+    dialogModule.showAlert(options, errorCallback, actionCallback)
     shadowOf(getMainLooper()).idle()
 
     getFragment().dialog?.dismiss()
     shadowOf(getMainLooper()).idle()
 
+    assertThat(errorCallback.calls).isEqualTo(0)
     assertThat(actionCallback.calls).isEqualTo(1)
     assertThat(actionCallback.args?.get(0)).isEqualTo(DialogModule.ACTION_DISMISSED)
   }
@@ -153,13 +161,15 @@ class DialogModuleTest {
 
     val options = JavaOnlyMap()
 
+    val errorCallback = SimpleCallback()
     val actionCallback = SimpleCallback()
-    dialogModule.showAlert(options, null, actionCallback)
+    dialogModule.showAlert(options, errorCallback, actionCallback)
     shadowOf(getMainLooper()).idle()
 
     getFragment().dialog?.dismiss()
     shadowOf(getMainLooper()).idle()
 
+    assertThat(errorCallback.calls).isEqualTo(0)
     assertThat(actionCallback.calls).isEqualTo(1)
     assertThat(actionCallback.args?.get(0)).isEqualTo(DialogModule.ACTION_DISMISSED)
   }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/fakes/FakeUIManager.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/fakes/FakeUIManager.kt
@@ -30,14 +30,14 @@ class FakeUIManager : UIManager, UIBlockViewResolver {
   }
 
   @Deprecated("")
-  override fun <T : View?> addRootView(rootView: T, initialProps: WritableMap?): Int {
+  override fun <T : View?> addRootView(rootView: T, initialProps: WritableMap): Int {
     error("Not yet implemented")
   }
 
   override fun <T : View?> startSurface(
       rootView: T,
       moduleName: String,
-      initialProps: WritableMap?,
+      initialProps: WritableMap,
       widthMeasureSpec: Int,
       heightMeasureSpec: Int
   ): Int {
@@ -69,7 +69,7 @@ class FakeUIManager : UIManager, UIBlockViewResolver {
   override val eventDispatcher: EventDispatcher
     get() = TODO("Not yet implemented")
 
-  override fun synchronouslyUpdateViewOnUIThread(reactTag: Int, props: ReadableMap?) {
+  override fun synchronouslyUpdateViewOnUIThread(reactTag: Int, props: ReadableMap) {
     error("Not yet implemented")
   }
 
@@ -77,11 +77,11 @@ class FakeUIManager : UIManager, UIBlockViewResolver {
     error("Not yet implemented")
   }
 
-  override fun addUIManagerEventListener(listener: UIManagerListener?) {
+  override fun addUIManagerEventListener(listener: UIManagerListener) {
     error("Not yet implemented")
   }
 
-  override fun removeUIManagerEventListener(listener: UIManagerListener?) {
+  override fun removeUIManagerEventListener(listener: UIManagerListener) {
     error("Not yet implemented")
   }
 


### PR DESCRIPTION
Summary:
Gone trough all the FIXMEs added in the previous diff by the nullsafe tool, marked the class as nullsafe and ensured no remaining violations.
Changelog: [Android][Fixed] Made FabricUIManager.java nullsafe

Differential Revision: D71979601
