### PR TITLE
feat: add support for numeric font weight values in shadow tree

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
@@ -236,7 +236,6 @@ inline void fromRawValue(
       result = FontWeight::Weight900;
     } else {
       LOG(ERROR) << "Unsupported FontWeight value: " << string;
-      react_native_expect(false);
       // sane default for prod
       result = FontWeight::Regular;
     }
@@ -265,7 +264,6 @@ inline void fromRawValue(
       result = FontWeight::Weight900;
     } else {
       LOG(ERROR) << "Unsupported FontWeight value: " << numeric;
-      react_native_expect(false);
       // sane default for prod
       result = FontWeight::Regular;
     }

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
@@ -207,7 +207,7 @@ inline void fromRawValue(
     const PropsParserContext& context,
     const RawValue& value,
     FontWeight& result) {
-  react_native_expect(value.hasType<std::string>());
+  react_native_expect(value.hasType<std::string>() || value.hasType<int>());
   if (value.hasType<std::string>()) {
     auto string = (std::string)value;
     if (string == "normal") {
@@ -236,6 +236,35 @@ inline void fromRawValue(
       result = FontWeight::Weight900;
     } else {
       LOG(ERROR) << "Unsupported FontWeight value: " << string;
+      react_native_expect(false);
+      // sane default for prod
+      result = FontWeight::Regular;
+    }
+    return;
+  }
+
+  if(value.hasType<int>()) {
+    auto numeric = (int)value;
+    if (numeric == 100) {
+      result = FontWeight::Weight100;
+    } else if (numeric == 200) {
+      result = FontWeight::Weight200;
+    } else if (numeric == 300) {
+      result = FontWeight::Weight300;
+    } else if (numeric == 400) {
+      result = FontWeight::Weight400;
+    } else if (numeric == 500) {
+      result = FontWeight::Weight500;
+    } else if (numeric == 600) {
+      result = FontWeight::Weight600;
+    } else if (numeric == 700) {
+      result = FontWeight::Weight700;
+    } else if (numeric == 800) {
+      result = FontWeight::Weight800;
+    } else if (numeric == 900) {
+      result = FontWeight::Weight900;
+    } else {
+      LOG(ERROR) << "Unsupported FontWeight value: " << numeric;
       react_native_expect(false);
       // sane default for prod
       result = FontWeight::Regular;


### PR DESCRIPTION
## Summary:

This PR aligns the JS `fontWeight` types and supports numeric `fontWeight` values in the C++ converter.  
Previously, React Native cast `fontWeight` to a string on the JS layer, so handling integers was unnecessary.

Some libraries, such as `react-native-unistyles` and `react-native-reanimated`, use `ShadowTree` to update user styles. In these cases, `ShadowTree` cannot handle numeric `fontWeight` values passed directly from the user, resulting in the default `fontWeight` being applied instead.

This PR introduces a simple numeric converter to cover this case.

Fixes #50544 

## Changelog:

[INTERNAL] [ADDED]

## Test Plan:

Patched locally with the Unistyles repo, as it is very difficult to create a small reproducer for working with ShadowTree.

### Test description:

Add custom logic that changes the Text's `fontWeight` based on the user's color scheme.  
For light mode we should use `fontWeight: 100`; for dark mode `fontWeight: 500`.

#### Before:


https://github.com/user-attachments/assets/fe98fe92-3853-4bca-802a-8ec8b80862f3


https://github.com/user-attachments/assets/9ad82909-4b4f-4502-a2e1-d2837aacf524




#### After:

https://github.com/user-attachments/assets/520ed266-4d05-44ad-9dbe-e800917657a9

<video src="https://github.com/user-attachments/assets/acb37354-7ce4-4b9c-81bd-977cad04818b" width="400" />

