### PR TITLE
Make `SurfaceHandler` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2565,15 +2565,6 @@ public abstract interface class com/facebook/react/interfaces/fabric/ReactSurfac
 	public abstract fun stop ()Lcom/facebook/react/interfaces/TaskInterface;
 }
 
-public abstract interface class com/facebook/react/interfaces/fabric/SurfaceHandler {
-	public abstract fun getModuleName ()Ljava/lang/String;
-	public abstract fun getSurfaceId ()I
-	public abstract fun isRunning ()Z
-	public abstract fun setLayoutConstraints (IIIIZZF)V
-	public abstract fun setMountable (Z)V
-	public abstract fun setProps (Lcom/facebook/react/bridge/NativeMap;)V
-}
-
 public final class com/facebook/react/jscexecutor/JSCExecutor : com/facebook/react/bridge/JavaScriptExecutor {
 	public fun getName ()Ljava/lang/String;
 	public static final fun loadLibrary ()V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/interfaces/fabric/SurfaceHandler.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/interfaces/fabric/SurfaceHandler.kt
@@ -12,21 +12,21 @@ import javax.annotation.concurrent.ThreadSafe
 
 /** Represents a Java variant of the surface, its status and inner data required to display it. */
 @ThreadSafe
-public interface SurfaceHandler {
+internal interface SurfaceHandler {
 
   /**
    * Provides current surface id. Id should be updated after each call to {@link
    * SurfaceHandler#stop}
    */
-  public val surfaceId: Int
+  val surfaceId: Int
 
-  public val isRunning: Boolean
+  val isRunning: Boolean
 
-  public val moduleName: String
+  val moduleName: String
 
-  public fun setProps(props: NativeMap)
+  fun setProps(props: NativeMap)
 
-  public fun setLayoutConstraints(
+  fun setLayoutConstraints(
       widthMeasureSpec: Int,
       heightMeasureSpec: Int,
       offsetX: Int,
@@ -36,5 +36,5 @@ public interface SurfaceHandler {
       pixelDensity: Float
   )
 
-  public fun setMountable(mountable: Boolean)
+  fun setMountable(mountable: Boolean)
 }


### PR DESCRIPTION
## Summary:

This class can be internalized as part of the initiative to reduce the public API surface. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.interfaces.fabric.SurfaceHandler).

## Changelog:

[INTERNAL] - Make com.facebook.react.interfaces.fabric.SurfaceHandler internal

## Test Plan:

```bash
yarn test-android
yarn android
```