### PR TITLE
RNTester: Fix playground icon & test details button

### DIFF
--- a/packages/rn-tester/js/components/RNTTestDetails.js
+++ b/packages/rn-tester/js/components/RNTTestDetails.js
@@ -25,30 +25,31 @@ function RNTTestDetails({
 }): React.Node {
   const [collapsed, setCollapsed] = React.useState(true);
 
-  const content = (
-    <>
-      {description == null ? null : (
-        <View style={styles.section}>
-          <Text style={[styles.heading, {color: theme.LabelColor}]}>
-            Description
-          </Text>
-          <Text style={[styles.paragraph, {color: theme.LabelColor}]}>
-            {description}
-          </Text>
-        </View>
-      )}
-      {expect == null ? null : (
-        <View style={styles.section}>
-          <Text style={[styles.heading, {color: theme.LabelColor}]}>
-            Expectation
-          </Text>
-          <Text style={[styles.paragraph, {color: theme.LabelColor}]}>
-            {expect}
-          </Text>
-        </View>
-      )}
-    </>
-  );
+  const content =
+    description == null && expect == null ? null : (
+      <>
+        {description && (
+          <View style={styles.section}>
+            <Text style={[styles.heading, {color: theme.LabelColor}]}>
+              Description
+            </Text>
+            <Text style={[styles.paragraph, {color: theme.LabelColor}]}>
+              {description}
+            </Text>
+          </View>
+        )}
+        {expect && (
+          <View style={styles.section}>
+            <Text style={[styles.heading, {color: theme.LabelColor}]}>
+              Expectation
+            </Text>
+            <Text style={[styles.paragraph, {color: theme.LabelColor}]}>
+              {expect}
+            </Text>
+          </View>
+        )}
+      </>
+    );
   return (
     <View
       style={StyleSheet.compose(styles.container, {

--- a/packages/rn-tester/js/components/RNTesterTheme.js
+++ b/packages/rn-tester/js/components/RNTesterTheme.js
@@ -133,8 +133,8 @@ export const RNTesterDarkTheme = {
   NavBarComponentsInactiveIcon: require('./../assets/bottom-nav-components-icon-dark.png'),
   NavBarAPIsActiveIcon: require('./../assets/bottom-nav-apis-icon-light.png'),
   NavBarAPIsInactiveIcon: require('./../assets/bottom-nav-apis-icon-dark.png'),
-  NavBarPlaygroundActiveIcon: require('./../assets/bottom-nav-playgrounds-icon-dark.png'),
-  NavBarPlaygroundInactiveIcon: require('./../assets/bottom-nav-playgrounds-icon-light.png'),
+  NavBarPlaygroundActiveIcon: require('./../assets/bottom-nav-playgrounds-icon-light.png'),
+  NavBarPlaygroundInactiveIcon: require('./../assets/bottom-nav-playgrounds-icon-dark.png'),
 };
 
 export const themes = {light: RNTesterLightTheme, dark: RNTesterDarkTheme};

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityAndroidExample.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityAndroidExample.js
@@ -283,3 +283,4 @@ exports.examples = [
     },
   },
 ];
+

--- a/packages/rn-tester/js/examples/Playground/PlaygroundExample.js
+++ b/packages/rn-tester/js/examples/Playground/PlaygroundExample.js
@@ -12,7 +12,4 @@ import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 
 import Playground from './RNTesterPlayground';
 
-export const title = Playground.title;
-export const framework = 'React';
-export const description = 'Test out new features and ideas.';
 export const examples: Array<RNTesterModuleExample> = [Playground];

--- a/packages/rn-tester/js/examples/Playground/RNTesterPlayground.js
+++ b/packages/rn-tester/js/examples/Playground/RNTesterPlayground.js
@@ -34,5 +34,6 @@ const styles = StyleSheet.create({
 export default ({
   title: 'Playground',
   name: 'playground',
+  description: 'Test out new features and ideas.',
   render: (): React.Node => <Playground />,
 }: RNTesterModuleExample);


### PR DESCRIPTION
## Summary:

Some minor fixes in the RNTester that were bugging me a bit:

- Playground tab icon is not displaying the correct icon when the tab is active.
- The RNTTestDetails button is being displayed when there is nothing to display.
- Export the data for the Playground tab correctly to display the description.

## Changelog:

[INTERNAL] - RNTester: Fix playground icon & test details button 

## Test Plan:

<details>
<summary>Screenshots</summary>

| Before                           | After                          |
|------------------------------------|------------------------------------|
| ![Screenshot_1744044385](https://github.com/user-attachments/assets/d4a08423-531b-49a8-b3c5-314e0bd55b4c) | ![Screenshot_1744044377](https://github.com/user-attachments/assets/c36cde64-d48d-4f80-95db-2e4f9765b350) |

</details>


