### PR TITLE
Make `ReactInterceptingViewGroup` and `OnInterceptTouchEventListener` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3405,16 +3405,8 @@ public final class com/facebook/react/touch/JSResponderHandler : com/facebook/re
 	public final fun setJSResponder (ILandroid/view/ViewParent;)V
 }
 
-public abstract interface class com/facebook/react/touch/OnInterceptTouchEventListener {
-	public abstract fun onInterceptTouchEvent (Landroid/view/ViewGroup;Landroid/view/MotionEvent;)Z
-}
-
 public abstract interface class com/facebook/react/touch/ReactHitSlopView {
 	public abstract fun getHitSlopRect ()Landroid/graphics/Rect;
-}
-
-public abstract interface class com/facebook/react/touch/ReactInterceptingViewGroup {
-	public abstract fun setOnInterceptTouchEventListener (Lcom/facebook/react/touch/OnInterceptTouchEventListener;)V
 }
 
 public final class com/facebook/react/turbomodule/core/interfaces/BindingsInstallerHolder {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/touch/OnInterceptTouchEventListener.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/touch/OnInterceptTouchEventListener.kt
@@ -14,7 +14,7 @@ import android.view.ViewGroup
  * Interface definition for a callback to be invoked when a onInterceptTouch is called on a
  * [ViewGroup].
  */
-public fun interface OnInterceptTouchEventListener {
+internal fun interface OnInterceptTouchEventListener {
 
   /**
    * Called when a onInterceptTouch is invoked on a view group.
@@ -24,5 +24,5 @@ public fun interface OnInterceptTouchEventListener {
    * @return Return true to steal motion event from the children and have the dispatched to this
    *   view, or return false to allow motion event to be delivered to children view
    */
-  public fun onInterceptTouchEvent(view: ViewGroup, event: MotionEvent): Boolean
+  fun onInterceptTouchEvent(view: ViewGroup, event: MotionEvent): Boolean
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/touch/ReactInterceptingViewGroup.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/touch/ReactInterceptingViewGroup.kt
@@ -15,7 +15,7 @@ import android.view.ViewGroup
  * onInterceptTouch event listener which then is used to control touch event flow in cases in which
  * they requested to be intercepted by some parent view based on a JS gesture detector.
  */
-public interface ReactInterceptingViewGroup {
+internal interface ReactInterceptingViewGroup {
 
   /**
    * A [ViewGroup] instance that implement this interface is responsible for storing the listener
@@ -27,5 +27,5 @@ public interface ReactInterceptingViewGroup {
    * @param listener A callback that [ViewGroup] should delegate calls for
    *   [ViewGroup#onInterceptTouchEvent] to
    */
-  public fun setOnInterceptTouchEventListener(listener: OnInterceptTouchEventListener)
+  fun setOnInterceptTouchEventListener(listener: OnInterceptTouchEventListener)
 }


### PR DESCRIPTION
## Summary:

These classes can be internalized as part of the initiative to reduce the public API surface. I've checked there are no relevant OSS usages.

- [ReactInterceptingViewGroup](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.touch.ReactInterceptingViewGroup)
- [OnInterceptTouchEventListener](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.touch.OnInterceptTouchEventListener)

## Changelog:

[INTERNAL] - Make ReactInterceptingViewGroup and OnInterceptTouchEventListener internal

## Test Plan:

```bash
yarn test-android
yarn android
```