### PR TITLE
group reparenting tests for view culling together

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.cpp
@@ -711,6 +711,11 @@ static void calculateShadowViewMutationsFlattener(
 
           // Unflatten parent, flatten child
           if (childReparentMode == ReparentMode::Flatten) {
+            auto parentTagForUpdateWhenUnflattened =
+                ReactNativeFeatureFlags::
+                    enableFixForParentTagDuringReparenting()
+                ? newTreeNodePair.shadowView.tag
+                : parentTag;
             // Flatten old tree into new list
             // At the end of this loop we still want to know which of these
             // children are visited, so we reuse the `newRemainingPairs` map.
@@ -727,7 +732,7 @@ static void calculateShadowViewMutationsFlattener(
                 oldTreeNodePair,
                 (reparentMode == ReparentMode::Flatten
                      ? oldTreeNodePair.shadowView.tag
-                     : parentTag),
+                     : parentTagForUpdateWhenUnflattened),
                 subVisitedNewMap,
                 subVisitedOldMap,
                 adjustedOldCullingContext,

--- a/packages/react-native/src/private/renderer/mounting/__tests__/Mounting-itest.js
+++ b/packages/react-native/src/private/renderer/mounting/__tests__/Mounting-itest.js
@@ -295,6 +295,62 @@ test('parent-child switching from unflattened-flattened to flattened-unflattened
   ]);
 });
 
+test('parent-child switching from flattened-unflattened to unflattened-flattened', () => {
+  const root = Fantom.createRoot();
+
+  Fantom.runTask(() => {
+    root.render(
+      <View
+        style={{
+          marginTop: 100,
+        }}>
+        <View
+          style={{
+            marginTop: 50,
+            opacity: 0,
+          }}>
+          <View nativeID={'child'} style={{height: 10, width: 10}} />
+        </View>
+      </View>,
+    );
+  });
+
+  expect(root.takeMountingManagerLogs()).toEqual([
+    'Update {type: "RootView", nativeID: (root)}',
+    'Create {type: "View", nativeID: (N/A)}',
+    'Create {type: "View", nativeID: "child"}',
+    'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: "child"}',
+    'Insert {type: "View", parentNativeID: (root), index: 0, nativeID: (N/A)}',
+  ]);
+
+  // force view to be flattened.
+  Fantom.runTask(() => {
+    root.render(
+      <View
+        style={{
+          marginTop: 100,
+          opacity: 0,
+        }}>
+        <View
+          style={{
+            marginTop: 50,
+          }}>
+          <View nativeID={'child'} style={{height: 10, width: 10}} />
+        </View>
+      </View>,
+    );
+  });
+  expect(root.takeMountingManagerLogs()).toEqual([
+    'Update {type: "View", nativeID: "child"}',
+    'Remove {type: "View", parentNativeID: (root), index: 0, nativeID: (N/A)}',
+    'Remove {type: "View", parentNativeID: (N/A), index: 0, nativeID: "child"}',
+    'Delete {type: "View", nativeID: (N/A)}',
+    'Create {type: "View", nativeID: (N/A)}',
+    'Insert {type: "View", parentNativeID: (root), index: 0, nativeID: (N/A)}',
+    'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: "child"}',
+  ]);
+});
+
 describe('reconciliation of setNativeProps and React commit', () => {
   it('props set by setNativeProps must not be overriden by React commit', () => {
     const root = Fantom.createRoot();


### PR DESCRIPTION
Summary:
changelog: [internal]

Group tests related to reparenting in "describe" block. Differentiator is two algorithms hidden behind a single interface: regular and reparenting. The tests are structured this way as well where regular tests focus on common scenarios and reparenting section focuses on reparenting and special cases around that. The reparenting implementation is considerably more complex as it handles edge cases that don't happen often.

Reviewed By: mdvacca

Differential Revision: D73541053


