### PR TITLE
migrate deprecated onBackPressed()

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
@@ -11,6 +11,7 @@ import android.content.Intent;
 import android.content.res.Configuration;
 import android.os.Bundle;
 import android.view.KeyEvent;
+import androidx.activity.OnBackPressedCallback;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
@@ -23,6 +24,17 @@ public abstract class ReactActivity extends AppCompatActivity
     implements DefaultHardwareBackBtnHandler, PermissionAwareActivity {
 
   private final ReactActivityDelegate mDelegate;
+
+  private final OnBackPressedCallback mBackPressedCallback =
+      new OnBackPressedCallback(true) {
+        @Override
+        public void handleOnBackPressed() {
+          if (!mDelegate.onBackPressed()) {
+            setEnabled(false);
+            getOnBackPressedDispatcher().onBackPressed();
+          }
+        }
+      };
 
   protected ReactActivity() {
     mDelegate = createReactActivityDelegate();
@@ -45,6 +57,7 @@ public abstract class ReactActivity extends AppCompatActivity
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     mDelegate.onCreate(savedInstanceState);
+    getOnBackPressedDispatcher().addCallback(this, mBackPressedCallback);
   }
 
   @Override
@@ -95,15 +108,8 @@ public abstract class ReactActivity extends AppCompatActivity
   }
 
   @Override
-  public void onBackPressed() {
-    if (!mDelegate.onBackPressed()) {
-      super.onBackPressed();
-    }
-  }
-
-  @Override
   public void invokeDefaultOnBackPressed() {
-    super.onBackPressed();
+    getOnBackPressedDispatcher().onBackPressed();
   }
 
   @Override


### PR DESCRIPTION
Summary:
`Activity.onBackPressed()` has been deprecated and with targetSdk 36 predictive back will be enforced and the API no longer called. Migrate to backward compatible `OnBackPressedCallback`.
- https://developer.android.com/about/versions/16/behavior-changes-16#predictive-back


NOTE: `ReactDelegate.onHostResume()` sets up the `DefaultHardwareBackBtnHandler` using `ReactActivity` (https://github.com/facebook/react-native/blob/6ad41f9a3f60da87e4b95724199420cab7bed905/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java#L111-L125)

Changelog:
[Internal]

Differential Revision: D73369334


