### PR TITLE
Fixing Fabric Interop layer bug defaulting to UnstableLegacyViewManagerAutomaticComponentDescriptor irrespective of feature flag

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<5ad988b3cb0624cb9b46331d54c09f0a>>
+ * @generated SignedSource<<b8e277be7a521cbc3c4034d127af0a8a>>
  */
 
 /**
@@ -95,7 +95,7 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
 
   override fun useEditTextStockAndroidFocusBehavior(): Boolean = true
 
-  override fun useFabricInterop(): Boolean = false
+  override fun useFabricInterop(): Boolean = true
 
   override fun useNativeViewConfigsInBridgelessMode(): Boolean = false
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Canary_Android.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Canary_Android.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<04b05f74eacf566f99d00c630dcb61f4>>
+ * @generated SignedSource<<f82b5905d822f8009c054a9443f86e39>>
  */
 
 /**
@@ -26,8 +26,6 @@ public open class ReactNativeFeatureFlagsOverrides_RNOSS_Canary_Android : ReactN
   override fun enableBridgelessArchitecture(): Boolean = true
 
   override fun enableFabricRenderer(): Boolean = true
-
-  override fun useFabricInterop(): Boolean = true
 
   override fun useNativeViewConfigsInBridgelessMode(): Boolean = true
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeNewArchitectureFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeNewArchitectureFeatureFlagsDefaults.kt
@@ -27,8 +27,6 @@ public open class ReactNativeNewArchitectureFeatureFlagsDefaults(
 
   override fun enableFabricRenderer(): Boolean = newArchitectureEnabled
 
-  override fun useFabricInterop(): Boolean = newArchitectureEnabled
-
   override fun useNativeViewConfigsInBridgelessMode(): Boolean =
       newArchitectureEnabled || super.useNativeViewConfigsInBridgelessMode()
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c7344e302f7ece9f41eec0dff5714d6e>>
+ * @generated SignedSource<<a98f50869ebeb68bd94bca19b7b40123>>
  */
 
 /**
@@ -172,7 +172,7 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool useFabricInterop() override {
-    return false;
+    return true;
   }
 
   bool useNativeViewConfigsInBridgelessMode() override {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSCanary.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSCanary.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<3e23c7633c684049fdcbdd9655bfbe46>>
+ * @generated SignedSource<<c44a616fd7c941ead315be0b83ae15a7>>
  */
 
 /**
@@ -103,9 +103,7 @@ class ReactNativeFeatureFlagsOverridesOSSCanary : public ReactNativeFeatureFlags
 
 
 
-  bool useFabricInterop() override {
-    return true;
-  }
+
 
   bool useNativeViewConfigsInBridgelessMode() override {
     return true;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSStable.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSStable.h
@@ -26,8 +26,5 @@ class ReactNativeFeatureFlagsOverridesOSSStable
   bool useNativeViewConfigsInBridgelessMode() override {
     return true;
   }
-  bool useFabricInterop() override {
-    return true;
-  }
 };
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorRegistry.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorRegistry.cpp
@@ -10,6 +10,7 @@
 #include "componentNameByReactViewName.h"
 
 #include <react/debug/react_native_assert.h>
+#include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/componentregistry/ComponentDescriptorProviderRegistry.h>
 #include <react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticComponentDescriptor.h>
 #include <react/renderer/components/legacyviewmanagerinterop/UnstableLegacyViewManagerAutomaticShadowNode.h>
@@ -83,11 +84,21 @@ const ComponentDescriptor& ComponentDescriptorRegistry::at(
   }
 
   if (it == _registryByName.end()) {
-    auto componentDescriptor = std::make_shared<
-        const UnstableLegacyViewManagerAutomaticComponentDescriptor>(
-        parameters_, unifiedComponentName);
-    registerComponentDescriptor(componentDescriptor);
-    return *_registryByName.find(unifiedComponentName)->second;
+    if (ReactNativeFeatureFlags::useFabricInterop()) {
+      auto componentDescriptor = std::make_shared<
+          const UnstableLegacyViewManagerAutomaticComponentDescriptor>(
+          parameters_, unifiedComponentName);
+      registerComponentDescriptor(componentDescriptor);
+      return *_registryByName.find(unifiedComponentName)->second;
+    } else {
+      if (_fallbackComponentDescriptor == nullptr) {
+        throw std::invalid_argument(
+            ("Unable to find componentDescriptor for " + unifiedComponentName)
+                .c_str());
+      } else {
+        return *_fallbackComponentDescriptor.get();
+      }
+    }
   }
 
   return *it->second;

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -427,14 +427,14 @@ const definitions: FeatureFlagDefinitions = {
       ossReleaseStage: 'none',
     },
     useFabricInterop: {
-      defaultValue: false,
+      defaultValue: true,
       metadata: {
         description:
           'Should this application enable the Fabric Interop Layer for Android? If yes, the application will behave so that it can accept non-Fabric components and render them on Fabric. This toggle is controlling extra logic such as custom event dispatching that are needed for the Fabric Interop Layer to work correctly.',
-        expectedReleaseValue: true,
+        expectedReleaseValue: false,
         purpose: 'release',
       },
-      ossReleaseStage: 'canary',
+      ossReleaseStage: 'none',
     },
     useNativeViewConfigsInBridgelessMode: {
       defaultValue: false,

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<2a2b48a836bfc7c29fddd2a10c4642b9>>
+ * @generated SignedSource<<5e3d982c0dfc71417fc6a1838758c6f4>>
  * @flow strict
  */
 
@@ -307,7 +307,7 @@ export const useEditTextStockAndroidFocusBehavior: Getter<boolean> = createNativ
 /**
  * Should this application enable the Fabric Interop Layer for Android? If yes, the application will behave so that it can accept non-Fabric components and render them on Fabric. This toggle is controlling extra logic such as custom event dispatching that are needed for the Fabric Interop Layer to work correctly.
  */
-export const useFabricInterop: Getter<boolean> = createNativeFlagGetter('useFabricInterop', false);
+export const useFabricInterop: Getter<boolean> = createNativeFlagGetter('useFabricInterop', true);
 /**
  * When enabled, the native view configs are used in bridgeless mode.
  */


### PR DESCRIPTION
Summary:
When useFabricInterop is disabled, deleting component descriptors in Component Registry is failing since  https://github.com/facebook/react-native/pull/47321 removed the Fabric Interop check from the ComponentDescriptorRegistry.cpp which was added earlier in https://github.com/facebook/react-native/pull/42294
Adding back the logic of Fallback component descriptor and error for the same.


Changelog:
[General][Fixed] Fixing Fabric Interop layer bug defaulting to UnstableLegacyViewManagerAutomaticComponentDescriptor irrespective of feature flags.

Differential Revision: D72266017


