### PR TITLE
Rename `assertWhenLegacyArchitectureMinifyingEnabled` to `assertLegacyArchitecture`

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/CoreModulesPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/CoreModulesPackage.java
@@ -66,7 +66,7 @@ import java.util.Map;
 class CoreModulesPackage extends BaseReactPackage implements ReactPackageLogger {
 
   static {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+    LegacyArchitectureLogger.assertLegacyArchitecture(
         "CoreModulesPackage", LegacyArchitectureLogLevel.WARNING);
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/LazyReactPackage.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/LazyReactPackage.java
@@ -36,7 +36,7 @@ import java.util.Map;
 public abstract class LazyReactPackage implements ReactPackage {
 
   static {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+    LegacyArchitectureLogger.assertLegacyArchitecture(
         "LazyReactPackage", LegacyArchitectureLogLevel.WARNING);
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/NativeModuleRegistryBuilder.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/NativeModuleRegistryBuilder.kt
@@ -65,7 +65,7 @@ by autolinking. Try removing the existing entry and rebuild.
 
   private companion object {
     init {
-      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+      LegacyArchitectureLogger.assertLegacyArchitecture(
           "NativeModuleRegistryBuilder", LegacyArchitectureLogLevel.WARNING)
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -150,7 +150,7 @@ import java.util.Set;
 public class ReactInstanceManager {
 
   static {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+    LegacyArchitectureLogger.assertLegacyArchitecture(
         "ReactInstanceManager", LegacyArchitectureLogLevel.WARNING);
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.java
@@ -51,7 +51,7 @@ import java.util.Map;
 public class ReactInstanceManagerBuilder {
 
   static {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+    LegacyArchitectureLogger.assertLegacyArchitecture(
         "ReactInstanceManagerBuilder", LegacyArchitectureLogLevel.WARNING);
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactNativeHost.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactNativeHost.java
@@ -41,7 +41,7 @@ import java.util.List;
 public abstract class ReactNativeHost {
 
   static {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+    LegacyArchitectureLogger.assertLegacyArchitecture(
         "ReactNativeHost", LegacyArchitectureLogLevel.WARNING);
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BridgeReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BridgeReactContext.java
@@ -39,7 +39,7 @@ import java.util.Collection;
 @LegacyArchitecture
 public class BridgeReactContext extends ReactApplicationContext {
   static {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+    LegacyArchitectureLogger.assertLegacyArchitecture(
         "BridgeReactContext", LegacyArchitectureLogLevel.WARNING);
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BridgeSoLoader.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BridgeSoLoader.kt
@@ -16,7 +16,7 @@ import com.facebook.systrace.Systrace.TRACE_TAG_REACT_JAVA_BRIDGE
 @LegacyArchitecture
 internal object BridgeSoLoader {
   init {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled("BridgeSoLoader")
+    LegacyArchitectureLogger.assertLegacyArchitecture("BridgeSoLoader")
   }
 
   @JvmStatic

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CallbackImpl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CallbackImpl.kt
@@ -28,7 +28,7 @@ internal class CallbackImpl(private val jsInstance: JSInstance, private val call
 
   private companion object {
     init {
-      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+      LegacyArchitectureLogger.assertLegacyArchitecture(
           "CallbackImpl", LegacyArchitectureLogLevel.WARNING)
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
@@ -51,7 +51,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class CatalystInstanceImpl implements CatalystInstance {
   static {
     BridgeSoLoader.staticInit();
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+    LegacyArchitectureLogger.assertLegacyArchitecture(
         "CatalystInstanceImpl", LegacyArchitectureLogLevel.WARNING);
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CxxModuleWrapper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CxxModuleWrapper.kt
@@ -19,7 +19,7 @@ public open class CxxModuleWrapper protected constructor(hybridData: HybridData)
     CxxModuleWrapperBase(hybridData) {
   private companion object {
     init {
-      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled("CxxModuleWrapper")
+      LegacyArchitectureLogger.assertLegacyArchitecture("CxxModuleWrapper")
     }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CxxModuleWrapperBase.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CxxModuleWrapperBase.kt
@@ -49,7 +49,7 @@ protected constructor(
   private companion object {
     init {
       BridgeSoLoader.staticInit()
-      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+      LegacyArchitectureLogger.assertLegacyArchitecture(
           "CxxModuleWrapperBase", LegacyArchitectureLogLevel.WARNING)
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/DynamicNative.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/DynamicNative.kt
@@ -9,7 +9,6 @@ package com.facebook.react.bridge
 
 import com.facebook.jni.HybridClassBase
 import com.facebook.proguard.annotations.DoNotStripAny
-import com.facebook.soloader.SoLoader
 
 /**
  * An implementation of [Dynamic] that has a C++ implementation.
@@ -49,7 +48,7 @@ private class DynamicNative : HybridClassBase(), Dynamic {
 
   private companion object {
     init {
-      SoLoader.loadLibrary("reactnativejni_common")
+      ReactNativeJniCommonSoLoader.staticInit()
     }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/InvalidIteratorException.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/InvalidIteratorException.kt
@@ -21,8 +21,7 @@ internal class InvalidIteratorException @DoNotStrip constructor(msg: String) :
     RuntimeException(msg) {
   private companion object {
     init {
-      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
-          "InvalidIteratorException")
+      LegacyArchitectureLogger.assertLegacyArchitecture("InvalidIteratorException")
     }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JSONArguments.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JSONArguments.java
@@ -18,7 +18,7 @@ import org.json.JSONObject;
 @LegacyArchitecture
 public class JSONArguments {
   static {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+    LegacyArchitectureLogger.assertLegacyArchitecture(
         "JSONArguments", LegacyArchitectureLogLevel.WARNING);
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaMethodWrapper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaMethodWrapper.java
@@ -24,7 +24,7 @@ import java.lang.reflect.Method;
 @LegacyArchitecture
 class JavaMethodWrapper implements JavaModuleWrapper.NativeMethod {
   static {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+    LegacyArchitectureLogger.assertLegacyArchitecture(
         "JavaMethodWrapper", LegacyArchitectureLogLevel.WARNING);
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaModuleWrapper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaModuleWrapper.java
@@ -35,7 +35,7 @@ import java.util.Map;
 @LegacyArchitecture
 class JavaModuleWrapper {
   static {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+    LegacyArchitectureLogger.assertLegacyArchitecture(
         "JavaModuleWrapper", LegacyArchitectureLogLevel.WARNING);
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeArgumentsParseException.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeArgumentsParseException.kt
@@ -20,8 +20,7 @@ internal class NativeArgumentsParseException : JSApplicationCausedNativeExceptio
 
   private companion object {
     init {
-      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
-          "NativeArgumentsParseException")
+      LegacyArchitectureLogger.assertLegacyArchitecture("NativeArgumentsParseException")
     }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeArray.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeArray.kt
@@ -9,7 +9,6 @@ package com.facebook.react.bridge
 
 import com.facebook.jni.HybridClassBase
 import com.facebook.proguard.annotations.DoNotStrip
-import com.facebook.soloader.SoLoader
 
 /** Base class for an array whose members are stored in native code (C++). */
 @DoNotStrip
@@ -20,7 +19,7 @@ public abstract class NativeArray protected constructor() :
 
   private companion object {
     init {
-      SoLoader.loadLibrary("reactnativejni_common")
+      ReactNativeJniCommonSoLoader.staticInit()
     }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeMap.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeMap.kt
@@ -9,7 +9,6 @@ package com.facebook.react.bridge
 
 import com.facebook.jni.HybridClassBase
 import com.facebook.proguard.annotations.DoNotStrip
-import com.facebook.soloader.SoLoader
 
 /** Base class for a Map whose keys and values are stored in native code (C++). */
 @DoNotStrip
@@ -18,7 +17,7 @@ public abstract class NativeMap : HybridClassBase() {
 
   private companion object {
     init {
-      SoLoader.loadLibrary("reactnativejni_common")
+      ReactNativeJniCommonSoLoader.staticInit()
     }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeModuleRegistry.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeModuleRegistry.java
@@ -115,7 +115,7 @@ public class NativeModuleRegistry {
     // short-circuit
     // the search, and simply call OnBatchComplete on the UI Manager.
     // With Fabric, UIManager would no longer be a NativeModule, so this call would simply go away
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+    LegacyArchitectureLogger.assertLegacyArchitecture(
         "NativeModuleRegistry.onBatchComplete()", LegacyArchitectureLogLevel.ERROR);
     ModuleHolder moduleHolder = mModules.get("UIManager");
     if (moduleHolder != null && moduleHolder.hasInstance()) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactCxxErrorHandler.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactCxxErrorHandler.kt
@@ -18,7 +18,7 @@ import java.lang.reflect.Method
 @LegacyArchitecture
 public object ReactCxxErrorHandler {
   init {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+    LegacyArchitectureLogger.assertLegacyArchitecture(
         "ReactCxxErrorHandler", LegacyArchitectureLogLevel.WARNING)
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactInstanceManagerInspectorTarget.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactInstanceManagerInspectorTarget.java
@@ -68,7 +68,7 @@ public class ReactInstanceManagerInspectorTarget implements AutoCloseable {
   }
 
   static {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+    LegacyArchitectureLogger.assertLegacyArchitecture(
         "ReactInstanceManagerInspectorTarget", LegacyArchitectureLogLevel.WARNING);
     BridgeSoLoader.staticInit();
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactMarker.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactMarker.java
@@ -211,7 +211,7 @@ public class ReactMarker {
       now = SystemClock.uptimeMillis();
     }
 
-    if (BridgeSoLoader.isInitialized()) {
+    if (ReactNativeJniCommonSoLoader.isInitialized()) {
       // First send the current marker
       nativeLogMarker(name.name(), now);
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactNativeJniCommonSoLoader.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactNativeJniCommonSoLoader.kt
@@ -7,17 +7,9 @@
 
 package com.facebook.react.bridge
 
-import com.facebook.react.common.annotations.internal.LegacyArchitecture
-import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
 import com.facebook.soloader.SoLoader
-import com.facebook.systrace.Systrace
-import com.facebook.systrace.Systrace.TRACE_TAG_REACT_JAVA_BRIDGE
 
-@LegacyArchitecture
-internal object BridgeSoLoader {
-  init {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled("BridgeSoLoader")
-  }
+internal object ReactNativeJniCommonSoLoader {
 
   @JvmStatic
   @Synchronized
@@ -25,16 +17,15 @@ internal object BridgeSoLoader {
     if (initialized) {
       return
     }
-    Systrace.beginSection(TRACE_TAG_REACT_JAVA_BRIDGE, "BridgeSoLoader")
     ReactMarker.logMarker(ReactMarkerConstants.LOAD_REACT_NATIVE_SO_FILE_START)
-    SoLoader.loadLibrary("reactnativejni")
+    SoLoader.loadLibrary("reactnativejni_common")
     ReactMarker.logMarker(ReactMarkerConstants.LOAD_REACT_NATIVE_SO_FILE_END)
-    Systrace.endSection(TRACE_TAG_REACT_JAVA_BRIDGE)
     initialized = true
   }
 
   @get:JvmStatic
   @get:JvmName("isInitialized")
+  @Volatile
   var initialized: Boolean = false
     private set
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactNoCrashBridgeNotAllowedSoftException.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactNoCrashBridgeNotAllowedSoftException.kt
@@ -21,8 +21,7 @@ public class ReactNoCrashBridgeNotAllowedSoftException : ReactNoCrashSoftExcepti
 
   private companion object {
     init {
-      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
-          "ReactNoCrashBridgeNotAllowedSoftException")
+      LegacyArchitectureLogger.assertLegacyArchitecture("ReactNoCrashBridgeNotAllowedSoftException")
     }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/interop/InteropModuleRegistry.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/interop/InteropModuleRegistry.kt
@@ -53,7 +53,7 @@ internal class InteropModuleRegistry {
 
   private companion object {
     init {
-      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled("InteropModuleRegistry")
+      LegacyArchitectureLogger.assertLegacyArchitecture("InteropModuleRegistry")
     }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/internal/LegacyArchitectureLogger.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/internal/LegacyArchitectureLogger.kt
@@ -62,7 +62,7 @@ public object LegacyArchitectureLogger {
         }
         LegacyArchitectureLogLevel.WARNING -> {
           ReactSoftExceptionLogger.logSoftException(
-              tag, ReactNoCrashSoftException("$name $exceptionMessage."))
+              tag, ReactNoCrashSoftException("$name $exceptionMessage"))
         }
       }
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/internal/LegacyArchitectureLogger.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/internal/LegacyArchitectureLogger.kt
@@ -42,28 +42,54 @@ public object LegacyArchitectureLogger {
         }
 
   /**
-   * Asserts and logs when legacy architecture components are being used in new architecture. This
+   * Asserts and logs when legacy architecture classes are being used in New Architecture. This
    * method will throw an exception if the app is running on the new architecture and the logLevel
-   * received by parameter is [LegacyArchitectureLogLevel.ERROR].
+   * received by parameter is [LegacyArchitectureLogLevel.ERROR]. Otherwise it will show a warning
+   * on logcat.
    *
-   * @param name The name of the legacy component being used
+   * @param name The name of the legacy class being used
    * @param logLevel The severity level of the log (ERROR or WARNING, defaults to WARNING)
    */
   @JvmStatic
-  public fun assertWhenLegacyArchitectureMinifyingEnabled(
+  public fun assertLegacyArchitecture(
       name: String,
       logLevel: LegacyArchitectureLogLevel = LegacyArchitectureLogLevel.WARNING
   ) {
     if (ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE ||
         OSS_LEGACY_WARNINGS_ENABLED) {
-      when (logLevel) {
-        LegacyArchitectureLogLevel.ERROR -> {
-          throw AssertionException("$name $exceptionMessage")
-        }
-        LegacyArchitectureLogLevel.WARNING -> {
-          ReactSoftExceptionLogger.logSoftException(
-              tag, ReactNoCrashSoftException("$name $exceptionMessage"))
-        }
+      executeAssert(name, logLevel)
+    }
+  }
+
+  /**
+   * Similar to [assertLegacyArchitecture] but executes only when
+   * [UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE] is set to true. This applies only to internal
+   * builds.
+   *
+   * @param name The name of the legacy class being used
+   * @param logLevel The severity level of the log (ERROR or WARNING, defaults to WARNING)
+   */
+  @JvmStatic
+  public fun assertLegacyArchitectureOnlyWhenMinifyEnabled(
+      name: String,
+      logLevel: LegacyArchitectureLogLevel = LegacyArchitectureLogLevel.WARNING
+  ) {
+    if (ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE) {
+      executeAssert(name, logLevel)
+    }
+  }
+
+  private fun executeAssert(
+      name: String,
+      logLevel: LegacyArchitectureLogLevel = LegacyArchitectureLogLevel.WARNING
+  ) {
+    when (logLevel) {
+      LegacyArchitectureLogLevel.ERROR -> {
+        throw AssertionException("$name $exceptionMessage")
+      }
+      LegacyArchitectureLogLevel.WARNING -> {
+        ReactSoftExceptionLogger.logSoftException(
+            tag, ReactNoCrashSoftException("$name $exceptionMessage"))
       }
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/BridgeDevSupportManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/BridgeDevSupportManager.java
@@ -54,7 +54,7 @@ import java.util.Map;
 public final class BridgeDevSupportManager extends DevSupportManagerBase {
 
   static {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+    LegacyArchitectureLogger.assertLegacyArchitecture(
         "BridgeDevSupportManager", LegacyArchitectureLogLevel.WARNING);
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/interop/InteropEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/interop/InteropEvent.kt
@@ -31,7 +31,7 @@ public class InteropEvent(
 
   private companion object {
     init {
-      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled("InteropEvent")
+      LegacyArchitectureLogger.assertLegacyArchitecture("InteropEvent")
     }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/interop/InteropEventEmitter.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/interop/InteropEventEmitter.kt
@@ -60,7 +60,7 @@ public class InteropEventEmitter(private val reactContext: ReactContext) : RCTEv
 
   private companion object {
     init {
-      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled("InteropEventEmitter")
+      LegacyArchitectureLogger.assertLegacyArchitecture("InteropEventEmitter")
     }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/jscexecutor/JSCExecutor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/jscexecutor/JSCExecutor.kt
@@ -27,7 +27,7 @@ public class JSCExecutor internal constructor(jscConfig: ReadableNativeMap) :
   private companion object {
     init {
       loadLibrary()
-      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled("JSCExecutor")
+      LegacyArchitectureLogger.assertLegacyArchitecture("JSCExecutor")
     }
 
     @JvmStatic

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/jscexecutor/JSCExecutorFactory.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/jscexecutor/JSCExecutorFactory.kt
@@ -18,7 +18,7 @@ public class JSCExecutorFactory(private val appName: String, private val deviceN
     JavaScriptExecutorFactory {
 
   init {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled("JSCExecutorFactory")
+    LegacyArchitectureLogger.assertLegacyArchitecture("JSCExecutorFactory")
   }
 
   @Throws(Exception::class)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LayoutDirectionUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LayoutDirectionUtil.kt
@@ -15,7 +15,7 @@ import com.facebook.yoga.YogaDirection
 @LegacyArchitecture
 internal object LayoutDirectionUtil {
   init {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled("LayoutDirectionUtil")
+    LegacyArchitectureLogger.assertLegacyArchitecture("LayoutDirectionUtil")
   }
 
   @JvmStatic

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LayoutShadowNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LayoutShadowNode.java
@@ -40,7 +40,7 @@ import com.facebook.yoga.YogaWrap;
 @LegacyArchitecture
 public class LayoutShadowNode extends ReactShadowNodeImpl {
   static {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+    LegacyArchitectureLogger.assertLegacyArchitecture(
         "LayoutShadowNode", LegacyArchitectureLogLevel.WARNING);
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
@@ -71,7 +71,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 public class NativeViewHierarchyManager {
 
   static {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+    LegacyArchitectureLogger.assertLegacyArchitecture(
         "NativeViewHierarchyManager", LegacyArchitectureLogLevel.WARNING);
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyOptimizer.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyOptimizer.java
@@ -52,7 +52,7 @@ import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger;
 public class NativeViewHierarchyOptimizer {
 
   static {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+    LegacyArchitectureLogger.assertLegacyArchitecture(
         "NativeViewHierarchyOptimizer", LegacyArchitectureLogLevel.WARNING);
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NoSuchNativeViewException.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NoSuchNativeViewException.kt
@@ -20,8 +20,7 @@ internal class NoSuchNativeViewException(detailMessage: String) :
 
   private companion object {
     init {
-      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
-          "NoSuchNativeViewException")
+      LegacyArchitectureLogger.assertLegacyArchitecture("NoSuchNativeViewException")
     }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/OnLayoutEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/OnLayoutEvent.kt
@@ -59,7 +59,7 @@ public class OnLayoutEvent private constructor() : Event<OnLayoutEvent>() {
 
   public companion object {
     init {
-      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+      LegacyArchitectureLogger.assertLegacyArchitecture(
           "OnLayoutEvent", LegacyArchitectureLogLevel.WARNING)
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactShadowNodeImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactShadowNodeImpl.java
@@ -67,7 +67,7 @@ public class ReactShadowNodeImpl implements ReactShadowNode<ReactShadowNodeImpl>
   }
 
   static {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+    LegacyArchitectureLogger.assertLegacyArchitecture(
         "ReactShadowNodeImpl", LegacyArchitectureLogLevel.WARNING);
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactYogaConfigProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactYogaConfigProvider.kt
@@ -16,7 +16,7 @@ import com.facebook.yoga.YogaErrata
 @LegacyArchitecture
 internal object ReactYogaConfigProvider {
   init {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled("ReactYogaConfigProvider")
+    LegacyArchitectureLogger.assertLegacyArchitecture("ReactYogaConfigProvider")
   }
 
   val yogaConfig: YogaConfig by

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ShadowNodeRegistry.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ShadowNodeRegistry.kt
@@ -84,7 +84,7 @@ internal class ShadowNodeRegistry {
 
   private companion object {
     init {
-      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+      LegacyArchitectureLogger.assertLegacyArchitecture(
           "ShadowNodeRegistry", LegacyArchitectureLogLevel.WARNING)
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java
@@ -44,7 +44,7 @@ import java.util.Map;
 @LegacyArchitecture
 public class UIImplementation {
   static {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+    LegacyArchitectureLogger.assertLegacyArchitecture(
         "UIImplementation", LegacyArchitectureLogLevel.WARNING);
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerHelper.java
@@ -78,7 +78,7 @@ public class UIManagerHelper {
     // - BridgeReactContext is compiled-out when UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE == true
     //
     // To detect a potential regression we add the following assertion ERROR
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+    LegacyArchitectureLogger.assertLegacyArchitecture(
         "UIManagerHelper.getUIManager(context, uiManagerType)", LegacyArchitectureLogLevel.ERROR);
     if (!context.hasCatalystInstance()) {
       ReactSoftExceptionLogger.logSoftException(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
@@ -89,7 +89,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 public class UIManagerModule extends ReactContextBaseJavaModule
     implements OnBatchCompleteListener, LifecycleEventListener, UIManager {
   static {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+    LegacyArchitectureLogger.assertLegacyArchitecture(
         "UIManagerModule", LegacyArchitectureLogLevel.WARNING);
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIViewOperationQueue.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIViewOperationQueue.java
@@ -52,7 +52,7 @@ import java.util.Map;
 public class UIViewOperationQueue {
 
   static {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+    LegacyArchitectureLogger.assertLegacyArchitecture(
         "UIViewOperationQueue", LegacyArchitectureLogLevel.WARNING);
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewAtIndex.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewAtIndex.kt
@@ -41,7 +41,7 @@ public class ViewAtIndex(
     }
 
     init {
-      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+      LegacyArchitectureLogger.assertLegacyArchitecture(
           "ViewAtIndex", LegacyArchitectureLogLevel.WARNING)
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/YogaNodePool.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/YogaNodePool.kt
@@ -16,7 +16,7 @@ import com.facebook.yoga.YogaNode
 @LegacyArchitecture
 internal object YogaNodePool {
   init {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled("YogaNodePool")
+    LegacyArchitectureLogger.assertLegacyArchitecture("YogaNodePool")
   }
 
   private val pool: ClearableSynchronizedPool<YogaNode> by

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/AbstractLayoutAnimation.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/AbstractLayoutAnimation.kt
@@ -99,7 +99,7 @@ internal abstract class AbstractLayoutAnimation {
 
   companion object {
     init {
-      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+      LegacyArchitectureLogger.assertLegacyArchitecture(
           "AbstractLayoutAnimation", LegacyArchitectureLogLevel.WARNING)
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/BaseLayoutAnimation.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/BaseLayoutAnimation.kt
@@ -78,7 +78,7 @@ internal abstract class BaseLayoutAnimation : AbstractLayoutAnimation() {
 
   private companion object {
     init {
-      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+      LegacyArchitectureLogger.assertLegacyArchitecture(
           "BaseLayoutAnimation", LegacyArchitectureLogLevel.WARNING)
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutAnimationController.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutAnimationController.java
@@ -31,7 +31,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 public class LayoutAnimationController {
 
   static {
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+    LegacyArchitectureLogger.assertLegacyArchitecture(
         "LayoutAnimationController", LegacyArchitectureLogLevel.WARNING);
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutAnimationType.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutAnimationType.kt
@@ -22,7 +22,7 @@ internal enum class LayoutAnimationType {
 
   companion object {
     init {
-      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+      LegacyArchitectureLogger.assertLegacyArchitecture(
           "LayoutAnimationType", LegacyArchitectureLogLevel.WARNING)
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutCreateAnimation.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutCreateAnimation.kt
@@ -22,7 +22,7 @@ internal class LayoutCreateAnimation : BaseLayoutAnimation() {
 
   private companion object {
     init {
-      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+      LegacyArchitectureLogger.assertLegacyArchitecture(
           "LayoutCreateAnimation", LegacyArchitectureLogLevel.WARNING)
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutDeleteAnimation.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutDeleteAnimation.kt
@@ -22,7 +22,7 @@ internal class LayoutDeleteAnimation : BaseLayoutAnimation() {
 
   private companion object {
     init {
-      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+      LegacyArchitectureLogger.assertLegacyArchitecture(
           "LayoutDeleteAnimation", LegacyArchitectureLogLevel.WARNING)
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutUpdateAnimation.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutUpdateAnimation.kt
@@ -51,7 +51,7 @@ internal class LayoutUpdateAnimation : AbstractLayoutAnimation() {
     private const val USE_TRANSLATE_ANIMATION = false
 
     init {
-      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+      LegacyArchitectureLogger.assertLegacyArchitecture(
           "LayoutUpdateAnimation", LegacyArchitectureLogLevel.WARNING)
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/OpacityAnimation.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/OpacityAnimation.kt
@@ -28,7 +28,7 @@ internal class OpacityAnimation(view: View, private val startOpacity: Float, end
 
   init {
     setAnimationListener(OpacityAnimationListener(view))
-    LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+    LegacyArchitectureLogger.assertLegacyArchitecture(
         "OpacityAnimation", LegacyArchitectureLogLevel.WARNING)
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/PositionAndSizeAnimation.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/PositionAndSizeAnimation.kt
@@ -81,8 +81,7 @@ internal class PositionAndSizeAnimation(view: View, x: Int, y: Int, width: Int, 
 
   private companion object {
     init {
-      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
-          "PositionAndSizeAnimation")
+      LegacyArchitectureLogger.assertLegacyArchitecture("PositionAndSizeAnimation")
     }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/SimpleSpringInterpolator.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/SimpleSpringInterpolator.kt
@@ -10,7 +10,6 @@ package com.facebook.react.uimanager.layoutanimation
 import android.view.animation.Interpolator
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.ReadableType
-import com.facebook.react.bridge.ReadableType.Number
 import com.facebook.react.common.annotations.internal.LegacyArchitecture
 import com.facebook.react.common.annotations.internal.LegacyArchitectureLogLevel
 import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
@@ -39,7 +38,7 @@ internal class SimpleSpringInterpolator : Interpolator {
   companion object {
 
     init {
-      LegacyArchitectureLogger.assertWhenLegacyArchitectureMinifyingEnabled(
+      LegacyArchitectureLogger.assertLegacyArchitecture(
           "SimpleSpringInterpolator", LegacyArchitectureLogLevel.WARNING)
     }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/CMakeLists.txt
@@ -24,10 +24,11 @@ add_library(
         reactnativejni_common
         OBJECT
           JDynamicNative.cpp
+          JReactMarker.cpp
           NativeArray.cpp
           NativeCommon.cpp
           NativeMap.cpp
-        OnLoad-common.cpp
+          OnLoad-common.cpp
           ReadableNativeArray.cpp
           ReadableNativeMap.cpp
           WritableNativeArray.cpp
@@ -36,7 +37,7 @@ add_library(
 target_merge_so(reactnativejni_common)
 target_include_directories(reactnativejni_common PUBLIC ../../)
 
-target_link_libraries(reactnativejni_common fbjni folly_runtime)
+target_link_libraries(reactnativejni_common fbjni folly_runtime react_cxxreact)
 target_compile_reactnative_options(reactnativejni_common PRIVATE)
 target_compile_options(reactnativejni_common PRIVATE -Wno-unused-lambda-capture)
 
@@ -55,7 +56,6 @@ add_library(
           JInspector.cpp
           JMessageQueueThread.cpp
           JReactCxxErrorHandler.cpp
-          JReactMarker.cpp
           JReactSoftExceptionLogger.cpp
           JRuntimeExecutor.cpp
           JRuntimeScheduler.cpp

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/OnLoad-common.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/OnLoad-common.cpp
@@ -8,6 +8,7 @@
 #include <fbjni/fbjni.h>
 #include "JCallback.h"
 #include "JDynamicNative.h"
+#include "JReactMarker.h"
 #include "NativeArray.h"
 #include "NativeMap.h"
 #include "WritableNativeArray.h"
@@ -19,6 +20,7 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
   return facebook::jni::initialize(vm, [] {
     JCxxCallbackImpl::registerNatives();
     JDynamicNative::registerNatives();
+    JReactMarker::registerNatives();
     NativeArray::registerNatives();
     NativeMap::registerNatives();
     ReadableNativeArray::registerNatives();

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
@@ -16,7 +16,6 @@
 #include "CxxModuleWrapperBase.h"
 #include "InspectorNetworkRequestListener.h"
 #include "JInspector.h"
-#include "JReactMarker.h"
 #include "JavaScriptExecutorHolder.h"
 #include "ReactInstanceManagerInspectorTarget.h"
 
@@ -42,7 +41,6 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
 #endif
     CatalystInstanceImpl::registerNatives();
     CxxModuleWrapperBase::registerNatives();
-    JReactMarker::registerNatives();
     JInspector::registerNatives();
     ReactInstanceManagerInspectorTarget::registerNatives();
     InspectorNetworkRequestListener::registerNatives();


### PR DESCRIPTION
Summary:
Reland of D72389708

This renames the method to be more aligned to the fact that we're using this entrypoint both for internal
and for OSS users.

I've also added a `assertLegacyArchitectureOnlyWhenMinifyEnabled` that will run only for internal builds.

Changelog:
[Internal] [Changed] -

Differential Revision: D72552028
