### PR TITLE
Add lint rule preventing importing React as default

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -75,6 +75,7 @@ module.exports = {
         'lint/no-react-native-imports': 2,
         'lint/require-extends-error': 2,
         'lint/no-react-node-imports': 2,
+        'lint/no-react-default-imports': 2,
       },
     },
     {

--- a/packages/react-native/Libraries/Components/RefreshControl/RefreshControl.js
+++ b/packages/react-native/Libraries/Components/RefreshControl/RefreshControl.js
@@ -17,7 +17,7 @@ import AndroidSwipeRefreshLayoutNativeComponent, {
 import PullToRefreshViewNativeComponent, {
   Commands as PullToRefreshCommands,
 } from './PullToRefreshViewNativeComponent';
-import React from 'react';
+import * as React from 'react';
 
 const Platform = require('../../Utilities/Platform').default;
 

--- a/packages/react-native/Libraries/Components/StaticRenderer.js
+++ b/packages/react-native/Libraries/Components/StaticRenderer.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-import React from 'react';
+import * as React from 'react';
 
 type Props = $ReadOnly<{
   /**

--- a/packages/react-native/Libraries/Components/View/ViewPropTypes.js
+++ b/packages/react-native/Libraries/Components/View/ViewPropTypes.js
@@ -26,7 +26,7 @@ import type {
   AccessibilityProps,
 } from './ViewAccessibility';
 
-import React from 'react';
+import * as React from 'react';
 
 export type ViewLayout = LayoutRectangle;
 export type ViewLayoutEvent = LayoutChangeEvent;

--- a/packages/react-native/Libraries/Image/ImageProps.js
+++ b/packages/react-native/Libraries/Image/ImageProps.js
@@ -24,8 +24,9 @@ import type {
 import typeof Image from './Image';
 import type {ImageResizeMode} from './ImageResizeMode';
 import type {ImageSource, ImageURISource} from './ImageSource';
-import type React from 'react';
 import type {ElementRef, RefSetter} from 'react';
+
+import * as React from 'react';
 
 export type ImageSourcePropType = ImageSource;
 

--- a/packages/react-native/Libraries/Lists/FlatList.js
+++ b/packages/react-native/Libraries/Lists/FlatList.js
@@ -22,7 +22,7 @@ import {type ScrollResponderType} from '../Components/ScrollView/ScrollView';
 import View from '../Components/View/View';
 import VirtualizedLists from '@react-native/virtualized-lists';
 import memoizeOne from 'memoize-one';
-import React from 'react';
+import * as React from 'react';
 
 const StyleSheet = require('../StyleSheet/StyleSheet').default;
 const deepDiffer = require('../Utilities/differ/deepDiffer').default;

--- a/packages/react-native/Libraries/Lists/SectionListModern.js
+++ b/packages/react-native/Libraries/Lists/SectionListModern.js
@@ -21,7 +21,8 @@ import type {ElementRef} from 'react';
 
 import Platform from '../Utilities/Platform';
 import VirtualizedLists from '@react-native/virtualized-lists';
-import React, {forwardRef, useImperativeHandle, useRef} from 'react';
+import * as React from 'react';
+import {forwardRef, useImperativeHandle, useRef} from 'react';
 
 const VirtualizedSectionList = VirtualizedLists.VirtualizedSectionList;
 

--- a/packages/react-native/Libraries/Modal/Modal.js
+++ b/packages/react-native/Libraries/Modal/Modal.js
@@ -19,7 +19,7 @@ import {type EventSubscription} from '../vendor/emitter/EventEmitter';
 import NativeModalManager from './NativeModalManager';
 import RCTModalHostView from './RCTModalHostViewNativeComponent';
 import VirtualizedLists from '@react-native/virtualized-lists';
-import React from 'react';
+import * as React from 'react';
 
 const ScrollView = require('../Components/ScrollView/ScrollView').default;
 const View = require('../Components/View/View').default;

--- a/packages/react-native/Libraries/NewAppScreen/components/DebugInstructions.js
+++ b/packages/react-native/Libraries/NewAppScreen/components/DebugInstructions.js
@@ -11,7 +11,7 @@
 import StyleSheet from '../../StyleSheet/StyleSheet';
 import Text from '../../Text/Text';
 import Platform from '../../Utilities/Platform';
-import React from 'react';
+import * as React from 'react';
 
 const styles = StyleSheet.create({
   highlight: {

--- a/packages/react-native/Libraries/NewAppScreen/components/Header.js
+++ b/packages/react-native/Libraries/NewAppScreen/components/Header.js
@@ -14,7 +14,7 @@ import Text from '../../Text/Text';
 import useColorScheme from '../../Utilities/useColorScheme';
 import Colors from './Colors';
 import HermesBadge from './HermesBadge';
-import React from 'react';
+import * as React from 'react';
 
 const Header = (): React.Node => {
   const isDarkMode = useColorScheme() === 'dark';

--- a/packages/react-native/Libraries/NewAppScreen/components/HermesBadge.js
+++ b/packages/react-native/Libraries/NewAppScreen/components/HermesBadge.js
@@ -13,7 +13,7 @@ import StyleSheet from '../../StyleSheet/StyleSheet';
 import Text from '../../Text/Text';
 import useColorScheme from '../../Utilities/useColorScheme';
 import Colors from './Colors';
-import React from 'react';
+import * as React from 'react';
 
 const HermesBadge = (): React.Node => {
   const isDarkMode = useColorScheme() === 'dark';

--- a/packages/react-native/Libraries/NewAppScreen/components/LearnMoreLinks.js
+++ b/packages/react-native/Libraries/NewAppScreen/components/LearnMoreLinks.js
@@ -15,7 +15,7 @@ import StyleSheet from '../../StyleSheet/StyleSheet';
 import Text from '../../Text/Text';
 import useColorScheme from '../../Utilities/useColorScheme';
 import Colors from './Colors';
-import React, {Fragment} from 'react';
+import * as React from 'react';
 
 const links = [
   {
@@ -84,7 +84,7 @@ const LinkList = (): React.Node => {
   return (
     <View style={styles.container}>
       {links.map(({id, title, link, description}) => (
-        <Fragment key={id}>
+        <React.Fragment key={id}>
           <View
             style={[
               styles.separator,
@@ -108,7 +108,7 @@ const LinkList = (): React.Node => {
               {description}
             </Text>
           </TouchableOpacity>
-        </Fragment>
+        </React.Fragment>
       ))}
     </View>
   );

--- a/packages/react-native/Libraries/NewAppScreen/components/ReloadInstructions.js
+++ b/packages/react-native/Libraries/NewAppScreen/components/ReloadInstructions.js
@@ -11,7 +11,7 @@
 import StyleSheet from '../../StyleSheet/StyleSheet';
 import Text from '../../Text/Text';
 import Platform from '../../Utilities/Platform';
-import React from 'react';
+import * as React from 'react';
 
 const styles = StyleSheet.create({
   highlight: {

--- a/packages/react-native/Libraries/Text/TextProps.js
+++ b/packages/react-native/Libraries/Text/TextProps.js
@@ -25,7 +25,7 @@ import type {
   TextLayoutEvent,
 } from '../Types/CoreEventTypes';
 
-import React from 'react';
+import * as React from 'react';
 
 export type PressRetentionOffset = $ReadOnly<{
   top: number,

--- a/packages/react-native/Libraries/Text/__tests__/Text-test.js
+++ b/packages/react-native/Libraries/Text/__tests__/Text-test.js
@@ -11,7 +11,7 @@
 'use strict';
 
 import flattenStyle from '../../StyleSheet/flattenStyle';
-import React from 'react';
+import * as React from 'react';
 
 const render = require('../../../jest/renderer');
 const Text = require('../Text').default;

--- a/packages/react-native/Libraries/Utilities/ReactNativeTestTools.js
+++ b/packages/react-native/Libraries/Utilities/ReactNativeTestTools.js
@@ -13,7 +13,7 @@
 import type {ReactTestRenderer as ReactTestRendererType} from 'react-test-renderer';
 
 import TouchableWithoutFeedback from '../Components/Touchable/TouchableWithoutFeedback';
-import React from 'react';
+import * as React from 'react';
 import ReactTestRenderer from 'react-test-renderer';
 
 const Switch = require('../Components/Switch/Switch').default;

--- a/packages/react-native/src/private/inspector/BorderBox.js
+++ b/packages/react-native/src/private/inspector/BorderBox.js
@@ -12,7 +12,7 @@
 
 import type {ViewStyleProp} from '../../../Libraries/StyleSheet/StyleSheet';
 
-import React from 'react';
+import * as React from 'react';
 
 const View = require('../../../Libraries/Components/View/View').default;
 

--- a/packages/react-native/src/private/inspector/BoxInspector.js
+++ b/packages/react-native/src/private/inspector/BoxInspector.js
@@ -16,7 +16,7 @@ import type {
 } from '../../../Libraries/StyleSheet/StyleSheet';
 import type {InspectedElementFrame} from './Inspector';
 
-import React from 'react';
+import * as React from 'react';
 
 const View = require('../../../Libraries/Components/View/View').default;
 const StyleSheet = require('../../../Libraries/StyleSheet/StyleSheet').default;

--- a/packages/react-native/src/private/inspector/ElementBox.js
+++ b/packages/react-native/src/private/inspector/ElementBox.js
@@ -13,7 +13,7 @@
 import type {ViewStyleProp} from '../../../Libraries/StyleSheet/StyleSheet';
 import type {InspectedElementFrame} from './Inspector';
 
-import React from 'react';
+import * as React from 'react';
 
 const View = require('../../../Libraries/Components/View/View').default;
 const flattenStyle =

--- a/packages/react-native/src/private/inspector/ElementProperties.js
+++ b/packages/react-native/src/private/inspector/ElementProperties.js
@@ -13,7 +13,7 @@
 import type {InspectorData} from '../../../Libraries/Renderer/shims/ReactNativeTypes';
 import type {ViewStyleProp} from '../../../Libraries/StyleSheet/StyleSheet';
 
-import React from 'react';
+import * as React from 'react';
 
 const TouchableHighlight =
   require('../../../Libraries/Components/Touchable/TouchableHighlight').default;

--- a/packages/react-native/src/private/inspector/Inspector.js
+++ b/packages/react-native/src/private/inspector/Inspector.js
@@ -19,7 +19,7 @@ import type {ViewStyleProp} from '../../../Libraries/StyleSheet/StyleSheet';
 import type {ReactDevToolsAgent} from '../../../Libraries/Types/ReactDevToolsTypes';
 
 import SafeAreaView from '../components/SafeAreaView_INTERNAL_DO_NOT_USE';
-import React from 'react';
+import * as React from 'react';
 
 const View = require('../../../Libraries/Components/View/View').default;
 const PressabilityDebug = require('../../../Libraries/Pressability/PressabilityDebug');

--- a/packages/react-native/src/private/inspector/InspectorOverlay.js
+++ b/packages/react-native/src/private/inspector/InspectorOverlay.js
@@ -13,7 +13,7 @@
 import type {GestureResponderEvent} from '../../../Libraries/Types/CoreEventTypes';
 import type {InspectedElement} from './Inspector';
 
-import React from 'react';
+import * as React from 'react';
 
 const View = require('../../../Libraries/Components/View/View').default;
 const StyleSheet = require('../../../Libraries/StyleSheet/StyleSheet').default;

--- a/packages/react-native/src/private/inspector/InspectorPanel.js
+++ b/packages/react-native/src/private/inspector/InspectorPanel.js
@@ -13,7 +13,7 @@
 import type {ElementsHierarchy, InspectedElement} from './Inspector';
 
 import SafeAreaView from '../../../Libraries/Components/SafeAreaView/SafeAreaView';
-import React from 'react';
+import * as React from 'react';
 
 const ScrollView =
   require('../../../Libraries/Components/ScrollView/ScrollView').default;

--- a/packages/react-native/src/private/inspector/NetworkOverlay.js
+++ b/packages/react-native/src/private/inspector/NetworkOverlay.js
@@ -14,7 +14,7 @@ import type XMLHttpRequest from '../../../Libraries/Network/XMLHttpRequest';
 import type {ListRenderItemInfo} from '@react-native/virtualized-lists';
 
 import ScrollView from '../../../Libraries/Components/ScrollView/ScrollView';
-import React from 'react';
+import * as React from 'react';
 
 const TouchableHighlight =
   require('../../../Libraries/Components/Touchable/TouchableHighlight').default;

--- a/packages/react-native/src/private/inspector/PerformanceOverlay.js
+++ b/packages/react-native/src/private/inspector/PerformanceOverlay.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-import React from 'react';
+import * as React from 'react';
 
 const View = require('../../../Libraries/Components/View/View').default;
 const StyleSheet = require('../../../Libraries/StyleSheet/StyleSheet').default;

--- a/packages/react-native/src/private/inspector/StyleInspector.js
+++ b/packages/react-native/src/private/inspector/StyleInspector.js
@@ -13,7 +13,7 @@
 import type {ViewStyleProp} from '../../../Libraries/StyleSheet/StyleSheet';
 import type {____FlattenStyleProp_Internal} from '../../../Libraries/StyleSheet/StyleSheetTypes';
 
-import React from 'react';
+import * as React from 'react';
 
 const View = require('../../../Libraries/Components/View/View').default;
 const StyleSheet = require('../../../Libraries/StyleSheet/StyleSheet').default;

--- a/tools/eslint/rules/__tests__/no-react-default-imports.js
+++ b/tools/eslint/rules/__tests__/no-react-default-imports.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+'use strict';
+
+const rule = require('../no-react-default-imports');
+const {RuleTester} = require('eslint');
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('hermes-eslint'),
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run('import React from "react"', rule, {
+  valid: [
+    {
+      code: `import * as React from "react";`,
+    },
+  ],
+  invalid: [
+    {
+      code: `import React from "react";`,
+      errors: [{messageId: 'defaultReactImport'}],
+      output: "import * as React from 'react';",
+    },
+    {
+      code: `import React, {View} from "react";`,
+      errors: [{messageId: 'defaultReactImport'}],
+      output: null,
+    },
+  ],
+});

--- a/tools/eslint/rules/no-react-default-imports.js
+++ b/tools/eslint/rules/no-react-default-imports.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+'use strict';
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow default React imports from react',
+    },
+    messages: {
+      defaultReactImport:
+        'import React from "react" is not consistent. Prefer `import * as React`.',
+    },
+    schema: [],
+    fixable: 'code',
+  },
+
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value === 'react') {
+          const defaultSpecifier = node.specifiers.find(
+            specifier => specifier.type === 'ImportDefaultSpecifier',
+          );
+
+          if (defaultSpecifier && defaultSpecifier.local.name === 'React') {
+            if (node.specifiers.length === 1) {
+              context.report({
+                node: defaultSpecifier,
+                messageId: 'defaultReactImport',
+                fix(fixer) {
+                  return fixer.replaceText(
+                    node,
+                    "import * as React from 'react';",
+                  );
+                },
+              });
+            } else {
+              context.report({
+                node: defaultSpecifier,
+                messageId: 'defaultReactImport',
+              });
+            }
+          }
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
Summary: This diff adds lint rule to keep React imports consistent across the react native repo. There is a fix suggestion in case if only React is imported.

Differential Revision: D72244838


