### PR TITLE
Fix disappearing redbox on initial load of an invalid bundle.

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -507,7 +507,6 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
 
         if (error) {
           [strongSelf handleBundleLoadingError:error];
-          [strongSelf invalidate];
           return;
         }
         // DevSettings module is needed by _loadScriptFromSource's callback so prior initialization is required


### PR DESCRIPTION
## Summary:

Right now having a javascript error like an invalid import statement during first bundle load results in a disappearing redbox screen.


https://github.com/user-attachments/assets/ab9c64f5-6e32-481c-a58f-6d37bb920acb

The `invalidate` call removed in this PR cleans up all turbomodules, including the RedBox module, which in turns calls `dismiss` in `RCTRedBox`.

After removing this line the result is as following:

https://github.com/user-attachments/assets/6eeb4d43-f883-440f-ade3-5628f85f833a

I made sure that the `invalidate` function is still called when executing only two possible ways to reload the bundle:
- the Reload button
- Cmd+R

The HMR/hot reload is not connected if the bundle has an error on initial load, so we don't need to worry about it.

Longer term, it would be better to establish HMR and use a different redbox in this case:

![simulator_screenshot_DFF4EA47-DA12-46A9-81DF-9904B35EB1D9](https://github.com/user-attachments/assets/c46eb0e9-845a-4b62-96e2-74215cbdad18)

Doing this requires larger changes to the bundle loading flow – happy to to try and land that change if there's any guidance you could give.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS][FIXED] – Fix disappearing redbox on initial load of an invalid bundle.

## Test Plan:

I have tested this change using RN from main and RNTester app (see videos).
