### PR TITLE
Make `I18nManagerModule` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2961,19 +2961,6 @@ public final class com/facebook/react/modules/fresco/ReactNetworkImageRequest$Co
 	public static synthetic fun fromBuilderWithHeaders$default (Lcom/facebook/react/modules/fresco/ReactNetworkImageRequest$Companion;Lcom/facebook/imagepipeline/request/ImageRequestBuilder;Lcom/facebook/react/bridge/ReadableMap;Lcom/facebook/react/modules/fresco/ImageCacheControl;ILjava/lang/Object;)Lcom/facebook/react/modules/fresco/ReactNetworkImageRequest;
 }
 
-public final class com/facebook/react/modules/i18nmanager/I18nManagerModule : com/facebook/fbreact/specs/NativeI18nManagerSpec {
-	public static final field Companion Lcom/facebook/react/modules/i18nmanager/I18nManagerModule$Companion;
-	public static final field NAME Ljava/lang/String;
-	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;)V
-	public fun allowRTL (Z)V
-	public fun forceRTL (Z)V
-	public fun getTypedExportedConstants ()Ljava/util/Map;
-	public fun swapLeftAndRightInRTL (Z)V
-}
-
-public final class com/facebook/react/modules/i18nmanager/I18nManagerModule$Companion {
-}
-
 public final class com/facebook/react/modules/i18nmanager/I18nUtil {
 	public static final field Companion Lcom/facebook/react/modules/i18nmanager/I18nUtil$Companion;
 	public final fun allowRTL (Landroid/content/Context;Z)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nManagerModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nManagerModule.kt
@@ -13,8 +13,8 @@ import com.facebook.react.module.annotations.ReactModule
 
 /** [com.facebook.react.bridge.NativeModule] that allows JS to set allowRTL and get isRTL status. */
 @ReactModule(name = NativeI18nManagerSpec.NAME)
-public class I18nManagerModule(context: ReactApplicationContext?) : NativeI18nManagerSpec(context) {
-  public override fun getTypedExportedConstants(): Map<String, Any> {
+internal class I18nManagerModule(context: ReactApplicationContext?) : NativeI18nManagerSpec(context) {
+  override fun getTypedExportedConstants(): Map<String, Any> {
     val context = getReactApplicationContext()
     val locale = context.resources.configuration.locales[0]
 
@@ -36,7 +36,7 @@ public class I18nManagerModule(context: ReactApplicationContext?) : NativeI18nMa
     I18nUtil.instance.swapLeftAndRightInRTL(getReactApplicationContext(), value)
   }
 
-  public companion object {
-    public const val NAME: String = NativeI18nManagerSpec.NAME
+  companion object {
+    const val NAME: String = NativeI18nManagerSpec.NAME
   }
 }


### PR DESCRIPTION
## Summary:

This class can be internalized as part of the initiative to reduce the public API surface. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.modules.i18nmanager.I18nManagerModule).

There is only one usage in [qunarcorp/imsdk-android](https://github.com/qunarcorp/imsdk-android), but the project has not been updated for 6 years so I'm not considering it breaking.

## Changelog:

[INTERNAL] - Make com.facebook.react.modules.i18nmanager.I18nManagerModule internal

## Test Plan:

```bash
yarn test-android
yarn android
```