### PR TITLE
Fix tons of extra whitespace in OSS feature flag files

### DIFF
--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSCanary.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSCanary.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c44a616fd7c941ead315be0b83ae15a7>>
+ * @generated SignedSource<<db8626cf78a3ed226bbbe6bf20cc03a2>>
  */
 
 /**
@@ -27,91 +27,17 @@ class ReactNativeFeatureFlagsOverridesOSSCanary : public ReactNativeFeatureFlags
  public:
     ReactNativeFeatureFlagsOverridesOSSCanary() = default;
 
-
-
-
-
-
-
-
-
-
-
-
-
   bool enableBridgelessArchitecture() override {
     return true;
   }
-
-
-
-
-
-
 
   bool enableFabricRenderer() override {
     return true;
   }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
   bool useNativeViewConfigsInBridgelessMode() override {
     return true;
   }
-
-
-
-
 
   bool useTurboModuleInterop() override {
     return true;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSExperimental.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSExperimental.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<ddf338308d0390152ddbec172c0ad40e>>
+ * @generated SignedSource<<1de02178e1be302bb4b19501950b260a>>
  */
 
 /**
@@ -26,88 +26,6 @@ namespace facebook::react {
 class ReactNativeFeatureFlagsOverridesOSSExperimental : public ReactNativeFeatureFlagsOverridesOSSCanary {
  public:
     ReactNativeFeatureFlagsOverridesOSSExperimental() = default;
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 };

--- a/packages/react-native/scripts/featureflags/templates/common-cxx/ReactNativeFeatureFlagsOverridesOSS_Stage_.h-template.js
+++ b/packages/react-native/scripts/featureflags/templates/common-cxx/ReactNativeFeatureFlagsOverridesOSS_Stage_.h-template.js
@@ -68,6 +68,7 @@ ${Object.entries(definitions.common)
   }`;
     }
   })
+  .filter(Boolean)
   .join('\n\n')}
 };
 


### PR DESCRIPTION
Summary:
The map in the script has an if in it checking for proper release channel. For feature flags that do not pass this if, they do not have an alternative return, so `map` just maps this to `undefined`. That means there is still an element in this array which gets joined by 2 new lines. As a result every new feature flag will add 2 new lines of white space making these files look rather silly.

Fix is to filter undefined out.

Changelog: [Internal]

Differential Revision: D72427349
