### PR TITLE
Log LegacyArchitectureLogger asserts only in Debug mode

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/internal/LegacyArchitectureLogger.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/internal/LegacyArchitectureLogger.kt
@@ -83,14 +83,20 @@ public object LegacyArchitectureLogger {
       name: String,
       logLevel: LegacyArchitectureLogLevel = LegacyArchitectureLogLevel.WARNING
   ) {
-    when (logLevel) {
-      LegacyArchitectureLogLevel.ERROR -> {
-        throw AssertionException("$name $exceptionMessage")
-      }
-      LegacyArchitectureLogLevel.WARNING -> {
-        ReactSoftExceptionLogger.logSoftException(
-            ReactSoftExceptionLogger.Categories.SOFT_ASSERTIONS,
-            ReactNoCrashSoftException("$name $exceptionMessage"))
+    // Assert is being reported only in DEBUG mode to prevent over logging in production while we
+    // we are working on decoupling legacy / new architecture.
+    // Long term the assert will be executed in production and debug environments.
+    if (ReactBuildConfig.DEBUG) {
+      when (logLevel) {
+        LegacyArchitectureLogLevel.ERROR -> {
+          throw AssertionException("$name $exceptionMessage")
+        }
+
+        LegacyArchitectureLogLevel.WARNING -> {
+          ReactSoftExceptionLogger.logSoftException(
+              ReactSoftExceptionLogger.Categories.SOFT_ASSERTIONS,
+              ReactNoCrashSoftException("$name $exceptionMessage"))
+        }
       }
     }
   }


### PR DESCRIPTION
Summary:
Logging LegacyArchitectureLogger asserts only in Debug mode as that will give us enough information about wrong usages of Legacy Architecture at this point

changelog: [internal] internal

Differential Revision: D73322301


