### PR TITLE
Make `EventDispatcherProvider` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -5153,10 +5153,6 @@ public abstract interface class com/facebook/react/uimanager/events/EventDispatc
 	public abstract fun onEventDispatch (Lcom/facebook/react/uimanager/events/Event;)V
 }
 
-public abstract interface class com/facebook/react/uimanager/events/EventDispatcherProvider {
-	public abstract fun getEventDispatcher ()Lcom/facebook/react/uimanager/events/EventDispatcher;
-}
-
 public final class com/facebook/react/uimanager/events/NativeGestureUtil {
 	public static final field INSTANCE Lcom/facebook/react/uimanager/events/NativeGestureUtil;
 	public static final fun notifyNativeGestureEnded (Landroid/view/View;Landroid/view/MotionEvent;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/EventDispatcherProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/EventDispatcherProvider.kt
@@ -12,7 +12,7 @@ package com.facebook.react.uimanager.events
  * first-class API for accessing the [EventDispatcher] from the
  * [com.facebook.react.bridge.UIManager].
  */
-public fun interface EventDispatcherProvider {
+internal fun interface EventDispatcherProvider {
   /**
    * This should always return an [EventDispatcher], even if the instance doesn't exist; in that
    * case it should return the empty [BlackHoleEventDispatcher].


### PR DESCRIPTION
## Summary:

This class can be internalized as part of the initiative to reduce the public API surface. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.uimanager.events.EventDispatcherProvider).

## Changelog:

[INTERNAL] - Make com.facebook.react.uimanager.events.EventDispatcherProvider internal

## Test Plan:

```bash
yarn test-android
yarn android
```