### PR TITLE
Generate RCTThirdPartyComponents.mm with platform-specific macros

### DIFF
--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/__tests__/generateRCTThirdPartyComponents-test.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/__tests__/generateRCTThirdPartyComponents-test.js
@@ -1,0 +1,341 @@
+const { _generateComponentRegistry } = require('../generateRCTThirdPartyComponents');
+
+describe('_generateComponentRegistry', () => {
+  it('returns an empty string when componentsInLibraries is undefined', () => {
+    const componentsInLibraries = undefined;
+    const componentsSupportedApplePlatforms = {};
+    const result = _generateComponentRegistry(componentsInLibraries, componentsSupportedApplePlatforms);
+    expect(result).toEqual("");
+  });
+
+  it('returns an empty string when componentsInLibraries is null', () => {
+    const componentsInLibraries = null;
+    const componentsSupportedApplePlatforms = {};
+    const result = _generateComponentRegistry(componentsInLibraries, componentsSupportedApplePlatforms);
+    expect(result).toEqual("");
+  });
+
+  it('returns an empty string when componentsInLibraries is an empty object', () => {
+    const componentsInLibraries = {};
+    const componentsSupportedApplePlatforms = {};
+    const result = _generateComponentRegistry(componentsInLibraries, componentsSupportedApplePlatforms);
+    expect(result).toEqual("");
+  });
+
+  it('returns an empty string when both componentsInLibraries and componentsSupportedApplePlatforms are empty', () => {
+    const componentsInLibraries = {};
+    const componentsSupportedApplePlatforms = {};
+    const result = _generateComponentRegistry(componentsInLibraries, componentsSupportedApplePlatforms);
+    expect(result).toEqual("");
+  });
+
+  it('returns an empty string when componentsInLibraries contains an empty array for a library', () => {
+    const componentsInLibraries = {
+      "my-library": [],
+    };
+    const componentsSupportedApplePlatforms = {};
+    const result = _generateComponentRegistry(componentsInLibraries, componentsSupportedApplePlatforms);
+    expect(result).toEqual("");
+  });
+
+  it('returns a string for a single component in a library', () => {
+    const componentsInLibraries = {
+      "my-library": [
+        {
+          componentName: 'MyComponent',
+          className: 'MyComponentClass',
+        },
+      ],
+    };
+    const componentsSupportedApplePlatforms = {};
+    const result = _generateComponentRegistry(componentsInLibraries, componentsSupportedApplePlatforms);
+    expect(result).toEqual("		@\"MyComponent\": NSClassFromString(@\"MyComponentClass\"), // my-library");
+  });
+
+  it('returns a string for multiple components in a single library', () => {
+    const componentsInLibraries = {
+      "my-library": [
+        {
+          componentName: 'MyComponent',
+          className: 'MyComponentClass',
+        },
+        {
+          componentName: 'MyComponent2',
+          className: 'MyComponentClass2',
+        },
+      ],
+    };
+    const componentsSupportedApplePlatforms = {};
+    const result = _generateComponentRegistry(componentsInLibraries, componentsSupportedApplePlatforms);
+    expect(result).toEqual(
+      "		@\"MyComponent\": NSClassFromString(@\"MyComponentClass\"), // my-library\n" +
+      "		@\"MyComponent2\": NSClassFromString(@\"MyComponentClass2\"), // my-library"
+    );
+  });
+
+  it('returns a string for components in multiple libraries', () => {
+    const componentsInLibraries = {
+      "my-library": [
+        {
+          componentName: 'MyComponent',
+          className: 'MyComponentClass',
+        },
+      ],
+      "my-library2": [
+        {
+          componentName: 'MyComponent2',
+          className: 'MyComponentClass2',
+        },
+      ],
+    };
+    const componentsSupportedApplePlatforms = {};
+    const result = _generateComponentRegistry(componentsInLibraries, componentsSupportedApplePlatforms);
+    expect(result).toEqual(
+      "		@\"MyComponent\": NSClassFromString(@\"MyComponentClass\"), // my-library\n" +
+      "		@\"MyComponent2\": NSClassFromString(@\"MyComponentClass2\"), // my-library2"
+    );
+  });
+
+  it('returns a string for a single library when another library is empty', () => {
+    const componentsInLibraries = {
+      "my-library": [
+        {
+          componentName: 'MyComponent',
+          className: 'MyComponentClass',
+        },
+      ],
+      "my-library2": [],
+    };
+    const componentsSupportedApplePlatforms = {};
+    const result = _generateComponentRegistry(componentsInLibraries, componentsSupportedApplePlatforms);
+    expect(result).toEqual(
+      "		@\"MyComponent\": NSClassFromString(@\"MyComponentClass\"), // my-library"
+    );
+  });
+
+  it('returns a string with platform-specific macros for a single library', () => {
+    const componentsInLibraries = {
+      "my-library": [
+        {
+          componentName: 'MyComponent',
+          className: 'MyComponentClass',
+        },
+      ],
+    };
+    const componentsSupportedApplePlatforms = {
+      "my-library": {
+        ios: true,
+        tvos: false,
+        macos: false,
+        visionos: false,
+      },
+    };
+    const result = _generateComponentRegistry(componentsInLibraries, componentsSupportedApplePlatforms);
+    expect(result).toEqual(
+      "#if !TARGET_OS_TV && !TARGET_OS_OSX && !TARGET_OS_VISION\n" +
+      "		@\"MyComponent\": NSClassFromString(@\"MyComponentClass\"), // my-library\n" +
+      "#endif"
+    );
+  });
+
+  it('returns a string with platform-specific macros for multiple components in a library', () => {
+    const componentsInLibraries = {
+      "my-library": [
+        {
+          componentName: 'MyComponent',
+          className: 'MyComponentClass',
+        },
+        {
+          componentName: 'MyComponent2',
+          className: 'MyComponentClass2',
+        },
+        {
+          componentName: 'MyComponent3',
+          className: 'MyComponentClass3',
+        },
+      ],
+    };
+    const componentsSupportedApplePlatforms = {
+      "my-library": {
+        ios: false,
+        tvos: true,
+        macos: false,
+        visionos: false,
+      },
+    };
+    const result = _generateComponentRegistry(componentsInLibraries, componentsSupportedApplePlatforms);
+    expect(result).toEqual(
+      "#if !TARGET_OS_IOS && !TARGET_OS_OSX && !TARGET_OS_VISION\n" +
+      "		@\"MyComponent\": NSClassFromString(@\"MyComponentClass\"), // my-library\n" +
+      "		@\"MyComponent2\": NSClassFromString(@\"MyComponentClass2\"), // my-library\n" +
+      "		@\"MyComponent3\": NSClassFromString(@\"MyComponentClass3\"), // my-library\n" +
+      "#endif"
+    );
+  });
+
+  it('returns a string with platform-specific macros sandwiched between components from multiple libraries', () => {
+    const componentsInLibraries = {
+      "my-library": [
+        {
+          componentName: 'MyComponent',
+          className: 'MyComponentClass',
+        },
+      ],
+      "my-library2": [
+        {
+          componentName: 'MyComponent2',
+          className: 'MyComponentClass2',
+        },
+        {
+          componentName: 'MyComponent3',
+          className: 'MyComponentClass3',
+        },
+      ],
+      "my-library3": [
+        {
+          componentName: 'MyComponent4',
+          className: 'MyComponentClass4',
+        },
+      ],
+    };
+    const componentsSupportedApplePlatforms = {
+      "my-library2": {
+        ios: false,
+        tvos: true,
+        macos: true,
+        visionos: true,
+      },
+    };
+    const result = _generateComponentRegistry(componentsInLibraries, componentsSupportedApplePlatforms);
+    expect(result).toEqual(
+      "		@\"MyComponent\": NSClassFromString(@\"MyComponentClass\"), // my-library\n" +
+      "#if !TARGET_OS_IOS\n" +
+      "		@\"MyComponent2\": NSClassFromString(@\"MyComponentClass2\"), // my-library2\n" +
+      "		@\"MyComponent3\": NSClassFromString(@\"MyComponentClass3\"), // my-library2\n" +
+      "#endif\n" +
+      "		@\"MyComponent4\": NSClassFromString(@\"MyComponentClass4\"), // my-library3"
+    );
+  });
+
+  it('returns a string when componentsSupportedApplePlatforms is undefined', () => {
+    const componentsInLibraries = {
+      "my-library": [
+        {
+          componentName: 'MyComponent',
+          className: 'MyComponentClass',
+        },
+      ],
+    };
+    const componentsSupportedApplePlatforms = undefined;
+    const result = _generateComponentRegistry(componentsInLibraries, componentsSupportedApplePlatforms);
+    expect(result).toEqual("		@\"MyComponent\": NSClassFromString(@\"MyComponentClass\"), // my-library");
+  });
+
+  it('returns a string when componentsSupportedApplePlatforms is null', () => {
+    const componentsInLibraries = {
+      "my-library": [
+        {
+          componentName: 'MyComponent',
+          className: 'MyComponentClass',
+        },
+      ],
+    };
+    const componentsSupportedApplePlatforms = null;
+    const result = _generateComponentRegistry(componentsInLibraries, componentsSupportedApplePlatforms);
+    expect(result).toEqual("		@\"MyComponent\": NSClassFromString(@\"MyComponentClass\"), // my-library");
+  });
+
+  it('handles a library with mixed valid and invalid components', () => {
+    const componentsInLibraries = {
+      "my-library": [
+        {
+          componentName: 'ValidComponent',
+          className: 'ValidComponentClass',
+        },
+        {
+          componentName: null, // Invalid component
+          className: 'InvalidComponentClass',
+        },
+      ],
+    };
+    const componentsSupportedApplePlatforms = {};
+    const result = _generateComponentRegistry(componentsInLibraries, componentsSupportedApplePlatforms);
+    expect(result).toEqual(
+      "		@\"ValidComponent\": NSClassFromString(@\"ValidComponentClass\"), // my-library"
+    );
+  });
+
+  it('handles a library with no className for a component', () => {
+    const componentsInLibraries = {
+      "my-library": [
+        {
+          componentName: 'ComponentWithoutClass',
+          className: null,
+        },
+      ],
+    };
+    const componentsSupportedApplePlatforms = {};
+    const result = _generateComponentRegistry(componentsInLibraries, componentsSupportedApplePlatforms);
+    expect(result).toEqual("");
+  });
+
+  it('handles platform-specific macros when all platforms are true', () => {
+    const componentsInLibraries = {
+      "my-library": [
+        {
+          componentName: 'MyComponent',
+          className: 'MyComponentClass',
+        },
+      ],
+    };
+    const componentsSupportedApplePlatforms = {
+      "my-library": {
+        ios: true,
+        tvos: true,
+        macos: true,
+        visionos: true,
+      },
+    };
+    const result = _generateComponentRegistry(componentsInLibraries, componentsSupportedApplePlatforms);
+    expect(result).toEqual(
+      "		@\"MyComponent\": NSClassFromString(@\"MyComponentClass\"), // my-library"
+    );
+  });
+
+  it('handles a library with components having special characters in names', () => {
+    const componentsInLibraries = {
+      "my-library": [
+        {
+          componentName: 'My-Component',
+          className: 'MyComponentClass',
+        },
+        {
+          componentName: 'My_Component',
+          className: 'MyComponentClass2',
+        },
+      ],
+    };
+    const componentsSupportedApplePlatforms = {};
+    const result = _generateComponentRegistry(componentsInLibraries, componentsSupportedApplePlatforms);
+    expect(result).toEqual(
+      "		@\"My-Component\": NSClassFromString(@\"MyComponentClass\"), // my-library\n" +
+      "		@\"My_Component\": NSClassFromString(@\"MyComponentClass2\"), // my-library"
+    );
+  });
+
+  it('handles a library with components having numeric names', () => {
+    const componentsInLibraries = {
+      "my-library": [
+        {
+          componentName: 'Component123',
+          className: 'ComponentClass123',
+        },
+      ],
+    };
+    const componentsSupportedApplePlatforms = {};
+    const result = _generateComponentRegistry(componentsInLibraries, componentsSupportedApplePlatforms);
+    expect(result).toEqual(
+      "		@\"Component123\": NSClassFromString(@\"ComponentClass123\"), // my-library"
+    );
+  });
+});

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/generateRCTThirdPartyComponents.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/generateRCTThirdPartyComponents.js
@@ -15,6 +15,9 @@ const {
   isReactNativeCoreLibrary,
   parseiOSAnnotations,
 } = require('./utils');
+const {
+  generateSupportedApplePlatformsMacro,
+} = require('@react-native/codegen/lib/generators/components/ComponentsProviderUtils');
 const fs = require('fs');
 const path = require('path');
 
@@ -28,7 +31,11 @@ const THIRD_PARTY_COMPONENTS_MM_TEMPLATE_PATH = path.join(
   'RCTThirdPartyComponentsProviderMM.template',
 );
 
-function generateRCTThirdPartyComponents(libraries, outputDir) {
+function generateRCTThirdPartyComponents(
+  libraries,
+  librariesSupportedApplePlatforms,
+  outputDir,
+) {
   fs.mkdirSync(outputDir, {recursive: true});
   // Generate Header File
   codegenLog('Generating RCTThirdPartyComponentsProvider.h');
@@ -42,6 +49,7 @@ function generateRCTThirdPartyComponents(libraries, outputDir) {
 
   codegenLog('Generating RCTThirdPartyComponentsProvider.mm');
   let componentsInLibraries = {};
+  let componentsSupportedApplePlatforms = {};
 
   const componentLibraries = libraries.filter(({config, libraryPath}) => {
     if (isReactNativeCoreLibrary(config.name) || config.type === 'modules') {
@@ -58,6 +66,9 @@ function generateRCTThirdPartyComponents(libraries, outputDir) {
     const libraryName = JSON.parse(
       fs.readFileSync(path.join(libraryPath, 'package.json')),
     ).name;
+
+    componentsSupportedApplePlatforms[libraryName] =
+      librariesSupportedApplePlatforms[config.name];
 
     librariesToCrawl[libraryName] = library;
 
@@ -118,14 +129,8 @@ function generateRCTThirdPartyComponents(libraries, outputDir) {
     componentsInLibraries[libraryName] = componentsMapping;
   });
 
-  const thirdPartyComponentsMapping = Object.keys(componentsInLibraries)
-    .flatMap(library => {
-      const components = componentsInLibraries[library];
-      return components.map(({componentName, className}) => {
-        return `\t\t@"${componentName}": NSClassFromString(@"${className}"), // ${library}`;
-      });
-    })
-    .join('\n');
+  const thirdPartyComponentsMapping = _generateComponentRegistry(componentsInLibraries, componentsSupportedApplePlatforms);
+
   // Generate implementation file
   const templateMM = fs
     .readFileSync(THIRD_PARTY_COMPONENTS_MM_TEMPLATE_PATH, 'utf8')
@@ -206,6 +211,44 @@ function findRCTComponentViewProtocolClass(filepath) {
   return null;
 }
 
+function _generateComponentRegistry(libraryComponentsMap, platformSupportByLibrary) {
+  if (!libraryComponentsMap || Object.keys(libraryComponentsMap).length === 0) {
+    return '';
+  }
+
+  const generatedComponentMappings = Object.keys(libraryComponentsMap)
+    .flatMap(library => {
+      const components = libraryComponentsMap[library];
+
+      const componentMappings = components.map(
+        ({ componentName, className }) => {
+          if (!className || !componentName) {
+            return null;
+          }
+
+          return `\t\t@"${componentName}": NSClassFromString(@"${className}"), // ${library}`;
+        },
+      ).filter(item => item !== null);
+
+      if (componentMappings.length === 0) {
+        return [];
+      }
+
+      return generateSupportedApplePlatformsMacro(
+        componentMappings.join('\n'),
+        platformSupportByLibrary?.[library]
+      );
+    });
+
+  const sanitizedComponentMappings = generatedComponentMappings
+    .map(line => line.replace(/[\r\n]+$/, ''))
+    .filter(line => line.length > 0);
+
+  return sanitizedComponentMappings.join('\n');
+}
+
 module.exports = {
   generateRCTThirdPartyComponents,
+  // exported for testing purposes only:
+  _generateComponentRegistry,
 };

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/index.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/index.js
@@ -101,6 +101,7 @@ function execute(
         platform,
       );
 
+      let librariesSupportedApplePlatforms = {};
       if (runReactNativeCodegen) {
         const schemaInfos = generateSchemaInfos(libraries);
         generateNativeCode(
@@ -111,11 +112,23 @@ function execute(
           pkgJsonIncludesGeneratedCode(pkgJson),
           platform,
         );
+
+        librariesSupportedApplePlatforms = schemaInfos.reduce(
+          (acc, {library, supportedApplePlatforms}) => {
+            acc[library.config.name] = supportedApplePlatforms;
+            return acc;
+          },
+          {},
+        );
       }
 
       if (source === 'app') {
         // These components are only required by apps, not by libraries
-        generateRCTThirdPartyComponents(libraries, outputPath);
+        generateRCTThirdPartyComponents(
+          libraries,
+          librariesSupportedApplePlatforms,
+          outputPath,
+        );
         generateRCTModuleProviders(projectRoot, pkgJson, libraries, outputPath);
         generateCustomURLHandlers(libraries, outputPath);
         generateUnstableModulesRequiringMainQueueSetupProvider(


### PR DESCRIPTION
## Summary:

iOS crashes in the **New Architecture** because Codegen includes all installed packages — even ones that don’t support iOS. The **Legacy Architecture** uses a different code generator that doesn’t have this issue. In both architectures, CocoaPods correctly excludes platform-specific native code — but Codegen doesn’t respect those exclusions in the New Architecture.

To prevent this, a macro was originally introduced to guard Objective-C code in generated components:
→ facebook/react-native#42047

However, that macro usage was inadvertently lost during a later refactor that moved the Codegen provider to a static template:
→ facebook/react-native#47518

This PR restores those platform guard macros in `RCTThirdPartyComponentsProvider`, ensuring that unsupported packages do not cause runtime crashes on iOS:

```diff
		@"RNSVGTextPath": NSClassFromString(@"RNSVGTextPath"), // react-native-svg
+ #if !TARGET_OS_IOS && !TARGET_OS_TV && !TARGET_OS_VISION
		@"MacOSClass": NSClassFromString(@"MacOSClass"), // test-library-macos
+ #endif
+ #if !TARGET_OS_IOS && !TARGET_OS_OSX && !TARGET_OS_VISION
		@"TvOSClass": NSClassFromString(@"TvOSClass"), // test-library-tvos
+ #endif
#if !TARGET_OS_IOS && !TARGET_OS_OSX && !TARGET_OS_TV
		@"VisionOSClass": NSClassFromString(@"VisionOSClass"), // test-library-visionos
+ #endif
+ #if !TARGET_OS_TV
		@"RNCWebView": NSClassFromString(@"RNCWebView"), // react-native-webview
+ #endif
    };
  });

  return thirdPartyComponents;
}
```

This issue was initially reported in [react-native-tvos#889](https://github.com/react-native-tvos/react-native-tvos/issues/889), where a developer's iOS app crashed after including a tvOS-only package. CocoaPods correctly excluded the code, but Codegen still attempted to register the component at runtime.

## Changelog:

[iOS] [Fixed] - Reintroduce platform guard macros in RCTThirdPartyComponentsProvider to prevent crashes when including platform-specific packages in OOT apps.

## Test Plan:
[MyApp](https://github.com/cgoldsby/RN-889) contains several React Native packages that do not support iOS. When running on an iOS device, the app crashes.

### Reproduce the steps for crash:

```shell
gh repo clone cgoldsby/RN-889
yarn
yarn ios -i
```

❌ MyApp launches and crashes immediately.

### Apply patch to fix:

```shell
git apply patches/*
yarn ios -i
```

✅ MyApp launches and does not crash.

## Related Issues:

facebook/react-native#42047 (Macro introduced)

facebook/react-native#47518 (Regression)

react-native-tvos/react-native-tvos#889 (Original crash report)

https://github.com/cgoldsby/RNTV-889 (RVTV example)