### PR TITLE
a11y] Let links discovered by dataDetectorType be accessible

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextViewManager.kt
@@ -31,7 +31,6 @@ import com.facebook.react.uimanager.style.BorderStyle
 import com.facebook.react.uimanager.style.LogicalEdge
 import com.facebook.react.uimanager.style.Overflow
 import com.facebook.react.views.text.ReactTextViewAccessibilityDelegate.AccessibilityLinks
-import com.facebook.react.views.text.internal.span.ReactClickableSpan
 import java.util.HashMap
 
 @ReactModule(name = PreparedLayoutTextViewManager.REACT_CLASS)
@@ -71,12 +70,10 @@ internal class PreparedLayoutTextViewManager :
       // delegate so that these can be picked up by the accessibility system.
       if (layout.text is Spanned) {
         val spannedText = layout.text as Spanned
-
-        val clickableSpans =
-            spannedText.getSpans(0, layout.text.length, ReactClickableSpan::class.java)
+        val accessibilityLinks = AccessibilityLinks(spannedText)
         view.setTag(
             R.id.accessibility_links,
-            if (clickableSpans.size > 0) AccessibilityLinks(clickableSpans, spannedText) else null)
+            if (accessibilityLinks.size() > 0) accessibilityLinks else null)
         ReactTextViewAccessibilityDelegate.resetDelegate(
             view, view.isFocusable, view.importantForAccessibility)
       }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -734,6 +734,14 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
     return super.dispatchHoverEvent(event);
   }
 
+  /**
+   * Note that if we have a movement method then we DO NOT forward these events to the accessibility
+   * delegate. This is because the movement method should handle the focus highlighting and
+   * changing. If we don't do this then we have mutliple selections happening at once. We cannot get
+   * rid of movement method since links found by Linkify will not be clickable. Also, putting this
+   * gating in the accessibility delegate itself will break screen reader accessibility more
+   * generally, since we still need to register virtual views.
+   */
   @Override
   public final void onFocusChanged(
       boolean gainFocus, int direction, @Nullable Rect previouslyFocusedRect) {
@@ -741,7 +749,8 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
     AccessibilityDelegateCompat accessibilityDelegateCompat =
         ViewCompat.getAccessibilityDelegate(this);
     if (accessibilityDelegateCompat != null
-        && accessibilityDelegateCompat instanceof ReactTextViewAccessibilityDelegate) {
+        && accessibilityDelegateCompat instanceof ReactTextViewAccessibilityDelegate
+        && getMovementMethod() == null) {
       ((ReactTextViewAccessibilityDelegate) accessibilityDelegateCompat)
           .onFocusChanged(gainFocus, direction, previouslyFocusedRect);
     }
@@ -752,6 +761,7 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
     AccessibilityDelegateCompat accessibilityDelegateCompat =
         ViewCompat.getAccessibilityDelegate(this);
     return (accessibilityDelegateCompat != null
+            && getMovementMethod() == null
             && accessibilityDelegateCompat instanceof ReactTextViewAccessibilityDelegate
             && ((ReactTextViewAccessibilityDelegate) accessibilityDelegateCompat)
                 .dispatchKeyEvent(event))

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewAccessibilityDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewAccessibilityDelegate.kt
@@ -269,11 +269,13 @@ internal class ReactTextViewAccessibilityDelegate : ReactAccessibilityDelegate {
     return null
   }
 
-  public class AccessibilityLinks(spans: Array<out ClickableSpan>, text: Spanned) {
+  public class AccessibilityLinks(text: Spanned) {
     private val links: List<AccessibleLink>
 
     init {
       val accessibleLinks = mutableListOf<AccessibleLink>()
+      val spans = text.getSpans(0, text.length, ClickableSpan::class.java)
+      spans.sortBy { text.getSpanStart(it) }
       for (i in spans.indices) {
         val span = spans[i]
         val start = text.getSpanStart(span)
@@ -287,14 +289,7 @@ internal class ReactTextViewAccessibilityDelegate : ReactAccessibilityDelegate {
         link.description = text.subSequence(start, end).toString()
         link.start = start
         link.end = end
-
-        // ID is the reverse of what is expected, since the ClickableSpans are returned in reverse
-        // order due to being added in reverse order. If we don't do this, focus will move to the
-        // last link first and move backwards.
-        //
-        // If this approach becomes unreliable, we should instead look at their start position and
-        // order them manually.
-        link.id = spans.size - 1 - i
+        link.id = i
         accessibleLinks.add(link)
       }
       links = accessibleLinks

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.java
@@ -26,7 +26,6 @@ import com.facebook.react.uimanager.ReactStylesDiffMap;
 import com.facebook.react.uimanager.StateWrapper;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.annotations.ReactProp;
-import com.facebook.react.views.text.internal.span.ReactClickableSpan;
 import com.facebook.react.views.text.internal.span.TextInlineImageSpan;
 import com.facebook.yoga.YogaMeasureMode;
 import java.util.HashMap;
@@ -106,13 +105,10 @@ public class ReactTextViewManager extends ReactTextAnchorViewManager<ReactTextSh
 
       // If this text view contains any clickable spans, set a view tag and reset the accessibility
       // delegate so that these can be picked up by the accessibility system.
-      ReactClickableSpan[] clickableSpans =
-          spannable.getSpans(0, update.getText().length(), ReactClickableSpan.class);
+      ReactTextViewAccessibilityDelegate.AccessibilityLinks accessibilityLinks =
+          new ReactTextViewAccessibilityDelegate.AccessibilityLinks(spannable);
       view.setTag(
-          R.id.accessibility_links,
-          clickableSpans.length > 0
-              ? new ReactTextViewAccessibilityDelegate.AccessibilityLinks(clickableSpans, spannable)
-              : null);
+          R.id.accessibility_links, accessibilityLinks.size() > 0 ? accessibilityLinks : null);
       ReactTextViewAccessibilityDelegate.Companion.resetDelegate(
           view, view.isFocusable(), view.getImportantForAccessibility());
     }


### PR DESCRIPTION
Summary:
The URL spans generated by Linkify are not actually accessible because we do not update the delegate's virtual views. 

I also had to change how AccessibilityLinks get generated, since it does not work well if it includes spans that are not `ReactClickableSpans`

Differential Revision: D73612119


