### PR TITLE
Revert [RN][JS Stable API] Limit @react-native/virtualized-lists subpath imports

### DIFF
--- a/packages/rn-tester/js/examples/FlatList/FlatList-maintainVisibleContentPosition.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatList-maintainVisibleContentPosition.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-import type {ListRenderItemInfo} from '../../../../virtualized-lists';
+import type {ListRenderItemInfo} from '../../../../virtualized-lists/Lists/VirtualizedListProps';
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 
 import * as React from 'react';

--- a/packages/virtualized-lists/index.js
+++ b/packages/virtualized-lists/index.js
@@ -10,18 +10,12 @@
 
 'use strict';
 
-import typeof ChildListCollection from './Lists/ChildListCollection';
 import typeof FillRateHelper from './Lists/FillRateHelper';
 import typeof ViewabilityHelper from './Lists/ViewabilityHelper';
 import typeof VirtualizedList from './Lists/VirtualizedList';
 import typeof VirtualizedSectionList from './Lists/VirtualizedSectionList';
 
-import {
-  typeof VirtualizedListCellContextProvider,
-  typeof VirtualizedListContext,
-  typeof VirtualizedListContextProvider,
-  typeof VirtualizedListContextResetter,
-} from './Lists/VirtualizedListContext';
+import {typeof VirtualizedListContextResetter} from './Lists/VirtualizedListContext';
 import {keyExtractor} from './Lists/VirtualizeUtils';
 
 export type {
@@ -55,27 +49,13 @@ export default {
     return require('./Lists/VirtualizedSectionList').default;
   },
   get VirtualizedListContextResetter(): VirtualizedListContextResetter {
-    return require('./Lists/VirtualizedListContext')
-      .VirtualizedListContextResetter;
-  },
-  get VirtualizedListContext(): VirtualizedListContext {
-    return require('./Lists/VirtualizedListContext').VirtualizedListContext;
-  },
-  get VirtualizedListContextProvider(): VirtualizedListContextProvider {
-    return require('./Lists/VirtualizedListContext')
-      .VirtualizedListContextProvider;
-  },
-  get VirtualizedListCellContextProvider(): VirtualizedListCellContextProvider {
-    return require('./Lists/VirtualizedListContext')
-      .VirtualizedListCellContextProvider;
+    const VirtualizedListContext = require('./Lists/VirtualizedListContext');
+    return VirtualizedListContext.VirtualizedListContextResetter;
   },
   get ViewabilityHelper(): ViewabilityHelper {
     return require('./Lists/ViewabilityHelper').default;
   },
   get FillRateHelper(): FillRateHelper {
     return require('./Lists/FillRateHelper').default;
-  },
-  get ChildListCollection(): ChildListCollection {
-    return require('./Lists/ChildListCollection').default;
   },
 };

--- a/packages/virtualized-lists/package.json
+++ b/packages/virtualized-lists/package.json
@@ -19,10 +19,6 @@
   "engines": {
     "node": ">=18"
   },
-  "exports": {
-    ".": "./index.js",
-    "./package.json": "./package.json"
-  },
   "files": [
     "index.js",
     "index.d.ts",


### PR DESCRIPTION
Summary:
## Motivation
After a more rigorous search through GitHub uses of the restricted APIs, and consultation with framework authors, it became apparent that this restriction should be lifted.

Changelog: [Internal]

Reviewed By: zeyap

Differential Revision: D73267844


