### PR TITLE
Fix SurfaceHandler.setProps is nullable

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/SurfaceHandlerBinding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/SurfaceHandlerBinding.cpp
@@ -63,7 +63,8 @@ void SurfaceHandlerBinding::setLayoutConstraints(
 }
 
 void SurfaceHandlerBinding::setProps(NativeMap* props) {
-  surfaceHandler_.setProps(props->consume());
+  surfaceHandler_.setProps(
+      props != nullptr ? props->consume() : folly::dynamic::object());
 }
 
 const SurfaceHandler& SurfaceHandlerBinding::getSurfaceHandler() {


### PR DESCRIPTION
Summary:
As part of D72558674, I made SurfaceHandlerBinding.setProps nullable, to align with D71979601 - but I didn't realize this wasn't properly handled on the JNI side.

Changelog: [Android][FIxed] Fix crash when passing null initialProps

Differential Revision: D72632625


