### PR TITLE
Make `MultiSourceHelper` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -5717,18 +5717,6 @@ public final class com/facebook/react/views/imagehelper/ImageSource$Companion {
 	public final fun getTransparentBitmapImageSource (Landroid/content/Context;)Lcom/facebook/react/views/imagehelper/ImageSource;
 }
 
-public final class com/facebook/react/views/imagehelper/MultiSourceHelper {
-	public static final field INSTANCE Lcom/facebook/react/views/imagehelper/MultiSourceHelper;
-	public static final fun getBestSourceForSize (IILjava/util/List;)Lcom/facebook/react/views/imagehelper/MultiSourceHelper$MultiSourceResult;
-	public static final fun getBestSourceForSize (IILjava/util/List;D)Lcom/facebook/react/views/imagehelper/MultiSourceHelper$MultiSourceResult;
-}
-
-public final class com/facebook/react/views/imagehelper/MultiSourceHelper$MultiSourceResult {
-	public final field bestResult Lcom/facebook/react/views/imagehelper/ImageSource;
-	public final field bestResultInCache Lcom/facebook/react/views/imagehelper/ImageSource;
-	public fun <init> (Lcom/facebook/react/views/imagehelper/ImageSource;Lcom/facebook/react/views/imagehelper/ImageSource;)V
-}
-
 public final class com/facebook/react/views/imagehelper/ResourceDrawableIdHelper {
 	public static final field Companion Lcom/facebook/react/views/imagehelper/ResourceDrawableIdHelper$Companion;
 	public final fun clear ()V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/imagehelper/MultiSourceHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/imagehelper/MultiSourceHelper.kt
@@ -11,9 +11,9 @@ import com.facebook.imagepipeline.core.ImagePipelineFactory
 import com.facebook.react.modules.fresco.ImageCacheControl
 
 /** Helper class for dealing with multisource images. */
-public object MultiSourceHelper {
+internal object MultiSourceHelper {
   @JvmStatic
-  public fun getBestSourceForSize(
+  fun getBestSourceForSize(
       width: Int,
       height: Int,
       sources: List<ImageSource>
@@ -29,7 +29,7 @@ public object MultiSourceHelper {
    *   best source; this is useful if the image will be displayed bigger than the view (e.g. zoomed)
    */
   @JvmStatic
-  public fun getBestSourceForSize(
+  fun getBestSourceForSize(
       width: Int,
       height: Int,
       sources: List<ImageSource>,
@@ -78,16 +78,16 @@ public object MultiSourceHelper {
     return MultiSourceResult(best, bestCached)
   }
 
-  public class MultiSourceResult(
+  class MultiSourceResult(
       /**
        * Get the best result overall (closest in size to the view's size). Can be null if there were
        * no sources to choose from, or if there were more than 1 sources but width/height were 0.
        */
-      @JvmField public val bestResult: ImageSource?,
+      @JvmField val bestResult: ImageSource?,
       /**
        * Get the best result (closest in size to the view's size) that is also in cache. If this
        * would be the same as the source from [.getBestResult], this will return `null` instead.
        */
-      @JvmField public val bestResultInCache: ImageSource?
+      @JvmField val bestResultInCache: ImageSource?
   )
 }


### PR DESCRIPTION
## Summary:

This class can be internalized as part of the initiative to reduce the public API surface. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.views.imagehelper.MultiSourceHelper).

## Changelog:

[INTERNAL] - Make com.facebook.react.views.imagehelper.MultiSourceHelper internal

## Test Plan:

```bash
yarn test-android
yarn android
```