### PR TITLE
add a view culling test case when for reparenting a culled grand

### DIFF
--- a/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-viewCulling-itest.js
+++ b/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-viewCulling-itest.js
@@ -1561,4 +1561,168 @@ describe('reparenting', () => {
       'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: "grandchild"}',
     ]);
   });
+
+  test('parent-child switching from flattened-unflattened to unflattened-flattened and grandchild is culled', () => {
+    const root = Fantom.createRoot({viewportWidth: 100, viewportHeight: 100});
+
+    // First render unflattened view container with flattened child that has a culled grandchild.
+    Fantom.runTask(() => {
+      root.render(
+        <ScrollView
+          style={{height: 100, width: 100}}
+          contentOffset={{x: 0, y: 60}}>
+          <View
+            style={{
+              marginTop: 100,
+            }}>
+            <View
+              style={{
+                marginTop: 50,
+                opacity: 0,
+              }}>
+              <View
+                nativeID={'grandchild'}
+                style={{height: 10, width: 10, marginTop: 11}}
+              />
+            </View>
+          </View>
+        </ScrollView>,
+      );
+    });
+
+    // Note that `grandchild` is not mounted.
+    expect(root.takeMountingManagerLogs()).toEqual([
+      'Update {type: "RootView", nativeID: (root)}',
+      'Create {type: "ScrollView", nativeID: (N/A)}',
+      'Create {type: "View", nativeID: (N/A)}',
+      'Create {type: "View", nativeID: (N/A)}',
+      'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+      'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+      'Insert {type: "ScrollView", parentNativeID: (root), index: 0, nativeID: (N/A)}',
+    ]);
+
+    let maybeNode = null;
+
+    // Now change unflattened view container to flattened and change its child to be unflattened.
+    Fantom.runTask(() => {
+      root.render(
+        <ScrollView
+          style={{height: 100, width: 100}}
+          ref={node => {
+            maybeNode = node;
+          }}
+          contentOffset={{x: 0, y: 60}}>
+          <View
+            style={{
+              marginTop: 100,
+              opacity: 0,
+            }}>
+            <View
+              style={{
+                marginTop: 50,
+              }}>
+              <View
+                nativeID={'grandchild'}
+                style={{height: 10, width: 10, marginTop: 11}}
+              />
+            </View>
+          </View>
+        </ScrollView>,
+      );
+    });
+
+    // Note that `grandchild` is not mounted.
+    expect(root.takeMountingManagerLogs()).toEqual([
+      'Remove {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+      'Delete {type: "View", nativeID: (N/A)}',
+      'Create {type: "View", nativeID: (N/A)}',
+      'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+    ]);
+
+    const element = ensureInstance(maybeNode, ReactNativeElement);
+
+    // Scroll to reveal grandchild.
+    Fantom.scrollTo(element, {
+      x: 0,
+      y: 70,
+    });
+
+    expect(root.takeMountingManagerLogs()).toEqual([
+      'Update {type: "ScrollView", nativeID: (N/A)}',
+      'Create {type: "View", nativeID: "grandchild"}',
+      'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: "grandchild"}',
+    ]);
+  });
+
+  test('parent-child switching from flattened-unflattened to unflattened-flattened', () => {
+    const root = Fantom.createRoot({viewportWidth: 100, viewportHeight: 100});
+
+    // First create a view hierarchy where parent is flattened but child is not.
+    // `grandchild` is not culled.
+    Fantom.runTask(() => {
+      root.render(
+        <ScrollView
+          style={{height: 100, width: 100}}
+          contentOffset={{x: 0, y: 60}}>
+          <View
+            style={{
+              marginTop: 100,
+            }}>
+            <View
+              style={{
+                marginTop: 50,
+                opacity: 0,
+              }}>
+              <View nativeID={'grandchild'} style={{height: 10, width: 10}} />
+            </View>
+          </View>
+        </ScrollView>,
+      );
+    });
+
+    expect(root.takeMountingManagerLogs()).toEqual([
+      'Update {type: "RootView", nativeID: (root)}',
+      'Create {type: "ScrollView", nativeID: (N/A)}',
+      'Create {type: "View", nativeID: (N/A)}',
+      'Create {type: "View", nativeID: (N/A)}',
+      'Create {type: "View", nativeID: "grandchild"}',
+      'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: "grandchild"}',
+      'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+      'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+      'Insert {type: "ScrollView", parentNativeID: (root), index: 0, nativeID: (N/A)}',
+    ]);
+
+    // Now switch parent to be unflattened and child to be flattened.
+    // `grandchild` remains visible.
+    Fantom.runTask(() => {
+      root.render(
+        <ScrollView
+          style={{height: 100, width: 100}}
+          contentOffset={{x: 0, y: 60}}>
+          <View
+            style={{
+              marginTop: 100,
+              opacity: 0,
+            }}>
+            <View
+              style={{
+                marginTop: 50,
+              }}>
+              <View nativeID={'grandchild'} style={{height: 10, width: 10}} />
+            </View>
+          </View>
+        </ScrollView>,
+      );
+    });
+
+    expect(root.takeMountingManagerLogs()).toEqual([
+      'Update {type: "View", nativeID: "grandchild"}',
+      'Remove {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+      'Remove {type: "View", parentNativeID: (N/A), index: 0, nativeID: "grandchild"}',
+      'Delete {type: "View", nativeID: (N/A)}',
+      'Create {type: "View", nativeID: (N/A)}',
+      'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+      'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: "grandchild"}',
+    ]);
+  });
 });

--- a/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.cpp
@@ -710,8 +710,6 @@ static void calculateShadowViewMutationsFlattener(
             // Flatten old tree into new list
             // At the end of this loop we still want to know which of these
             // children are visited, so we reuse the `newRemainingPairs` map.
-            // TODO(T217775046): Find a test case for this branch of view
-            // flattening + culling.
             calculateShadowViewMutationsFlattener(
                 scope,
                 ReparentMode::Flatten,

--- a/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/Differentiator.cpp
@@ -699,9 +699,10 @@ static void calculateShadowViewMutationsFlattener(
             }
           }
 
-          // Unflatten parent, flatten child
           if (childReparentMode == ReparentMode::Flatten) {
-            auto parentTagForUpdateWhenUnflattened =
+            // Unflatten parent, flatten child
+            react_native_assert(reparentMode == ReparentMode::Unflatten);
+            auto fixedParentTagForUpdate =
                 ReactNativeFeatureFlags::
                     enableFixForParentTagDuringReparenting()
                 ? newTreeNodePair.shadowView.tag
@@ -715,22 +716,18 @@ static void calculateShadowViewMutationsFlattener(
                 scope,
                 ReparentMode::Flatten,
                 mutationContainer,
-                (reparentMode == ReparentMode::Flatten
-                     ? parentTag
-                     : newTreeNodePair.shadowView.tag),
+                newTreeNodePair.shadowView.tag,
                 unvisitedRecursiveChildPairs,
                 oldTreeNodePair,
-                (reparentMode == ReparentMode::Flatten
-                     ? oldTreeNodePair.shadowView.tag
-                     : parentTagForUpdateWhenUnflattened),
+                fixedParentTagForUpdate,
                 subVisitedNewMap,
                 subVisitedOldMap,
-                cullingContext.adjustCullingContextIfNeeded(oldTreeNodePair));
-          }
-          // Flatten parent, unflatten child
-          else {
+                adjustedNewCullingContext);
+          } else {
+            // Flatten parent, unflatten child
+            react_native_assert(reparentMode == ReparentMode::Flatten);
             // Unflatten old list into new tree
-            auto parentTagForUpdateWhenFlattened =
+            auto fixedParentTagForUpdate =
                 ReactNativeFeatureFlags::
                     enableFixForParentTagDuringReparenting()
                 ? parentTagForUpdate
@@ -739,21 +736,13 @@ static void calculateShadowViewMutationsFlattener(
                 scope,
                 /* reparentMode */ ReparentMode::Unflatten,
                 mutationContainer,
-                /* parentTag */
-                (reparentMode == ReparentMode::Flatten
-                     ? parentTag
-                     : newTreeNodePair.shadowView.tag),
+                parentTag,
                 /* unvisitedOtherNodes */ unvisitedRecursiveChildPairs,
                 /* node */ newTreeNodePair,
-                /* parentTagForUpdate */
-                (reparentMode == ReparentMode::Flatten
-                     ? parentTagForUpdateWhenFlattened
-                     : parentTag),
+                /* parentTagForUpdate */ fixedParentTagForUpdate,
                 /* parentSubVisitedOtherNewNodes */ subVisitedNewMap,
                 /* parentSubVisitedOtherOldNodes */ subVisitedOldMap,
-                reparentMode == ReparentMode::Flatten
-                    ? adjustedOldCullingContext
-                    : adjustedNewCullingContext);
+                /* cullingContext */ adjustedOldCullingContext);
 
             // If old nodes were not visited, we know that we can delete them
             // now. They will be removed from the hierarchy by the outermost


### PR DESCRIPTION
Summary:
changelog: [internal]

adding more tests to cover all branches of `calculateShadowViewMutationsFlattener`.

calculateShadowViewMutationsFlattener is over 400 lines of code and covers quite a few edge cases. I plan to cover every branch with a test to make it easier to refactor Differentiator in the future.

Reviewed By: rubennorte

Differential Revision: D73543444


