### PR TITLE
PreparedLayoutTextViewManager

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2384,15 +2384,6 @@ public final class com/facebook/react/fabric/FabricUIManagerProviderImpl : com/f
 	public fun createUIManager (Lcom/facebook/react/bridge/ReactApplicationContext;)Lcom/facebook/react/bridge/UIManager;
 }
 
-public final class com/facebook/react/fabric/StateWrapperImpl : com/facebook/jni/HybridClassBase, com/facebook/react/uimanager/StateWrapper {
-	public fun destroyState ()V
-	public fun getStateData ()Lcom/facebook/react/bridge/ReadableNativeMap;
-	public fun getStateDataMapBuffer ()Lcom/facebook/react/common/mapbuffer/ReadableMapBuffer;
-	public fun toString ()Ljava/lang/String;
-	public fun updateState (Lcom/facebook/react/bridge/WritableMap;)V
-	public final fun updateStateImpl (Lcom/facebook/react/bridge/NativeMap;)V
-}
-
 public final class com/facebook/react/fabric/events/EventBeatManager : com/facebook/jni/HybridClassBase, com/facebook/react/uimanager/events/BatchEventDispatchedListener {
 	public fun <init> ()V
 	public fun onBatchEventDispatched ()V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/StateWrapperImpl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/StateWrapperImpl.kt
@@ -15,7 +15,7 @@ import com.facebook.react.bridge.NativeMap
 import com.facebook.react.bridge.ReadableNativeMap
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.common.mapbuffer.ReadableMapBuffer
-import com.facebook.react.uimanager.StateWrapper
+import com.facebook.react.uimanager.ReferenceStateWrapper
 
 /**
  * This class holds reference to the C++ EventEmitter object. Instances of this class are created on
@@ -23,13 +23,15 @@ import com.facebook.react.uimanager.StateWrapper
  */
 @SuppressLint("MissingNativeLoadLibrary")
 @DoNotStripAny
-internal class StateWrapperImpl private constructor() : HybridClassBase(), StateWrapper {
+internal class StateWrapperImpl private constructor() : HybridClassBase(), ReferenceStateWrapper {
 
   private external fun initHybrid()
 
   private external fun getStateDataImpl(): ReadableNativeMap?
 
   private external fun getStateMapBufferDataImpl(): ReadableMapBuffer?
+
+  private external fun getStateDataReferenceImpl(): Any?
 
   public external fun updateStateImpl(map: NativeMap)
 
@@ -49,6 +51,15 @@ internal class StateWrapperImpl private constructor() : HybridClassBase(), State
         return null
       }
       return getStateDataImpl()
+    }
+
+  public override val stateDataReference: Any?
+    get() {
+      if (!isValid) {
+        FLog.e(TAG, "Race between StateWrapperImpl destruction and getState")
+        return null
+      }
+      return getStateDataReferenceImpl()
     }
 
   init {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/StateWrapperImpl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/StateWrapperImpl.kt
@@ -23,7 +23,7 @@ import com.facebook.react.uimanager.StateWrapper
  */
 @SuppressLint("MissingNativeLoadLibrary")
 @DoNotStripAny
-public class StateWrapperImpl private constructor() : HybridClassBase(), StateWrapper {
+internal class StateWrapperImpl private constructor() : HybridClassBase(), StateWrapper {
 
   private external fun initHybrid()
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReferenceStateWrapper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReferenceStateWrapper.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.uimanager
+
+internal interface ReferenceStateWrapper : StateWrapper {
+  /** Returns state data backed by JNI reference. The underlying object should not be modified. */
+  public val stateDataReference: Any?
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextView.kt
@@ -1,0 +1,418 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.views.text
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.Path
+import android.graphics.Rect
+import android.os.Build
+import android.text.Layout
+import android.text.Spanned
+import android.text.style.ClickableSpan
+import android.view.KeyEvent
+import android.view.MotionEvent
+import android.view.ViewGroup
+import androidx.annotation.ColorInt
+import androidx.annotation.DoNotInline
+import androidx.annotation.RequiresApi
+import com.facebook.react.uimanager.BackgroundStyleApplicator
+import com.facebook.react.uimanager.style.Overflow
+import kotlin.collections.ArrayList
+
+/**
+ * A custom version of Android's TextView, providing React Native with lower-level hooks for text
+ * drawing, such as fine-grained control over clipping. PreparedLayoutTextView directly draws an
+ * existing layout, previously generated for measurement by Fabric, to ensure consistency of
+ * measurements, and avoid duplicate work.
+ */
+internal class PreparedLayoutTextView(context: Context) : ViewGroup(context) {
+
+  private var clickableSpans: List<ClickableSpan> = emptyList()
+  private var selection: TextSelection? = null
+
+  public var layout: Layout? = null
+    set(value) {
+      if (field != value) {
+        val lastSelection = selection
+        if (lastSelection != null) {
+          if (value != null && field?.text.toString() == value.text.toString()) {
+            value.getSelectionPath(lastSelection.start, lastSelection.end, lastSelection.path)
+          } else {
+            clearSelection()
+          }
+        }
+
+        clickableSpans = value?.text?.let { filterClickableSpans(it) } ?: emptyList()
+
+        // T221698736: This and `accessible` prop can clobber each other, and ShadowTree does not
+        // know
+        // about this. Need to figure out desired behavior for controlling implicit focusability.
+        isFocusable = clickableSpans.isNotEmpty()
+
+        field = value
+        invalidate()
+      }
+    }
+
+  // T221698007: This is closest to existing behavior, but does not align with web. We may want to
+  // change in the future if not too breaking.
+  public var overflow: Overflow = Overflow.HIDDEN
+    set(value) {
+      if (field != value) {
+        field = value
+        invalidate()
+      }
+    }
+
+  public @ColorInt var selectionColor: Int? = null
+
+  public val text: CharSequence?
+    get() = layout?.text
+
+  init {
+    initView()
+    // ViewGroup by default says only its children will draw
+    setWillNotDraw(false)
+  }
+
+  private fun initView() {
+    clickableSpans = emptyList()
+    selection = null
+    layout = null
+  }
+
+  public fun recycleView(): Unit {
+    initView()
+    BackgroundStyleApplicator.reset(this)
+    isFocusable = false
+    overflow = Overflow.HIDDEN
+  }
+
+  override fun onDraw(canvas: Canvas) {
+    if (overflow != Overflow.VISIBLE) {
+      BackgroundStyleApplicator.clipToPaddingBox(this, canvas)
+    }
+
+    super.onDraw(canvas)
+    canvas.translate(paddingLeft.toFloat(), paddingTop.toFloat())
+
+    val textLayout = layout
+    if (textLayout != null) {
+      if (selection != null) {
+        selectionPaint.setColor(
+            selectionColor ?: DefaultStyleValuesUtil.getDefaultTextColorHighlight(context))
+      }
+
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+        Api34Utils.draw(textLayout, canvas, selection?.path, selectionPaint)
+      } else {
+        textLayout.draw(canvas, selection?.path, selectionPaint, 0)
+      }
+    }
+  }
+
+  override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
+    // No-op
+  }
+
+  private fun setSelection(span: ClickableSpan) {
+    val textLayout = checkNotNull(layout)
+    val start = (textLayout.text as Spanned).getSpanStart(span)
+    val end = (textLayout.text as Spanned).getSpanEnd(span)
+
+    val textSelection = selection
+    if (textSelection == null) {
+      val selectionPath = Path()
+      textLayout.getSelectionPath(start, end, selectionPath)
+      selection = TextSelection(start, end, selectionPath)
+    } else {
+      textSelection.start = start
+      textSelection.end = end
+      textLayout.getSelectionPath(start, end, textSelection.path)
+    }
+
+    invalidate()
+  }
+
+  private fun clearSelection() {
+    selection = null
+    invalidate()
+  }
+
+  // T222163602: We should reconcile this hit testing with ReactCompoundView hit testing
+  override fun onTouchEvent(event: MotionEvent): Boolean {
+    if (!isEnabled || clickableSpans.isEmpty()) {
+      return super.onTouchEvent(event)
+    }
+
+    val action = event.actionMasked
+    if (action == MotionEvent.ACTION_CANCEL) {
+      clearSelection()
+      return false
+    }
+
+    val x = event.x.toInt()
+    val y = event.y.toInt()
+
+    val clickedSpan = getClickableSpanInCoords(x, y)
+
+    if (clickedSpan == null) {
+      clearSelection()
+      return super.onTouchEvent(event)
+    }
+
+    if (action == MotionEvent.ACTION_UP) {
+      clearSelection()
+      clickedSpan.onClick(this)
+    } else if (action == MotionEvent.ACTION_DOWN) {
+      setSelection(clickedSpan)
+    }
+
+    return true
+  }
+
+  /**
+   * Get the clickable span that is at the exact coordinates
+   *
+   * @param x x-position of the click
+   * @param y y-position of the click
+   * @return a clickable span that's located where the click occurred, or: `null` if no clickable
+   *   span was located there
+   */
+  private fun getClickableSpanInCoords(x: Int, y: Int): ClickableSpan? {
+    val offset = getTextOffsetAt(x, y)
+    if (offset < 0) {
+      return null
+    }
+
+    val spanned = text as? Spanned ?: return null
+
+    val clickableSpans = spanned.getSpans(offset, offset, ClickableSpan::class.java)
+    if (clickableSpans.isNotEmpty()) {
+      return clickableSpans[0]
+    }
+
+    return null
+  }
+
+  private fun getTextOffsetAt(x: Int, y: Int): Int {
+    val textLayout = layout ?: return -1
+    val line = textLayout.getLineForVertical(y)
+
+    val left: Float
+    val right: Float
+
+    if (textLayout.alignment == Layout.Alignment.ALIGN_CENTER) {
+      /**
+       * [Layout#getLineLeft] and [Layout#getLineRight] properly account for paragraph margins on
+       * centered text.
+       */
+      left = textLayout.getLineLeft(line)
+      right = textLayout.getLineRight(line)
+    } else {
+      /**
+       * [Layout#getLineLeft] and [Layout#getLineRight] do NOT properly account for paragraph
+       * margins on non-centered text, so we need an alternative.
+       *
+       * To determine the actual bounds of the line, we need the line's direction, leading margin,
+       * and extent, but only the first is available directly. The margin is given by either
+       * [Layout#getParagraphLeft] or [Layout#getParagraphRight] depending on line direction, and
+       * [Layout#getLineMax] gives the extent *plus* the leading margin, so we can figure out the
+       * rest from there.
+       */
+      val rtl = textLayout.getParagraphDirection(line) == Layout.DIR_RIGHT_TO_LEFT
+      left =
+          if (rtl) (textLayout.width - textLayout.getLineMax(line))
+          else textLayout.getParagraphLeft(line).toFloat()
+      right = if (rtl) textLayout.getParagraphRight(line).toFloat() else textLayout.getLineMax(line)
+    }
+
+    if (x < left || x > right) {
+      return -1
+    }
+
+    return try {
+      textLayout.getOffsetForHorizontal(line, x.toFloat())
+    } catch (e: ArrayIndexOutOfBoundsException) {
+      // This happens for bidi text on Android 7-8.
+      // See
+      // https://android.googlesource.com/platform/frameworks/base/+/821e9bd5cc2be4b3210cb0226e40ba0f42b51aed
+      -1
+    }
+  }
+
+  public override fun dispatchHoverEvent(event: MotionEvent): Boolean =
+      // TODO T221698305: Dispatch to AccessibilityDelegate
+      super.dispatchHoverEvent(event)
+
+  public override fun onFocusChanged(
+      gainFocus: Boolean,
+      direction: Int,
+      previouslyFocusedRect: Rect?
+  ) {
+    if (clickableSpans.isNotEmpty() && !gainFocus) {
+      clearSelection()
+    }
+    super.onFocusChanged(gainFocus, direction, previouslyFocusedRect)
+    // TODO T221698305: Dispatch to AccessibilityDelegate
+  }
+
+  override fun dispatchKeyEvent(event: KeyEvent): Boolean =
+      // TODO T221698305: Dispatch to AccessibilityDelegate
+      super.dispatchKeyEvent(event)
+
+  override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
+    if (isEnabled &&
+        clickableSpans.isNotEmpty() &&
+        selection == null &&
+        (isDirectionKey(keyCode) || keyCode == KeyEvent.KEYCODE_TAB)) {
+      // View just received focus due to keyboard navigation. Nothing is currently selected,
+      // let's select first span according to the navigation direction.
+      var targetSpan: ClickableSpan? = null
+      if (isDirectionKey(keyCode) && event.hasNoModifiers()) {
+        if (keyCode == KeyEvent.KEYCODE_DPAD_RIGHT || keyCode == KeyEvent.KEYCODE_DPAD_DOWN) {
+          targetSpan = clickableSpans[0]
+        } else if (keyCode == KeyEvent.KEYCODE_DPAD_LEFT || keyCode == KeyEvent.KEYCODE_DPAD_UP) {
+          targetSpan = clickableSpans[clickableSpans.size - 1]
+        }
+      }
+
+      if (keyCode == KeyEvent.KEYCODE_TAB) {
+        if (event.hasNoModifiers()) {
+          targetSpan = clickableSpans[0]
+        } else if (event.hasModifiers(KeyEvent.META_SHIFT_ON)) {
+          targetSpan = clickableSpans[clickableSpans.size - 1]
+        }
+      }
+
+      if (targetSpan != null) {
+        setSelection(targetSpan)
+        return true
+      }
+    }
+
+    return super.onKeyUp(keyCode, event)
+  }
+
+  override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
+    if (isEnabled &&
+        clickableSpans.isNotEmpty() &&
+        (isDirectionKey(keyCode) || isConfirmKey(keyCode)) &&
+        event.hasNoModifiers()) {
+      val selectedSpanIndex = selectedSpanIndex()
+      if (selectedSpanIndex == -1) {
+        return super.onKeyDown(keyCode, event)
+      }
+
+      if (isDirectionKey(keyCode)) {
+        val direction =
+            if (keyCode == KeyEvent.KEYCODE_DPAD_RIGHT || keyCode == KeyEvent.KEYCODE_DPAD_DOWN) {
+              1
+            } else {
+              // keyCode == KeyEvent.KEYCODE_DPAD_LEFT || keyCode == KeyEvent.KEYCODE_DPAD_UP
+              -1
+            }
+        val repeatCount = 1 + event.repeatCount
+        val targetIndex = selectedSpanIndex + direction * repeatCount
+        if (targetIndex >= 0 && targetIndex < clickableSpans.size) {
+          setSelection(clickableSpans[targetIndex])
+          return true
+        }
+      }
+
+      if (isConfirmKey(keyCode) && event.repeatCount == 0) {
+        clearSelection()
+        clickableSpans[selectedSpanIndex].onClick(this)
+        return true
+      }
+    }
+
+    return super.onKeyDown(keyCode, event)
+  }
+
+  private fun selectedSpanIndex(): Int {
+    val spanned = text as? Spanned ?: return -1
+    val textSelection = selection ?: return -1
+
+    if (clickableSpans.isEmpty()) {
+      return -1
+    }
+
+    for (i in clickableSpans.indices) {
+      val span = clickableSpans[i]
+      val spanStart = spanned.getSpanStart(span)
+      val spanEnd = spanned.getSpanEnd(span)
+      if (spanStart == textSelection.start && spanEnd == textSelection.end) {
+        return i
+      }
+    }
+    return -1
+  }
+
+  @RequiresApi(api = Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+  private object Api34Utils {
+    private var highlightPaths: List<Path>? = null
+    private var highlightPaints: List<Paint>? = null
+
+    @DoNotInline
+    fun draw(layout: Layout, canvas: Canvas, selectionPath: Path?, selectionPaint: Paint?) {
+      if (selectionPath != null) {
+        // Layout#drawHighlights noops when highlightPaths and highlightPaints are nulls
+        // Passing empty lists to fix that
+        if (highlightPaths == null) {
+          highlightPaths = ArrayList()
+        }
+        if (highlightPaints == null) {
+          highlightPaints = ArrayList()
+        }
+      }
+      layout.draw(canvas, highlightPaths, highlightPaints, selectionPath, selectionPaint, 0)
+    }
+  }
+
+  private class TextSelection(
+      var start: Int,
+      var end: Int,
+      var path: Path,
+  )
+
+  private companion object {
+    private val selectionPaint = Paint()
+
+    private fun isDirectionKey(keyCode: Int): Boolean =
+        keyCode == KeyEvent.KEYCODE_DPAD_LEFT ||
+            keyCode == KeyEvent.KEYCODE_DPAD_RIGHT ||
+            keyCode == KeyEvent.KEYCODE_DPAD_UP ||
+            keyCode == KeyEvent.KEYCODE_DPAD_DOWN
+
+    private fun isConfirmKey(keyCode: Int): Boolean =
+        keyCode == KeyEvent.KEYCODE_DPAD_CENTER ||
+            keyCode == KeyEvent.KEYCODE_ENTER ||
+            keyCode == KeyEvent.KEYCODE_SPACE ||
+            keyCode == KeyEvent.KEYCODE_NUMPAD_ENTER
+
+    private fun filterClickableSpans(text: CharSequence): List<ClickableSpan> {
+      if (text !is Spanned ||
+          text.nextSpanTransition(0, text.length, ClickableSpan::class.java) == text.length) {
+        return emptyList()
+      }
+
+      val spans = ArrayList<ClickableSpan>()
+      var i = 0
+      while (i < text.length) {
+        val next = text.nextSpanTransition(i, text.length, ClickableSpan::class.java)
+        spans.addAll(text.getSpans(i, next, ClickableSpan::class.java))
+        i = next
+      }
+
+      return spans
+    }
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextViewManager.kt
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.views.text
+
+import android.text.Layout
+import android.text.Spannable
+import android.view.View
+import com.facebook.react.R
+import com.facebook.react.internal.SystraceSection
+import com.facebook.react.module.annotations.ReactModule
+import com.facebook.react.uimanager.BackgroundStyleApplicator
+import com.facebook.react.uimanager.BaseViewManager
+import com.facebook.react.uimanager.IViewGroupManager
+import com.facebook.react.uimanager.LayoutShadowNode
+import com.facebook.react.uimanager.LengthPercentage
+import com.facebook.react.uimanager.LengthPercentageType
+import com.facebook.react.uimanager.ReactStylesDiffMap
+import com.facebook.react.uimanager.ReferenceStateWrapper
+import com.facebook.react.uimanager.StateWrapper
+import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.ViewProps
+import com.facebook.react.uimanager.annotations.ReactProp
+import com.facebook.react.uimanager.annotations.ReactPropGroup
+import com.facebook.react.uimanager.style.BorderRadiusProp
+import com.facebook.react.uimanager.style.BorderStyle
+import com.facebook.react.uimanager.style.LogicalEdge
+import com.facebook.react.uimanager.style.Overflow
+import com.facebook.react.views.text.ReactTextViewAccessibilityDelegate.AccessibilityLinks
+import com.facebook.react.views.text.internal.span.ReactClickableSpan
+import java.util.HashMap
+
+@ReactModule(name = PreparedLayoutTextViewManager.REACT_CLASS)
+internal class PreparedLayoutTextViewManager :
+    BaseViewManager<PreparedLayoutTextView, LayoutShadowNode>(),
+    IViewGroupManager<PreparedLayoutTextView> {
+
+  init {
+    setupViewRecycling()
+  }
+
+  override fun prepareToRecycleView(
+      reactContext: ThemedReactContext,
+      view: PreparedLayoutTextView
+  ): PreparedLayoutTextView? {
+    val preparedView = super.prepareToRecycleView(reactContext, view)
+    preparedView?.recycleView()
+    return preparedView
+  }
+
+  override fun getName(): String = REACT_CLASS
+
+  override fun updateViewAccessibility(view: PreparedLayoutTextView) {
+    ReactTextViewAccessibilityDelegate.setDelegate(
+        view, view.isFocusable, view.importantForAccessibility)
+  }
+
+  public override fun createViewInstance(context: ThemedReactContext): PreparedLayoutTextView =
+      PreparedLayoutTextView(context)
+
+  override fun updateExtraData(view: PreparedLayoutTextView, extraData: Any) {
+    SystraceSection("PreparedLayoutTextViewManager.updateExtraData").use { _ ->
+      val layout = extraData as Layout
+      view.layout = layout
+
+      // If this text view contains any clickable spans, set a view tag and reset the accessibility
+      // delegate so that these can be picked up by the accessibility system.
+      if (layout.text is Spannable) {
+        val spannableText = layout.text as Spannable
+
+        val clickableSpans =
+            spannableText.getSpans(0, layout.text.length, ReactClickableSpan::class.java)
+        view.setTag(
+            R.id.accessibility_links,
+            if (clickableSpans.size > 0) AccessibilityLinks(clickableSpans, spannableText)
+            else null)
+        ReactTextViewAccessibilityDelegate.resetDelegate(
+            view, view.isFocusable, view.importantForAccessibility)
+      }
+    }
+  }
+
+  override fun updateState(
+      view: PreparedLayoutTextView,
+      props: ReactStylesDiffMap,
+      stateWrapper: StateWrapper
+  ): Any? = (stateWrapper as? ReferenceStateWrapper)?.stateDataReference
+
+  override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any>? {
+    val baseEventTypeConstants = super.getExportedCustomDirectEventTypeConstants()
+    val eventTypeConstants = baseEventTypeConstants ?: HashMap()
+    eventTypeConstants.put("topTextLayout", mapOf("registrationName" to "onTextLayout"))
+    return eventTypeConstants
+  }
+
+  @ReactProp(name = "overflow")
+  public fun setOverflow(view: PreparedLayoutTextView, overflow: String?): Unit {
+    view.overflow = overflow?.let { Overflow.fromString(it) } ?: Overflow.HIDDEN
+  }
+
+  @ReactProp(name = "accessible")
+  public fun setAccessible(view: PreparedLayoutTextView, accessible: Boolean): Unit {
+    view.isFocusable = accessible
+  }
+
+  @ReactProp(name = "selectable", defaultBoolean = false)
+  public fun setSelectable(view: PreparedLayoutTextView, isSelectable: Boolean): Unit {
+    // T222052152: Implement fine-grained text selection for PreparedLayoutTextView
+    // view.setTextIsSelectable(isSelectable);
+  }
+
+  @ReactProp(name = "selectionColor", customType = "Color")
+  public fun setSelectionColor(view: PreparedLayoutTextView, color: Int?): Unit {
+    if (color == null) {
+      view.selectionColor = DefaultStyleValuesUtil.getDefaultTextColorHighlight(view.context)
+    } else {
+      view.selectionColor = color
+    }
+  }
+
+  @ReactPropGroup(
+      names =
+          [
+              ViewProps.BORDER_RADIUS,
+              ViewProps.BORDER_TOP_LEFT_RADIUS,
+              ViewProps.BORDER_TOP_RIGHT_RADIUS,
+              ViewProps.BORDER_BOTTOM_RIGHT_RADIUS,
+              ViewProps.BORDER_BOTTOM_LEFT_RADIUS],
+      defaultFloat = Float.NaN)
+  public fun setBorderRadius(view: PreparedLayoutTextView, index: Int, borderRadius: Float): Unit {
+    val radius =
+        if (borderRadius.isNaN()) null
+        else LengthPercentage(borderRadius, LengthPercentageType.POINT)
+    BackgroundStyleApplicator.setBorderRadius(view, BorderRadiusProp.values()[index], radius)
+  }
+
+  @ReactProp(name = "borderStyle")
+  public fun setBorderStyle(view: PreparedLayoutTextView, borderStyle: String?): Unit {
+    val parsedBorderStyle = if (borderStyle == null) null else BorderStyle.fromString(borderStyle)
+    BackgroundStyleApplicator.setBorderStyle(view, parsedBorderStyle)
+  }
+
+  @ReactPropGroup(
+      names =
+          [
+              ViewProps.BORDER_WIDTH,
+              ViewProps.BORDER_LEFT_WIDTH,
+              ViewProps.BORDER_RIGHT_WIDTH,
+              ViewProps.BORDER_TOP_WIDTH,
+              ViewProps.BORDER_BOTTOM_WIDTH,
+              ViewProps.BORDER_START_WIDTH,
+              ViewProps.BORDER_END_WIDTH],
+      defaultFloat = Float.NaN)
+  public fun setBorderWidth(view: PreparedLayoutTextView, index: Int, width: Float): Unit {
+    BackgroundStyleApplicator.setBorderWidth(view, LogicalEdge.values()[index], width)
+  }
+
+  @ReactPropGroup(
+      names =
+          [
+              ViewProps.BORDER_COLOR,
+              ViewProps.BORDER_LEFT_COLOR,
+              ViewProps.BORDER_RIGHT_COLOR,
+              ViewProps.BORDER_TOP_COLOR,
+              ViewProps.BORDER_BOTTOM_COLOR,
+              ViewProps.BORDER_START_COLOR,
+              ViewProps.BORDER_END_COLOR,
+              ViewProps.BORDER_BLOCK_COLOR,
+              ViewProps.BORDER_BLOCK_END_COLOR,
+              ViewProps.BORDER_BLOCK_START_COLOR,
+          ],
+      customType = "Color")
+  public fun setBorderColor(view: PreparedLayoutTextView, index: Int, color: Int?): Unit {
+    BackgroundStyleApplicator.setBorderColor(view, LogicalEdge.values()[index], color)
+  }
+
+  @ReactProp(name = "disabled", defaultBoolean = false)
+  public fun setDisabled(view: PreparedLayoutTextView, disabled: Boolean): Unit {
+    view.setEnabled(!disabled)
+  }
+
+  override fun setPadding(
+      view: PreparedLayoutTextView,
+      left: Int,
+      top: Int,
+      right: Int,
+      bottom: Int
+  ): Unit {
+    view.setPadding(left, top, right, bottom)
+  }
+
+  override fun getShadowNodeClass(): Class<out LayoutShadowNode> {
+    throw UnsupportedOperationException(
+        "PreparedLayoutTextViewManager does not use legacy arch shadow nodes")
+  }
+
+  override fun addView(parent: PreparedLayoutTextView, child: View, index: Int) {
+    parent.addView(child, index)
+  }
+
+  override fun getChildAt(parent: PreparedLayoutTextView, index: Int): View? =
+      parent.getChildAt(index)
+
+  override fun removeViewAt(parent: PreparedLayoutTextView, index: Int) {
+    parent.removeViewAt(index)
+  }
+
+  override fun getChildCount(parent: PreparedLayoutTextView): Int = parent.childCount
+
+  override fun needsCustomLayoutForChildren(): Boolean = false
+
+  public companion object {
+    public const val REACT_CLASS: String = "RCTText"
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewAccessibilityDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewAccessibilityDelegate.kt
@@ -270,7 +270,7 @@ internal class ReactTextViewAccessibilityDelegate : ReactAccessibilityDelegate {
     return null
   }
 
-  public class AccessibilityLinks(spans: Array<ClickableSpan?>, text: Spannable) {
+  public class AccessibilityLinks(spans: Array<out ClickableSpan>, text: Spannable) {
     private val links: List<AccessibleLink>
 
     init {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/StateWrapperImpl.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/StateWrapperImpl.cpp
@@ -43,6 +43,13 @@ StateWrapperImpl::getStateMapBufferDataImpl() {
   }
 }
 
+jni::local_ref<jobject> StateWrapperImpl::getStateDataReferenceImpl() {
+  if (state_) {
+    return state_->getJNIReference();
+  }
+  return nullptr;
+}
+
 void StateWrapperImpl::updateStateImpl(NativeMap* map) {
   if (state_) {
     // Get folly::dynamic from map
@@ -68,6 +75,9 @@ void StateWrapperImpl::registerNatives() {
       makeNativeMethod(
           "getStateMapBufferDataImpl",
           StateWrapperImpl::getStateMapBufferDataImpl),
+      makeNativeMethod(
+          "getStateDataReferenceImpl",
+          StateWrapperImpl::getStateDataReferenceImpl),
   });
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/StateWrapperImpl.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/StateWrapperImpl.h
@@ -27,6 +27,7 @@ class StateWrapperImpl : public jni::HybridClass<StateWrapperImpl> {
 
   jni::local_ref<JReadableMapBuffer::jhybridobject> getStateMapBufferDataImpl();
   jni::local_ref<ReadableNativeMap::jhybridobject> getStateDataImpl();
+  jni::local_ref<jobject> getStateDataReferenceImpl();
   void updateStateImpl(NativeMap* map);
   void setState(std::shared_ptr<const State> state);
   std::shared_ptr<const State> getState() const;

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.h
@@ -52,6 +52,8 @@ class ParagraphShadowNode final : public ConcreteViewShadowNode<
 #ifdef ANDROID
     // Unsetting `FormsStackingContext` trait is essential on Android where we
     // can't mount views inside `TextView`.
+    // T221699219: This should be removed when PreparedLayoutTextView is rolled
+    // out.
     traits.unset(ShadowNodeTraits::Trait::FormsStackingContext);
 #endif
 

--- a/packages/react-native/ReactCommon/react/renderer/core/ConcreteState.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ConcreteState.h
@@ -14,6 +14,7 @@
 #include <react/renderer/core/State.h>
 
 #ifdef ANDROID
+#include <fbjni/fbjni.h>
 #include <react/renderer/mapbuffer/MapBuffer.h>
 #include <react/renderer/mapbuffer/MapBufferBuilder.h>
 #endif
@@ -24,6 +25,11 @@ namespace facebook::react {
 template <typename StateDataT>
 concept StateDataWithMapBuffer = requires(StateDataT stateData) {
   { stateData.getMapBuffer() } -> std::same_as<MapBuffer>;
+};
+
+template <typename StateDataT>
+concept StateDataWithJNIReference = requires(StateDataT stateData) {
+  { stateData.getJNIReference() } -> std::same_as<jni::local_ref<jobject>>;
 };
 #endif
 
@@ -117,6 +123,14 @@ class ConcreteState : public State {
       return getData().getMapBuffer();
     } else {
       return MapBufferBuilder::EMPTY();
+    }
+  }
+
+  jni::local_ref<jobject> getJNIReference() const override {
+    if constexpr (StateDataWithJNIReference<DataT>) {
+      return getData().getJNIReference();
+    } else {
+      return nullptr;
     }
   }
 #endif

--- a/packages/react-native/ReactCommon/react/renderer/core/State.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/State.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #ifdef ANDROID
+#include <fbjni/fbjni.h>
 #include <folly/dynamic.h>
 #include <react/renderer/mapbuffer/MapBuffer.h>
 #endif
@@ -66,6 +67,7 @@ class State {
 #ifdef ANDROID
   virtual folly::dynamic getDynamic() const = 0;
   virtual MapBuffer getMapBuffer() const = 0;
+  virtual jni::local_ref<jobject> getJNIReference() const = 0;
   virtual void updateState(folly::dynamic&& data) const = 0;
 #endif
 


### PR DESCRIPTION
Summary:
This implements the view manager for `PreparedLayoutTextView`, originating by taking the view managers composing `ReactTextView`, converting to Kotlin, and removing everything no longer needed.

In Facsimile, anything influencing text appearance is applied earlier, when creating the Fabric layout, so there are many less setters here. Most visual attributes are instead present in the state we are presenting.

We have tasks for some of these, that need to be reimplemented, as they do not currently influence the Spannable being measured. That includes e.g. `ReactTextViewManagerCallback`, used for injection, and `dataDetectorType` for linkifying Spannable.

Changelog: [Internal]

Reviewed By: rshest

Differential Revision: D73287706


