### PR TITLE
add view culling test when unflattening a subtree

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.cpp
@@ -872,8 +872,6 @@ static void calculateShadowViewMutationsFlattener(
 
       if (!treeChildPair.flattened) {
         ViewNodePairScope innerScope{};
-        // TODO(T217775046): Find a test case for this branch of view
-        // flattening + culling.
         calculateShadowViewMutations(
             innerScope,
             mutationContainer.downwardMutations,


### PR DESCRIPTION
Summary:
changelog: [internal]

Adding a test to verify view culling in scenario where a subtree is revealed and part of it is culled.

Differential Revision: D73454202


