### PR TITLE
Remove usage of HERMES_BUILD_APPLE_DSYM

### DIFF
--- a/packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh
+++ b/packages/react-native/sdks/hermes-engine/utils/build-apple-framework.sh
@@ -102,7 +102,8 @@ function configure_apple_framework {
       -DHERMES_ENABLE_BITCODE:BOOLEAN=false \
       -DHERMES_BUILD_APPLE_FRAMEWORK:BOOLEAN=true \
       -DHERMES_BUILD_SHARED_JSI:BOOLEAN=false \
-      -DHERMES_BUILD_APPLE_DSYM:BOOLEAN=true \
+      -DCMAKE_CXX_FLAGS:STRING="-gdwarf" \
+      -DCMAKE_C_FLAGS:STRING="-gdwarf" \
       -DIMPORT_HERMESC:PATH="$IMPORT_HERMESC_PATH" \
       -DJSI_DIR="$JSI_PATH" \
       -DHERMES_RELEASE_VERSION="for RN $(get_release_version)" \
@@ -134,6 +135,8 @@ function build_apple_framework {
   pushd "$HERMES_PATH" > /dev/null || exit 1
     mkdir -p "destroot/Library/Frameworks/$1"
     cmake --build "./build_$1" --target libhermes -j "${NUM_CORES}"
+    # Produce the dSYM.
+    xcrun dsymutil "./build_$1/API/hermes/hermes.framework/hermes" -o "./build_$1/API/hermes/hermes.framework.dSYM"
     cp -R "./build_$1"/API/hermes/hermes.framework* "destroot/Library/Frameworks/$1"
 
     # In a MacOS build, also produce the hermes and hermesc CLI tools.

--- a/packages/react-native/sdks/hermes-engine/utils/build-hermes-xcode.sh
+++ b/packages/react-native/sdks/hermes-engine/utils/build-hermes-xcode.sh
@@ -78,7 +78,8 @@ echo "Configure Apple framework"
   -DHERMES_ENABLE_BITCODE:BOOLEAN=false \
   -DHERMES_BUILD_APPLE_FRAMEWORK:BOOLEAN=true \
   -DHERMES_BUILD_SHARED_JSI:BOOLEAN=false \
-  -DHERMES_BUILD_APPLE_DSYM:BOOLEAN=true \
+  -DCMAKE_CXX_FLAGS:STRING="-gdwarf" \
+  -DCMAKE_C_FLAGS:STRING="-gdwarf" \
   -DIMPORT_HERMESC:PATH="${hermesc_path}" \
   -DJSI_DIR="$jsi_path" \
   -DHERMES_RELEASE_VERSION="for RN $release_version" \


### PR DESCRIPTION
Summary:
The implementation of this in Hermes depends on a deprecated CMake
feature. Since it just needs to run a command to generate the dSYM, it
seems simpler to eliminate the flag and move the work into the RN build
script.

Differential Revision: D73054511


