### PR TITLE
Downgrade markdownlint-rule-relative-links to v3 to avoid yarn errors with incompatible engines

### DIFF
--- a/.github/actions/yarn-install/action.yml
+++ b/.github/actions/yarn-install/action.yml
@@ -9,7 +9,7 @@ runs:
         ATTEMPT=0
         WAIT_TIME=20
         while [ $ATTEMPT -lt $MAX_ATTEMPTS ]; do
-            yarn install --non-interactive --frozen-lockfile --ignore-engines && break
+            yarn install --non-interactive --frozen-lockfile && break
             echo "yarn install failed. Retrying in $WAIT_TIME seconds..."
             sleep $WAIT_TIME
             ATTEMPT=$((ATTEMPT + 1))

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "jest-junit": "^10.0.0",
     "jest-snapshot": "^29.7.0",
     "markdownlint-cli2": "^0.17.2",
-    "markdownlint-rule-relative-links": "^4.0.1",
+    "markdownlint-rule-relative-links": "^3.0.0",
     "metro-babel-register": "^0.82.0",
     "metro-memory-fs": "^0.82.0",
     "metro-transform-plugins": "^0.82.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6347,10 +6347,10 @@ markdownlint-cli2@^0.17.2:
     markdownlint-cli2-formatter-default "0.0.5"
     micromatch "4.0.8"
 
-markdownlint-rule-relative-links@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/markdownlint-rule-relative-links/-/markdownlint-rule-relative-links-4.0.1.tgz#3db474bcb4b5c9b6cf7d7095103428ff36e3e3f2"
-  integrity sha512-tLr8YVR1qeZfMsixFtj49N0ABrPZpTFqk0cz6+j4zB9ZIJ9diiQ7f+npykTeGYvPUVkf5Zw8y4U0JDGGsU+zKQ==
+markdownlint-rule-relative-links@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/markdownlint-rule-relative-links/-/markdownlint-rule-relative-links-3.0.0.tgz#e4de472298f3859c51ea3e421350cf7649bbef12"
+  integrity sha512-+Ek2J8kXKtL8IcjmPYBsxtS37etKIbPE85aj/ehwSlxcWIlT0BCsA/SPHZlIICiZON786XVrLStMCJ1x25D3oA==
   dependencies:
     markdown-it "14.1.0"
 


### PR DESCRIPTION
Summary:
Changelog: [internal]

This fixes yarn install errors coming from repositories other than `react-native` where `--ignore-engines` isn't specified. This was caused by `markdownlint-rule-relative-links` requiring Node.js >= v22 when we're using v20 in most cases.

Fixes https://github.com/react-native-community/docker-android/actions/runs/14380730414/job/40323632337?pr=234

Differential Revision: D72789007


