### PR TITLE
Animated: Ship `avoidAnimatedRefInvalidation`

### DIFF
--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -518,17 +518,6 @@ const definitions: FeatureFlagDefinitions = {
       },
       ossReleaseStage: 'none',
     },
-    avoidAnimatedRefInvalidation: {
-      defaultValue: false,
-      metadata: {
-        dateAdded: '2025-03-12',
-        description:
-          'Changes `useAnimatedProps` to avoid invalidating the callback ref whenever `props` changes.',
-        expectedReleaseValue: true,
-        purpose: 'experimentation',
-      },
-      ossReleaseStage: 'none',
-    },
     avoidStateUpdateInAnimatedPropsMemo: {
       defaultValue: false,
       metadata: {

--- a/packages/react-native/src/private/animated/__tests__/createAnimatedPropsHook-test.js
+++ b/packages/react-native/src/private/animated/__tests__/createAnimatedPropsHook-test.js
@@ -38,36 +38,8 @@ describe('useAnimatedProps', () => {
     jest.resetModules();
   });
 
-  it('returns a new ref callback when `props` changes', async () => {
-    const {createAnimatedPropsHook} = importModules({
-      avoidAnimatedRefInvalidation: () => false,
-    });
-    const useAnimatedProps = createAnimatedPropsHook(null);
-
-    const refs = [];
-    function Sentinel(props: {[string]: mixed}): React.Node {
-      const [, ref] = useAnimatedProps<{[string]: mixed}, mixed>(props);
-      useLayoutEffect(() => {
-        refs.push(ref);
-      }, [ref]);
-      return null;
-    }
-
-    const root = await create(<Sentinel foo={1} />);
-    expect(refs.length).toBe(1);
-    expect(refs[0]).toBeInstanceOf(Function);
-
-    await update(root, <Sentinel foo={2} />);
-    expect(refs.length).toBe(2);
-    expect(refs[1]).toBeInstanceOf(Function);
-
-    expect(refs[0]).not.toBe(refs[1]);
-  });
-
   it('returns the same ref callback when `props` changes', async () => {
-    const {createAnimatedPropsHook} = importModules({
-      avoidAnimatedRefInvalidation: () => true,
-    });
+    const {createAnimatedPropsHook} = importModules({});
     const useAnimatedProps = createAnimatedPropsHook(null);
 
     const refs = [];
@@ -88,9 +60,7 @@ describe('useAnimatedProps', () => {
   });
 
   it('returns the same ref callback when `AnimatedEvent` is the same', async () => {
-    const {AnimatedEvent, createAnimatedPropsHook} = importModules({
-      avoidAnimatedRefInvalidation: () => true,
-    });
+    const {AnimatedEvent, createAnimatedPropsHook} = importModules({});
     const useAnimatedProps = createAnimatedPropsHook(null);
 
     const refs = [];
@@ -113,9 +83,7 @@ describe('useAnimatedProps', () => {
   });
 
   it('returns a new ref callback when `AnimatedEvent` changes', async () => {
-    const {AnimatedEvent, createAnimatedPropsHook} = importModules({
-      avoidAnimatedRefInvalidation: () => true,
-    });
+    const {AnimatedEvent, createAnimatedPropsHook} = importModules({});
     const useAnimatedProps = createAnimatedPropsHook(null);
 
     const refs = [];

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<4da4c4feadaf11301733bbaa0c7fd3ee>>
+ * @generated SignedSource<<698f8a486eeea1daca9e0f74dcdc2140>>
  * @flow strict
  */
 
@@ -30,7 +30,6 @@ export type ReactNativeFeatureFlagsJsOnly = $ReadOnly<{
   jsOnlyTestFlag: Getter<boolean>,
   animatedShouldDebounceQueueFlush: Getter<boolean>,
   animatedShouldUseSingleOp: Getter<boolean>,
-  avoidAnimatedRefInvalidation: Getter<boolean>,
   avoidStateUpdateInAnimatedPropsMemo: Getter<boolean>,
   disableInteractionManager: Getter<boolean>,
   enableAccessToHostTreeInFabric: Getter<boolean>,
@@ -105,11 +104,6 @@ export const animatedShouldDebounceQueueFlush: Getter<boolean> = createJavaScrip
  * Enables an experimental mega-operation for Animated.js that replaces many calls to native with a single call into native, to reduce JSI/JNI traffic.
  */
 export const animatedShouldUseSingleOp: Getter<boolean> = createJavaScriptFlagGetter('animatedShouldUseSingleOp', false);
-
-/**
- * Changes `useAnimatedProps` to avoid invalidating the callback ref whenever `props` changes.
- */
-export const avoidAnimatedRefInvalidation: Getter<boolean> = createJavaScriptFlagGetter('avoidAnimatedRefInvalidation', false);
 
 /**
  * Changes `useAnimatedPropsMemo` to avoid state updates to invalidate the cached `AnimatedProps`.


### PR DESCRIPTION
Summary:
Ships the feature flag introduced by https://github.com/facebook/react-native/pull/50002.

Changelog:
[General][Changed] - Animated components' `ref` will now only reattach when receiving new props if the new props contain different `AnimatedValue` or `AnimatedEvent` instances. (Previously, Animated components' `ref` would always reattach when receiving new props.)

Differential Revision: D72802613
