### PR TITLE
Add a lint rule preventing named type imports from React

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -82,6 +82,7 @@ module.exports = {
         'lint/require-extends-error': 2,
         'lint/no-react-node-imports': 2,
         'lint/no-react-default-imports': 2,
+        'lint/no-react-named-type-imports': 2,
       },
     },
     {

--- a/packages/react-native/Libraries/Image/__tests__/Image-test.js
+++ b/packages/react-native/Libraries/Image/__tests__/Image-test.js
@@ -11,16 +11,14 @@
 
 'use strict';
 
-import type {ElementRef} from 'react';
-
 import NativeImageLoaderAndroid from '../NativeImageLoaderAndroid';
 import NativeImageLoaderIOS from '../NativeImageLoaderIOS';
+import * as React from 'react';
 import {act, create} from 'react-test-renderer';
 
 const render = require('../../../jest/renderer');
 const Image = require('../Image').default;
 const ImageInjection = require('../ImageInjection');
-const React = require('react');
 
 describe('Image', () => {
   it('should render as <Image> when mocked', async () => {
@@ -46,7 +44,7 @@ describe('Image', () => {
     let imageInstanceFromRef1 = null;
     let imageInstanceFromRef2 = null;
 
-    const callback = jest.fn((instance: ElementRef<typeof Image>) => {
+    const callback = jest.fn((instance: React.ElementRef<typeof Image>) => {
       imageInstanceFromCallback = instance;
 
       return () => {
@@ -106,7 +104,7 @@ describe('Image', () => {
     let imageInstanceFromCallback = null;
     let imageInstanceFromRef = null;
 
-    const callback = (instance: ElementRef<typeof Image>) => {
+    const callback = (instance: React.ElementRef<typeof Image>) => {
       imageInstanceFromCallback = instance;
 
       return () => {
@@ -216,7 +214,7 @@ describe('Image', () => {
   it('should call image attached callbacks (multiple images)', () => {
     jest.dontMock('../Image');
 
-    let imageInstancesFromCallback = new Set<ElementRef<typeof Image>>();
+    let imageInstancesFromCallback = new Set<React.ElementRef<typeof Image>>();
 
     ImageInjection.unstable_registerImageAttachedCallback(instance => {
       imageInstancesFromCallback.add(instance);

--- a/packages/react-native/Libraries/Lists/SectionListModern.js
+++ b/packages/react-native/Libraries/Lists/SectionListModern.js
@@ -17,7 +17,6 @@ import type {
   SectionData,
   VirtualizedSectionListProps,
 } from '@react-native/virtualized-lists';
-import type {ElementRef} from 'react';
 
 import Platform from '../Utilities/Platform';
 import VirtualizedLists from '@react-native/virtualized-lists';
@@ -175,7 +174,7 @@ const SectionList: component(
     ...props,
   };
 
-  const wrapperRef = useRef<?ElementRef<typeof VirtualizedSectionList>>();
+  const wrapperRef = useRef<?React.ElementRef<typeof VirtualizedSectionList>>();
 
   useImperativeHandle(
     ref,

--- a/packages/react-native/src/private/renderer/errorhandling/ErrorHandlers.js
+++ b/packages/react-native/src/private/renderer/errorhandling/ErrorHandlers.js
@@ -9,16 +9,16 @@
  */
 
 import type {ExtendedError} from '../../../../Libraries/Core/ExtendedError';
-import type {Component as ReactComponent} from 'react';
 
 import ExceptionsManager, {
   SyntheticError,
 } from '../../../../Libraries/Core/ExceptionsManager';
+import * as React from 'react';
 
 type ErrorInfo = {
   +componentStack?: ?string,
   // $FlowFixMe[unclear-type] unknown props and state.
-  +errorBoundary?: ?ReactComponent<any, any>,
+  +errorBoundary?: ?React.Component<any, any>,
 };
 
 function getExtendedError(

--- a/tools/eslint/rules/__tests__/no-react-named-type-imports.js
+++ b/tools/eslint/rules/__tests__/no-react-named-type-imports.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+'use strict';
+
+const rule = require('../no-react-named-type-imports');
+const {RuleTester} = require('eslint');
+
+const ruleTester = new RuleTester({
+  parser: require.resolve('hermes-eslint'),
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run('import type { ... } from "react"', rule, {
+  valid: [],
+  invalid: [
+    {
+      code: `import type { ElementRef } from "react";`,
+      errors: [{messageId: 'noNamedTypeImports'}],
+      output: null,
+    },
+  ],
+});
+
+ruleTester.run('import { ... } from "react"', rule, {
+  valid: [
+    {
+      code: `import { useRef } from "react";`,
+    },
+    {
+      code: `import { useRef, useState } from "react";`,
+    },
+  ],
+  invalid: [
+    {
+      code: `import { type ElementRef } from "react";`,
+      errors: [{messageId: 'noNamedTypeImports'}],
+      output: null,
+    },
+    {
+      code: `import { useState, type ElementRef } from "react";`,
+      errors: [{messageId: 'noNamedTypeImports'}],
+      output: null,
+    },
+  ],
+});

--- a/tools/eslint/rules/no-react-named-type-imports.js
+++ b/tools/eslint/rules/no-react-named-type-imports.js
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+'use strict';
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow named type imports from react',
+    },
+    messages: {
+      noNamedTypeImports:
+        'flow-api-translator relies on react types being used under a single React namespace. Prefer `import * as React`.',
+    },
+    schema: [],
+    fixable: 'code',
+  },
+
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value !== 'react') {
+          return;
+        }
+
+        if (node.importKind === 'type') {
+          context.report({
+            node,
+            messageId: 'noNamedTypeImports',
+          });
+
+          return;
+        }
+
+        const hasTypeSpecifier = node.specifiers.some(
+          specifier =>
+            specifier.type === 'ImportSpecifier' &&
+            specifier.importKind === 'type',
+        );
+
+        if (hasTypeSpecifier) {
+          context.report({
+            node,
+            messageId: 'noNamedTypeImports',
+          });
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Adds a lint rule that prevents the use of named imports when importing types from React. `flow-api-translator` relies on the `React` namespace being used when generating TypeScript definitions based on Flow.

Differential Revision: D73170799
