### PR TITLE
add view culling tests when flattetning and deleting a subtree

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.cpp
@@ -854,8 +854,6 @@ static void calculateShadowViewMutationsFlattener(
 
       if (!treeChildPair.flattened) {
         ViewNodePairScope innerScope{};
-        // TODO(T217775046): Find a test case for this branch of view
-        // flattening + culling.
         calculateShadowViewMutations(
             innerScope,
             mutationContainer.destructiveDownwardMutations,

--- a/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.cpp
@@ -872,8 +872,6 @@ static void calculateShadowViewMutationsFlattener(
 
       if (!treeChildPair.flattened) {
         ViewNodePairScope innerScope{};
-        // TODO(T217775046): Find a test case for this branch of view
-        // flattening + culling.
         calculateShadowViewMutations(
             innerScope,
             mutationContainer.downwardMutations,


### PR DESCRIPTION
Summary:
changelog: [internal]

Adding a test case verifying branch of code starting in [Differentiator:855](https://github.com/facebook/react-native/blob/main/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.cpp#L855)


Without using `adjustedOldCullingContext` in the branch, it leads to a crash on [StubViewTree:177](https://github.com/facebook/react-native/blob/main/packages/react-native/ReactCommon/react/renderer/mounting/stubs/StubViewTree.cpp#L177):  trying to remove view that does not exist.

Differential Revision: D73493001


