### PR TITLE
Make `DeviceInfoModule` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2963,17 +2963,6 @@ public abstract interface class com/facebook/react/modules/debug/interfaces/Deve
 	public abstract fun setStartSamplingProfilerOnInit (Z)V
 }
 
-public final class com/facebook/react/modules/deviceinfo/DeviceInfoModule : com/facebook/fbreact/specs/NativeDeviceInfoSpec, com/facebook/react/bridge/LifecycleEventListener {
-	public fun <init> (Landroid/content/Context;)V
-	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;)V
-	public final fun emitUpdateDimensionsEvent ()V
-	public fun getTypedExportedConstants ()Ljava/util/Map;
-	public fun invalidate ()V
-	public fun onHostDestroy ()V
-	public fun onHostPause ()V
-	public fun onHostResume ()V
-}
-
 public class com/facebook/react/modules/dialog/AlertFragment : androidx/fragment/app/DialogFragment, android/content/DialogInterface$OnClickListener {
 	public fun <init> ()V
 	public fun <init> (Lcom/facebook/react/modules/dialog/DialogModule$AlertFragmentListener;Landroid/os/Bundle;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/deviceinfo/DeviceInfoModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/deviceinfo/DeviceInfoModule.kt
@@ -20,25 +20,25 @@ import com.facebook.react.uimanager.DisplayMetricsHolder.initDisplayMetricsIfNot
 
 /** Module that exposes Android Constants to JS. */
 @ReactModule(name = NativeDeviceInfoSpec.NAME)
-public class DeviceInfoModule : NativeDeviceInfoSpec, LifecycleEventListener {
+internal class DeviceInfoModule : NativeDeviceInfoSpec, LifecycleEventListener {
   private var reactApplicationContext: ReactApplicationContext? = null
   private var fontScale: Float
   private var previousDisplayMetrics: ReadableMap? = null
 
-  public constructor(reactContext: ReactApplicationContext) : super(reactContext) {
+  constructor(reactContext: ReactApplicationContext) : super(reactContext) {
     initDisplayMetricsIfNotInitialized(reactContext)
     fontScale = reactContext.resources.configuration.fontScale
     reactContext.addLifecycleEventListener(this)
     reactApplicationContext = reactContext
   }
 
-  public constructor(context: Context) : super(null) {
+  constructor(context: Context) : super(null) {
     reactApplicationContext = null
     initDisplayMetricsIfNotInitialized(context)
     fontScale = context.resources.configuration.fontScale
   }
 
-  public override fun getTypedExportedConstants(): Map<String, Any> {
+  override fun getTypedExportedConstants(): Map<String, Any> {
     val displayMetrics = getDisplayMetricsWritableMap(fontScale.toDouble())
 
     // Cache the initial dimensions for later comparison in emitUpdateDimensionsEvent
@@ -58,7 +58,7 @@ public class DeviceInfoModule : NativeDeviceInfoSpec, LifecycleEventListener {
 
   override fun onHostDestroy(): Unit = Unit
 
-  public fun emitUpdateDimensionsEvent() {
+  fun emitUpdateDimensionsEvent() {
     reactApplicationContext?.let { context ->
       if (context.hasActiveReactInstance()) {
         // Don't emit an event to JS if the dimensions haven't changed

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/deviceinfo/DeviceInfoModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/deviceinfo/DeviceInfoModule.kt
@@ -38,7 +38,7 @@ internal class DeviceInfoModule : NativeDeviceInfoSpec, LifecycleEventListener {
     fontScale = context.resources.configuration.fontScale
   }
 
-  override fun getTypedExportedConstants(): Map<String, Any> {
+  public override fun getTypedExportedConstants(): Map<String, Any> {
     val displayMetrics = getDisplayMetricsWritableMap(fontScale.toDouble())
 
     // Cache the initial dimensions for later comparison in emitUpdateDimensionsEvent


### PR DESCRIPTION
## Summary:

This class can be internalized as part of the initiative to reduce the public API surface. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.modules.deviceinfo.DeviceInfoModule).

All GH search results are forks – there is only one relevant case for the repository [renavigation2/renavigation2](https://github.com/renavigation2/renavigation2/blob/82582c11a9eb2e4e7c56d84d53fbc4e575cb0174/packages/navigation/android/src/main/java/com/navigation/reactnative/SceneView.java#L17), but the repo has no been updated for 4 years, marked as work in progress and its packages have 0 downloads, so this won't break OSS but I'm marking it as breaking just in case (let me know if you think we should open an issue on their side).

## Changelog:

[ANDROID][BREAKING] - Make com.facebook.react.modules.deviceinfo.DeviceInfoModule internal

## Test Plan:

```bash
yarn test-android
yarn android
```