### PR TITLE
RN/Metro: Configure Transformer for React 19

### DIFF
--- a/packages/react-native-babel-transformer/src/index.js
+++ b/packages/react-native-babel-transformer/src/index.js
@@ -210,6 +210,7 @@ const transform /*: BabelTransformer['transform'] */ = ({
         : // $FlowFixMe[incompatible-exact]
           require('hermes-parser').parse(src, {
             babel: true,
+            reactRuntimeTarget: '19',
             sourceType: babelConfig.sourceType,
           });
 


### PR DESCRIPTION
Summary:
Configures `react-native/metro-babel-transformer` (used by `react-native/babel-preset`) to parse source using `hermes-parser` to target React 19. This changes components written with Component Syntax to stop generating `forwardRef` calls (because `ref` is now a prop).

Most of this was already accomplished in https://github.com/facebook/react-native/pull/50377 ({D72070021}), but this call site was missed.

Changelog:
[General][Changed] - Configured Hermes Parser to target React 19, resulting in Component Syntax no longer producing `forwardRef` calls.

Differential Revision: D73279825


