### PR TITLE
Make `EventCategoryDef` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -5056,23 +5056,6 @@ public abstract interface class com/facebook/react/uimanager/events/Event$EventA
 	public abstract fun match (ILjava/lang/String;)Z
 }
 
-public abstract interface annotation class com/facebook/react/uimanager/events/EventCategoryDef : java/lang/annotation/Annotation {
-	public static final field CONTINUOUS I
-	public static final field CONTINUOUS_END I
-	public static final field CONTINUOUS_START I
-	public static final field Companion Lcom/facebook/react/uimanager/events/EventCategoryDef$Companion;
-	public static final field DISCRETE I
-	public static final field UNSPECIFIED I
-}
-
-public final class com/facebook/react/uimanager/events/EventCategoryDef$Companion {
-	public static final field CONTINUOUS I
-	public static final field CONTINUOUS_END I
-	public static final field CONTINUOUS_START I
-	public static final field DISCRETE I
-	public static final field UNSPECIFIED I
-}
-
 public abstract interface class com/facebook/react/uimanager/events/EventDispatcher {
 	public abstract fun addBatchEventDispatchedListener (Lcom/facebook/react/uimanager/events/BatchEventDispatchedListener;)V
 	public abstract fun addListener (Lcom/facebook/react/uimanager/events/EventDispatcherListener;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/EventCategoryDef.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/EventCategoryDef.kt
@@ -22,25 +22,25 @@ import androidx.annotation.IntDef
             EventCategoryDef.DISCRETE,
             EventCategoryDef.CONTINUOUS])
 @Retention(AnnotationRetention.SOURCE)
-public annotation class EventCategoryDef {
-  public companion object {
+internal annotation class EventCategoryDef {
+  companion object {
     /** Start of a continuous event. To be used with touchStart. */
-    public const val CONTINUOUS_START: Int = 0
+    const val CONTINUOUS_START: Int = 0
 
     /** End of a continuous event. To be used with touchEnd. */
-    public const val CONTINUOUS_END: Int = 1
+    const val CONTINUOUS_END: Int = 1
 
     /**
      * Priority for this event will be determined from other events in the queue. If it is triggered
      * by continuous event, its priority will be default. If it is not triggered by continuous
      * event, its priority will be discrete.
      */
-    public const val UNSPECIFIED: Int = 2
+    const val UNSPECIFIED: Int = 2
 
     /** Forces discrete type for the event. Regardless if continuous event is ongoing. */
-    public const val DISCRETE: Int = 3
+    const val DISCRETE: Int = 3
 
     /** Forces continuous type for the event. Regardless if continuous event isn't ongoing. */
-    public const val CONTINUOUS: Int = 4
+    const val CONTINUOUS: Int = 4
   }
 }


### PR DESCRIPTION
## Summary:

This class can be internalized as part of the initiative to reduce the public API surface. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.uimanager.events.EventCategoryDef).

## Changelog:

[INTERNAL] - Make com.facebook.react.uimanager.events.EventCategoryDef internal

## Test Plan:

```bash
yarn test-android
yarn android
```