### PR TITLE
Add `cloneMultiple` method to the `ShadowNode` class

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -370,7 +370,7 @@ ShadowNode::Unshared ShadowNode::cloneTree(
 
 ShadowNode::Unshared ShadowNode::cloneMultipleRecursive(
     const ShadowNode& shadowNode,
-    const std::unordered_set<const ShadowNodeFamily*>& families,
+    const std::unordered_set<const ShadowNodeFamily*>& familiesToUpdate,
     const std::unordered_map<const ShadowNodeFamily*, int>& childrenCount,
     const std::function<Unshared(
         const ShadowNode& oldShadowNode,
@@ -388,7 +388,7 @@ ShadowNode::Unshared ShadowNode::cloneMultipleRecursive(
       count--;
       shouldUpdateChildren = true;
       children[i] = cloneMultipleRecursive(
-          *children[i], families, childrenCount, callback);
+          *children[i], familiesToUpdate, childrenCount, callback);
     }
   }
 
@@ -396,7 +396,7 @@ ShadowNode::Unshared ShadowNode::cloneMultipleRecursive(
     newChildren = std::move(children);
   }
 
-  if (families.contains(family)) {
+  if (familiesToUpdate.contains(family)) {
     return callback(shadowNode, newChildren);
   }
 
@@ -408,14 +408,14 @@ ShadowNode::Unshared ShadowNode::cloneMultipleRecursive(
 }
 
 ShadowNode::Unshared ShadowNode::cloneMultiple(
-    const std::unordered_set<const ShadowNodeFamily*>& families,
+    const std::unordered_set<const ShadowNodeFamily*>& familiesToUpdate,
     const std::function<Unshared(
         const ShadowNode& oldShadowNode,
         const std::optional<ShadowNode::ListOfShared>& newChildren)>& callback)
     const {
   std::unordered_map<const ShadowNodeFamily*, int> childrenCount;
 
-  for (const auto& family : families) {
+  for (const auto& family : familiesToUpdate) {
     if (childrenCount.contains(family)) {
       continue;
     }
@@ -439,7 +439,7 @@ ShadowNode::Unshared ShadowNode::cloneMultiple(
     return ShadowNode::Unshared{nullptr};
   }
 
-  return cloneMultipleRecursive(*this, families, childrenCount, callback);
+  return cloneMultipleRecursive(*this, familiesToUpdate, childrenCount, callback);
 }
 
 #pragma mark - DebugStringConvertible

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -417,16 +417,20 @@ ShadowNode::Unshared ShadowNode::cloneMultiple(
 
     childrenCount[family] = 0;
 
-    auto ancestor = family;
-    while ((ancestor != nullptr) && ancestor != this->family_.get()) {
-      ancestor = ancestor->parent_.lock().get();
-      auto ancestorIt = childrenCount.find(ancestor);
+    auto ancestor = family->parent_.lock();
+    while ((ancestor != nullptr) && ancestor != this->family_) {
+      auto ancestorIt = childrenCount.find(ancestor.get());
       if (ancestorIt != childrenCount.end()) {
         ancestorIt->second++;
         break;
       }
-
-      childrenCount[ancestor] = 1;
+      childrenCount[ancestor.get()] = 1;
+      
+      ancestor = ancestor->parent_.lock();
+    }
+    
+    if (ancestor == this->family_){
+      childrenCount[ancestor.get()]++;
     }
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -376,14 +376,14 @@ ShadowNode::Unshared ShadowNode::cloneMultipleRecursive(
         const ShadowNode& oldShadowNode,
         const std::optional<ShadowNode::ListOfShared>& newChildren)>& callback)
     const {
+  const auto family = &shadowNode.getFamily();
   auto children = shadowNode.getChildren();
-  auto family = &shadowNode.getFamily();
   auto count = childrenCount.at(family);
   auto shouldUpdateChildren = false;
   std::optional<ShadowNode::ListOfShared> newChildren;
 
   for (int i = 0; count > 0 && i < children.size(); i++) {
-    auto childFamily = &children[i]->getFamily();
+    const auto childFamily = &children[i]->getFamily();
     if (childrenCount.contains(childFamily)) {
       count--;
       shouldUpdateChildren = true;
@@ -415,7 +415,7 @@ ShadowNode::Unshared ShadowNode::cloneMultiple(
     const {
   std::unordered_map<const ShadowNodeFamily*, int> childrenCount;
 
-  for (auto family : families) {
+  for (const auto& family : families) {
     if (childrenCount.contains(family)) {
       continue;
     }

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -382,13 +382,9 @@ ShadowNode::Unshared ShadowNode::cloneMultipleRecursive(
   auto shouldUpdateChildren = false;
   std::optional<ShadowNode::ListOfShared> newChildren;
 
-  for (int i = 0; i < children.size(); i++) {
-    if (!count) {
-      break;
-    }
-
+  for (int i = 0; count > 0 && i < children.size(); i++) {
     auto childFamily = &children[i]->getFamily();
-    if (childrenCount.contains(childFamily) || families.contains(childFamily)) {
+    if (childrenCount.contains(childFamily)) {
       count--;
       shouldUpdateChildren = true;
       children[i] = cloneMultipleRecursive(
@@ -424,12 +420,18 @@ ShadowNode::Unshared ShadowNode::cloneMultiple(
       continue;
     }
 
+    childrenCount[family] = 0;
+
     auto ancestor = family;
     while ((ancestor != nullptr) && ancestor != this->family_.get()) {
       ancestor = ancestor->parent_.lock().get();
-      if (childrenCount[ancestor]++) {
+      auto ancestorIt = childrenCount.find(ancestor);
+      if (ancestorIt != childrenCount.end()) {
+        ancestorIt->second++;
         break;
       }
+
+      childrenCount[ancestor] = 1;
     }
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -378,7 +378,7 @@ ShadowNode::Unshared ShadowNode::cloneMultipleRecursive(
     const {
   auto children = shadowNode.getChildren();
   auto family = &shadowNode.getFamily();
-  auto count = childrenCount[family];
+  auto count = childrenCount.at(family);
   auto shouldUpdateChildren = false;
   std::optional<ShadowNode::ListOfShared> newChildren;
 

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
@@ -109,13 +109,13 @@ class ShadowNode : public Sealable,
 
   /*
    * Clones the nodes (and the subtree containing all the nodes) by
-   * replacing the `oldShadowNode` for every `shadowNodeFamily` from `families`
+   * replacing the `oldShadowNode` for every `shadowNodeFamily` from `familiesToUpdate`
    * with a node that `callback` returns.
    *
    * Returns `nullptr` if the operation cannot be performed successfully.
    */
   Unshared cloneMultiple(
-      const std::unordered_set<const ShadowNodeFamily*>& families,
+      const std::unordered_set<const ShadowNodeFamily*>& familiesToUpdate,
       const std::function<Unshared(
           const ShadowNode& oldShadowNode,
           const std::optional<ShadowNode::ListOfShared>& newChildren)>&
@@ -268,7 +268,7 @@ class ShadowNode : public Sealable,
 
   Unshared cloneMultipleRecursive(
       const ShadowNode& shadowNode,
-      const std::unordered_set<const ShadowNodeFamily*>& families,
+      const std::unordered_set<const ShadowNodeFamily*>& familiesToUpdate,
       const std::unordered_map<const ShadowNodeFamily*, int>& childrenCount,
       const std::function<Unshared(
           const ShadowNode& oldShadowNode,

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
@@ -107,15 +107,13 @@ class ShadowNode : public Sealable,
       const std::function<Unshared(const ShadowNode& oldShadowNode)>& callback)
       const;
 
-  Unshared cloneMultipleRecursive(
-      const ShadowNode& shadowNode,
-      const std::unordered_set<const ShadowNodeFamily*>& families,
-      const std::unordered_map<const ShadowNodeFamily*, int>& childrenCount,
-      const std::function<Unshared(
-          const ShadowNode& oldShadowNode,
-          const std::optional<ShadowNode::ListOfShared>& newChildren)>&
-          callback) const;
-
+  /*
+   * Clones the nodes (and the subtree containing all the nodes) by
+   * replacing the `oldShadowNode` for every `shadowNodeFamily` from `families`
+   * with a node that `callback` returns.
+   *
+   * Returns `nullptr` if the operation cannot be performed successfully.
+   */
   Unshared cloneMultiple(
       const std::unordered_set<const ShadowNodeFamily*>& families,
       const std::function<Unshared(
@@ -267,6 +265,15 @@ class ShadowNode : public Sealable,
   static Props::Shared propsForClonedShadowNode(
       const ShadowNode& sourceShadowNode,
       const Props::Shared& props);
+
+  Unshared cloneMultipleRecursive(
+      const ShadowNode& shadowNode,
+      const std::unordered_set<const ShadowNodeFamily*>& families,
+      const std::unordered_map<const ShadowNodeFamily*, int>& childrenCount,
+      const std::function<Unshared(
+          const ShadowNode& oldShadowNode,
+          const std::optional<ShadowNode::ListOfShared>& newChildren)>&
+          callback) const;
 
  protected:
   /*

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
@@ -118,7 +118,7 @@ class ShadowNode : public Sealable,
       const std::unordered_set<const ShadowNodeFamily*>& familiesToUpdate,
       const std::function<Unshared(
           const ShadowNode& oldShadowNode,
-          const std::optional<ShadowNode::ListOfShared>& newChildren)>&
+          const ShadowNodeFragment& fragment)>&
           callback) const;
 
 #pragma mark - Getters
@@ -272,7 +272,7 @@ class ShadowNode : public Sealable,
       const std::unordered_map<const ShadowNodeFamily*, int>& childrenCount,
       const std::function<Unshared(
           const ShadowNode& oldShadowNode,
-          const std::optional<ShadowNode::ListOfShared>& newChildren)>&
+          const ShadowNodeFragment& fragment)>&
           callback) const;
 
  protected:

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
@@ -107,6 +107,22 @@ class ShadowNode : public Sealable,
       const std::function<Unshared(const ShadowNode& oldShadowNode)>& callback)
       const;
 
+  Unshared cloneMultipleRecursive(
+      const ShadowNode& shadowNode,
+      const std::unordered_set<const ShadowNodeFamily*>& families,
+      const std::unordered_map<const ShadowNodeFamily*, int>& childrenCount,
+      const std::function<Unshared(
+          const ShadowNode& oldShadowNode,
+          const std::optional<ShadowNode::ListOfShared>& newChildren)>&
+          callback) const;
+
+  Unshared cloneMultiple(
+      const std::unordered_set<const ShadowNodeFamily*>& families,
+      const std::function<Unshared(
+          const ShadowNode& oldShadowNode,
+          const std::optional<ShadowNode::ListOfShared>& newChildren)>&
+          callback) const;
+
 #pragma mark - Getters
 
   ComponentName getComponentName() const;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

This PR adds a new cloning method, allowing for updating multiple nodes in a single transaction. It works in two phases:
1. Find which nodes have to be cloned (i.e. nodes given on input and all their ancestors) 
2. Clone nodes in the bottom up order - so that every node is cloned exactly once

So the idea is that when we want to update all the red nodes in this picture, we first find the nodes in the green area and the clone only them in the correct order (children are cloned before parents):
![Screenshot 2025-04-10 at 14 31 14](https://github.com/user-attachments/assets/f397eeff-8279-4d0c-bf87-083bfb44b86a)

Adapting this method [brought a huge performance gain to reanimated](https://github.com/software-mansion/react-native-reanimated/pull/6214). I want to upstream it, so that:
1. we can optimize it further, because making it a part of the `ShadowNode` class gives us access to the parent field in `ShadowNodeFamily` so we can traverse the tree upwards, allowing for a optimal implementation of the first phase (in reanimated we repeatedly call `getAncestors`, which revisits some nodes multiple times) 
2. the community can use it

A naive approach that calls `cloneTree` for every node is much slower, as it has to repeat many operations.
## Changelog:

[GENERAL] [ADDED] - Added `cloneMultiple` to `ShadowNode` class.

## Test Plan:

I tested it with the following reanimated implementation and everything works fine:

<details>

```c++
const auto callback =
      [&](const ShadowNode &shadowNode,
          const std::optional<ShadowNode::ListOfShared> &newChildren) {
        return shadowNode.clone(
            {mergeProps(shadowNode, propsMap, shadowNode.getFamily()),
             newChildren
                 ? std::make_shared<ShadowNode::ListOfShared>(*newChildren)
                 : ShadowNodeFragment::childrenPlaceholder(),
             shadowNode.getState()});
      };
  return std::static_pointer_cast<RootShadowNode>(
      oldRootNode.cloneMultiple(families, callback));

```

</details>

I would like to add tests for it, but I'm not sure what's the best approach for that in the repo.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
