### PR TITLE
Fix leaked ParagraphState when recycling

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
@@ -41,7 +41,6 @@ using namespace facebook::react;
 @end
 
 @implementation RCTParagraphComponentView {
-  ParagraphShadowNode::ConcreteState::Shared _state;
   ParagraphAttributes _paragraphAttributes;
   RCTParagraphComponentAccessibilityProvider *_accessibilityProvider;
   UILongPressGestureRecognizer *_longPressGestureRecognizer;
@@ -76,11 +75,11 @@ using namespace facebook::react;
 
 - (NSAttributedString *_Nullable)attributedText
 {
-  if (!_state) {
+  if (!_textView.state) {
     return nil;
   }
 
-  return RCTNSAttributedStringFromAttributedString(_state->getData().attributedString);
+  return RCTNSAttributedStringFromAttributedString(_textView.state->getData().attributedString);
 }
 
 #pragma mark - RCTComponentViewProtocol
@@ -118,8 +117,7 @@ using namespace facebook::react;
 
 - (void)updateState:(const State::Shared &)state oldState:(const State::Shared &)oldState
 {
-  _state = std::static_pointer_cast<const ParagraphShadowNode::ConcreteState>(state);
-  _textView.state = _state;
+  _textView.state = std::static_pointer_cast<const ParagraphShadowNode::ConcreteState>(state);
   [_textView setNeedsDisplay];
   [self setNeedsLayout];
 }
@@ -138,7 +136,7 @@ using namespace facebook::react;
 - (void)prepareForRecycle
 {
   [super prepareForRecycle];
-  _state.reset();
+  _textView.state = nullptr;
   _accessibilityProvider = nil;
 }
 
@@ -180,11 +178,11 @@ using namespace facebook::react;
   // If the component is not `accessible`, we return an empty array.
   // We do this because logically all nested <Text> components represent the content of the <Paragraph> component;
   // in other words, all nested <Text> components individually have no sense without the <Paragraph>.
-  if (!_state || !paragraphProps.accessible) {
+  if (!_textView.state || !paragraphProps.accessible) {
     return [NSArray new];
   }
 
-  auto &data = _state->getData();
+  auto &data = _textView.state->getData();
 
   if (![_accessibilityProvider isUpToDate:data.attributedString]) {
     auto textLayoutManager = data.layoutManager.lock();
@@ -251,11 +249,13 @@ using namespace facebook::react;
 
 - (SharedTouchEventEmitter)touchEventEmitterAtPoint:(CGPoint)point
 {
-  if (!_state) {
+  const auto &state = _textView.state;
+  if (!state) {
     return _eventEmitter;
   }
 
-  auto textLayoutManager = _state->getData().layoutManager.lock();
+  const auto &stateData = state->getData();
+  auto textLayoutManager = stateData.layoutManager.lock();
 
   if (!textLayoutManager) {
     return _eventEmitter;
@@ -265,7 +265,7 @@ using namespace facebook::react;
       (RCTTextLayoutManager *)unwrapManagedObject(textLayoutManager->getNativeTextLayoutManager());
   CGRect frame = RCTCGRectFromRect(_layoutMetrics.getContentFrame());
 
-  auto eventEmitter = [nativeTextLayoutManager getEventEmitterWithAttributeString:_state->getData().attributedString
+  auto eventEmitter = [nativeTextLayoutManager getEventEmitterWithAttributeString:stateData.attributedString
                                                               paragraphAttributes:_paragraphAttributes
                                                                             frame:frame
                                                                           atPoint:point];
@@ -380,8 +380,8 @@ Class<RCTComponentViewProtocol> RCTParagraphCls(void)
     return;
   }
 
-  auto textLayoutManager = _state->getData().layoutManager.lock();
-
+  const auto &stateData = _state->getData();
+  auto textLayoutManager = stateData.layoutManager.lock();
   if (!textLayoutManager) {
     return;
   }
@@ -391,7 +391,7 @@ Class<RCTComponentViewProtocol> RCTParagraphCls(void)
 
   CGRect frame = RCTCGRectFromRect(_layoutMetrics.getContentFrame());
 
-  [nativeTextLayoutManager drawAttributedString:_state->getData().attributedString
+  [nativeTextLayoutManager drawAttributedString:stateData.attributedString
                             paragraphAttributes:_paragraphAttributes
                                           frame:frame
                               drawHighlightPath:^(UIBezierPath *highlightPath) {


### PR DESCRIPTION
Summary:
ParagraphState is shared between ParagraphTextView and ParagraphComponentView, but we only need one copy. We were forgetting to clear this on ParagraphTextView when recyling.

Changelog: [iOS][Fixed] ParagraphState is correctly deallocated when recycling Text

Differential Revision: D72454038


