### PR TITLE
chore(android-new-arch): reproduce modal layout issues

### DIFF
--- a/packages/rn-tester/js/examples/Playground/RNTesterPlayground.js
+++ b/packages/rn-tester/js/examples/Playground/RNTesterPlayground.js
@@ -6,34 +6,157 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
-
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 
-import RNTesterText from '../../components/RNTesterText';
 import * as React from 'react';
-import {StyleSheet, View} from 'react-native';
+import {useState} from 'react';
+import {Modal, Pressable, StyleSheet, Text, View} from 'react-native';
 
-function Playground() {
+function causeJSThreadBlocking() {
+  const intervalId = setInterval(() => {
+    const start = Date.now();
+    while (Date.now() - start < 20) {
+      // Blocking operation
+      Math.random() * Math.random();
+    }
+  }, 16);
+  setTimeout(() => {
+    clearInterval(intervalId);
+  }, 10000);
+}
+
+function ModalInSequence(): React.Node {
+  const [firstModalVisible, setFirstModalVisible] = useState(false);
+  const [secondModalVisible, setSecondModalVisible] = useState(false);
+
+  const showSecondHideFirst = () => {
+    setFirstModalVisible(false);
+    setSecondModalVisible(true);
+  };
+
   return (
     <View style={styles.container}>
-      <RNTesterText>
-        Edit "RNTesterPlayground.js" to change this file
-      </RNTesterText>
+      <Modal
+        key="first"
+        animationType="slide"
+        transparent={true}
+        visible={firstModalVisible}
+        onRequestClose={() => setFirstModalVisible(false)}>
+        <View
+          onLayout={e => {
+            causeJSThreadBlocking();
+            console.log('modal first', e.nativeEvent.layout);
+          }}
+          style={[styles.centeredView, styles.modalBackdrop]}>
+          <View style={styles.modalView}>
+            <Text style={styles.modalText}>This is the first modal</Text>
+            <Pressable
+              style={[styles.button, styles.buttonClose]}
+              onPress={async () => {
+                // await new Promise(resolve => setTimeout(resolve, 100));
+                setFirstModalVisible(false);
+              }}>
+              <Text style={styles.textStyle}>Close Modal</Text>
+            </Pressable>
+            <Pressable
+              style={[styles.button, styles.buttonOpen]}
+              onPress={showSecondHideFirst}>
+              <Text style={styles.textStyle}>Show Second Modal</Text>
+            </Pressable>
+          </View>
+        </View>
+      </Modal>
+
+      <Modal
+        key="second"
+        animationType="slide"
+        transparent={true}
+        visible={secondModalVisible}
+        onRequestClose={() => setSecondModalVisible(false)}>
+        <View
+          onLayout={e => {
+            console.log('modal second', e.nativeEvent.layout);
+          }}
+          style={[styles.centeredView, styles.modalBackdrop]}>
+          <View style={styles.modalView}>
+            <Text style={styles.modalText}>This is the second modal</Text>
+            <Pressable
+              style={[styles.button, styles.buttonClose]}
+              onPress={() => setSecondModalVisible(false)}>
+              <Text style={styles.textStyle}>Close Modal</Text>
+            </Pressable>
+          </View>
+        </View>
+      </Modal>
+
+      <Pressable
+        style={[styles.button, styles.buttonOpen]}
+        onPress={() => setFirstModalVisible(true)}>
+        <Text style={styles.textStyle}>Show First Modal</Text>
+      </Pressable>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
+    display: 'flex',
+    alignItems: 'center',
+    paddingVertical: 30,
+  },
+  centeredView: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  modalBackdrop: {
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+  },
+  modalView: {
+    backgroundColor: 'white',
+    margin: 20,
+    borderRadius: 20,
+    padding: 35,
+    alignItems: 'center',
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 2,
+    },
+    shadowOpacity: 0.25,
+    shadowRadius: 4,
+    elevation: 5,
+  },
+  modalText: {
+    marginBottom: 15,
+    textAlign: 'center',
+  },
+  button: {
+    borderRadius: 20,
     padding: 10,
+    marginVertical: 10,
+    elevation: 2,
+    minWidth: 150,
+  },
+  buttonOpen: {
+    backgroundColor: '#F194FF',
+  },
+  buttonClose: {
+    backgroundColor: '#2196F3',
+  },
+  textStyle: {
+    color: 'white',
+    fontWeight: 'bold',
+    textAlign: 'center',
   },
 });
+
 
 export default ({
   title: 'Playground',
   name: 'playground',
   description: 'Test out new features and ideas.',
-  render: (): React.Node => <Playground />,
+  render: (): React.Node => <ModalInSequence />,
 }: RNTesterModuleExample);
+


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

See https://github.com/facebook/react-native/issues/50442

_Note: this reproducible patch was made on top of 0.76 stable branch however this is reproducible on latest main._

We are experiencing an issue with Modals on Android when the new architecture is enabled. 

When trying to render a modal, especially in a busy JS thread on Android, the rendered UI does not match expected layout. This either causes a layout glitch, where the Modal content flashes an incorrect layout, or a Modal's inner content layout fully broken (see image below).

In this example below, we were mounting then unmounting a few Modals in sequence and eventually (inconsistently happening) the app gets into a frozen state where no user input gets through the app anymore. When inspecting the UI layout on Android Studio it shows that Android's Dialog is rendered as expected fully covering the UI however its children content has incorrect width values:

![image](https://github.com/user-attachments/assets/eb735b4e-3fd2-48f5-8bd2-200e04bf32dd)

When we attempt to reproduce this issue in rn-tester we couldn't exactly replicate the frozen UI state however we can see  replicate the incorect layout issues occuring when in a busy thread:


[Video of the incorrect layout rendered on Android with new architecture enabled.](https://drive.google.com/file/d/17aL1palyWmBJOoNPAGP7tz5JWsJPXWdc/view?usp=sharing)

[Same experience without new arch enabled on Android - has o glitch despite very busy JS thread](https://drive.google.com/file/d/15wYc0yaZsJclY5AdIsZ3VP3F_1LErfyG/view?usp=sharing).

There seems to be a shared theme here with onLayout returning empty layout dimensions during first mount which [others have observed that this also breaks layout animations from Reanimated](https://x.com/hirbod_dev/status/1911030588296884455).

Other observations. If we wrap the Modal's children with a View that has fixed width and height we do see the entire content properly rendered however the touch system is broken and the children is unable to receive presses. 


## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
