### PR TITLE
Fix verifyPublishedTemplate after failure for 0.79.0

### DIFF
--- a/.github/workflow-scripts/publishTemplate.js
+++ b/.github/workflow-scripts/publishTemplate.js
@@ -69,6 +69,9 @@ module.exports.verifyPublishedTemplate = async (
   retries = MAX_RETRIES,
 ) => {
   try {
+    if (version.startsWith('v')) {
+      version = version.slice(1);
+    }
     await verifyPublishedPackage(
       TEMPLATE_NPM_PKG,
       version,


### PR DESCRIPTION
Summary:
This should fix the issue found during the 0.79.0 release.

https://github.com/facebook/react-native/actions/runs/14329766551/job/40166165007

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D72637751


