### PR TITLE
Make `ReactJsExceptionHandler` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2534,24 +2534,6 @@ public abstract interface class com/facebook/react/interfaces/TaskInterface {
 	public abstract fun waitForCompletion (JLjava/util/concurrent/TimeUnit;)Z
 }
 
-public abstract interface class com/facebook/react/interfaces/exceptionmanager/ReactJsExceptionHandler$ProcessedError {
-	public abstract fun getComponentStack ()Ljava/lang/String;
-	public abstract fun getExtraData ()Lcom/facebook/react/bridge/ReadableMap;
-	public abstract fun getId ()I
-	public abstract fun getMessage ()Ljava/lang/String;
-	public abstract fun getName ()Ljava/lang/String;
-	public abstract fun getOriginalMessage ()Ljava/lang/String;
-	public abstract fun getStack ()Ljava/util/List;
-	public abstract fun isFatal ()Z
-}
-
-public abstract interface class com/facebook/react/interfaces/exceptionmanager/ReactJsExceptionHandler$ProcessedError$StackFrame {
-	public abstract fun getColumn ()Ljava/lang/Integer;
-	public abstract fun getFile ()Ljava/lang/String;
-	public abstract fun getLineNumber ()Ljava/lang/Integer;
-	public abstract fun getMethodName ()Ljava/lang/String;
-}
-
 public abstract interface class com/facebook/react/interfaces/fabric/ReactSurface {
 	public abstract fun clear ()V
 	public abstract fun detach ()V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/interfaces/exceptionmanager/ReactJsExceptionHandler.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/interfaces/exceptionmanager/ReactJsExceptionHandler.kt
@@ -15,25 +15,25 @@ import java.util.ArrayList
 
 @DoNotStripAny
 @UnstableReactNativeAPI
-public fun interface ReactJsExceptionHandler {
+internal fun interface ReactJsExceptionHandler {
   @DoNotStripAny
-  public interface ProcessedError {
+  interface ProcessedError {
     @DoNotStripAny
-    public interface StackFrame {
-      public val file: String?
-      public val methodName: String
-      public val lineNumber: Int?
-      public val column: Int?
+    interface StackFrame {
+      val file: String?
+      val methodName: String
+      val lineNumber: Int?
+      val column: Int?
     }
 
-    public val message: String
-    public val originalMessage: String?
-    public val name: String?
-    public val componentStack: String?
-    public val stack: List<StackFrame>
-    public val id: Int
-    public val isFatal: Boolean
-    public val extraData: ReadableMap
+    val message: String
+    val originalMessage: String?
+    val name: String?
+    val componentStack: String?
+    val stack: List<StackFrame>
+    val id: Int
+    val isFatal: Boolean
+    val extraData: ReadableMap
   }
 
   @DoNotStripAny
@@ -56,5 +56,5 @@ public fun interface ReactJsExceptionHandler {
       override val extraData: ReadableNativeMap,
   ) : ProcessedError
 
-  public fun reportJsException(errorMap: ProcessedError)
+  fun reportJsException(errorMap: ProcessedError)
 }


### PR DESCRIPTION
## Summary:

This class can be internalized as part of the initiative to reduce the public API surface. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.interfaces.exceptionmanager.ReactJsExceptionHandler).

## Changelog:

[INTERNAL] - Make com.facebook.react.interfaces.exceptionmanager.ReactJsExceptionHandler internal

## Test Plan:

```bash
yarn test-android
yarn android
```