### PR TITLE
Split shadow node reference setter and update functionality

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -310,14 +310,19 @@ void ShadowNode::setRuntimeShadowNodeReference(
   runtimeShadowNodeReference_ = runtimeShadowNodeReference;
 }
 
+void ShadowNode::updateRuntimeShadowNodeReference(
+    const Shared& destinationShadowNode) const {
+  if (auto reference = runtimeShadowNodeReference_.lock()) {
+    reference->shadowNode = destinationShadowNode;
+  }
+}
+
 void ShadowNode::transferRuntimeShadowNodeReference(
     const Shared& destinationShadowNode) const {
   destinationShadowNode->runtimeShadowNodeReference_ =
       runtimeShadowNodeReference_;
 
-  if (auto reference = runtimeShadowNodeReference_.lock()) {
-    reference->shadowNode = destinationShadowNode;
-  }
+  updateRuntimeShadowNodeReference(destinationShadowNode);
 }
 
 void ShadowNode::transferRuntimeShadowNodeReference(

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
@@ -188,6 +188,12 @@ class ShadowNode : public Sealable,
                                          runtimeShadowNodeReference) const;
 
   /*
+   * Update the runtime reference to point to the provided shadow node.
+   */
+  void updateRuntimeShadowNodeReference(
+      const Shared& destinationShadowNode) const;
+
+  /*
    * Transfer the runtime reference to this `ShadowNode` to a new instance,
    * updating the reference to point to the new `ShadowNode` referencing it.
    */


### PR DESCRIPTION
Summary:
Storing the runtime reference for a shadow node and updating the runtime reference to point at a specific shadow node should be separated so that these actions can be done at different moments in time.

We want to keep a reference to the runtime reference of a shadow node for all revisions cloned internally (not triggered by the React renderer, e.g. on layout or shadow node state updates).

We also want to support updating that runtime reference to point at a specific shadow node revision, ideally the one that will end up being used to mount the host component.

Changelog: [Internal]

Differential Revision: D73038438


