### PR TITLE
Re-add an `eventName` field inside Event.kt to unbreak several libraries

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -5004,6 +5004,7 @@ public abstract class com/facebook/react/uimanager/events/Event {
 	protected final fun init (I)V
 	protected final fun init (II)V
 	protected final fun init (IIJ)V
+	public final fun internal_getEventNameCompat ()Ljava/lang/String;
 	public final fun isInitialized ()Z
 	public fun onDispose ()V
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/interop/InteropEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/interop/InteropEvent.kt
@@ -19,13 +19,13 @@ import com.facebook.react.uimanager.events.Event
  */
 @LegacyArchitecture
 internal class InteropEvent(
-    @get:JvmName("eventName") val eventName: String,
+    @get:JvmName("eventName") val interopEventName: String,
     @get:JvmName("eventData") val eventData: WritableMap?,
     surfaceId: Int,
     viewTag: Int
 ) : Event<InteropEvent>(surfaceId, viewTag) {
 
-  override fun getEventName(): String = eventName
+  override fun getEventName(): String = interopEventName
 
   override fun getEventData(): WritableMap? = eventData
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/Event.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/Event.kt
@@ -117,13 +117,18 @@ public abstract class Event<T : Event<T>> {
   /** @return the name of this event as registered in JS */
   public abstract fun getEventName(): String
 
+  /** Property added for backward compatibility with property accessors */
+  @get:JvmName("internal_getEventNameCompat")
+  public val eventName: String
+    get() = getEventName()
+
   public open val eventAnimationDriverMatchSpec: EventAnimationDriverMatchSpec?
     get() {
       if (eventAnimationDriverMatchSpecCached == null) {
         eventAnimationDriverMatchSpecCached =
             object : EventAnimationDriverMatchSpec {
               override fun match(viewTagRhs: Int, eventNameRhs: String): Boolean {
-                return viewTag == viewTagRhs && getEventName() == eventNameRhs
+                return viewTag == viewTagRhs && eventName == eventNameRhs
               }
             }
       }
@@ -137,7 +142,7 @@ public abstract class Event<T : Event<T>> {
    */
   @Deprecated("Prefer to override getEventData instead")
   public open fun dispatch(rctEventEmitter: RCTEventEmitter) {
-    rctEventEmitter.receiveEvent(viewTag, getEventName(), getEventData())
+    rctEventEmitter.receiveEvent(viewTag, eventName, getEventData())
   }
 
   /** Can be overridden by classes when no custom logic for dispatching is needed. */
@@ -181,7 +186,7 @@ public abstract class Event<T : Event<T>> {
       rctEventEmitter.receiveEvent(
           surfaceId,
           viewTag,
-          getEventName(),
+          eventName,
           canCoalesce(),
           getCoalescingKey().toInt(),
           getEventData(),


### PR DESCRIPTION
Summary:
Converting Event from Java to Kotlin resulted in a number of breaking changes for Kotlin
libraries that were using an `.eventName` accessors from the `getEventName()` Java method.

This diff re-adds the `eventName` property without backing field.
This could potentially be disruptive in OSS but only one library is affected:
https://github.com/search?type=code&q=%22import+com.facebook.react.uimanager.events.Event%22+%22val+eventName%3A%22+%22%3A+Event%3C%22+language%3AKotlin+path%3A*Event.kt+NOT+is%3Afork+NOT+org%3Afacebook+NOT+path%3AInteropEvent.kt

Changelog:
[Internal] [Changed] -

Reviewed By: cipolleschi

Differential Revision: D73193202


