### PR TITLE
Fix nullsafe FIXMEs for BlobModule.java and mark nullsafe

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleInteropUtils.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleInteropUtils.java
@@ -8,6 +8,8 @@
 package com.facebook.react.internal.turbomodule.core;
 
 import androidx.annotation.Nullable;
+import com.facebook.infer.annotation.Assertions;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.Dynamic;
@@ -26,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+@Nullsafe(Nullsafe.Mode.LOCAL)
 class TurboModuleInteropUtils {
 
   static class MethodDescriptor {
@@ -117,14 +120,12 @@ class TurboModuleInteropUtils {
     Class<? extends NativeModule> classForMethods = module.getClass();
     Class<? extends NativeModule> superClass =
         (Class<? extends NativeModule>) classForMethods.getSuperclass();
-    // NULLSAFE_FIXME[Parameter Not Nullable]
-    if (TurboModule.class.isAssignableFrom(superClass)) {
+    if (superClass != null && TurboModule.class.isAssignableFrom(superClass)) {
       // For java module that is based on generated flow-type spec, inspect the
       // spec abstract class instead, which is the super class of the given java
       // module.
       classForMethods = superClass;
     }
-    // NULLSAFE_FIXME[Nullable Dereference]
     return classForMethods.getDeclaredMethods();
   }
 
@@ -218,8 +219,9 @@ class TurboModuleInteropUtils {
   }
 
   private static String convertClassToJniType(Class<?> cls) {
-    // NULLSAFE_FIXME[Nullable Dereference]
-    return 'L' + cls.getCanonicalName().replace('.', '/') + ';';
+    String canonicalName = cls.getCanonicalName();
+    Assertions.assertNotNull(canonicalName, "Class must have a canonical name");
+    return 'L' + canonicalName.replace('.', '/') + ';';
   }
 
   private static int getJsArgCount(String moduleName, String methodName, Class<?>[] paramClasses) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleInteropUtils.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleInteropUtils.java
@@ -94,7 +94,9 @@ class TurboModuleInteropUtils {
         if (returnType != Map.class) {
           // TODO(T145105887) Output error. getConstants must always have a return type of Map
         }
+        // NULLSAFE_FIXME[Nullable Dereference]
       } else if (annotation.isBlockingSynchronousMethod() && returnType == void.class
+          // NULLSAFE_FIXME[Nullable Dereference]
           || !annotation.isBlockingSynchronousMethod() && returnType != void.class) {
         // TODO(T145105887): Output error. TurboModule system assumes returnType == void iff the
         // method is synchronous.
@@ -115,12 +117,14 @@ class TurboModuleInteropUtils {
     Class<? extends NativeModule> classForMethods = module.getClass();
     Class<? extends NativeModule> superClass =
         (Class<? extends NativeModule>) classForMethods.getSuperclass();
+    // NULLSAFE_FIXME[Parameter Not Nullable]
     if (TurboModule.class.isAssignableFrom(superClass)) {
       // For java module that is based on generated flow-type spec, inspect the
       // spec abstract class instead, which is the super class of the given java
       // module.
       classForMethods = superClass;
     }
+    // NULLSAFE_FIXME[Nullable Dereference]
     return classForMethods.getDeclaredMethods();
   }
 
@@ -214,6 +218,7 @@ class TurboModuleInteropUtils {
   }
 
   private static String convertClassToJniType(Class<?> cls) {
+    // NULLSAFE_FIXME[Nullable Dereference]
     return 'L' + cls.getCanonicalName().replace('.', '/') + ';';
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleInteropUtils.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleInteropUtils.java
@@ -92,14 +92,14 @@ class TurboModuleInteropUtils {
 
       if ("getConstants".equals(methodName)) {
         if (returnType != Map.class) {
-          // TODO(T145105887) Output error. getConstants must always have a return type of Map
+          throw new ParsingException(moduleName, "getConstants must return a Map");
         }
-        // NULLSAFE_FIXME[Nullable Dereference]
-      } else if (annotation.isBlockingSynchronousMethod() && returnType == void.class
-          // NULLSAFE_FIXME[Nullable Dereference]
-          || !annotation.isBlockingSynchronousMethod() && returnType != void.class) {
-        // TODO(T145105887): Output error. TurboModule system assumes returnType == void iff the
-        // method is synchronous.
+      } else if (annotation != null
+          && (annotation.isBlockingSynchronousMethod() && returnType == void.class
+              || !annotation.isBlockingSynchronousMethod() && returnType != void.class)) {
+        throw new ParsingException(
+            moduleName,
+            "TurboModule system assumes returnType == void iff the method is synchronous.");
       }
 
       methodDescriptors.add(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleManager.java
@@ -8,10 +8,10 @@
 package com.facebook.react.internal.turbomodule.core;
 
 import androidx.annotation.GuardedBy;
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.CxxModuleWrapper;
@@ -36,13 +36,14 @@ import java.util.Map;
  * has a C++ counterpart This class installs the JSI bindings. It also implements the method to get
  * a Java module, that the C++ counterpart calls.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class TurboModuleManager implements TurboModuleRegistry {
   private static final String TAG = "TurboModuleManager";
 
   private final List<String> mEagerInitModuleNames;
   private final ModuleProvider mTurboModuleProvider;
   private final ModuleProvider mLegacyModuleProvider;
-  private final TurboModuleManagerDelegate mDelegate;
+  private final @Nullable TurboModuleManagerDelegate mDelegate;
 
   static {
     SoLoader.loadLibrary("turbomodulejsijni");
@@ -67,14 +68,12 @@ public class TurboModuleManager implements TurboModuleRegistry {
       @Nullable final TurboModuleManagerDelegate delegate,
       CallInvokerHolder jsCallInvokerHolder,
       NativeMethodCallInvokerHolder nativeMethodCallInvokerHolder) {
-    // NULLSAFE_FIXME[Field Not Nullable]
     mDelegate = delegate;
     mHybridData =
         initHybrid(
             runtimeExecutor,
             (CallInvokerHolderImpl) jsCallInvokerHolder,
             (NativeMethodCallInvokerHolderImpl) nativeMethodCallInvokerHolder,
-            // NULLSAFE_FIXME[Parameter Not Nullable]
             delegate);
     installJSIBindings(shouldEnableLegacyModuleInterop());
 
@@ -117,7 +116,6 @@ public class TurboModuleManager implements TurboModuleRegistry {
   }
 
   @Override
-  @NonNull
   public List<String> getEagerInitModuleNames() {
     return mEagerInitModuleNames;
   }
@@ -242,16 +240,17 @@ public class TurboModuleManager implements TurboModuleRegistry {
       moduleHolder = mModuleHolders.get(moduleName);
     }
 
-    // NULLSAFE_FIXME[Nullable Dereference]
+    if (moduleHolder == null) {
+      FLog.e(TAG, "getModule(): Tried to get module \"%s\", but moduleHolder was null", moduleName);
+      return null;
+    }
+
     TurboModulePerfLogger.moduleCreateStart(moduleName, moduleHolder.getModuleId());
-    // NULLSAFE_FIXME[Parameter Not Nullable]
     NativeModule module = getOrCreateModule(moduleName, moduleHolder, true);
 
     if (module != null) {
-      // NULLSAFE_FIXME[Nullable Dereference]
       TurboModulePerfLogger.moduleCreateEnd(moduleName, moduleHolder.getModuleId());
     } else {
-      // NULLSAFE_FIXME[Nullable Dereference]
       TurboModulePerfLogger.moduleCreateFail(moduleName, moduleHolder.getModuleId());
     }
 
@@ -266,7 +265,7 @@ public class TurboModuleManager implements TurboModuleRegistry {
    */
   @Nullable
   private NativeModule getOrCreateModule(
-      String moduleName, @NonNull ModuleHolder moduleHolder, boolean shouldPerfLog) {
+      String moduleName, ModuleHolder moduleHolder, boolean shouldPerfLog) {
     boolean shouldCreateModule = false;
 
     synchronized (moduleHolder) {
@@ -390,7 +389,7 @@ public class TurboModuleManager implements TurboModuleRegistry {
       RuntimeExecutor runtimeExecutor,
       CallInvokerHolderImpl jsCallInvokerHolder,
       NativeMethodCallInvokerHolderImpl nativeMethodCallInvoker,
-      TurboModuleManagerDelegate tmmDelegate);
+      @Nullable TurboModuleManagerDelegate tmmDelegate);
 
   private native void installJSIBindings(boolean shouldCreateLegacyModules);
 
@@ -432,8 +431,7 @@ public class TurboModuleManager implements TurboModuleRegistry {
   }
 
   private static class ModuleHolder {
-    // NULLSAFE_FIXME[Field Not Nullable]
-    private volatile NativeModule mModule = null;
+    private volatile @Nullable NativeModule mModule = null;
     private volatile boolean mIsTryingToCreate = false;
     private volatile boolean mIsDoneCreatingModule = false;
     private static volatile int sHolderCount = 0;
@@ -448,7 +446,7 @@ public class TurboModuleManager implements TurboModuleRegistry {
       return mModuleId;
     }
 
-    void setModule(@NonNull NativeModule module) {
+    void setModule(NativeModule module) {
       mModule = module;
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleManager.java
@@ -67,12 +67,14 @@ public class TurboModuleManager implements TurboModuleRegistry {
       @Nullable final TurboModuleManagerDelegate delegate,
       CallInvokerHolder jsCallInvokerHolder,
       NativeMethodCallInvokerHolder nativeMethodCallInvokerHolder) {
+    // NULLSAFE_FIXME[Field Not Nullable]
     mDelegate = delegate;
     mHybridData =
         initHybrid(
             runtimeExecutor,
             (CallInvokerHolderImpl) jsCallInvokerHolder,
             (NativeMethodCallInvokerHolderImpl) nativeMethodCallInvokerHolder,
+            // NULLSAFE_FIXME[Parameter Not Nullable]
             delegate);
     installJSIBindings(shouldEnableLegacyModuleInterop());
 
@@ -240,12 +242,16 @@ public class TurboModuleManager implements TurboModuleRegistry {
       moduleHolder = mModuleHolders.get(moduleName);
     }
 
+    // NULLSAFE_FIXME[Nullable Dereference]
     TurboModulePerfLogger.moduleCreateStart(moduleName, moduleHolder.getModuleId());
+    // NULLSAFE_FIXME[Parameter Not Nullable]
     NativeModule module = getOrCreateModule(moduleName, moduleHolder, true);
 
     if (module != null) {
+      // NULLSAFE_FIXME[Nullable Dereference]
       TurboModulePerfLogger.moduleCreateEnd(moduleName, moduleHolder.getModuleId());
     } else {
+      // NULLSAFE_FIXME[Nullable Dereference]
       TurboModulePerfLogger.moduleCreateFail(moduleName, moduleHolder.getModuleId());
     }
 
@@ -426,6 +432,7 @@ public class TurboModuleManager implements TurboModuleRegistry {
   }
 
   private static class ModuleHolder {
+    // NULLSAFE_FIXME[Field Not Nullable]
     private volatile NativeModule mModule = null;
     private volatile boolean mIsTryingToCreate = false;
     private volatile boolean mIsDoneCreatingModule = false;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobModule.java
@@ -106,6 +106,7 @@ public class BlobModule extends NativeBlobModuleSpec {
         @Override
         public RequestBody toRequestBody(ReadableMap data, String contentType) {
           String type = contentType;
+          // NULLSAFE_FIXME[Nullable Dereference]
           if (data.hasKey("type") && !data.getString("type").isEmpty()) {
             type = data.getString("type");
           }
@@ -113,7 +114,9 @@ public class BlobModule extends NativeBlobModuleSpec {
             type = "application/octet-stream";
           }
           ReadableMap blob = data.getMap("blob");
+          // NULLSAFE_FIXME[Nullable Dereference]
           String blobId = blob.getString("blobId");
+          // NULLSAFE_FIXME[Parameter Not Nullable, Nullable Dereference]
           byte[] bytes = resolve(blobId, blob.getInt("offset"), blob.getInt("size"));
 
           return RequestBody.create(MediaType.parse(type), bytes);
@@ -148,6 +151,7 @@ public class BlobModule extends NativeBlobModuleSpec {
   }
 
   @Override
+  // NULLSAFE_FIXME[Inconsistent Subclass Return Annotation]
   public @Nullable Map<String, Object> getTypedExportedConstants() {
     // The application can register BlobProvider as a ContentProvider so that blobs are resolvable.
     // If it does, it needs to tell us what authority was used via this string resource.
@@ -201,6 +205,7 @@ public class BlobModule extends NativeBlobModuleSpec {
     if (sizeParam != null) {
       size = Integer.parseInt(sizeParam, 10);
     }
+    // NULLSAFE_FIXME[Parameter Not Nullable]
     return resolve(blobId, offset, size);
   }
 
@@ -221,6 +226,7 @@ public class BlobModule extends NativeBlobModuleSpec {
   }
 
   public @Nullable byte[] resolve(ReadableMap blob) {
+    // NULLSAFE_FIXME[Parameter Not Nullable]
     return resolve(blob.getString("blobId"), blob.getInt("offset"), blob.getInt("size"));
   }
 
@@ -269,6 +275,7 @@ public class BlobModule extends NativeBlobModuleSpec {
 
   private String getNameFromUri(Uri contentUri) {
     if ("file".equals(contentUri.getScheme())) {
+      // NULLSAFE_FIXME[Return Not Nullable]
       return contentUri.getLastPathSegment();
     }
     String[] projection = {MediaStore.MediaColumns.DISPLAY_NAME};
@@ -279,12 +286,14 @@ public class BlobModule extends NativeBlobModuleSpec {
     if (metaCursor != null) {
       try {
         if (metaCursor.moveToFirst()) {
+          // NULLSAFE_FIXME[Return Not Nullable]
           return metaCursor.getString(0);
         }
       } finally {
         metaCursor.close();
       }
     }
+    // NULLSAFE_FIXME[Return Not Nullable]
     return contentUri.getLastPathSegment();
   }
 
@@ -316,9 +325,11 @@ public class BlobModule extends NativeBlobModuleSpec {
     ReactApplicationContext reactApplicationContext = getReactApplicationContextIfActiveOrWarn();
 
     if (reactApplicationContext != null) {
+      // NULLSAFE_FIXME[Return Not Nullable]
       return reactApplicationContext.getNativeModule(WebSocketModule.class);
     }
 
+    // NULLSAFE_FIXME[Return Not Nullable]
     return null;
   }
 
@@ -329,8 +340,11 @@ public class BlobModule extends NativeBlobModuleSpec {
     if (reactApplicationContext != null) {
       NetworkingModule networkingModule =
           reactApplicationContext.getNativeModule(NetworkingModule.class);
+      // NULLSAFE_FIXME[Nullable Dereference]
       networkingModule.addUriHandler(mNetworkingUriHandler);
+      // NULLSAFE_FIXME[Nullable Dereference]
       networkingModule.addRequestBodyHandler(mNetworkingRequestBodyHandler);
+      // NULLSAFE_FIXME[Nullable Dereference]
       networkingModule.addResponseHandler(mNetworkingResponseHandler);
     }
   }
@@ -364,11 +378,13 @@ public class BlobModule extends NativeBlobModuleSpec {
     WebSocketModule webSocketModule = getWebSocketModule("sendOverSocket");
 
     if (webSocketModule != null) {
+      // NULLSAFE_FIXME[Parameter Not Nullable]
       byte[] data = resolve(blob.getString("blobId"), blob.getInt("offset"), blob.getInt("size"));
 
       if (data != null) {
         webSocketModule.sendBinary(ByteString.of(data), id);
       } else {
+        // NULLSAFE_FIXME[Parameter Not Nullable]
         webSocketModule.sendBinary((ByteString) null, id);
       }
     }
@@ -380,18 +396,24 @@ public class BlobModule extends NativeBlobModuleSpec {
     ArrayList<byte[]> partList = new ArrayList<>(parts.size());
     for (int i = 0; i < parts.size(); i++) {
       ReadableMap part = parts.getMap(i);
+      // NULLSAFE_FIXME[Nullable Dereference]
       switch (part.getString("type")) {
         case "blob":
+          // NULLSAFE_FIXME[Nullable Dereference]
           ReadableMap blob = part.getMap("data");
+          // NULLSAFE_FIXME[Nullable Dereference]
           totalBlobSize += blob.getInt("size");
+          // NULLSAFE_FIXME[Parameter Not Nullable]
           partList.add(i, resolve(blob));
           break;
         case "string":
+          // NULLSAFE_FIXME[Nullable Dereference]
           byte[] bytes = part.getString("data").getBytes(Charset.forName("UTF-8"));
           totalBlobSize += bytes.length;
           partList.add(i, bytes);
           break;
         default:
+          // NULLSAFE_FIXME[Nullable Dereference]
           throw new IllegalArgumentException("Invalid type for blob: " + part.getString("type"));
       }
     }


### PR DESCRIPTION
Summary:
Gone trough all the FIXMEs added in the previous diff by the nullsafe tool, marked the class as nullsafe and ensured no remaining violations.
Changelog: [Android][Fixed] Made BlobModule.java nullsafe

Differential Revision: D71979598
