### PR TITLE
Add warning when app is running with the old architecture

### DIFF
--- a/packages/react-native/Libraries/ReactNative/renderApplication.js
+++ b/packages/react-native/Libraries/ReactNative/renderApplication.js
@@ -13,6 +13,7 @@ import type {IPerformanceLogger} from '../Utilities/createPerformanceLogger';
 
 import GlobalPerformanceLogger from '../Utilities/GlobalPerformanceLogger';
 import PerformanceLoggerContext from '../Utilities/PerformanceLoggerContext';
+import warnOnce from '../Utilities/warnOnce';
 import AppContainer from './AppContainer';
 import DisplayMode, {type DisplayModeType} from './DisplayMode';
 import getCachedComponentWithDebugName from './getCachedComponentWithDebugName';
@@ -104,5 +105,13 @@ export default function renderApplication<Props: Object>(
     useFabric: Boolean(fabric),
     useConcurrentRoot,
   });
+
+  const newArchitecture = !!fabric;
+  if (!newArchitecture) {
+    warnOnce(
+      '[OSS][OldArchDeprecatedWarning]',
+      'The app is running using the Legacy Architecture. The Legacy Architecture is deprecated and will be removed in a future version of React Native. Please consider migrating to the New Architecture. For more information, please see https://reactnative.dev/blog/2024/10/23/the-new-architecture-is-here',
+    );
+  }
   performanceLogger.stopTimespan('renderApplication_React_render');
 }


### PR DESCRIPTION
Summary:
This change adds a warning in JS that is printed when the app is running using the old architecture.

The assumption is that, if it is running with Fabric, it is running with the new architecture. So running without Fabric implies old architecture.

## Changelog:
[General][Added] - Add warning when the app runs with the legacy architecture

Reviewed By: cortinico

Differential Revision: D73041156


