### PR TITLE
Make module registry instance scoped

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
@@ -122,8 +122,6 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
 
   std::vector<__weak RCTFabricSurface *> _attachedSurfaces;
 
-  RCTModuleRegistry *_moduleRegistry;
-
   std::unique_ptr<RCTHostHostTargetDelegate> _inspectorHostDelegate;
   std::shared_ptr<jsinspector_modern::HostTarget> _inspectorTarget;
   std::optional<int> _inspectorPageId;
@@ -164,7 +162,6 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
     _hostDelegate = hostDelegate;
     _turboModuleManagerDelegate = turboModuleManagerDelegate;
     _bundleManager = [RCTBundleManager new];
-    _moduleRegistry = [RCTModuleRegistry new];
     _jsEngineProvider = [jsEngineProvider copy];
     _launchOptions = [launchOptions copy];
 
@@ -244,7 +241,6 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
                                    jsRuntimeFactory:[self _provideJSEngine]
                                       bundleManager:_bundleManager
                          turboModuleManagerDelegate:_turboModuleManagerDelegate
-                                     moduleRegistry:_moduleRegistry
                               parentInspectorTarget:_inspectorTarget.get()
                                       launchOptions:_launchOptions];
   [_hostDelegate hostDidStart:self];
@@ -273,7 +269,7 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
 
 - (RCTModuleRegistry *)moduleRegistry
 {
-  return _moduleRegistry;
+  return [_instance moduleRegistry];
 }
 
 - (RCTSurfacePresenter *)surfacePresenter
@@ -447,7 +443,6 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
                                    jsRuntimeFactory:[self _provideJSEngine]
                                       bundleManager:_bundleManager
                          turboModuleManagerDelegate:_turboModuleManagerDelegate
-                                     moduleRegistry:_moduleRegistry
                               parentInspectorTarget:_inspectorTarget.get()
                                       launchOptions:_launchOptions];
   [_hostDelegate hostDidStart:self];

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.h
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.h
@@ -69,7 +69,6 @@ RCT_EXTERN void RCTInstanceSetRuntimeDiagnosticFlags(NSString *_Nullable flags);
                 jsRuntimeFactory:(std::shared_ptr<facebook::react::JSRuntimeFactory>)jsRuntimeFactory
                    bundleManager:(RCTBundleManager *)bundleManager
       turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)turboModuleManagerDelegate
-                  moduleRegistry:(RCTModuleRegistry *)moduleRegistry
            parentInspectorTarget:(facebook::react::jsinspector_modern::HostTarget *)parentInspectorTarget
                    launchOptions:(nullable NSDictionary *)launchOptions;
 
@@ -77,6 +76,7 @@ RCT_EXTERN void RCTInstanceSetRuntimeDiagnosticFlags(NSString *_Nullable flags);
 - (void)callFunctionOnBufferedRuntimeExecutor:(std::function<void(facebook::jsi::Runtime &runtime)> &&)executor;
 
 - (void)registerSegmentWithId:(NSNumber *)segmentId path:(NSString *)path;
+- (RCTModuleRegistry *)moduleRegistry;
 
 - (void)invalidate;
 

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -99,7 +99,6 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
                 jsRuntimeFactory:(std::shared_ptr<facebook::react::JSRuntimeFactory>)jsRuntimeFactory
                    bundleManager:(RCTBundleManager *)bundleManager
       turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)tmmDelegate
-                  moduleRegistry:(RCTModuleRegistry *)moduleRegistry
            parentInspectorTarget:(jsinspector_modern::HostTarget *)parentInspectorTarget
                    launchOptions:(nullable NSDictionary *)launchOptions
 {
@@ -113,7 +112,7 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
     _appTMMDelegate = tmmDelegate;
     _jsThreadManager = [RCTJSThreadManager new];
     _bridgeModuleDecorator = [[RCTBridgeModuleDecorator alloc] initWithViewRegistry:[RCTViewRegistry new]
-                                                                     moduleRegistry:moduleRegistry
+                                                                     moduleRegistry:[RCTModuleRegistry new]
                                                                       bundleManager:bundleManager
                                                                   callableJSModules:[RCTCallableJSModules new]];
     _parentInspectorTarget = parentInspectorTarget;
@@ -150,6 +149,11 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
                                                     name:UIApplicationDidReceiveMemoryWarningNotification
                                                   object:nil];
   }
+}
+
+- (RCTModuleRegistry *)moduleRegistry
+{
+  return _bridgeModuleDecorator.moduleRegistry;
 }
 
 - (void)callFunctionOnJSModule:(NSString *)moduleName method:(NSString *)method args:(NSArray *)args

--- a/packages/react-native/ReactCommon/react/test_utils/ios/Shims/ShimRCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/test_utils/ios/Shims/ShimRCTInstance.mm
@@ -23,8 +23,7 @@ static __weak ShimRCTInstance *weakShim = nil;
         [RCTInstance class],
         [ShimRCTInstance class],
         @selector(initWithDelegate:
-                  jsRuntimeFactory:bundleManager:turboModuleManagerDelegate:moduleRegistry:parentInspectorTarget
-                                  :launchOptions:));
+                  jsRuntimeFactory:bundleManager:turboModuleManagerDelegate:parentInspectorTarget:launchOptions:));
     RCTSwizzleInstanceSelector([RCTInstance class], [ShimRCTInstance class], @selector(invalidate));
     RCTSwizzleInstanceSelector(
         [RCTInstance class], [ShimRCTInstance class], @selector(callFunctionOnJSModule:method:args:));
@@ -39,8 +38,7 @@ static __weak ShimRCTInstance *weakShim = nil;
       [RCTInstance class],
       [ShimRCTInstance class],
       @selector(initWithDelegate:
-                jsRuntimeFactory:bundleManager:turboModuleManagerDelegate:moduleRegistry:parentInspectorTarget
-                                :launchOptions:));
+                jsRuntimeFactory:bundleManager:turboModuleManagerDelegate:parentInspectorTarget:launchOptions:));
   RCTSwizzleInstanceSelector([RCTInstance class], [ShimRCTInstance class], @selector(invalidate));
   RCTSwizzleInstanceSelector(
       [RCTInstance class], [ShimRCTInstance class], @selector(callFunctionOnJSModule:method:args:));
@@ -52,7 +50,6 @@ static __weak ShimRCTInstance *weakShim = nil;
                 jsRuntimeFactory:(std::shared_ptr<facebook::react::JSRuntimeFactory>)jsRuntimeFactory
                    bundleManager:(RCTBundleManager *)bundleManager
       turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)tmmDelegate
-                  moduleRegistry:(RCTModuleRegistry *)moduleRegistry
            parentInspectorTarget:(facebook::react::jsinspector_modern::HostTarget *)parentInspectorTarget
                    launchOptions:(NSDictionary *)launchOptions
 {


### PR DESCRIPTION
Summary:
In open source, we are running into this issue:

Multiple react instances can exist concurrently (e.g: during reload). And, since they all use the same module registry, module lookup fails:
- https://github.com/software-mansion/react-native-reanimated/pull
- https://github.com/facebook/react-native/issues/50210

## Changes
Make the module registry scoped to the react instance. So, multiple react instances interleaving can't run into this particular problem.

Changelog: [Internal]

Reviewed By: philIip

Differential Revision: D72001690


