### PR TITLE
Add fabric implementation to find Top-Most relative and relevant parent of a child view (#50404)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManagerBinding.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManagerBinding.kt
@@ -57,6 +57,8 @@ internal class FabricUIManagerBinding : HybridClassBase() {
 
   external fun findNextFocusableElement(parentTag: Int, focusedTag: Int, direction: Int): Int
 
+  external fun findRelativeTopMostParent(rootTag: Int, childTag: Int): Int
+
   external fun stopSurface(surfaceId: Int)
 
   external fun stopSurfaceWithSurfaceHandler(surfaceHandler: SurfaceHandlerBinding)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManagerBinding.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManagerBinding.kt
@@ -55,6 +55,8 @@ internal class FabricUIManagerBinding : HybridClassBase() {
       isMountable: Boolean
   )
 
+  external fun findNextFocusableElement(parentTag: Int, focusedTag: Int, direction: Int): Int
+
   external fun stopSurface(surfaceId: Int)
 
   external fun stopSurfaceWithSurfaceHandler(surfaceHandler: SurfaceHandlerBinding)

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
@@ -253,6 +253,40 @@ jint FabricUIManagerBinding::findNextFocusableElement(
   return nextNode->getTag();
 }
 
+jint FabricUIManagerBinding::findRelativeTopMostParent(
+    jint rootTag,
+    jint childTag) {
+  std::shared_ptr<UIManager> uimanager = getScheduler()->getUIManager();
+
+  ShadowNode::Shared childShadowNode =
+      uimanager->findShadowNodeByTag_DEPRECATED(childTag);
+  ShadowNode::Shared rootShadowNode =
+      uimanager->findShadowNodeByTag_DEPRECATED(rootTag);
+
+  if (childShadowNode == nullptr || rootShadowNode == nullptr) {
+    return -1;
+  }
+
+  ShadowNode::AncestorList ancestorList =
+      childShadowNode->getFamily().getAncestors(*rootShadowNode);
+
+  if (ancestorList.empty() || ancestorList.size() < 2) {
+    return -1;
+  }
+
+  // ignore the first ancestor as it is the rootShadowNode itself
+  for (auto it = std::next(ancestorList.begin()); it != ancestorList.end();
+       ++it) {
+    auto& ancestor = *it;
+    if (ancestor.first.get().getTraits().check(
+            ShadowNodeTraits::Trait::FormsStackingContext)) {
+      return ancestor.first.get().getTag();
+    }
+  }
+
+  return -1;
+}
+
 // Used by non-bridgeless+Fabric
 void FabricUIManagerBinding::startSurfaceWithConstraints(
     jint surfaceId,
@@ -728,6 +762,9 @@ void FabricUIManagerBinding::registerNatives() {
       makeNativeMethod(
           "findNextFocusableElement",
           FabricUIManagerBinding::findNextFocusableElement),
+      makeNativeMethod(
+          "findRelativeTopMostParent",
+          FabricUIManagerBinding::findRelativeTopMostParent),
   });
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
@@ -11,6 +11,7 @@
 #include "ComponentFactory.h"
 #include "EventBeatManager.h"
 #include "FabricMountingManager.h"
+#include "FocusOrderingHelper.h"
 
 #include <cxxreact/TraceSection.h>
 #include <fbjni/fbjni.h>
@@ -193,6 +194,63 @@ void FabricUIManagerBinding::startSurface(
     std::unique_lock lock(surfaceHandlerRegistryMutex_);
     surfaceHandlerRegistry_.emplace(surfaceId, std::move(surfaceHandler));
   }
+}
+
+jint FabricUIManagerBinding::findNextFocusableElement(
+    jint parentTag,
+    jint focusedTag,
+    jint direction) {
+  ShadowNode::Shared nextNode;
+
+  std::optional<FocusDirection> focusDirection =
+      FocusOrderingHelper::resolveFocusDirection(direction);
+
+  if (!focusDirection.has_value()) {
+    return -1;
+  }
+
+  std::shared_ptr<UIManager> uimanager = getScheduler()->getUIManager();
+
+  ShadowNode::Shared parentShadowNode =
+      uimanager->findShadowNodeByTag_DEPRECATED(parentTag);
+
+  if (parentShadowNode == nullptr) {
+    return -1;
+  }
+
+  ShadowNode::Shared focusedShadowNode =
+      FocusOrderingHelper::findShadowNodeByTagRecursively(
+          parentShadowNode, focusedTag);
+
+  if (focusedShadowNode == nullptr) {
+    return -1;
+  }
+
+  LayoutMetrics childLayoutMetrics = uimanager->getRelativeLayoutMetrics(
+      *focusedShadowNode, parentShadowNode.get(), {.includeTransform = true});
+
+  Rect sourceRect = childLayoutMetrics.frame;
+
+  /*
+   * Traverse the tree recursively to find the next focusable element in the
+   * given direction
+   */
+  std::optional<Rect> nextRect = std::nullopt;
+  FocusOrderingHelper::traverseAndUpdateNextFocusableElement(
+      parentShadowNode,
+      focusedShadowNode,
+      parentShadowNode,
+      focusDirection.value(),
+      *uimanager,
+      sourceRect,
+      nextRect,
+      nextNode);
+
+  if (nextNode == nullptr) {
+    return -1;
+  }
+
+  return nextNode->getTag();
 }
 
 // Used by non-bridgeless+Fabric
@@ -667,6 +725,9 @@ void FabricUIManagerBinding::registerNatives() {
       makeNativeMethod(
           "stopSurfaceWithSurfaceHandler",
           FabricUIManagerBinding::stopSurfaceWithSurfaceHandler),
+      makeNativeMethod(
+          "findNextFocusableElement",
+          FabricUIManagerBinding::findNextFocusableElement),
   });
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.h
@@ -132,6 +132,9 @@ class FabricUIManagerBinding : public jni::HybridClass<FabricUIManagerBinding>,
 
   void reportMount(SurfaceId surfaceId);
 
+  jint
+  findNextFocusableElement(jint parentTag, jint focusedTag, jint direction);
+
   void uninstallFabricUIManager();
 
   // Private member variables

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.h
@@ -135,6 +135,8 @@ class FabricUIManagerBinding : public jni::HybridClass<FabricUIManagerBinding>,
   jint
   findNextFocusableElement(jint parentTag, jint focusedTag, jint direction);
 
+  jint findRelativeTopMostParent(jint rootTag, jint childTag);
+
   void uninstallFabricUIManager();
 
   // Private member variables

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FocusOrderingHelper.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FocusOrderingHelper.cpp
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "FocusOrderingHelper.h"
+#include <android/log.h>
+#include <react/renderer/uimanager/UIManager.h>
+
+namespace facebook::react {
+
+int majorAxisDistanceRaw(
+    FocusDirection focusDirection,
+    Rect source,
+    Rect dest) {
+  switch (focusDirection) {
+    case FocusDirection::FocusLeft:
+      return static_cast<int>(
+          source.origin.x - (dest.origin.x + dest.size.width));
+    case FocusDirection::FocusRight:
+      return static_cast<int>(
+          dest.origin.x - (source.origin.x + source.size.width));
+    case FocusDirection::FocusUp:
+      return static_cast<int>(
+          source.origin.y - (dest.origin.y + dest.size.height));
+    case FocusDirection::FocusDown:
+      return static_cast<int>(
+          dest.origin.y - (source.origin.y + source.size.height));
+  }
+}
+
+int majorAxisDistance(FocusDirection focusDirection, Rect source, Rect dest) {
+  return std::max(0, majorAxisDistanceRaw(focusDirection, source, dest));
+}
+
+int minorAxisDistance(FocusDirection direction, Rect source, Rect dest) {
+  switch (direction) {
+    case FocusDirection::FocusLeft:
+    case FocusDirection::FocusRight:
+      // the distance between the center verticals
+      return static_cast<int>(abs((source.getMidY() - dest.getMidY())));
+    case FocusDirection::FocusUp:
+    case FocusDirection::FocusDown:
+      // the distance between the center horizontals
+      return static_cast<int>(abs((source.getMidX() - dest.getMidX())));
+  }
+}
+
+// 13 is a magic number that comes from Android's implementation. We opt to use
+// this to get the same focus ordering as Android. See:
+// https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/core/java/android/view/FocusFinder.java;l=547
+int getWeightedDistanceFor(int majorAxisDistance, int minorAxisDistance) {
+  return 13 * majorAxisDistance * majorAxisDistance +
+      minorAxisDistance * minorAxisDistance;
+}
+
+// Make sure dest rect is actually on the direction of focus
+bool isCandidate(Rect source, Rect dest, FocusDirection focusDirection) {
+  switch (focusDirection) {
+    case FocusDirection::FocusLeft:
+      return ((source.origin.x + source.size.width) >
+                  (dest.origin.x + dest.size.width) ||
+              source.origin.x >= (dest.origin.x + dest.size.width)) &&
+          source.origin.x > dest.origin.x;
+    case FocusDirection::FocusRight:
+      return (source.origin.x < dest.origin.x ||
+              (source.origin.x + source.size.width) <= dest.origin.x) &&
+          (source.origin.x + source.size.width) <
+          (dest.origin.x + dest.size.width);
+    case FocusDirection::FocusUp:
+      return ((source.origin.y + source.size.height) >
+                  (dest.origin.y + dest.size.height) ||
+              source.origin.y >= (dest.origin.y + dest.size.height)) &&
+          source.origin.y > dest.origin.y;
+    case FocusDirection::FocusDown:
+      return (source.origin.y < dest.origin.y ||
+              (source.origin.y + source.size.height) <= dest.origin.y) &&
+          ((source.origin.y + source.size.height) <
+           (dest.origin.y + dest.size.height));
+  }
+}
+
+bool isBetterCandidate(
+    FocusDirection focusDirection,
+    Rect source,
+    Rect current,
+    Rect candidate) {
+  if (!isCandidate(source, candidate, focusDirection)) {
+    return false;
+  }
+
+  int candidateWeightedDistance = getWeightedDistanceFor(
+      majorAxisDistance(focusDirection, source, candidate),
+      minorAxisDistance(focusDirection, source, candidate));
+
+  int currentWeightedDistance = getWeightedDistanceFor(
+      majorAxisDistance(focusDirection, source, current),
+      minorAxisDistance(focusDirection, source, current));
+
+  return candidateWeightedDistance < currentWeightedDistance;
+}
+
+void FocusOrderingHelper::traverseAndUpdateNextFocusableElement(
+    const ShadowNode::Shared& parentShadowNode,
+    const ShadowNode::Shared& focusedShadowNode,
+    const ShadowNode::Shared& currNode,
+    FocusDirection focusDirection,
+    const UIManager& uimanager,
+    Rect sourceRect,
+    std::optional<Rect>& nextRect,
+    ShadowNode::Shared& nextNode) {
+  const auto* props =
+      dynamic_cast<const ViewProps*>(currNode->getProps().get());
+
+  // We only care about focusable elements since only they can be both
+  // focused and present in the hierarchy
+  if (currNode->getTraits().check(ShadowNodeTraits::Trait::KeyboardFocusable) ||
+      (props != nullptr &&
+       (props->focusable || props->accessible || props->hasTVPreferredFocus))) {
+    LayoutMetrics nodeLayoutMetrics = uimanager.getRelativeLayoutMetrics(
+        *currNode, parentShadowNode.get(), {.includeTransform = true});
+
+    if (nextRect == std::nullopt &&
+        isCandidate(sourceRect, nodeLayoutMetrics.frame, focusDirection)) {
+      nextNode = currNode;
+      nextRect = nodeLayoutMetrics.frame;
+    } else if (
+        nextRect != std::nullopt &&
+        isBetterCandidate(
+            focusDirection,
+            sourceRect,
+            nextRect.value(),
+            nodeLayoutMetrics.frame)) {
+      nextNode = currNode;
+      nextRect = nodeLayoutMetrics.frame;
+    }
+  }
+
+  for (auto& child : currNode->getChildren()) {
+    if (child->getTraits().check(ShadowNodeTraits::Trait::RootNodeKind)) {
+      continue;
+    }
+
+    traverseAndUpdateNextFocusableElement(
+        parentShadowNode,
+        focusedShadowNode,
+        child,
+        focusDirection,
+        uimanager,
+        sourceRect,
+        nextRect,
+        nextNode);
+  };
+};
+
+ShadowNode::Shared FocusOrderingHelper::findShadowNodeByTagRecursively(
+    const ShadowNode::Shared& parentShadowNode,
+    Tag tag) {
+  if (parentShadowNode->getTag() == tag) {
+    return parentShadowNode;
+  }
+
+  for (auto& shadowNode : parentShadowNode->getChildren()) {
+    if (auto result = findShadowNodeByTagRecursively(shadowNode, tag)) {
+      return result;
+    }
+  }
+
+  return nullptr;
+}
+
+std::optional<FocusDirection> FocusOrderingHelper::resolveFocusDirection(
+    int direction) {
+  switch (static_cast<FocusDirection>(direction)) {
+    case FocusDirection::FocusDown:
+    case FocusDirection::FocusUp:
+    case FocusDirection::FocusRight:
+    case FocusDirection::FocusLeft:
+      return static_cast<FocusDirection>(direction);
+  }
+
+  return std::nullopt;
+}
+} // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FocusOrderingHelper.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FocusOrderingHelper.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <react/renderer/uimanager/UIManager.h>
+#include "FabricUIManagerBinding.h"
+
+namespace facebook::react {
+
+enum class FocusDirection {
+  FocusDown = 0,
+  FocusUp = 1,
+  FocusRight = 2,
+  FocusLeft = 3,
+};
+
+class FocusOrderingHelper {
+ public:
+  static void traverseAndUpdateNextFocusableElement(
+      const ShadowNode::Shared& parentShadowNode,
+      const ShadowNode::Shared& focusedShadowNode,
+      const ShadowNode::Shared& currNode,
+      FocusDirection focusDirection,
+      const UIManager& uimanager,
+      Rect sourceRect,
+      std::optional<Rect>& nextRect,
+      ShadowNode::Shared& nextNode);
+
+  static ShadowNode::Shared findShadowNodeByTagRecursively(
+      const ShadowNode::Shared& parentShadowNode,
+      Tag tag);
+
+  static std::optional<FocusDirection> resolveFocusDirection(int direction);
+};
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.cpp
@@ -26,6 +26,22 @@ using Content = ParagraphShadowNode::Content;
 
 const char ParagraphComponentName[] = "Paragraph";
 
+void ParagraphShadowNode::initialize() noexcept {
+#ifdef ANDROID
+  if (getConcreteProps().isSelectable) {
+    traits_.set(ShadowNodeTraits::Trait::KeyboardFocusable);
+  }
+#endif
+}
+
+ParagraphShadowNode::ParagraphShadowNode(
+    const ShadowNodeFragment& fragment,
+    const ShadowNodeFamily::Shared& family,
+    ShadowNodeTraits traits)
+    : ConcreteViewShadowNode(fragment, family, traits) {
+  initialize();
+}
+
 ParagraphShadowNode::ParagraphShadowNode(
     const ShadowNode& sourceShadowNode,
     const ShadowNodeFragment& fragment)
@@ -49,6 +65,7 @@ ParagraphShadowNode::ParagraphShadowNode(
     // to stop Yoga from traversing it.
     cleanLayout();
   }
+  initialize();
 }
 
 const Content& ParagraphShadowNode::getContent(

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.h
@@ -35,6 +35,11 @@ class ParagraphShadowNode final : public ConcreteViewShadowNode<
   using ConcreteViewShadowNode::ConcreteViewShadowNode;
 
   ParagraphShadowNode(
+      const ShadowNodeFragment& fragment,
+      const ShadowNodeFamily::Shared& family,
+      ShadowNodeTraits traits);
+
+  ParagraphShadowNode(
       const ShadowNode& sourceShadowNode,
       const ShadowNodeFragment& fragment);
 
@@ -83,6 +88,7 @@ class ParagraphShadowNode final : public ConcreteViewShadowNode<
   };
 
  private:
+  void initialize() noexcept;
   /*
    * Builds (if needed) and returns a reference to a `Content` object.
    */

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ConcreteViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ConcreteViewShadowNode.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <react/renderer/components/view/HostPlatformViewTraitsInitializer.h>
 #include <react/renderer/components/view/ViewEventEmitter.h>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/components/view/YogaLayoutableShadowNode.h>
@@ -15,6 +16,7 @@
 #include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/core/ShadowNodeFragment.h>
 #include <react/renderer/debug/DebugStringConvertibleItem.h>
+#include <type_traits>
 
 namespace facebook::react {
 
@@ -28,6 +30,7 @@ template <
     typename ViewPropsT = ViewProps,
     typename ViewEventEmitterT = ViewEventEmitter,
     typename StateDataT = StateData>
+  requires(std::is_base_of_v<ViewProps, ViewPropsT>)
 class ConcreteViewShadowNode : public ConcreteShadowNode<
                                    concreteComponentName,
                                    YogaLayoutableShadowNode,
@@ -113,6 +116,16 @@ class ConcreteViewShadowNode : public ConcreteShadowNode<
       BaseShadowNode::orderIndex_ = props.zIndex.value_or(0);
     } else {
       BaseShadowNode::orderIndex_ = 0;
+    }
+
+    bool isKeyboardFocusable =
+        HostPlatformViewTraitsInitializer::isKeyboardFocusable(props) ||
+        props.accessible;
+
+    if (isKeyboardFocusable) {
+      BaseShadowNode::traits_.set(ShadowNodeTraits::Trait::KeyboardFocusable);
+    } else {
+      BaseShadowNode::traits_.unset(ShadowNodeTraits::Trait::KeyboardFocusable);
     }
   }
 };

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewTraitsInitializer.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewTraitsInitializer.h
@@ -24,4 +24,8 @@ inline bool formsView(const ViewProps& viewProps) {
       viewProps.renderToHardwareTextureAndroid;
 }
 
+inline bool isKeyboardFocusable(const ViewProps& viewProps) {
+  return (viewProps.focusable || viewProps.hasTVPreferredFocus);
+}
+
 } // namespace facebook::react::HostPlatformViewTraitsInitializer

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/cxx/react/renderer/components/view/HostPlatformViewTraitsInitializer.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/cxx/react/renderer/components/view/HostPlatformViewTraitsInitializer.h
@@ -20,4 +20,8 @@ inline bool formsView(const ViewProps& props) {
   return false;
 }
 
+inline bool isKeyboardFocusable(const ViewProps& /*props*/) {
+  return false;
+}
+
 } // namespace facebook::react::HostPlatformViewTraitsInitializer

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeTraits.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeTraits.h
@@ -78,6 +78,9 @@ class ShadowNodeTraits {
 
     // Forces the node not to form a host view.
     ForceFlattenView = 1 << 11,
+
+    // Indicates if the node is keyboard focusable.
+    KeyboardFocusable = 1 << 12,
   };
 
   /*


### PR DESCRIPTION
Summary:

Add another function to fabric to get the topmost stacking context parent given a root and a child.

This is to be used on focus searching algorithm in the case where the next focusable child is deeper in the hierarchy meaning we need to find the top most parent in the Android hierarchy and lay that out as well before transferring focus.

If we don't lay out the parent as well as the next focusable view:

- The next focusable view might lack context given by the parent
- If the parent is a scrollview and has removeClippedSubviews enabled then laying out the next focusable view will not work
- If the view is deeper in the android hierarchy in some cases it won't be layed out unless the parent is

Changelog: [Internal]

Reviewed By: NickGerleman

Differential Revision: D73114933


