### PR TITLE
Make `ReactIgnorableMountingException` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1129,18 +1129,6 @@ public final class com/facebook/react/bridge/ReactCxxErrorHandler {
 	public static final fun setHandleErrorFunc (Ljava/lang/Object;Ljava/lang/reflect/Method;)V
 }
 
-public final class com/facebook/react/bridge/ReactIgnorableMountingException : java/lang/RuntimeException {
-	public static final field Companion Lcom/facebook/react/bridge/ReactIgnorableMountingException$Companion;
-	public fun <init> (Ljava/lang/String;)V
-	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
-	public fun <init> (Ljava/lang/Throwable;)V
-	public static final fun isIgnorable (Ljava/lang/Throwable;)Z
-}
-
-public final class com/facebook/react/bridge/ReactIgnorableMountingException$Companion {
-	public final fun isIgnorable (Ljava/lang/Throwable;)Z
-}
-
 public class com/facebook/react/bridge/ReactInstanceManagerInspectorTarget : java/lang/AutoCloseable {
 	public fun <init> (Lcom/facebook/react/bridge/ReactInstanceManagerInspectorTarget$TargetDelegate;)V
 	public fun close ()V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactIgnorableMountingException.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactIgnorableMountingException.kt
@@ -11,17 +11,17 @@ package com.facebook.react.bridge
  * If thrown during a MountItem execution, FabricUIManager will print diagnostics and ignore the
  * error. Use this carefully and sparingly!
  */
-public class ReactIgnorableMountingException : RuntimeException {
+internal class ReactIgnorableMountingException : RuntimeException {
 
-  public constructor(m: String) : super(m)
+  constructor(m: String) : super(m)
 
-  public constructor(e: Throwable) : super(e)
+  constructor(e: Throwable) : super(e)
 
-  public constructor(m: String, e: Throwable) : super(m, e)
+  constructor(m: String, e: Throwable) : super(m, e)
 
-  public companion object {
+  companion object {
     @JvmStatic
-    public fun isIgnorable(e: Throwable): Boolean {
+    fun isIgnorable(e: Throwable): Boolean {
       var cause: Throwable? = e
       while (cause != null) {
         if (cause is ReactIgnorableMountingException) {


### PR DESCRIPTION
## Summary:

This class can be internalized as part of the initiative to reduce the public API surface. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.bridge.ReactIgnorableMountingException).

## Changelog:

[INTERNAL] - Make com.facebook.react.bridge.ReactIgnorableMountingException internal

## Test Plan:

```bash
yarn test-android
yarn android
```