### PR TITLE
Make `CxxModuleWrapper` & `CxxModuleWrapperBase` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -683,19 +683,6 @@ public final class com/facebook/react/bridge/CxxCallbackImpl : com/facebook/jni/
 	public fun invoke ([Ljava/lang/Object;)V
 }
 
-public class com/facebook/react/bridge/CxxModuleWrapper : com/facebook/react/bridge/CxxModuleWrapperBase {
-	protected fun <init> (Lcom/facebook/jni/HybridData;)V
-}
-
-public class com/facebook/react/bridge/CxxModuleWrapperBase : com/facebook/react/bridge/NativeModule {
-	protected fun <init> (Lcom/facebook/jni/HybridData;)V
-	public fun canOverrideExistingModule ()Z
-	public fun getName ()Ljava/lang/String;
-	public fun initialize ()V
-	public fun invalidate ()V
-	protected final fun resetModule (Lcom/facebook/jni/HybridData;)V
-}
-
 public final class com/facebook/react/bridge/DefaultJSExceptionHandler : com/facebook/react/bridge/JSExceptionHandler {
 	public fun <init> ()V
 	public fun handleException (Ljava/lang/Exception;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CxxModuleWrapper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CxxModuleWrapper.kt
@@ -15,7 +15,7 @@ import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
 /** This does nothing interesting, except avoid breaking existing code. */
 @DoNotStrip
 @LegacyArchitecture
-public open class CxxModuleWrapper protected constructor(hybridData: HybridData) :
+internal open class CxxModuleWrapper protected constructor(hybridData: HybridData) :
     CxxModuleWrapperBase(hybridData) {
   private companion object {
     init {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CxxModuleWrapperBase.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CxxModuleWrapperBase.kt
@@ -21,7 +21,7 @@ import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
  */
 @DoNotStrip
 @LegacyArchitecture
-public open class CxxModuleWrapperBase
+internal open class CxxModuleWrapperBase
 protected constructor(
     // For creating a wrapper from C++, or from a derived class.
     @Suppress("NoHungarianNotation") @DoNotStrip private var mHybridData: HybridData


### PR DESCRIPTION
## Summary:

These classes can be internalized as part of the initiative to reduce the public API surface. I've checked there are no relevant OSS usages.

- [CxxModuleWrapper](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.bridge.CxxModuleWrapper) – points to forks and other non-relevant usages
- [CxxModuleWrapperBase](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.bridge.CxxModuleWrapperBase)

## Changelog:

[INTERNAL] - Make com.facebook.react.bridge CxxModuleWrapper & CxxModuleWrapperBase internal

## Test Plan:

```bash
yarn test-android
yarn android
```