### PR TITLE
Record Microtasks step

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/EventLoopReporter.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/EventLoopReporter.h
@@ -11,20 +11,26 @@
 
 namespace facebook::react::jsinspector_modern::tracing {
 
-struct EventLoopTaskReporter {
+enum class EventLoopPhase {
+  Task,
+  Microtasks,
+};
+
+struct EventLoopReporter {
  public:
-  EventLoopTaskReporter();
+  explicit EventLoopReporter(EventLoopPhase phase);
 
-  EventLoopTaskReporter(const EventLoopTaskReporter&) = delete;
-  EventLoopTaskReporter(EventLoopTaskReporter&&) = delete;
-  EventLoopTaskReporter& operator=(const EventLoopTaskReporter&) = delete;
-  EventLoopTaskReporter& operator=(EventLoopTaskReporter&&) = delete;
+  EventLoopReporter(const EventLoopReporter&) = delete;
+  EventLoopReporter(EventLoopReporter&&) = delete;
+  EventLoopReporter& operator=(const EventLoopReporter&) = delete;
+  EventLoopReporter& operator=(EventLoopReporter&&) = delete;
 
-  ~EventLoopTaskReporter();
+  ~EventLoopReporter();
 
  private:
 #if defined(REACT_NATIVE_DEBUGGER_ENABLED)
   std::chrono::steady_clock::time_point startTimestamp_;
+  EventLoopPhase phase_;
 #endif
 };
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
@@ -264,6 +264,29 @@ void PerformanceTracer::reportEventLoopTask(uint64_t start, uint64_t end) {
   });
 }
 
+void PerformanceTracer::reportEventLoopMicrotasks(
+    uint64_t start,
+    uint64_t end) {
+  if (!tracing_) {
+    return;
+  }
+
+  std::lock_guard lock(mutex_);
+  if (!tracing_) {
+    return;
+  }
+
+  buffer_.push_back(TraceEvent{
+      .name = "RunMicrotasks",
+      .cat = "v8.execute",
+      .ph = 'X',
+      .ts = start,
+      .pid = oscompat::getCurrentProcessId(),
+      .tid = oscompat::getCurrentThreadId(),
+      .dur = end - start,
+  });
+}
+
 folly::dynamic PerformanceTracer::getSerializedRuntimeProfileTraceEvent(
     uint64_t threadId,
     uint16_t profileId,

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -102,6 +102,12 @@ class PerformanceTracer {
   void reportEventLoopTask(uint64_t start, uint64_t end);
 
   /**
+   * Record Microtasks phase of the Event Loop tick. Will be represented as a
+   * "Run Microtasks" block under a task.
+   */
+  void reportEventLoopMicrotasks(uint64_t start, uint64_t end);
+
+  /**
    * Create and serialize Profile Trace Event.
    * \return serialized Trace Event that represents a Profile for CDT.
    */


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

We are going to record microtasks phase of the Event Loop.

RAII reporter that was added in D69399955 will be updated to support phase as a parameter.

There is one downside of the current implementation. Every Event Loop task will have a corresponding "Run Microtasks" block displayed, even if the microtasks queue was empty. There is no API in `jsi` that would allow us to get the size of the queue. If we had that, we could emit this event only when there is something in a microtasks queue.

The good this is that these frames usually have duration of 1-2 microseconds, so they are not visible, until user fully zooms in.

Differential Revision: D72649816
