### PR TITLE
[iOS] Fixes right border stretching when the left side has a corner while the right side does not

### DIFF
--- a/packages/react-native/React/Views/RCTBorderDrawing.m
+++ b/packages/react-native/React/Views/RCTBorderDrawing.m
@@ -218,15 +218,13 @@ static UIImage *RCTGetSolidBorderImage(
       (borderInsets.top + cornerInsets.topRight.height + borderInsets.bottom + cornerInsets.bottomLeft.height <=
        viewSize.height);
 
-  BOOL hasOnlyLeftRoundedCorners = (cornerRadii.topLeftHorizontal > 0 || cornerRadii.bottomLeftHorizontal > 0) &&
-      cornerRadii.topRightHorizontal == 0 && cornerRadii.bottomRightHorizontal == 0;
-
-  UIEdgeInsets edgeInsets =
-      (UIEdgeInsets){borderInsets.top + MAX(cornerInsets.topLeft.height, cornerInsets.topRight.height),
-                     borderInsets.left + MAX(cornerInsets.topLeft.width, cornerInsets.bottomLeft.width),
-                     borderInsets.bottom + MAX(cornerInsets.bottomLeft.height, cornerInsets.bottomRight.height),
-                     borderInsets.right + MAX(cornerInsets.bottomRight.width, cornerInsets.topRight.width) +
-                         (makeStretchable && hasOnlyLeftRoundedCorners ? 1 : 0)};
+  UIEdgeInsets edgeInsets = (UIEdgeInsets){
+      borderInsets.top + MAX(cornerInsets.topLeft.height, cornerInsets.topRight.height),
+      borderInsets.left + MAX(cornerInsets.topLeft.width, cornerInsets.bottomLeft.width),
+      borderInsets.bottom +
+          MAX(cornerInsets.bottomLeft.height, cornerInsets.bottomRight.height + (makeStretchable ? 1 : 0)),
+      borderInsets.right + MAX(cornerInsets.bottomRight.width, cornerInsets.topRight.width) +
+          (makeStretchable ? 1 : 0)};
 
   const CGSize size = makeStretchable ? (CGSize){
     // 1pt for the middle stretchable area along each axis

--- a/packages/react-native/React/Views/RCTBorderDrawing.m
+++ b/packages/react-native/React/Views/RCTBorderDrawing.m
@@ -218,11 +218,15 @@ static UIImage *RCTGetSolidBorderImage(
       (borderInsets.top + cornerInsets.topRight.height + borderInsets.bottom + cornerInsets.bottomLeft.height <=
        viewSize.height);
 
-  UIEdgeInsets edgeInsets = (UIEdgeInsets){
-      borderInsets.top + MAX(cornerInsets.topLeft.height, cornerInsets.topRight.height),
-      borderInsets.left + MAX(cornerInsets.topLeft.width, cornerInsets.bottomLeft.width),
-      borderInsets.bottom + MAX(cornerInsets.bottomLeft.height, cornerInsets.bottomRight.height),
-      borderInsets.right + MAX(cornerInsets.bottomRight.width, cornerInsets.topRight.width)};
+  BOOL hasOnlyLeftRoundedCorners = (cornerRadii.topLeftHorizontal > 0 || cornerRadii.bottomLeftHorizontal > 0) &&
+      cornerRadii.topRightHorizontal == 0 && cornerRadii.bottomRightHorizontal == 0;
+
+  UIEdgeInsets edgeInsets =
+      (UIEdgeInsets){borderInsets.top + MAX(cornerInsets.topLeft.height, cornerInsets.topRight.height),
+                     borderInsets.left + MAX(cornerInsets.topLeft.width, cornerInsets.bottomLeft.width),
+                     borderInsets.bottom + MAX(cornerInsets.bottomLeft.height, cornerInsets.bottomRight.height),
+                     borderInsets.right + MAX(cornerInsets.bottomRight.width, cornerInsets.topRight.width) +
+                         (makeStretchable && hasOnlyLeftRoundedCorners ? 1 : 0)};
 
   const CGSize size = makeStretchable ? (CGSize){
     // 1pt for the middle stretchable area along each axis


### PR DESCRIPTION
## Summary:

Fixes #46801. If the left side has a corner while the right side does not, it seems that iOS stretches the right border. Therefore, we can add 1 point to create a gap between the stretchable region and the border.

## Changelog:

[IOS] [FIXED] - Fixes right border stretching when the left side has a corner while the right side does not

## Test Plan:

Repro please see #46801
