### PR TITLE
Fix out-of-date "Direct Manipulation" link

### DIFF
--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.d.ts
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.d.ts
@@ -869,7 +869,7 @@ export class ScrollView extends ScrollViewBase {
    * This function sends props straight to native. They will not participate in
    * future diff process - this means that if you do not include them in the
    * next render, they will remain active (see [Direct
-   * Manipulation](https://reactnative.dev/docs/direct-manipulation)).
+   * Manipulation](https://reactnative.dev/docs/the-new-architecture/direct-manipulation-new-architecture)).
    */
   setNativeProps(nativeProps: object): void;
 }

--- a/packages/react-native/src/private/types/HostInstance.js
+++ b/packages/react-native/src/private/types/HostInstance.js
@@ -38,7 +38,7 @@ export type MeasureLayoutOnSuccessCallback = (
  * The methods described here are available on most of the default components provided by React Native.
  * Note, however, that they are not available on composite components that aren't directly backed by a
  * native view. This will generally include most components that you define in your own app.
- * For more information, see [Direct Manipulation](https://reactnative.dev/docs/direct-manipulation).
+ * For more information, see [Direct Manipulation](https://reactnative.dev/docs/the-new-architecture/direct-manipulation-new-architecture).
  * @see https://github.com/facebook/react-native/blob/master/Libraries/Renderer/shims/ReactNativeTypes.js#L87
  */
 export interface LegacyHostInstanceMethods {
@@ -100,7 +100,7 @@ export interface LegacyHostInstanceMethods {
    * This function sends props straight to native. They will not participate in
    * future diff process - this means that if you do not include them in the
    * next render, they will remain active (see [Direct
-   * Manipulation](https://reactnative.dev/docs/direct-manipulation)).
+   * Manipulation](https://reactnative.dev/docs/the-new-architecture/direct-manipulation-new-architecture)).
    */
   setNativeProps(nativeProps: {...}): void;
 }

--- a/packages/react-native/types/public/ReactNativeTypes.d.ts
+++ b/packages/react-native/types/public/ReactNativeTypes.d.ts
@@ -39,7 +39,7 @@ export type MeasureLayoutOnSuccessCallback = (
  * The methods described here are available on most of the default components provided by React Native.
  * Note, however, that they are not available on composite components that aren't directly backed by a
  * native view. This will generally include most components that you define in your own app.
- * For more information, see [Direct Manipulation](https://reactnative.dev/docs/direct-manipulation).
+ * For more information, see [Direct Manipulation](https://reactnative.dev/docs/the-new-architecture/direct-manipulation-new-architecture).
  * @see https://github.com/facebook/react-native/blob/master/Libraries/Renderer/shims/ReactNativeTypes.js#L87
  */
 export interface NativeMethods {
@@ -95,7 +95,7 @@ export interface NativeMethods {
    * This function sends props straight to native. They will not participate in
    * future diff process - this means that if you do not include them in the
    * next render, they will remain active (see [Direct
-   * Manipulation](https://reactnative.dev/docs/direct-manipulation)).
+   * Manipulation](https://reactnative.dev/docs/the-new-architecture/direct-manipulation-new-architecture)).
    */
   setNativeProps(nativeProps: object): void;
 


### PR DESCRIPTION
## Summary:

Was triaging an issue and saw this dead link that has changed. This diff adds the equivalent link that works.

<details>
<summary>See screenshot of previous link:</summary>

![image](https://github.com/user-attachments/assets/f17e72a0-75b2-4446-9f4b-7a6470580f17)

</details>

## Changelog:

[INTERNAL] - Fix out-of-date "Direct Manipulation" link

## Test Plan:

<details>
<summary>See screenshot of new link:</summary>

![image](https://github.com/user-attachments/assets/a284ba3c-050d-4c4c-9f8e-4770608f529a)

</details>
