### PR TITLE
Reproduce #50904 — Android text truncation issues

### DIFF
--- a/packages/rn-tester/js/examples/Text/TextExample.android.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.android.js
@@ -1064,7 +1064,136 @@ function TextBaseLineLayoutExample(props: {}): React.Node {
   );
 }
 
+function TruncationIssue() {
+  const common = {
+    paddingTop: 8,
+    color: "black",
+    fontWeight: "700",
+    flexShrink: 1,
+    flexBasis: "auto",
+    /**
+     * Value of 1 helps with taking up as much space as it needs to, but then
+     * short names align to the left
+     */
+    flexGrow: 0,
+    /**
+     * Adjusting font size also arbitrarily affects the truncation of text
+     */
+    fontSize: 24,
+    borderWidth: 1,
+    borderColor: "red",
+  };
+  return (
+    <View>
+      <View
+        style={{
+          paddingVertical: 20,
+          width: "100%",
+          alignItems: "center",
+        }}
+      >
+        <View
+          style={{
+            flexDirection: "row",
+            gap: 8,
+            alignItems: "center",
+            justifyContent: "center",
+            width: "100%",
+            borderWidth: 1,
+            borderStyle: "dashed",
+            borderColor: "red",
+          }}
+        >
+          <Text
+            testID="profileHeaderDisplayName"
+            numberOfLines={1}
+            style={common}
+          >
+            Tom
+          </Text>
+          <View>
+            <View style={{ width: 40, height: 40, backgroundColor: "black" }} />
+          </View>
+        </View>
+      </View>
+      <View
+        style={{
+          paddingVertical: 20,
+          width: "100%",
+          alignItems: "center",
+        }}
+      >
+        <View
+          style={{
+            flexDirection: "row",
+            gap: 8,
+            alignItems: "center",
+            justifyContent: "center",
+            width: "100%",
+            borderWidth: 1,
+            borderStyle: "dashed",
+            borderColor: "red",
+          }}
+        >
+          <Text
+            testID="profileHeaderDisplayName"
+            numberOfLines={1}
+            style={common}
+          >
+            Today's Tom Sawyeeeeeeeeeeeeee Mean Mean Stride
+          </Text>
+          <View>
+            <View style={{ width: 40, height: 40, backgroundColor: "black" }} />
+          </View>
+        </View>
+      </View>
+
+      {/**
+       * The content of the text clearly names a difference too
+       */}
+      <View
+        style={{
+          paddingVertical: 20,
+          width: "100%",
+          alignItems: "center",
+        }}
+      >
+        <View
+          style={{
+            flexDirection: "row",
+            gap: 8,
+            alignItems: "center",
+            justifyContent: "center",
+            width: "100%",
+            borderWidth: 1,
+            borderStyle: "dashed",
+            borderColor: "red",
+          }}
+        >
+          <Text
+            testID="profileHeaderDisplayName"
+            numberOfLines={1}
+            style={common}
+          >
+            Today Tom Sawyeeeeeeeeeeeeee Mean Mean Stride
+          </Text>
+          <View>
+            <View style={{ width: 40, height: 40, backgroundColor: "black" }} />
+          </View>
+        </View>
+      </View>
+    </View>
+  )
+}
+
 const examples = [
+  {
+    title: 'Truncation Issue',
+    name: 'truncationIssue',
+    render(): React.Node {
+      return <TruncationIssue />
+    }
+  },
   {
     title: 'Dynamic Font Size Adjustment',
     name: 'ajustingFontSize',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

This PR adds a minimal reproduction for #50904. It illustrates that text is unnecessarily truncated on Android under certain circumstances. I would expect these cases to expand to fill the width of their parent container, minus the width of sibling elements.

This PR is opened against the `0.76-stable` branch and does NOT repro on `main`.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
