### PR TITLE
[CI][Windows] Downgrade CMake to 3.31.6

### DIFF
--- a/.github/actions/build-hermesc-windows/action.yml
+++ b/.github/actions/build-hermesc-windows/action.yml
@@ -39,6 +39,9 @@ runs:
         New-Item -ItemType Directory -ErrorAction SilentlyContinue $Env:HERMES_WS_DIR\icu
         New-Item -ItemType Directory -ErrorAction SilentlyContinue $Env:HERMES_WS_DIR\deps
         New-Item -ItemType Directory -ErrorAction SilentlyContinue $Env:HERMES_WS_DIR\win64-bin
+    - name: Downgrade CMake
+      shell: powershell
+      run: choco install cmake --version 3.31.6 --force
     - name: Build HermesC for Windows
       shell: powershell
       run: |


### PR DESCRIPTION
## Summary:
Windows executor has been updated by github and they now ship with CMake 4.0. (https://github.com/actions/runner-images/issues/11926)

This is not compatible with building HermesC on windows machines. This change attempts to downgrade cmake to 3.31.6, the same version we used to use before.

## Changelog:
[Internal] - downgrage Cmake to 3.31.6

## Test Plan:
GHA