### PR TITLE
Use sum of subpaths instead of path.join in `no-deep-imports` lint rule

### DIFF
--- a/packages/eslint-plugin-react-native/__tests__/no-deep-imports-test.js
+++ b/packages/eslint-plugin-react-native/__tests__/no-deep-imports-test.js
@@ -13,13 +13,12 @@
 const rule = require('../no-deep-imports.js');
 const {publicAPIMapping} = require('../utils.js');
 const ESLintTester = require('./eslint-tester.js');
-const path = require('path');
 
 const eslintTester = new ESLintTester();
 
 test('resolve all public API paths', () => {
   for (const subpath of Object.keys(publicAPIMapping)) {
-    require.resolve(path.join('react-native', subpath));
+    require.resolve('react-native/' + subpath);
   }
 });
 


### PR DESCRIPTION
Summary:
On Windows `path.join` returns path with separators unsupported by resolution mechanism. This change enforces the use of `/` separators in `no-deep-imports` rule tests.

Changelog:
[Internal]

Differential Revision: D73021185


