### PR TITLE
call `TurboModuleWithJSIBindings::installJSIBindings` at core TurboModuleBinding instead of on each platform

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.cpp
@@ -20,7 +20,6 @@
 #include <ReactCommon/TurboCxxModule.h>
 #include <ReactCommon/TurboModuleBinding.h>
 #include <ReactCommon/TurboModulePerfLogger.h>
-#include <ReactCommon/TurboModuleWithJSIBindings.h>
 #include <react/jni/CxxModuleWrapper.h>
 
 namespace facebook::react {
@@ -166,7 +165,6 @@ std::shared_ptr<TurboModule> TurboModuleManager::getTurboModule(
 
   auto cxxModule = cxxDelegate->getTurboModule(name, jsCallInvoker_);
   if (cxxModule) {
-    TurboModuleWithJSIBindings::installJSIBindings(cxxModule, runtime);
     turboModuleCache_.insert({name, cxxModule});
     return cxxModule;
   }

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.cpp
@@ -7,6 +7,7 @@
 
 #include "TurboModuleBinding.h"
 
+#include <ReactCommon/TurboModuleWithJSIBindings.h>
 #include <cxxreact/TraceSection.h>
 #include <react/utils/jsi-utils.h>
 #include <stdexcept>
@@ -156,6 +157,7 @@ jsi::Value TurboModuleBinding::getModule(
     module = moduleProvider_(moduleName);
   }
   if (module) {
+    TurboModuleWithJSIBindings::installJSIBindings(module, runtime);
     // What is jsRepresentation? A cache for the TurboModule's properties
     // Henceforth, always return the cache (i.e: jsRepresentation) to JavaScript
     //


### PR DESCRIPTION
Summary:
## Changelog:

[Internal] [Changed] - call `TurboModuleWithJSIBindings::installJSIBindings` at core TurboModuleBinding instead of on each platform

Differential Revision: D72073835


