### PR TITLE
[RN][Codegen] Do not generate Apple specific file for Android

### DIFF
--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -1081,8 +1081,8 @@ function execute(projectRoot, targetPlatform, baseOutputPath, source) {
         platform,
       );
 
-      if (source === 'app') {
-        // These components are only required by apps, not by libraries
+      if (source === 'app' && platform !== 'android') {
+        // These components are only required by apps, not by libraries. They are also Apple specific.
         generateRCTThirdPartyComponents(libraries, outputPath);
         generateRCTModuleProviders(projectRoot, pkgJson, libraries, outputPath);
         generateCustomURLHandlers(libraries, outputPath);


### PR DESCRIPTION
## Summary:

We realized that when calling

npx react-native-community/cli codegen --path . --platform all --outputPath /tmp/codegen
We were generating in the android folder some files that are Apple-specific.

With this change, we should stop generating the Apple specific files in Android.

## Changelog:
[General][Fixed] - Do not generate Apple specific files for Android

## Test Plan:
| Before | After |
| ------ | ------|
|  <img width="441" alt="Screenshot_2025-04-11_at_13 30 09" src="https://github.com/user-attachments/assets/cfa873b3-bc84-414c-8308-972a1169dff9" /> |  <img width="471" alt="Screenshot 2025-04-11 at 13 44 16" src="https://github.com/user-attachments/assets/7a398b61-8faf-4810-a830-802be560a4d5" /> |