### PR TITLE
Use ReactNativeFeatureFlagsForTests in uimanager tests

### DIFF
--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/BorderRadiusStyleTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/BorderRadiusStyleTest.kt
@@ -8,11 +8,13 @@
 package com.facebook.react.uimanager
 
 import android.content.Context
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsForTests
 import com.facebook.react.uimanager.style.BorderRadiusProp
 import com.facebook.react.uimanager.style.BorderRadiusStyle
 import com.facebook.react.uimanager.style.ComputedBorderRadiusProp
 import com.facebook.react.uimanager.style.CornerRadii
 import org.assertj.core.api.Assertions.*
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -65,6 +67,11 @@ class BorderRadiusStyleTest {
         count -= 1f
       }
     }
+  }
+
+  @Before
+  fun setup() {
+    ReactNativeFeatureFlagsForTests.setUp()
   }
 
   @Test

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/JSPointerDispatcherTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/JSPointerDispatcherTest.kt
@@ -15,6 +15,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import android.widget.TextView
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsForTests
 import com.facebook.react.uimanager.events.Event
 import com.facebook.react.uimanager.events.EventDispatcher
 import com.facebook.react.uimanager.events.PointerEventHelper
@@ -42,6 +43,7 @@ class JSPointerDispatcherTest {
 
   @Before
   fun setupViewHierarchy() {
+    ReactNativeFeatureFlagsForTests.setUp()
     val ctx: Context = RuntimeEnvironment.getApplication()
     root = LinearLayout(ctx)
     val childView = TextView(ctx)

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/MatrixMathHelperTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/MatrixMathHelperTest.kt
@@ -7,14 +7,21 @@
 
 package com.facebook.react.uimanager
 
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsForTests
 import com.facebook.react.uimanager.MatrixMathHelper.MatrixDecompositionContext
 import kotlin.math.cos
 import kotlin.math.sin
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
 import org.junit.Test
 
 /** Test for [MatrixMathHelper] */
 class MatrixMathHelperTest {
+
+  @Before
+  fun setup() {
+    ReactNativeFeatureFlagsForTests.setUp()
+  }
 
   @Test
   fun testDecomposing4x4MatrixToProduceAccurateZaxisAngles() {

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/OnLayoutEventTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/OnLayoutEventTest.kt
@@ -8,6 +8,7 @@
 package com.facebook.react.uimanager
 
 import com.facebook.react.common.SystemClock
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsForTests
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
@@ -23,6 +24,7 @@ class OnLayoutEventTest {
 
   @Before
   fun setup() {
+    ReactNativeFeatureFlagsForTests.setUp()
     val ts = SystemClock.uptimeMillis()
     systemClock = mockStatic(SystemClock::class.java)
     systemClock.`when`<Long> { SystemClock.uptimeMillis() }.thenReturn(ts)

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropAnnotationSetterSpecTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropAnnotationSetterSpecTest.kt
@@ -8,9 +8,11 @@
 package com.facebook.react.uimanager
 
 import android.view.View
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsForTests
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.uimanager.annotations.ReactPropGroup
 import java.util.Date
+import org.junit.Before
 import org.junit.Test
 
 /** Test that verifies that spec of methods annotated with @ReactProp is correct */
@@ -29,6 +31,11 @@ class ReactPropAnnotationSetterSpecTest {
     override fun prepareToRecycleView(reactContext: ThemedReactContext, view: View): View? = null
 
     override fun updateExtraData(root: View, extraData: Any) = Unit
+  }
+
+  @Before
+  fun setup() {
+    ReactNativeFeatureFlagsForTests.setUp()
   }
 
   @Test(expected = RuntimeException::class)

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropAnnotationSetterTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropAnnotationSetterTest.kt
@@ -13,6 +13,7 @@ import com.facebook.react.bridge.JavaOnlyArray
 import com.facebook.react.bridge.JavaOnlyMap
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsForTests
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.uimanager.annotations.ReactPropGroup
 import org.junit.Before
@@ -172,6 +173,7 @@ class ReactPropAnnotationSetterTest {
 
   @Before
   fun setup() {
+    ReactNativeFeatureFlagsForTests.setUp()
     updatesReceiverMock = Mockito.mock(ViewManagerUpdatesReceiver::class.java)
     viewManager = ViewManagerUnderTest(updatesReceiverMock)
     targetView = View(RuntimeEnvironment.getApplication())

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropConstantsTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropConstantsTest.kt
@@ -11,9 +11,11 @@ import android.view.View
 import com.facebook.react.bridge.BridgeReactContext
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsForTests
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.uimanager.annotations.ReactPropGroup
 import org.assertj.core.api.Assertions
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -82,6 +84,11 @@ class ReactPropConstantsTest {
         names = ["customBoxedIntGroupPropFirst", "customBoxedIntGroupPropSecond"],
         customType = "color")
     fun customIntGroupProp(v: View?, index: Int, value: Int?) = Unit
+  }
+
+  @Before
+  fun setup() {
+    ReactNativeFeatureFlagsForTests.setUp()
   }
 
   @Test

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropForShadowNodeSetterTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropForShadowNodeSetterTest.kt
@@ -11,6 +11,7 @@ import com.facebook.react.bridge.BridgeReactContext
 import com.facebook.react.bridge.JavaOnlyMap
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsForTests
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.uimanager.annotations.ReactPropGroup
 import com.facebook.testutils.shadows.ShadowSoLoader
@@ -101,6 +102,7 @@ class ReactPropForShadowNodeSetterTest {
 
   @Before
   fun setup() {
+    ReactNativeFeatureFlagsForTests.setUp()
     yogaNodeFactory = mockStatic(YogaNodeFactory::class.java)
     yogaNodeFactory
         .`when`<YogaNode> { YogaNodeFactory.create(any()) }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropForShadowNodeSpecTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropForShadowNodeSpecTest.kt
@@ -8,6 +8,7 @@
 package com.facebook.react.uimanager
 
 import android.view.View
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsForTests
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.uimanager.annotations.ReactPropGroup
 import com.facebook.testutils.shadows.ShadowSoLoader
@@ -39,6 +40,7 @@ class ReactPropForShadowNodeSpecTest {
 
   @Before
   fun setup() {
+    ReactNativeFeatureFlagsForTests.setUp()
     yogaNodeFactory = mockStatic(YogaNodeFactory::class.java)
     yogaNodeFactory
         .`when`<YogaNode> { YogaNodeFactory.create(any()) }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/SimpleViewPropertyTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/SimpleViewPropertyTest.kt
@@ -17,6 +17,7 @@ import com.facebook.react.bridge.CatalystInstance
 import com.facebook.react.bridge.JavaOnlyMap
 import com.facebook.react.bridge.ReactTestHelper.createMockCatalystInstance
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsForTests
 import com.facebook.react.touch.JSResponderHandler
 import com.facebook.react.uimanager.annotations.ReactProp
 import org.assertj.core.api.Assertions
@@ -55,6 +56,7 @@ class SimpleViewPropertyTest {
 
   @Before
   fun setup() {
+    ReactNativeFeatureFlagsForTests.setUp()
     context = BridgeReactContext(RuntimeEnvironment.getApplication())
     catalystInstanceMock = createMockCatalystInstance()
     context.initializeWithInstance(catalystInstanceMock)

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelperTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelperTest.kt
@@ -7,10 +7,18 @@
 
 package com.facebook.react.uimanager
 
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsForTests
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
 import org.junit.Test
 
 class UIManagerModuleConstantsHelperTest {
+
+  @Before
+  fun setup() {
+    ReactNativeFeatureFlagsForTests.setUp()
+  }
+
   @Test
   fun normalizeEventTypes_withNull_doesNothing() {
     assertThat(UIManagerModuleConstantsHelper.normalizeEventTypes(null)).isNull()


### PR DESCRIPTION
Summary:
Some tests are failing due to unsatisfied error when looking for C++ classes of feature flags, we fix this by calling ReactNativeFeatureFlagsForTests.setup()

changelog: [internal] internal

Reviewed By: yungsters, sbuggay

Differential Revision: D72721786


