### PR TITLE
Add ScrollViewBaseProps and small type changes to align Flow with TS

### DIFF
--- a/packages/react-native/Libraries/Animated/AnimatedExports.js.flow
+++ b/packages/react-native/Libraries/Animated/AnimatedExports.js.flow
@@ -38,6 +38,7 @@ export type {default as AnimatedModulo} from './nodes/AnimatedModulo';
 export type {default as AnimatedMultiplication} from './nodes/AnimatedMultiplication';
 export type {default as AnimatedSubtraction} from './nodes/AnimatedSubtraction';
 export type {WithAnimatedValue} from './createAnimatedComponent';
+export type {AnimatedComponentType as AnimatedComponent} from './createAnimatedComponent';
 
 export const add = AnimatedImplementation.add;
 export const attachNativeEvent = AnimatedImplementation.attachNativeEvent;

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
@@ -390,11 +390,7 @@ type StickyHeaderComponentType = component(
   ...ScrollViewStickyHeaderProps
 );
 
-export type ScrollViewProps = $ReadOnly<{
-  ...ViewProps,
-  ...ScrollViewPropsIOS,
-  ...ScrollViewPropsAndroid,
-
+type ScrollViewBaseProps = $ReadOnly<{
   /**
    * These styles will be applied to the scroll view content container which
    * wraps all of the child views. Example:
@@ -670,6 +666,13 @@ export type ScrollViewProps = $ReadOnly<{
    * measure, measureLayout, etc.
    */
   scrollViewRef?: React.RefSetter<PublicScrollViewInstance>,
+}>;
+
+export type ScrollViewProps = $ReadOnly<{
+  ...ViewProps,
+  ...ScrollViewPropsIOS,
+  ...ScrollViewPropsAndroid,
+  ...ScrollViewBaseProps,
 }>;
 
 type ScrollViewState = {

--- a/packages/react-native/Libraries/Lists/SectionList.js
+++ b/packages/react-native/Libraries/Lists/SectionList.js
@@ -170,7 +170,7 @@ export type SectionListProps<ItemT, SectionT = DefaultSectionT> = {
  *
  */
 export default class SectionList<
-  ItemT,
+  ItemT = any,
   SectionT = DefaultSectionT,
 > extends React.PureComponent<SectionListProps<ItemT, SectionT>> {
   props: SectionListProps<ItemT, SectionT>;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -191,6 +191,7 @@ export type { default as AnimatedModulo } from \\"./nodes/AnimatedModulo\\";
 export type { default as AnimatedMultiplication } from \\"./nodes/AnimatedMultiplication\\";
 export type { default as AnimatedSubtraction } from \\"./nodes/AnimatedSubtraction\\";
 export type { WithAnimatedValue } from \\"./createAnimatedComponent\\";
+export type { AnimatedComponentType as AnimatedComponent } from \\"./createAnimatedComponent\\";
 declare export const add: $FlowFixMe;
 declare export const attachNativeEvent: $FlowFixMe;
 declare export const createAnimatedComponent: $FlowFixMe;
@@ -2020,10 +2021,7 @@ type StickyHeaderComponentType = component(
   >,
   ...ScrollViewStickyHeaderProps
 );
-export type ScrollViewProps = $ReadOnly<{
-  ...ViewProps,
-  ...ScrollViewPropsIOS,
-  ...ScrollViewPropsAndroid,
+type ScrollViewBaseProps = $ReadOnly<{
   contentContainerStyle?: ?ViewStyleProp,
   contentOffset?: ?PointProp,
   disableIntervalMomentum?: ?boolean,
@@ -2064,6 +2062,12 @@ export type ScrollViewProps = $ReadOnly<{
   children?: React.Node,
   innerViewRef?: React.RefSetter<InnerViewInstance>,
   scrollViewRef?: React.RefSetter<PublicScrollViewInstance>,
+}>;
+export type ScrollViewProps = $ReadOnly<{
+  ...ViewProps,
+  ...ScrollViewPropsIOS,
+  ...ScrollViewPropsAndroid,
+  ...ScrollViewBaseProps,
 }>;
 export type ScrollViewComponentStatics = $ReadOnly<{
   Context: typeof ScrollViewContext,
@@ -5011,8 +5015,10 @@ export type SectionListProps<ItemT, SectionT = DefaultSectionT> = {
   ...RequiredProps<ItemT, SectionT>,
   ...OptionalProps<ItemT, SectionT>,
 };
-declare export default class SectionList<ItemT, SectionT = DefaultSectionT>
-  extends React.PureComponent<SectionListProps<ItemT, SectionT>>
+declare export default class SectionList<
+  ItemT = any,
+  SectionT = DefaultSectionT,
+> extends React.PureComponent<SectionListProps<ItemT, SectionT>>
 {
   props: SectionListProps<ItemT, SectionT>;
   scrollToLocation(params: ScrollToLocationParamsType): void;


### PR DESCRIPTION
Summary:
This diff breaks down ScrollView props into ScrollViewBaseProps to generate more readable TS types, re-exports AnimatedComponent and sets the default SectionList Item type to `any`.

Changelog:
[Internal]

Reviewed By: huntie

Differential Revision: D72061941
