### PR TITLE
Define continuous and idle priority for raw events and expose them to React via nativeFabricUIManager

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
@@ -10,7 +10,6 @@
 #include "AndroidEventBeat.h"
 #include "ComponentFactory.h"
 #include "EventBeatManager.h"
-#include "EventEmitterWrapper.h"
 #include "FabricMountingManager.h"
 
 #include <cxxreact/TraceSection.h>

--- a/packages/react-native/ReactCommon/react/renderer/core/EventQueueProcessor.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventQueueProcessor.cpp
@@ -55,6 +55,8 @@ void EventQueueProcessor::flushEvents(
             return ReactEventPriority::Discrete;
           case RawEvent::Category::Continuous:
             return ReactEventPriority::Continuous;
+          case RawEvent::Category::Idle:
+            return ReactEventPriority::Idle;
           case RawEvent::Category::Unspecified:
             return hasContinuousEventStarted_ ? ReactEventPriority::Continuous
                                               : ReactEventPriority::Default;

--- a/packages/react-native/ReactCommon/react/renderer/core/RawEvent.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawEvent.h
@@ -56,7 +56,13 @@ struct RawEvent {
      * Forces continuous type for the event. Regardless if continuous event
      * isn't ongoing.
      */
-    Continuous = 4
+    Continuous = 4,
+
+    /*
+     * Priority for events that can be processed in idle times or in the
+     * background.
+     */
+    Idle = 5,
   };
 
   RawEvent(

--- a/packages/react-native/ReactCommon/react/renderer/core/ReactEventPriority.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ReactEventPriority.h
@@ -30,6 +30,11 @@ enum class ReactEventPriority {
    * scrolling.
    */
   Continuous,
+
+  /*
+   * Other events that can be processed in the background.
+   */
+  Idle,
 };
 
 static constexpr std::underlying_type<ReactEventPriority>::type serialize(

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
@@ -747,6 +747,14 @@ jsi::Value UIManagerBinding::get(
     return {serialize(ReactEventPriority::Discrete)};
   }
 
+  if (methodName == "unstable_ContinuousEventPriority") {
+    return {serialize(ReactEventPriority::Continuous)};
+  }
+
+  if (methodName == "unstable_IdleEventPriority") {
+    return {serialize(ReactEventPriority::Idle)};
+  }
+
   if (methodName == "findShadowNodeByTag_DEPRECATED") {
     auto paramCount = 1;
     return jsi::Function::createFromHostFunction(


### PR DESCRIPTION
Summary:
Changelog: [internal]

This defines 2 new priorities in Fabric, matching the definitions in React:
* Continuous
* Idle

They're exposed to React via 2 new properties in `nativeFabricUIManager`: `unstable_ContinuousEventPriority` and `unstable_IdleEventPriority`.

It also adds the mapping from the raw event priorities to the Fabric event priorities.

This change doesn't have any effect at the moment. For these to come into effect, we need to:
1. Fix the mapping between Fabric priorities and React priorities in the React repository. See 
2. Enable the `fixMappingOfEventPrioritiesBetweenFabricAndReact` feature flag.

Differential Revision: D72791968


