### PR TITLE
fix naming error in AndroidInfoModule

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoModule.kt
@@ -81,7 +81,7 @@ public class AndroidInfoModule(reactContext: ReactApplicationContext) :
   }
 
   public companion object {
-    public const val NAME: String = "NativePlatformConstantsAndroidSpec.NAME"
+    public const val NAME: String = NativePlatformConstantsAndroidSpec.NAME
     private const val IS_TESTING = "IS_TESTING"
     private const val IS_DISABLE_ANIMATIONS = "IS_DISABLE_ANIMATIONS"
   }


### PR DESCRIPTION
Summary:
const val NAME had quotes around it breaking native module loading from CoreReactPackage
This error was uncaught in previous diff.

Differential Revision: D73070533


