### PR TITLE
fix flaky RuntimeSchedulerTest

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/RuntimeSchedulerTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/RuntimeSchedulerTest.cpp
@@ -708,11 +708,11 @@ TEST_P(RuntimeSchedulerTest, normalTaskYieldsToSynchronousAccessAndResumes) {
 
   // Scheduling sync task.
   std::thread t1([this, &syncTaskExecutionCount, &signalTaskToSync]() {
-    signalTaskToSync.release();
     runtimeScheduler_->executeNowOnTheSameThread(
         [&syncTaskExecutionCount](jsi::Runtime& /*runtime*/) {
           syncTaskExecutionCount++;
         });
+    signalTaskToSync.release();
   });
 
   signalTaskToSync.acquire();


### PR DESCRIPTION
Summary:
changelog: [internal]

`signalTaskToSync` should be released after `executeNowOnTheSameThread` is called to prevent race condition between `executeNowOnTheSameThread` and reading stubQueue's size on line 723.

Differential Revision: D73437449


