### PR TITLE
Take 2: Mitigate deadlock hazard in RCTUtils.m

### DIFF
--- a/packages/react-native/React/Base/RCTUtils.mm
+++ b/packages/react-native/React/Base/RCTUtils.mm
@@ -35,15 +35,10 @@ NSString *__nullable RCTHomePathForURL(NSURL *__nullable URL);
 BOOL RCTIsHomeAssetURL(NSURL *__nullable imageURL);
 
 // Whether the New Architecture is enabled or not
-static BOOL _newArchEnabled = false;
 BOOL RCTIsNewArchEnabled(void)
 {
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    NSNumber *rctNewArchEnabled = (NSNumber *)[[NSBundle mainBundle] objectForInfoDictionaryKey:@"RCTNewArchEnabled"];
-    _newArchEnabled = rctNewArchEnabled == nil || rctNewArchEnabled.boolValue;
-  });
-  return _newArchEnabled;
+  NSNumber *rctNewArchEnabled = (NSNumber *)[[NSBundle mainBundle] objectForInfoDictionaryKey:@"RCTNewArchEnabled"];
+  return rctNewArchEnabled == nil || rctNewArchEnabled.boolValue;
 }
 void RCTSetNewArchEnabled(BOOL enabled)
 {
@@ -52,16 +47,11 @@ void RCTSetNewArchEnabled(BOOL enabled)
   // whether the New Arch is enabled or not.
 }
 
-static BOOL _legacyWarningEnabled = true;
 BOOL RCTAreLegacyLogsEnabled(void)
 {
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    NSNumber *rctNewArchEnabled =
-        (NSNumber *)[[NSBundle mainBundle] objectForInfoDictionaryKey:@"RCTLegacyWarningsEnabled"];
-    _legacyWarningEnabled = rctNewArchEnabled.boolValue;
-  });
-  return _legacyWarningEnabled;
+  NSNumber *rctNewArchEnabled =
+      (NSNumber *)[[NSBundle mainBundle] objectForInfoDictionaryKey:@"RCTLegacyWarningsEnabled"];
+  return rctNewArchEnabled.boolValue;
 }
 
 static NSString *__nullable _RCTJSONStringifyNoRetry(id __nullable jsonObject, NSError **error)


### PR DESCRIPTION
Summary:
This structure is unsafe:

```
// In each native module:
+load
  dispatch_once
    NSBundle mainBundle
```

NSBundle mainBundle itself uses dispatch_once during initialization. If that initialization triggers a native module class load, we could end up with a circular dependency chain. This could deadlock the application.

## Changes
Just remove the dispatch_once. Getting the NSBundle mainBundle is very efficient after the first access. And NSBundle objectForInfoDictionaryKey is also very efficient.

Created from CodeHub with https://fburl.com/edit-in-codehub

Changelog: [Internal]

Reviewed By: NickGerleman

Differential Revision: D73265906


