### PR TITLE
Allow Switch to use default UISwitch accessibility annoucements

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Switch/RCTSwitchComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Switch/RCTSwitchComponentView.mm
@@ -101,6 +101,18 @@ using namespace facebook::react;
       .onChange(SwitchEventEmitter::OnChange{.value = static_cast<bool>(sender.on)});
 }
 
+// UISwitch is the accessibility element not this view. If this is YES we block
+// accessibility on the switch itself
+- (BOOL)isAccessibilityElement
+{
+  return NO;
+}
+
+- (NSObject *)accessibilityElement
+{
+  return _switchView;
+}
+
 #pragma mark - Native Commands
 
 - (void)handleCommand:(const NSString *)commandName args:(const NSArray *)args


### PR DESCRIPTION
Summary:
When we render a `Switch` today we are never actually focusing on the native `UISwitch` that gets rendered. We instead focus on the parent `RCTViewComponentView` which houses the `UISwitch` as a `contentView`. That is because of [this logic](https://www.internalfb.com/code/fbsource/[b7e1547dab5a]/xplat/js/react-native-github/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm?lines=1211-1213). This blocks the accessibility of any descendants, including the `contentView`. 

What we lose here is the announcement of "on" and "off" based on the toggle state that comes built into `UISwitch`. To do this today you need to add `accessibilityState={{checked: ...}}` which is very unintuitive. Android DOES announce "on" and "off".

We can fix this with an override on the switch class.

Changelog: [iOS][Fixed] - Fix "on" and "off" announcements on `Switch`

Differential Revision: D73226500


