### PR TITLE
Add prop to filter drag and drop pasting on iOS

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
+++ b/packages/react-native/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
@@ -658,6 +658,7 @@ export const __INTERNAL_VIEW_CONFIG: PartialViewConfig = {
     },
   },
   validAttributes: {
+    acceptDragAndDropTypes: true,
     maxFontSizeMultiplier: true,
     adjustsFontSizeToFit: true,
     minimumFontScale: true,

--- a/packages/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js
+++ b/packages/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js
@@ -90,6 +90,7 @@ const RCTTextInputViewConfig = {
     },
   },
   validAttributes: {
+    acceptDragAndDropTypes: true,
     dynamicTypeRamp: true,
     fontSize: true,
     fontWeight: true,

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
@@ -406,19 +406,6 @@ export type TextInputIOSProps = $ReadOnly<{
 
 export type TextInputAndroidProps = $ReadOnly<{
   /**
-   * When provided, the text input will only accept drag and drop events for the specified
-   * mime types. If null or not provided, the text input will accept all types of drag and drop
-   * events.
-   * Defaults to null.
-   *
-   * *NOTE*: This prop is experimental and its API may change in the future. Use at your own risk.
-   *
-   * @platform android
-   * @see https://developer.android.com/reference/android/content/ClipData for more information on MIME types
-   */
-  experimental_acceptDragAndDropTypes?: ?$ReadOnlyArray<string>,
-
-  /**
    * When provided it will set the color of the cursor (or "caret") in the component.
    * Unlike the behavior of `selectionColor` the cursor color will be set independently
    * from the color of the text selection box.
@@ -527,6 +514,26 @@ export type TextInputAndroidProps = $ReadOnly<{
 }>;
 
 type TextInputBaseProps = $ReadOnly<{
+  /**
+   * When provided, the text input will only accept drag and drop events for the specified
+   * types. If null or not provided, the text input will accept all types of drag and drop events.
+   * An empty array will accept no drag and drop events.
+   * Defaults to null.
+   *
+   * On Android, types must correspond to MIME types from ClipData:
+   * https://developer.android.com/reference/android/content/ClipData
+   * (e.g. "text/plain" or "image/*")
+   *
+   * On iOS, types must correspond to UTIs:
+   * https://developer.apple.com/documentation/uniformtypeidentifiers
+   * (e.g. "public.plain-text" or "public.image")
+   *
+   * *NOTE*: This prop is experimental and its API may change in the future. Use at your own risk.
+   *
+   * @see https://developer.android.com/reference/android/content/ClipData for more information on MIME types
+   */
+  experimental_acceptDragAndDropTypes?: ?$ReadOnlyArray<string>,
+
   /**
    * Can tell `TextInput` to automatically capitalize certain characters.
    *

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
@@ -406,6 +406,19 @@ export type TextInputIOSProps = $ReadOnly<{
 
 export type TextInputAndroidProps = $ReadOnly<{
   /**
+   * When provided, the text input will only accept drag and drop events for the specified
+   * mime types. If null or not provided, the text input will accept all types of drag and drop
+   * events.
+   * Defaults to null.
+   *
+   * *NOTE*: This prop is experimental and its API may change in the future. Use at your own risk.
+   *
+   * @platform android
+   * @see https://developer.android.com/reference/android/content/ClipData for more information on MIME types
+   */
+  experimental_acceptDragAndDropTypes?: ?$ReadOnlyArray<string>,
+
+  /**
    * When provided it will set the color of the cursor (or "caret") in the component.
    * Unlike the behavior of `selectionColor` the cursor color will be set independently
    * from the color of the text selection box.

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -675,6 +675,7 @@ function InternalTextInput(props: TextInputProps): React.Node {
         ref={(ref: $FlowFixMe)}
         {...otherProps}
         {...eventHandlers}
+        acceptDragAndDropTypes={props.experimental_acceptDragAndDropTypes}
         accessibilityState={_accessibilityState}
         accessible={accessible}
         submitBehavior={submitBehavior}

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -741,6 +741,7 @@ function InternalTextInput(props: TextInputProps): React.Node {
         accessibilityState={_accessibilityState}
         accessibilityLabelledBy={_accessibilityLabelledBy}
         accessible={accessible}
+        acceptDragAndDropTypes={props.experimental_acceptDragAndDropTypes}
         autoCapitalize={autoCapitalize}
         submitBehavior={submitBehavior}
         caretHidden={caretHidden}

--- a/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Multiline/RCTUITextView.mm
@@ -20,6 +20,7 @@
   NSDictionary<NSAttributedStringKey, id> *_defaultTextAttributes;
   NSArray<UIBarButtonItemGroup *> *_initialValueLeadingBarButtonGroups;
   NSArray<UIBarButtonItemGroup *> *_initialValueTrailingBarButtonGroups;
+  NSArray<NSString *> *_acceptDragAndDropTypes;
 }
 
 static UIFont *defaultPlaceholderFont(void)
@@ -101,6 +102,16 @@ static UIColor *defaultPlaceholderColor(void)
 }
 
 #pragma mark - Properties
+
+- (void)setAcceptDragAndDropTypes:(NSArray<NSString *> *)acceptDragAndDropTypes
+{
+  _acceptDragAndDropTypes = acceptDragAndDropTypes;
+}
+
+- (nullable NSArray<NSString *> *)acceptDragAndDropTypes
+{
+  return _acceptDragAndDropTypes;
+}
 
 - (void)setPlaceholder:(NSString *)placeholder
 {

--- a/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputViewProtocol.h
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBackedTextInputViewProtocol.h
@@ -38,6 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign, readonly) CGPoint contentOffset;
 @property (nonatomic, assign, readonly) UIEdgeInsets contentInset;
 @property (nullable, nonatomic, copy) NSDictionary<NSAttributedStringKey, id> *typingAttributes;
+@property (nonatomic, strong, nullable) NSArray<NSString *> *acceptDragAndDropTypes;
 
 // This protocol disallows direct access to `selectedTextRange` property because
 // unwise usage of it can break the `delegate` behavior. So, we always have to

--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputViewManager.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputViewManager.mm
@@ -48,6 +48,7 @@ RCT_REMAP_VIEW_PROPERTY(clearButtonMode, backedTextInputView.clearButtonMode, UI
 RCT_REMAP_VIEW_PROPERTY(scrollEnabled, backedTextInputView.scrollEnabled, BOOL)
 RCT_REMAP_VIEW_PROPERTY(secureTextEntry, backedTextInputView.secureTextEntry, BOOL)
 RCT_REMAP_VIEW_PROPERTY(smartInsertDelete, backedTextInputView.smartInsertDeleteType, UITextSmartInsertDeleteType)
+
 RCT_EXPORT_VIEW_PROPERTY(autoFocus, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(submitBehavior, NSString)
 RCT_EXPORT_VIEW_PROPERTY(clearTextOnFocus, BOOL)
@@ -60,16 +61,15 @@ RCT_EXPORT_VIEW_PROPERTY(inputAccessoryViewID, NSString)
 RCT_EXPORT_VIEW_PROPERTY(inputAccessoryViewButtonLabel, NSString)
 RCT_EXPORT_VIEW_PROPERTY(textContentType, NSString)
 RCT_EXPORT_VIEW_PROPERTY(passwordRules, NSString)
+RCT_EXPORT_VIEW_PROPERTY(mostRecentEventCount, NSInteger)
+RCT_EXPORT_VIEW_PROPERTY(disableKeyboardShortcuts, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(acceptDragAndDropTypes, NSArray<NSString *>)
 
 RCT_EXPORT_VIEW_PROPERTY(onChange, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onKeyPressSync, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onChangeSync, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onSelectionChange, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onScroll, RCTDirectEventBlock)
-
-RCT_EXPORT_VIEW_PROPERTY(mostRecentEventCount, NSInteger)
-
-RCT_EXPORT_VIEW_PROPERTY(disableKeyboardShortcuts, BOOL)
 
 RCT_EXPORT_SHADOW_PROPERTY(text, NSString)
 RCT_EXPORT_SHADOW_PROPERTY(placeholder, NSString)

--- a/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Singleline/RCTUITextField.mm
@@ -17,6 +17,7 @@
   NSDictionary<NSAttributedStringKey, id> *_defaultTextAttributes;
   NSArray<UIBarButtonItemGroup *> *_initialValueLeadingBarButtonGroups;
   NSArray<UIBarButtonItemGroup *> *_initialValueTrailingBarButtonGroups;
+  NSArray<NSString *> *_acceptDragAndDropTypes;
 }
 
 // This should not be needed but internal build were failing without it.
@@ -56,6 +57,16 @@
 }
 
 #pragma mark - Properties
+
+- (void)setAcceptDragAndDropTypes:(NSArray<NSString *> *)acceptDragAndDropTypes
+{
+  _acceptDragAndDropTypes = acceptDragAndDropTypes;
+}
+
+- (nullable NSArray<NSString *> *)acceptDragAndDropTypes
+{
+  return _acceptDragAndDropTypes;
+}
 
 - (void)setTextContainerInset:(UIEdgeInsets)textContainerInset
 {

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -2831,6 +2831,7 @@ export type TextInputIOSProps = $ReadOnly<{
   smartInsertDelete?: ?boolean,
 }>;
 export type TextInputAndroidProps = $ReadOnly<{
+  experimental_acceptDragAndDropTypes?: ?$ReadOnlyArray<string>,
   cursorColor?: ?ColorValue,
   selectionHandleColor?: ?ColorValue,
   disableFullscreenUI?: ?boolean,

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -2831,7 +2831,6 @@ export type TextInputIOSProps = $ReadOnly<{
   smartInsertDelete?: ?boolean,
 }>;
 export type TextInputAndroidProps = $ReadOnly<{
-  experimental_acceptDragAndDropTypes?: ?$ReadOnlyArray<string>,
   cursorColor?: ?ColorValue,
   selectionHandleColor?: ?ColorValue,
   disableFullscreenUI?: ?boolean,
@@ -2852,6 +2851,7 @@ export type TextInputAndroidProps = $ReadOnly<{
   underlineColorAndroid?: ?ColorValue,
 }>;
 type TextInputBaseProps = $ReadOnly<{
+  experimental_acceptDragAndDropTypes?: ?$ReadOnlyArray<string>,
   autoCapitalize?: ?AutoCapitalize,
   autoComplete?: ?(
     | \\"additional-name\\"

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -29,7 +29,10 @@ static const CGFloat kSingleLineKeyboardBottomOffset = 15.0;
 
 using namespace facebook::react;
 
-@interface RCTTextInputComponentView () <RCTBackedTextInputDelegate, RCTTextInputViewProtocol>
+@interface RCTTextInputComponentView () <
+    RCTBackedTextInputDelegate,
+    RCTTextInputViewProtocol,
+    UIDropInteractionDelegate>
 @end
 
 static NSSet<NSNumber *> *returnKeyTypesSet;
@@ -305,6 +308,19 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
 
   if (newTextInputProps.disableKeyboardShortcuts != oldTextInputProps.disableKeyboardShortcuts) {
     _backedTextInputView.disableKeyboardShortcuts = newTextInputProps.disableKeyboardShortcuts;
+  }
+
+  if (newTextInputProps.acceptDragAndDropTypes != oldTextInputProps.acceptDragAndDropTypes) {
+    if (!newTextInputProps.acceptDragAndDropTypes.has_value()) {
+      _backedTextInputView.acceptDragAndDropTypes = nil;
+    } else {
+      auto &vector = newTextInputProps.acceptDragAndDropTypes.value();
+      NSMutableArray<NSString *> *array = [NSMutableArray arrayWithCapacity:vector.size()];
+      for (const std::string &str : vector) {
+        [array addObject:[NSString stringWithUTF8String:str.c_str()]];
+      }
+      _backedTextInputView.acceptDragAndDropTypes = array;
+    }
   }
 
   [super updateProps:props oldProps:oldProps];

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputUtils.mm
@@ -46,6 +46,7 @@ void RCTCopyBackedTextInput(
   toTextInput.smartInsertDeleteType = fromTextInput.smartInsertDeleteType;
   toTextInput.passwordRules = fromTextInput.passwordRules;
   toTextInput.disableKeyboardShortcuts = fromTextInput.disableKeyboardShortcuts;
+  toTextInput.acceptDragAndDropTypes = fromTextInput.acceptDragAndDropTypes;
 
   [toTextInput setSelectedTextRange:fromTextInput.selectedTextRange notifyDelegate:NO];
 }

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -6650,6 +6650,7 @@ public class com/facebook/react/views/textinput/ReactEditText : androidx/appcomp
 	public final fun getBorderColor (I)I
 	protected final fun getContainsImages ()Z
 	public final fun getDisableFullscreenUI ()Z
+	public final fun getDragAndDropFilter ()Ljava/util/List;
 	protected final fun getNativeEventCount ()I
 	public final fun getReturnKeyType ()Ljava/lang/String;
 	public final fun getStagedInputType ()I
@@ -6669,6 +6670,7 @@ public class com/facebook/react/views/textinput/ReactEditText : androidx/appcomp
 	public fun onConfigurationChanged (Landroid/content/res/Configuration;)V
 	public fun onCreateInputConnection (Landroid/view/inputmethod/EditorInfo;)Landroid/view/inputmethod/InputConnection;
 	public fun onDetachedFromWindow ()V
+	public fun onDragEvent (Landroid/view/DragEvent;)Z
 	public fun onDraw (Landroid/graphics/Canvas;)V
 	public fun onFinishTemporaryDetach ()V
 	protected fun onFocusChanged (ZILandroid/graphics/Rect;)V
@@ -6694,6 +6696,7 @@ public class com/facebook/react/views/textinput/ReactEditText : androidx/appcomp
 	public final fun setContentSizeWatcher (Lcom/facebook/react/views/textinput/ContentSizeWatcher;)V
 	public final fun setContextMenuHidden (Z)V
 	public final fun setDisableFullscreenUI (Z)V
+	public final fun setDragAndDropFilter (Ljava/util/List;)V
 	public final fun setEventDispatcher (Lcom/facebook/react/uimanager/events/EventDispatcher;)V
 	public final fun setFontFamily (Ljava/lang/String;)V
 	public fun setFontFeatureSettings (Ljava/lang/String;)V
@@ -6757,6 +6760,7 @@ public class com/facebook/react/views/textinput/ReactTextInputManager : com/face
 	public synthetic fun receiveCommand (Landroid/view/View;Ljava/lang/String;Lcom/facebook/react/bridge/ReadableArray;)V
 	public fun receiveCommand (Lcom/facebook/react/views/textinput/ReactEditText;ILcom/facebook/react/bridge/ReadableArray;)V
 	public fun receiveCommand (Lcom/facebook/react/views/textinput/ReactEditText;Ljava/lang/String;Lcom/facebook/react/bridge/ReadableArray;)V
+	public final fun setAcceptDragAndDropTypes (Lcom/facebook/react/views/textinput/ReactEditText;Lcom/facebook/react/bridge/ReadableArray;)V
 	public final fun setAllowFontScaling (Lcom/facebook/react/views/textinput/ReactEditText;Z)V
 	public final fun setAutoCapitalize (Lcom/facebook/react/views/textinput/ReactEditText;Lcom/facebook/react/bridge/Dynamic;)V
 	public final fun setAutoCorrect (Lcom/facebook/react/views/textinput/ReactEditText;Ljava/lang/Boolean;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.kt
@@ -28,6 +28,7 @@ import android.text.method.KeyListener
 import android.text.method.QwertyKeyListener
 import android.util.TypedValue
 import android.view.ActionMode
+import android.view.DragEvent
 import android.view.Gravity
 import android.view.KeyEvent
 import android.view.Menu
@@ -121,6 +122,7 @@ public open class ReactEditText public constructor(context: Context) : AppCompat
   public var stagedInputType: Int
   protected var containsImages: Boolean = false
   public var submitBehavior: String? = null
+  public var dragAndDropFilter: List<String>? = null
 
   private var disableFullscreen: Boolean
   private var selectionWatcher: SelectionWatcher? = null
@@ -1190,6 +1192,17 @@ public open class ReactEditText public constructor(context: Context) : AppCompat
     }
 
     super.onDraw(canvas)
+  }
+
+  public override fun onDragEvent(event: DragEvent): Boolean {
+    val dragFilter = dragAndDropFilter
+    if (dragFilter != null && event.action == DragEvent.ACTION_DRAG_STARTED) {
+      val shouldHandle = dragFilter.any { filter -> event.clipDescription.hasMimeType(filter) }
+      if (!shouldHandle) {
+        return false
+      }
+    }
+    return super.onDragEvent(event)
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.kt
@@ -770,6 +770,22 @@ public open class ReactTextInputManager public constructor() :
     view.returnKeyType = returnKeyType
   }
 
+  @ReactProp(name = "acceptDragAndDropTypes")
+  public fun setAcceptDragAndDropTypes(
+      view: ReactEditText,
+      acceptDragAndDropTypes: ReadableArray?
+  ) {
+    if (acceptDragAndDropTypes == null) {
+      view.dragAndDropFilter = null
+    } else {
+      val acceptedTypes = mutableListOf<String>()
+      for (i in 0 until acceptDragAndDropTypes.size()) {
+        acceptDragAndDropTypes.getString(i)?.also(acceptedTypes::add)
+      }
+      view.dragAndDropFilter = acceptedTypes
+    }
+  }
+
   @ReactProp(name = "disableFullscreenUI", defaultBoolean = false)
   public fun setDisableFullscreenUI(view: ReactEditText, disableFullscreenUI: Boolean) {
     view.disableFullscreenUI = disableFullscreenUI

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.cpp
@@ -132,7 +132,13 @@ BaseTextInputProps::BaseTextInputProps(
           rawProps,
           "disableKeyboardShortcuts",
           sourceProps.disableKeyboardShortcuts,
-          {false})) {}
+          {false})),
+      acceptDragAndDropTypes(convertRawProp(
+          context,
+          rawProps,
+          "acceptDragAndDropTypes",
+          sourceProps.acceptDragAndDropTypes,
+          {})) {}
 
 void BaseTextInputProps::setProp(
     const PropsParserContext& context,
@@ -215,6 +221,7 @@ void BaseTextInputProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(submitBehavior);
     RAW_SET_PROP_SWITCH_CASE_BASIC(multiline);
     RAW_SET_PROP_SWITCH_CASE_BASIC(disableKeyboardShortcuts);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(acceptDragAndDropTypes);
   }
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.h
@@ -80,6 +80,8 @@ class BaseTextInputProps : public ViewProps, public BaseTextProps {
   bool multiline{false};
 
   bool disableKeyboardShortcuts{false};
+
+  std::optional<std::vector<std::string>> acceptDragAndDropTypes{};
 };
 
 } // namespace facebook::react

--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.android.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.android.js
@@ -448,27 +448,6 @@ const examples: Array<RNTesterModuleExample> = [
       return <ToggleDefaultPaddingExample />;
     },
   },
-  {
-    title: 'Drag and drop',
-    render: function (): React.Node {
-      return (
-        <View>
-          <ExampleTextInput
-            experimental_acceptDragAndDropTypes={[]}
-            placeholder="Does not accept drag drops"
-          />
-          <ExampleTextInput
-            experimental_acceptDragAndDropTypes={['text/plain']}
-            placeholder="Only accepts plaintext drag drops"
-          />
-          <ExampleTextInput
-            experimental_acceptDragAndDropTypes={null}
-            placeholder="Accepts all drag drops"
-          />
-        </View>
-      );
-    },
-  },
 ];
 
 module.exports = ({

--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.android.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.android.js
@@ -448,6 +448,27 @@ const examples: Array<RNTesterModuleExample> = [
       return <ToggleDefaultPaddingExample />;
     },
   },
+  {
+    title: 'Drag and drop',
+    render: function (): React.Node {
+      return (
+        <View>
+          <ExampleTextInput
+            experimental_acceptDragAndDropTypes={[]}
+            placeholder="Does not accept drag drops"
+          />
+          <ExampleTextInput
+            experimental_acceptDragAndDropTypes={['text/plain']}
+            placeholder="Only accepts plaintext drag drops"
+          />
+          <ExampleTextInput
+            experimental_acceptDragAndDropTypes={null}
+            placeholder="Accepts all drag drops"
+          />
+        </View>
+      );
+    },
+  },
 ];
 
 module.exports = ({

--- a/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
@@ -1253,4 +1253,38 @@ module.exports = ([
       );
     },
   },
+  {
+    title: 'Drag and drop',
+    render: function (): React.Node {
+      return (
+        <View>
+          <ExampleTextInput
+            experimental_acceptDragAndDropTypes={[]}
+            placeholder="Does not accept drag drops"
+          />
+          <ExampleTextInput
+            experimental_acceptDragAndDropTypes={
+              Platform.OS === 'android' ? ['text/plain'] : ['public.plain-text']
+            }
+            placeholder="Only accepts plaintext drag drops"
+          />
+          <ExampleTextInput
+            experimental_acceptDragAndDropTypes={
+              Platform.OS === 'android' ? ['text/plain'] : ['public.plain-text']
+            }
+            multiline={true}
+            numberOfLines={3}
+            placeholder="Only accepts plaintext drag drops"
+            style={{
+              height: 60,
+            }}
+          />
+          <ExampleTextInput
+            experimental_acceptDragAndDropTypes={null}
+            placeholder="Accepts all drag drops"
+          />
+        </View>
+      );
+    },
+  },
 ]: Array<RNTesterModuleExample>);


### PR DESCRIPTION
Summary:
Builds upon https://github.com/facebook/react-native/pull/49446

On iOS, by default, every EditText accepts DragEvent and will automatically focus themselves to accept these data. In some rare cases, it might not be desirable to allow data from arbitrary drag and drop events to be pasted into a text input.

This change adds a new prop `acceptDragAndDropTypes` to do exactly that: reject drag and drop events by telling the system to ignore certain types of drag data and, by proxy, disabling behavior that automatically focuses the text input. 

The prop accepts a list of [Uniform Type Identifiers](https://developer.apple.com/documentation/uniformtypeidentifiers) that iOS supports. It's important to note that these are *not* MIME types. A MIME type would be something like `text/plain` but the equivalent for iOS is `public.plain-text`.

It's important to note that this is an experimental prop, as is evident by the `experimental_` prefix on the JS side. Its signature could change before the prop has fully matured, use at your own risk

Changelog: [iOS][Added] - Add new prop for filtering drag and drop targeting to text inputs

Differential Revision: D70992749


