### PR TITLE
Fix nullsafe FIXMEs for TurboModuleManager and mark nullsafe

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleInteropUtils.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleInteropUtils.java
@@ -8,6 +8,8 @@
 package com.facebook.react.internal.turbomodule.core;
 
 import androidx.annotation.Nullable;
+import com.facebook.infer.annotation.Assertions;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.Dynamic;
@@ -26,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+@Nullsafe(Nullsafe.Mode.LOCAL)
 class TurboModuleInteropUtils {
 
   static class MethodDescriptor {
@@ -117,14 +120,12 @@ class TurboModuleInteropUtils {
     Class<? extends NativeModule> classForMethods = module.getClass();
     Class<? extends NativeModule> superClass =
         (Class<? extends NativeModule>) classForMethods.getSuperclass();
-    // NULLSAFE_FIXME[Parameter Not Nullable]
-    if (TurboModule.class.isAssignableFrom(superClass)) {
+    if (superClass != null && TurboModule.class.isAssignableFrom(superClass)) {
       // For java module that is based on generated flow-type spec, inspect the
       // spec abstract class instead, which is the super class of the given java
       // module.
       classForMethods = superClass;
     }
-    // NULLSAFE_FIXME[Nullable Dereference]
     return classForMethods.getDeclaredMethods();
   }
 
@@ -218,8 +219,9 @@ class TurboModuleInteropUtils {
   }
 
   private static String convertClassToJniType(Class<?> cls) {
-    // NULLSAFE_FIXME[Nullable Dereference]
-    return 'L' + cls.getCanonicalName().replace('.', '/') + ';';
+    String canonicalName = cls.getCanonicalName();
+    Assertions.assertNotNull(canonicalName, "Class must have a canonical name");
+    return 'L' + canonicalName.replace('.', '/') + ';';
   }
 
   private static int getJsArgCount(String moduleName, String methodName, Class<?>[] paramClasses) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleInteropUtils.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleInteropUtils.java
@@ -94,7 +94,9 @@ class TurboModuleInteropUtils {
         if (returnType != Map.class) {
           // TODO(T145105887) Output error. getConstants must always have a return type of Map
         }
+        // NULLSAFE_FIXME[Nullable Dereference]
       } else if (annotation.isBlockingSynchronousMethod() && returnType == void.class
+          // NULLSAFE_FIXME[Nullable Dereference]
           || !annotation.isBlockingSynchronousMethod() && returnType != void.class) {
         // TODO(T145105887): Output error. TurboModule system assumes returnType == void iff the
         // method is synchronous.
@@ -115,12 +117,14 @@ class TurboModuleInteropUtils {
     Class<? extends NativeModule> classForMethods = module.getClass();
     Class<? extends NativeModule> superClass =
         (Class<? extends NativeModule>) classForMethods.getSuperclass();
+    // NULLSAFE_FIXME[Parameter Not Nullable]
     if (TurboModule.class.isAssignableFrom(superClass)) {
       // For java module that is based on generated flow-type spec, inspect the
       // spec abstract class instead, which is the super class of the given java
       // module.
       classForMethods = superClass;
     }
+    // NULLSAFE_FIXME[Nullable Dereference]
     return classForMethods.getDeclaredMethods();
   }
 
@@ -214,6 +218,7 @@ class TurboModuleInteropUtils {
   }
 
   private static String convertClassToJniType(Class<?> cls) {
+    // NULLSAFE_FIXME[Nullable Dereference]
     return 'L' + cls.getCanonicalName().replace('.', '/') + ';';
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleInteropUtils.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleInteropUtils.java
@@ -92,14 +92,14 @@ class TurboModuleInteropUtils {
 
       if ("getConstants".equals(methodName)) {
         if (returnType != Map.class) {
-          // TODO(T145105887) Output error. getConstants must always have a return type of Map
+          throw new ParsingException(moduleName, "getConstants must return a Map");
         }
-        // NULLSAFE_FIXME[Nullable Dereference]
-      } else if (annotation.isBlockingSynchronousMethod() && returnType == void.class
-          // NULLSAFE_FIXME[Nullable Dereference]
-          || !annotation.isBlockingSynchronousMethod() && returnType != void.class) {
-        // TODO(T145105887): Output error. TurboModule system assumes returnType == void iff the
-        // method is synchronous.
+      } else if (annotation != null
+          && (annotation.isBlockingSynchronousMethod() && returnType == void.class
+              || !annotation.isBlockingSynchronousMethod() && returnType != void.class)) {
+        throw new ParsingException(
+            moduleName,
+            "TurboModule system assumes returnType == void iff the method is synchronous.");
       }
 
       methodDescriptors.add(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleManager.java
@@ -8,10 +8,10 @@
 package com.facebook.react.internal.turbomodule.core;
 
 import androidx.annotation.GuardedBy;
-import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
+import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.jni.HybridData;
 import com.facebook.proguard.annotations.DoNotStrip;
 import com.facebook.react.bridge.CxxModuleWrapper;
@@ -36,13 +36,14 @@ import java.util.Map;
  * has a C++ counterpart This class installs the JSI bindings. It also implements the method to get
  * a Java module, that the C++ counterpart calls.
  */
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class TurboModuleManager implements TurboModuleRegistry {
   private static final String TAG = "TurboModuleManager";
 
   private final List<String> mEagerInitModuleNames;
   private final ModuleProvider mTurboModuleProvider;
   private final ModuleProvider mLegacyModuleProvider;
-  private final TurboModuleManagerDelegate mDelegate;
+  private final @Nullable TurboModuleManagerDelegate mDelegate;
 
   static {
     SoLoader.loadLibrary("turbomodulejsijni");
@@ -67,14 +68,12 @@ public class TurboModuleManager implements TurboModuleRegistry {
       @Nullable final TurboModuleManagerDelegate delegate,
       CallInvokerHolder jsCallInvokerHolder,
       NativeMethodCallInvokerHolder nativeMethodCallInvokerHolder) {
-    // NULLSAFE_FIXME[Field Not Nullable]
     mDelegate = delegate;
     mHybridData =
         initHybrid(
             runtimeExecutor,
             (CallInvokerHolderImpl) jsCallInvokerHolder,
             (NativeMethodCallInvokerHolderImpl) nativeMethodCallInvokerHolder,
-            // NULLSAFE_FIXME[Parameter Not Nullable]
             delegate);
     installJSIBindings(shouldEnableLegacyModuleInterop());
 
@@ -117,7 +116,6 @@ public class TurboModuleManager implements TurboModuleRegistry {
   }
 
   @Override
-  @NonNull
   public List<String> getEagerInitModuleNames() {
     return mEagerInitModuleNames;
   }
@@ -242,16 +240,17 @@ public class TurboModuleManager implements TurboModuleRegistry {
       moduleHolder = mModuleHolders.get(moduleName);
     }
 
-    // NULLSAFE_FIXME[Nullable Dereference]
+    if (moduleHolder == null) {
+      FLog.e(TAG, "getModule(): Tried to get module \"%s\", but moduleHolder was null", moduleName);
+      return null;
+    }
+
     TurboModulePerfLogger.moduleCreateStart(moduleName, moduleHolder.getModuleId());
-    // NULLSAFE_FIXME[Parameter Not Nullable]
     NativeModule module = getOrCreateModule(moduleName, moduleHolder, true);
 
     if (module != null) {
-      // NULLSAFE_FIXME[Nullable Dereference]
       TurboModulePerfLogger.moduleCreateEnd(moduleName, moduleHolder.getModuleId());
     } else {
-      // NULLSAFE_FIXME[Nullable Dereference]
       TurboModulePerfLogger.moduleCreateFail(moduleName, moduleHolder.getModuleId());
     }
 
@@ -266,7 +265,7 @@ public class TurboModuleManager implements TurboModuleRegistry {
    */
   @Nullable
   private NativeModule getOrCreateModule(
-      String moduleName, @NonNull ModuleHolder moduleHolder, boolean shouldPerfLog) {
+      String moduleName, ModuleHolder moduleHolder, boolean shouldPerfLog) {
     boolean shouldCreateModule = false;
 
     synchronized (moduleHolder) {
@@ -390,7 +389,7 @@ public class TurboModuleManager implements TurboModuleRegistry {
       RuntimeExecutor runtimeExecutor,
       CallInvokerHolderImpl jsCallInvokerHolder,
       NativeMethodCallInvokerHolderImpl nativeMethodCallInvoker,
-      TurboModuleManagerDelegate tmmDelegate);
+      @Nullable TurboModuleManagerDelegate tmmDelegate);
 
   private native void installJSIBindings(boolean shouldCreateLegacyModules);
 
@@ -432,8 +431,7 @@ public class TurboModuleManager implements TurboModuleRegistry {
   }
 
   private static class ModuleHolder {
-    // NULLSAFE_FIXME[Field Not Nullable]
-    private volatile NativeModule mModule = null;
+    private volatile @Nullable NativeModule mModule = null;
     private volatile boolean mIsTryingToCreate = false;
     private volatile boolean mIsDoneCreatingModule = false;
     private static volatile int sHolderCount = 0;
@@ -448,7 +446,7 @@ public class TurboModuleManager implements TurboModuleRegistry {
       return mModuleId;
     }
 
-    void setModule(@NonNull NativeModule module) {
+    void setModule(NativeModule module) {
       mModule = module;
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleManager.java
@@ -67,12 +67,14 @@ public class TurboModuleManager implements TurboModuleRegistry {
       @Nullable final TurboModuleManagerDelegate delegate,
       CallInvokerHolder jsCallInvokerHolder,
       NativeMethodCallInvokerHolder nativeMethodCallInvokerHolder) {
+    // NULLSAFE_FIXME[Field Not Nullable]
     mDelegate = delegate;
     mHybridData =
         initHybrid(
             runtimeExecutor,
             (CallInvokerHolderImpl) jsCallInvokerHolder,
             (NativeMethodCallInvokerHolderImpl) nativeMethodCallInvokerHolder,
+            // NULLSAFE_FIXME[Parameter Not Nullable]
             delegate);
     installJSIBindings(shouldEnableLegacyModuleInterop());
 
@@ -240,12 +242,16 @@ public class TurboModuleManager implements TurboModuleRegistry {
       moduleHolder = mModuleHolders.get(moduleName);
     }
 
+    // NULLSAFE_FIXME[Nullable Dereference]
     TurboModulePerfLogger.moduleCreateStart(moduleName, moduleHolder.getModuleId());
+    // NULLSAFE_FIXME[Parameter Not Nullable]
     NativeModule module = getOrCreateModule(moduleName, moduleHolder, true);
 
     if (module != null) {
+      // NULLSAFE_FIXME[Nullable Dereference]
       TurboModulePerfLogger.moduleCreateEnd(moduleName, moduleHolder.getModuleId());
     } else {
+      // NULLSAFE_FIXME[Nullable Dereference]
       TurboModulePerfLogger.moduleCreateFail(moduleName, moduleHolder.getModuleId());
     }
 
@@ -426,6 +432,7 @@ public class TurboModuleManager implements TurboModuleRegistry {
   }
 
   private static class ModuleHolder {
+    // NULLSAFE_FIXME[Field Not Nullable]
     private volatile NativeModule mModule = null;
     private volatile boolean mIsTryingToCreate = false;
     private volatile boolean mIsDoneCreatingModule = false;


### PR DESCRIPTION
Summary:
Gone trough all the FIXMEs added in the previous diff by the nullsafe tool, marked the class as nullsafe and ensured no remaining violations.
Changelog: [Android][Fixed] Made TurboModuleManager.java nullsafe

Differential Revision: D71979605
