### PR TITLE
Create a transform for sorting the object properties and methods

### DIFF
--- a/scripts/build/build-types/transforms/__fixtures__/sortProperties.d.ts
+++ b/scripts/build/build-types/transforms/__fixtures__/sortProperties.d.ts
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+type A = {
+  bFn: () => void,
+  aFn: () => void,
+  bMethod(): void;
+  aMethod(): void;
+  b: string,
+  a: string,
+}
+
+interface B {
+  bFn: () => void,
+  aFn: () => void,
+  bMethod(): void;
+  aMethod(): void;
+  b: string,
+  a: string,
+}
+
+declare class C {
+  bFn: () => void;
+  aFn: () => void;
+  bMethod(): void;
+  aMethod(): void;
+  b: string;
+  a: string;
+  #d: string;
+  #c: string;
+}
+
+type Fn = (arg: {
+  bFn: () => void,
+  aFn: () => void,
+  bMethod(): void;
+  aMethod(): void;
+  b: string,
+  a: string,
+}) => void;
+
+enum E {
+  C,
+  B,
+  A,
+}
+
+enum F {
+  C = 3,
+  B = 2,
+  A = 1,
+}

--- a/scripts/build/build-types/transforms/__fixtures__/sortTypeDefinitions.d.ts
+++ b/scripts/build/build-types/transforms/__fixtures__/sortTypeDefinitions.d.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as React from "react";
+
+declare type Foo =
+  | "A"
+  | "B"
+declare type Bar =
+  | null
+  | string
+  | number;
+declare class Baz {
+  foo: string;
+}
+declare function fn(): void;
+
+export declare type ExportedFoo =
+  | "A"
+  | "B"
+export declare type ExportedBar =
+  | null
+  | string
+  | number;
+export declare class ExportedBaz {
+  foo: string;
+}
+export declare function exportedFn(): void;

--- a/scripts/build/build-types/transforms/__tests__/__snapshots__/sortProperties-test.js.snap
+++ b/scripts/build/build-types/transforms/__tests__/__snapshots__/sortProperties-test.js.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`sortProperties should divide type properties into methods, functions and others and sort them within each group 1`] = `
+"/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+type A = {
+  a: string;
+  b: string;
+  aFn: () => void;
+  bFn: () => void;
+  aMethod(): void;
+  bMethod(): void;
+};
+interface B {
+  a: string;
+  b: string;
+  aFn: () => void;
+  bFn: () => void;
+  aMethod(): void;
+  bMethod(): void;
+}
+declare class C {
+  a: string;
+  b: string;
+  #c: string;
+  #d: string;
+  aFn: () => void;
+  bFn: () => void;
+  aMethod(): void;
+  bMethod(): void;
+}
+type Fn = (arg: {
+  a: string;
+  b: string;
+  aFn: () => void;
+  bFn: () => void;
+  aMethod(): void;
+  bMethod(): void;
+}) => void;
+enum E {
+  A,
+  B,
+  C,
+}
+enum F {
+  A = 1,
+  B = 2,
+  C = 3,
+}"
+`;

--- a/scripts/build/build-types/transforms/__tests__/__snapshots__/sortTypeDefinitions-test.js.snap
+++ b/scripts/build/build-types/transforms/__tests__/__snapshots__/sortTypeDefinitions-test.js.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`sortTypeDefinitions should divide top-lelvel declarations into exported and non-exported sections 1`] = `
+"/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as React from \\"react\\";
+export declare type ExportedFoo = \\"A\\" | \\"B\\";
+export declare type ExportedBar = null | string | number;
+export declare class ExportedBaz {
+  foo: string;
+}
+export declare function exportedFn(): void;
+declare type Foo = \\"A\\" | \\"B\\";
+declare type Bar = null | string | number;
+declare class Baz {
+  foo: string;
+}
+declare function fn(): void;"
+`;

--- a/scripts/build/build-types/transforms/__tests__/sortProperties-test.js
+++ b/scripts/build/build-types/transforms/__tests__/sortProperties-test.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+const sortPropertiesVisitor = require('../sortProperties.js');
+const babel = require('@babel/core');
+const {promises: fs} = require('fs');
+const path = require('path');
+
+async function translate(code: string): Promise<string> {
+  const result = await babel.transformAsync(code, {
+    plugins: ['@babel/plugin-syntax-typescript', sortPropertiesVisitor],
+  });
+
+  return result.code;
+}
+
+describe('sortProperties', () => {
+  test('should divide type properties into methods, functions and others and sort them within each group', async () => {
+    const code = await fs.readFile(
+      path.join(__dirname, '../__fixtures__/sortProperties.d.ts'),
+      'utf-8',
+    );
+    const result = await translate(code);
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/scripts/build/build-types/transforms/__tests__/sortTypeDefinitions-test.js
+++ b/scripts/build/build-types/transforms/__tests__/sortTypeDefinitions-test.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+const sortTypeDefinitionsVisitor = require('../sortTypeDefinitions.js');
+const babel = require('@babel/core');
+const {promises: fs} = require('fs');
+const path = require('path');
+
+async function translate(code: string): Promise<string> {
+  const result = await babel.transformAsync(code, {
+    plugins: ['@babel/plugin-syntax-typescript', sortTypeDefinitionsVisitor],
+  });
+
+  return result.code;
+}
+
+describe('sortTypeDefinitions', () => {
+  test('should divide top-lelvel declarations into exported and non-exported sections', async () => {
+    const code = await fs.readFile(
+      path.join(__dirname, '../__fixtures__/sortTypeDefinitions.d.ts'),
+      'utf-8',
+    );
+    const result = await translate(code);
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/scripts/build/build-types/transforms/sortProperties.js
+++ b/scripts/build/build-types/transforms/sortProperties.js
@@ -1,0 +1,91 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {PluginObj} from '@babel/core';
+
+import * as t from '@babel/types';
+
+function sortMembers<T>(members: T[]): T[] {
+  const properties = [];
+  const functionProperties = [];
+  const methods = [];
+  const enumMembers = [];
+
+  for (const member of members) {
+    if (t.isTSEnumMember(member)) {
+      enumMembers.push(member);
+    } else if (
+      t.isTSPropertySignature(member) ||
+      t.isClassProperty(member) ||
+      t.isClassPrivateProperty(member)
+    ) {
+      if (
+        t.isTSTypeAnnotation(member.typeAnnotation) &&
+        t.isTSFunctionType(member.typeAnnotation.typeAnnotation)
+      ) {
+        functionProperties.push(member);
+      } else {
+        properties.push(member);
+      }
+    } else {
+      methods.push(member);
+    }
+  }
+
+  // $FlowFixMe[unclear-type]
+  function comparator(a: any, b: any): number {
+    const aName = t.isClassPrivateProperty(a)
+      ? a.key.id.name
+      : t.isTSEnumMember(a)
+        ? a.id.name
+        : a.key.name;
+    const bName = t.isClassPrivateProperty(b)
+      ? b.key.id.name
+      : t.isTSEnumMember(b)
+        ? b.id.name
+        : b.key.name;
+
+    if (aName === undefined || bName === undefined) {
+      return 0;
+    }
+
+    return aName.localeCompare(bName);
+  }
+
+  properties.sort(comparator);
+  functionProperties.sort(comparator);
+  methods.sort(comparator);
+  enumMembers.sort(comparator);
+
+  return properties
+    .concat(functionProperties)
+    .concat(methods)
+    .concat(enumMembers);
+}
+
+const visitor: PluginObj<mixed> = {
+  visitor: {
+    TSInterfaceBody(path) {
+      path.node.body = sortMembers(path.node.body);
+    },
+    ClassBody(path) {
+      path.node.body = sortMembers(path.node.body);
+    },
+    TSTypeLiteral(path) {
+      path.node.members = sortMembers(path.node.members);
+    },
+    TSEnumDeclaration(path) {
+      path.node.members = sortMembers(path.node.members);
+    },
+  },
+};
+
+module.exports = visitor;

--- a/scripts/build/build-types/transforms/sortTypeDefinitions.js
+++ b/scripts/build/build-types/transforms/sortTypeDefinitions.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {PluginObj} from '@babel/core';
+
+import * as t from '@babel/types';
+
+const visitor: PluginObj<mixed> = {
+  visitor: {
+    Program(path) {
+      path.node.body.sort((a, b) => {
+        // Push import declarations at the top of the file
+        if (t.isImportDeclaration(a) && !t.isImportDeclaration(b)) {
+          return -1;
+        } else if (!t.isImportDeclaration(a) && t.isImportDeclaration(b)) {
+          return 1;
+        }
+
+        const aExported = t.isExportNamedDeclaration(a);
+        const bExported = t.isExportNamedDeclaration(b);
+
+        // Push exported declarations before non-exported declarations
+        if (aExported && !bExported) {
+          return -1;
+        } else if (!aExported && bExported) {
+          return 1;
+        }
+
+        return 0;
+      });
+    },
+  },
+};
+
+module.exports = visitor;


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Adds a transform that is able to divide properies of interaces, types and classes into sections:
- properties
- properties typed as functions
- methods
ands sorts them alphabetically within the groups.

Differential Revision: D72381050


