### PR TITLE
log time since last communication

### DIFF
--- a/packages/dev-middleware/src/types/EventReporter.js
+++ b/packages/dev-middleware/src/types/EventReporter.js
@@ -106,14 +106,14 @@ export type ReportableEvent =
   | {
       type: 'debugger_high_ping' | 'device_high_ping',
       duration: number,
-      isIdle: boolean,
+      timeSinceLastCommunication: number | null,
       ...ConnectionUptime,
       ...DebuggerSessionIDs,
     }
   | {
       type: 'debugger_timeout' | 'device_timeout',
       duration: number,
-      isIdle: boolean,
+      timeSinceLastCommunication: number | null,
       ...ConnectionUptime,
       ...DebuggerSessionIDs,
     }
@@ -121,7 +121,7 @@ export type ReportableEvent =
       type: 'debugger_connection_closed' | 'device_connection_closed',
       code: number,
       reason: string,
-      isIdle: boolean,
+      timeSinceLastCommunication: number | null,
       ...ConnectionUptime,
       ...DebuggerSessionIDs,
     }


### PR DESCRIPTION
Summary:
Changelog: [Internal]

`is_idle` was a confusing concept that I didn't find useful when researching why disconnections happen. Instead, I'd like to know when the last communication with inspector proxy took place.

Differential Revision: D72251072


