### PR TITLE
Fix border rendering incorrectly when it has translucent alpha

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<6f24701d1581b744185caaee1ca5fc06>>
+ * @generated SignedSource<<cc12c314bd1f9116af50f4653fe71521>>
  */
 
 /**
@@ -63,7 +63,7 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
 
   override fun enableNativeCSSParsing(): Boolean = false
 
-  override fun enableNewBackgroundAndBorderDrawables(): Boolean = false
+  override fun enableNewBackgroundAndBorderDrawables(): Boolean = true
 
   override fun enablePropsUpdateReconciliationAndroid(): Boolean = false
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/BorderDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/BorderDrawable.kt
@@ -490,6 +490,14 @@ internal class BorderDrawable(
       colorRight: Int,
       colorBottom: Int
   ): Int {
+    // If any of the border colors are translucent then we can't use the fast path.
+    if (Color.alpha(colorLeft) < 255 ||
+        Color.alpha(colorTop) < 255 ||
+        Color.alpha(colorRight) < 255 ||
+        Color.alpha(colorBottom) < 255) {
+      return 0
+    }
+
     val andSmear =
         ((if (borderLeft > 0) colorLeft else ALL_BITS_SET) and
             (if (borderTop > 0) colorTop else ALL_BITS_SET) and

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<377c3de6bcd7de45efa0d58e0de94fb1>>
+ * @generated SignedSource<<febce599420f496a5b0f38903565a189>>
  */
 
 /**
@@ -108,7 +108,7 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool enableNewBackgroundAndBorderDrawables() override {
-    return false;
+    return true;
   }
 
   bool enablePropsUpdateReconciliationAndroid() override {

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -257,7 +257,7 @@ const definitions: FeatureFlagDefinitions = {
       ossReleaseStage: 'none',
     },
     enableNewBackgroundAndBorderDrawables: {
-      defaultValue: false,
+      defaultValue: true,
       metadata: {
         dateAdded: '2024-09-24',
         description:

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<23e97cba20fdf4afc991cbae70c57b1f>>
+ * @generated SignedSource<<33e6d0e756c6eaff90e5a50a8a482d24>>
  * @flow strict
  */
 
@@ -237,7 +237,7 @@ export const enableNativeCSSParsing: Getter<boolean> = createNativeFlagGetter('e
 /**
  * Use BackgroundDrawable and BorderDrawable instead of CSSBackgroundDrawable
  */
-export const enableNewBackgroundAndBorderDrawables: Getter<boolean> = createNativeFlagGetter('enableNewBackgroundAndBorderDrawables', false);
+export const enableNewBackgroundAndBorderDrawables: Getter<boolean> = createNativeFlagGetter('enableNewBackgroundAndBorderDrawables', true);
 /**
  * When enabled, Android will receive prop updates based on the differences between the last rendered shadow node and the last committed shadow node.
  */


### PR DESCRIPTION
Summary:
It is not appropriate to go through the fast path for border drawing when we have translucent border colors since it will cause overlapping borders to look weird.

Adding an if statement to prevent fastpath when the alpha value of any border is less than 255 (opaque)

Reviewed By: NickGerleman

Differential Revision: D73145119


