### PR TITLE
Mark ReactPackageLogger as @LegacyArchitecture

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageLogger.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageLogger.kt
@@ -7,7 +7,10 @@
 
 package com.facebook.react
 
+import com.facebook.react.common.annotations.internal.LegacyArchitecture
+
 /** Interface for the bridge to call for TTI start and end markers. */
+@LegacyArchitecture
 internal interface ReactPackageLogger {
   fun startProcessPackage(): Unit
 


### PR DESCRIPTION
Summary:
Mark ReactPackageLogger as LegacyArchitecture

changelog: [internal] internal

Reviewed By: shwanton

Differential Revision: D72067076


