### PR TITLE
RN: Configure Hermes Parser for React 19

### DIFF
--- a/packages/react-native-codegen/src/parsers/flow/parseFlowAndThrowErrors.js
+++ b/packages/react-native-codegen/src/parsers/flow/parseFlowAndThrowErrors.js
@@ -25,7 +25,7 @@ function parseFlowAndThrowErrors(
       babel: false,
       // Parse Flow without a pragma
       flow: 'all',
-      reactRuntimeTarget: '18',
+      reactRuntimeTarget: '19',
       ...(options.filename != null ? {sourceFilename: options.filename} : {}),
     });
   } catch (e) {


### PR DESCRIPTION
Summary:
Configures the Hermes Parser to target React 19, which changes components written with Component Syntax to stop generating `forwardRef` calls (because `ref` is now a prop).

Changelog:
[General][Changed] - Configured Hermes Parser to target React 19, resulting in Component Syntax no longer producing `forwardRef` calls.

Differential Revision: D72070021


