### PR TITLE
Make `InvalidIteratorException` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -768,10 +768,6 @@ public abstract interface class com/facebook/react/bridge/Inspector$RemoteConnec
 	public abstract fun onMessage (Ljava/lang/String;)V
 }
 
-public final class com/facebook/react/bridge/InvalidIteratorException : java/lang/RuntimeException {
-	public fun <init> (Ljava/lang/String;)V
-}
-
 public class com/facebook/react/bridge/JSApplicationCausedNativeException : java/lang/RuntimeException {
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/InvalidIteratorException.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/InvalidIteratorException.kt
@@ -17,7 +17,7 @@ import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
  */
 @DoNotStrip
 @LegacyArchitecture
-public class InvalidIteratorException @DoNotStrip public constructor(msg: String) :
+internal class InvalidIteratorException @DoNotStrip constructor(msg: String) :
     RuntimeException(msg) {
   private companion object {
     init {


### PR DESCRIPTION
## Summary:

This class can be internalized as part of the initiative to reduce the public API surface. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.bridge.InvalidIteratorException).

All GH search results are forks.

## Changelog:

[INTERNAL] - Make com.facebook.react.bridge.InvalidIteratorException internal

## Test Plan:

```bash
yarn test-android
yarn android
```