### PR TITLE
Make `RequestOnlyHandler` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3283,12 +3283,6 @@ public abstract interface class com/facebook/react/packagerconnection/RequestHan
 	public abstract fun onRequest (Ljava/lang/Object;Lcom/facebook/react/packagerconnection/Responder;)V
 }
 
-public abstract class com/facebook/react/packagerconnection/RequestOnlyHandler : com/facebook/react/packagerconnection/RequestHandler {
-	public fun <init> ()V
-	public final fun onNotification (Ljava/lang/Object;)V
-	public abstract fun onRequest (Ljava/lang/Object;Lcom/facebook/react/packagerconnection/Responder;)V
-}
-
 public abstract interface class com/facebook/react/packagerconnection/Responder {
 	public abstract fun error (Ljava/lang/Object;)V
 	public abstract fun respond (Ljava/lang/Object;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/RequestOnlyHandler.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/RequestOnlyHandler.kt
@@ -9,7 +9,7 @@ package com.facebook.react.packagerconnection
 
 import com.facebook.common.logging.FLog
 
-public abstract class RequestOnlyHandler : RequestHandler {
+internal abstract class RequestOnlyHandler : RequestHandler {
 
   abstract override fun onRequest(params: Any?, responder: Responder)
 


### PR DESCRIPTION
## Summary:

This class can be internalized as part of the initiative to reduce the public API surface. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.packagerconnection.RequestOnlyHandler).

## Changelog:

[INTERNAL] - Make com.facebook.react.packagerconnection.RequestOnlyHandler internal

## Test Plan:

```bash
yarn test-android
yarn android
```