### PR TITLE
Limit @react-native/virtualized-lists subpath imports

### DIFF
--- a/packages/rn-tester/js/examples/FlatList/FlatList-maintainVisibleContentPosition.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatList-maintainVisibleContentPosition.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-import type {ListRenderItemInfo} from '../../../../virtualized-lists/Lists/VirtualizedListProps';
+import type {ListRenderItemInfo} from '../../../../virtualized-lists';
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 
 import * as React from 'react';

--- a/packages/virtualized-lists/index.js
+++ b/packages/virtualized-lists/index.js
@@ -10,12 +10,18 @@
 
 'use strict';
 
+import typeof ChildListCollection from './Lists/ChildListCollection';
 import typeof FillRateHelper from './Lists/FillRateHelper';
 import typeof ViewabilityHelper from './Lists/ViewabilityHelper';
 import typeof VirtualizedList from './Lists/VirtualizedList';
 import typeof VirtualizedSectionList from './Lists/VirtualizedSectionList';
 
-import {typeof VirtualizedListContextResetter} from './Lists/VirtualizedListContext';
+import {
+  typeof VirtualizedListCellContextProvider,
+  typeof VirtualizedListContext,
+  typeof VirtualizedListContextProvider,
+  typeof VirtualizedListContextResetter,
+} from './Lists/VirtualizedListContext';
 import {keyExtractor} from './Lists/VirtualizeUtils';
 
 export type {
@@ -49,13 +55,27 @@ export default {
     return require('./Lists/VirtualizedSectionList').default;
   },
   get VirtualizedListContextResetter(): VirtualizedListContextResetter {
-    const VirtualizedListContext = require('./Lists/VirtualizedListContext');
-    return VirtualizedListContext.VirtualizedListContextResetter;
+    return require('./Lists/VirtualizedListContext')
+      .VirtualizedListContextResetter;
+  },
+  get VirtualizedListContext(): VirtualizedListContext {
+    return require('./Lists/VirtualizedListContext').VirtualizedListContext;
+  },
+  get VirtualizedListContextProvider(): VirtualizedListContextProvider {
+    return require('./Lists/VirtualizedListContext')
+      .VirtualizedListContextProvider;
+  },
+  get VirtualizedListCellContextProvider(): VirtualizedListCellContextProvider {
+    return require('./Lists/VirtualizedListContext')
+      .VirtualizedListCellContextProvider;
   },
   get ViewabilityHelper(): ViewabilityHelper {
     return require('./Lists/ViewabilityHelper').default;
   },
   get FillRateHelper(): FillRateHelper {
     return require('./Lists/FillRateHelper').default;
+  },
+  get ChildListCollection(): ChildListCollection {
+    return require('./Lists/ChildListCollection').default;
   },
 };

--- a/packages/virtualized-lists/package.json
+++ b/packages/virtualized-lists/package.json
@@ -3,6 +3,10 @@
   "version": "0.80.0-main",
   "description": "Virtualized lists for React Native.",
   "license": "MIT",
+  "exports": {
+    ".": "./index.js",
+    "./package.json": "./package.json"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/facebook/react-native.git",


### PR DESCRIPTION
Summary:
## This diff
Defines an exports field for the "react-native/virtualized-lists" package. Limits internal use of subpath
imports to virtualized-lists package, and exports all currently used APIs one the root level.

Changelog:
- [Breaking] Subpath imports to the internal react-native/virtualized-lists package are not allowed.

Differential Revision: D72162344


