### PR TITLE
Enable INTERPROCEDURAL_OPTIMIZATION for React Native

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
@@ -8,6 +8,13 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 project(ReactAndroid)
 
+include(CheckIPOSupported)
+check_ipo_supported(RESULT IPO_SUPPORT)
+if (IPO_SUPPORT)
+  message(STATUS "LTO support is enabled")
+  set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+endif()
+
 include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 # Convert input paths to CMake format (with forward slashes)


### PR DESCRIPTION
Summary:
This enables INTERPROCEDURAL_OPTIMIZATION for the CMake build of React Native.

Changelog:
[Android] [Changed] - Enable INTERPROCEDURAL_OPTIMIZATION for React Native

Differential Revision: D72574119


