### PR TITLE
Add build-types to release workflows

### DIFF
--- a/.github/actions/build-npm-package/action.yml
+++ b/.github/actions/build-npm-package/action.yml
@@ -121,6 +121,9 @@ runs:
     - name: Build packages
       shell: bash
       run: yarn build
+    - name: Build types
+      shell: bash
+      run: yarn build-types
     # Continue with publish steps
     - name: Set npm credentials
       if: ${{ inputs.release-type == 'release' ||

--- a/.github/workflows/publish-bumped-packages.yml
+++ b/.github/workflows/publish-bumped-packages.yml
@@ -20,6 +20,8 @@ jobs:
         uses: ./.github/actions/yarn-install
       - name: Build packages
         run: yarn build
+      - name: Build types
+        run: yarn build-types
       - name: Set NPM auth token
         run: echo "//registry.npmjs.org/:_authToken=$GHA_NPM_TOKEN" > ~/.npmrc
       - name: Find and publish all bumped packages


### PR DESCRIPTION
Summary:
Integrates the `yarn build-types` script into our CI workflows.

**Notes**

- Will validate type generation in future PRs as part of the `test-all` workflow (this has been stable (i.e. successfully runs for our codebase) for the last 3 weeks).
- This is not load bearing in production code until D71969602.

Changelog: [Internal]

Differential Revision: D71975705


