### PR TITLE
Fix ReactTextAnchorViewManager Nullability

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -6352,27 +6352,6 @@ public final class com/facebook/react/views/text/ReactFontManager$Companion {
 	public final fun getInstance ()Lcom/facebook/react/views/text/ReactFontManager;
 }
 
-public abstract class com/facebook/react/views/text/ReactTextAnchorViewManager : com/facebook/react/uimanager/BaseViewManager {
-	public fun <init> ()V
-	public final fun setAccessible (Lcom/facebook/react/views/text/ReactTextView;Z)V
-	public final fun setAdjustFontSizeToFit (Lcom/facebook/react/views/text/ReactTextView;Z)V
-	public final fun setAndroidHyphenationFrequency (Lcom/facebook/react/views/text/ReactTextView;Ljava/lang/String;)V
-	public final fun setBorderColor (Lcom/facebook/react/views/text/ReactTextView;ILjava/lang/Integer;)V
-	public final fun setBorderRadius (Lcom/facebook/react/views/text/ReactTextView;IF)V
-	public final fun setBorderStyle (Lcom/facebook/react/views/text/ReactTextView;Ljava/lang/String;)V
-	public final fun setBorderWidth (Lcom/facebook/react/views/text/ReactTextView;IF)V
-	public final fun setDataDetectorType (Lcom/facebook/react/views/text/ReactTextView;Ljava/lang/String;)V
-	public final fun setDisabled (Lcom/facebook/react/views/text/ReactTextView;Z)V
-	public final fun setEllipsizeMode (Lcom/facebook/react/views/text/ReactTextView;Ljava/lang/String;)V
-	public final fun setFontSize (Lcom/facebook/react/views/text/ReactTextView;F)V
-	public final fun setIncludeFontPadding (Lcom/facebook/react/views/text/ReactTextView;Z)V
-	public final fun setLetterSpacing (Lcom/facebook/react/views/text/ReactTextView;F)V
-	public final fun setNumberOfLines (Lcom/facebook/react/views/text/ReactTextView;I)V
-	public final fun setSelectable (Lcom/facebook/react/views/text/ReactTextView;Z)V
-	public final fun setSelectionColor (Lcom/facebook/react/views/text/ReactTextView;Ljava/lang/Integer;)V
-	public final fun setTextAlignVertical (Lcom/facebook/react/views/text/ReactTextView;Ljava/lang/String;)V
-}
-
 public class com/facebook/react/views/text/ReactTextShadowNode : com/facebook/react/views/text/ReactBaseTextShadowNode {
 	public fun <init> ()V
 	public fun <init> (Lcom/facebook/react/views/text/ReactTextViewManagerCallback;)V
@@ -6448,7 +6427,7 @@ public class com/facebook/react/views/text/ReactTextView : androidx/appcompat/wi
 	protected fun verifyDrawable (Landroid/graphics/drawable/Drawable;)Z
 }
 
-public class com/facebook/react/views/text/ReactTextViewManager : com/facebook/react/views/text/ReactTextAnchorViewManager, com/facebook/react/uimanager/IViewManagerWithChildren {
+public class com/facebook/react/views/text/ReactTextViewManager : com/facebook/react/uimanager/IViewManagerWithChildren {
 	protected field mReactTextViewManagerCallback Lcom/facebook/react/views/text/ReactTextViewManagerCallback;
 	public fun <init> ()V
 	public fun <init> (Lcom/facebook/react/views/text/ReactTextViewManagerCallback;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextAnchorViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextAnchorViewManager.kt
@@ -11,13 +11,9 @@ import android.text.Layout
 import android.text.TextUtils
 import android.text.util.Linkify
 import android.view.Gravity
-import android.view.View
 import com.facebook.common.logging.FLog
 import com.facebook.react.common.ReactConstants
-import com.facebook.react.uimanager.BackgroundStyleApplicator.setBorderColor
-import com.facebook.react.uimanager.BackgroundStyleApplicator.setBorderRadius
-import com.facebook.react.uimanager.BackgroundStyleApplicator.setBorderStyle
-import com.facebook.react.uimanager.BackgroundStyleApplicator.setBorderWidth
+import com.facebook.react.uimanager.BackgroundStyleApplicator
 import com.facebook.react.uimanager.BaseViewManager
 import com.facebook.react.uimanager.LengthPercentage
 import com.facebook.react.uimanager.LengthPercentageType
@@ -31,15 +27,15 @@ import com.facebook.react.uimanager.style.LogicalEdge
 import com.facebook.react.views.text.DefaultStyleValuesUtil.getDefaultTextColorHighlight
 
 /**
- * Abstract class for anchor `<Text>`-ish spannable views, such as [TextView] or [EditText].
+ * Previously a superclass of multiple text view managers. Now only used by [ReactTextViewManager].
  *
  * This is a "shadowing" view manager, which means that the [NativeViewHierarchyManager] will NOT
  * manage children of native [TextView] instances instantiated by this manager. Instead we
  * use @{link ReactBaseTextShadowNode} hierarchy to calculate a [Spannable] text represented the
  * whole text subtree.
  */
-public abstract class ReactTextAnchorViewManager<T : View?, C : ReactBaseTextShadowNode?> :
-    BaseViewManager<T, C>() {
+internal abstract class ReactTextAnchorViewManager<C : ReactBaseTextShadowNode?> :
+    BaseViewManager<ReactTextView, C>() {
 
   @ReactProp(name = "accessible")
   public fun setAccessible(view: ReactTextView, accessible: Boolean) {
@@ -130,20 +126,20 @@ public abstract class ReactTextAnchorViewManager<T : View?, C : ReactBaseTextSha
               ViewProps.BORDER_BOTTOM_RIGHT_RADIUS,
               ViewProps.BORDER_BOTTOM_LEFT_RADIUS],
       defaultFloat = Float.NaN)
-  public fun setBorderRadius(view: ReactTextView?, index: Int, borderRadius: Float) {
+  public fun setBorderRadius(view: ReactTextView, index: Int, borderRadius: Float) {
     val radius =
         if (java.lang.Float.isNaN(borderRadius)) {
           null
         } else {
           LengthPercentage(borderRadius, LengthPercentageType.POINT)
         }
-    setBorderRadius(checkNotNull(view), BorderRadiusProp.entries[index], radius)
+    BackgroundStyleApplicator.setBorderRadius(view, BorderRadiusProp.values()[index], radius)
   }
 
   @ReactProp(name = "borderStyle")
-  public fun setBorderStyle(view: ReactTextView?, borderStyle: String?) {
+  public fun setBorderStyle(view: ReactTextView, borderStyle: String?) {
     val parsedBorderStyle = if (borderStyle == null) null else fromString(borderStyle)
-    setBorderStyle(checkNotNull(view), parsedBorderStyle)
+    BackgroundStyleApplicator.setBorderStyle(view, parsedBorderStyle)
   }
 
   @ReactPropGroup(
@@ -157,8 +153,8 @@ public abstract class ReactTextAnchorViewManager<T : View?, C : ReactBaseTextSha
               ViewProps.BORDER_START_WIDTH,
               ViewProps.BORDER_END_WIDTH],
       defaultFloat = Float.NaN)
-  public fun setBorderWidth(view: ReactTextView?, index: Int, width: Float) {
-    setBorderWidth(checkNotNull(view), LogicalEdge.entries[index], width)
+  public fun setBorderWidth(view: ReactTextView, index: Int, width: Float) {
+    BackgroundStyleApplicator.setBorderWidth(view, LogicalEdge.values()[index], width)
   }
 
   @ReactPropGroup(
@@ -170,8 +166,8 @@ public abstract class ReactTextAnchorViewManager<T : View?, C : ReactBaseTextSha
               "borderTopColor",
               "borderBottomColor"],
       customType = "Color")
-  public fun setBorderColor(view: ReactTextView?, index: Int, color: Int?) {
-    setBorderColor(checkNotNull(view), LogicalEdge.ALL, color)
+  public fun setBorderColor(view: ReactTextView, index: Int, color: Int?) {
+    BackgroundStyleApplicator.setBorderColor(view, LogicalEdge.ALL, color)
   }
 
   @ReactProp(name = ViewProps.INCLUDE_FONT_PADDING, defaultBoolean = true)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
@@ -38,8 +38,7 @@ import java.util.Map;
  */
 @Nullsafe(Nullsafe.Mode.LOCAL)
 @ReactModule(name = ReactTextViewManager.REACT_CLASS)
-public class ReactTextViewManager
-    extends ReactTextAnchorViewManager<ReactTextView, ReactTextShadowNode>
+public class ReactTextViewManager extends ReactTextAnchorViewManager<ReactTextShadowNode>
     implements IViewManagerWithChildren {
 
   private static final String TAG = "ReactTextViewManager";


### PR DESCRIPTION
Summary:
The view for a view manager should not be nullable. Let's fix that.

These are also all bound specifically to `ReactTextView` instead of the generic constraint, so I just changed the constraint. Really this should just be totally merged with `ReactTextViewManager`.

Changelog: [Internal]

Reviewed By: cortinico, rshest

Differential Revision: D73453631


