### PR TITLE
Fix backgroundImage on new Background Drawable

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/BackgroundDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/BackgroundDrawable.kt
@@ -122,6 +122,7 @@ internal class BackgroundDrawable(
       }
     }
 
+    backgroundPaint.alpha = 255
     if (backgroundImageLayers != null && backgroundImageLayers?.isNotEmpty() == true) {
       backgroundPaint.setShader(getBackgroundImageShader())
       if (computedBorderRadius?.isUniform() == true && borderRadius?.hasRoundedBorders() == true) {
@@ -137,6 +138,7 @@ internal class BackgroundDrawable(
       }
       backgroundPaint.setShader(null)
     }
+    backgroundPaint.alpha = Color.alpha(backgroundColor)
     canvas.restore()
   }
 


### PR DESCRIPTION
Summary:
At some point I made some changes to how alpha works on BackgroundDrawable. This inadvertently broke BackgroundImage because we need a non transparent color to apply shaders.

Setting the alpha to 255 temporarily when drawing background-image layers fixes it

Changelog: [Internal]

Reviewed By: joevilches

Differential Revision: D73520952


