### PR TITLE
Remove unique_ptr for globalRootComponentDescriptor

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
@@ -167,10 +167,9 @@ ShadowTree::ShadowTree(
     const ShadowTreeDelegate& delegate,
     const ContextContainer& contextContainer)
     : surfaceId_(surfaceId), delegate_(delegate) {
-  static auto globalRootComponentDescriptor =
-      std::make_unique<const RootComponentDescriptor>(
-          ComponentDescriptorParameters{
-              EventDispatcher::Shared{}, nullptr, nullptr});
+  static RootComponentDescriptor globalRootComponentDescriptor(
+      ComponentDescriptorParameters{
+          EventDispatcher::Shared{}, nullptr, nullptr});
 
   const auto props = std::make_shared<const RootProps>(
       PropsParserContext{surfaceId, contextContainer},
@@ -178,11 +177,11 @@ ShadowTree::ShadowTree(
       layoutConstraints,
       layoutContext);
 
-  auto family = globalRootComponentDescriptor->createFamily(
+  auto family = globalRootComponentDescriptor.createFamily(
       {surfaceId, surfaceId, nullptr});
 
   auto rootShadowNode = std::static_pointer_cast<const RootShadowNode>(
-      globalRootComponentDescriptor->createShadowNode(
+      globalRootComponentDescriptor.createShadowNode(
           ShadowNodeFragment{
               /* .props = */ props,
           },

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.h
@@ -9,7 +9,6 @@
 
 #include <memory>
 
-#include <react/renderer/components/root/RootComponentDescriptor.h>
 #include <react/renderer/components/root/RootShadowNode.h>
 #include <react/renderer/core/LayoutConstraints.h>
 #include <react/renderer/core/ReactPrimitives.h>

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
@@ -13,7 +13,6 @@
 #include <ReactCommon/RuntimeExecutor.h>
 #include <react/performance/timeline/PerformanceEntryReporter.h>
 #include <react/renderer/componentregistry/ComponentDescriptorFactory.h>
-#include <react/renderer/components/root/RootComponentDescriptor.h>
 #include <react/renderer/core/ComponentDescriptor.h>
 #include <react/renderer/core/EventEmitter.h>
 #include <react/renderer/core/EventListener.h>

--- a/packages/react-native/ReactCommon/react/test_utils/shadowTreeGeneration.h
+++ b/packages/react-native/ReactCommon/react/test_utils/shadowTreeGeneration.h
@@ -18,9 +18,6 @@
 #include <react/renderer/mounting/Differentiator.h>
 #include <react/renderer/mounting/stubs/stubs.h>
 
-#include <react/renderer/components/root/RootComponentDescriptor.h>
-#include <react/renderer/components/view/ViewComponentDescriptor.h>
-
 #include "Entropy.h"
 
 namespace facebook::react {


### PR DESCRIPTION
Summary:
No need for the indirection here of a heap allocated pointer.

Since we have the RootComponentDescriptor we generally don't need it in any other component registry.

Changelog: [Internal]

Differential Revision: D72058916


