### PR TITLE
Make class internal - package com.facebook.react.internal

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/SystraceSection.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/SystraceSection.kt
@@ -12,7 +12,7 @@ import com.facebook.systrace.Systrace
 /**
  * Helper to guarantee firing Systrace begin and end markers around a try with resources statement.
  */
-public class SystraceSection(sectionName: String) : AutoCloseable {
+internal class SystraceSection(sectionName: String) : AutoCloseable {
   init {
     Systrace.beginSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE, sectionName)
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/interop/InteropEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/interop/InteropEvent.kt
@@ -18,9 +18,9 @@ import com.facebook.react.uimanager.events.Event
  * [com.facebook.react.uimanager.events.EventDispatcher]
  */
 @LegacyArchitecture
-public class InteropEvent(
-    @get:JvmName("eventName") public val eventName: String,
-    @get:JvmName("eventData") public val eventData: WritableMap?,
+internal class InteropEvent(
+    @get:JvmName("eventName") val eventName: String,
+    @get:JvmName("eventData") val eventData: WritableMap?,
     surfaceId: Int,
     viewTag: Int
 ) : Event<InteropEvent>(surfaceId, viewTag) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/interop/InteropEventEmitter.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/interop/InteropEventEmitter.kt
@@ -30,7 +30,7 @@ import com.facebook.react.uimanager.events.RCTEventEmitter
  * to deliver events also when Fabric is turned on.
  */
 @LegacyArchitecture
-public class InteropEventEmitter(private val reactContext: ReactContext) : RCTEventEmitter {
+internal class InteropEventEmitter(private val reactContext: ReactContext) : RCTEventEmitter {
 
   private var eventDispatcherOverride: EventDispatcher? = null
 
@@ -54,7 +54,7 @@ public class InteropEventEmitter(private val reactContext: ReactContext) : RCTEv
   }
 
   @VisibleForTesting
-  public fun overrideEventDispatcher(eventDispatcherOverride: EventDispatcher?) {
+  fun overrideEventDispatcher(eventDispatcherOverride: EventDispatcher?) {
     this.eventDispatcherOverride = eventDispatcherOverride
   }
 


### PR DESCRIPTION
Summary:
This diff makes the following file internal - package com.facebook.react.internal
as part of our ongoing effort of reducing the API surface.
Changelog:
[Internal] [Changed] - com.facebook.react.internal pakcage is now internal

Differential Revision: D72645991


