### PR TITLE
Categorize LegacyArchitectureLogger soft errors as SOFT_ASSERTIONS

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/internal/LegacyArchitectureLogger.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/internal/LegacyArchitectureLogger.kt
@@ -89,7 +89,8 @@ public object LegacyArchitectureLogger {
       }
       LegacyArchitectureLogLevel.WARNING -> {
         ReactSoftExceptionLogger.logSoftException(
-            tag, ReactNoCrashSoftException("$name $exceptionMessage"))
+            ReactSoftExceptionLogger.Categories.SOFT_ASSERTIONS,
+            ReactNoCrashSoftException("$name $exceptionMessage"))
       }
     }
   }


### PR DESCRIPTION
Summary:
This diff changes the category used by LegacyArchitectureLogger soft errors to be SOFT_ASSERTIONS

changelog: [internal] internal

Reviewed By: makovkastar

Differential Revision: D72999455


