### PR TITLE
Add high resolution CPU time support on macOS

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/cputime/CPUTime.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/cputime/CPUTime.h
@@ -7,8 +7,10 @@
 
 #pragma once
 
-#ifdef USE_POSIX_TIME
+#if defined USE_POSIX_TIME
 #include <time.h>
+#elif defined __MACH__
+#include <mach/mach_time.h>
 #else
 #include <chrono>
 #endif
@@ -21,15 +23,41 @@ const double NANOSECONDS_IN_A_SECOND = 1000000000;
 
 #endif
 
+#ifdef __MACH__
+
+namespace {
+inline double getConversionFactor() {
+  double conversionFactor;
+  mach_timebase_info_data_t info;
+  mach_timebase_info(&info);
+  conversionFactor = static_cast<double>(info.numer) / info.denom;
+  return conversionFactor;
+}
+} // namespace
+
+#endif
+
 namespace facebook::react {
 
-#ifdef USE_POSIX_TIME
+#if defined USE_POSIX_TIME
 
 inline double getCPUTimeNanos() {
   struct timespec time {};
   clock_gettime(CLOCK_THREAD_CPUTIME_ID, &time);
   return static_cast<double>(time.tv_sec) * NANOSECONDS_IN_A_SECOND +
       static_cast<double>(time.tv_nsec);
+}
+
+inline bool hasAccurateCPUTimeNanosForBenchmarks() {
+  return true;
+}
+
+#elif defined __MACH__
+
+inline double getCPUTimeNanos() {
+  static auto conversionFactor = getConversionFactor();
+  uint64_t time = mach_absolute_time();
+  return static_cast<double>(time) * conversionFactor;
 }
 
 inline bool hasAccurateCPUTimeNanosForBenchmarks() {


### PR DESCRIPTION
Summary:
Adding nanosecond resolution for macOS to the NativeCPUTime native module. This allows for running Fantom benchmarks on macOS with high resolution CPUTime counters.

This change adds the internal `getCPUTimeConversionFactor` function which is needed to convert the output from `mach_absolute_time` to a double representing time in nanoseconds. The native module calls `getCPUTTimeConversionFactor` once in the constructor and stores the result for future calls. The conversion factor defaults to 1.0 for all other platforms.

Changelog: [internal]

Differential Revision: D72631963


