### PR TITLE
pre-suppress errors for natural_inference.local_primitive_literals=partial in fbsource

### DIFF
--- a/packages/rn-tester/js/examples/Switch/SwitchExample.js
+++ b/packages/rn-tester/js/examples/Switch/SwitchExample.js
@@ -321,6 +321,8 @@ exports.examples = [
 ];
 
 if (Platform.OS === 'ios') {
+  /* $FlowFixMe[incompatible-call] error found during natural inference roll-
+   * out. See https://fburl.com/workplace/tc9m3tcf */
   exports.examples.push({
     title: '[iOS Only] Custom background colors can be set',
     render(): React.MixedElement {


### PR DESCRIPTION
Summary:
Pre-suppresses errors in xplat/js and arvr/js for phase 1 of Natural Inference for Primitive Literals

See https://fb.workplace.com/groups/floweng/permalink/28092444257044156/

Reviewed By: gkz

Differential Revision: D72088386


