### PR TITLE
Update the reproducer message

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -19,10 +19,10 @@ body:
         * Please [search for similar issues](https://github.com/facebook/react-native/issues) in our issue tracker.
 
         Make sure that your issue:
-        * Have a **valid reproducer** (either a [Expo Snack](https://snack.expo.dev/) or a [empty project from template](https://github.com/react-native-community/reproducer-react-native).
+        * Have a **valid reproducer** (See [How to report a bug](https://reactnative.dev/contributing/how-to-report-a-bug)).
         * Is tested against the [**latest stable**](https://github.com/facebook/react-native/releases/) of React Native.
 
-        Due to the extreme number of bugs we receive, we will be looking **ONLY** into issues with a reproducer, and on [supported versions](https://github.com/reactwg/react-native-releases#which-versions-are-currently-supported) of React Native.
+        🚨 IMPORTANT: Due to the extreme number of bugs we receive, issues **without a reproducer** or for an [**unsupported versions**](https://github.com/reactwg/react-native-releases#which-versions-are-currently-supported) of React Native **will be closed**.
   - type: textarea
     id: description
     attributes:
@@ -109,8 +109,8 @@ body:
   - type: input
     id: reproducer
     attributes:
-      label: Reproducer
-      description: A link to a Expo Snack or a public repository that reproduces this bug, using [this template](https://github.com/react-native-community/reproducer-react-native). Reproducers are **mandatory**.
+      label: MANDATORY Reproducer
+      description: A link to either a failing RNTesterPlayground.js file, an Expo Snack or a public repository from [this template](https://github.com/react-native-community/reproducer-react-native) that reproduces this bug. Reproducers are **mandatory**, issues without a reproducer will be closed.
       placeholder: "https://github.com/<myuser>/<myreproducer>"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/new_architecture_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/new_architecture_bug_report.yml
@@ -16,10 +16,10 @@ body:
         Do not attempt to open a bug in this category if you're not using the New Architecture as your bug will be closed.
 
         Make sure that your issue:
-        * Have a **valid reproducer** (either a [Expo Snack](https://snack.expo.dev/) or a [empty project from template](https://github.com/react-native-community/reproducer-react-native).
+        * Have a **valid reproducer** (See [How to report a bug](https://reactnative.dev/contributing/how-to-report-a-bug)).
         * Is tested against the [**latest stable**](https://github.com/facebook/react-native/releases/) of React Native.
 
-        Due to the extreme number of bugs we receive, we will be looking **ONLY** into issues with a reproducer, and on [supported versions](https://github.com/reactwg/react-native-releases#which-versions-are-currently-supported) of React Native.
+        🚨 IMPORTANT: Due to the extreme number of bugs we receive, issues **without a reproducer** or for an [**unsupported versions**](https://github.com/reactwg/react-native-releases#which-versions-are-currently-supported) of React Native **will be closed**.
   - type: textarea
     id: description
     attributes:
@@ -121,8 +121,8 @@ body:
   - type: input
     id: reproducer
     attributes:
-      label: Reproducer
-      description: A link to a Expo Snack or a public repository that reproduces this bug, using [this template](https://github.com/react-native-community/reproducer-react-native). Reproducers are **mandatory**.
+      label: MANDATORY Reproducer
+      description: A link to either a failing RNTesterPlayground.js file, an Expo Snack or a public repository from [this template](https://github.com/react-native-community/reproducer-react-native) that reproduces this bug. Reproducers are **mandatory**, issues without a reproducer will be closed.
       placeholder: "https://github.com/<myuser>/<myreproducer>"
     validations:
       required: true

--- a/.github/workflow-scripts/actOnLabel.js
+++ b/.github/workflow-scripts/actOnLabel.js
@@ -111,7 +111,7 @@ module.exports = async (github, context, labelWithContext) => {
     case 'Needs: Repro':
       await addComment(
         `> [!WARNING]\n` +
-          `> **Missing reproducer**: We could not detect a reproducible example in your issue report. Please provide either: <br/><ul><li>If your bug is UI related: a [Snack](https://snack.expo.dev)</li><li> If your bug is build/upgrade related: a project using our [Reproducer Template](https://github.com/react-native-community/reproducer-react-native/generate)</li><li>Otherwise send us a Pull Request with the [RNTesterPlayground.js](https://github.com/facebook/react-native/blob/main/packages/rn-tester/js/examples/Playground/RNTesterPlayground.js) edited to reproduce your bug.</li></ul>`,
+          `> **Missing reproducer**: We could not detect a reproducible example in your issue report. Reproducers are **mandatory** and we can accept only one of those as a valid reproducer: <br/><ul><li>For majority of bugs: send us a Pull Request with the [RNTesterPlayground.js](https://github.com/facebook/react-native/blob/main/packages/rn-tester/js/examples/Playground/RNTesterPlayground.js) edited to reproduce your bug.</li><li>If your bug is UI related: a [Snack](https://snack.expo.dev)</li><li> If your bug is build/upgrade related: a project using our [Reproducer Template](https://github.com/react-native-community/reproducer-react-native/generate)</li></ul><br/>You can read more about about it on our website: [How to report a bug](https://reactnative.dev/contributing/how-to-report-a-bug).`,
       );
       await requestAuthorFeedback();
       return;

--- a/.github/workflow-scripts/checkForReproducer.js
+++ b/.github/workflow-scripts/checkForReproducer.js
@@ -41,6 +41,11 @@ module.exports = async (github, context) => {
 
   // Look for Snack or a GH repo associated with the user that added an issue or comment
   const hasValidReproducer = entities.some(entity => {
+    const hasPullRequestRepoLink = containsPattern(
+      entity.body,
+      `https?:\/\/github\.com\/facebook\/react-native\/pull\/\d+\/?`,
+    );
+
     const hasExpoSnackLink = containsPattern(
       entity.body,
       `https?:\\/\\/snack\\.expo\\.dev\\/[^\\s)\\]]+`,
@@ -50,7 +55,7 @@ module.exports = async (github, context) => {
       entity.body,
       `https?:\\/\\/github\\.com\\/(${entity.user.login})\\/[^/]+\\/?\\s?`,
     );
-    return hasExpoSnackLink || hasGithubRepoLink;
+    return hasPullRequestRepoLink || hasExpoSnackLink || hasGithubRepoLink;
   });
 
   if (hasValidReproducer) {


### PR DESCRIPTION
Summary:
This clarifies our reproducer guidelines.
It's also currently pending on this other PR on the website: 
https://github.com/facebook/react-native-website/pull/4589

Changelog:
[Internal] [Changed] -

Differential Revision: D73194317


