### PR TITLE
[RN][iOS] Make fmt and SocketRocket compatible with Swift

### DIFF
--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -174,8 +174,9 @@ def use_react_native! (
     pod 'glog', :podspec => "#{prefix}/third-party-podspecs/glog.podspec"
     pod 'boost', :podspec => "#{prefix}/third-party-podspecs/boost.podspec"
     pod 'fast_float', :podspec => "#{prefix}/third-party-podspecs/fast_float.podspec"
-    pod 'fmt', :podspec => "#{prefix}/third-party-podspecs/fmt.podspec"
+    pod 'fmt', :podspec => "#{prefix}/third-party-podspecs/fmt.podspec", :modular_headers => true
     pod 'RCT-Folly', :podspec => "#{prefix}/third-party-podspecs/RCT-Folly.podspec", :modular_headers => true
+    pod 'SocketRocket', "~> #{Helpers::Constants::socket_rocket_config[:version]}", :modular_headers => true
   else
     pod 'ReactNativeDependencies', :podspec => "#{prefix}/third-party-podspecs/ReactNativeDependencies.podspec", :modular_headers => true
   end

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -2392,6 +2392,7 @@ DEPENDENCIES:
   - ReactCommon-Samples (from `../react-native/ReactCommon/react/nativemodule/samples`)
   - ReactCommon/turbomodule/core (from `../react-native/ReactCommon`)
   - ScreenshotManager (from `NativeModuleExample`)
+  - SocketRocket (~> 0.7.1)
   - Yoga (from `../react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -2561,87 +2562,87 @@ EXTERNAL SOURCES:
     :path: "../react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
-  DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
+  boost: 1dca942403ed9342f98334bf4c3621f011aa7946
+  DoubleConversion: f16ae600a246532c4020132d54af21d0ddb2a385
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
-  FBLazyVector: d3c2dd739a63c1a124e775df075dc7c517a719cb
-  fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
-  glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
-  hermes-engine: 4be07099027e1372268b255c29525480cddcd356
+  FBLazyVector: 05133a4d3886934758fc5a9b149e1881dc333ab7
+  fmt: 01b82d4ca6470831d1cc0852a1af644be019e8f6
+  glog: 08b301085f15bcbb6ff8632a8ebaf239aae04e6a
+  hermes-engine: 1d4ebea15d13af28be0dd602bf09c8a27bdf5163
   MyNativeView: 649cc955b283053e5832e8d45c2a20597daa94cd
   NativeCxxModuleExample: d9bac8e847a427f0a40b0c9fb066ab102b3aefd0
   OCMock: 589f2c84dacb1f5aaf6e4cec1f292551fe748e74
   OSSLibraryExample: 9264008f6ba6a068cb2db3765ffdf519c9c0f6a4
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: 3808e36294137f9ee5668f4df2e73dc079cd1dcf
-  RCTRequired: a00614e2da5344c2cda3d287050b6cee00e21dc6
-  RCTTypeSafety: 459a16418c6b413060d35434ba3e83f5b0bd2651
-  React: 170a01a19ba2525ab7f11243e2df6b19bf268093
-  React-callinvoker: f08f425e4043cd1998a158b6e39a6aed1fd1d718
-  React-Core: 798334ba9a8a5a97e84ab56b5565d6ed5ac09712
-  React-CoreModules: 25e5ff9b077e8a3780672a9eae5197e54ce367e1
-  React-cxxreact: 8a5de0fe0933c56fdf4c3548902d9525ea73322b
-  React-debug: 195df38487d3f48a7af04deddeb4a5c6d4440416
-  React-defaultsnativemodule: 47959b704240e39c6b401d3e3fe1da114b271ac6
-  React-domnativemodule: b6dd0c3be3e4514052f68d0b5a94a8d06e0f14fd
-  React-Fabric: 06175f348d6df210e7545ee513e38fe1709a6d82
-  React-FabricComponents: 86f8fef5d74fad3f4a642c044d4baf6558be74b9
-  React-FabricImage: ff9dc6afafc92e0da3f3d33d96ec40317bb8ec10
-  React-featureflags: 595651ea13c63a9f77f06d9a1973b665b4a28b7e
-  React-featureflagsnativemodule: f5f69151bc4c2945003fc502ebaecee7fda02c42
-  React-graphics: 38cc9ba3336bd50960e6052648374f3591abc7a6
-  React-hermes: 34666bbd8d6b585e290f000d4d31c2182ece8940
-  React-idlecallbacksnativemodule: b66d99ffb2ff765e1bd952b6bc6bf4ba3d5204d3
-  React-ImageManager: a6833445e17879933378b7c0ba45ee42115c14bc
-  React-jserrorhandler: bec134a192c50338193544404d45df24fb8a19ca
-  React-jsi: 4ad77650fb0ca4229569eb2532db7a87e3d12662
-  React-jsiexecutor: 569425f7cd2c3e005a17e5211843e541c11d6916
-  React-jsinspector: 885e8180e898f07e4d7df29e2681a89e69d736d3
-  React-jsinspectorcdp: 5fb266e5f23d3a2819ba848e9d4d0b6b00f95934
-  React-jsinspectornetwork: 207422b56a7918e83c94c207570849f83ab9052a
-  React-jsinspectortracing: 80e9418ac67630c76f15ef06534087037a822330
-  React-jsitooling: b1af12acbfcb039bf87f8f2a82bde3a79c2ddade
-  React-jsitracing: ce443686f52538d1033ce7db1e7d643e866262f0
-  React-logger: 116c3ae5a9906671d157aa00882a5ee75a5a7ebc
-  React-Mapbuffer: fc937cfa41140d7724c559c3d16c50dd725361c8
-  React-microtasksnativemodule: dd4dfd6306d8b42f5dab9ecb3bf04124e979a3da
-  React-NativeModulesApple: d3aec3f4d3cb80507777e1feeba3bdc70f9504a0
-  React-oscompat: 7133e0e945cda067ae36b22502df663d73002864
-  React-perflogger: ada3cdf3dfc8b7cd1fabe3c91b672e23981611ab
-  React-performancetimeline: 3de39e3c3deb17b2fc4d252578b63f215ea087c3
-  React-RCTActionSheet: 1bf8cc8086ad1c15da3407dfb7bc9dd94dc7595d
-  React-RCTAnimation: 263593e66c89bf810604b1ace15dfa382a1ca2df
-  React-RCTAppDelegate: 3d35d7226338009b22d1cf9621eaa827acb8fd1d
-  React-RCTBlob: 7b76230c53fe87d305eeeb250b0aae031bb6cbae
-  React-RCTFabric: 78b6aec5985ef438a9c088032c0e89d2bd77b3ba
-  React-RCTFBReactNativeSpec: 503491a0584dc29f03ef9f8ed366794604cd59ef
-  React-RCTImage: de404b6b0ebe53976a97e3a0dee819c83e12977b
-  React-RCTLinking: 06742cfad41c506091403a414370743a4ed75af3
-  React-RCTNetwork: f8f7ac330958ac85300827267390bc8decc06ba0
-  React-RCTPushNotification: ea11178d499696516e0ff9ae335edbe99b06f94b
-  React-RCTRuntime: 07b41aed797e8d950ada851c6363ecf931335663
-  React-RCTSettings: d3c2dd305ec81f7faf42762ec598d57f07fd43be
-  React-RCTTest: 2db46eda60bc2228cb67622a580e8e86b00088d9
-  React-RCTText: e416825b80c530647040ef91d23ffd35ccc87981
-  React-RCTVibration: 1837a27fc16eeffc9509779c3334fde54c012bcc
-  React-rendererconsistency: 777c894edc43dde01499189917ac54ee76ae6a6a
-  React-renderercss: a9cb6ba7f49a80dc4b4f7008bae1590d12f27049
-  React-rendererdebug: fea8bde927403a198742b2d940a5f1cd8230c0b4
-  React-rncore: 4a81ce7b8e47448973a6b29c765b07e01715921e
-  React-RuntimeApple: 97755a0b9f6adff1e1911ef4894cb0c5a9e40c77
-  React-RuntimeCore: 6854e513a18b7b8980732f561679de6cab1b5b4d
-  React-runtimeexecutor: fb2d342a477bb13f7128cceb711ee8311edce0c0
-  React-RuntimeHermes: 90f09fae56f0b1f458927beb171177a157334fe6
-  React-runtimescheduler: 0b50423a4c40db7d1d0c3cc6893b407bf7fb946c
-  React-timing: 9d49179631e5e3c759e6e82d4c613c73da80a144
-  React-utils: 3ea3fa757fec88afb26db14889fb4e7e8b5ca134
-  ReactAppDependencyProvider: 68f2d2cefd6c9b9f2865246be2bfe86ebd49238d
+  RCTRequired: c482db71773e4c26f5590519ee0146ff97969018
+  RCTTypeSafety: 9dbb69d76b01b3eb6cfff10751b120eb4719ce90
+  React: 879e9950c4e457a0b9be526798a2203056afed3f
+  React-callinvoker: e88f762ae931d38f3cfc01264c40c1b8f96bfec5
+  React-Core: b2c9b5ddac40521fcb16f20207e0d90e699f0c4a
+  React-CoreModules: 959fe435b21b13b20dd7ef6704c842e5df0dfa5b
+  React-cxxreact: 70dba7dd6868ac16f35972ca1530adaae213847a
+  React-debug: 19bd15a4a86f82d088b818dcbde0f0d0cb390295
+  React-defaultsnativemodule: a10c0e1ce88b78d8592f16c36baa0b3606688577
+  React-domnativemodule: b3dadb6d8e294af4ac3753ef149aae65460477ac
+  React-Fabric: 3d970b3cb38e9caff5f23e5bd9084524682df818
+  React-FabricComponents: 573612e5e9860abc659022d5cc7e1ea8f3353097
+  React-FabricImage: 2d08fc8b5cd765296d1c94b8ecb309195cd92359
+  React-featureflags: f1aa11419d898f0e37fcb69aafbb998ad29f401e
+  React-featureflagsnativemodule: ade1ba31d23165a496b79d796ae90b6e09456c7b
+  React-graphics: ef012d8da4de9f8918245695d94632a3574e8ea5
+  React-hermes: 1c67e1a0fc49390e87cdbf94c593ea067d32ce7b
+  React-idlecallbacksnativemodule: 819e49f01e4ec1c734b79963c6e199456445fed0
+  React-ImageManager: 491286f8492d005ddd9c9d26fc6148f718754eb0
+  React-jserrorhandler: e127c151810a44eef37e217ce3ea8dc53420aa98
+  React-jsi: 59b237396968e53b088eb7bca9c95234ea1450f5
+  React-jsiexecutor: a4c1de07d91be19a293ec81d291f9d4ba345cf23
+  React-jsinspector: a3a3c0734d8653dfaafd7935350f5f43ff59e60e
+  React-jsinspectorcdp: f9f23167d4badcd29964aa33d1f60e649bde6f21
+  React-jsinspectornetwork: 87f3a2fe7b04888d0941c1c5153607ed4d76c729
+  React-jsinspectortracing: a1746d20ea583ddd63235d152016fa2fabbedd74
+  React-jsitooling: 13a6ebc6c03a50ca547f62a91035e2ecce9faa4d
+  React-jsitracing: 2cb26de27216895357b7210c5a3b667d40a2a528
+  React-logger: 69cbfaada2b1c8afe1bc9f07321887f8b77e1cb0
+  React-Mapbuffer: 0dc40f635b0bbe2bb5233157a5ca55c55f975bee
+  React-microtasksnativemodule: 1c80957ecd552c51a72ae1fdd7e2c5d48d6e2198
+  React-NativeModulesApple: d1dc1e75a9a14f03dc2f92670c9a47b3700b909f
+  React-oscompat: 3901fd714c34a966ec7bae2a9174c0cbe1ac1cfb
+  React-perflogger: b0932efaaba483aa13641b9353617c26ea2c124d
+  React-performancetimeline: 63e45db09d75e583b1936650cceb5b046ee58523
+  React-RCTActionSheet: de1d8b7aeb3ae93a251a63f8e8038cc93b9d6ca7
+  React-RCTAnimation: 3e795e73197b73e03f5d0f304bba1064778cc2ed
+  React-RCTAppDelegate: 08268b740164533a5aae8f7c7c92b4699e7c4863
+  React-RCTBlob: 010dc14969ca00e517f4787f8cd753a0fd4ae500
+  React-RCTFabric: 714bceb61d1f756ed51e1487ba420e149bb92c00
+  React-RCTFBReactNativeSpec: 63ae58457f1fac05840b1b5cc647e347d12059cd
+  React-RCTImage: e111fae23fcd63032a44359e2706557dc36d5179
+  React-RCTLinking: 4cb3934aa86071ba4944f05d068b62e407aa30d6
+  React-RCTNetwork: 675ad1254b2acf6c8ec8c458ca8b272852bbeac1
+  React-RCTPushNotification: 69e20f2132e9c6ef4b1f3d259931846d6f557694
+  React-RCTRuntime: 7100e6ea948233548900ca58a3165c38e7624f7b
+  React-RCTSettings: bde52ef71ca7bdd23b4811e3abc8d4b0ecec8856
+  React-RCTTest: 9671edc72a8cc2d5ed6bcbdd7203ab5d5b992d06
+  React-RCTText: 564f5a51a1dd2916d4e2711acb10d238ff4c605d
+  React-RCTVibration: daf99169033e893ee17aa8690593cac6626fab81
+  React-rendererconsistency: afa3b7b2f1e5c890e782de21c7f99f190953a2c5
+  React-renderercss: ebafade0a3898cd029adbb08fea725c56bf6231c
+  React-rendererdebug: 6953132835c928321f2cefb866dd0b66b5cdd1b1
+  React-rncore: 06ab92ea476589c10e8f0f57a54617312a2e6c5e
+  React-RuntimeApple: ea3a775f149d886455320498fd25bb207b827cde
+  React-RuntimeCore: 562bffbcfc958d9fa5c91f50ed642713165c51fa
+  React-runtimeexecutor: 09cce6fc74b13861ec60fdfd91066a393812fde5
+  React-RuntimeHermes: 8609744a966766484b0615955b783d3419157c6b
+  React-runtimescheduler: 2251e2735d02b45f01b1116e8e5bfe0c9bc755df
+  React-timing: 3603ea1f09bcf7dd97cf62604218f7b471b90942
+  React-utils: e2117130776cd778c123a31fcc0c7270b4f87f66
+  ReactAppDependencyProvider: 7fa8930678f4d59ea5c58e22ba8bf73039b257fb
   ReactCodegen: 0c8d830ce35b1b48f8b674b0d00e532abc448470
-  ReactCommon: a53973ab35d399560ace331ec9e2b26db0592cec
-  ReactCommon-Samples: 3dd174c775b04ab7d59a1b3c1a832e04377c9538
+  ReactCommon: 621bc6d58e5f902e35e9f3452092aaab7fcd025f
+  ReactCommon-Samples: 25ccde761335cc3fca1aa2adf670625823c98f6e
   ScreenshotManager: 8687f6358b007230590842b03505606e905c3ce9
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: 59290f2ce3fc5c34797a21244288cad99b357b63
+  Yoga: a99949337fd8434aedb236685499ef43362c7c18
 
 PODFILE CHECKSUM: 8591f96a513620a2a83a0b9a125ad3fa32ea1369
 

--- a/scripts/releases/ios-prebuild/configuration.js
+++ b/scripts/releases/ios-prebuild/configuration.js
@@ -95,6 +95,7 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
       headerSearchPaths: ['include'],
       linkedLibraries: ['c++'],
       cxxCompilerFlags: [`-std=${CPP_STANDARD}`],
+      defines: [{name: 'DEFINES_MODULE', value: 'YES'}],
     },
   },
   {
@@ -159,6 +160,7 @@ const dependencies /*: $ReadOnlyArray<Dependency> */ = [
         'SocketRocket/Internal/Security',
         'SocketRocket/Internal/Utilities',
       ],
+      defines: [{name: 'DEFINES_MODULE', value: 'YES'}],
     },
   },
   {


### PR DESCRIPTION
## Summary:
`SocketRocket` and `fmt` are part of React Native dependencies.
If a library is written in swift and depends on them, it will fail to install the pods because these pods are not compatible with Swift.

This change makes sure that the pods are installed in a way that is swift compatible.

## Changelog:
[iOS][Fixed] - Make fmt and SocketRocket Swift friendly

## Test Plan:

Tested locally in a nightly app.

### Before the change:

```
yarn add react-native-video
cd ios
bundle exec pod install
```

This script resulted in this error:

```
[!] The following Swift pods cannot yet be integrated as static libraries:

The Swift pod `react-native-video` depends upon `fmt` and `SocketRocket`, which do not define modules. To opt into those targets generating module maps (which is necessary to import them from Swift when building as static libraries), you may set `use_modular_headers!` globally in your Podfile, or specify `:modular_headers => true` for particular dependencies.
```


### After the change

```
yarn add react-native-video
cd ios
bundle exec pod install
```

This script installed pods successfully.
