### PR TITLE
Define "react-native-strict-api" type exports

### DIFF
--- a/packages/react-native/Libraries/Core/Devtools/__tests__/loadBundleFromServer-test.js
+++ b/packages/react-native/Libraries/Core/Devtools/__tests__/loadBundleFromServer-test.js
@@ -14,9 +14,9 @@
 // TODO(legacy-fake-timers): Fix these tests to work with modern timers.
 jest.useFakeTimers({legacyFakeTimers: true});
 
-jest.mock('react-native/Libraries/Utilities/HMRClient');
+jest.mock('../../../Utilities/HMRClient');
 
-jest.mock('react-native/Libraries/Core/Devtools/getDevServer', () => ({
+jest.mock('../../../Core/Devtools/getDevServer', () => ({
   __esModule: true,
   default: jest.fn(() => ({
     url: 'localhost:8042/',
@@ -32,7 +32,7 @@ const loadingViewMock = {
   showMessage: jest.fn(),
   hide: jest.fn(),
 };
-jest.mock('react-native/Libraries/Utilities/DevLoadingView', () => ({
+jest.mock('../../../Utilities/DevLoadingView', () => ({
   __esModule: true,
   default: loadingViewMock,
 }));
@@ -54,7 +54,7 @@ const sendRequest = jest.fn(
   },
 );
 
-jest.mock('react-native/Libraries/Network/RCTNetworking', () => ({
+jest.mock('../../../Network/RCTNetworking', () => ({
   __esModule: true,
   default: {
     sendRequest,

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -26,7 +26,25 @@
   "bin": {
     "react-native": "cli.js"
   },
+  "main": "./index.js",
   "types": "types",
+  "exports": {
+    ".": "./index.js",
+    "./*": "./*.js",
+    "./*.js": "./*.js",
+    "./Libraries/*.d.ts": "./Libraries/*.d.ts",
+    "./types/*.d.ts": "./types/*.d.ts",
+    "./gradle/*": null,
+    "./React/*": null,
+    "./ReactAndroid/*": null,
+    "./ReactApple/*": null,
+    "./ReactCommon/*": null,
+    "./sdks/*": null,
+    "./src/*": null,
+    "./third-party-podspecs/*": null,
+    "./types/*": null,
+    "./package.json": "./package.json"
+  },
   "jest-junit": {
     "outputDirectory": "reports/junit",
     "outputName": "js-test-results.xml"
@@ -90,11 +108,6 @@
     "settings.gradle.kts",
     "src",
     "!src/private/testing",
-    "template.config.js",
-    "template",
-    "!template/node_modules",
-    "!template/package-lock.json",
-    "!template/yarn.lock",
     "third-party-podspecs",
     "types",
     "!**/__docs__/**",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -29,11 +29,28 @@
   "main": "./index.js",
   "types": "types",
   "exports": {
-    ".": "./index.js",
-    "./*": "./*.js",
-    "./*.js": "./*.js",
-    "./Libraries/*.d.ts": "./Libraries/*.d.ts",
-    "./types/*.d.ts": "./types/*.d.ts",
+    ".": {
+      "react-native-strict-api": "./types_generated/index.d.ts",
+      "react-native-strict-api-UNSAFE-ALLOW-SUBPATHS": "./types_generated/index.d.ts",
+      "default": "./index.js"
+    },
+    "./*": {
+      "react-native-strict-api": null,
+      "react-native-strict-api-UNSAFE-ALLOW-SUBPATHS": "./types_generated/*.d.ts",
+      "default": "./*.js"
+    },
+    "./*.js": {
+      "react-native-strict-api": null,
+      "default": "./*.js"
+    },
+    "./Libraries/*.d.ts": {
+      "react-native-strict-api": null,
+      "default": "./Libraries/*.d.ts"
+    },
+    "./types/*.d.ts": {
+      "react-native-strict-api": null,
+      "default": "./types/*.d.ts"
+    },
     "./gradle/*": null,
     "./React/*": null,
     "./ReactAndroid/*": null,
@@ -110,6 +127,7 @@
     "!src/private/testing",
     "third-party-podspecs",
     "types",
+    "types_generated",
     "!**/__docs__/**",
     "!**/__fixtures__/**",
     "!**/__flowtests__/**",

--- a/packages/virtualized-lists/package.json
+++ b/packages/virtualized-lists/package.json
@@ -19,11 +19,23 @@
   "engines": {
     "node": ">=18"
   },
+  "exports": {
+    ".": {
+      "types": "./types_generated/index.d.ts",
+      "default": "./index.js"
+    },
+    "./*": {
+      "types": null,
+      "default": "./*.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "index.js",
     "index.d.ts",
     "Lists",
     "README.md",
+    "types_generated",
     "Utilities",
     "!**/__docs__/**",
     "!**/__fixtures__/**",


### PR DESCRIPTION
Summary:
Enables and maps the `types_generated/` directory for `react-native` and `react-native/virtualized-lists` — exposing the new Strict TypeScript API entry points to React Native.

**New `"exports"` conditions**

- `"react-native-strict-api"` — The Strict TypeScript API opt in, exposing the `index.d.ts` entry point only.
- `"react-native-strict-api-UNSAFE-ALLOW-SUBPATHS"` — Opts into the new from-source generated types, but allows accessing subpaths (unsafe).
    - We intend for this unsafe condition to be an escape hatch for Frameworks only (i.e. Expo).

Note: In the case of `virtualized-lists`, we simply use the `"types"` condition — since this package did not expose any TypeScript API previously.

NOTE: Should we need to roll back JS Stable API phase 1, **this is the single diff to revert**.

Changelog:
[General][Added] - Configure the "react-native-strict-api" opt in for our next-gen TypeScript API

Differential Revision: D71969602


