### PR TITLE
Make `JSStackTrace` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -5320,15 +5320,6 @@ public abstract interface class com/facebook/react/uimanager/util/ReactFindViewU
 	public abstract fun onViewFound (Landroid/view/View;)V
 }
 
-public final class com/facebook/react/util/JSStackTrace {
-	public static final field COLUMN_KEY Ljava/lang/String;
-	public static final field FILE_KEY Ljava/lang/String;
-	public static final field INSTANCE Lcom/facebook/react/util/JSStackTrace;
-	public static final field LINE_NUMBER_KEY Ljava/lang/String;
-	public static final field METHOD_NAME_KEY Ljava/lang/String;
-	public static final fun format (Ljava/lang/String;Lcom/facebook/react/bridge/ReadableArray;)Ljava/lang/String;
-}
-
 public final class com/facebook/react/util/RNLog {
 	public static final field ADVICE I
 	public static final field ERROR I

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/util/JSStackTrace.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/util/JSStackTrace.kt
@@ -12,16 +12,16 @@ import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.ReadableType
 import java.util.regex.Pattern
 
-public object JSStackTrace {
+internal object JSStackTrace {
 
-  public const val LINE_NUMBER_KEY: String = "lineNumber"
-  public const val FILE_KEY: String = "file"
-  public const val COLUMN_KEY: String = "column"
-  public const val METHOD_NAME_KEY: String = "methodName"
+  const val LINE_NUMBER_KEY: String = "lineNumber"
+  const val FILE_KEY: String = "file"
+  const val COLUMN_KEY: String = "column"
+  const val METHOD_NAME_KEY: String = "methodName"
   private val FILE_ID_PATTERN = Pattern.compile("\\b((?:seg-\\d+(?:_\\d+)?|\\d+)\\.js)")
 
   @JvmStatic
-  public fun format(message: String, stack: ReadableArray): String {
+  fun format(message: String, stack: ReadableArray): String {
     val stringBuilder = StringBuilder(message).append(", stack:\n")
     for (i in 0 until stack.size()) {
       val frame = stack.getMap(i) ?: continue


### PR DESCRIPTION
## Summary:

This class can be internalized as part of the initiative to reduce the public API surface. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.util.JSStackTrace).

## Changelog:

[INTERNAL] - Make com.facebook.react.util.JSStackTrace internal

## Test Plan:

```bash
yarn test-android
yarn android
```