### PR TITLE
'[skip ci] [RN][Android] Move ReactMarker to as it'\''s used in NewArch also

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/DynamicNative.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/DynamicNative.kt
@@ -9,7 +9,6 @@ package com.facebook.react.bridge
 
 import com.facebook.jni.HybridClassBase
 import com.facebook.proguard.annotations.DoNotStripAny
-import com.facebook.soloader.SoLoader
 
 /**
  * An implementation of [Dynamic] that has a C++ implementation.
@@ -49,7 +48,7 @@ private class DynamicNative : HybridClassBase(), Dynamic {
 
   private companion object {
     init {
-      SoLoader.loadLibrary("reactnativejni_common")
+      ReactNativeJniCommonSoLoader.staticInit()
     }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeArray.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeArray.kt
@@ -9,7 +9,6 @@ package com.facebook.react.bridge
 
 import com.facebook.jni.HybridClassBase
 import com.facebook.proguard.annotations.DoNotStrip
-import com.facebook.soloader.SoLoader
 
 /** Base class for an array whose members are stored in native code (C++). */
 @DoNotStrip
@@ -20,7 +19,7 @@ public abstract class NativeArray protected constructor() :
 
   private companion object {
     init {
-      SoLoader.loadLibrary("reactnativejni_common")
+      ReactNativeJniCommonSoLoader.staticInit()
     }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeMap.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeMap.kt
@@ -9,7 +9,6 @@ package com.facebook.react.bridge
 
 import com.facebook.jni.HybridClassBase
 import com.facebook.proguard.annotations.DoNotStrip
-import com.facebook.soloader.SoLoader
 
 /** Base class for a Map whose keys and values are stored in native code (C++). */
 @DoNotStrip
@@ -18,7 +17,7 @@ public abstract class NativeMap : HybridClassBase() {
 
   private companion object {
     init {
-      SoLoader.loadLibrary("reactnativejni_common")
+      ReactNativeJniCommonSoLoader.staticInit()
     }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactMarker.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactMarker.java
@@ -211,7 +211,7 @@ public class ReactMarker {
       now = SystemClock.uptimeMillis();
     }
 
-    if (BridgeSoLoader.isInitialized()) {
+    if (ReactNativeJniCommonSoLoader.isInitialized()) {
       // First send the current marker
       nativeLogMarker(name.name(), now);
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactNativeJniCommonSoLoader.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactNativeJniCommonSoLoader.kt
@@ -7,17 +7,9 @@
 
 package com.facebook.react.bridge
 
-import com.facebook.react.common.annotations.internal.LegacyArchitecture
-import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
 import com.facebook.soloader.SoLoader
-import com.facebook.systrace.Systrace
-import com.facebook.systrace.Systrace.TRACE_TAG_REACT_JAVA_BRIDGE
 
-@LegacyArchitecture
-internal object BridgeSoLoader {
-  init {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled("BridgeSoLoader")
-  }
+internal object ReactNativeJniCommonSoLoader {
 
   @JvmStatic
   @Synchronized
@@ -25,16 +17,15 @@ internal object BridgeSoLoader {
     if (initialized) {
       return
     }
-    Systrace.beginSection(TRACE_TAG_REACT_JAVA_BRIDGE, "BridgeSoLoader")
     ReactMarker.logMarker(ReactMarkerConstants.LOAD_REACT_NATIVE_SO_FILE_START)
-    SoLoader.loadLibrary("reactnativejni")
+    SoLoader.loadLibrary("reactnativejni_common")
     ReactMarker.logMarker(ReactMarkerConstants.LOAD_REACT_NATIVE_SO_FILE_END)
-    Systrace.endSection(TRACE_TAG_REACT_JAVA_BRIDGE)
     initialized = true
   }
 
   @get:JvmStatic
   @get:JvmName("isInitialized")
+  @Volatile
   var initialized: Boolean = false
     private set
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/internal/LegacyArchitectureLogger.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/internal/LegacyArchitectureLogger.kt
@@ -62,7 +62,7 @@ public object LegacyArchitectureLogger {
         }
         LegacyArchitectureLogLevel.WARNING -> {
           ReactSoftExceptionLogger.logSoftException(
-              tag, ReactNoCrashSoftException("$name $exceptionMessage."))
+              tag, ReactNoCrashSoftException("$name $exceptionMessage"))
         }
       }
     }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/CMakeLists.txt
@@ -24,10 +24,11 @@ add_library(
         reactnativejni_common
         OBJECT
           JDynamicNative.cpp
+          JReactMarker.cpp
           NativeArray.cpp
           NativeCommon.cpp
           NativeMap.cpp
-        OnLoad-common.cpp
+          OnLoad-common.cpp
           ReadableNativeArray.cpp
           ReadableNativeMap.cpp
           WritableNativeArray.cpp
@@ -36,7 +37,7 @@ add_library(
 target_merge_so(reactnativejni_common)
 target_include_directories(reactnativejni_common PUBLIC ../../)
 
-target_link_libraries(reactnativejni_common fbjni folly_runtime)
+target_link_libraries(reactnativejni_common fbjni folly_runtime react_cxxreact)
 target_compile_reactnative_options(reactnativejni_common PRIVATE)
 target_compile_options(reactnativejni_common PRIVATE -Wno-unused-lambda-capture)
 
@@ -55,7 +56,6 @@ add_library(
           JInspector.cpp
           JMessageQueueThread.cpp
           JReactCxxErrorHandler.cpp
-          JReactMarker.cpp
           JReactSoftExceptionLogger.cpp
           JRuntimeExecutor.cpp
           JRuntimeScheduler.cpp

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/OnLoad-common.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/OnLoad-common.cpp
@@ -8,6 +8,7 @@
 #include <fbjni/fbjni.h>
 #include "JCallback.h"
 #include "JDynamicNative.h"
+#include "JReactMarker.h"
 #include "NativeArray.h"
 #include "NativeMap.h"
 #include "WritableNativeArray.h"
@@ -19,6 +20,7 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
   return facebook::jni::initialize(vm, [] {
     JCxxCallbackImpl::registerNatives();
     JDynamicNative::registerNatives();
+    JReactMarker::registerNatives();
     NativeArray::registerNatives();
     NativeMap::registerNatives();
     ReadableNativeArray::registerNatives();

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
@@ -16,7 +16,6 @@
 #include "CxxModuleWrapperBase.h"
 #include "InspectorNetworkRequestListener.h"
 #include "JInspector.h"
-#include "JReactMarker.h"
 #include "JavaScriptExecutorHolder.h"
 #include "ReactInstanceManagerInspectorTarget.h"
 
@@ -42,7 +41,6 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
 #endif
     CatalystInstanceImpl::registerNatives();
     CxxModuleWrapperBase::registerNatives();
-    JReactMarker::registerNatives();
     JInspector::registerNatives();
     ReactInstanceManagerInspectorTarget::registerNatives();
     InspectorNetworkRequestListener::registerNatives();


### PR DESCRIPTION
Summary:
Reland of D72384347

ReactMarker is currently loading the whole  which we should not be loading in NewArch.
This is resulting in a warning fired for all the NewArch users with .

I'\''m cleaning this up by moving it inside .

Changelog:
[Internal] [Changed] - Move ReactMarker to  as it'\''s used in NewArch also

Differential Revision: D72552075
