### PR TITLE
cleanup rn_ama_new_arch_ios.bridge_batch_did_complete_fix

### DIFF
--- a/packages/react-native/React/Base/RCTBridge.h
+++ b/packages/react-native/React/Base/RCTBridge.h
@@ -82,9 +82,6 @@ void RCTSetTurboModuleInteropBridgeProxyLogLevel(RCTBridgeProxyLoggingLevel logL
 BOOL RCTTurboModuleInteropForAllTurboModulesEnabled(void);
 void RCTEnableTurboModuleInteropForAllTurboModules(BOOL enabled);
 
-BOOL RCTBridgeModuleBatchDidCompleteDisabled(void);
-void RCTDisableBridgeModuleBatchDidComplete(BOOL disabled);
-
 typedef enum {
   kRCTGlobalScope,
   kRCTGlobalScopeUsingRetainJSCallback,

--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -254,17 +254,6 @@ void RCTEnableTurboModuleSyncVoidMethods(BOOL enabled)
   gTurboModuleEnableSyncVoidMethods = enabled;
 }
 
-static BOOL gBridgeModuleDisableBatchDidComplete = NO;
-BOOL RCTBridgeModuleBatchDidCompleteDisabled(void)
-{
-  return gBridgeModuleDisableBatchDidComplete;
-}
-
-void RCTDisableBridgeModuleBatchDidComplete(BOOL disabled)
-{
-  gBridgeModuleDisableBatchDidComplete = disabled;
-}
-
 BOOL kDispatchAccessibilityManagerInitOntoMain = NO;
 BOOL RCTUIManagerDispatchAccessibilityManagerInitOntoMain(void)
 {

--- a/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
+++ b/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
@@ -1458,27 +1458,15 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithBundleURL
 
 - (void)batchDidComplete
 {
-  if (RCTBridgeModuleBatchDidCompleteDisabled()) {
-    id uiManager = [self moduleForName:@"UIManager"];
-    if ([uiManager respondsToSelector:@selector(batchDidComplete)] &&
-        [uiManager respondsToSelector:@selector(methodQueue)]) {
+  // TODO #12592471: batchDidComplete is only used by RCTUIManager,
+  // can we eliminate this special case?
+  for (RCTModuleData *moduleData in _moduleDataByID) {
+    if (moduleData.implementsBatchDidComplete) {
       [self
           dispatchBlock:^{
-            [uiManager batchDidComplete];
+            [moduleData.instance batchDidComplete];
           }
-                  queue:[uiManager methodQueue]];
-    }
-  } else {
-    // TODO #12592471: batchDidComplete is only used by RCTUIManager,
-    // can we eliminate this special case?
-    for (RCTModuleData *moduleData in _moduleDataByID) {
-      if (moduleData.implementsBatchDidComplete) {
-        [self
-            dispatchBlock:^{
-              [moduleData.instance batchDidComplete];
-            }
-                    queue:moduleData.methodQueue];
-      }
+                  queue:moduleData.methodQueue];
     }
   }
 }


### PR DESCRIPTION
Summary:
changelog: [ios][breaking] delete BridgeModuleBatchDidComplete config helpers

this is not used anywhere, cleanup

Reviewed By: srinathvijay

Differential Revision: D72692359


