### PR TITLE
Ignore warnings for imports from `react-native/Libraries/Core/InitializeCore`

### DIFF
--- a/packages/eslint-plugin-react-native/__tests__/no-deep-imports-test.js
+++ b/packages/eslint-plugin-react-native/__tests__/no-deep-imports-test.js
@@ -29,6 +29,8 @@ eslintTester.run('../no-deep-imports', rule, {
     "import Foo from 'react-native-foo';",
     "import Foo from 'react-native-foo/Foo';",
     "import Foo from 'react/native/Foo';",
+    "import 'react-native/Libraries/Core/InitializeCore';",
+    "require('react-native/Libraries/Core/InitializeCore');",
   ],
   invalid: [
     {

--- a/packages/eslint-plugin-react-native/no-deep-imports.js
+++ b/packages/eslint-plugin-react-native/no-deep-imports.js
@@ -28,7 +28,10 @@ module.exports = {
   create: function (context) {
     return {
       ImportDeclaration(node) {
-        if (!isDeepReactNativeImport(node.source)) {
+        if (
+          !isDeepReactNativeImport(node.source) ||
+          isInitializeCoreImport(node.source)
+        ) {
           return;
         }
         if (isDefaultImport(node)) {
@@ -54,7 +57,7 @@ module.exports = {
         }
       },
       CallExpression(node) {
-        if (!isDeepRequire(node)) {
+        if (!isDeepRequire(node) || isInitializeCoreImport(node.arguments[0])) {
           return;
         }
 
@@ -124,6 +127,14 @@ module.exports = {
       const importPath = source.value;
       const parts = importPath.split('/');
       return parts.length > 1 && parts[0] === 'react-native';
+    }
+
+    function isInitializeCoreImport(source) {
+      if (source.type !== 'Literal' || typeof source.value !== 'string') {
+        return false;
+      }
+
+      return source.value === 'react-native/Libraries/Core/InitializeCore';
     }
   },
 };

--- a/packages/react-native-babel-preset/src/__tests__/plugin-warn-on-deep-imports-test.js
+++ b/packages/react-native-babel-preset/src/__tests__/plugin-warn-on-deep-imports-test.js
@@ -3,9 +3,6 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
- * @format
- * @oncall react_native
  */
 
 'use strict';
@@ -81,4 +78,18 @@ test('import from other package', () => {
   expect(transform(code, [rnDeepImportsWarningPlugin])).toMatchInlineSnapshot(
     `"import { foo } from 'react-native-foo';"`,
   );
+});
+
+test('import react-native/Libraries/Core/InitializeCore', () => {
+  const code = `
+    import 'react-native/Libraries/Core/InitializeCore';
+    require('react-native/Libraries/Core/InitializeCore');
+    export * from 'react-native/Libraries/Core/InitializeCore';
+  `;
+
+  expect(transform(code, [rnDeepImportsWarningPlugin])).toMatchInlineSnapshot(`
+    "import 'react-native/Libraries/Core/InitializeCore';
+    require('react-native/Libraries/Core/InitializeCore');
+    export * from 'react-native/Libraries/Core/InitializeCore';"
+  `);
 });

--- a/packages/react-native-babel-preset/src/plugin-warn-on-deep-imports.js
+++ b/packages/react-native-babel-preset/src/plugin-warn-on-deep-imports.js
@@ -38,6 +38,10 @@ function isDeepReactNativeImport(source) {
   return parts.length > 1 && parts[0] === 'react-native';
 }
 
+function isInitializeCoreImport(source) {
+  return source === 'react-native/Libraries/Core/InitializeCore';
+}
+
 function withLocation(node, loc) {
   if (!node.loc) {
     return {...node, loc};
@@ -51,7 +55,7 @@ module.exports = ({types: t}) => ({
     ImportDeclaration(path, state) {
       const source = path.node.source.value;
 
-      if (isDeepReactNativeImport(source)) {
+      if (isDeepReactNativeImport(source) && !isInitializeCoreImport(source)) {
         const loc = path.node.loc;
         state.import.push({source, loc});
       }
@@ -67,7 +71,10 @@ module.exports = ({types: t}) => ({
       ) {
         const source =
           args[0].node.type === 'StringLiteral' ? args[0].node.value : '';
-        if (isDeepReactNativeImport(source)) {
+        if (
+          isDeepReactNativeImport(source) &&
+          !isInitializeCoreImport(source)
+        ) {
           const loc = path.node.loc;
           state.require.push({source, loc});
         }
@@ -76,7 +83,11 @@ module.exports = ({types: t}) => ({
     ExportNamedDeclaration(path, state) {
       const source = path.node.source;
 
-      if (source && isDeepReactNativeImport(source.value)) {
+      if (
+        source &&
+        isDeepReactNativeImport(source.value) &&
+        !isInitializeCoreImport(source)
+      ) {
         const loc = path.node.loc;
         state.export.push({source: source.value, loc});
       }


### PR DESCRIPTION
Summary:
This path is not root exported and  `no-deep-imports` rule and plugin shouldn't emit a warning when encountered.

Changelog:
[Internal]

Differential Revision: D73590627


