### PR TITLE
Make `ClearableSynchronizedPool` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1649,13 +1649,6 @@ public final class com/facebook/react/bridge/queue/ReactQueueConfigurationSpec$C
 	public final fun createDefault ()Lcom/facebook/react/bridge/queue/ReactQueueConfigurationSpec;
 }
 
-public final class com/facebook/react/common/ClearableSynchronizedPool : androidx/core/util/Pools$Pool {
-	public fun <init> (I)V
-	public fun acquire ()Ljava/lang/Object;
-	public final fun clear ()V
-	public fun release (Ljava/lang/Object;)Z
-}
-
 public final class com/facebook/react/common/DebugServerException : java/lang/RuntimeException {
 	public static final field Companion Lcom/facebook/react/common/DebugServerException$Companion;
 	public fun <init> (Ljava/lang/String;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/ClearableSynchronizedPool.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/ClearableSynchronizedPool.kt
@@ -13,7 +13,7 @@ import androidx.core.util.Pools.Pool
  * Like [androidx.core.util.Pools.SynchronizedPool] with the option to clear the pool (e.g. on
  * memory pressure).
  */
-public class ClearableSynchronizedPool<T : Any>(maxSize: Int) : Pool<T> {
+internal class ClearableSynchronizedPool<T : Any>(maxSize: Int) : Pool<T> {
 
   private val pool: Array<Any?> = arrayOfNulls(maxSize)
   private var size = 0
@@ -42,7 +42,7 @@ public class ClearableSynchronizedPool<T : Any>(maxSize: Int) : Pool<T> {
   }
 
   @Synchronized
-  public fun clear(): Unit {
+  fun clear(): Unit {
     for (i in 0 until size) {
       pool[i] = null
     }


### PR DESCRIPTION
## Summary:

This class can be internalized as part of the initiative to reduce the public API surface. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.common.ClearableSynchronizedPool).

## Changelog:

[INTERNAL] - Make com.facebook.react.common.ClearableSynchronizedPool internal

## Test Plan:

```bash
yarn test-android
yarn android
```