### PR TITLE
Introduce UseReactNativeNewArchitectureFeatureFlagDetector

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/BaseReactPackage.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/BaseReactPackage.kt
@@ -11,7 +11,7 @@ import com.facebook.react.bridge.ModuleHolder
 import com.facebook.react.bridge.ModuleSpec
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
+import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags
 import com.facebook.react.module.model.ReactModuleInfo
 import com.facebook.react.module.model.ReactModuleInfoProvider
 import com.facebook.react.uimanager.ViewManager
@@ -65,7 +65,8 @@ public abstract class BaseReactPackage : ReactPackage {
             // This Iterator is used to create the NativeModule registry. The NativeModule
             // registry must not have TurboModules. Therefore, if TurboModules are enabled, and
             // the current NativeModule is a TurboModule, we need to skip iterating over it.
-            if (ReactNativeFeatureFlags.useTurboModules() && reactModuleInfo.isTurboModule) {
+            if (ReactNativeNewArchitectureFeatureFlags.useTurboModules() &&
+                reactModuleInfo.isTurboModule) {
               continue
             }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/HeadlessJsTaskService.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/HeadlessJsTaskService.kt
@@ -17,7 +17,7 @@ import android.os.PowerManager
 import android.os.PowerManager.WakeLock
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.UiThreadUtil
-import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
+import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags
 import com.facebook.react.jstasks.HeadlessJsTaskConfig
 import com.facebook.react.jstasks.HeadlessJsTaskContext.Companion.getInstance
 import com.facebook.react.jstasks.HeadlessJsTaskEventListener
@@ -125,7 +125,7 @@ public abstract class HeadlessJsTaskService : Service(), HeadlessJsTaskEventList
 
   protected val reactContext: ReactContext?
     get() {
-      if (ReactNativeFeatureFlags.enableBridgelessArchitecture()) {
+      if (ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()) {
         val reactHost =
             checkNotNull(reactHost) { "ReactHost is not initialized in New Architecture" }
         return reactHost.currentReactContext
@@ -136,7 +136,7 @@ public abstract class HeadlessJsTaskService : Service(), HeadlessJsTaskEventList
     }
 
   private fun createReactContextAndScheduleTask(taskConfig: HeadlessJsTaskConfig) {
-    if (ReactNativeFeatureFlags.enableBridgelessArchitecture()) {
+    if (ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()) {
       val reactHost = checkNotNull(reactHost)
       reactHost.addReactInstanceEventListener(
           object : ReactInstanceEventListener {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
@@ -21,7 +21,7 @@ import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.common.annotations.DeprecatedInNewArchitecture;
 import com.facebook.react.interfaces.fabric.ReactSurface;
-import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags;
+import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags;
 import com.facebook.react.modules.core.PermissionListener;
 import com.facebook.systrace.Systrace;
 
@@ -124,7 +124,7 @@ public class ReactActivityDelegate {
           if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && isWideColorGamutEnabled()) {
             mActivity.getWindow().setColorMode(ActivityInfo.COLOR_MODE_WIDE_COLOR_GAMUT);
           }
-          if (ReactNativeFeatureFlags.enableBridgelessArchitecture()) {
+          if (ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()) {
             mReactDelegate =
                 new ReactDelegate(
                     getPlainActivity(), getReactHost(), mainComponentName, launchOptions);
@@ -267,7 +267,7 @@ public class ReactActivityDelegate {
    * @return true if Fabric is enabled for this Activity, false otherwise.
    */
   protected boolean isFabricEnabled() {
-    return ReactNativeFeatureFlags.enableFabricRenderer();
+    return ReactNativeNewArchitectureFeatureFlags.enableFabricRenderer();
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
@@ -21,7 +21,7 @@ import com.facebook.react.devsupport.DoubleTapReloadRecognizer;
 import com.facebook.react.devsupport.ReleaseDevSupportManager;
 import com.facebook.react.devsupport.interfaces.DevSupportManager;
 import com.facebook.react.interfaces.fabric.ReactSurface;
-import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags;
+import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 
 /**
@@ -45,7 +45,7 @@ public class ReactDelegate {
 
   @Nullable private ReactSurface mReactSurface;
 
-  private boolean mFabricEnabled = ReactNativeFeatureFlags.enableFabricRenderer();
+  private boolean mFabricEnabled = ReactNativeNewArchitectureFeatureFlags.enableFabricRenderer();
 
   /**
    * Do not use this constructor as it's not accounting for New Architecture at all. You should
@@ -96,7 +96,7 @@ public class ReactDelegate {
 
   @Nullable
   private DevSupportManager getDevSupportManager() {
-    if (ReactNativeFeatureFlags.enableBridgelessArchitecture()
+    if (ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()
         && mReactHost != null
         && mReactHost.getDevSupportManager() != null) {
       return mReactHost.getDevSupportManager();
@@ -113,7 +113,7 @@ public class ReactDelegate {
       throw new ClassCastException(
           "Host Activity does not implement DefaultHardwareBackBtnHandler");
     }
-    if (ReactNativeFeatureFlags.enableBridgelessArchitecture()) {
+    if (ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()) {
       mReactHost.onHostResume(mActivity, (DefaultHardwareBackBtnHandler) mActivity);
     } else {
       if (getReactNativeHost().hasInstance()) {
@@ -125,7 +125,7 @@ public class ReactDelegate {
   }
 
   public void onUserLeaveHint() {
-    if (ReactNativeFeatureFlags.enableBridgelessArchitecture()) {
+    if (ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()) {
       mReactHost.onHostLeaveHint(mActivity);
     } else {
       if (getReactNativeHost().hasInstance()) {
@@ -135,7 +135,7 @@ public class ReactDelegate {
   }
 
   public void onHostPause() {
-    if (ReactNativeFeatureFlags.enableBridgelessArchitecture()) {
+    if (ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()) {
       mReactHost.onHostPause(mActivity);
     } else {
       if (getReactNativeHost().hasInstance()) {
@@ -146,7 +146,7 @@ public class ReactDelegate {
 
   public void onHostDestroy() {
     unloadApp();
-    if (ReactNativeFeatureFlags.enableBridgelessArchitecture()) {
+    if (ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()) {
       mReactHost.onHostDestroy(mActivity);
     } else {
       if (getReactNativeHost().hasInstance()) {
@@ -156,7 +156,7 @@ public class ReactDelegate {
   }
 
   public boolean onBackPressed() {
-    if (ReactNativeFeatureFlags.enableBridgelessArchitecture()) {
+    if (ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()) {
       mReactHost.onBackPressed();
       return true;
     } else {
@@ -169,7 +169,7 @@ public class ReactDelegate {
   }
 
   public boolean onNewIntent(Intent intent) {
-    if (ReactNativeFeatureFlags.enableBridgelessArchitecture()) {
+    if (ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()) {
       mReactHost.onNewIntent(intent);
       return true;
     } else {
@@ -183,7 +183,7 @@ public class ReactDelegate {
 
   public void onActivityResult(
       int requestCode, int resultCode, Intent data, boolean shouldForwardToReactInstance) {
-    if (ReactNativeFeatureFlags.enableBridgelessArchitecture()) {
+    if (ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()) {
       mReactHost.onActivityResult(mActivity, requestCode, resultCode, data);
     } else {
       if (getReactNativeHost().hasInstance() && shouldForwardToReactInstance) {
@@ -195,7 +195,7 @@ public class ReactDelegate {
   }
 
   public void onWindowFocusChanged(boolean hasFocus) {
-    if (ReactNativeFeatureFlags.enableBridgelessArchitecture()) {
+    if (ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()) {
       mReactHost.onWindowFocusChange(hasFocus);
     } else {
       if (getReactNativeHost().hasInstance()) {
@@ -205,7 +205,7 @@ public class ReactDelegate {
   }
 
   public void onConfigurationChanged(Configuration newConfig) {
-    if (ReactNativeFeatureFlags.enableBridgelessArchitecture()) {
+    if (ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()) {
       mReactHost.onConfigurationChanged(Assertions.assertNotNull(mActivity));
     } else {
       if (getReactNativeHost().hasInstance()) {
@@ -217,7 +217,7 @@ public class ReactDelegate {
 
   public boolean onKeyDown(int keyCode, KeyEvent event) {
     if (keyCode == KeyEvent.KEYCODE_MEDIA_FAST_FORWARD
-        && ((ReactNativeFeatureFlags.enableBridgelessArchitecture()
+        && ((ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()
                 && mReactHost != null
                 && mReactHost.getDevSupportManager() != null)
             || (getReactNativeHost().hasInstance()
@@ -230,7 +230,8 @@ public class ReactDelegate {
 
   public boolean onKeyLongPress(int keyCode) {
     if (keyCode == KeyEvent.KEYCODE_MEDIA_FAST_FORWARD) {
-      if (ReactNativeFeatureFlags.enableBridgelessArchitecture() && mReactHost != null) {
+      if (ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()
+          && mReactHost != null) {
         DevSupportManager devSupportManager = mReactHost.getDevSupportManager();
         // onKeyLongPress is a Dev API and not supported in RELEASE mode.
         if (devSupportManager != null && !(devSupportManager instanceof ReleaseDevSupportManager)) {
@@ -256,7 +257,7 @@ public class ReactDelegate {
     // Reload in RELEASE mode
     if (devSupportManager instanceof ReleaseDevSupportManager) {
       // Do not reload the bundle from JS as there is no bundler running in release mode.
-      if (ReactNativeFeatureFlags.enableBridgelessArchitecture()) {
+      if (ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()) {
         if (mReactHost != null) {
           mReactHost.reload("ReactDelegate.reload()");
         }
@@ -288,7 +289,7 @@ public class ReactDelegate {
    */
   public void loadApp(String appKey) {
     // With Bridgeless enabled, create and start the surface
-    if (ReactNativeFeatureFlags.enableBridgelessArchitecture()) {
+    if (ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()) {
       if (mReactSurface == null) {
         mReactSurface = mReactHost.createSurface(mActivity, appKey, mLaunchOptions);
       }
@@ -305,7 +306,7 @@ public class ReactDelegate {
 
   /** Stop the React surface started with {@link ReactDelegate#loadApp()}. */
   public void unloadApp() {
-    if (ReactNativeFeatureFlags.enableBridgelessArchitecture()) {
+    if (ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()) {
       if (mReactSurface != null) {
         mReactSurface.stop();
         mReactSurface = null;
@@ -328,7 +329,7 @@ public class ReactDelegate {
 
   @Nullable
   public ReactRootView getReactRootView() {
-    if (ReactNativeFeatureFlags.enableBridgelessArchitecture()) {
+    if (ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()) {
       if (mReactSurface != null) {
         return (ReactRootView) mReactSurface.getView();
       } else {
@@ -396,7 +397,7 @@ public class ReactDelegate {
    * context will no longer be valid.
    */
   public @Nullable ReactContext getCurrentReactContext() {
-    if (ReactNativeFeatureFlags.enableBridgelessArchitecture()) {
+    if (ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()) {
       if (mReactHost != null) {
         return mReactHost.getCurrentReactContext();
       } else {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactFragment.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactFragment.java
@@ -17,7 +17,7 @@ import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
-import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags;
+import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags;
 import com.facebook.react.modules.core.PermissionAwareActivity;
 import com.facebook.react.modules.core.PermissionListener;
 
@@ -81,7 +81,7 @@ public class ReactFragment extends Fragment implements PermissionAwareActivity {
     if (mainComponentName == null) {
       throw new IllegalStateException("Cannot loadApp if component name is null");
     }
-    if (ReactNativeFeatureFlags.enableBridgelessArchitecture()) {
+    if (ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()) {
       mReactDelegate =
           new ReactDelegate(getActivity(), getReactHost(), mainComponentName, launchOptions);
     } else {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -96,7 +96,7 @@ import com.facebook.react.devsupport.interfaces.RedBoxHandler;
 import com.facebook.react.interfaces.TaskInterface;
 import com.facebook.react.internal.AndroidChoreographerProvider;
 import com.facebook.react.internal.ChoreographerProvider;
-import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags;
+import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags;
 import com.facebook.react.internal.turbomodule.core.TurboModuleManager;
 import com.facebook.react.internal.turbomodule.core.TurboModuleManagerDelegate;
 import com.facebook.react.modules.appearance.AppearanceModule;
@@ -357,7 +357,7 @@ public class ReactInstanceManager {
         Activity currentActivity = getCurrentActivity();
         if (currentActivity != null) {
           ReactRootView rootView = new ReactRootView(currentActivity);
-          boolean isFabric = ReactNativeFeatureFlags.enableFabricRenderer();
+          boolean isFabric = ReactNativeNewArchitectureFeatureFlags.enableFabricRenderer();
           rootView.setIsFabric(isFabric);
           rootView.startReactApplication(ReactInstanceManager.this, appKey, new Bundle());
           return rootView;
@@ -1485,7 +1485,7 @@ public class ReactInstanceManager {
     // architecture so it will always be there.
     catalystInstance.getRuntimeScheduler();
 
-    if (ReactNativeFeatureFlags.useTurboModules() && mTMMDelegateBuilder != null) {
+    if (ReactNativeNewArchitectureFeatureFlags.useTurboModules() && mTMMDelegateBuilder != null) {
       TurboModuleManagerDelegate tmmDelegate =
           mTMMDelegateBuilder
               .setPackages(mPackages)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageLogger.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageLogger.kt
@@ -7,7 +7,10 @@
 
 package com.facebook.react
 
+import com.facebook.react.common.annotations.internal.LegacyArchitecture
+
 /** Interface for the bridge to call for TTI start and end markers. */
+@LegacyArchitecture
 internal interface ReactPackageLogger {
   fun startProcessPackage(): Unit
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.java
@@ -14,7 +14,7 @@ import com.facebook.react.bridge.CxxModuleWrapper;
 import com.facebook.react.bridge.ModuleSpec;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags;
+import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags;
 import com.facebook.react.internal.turbomodule.core.TurboModuleManagerDelegate;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.module.model.ReactModuleInfo;
@@ -36,8 +36,8 @@ public abstract class ReactPackageTurboModuleManagerDelegate extends TurboModule
       new HashMap<>();
 
   private final boolean mShouldEnableLegacyModuleInterop =
-      ReactNativeFeatureFlags.enableBridgelessArchitecture()
-          && ReactNativeFeatureFlags.useTurboModuleInterop();
+      ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()
+          && ReactNativeNewArchitectureFeatureFlags.useTurboModuleInterop();
 
   // Lazy Props
   private List<ReactPackage> mPackages;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
@@ -29,7 +29,7 @@ import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.common.annotations.internal.LegacyArchitecture;
 import com.facebook.react.common.annotations.internal.LegacyArchitectureLogLevel;
 import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger;
-import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags;
+import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags;
 import com.facebook.react.internal.turbomodule.core.interfaces.TurboModuleRegistry;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.turbomodule.core.CallInvokerHolderImpl;
@@ -465,7 +465,7 @@ public class CatalystInstanceImpl implements CatalystInstance {
   }
 
   private TurboModuleRegistry getTurboModuleRegistry() {
-    if (ReactNativeFeatureFlags.useTurboModules()) {
+    if (ReactNativeNewArchitectureFeatureFlags.useTurboModules()) {
       return Assertions.assertNotNull(
           mTurboModuleRegistry,
           "TurboModules are enabled, but mTurboModuleRegistry hasn't been set.");

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/interop/InteropModuleRegistry.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/interop/InteropModuleRegistry.kt
@@ -10,8 +10,8 @@ package com.facebook.react.bridge.interop
 import com.facebook.react.bridge.JavaScriptModule
 import com.facebook.react.common.annotations.internal.LegacyArchitecture
 import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
-import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags.enableFabricRenderer
-import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags.useFabricInterop
+import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags.enableFabricRenderer
+import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags.useFabricInterop
 
 /**
  * A utility class that takes care of returning [JavaScriptModule] which are used for the Fabric

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -64,6 +64,7 @@ import com.facebook.react.fabric.mounting.mountitems.DispatchCommandMountItem;
 import com.facebook.react.fabric.mounting.mountitems.MountItem;
 import com.facebook.react.fabric.mounting.mountitems.MountItemFactory;
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags;
+import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags;
 import com.facebook.react.internal.interop.InteropEventEmitter;
 import com.facebook.react.modules.core.ReactChoreographer;
 import com.facebook.react.modules.i18nmanager.I18nUtil;
@@ -368,7 +369,7 @@ public class FabricUIManager
 
       ReactMarker.addFabricListener(mDevToolsReactPerfLogger);
     }
-    if (ReactNativeFeatureFlags.useFabricInterop()) {
+    if (ReactNativeNewArchitectureFeatureFlags.useFabricInterop()) {
       InteropEventEmitter interopEventEmitter = new InteropEventEmitter(mReactApplicationContext);
       mReactApplicationContext.internal_registerInteropModule(
           RCTEventEmitter.class, interopEventEmitter);
@@ -435,7 +436,7 @@ public class FabricUIManager
    * [addUiBlock] and [prependUiBlock] on UIManagerModule.
    */
   public void addUIBlock(UIBlock block) {
-    if (ReactNativeFeatureFlags.useFabricInterop()) {
+    if (ReactNativeNewArchitectureFeatureFlags.useFabricInterop()) {
       InteropUIBlockListener listener = getInteropUIBlockListener();
       listener.addUIBlock(block);
     }
@@ -446,7 +447,7 @@ public class FabricUIManager
    * [addUiBlock] and [prependUiBlock] on UIManagerModule.
    */
   public void prependUIBlock(UIBlock block) {
-    if (ReactNativeFeatureFlags.useFabricInterop()) {
+    if (ReactNativeNewArchitectureFeatureFlags.useFabricInterop()) {
       InteropUIBlockListener listener = getInteropUIBlockListener();
       listener.prependUIBlock(block);
     }
@@ -1074,7 +1075,7 @@ public class FabricUIManager
       final int reactTag,
       final String commandId,
       @Nullable final ReadableArray commandArgs) {
-    if (ReactNativeFeatureFlags.useFabricInterop()) {
+    if (ReactNativeNewArchitectureFeatureFlags.useFabricInterop()) {
       // For Fabric Interop, we check if the commandId is an integer. If it is, we use the integer
       // overload of dispatchCommand. Otherwise, we use the string overload.
       // and the events won't be correctly dispatched.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeNewArchitectureFeatureFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeNewArchitectureFeatureFlags.kt
@@ -7,9 +7,20 @@
 
 package com.facebook.react.internal.featureflags
 
+import android.annotation.SuppressLint
 import com.facebook.infer.annotation.Assertions
 import com.facebook.react.common.build.ReactBuildConfig
 
+/**
+ * This class provides feature flags for the React Native New Architecture. It wraps the base
+ * ReactNativeFeatureFlags with additional logic for strict mode. When strict mode is enabled (via
+ * UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE), it enforces specific configurations and provides
+ * assertions to ensure proper setup.
+ *
+ * This class suppress the lint UseReactNativeNewArchitectureFeatureFlagDetector as it is expected
+ * to access ReactNativeFeatureFlags from this file.
+ */
+@SuppressLint("UseReactNativeNewArchitectureFeatureFlagDetector")
 public object ReactNativeNewArchitectureFeatureFlags {
 
   @JvmStatic

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeNewArchitectureFeatureFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeNewArchitectureFeatureFlags.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.internal.featureflags
+
+import com.facebook.infer.annotation.Assertions
+import com.facebook.react.common.build.ReactBuildConfig
+
+public object ReactNativeNewArchitectureFeatureFlags {
+
+  @JvmStatic
+  public fun isNewArchitectureStrictModeEnabled(): Boolean =
+      ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE
+
+  @JvmStatic
+  public fun enableBridgelessArchitecture(): Boolean {
+    if (ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE) {
+      Assertions.assertCondition(
+          ReactNativeFeatureFlags.enableBridgelessArchitecture(),
+          "ReactNativeFeatureFlags.enableBridgelessArchitecture() should be set to true when Strict Mode is enabled")
+      return true
+    }
+    return ReactNativeFeatureFlags.enableBridgelessArchitecture()
+  }
+
+  @JvmStatic
+  public fun enableFabricRenderer(): Boolean {
+    if (ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE) {
+      Assertions.assertCondition(
+          ReactNativeFeatureFlags.enableFabricRenderer(),
+          "ReactNativeFeatureFlags.enableFabricRenderer() should be set to true when Strict Mode is enabled")
+      return true
+    }
+    return ReactNativeFeatureFlags.enableFabricRenderer()
+  }
+
+  @JvmStatic
+  public fun useFabricInterop(): Boolean {
+    if (ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE) {
+      Assertions.assertCondition(
+          !ReactNativeFeatureFlags.useFabricInterop(),
+          "ReactNativeFeatureFlags.useFabricInterop() should be set to FALSE when Strict Mode is enabled")
+      return false
+    }
+    return ReactNativeFeatureFlags.useFabricInterop()
+  }
+
+  @JvmStatic
+  public fun useTurboModuleInterop(): Boolean {
+    if (ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE) {
+      Assertions.assertCondition(
+          !ReactNativeFeatureFlags.useTurboModuleInterop(),
+          "ReactNativeFeatureFlags.useTurboModuleInterop() should be set to FALSE when Strict Mode is enabled")
+      return false
+    }
+    return ReactNativeFeatureFlags.useTurboModuleInterop()
+  }
+
+  @JvmStatic
+  public fun useTurboModules(): Boolean {
+    if (ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE) {
+      Assertions.assertCondition(
+          ReactNativeFeatureFlags.useTurboModules(),
+          "ReactNativeFeatureFlags.useTurboModules() should be set to FALSE when Strict Mode is enabled")
+      return true
+    }
+    return ReactNativeFeatureFlags.useTurboModules()
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.java
@@ -24,7 +24,7 @@ import com.facebook.react.bridge.WritableNativeArray;
 import com.facebook.react.common.annotations.FrameworkAPI;
 import com.facebook.react.common.annotations.UnstableReactNativeAPI;
 import com.facebook.react.devsupport.interfaces.DevSupportManager;
-import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags;
+import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.facebook.react.turbomodule.core.interfaces.CallInvokerHolder;
 import com.facebook.react.uimanager.events.EventDispatcher;
@@ -52,7 +52,7 @@ class BridgelessReactContext extends ReactApplicationContext implements EventDis
   BridgelessReactContext(Context context, ReactHostImpl host) {
     super(context);
     mReactHost = host;
-    if (ReactNativeFeatureFlags.useFabricInterop()) {
+    if (ReactNativeNewArchitectureFeatureFlags.useFabricInterop()) {
       initializeInteropModules();
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -986,6 +986,16 @@ public class ReactHostImpl implements ReactHost {
             ReactNativeFeatureFlags.useTurboModules(),
             "useTurboModules FeatureFlag must be set to start ReactNative.");
       }
+      if (ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE) {
+        Assertions.assertCondition(
+            !ReactNativeFeatureFlags.useFabricInterop(),
+            "useFabricInterop FeatureFlag must be false when"
+                + " UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE == true.");
+        Assertions.assertCondition(
+            !ReactNativeFeatureFlags.useTurboModuleInterop(),
+            "useTurboModuleInterop FeatureFlag must be false when"
+                + " UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE == true.");
+      }
       mStartTask =
           waitThenCallGetOrCreateReactInstanceTask()
               .continueWithTask(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.java
@@ -60,7 +60,7 @@ import com.facebook.react.fabric.ComponentFactory;
 import com.facebook.react.fabric.FabricUIManager;
 import com.facebook.react.interfaces.TaskInterface;
 import com.facebook.react.interfaces.fabric.ReactSurface;
-import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags;
+import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags;
 import com.facebook.react.modules.appearance.AppearanceModule;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
@@ -975,24 +975,24 @@ public class ReactHostImpl implements ReactHost {
       log(method, "Schedule");
       if (ReactBuildConfig.DEBUG) {
         Assertions.assertCondition(
-            ReactNativeFeatureFlags.enableBridgelessArchitecture(),
+            ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture(),
             "enableBridgelessArchitecture FeatureFlag must be set to start ReactNative.");
 
         Assertions.assertCondition(
-            ReactNativeFeatureFlags.enableFabricRenderer(),
+            ReactNativeNewArchitectureFeatureFlags.enableFabricRenderer(),
             "enableFabricRenderer FeatureFlag must be set to start ReactNative.");
 
         Assertions.assertCondition(
-            ReactNativeFeatureFlags.useTurboModules(),
+            ReactNativeNewArchitectureFeatureFlags.useTurboModules(),
             "useTurboModules FeatureFlag must be set to start ReactNative.");
       }
       if (ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE) {
         Assertions.assertCondition(
-            !ReactNativeFeatureFlags.useFabricInterop(),
+            !ReactNativeNewArchitectureFeatureFlags.useFabricInterop(),
             "useFabricInterop FeatureFlag must be false when"
                 + " UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE == true.");
         Assertions.assertCondition(
-            !ReactNativeFeatureFlags.useTurboModuleInterop(),
+            !ReactNativeNewArchitectureFeatureFlags.useTurboModuleInterop(),
             "useTurboModuleInterop FeatureFlag must be false when"
                 + " UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE == true.");
       }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelper.java
@@ -13,7 +13,7 @@ import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.common.build.ReactBuildConfig;
-import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags;
+import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -138,8 +138,8 @@ public class UIManagerModuleConstantsHelper {
 
     Map viewManagerBubblingEvents = viewManager.getExportedCustomBubblingEventTypeConstants();
     if (viewManagerBubblingEvents != null) {
-      if (ReactNativeFeatureFlags.enableFabricRenderer()
-          && ReactNativeFeatureFlags.useFabricInterop()) {
+      if (ReactNativeNewArchitectureFeatureFlags.enableFabricRenderer()
+          && ReactNativeNewArchitectureFeatureFlags.useFabricInterop()) {
         // For Fabric, events needs to be fired with a "top" prefix.
         // For the sake of Fabric Interop, here we normalize events adding "top" in their
         // name if the user hasn't provided it.
@@ -155,8 +155,8 @@ public class UIManagerModuleConstantsHelper {
     Map viewManagerDirectEvents = viewManager.getExportedCustomDirectEventTypeConstants();
     validateDirectEventNames(viewManager.getName(), viewManagerDirectEvents);
     if (viewManagerDirectEvents != null) {
-      if (ReactNativeFeatureFlags.enableFabricRenderer()
-          && ReactNativeFeatureFlags.useFabricInterop()) {
+      if (ReactNativeNewArchitectureFeatureFlags.enableFabricRenderer()
+          && ReactNativeNewArchitectureFeatureFlags.useFabricInterop()) {
         // For Fabric, events needs to be fired with a "top" prefix.
         // For the sake of Fabric Interop, here we normalize events adding "top" in their
         // name if the user hasn't provided it.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
@@ -21,9 +21,9 @@ import com.facebook.react.bridge.ReactSoftExceptionLogger;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.annotations.UnstableReactNativeAPI;
-import com.facebook.react.common.build.ReactBuildConfig;
 import com.facebook.react.common.mapbuffer.MapBuffer;
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags;
+import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags;
 import com.facebook.react.touch.JSResponderHandler;
 import com.facebook.react.touch.ReactInterceptingViewGroup;
 import com.facebook.react.uimanager.annotations.ReactProp;
@@ -407,8 +407,7 @@ public abstract class ViewManager<T extends View, C extends ReactShadowNode>
    * Map contains the names (key) and types (value) of the ViewManager's props.
    */
   public Map<String, String> getNativeProps() {
-    if (ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE
-        && ReactNativeFeatureFlags.enableBridgelessArchitecture()
+    if (ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()
         && ReactNativeFeatureFlags.disableShadowNodeOnNewArchitectureAndroid()) {
       return ViewManagerPropertyUpdater.getNativeProps(getClass(), null);
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.kt
@@ -50,7 +50,7 @@ import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.common.annotations.VisibleForTesting
 import com.facebook.react.common.build.ReactBuildConfig
-import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
+import com.facebook.react.internal.featureflags.ReactNativeNewArchitectureFeatureFlags
 import com.facebook.react.modules.fresco.ImageCacheControl
 import com.facebook.react.modules.fresco.ReactNetworkImageRequest
 import com.facebook.react.uimanager.BackgroundStyleApplicator
@@ -581,7 +581,8 @@ public class ReactImageView(
     // 3. ReactImageView detects the null src; displays a warning in LogBox (via this code).
     // 3. LogBox renders an <Image/>, which fabric preallocates.
     // 4. Rinse and repeat.
-    if (ReactBuildConfig.DEBUG && !ReactNativeFeatureFlags.enableBridgelessArchitecture()) {
+    if (ReactBuildConfig.DEBUG &&
+        !ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture()) {
       RNLog.w(context as ReactContext, "ReactImageView: Image source \"$uri\" doesn't exist")
     }
   }


### PR DESCRIPTION
Summary:
In this diff I'm introducing a new lint error called UseReactNativeNewArchitectureFeatureFlagDetector to prevent usages of: 

```
ReactNativeFeatureFlags.enableBridgelessArchitecture
ReactNativeFeatureFlags.enableFabricRenderer
ReactNativeFeatureFlags.useFabricInterop
ReactNativeFeatureFlags.useTurboModuleInterop
ReactNativeFeatureFlags.useTurboModules
```

in favor of:
```
ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture
ReactNativeNewArchitectureFeatureFlags.enableFabricRenderer
ReactNativeNewArchitectureFeatureFlags.useFabricInterop
ReactNativeNewArchitectureFeatureFlags.useTurboModuleInterop
ReactNativeNewArchitectureFeatureFlags.useTurboModules
```

I created lint by following: https://www.internalfb.com/wiki/Android-lint/adding-a-new-lint-detector/

Reviewed By: cortinico

Differential Revision: D72028734


