### PR TITLE
`synchronouslyUpdateViewOnUIThread` on UIManager

### DIFF
--- a/packages/react-native/React/Fabric/RCTScheduler.mm
+++ b/packages/react-native/React/Fabric/RCTScheduler.mm
@@ -68,6 +68,12 @@ class SchedulerDelegateProxy : public SchedulerDelegate {
     [scheduler.delegate schedulerDidSendAccessibilityEvent:shadowView eventType:eventType];
   }
 
+  void schedulerShouldSynchronouslyUpdateViewOnUIThread(facebook::react::Tag tag, const folly::dynamic &props) override
+  {
+    // Does nothing.
+    // This delegate method is not currently used on iOS.
+  }
+
  private:
   void *scheduler_;
 };

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
@@ -620,6 +620,10 @@ void FabricUIManagerBinding::schedulerDidSetIsJSResponder(
       shadowView, isJSResponder, blockNativeResponder);
 }
 
+void FabricUIManagerBinding::schedulerShouldSynchronouslyUpdateViewOnUIThread(
+    Tag tag,
+    const folly::dynamic& props) {}
+
 void FabricUIManagerBinding::onAnimationStarted() {
   auto mountingManager = getMountingManager("onAnimationStarted");
   if (!mountingManager) {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.h
@@ -120,6 +120,10 @@ class FabricUIManagerBinding : public jni::HybridClass<FabricUIManagerBinding>,
       bool isJSResponder,
       bool blockNativeResponder) override;
 
+  void schedulerShouldSynchronouslyUpdateViewOnUIThread(
+      Tag tag,
+      const folly::dynamic& props) override;
+
   void setPixelDensity(float pointScaleFactor);
 
   void driveCxxAnimations();

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -320,6 +320,14 @@ void Scheduler::uiManagerDidSetIsJSResponder(
   }
 }
 
+void Scheduler::uiManagerShouldSynchronouslyUpdateViewOnUIThread(
+    Tag tag,
+    const folly::dynamic& props) {
+  if (delegate_ != nullptr) {
+    delegate_->schedulerShouldSynchronouslyUpdateViewOnUIThread(tag, props);
+  }
+}
+
 void Scheduler::reportMount(SurfaceId surfaceId) const {
   uiManager_->reportMount(surfaceId);
 }

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
@@ -95,6 +95,9 @@ class Scheduler final : public UIManagerDelegate {
       const ShadowNode::Shared& shadowNode,
       bool isJSResponder,
       bool blockNativeResponder) override;
+  void uiManagerShouldSynchronouslyUpdateViewOnUIThread(
+      Tag tag,
+      const folly::dynamic& props) override;
 
 #pragma mark - ContextContainer
   ContextContainer::Shared getContextContainer() const;

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerDelegate.h
@@ -64,6 +64,10 @@ class SchedulerDelegate {
       bool isJSResponder,
       bool blockNativeResponder) = 0;
 
+  virtual void schedulerShouldSynchronouslyUpdateViewOnUIThread(
+      Tag tag,
+      const folly::dynamic& props) = 0;
+
   virtual ~SchedulerDelegate() noexcept = default;
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
@@ -690,4 +690,12 @@ void UIManager::animationTick() const {
   }
 }
 
+void UIManager::synchronouslyUpdateViewOnUIThread(
+    Tag tag,
+    const folly::dynamic& props) {
+  if (delegate_ != nullptr) {
+    delegate_->uiManagerShouldSynchronouslyUpdateViewOnUIThread(tag, props);
+  }
+}
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
@@ -70,6 +70,8 @@ class UIManager final : public ShadowTreeDelegate {
 
   void animationTick() const;
 
+  void synchronouslyUpdateViewOnUIThread(Tag tag, const folly::dynamic& props);
+
   /*
    * Provides access to a UIManagerBindging.
    * The `callback` methods will not be called if the internal pointer to

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerDelegate.h
@@ -58,6 +58,13 @@ class UIManagerDelegate {
       bool isJSResponder,
       bool blockNativeResponder) = 0;
 
+  /*
+   * Synchronous view update.
+   */
+  virtual void uiManagerShouldSynchronouslyUpdateViewOnUIThread(
+      Tag tag,
+      const folly::dynamic& props) = 0;
+
   virtual ~UIManagerDelegate() noexcept = default;
 };
 


### PR DESCRIPTION
Summary:
## Changelog:

[Android] [Added] - Allow invoking `synchronouslyUpdateViewOnUIThread` from c++ via `UIManager`
implementation is provided by SchedulerDelegate on the platform

Differential Revision: D71648772


