### PR TITLE
Fix logic around hiding chrome with deeplinks on small screen

### DIFF
--- a/packages/rn-tester/js/RNTesterAppShared.js
+++ b/packages/rn-tester/js/RNTesterAppShared.js
@@ -79,8 +79,7 @@ const RNTesterApp = ({
     hadDeepLink,
   } = state;
 
-  const {height, scale} = useWindowDimensions();
-  const isScreenTiny = height / scale < 400;
+  const isScreenTiny = useWindowDimensions().height < 600;
 
   const examplesList = React.useMemo(
     () => getExamplesListWithRecentlyUsed({recentlyUsed, testList}),

--- a/packages/rn-tester/js/utils/RNTesterNavigationReducer.js
+++ b/packages/rn-tester/js/utils/RNTesterNavigationReducer.js
@@ -85,7 +85,7 @@ export const RNTesterNavigationReducer = (
         activeModuleTitle: title,
         activeModuleExampleKey: null,
         screen,
-        hadDeepLink: true,
+        hadDeepLink: false,
       };
 
     case RNTesterNavigationActionsType.MODULE_CARD_PRESS:
@@ -94,6 +94,7 @@ export const RNTesterNavigationReducer = (
         activeModuleKey: key,
         activeModuleTitle: title,
         activeModuleExampleKey: null,
+        hadDeepLink: false,
         // $FlowFixMe[incompatible-return]
         recentlyUsed: getUpdatedRecentlyUsed({
           exampleType: exampleType,
@@ -105,6 +106,7 @@ export const RNTesterNavigationReducer = (
     case RNTesterNavigationActionsType.EXAMPLE_CARD_PRESS:
       return {
         ...state,
+        hadDeepLink: false,
         activeModuleExampleKey: key,
       };
 


### PR DESCRIPTION
Summary:
1. `useWindowDimensions` is already returning in DIPs, my math was just wrong before
2. Playground is marking itself as a deeplink when it shouldn't be

Changelog: [internal]

Reviewed By: cortinico, joevilches

Differential Revision: D73221335


