### PR TITLE
Make `ReactRootViewTagGenerator` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -4063,11 +4063,6 @@ public abstract interface class com/facebook/react/uimanager/ReactRoot {
 	public abstract fun setShouldLogContentAppeared (Z)V
 }
 
-public final class com/facebook/react/uimanager/ReactRootViewTagGenerator {
-	public static final field INSTANCE Lcom/facebook/react/uimanager/ReactRootViewTagGenerator;
-	public static final fun getNextRootViewTag ()I
-}
-
 public abstract interface class com/facebook/react/uimanager/ReactShadowNode {
 	public abstract fun addChildAt (Lcom/facebook/react/uimanager/ReactShadowNode;I)V
 	public abstract fun addNativeChildAt (Lcom/facebook/react/uimanager/ReactShadowNode;I)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactRootViewTagGenerator.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactRootViewTagGenerator.kt
@@ -8,7 +8,7 @@
 package com.facebook.react.uimanager
 
 /** Incremental counter for React Root View tag. */
-public object ReactRootViewTagGenerator {
+internal object ReactRootViewTagGenerator {
 
   // Keep in sync with ReactRootViewTagGenerator.h - see that file for an explanation on why the
   // increment here is 10.
@@ -17,6 +17,6 @@ public object ReactRootViewTagGenerator {
 
   @JvmStatic
   @Synchronized
-  public fun getNextRootViewTag(): Int =
+  fun getNextRootViewTag(): Int =
       nextRootViewTag.also { nextRootViewTag += ROOT_VIEW_TAG_INCREMENT }
 }


### PR DESCRIPTION
## Summary:

This class can be internalized as part of the initiative to reduce the public API surface. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.uimanager.ReactRootViewTagGenerator).

## Changelog:

[INTERNAL] - Make com.facebook.react.uimanager.ReactRootViewTagGenerator internal

## Test Plan:

```bash
yarn test-android
yarn android
```