### PR TITLE
RN: Revert `Okio.buffer(…)` Change from D72632266

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.kt
@@ -318,7 +318,9 @@ public class DevServerHelper(
         if (!response.isSuccessful || response.body() == null) {
           return null
         }
-        Okio.sink(outputFile).use { output -> response.body()?.source()?.buffer()?.readAll(output) }
+        Okio.sink(outputFile).use { output ->
+          Okio.buffer(response.body()?.source()!!).readAll(output)
+        }
         return outputFile
       }
     } catch (e: Exception) {


### PR DESCRIPTION
Summary:
Fixes a bug that was introduced while migrating from Java to Kotlin.

Changelog:
[Android][Changed] - Fixed a bug with synchronously fetching resources from Metro.

Reviewed By: mdvacca

Differential Revision: D72878362


