### PR TITLE
Make `ViewAtIndex` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -4786,20 +4786,6 @@ public abstract interface class com/facebook/react/uimanager/UIViewOperationQueu
 	public abstract fun execute ()V
 }
 
-public final class com/facebook/react/uimanager/ViewAtIndex {
-	public static field COMPARATOR Ljava/util/Comparator;
-	public static final field Companion Lcom/facebook/react/uimanager/ViewAtIndex$Companion;
-	public final field mIndex I
-	public final field mTag I
-	public fun <init> (II)V
-	public fun equals (Ljava/lang/Object;)Z
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public final class com/facebook/react/uimanager/ViewAtIndex$Companion {
-}
-
 public final class com/facebook/react/uimanager/ViewDefaults {
 	public static final field FONT_SIZE_SP F
 	public static final field INSTANCE Lcom/facebook/react/uimanager/ViewDefaults;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewAtIndex.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewAtIndex.kt
@@ -17,7 +17,7 @@ import java.util.Objects
  * operation.
  */
 @LegacyArchitecture
-public class ViewAtIndex(
+internal class ViewAtIndex(
     @Suppress("NoHungarianNotation") @JvmField public val mTag: Int,
     @Suppress("NoHungarianNotation") @JvmField public val mIndex: Int
 ) {
@@ -34,9 +34,9 @@ public class ViewAtIndex(
 
   override fun toString(): String = "[$mTag, $mIndex]"
 
-  public companion object {
+  companion object {
     @JvmField
-    public var COMPARATOR: Comparator<ViewAtIndex> = Comparator { lhs, rhs ->
+    var COMPARATOR: Comparator<ViewAtIndex> = Comparator { lhs, rhs ->
       lhs.mIndex - rhs.mIndex
     }
 


### PR DESCRIPTION
## Summary:

This class can be internalized as part of the initiative to reduce the public API surface. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.uimanager.ViewAtIndex).

## Changelog:

[INTERNAL] - Make com.facebook.react.uimanager.ViewAtIndex internal

## Test Plan:

```bash
yarn test-android
yarn android
```