### PR TITLE
Use emojis in technical docs titles

### DIFF
--- a/__docs__/README-template.md
+++ b/__docs__/README-template.md
@@ -4,16 +4,16 @@
 
 _Description of the subsystem with the necessary context._
 
-## Usage
+## 🚀 Usage
 
 _Explanation of how the subsystem is used._
 
-## Design
+## 📐 Design
 
 _Explain how the subsystem is designed, relevant implementation details, etc.
 Ideally include an Excalidraw diagram._
 
-## Relationship with other systems
+## 🔗 Relationship with other systems
 
 ### Part of
 

--- a/__docs__/README.md
+++ b/__docs__/README.md
@@ -12,7 +12,7 @@ Native and contribute to it. **End users of React Native are meant to use the
 For details on how we approach technical documentation in this repository, see
 [GUIDELINES.md](./GUIDELINES.md).
 
-## Usage
+## 🚀 Usage
 
 This repository is not meant to be consumed directly by end users. Instead, it
 creates several packages that are published to the NPM registry for direct
@@ -30,11 +30,11 @@ JavaScript API.
 This repository provides the Android and iOS versions of React Native. Versions
 for other platforms are maintained in their own repositories.
 
-## Design
+## 📐 Design
 
 TODO: Explain the different components of React Native at a high level.
 
-## Relationship with other systems
+## 🔗 Relationship with other systems
 
 ### Part of this
 

--- a/packages/react-native-fantom/__docs__/README.md
+++ b/packages/react-native-fantom/__docs__/README.md
@@ -47,7 +47,7 @@ interact with React Native and observe what effects it has on a mock host
 platform. It exposes fine grained controls over scheduling, making it possible
 to test cases that are hard to reproduce manually.
 
-## Usage
+## 🚀 Usage
 
 > [!WARNING]
 >
@@ -194,7 +194,7 @@ has simple examples you can learn from.
 
 If you have any questions not answered here, please reach out to us.
 
-## Design
+## 📐 Design
 
 ![Diagram of the architecture of Fantom in React Native](./architecture.excalidraw.svg)
 
@@ -223,7 +223,7 @@ The runner then follows these steps:
 3. The runner receives the output from the Fantom CLI and reports the provided
    results back to Jest in the correct format.
 
-## Relationship with other systems
+## 🔗 Relationship with other systems
 
 ### Part of this
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/events/__docs__/README.md
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/events/__docs__/README.md
@@ -5,11 +5,11 @@
 This directory contains Kotlin classes specific to Android event dispatching in
 the new architecture.
 
-## Design
+## 📐 Design
 
 ![Diagram showing how an event is processed in the new architecture](./life-of-an-event.excalidraw.svg)
 
-## Relationship with other systems
+## 🔗 Relationship with other systems
 
 ### Part of
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/__docs__/README.md
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/__docs__/README.md
@@ -5,7 +5,7 @@
 This directory contains the Java/Kotlin bindings for the internal React Native
 feature flags system.
 
-## Relationship with other systems
+## 🔗 Relationship with other systems
 
 ### Part of
 

--- a/packages/react-native/ReactCommon/react/featureflags/__docs__/README.md
+++ b/packages/react-native/ReactCommon/react/featureflags/__docs__/README.md
@@ -5,7 +5,7 @@
 This directory contains the shared C++ implementation of the internal React
 Native feature flags system.
 
-## Relationship with other systems
+## 🔗 Relationship with other systems
 
 ### Part of
 

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/__docs__/README.md
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/__docs__/README.md
@@ -5,7 +5,7 @@
 This directory contains the native C++ TurboModule for the internal React Native
 feature flags system.
 
-## Relationship with other systems
+## 🔗 Relationship with other systems
 
 ### Part of
 

--- a/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/__docs__/README.md
+++ b/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/__docs__/README.md
@@ -6,7 +6,7 @@ This directory contains the native module used by the
 [IntersectionObserver API](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver)
 in React Native.
 
-## Relationship with other systems
+## 🔗 Relationship with other systems
 
 ### Part of
 

--- a/packages/react-native/ReactCommon/react/nativemodule/microtasks/__docs__/README.md
+++ b/packages/react-native/ReactCommon/react/nativemodule/microtasks/__docs__/README.md
@@ -6,7 +6,7 @@ This directory contains the native module used to implement `queueMicrotask` in
 React Native, which schedules microtasks in the
 [Event Loop](../../../renderer/runtimescheduler/__docs__/README.md).
 
-## Relationship with other systems
+## 🔗 Relationship with other systems
 
 ### Part of
 

--- a/packages/react-native/ReactCommon/react/nativemodule/mutationobserver/__docs__/README.md
+++ b/packages/react-native/ReactCommon/react/nativemodule/mutationobserver/__docs__/README.md
@@ -6,7 +6,7 @@ This directory contains the native module used by the
 [MutationObserver API](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver)
 in React Native.
 
-## Relationship with other systems
+## 🔗 Relationship with other systems
 
 ### Part of
 

--- a/packages/react-native/ReactCommon/react/renderer/observers/intersection/__docs__/README.md
+++ b/packages/react-native/ReactCommon/react/renderer/observers/intersection/__docs__/README.md
@@ -6,7 +6,7 @@ This directory contains the C++ implementation of the
 [IntersectionObserver API](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver)
 in React Native.
 
-## Relationship with other systems
+## 🔗 Relationship with other systems
 
 ### Part of
 

--- a/packages/react-native/ReactCommon/react/renderer/observers/mutation/__docs__/README.md
+++ b/packages/react-native/ReactCommon/react/renderer/observers/mutation/__docs__/README.md
@@ -6,7 +6,7 @@ This directory contains the C++ implementation of the
 [MutationObserver API](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver)
 in React Native.
 
-## Relationship with other systems
+## 🔗 Relationship with other systems
 
 ### Part of
 

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/__docs__/README.md
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/__docs__/README.md
@@ -27,7 +27,7 @@ semantics and APIs.
 > which contains additional context (e.g.: how this was introduced and what
 > React Native had before).
 
-## Usage
+## 🚀 Usage
 
 The event loop is an implementation detail so it is not used directly, but
 several APIs integrate deeply with it:
@@ -99,7 +99,7 @@ function Content(props) {
 }
 ```
 
-## Design
+## 📐 Design
 
 The conceptual model is **aligned with
 [the model on the Web](https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-processing-model)**
@@ -185,7 +185,7 @@ used in the new architecture).
 That class implements both the task scheduler that handles priorities and the
 processing of those tasks within the event loop.
 
-## Relationship with other systems
+## 🔗 Relationship with other systems
 
 ### Part of this
 

--- a/packages/react-native/scripts/featureflags/__docs__/README.md
+++ b/packages/react-native/scripts/featureflags/__docs__/README.md
@@ -5,7 +5,7 @@
 This directory contains the flag definitions and codegen for the internal React
 Native feature flags system.
 
-## Relationship with other systems
+## 🔗 Relationship with other systems
 
 ### Part of
 

--- a/packages/react-native/src/private/featureflags/__docs__/README.md
+++ b/packages/react-native/src/private/featureflags/__docs__/README.md
@@ -12,7 +12,7 @@ There are 2 types of feature flags:
   everywhere.
 - JS-only: they can only be accessed and customized from JavaScript.
 
-## Usage
+## 🚀 Usage
 
 ### Defining feature flags
 
@@ -188,7 +188,7 @@ If you need to consume this as structured data, you can print it as JSON using:
 yarn featureflags --print --json
 ```
 
-## Design
+## 📐 Design
 
 The architecture of this feature flags system can be described as follows:
 
@@ -210,7 +210,7 @@ The codegen uses a simple templating system based on JavaScript template strings
 to generate the files (see files ending with `-template.js` in the
 [`templates`](../../../../scripts/featureflags/templates/) directory),
 
-## Relationship with other systems
+## 🔗 Relationship with other systems
 
 ### Part of this
 

--- a/packages/react-native/src/private/webapis/intersectionobserver/__docs__/README.md
+++ b/packages/react-native/src/private/webapis/intersectionobserver/__docs__/README.md
@@ -5,12 +5,12 @@
 This directory contains the React Native implementation of the
 [IntersectionObserver API](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver).
 
-## Usage
+## 🚀 Usage
 
 `IntersectionObserver` is meant to be used from JavaScript, exposed as a global
 class.
 
-## Design
+## 📐 Design
 
 This is the high-level design of the IntersectionObserver API:
 
@@ -32,7 +32,7 @@ for the given surface. If there are, we just wait for the transaction to be
 mounted and use the mount hook to report the initial notification. If there
 aren't, we dispatch the notification immediately.
 
-## Relationship with other systems
+## 🔗 Relationship with other systems
 
 ### Part of this
 

--- a/packages/react-native/src/private/webapis/mutationobserver/__docs__/README.md
+++ b/packages/react-native/src/private/webapis/mutationobserver/__docs__/README.md
@@ -5,12 +5,12 @@
 This directory contains the React Native implementation of the
 [MutationObserver API](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver).
 
-## Usage
+## 🚀 Usage
 
 `MutationObserver` is meant to be used from JavaScript, exposed as a global
 class.
 
-## Design
+## 📐 Design
 
 This is the high-level design of the MutationObserver API:
 
@@ -24,7 +24,7 @@ changes in the tree, and detects mutations using the before/after revisions. It
 relies on referential equality of the shadow nodes for performance
 optimizations.
 
-## Relationship with other systems
+## 🔗 Relationship with other systems
 
 ### Part of this
 


### PR DESCRIPTION
Summary:
Changelog: [internal]

Just changing the template to include emojis in the top level titles to make it easier to scan the doc

Differential Revision: D72961870


