### PR TITLE
Make class internal - Package com.facebook.react.views.text.internal.span

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3311,40 +3311,6 @@ public abstract class com/facebook/react/runtime/BindingsInstaller {
 	public fun <init> (Lcom/facebook/jni/HybridData;)V
 }
 
-public final class com/facebook/react/runtime/BridgelessCatalystInstance : com/facebook/react/bridge/CatalystInstance {
-	public fun <init> (Lcom/facebook/react/runtime/ReactHostImpl;)V
-	public fun addBridgeIdleDebugListener (Lcom/facebook/react/bridge/NotThreadSafeBridgeIdleDebugListener;)V
-	public fun callFunction (Ljava/lang/String;Ljava/lang/String;Lcom/facebook/react/bridge/NativeArray;)V
-	public fun destroy ()V
-	public fun extendNativeModules (Lcom/facebook/react/bridge/NativeModuleRegistry;)V
-	public fun getFabricUIManager ()Lcom/facebook/react/bridge/UIManager;
-	public fun getJSCallInvokerHolder ()Lcom/facebook/react/turbomodule/core/interfaces/CallInvokerHolder;
-	public fun getJSModule (Ljava/lang/Class;)Lcom/facebook/react/bridge/JavaScriptModule;
-	public fun getJavaScriptContextHolder ()Lcom/facebook/react/bridge/JavaScriptContextHolder;
-	public fun getNativeMethodCallInvokerHolder ()Lcom/facebook/react/turbomodule/core/interfaces/NativeMethodCallInvokerHolder;
-	public fun getNativeModule (Ljava/lang/Class;)Lcom/facebook/react/bridge/NativeModule;
-	public fun getNativeModule (Ljava/lang/String;)Lcom/facebook/react/bridge/NativeModule;
-	public fun getNativeModules ()Ljava/util/Collection;
-	public fun getReactQueueConfiguration ()Lcom/facebook/react/bridge/queue/ReactQueueConfiguration;
-	public fun getRuntimeExecutor ()Lcom/facebook/react/bridge/RuntimeExecutor;
-	public fun getRuntimeScheduler ()Lcom/facebook/react/bridge/RuntimeScheduler;
-	public fun getSourceURL ()Ljava/lang/String;
-	public fun handleMemoryPressure (I)V
-	public fun hasNativeModule (Ljava/lang/Class;)Z
-	public fun hasRunJSBundle ()Z
-	public fun invokeCallback (ILcom/facebook/react/bridge/NativeArrayInterface;)V
-	public fun isDestroyed ()Z
-	public fun loadScriptFromAssets (Landroid/content/res/AssetManager;Ljava/lang/String;Z)V
-	public fun loadScriptFromFile (Ljava/lang/String;Ljava/lang/String;Z)V
-	public fun loadSplitBundleFromFile (Ljava/lang/String;Ljava/lang/String;)V
-	public fun registerSegment (ILjava/lang/String;)V
-	public fun removeBridgeIdleDebugListener (Lcom/facebook/react/bridge/NotThreadSafeBridgeIdleDebugListener;)V
-	public fun runJSBundle ()V
-	public fun setFabricUIManager (Lcom/facebook/react/bridge/UIManager;)V
-	public fun setSourceURLs (Ljava/lang/String;Ljava/lang/String;)V
-	public fun setTurboModuleRegistry (Lcom/facebook/react/internal/turbomodule/core/interfaces/TurboModuleRegistry;)V
-}
-
 public class com/facebook/react/runtime/CoreReactPackage$$ReactModuleInfoProvider : com/facebook/react/module/model/ReactModuleInfoProvider {
 	public fun <init> ()V
 	public fun getReactModuleInfos ()Ljava/util/Map;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessCatalystInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessCatalystInstance.kt
@@ -34,7 +34,7 @@ import com.facebook.react.turbomodule.core.interfaces.NativeMethodCallInvokerHol
 @Deprecated(
     message =
         "This class is deprecated, please to migrate to new architecture using [com.facebook.react.defaults.DefaultReactHost] instead.")
-public class BridgelessCatalystInstance(private val reactHost: ReactHostImpl) : CatalystInstance {
+internal class BridgelessCatalystInstance(private val reactHost: ReactHostImpl) : CatalystInstance {
 
   override fun handleMemoryPressure(level: Int) {
     throw UnsupportedOperationException("Unimplemented method 'handleMemoryPressure'")

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/CustomLetterSpacingSpan.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/CustomLetterSpacingSpan.kt
@@ -16,12 +16,13 @@ import android.text.style.MetricAffectingSpan
  * The letter spacing is specified in pixels, which are converted to ems at paint time; this span
  * must therefore be applied after any spans affecting font size.
  */
-public class CustomLetterSpacingSpan(public val spacing: Float) : MetricAffectingSpan(), ReactSpan {
-  public override fun updateDrawState(paint: TextPaint) {
+internal class CustomLetterSpacingSpan(public val spacing: Float) :
+    MetricAffectingSpan(), ReactSpan {
+  override fun updateDrawState(paint: TextPaint) {
     apply(paint)
   }
 
-  public override fun updateMeasureState(paint: TextPaint) {
+  override fun updateMeasureState(paint: TextPaint) {
     apply(paint)
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/CustomLineHeightSpan.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/CustomLineHeightSpan.kt
@@ -17,10 +17,10 @@ import kotlin.math.floor
  * LineHeightSpan.Standard which only effects space between the baselines of adjacent line boxes
  * (does not impact space before the first line or after the last).
  */
-public class CustomLineHeightSpan(height: Float) : LineHeightSpan, ReactSpan {
-  public val lineHeight: Int = ceil(height.toDouble()).toInt()
+internal class CustomLineHeightSpan(height: Float) : LineHeightSpan, ReactSpan {
+  val lineHeight: Int = ceil(height.toDouble()).toInt()
 
-  public override fun chooseHeight(
+  override fun chooseHeight(
       text: CharSequence,
       start: Int,
       end: Int,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/CustomStyleSpan.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/CustomStyleSpan.kt
@@ -27,22 +27,22 @@ import com.facebook.react.views.text.ReactTypefaceUtils
  * appropriate default typeface depending on the style. Fonts are retrieved and cached using the
  * [ReactFontManager]
  */
-public class CustomStyleSpan(
+internal class CustomStyleSpan(
     private val privateStyle: Int,
     private val privateWeight: Int,
-    public val fontFeatureSettings: String?,
-    public val fontFamily: String?,
+    val fontFeatureSettings: String?,
+    val fontFamily: String?,
     private val assetManager: AssetManager
 ) : MetricAffectingSpan(), ReactSpan {
-  public override fun updateDrawState(ds: TextPaint) {
+  override fun updateDrawState(ds: TextPaint) {
     apply(ds, privateStyle, privateWeight, fontFeatureSettings, fontFamily, assetManager)
   }
 
-  public override fun updateMeasureState(paint: TextPaint) {
+  override fun updateMeasureState(paint: TextPaint) {
     apply(paint, privateStyle, privateWeight, fontFeatureSettings, fontFamily, assetManager)
   }
 
-  public val style: Int
+  val style: Int
     get() =
         if (privateStyle == ReactConstants.UNSET) {
           Typeface.NORMAL
@@ -50,7 +50,7 @@ public class CustomStyleSpan(
           privateStyle
         }
 
-  public val weight: Int
+  val weight: Int
     get() =
         if (privateWeight == ReactConstants.UNSET) {
           ReactFontManager.TypefaceStyle.NORMAL
@@ -58,7 +58,7 @@ public class CustomStyleSpan(
           privateWeight
         }
 
-  public companion object {
+  companion object {
     private fun apply(
         paint: Paint,
         style: Int,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactAbsoluteSizeSpan.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactAbsoluteSizeSpan.kt
@@ -10,4 +10,4 @@ package com.facebook.react.views.text.internal.span
 import android.text.style.AbsoluteSizeSpan
 
 /** Wraps [AbsoluteSizeSpan] as a [ReactSpan]. */
-public class ReactAbsoluteSizeSpan(size: Int) : AbsoluteSizeSpan(size), ReactSpan
+internal class ReactAbsoluteSizeSpan(size: Int) : AbsoluteSizeSpan(size), ReactSpan

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactBackgroundColorSpan.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactBackgroundColorSpan.kt
@@ -10,4 +10,4 @@ package com.facebook.react.views.text.internal.span
 import android.text.style.BackgroundColorSpan
 
 /** Wraps [BackgroundColorSpan] as a [ReactSpan]. */
-public class ReactBackgroundColorSpan(color: Int) : BackgroundColorSpan(color), ReactSpan
+internal class ReactBackgroundColorSpan(color: Int) : BackgroundColorSpan(color), ReactSpan

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactClickableSpan.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactClickableSpan.kt
@@ -36,18 +36,18 @@ import com.facebook.react.views.view.ViewGroupClickEvent
  * (TalkBack announces that the text has links available, and the links are exposed in the context
  * menu).
  */
-public class ReactClickableSpan(public val reactTag: Int) : ClickableSpan(), ReactSpan {
-  public var isKeyboardFocused: Boolean = false
-  public var focusBgColor: Int = Color.TRANSPARENT
+internal class ReactClickableSpan(val reactTag: Int) : ClickableSpan(), ReactSpan {
+  var isKeyboardFocused: Boolean = false
+  var focusBgColor: Int = Color.TRANSPARENT
 
-  public override fun onClick(view: View) {
+  override fun onClick(view: View) {
     val context = view.context as ReactContext
     val eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(context, reactTag)
     eventDispatcher?.dispatchEvent(
         ViewGroupClickEvent(UIManagerHelper.getSurfaceId(context), reactTag))
   }
 
-  public override fun updateDrawState(ds: TextPaint) {
+  override fun updateDrawState(ds: TextPaint) {
     // no super call so we don't change the link color or add an underline by default, as the
     // superclass does.
     if (isKeyboardFocused) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactForegroundColorSpan.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactForegroundColorSpan.kt
@@ -10,4 +10,4 @@ package com.facebook.react.views.text.internal.span
 import android.text.style.ForegroundColorSpan
 
 /** Wraps [ForegroundColorSpan] as a [ReactSpan]. */
-public class ReactForegroundColorSpan(color: Int) : ForegroundColorSpan(color), ReactSpan
+internal class ReactForegroundColorSpan(color: Int) : ForegroundColorSpan(color), ReactSpan

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactOpacitySpan.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactOpacitySpan.kt
@@ -14,7 +14,7 @@ import android.text.style.UpdateAppearance
 import kotlin.math.roundToInt
 
 /** Multiplies foreground and background alpha channels by given opacity */
-public class ReactOpacitySpan(public val opacity: Float) :
+internal class ReactOpacitySpan(val opacity: Float) :
     CharacterStyle(), UpdateAppearance, ReactSpan {
 
   override fun updateDrawState(paint: TextPaint) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactSpan.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactSpan.kt
@@ -11,4 +11,4 @@ package com.facebook.react.views.text.internal.span
  * Enables us to distinguish between spans that were added by React Native and spans that were added
  * by something else. All spans that React Native adds should implement this interface.
  */
-public interface ReactSpan
+internal interface ReactSpan

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactStrikethroughSpan.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactStrikethroughSpan.kt
@@ -10,4 +10,4 @@ package com.facebook.react.views.text.internal.span
 import android.text.style.StrikethroughSpan
 
 /** Wraps [StrikethroughSpan] as a [ReactSpan]. */
-public class ReactStrikethroughSpan : StrikethroughSpan(), ReactSpan
+internal class ReactStrikethroughSpan : StrikethroughSpan(), ReactSpan

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactTagSpan.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactTagSpan.kt
@@ -11,4 +11,4 @@ package com.facebook.react.views.text.internal.span
  * Instances of this class are used to place reactTag information of nested text react nodes into
  * spannable text rendered by single [TextView]
  */
-public class ReactTagSpan(public val reactTag: Int) : ReactSpan
+internal class ReactTagSpan(val reactTag: Int) : ReactSpan

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactTextPaintHolderSpan.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactTextPaintHolderSpan.kt
@@ -10,4 +10,4 @@ package com.facebook.react.views.text.internal.span
 import android.text.TextPaint
 
 /** Associates a TextPaint instance with a Spannable for convenience */
-public data class ReactTextPaintHolderSpan(public val textPaint: TextPaint) : ReactSpan
+internal data class ReactTextPaintHolderSpan(val textPaint: TextPaint) : ReactSpan

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactUnderlineSpan.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ReactUnderlineSpan.kt
@@ -10,4 +10,4 @@ package com.facebook.react.views.text.internal.span
 import android.text.style.UnderlineSpan
 
 /** Wraps [UnderlineSpan] as a [ReactSpan]. */
-public class ReactUnderlineSpan : UnderlineSpan(), ReactSpan
+internal class ReactUnderlineSpan : UnderlineSpan(), ReactSpan

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/SetSpanOperation.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/SetSpanOperation.kt
@@ -13,17 +13,17 @@ import android.text.Spanned
 import com.facebook.common.logging.FLog
 import kotlin.math.max
 
-public class SetSpanOperation(
+internal class SetSpanOperation(
     private val start: Int,
     private val end: Int,
-    @JvmField public val what: ReactSpan
+    @JvmField val what: ReactSpan
 ) {
   /**
    * @param builder Spannable string builder
    * @param priorityIndex index of this operation in the topological sorting which puts operations
    *   with higher priority before operations with lower priority.
    */
-  public fun execute(builder: SpannableStringBuilder, priorityIndex: Int) {
+  fun execute(builder: SpannableStringBuilder, priorityIndex: Int) {
     check(priorityIndex >= 0)
     // All spans will automatically extend to the right of the text, but not the left - except
     // for spans that start at the beginning of the text.
@@ -51,8 +51,8 @@ public class SetSpanOperation(
     builder.setSpan(what, start, end, spanFlags)
   }
 
-  public companion object {
+  companion object {
     private const val TAG = "SetSpanOperation"
-    public const val SPAN_MAX_PRIORITY: Int = Spanned.SPAN_PRIORITY shr Spanned.SPAN_PRIORITY_SHIFT
+    const val SPAN_MAX_PRIORITY: Int = Spanned.SPAN_PRIORITY shr Spanned.SPAN_PRIORITY_SHIFT
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ShadowStyleSpan.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/ShadowStyleSpan.kt
@@ -10,13 +10,13 @@ package com.facebook.react.views.text.internal.span
 import android.text.TextPaint
 import android.text.style.CharacterStyle
 
-public class ShadowStyleSpan(
+internal class ShadowStyleSpan(
     private val dx: Float,
     private val dy: Float,
     private val radius: Float,
-    public val color: Int
+    val color: Int
 ) : CharacterStyle(), ReactSpan {
-  public override fun updateDrawState(textPaint: TextPaint) {
+  override fun updateDrawState(textPaint: TextPaint) {
     textPaint.setShadowLayer(radius, dx, dy, color)
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/TextInlineImageSpan.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/TextInlineImageSpan.kt
@@ -14,32 +14,32 @@ import android.view.View
 import android.widget.TextView
 
 /** Base class for inline image spans. */
-public abstract class TextInlineImageSpan : ReplacementSpan(), ReactSpan {
+internal abstract class TextInlineImageSpan : ReplacementSpan(), ReactSpan {
   /** Get the drawable that is span represents. */
-  public abstract val drawable: Drawable?
+  abstract val drawable: Drawable?
 
   /** Called by the text view from [View.onDetachedFromWindow], */
-  public abstract fun onDetachedFromWindow()
+  abstract fun onDetachedFromWindow()
 
   /** Called by the text view from [View.onStartTemporaryDetach]. */
-  public abstract fun onStartTemporaryDetach()
+  abstract fun onStartTemporaryDetach()
 
   /** Called by the text view from [View.onAttachedToWindow]. */
-  public abstract fun onAttachedToWindow()
+  abstract fun onAttachedToWindow()
 
   /** Called by the text view from [View.onFinishTemporaryDetach]. */
-  public abstract fun onFinishTemporaryDetach()
+  abstract fun onFinishTemporaryDetach()
 
   /** Set the textview that will contain this span. */
-  public abstract fun setTextView(textView: TextView?)
+  abstract fun setTextView(textView: TextView?)
 
   /** Get the width of the span. */
-  public abstract val width: Int
+  abstract val width: Int
 
   /** Get the height of the span. */
-  public abstract val height: Int
+  abstract val height: Int
 
-  public companion object {
+  companion object {
     /**
      * For TextInlineImageSpan we need to update the Span to know that the window is attached and
      * the TextView that we will set as the callback on the Drawable.
@@ -48,7 +48,7 @@ public abstract class TextInlineImageSpan : ReplacementSpan(), ReactSpan {
      * @param view The view which will be set as the callback for the Drawable
      */
     @JvmStatic
-    public fun possiblyUpdateInlineImageSpans(spannable: Spannable, view: TextView?) {
+    fun possiblyUpdateInlineImageSpans(spannable: Spannable, view: TextView?) {
       spannable.getSpans(0, spannable.length, TextInlineImageSpan::class.java).forEach { s ->
         s.onAttachedToWindow()
         s.setTextView(view)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/TextInlineViewPlaceholderSpan.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/span/TextInlineViewPlaceholderSpan.kt
@@ -16,12 +16,9 @@ import android.text.style.ReplacementSpan
  * TextInlineViewPlaceholderSpan is a span for inlined views that are inside <Text></Text>. It
  * computes its size based on the input size. It contains no draw logic, just positioning logic.
  */
-public class TextInlineViewPlaceholderSpan(
-    public val reactTag: Int,
-    public val width: Int,
-    public val height: Int
-) : ReplacementSpan(), ReactSpan {
-  public override fun getSize(
+internal class TextInlineViewPlaceholderSpan(val reactTag: Int, val width: Int, val height: Int) :
+    ReplacementSpan(), ReactSpan {
+  override fun getSize(
       paint: Paint,
       text: CharSequence?,
       start: Int,
@@ -38,7 +35,7 @@ public class TextInlineViewPlaceholderSpan(
     return width
   }
 
-  public override fun draw(
+  override fun draw(
       canvas: Canvas,
       text: CharSequence?,
       start: Int,


### PR DESCRIPTION
Summary:
This diff makes all the classes inside `com.facebook.react.views.text.internal.span` internal.

Those classes are already inside an `.internal` package. By making them `internal` with the Kotlin keyword
we're making harder for them to be accidentally referenced outside React Native.

as part of our ongoing effort of reducing the API surface.
Changelog:
[Internal] [Changed] - com.facebook.react.views.text.internal.span is now internal

Differential Revision: D72644962


