### PR TITLE
Fix link in the bug_report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -19,7 +19,7 @@ body:
         * Please [search for similar issues](https://github.com/facebook/react-native/issues) in our issue tracker.
 
         Make sure that your issue:
-        * Have a **valid reproducer** (See [How to report a bug](https://reactnative.dev/contributing/how-to-report-a-bug)).
+        * Have a **valid reproducer** (See [How to report a bug](https://reactnative.dev/contributing/how-to-file-an-issue)).
         * Is tested against the [**latest stable**](https://github.com/facebook/react-native/releases/) of React Native.
 
         🚨 IMPORTANT: Due to the extreme number of bugs we receive, issues **without a reproducer** or for an [**unsupported versions**](https://github.com/reactwg/react-native-releases#which-versions-are-currently-supported) of React Native **will be closed**.


### PR DESCRIPTION
Summary:
This change fixes a broken link in the bug report template

## Changelog:
[Internal] - Fix link in bug report template

Differential Revision: D73578200


