### PR TITLE
[RN][iOS] Add back the folly_compiler_flags for backward compatibility

### DIFF
--- a/packages/react-native/scripts/cocoapods/new_architecture.rb
+++ b/packages/react-native/scripts/cocoapods/new_architecture.rb
@@ -145,6 +145,12 @@ class NewArchitectureHelper
         return package["version"]
     end
 
+    # Deprecated method. This has been restored because some libraries (e.g. react-native-exit-app) still use it.
+    def self.folly_compiler_flags
+      folly_config = Helpers::Constants.folly_config
+      return folly_config[:compiler_flags]
+    end
+
     def self.new_arch_enabled
         return ENV["RCT_NEW_ARCH_ENABLED"] == '0' ? false : true
     end


### PR DESCRIPTION
## Summary:
Some libraries still use the `folly_flags` method provided by our infra. When updating how folly should be installed in an app, we removed that function.
We are putting it back as deprecated, to avoid unnecessary breaking changes in libraries

## Changelog:
[iOS][Fixed] - Put back the `folly_compiler_flag` function to make libraries install pods

## Test Plan:
Tested locally in a nightly app, using the react-native-exit-app library which still uses these flags
