### PR TITLE
Make `ToastModule` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3174,19 +3174,6 @@ public final class com/facebook/react/modules/systeminfo/ReactNativeVersion {
 	public static final field VERSION Ljava/util/Map;
 }
 
-public final class com/facebook/react/modules/toast/ToastModule : com/facebook/fbreact/specs/NativeToastAndroidSpec {
-	public static final field Companion Lcom/facebook/react/modules/toast/ToastModule$Companion;
-	public static final field NAME Ljava/lang/String;
-	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;)V
-	public fun getTypedExportedConstants ()Ljava/util/Map;
-	public fun show (Ljava/lang/String;D)V
-	public fun showWithGravity (Ljava/lang/String;DD)V
-	public fun showWithGravityAndOffset (Ljava/lang/String;DDDD)V
-}
-
-public final class com/facebook/react/modules/toast/ToastModule$Companion {
-}
-
 public final class com/facebook/react/modules/websocket/WebSocketModule : com/facebook/fbreact/specs/NativeWebSocketModuleSpec {
 	public static final field Companion Lcom/facebook/react/modules/websocket/WebSocketModule$Companion;
 	public static final field NAME Ljava/lang/String;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/toast/ToastModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/toast/ToastModule.kt
@@ -17,10 +17,10 @@ import com.facebook.react.module.annotations.ReactModule
 
 /** [NativeModule] that allows JS to show an Android Toast. */
 @ReactModule(name = NativeToastAndroidSpec.NAME)
-public class ToastModule(reactContext: ReactApplicationContext) :
+internal class ToastModule(reactContext: ReactApplicationContext) :
     NativeToastAndroidSpec(reactContext) {
 
-  public override fun getTypedExportedConstants(): Map<String, Any> =
+  override fun getTypedExportedConstants(): Map<String, Any> =
       mutableMapOf(
           DURATION_SHORT_KEY to Toast.LENGTH_SHORT,
           DURATION_LONG_KEY to Toast.LENGTH_LONG,
@@ -29,13 +29,13 @@ public class ToastModule(reactContext: ReactApplicationContext) :
           GRAVITY_CENTER to (Gravity.CENTER_HORIZONTAL or Gravity.CENTER_VERTICAL),
       )
 
-  public override fun show(message: String?, durationDouble: Double) {
+  override fun show(message: String?, durationDouble: Double) {
     val duration = durationDouble.toInt()
     UiThreadUtil.runOnUiThread(
         Runnable { Toast.makeText(getReactApplicationContext(), message, duration).show() })
   }
 
-  public override fun showWithGravity(
+  override fun showWithGravity(
       message: String?,
       durationDouble: Double,
       gravityDouble: Double
@@ -50,7 +50,7 @@ public class ToastModule(reactContext: ReactApplicationContext) :
         })
   }
 
-  public override fun showWithGravityAndOffset(
+  override fun showWithGravityAndOffset(
       message: String?,
       durationDouble: Double,
       gravityDouble: Double,
@@ -69,8 +69,8 @@ public class ToastModule(reactContext: ReactApplicationContext) :
         })
   }
 
-  public companion object {
-    public const val NAME: String = NativeToastAndroidSpec.NAME
+  companion object {
+    const val NAME: String = NativeToastAndroidSpec.NAME
     private const val DURATION_SHORT_KEY = "SHORT"
     private const val DURATION_LONG_KEY = "LONG"
     private const val GRAVITY_TOP_KEY = "TOP"


### PR DESCRIPTION
## Summary:

This class can be internalized as part of the initiative to reduce the public API surface. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.modules.toast.ToastModule).

GH results are mostly forks and some very old repos (~8, 9 old)

## Changelog:

[INTERNAL] - Make com.facebook.react.modules.toast.ToastModule internal

## Test Plan:

```bash
yarn test-android
yarn android
```