### PR TITLE
Simplify InteropModuleRegistry API

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1320,6 +1320,7 @@ public final class com/facebook/react/bridge/ReactSoftExceptionLogger {
 }
 
 public final class com/facebook/react/bridge/ReactSoftExceptionLogger$Categories {
+	public static final field CLIPPING_PROHIBITED_VIEW Ljava/lang/String;
 	public static final field INSTANCE Lcom/facebook/react/bridge/ReactSoftExceptionLogger$Categories;
 	public static final field RVG_IS_VIEW_CLIPPED Ljava/lang/String;
 	public static final field RVG_ON_VIEW_REMOVED Ljava/lang/String;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BridgeReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BridgeReactContext.java
@@ -105,9 +105,11 @@ public class BridgeReactContext extends ReactApplicationContext {
       }
       throw new IllegalStateException(EARLY_JS_ACCESS_EXCEPTION_MESSAGE);
     }
-    if (mInteropModuleRegistry != null
-        && mInteropModuleRegistry.shouldReturnInteropModule(jsInterface)) {
-      return mInteropModuleRegistry.getInteropModule(jsInterface);
+    if (mInteropModuleRegistry != null) {
+      T jsModule = mInteropModuleRegistry.getInteropModule(jsInterface);
+      if (jsModule != null) {
+        return jsModule;
+      }
     }
     return mCatalystInstance.getJSModule(jsInterface);
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
@@ -44,7 +44,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * This provides an implementation of the public CatalystInstance instance. It is public because it
- * is built by XReactInstanceManager which is in a different package.
+ * is built by ReactInstanceManager which is in a different package.
  */
 @DoNotStrip
 @LegacyArchitecture

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactSoftExceptionLogger.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactSoftExceptionLogger.kt
@@ -18,6 +18,7 @@ public object ReactSoftExceptionLogger {
   public object Categories {
     public const val RVG_IS_VIEW_CLIPPED: String = "ReactViewGroup.isViewClipped"
     public const val RVG_ON_VIEW_REMOVED: String = "ReactViewGroup.onViewRemoved"
+    public const val CLIPPING_PROHIBITED_VIEW: String = "ReactClippingProhibitedView"
     public const val SOFT_ASSERTIONS: String = "SoftAssertions"
     public const val SURFACE_MOUNTING_MANAGER_MISSING_VIEWSTATE: String =
         "SurfaceMountingManager:MissingViewState"

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/interop/InteropModuleRegistry.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/interop/InteropModuleRegistry.kt
@@ -26,14 +26,10 @@ internal class InteropModuleRegistry {
 
   private val supportedModules = mutableMapOf<Class<*>, Any?>()
 
-  fun <T : JavaScriptModule?> shouldReturnInteropModule(requestedModule: Class<T>): Boolean {
-    return checkReactFeatureFlagsConditions() && supportedModules.containsKey(requestedModule)
-  }
-
   fun <T : JavaScriptModule?> getInteropModule(requestedModule: Class<T>): T? {
     return if (checkReactFeatureFlagsConditions()) {
       @Suppress("UNCHECKED_CAST")
-      supportedModules[requestedModule] as? T?
+      supportedModules[requestedModule] as? T
     } else {
       null
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.java
@@ -462,7 +462,7 @@ public class SurfaceMountingManager {
     // TODO: throw exception here?
     if (parentViewState == null) {
       ReactSoftExceptionLogger.logSoftException(
-          MountingManager.TAG,
+          ReactSoftExceptionLogger.Categories.SURFACE_MOUNTING_MANAGER_MISSING_VIEWSTATE,
           new IllegalStateException(
               "Unable to find viewState for tag: [" + parentTag + "] for removeViewAt"));
       return;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.kt
@@ -108,10 +108,8 @@ internal class BridgelessReactContext(context: Context, private val reactHost: R
   }
 
   override fun <T : JavaScriptModule> getJSModule(jsInterface: Class<T>): T? {
-    mInteropModuleRegistry?.let { reg ->
-      if (reg.shouldReturnInteropModule(jsInterface)) {
-        return reg.getInteropModule(jsInterface)
-      }
+    mInteropModuleRegistry?.getInteropModule(jsInterface)?.let {
+      return it
     }
 
     // TODO T189052462: ReactContext caches JavaScriptModule instances

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerHelper.java
@@ -33,7 +33,7 @@ import com.facebook.react.uimanager.events.EventDispatcherProvider;
 @Nullsafe(Nullsafe.Mode.LOCAL)
 public class UIManagerHelper {
 
-  private static final String TAG = UIManagerHelper.class.getName();
+  private static final String TAG = "UIManagerHelper";
   public static final int PADDING_START_INDEX = 0;
   public static final int PADDING_END_INDEX = 1;
   public static final int PADDING_TOP_INDEX = 2;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -720,7 +720,7 @@ public class ReactViewGroup extends ViewGroup
             public void run() {
               if (!child.isShown()) {
                 ReactSoftExceptionLogger.logSoftException(
-                    TAG,
+                    ReactSoftExceptionLogger.Categories.CLIPPING_PROHIBITED_VIEW,
                     new ReactNoCrashSoftException(
                         "Child view has been added to Parent view in which it is clipped and not"
                             + " visible. This is not legal for this particular child view. Child: ["

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/interop/InteropModuleRegistryTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/interop/InteropModuleRegistryTest.kt
@@ -38,36 +38,6 @@ class InteropModuleRegistryTest {
   }
 
   @Test
-  fun shouldReturnInteropModule_withFabricDisabled_returnsFalse() {
-    overrideFeatureFlags(false, false)
-
-    assertThat(underTest.shouldReturnInteropModule(RCTEventEmitter::class.java)).isFalse()
-  }
-
-  @Test
-  fun shouldReturnInteropModule_withFabricInteropDisabled_returnsFalse() {
-    overrideFeatureFlags(false, true)
-
-    assertThat(underTest.shouldReturnInteropModule(RCTEventEmitter::class.java)).isFalse()
-  }
-
-  @Test
-  fun shouldReturnInteropModule_withUnregisteredClass_returnsFalse() {
-    overrideFeatureFlags(true, true)
-
-    assertThat(underTest.shouldReturnInteropModule(JSTimers::class.java)).isFalse()
-  }
-
-  @Test
-  fun shouldReturnInteropModule_withRegisteredClass_returnsTrue() {
-    overrideFeatureFlags(true, true)
-
-    underTest.registerInteropModule(RCTEventEmitter::class.java, FakeRCTEventEmitter())
-
-    assertThat(underTest.shouldReturnInteropModule(RCTEventEmitter::class.java)).isTrue()
-  }
-
-  @Test
   fun getInteropModule_withRegisteredClassAndInvalidFlags_returnsNull() {
     overrideFeatureFlags(false, false)
     underTest.registerInteropModule(RCTEventEmitter::class.java, FakeRCTEventEmitter())


### PR DESCRIPTION
Summary:
No need for `shouldReturnInteropModule` if we can just use the nullability of what's returned by `getInteropModule` instead.

Changelog: [Internal]

Differential Revision: D73501845


