### PR TITLE
[RN][iOS][CI] Disable react-native-maps for nightlies

### DIFF
--- a/.github/workflows/test-libraries-on-nightlies.yml
+++ b/.github/workflows/test-libraries-on-nightlies.yml
@@ -30,7 +30,7 @@ jobs:
           "react-native-image-picker",
           "react-native-linear-gradient",
           "@react-native-masked-view/masked-view",
-          "react-native-maps",
+          # "react-native-maps", React Native Maps with the New Arch support has a complex cocoapods setup for iOS. It needs a dedicated workflow.
           "@react-native-community/netinfo",
           "react-native-reanimated@nightly react-native-worklets@nightly", #reanimated requires worklet to be explicitly installed as a separate package
           "react-native-svg",
@@ -40,7 +40,7 @@ jobs:
           "react-native-screens",
           "react-native-pager-view",
           "@react-native-community/slider",
-          #additional OSS libs used internally
+          # additional OSS libs used internally
           "scandit-react-native-datacapture-barcode scandit-react-native-datacapture-core",
           "react-native-contacts",
           "react-native-device-info",


### PR DESCRIPTION
## Summary:
the `react-native-maps` library has a complex setup for iOS. It doesn't work with autolinking, therefore we need to disable the test with the nightlies

## Changelog:
[Internal] - Disable nitghtly test for react-native-maps

## Test Plan:
GHA
