### PR TITLE
fix nullsafe FIXMEs for FabicUIManager.java and mark nullsafe (#50365)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/UIManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/UIManager.kt
@@ -20,7 +20,7 @@ public interface UIManager : PerformanceCounter {
   @UiThread
   @ThreadConfined(ThreadConfined.UI)
   @Deprecated("")
-  public fun <T : View?> addRootView(rootView: T, initialProps: WritableMap?): Int
+  public fun <T : View> addRootView(rootView: T, initialProps: WritableMap?): Int
 
   /** Registers a new root view with width and height. */
   @AnyThread
@@ -92,7 +92,7 @@ public interface UIManager : PerformanceCounter {
    */
   @UiThread
   @ThreadConfined(ThreadConfined.UI)
-  public fun synchronouslyUpdateViewOnUIThread(reactTag: Int, props: ReadableMap?)
+  public fun synchronouslyUpdateViewOnUIThread(reactTag: Int, props: ReadableMap)
 
   /**
    * Dispatch an accessibility event to a view asynchronously.
@@ -109,14 +109,14 @@ public interface UIManager : PerformanceCounter {
    *
    * @param listener
    */
-  public fun addUIManagerEventListener(listener: UIManagerListener?)
+  public fun addUIManagerEventListener(listener: UIManagerListener)
 
   /**
    * Unregister a [UIManagerListener] from this UIManager to stop receiving lifecycle callbacks.
    *
    * @param listener
    */
-  public fun removeUIManagerEventListener(listener: UIManagerListener?)
+  public fun removeUIManagerEventListener(listener: UIManagerListener)
 
   /**
    * Resolves a view based on its reactTag. Do not mutate properties on this view that are already

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -106,6 +106,7 @@ public class FabricUIManager
   // The IS_DEVELOPMENT_ENVIRONMENT variable is used to log extra data when running fabric in a
   // development environment. DO NOT ENABLE THIS ON PRODUCTION OR YOU WILL BE FIRED!
   public static final boolean IS_DEVELOPMENT_ENVIRONMENT = false && ReactBuildConfig.DEBUG;
+  // NULLSAFE_FIXME[Field Not Initialized]
   public DevToolsReactPerfLogger mDevToolsReactPerfLogger;
 
   private static final DevToolsReactPerfLogger.DevToolsReactPerfLoggerListener FABRIC_PERF_LOGGER =
@@ -237,6 +238,7 @@ public class FabricUIManager
   @UiThread
   @ThreadConfined(UI)
   @Deprecated
+  // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
   public <T extends View> int addRootView(final T rootView, final WritableMap initialProps) {
     ReactSoftExceptionLogger.logSoftException(
         TAG,
@@ -254,6 +256,7 @@ public class FabricUIManager
     if (ReactNativeFeatureFlags.enableFabricLogs()) {
       FLog.d(TAG, "Starting surface for module: %s and reactTag: %d", moduleName, rootTag);
     }
+    // NULLSAFE_FIXME[Nullable Dereference]
     mBinding.startSurface(rootTag, moduleName, (NativeMap) initialProps);
     return rootTag;
   }
@@ -261,6 +264,7 @@ public class FabricUIManager
   @Override
   @AnyThread
   @ThreadConfined(ANY)
+  // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
   public <T extends View> int startSurface(
       final T rootView,
       final String moduleName,
@@ -283,6 +287,7 @@ public class FabricUIManager
     Point viewportOffset =
         UiThreadUtil.isOnUiThread() ? RootViewUtil.getViewportOffset(rootView) : new Point(0, 0);
 
+    // NULLSAFE_FIXME[Nullable Dereference]
     mBinding.startSurfaceWithConstraints(
         rootTag,
         moduleName,
@@ -308,6 +313,7 @@ public class FabricUIManager
         new ThemedReactContext(
             mReactApplicationContext, context, surfaceHandler.getModuleName(), rootTag);
     mMountingManager.startSurface(rootTag, reactContext, rootView);
+    // NULLSAFE_FIXME[Nullable Dereference]
     mBinding.startSurfaceWithSurfaceHandler(rootTag, surfaceHandler, rootView != null);
   }
 
@@ -332,6 +338,7 @@ public class FabricUIManager
     }
 
     mMountingManager.stopSurface(surfaceHandler.getSurfaceId());
+    // NULLSAFE_FIXME[Nullable Dereference]
     mBinding.stopSurfaceWithSurfaceHandler(surfaceHandler);
   }
 
@@ -351,6 +358,7 @@ public class FabricUIManager
     // Communicate stopSurface to Cxx - causes an empty ShadowTree to be committed,
     // but all mounting instructions will be ignored because stopSurface was called
     // on the MountingManager
+    // NULLSAFE_FIXME[Nullable Dereference]
     mBinding.stopSurface(surfaceID);
   }
 
@@ -401,6 +409,7 @@ public class FabricUIManager
     mReactApplicationContext.removeLifecycleEventListener(this);
     onHostPause();
 
+    // NULLSAFE_FIXME[Nullable Dereference]
     mBinding.unregister();
     mBinding = null;
 
@@ -537,6 +546,7 @@ public class FabricUIManager
     }
 
     return mMountingManager.measure(
+        // NULLSAFE_FIXME[Parameter Not Nullable]
         context,
         componentName,
         localData,
@@ -576,6 +586,7 @@ public class FabricUIManager
 
     // TODO: replace ReadableNativeMap -> ReadableMapBuffer
     return mMountingManager.measureMapBuffer(
+        // NULLSAFE_FIXME[Parameter Not Nullable]
         context,
         componentName,
         localData,
@@ -612,11 +623,13 @@ public class FabricUIManager
   }
 
   @Override
+  // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
   public void addUIManagerEventListener(UIManagerListener listener) {
     mListeners.add(listener);
   }
 
   @Override
+  // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
   public void removeUIManagerEventListener(UIManagerListener listener) {
     mListeners.remove(listener);
   }
@@ -624,6 +637,7 @@ public class FabricUIManager
   @Override
   @UiThread
   @ThreadConfined(UI)
+  // NULLSAFE_FIXME[Inconsistent Subclass Parameter Annotation]
   public void synchronouslyUpdateViewOnUIThread(
       final int reactTag, @NonNull final ReadableMap props) {
     UiThreadUtil.assertOnUiThread();
@@ -780,6 +794,7 @@ public class FabricUIManager
     long scheduleMountItemStartTime = SystemClock.uptimeMillis();
     boolean isBatchMountItem = mountItem instanceof BatchMountItem;
     boolean shouldSchedule =
+        // NULLSAFE_FIXME[Nullable Dereference]
         (isBatchMountItem && !((BatchMountItem) mountItem).isBatchEmpty())
             || (!isBatchMountItem && mountItem != null);
 
@@ -798,6 +813,7 @@ public class FabricUIManager
     }
 
     if (shouldSchedule) {
+      // NULLSAFE_FIXME[Parameter Not Nullable]
       mMountItemDispatcher.addMountItem(mountItem);
       Runnable runnable =
           new GuardedRunnable(mReactApplicationContext) {
@@ -894,6 +910,7 @@ public class FabricUIManager
       doLeftAndRightSwapInRTL = I18nUtil.getInstance().doLeftAndRightSwapInRTL(context);
     }
 
+    // NULLSAFE_FIXME[Nullable Dereference]
     mBinding.setConstraints(
         surfaceId,
         getMinSize(widthMeasureSpec),
@@ -911,6 +928,7 @@ public class FabricUIManager
     UiThreadUtil.assertOnUiThread();
 
     SurfaceMountingManager surfaceManager = mMountingManager.getSurfaceManagerForView(reactTag);
+    // NULLSAFE_FIXME[Return Not Nullable]
     return surfaceManager == null ? null : surfaceManager.getView(reactTag);
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManagerBinding.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManagerBinding.kt
@@ -33,12 +33,12 @@ internal class FabricUIManagerBinding : HybridClassBase() {
       componentsRegistry: ComponentFactory,
   )
 
-  external fun startSurface(surfaceId: Int, moduleName: String, initialProps: NativeMap)
+  external fun startSurface(surfaceId: Int, moduleName: String, initialProps: NativeMap?)
 
   external fun startSurfaceWithConstraints(
       surfaceId: Int,
       moduleName: String,
-      initialProps: NativeMap,
+      initialProps: NativeMap?,
       minWidth: Float,
       maxWidth: Float,
       minHeight: Float,

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
@@ -172,7 +172,9 @@ void FabricUIManagerBinding::startSurface(
 
   auto surfaceHandler = SurfaceHandler{moduleName->toStdString(), surfaceId};
   surfaceHandler.setContextContainer(scheduler->getContextContainer());
-  surfaceHandler.setProps(initialProps->consume());
+  if (initialProps != nullptr) {
+    surfaceHandler.setProps(initialProps->consume());
+  }
   surfaceHandler.constraintLayout({}, layoutContext);
 
   scheduler->registerSurface(surfaceHandler);
@@ -241,7 +243,9 @@ void FabricUIManagerBinding::startSurfaceWithConstraints(
 
   auto surfaceHandler = SurfaceHandler{moduleName->toStdString(), surfaceId};
   surfaceHandler.setContextContainer(scheduler->getContextContainer());
-  surfaceHandler.setProps(initialProps->consume());
+  if (initialProps != nullptr) {
+    surfaceHandler.setProps(initialProps->consume());
+  }
   surfaceHandler.constraintLayout(constraints, context);
 
   scheduler->registerSurface(surfaceHandler);

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/fakes/FakeUIManager.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/fakes/FakeUIManager.kt
@@ -30,7 +30,7 @@ class FakeUIManager : UIManager, UIBlockViewResolver {
   }
 
   @Deprecated("")
-  override fun <T : View?> addRootView(rootView: T, initialProps: WritableMap?): Int {
+  override fun <T : View> addRootView(rootView: T, initialProps: WritableMap?): Int {
     error("Not yet implemented")
   }
 
@@ -69,7 +69,7 @@ class FakeUIManager : UIManager, UIBlockViewResolver {
   override val eventDispatcher: EventDispatcher
     get() = TODO("Not yet implemented")
 
-  override fun synchronouslyUpdateViewOnUIThread(reactTag: Int, props: ReadableMap?) {
+  override fun synchronouslyUpdateViewOnUIThread(reactTag: Int, props: ReadableMap) {
     error("Not yet implemented")
   }
 
@@ -77,11 +77,11 @@ class FakeUIManager : UIManager, UIBlockViewResolver {
     error("Not yet implemented")
   }
 
-  override fun addUIManagerEventListener(listener: UIManagerListener?) {
+  override fun addUIManagerEventListener(listener: UIManagerListener) {
     error("Not yet implemented")
   }
 
-  override fun removeUIManagerEventListener(listener: UIManagerListener?) {
+  override fun removeUIManagerEventListener(listener: UIManagerListener) {
     error("Not yet implemented")
   }
 


### PR DESCRIPTION
Summary:

Gone trough all the FIXMEs added in the previous diff by the nullsafe tool, marked the class as nullsafe and ensured no remaining violations.
Changelog: [Android][Fixed] Made FabricUIManager.java nullsafe

Reviewed By: GijsWeterings

Differential Revision: D71979601
