### PR TITLE
Change exception handler type in ReleaseDevSupportManager

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/ReleaseDevSupportManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/ReleaseDevSupportManager.kt
@@ -11,6 +11,7 @@ import android.app.Activity
 import android.util.Pair
 import android.view.View
 import com.facebook.react.bridge.DefaultJSExceptionHandler
+import com.facebook.react.bridge.JSExceptionHandler
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.common.SurfaceDelegate
@@ -34,7 +35,7 @@ import java.io.File
  */
 public open class ReleaseDevSupportManager : DevSupportManager {
 
-  private val defaultJSExceptionHandler: DefaultJSExceptionHandler = DefaultJSExceptionHandler()
+  private val defaultJSExceptionHandler: JSExceptionHandler = DefaultJSExceptionHandler()
 
   public override fun showNewJavaError(message: String?, e: Throwable): Unit = Unit
 


### PR DESCRIPTION
## Summary:
In expo-updates, we would like to handle exceptions on app launch. We used to do this by reassigning our own `DefaultJSExceptionHandler` to the property on the  `ReleaseDevSupportManager `.  This class has been migrated to kotlin and is now final so we can no longer do this. Instead of having the `defaultJSExceptionHandler` typed as `DefaultJSExceptionHandler` we'd like to change it to the interface, `JSExceptionHandler` so we can do this https://github.com/expo/expo/blob/93b7e9b1724a7be11b9d79c0313a2e5a2fd5e5bf/packages/expo-updates/android/src/main/java/expo/modules/updates/errorrecovery/ErrorRecovery.kt#L118C82-L118C97

## Changelog:

[ANDROID] [CHANGED] Change `defaultJSExceptionHandler`'s type to  `JSExceptionHandler` on the `ReleaseDevSupportManager`

## Test Plan:
RNTester runs without issue in a release build.
