### PR TITLE
[iOS] Fabric: Make view touchable when alpha less than 0.01

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -621,7 +621,7 @@ const CGFloat BACKGROUND_COLOR_ZPOSITION = -1024.0f;
   //   * Taking `layer.zIndex` field into an account is not required because
   //     lists of `ShadowView`s are already sorted based on `zIndex` prop.
 
-  if (!self.userInteractionEnabled || self.hidden || self.alpha < 0.01) {
+  if (!self.userInteractionEnabled || self.hidden) {
     return nil;
   }
 


### PR DESCRIPTION
## Summary:

Fixes #50465. Make view touchable when the alpha is less than 0.01, thus keeping it consistent with the old architecture and the behavior on Android/Web.

## Changelog:

[IOS] [FIXED] - Fabric: Make view touchable when alpha less than 0.01

## Test Plan:

Repro please see #50465
