### PR TITLE
Make `ClassFinder` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1669,12 +1669,6 @@ public final class com/facebook/react/bridge/queue/ReactQueueConfigurationSpec$C
 	public final fun createDefault ()Lcom/facebook/react/bridge/queue/ReactQueueConfigurationSpec;
 }
 
-public final class com/facebook/react/common/ClassFinder {
-	public static final field INSTANCE Lcom/facebook/react/common/ClassFinder;
-	public static final fun canLoadClassesFromAnnotationProcessors ()Z
-	public static final fun findClass (Ljava/lang/String;)Ljava/lang/Class;
-}
-
 public final class com/facebook/react/common/ClearableSynchronizedPool : androidx/core/util/Pools$Pool {
 	public fun <init> (I)V
 	public fun acquire ()Ljava/lang/Object;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/ClassFinder.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/ClassFinder.kt
@@ -10,18 +10,18 @@ package com.facebook.react.common
 import com.facebook.react.BuildConfig
 import kotlin.jvm.Throws
 
-public object ClassFinder {
+internal object ClassFinder {
 
   /**
    * We don't run the ModuleInfoProvider Annotation Processor in OSS, so there is no need to attempt
    * to call Class.forName() as we know for sure that those classes won't be there.
    */
   @JvmStatic
-  public fun canLoadClassesFromAnnotationProcessors(): Boolean = BuildConfig.IS_INTERNAL_BUILD
+  fun canLoadClassesFromAnnotationProcessors(): Boolean = BuildConfig.IS_INTERNAL_BUILD
 
   @JvmStatic
   @Throws(ClassNotFoundException::class)
-  public fun findClass(className: String): Class<*>? {
+  fun findClass(className: String): Class<*>? {
     if (canLoadClassesFromAnnotationProcessors().not()) {
       return null
     }


### PR DESCRIPTION
## Summary:

This class can be internalized as part of the initiative to reduce the public API surface. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.common.ClassFinder).

## Changelog:

[INTERNAL] - Make com.facebook.react.common.ClassFinder internal

## Test Plan:

```bash
yarn test-android
yarn android
```