### PR TITLE
Replace hsr_core dependency for react profiling with hz_tracing dependency

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/profiling/tracy_noop.h
+++ b/packages/react-native/ReactCxxPlatform/react/profiling/tracy_noop.h
@@ -12,7 +12,23 @@
 #endif
 
 #if RNCXX_WITH_PROFILING_PROVIDER
-#include <core/Trace.h>
+#include <hz_tracing/TracingMacros.h>
+
+#define SCOPED_TRACE_CPU_AUTO()                  \
+  HZT_TRACE_SCOPE_AUTO(                          \
+      ::horizon::tracing::TraceLevel::Important, \
+      ::horizon::tracing::EventCategory::Update, \
+      "react_native",                            \
+      ::horizon::tracing::DestinationFlag::Default);
+
+#define SCOPED_TRACE_CPU(name)                   \
+  HZT_TRACE_SCOPE(                               \
+      name,                                      \
+      ::horizon::tracing::TraceLevel::Important, \
+      ::horizon::tracing::EventCategory::Update, \
+      "react_native",                            \
+      ::horizon::tracing::DestinationFlag::Default);
+
 #else
 #ifndef SCOPED_TRACE_CPU_AUTO
 #define SCOPED_TRACE_CPU_AUTO() ((void)0)


### PR DESCRIPTION
Summary:
This PR replaces a one internal header dependency with another.  This is only relevant to an unsupported build mode.

Differential Revision: D73532803


