### PR TITLE
Make `DevMenuModule` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2873,14 +2873,6 @@ public final class com/facebook/react/modules/core/TimingModule : com/facebook/f
 public final class com/facebook/react/modules/core/TimingModule$Companion {
 }
 
-public final class com/facebook/react/modules/debug/DevMenuModule : com/facebook/fbreact/specs/NativeDevMenuSpec {
-	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;Lcom/facebook/react/devsupport/interfaces/DevSupportManager;)V
-	public fun reload ()V
-	public fun setHotLoadingEnabled (Z)V
-	public fun setProfilingEnabled (Z)V
-	public fun show ()V
-}
-
 public final class com/facebook/react/modules/debug/DevSettingsModule : com/facebook/fbreact/specs/NativeDevSettingsSpec {
 	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;Lcom/facebook/react/devsupport/interfaces/DevSupportManager;)V
 	public fun addListener (Ljava/lang/String;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/DevMenuModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/DevMenuModule.kt
@@ -15,7 +15,7 @@ import com.facebook.react.module.annotations.ReactModule
 
 /** Module that exposes the DevMenu to JS so that it can be used to programmatically open it. */
 @ReactModule(name = NativeDevMenuSpec.NAME)
-public class DevMenuModule(
+internal class DevMenuModule(
     reactContext: ReactApplicationContext?,
     private val devSupportManager: DevSupportManager
 ) : NativeDevMenuSpec(reactContext) {


### PR DESCRIPTION
## Summary:

This class can be internalized as part of the initiative to reduce the public API surface. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.modules.debug.DevMenuModule).

## Changelog:

[INTERNAL] - Make com.facebook.react.modules.debug.DevMenuModule internal

## Test Plan:

```bash
yarn test-android
yarn android
```