### PR TITLE
Do not generate Apple specific files for Android

### DIFF
--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/index.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/index.js
@@ -113,8 +113,8 @@ function execute(
         );
       }
 
-      if (source === 'app') {
-        // These components are only required by apps, not by libraries
+      if (source === 'app' && platform !== 'android') {
+        // These components are only required by apps, not by libraries and are Apple specific.
         generateRCTThirdPartyComponents(libraries, outputPath);
         generateRCTModuleProviders(projectRoot, pkgJson, libraries, outputPath);
         generateCustomURLHandlers(libraries, outputPath);


### PR DESCRIPTION
Summary:
We realized that when calling
```
npx react-native-community/cli codegen --path . --platform all --outputPath /tmp/codegen
```

We were generating in the android folder some files that are Apple-specific.

With this change, we should stop generating the Apple specific files in Android.

## Changelog
[General][Fixed] - Do not generate Apple specific files for Android

Differential Revision: D72859336


