### PR TITLE
Implement LegacyArchitecture warning for ShadowNode measure()

### DIFF
--- a/packages/react-native/ReactAndroid/gradle.properties
+++ b/packages/react-native/ReactAndroid/gradle.properties
@@ -28,6 +28,7 @@ binaryCompatibilityValidator.ignoredPackages=com.facebook.debug,\
   com.facebook.react.module.processing,\
   com.facebook.react.processing,\
   com.facebook.react.runtime.internal,\
+  com.facebook.react.uimanager.internal,\
   com.facebook.react.views.text.internal,\
   com.facebook.systrace,\
   com.facebook.yoga

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/LegacyArchitectureShadowNodeWithCxxImpl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/LegacyArchitectureShadowNodeWithCxxImpl.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.common.annotations
+
+/**
+ * Annotation class used to mark a class as a [ShadowNode] that implements the [YogaMeasureFunction]
+ * interface but that it also has a C++ Shadow Node implementation.
+ *
+ * In the NewArchitecture, the `measure()` method offered by the [YogaMeasureFunction] is never
+ * invoked, so we're emitting a warning for legacy arch users that are using such ShadowNodes.
+ *
+ * However, if a ShadowNode also has a C++ implementation, because the library has been implemented
+ * as backward compatible, you can annotate your shadow node with this annotation to suppress the
+ * warning for all of your users.
+ */
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS)
+public annotation class LegacyArchitectureShadowNodeWithCxxImpl

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/internal/LegacyArchitectureLogger.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/internal/LegacyArchitectureLogger.kt
@@ -41,24 +41,6 @@ public object LegacyArchitectureLogger {
     }
   }
 
-  /**
-   * Similar to [assertLegacyArchitecture] but executes only when
-   * [UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE] is set to true. This applies only to internal
-   * builds.
-   *
-   * @param name The name of the legacy class being used
-   * @param logLevel The severity level of the log (ERROR or WARNING, defaults to WARNING)
-   */
-  @JvmStatic
-  public fun assertLegacyArchitectureOnlyWhenMinifyEnabled(
-      name: String,
-      logLevel: LegacyArchitectureLogLevel = LegacyArchitectureLogLevel.WARNING
-  ) {
-    if (ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE) {
-      executeAssert(name, logLevel)
-    }
-  }
-
   private fun executeAssert(
       name: String,
       logLevel: LegacyArchitectureLogLevel = LegacyArchitectureLogLevel.WARNING

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
@@ -42,12 +42,14 @@ import com.facebook.react.common.ReactConstants;
 import com.facebook.react.common.annotations.internal.LegacyArchitecture;
 import com.facebook.react.common.annotations.internal.LegacyArchitectureLogLevel;
 import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger;
+import com.facebook.react.common.build.ReactBuildConfig;
 import com.facebook.react.module.annotations.ReactModule;
 import com.facebook.react.uimanager.common.ViewUtil;
 import com.facebook.react.uimanager.debug.NotThreadSafeViewHierarchyUpdateDebugListener;
 import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.react.uimanager.events.EventDispatcherImpl;
 import com.facebook.react.uimanager.events.RCTEventEmitter;
+import com.facebook.react.uimanager.internal.LegacyArchitectureShadowNodeLogger;
 import com.facebook.systrace.Systrace;
 import com.facebook.systrace.SystraceMessage;
 import java.util.ArrayList;
@@ -155,6 +157,13 @@ public class UIManagerModule extends ReactContextBaseJavaModule
             mViewManagerRegistry,
             mEventDispatcher,
             minTimeLeftInFrameForNonBatchedOperationMs);
+
+    if (ReactBuildConfig.DEBUG) {
+      for (ViewManager<?, ?> viewManager : viewManagersList) {
+        LegacyArchitectureShadowNodeLogger.assertUnsupportedViewManager(
+            reactContext, viewManager.getShadowNodeClass(), viewManager.getClass().getSimpleName());
+      }
+    }
 
     reactContext.addLifecycleEventListener(this);
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/internal/LegacyArchitectureShadowNodeLogger.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/internal/LegacyArchitectureShadowNodeLogger.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.uimanager.internal
+
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactNoCrashSoftException
+import com.facebook.react.bridge.ReactSoftExceptionLogger
+import com.facebook.react.common.annotations.LegacyArchitectureShadowNodeWithCxxImpl
+import com.facebook.react.common.build.ReactBuildConfig
+import com.facebook.react.util.RNLog
+import com.facebook.yoga.YogaMeasureFunction
+
+/**
+ * Logger class to track usage of ShadowNodes in Legacy Architecture.
+ *
+ * This class is similar to [LegacyArchitectureLogger] but focuses only on ShadowNodes warning for
+ * users.
+ */
+public object LegacyArchitectureShadowNodeLogger {
+
+  @JvmStatic
+  public fun assertUnsupportedViewManager(
+      reactContext: ReactApplicationContext,
+      shadowNodeClass: Class<*>,
+      viewManagerName: String
+  ) {
+    val implementsYogaMeasureFunction =
+        YogaMeasureFunction::class.java in shadowNodeClass.interfaces
+    val annotatedWithCxxImpl =
+        shadowNodeClass.isAnnotationPresent(LegacyArchitectureShadowNodeWithCxxImpl::class.java)
+    if (implementsYogaMeasureFunction && !annotatedWithCxxImpl) {
+      val message =
+          """
+              [Legacy Architecture] The ViewManager `$viewManagerName` is unlikely to work with the New Architecture.
+              That's because the shadow node `${shadowNodeClass.simpleName}` implements the `YogaMeasureFunction.measure()` method.
+              This is not supported in the New Architecture as shadow nodes with custom measurements should be implemented in C++.
+              """
+              .trimIndent()
+
+      if (ReactBuildConfig.DEBUG) {
+        RNLog.w(reactContext, message)
+        ReactSoftExceptionLogger.logSoftException(
+            ReactSoftExceptionLogger.Categories.SOFT_ASSERTIONS, ReactNoCrashSoftException(message))
+      }
+    }
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/progressbar/ProgressBarShadowNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/progressbar/ProgressBarShadowNode.kt
@@ -10,6 +10,7 @@ package com.facebook.react.views.progressbar
 import android.util.SparseIntArray
 import android.view.View
 import android.view.ViewGroup
+import com.facebook.react.common.annotations.LegacyArchitectureShadowNodeWithCxxImpl
 import com.facebook.react.common.annotations.internal.LegacyArchitecture
 import com.facebook.react.uimanager.LayoutShadowNode
 import com.facebook.react.uimanager.annotations.ReactProp
@@ -23,6 +24,7 @@ import com.facebook.yoga.YogaNode
  * ReactProgressBarViewManager manages how this style is applied to the ProgressBar.
  */
 @LegacyArchitecture
+@LegacyArchitectureShadowNodeWithCxxImpl
 internal class ProgressBarShadowNode : LayoutShadowNode(), YogaMeasureFunction {
   private val height: SparseIntArray = SparseIntArray()
   private val width: SparseIntArray = SparseIntArray()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitchShadowNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitchShadowNode.kt
@@ -8,6 +8,7 @@
 package com.facebook.react.views.switchview
 
 import android.view.View
+import com.facebook.react.common.annotations.LegacyArchitectureShadowNodeWithCxxImpl
 import com.facebook.react.common.annotations.internal.LegacyArchitecture
 import com.facebook.react.uimanager.LayoutShadowNode
 import com.facebook.yoga.YogaMeasureFunction
@@ -16,6 +17,7 @@ import com.facebook.yoga.YogaMeasureOutput
 import com.facebook.yoga.YogaNode
 
 @LegacyArchitecture
+@LegacyArchitectureShadowNodeWithCxxImpl
 internal class ReactSwitchShadowNode : LayoutShadowNode(), YogaMeasureFunction {
   private var width = 0
   private var height = 0

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.kt
@@ -18,6 +18,7 @@ import com.facebook.common.logging.FLog
 import com.facebook.infer.annotation.Assertions
 import com.facebook.react.R
 import com.facebook.react.common.ReactConstants
+import com.facebook.react.common.annotations.LegacyArchitectureShadowNodeWithCxxImpl
 import com.facebook.react.common.annotations.internal.LegacyArchitecture
 import com.facebook.react.uimanager.Spacing
 import com.facebook.react.uimanager.ThemedReactContext
@@ -33,6 +34,7 @@ import com.facebook.yoga.YogaMeasureOutput
 import com.facebook.yoga.YogaNode
 
 @LegacyArchitecture
+@LegacyArchitectureShadowNodeWithCxxImpl
 internal class ReactTextInputShadowNode
 @JvmOverloads
 constructor(reactTextViewManagerCallback: ReactTextViewManagerCallback? = null) :


### PR DESCRIPTION
Summary:
Add a warning for LegacyArch users that are providing a ViewManager with a corresponding shadow node that implements the `YogaMeasureFunction`.

For those users, we know that the ViewManager is most likely not working on the NewArch (unless they have a backward compat ViewManager with a C++ shadow node implementation).

Changelog:
[Android] [Added] - Warn Legacy Arch users if they use a Component with a ShadowNode with `YogaMeasureFunction.measure()` function. That Component will stop working on NewArch.

Differential Revision: D73654273


