### PR TITLE
feat: optimize Hermes for speed rather than size in Android

### DIFF
--- a/packages/react-native/ReactAndroid/hermes-engine/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/hermes-engine/build.gradle.kts
@@ -275,7 +275,7 @@ android {
       externalNativeBuild {
         cmake {
           arguments(
-              "-DCMAKE_BUILD_TYPE=MinSizeRel",
+              "-DCMAKE_BUILD_TYPE=Release",
               // For release builds, we don't want to enable the Hermes Debugger.
               "-DHERMES_ENABLE_DEBUGGER=False")
         }


### PR DESCRIPTION
## Summary:

The `Release` flag is being used for iOS but interestingly, on Android it is optimized for size.
I haven't done any performance testing but from my experience within our react native application, we have noticed that Hermes on iOS devices generally runs much faster than comparable Android devices.

We'll be conducting performance testing on our hermes fork & inside our own application soon but I don't have numbers yet.
LTO was also recently enabled in https://github.com/facebook/react-native/pull/50529 which may also affect performance which makes estimating the isolated performance impact of this PR alone a bit more complicated.

Size changes: 
* hermes-release.aar went from 6.9 MB to 9.2 MB on our fork.
* `hermes-release.aar/jni/{arch}/libhermes.so`
  * arm64-v8a: 1.8 MB -> 2.3 MB
  * armeabi-v7a: 1.3 MB -> 1.8 MB
  * x86: 2.2MB -> 3.2MB
  * x86_64: 2MB -> 2.7 MB

## Changelog:

[ANDROID] [CHANGED] - build hermes release version optimized for speed rather than size 

## Test Plan:

- [ ] Does the libhermes dynamic library change a lot in size?
- [ ] Is the performance difference worth it?