### PR TITLE
TypeScript: Replace deprecated React.ElementRef usages to React.ComponentRef

### DIFF
--- a/packages/react-native/Libraries/Lists/FlatList.d.ts
+++ b/packages/react-native/Libraries/Lists/FlatList.d.ts
@@ -228,8 +228,8 @@ export abstract class FlatListComponent<
    * Provides a reference to the underlying host component
    */
   getNativeScrollRef: () =>
-    | React.ElementRef<typeof View>
-    | React.ElementRef<typeof ScrollViewComponent>
+    | React.ComponentRef<typeof View>
+    | React.ComponentRef<typeof ScrollViewComponent>
     | null
     | undefined;
 

--- a/packages/react-native/types/__typetests__/fabric-component-sample.ts
+++ b/packages/react-native/types/__typetests__/fabric-component-sample.ts
@@ -43,7 +43,7 @@ export type SampleViewType = NativeComponentType<NativeProps>;
 
 interface NativeCommands {
   changeBackgroundColor: (
-    viewRef: React.ElementRef<SampleViewType>,
+    viewRef: React.ComponentRef<SampleViewType>,
     color: string,
   ) => void;
 }

--- a/packages/virtualized-lists/Lists/VirtualizedList.d.ts
+++ b/packages/virtualized-lists/Lists/VirtualizedList.d.ts
@@ -131,8 +131,8 @@ export class VirtualizedList<ItemT> extends React.Component<
   recordInteraction: () => void;
 
   getScrollRef: () =>
-    | React.ElementRef<typeof ScrollView>
-    | React.ElementRef<typeof View>
+    | React.ComponentRef<typeof ScrollView>
+    | React.ComponentRef<typeof View>
     | null;
 
   getScrollResponder: () => ScrollResponderMixin | null;


### PR DESCRIPTION
## Summary:

While upgrading a project to React 19, I noticed React.ElementRef is deprecated (see [types/react/index.d.ts#L199](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L199)). I think we can replace it for the RN types as well.

Not sure if this is considered as a breaking change.

## Changelog:

[GENERAL] [CHANGED] - TypeScript: Replace deprecated React.ElementRef usages to React.ComponentRef

## Test Plan:

Create a RNTesterPlayground.tsx next to the normal .js just to validate the type checking is not throwing an unexpected error.

<details>
<summary>Code snippet:</summary>

```tsx
import React, { useRef, useEffect } from 'react';
import { FlatList, Text, View } from 'react-native';

type Item = { id: string; title: string };

const data: Item[] = Array.from({ length: 10 }, (_, i) => ({
  id: i.toString(),
  title: `Item ${i + 1}`,
}));

const FlatListScrollRefExample: React.FC = () => {
  const flatListRef = useRef<FlatList<Item>>(null);

  useEffect(() => {
    if (flatListRef.current) {
      const nativeRef = flatListRef.current.getNativeScrollRef();

      console.log('nativeRef', nativeRef?.componentWillUnmount);
    }
  }, []);

  return (
    <FlatList
      ref={flatListRef}
      data={data}
      keyExtractor={(item) => item.id}
      renderItem={({ item }) => (
        <View style={{ padding: 16 }}>
          <Text>{item.title}</Text>
        </View>
      )}
    />
  );
};

export default FlatListScrollRefExample;

```

</details>
