### PR TITLE
Add a `legacyWarningsEnabled` property to enable Legacy Warnings on NewArch

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -13,6 +13,7 @@ import com.facebook.react.internal.PrivateReactExtension
 import com.facebook.react.tasks.GenerateAutolinkingNewArchitecturesFileTask
 import com.facebook.react.tasks.GenerateCodegenArtifactsTask
 import com.facebook.react.tasks.GenerateCodegenSchemaTask
+import com.facebook.react.tasks.GenerateEntryPointTask
 import com.facebook.react.tasks.GeneratePackageListTask
 import com.facebook.react.utils.AgpConfiguratorUtils.configureBuildConfigFieldsForApp
 import com.facebook.react.utils.AgpConfiguratorUtils.configureBuildConfigFieldsForLibraries
@@ -248,6 +249,16 @@ class ReactPlugin : Plugin<Project> {
               task.generatedOutputDirectory.set(generatedAutolinkingJavaDir)
             }
 
+    // We add a task called generateAutolinkingPackageList to do not clash with the existing task
+    // called generatePackageList. This can to be renamed once we unlink the rn <-> cli
+    // dependency.
+    val generateEntryPointTask =
+        project.tasks.register(
+            "generateReactNativeEntryPoint", GenerateEntryPointTask::class.java) { task ->
+              task.autolinkInputFile.set(rootGeneratedAutolinkingFile)
+              task.generatedOutputDirectory.set(generatedAutolinkingJavaDir)
+            }
+
     if (project.isNewArchEnabled(extension)) {
       // For New Arch, we also need to generate code for C++ Autolinking
       val generateAutolinkingNewArchitectureFilesTask =
@@ -262,9 +273,12 @@ class ReactPlugin : Plugin<Project> {
           .dependsOn(generateAutolinkingNewArchitectureFilesTask)
     }
 
-    // We let generateAutolinkingPackageList depend on the preBuild task so it's executed before
+    // We let generateAutolinkingPackageList and generateEntryPoint depend on the preBuild task so
+    // it's executed before
     // everything else.
-    project.tasks.named("preBuild", Task::class.java).dependsOn(generatePackageListTask)
+    project.tasks
+        .named("preBuild", Task::class.java)
+        .dependsOn(generatePackageListTask, generateEntryPointTask)
 
     // We tell Android Gradle Plugin that inside /build/generated/autolinking/src/main/java there
     // are sources to be compiled as well.

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/GenerateEntryPointTask.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/GenerateEntryPointTask.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.tasks
+
+import com.facebook.react.utils.JsonUtils
+import java.io.File
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+
+abstract class GenerateEntryPointTask : DefaultTask() {
+
+  init {
+    group = "react"
+  }
+
+  @get:InputFile abstract val autolinkInputFile: RegularFileProperty
+
+  @get:OutputDirectory abstract val generatedOutputDirectory: DirectoryProperty
+
+  @TaskAction
+  fun taskAction() {
+    val model =
+        JsonUtils.fromAutolinkingConfigJson(autolinkInputFile.get().asFile)
+            ?: error(
+                """
+        RNGP - Autolinking: Could not parse autolinking config file:
+        ${autolinkInputFile.get().asFile.absolutePath}
+        
+        The file is either missing or not containing valid JSON so the build won't succeed. 
+      """
+                    .trimIndent())
+
+    val packageName =
+        model.project?.android?.packageName
+            ?: error(
+                "RNGP - Autolinking: Could not find project.android.packageName in react-native config output! Could not autolink packages without this field.")
+    val generatedFileContents = composeFileContent(packageName)
+
+    val outputDir = generatedOutputDirectory.get().asFile
+    outputDir.mkdirs()
+    File(outputDir, GENERATED_FILENAME).apply {
+      parentFile.mkdirs()
+      writeText(generatedFileContents)
+    }
+  }
+
+  internal fun composeFileContent(packageName: String): String =
+      generatedFileContentsTemplate.replace("{{packageName}}", packageName)
+
+  companion object {
+    const val GENERATED_FILENAME = "com/facebook/react/ReactNativeApplicationEntryPoint.java"
+
+    // language=java
+    val generatedFileContentsTemplate =
+        """
+      package com.facebook.react;
+      
+      import android.app.Application;
+      import android.content.Context;
+      import android.content.res.Resources;
+      
+      import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint;
+      import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger;
+      import com.facebook.react.soloader.OpenSourceMergedSoMapping;
+      import com.facebook.soloader.SoLoader;
+      
+      import java.io.IOException;
+      
+      /**
+        * This class is the entry point for loading React Native using the configuration
+        * that the users specifies in their .gradle files.
+        *
+        * The `loadReactNative(this)` method invocation should be called inside the
+        * application onCreate otherwise the app won't load correctly.            
+        */
+      public class ReactNativeApplicationEntryPoint {
+        public static void loadReactNative(Context context) {
+          try {
+             SoLoader.init(context, OpenSourceMergedSoMapping.INSTANCE);
+          } catch (IOException error) {
+            throw new RuntimeException(error);
+          }
+          
+          if ({{packageName}}.BuildConfig.LEGACY_WARNINGS_ENABLED) {
+            LegacyArchitectureLogger.OSS_LEGACY_WARNINGS_ENABLED = true;
+          }
+          if ({{packageName}}.BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+            DefaultNewArchitectureEntryPoint.load();
+          }
+        }
+      }
+            """
+            .trimIndent()
+  }
+}

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/AgpConfiguratorUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/AgpConfiguratorUtils.kt
@@ -10,6 +10,7 @@ package com.facebook.react.utils
 import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.gradle.LibraryExtension
 import com.facebook.react.ReactExtension
+import com.facebook.react.utils.ProjectUtils.areLegacyWarningsEnabled
 import com.facebook.react.utils.ProjectUtils.isHermesEnabled
 import com.facebook.react.utils.ProjectUtils.isNewArchEnabled
 import java.io.File
@@ -32,6 +33,8 @@ internal object AgpConfiguratorUtils {
                 "boolean",
                 "IS_NEW_ARCHITECTURE_ENABLED",
                 project.isNewArchEnabled(extension).toString())
+            ext.defaultConfig.buildConfigField(
+                "boolean", "LEGACY_WARNINGS_ENABLED", project.areLegacyWarningsEnabled().toString())
             ext.defaultConfig.buildConfigField(
                 "boolean", "IS_HERMES_ENABLED", project.isHermesEnabled.toString())
           }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/ProjectUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/ProjectUtils.kt
@@ -12,9 +12,11 @@ import com.facebook.react.model.ModelPackageJson
 import com.facebook.react.utils.KotlinStdlibCompatUtils.lowercaseCompat
 import com.facebook.react.utils.KotlinStdlibCompatUtils.toBooleanStrictOrNullCompat
 import com.facebook.react.utils.PropertyUtils.HERMES_ENABLED
+import com.facebook.react.utils.PropertyUtils.LEGACY_WARNINGS_ENABLED
 import com.facebook.react.utils.PropertyUtils.NEW_ARCH_ENABLED
 import com.facebook.react.utils.PropertyUtils.REACT_NATIVE_ARCHITECTURES
 import com.facebook.react.utils.PropertyUtils.SCOPED_HERMES_ENABLED
+import com.facebook.react.utils.PropertyUtils.SCOPED_LEGACY_WARNINGS_ENABLED
 import com.facebook.react.utils.PropertyUtils.SCOPED_NEW_ARCH_ENABLED
 import com.facebook.react.utils.PropertyUtils.SCOPED_REACT_NATIVE_ARCHITECTURES
 import com.facebook.react.utils.PropertyUtils.SCOPED_USE_THIRD_PARTY_JSC
@@ -31,6 +33,13 @@ internal object ProjectUtils {
         project.property(NEW_ARCH_ENABLED).toString().toBoolean()) ||
         (project.hasProperty(SCOPED_NEW_ARCH_ENABLED) &&
             project.property(SCOPED_NEW_ARCH_ENABLED).toString().toBoolean())
+  }
+
+  internal fun Project.areLegacyWarningsEnabled(): Boolean {
+    return (project.hasProperty(LEGACY_WARNINGS_ENABLED) &&
+        project.property(LEGACY_WARNINGS_ENABLED).toString().toBoolean()) ||
+        (project.hasProperty(SCOPED_LEGACY_WARNINGS_ENABLED) &&
+            project.property(SCOPED_LEGACY_WARNINGS_ENABLED).toString().toBoolean())
   }
 
   internal val Project.isHermesEnabled: Boolean

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PropertyUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PropertyUtils.kt
@@ -14,6 +14,10 @@ object PropertyUtils {
   const val NEW_ARCH_ENABLED = "newArchEnabled"
   const val SCOPED_NEW_ARCH_ENABLED = "react.newArchEnabled"
 
+  /** Public property that toggles the Legacy Architecture Warnings */
+  const val LEGACY_WARNINGS_ENABLED = "legacyWarningsEnabled"
+  const val SCOPED_LEGACY_WARNINGS_ENABLED = "react.legacyWarningsEnabled"
+
   /** Public property that toggles the New Architecture */
   const val HERMES_ENABLED = "hermesEnabled"
   const val SCOPED_HERMES_ENABLED = "react.hermesEnabled"

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateEntryPointTaskTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateEntryPointTaskTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.tasks
+
+import com.facebook.react.tests.createTestTask
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class GenerateEntryPointTaskTest {
+
+  @get:Rule val tempFolder = TemporaryFolder()
+
+  @Test
+  fun generatePackageListTask_groupIsSetCorrectly() {
+    val task = createTestTask<GenerateEntryPointTask> {}
+    assertThat(task.group).isEqualTo("react")
+  }
+
+  @Test
+  fun generatePackageListTask_staticInputs_areSetCorrectly() {
+    val outputFolder = tempFolder.newFolder("build")
+    val inputFile = tempFolder.newFile("config.json")
+
+    val task =
+        createTestTask<GenerateEntryPointTask> { task ->
+          task.generatedOutputDirectory.set(outputFolder)
+          task.autolinkInputFile.set(inputFile)
+        }
+
+    assertThat(task.inputs.files.singleFile).isEqualTo(inputFile)
+    assertThat(task.outputs.files.singleFile).isEqualTo(outputFolder)
+  }
+
+  @Test
+  fun composeFileContent_withNoPackages_returnsValidFile() {
+    val task = createTestTask<GenerateEntryPointTask>()
+    val packageName = "com.facebook.react"
+    val result = task.composeFileContent(packageName)
+    // language=java
+    assertThat(result)
+        .isEqualTo(
+            """
+        package com.facebook.react;
+        
+        import android.app.Application;
+        import android.content.Context;
+        import android.content.res.Resources;
+        
+        import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint;
+        import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger;
+        import com.facebook.react.soloader.OpenSourceMergedSoMapping;
+        import com.facebook.soloader.SoLoader;
+        
+        import java.io.IOException;
+        
+        /**
+          * This class is the entry point for loading React Native using the configuration
+          * that the users specifies in their .gradle files.
+          *
+          * The `loadReactNative(this)` method invocation should be called inside the
+          * application onCreate otherwise the app won't load correctly.            
+          */
+        public class ReactNativeApplicationEntryPoint {
+          public static void loadReactNative(Context context) {
+            try {
+               SoLoader.init(context, OpenSourceMergedSoMapping.INSTANCE);
+            } catch (IOException error) {
+              throw new RuntimeException(error);
+            }
+            
+            if (com.facebook.react.BuildConfig.LEGACY_WARNINGS_ENABLED) {
+              LegacyArchitectureLogger.OSS_LEGACY_WARNINGS_ENABLED = true;
+            }
+            if (com.facebook.react.BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+              DefaultNewArchitectureEntryPoint.load();
+            }
+          }
+        }
+    """
+                .trimIndent())
+  }
+}

--- a/packages/helloworld/android/app/src/main/java/com/helloworld/MainApplication.kt
+++ b/packages/helloworld/android/app/src/main/java/com/helloworld/MainApplication.kt
@@ -13,11 +13,8 @@ import com.facebook.react.ReactApplication
 import com.facebook.react.ReactHost
 import com.facebook.react.ReactNativeHost
 import com.facebook.react.ReactPackage
-import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.load
 import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
 import com.facebook.react.defaults.DefaultReactNativeHost
-import com.facebook.react.soloader.OpenSourceMergedSoMapping
-import com.facebook.soloader.SoLoader
 
 class MainApplication : Application(), ReactApplication {
 
@@ -42,10 +39,6 @@ class MainApplication : Application(), ReactApplication {
 
   override fun onCreate() {
     super.onCreate()
-    SoLoader.init(this, OpenSourceMergedSoMapping)
-    if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
-      // If you opted-in for the New Architecture, we load the native entry point for this app.
-      load()
-    }
+    loadReactNative(this)
   }
 }

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3565,6 +3565,7 @@ public final class com/facebook/react/soloader/OpenSourceMergedSoMapping : com/f
 	public final fun libreact_newarchdefaults_so ()I
 	public final fun libreactnative_so ()I
 	public final fun libreactnativeblob_so ()I
+	public final fun libreactnativejni_common_so ()I
 	public final fun libreactnativejni_so ()I
 	public final fun librninstance_so ()I
 	public final fun libturbomodulejsijni_so ()I

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/DynamicNative.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/DynamicNative.kt
@@ -9,6 +9,7 @@ package com.facebook.react.bridge
 
 import com.facebook.jni.HybridClassBase
 import com.facebook.proguard.annotations.DoNotStripAny
+import com.facebook.soloader.SoLoader
 
 /**
  * An implementation of [Dynamic] that has a C++ implementation.
@@ -44,5 +45,11 @@ private class DynamicNative : HybridClassBase(), Dynamic {
 
   override fun recycle() {
     // Noop - nothing to recycle since there is no pooling
+  }
+
+  private companion object {
+    init {
+      SoLoader.loadLibrary("reactnativejni_common")
+    }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeArray.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeArray.kt
@@ -9,6 +9,7 @@ package com.facebook.react.bridge
 
 import com.facebook.jni.HybridClassBase
 import com.facebook.proguard.annotations.DoNotStrip
+import com.facebook.soloader.SoLoader
 
 /** Base class for an array whose members are stored in native code (C++). */
 @DoNotStrip
@@ -19,7 +20,7 @@ public abstract class NativeArray protected constructor() :
 
   private companion object {
     init {
-      BridgeSoLoader.staticInit()
+      SoLoader.loadLibrary("reactnativejni_common")
     }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeMap.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeMap.kt
@@ -9,6 +9,7 @@ package com.facebook.react.bridge
 
 import com.facebook.jni.HybridClassBase
 import com.facebook.proguard.annotations.DoNotStrip
+import com.facebook.soloader.SoLoader
 
 /** Base class for a Map whose keys and values are stored in native code (C++). */
 @DoNotStrip
@@ -17,7 +18,7 @@ public abstract class NativeMap : HybridClassBase() {
 
   private companion object {
     init {
-      BridgeSoLoader.staticInit()
+      SoLoader.loadLibrary("reactnativejni_common")
     }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/soloader/OpenSourceMergedSoMapping.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/soloader/OpenSourceMergedSoMapping.kt
@@ -30,6 +30,7 @@ public object OpenSourceMergedSoMapping : ExternalSoMapping {
         "react_newarchdefaults",
         "reactnativeblob",
         "reactnativejni",
+        "reactnativejni_common",
         "rninstance",
         "turbomodulejsijni",
         "uimanagerjni",
@@ -68,6 +69,7 @@ public object OpenSourceMergedSoMapping : ExternalSoMapping {
       "reactnative" -> libreactnative_so()
       "reactnativeblob" -> libreactnativeblob_so()
       "reactnativejni" -> libreactnativejni_so()
+      "reactnativejni_common" -> libreactnativejni_common_so()
       "rninstance" -> librninstance_so()
       "turbomodulejsijni" -> libturbomodulejsijni_so()
       "uimanagerjni" -> libuimanagerjni_so()
@@ -108,6 +110,8 @@ public object OpenSourceMergedSoMapping : ExternalSoMapping {
   public external fun libreactnativeblob_so(): Int
 
   public external fun libreactnativejni_so(): Int
+
+  public external fun libreactnativejni_common_so(): Int
 
   public external fun librninstance_so(): Int
 

--- a/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
@@ -214,6 +214,7 @@ add_library(reactnative
           $<TARGET_OBJECTS:react_utils>
           $<TARGET_OBJECTS:reactnativeblob>
           $<TARGET_OBJECTS:reactnativejni>
+          $<TARGET_OBJECTS:reactnativejni_common>
           $<TARGET_OBJECTS:reactperflogger>
           $<TARGET_OBJECTS:rninstance>
           $<TARGET_OBJECTS:rrc_image>
@@ -303,6 +304,7 @@ target_include_directories(reactnative
         $<TARGET_PROPERTY:react_utils,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:reactnativeblob,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:reactnativejni,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:reactnativejni_common,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:reactperflogger,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:rninstance,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:rrc_image,INTERFACE_INCLUDE_DIRECTORIES>

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/CMakeLists.txt
@@ -8,7 +8,37 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
-file(GLOB reactnativejni_SRC CONFIGURE_DEPENDS *.cpp)
+
+file(GLOB reactnativejni_common_SRC CONFIGURE_DEPENDS *.cpp)
+
+#############################
+### reactnativejni_common ###
+#############################
+
+# This library contains the code from reactnativejni that is used by both old and new
+# arch so it can be built in a separate library.
+
+include(${REACT_ANDROID_DIR}/src/main/jni/first-party/jni-lib-merge/SoMerging-utils.cmake)
+
+add_library(
+        reactnativejni_common
+        OBJECT
+          JDynamicNative.cpp
+          NativeArray.cpp
+          NativeCommon.cpp
+          NativeMap.cpp
+        OnLoad-common.cpp
+          ReadableNativeArray.cpp
+          ReadableNativeMap.cpp
+          WritableNativeArray.cpp
+          WritableNativeMap.cpp
+)
+target_merge_so(reactnativejni_common)
+target_include_directories(reactnativejni_common PUBLIC ../../)
+
+target_link_libraries(reactnativejni_common fbjni folly_runtime)
+target_compile_reactnative_options(reactnativejni_common PRIVATE)
+target_compile_options(reactnativejni_common PRIVATE -Wno-unused-lambda-capture)
 
 ######################
 ### reactnativejni ###
@@ -19,7 +49,25 @@ include(${REACT_ANDROID_DIR}/src/main/jni/first-party/jni-lib-merge/SoMerging-ut
 add_library(
         reactnativejni
         OBJECT
-        ${reactnativejni_SRC}
+          CatalystInstanceImpl.cpp
+          InspectorNetworkRequestListener.cpp
+          JExecutor.cpp
+          JInspector.cpp
+          JMessageQueueThread.cpp
+          JReactCxxErrorHandler.cpp
+          JReactMarker.cpp
+          JReactSoftExceptionLogger.cpp
+          JRuntimeExecutor.cpp
+          JRuntimeScheduler.cpp
+          JSLoader.cpp
+          JSLogging.cpp
+          JavaModuleWrapper.cpp
+          JniJSModulesUnbundle.cpp
+          MethodInvoker.cpp
+          ModuleRegistryBuilder.cpp
+          OnLoad.cpp
+          ReactInstanceManagerInspectorTarget.cpp
+          SafeReleaseJniRef.cpp
 )
 target_merge_so(reactnativejni)
 
@@ -35,6 +83,7 @@ target_link_libraries(reactnativejni
         logger
         react_cxxreact
         react_renderer_runtimescheduler
+        reactnativejni_common
         runtimeexecutor
         yoga
         )

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/OnLoad-common.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/OnLoad-common.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <fbjni/fbjni.h>
+#include "JCallback.h"
+#include "JDynamicNative.h"
+#include "NativeArray.h"
+#include "NativeMap.h"
+#include "WritableNativeArray.h"
+#include "WritableNativeMap.h"
+
+namespace facebook::react {
+
+extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
+  return facebook::jni::initialize(vm, [] {
+    JCxxCallbackImpl::registerNatives();
+    JDynamicNative::registerNatives();
+    NativeArray::registerNatives();
+    NativeMap::registerNatives();
+    ReadableNativeArray::registerNatives();
+    ReadableNativeMap::registerNatives();
+    WritableNativeArray::registerNatives();
+    WritableNativeMap::registerNatives();
+  });
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
@@ -15,14 +15,10 @@
 #include "CatalystInstanceImpl.h"
 #include "CxxModuleWrapperBase.h"
 #include "InspectorNetworkRequestListener.h"
-#include "JCallback.h"
-#include "JDynamicNative.h"
 #include "JInspector.h"
 #include "JReactMarker.h"
 #include "JavaScriptExecutorHolder.h"
 #include "ReactInstanceManagerInspectorTarget.h"
-#include "WritableNativeArray.h"
-#include "WritableNativeMap.h"
 
 #ifndef WITH_GLOGINIT
 #define WITH_GLOGINIT 1
@@ -44,17 +40,8 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
     gloginit::initialize();
     FLAGS_minloglevel = 0;
 #endif
-
     CatalystInstanceImpl::registerNatives();
     CxxModuleWrapperBase::registerNatives();
-    JCxxCallbackImpl::registerNatives();
-    NativeArray::registerNatives();
-    ReadableNativeArray::registerNatives();
-    WritableNativeArray::registerNatives();
-    NativeMap::registerNatives();
-    ReadableNativeMap::registerNatives();
-    WritableNativeMap::registerNatives();
-    JDynamicNative::registerNatives();
     JReactMarker::registerNatives();
     JInspector::registerNatives();
     ReactInstanceManagerInspectorTarget::registerNatives();

--- a/packages/rn-tester/android/app/gradle.properties
+++ b/packages/rn-tester/android/app/gradle.properties
@@ -7,3 +7,5 @@ android.useAndroidX=true
 newArchEnabled=true
 # RN-Tester is running with Hermes enabled and filtering variants with enableHermesOnlyInVariants
 hermesEnabled=true
+# RN-Tester has Legacy Arch warnings enabled when built via OSS
+legacyWarningsEnabled=true

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.kt
@@ -18,6 +18,7 @@ import com.facebook.react.ReactPackage
 import com.facebook.react.ViewManagerOnDemandReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
 import com.facebook.react.common.assets.ReactFontManager
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.load
 import com.facebook.react.defaults.DefaultReactHost
@@ -144,6 +145,7 @@ internal class RNTesterApplication : Application(), ReactApplication {
     }
 
     if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+      LegacyArchitectureLogger.OSS_LEGACY_WARNINGS_ENABLED = true
       load()
     }
   }


### PR DESCRIPTION
Summary:
This diff introduces a new property called `legacyWarningsEnabled` for `gradle.properties` that
toggles the Legacy Arch warnings for users.

I've also introduced a new `ReactNativeApplicationEntryPoint` that is generated by RNGP. This class
effectively wrap `DefaultNewArchitectureEntryPoint` by setting warnings and also invoking SoLoader.
It will reduce the errors in the user space.

As of now warnigns appear in Logcat, but I'm looking into adding some UI in a subsequent diff.

Changelog:
[Android] [Added] - Add a `legacyWarningsEnabled` property to enable Legacy Warnings on NewArch

Differential Revision: D72383907


