### PR TITLE
Make `ImageLoaderModule` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2989,25 +2989,6 @@ public final class com/facebook/react/modules/i18nmanager/I18nUtil$Companion {
 	public final fun getInstance ()Lcom/facebook/react/modules/i18nmanager/I18nUtil;
 }
 
-public final class com/facebook/react/modules/image/ImageLoaderModule : com/facebook/fbreact/specs/NativeImageLoaderAndroidSpec, com/facebook/react/bridge/LifecycleEventListener {
-	public static final field Companion Lcom/facebook/react/modules/image/ImageLoaderModule$Companion;
-	public static final field NAME Ljava/lang/String;
-	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;)V
-	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;Lcom/facebook/imagepipeline/core/ImagePipeline;Lcom/facebook/react/views/image/ReactCallerContextFactory;)V
-	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;Ljava/lang/Object;)V
-	public fun abortRequest (D)V
-	public fun getSize (Ljava/lang/String;Lcom/facebook/react/bridge/Promise;)V
-	public fun getSizeWithHeaders (Ljava/lang/String;Lcom/facebook/react/bridge/ReadableMap;Lcom/facebook/react/bridge/Promise;)V
-	public fun onHostDestroy ()V
-	public fun onHostPause ()V
-	public fun onHostResume ()V
-	public fun prefetchImage (Ljava/lang/String;DLcom/facebook/react/bridge/Promise;)V
-	public fun queryCache (Lcom/facebook/react/bridge/ReadableArray;Lcom/facebook/react/bridge/Promise;)V
-}
-
-public final class com/facebook/react/modules/image/ImageLoaderModule$Companion {
-}
-
 public class com/facebook/react/modules/intent/IntentModule : com/facebook/fbreact/specs/NativeIntentAndroidSpec {
 	public static final field Companion Lcom/facebook/react/modules/intent/IntentModule$Companion;
 	public static final field NAME Ljava/lang/String;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/image/ImageLoaderModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/image/ImageLoaderModule.kt
@@ -35,7 +35,7 @@ import com.facebook.react.views.image.ReactCallerContextFactory
 import com.facebook.react.views.imagehelper.ImageSource
 
 @ReactModule(name = NativeImageLoaderAndroidSpec.NAME)
-public class ImageLoaderModule : NativeImageLoaderAndroidSpec, LifecycleEventListener {
+internal class ImageLoaderModule : NativeImageLoaderAndroidSpec, LifecycleEventListener {
   private var _imagePipeline: ImagePipeline? = null
 
   private val enqueuedRequestMonitor = Any()
@@ -51,18 +51,18 @@ public class ImageLoaderModule : NativeImageLoaderAndroidSpec, LifecycleEventLis
       _imagePipeline = value
     }
 
-  public constructor(reactContext: ReactApplicationContext) : super(reactContext) {
+  constructor(reactContext: ReactApplicationContext) : super(reactContext) {
     this.callerContext = this
   }
 
-  public constructor(
+  constructor(
       reactContext: ReactApplicationContext,
       callerContext: Any?
   ) : super(reactContext) {
     this.callerContext = callerContext
   }
 
-  public constructor(
+  constructor(
       reactContext: ReactApplicationContext,
       imagePipeline: ImagePipeline,
       callerContextFactory: ReactCallerContextFactory
@@ -80,7 +80,7 @@ public class ImageLoaderModule : NativeImageLoaderAndroidSpec, LifecycleEventLis
    *   when there is an error
    */
   @ReactMethod
-  public override fun getSize(uriString: String?, promise: Promise) {
+  override fun getSize(uriString: String?, promise: Promise) {
     if (uriString.isNullOrEmpty()) {
       promise.reject(ERROR_INVALID_URI, "Cannot get the size of an image for an empty URI")
       return
@@ -129,7 +129,7 @@ public class ImageLoaderModule : NativeImageLoaderAndroidSpec, LifecycleEventLis
    *   when there is an error
    */
   @ReactMethod
-  public override fun getSizeWithHeaders(
+  override fun getSizeWithHeaders(
       uriString: String?,
       headers: ReadableMap?,
       promise: Promise
@@ -184,7 +184,7 @@ public class ImageLoaderModule : NativeImageLoaderAndroidSpec, LifecycleEventLis
    * @param promise the promise that is fulfilled when the image is successfully prefetched or
    *   rejected when there is an error
    */
-  public override fun prefetchImage(
+  override fun prefetchImage(
       uriString: String?,
       requestIdAsDouble: Double,
       promise: Promise
@@ -227,13 +227,13 @@ public class ImageLoaderModule : NativeImageLoaderAndroidSpec, LifecycleEventLis
     prefetchSource.subscribe(prefetchSubscriber, CallerThreadExecutor.getInstance())
   }
 
-  public override fun abortRequest(requestId: Double) {
+  override fun abortRequest(requestId: Double) {
     val request = removeRequest(requestId.toInt())
     request?.close()
   }
 
   @ReactMethod
-  public override fun queryCache(uris: ReadableArray, promise: Promise) {
+  override fun queryCache(uris: ReadableArray, promise: Promise) {
     // perform cache interrogation in async task as disk cache checks are expensive
     @Suppress("DEPRECATION", "StaticFieldLeak")
     object : GuardedAsyncTask<Void, Void>(getReactApplicationContext()) {
@@ -287,11 +287,11 @@ public class ImageLoaderModule : NativeImageLoaderAndroidSpec, LifecycleEventLis
     }
   }
 
-  public companion object {
+  companion object {
     private const val ERROR_INVALID_URI = "E_INVALID_URI"
     private const val ERROR_PREFETCH_FAILURE = "E_PREFETCH_FAILURE"
     private const val ERROR_GET_SIZE_FAILURE = "E_GET_SIZE_FAILURE"
 
-    public const val NAME: String = "ImageLoader"
+    const val NAME: String = "ImageLoader"
   }
 }


### PR DESCRIPTION
## Summary:

This class can be internalized as part of the initiative to reduce the public API surface. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.modules.image.ImageLoaderModule).

## Changelog:

[INTERNAL] - Make com.facebook.react.modules.image.ImageLoaderModule internal

## Test Plan:

```bash
yarn test-android
yarn android
```