### PR TITLE
Introduce ReactNativeNewArchitectureFeatureFlags

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageLogger.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageLogger.kt
@@ -7,7 +7,10 @@
 
 package com.facebook.react
 
+import com.facebook.react.common.annotations.internal.LegacyArchitecture
+
 /** Interface for the bridge to call for TTI start and end markers. */
+@LegacyArchitecture
 internal interface ReactPackageLogger {
   fun startProcessPackage(): Unit
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeNewArchitectureFeatureFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeNewArchitectureFeatureFlags.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.internal.featureflags
+
+import com.facebook.infer.annotation.Assertions
+import com.facebook.react.common.build.ReactBuildConfig
+
+public object ReactNativeNewArchitectureFeatureFlags {
+
+  @JvmStatic
+  public fun isNewArchitectureStrictModeEnabled(): Boolean =
+      ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE
+
+  @JvmStatic
+  public fun enableBridgelessArchitecture(): Boolean {
+    if (ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE) {
+      Assertions.assertCondition(
+          ReactNativeFeatureFlags.enableBridgelessArchitecture(),
+          "ReactNativeFeatureFlags.enableBridgelessArchitecture() should be set to true when Strict Mode is enabled")
+      return true
+    }
+    return ReactNativeFeatureFlags.enableBridgelessArchitecture()
+  }
+
+  @JvmStatic
+  public fun enableFabricRenderer(): Boolean {
+    if (ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE) {
+      Assertions.assertCondition(
+          ReactNativeFeatureFlags.enableFabricRenderer(),
+          "ReactNativeFeatureFlags.enableFabricRenderer() should be set to true when Strict Mode is enabled")
+      return true
+    }
+    return ReactNativeFeatureFlags.enableFabricRenderer()
+  }
+
+  @JvmStatic
+  public fun useFabricInterop(): Boolean {
+    if (ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE) {
+      Assertions.assertCondition(
+          !ReactNativeFeatureFlags.useFabricInterop(),
+          "ReactNativeFeatureFlags.useFabricInterop() should be set to FALSE when Strict Mode is enabled")
+      return false
+    }
+    return ReactNativeFeatureFlags.useFabricInterop()
+  }
+
+  @JvmStatic
+  public fun useTurboModuleInterop(): Boolean {
+    if (ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE) {
+      Assertions.assertCondition(
+          !ReactNativeFeatureFlags.useTurboModuleInterop(),
+          "ReactNativeFeatureFlags.useTurboModuleInterop() should be set to FALSE when Strict Mode is enabled")
+      return false
+    }
+    return ReactNativeFeatureFlags.useTurboModuleInterop()
+  }
+
+  @JvmStatic
+  public fun useTurboModules(): Boolean {
+    if (ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE) {
+      Assertions.assertCondition(
+          ReactNativeFeatureFlags.useTurboModules(),
+          "ReactNativeFeatureFlags.useTurboModules() should be set to FALSE when Strict Mode is enabled")
+      return true
+    }
+    return ReactNativeFeatureFlags.useTurboModules()
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -983,6 +983,16 @@ public class ReactHostImpl implements ReactHost {
             ReactNativeFeatureFlags.useTurboModules(),
             "useTurboModules FeatureFlag must be set to start ReactNative.");
       }
+      if (ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE) {
+        Assertions.assertCondition(
+            !ReactNativeFeatureFlags.useFabricInterop(),
+            "useFabricInterop FeatureFlag must be false when"
+                + " UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE == true.");
+        Assertions.assertCondition(
+            !ReactNativeFeatureFlags.useTurboModuleInterop(),
+            "useTurboModuleInterop FeatureFlag must be false when"
+                + " UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE == true.");
+      }
       mStartTask =
           waitThenCallGetOrCreateReactInstanceTask()
               .continueWithTask(


### PR DESCRIPTION
Summary:
In order to help Proguard to stripping-out bytecode, we need a way to statically enable all Feature Flags used by the New Architecture at build time (e.g. enableBridgelessArchitecture, useTurboModule, etc). The React Native Feature Flag system is mostly implemented in C++ and unfortunately Proguard can’t follow C++ code to understand what feature flags are enabled or disabled at build time.

After analyzing several proposals, we decided to introduce a new internal API called ReactNativeNewArchitectureFeatureFlags, this API will help us detect if an app is using the new architecture at build time.
In order to make this API to work I’ve migrated all usages of new architecture feature flags from ReactNativeFeatureFlags -> ReactNativeNewArchitectureFeatureFlags 

changelog: [internal] internal

Reviewed By: mlord93

Differential Revision: D71988912


