### PR TITLE
react native devtools extra telemetry

### DIFF
--- a/packages/dev-middleware/src/__tests__/getDevToolsFrontendUrl-test.js
+++ b/packages/dev-middleware/src/__tests__/getDevToolsFrontendUrl-test.js
@@ -21,7 +21,7 @@ describe('getDevToolsFrontendUrl', () => {
     enableOpenDebuggerRedirect: false,
   };
 
-  describe('relative: false, launchId: undefined (default)', () => {
+  describe('relative: false, launchId: undefined, telemetryInfo: undefined, (default)', () => {
     test('should return a valid url for all experiments off', async () => {
       const actual = getDevToolsFrontendUrl(
         experiments,
@@ -128,8 +128,13 @@ describe('getDevToolsFrontendUrl', () => {
     });
   });
 
-  describe('launchId: non-null', () => {
+  describe('non-null launchId and telemetryInfo', () => {
     const launchId = 'dG8gdGhlIG1vb24h%21';
+
+    const telemetryInfo = JSON.stringify({
+      username: 'testuser123',
+      reactTechnologiesDeveloper: true,
+    });
 
     test('should return a valid url for all experiments off', async () => {
       const actual = getDevToolsFrontendUrl(
@@ -138,6 +143,7 @@ describe('getDevToolsFrontendUrl', () => {
         devServerUrl,
         {
           launchId,
+          telemetryInfo,
         },
       );
       const url = new URL(actual);
@@ -146,6 +152,9 @@ describe('getDevToolsFrontendUrl', () => {
         '/inspector/debug?device=1a9372c&page=-1',
       );
       expect(url.searchParams.get('launchId')).toBe(launchId);
+      expect(JSON.parse(url.searchParams.get('telemetryInfo') || '{}')).toEqual(
+        JSON.parse(telemetryInfo),
+      );
     });
 
     test('should return a valid url for enableNetworkInspector experiment on', async () => {
@@ -155,6 +164,7 @@ describe('getDevToolsFrontendUrl', () => {
         devServerUrl,
         {
           launchId,
+          telemetryInfo,
         },
       );
       const url = new URL(actual);
@@ -164,6 +174,9 @@ describe('getDevToolsFrontendUrl', () => {
         '/inspector/debug?device=1a9372c&page=-1',
       );
       expect(url.searchParams.get('launchId')).toBe(launchId);
+      expect(JSON.parse(url.searchParams.get('telemetryInfo') || '{}')).toEqual(
+        JSON.parse(telemetryInfo),
+      );
     });
 
     test('should return a full WS URL if on a different host than the dev server', () => {
@@ -175,6 +188,7 @@ describe('getDevToolsFrontendUrl', () => {
         devServerUrl,
         {
           launchId,
+          telemetryInfo,
         },
       );
       const url = new URL(actual);
@@ -182,6 +196,9 @@ describe('getDevToolsFrontendUrl', () => {
         'localhost:8082/inspector/debug?device=1a9372c&page=-1',
       );
       expect(url.searchParams.get('launchId')).toBe(launchId);
+      expect(JSON.parse(url.searchParams.get('telemetryInfo') || '{}')).toEqual(
+        JSON.parse(telemetryInfo),
+      );
     });
   });
 

--- a/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
+++ b/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
@@ -65,6 +65,7 @@ export default function openDebuggerMiddleware({
         /** @deprecated Will only match legacy Hermes targets */
         device?: string,
         launchId?: string,
+        telemetryInfo?: string,
         target?: string,
         ...
       } = paresedUrl.query;
@@ -146,7 +147,12 @@ export default function openDebuggerMiddleware({
                 experiments,
                 target.webSocketDebuggerUrl,
                 serverBaseUrl,
-                {launchId: query.launchId, useFuseboxEntryPoint},
+                {
+                  launchId: query.launchId,
+                  telemetryInfo: query.telemetryInfo,
+                  appId: target.appId,
+                  useFuseboxEntryPoint,
+                },
               ),
             );
             res.writeHead(200);
@@ -161,6 +167,8 @@ export default function openDebuggerMiddleware({
                 {
                   relative: true,
                   launchId: query.launchId,
+                  telemetryInfo: query.telemetryInfo,
+                  appId: target.appId,
                   useFuseboxEntryPoint,
                 },
               ),

--- a/packages/dev-middleware/src/utils/getDevToolsFrontendUrl.js
+++ b/packages/dev-middleware/src/utils/getDevToolsFrontendUrl.js
@@ -21,8 +21,10 @@ export default function getDevToolsFrontendUrl(
   options?: $ReadOnly<{
     relative?: boolean,
     launchId?: string,
+    telemetryInfo?: string,
     /** Whether to use the modern `rn_fusebox.html` entry point. */
     useFuseboxEntryPoint?: boolean,
+    appId?: string,
   }>,
 ): string {
   const wsParam = getWsParam({
@@ -46,6 +48,12 @@ export default function getDevToolsFrontendUrl(
   }
   if (options?.launchId != null && options.launchId !== '') {
     searchParams.append('launchId', options.launchId);
+  }
+  if (options?.appId != null && options.appId !== '') {
+    searchParams.append('appId', options.appId);
+  }
+  if (options?.telemetryInfo != null && options.telemetryInfo !== '') {
+    searchParams.append('telemetryInfo', options.telemetryInfo);
   }
 
   return appUrl + '?' + searchParams.toString();


### PR DESCRIPTION
Summary:
Changelog: [Internal][General] the debugger can now be opened with the query param "telemetryInfo"

Corresponding PR on debugger: https://github.com/facebook/react-native-devtools-frontend/pull/157

Reviewed By: huntie

Differential Revision: D72972397


