### PR TITLE
Disable default markdownlint rules to prevent conflicts with prettier

### DIFF
--- a/.markdownlint-cli2.mjs
+++ b/.markdownlint-cli2.mjs
@@ -11,6 +11,7 @@ import relativeLinksRule from 'markdownlint-rule-relative-links';
 
 const config = {
   config: {
+    default: false,
     'heading-increment': true,
     'no-reversed-links': true,
     'no-missing-space-atx': true,


### PR DESCRIPTION
Summary:
Changelog: [internal]

`markdownlint` failed on https://github.com/facebook/react-native/actions/runs/14400262967/job/40384250331?fbclid=IwZXh0bgNhZW0CMTEAAR51hcoM4zuGTG4SNbqas4z9X0FsIO8Y9DsCgxJepvD5qSdDezhhIV-uLTpn5w_aem_FF2OiYft3uMzK4xJrKGvuA because lines were too long, but that's already handled by Prettier and I thought that I had disabled that rule in the configuration/

It turns out you have to explicitly set `default: false` to actually disable the default rules and only use the options explicitly set in the config (which this does).

Differential Revision: D72855229


