### PR TITLE
fix: build proper hermes for all debug variants

### DIFF
--- a/packages/react-native/sdks/hermes-engine/utils/build-hermes-xcode.sh
+++ b/packages/react-native/sdks/hermes-engine/utils/build-hermes-xcode.sh
@@ -37,12 +37,12 @@ function get_deployment_target {
 }
 
 enable_debugger="false"
-if [[ "$CONFIGURATION" == "Debug" ]]; then
+if [[ "$CONFIGURATION" = *Debug* ]]; then
   enable_debugger="true"
 fi
 
 cmake_build_type=""
-if [[ $CONFIGURATION == "Debug" ]]; then
+if [[ "$CONFIGURATION" = *Debug* ]]; then
   # JS developers aren't VM developers.
   # Therefore we're passing as build type Release, to provide a faster build.
   cmake_build_type="Release"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
When building hermes from source in a project that has a debug scheme not named strictly "Debug", hermes is built with wrong flags which makes the compilation fail. We should use a better check for such cases, analogous to https://github.com/facebook/react-native/blob/ec43150b2a8db3a93137ae69ac414859a2fff73e/packages/react-native/scripts/react-native-xcode.sh#L16. I haven't found any other usages of this pattern: https://github.com/search?q=repo%3Afacebook%2Freact-native%20%24CONFIGURATION&type=code, hopefully other places use the correct semantics already.


## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[IOS] [FIXED] - properly check for debug schemes when building hermes from source

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [FIXED] - properly check for debug schemes when building hermes from source

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Use e.g. https://github.com/martinlAP/keyboardcrash with `Dev-Debug` scheme and try to build hermes from source based on https://github.com/facebook/hermes/blob/rn/0.79-stable/doc/ReactNativeIntegration.md. to see that it fails without this PR.
