### PR TITLE
Rename Codegen Component Descriptors Entrypoint for FAC and hook it up in DefaultComponentsRegistry

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultComponentsRegistry.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultComponentsRegistry.cpp
@@ -18,6 +18,10 @@ namespace facebook::react {
 std::function<void(std::shared_ptr<const ComponentDescriptorProviderRegistry>)>
     DefaultComponentsRegistry::registerComponentDescriptorsFromEntryPoint{};
 
+std::function<void(std::shared_ptr<const ComponentDescriptorProviderRegistry>)>
+    DefaultComponentsRegistry::
+        registerCodegenComponentDescriptorsFromEntryPoint{};
+
 void DefaultComponentsRegistry::setRegistryRunction(
     jni::alias_ref<jclass>,
     ComponentFactory* delegate) {
@@ -31,6 +35,12 @@ void DefaultComponentsRegistry::setRegistryRunction(
         .flavor = nullptr};
 
     auto providerRegistry = CoreComponentsRegistry::sharedProviderRegistry();
+    if (registerCodegenComponentDescriptorsFromEntryPoint) {
+      registerCodegenComponentDescriptorsFromEntryPoint(providerRegistry);
+    } else {
+      LOG(WARNING)
+          << "Codegen component descriptors were not configured from JNI_OnLoad";
+    }
     if (registerComponentDescriptorsFromEntryPoint) {
       registerComponentDescriptorsFromEntryPoint(providerRegistry);
     } else {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultComponentsRegistry.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/newarchdefaults/DefaultComponentsRegistry.h
@@ -27,6 +27,10 @@ class DefaultComponentsRegistry
       std::shared_ptr<const ComponentDescriptorProviderRegistry>)>
       registerComponentDescriptorsFromEntryPoint;
 
+  static std::function<void(
+      std::shared_ptr<const ComponentDescriptorProviderRegistry>)>
+      registerCodegenComponentDescriptorsFromEntryPoint;
+
  private:
   static void setRegistryRunction(
       jni::alias_ref<jclass>,


### PR DESCRIPTION
Summary:
Rename Codegen Component Descriptors Entrypoint for Fabric Auto Component Registration and hook it up in DefaultComponentsRegistry

Changelog: [Internal]

Differential Revision: D73535745


