### PR TITLE
getShadowNodeClass() impl in PreparedLayoutTextViewManager

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextViewManager.kt
@@ -192,10 +192,7 @@ internal class PreparedLayoutTextViewManager :
     view.setPadding(left, top, right, bottom)
   }
 
-  override fun getShadowNodeClass(): Class<out LayoutShadowNode> {
-    throw UnsupportedOperationException(
-        "PreparedLayoutTextViewManager does not use legacy arch shadow nodes")
-  }
+  override fun getShadowNodeClass(): Class<out LayoutShadowNode> = LayoutShadowNode::class.java
 
   override fun addView(parent: PreparedLayoutTextView, child: View, index: Int) {
     parent.addView(child, index)


### PR DESCRIPTION
Summary: This crashes without this change, now it does not!

Differential Revision: D73626930
