### PR TITLE
Fix TextInput `onContentSizeChange` event being dispatched only once on iOS

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -71,6 +71,7 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
   NSDictionary<NSAttributedStringKey, id> *_originalTypingAttributes;
 
   BOOL _hasInputAccessoryView;
+  CGSize _previousContentSize;
 }
 
 #pragma mark - UIView overrides
@@ -87,6 +88,7 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
     _comingFromJS = NO;
     _didMoveToWindow = NO;
     _originalTypingAttributes = [_backedTextInputView.typingAttributes copy];
+    _previousContentSize = CGSizeZero;
 
     [self addSubview:_backedTextInputView];
     [self initializeReturnKeyType];
@@ -336,8 +338,6 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
 - (void)updateLayoutMetrics:(const LayoutMetrics &)layoutMetrics
            oldLayoutMetrics:(const LayoutMetrics &)oldLayoutMetrics
 {
-  CGSize previousContentSize = _backedTextInputView.contentSize;
-
   [super updateLayoutMetrics:layoutMetrics oldLayoutMetrics:oldLayoutMetrics];
 
   _backedTextInputView.frame =
@@ -345,7 +345,8 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
   _backedTextInputView.textContainerInset =
       RCTUIEdgeInsetsFromEdgeInsets(layoutMetrics.contentInsets - layoutMetrics.borderWidth);
 
-  if (!CGSizeEqualToSize(previousContentSize, _backedTextInputView.contentSize) && _eventEmitter) {
+  if (!CGSizeEqualToSize(_previousContentSize, _backedTextInputView.contentSize) && _eventEmitter) {
+    _previousContentSize = _backedTextInputView.contentSize;
     static_cast<const TextInputEventEmitter &>(*_eventEmitter).onContentSizeChange([self _textInputMetrics]);
   }
 }


### PR DESCRIPTION
Summary:
Changelog: [IOS][FIXED] Fix TextInput `onContentSizeChange` event being dispatched only once on iOS on the new architecture

Currently, the comparison to decide whether to send event happens between the content size before and after layout metrics update. Those values turn out to be the same in all but the first call.

This updates the logic to use the previously send values in the comparison.

Differential Revision: D73182563


