### PR TITLE
Make `JSTimers` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2723,12 +2723,6 @@ public class com/facebook/react/modules/core/HeadlessJsTaskSupportModule : com/f
 	public fun notifyTaskRetry (DLcom/facebook/react/bridge/Promise;)V
 }
 
-public abstract interface class com/facebook/react/modules/core/JSTimers : com/facebook/react/bridge/JavaScriptModule {
-	public abstract fun callIdleCallbacks (D)V
-	public abstract fun callTimers (Lcom/facebook/react/bridge/WritableArray;)V
-	public abstract fun emitTimeDriftWarning (Ljava/lang/String;)V
-}
-
 public abstract interface class com/facebook/react/modules/core/JavaScriptTimerExecutor {
 	public abstract fun callIdleCallbacks (D)V
 	public abstract fun callTimers (Lcom/facebook/react/bridge/WritableArray;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/JSTimers.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/JSTimers.kt
@@ -12,10 +12,10 @@ import com.facebook.react.bridge.JavaScriptModule
 import com.facebook.react.bridge.WritableArray
 
 @DoNotStrip
-public interface JSTimers : JavaScriptModule {
-  public fun callTimers(timerIDs: WritableArray)
+internal interface JSTimers : JavaScriptModule {
+  fun callTimers(timerIDs: WritableArray)
 
-  public fun callIdleCallbacks(frameTime: Double)
+  fun callIdleCallbacks(frameTime: Double)
 
-  public fun emitTimeDriftWarning(warningMessage: String)
+  fun emitTimeDriftWarning(warningMessage: String)
 }


### PR DESCRIPTION
## Summary:

This class can be internalized as part of the initiative to reduce the public API surface. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.modules.core.JSTimers).

## Changelog:

[INTERNAL] - Make com.facebook.react.modules.core.JSTimers internal

## Test Plan:

```bash
yarn test-android
yarn android
```