### PR TITLE
[RN][CI] Fix check nightlies by escaping the artifact folder

### DIFF
--- a/.github/workflow-scripts/collectNightlyOutcomes.js
+++ b/.github/workflow-scripts/collectNightlyOutcomes.js
@@ -12,7 +12,7 @@ const path = require('path');
 
 function readOutcomes() {
   const baseDir = '/tmp';
-  let outcomes = {};
+  let outcomes = [];
   fs.readdirSync(baseDir).forEach(file => {
     const fullPath = path.join(baseDir, file);
     if (fullPath.endsWith('outcome') && fs.statSync(fullPath).isDirectory) {
@@ -26,10 +26,11 @@ function readOutcomes() {
           console.log(
             `[${platform}] ${library} completed with status ${status}`,
           );
-          outcomes[library.trim()] = {
+          outcomes.push({
+            library: library.trim(),
             platform,
             status: status.trim(),
-          };
+          });
         }
       });
     } else if (fullPath.endsWith('outcome')) {
@@ -38,10 +39,11 @@ function readOutcomes() {
         .split(':');
       const platform = file.includes('android') ? 'Android' : 'iOS';
       console.log(`[${platform}] ${library} completed with status ${status}`);
-      outcomes[library.trim()] = {
+      outcomes.push({
+        library: library.trim(),
         platform,
         status: status.trim(),
-      };
+      });
     }
   });
   return outcomes;
@@ -50,10 +52,10 @@ function readOutcomes() {
 function printFailures(outcomes) {
   console.log('Printing failures...');
   let failures = 0;
-  Object.entries(outcomes).forEach(([library, value]) => {
-    if (value.status !== 'success') {
+  outcomes.forEach(entry => {
+    if (entry.status !== 'success') {
       console.log(
-        `❌ [${value.platform}] ${library} failed with status ${value.status}`,
+        `❌ [${entry.platform}] ${entry.library} failed with status ${entry.status}`,
       );
       failures++;
     }

--- a/.github/workflows/test-libraries-on-nightlies.yml
+++ b/.github/workflows/test-libraries-on-nightlies.yml
@@ -7,9 +7,17 @@ on:
 # We use the matrix.library entry to specify the dependency we want to use
 # The key is used directly as the <pkg> in the `yarn add <pkg>` command.
 jobs:
-  test-library-on-nightly-android:
-    name: "[Android] ${{ matrix.library }}"
+  runner-setup:
     runs-on: ubuntu-latest
+    outputs:
+      runners: '{"ios":"macos-13-large", "android": "ubuntu-latest"}'
+    steps:
+      - run: echo no-op
+
+  test-library-on-nightly:
+    name: "[${{ matrix.platform }}] ${{ matrix.library }}"
+    needs: runner-setup
+    runs-on: ${{ fromJSON(needs.runner-setup.outputs.runners)[matrix.platform] }}
     continue-on-error: true
     strategy:
       matrix:
@@ -39,12 +47,12 @@ jobs:
           "react-native-email-link",
           "react-native-exit-app",
           "@dr.pogodin/react-native-fs",
-          "react-native-maps",
           "react-native-permissions",
           "react-native-vector-icons",
           "react-native-masked-view",
           "@react-native-community/image-editor",
         ]
+        platform: [ios, android]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -53,80 +61,25 @@ jobs:
         uses: ./.github/actions/test-library-on-nightly
         with:
           library-npm-package: ${{ matrix.library }}
-          platform: android
+          platform: ${{ matrix.platform}}
       - name: Save outcome
+        id: save-outcome
         if: always()
         run: |
-          echo "${{matrix.library}}: ${{steps.run-test.outcome}}" >> "/tmp/${{matrix.library}}-android-outcome"
+          LIB_FOLDER=$(echo "${{matrix.library}}"  | tr ' ' '_' | tr '/' '_')
+          echo "${{matrix.library}}: ${{steps.run-test.outcome}}" > "/tmp/$LIB_FOLDER-${{ matrix.platform }}-outcome"
+          echo "lib_folder=$LIB_FOLDER" >> $GITHUB_OUTPUT
       - name: Upload Artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.library }}-android-outcome
-          path: /tmp/${{ matrix.library }}-android-outcome
-
-  test-library-on-nightly-ios:
-    name: "[iOS] ${{ matrix.library }}"
-    runs-on: macos-13-large
-    continue-on-error: true
-    strategy:
-      matrix:
-        library: [
-          "react-native-async-storage",
-          "react-native-blob-util",
-          "@react-native-clipboard/clipboard",
-          "@react-native-community/datetimepicker",
-          "react-native-gesture-handler",
-          "react-native-image-picker",
-          "react-native-linear-gradient",
-          "@react-native-masked-view/masked-view",
-          "react-native-maps",
-          "@react-native-community/netinfo",
-          "react-native-reanimated@nightly  react-native-worklets@nightly", #reanimated requires worklet to be explicitly installed as a separate package
-          "react-native-svg",
-          "react-native-video",
-          "react-native-webview",
-          "react-native-mmkv",
-          "react-native-screens",
-          "react-native-pager-view",
-          "@react-native-community/slider",
-          #additional OSS libs used internally
-          "scandit-react-native-datacapture-barcode scandit-react-native-datacapture-core",
-          "react-native-contacts",
-          "react-native-device-info",
-          "react-native-email-link",
-          "react-native-exit-app",
-          "@dr.pogodin/react-native-fs",
-          "react-native-maps",
-          "react-native-permissions",
-          "react-native-vector-icons",
-          "react-native-masked-view",
-          "@react-native-community/image-editor",
-        ]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Test ${{ matrix.library }}
-        id: run-test
-        uses: ./.github/actions/test-library-on-nightly
-        with:
-          library-npm-package: ${{ matrix.library }}
-          platform: ios
-      - name: Save outcome
-        if: always()
-        run: |
-          echo "${{matrix.library}}: ${{steps.run-test.outcome}}" > "/tmp/${{matrix.library}}-ios-outcome"
-      - name: Upload Artifact
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.library }}-ios-outcome
-          path: /tmp/${{ matrix.library }}-ios-outcome
+          name: ${{ steps.save-outcome.outputs.lib_folder }}-${{ matrix.platform }}-outcome
+          path: /tmp/${{ steps.save-outcome.outputs.lib_folder }}-${{ matrix.platform }}-outcome
 
 
   collect-results:
     runs-on: ubuntu-latest
-    needs: [test-library-on-nightly-android, test-library-on-nightly-ios]
+    needs: [test-library-on-nightly]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary:
The check nightlies job is failing on some libraries because the library key contains `/` and ` ` characters that fails to be used properly when they are part of a path.
With this change, we are replacing those characters with `_` so this is a valid path were CI can save the outcome that needs to be collected later.

## Changelog:
[Internal] - Fix folder path

## Test Plan:
Running in GHA
