### PR TITLE
Add showsVerticalScrollIndicator in ScrollViewProps.cpp SetProp

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.cpp
@@ -407,6 +407,7 @@ void ScrollViewProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(pinchGestureEnabled);
     RAW_SET_PROP_SWITCH_CASE_BASIC(scrollsToTop);
     RAW_SET_PROP_SWITCH_CASE_BASIC(showsHorizontalScrollIndicator);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(showsVerticalScrollIndicator);
     RAW_SET_PROP_SWITCH_CASE_BASIC(persistentScrollbar);
     RAW_SET_PROP_SWITCH_CASE_BASIC(horizontal);
     RAW_SET_PROP_SWITCH_CASE_BASIC(scrollEventThrottle);


### PR DESCRIPTION
## Summary:

https://github.com/facebook/react-native/blob/a3252def1990c0d0afba67a4698357bc91c5bb2a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.cpp#L409

Need to add     `RAW_SET_PROP_SWITCH_CASE_BASIC(showsVerticalScrollIndicator);` as it's missing

Related PR: https://github.com/microsoft/react-native-windows/pull/14526
Resolves: https://github.com/facebook/react-native/issues/50779

## Changelog:

Add showsVerticalScrollIndicator in ScrollViewProps.cpp SetProp

Pick one each for the category and type tags:

[GENERAL] [ADDED] - Message

Windows : RNW

## Test Plan:
Tested here: Related PR: https://github.com/microsoft/react-native-windows/pull/14526
