### PR TITLE
Suppress deprecation error in OSS for BlobModule

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobModule.kt
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+@file:Suppress("DEPRECATION_ERROR") // Conflicting okhttp versions
+
 package com.facebook.react.modules.blob
 
 import android.net.Uri


### PR DESCRIPTION
Summary:
We have a different version of OkHttp internally and in OSS so we need to suppress these for now.

Changelog: [Internal]

Differential Revision: D73079163


