### PR TITLE
chore: update license-docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,4 @@ Larger discussions and proposals are discussed in [**@react-native-community/dis
 
 React Native is MIT licensed, as found in the [LICENSE][l] file.
 
-React Native documentation is Creative Commons licensed, as found in the [LICENSE-docs][ld] file.
-
 [l]: https://github.com/facebook/react-native/blob/main/LICENSE
-[ld]: https://github.com/facebook/react-native-website/blob/main/LICENSE-docs

--- a/README.md
+++ b/README.md
@@ -141,4 +141,4 @@ React Native is MIT licensed, as found in the [LICENSE][l] file.
 React Native documentation is Creative Commons licensed, as found in the [LICENSE-docs][ld] file.
 
 [l]: https://github.com/facebook/react-native/blob/main/LICENSE
-[ld]: https://github.com/facebook/react-native/blob/main/LICENSE-docs
+[ld]: https://github.com/facebook/react-native-website/blob/main/LICENSE-docs


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The source for the React Native documentation and website is hosted on a separate repository, [**@facebook/react-native-website**][repo-website]. [LICENSE-docs](https://github.com/facebook/react-native/blob/main/LICENSE-docs) had been removed, so it should be replaced by [**this link**](https://github.com/facebook/react-native-website/blob/main/LICENSE-docs). Of course we could delete it directly.

## Changelog:
[Internal] [Fixed] - Update link

## Test Plan:
nothing