### PR TITLE
Make `SoundManagerModule` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3235,16 +3235,6 @@ public final class com/facebook/react/modules/share/ShareModule : com/facebook/f
 public final class com/facebook/react/modules/share/ShareModule$Companion {
 }
 
-public final class com/facebook/react/modules/sound/SoundManagerModule : com/facebook/fbreact/specs/NativeSoundManagerSpec {
-	public static final field Companion Lcom/facebook/react/modules/sound/SoundManagerModule$Companion;
-	public static final field NAME Ljava/lang/String;
-	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;)V
-	public fun playTouchSound ()V
-}
-
-public final class com/facebook/react/modules/sound/SoundManagerModule$Companion {
-}
-
 public final class com/facebook/react/modules/statusbar/StatusBarModule : com/facebook/fbreact/specs/NativeStatusBarManagerAndroidSpec {
 	public static final field Companion Lcom/facebook/react/modules/statusbar/StatusBarModule$Companion;
 	public static final field NAME Ljava/lang/String;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/sound/SoundManagerModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/sound/SoundManagerModule.kt
@@ -16,15 +16,15 @@ import com.facebook.react.module.annotations.ReactModule
 
 /** [NativeModule] that allows Playing device sounds from JS. */
 @ReactModule(name = NativeSoundManagerSpec.NAME)
-public class SoundManagerModule(reactContext: ReactApplicationContext?) :
+internal class SoundManagerModule(reactContext: ReactApplicationContext?) :
     NativeSoundManagerSpec(reactContext) {
-  public override fun playTouchSound() {
+  override fun playTouchSound() {
     val audioManager =
         getReactApplicationContext().getSystemService(Context.AUDIO_SERVICE) as AudioManager
     audioManager.playSoundEffect(AudioManager.FX_KEY_CLICK)
   }
 
-  public companion object {
-    public const val NAME: String = NativeSoundManagerSpec.NAME
+  companion object {
+    const val NAME: String = NativeSoundManagerSpec.NAME
   }
 }


### PR DESCRIPTION
## Summary:

This class can be internalized as part of the initiative to reduce the public API surface. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.modules.sound.SoundManagerModule).

## Changelog:

[INTERNAL] - Make com.facebook.react.modules.sound.SoundManagerModule internal

## Test Plan:

```bash
yarn test-android
yarn android
```