### PR TITLE
Add unit test for shadow node state on clone

### DIFF
--- a/packages/react-native/Libraries/ReactNative/__tests__/State-ForcedCloneCommitHook-itest.js
+++ b/packages/react-native/Libraries/ReactNative/__tests__/State-ForcedCloneCommitHook-itest.js
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ * @fantom_flags useShadowNodeStateOnClone:true
+ */
+
+import 'react-native/Libraries/Core/InitializeCore';
+
+import ensureInstance from '../../../src/private/__tests__/utilities/ensureInstance';
+import * as Fantom from '@react-native/fantom';
+import * as React from 'react';
+import {ScrollView, View} from 'react-native';
+import NativeFantomForcedCloneCommitHook from 'react-native/src/private/testing/fantom/specs/NativeFantomForcedCloneCommitHook';
+import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
+
+NativeFantomForcedCloneCommitHook.setup();
+
+describe('ScrollViewShadowNode', () => {
+  it('maintains state after commit hook processing', () => {
+    const root = Fantom.createRoot();
+    let maybeScrollViewNode;
+
+    Fantom.runTask(() => {
+      root.render(
+        <View>
+          <ScrollView
+            ref={node => {
+              maybeScrollViewNode = node;
+            }}
+          />
+          <View nativeID="to-be-cloned-in-the-commit-hook" />
+        </View>,
+      );
+    });
+
+    const scrollViewElement = ensureInstance(
+      maybeScrollViewNode,
+      ReactNativeElement,
+    );
+
+    // Scrolling triggers a state update to store the scroll position
+    // - the state update gets committed
+    // - during the commit, the shadow tree gets processed by the commit hook
+    // - the commit hook clones the View with nativeID set to 'to-be-cloned-in-the-commit-hook'
+    // - the parent YogaLayoutableShadowNode receives the changed children
+    // - this leads to all direct children to be adopted
+    // - the ScrollViewShadowNode gets cloned as part of the child adoption
+    Fantom.scrollTo(scrollViewElement, {x: 0, y: 777});
+
+    // With the useShadowNodeStateOnClone feature flag enabled, state is maintained after the commit hook processing
+    expect(scrollViewElement.scrollTop).toBe(777);
+  });
+});

--- a/packages/react-native/ReactCommon/react/nativemodule/fantomforcedclonecommithook/NativeFantomForcedCloneCommitHook.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/fantomforcedclonecommithook/NativeFantomForcedCloneCommitHook.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "NativeFantomForcedCloneCommitHook.h"
+#include <cxxreact/TraceSection.h>
+#include <react/featureflags/ReactNativeFeatureFlags.h>
+#include <react/renderer/components/scrollview/ScrollViewShadowNode.h>
+#include <react/renderer/core/ShadowNode.h>
+#include <react/renderer/uimanager/UIManagerBinding.h>
+#include <react/renderer/uimanager/UIManagerCommitHook.h>
+#include <react/renderer/uimanager/primitives.h>
+
+#include "Plugins.h"
+
+std::shared_ptr<facebook::react::TurboModule>
+NativeFantomForcedCloneCommitHookModuleProvider(
+    std::shared_ptr<facebook::react::CallInvoker> jsInvoker) {
+  return std::make_shared<facebook::react::NativeFantomForcedCloneCommitHook>(
+      std::move(jsInvoker));
+}
+
+namespace facebook::react {
+
+struct FantomForcedCloneCommitHook : public UIManagerCommitHook {
+  void commitHookWasRegistered(
+      const UIManager& /*uiManager*/) noexcept override {}
+  void commitHookWasUnregistered(
+      const UIManager& /*uiManager*/) noexcept override {}
+  RootShadowNode::Unshared shadowTreeWillCommit(
+      const ShadowTree& shadowTree,
+      const RootShadowNode::Shared& oldRootShadowNode,
+      const RootShadowNode::Unshared& newRootShadowNode) noexcept override;
+};
+
+ShadowNode::Shared findAndClone(const ShadowNode::Shared& node) {
+  if (node->getProps()->nativeId == "to-be-cloned-in-the-commit-hook") {
+    return node->clone({});
+  }
+
+  auto children = node->getChildren();
+  for (int i = 0; i < children.size(); i++) {
+    auto& child = children[i];
+    auto maybeClone = findAndClone(child);
+    if (maybeClone != child) {
+      children[i] = maybeClone;
+      return node->clone(
+          {ShadowNodeFragment::propsPlaceholder(),
+           std::make_shared<ShadowNode::ListOfShared>(children)});
+    }
+  }
+
+  return node;
+}
+
+RootShadowNode::Unshared FantomForcedCloneCommitHook::shadowTreeWillCommit(
+    const ShadowTree& /*shadowTree*/,
+    const RootShadowNode::Shared& /*oldRootShadowNode*/,
+    const RootShadowNode::Unshared& newRootShadowNode) noexcept {
+  auto result = findAndClone(newRootShadowNode);
+
+  return std::static_pointer_cast<RootShadowNode>(
+      std::const_pointer_cast<ShadowNode>(result));
+}
+
+static UIManager& getUIManagerFromRuntime(jsi::Runtime& runtime) {
+  return UIManagerBinding::getBinding(runtime)->getUIManager();
+}
+
+NativeFantomForcedCloneCommitHook::NativeFantomForcedCloneCommitHook(
+    std::shared_ptr<CallInvoker> jsInvoker)
+    : NativeFantomForcedCloneCommitHookCxxSpec(std::move(jsInvoker)),
+      fantomForcedCloneCommitHook_(
+          std::make_shared<FantomForcedCloneCommitHook>()) {}
+
+void NativeFantomForcedCloneCommitHook::setup(jsi::Runtime& runtime) {
+  auto& uiManager = getUIManagerFromRuntime(runtime);
+  uiManager.registerCommitHook(*fantomForcedCloneCommitHook_);
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/fantomforcedclonecommithook/NativeFantomForcedCloneCommitHook.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/fantomforcedclonecommithook/NativeFantomForcedCloneCommitHook.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <FBReactNativeSpec/FBReactNativeSpecJSI.h>
+#include <react/renderer/uimanager/UIManager.h>
+
+namespace facebook::react {
+
+struct FantomForcedCloneCommitHook;
+
+class NativeFantomForcedCloneCommitHook
+    : public NativeFantomForcedCloneCommitHookCxxSpec<
+          NativeFantomForcedCloneCommitHook> {
+ public:
+  explicit NativeFantomForcedCloneCommitHook(
+      std::shared_ptr<CallInvoker> jsInvoker);
+
+  void setup(jsi::Runtime& runtime);
+
+ private:
+  std::shared_ptr<FantomForcedCloneCommitHook> fantomForcedCloneCommitHook_{};
+};
+
+} // namespace facebook::react

--- a/packages/react-native/src/private/testing/fantom/specs/NativeFantomForcedCloneCommitHook.js
+++ b/packages/react-native/src/private/testing/fantom/specs/NativeFantomForcedCloneCommitHook.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ */
+
+import type {TurboModule} from '../../../../../Libraries/TurboModule/RCTExport';
+
+import * as TurboModuleRegistry from '../../../../../Libraries/TurboModule/TurboModuleRegistry';
+
+export interface Spec extends TurboModule {
+  +setup: () => void;
+}
+
+export default (TurboModuleRegistry.getEnforcing<Spec>(
+  'NativeFantomForcedCloneCommitHookCxx',
+): Spec);


### PR DESCRIPTION
Summary:
Adding a Fantom test for the `useShadowNodeStateOnClone` feature flag, showing that the shadow node state is maintained after commit hook processing only when the feature flag is enabled.

Changelog: [Internal]

Differential Revision: D73121159
