### PR TITLE
Remove obsolete `@TargetApi` annotations for Lollipop (API 21)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.kt
@@ -30,7 +30,6 @@ import com.facebook.react.module.annotations.ReactModule
 @ReactModule(name = NativeAccessibilityInfoSpec.NAME)
 internal class AccessibilityInfoModule(context: ReactApplicationContext) :
     NativeAccessibilityInfoSpec(context), LifecycleEventListener {
-  @TargetApi(Build.VERSION_CODES.LOLLIPOP)
   private inner class ReactTouchExplorationStateChangeListener :
       AccessibilityManager.TouchExplorationStateChangeListener {
     override fun onTouchExplorationStateChanged(enabled: Boolean) {
@@ -41,7 +40,6 @@ internal class AccessibilityInfoModule(context: ReactApplicationContext) :
   // Android can listen for accessibility service enable with `accessibilityStateChange`, but
   // `accessibilityState` conflicts with React Native props and confuses developers. Therefore, the
   // name `accessibilityServiceChange` is used here instead.
-  @TargetApi(Build.VERSION_CODES.LOLLIPOP)
   private inner class ReactAccessibilityServiceChangeListener :
       AccessibilityManager.AccessibilityStateChangeListener {
     override fun onAccessibilityStateChanged(enabled: Boolean) {
@@ -101,7 +99,6 @@ internal class AccessibilityInfoModule(context: ReactApplicationContext) :
     grayscaleModeEnabled = isGrayscaleEnabledValue
   }
 
-  @get:TargetApi(Build.VERSION_CODES.LOLLIPOP)
   private val isReduceMotionEnabledValue: Boolean
     get() {
       // Disabling animations in developer settings will set the animation scale to "0.0"
@@ -114,7 +111,6 @@ internal class AccessibilityInfoModule(context: ReactApplicationContext) :
       return parsedValue == 0f
     }
 
-  @get:TargetApi(Build.VERSION_CODES.LOLLIPOP)
   private val isInvertColorsEnabledValue: Boolean
     get() {
       try {
@@ -125,7 +121,6 @@ internal class AccessibilityInfoModule(context: ReactApplicationContext) :
       }
     }
 
-  @get:TargetApi(Build.VERSION_CODES.LOLLIPOP)
   private val isGrayscaleEnabledValue: Boolean
     get() {
       try {
@@ -140,7 +135,6 @@ internal class AccessibilityInfoModule(context: ReactApplicationContext) :
       }
     }
 
-  @get:TargetApi(Build.VERSION_CODES.LOLLIPOP)
   private val isHighTextContrastEnabledValue: Boolean
     get() {
       return Settings.Secure.getInt(
@@ -243,7 +237,6 @@ internal class AccessibilityInfoModule(context: ReactApplicationContext) :
     }
   }
 
-  @TargetApi(Build.VERSION_CODES.LOLLIPOP)
   override fun onHostResume() {
     accessibilityManager?.addTouchExplorationStateChangeListener(
         touchExplorationStateChangeListener)
@@ -262,7 +255,6 @@ internal class AccessibilityInfoModule(context: ReactApplicationContext) :
     updateAndSendGrayscaleModeChangeEvent()
   }
 
-  @TargetApi(Build.VERSION_CODES.LOLLIPOP)
   override fun onHostPause() {
     accessibilityManager?.removeTouchExplorationStateChangeListener(
         touchExplorationStateChangeListener)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.kt
@@ -7,7 +7,6 @@
 
 package com.facebook.react.modules.accessibilityinfo
 
-import android.annotation.TargetApi
 import android.content.ContentResolver
 import android.content.Context
 import android.database.ContentObserver

--- a/packages/react-native/ReactAndroid/src/main/res/shell/values/styles.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/shell/values/styles.xml
@@ -12,20 +12,20 @@
         <item name="android:windowContentOverlay">@null</item>
     </style>
 
-    <style name="SpinnerDatePickerDialog" parent="Theme.AppCompat.Light.Dialog" tools:targetApi="lollipop">
+    <style name="SpinnerDatePickerDialog" parent="Theme.AppCompat.Light.Dialog">
         <item name="android:datePickerStyle">@style/SpinnerDatePickerStyle</item>
     </style>
 
-    <style name="SpinnerDatePickerStyle" parent="android:Widget.Material.Light.DatePicker" tools:targetApi="lollipop">
+    <style name="SpinnerDatePickerStyle" parent="android:Widget.Material.Light.DatePicker">
         <item name="android:datePickerMode">spinner</item>
     </style>
 
-    <style name="CalendarDatePickerDialog" parent="android:Theme.Material.Dialog.Alert" tools:targetApi="lollipop">
+    <style name="CalendarDatePickerDialog" parent="android:Theme.Material.Dialog.Alert">
         <item name="android:datePickerStyle">@style/CalendarDatePickerStyle</item>
         <item name="android:windowIsFloating">true</item>
     </style>
 
-    <style name="CalendarDatePickerStyle" parent="android:Widget.Material.DatePicker" tools:targetApi="lollipop">
+    <style name="CalendarDatePickerStyle" parent="android:Widget.Material.DatePicker">
         <item name="android:datePickerMode">calendar</item>
     </style>
 


### PR DESCRIPTION
## Summary:

Static code analysis detected obsolete SDK version checks.

Since [the minimum supported SDK version is API 24](https://github.com/react-native-community/discussions-and-proposals/discussions/802), these checks for API 21 are no longer necessary and can be safely removed.

## Changelog:

[INTERNAL] - Remove obsolete @TargetApi annotations for LOLLIPOP (API 21)

## Test Plan:

```sh
yarn test-android
yarn android
```

CI should be green.

