### PR TITLE
write a test for setNativeProps+props update

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.cpp
@@ -294,7 +294,7 @@ void AccessibilityProps::setProp(
 SharedDebugStringConvertibleList AccessibilityProps::getDebugProps() const {
   const auto& defaultProps = AccessibilityProps();
   return SharedDebugStringConvertibleList{
-      debugStringConvertibleItem("testId", testId, defaultProps.testId),
+      debugStringConvertibleItem("testID", testId, defaultProps.testId),
   };
 }
 #endif // RN_DEBUG_STRING_CONVERTIBLE


### PR DESCRIPTION
Summary:
changelog: [internal]

Previously we didn't have a way to properly test bug reported in https://github.com/facebook/react-native/issues/47476. But with Fantom we do! Let's write a test for it to make sure this is not broken in the future.

Differential Revision: D73432279


