### PR TITLE
Make class internal - ReactRawText*

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -6555,26 +6555,6 @@ public final class com/facebook/react/views/text/ReactFontManager$Companion {
 	public final fun getInstance ()Lcom/facebook/react/views/text/ReactFontManager;
 }
 
-public final class com/facebook/react/views/text/ReactRawTextManager : com/facebook/react/uimanager/ViewManager {
-	public static final field REACT_CLASS Ljava/lang/String;
-	public fun <init> ()V
-	public synthetic fun createShadowNodeInstance ()Lcom/facebook/react/uimanager/ReactShadowNode;
-	public fun createShadowNodeInstance ()Lcom/facebook/react/views/text/ReactRawTextShadowNode;
-	public synthetic fun createViewInstance (Lcom/facebook/react/uimanager/ThemedReactContext;)Landroid/view/View;
-	public fun createViewInstance (Lcom/facebook/react/uimanager/ThemedReactContext;)Lcom/facebook/react/views/text/ReactTextView;
-	public fun getName ()Ljava/lang/String;
-	public fun getShadowNodeClass ()Ljava/lang/Class;
-	public fun updateExtraData (Landroid/view/View;Ljava/lang/Object;)V
-}
-
-public final class com/facebook/react/views/text/ReactRawTextShadowNode : com/facebook/react/uimanager/ReactShadowNodeImpl {
-	public fun <init> ()V
-	public final fun getText ()Ljava/lang/String;
-	public fun isVirtual ()Z
-	public final fun setText (Ljava/lang/String;)V
-	public fun toString ()Ljava/lang/String;
-}
-
 public abstract class com/facebook/react/views/text/ReactTextAnchorViewManager : com/facebook/react/uimanager/BaseViewManager {
 	public fun <init> ()V
 	public fun setAccessible (Lcom/facebook/react/views/text/ReactTextView;Z)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactRawTextManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactRawTextManager.kt
@@ -17,25 +17,25 @@ import com.facebook.react.uimanager.ViewManager
  * nodes, any type of native view operation will throw an [IllegalStateException].
  */
 @ReactModule(name = ReactRawTextManager.REACT_CLASS)
-public class ReactRawTextManager : ViewManager<View, ReactRawTextShadowNode>() {
+internal class ReactRawTextManager : ViewManager<View, ReactRawTextShadowNode>() {
 
-  public override fun getName(): String {
+  override fun getName(): String {
     return REACT_CLASS
   }
 
   public override fun createViewInstance(context: ThemedReactContext): ReactTextView =
       throw IllegalStateException("Attempt to create a native view for RCTRawText")
 
-  protected override fun prepareToRecycleView(reactContext: ThemedReactContext, view: View): View? =
+  override fun prepareToRecycleView(reactContext: ThemedReactContext, view: View): View? =
       throw IllegalStateException("Attempt to recycle a native view for RCTRawText")
 
-  public override fun updateExtraData(view: View, extraData: Any): Unit = Unit
+  override fun updateExtraData(view: View, extraData: Any): Unit = Unit
 
-  public override fun getShadowNodeClass(): Class<ReactRawTextShadowNode> {
+  override fun getShadowNodeClass(): Class<ReactRawTextShadowNode> {
     return ReactRawTextShadowNode::class.java
   }
 
-  public override fun createShadowNodeInstance(): ReactRawTextShadowNode {
+  override fun createShadowNodeInstance(): ReactRawTextShadowNode {
     return ReactRawTextShadowNode()
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactRawTextShadowNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactRawTextShadowNode.kt
@@ -16,9 +16,9 @@ import com.facebook.react.uimanager.annotations.ReactProp
  * can only have simple string value without any attributes, properties or state.
  */
 @LegacyArchitecture
-public class ReactRawTextShadowNode : ReactShadowNodeImpl() {
+internal class ReactRawTextShadowNode : ReactShadowNodeImpl() {
   @set:ReactProp(name = "text")
-  public var text: String? = null
+  var text: String? = null
     set(value) {
       field = value
       markUpdated()


### PR DESCRIPTION
Summary:
This diff makes the following file internal - ReactRawTextShadowNode and ReactRawTextManager
as part of our ongoing effort of reducing the API surface.

The only meaningful user of this API is this library:
https://github.com/iyegoroff/react-native-text-gradient

Which is umaintained (last supported version is RN 0.59) so I'm not considering this breaking.

Changelog:
[Android] [Changed] - Make ReactRawTextManager internal. We verified no popular libraries are impacted by this change

Differential Revision: D72647702


