### PR TITLE
Define "exports" field on main package

### DIFF
--- a/packages/react-native/Libraries/Core/Devtools/__tests__/loadBundleFromServer-test.js
+++ b/packages/react-native/Libraries/Core/Devtools/__tests__/loadBundleFromServer-test.js
@@ -14,9 +14,9 @@
 // TODO(legacy-fake-timers): Fix these tests to work with modern timers.
 jest.useFakeTimers({legacyFakeTimers: true});
 
-jest.mock('react-native/Libraries/Utilities/HMRClient');
+jest.mock('../../../Utilities/HMRClient');
 
-jest.mock('react-native/Libraries/Core/Devtools/getDevServer', () => ({
+jest.mock('../../../Core/Devtools/getDevServer', () => ({
   __esModule: true,
   default: jest.fn(() => ({
     url: 'localhost:8042/',
@@ -32,7 +32,7 @@ const loadingViewMock = {
   showMessage: jest.fn(),
   hide: jest.fn(),
 };
-jest.mock('react-native/Libraries/Utilities/DevLoadingView', () => ({
+jest.mock('../../../Utilities/DevLoadingView', () => ({
   __esModule: true,
   default: loadingViewMock,
 }));
@@ -54,7 +54,7 @@ const sendRequest = jest.fn(
   },
 );
 
-jest.mock('react-native/Libraries/Network/RCTNetworking', () => ({
+jest.mock('../../../Network/RCTNetworking', () => ({
   __esModule: true,
   default: {
     sendRequest,

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -26,7 +26,25 @@
   "bin": {
     "react-native": "cli.js"
   },
+  "main": "./index.js",
   "types": "types",
+  "exports": {
+    ".": "./index.js",
+    "./*": "./*.js",
+    "./*.js": "./*.js",
+    "./Libraries/*.d.ts": "./Libraries/*.d.ts",
+    "./types/*.d.ts": "./types/*.d.ts",
+    "./gradle/*": null,
+    "./React/*": null,
+    "./ReactAndroid/*": null,
+    "./ReactApple/*": null,
+    "./ReactCommon/*": null,
+    "./sdks/*": null,
+    "./src/*": null,
+    "./third-party-podspecs/*": null,
+    "./types/*": null,
+    "./package.json": "./package.json"
+  },
   "jest-junit": {
     "outputDirectory": "reports/junit",
     "outputName": "js-test-results.xml"
@@ -90,11 +108,6 @@
     "settings.gradle.kts",
     "src",
     "!src/private/testing",
-    "template.config.js",
-    "template",
-    "!template/node_modules",
-    "!template/package-lock.json",
-    "!template/yarn.lock",
     "third-party-podspecs",
     "types",
     "!**/__docs__/**",


### PR DESCRIPTION
Summary:
NOTE: Resubmission of D71968187.

Define `"exports"` field on the main `react-native` package.

**Notes**

Module resolution should be equivalent to the previous implicit `"main"` field (backwards compatible).

- Exports all module subpaths to JavaScript (Flow) source files, with and without `.js` suffix (unchanged ✅)
    - These are restricted to the `flow/` and `Libraries/` subdirectories (ℹ️ this should be unchanged, matching any JS imports apps may have today)
        - Still includes 3P integration scripts such as `./jest-preset.js` and `./rn-get-polyfills.js` (unchanged ✅)
- Exports `./package.json` (unchanged ✅)
- TypeScript should:
    - fall back to the `"types"` field (unchanged ✅)
    - OR to `"."`,`"./*"` when Package Exports support is enabled via `compilerOptions`, and use the *adjacent `.d.ts` file* (unchanged ✅)

Changelog:
[General][Breaking] - The `react-native` package now defines package.json `"exports"`.
- While these expose existing JavaScript and TypeScript modules, this change may affect deep imports of non-JS files via Node in third party tools.
- Jest mocks to a `react-native` subpath will need to be updated to match the import path used in your code.
- Imports from `src/` and `src/private/` directories are disallowed.

Differential Revision: D72228547


