### PR TITLE
Cleanup LegacyArchitectureLogger.OSS_LEGACY_WARNINGS_ENABLED

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/GenerateEntryPointTask.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/GenerateEntryPointTask.kt
@@ -90,9 +90,6 @@ abstract class GenerateEntryPointTask : DefaultTask() {
             throw new RuntimeException(error);
           }
           
-          if ({{packageName}}.BuildConfig.LEGACY_WARNINGS_ENABLED) {
-            LegacyArchitectureLogger.OSS_LEGACY_WARNINGS_ENABLED = true;
-          }
           if ({{packageName}}.BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
             DefaultNewArchitectureEntryPoint.load();
           }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/AgpConfiguratorUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/AgpConfiguratorUtils.kt
@@ -10,7 +10,6 @@ package com.facebook.react.utils
 import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.gradle.LibraryExtension
 import com.facebook.react.ReactExtension
-import com.facebook.react.utils.ProjectUtils.areLegacyWarningsEnabled
 import com.facebook.react.utils.ProjectUtils.isHermesEnabled
 import com.facebook.react.utils.ProjectUtils.isNewArchEnabled
 import java.io.File
@@ -35,8 +34,6 @@ internal object AgpConfiguratorUtils {
                 "boolean",
                 "IS_NEW_ARCHITECTURE_ENABLED",
                 project.isNewArchEnabled(extension).toString())
-            ext.defaultConfig.buildConfigField(
-                "boolean", "LEGACY_WARNINGS_ENABLED", project.areLegacyWarningsEnabled().toString())
             ext.defaultConfig.buildConfigField(
                 "boolean", "IS_HERMES_ENABLED", project.isHermesEnabled.toString())
           }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/ProjectUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/ProjectUtils.kt
@@ -12,11 +12,9 @@ import com.facebook.react.model.ModelPackageJson
 import com.facebook.react.utils.KotlinStdlibCompatUtils.lowercaseCompat
 import com.facebook.react.utils.KotlinStdlibCompatUtils.toBooleanStrictOrNullCompat
 import com.facebook.react.utils.PropertyUtils.HERMES_ENABLED
-import com.facebook.react.utils.PropertyUtils.LEGACY_WARNINGS_ENABLED
 import com.facebook.react.utils.PropertyUtils.NEW_ARCH_ENABLED
 import com.facebook.react.utils.PropertyUtils.REACT_NATIVE_ARCHITECTURES
 import com.facebook.react.utils.PropertyUtils.SCOPED_HERMES_ENABLED
-import com.facebook.react.utils.PropertyUtils.SCOPED_LEGACY_WARNINGS_ENABLED
 import com.facebook.react.utils.PropertyUtils.SCOPED_NEW_ARCH_ENABLED
 import com.facebook.react.utils.PropertyUtils.SCOPED_REACT_NATIVE_ARCHITECTURES
 import com.facebook.react.utils.PropertyUtils.SCOPED_USE_THIRD_PARTY_JSC
@@ -33,13 +31,6 @@ internal object ProjectUtils {
         project.property(NEW_ARCH_ENABLED).toString().toBoolean()) ||
         (project.hasProperty(SCOPED_NEW_ARCH_ENABLED) &&
             project.property(SCOPED_NEW_ARCH_ENABLED).toString().toBoolean())
-  }
-
-  internal fun Project.areLegacyWarningsEnabled(): Boolean {
-    return (project.hasProperty(LEGACY_WARNINGS_ENABLED) &&
-        project.property(LEGACY_WARNINGS_ENABLED).toString().toBoolean()) ||
-        (project.hasProperty(SCOPED_LEGACY_WARNINGS_ENABLED) &&
-            project.property(SCOPED_LEGACY_WARNINGS_ENABLED).toString().toBoolean())
   }
 
   internal val Project.isHermesEnabled: Boolean

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PropertyUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PropertyUtils.kt
@@ -14,10 +14,6 @@ object PropertyUtils {
   const val NEW_ARCH_ENABLED = "newArchEnabled"
   const val SCOPED_NEW_ARCH_ENABLED = "react.newArchEnabled"
 
-  /** Public property that toggles the Legacy Architecture Warnings */
-  const val LEGACY_WARNINGS_ENABLED = "legacyWarningsEnabled"
-  const val SCOPED_LEGACY_WARNINGS_ENABLED = "react.legacyWarningsEnabled"
-
   /** Public property that toggles the New Architecture */
   const val HERMES_ENABLED = "hermesEnabled"
   const val SCOPED_HERMES_ENABLED = "react.hermesEnabled"

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateEntryPointTaskTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/tasks/GenerateEntryPointTaskTest.kt
@@ -75,9 +75,6 @@ class GenerateEntryPointTaskTest {
               throw new RuntimeException(error);
             }
             
-            if (com.facebook.react.BuildConfig.LEGACY_WARNINGS_ENABLED) {
-              LegacyArchitectureLogger.OSS_LEGACY_WARNINGS_ENABLED = true;
-            }
             if (com.facebook.react.BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
               DefaultNewArchitectureEntryPoint.load();
             }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/internal/LegacyArchitecture.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/internal/LegacyArchitecture.kt
@@ -21,4 +21,4 @@ package com.facebook.react.common.annotations.internal
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
 public annotation class LegacyArchitecture(
     val logLevel: LegacyArchitectureLogLevel = LegacyArchitectureLogLevel.WARNING
-) {}
+)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/internal/LegacyArchitectureLogger.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/internal/LegacyArchitectureLogger.kt
@@ -23,23 +23,6 @@ import com.facebook.react.common.build.ReactBuildConfig
 public object LegacyArchitectureLogger {
 
   /**
-   * Whether the OSS_LEGACY_WARNINGS_ENABLED should be enabled or not for OSS users. This is
-   * controlled through the `legacyWarningsEnabled` property in the gradle.properties file.
-   */
-  @JvmField public var OSS_LEGACY_WARNINGS_ENABLED: Boolean = false
-
-  private val exceptionMessage: String
-    get() =
-        if (OSS_LEGACY_WARNINGS_ENABLED) {
-          "is being executed when `legacyWarningsEnabled` is enabled. " +
-              "You're accessing a legacy API that will be removed in a future version of React Native. " +
-              "You should investigate the stacktrace you find below and understand which class is " +
-              "accessing this API and clean it up."
-        } else {
-          "is being executed when app is fully running on the NEW Architecture."
-        }
-
-  /**
    * Asserts and logs when legacy architecture classes are being used in New Architecture. This
    * method will throw an exception if the app is running on the new architecture and the logLevel
    * received by parameter is [LegacyArchitectureLogLevel.ERROR]. Otherwise it will show a warning
@@ -53,8 +36,7 @@ public object LegacyArchitectureLogger {
       name: String,
       logLevel: LegacyArchitectureLogLevel = LegacyArchitectureLogLevel.WARNING
   ) {
-    if (ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE ||
-        OSS_LEGACY_WARNINGS_ENABLED) {
+    if (ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE) {
       executeAssert(name, logLevel)
     }
   }
@@ -85,6 +67,7 @@ public object LegacyArchitectureLogger {
     // we are working on decoupling legacy / new architecture.
     // Long term the assert will be executed in production and debug environments.
     if (ReactBuildConfig.DEBUG) {
+      val exceptionMessage = "is being executed when app is fully running on the NEW Architecture."
       when (logLevel) {
         LegacyArchitectureLogLevel.ERROR -> {
           throw AssertionException("$name $exceptionMessage")

--- a/packages/rn-tester/android/app/gradle.properties
+++ b/packages/rn-tester/android/app/gradle.properties
@@ -7,5 +7,3 @@ android.useAndroidX=true
 newArchEnabled=true
 # RN-Tester is running with Hermes enabled and filtering variants with enableHermesOnlyInVariants
 hermesEnabled=true
-# RN-Tester has Legacy Arch warnings enabled when built via OSS
-legacyWarningsEnabled=true

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.kt
@@ -18,7 +18,6 @@ import com.facebook.react.ReactPackage
 import com.facebook.react.ViewManagerOnDemandReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
 import com.facebook.react.common.assets.ReactFontManager
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.load
 import com.facebook.react.defaults.DefaultReactHost
@@ -145,7 +144,6 @@ internal class RNTesterApplication : Application(), ReactApplication {
     }
 
     if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
-      LegacyArchitectureLogger.OSS_LEGACY_WARNINGS_ENABLED = true
       load()
     }
   }


### PR DESCRIPTION
Summary:
This removes all the `OSS_LEGACY_WARNINGS_ENABLED` infrastructure from LegacyArchitectureLogger. We'll instead pivot to use ad-hoc functions for scenarios that don't work in LegacyArch + Interop Layers (see D73654273).

Changelog:
[Internal] [Changed] -

Differential Revision: D73654272


