### PR TITLE
Make `DrawerStateChangedEvent` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -5539,18 +5539,6 @@ public final class com/facebook/react/views/drawer/ReactDrawerLayoutManager : co
 public final class com/facebook/react/views/drawer/ReactDrawerLayoutManager$Companion {
 }
 
-public final class com/facebook/react/views/drawer/events/DrawerStateChangedEvent : com/facebook/react/uimanager/events/Event {
-	public static final field Companion Lcom/facebook/react/views/drawer/events/DrawerStateChangedEvent$Companion;
-	public static final field EVENT_NAME Ljava/lang/String;
-	public fun <init> (II)V
-	public fun <init> (III)V
-	public final fun getDrawerState ()I
-	public fun getEventName ()Ljava/lang/String;
-}
-
-public final class com/facebook/react/views/drawer/events/DrawerStateChangedEvent$Companion {
-}
-
 public abstract interface class com/facebook/react/views/image/GlobalImageLoadListener {
 	public abstract fun onLoadAttempt (Landroid/net/Uri;)V
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/events/DrawerStateChangedEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/events/DrawerStateChangedEvent.kt
@@ -12,25 +12,25 @@ import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.common.ViewUtil
 import com.facebook.react.uimanager.events.Event
 
-public class DrawerStateChangedEvent : Event<DrawerStateChangedEvent> {
+internal class DrawerStateChangedEvent : Event<DrawerStateChangedEvent> {
 
   private val drawerState: Int
 
   @Deprecated(
       "Use constructor with surfaceId",
       ReplaceWith("DrawerStateChangedEvent(surfaceId, viewId, drawerState)"))
-  public constructor(
+  constructor(
       viewId: Int,
       drawerState: Int
   ) : this(ViewUtil.NO_SURFACE_ID, viewId, drawerState)
 
-  public constructor(surfaceId: Int, viewId: Int, drawerState: Int) : super(surfaceId, viewId) {
+  constructor(surfaceId: Int, viewId: Int, drawerState: Int) : super(surfaceId, viewId) {
     this.drawerState = drawerState
   }
 
-  public fun getDrawerState(): Int = drawerState
+  fun getDrawerState(): Int = drawerState
 
-  public override fun getEventName(): String = EVENT_NAME
+  override fun getEventName(): String = EVENT_NAME
 
   protected override fun getEventData(): WritableMap? {
     val eventData: WritableMap = Arguments.createMap()
@@ -38,7 +38,7 @@ public class DrawerStateChangedEvent : Event<DrawerStateChangedEvent> {
     return eventData
   }
 
-  public companion object {
-    public const val EVENT_NAME: String = "topDrawerStateChanged"
+  companion object {
+    const val EVENT_NAME: String = "topDrawerStateChanged"
   }
 }


### PR DESCRIPTION
## Summary:

This class can be internalized as part of the initiative to reduce the public API surface. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.views.drawer.events.DrawerStateChangedEvent).

## Changelog:

[INTERNAL] - Make com.facebook.react.views.drawer.events.DrawerStateChangedEvent internal

## Test Plan:

```bash
yarn test-android
yarn android
```