### PR TITLE
Calling setOffset actually calls setAnimatedNodeOffset currently

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.kt
@@ -1014,7 +1014,7 @@ public class NativeAnimatedModule(reactContext: ReactApplicationContext?) :
                         opsAndArgs.getInt(i++), opsAndArgs.getDouble(i++))
 
                 BatchExecutionOpCodes.OP_CODE_SET_ANIMATED_NODE_OFFSET ->
-                    animatedNodesManager.setAnimatedNodeValue(
+                    animatedNodesManager.setAnimatedNodeOffset(
                         opsAndArgs.getInt(i++), opsAndArgs.getDouble(i++))
 
                 BatchExecutionOpCodes.OP_CODE_FLATTEN_ANIMATED_NODE_OFFSET ->


### PR DESCRIPTION
Changelog: [Android][Fixed] - Fix BatchExecutionOpCodes.OP_CODE_SET_ANIMATED_NODE_OFFSET mapping to call setAnimatedNodeOffset (rather than setAnimatedNodeValue)

Differential Revision: D73608624


