### PR TITLE
Avoid build failure on Catalyst (x86_64)

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -609,7 +609,7 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
                             name:errorData[@"name"]
                   componentStack:errorData[@"componentStack"]
                      exceptionId:error.id
-                         isFatal:errorData[@"isFatal"]
+                         isFatal:[errorData[@"isFatal"] boolValue]
                        extraData:errorData[@"extraData"]]) {
     JS::NativeExceptionsManager::ExceptionData jsErrorData{errorData};
     id<NativeExceptionsManagerSpec> exceptionsManager = [_turboModuleManager moduleForName:"ExceptionsManager"];


### PR DESCRIPTION
Summary:
When building React Native for mac catalyst on intel architecture, we are observing a build failure in RCTInstance.
See issue: https://github.com/facebook/react-native/issues/50388

Apparently, the compiler don't understand that `errorData[@"isFatal"]` is a BOOL, so we are helping it by extracting the `boolValue`.

## Changelog:
[iOS][Fixed] -  Avoid build failure on Catalyst (x86_64)

Differential Revision: D72558024


