### PR TITLE
Add deprecation message for receiveCommand

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.kt
@@ -181,6 +181,10 @@ constructor(private val fpsListener: FpsListener? = null) :
 
   override fun getCommandsMap(): Map<String, Int>? = ReactScrollViewCommandHelper.getCommandsMap()
 
+  @Deprecated(
+      message =
+          "ReceiveCommand with an int commandId param is deprecated. Use the overload where commandId is a string.",
+      ReplaceWith("receiveCommand(scrollView, commandId, args)"))
   override fun receiveCommand(scrollView: ReactScrollView, commandId: Int, args: ReadableArray?) {
     receiveCommand<ReactScrollView>(this, scrollView, commandId, args)
   }


### PR DESCRIPTION
Summary:
OSS CI is failing because the we forgot a deprecation message in ReactScrollViewManager.

## Changelog:
[Internal] - Add deprecation annotation to fix ci build

Differential Revision: D73136939


