### PR TITLE
Refactor RuntimeSamplingProfileTraceEventSerializer: use smart pointers, split code, add tests

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.cpp
@@ -72,7 +72,9 @@ bool TracingAgent::handleRequest(const cdp::PreparsedRequest& req) {
     }
 
     instanceAgent_->stopTracing();
-    bool correctlyStopped = PerformanceTracer::getInstance().stopTracing();
+
+    PerformanceTracer& performanceTracer = PerformanceTracer::getInstance();
+    bool correctlyStopped = performanceTracer.stopTracing();
     if (!correctlyStopped) {
       frontendChannel_(cdp::jsonError(
           req.id,
@@ -90,15 +92,16 @@ bool TracingAgent::handleRequest(const cdp::PreparsedRequest& req) {
           "Tracing.dataCollected",
           folly::dynamic::object("value", eventsChunk)));
     };
-    PerformanceTracer::getInstance().collectEvents(
+    performanceTracer.collectEvents(
         dataCollectedCallback, TRACE_EVENT_CHUNK_SIZE);
 
-    tracing::RuntimeSamplingProfileTraceEventSerializer::serializeAndNotify(
-        PerformanceTracer::getInstance(),
-        instanceAgent_->collectTracingProfile().getRuntimeSamplingProfile(),
-        instanceTracingStartTimestamp_,
+    tracing::RuntimeSamplingProfileTraceEventSerializer serializer(
+        performanceTracer,
         dataCollectedCallback,
         PROFILE_TRACE_EVENT_CHUNK_SIZE);
+    serializer.serializeAndNotify(
+        instanceAgent_->collectTracingProfile().getRuntimeSamplingProfile(),
+        instanceTracingStartTimestamp_);
 
     frontendChannel_(cdp::jsonNotification(
         "Tracing.tracingComplete",

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/ProfileTreeNode.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/ProfileTreeNode.h
@@ -7,7 +7,10 @@
 
 #pragma once
 
-#include "RuntimeSamplingProfile.h"
+#include <memory>
+#include <utility>
+
+#include <jsinspector-modern/tracing/RuntimeSamplingProfile.h>
 
 namespace facebook::react::jsinspector_modern::tracing {
 
@@ -28,7 +31,7 @@ class ProfileTreeNode {
   ProfileTreeNode(
       uint32_t id,
       CodeType codeType,
-      ProfileTreeNode* parent,
+      std::shared_ptr<ProfileTreeNode> parent,
       RuntimeSamplingProfile::SampleCallStackFrame callFrame)
       : id_(id),
         codeType_(codeType),
@@ -47,7 +50,7 @@ class ProfileTreeNode {
    * \return pointer to the parent node, nullptr if this is the root node.
    */
   ProfileTreeNode* getParent() const {
-    return parent_;
+    return parent_.get();
   }
 
   /**
@@ -58,12 +61,14 @@ class ProfileTreeNode {
   }
 
   /**
-   * Will only add unique child node. Returns pointer to the already existing
-   * child node, nullptr if the added child node is unique.
+   * Will only add unique child node.
+   * \return shared pointer to the already existing child node, nullptr if the
+   * added child node is unique.
    */
-  ProfileTreeNode* addChild(ProfileTreeNode* child) {
-    for (auto existingChild : children_) {
-      if (*existingChild == child) {
+  std::shared_ptr<ProfileTreeNode> addChild(
+      std::shared_ptr<ProfileTreeNode> child) {
+    for (const auto& existingChild : children_) {
+      if (*existingChild == child.get()) {
         return existingChild;
       }
     }
@@ -94,13 +99,13 @@ class ProfileTreeNode {
    */
   CodeType codeType_;
   /**
-   * Pointer to the parent node. Should be nullptr only for root node.
+   * Shared pointer to the parent node. Can be nullptr only for root node.
    */
-  ProfileTreeNode* parent_{nullptr};
+  std::shared_ptr<ProfileTreeNode> parent_;
   /**
-   * Lst of pointers to children nodes.
+   * Lst of shared pointers to children nodes.
    */
-  std::vector<ProfileTreeNode*> children_{};
+  std::vector<std::shared_ptr<ProfileTreeNode>> children_;
   /**
    * Information about the corresponding call frame that is represented by this
    * node.

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.h
@@ -8,39 +8,157 @@
 #pragma once
 
 #include "PerformanceTracer.h"
+#include "ProfileTreeNode.h"
 #include "RuntimeSamplingProfile.h"
 
 namespace facebook::react::jsinspector_modern::tracing {
+
+namespace {
+
+struct NodeIdGenerator {
+ public:
+  uint32_t getNext() {
+    return ++counter_;
+  }
+
+ private:
+  uint32_t counter_ = 0;
+};
+
+} // namespace
 
 /**
  * Serializes RuntimeSamplingProfile into collection of specific Trace Events,
  * which represent Profile information on a timeline.
  */
 class RuntimeSamplingProfileTraceEventSerializer {
- public:
-  RuntimeSamplingProfileTraceEventSerializer() = delete;
+  struct ProfileChunk {
+    ProfileChunk(
+        uint16_t chunkSize,
+        uint64_t chunkThreadId,
+        uint64_t chunkTimestamp)
+        : size(chunkSize), threadId(chunkThreadId), timestamp(chunkTimestamp) {
+      samples.reserve(size);
+      timeDeltas.reserve(size);
+    }
 
+    bool isFull() const {
+      return samples.size() == size;
+    }
+
+    bool isEmpty() const {
+      return samples.empty();
+    }
+
+    std::vector<std::shared_ptr<ProfileTreeNode>> nodes;
+    std::vector<uint32_t> samples;
+    std::vector<long long> timeDeltas;
+    uint16_t size;
+    uint64_t threadId;
+    uint64_t timestamp;
+  };
+
+ public:
   /**
    * \param performanceTracer A reference to PerformanceTracer instance.
-   * \param profile What we will be serializing.
-   * \param tracingStartTime A timestamp of when tracing of an
-   * Instance started, will be used as a starting reference point of JavaScript
-   * samples recording.
-   * \param notificationCallback A callback, which is called
+   * \param notificationCallback A reference to a callback, which is called
    * when a chunk of trace events is ready to be sent.
-   * \param traceEventChunkSize The maximum number of ProfileChunk trace events
-   * that can be sent in a single CDP Tracing.dataCollected message.
+   * \param traceEventChunkSize The maximum number of ProfileChunk trace
+   * events that can be sent in a single CDP Tracing.dataCollected message.
    * \param profileChunkSize The maximum number of ProfileChunk trace events
    * that can be sent in a single ProfileChunk trace event.
    */
-  static void serializeAndNotify(
+  RuntimeSamplingProfileTraceEventSerializer(
       PerformanceTracer& performanceTracer,
-      const RuntimeSamplingProfile& profile,
-      std::chrono::steady_clock::time_point tracingStartTime,
-      const std::function<void(const folly::dynamic& traceEventsChunk)>&
+      std::function<void(const folly::dynamic& traceEventsChunk)>
           notificationCallback,
       uint16_t traceEventChunkSize,
-      uint16_t profileChunkSize = 10);
+      uint16_t profileChunkSize = 10)
+      : performanceTracer_(performanceTracer),
+        notificationCallback_(std::move(notificationCallback)),
+        traceEventChunkSize_(traceEventChunkSize),
+        profileChunkSize_(profileChunkSize) {
+    traceEventBuffer_ = folly::dynamic::array();
+    traceEventBuffer_.reserve(traceEventChunkSize);
+  }
+
+  /**
+   * \param profile What we will be serializing.
+   * \param tracingStartTime A timestamp of when tracing of an Instance started,
+   * will be used as a starting reference point of JavaScript samples recording.
+   */
+  void serializeAndNotify(
+      const RuntimeSamplingProfile& profile,
+      std::chrono::steady_clock::time_point tracingStartTime);
+
+ private:
+  /**
+   * Sends a single "Profile" Trace Event via notificationCallback_.
+   * \param threadId The id of the thread, where the Profile was collected.
+   * \param profileId The id of the Profile.
+   * \param profileStartUnixTimestamp The Unix timestamp of the start of the
+   * profile.
+   */
+  void sendProfileTraceEvent(
+      uint64_t threadId,
+      uint16_t profileId,
+      uint64_t profileStartUnixTimestamp) const;
+
+  /**
+   * Encapsulates logic for processing the empty sample, when the VM was idling.
+   * \param chunk The profile chunk, which will record this sample.
+   * \param idleNodeId The id of the (idle) node.
+   * \param samplesTimeDelta Delta between the current sample and the
+   * previous one.
+   */
+  void chunkEmptySample(
+      ProfileChunk& chunk,
+      uint32_t idleNodeId,
+      long long samplesTimeDelta);
+
+  /**
+   * Records ProfileChunk as a "ProfileChunk" Trace Event in traceEventBuffer_.
+   * \param chunk The chunk that will be buffered.
+   * \param profileId The id of the Profile.
+   */
+  void bufferProfileChunkTraceEvent(ProfileChunk& chunk, uint16_t profileId);
+
+  /**
+   * Encapsulates logic for processing the call stack of the sample.
+   * \param callStack The call stack that will be processed.
+   * \param chunk The profile chunk, which will buffer the sample with the
+   * provided call stack.
+   * \param rootNode Shared pointer to the (root) node. Will be the parent node
+   * of the corresponding profile tree branch.
+   * \param idleNode Shared pointer to the (idle) node. Will be the only node
+   * that is used for the corresponding profile tree branch, in case of an empty
+   * call stack.
+   * \param samplesTimeDelta Delta between the current sample and the previous
+   * one.
+   * \param nodeIdGenerator NodeIdGenerator instance that will be used for
+   * generating unique node ids.
+   */
+  void processCallStack(
+      const std::vector<RuntimeSamplingProfile::SampleCallStackFrame>&
+          callStack,
+      ProfileChunk& chunk,
+      std::shared_ptr<ProfileTreeNode> rootNode,
+      std::shared_ptr<ProfileTreeNode> idleNode,
+      long long samplesTimeDelta,
+      NodeIdGenerator& nodeIdGenerator);
+
+  /**
+   * Sends buffered Trace Events via notificationCallback_ and then clears it.
+   */
+  void sendBufferedTraceEventsAndClear();
+
+  PerformanceTracer& performanceTracer_;
+  const std::function<void(const folly::dynamic& traceEventsChunk)>
+      notificationCallback_;
+  uint16_t traceEventChunkSize_;
+  uint16_t profileChunkSize_;
+
+  folly::dynamic traceEventBuffer_;
 };
 
 } // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/tests/ProfileTreeNodeTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/tests/ProfileTreeNodeTest.cpp
@@ -25,30 +25,39 @@ TEST(ProfileTreeNodeTest, EqualityOperator) {
   EXPECT_EQ(*node1 == node2, true);
 
   node1 = new ProfileTreeNode(
-      3, ProfileTreeNode::CodeType::JavaScript, node1, callFrame);
+      3,
+      ProfileTreeNode::CodeType::JavaScript,
+      std::shared_ptr<ProfileTreeNode>(node1),
+      callFrame);
   node2 = new ProfileTreeNode(
       4, ProfileTreeNode::CodeType::JavaScript, nullptr, callFrame);
   EXPECT_EQ(*node1 == node2, false);
 
   node1 = new ProfileTreeNode(
-      5, ProfileTreeNode::CodeType::JavaScript, node2, callFrame);
+      5,
+      ProfileTreeNode::CodeType::JavaScript,
+      std::shared_ptr<ProfileTreeNode>(node2),
+      callFrame);
   node2 = new ProfileTreeNode(
-      6, ProfileTreeNode::CodeType::JavaScript, node2, callFrame);
+      6,
+      ProfileTreeNode::CodeType::JavaScript,
+      std::shared_ptr<ProfileTreeNode>(node2),
+      callFrame);
   EXPECT_EQ(*node1 == node2, true);
 }
 
 TEST(ProfileTreeNodeTest, OnlyAddsUniqueChildren) {
   auto callFrame = RuntimeSamplingProfile::SampleCallStackFrame{
       RuntimeSamplingProfile::SampleCallStackFrame::Kind::JSFunction, 0, "foo"};
-  ProfileTreeNode* parent = new ProfileTreeNode(
+  auto parent = std::make_shared<ProfileTreeNode>(
       1, ProfileTreeNode::CodeType::JavaScript, nullptr, callFrame);
-  ProfileTreeNode* existingChild = new ProfileTreeNode(
+  auto existingChild = std::make_shared<ProfileTreeNode>(
       2, ProfileTreeNode::CodeType::JavaScript, parent, callFrame);
 
   auto maybeAlreadyExistingChild = parent->addChild(existingChild);
   EXPECT_EQ(maybeAlreadyExistingChild, nullptr);
 
-  auto copyOfExistingChild = new ProfileTreeNode(
+  auto copyOfExistingChild = std::make_shared<ProfileTreeNode>(
       3, ProfileTreeNode::CodeType::JavaScript, parent, callFrame);
 
   maybeAlreadyExistingChild = parent->addChild(copyOfExistingChild);

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/tests/RuntimeSamplingProfileTraceEventSerializerTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/tests/RuntimeSamplingProfileTraceEventSerializerTest.cpp
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.h>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <chrono>
+#include <utility>
+
+namespace facebook::react::jsinspector_modern::tracing {
+
+class RuntimeSamplingProfileTraceEventSerializerTest : public ::testing::Test {
+ protected:
+  std::vector<folly::dynamic> notificationEvents_;
+
+  std::function<void(const folly::dynamic& traceEventsChunk)>
+  createNotificationCallback() {
+    return [this](const folly::dynamic& traceEventsChunk) {
+      notificationEvents_.push_back(traceEventsChunk);
+    };
+  }
+
+  RuntimeSamplingProfile::SampleCallStackFrame createJSCallFrame(
+      std::string functionName,
+      uint32_t scriptId = 1,
+      std::optional<std::string> url = std::nullopt,
+      std::optional<uint32_t> lineNumber = std::nullopt,
+      std::optional<uint32_t> columnNumber = std::nullopt) {
+    return RuntimeSamplingProfile::SampleCallStackFrame(
+        RuntimeSamplingProfile::SampleCallStackFrame::Kind::JSFunction,
+        scriptId,
+        std::move(functionName),
+        std::move(url),
+        lineNumber,
+        columnNumber);
+  }
+
+  RuntimeSamplingProfile::SampleCallStackFrame createGCCallFrame() {
+    return RuntimeSamplingProfile::SampleCallStackFrame(
+        RuntimeSamplingProfile::SampleCallStackFrame::Kind::GarbageCollector,
+        0,
+        "(garbage collector)");
+  }
+
+  RuntimeSamplingProfile::Sample createSample(
+      uint64_t timestamp,
+      uint64_t threadId,
+      std::vector<RuntimeSamplingProfile::SampleCallStackFrame> callStack) {
+    return RuntimeSamplingProfile::Sample(
+        timestamp, threadId, std::move(callStack));
+  }
+
+  RuntimeSamplingProfile createEmptyProfile() {
+    return {"TestRuntime", {}};
+  }
+
+  RuntimeSamplingProfile createProfileWithSamples(
+      std::vector<RuntimeSamplingProfile::Sample> samples) {
+    return {"TestRuntime", std::move(samples)};
+  }
+};
+
+TEST_F(RuntimeSamplingProfileTraceEventSerializerTest, EmptyProfile) {
+  // Setup
+  auto notificationCallback = createNotificationCallback();
+  RuntimeSamplingProfileTraceEventSerializer serializer(
+      PerformanceTracer::getInstance(), notificationCallback, 10);
+
+  auto profile = createEmptyProfile();
+  auto tracingStartTime = std::chrono::steady_clock::now();
+
+  // Execute
+  serializer.serializeAndNotify(profile, tracingStartTime);
+
+  // Nothing should be reported if the profile is empty.
+  EXPECT_TRUE(notificationEvents_.empty());
+}
+
+TEST_F(
+    RuntimeSamplingProfileTraceEventSerializerTest,
+    SameCallFramesAreMerged) {
+  // Setup
+  auto notificationCallback = createNotificationCallback();
+  RuntimeSamplingProfileTraceEventSerializer serializer(
+      PerformanceTracer::getInstance(), notificationCallback, 10);
+
+  // [     foo     ]
+  // [     bar     ]
+  //     [baz][(gc)]
+  std::vector<RuntimeSamplingProfile::SampleCallStackFrame> callStack1 = {
+      createJSCallFrame("bar", 1, "test.js", 20, 10),
+      createJSCallFrame("foo", 1, "test.js", 10, 5),
+  };
+
+  std::vector<RuntimeSamplingProfile::SampleCallStackFrame> callStack2 = {
+      createJSCallFrame("baz", 1, "other.js", 5, 1),
+      createJSCallFrame("bar", 1, "test.js", 20, 10),
+      createJSCallFrame("foo", 1, "test.js", 10, 5),
+  };
+
+  std::vector<RuntimeSamplingProfile::SampleCallStackFrame> callStack3 = {
+      createGCCallFrame(),
+      createJSCallFrame("bar", 1, "test.js", 20, 10),
+      createJSCallFrame("foo", 1, "test.js", 10, 5),
+  };
+
+  uint64_t threadId = 1;
+  uint64_t timestamp1 = 1000000;
+  uint64_t timestamp2 = 2000000;
+  uint64_t timestamp3 = 3000000;
+
+  auto samples = std::vector<RuntimeSamplingProfile::Sample>{};
+  samples.emplace_back(createSample(timestamp1, threadId, callStack1));
+  samples.emplace_back(createSample(timestamp2, threadId, callStack2));
+  samples.emplace_back(createSample(timestamp3, threadId, callStack3));
+
+  auto profile = createProfileWithSamples(std::move(samples));
+  auto tracingStartTime = std::chrono::steady_clock::now();
+
+  // Execute
+  serializer.serializeAndNotify(profile, tracingStartTime);
+
+  // Verify
+  ASSERT_EQ(notificationEvents_.size(), 2);
+  // (root), (program), (idle), foo, bar, baz, (garbage collector)
+  ASSERT_EQ(
+      notificationEvents_[1][0]["args"]["data"]["cpuProfile"]["nodes"].size(),
+      7);
+}
+
+TEST_F(RuntimeSamplingProfileTraceEventSerializerTest, EmptySample) {
+  // Setup
+  auto notificationCallback = createNotificationCallback();
+  RuntimeSamplingProfileTraceEventSerializer serializer(
+      PerformanceTracer::getInstance(), notificationCallback, 10);
+
+  // Create an empty sample (no call stack)
+  std::vector<RuntimeSamplingProfile::SampleCallStackFrame> emptyCallStack;
+
+  uint64_t threadId = 1;
+  uint64_t timestamp = 1000000;
+
+  auto samples = std::vector<RuntimeSamplingProfile::Sample>{};
+  samples.emplace_back(createSample(timestamp, threadId, emptyCallStack));
+  auto profile = createProfileWithSamples(std::move(samples));
+
+  auto tracingStartTime = std::chrono::steady_clock::now();
+
+  // Mock the performance tracer methods
+  folly::dynamic profileEvent = folly::dynamic::object;
+  folly::dynamic chunkEvent = folly::dynamic::object;
+
+  // Execute
+  serializer.serializeAndNotify(profile, tracingStartTime);
+
+  // Verify
+  // [["Profile"], ["ProfileChunk"]]
+  ASSERT_EQ(notificationEvents_.size(), 2);
+  // (root), (program), (idle)
+  ASSERT_EQ(
+      notificationEvents_[1][0]["args"]["data"]["cpuProfile"]["nodes"].size(),
+      3);
+}
+
+TEST_F(
+    RuntimeSamplingProfileTraceEventSerializerTest,
+    SamplesFromDifferentThreads) {
+  // Setup
+  auto notificationCallback = createNotificationCallback();
+  RuntimeSamplingProfileTraceEventSerializer serializer(
+      PerformanceTracer::getInstance(), notificationCallback, 10);
+
+  // Create samples with different thread IDs
+  std::vector<RuntimeSamplingProfile::SampleCallStackFrame> callStack = {
+      createJSCallFrame("foo", 1, "test.js", 10, 5)};
+
+  uint64_t timestamp = 1000000;
+  uint64_t threadId1 = 1;
+  uint64_t threadId2 = 2;
+
+  auto samples = std::vector<RuntimeSamplingProfile::Sample>{};
+  samples.emplace_back(createSample(timestamp, threadId1, callStack));
+  samples.emplace_back(createSample(timestamp + 1000, threadId2, callStack));
+  samples.emplace_back(createSample(timestamp + 2000, threadId1, callStack));
+
+  auto profile = createProfileWithSamples(std::move(samples));
+
+  auto tracingStartTime = std::chrono::steady_clock::now();
+
+  // Execute
+  serializer.serializeAndNotify(profile, tracingStartTime);
+
+  // [["Profile"], ["ProfileChunk", "ProfileChunk", "ProfileChunk]]
+  // Samples from different thread should never be grouped together in the same
+  // chunk.
+  ASSERT_EQ(notificationEvents_.size(), 2);
+  ASSERT_EQ(notificationEvents_[1].size(), 3);
+}
+
+TEST_F(
+    RuntimeSamplingProfileTraceEventSerializerTest,
+    TraceEventChunkSizeLimit) {
+  // Setup
+  auto notificationCallback = createNotificationCallback();
+  uint16_t traceEventChunkSize = 2;
+  uint16_t profileChunkSize = 2;
+  RuntimeSamplingProfileTraceEventSerializer serializer(
+      PerformanceTracer::getInstance(),
+      notificationCallback,
+      traceEventChunkSize,
+      profileChunkSize);
+
+  // Create multiple samples
+  std::vector<RuntimeSamplingProfile::SampleCallStackFrame> callStack = {
+      createJSCallFrame("foo", 1, "test.js", 10, 5)};
+
+  uint64_t timestamp = 1000000;
+  uint64_t threadId = 1;
+
+  std::vector<RuntimeSamplingProfile::Sample> samples;
+  samples.reserve(5);
+  for (int i = 0; i < 5; i++) {
+    samples.push_back(createSample(timestamp + i * 1000, threadId, callStack));
+  }
+
+  auto profile = createProfileWithSamples(std::move(samples));
+  auto tracingStartTime = std::chrono::steady_clock::now();
+
+  // Execute
+  serializer.serializeAndNotify(profile, tracingStartTime);
+
+  // [["Profile"], ["ProfileChunk", "ProfileChunk"], ["ProfileChunk"]]
+  ASSERT_EQ(notificationEvents_.size(), 3);
+
+  // Check that each chunk has at most traceEventChunkSize events
+  for (size_t i = 1; i < notificationEvents_.size(); i++) {
+    EXPECT_LE(notificationEvents_[i].size(), traceEventChunkSize);
+  }
+}
+
+TEST_F(RuntimeSamplingProfileTraceEventSerializerTest, ProfileChunkSizeLimit) {
+  // Setup
+  auto notificationCallback = createNotificationCallback();
+  // Set a small profile chunk size to test profile chunking
+  uint16_t traceEventChunkSize = 10;
+  uint16_t profileChunkSize = 2;
+  double samplesCount = 5;
+  RuntimeSamplingProfileTraceEventSerializer serializer(
+      PerformanceTracer::getInstance(),
+      notificationCallback,
+      traceEventChunkSize,
+      profileChunkSize);
+
+  // Create multiple samples
+  std::vector<RuntimeSamplingProfile::SampleCallStackFrame> callStack = {
+      createJSCallFrame("foo", 1, "test.js", 10, 5)};
+
+  uint64_t timestamp = 1000000;
+  uint64_t threadId = 1;
+
+  std::vector<RuntimeSamplingProfile::Sample> samples;
+  samples.reserve(samplesCount);
+  for (int i = 0; i < samplesCount; i++) {
+    samples.push_back(createSample(timestamp + i * 1000, threadId, callStack));
+  }
+
+  auto profile = createProfileWithSamples(std::move(samples));
+  auto tracingStartTime = std::chrono::steady_clock::now();
+
+  // Execute
+  serializer.serializeAndNotify(profile, tracingStartTime);
+
+  // [["Profile"], ["ProfileChunk", "ProfileChunk", "ProfileChunk"]]
+  ASSERT_EQ(notificationEvents_.size(), 2);
+  ASSERT_EQ(
+      notificationEvents_[1].size(),
+      std::ceil(samplesCount / profileChunkSize));
+
+  for (auto& profileChunk : notificationEvents_[1]) {
+    EXPECT_LE(
+        profileChunk["args"]["data"]["cpuProfile"]["samples"].size(),
+        profileChunkSize);
+  }
+}
+
+} // namespace facebook::react::jsinspector_modern::tracing


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

This should not have any functional changes, mostly refactoring the previous code, splitting it into smaller methods, better documentation and added tests.

Main changes are:
1. We are going to use smart pointers for `ProfileTreeNode`
2. Split single static method into multiple smaller methods of one class, less cognitive load and smaller context window

Differential Revision: D72401690


