### PR TITLE
Support headers [crossOrigin and referralPolicy] in Image without src and srcSet and only remote source.uri

### DIFF
--- a/packages/react-native/Libraries/Image/ImageSourceUtils.js
+++ b/packages/react-native/Libraries/Image/ImageSourceUtils.js
@@ -73,6 +73,8 @@ export function getImageSourcesFromImageProps(
     sources = sourceList;
   } else if (src != null) {
     sources = [{uri: src, headers: headers, width, height}];
+  } else if (source != null && source.uri) {
+    sources = [{...source, headers}];
   } else {
     sources = source;
   }

--- a/packages/react-native/Libraries/Image/__tests__/__snapshots__/Image-test.js.snap
+++ b/packages/react-native/Libraries/Image/__tests__/__snapshots__/Image-test.js.snap
@@ -26,16 +26,13 @@ exports[`Image should render as <RCTImageView> when not mocked 1`] = `
   source={
     Array [
       Object {
+        "headers": Object {},
         "uri": "foo-bar.jpg",
       },
     ]
   }
   style={
     Array [
-      Object {
-        "height": undefined,
-        "width": undefined,
-      },
       Object {
         "overflow": "hidden",
       },


### PR DESCRIPTION
## Summary:

Resolves https://github.com/facebook/react-native/issues/50778

### Problem Description

Implement the crossOrigin property for Image in RNW Fabric when only source.uri is passed and not src/ srcSet.

For reference, check the public API documentation: https://reactnative.dev/docs/image#crossorigin

Implement the referrerPolicy property for Image in RNW Fabric when only source.uri is passed and not src/ srcSet.

For reference, check the public API documentation: https://reactnative.dev/docs/image#referrerpolicy

Also refer docs for source, src, srcSet
https://reactnative.dev/docs/image#source
https://reactnative.dev/docs/image#src
https://reactnative.dev/docs/image#srcset

It's not mentioned in the doc that when src / srcSet is missing then crossOrigin / referralPolicy would be ignored when source uri is a remote URL that is passed.

Currently these were ignored if src / srcSet was not passed and not added to sources headers.

This change adds headers support even without passing src / srcSet and only sources uri that consists of remote URL.

crossOrigin and referrerPolicy are passed as source.headers here:

![Image](https://github.com/user-attachments/assets/6df1a274-353e-4e03-9033-75695d04e2c0)


### Steps to reproduce


```
 <Image
              defaultSource={{uri: this.state.defaultImageUri}}
              source={{uri: this.state.imageUri}}
              crossOrigin="use-credentials"
              referrerPolicy="no-referrer"
            />
```

Pass this in React Native and check source headers

  
## Changelog:
[GENERAL] [ADDED] - Support headers [crossOrigin and referralPolicy] in Image without src and srcSet and only remote source.uri

## Test Plan:
Refer this PR for testing; https://github.com/microsoft/react-native-windows/pull/14521
## Screenshots
_Add any relevant screen captures here from before or after your changes._ 
Before
![image](https://github.com/user-attachments/assets/21804411-91f4-4a27-b6e9-971675cbd546)

After
<img width="790" alt="image" src="https://github.com/user-attachments/assets/8e0a2522-7009-430d-b848-da80896670f4" />

## Testing
_If you added tests that prove your changes are effective or that your feature works, add a few sentences here detailing the added test scenarios._

Tested in playground and RNW Tester and Visual Studio Debugger

_Optional_: Describe the tests that you ran locally to verify your changes.

1. Tested with only source remote uri passed
2. Tested with both source, src
3. Tested with source, src, srcSet