### PR TITLE
Add explicit compatibility for platform specific files under "exports"

### DIFF
--- a/packages/react-native/Libraries/Alert/RCTAlertManager.js
+++ b/packages/react-native/Libraries/Alert/RCTAlertManager.js
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
+ * @flow strict-local
  * @format
  */
 
@@ -11,21 +12,6 @@
 // from 'react-native' with platform-specific extensions. It can be deleted
 // once we remove the "./*" mapping from package.json "exports".
 
-'use strict';
+import RCTAlertManager from './RCTAlertManager';
 
-import Platform from '../../Utilities/Platform';
-
-export type {
-  DrawerLayoutAndroidProps,
-  DrawerSlideEvent,
-} from './DrawerLayoutAndroidTypes';
-
-let DrawerLayoutAndroid;
-
-if (Platform.OS === 'android') {
-  DrawerLayoutAndroid = require('./DrawerLayoutAndroid.android').default;
-} else {
-  DrawerLayoutAndroid = require('./DrawerLayoutAndroidFallback').default;
-}
-
-export default DrawerLayoutAndroid;
+export default RCTAlertManager;

--- a/packages/react-native/Libraries/Components/AccessibilityInfo/legacySendAccessibilityEvent.js
+++ b/packages/react-native/Libraries/Components/AccessibilityInfo/legacySendAccessibilityEvent.js
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
+ * @flow strict-local
  * @format
  */
 
@@ -11,21 +12,6 @@
 // from 'react-native' with platform-specific extensions. It can be deleted
 // once we remove the "./*" mapping from package.json "exports".
 
-'use strict';
+import legacySendAccessibilityEvent from './legacySendAccessibilityEvent';
 
-import Platform from '../../Utilities/Platform';
-
-export type {
-  DrawerLayoutAndroidProps,
-  DrawerSlideEvent,
-} from './DrawerLayoutAndroidTypes';
-
-let DrawerLayoutAndroid;
-
-if (Platform.OS === 'android') {
-  DrawerLayoutAndroid = require('./DrawerLayoutAndroid.android').default;
-} else {
-  DrawerLayoutAndroid = require('./DrawerLayoutAndroidFallback').default;
-}
-
-export default DrawerLayoutAndroid;
+export default legacySendAccessibilityEvent;

--- a/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
+++ b/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
@@ -14,7 +14,6 @@ import type {
   MeasureOnSuccessCallback,
 } from '../../../src/private/types/HostInstance';
 import type {AccessibilityRole} from '../../Components/View/ViewAccessibility';
-import typeof DrawerLayoutAndroidCommon from './DrawerLayoutAndroid.js';
 import type {
   DrawerLayoutAndroidMethods,
   DrawerLayoutAndroidProps,
@@ -305,4 +304,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default DrawerLayoutAndroid as $FlowFixMe as DrawerLayoutAndroidCommon;
+export default DrawerLayoutAndroid as $FlowFixMe;

--- a/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.ios.js
+++ b/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.ios.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict-local
+ */
+
+'use strict';
+
+import DrawerLayoutAndroidFallback from './DrawerLayoutAndroidFallback';
+
+export default DrawerLayoutAndroidFallback;

--- a/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.js.flow
+++ b/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.js.flow
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict-local
+ */
+
+import DrawerLayoutAndroid from './DrawerLayoutAndroidFallback';
+
+export type {
+  DrawerLayoutAndroidProps,
+  DrawerSlideEvent,
+} from './DrawerLayoutAndroidTypes';
+
+export default DrawerLayoutAndroid;

--- a/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroidFallback.js
+++ b/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroidFallback.js
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict-local
+ */
+
+'use strict';
+
+import type {
+  MeasureInWindowOnSuccessCallback,
+  MeasureLayoutOnSuccessCallback,
+  MeasureOnSuccessCallback,
+} from '../../../src/private/types/HostInstance';
+import type {
+  DrawerLayoutAndroidMethods,
+  DrawerLayoutAndroidProps,
+  DrawerLayoutAndroidState,
+} from './DrawerLayoutAndroidTypes';
+
+import UnimplementedView from '../UnimplementedViews/UnimplementedView';
+import * as React from 'react';
+
+export default class DrawerLayoutAndroid
+  extends React.Component<DrawerLayoutAndroidProps, DrawerLayoutAndroidState>
+  implements DrawerLayoutAndroidMethods
+{
+  render(): React.Node {
+    return <UnimplementedView {...this.props} />;
+  }
+
+  openDrawer(): void {
+    throw new Error('DrawerLayoutAndroid is only available on Android');
+  }
+
+  closeDrawer(): void {
+    throw new Error('DrawerLayoutAndroid is only available on Android');
+  }
+
+  blur(): void {
+    throw new Error('DrawerLayoutAndroid is only available on Android');
+  }
+
+  focus(): void {
+    throw new Error('DrawerLayoutAndroid is only available on Android');
+  }
+
+  measure(callback: MeasureOnSuccessCallback): void {
+    throw new Error('DrawerLayoutAndroid is only available on Android');
+  }
+
+  measureInWindow(callback: MeasureInWindowOnSuccessCallback): void {
+    throw new Error('DrawerLayoutAndroid is only available on Android');
+  }
+
+  measureLayout(
+    relativeToNativeNode: number,
+    onSuccess: MeasureLayoutOnSuccessCallback,
+    onFail?: () => void,
+  ): void {
+    throw new Error('DrawerLayoutAndroid is only available on Android');
+  }
+
+  // $FlowFixMe[unclear-type]
+  setNativeProps(nativeProps: Object): void {
+    throw new Error('DrawerLayoutAndroid is only available on Android');
+  }
+}

--- a/packages/react-native/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.js
+++ b/packages/react-native/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.js
@@ -13,12 +13,23 @@
 import typeof ProgressBarAndroidNativeComponentType from './ProgressBarAndroidNativeComponent';
 import type {ProgressBarAndroidProps} from './ProgressBarAndroidTypes';
 
+import Platform from '../../Utilities/Platform';
+
 export type {ProgressBarAndroidProps};
 
-export default require('../UnimplementedViews/UnimplementedView')
-  .default as $FlowFixMe as component(
+let ProgressBarAndroid: component(
   ref?: React.RefSetter<
     React.ElementRef<ProgressBarAndroidNativeComponentType>,
   >,
   ...props: ProgressBarAndroidProps
 );
+
+if (Platform.OS === 'android') {
+  // $FlowIgnore[missing-platform-support]
+  ProgressBarAndroid = require('./ProgressBarAndroid.android').default;
+} else {
+  ProgressBarAndroid = require('../UnimplementedViews/UnimplementedView')
+    .default as $FlowFixMe;
+}
+
+export default ProgressBarAndroid;

--- a/packages/react-native/Libraries/Components/ToastAndroid/ToastAndroid.js
+++ b/packages/react-native/Libraries/Components/ToastAndroid/ToastAndroid.js
@@ -8,38 +8,111 @@
  * @flow strict-local
  */
 
-'use strict';
+import Platform from '../../Utilities/Platform';
 
-const ToastAndroid = {
-  // Dummy fallback toast duration constants
-  SHORT: (0: number),
-  LONG: (0: number),
-  // Dummy fallback toast gravity constants
-  TOP: (0: number),
-  BOTTOM: (0: number),
-  CENTER: (0: number),
+/**
+ * This exposes the native ToastAndroid module as a JS module. This has a function 'show'
+ * which takes the following parameters:
+ *
+ * 1. String message: A string with the text to toast
+ * 2. int duration: The duration of the toast. May be ToastAndroid.SHORT or ToastAndroid.LONG
+ *
+ * There is also a function `showWithGravity` to specify the layout gravity. May be
+ * ToastAndroid.TOP, ToastAndroid.BOTTOM, ToastAndroid.CENTER
+ *
+ * **Note**: Starting from Android API level 30 (Android R) or higher, for apps targeting
+ * that API level, setting toast gravity is a no-op for text toasts.
+ * This means that in many cases `TOP`, `BOTTOM`, `CENTER`, or offsets may not have
+ * any visible effect on actual toast positioning.
+ *
+ * Reference: https://developer.android.com/reference/android/widget/Toast#setGravity(int,%20int,%20int)
+ */
+let ToastAndroid: {
+  /**
+   * Indicates a short duration on the screen.
+   *
+   * Value: 2000 milliseconds (2 seconds).
+   */
+  SHORT: number,
 
-  show: function (message: string, duration: number): void {
-    console.warn('ToastAndroid is not supported on this platform.');
-  },
+  /**
+   * Indicates a long duration on the screen.
+   *
+   * Value: 3500 milliseconds (3.5 seconds).
+   */
+  LONG: number,
 
-  showWithGravity: function (
-    message: string,
-    duration: number,
-    gravity: number,
-  ): void {
-    console.warn('ToastAndroid is not supported on this platform.');
-  },
+  /**
+   * Indicates that the toast message should appear at the top of the screen.
+   *
+   * **Note**: On Android R or later, this may not have any visible effect.
+   */
+  TOP: number,
 
-  showWithGravityAndOffset: function (
+  /**
+   * Indicates that the toast message should appear at the bottom of the screen.
+   *
+   * **Note**: On Android R or later, this may not have any visible effect.
+   */
+  BOTTOM: number,
+
+  /**
+   * Indicates that the toast message should appear at the center of the screen.
+   *
+   * **Note**: On Android R or later, this may not have any visible effect.
+   */
+  CENTER: number,
+
+  /**
+   * Display a toast message for a specified duration.
+   *
+   * @param message A string with the text to toast.
+   * @param duration The duration of the toast–either ToastAndroid.SHORT or ToastAndroid.LONG
+   */
+  show: (message: string, duration: number) => void,
+
+  /**
+   * Display a toast message for a specified duration with a given gravity.
+   *
+   * @param message A string with the text to display in the toast.
+   * @param duration The duration of the toast.
+   *                 May be `ToastAndroid.SHORT` or `ToastAndroid.LONG`.
+   * @param gravity Positioning on the screen, e.g.,
+   *                `ToastAndroid.TOP`, `ToastAndroid.BOTTOM`, or `ToastAndroid.CENTER`.
+   *
+   * **Note**: On Android R (API 30) or later (when targeting API 30+), this setting may
+   * not have any effect on text toast placement due to `setGravity` becoming a no-op.
+   */
+  showWithGravity: (message: string, duration: number, gravity: number) => void,
+
+  /**
+   * Display a toast message for a specified duration with a given gravity and custom offsets.
+   *
+   * @param message A string with the text to display in the toast.
+   * @param duration The duration of the toast.
+   *                 May be `ToastAndroid.SHORT` or `ToastAndroid.LONG`.
+   * @param gravity Positioning on the screen, e.g.,
+   *                `ToastAndroid.TOP`, `ToastAndroid.BOTTOM`, or `ToastAndroid.CENTER`.
+   * @param xOffset Horizontal offset from the given gravity.
+   * @param yOffset Vertical offset from the given gravity.
+   *
+   * **Note**: On Android R (API 30) or later (when targeting API 30+), setting gravity
+   * and offsets may not visibly affect the placement of text toasts.
+   */
+  showWithGravityAndOffset: (
     message: string,
     duration: number,
     gravity: number,
     xOffset: number,
     yOffset: number,
-  ): void {
-    console.warn('ToastAndroid is not supported on this platform.');
-  },
+  ) => void,
 };
+
+if (Platform.OS === 'android') {
+  // $FlowIgnore[missing-platform-support]
+  ToastAndroid = require('./ToastAndroid.android').default;
+} else {
+  ToastAndroid = require('./ToastAndroidFallback').default;
+}
 
 export default ToastAndroid;

--- a/packages/react-native/Libraries/Components/ToastAndroid/ToastAndroidFallback.js
+++ b/packages/react-native/Libraries/Components/ToastAndroid/ToastAndroidFallback.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict-local
+ */
+
+'use strict';
+
+const ToastAndroid = {
+  // Dummy fallback toast duration constants
+  SHORT: (0: number),
+  LONG: (0: number),
+  // Dummy fallback toast gravity constants
+  TOP: (0: number),
+  BOTTOM: (0: number),
+  CENTER: (0: number),
+
+  show: function (message: string, duration: number): void {
+    console.warn('ToastAndroid is not supported on this platform.');
+  },
+
+  showWithGravity: function (
+    message: string,
+    duration: number,
+    gravity: number,
+  ): void {
+    console.warn('ToastAndroid is not supported on this platform.');
+  },
+
+  showWithGravityAndOffset: function (
+    message: string,
+    duration: number,
+    gravity: number,
+    xOffset: number,
+    yOffset: number,
+  ): void {
+    console.warn('ToastAndroid is not supported on this platform.');
+  },
+};
+
+export default ToastAndroid;

--- a/packages/react-native/Libraries/Image/Image.js
+++ b/packages/react-native/Libraries/Image/Image.js
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
+ * @flow strict-local
  * @format
  */
 
@@ -11,21 +12,6 @@
 // from 'react-native' with platform-specific extensions. It can be deleted
 // once we remove the "./*" mapping from package.json "exports".
 
-'use strict';
+import Image from './Image';
 
-import Platform from '../../Utilities/Platform';
-
-export type {
-  DrawerLayoutAndroidProps,
-  DrawerSlideEvent,
-} from './DrawerLayoutAndroidTypes';
-
-let DrawerLayoutAndroid;
-
-if (Platform.OS === 'android') {
-  DrawerLayoutAndroid = require('./DrawerLayoutAndroid.android').default;
-} else {
-  DrawerLayoutAndroid = require('./DrawerLayoutAndroidFallback').default;
-}
-
-export default DrawerLayoutAndroid;
+export default Image;

--- a/packages/react-native/Libraries/NativeComponent/BaseViewConfig.js
+++ b/packages/react-native/Libraries/NativeComponent/BaseViewConfig.js
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
+ * @flow strict-local
  * @format
  */
 
@@ -11,21 +12,6 @@
 // from 'react-native' with platform-specific extensions. It can be deleted
 // once we remove the "./*" mapping from package.json "exports".
 
-'use strict';
+import BaseViewConfig from './BaseViewConfig';
 
-import Platform from '../../Utilities/Platform';
-
-export type {
-  DrawerLayoutAndroidProps,
-  DrawerSlideEvent,
-} from './DrawerLayoutAndroidTypes';
-
-let DrawerLayoutAndroid;
-
-if (Platform.OS === 'android') {
-  DrawerLayoutAndroid = require('./DrawerLayoutAndroid.android').default;
-} else {
-  DrawerLayoutAndroid = require('./DrawerLayoutAndroidFallback').default;
-}
-
-export default DrawerLayoutAndroid;
+export default BaseViewConfig;

--- a/packages/react-native/Libraries/Network/RCTNetworking.js
+++ b/packages/react-native/Libraries/Network/RCTNetworking.js
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
+ * @flow strict-local
  * @format
  */
 
@@ -11,21 +12,6 @@
 // from 'react-native' with platform-specific extensions. It can be deleted
 // once we remove the "./*" mapping from package.json "exports".
 
-'use strict';
+import RCTNetworking from './RCTNetworking';
 
-import Platform from '../../Utilities/Platform';
-
-export type {
-  DrawerLayoutAndroidProps,
-  DrawerSlideEvent,
-} from './DrawerLayoutAndroidTypes';
-
-let DrawerLayoutAndroid;
-
-if (Platform.OS === 'android') {
-  DrawerLayoutAndroid = require('./DrawerLayoutAndroid.android').default;
-} else {
-  DrawerLayoutAndroid = require('./DrawerLayoutAndroidFallback').default;
-}
-
-export default DrawerLayoutAndroid;
+export default RCTNetworking;

--- a/packages/react-native/Libraries/Settings/Settings.js
+++ b/packages/react-native/Libraries/Settings/Settings.js
@@ -8,26 +8,20 @@
  * @flow
  */
 
-'use strict';
+import Platform from '../Utilities/Platform';
 
-const Settings = {
-  get(key: string): any {
-    console.warn('Settings is not yet supported on this platform.');
-    return null;
-  },
-
-  set(settings: Object) {
-    console.warn('Settings is not yet supported on this platform.');
-  },
-
-  watchKeys(keys: string | Array<string>, callback: () => void): number {
-    console.warn('Settings is not yet supported on this platform.');
-    return -1;
-  },
-
-  clearWatch(watchId: number) {
-    console.warn('Settings is not yet supported on this platform.');
-  },
+let Settings: {
+  get(key: string): any,
+  set(settings: Object): void,
+  watchKeys(keys: string | Array<string>, callback: () => void): number,
+  clearWatch(watchId: number): void,
+  ...
 };
+
+if (Platform.OS === 'ios') {
+  Settings = require('./Settings').default;
+} else {
+  Settings = require('./SettingsFallback').default;
+}
 
 export default Settings;

--- a/packages/react-native/Libraries/Settings/SettingsFallback.js
+++ b/packages/react-native/Libraries/Settings/SettingsFallback.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+const Settings = {
+  get(key: string): any {
+    console.warn('Settings is not yet supported on this platform.');
+    return null;
+  },
+
+  set(settings: Object) {
+    console.warn('Settings is not yet supported on this platform.');
+  },
+
+  watchKeys(keys: string | Array<string>, callback: () => void): number {
+    console.warn('Settings is not yet supported on this platform.');
+    return -1;
+  },
+
+  clearWatch(watchId: number) {
+    console.warn('Settings is not yet supported on this platform.');
+  },
+};
+
+export default Settings;

--- a/packages/react-native/Libraries/StyleSheet/PlatformColorValueTypes.js
+++ b/packages/react-native/Libraries/StyleSheet/PlatformColorValueTypes.js
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
+ * @flow strict-local
  * @format
  */
 
@@ -11,21 +12,4 @@
 // from 'react-native' with platform-specific extensions. It can be deleted
 // once we remove the "./*" mapping from package.json "exports".
 
-'use strict';
-
-import Platform from '../../Utilities/Platform';
-
-export type {
-  DrawerLayoutAndroidProps,
-  DrawerSlideEvent,
-} from './DrawerLayoutAndroidTypes';
-
-let DrawerLayoutAndroid;
-
-if (Platform.OS === 'android') {
-  DrawerLayoutAndroid = require('./DrawerLayoutAndroid.android').default;
-} else {
-  DrawerLayoutAndroid = require('./DrawerLayoutAndroidFallback').default;
-}
-
-export default DrawerLayoutAndroid;
+export * from './PlatformColorValueTypes';

--- a/packages/react-native/Libraries/Utilities/BackHandler.js
+++ b/packages/react-native/Libraries/Utilities/BackHandler.js
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
+ * @flow strict-local
  * @format
  */
 
@@ -11,21 +12,6 @@
 // from 'react-native' with platform-specific extensions. It can be deleted
 // once we remove the "./*" mapping from package.json "exports".
 
-'use strict';
+import BackHandler from './BackHandler';
 
-import Platform from '../../Utilities/Platform';
-
-export type {
-  DrawerLayoutAndroidProps,
-  DrawerSlideEvent,
-} from './DrawerLayoutAndroidTypes';
-
-let DrawerLayoutAndroid;
-
-if (Platform.OS === 'android') {
-  DrawerLayoutAndroid = require('./DrawerLayoutAndroid.android').default;
-} else {
-  DrawerLayoutAndroid = require('./DrawerLayoutAndroidFallback').default;
-}
-
-export default DrawerLayoutAndroid;
+export default BackHandler;

--- a/packages/react-native/Libraries/Utilities/Platform.js
+++ b/packages/react-native/Libraries/Utilities/Platform.js
@@ -5,27 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @flow strict
  */
 
 // NOTE: This file supports backwards compatibility of subpath (deep) imports
 // from 'react-native' with platform-specific extensions. It can be deleted
 // once we remove the "./*" mapping from package.json "exports".
 
-'use strict';
+import Platform from './Platform';
 
-import Platform from '../../Utilities/Platform';
-
-export type {
-  DrawerLayoutAndroidProps,
-  DrawerSlideEvent,
-} from './DrawerLayoutAndroidTypes';
-
-let DrawerLayoutAndroid;
-
-if (Platform.OS === 'android') {
-  DrawerLayoutAndroid = require('./DrawerLayoutAndroid.android').default;
-} else {
-  DrawerLayoutAndroid = require('./DrawerLayoutAndroidFallback').default;
-}
-
-export default DrawerLayoutAndroid;
+export default Platform;


### PR DESCRIPTION
Summary:
Prepares [platform-specific extensions](https://reactnative.dev/docs/platform-specific-code) compatibility for subpath imports ahead of D72228547 (`"exports"` field reattempt).

Changelog: [Internal]

Differential Revision: D72235790
