### PR TITLE
[RN][iOS] Do not generate ReactCodegen.podspec for libraries

### DIFF
--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -1087,13 +1087,13 @@ function execute(projectRoot, targetPlatform, baseOutputPath, source) {
         generateRCTModuleProviders(projectRoot, pkgJson, libraries, outputPath);
         generateCustomURLHandlers(libraries, outputPath);
         generateAppDependencyProvider(outputPath);
+        generateReactCodegenPodspec(
+          projectRoot,
+          pkgJson,
+          outputPath,
+          baseOutputPath,
+        );
       }
-      generateReactCodegenPodspec(
-        projectRoot,
-        pkgJson,
-        outputPath,
-        baseOutputPath,
-      );
 
       cleanupEmptyFilesAndFolders(outputPath);
     }


### PR DESCRIPTION
## Summary:

While we were refactoring the generation of the podspec, we made a mistake and we started generating the `ReactCodegen.podspec` for both libraries and apps.

This must be generated only for apps.

## Changelog:
[iOS][Fixed] - Generate ReactCodegen.podspec only for apps.

## Test Plan:
GHA
