### PR TITLE
Pin cmake version to 3.31.6

### DIFF
--- a/.github/actions/build-hermesc-linux/action.yml
+++ b/.github/actions/build-hermesc-linux/action.yml
@@ -14,8 +14,12 @@ runs:
       shell: bash
       run: |
         sudo apt update
-        sudo apt install -y git openssh-client cmake build-essential \
+        sudo apt install -y git openssh-client build-essential \
             libreadline-dev libicu-dev jq zip python3
+
+        # Install cmake 3.28.3-1build7
+        sudo apt-get install cmake=3.28.3-1build7
+        sudo ln -sf /usr/bin/cmake /usr/local/bin/cmake
     - name: Restore Hermes workspace
       uses: ./.github/actions/restore-hermes-workspace
     - name: Linux cache

--- a/.github/actions/build-hermesc-windows/action.yml
+++ b/.github/actions/build-hermesc-windows/action.yml
@@ -39,6 +39,9 @@ runs:
         New-Item -ItemType Directory -ErrorAction SilentlyContinue $Env:HERMES_WS_DIR\icu
         New-Item -ItemType Directory -ErrorAction SilentlyContinue $Env:HERMES_WS_DIR\deps
         New-Item -ItemType Directory -ErrorAction SilentlyContinue $Env:HERMES_WS_DIR\win64-bin
+    - name: Downgrade CMake
+      shell: powershell
+      run: choco install cmake --version 3.31.6 --force
     - name: Build HermesC for Windows
       shell: powershell
       run: |


### PR DESCRIPTION
Summary:
Runners in GHA has been updated by github and they now ship with CMake 4.0. (actions/runner-images#11926)

This version is not compatible with React Native, so we are pinning cmake to 3.36.1

## Changelog:
[Internal] - Pin cmake to 3.36.1

Differential Revision: D72379834


