### PR TITLE
Add support for aria-invalid

### DIFF
--- a/packages/react-native/Libraries/Components/Button.js
+++ b/packages/react-native/Libraries/Components/Button.js
@@ -159,6 +159,7 @@ export type ButtonProps = $ReadOnly<{
   'aria-checked'?: ?boolean | 'mixed',
   'aria-disabled'?: ?boolean,
   'aria-expanded'?: ?boolean,
+  'aria-invalid'?: ?boolean,
   'aria-selected'?: ?boolean,
 
   /**
@@ -296,6 +297,7 @@ const Button: component(
     'aria-checked': ariaChecked,
     'aria-disabled': ariaDisabled,
     'aria-expanded': ariaExpanded,
+    'aria-invalid': ariaInvalid,
     'aria-label': ariaLabel,
     'aria-selected': ariaSelected,
     importantForAccessibility,
@@ -331,6 +333,7 @@ const Button: component(
     checked: ariaChecked ?? accessibilityState?.checked,
     disabled: ariaDisabled ?? accessibilityState?.disabled,
     expanded: ariaExpanded ?? accessibilityState?.expanded,
+    invalid: ariaInvalid ?? accessibilityState?.invalid,
     selected: ariaSelected ?? accessibilityState?.selected,
   };
 

--- a/packages/react-native/Libraries/Components/Pressable/Pressable.js
+++ b/packages/react-native/Libraries/Components/Pressable/Pressable.js
@@ -179,6 +179,7 @@ function Pressable(
     'aria-checked': ariaChecked,
     'aria-disabled': ariaDisabled,
     'aria-expanded': ariaExpanded,
+    'aria-invalid': ariaInvalid,
     'aria-label': ariaLabel,
     'aria-selected': ariaSelected,
     cancelable,
@@ -218,6 +219,7 @@ function Pressable(
     checked: ariaChecked ?? accessibilityState?.checked,
     disabled: ariaDisabled ?? accessibilityState?.disabled,
     expanded: ariaExpanded ?? accessibilityState?.expanded,
+    invalid: ariaInvalid ?? accessibilityState?.invalid,
     selected: ariaSelected ?? accessibilityState?.selected,
   };
 

--- a/packages/react-native/Libraries/Components/Pressable/__tests__/__snapshots__/Pressable-test.js.snap
+++ b/packages/react-native/Libraries/Components/Pressable/__tests__/__snapshots__/Pressable-test.js.snap
@@ -8,6 +8,7 @@ exports[`<Pressable /> should render as expected: should deep render when mocked
       "checked": undefined,
       "disabled": undefined,
       "expanded": undefined,
+      "invalid": undefined,
       "selected": undefined,
     }
   }
@@ -44,6 +45,7 @@ exports[`<Pressable /> should render as expected: should deep render when not mo
       "checked": undefined,
       "disabled": undefined,
       "expanded": undefined,
+      "invalid": undefined,
       "selected": undefined,
     }
   }
@@ -80,6 +82,7 @@ exports[`<Pressable disabled={true} /> should be disabled when disabled is true:
       "checked": undefined,
       "disabled": true,
       "expanded": undefined,
+      "invalid": undefined,
       "selected": undefined,
     }
   }
@@ -116,6 +119,7 @@ exports[`<Pressable disabled={true} /> should be disabled when disabled is true:
       "checked": undefined,
       "disabled": true,
       "expanded": undefined,
+      "invalid": undefined,
       "selected": undefined,
     }
   }
@@ -152,6 +156,7 @@ exports[`<Pressable disabled={true} accessibilityState={{}} /> should be disable
       "checked": undefined,
       "disabled": true,
       "expanded": undefined,
+      "invalid": undefined,
       "selected": undefined,
     }
   }
@@ -188,6 +193,7 @@ exports[`<Pressable disabled={true} accessibilityState={{}} /> should be disable
       "checked": undefined,
       "disabled": true,
       "expanded": undefined,
+      "invalid": undefined,
       "selected": undefined,
     }
   }
@@ -224,6 +230,7 @@ exports[`<Pressable disabled={true} accessibilityState={{checked: true}} /> shou
       "checked": true,
       "disabled": true,
       "expanded": undefined,
+      "invalid": undefined,
       "selected": undefined,
     }
   }
@@ -260,6 +267,7 @@ exports[`<Pressable disabled={true} accessibilityState={{checked: true}} /> shou
       "checked": true,
       "disabled": true,
       "expanded": undefined,
+      "invalid": undefined,
       "selected": undefined,
     }
   }
@@ -296,6 +304,7 @@ exports[`<Pressable disabled={true} accessibilityState={{disabled: false}} /> sh
       "checked": undefined,
       "disabled": true,
       "expanded": undefined,
+      "invalid": undefined,
       "selected": undefined,
     }
   }
@@ -332,6 +341,7 @@ exports[`<Pressable disabled={true} accessibilityState={{disabled: false}} /> sh
       "checked": undefined,
       "disabled": true,
       "expanded": undefined,
+      "invalid": undefined,
       "selected": undefined,
     }
   }

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -356,6 +356,7 @@ function InternalTextInput(props: TextInputProps): React.Node {
     'aria-checked': ariaChecked,
     'aria-disabled': ariaDisabled,
     'aria-expanded': ariaExpanded,
+    'aria-invalid': ariaInvalid,
     'aria-selected': ariaSelected,
     accessibilityState,
     id,
@@ -620,6 +621,7 @@ function InternalTextInput(props: TextInputProps): React.Node {
     ariaChecked != null ||
     ariaDisabled != null ||
     ariaExpanded != null ||
+    ariaInvalid != null ||
     ariaSelected != null
   ) {
     _accessibilityState = {
@@ -627,6 +629,7 @@ function InternalTextInput(props: TextInputProps): React.Node {
       checked: ariaChecked ?? accessibilityState?.checked,
       disabled: ariaDisabled ?? accessibilityState?.disabled,
       expanded: ariaExpanded ?? accessibilityState?.expanded,
+      invalid: ariaInvalid ?? accessibilityState?.invalid,
       selected: ariaSelected ?? accessibilityState?.selected,
     };
   }

--- a/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-test.js
+++ b/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-test.js
@@ -415,6 +415,7 @@ jest.unmock('../TextInput');
             "checked": true,
             "disabled": true,
             "expanded": true,
+            "invalid": true,
             "selected": true,
           }
         }
@@ -434,7 +435,6 @@ jest.unmock('../TextInput');
         aria-flowto="flowto"
         aria-haspopup={true}
         aria-hidden={true}
-        aria-invalid={true}
         aria-keyshortcuts="Cmd+S"
         aria-label="label"
         aria-labelledby="labelledby"

--- a/packages/react-native/Libraries/Components/Touchable/TouchableBounce.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableBounce.js
@@ -147,6 +147,8 @@ class TouchableBounce extends React.Component<
         this.props['aria-disabled'] ?? this.props.accessibilityState?.disabled,
       expanded:
         this.props['aria-expanded'] ?? this.props.accessibilityState?.expanded,
+      invalid:
+        this.props['aria-invalid'] ?? this.props.accessibilityState?.invalid,
       selected:
         this.props['aria-selected'] ?? this.props.accessibilityState?.selected,
     };

--- a/packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js
@@ -308,6 +308,8 @@ class TouchableNativeFeedback extends React.Component<
         this.props['aria-disabled'] ?? this.props.accessibilityState?.disabled,
       expanded:
         this.props['aria-expanded'] ?? this.props.accessibilityState?.expanded,
+      invalid:
+        this.props['aria-invalid'] ?? this.props.accessibilityState?.invalid,
       selected:
         this.props['aria-selected'] ?? this.props.accessibilityState?.selected,
     };

--- a/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
@@ -271,6 +271,8 @@ class TouchableOpacity extends React.Component<
         this.props['aria-disabled'] ?? this.props.accessibilityState?.disabled,
       expanded:
         this.props['aria-expanded'] ?? this.props.accessibilityState?.expanded,
+      invalid:
+        this.props['aria-invalid'] ?? this.props.accessibilityState?.invalid,
       selected:
         this.props['aria-selected'] ?? this.props.accessibilityState?.selected,
     };

--- a/packages/react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -243,6 +243,7 @@ export default function TouchableWithoutFeedback(
     checked: props['aria-checked'] ?? props.accessibilityState?.checked,
     disabled: props['aria-disabled'] ?? props.accessibilityState?.disabled,
     expanded: props['aria-expanded'] ?? props.accessibilityState?.expanded,
+    invalid: props['aria-invalid'] ?? props.accessibilityState?.invalid,
     selected: props['aria-selected'] ?? props.accessibilityState?.selected,
   };
 

--- a/packages/react-native/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableNativeFeedback-test.js.snap
+++ b/packages/react-native/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableNativeFeedback-test.js.snap
@@ -8,6 +8,7 @@ exports[`<TouchableNativeFeedback /> should render as expected 1`] = `
       "checked": undefined,
       "disabled": undefined,
       "expanded": undefined,
+      "invalid": undefined,
       "selected": undefined,
     }
   }
@@ -39,6 +40,7 @@ exports[`<TouchableNativeFeedback disabled={false} accessibilityState={{disabled
       "checked": undefined,
       "disabled": false,
       "expanded": undefined,
+      "invalid": undefined,
       "selected": undefined,
     }
   }
@@ -70,6 +72,7 @@ exports[`<TouchableNativeFeedback disabled={true} accessibilityState={{}}> shoul
       "checked": undefined,
       "disabled": true,
       "expanded": undefined,
+      "invalid": undefined,
       "selected": undefined,
     }
   }
@@ -101,6 +104,7 @@ exports[`<TouchableNativeFeedback disabled={true} accessibilityState={{checked: 
       "checked": true,
       "disabled": true,
       "expanded": undefined,
+      "invalid": undefined,
       "selected": undefined,
     }
   }
@@ -132,6 +136,7 @@ exports[`<TouchableNativeFeedback disabled={true} accessibilityState={{disabled:
       "checked": undefined,
       "disabled": true,
       "expanded": undefined,
+      "invalid": undefined,
       "selected": undefined,
     }
   }
@@ -163,6 +168,7 @@ exports[`<TouchableNativeFeedback disabled={true}> should be disabled when disab
       "checked": undefined,
       "disabled": true,
       "expanded": undefined,
+      "invalid": undefined,
       "selected": undefined,
     }
   }
@@ -194,6 +200,7 @@ exports[`TouchableWithoutFeedback renders correctly 1`] = `
       "checked": undefined,
       "disabled": undefined,
       "expanded": undefined,
+      "invalid": undefined,
       "selected": undefined,
     }
   }

--- a/packages/react-native/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableOpacity-test.js.snap
+++ b/packages/react-native/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableOpacity-test.js.snap
@@ -8,6 +8,7 @@ exports[`TouchableOpacity renders correctly 1`] = `
       "checked": undefined,
       "disabled": undefined,
       "expanded": undefined,
+      "invalid": undefined,
       "selected": undefined,
     }
   }
@@ -49,6 +50,7 @@ exports[`TouchableOpacity renders in disabled state when a disabled prop is pass
       "checked": undefined,
       "disabled": true,
       "expanded": undefined,
+      "invalid": undefined,
       "selected": undefined,
     }
   }
@@ -90,6 +92,7 @@ exports[`TouchableOpacity renders in disabled state when a key disabled in acces
       "checked": undefined,
       "disabled": true,
       "expanded": undefined,
+      "invalid": undefined,
       "selected": undefined,
     }
   }

--- a/packages/react-native/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableWithoutFeedback-test.js.snap
+++ b/packages/react-native/Libraries/Components/Touchable/__tests__/__snapshots__/TouchableWithoutFeedback-test.js.snap
@@ -8,6 +8,7 @@ exports[`TouchableWithoutFeedback renders correctly 1`] = `
       "checked": undefined,
       "disabled": undefined,
       "expanded": undefined,
+      "invalid": undefined,
       "selected": undefined,
     }
   }
@@ -33,6 +34,7 @@ exports[`TouchableWithoutFeedback with disabled state should be disabled when di
       "checked": undefined,
       "disabled": true,
       "expanded": undefined,
+      "invalid": undefined,
       "selected": undefined,
     }
   }
@@ -56,6 +58,7 @@ exports[`TouchableWithoutFeedback with disabled state should be disabled when di
       "checked": undefined,
       "disabled": true,
       "expanded": undefined,
+      "invalid": undefined,
       "selected": undefined,
     }
   }
@@ -79,6 +82,7 @@ exports[`TouchableWithoutFeedback with disabled state should disable button when
       "checked": undefined,
       "disabled": true,
       "expanded": undefined,
+      "invalid": undefined,
       "selected": undefined,
     }
   }
@@ -102,6 +106,7 @@ exports[`TouchableWithoutFeedback with disabled state should keep accessibilityS
       "checked": true,
       "disabled": true,
       "expanded": undefined,
+      "invalid": undefined,
       "selected": undefined,
     }
   }
@@ -125,6 +130,7 @@ exports[`TouchableWithoutFeedback with disabled state should overwrite accessibi
       "checked": undefined,
       "disabled": true,
       "expanded": undefined,
+      "invalid": undefined,
       "selected": undefined,
     }
   }

--- a/packages/react-native/Libraries/Components/View/View.js
+++ b/packages/react-native/Libraries/Components/View/View.js
@@ -40,6 +40,7 @@ const View: component(
       'aria-disabled': ariaDisabled,
       'aria-expanded': ariaExpanded,
       'aria-hidden': ariaHidden,
+      'aria-invalid': ariaInvalid,
       'aria-label': ariaLabel,
       'aria-labelledby': ariaLabelledBy,
       'aria-live': ariaLive,
@@ -67,12 +68,14 @@ const View: component(
       ariaChecked != null ||
       ariaDisabled != null ||
       ariaExpanded != null ||
+      ariaInvalid != null ||
       ariaSelected != null
         ? {
             busy: ariaBusy ?? accessibilityState?.busy,
             checked: ariaChecked ?? accessibilityState?.checked,
             disabled: ariaDisabled ?? accessibilityState?.disabled,
             expanded: ariaExpanded ?? accessibilityState?.expanded,
+            invalid: ariaInvalid ?? accessibilityState?.invalid,
             selected: ariaSelected ?? accessibilityState?.selected,
           }
         : undefined;

--- a/packages/react-native/Libraries/Components/View/ViewAccessibility.d.ts
+++ b/packages/react-native/Libraries/Components/View/ViewAccessibility.d.ts
@@ -56,6 +56,7 @@ export interface AccessibilityProps
   'aria-checked'?: boolean | 'mixed' | undefined;
   'aria-disabled'?: boolean | undefined;
   'aria-expanded'?: boolean | undefined;
+  'aria-invalid'?: boolean | undefined;
   'aria-selected'?: boolean | undefined;
 
   /**
@@ -161,6 +162,10 @@ export interface AccessibilityState {
    *  When present, informs accessible tools the element is expanded or collapsed
    */
   expanded?: boolean | undefined;
+  /**
+   *  When present, informs accessible tools the element is invalid
+   */
+  invalid?: boolean | undefined;
 }
 
 export interface AccessibilityValue {

--- a/packages/react-native/Libraries/Components/View/ViewAccessibility.js
+++ b/packages/react-native/Libraries/Components/View/ViewAccessibility.js
@@ -186,6 +186,10 @@ export type AccessibilityState = {
    *  When present, informs accessible tools the element is expanded or collapsed
    */
   expanded?: ?boolean,
+  /**
+   *  When present, informs accessible tools the element is invalid
+   */
+  invalid?: ?boolean,
   ...
 };
 
@@ -405,6 +409,7 @@ export type AccessibilityProps = $ReadOnly<{
   'aria-checked'?: ?boolean | 'mixed',
   'aria-disabled'?: ?boolean,
   'aria-expanded'?: ?boolean,
+  'aria-invalid'?: ?boolean,
   'aria-selected'?: ?boolean,
   /** A value indicating whether the accessibility elements contained within
    * this accessibility element are hidden.

--- a/packages/react-native/Libraries/Components/View/__tests__/View-test.js
+++ b/packages/react-native/Libraries/Components/View/__tests__/View-test.js
@@ -116,6 +116,7 @@ describe('View compat with web', () => {
             "checked": true,
             "disabled": true,
             "expanded": true,
+            "invalid": true,
             "selected": true,
           }
         }
@@ -140,7 +141,6 @@ describe('View compat with web', () => {
         aria-errormessage="errormessage"
         aria-flowto="flowto"
         aria-haspopup={true}
-        aria-invalid={true}
         aria-keyshortcuts="Cmd+S"
         aria-level={3}
         aria-modal={true}

--- a/packages/react-native/Libraries/Components/__tests__/__snapshots__/Button-test.js.snap
+++ b/packages/react-native/Libraries/Components/__tests__/__snapshots__/Button-test.js.snap
@@ -9,6 +9,7 @@ exports[`<Button /> should be disabled and it should set accessibilityState to d
       "checked": undefined,
       "disabled": true,
       "expanded": undefined,
+      "invalid": undefined,
       "selected": undefined,
     }
   }
@@ -75,6 +76,7 @@ exports[`<Button /> should be disabled when disabled is empty and accessibilityS
       "checked": undefined,
       "disabled": true,
       "expanded": undefined,
+      "invalid": undefined,
       "selected": undefined,
     }
   }
@@ -141,6 +143,7 @@ exports[`<Button /> should be disabled when disabled={true} and accessibilitySta
       "checked": undefined,
       "disabled": true,
       "expanded": undefined,
+      "invalid": undefined,
       "selected": undefined,
     }
   }
@@ -207,6 +210,7 @@ exports[`<Button /> should be set importantForAccessibility={no-hide-descendants
       "checked": undefined,
       "disabled": undefined,
       "expanded": undefined,
+      "invalid": undefined,
       "selected": undefined,
     }
   }
@@ -269,6 +273,7 @@ exports[`<Button /> should be set importantForAccessibility={no-hide-descendants
       "checked": undefined,
       "disabled": undefined,
       "expanded": undefined,
+      "invalid": undefined,
       "selected": undefined,
     }
   }
@@ -331,6 +336,7 @@ exports[`<Button /> should not be disabled when disabled={false} and accessibili
       "checked": undefined,
       "disabled": false,
       "expanded": undefined,
+      "invalid": undefined,
       "selected": undefined,
     }
   }
@@ -393,6 +399,7 @@ exports[`<Button /> should not be disabled when disabled={false} and accessibili
       "checked": undefined,
       "disabled": false,
       "expanded": undefined,
+      "invalid": undefined,
       "selected": undefined,
     }
   }
@@ -455,6 +462,7 @@ exports[`<Button /> should overwrite accessibilityState with value of disabled p
       "checked": undefined,
       "disabled": true,
       "expanded": undefined,
+      "invalid": undefined,
       "selected": undefined,
     }
   }
@@ -521,6 +529,7 @@ exports[`<Button /> should render as expected 1`] = `
       "checked": undefined,
       "disabled": undefined,
       "expanded": undefined,
+      "invalid": undefined,
       "selected": undefined,
     }
   }

--- a/packages/react-native/Libraries/Image/Image.android.js
+++ b/packages/react-native/Libraries/Image/Image.android.js
@@ -193,6 +193,7 @@ let BaseImage: AbstractImageAndroid = React.forwardRef(
         checked: props['aria-checked'] ?? props.accessibilityState?.checked,
         disabled: props['aria-disabled'] ?? props.accessibilityState?.disabled,
         expanded: props['aria-expanded'] ?? props.accessibilityState?.expanded,
+        invalid: props['aria-invalid'] ?? props.accessibilityState?.invalid,
         selected: props['aria-selected'] ?? props.accessibilityState?.selected,
       },
     };

--- a/packages/react-native/Libraries/Image/Image.ios.js
+++ b/packages/react-native/Libraries/Image/Image.ios.js
@@ -144,6 +144,7 @@ let BaseImage: AbstractImageIOS = React.forwardRef((props, forwardedRef) => {
     'aria-checked': ariaChecked,
     'aria-disabled': ariaDisabled,
     'aria-expanded': ariaExpanded,
+    'aria-invalid': ariaInvalid,
     'aria-selected': ariaSelected,
     src,
     ...restProps
@@ -154,6 +155,7 @@ let BaseImage: AbstractImageIOS = React.forwardRef((props, forwardedRef) => {
     checked: ariaChecked ?? props.accessibilityState?.checked,
     disabled: ariaDisabled ?? props.accessibilityState?.disabled,
     expanded: ariaExpanded ?? props.accessibilityState?.expanded,
+    invalid: ariaInvalid ?? props.accessibilityState?.invalid,
     selected: ariaSelected ?? props.accessibilityState?.selected,
   };
   const accessibilityLabel = props['aria-label'] ?? props.accessibilityLabel;

--- a/packages/react-native/Libraries/Image/__tests__/__snapshots__/Image-test.js.snap
+++ b/packages/react-native/Libraries/Image/__tests__/__snapshots__/Image-test.js.snap
@@ -18,6 +18,7 @@ exports[`Image should render as <RCTImageView> when not mocked 1`] = `
       "checked": undefined,
       "disabled": undefined,
       "expanded": undefined,
+      "invalid": undefined,
       "selected": undefined,
     }
   }

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxInspectorStackFrames-test.js.snap
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxInspectorStackFrames-test.js.snap
@@ -146,6 +146,7 @@ exports[`LogBoxInspectorStackFrames should render stack frames with 1 frame coll
             "checked": undefined,
             "disabled": undefined,
             "expanded": undefined,
+            "invalid": undefined,
             "selected": undefined,
           }
         }

--- a/packages/react-native/Libraries/Text/Text.js
+++ b/packages/react-native/Libraries/Text/Text.js
@@ -50,6 +50,7 @@ const TextImpl: component(
       'aria-disabled': ariaDisabled,
       'aria-expanded': ariaExpanded,
       'aria-label': ariaLabel,
+      'aria-invalid': ariaInvalid,
       'aria-selected': ariaSelected,
       children,
       ellipsizeMode,
@@ -85,6 +86,7 @@ const TextImpl: component(
       ariaChecked != null ||
       ariaDisabled != null ||
       ariaExpanded != null ||
+      ariaInvalid != null ||
       ariaSelected != null
     ) {
       if (_accessibilityState != null) {
@@ -93,6 +95,7 @@ const TextImpl: component(
           checked: ariaChecked ?? _accessibilityState.checked,
           disabled: ariaDisabled ?? _accessibilityState.disabled,
           expanded: ariaExpanded ?? _accessibilityState.expanded,
+          invalid: ariaInvalid ?? _accessibilityState.invalid,
           selected: ariaSelected ?? _accessibilityState.selected,
         };
       } else {
@@ -101,6 +104,7 @@ const TextImpl: component(
           checked: ariaChecked,
           disabled: ariaDisabled,
           expanded: ariaExpanded,
+          invalid: ariaInvalid,
           selected: ariaSelected,
         };
       }

--- a/packages/react-native/Libraries/Text/TextProps.js
+++ b/packages/react-native/Libraries/Text/TextProps.js
@@ -162,6 +162,7 @@ type TextBaseProps = $ReadOnly<{
   'aria-checked'?: ?boolean | 'mixed',
   'aria-disabled'?: ?boolean,
   'aria-expanded'?: ?boolean,
+  'aria-invalid'?: ?boolean,
   'aria-selected'?: ?boolean,
 
   /**

--- a/packages/react-native/Libraries/Text/__tests__/Text-test.js
+++ b/packages/react-native/Libraries/Text/__tests__/Text-test.js
@@ -128,6 +128,7 @@ describe('Text compat with web', () => {
             "checked": true,
             "disabled": true,
             "expanded": true,
+            "invalid": true,
             "selected": true,
           }
         }
@@ -147,7 +148,6 @@ describe('Text compat with web', () => {
         aria-flowto="flowto"
         aria-haspopup={true}
         aria-hidden={true}
-        aria-invalid={true}
         aria-keyshortcuts="Cmd+S"
         aria-labelledby="labelledby"
         aria-level={3}

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -1518,6 +1518,7 @@ exports[`public API should not change unintentionally Libraries/Components/Butto
   \\"aria-checked\\"?: ?boolean | \\"mixed\\",
   \\"aria-disabled\\"?: ?boolean,
   \\"aria-expanded\\"?: ?boolean,
+  \\"aria-invalid\\"?: ?boolean,
   \\"aria-selected\\"?: ?boolean,
   importantForAccessibility?: ?(\\"auto\\" | \\"yes\\" | \\"no\\" | \\"no-hide-descendants\\"),
   accessibilityHint?: ?string,
@@ -3629,6 +3630,7 @@ export type AccessibilityState = {
   checked?: ?boolean | \\"mixed\\",
   busy?: ?boolean,
   expanded?: ?boolean,
+  invalid?: ?boolean,
   ...
 };
 export type AccessibilityValue = $ReadOnly<{
@@ -3674,6 +3676,7 @@ export type AccessibilityProps = $ReadOnly<{
   \\"aria-checked\\"?: ?boolean | \\"mixed\\",
   \\"aria-disabled\\"?: ?boolean,
   \\"aria-expanded\\"?: ?boolean,
+  \\"aria-invalid\\"?: ?boolean,
   \\"aria-selected\\"?: ?boolean,
   \\"aria-hidden\\"?: ?boolean,
 }>;
@@ -7833,6 +7836,7 @@ type TextBaseProps = $ReadOnly<{
   \\"aria-checked\\"?: ?boolean | \\"mixed\\",
   \\"aria-disabled\\"?: ?boolean,
   \\"aria-expanded\\"?: ?boolean,
+  \\"aria-invalid\\"?: ?boolean,
   \\"aria-selected\\"?: ?boolean,
   \\"aria-labelledby\\"?: ?string,
   children?: ?React.Node,

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -1272,6 +1272,10 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
     [valueComponents addObject:RCTLocalizedString("busy", "an element currently being updated or modified")];
   }
 
+  if (accessibilityState.invalid) {
+    [valueComponents addObject:RCTLocalizedString("invalid", "an input field which has failed validation or does not conform to the expected format")];
+  }
+
   // Using super.accessibilityValue:
   // 1. to access the value that is set to accessibilityValue in updateProps
   // 2. can't access from self.accessibilityElement because it resolves to self

--- a/packages/react-native/React/Views/RCTView.m
+++ b/packages/react-native/React/Views/RCTView.m
@@ -325,6 +325,8 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
           RCTLocalizedString("collapsed", "a menu, dialog, accordian panel, or other widget which is collapsed"),
       @"mixed" :
           RCTLocalizedString("mixed", "a checkbox, radio button, or other widget which is both checked and unchecked"),
+      @"invalid" :
+          RCTLocalizedString("invalid", "an input field which has failed validation or does not conform to the expected format"),
     };
   });
 
@@ -368,6 +370,9 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
     }
     if ([state isEqualToString:@"busy"] && [val isKindOfClass:[NSNumber class]] && [val boolValue]) {
       [valueComponents addObject:rolesAndStatesDescription[@"busy"]];
+    }
+    if ([state isEqualToString:@"invalid"] && [val isKindOfClass:[NSNumber class]] && [val boolValue]) {
+      [valueComponents addObject:rolesAndStatesDescription[@"invalid"]];
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -60,6 +60,7 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
 
   private static final String STATE_CHECKED = "checked"; // Special case for mixed state checkboxes
   private static final String STATE_BUSY = "busy";
+  private static final String STATE_INVALID = "invalid";
   private static final String STATE_EXPANDED = "expanded";
   private static final String STATE_MIXED = "mixed";
 
@@ -425,6 +426,7 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
     while (i.hasNextKey()) {
       final String state = i.nextKey();
       if (state.equals(STATE_BUSY)
+          || state.equals(STATE_INVALID)
           || state.equals(STATE_EXPANDED)
           || (state.equals(STATE_CHECKED)
               && accessibilityState.getType(STATE_CHECKED) == ReadableType.String)) {
@@ -462,6 +464,10 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
             && value.getType() == ReadableType.Boolean
             && value.asBoolean()) {
           contentDescription.add(view.getContext().getString(R.string.state_busy_description));
+        } else if (state.equals(STATE_INVALID)
+            && value.getType() == ReadableType.Boolean
+            && value.asBoolean()) {
+          contentDescription.add(view.getContext().getString(R.string.state_invalid_description));
         }
       }
     }

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-af/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-af/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">Nutsbalk</string>
     <string name="summary_description" gender="unknown">Opsomming</string>
     <string name="state_busy_description" gender="unknown">besig</string>
+    <string name="state_invalid_description" gender="unknown">ongeldig</string>
     <string name="state_expanded_description" gender="unknown">is uitgevou</string>
     <string name="state_collapsed_description" gender="unknown">is ingevou</string>
     <string name="state_unselected_description" gender="unknown">ontkies</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-ar/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-ar/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">شريط الأدوات</string>
     <string name="summary_description" gender="unknown">ملخص</string>
     <string name="state_busy_description" gender="unknown">مشغول</string>
+    <string name="state_invalid_description" gender="unknown">غير صالح</string>
     <string name="state_expanded_description" gender="unknown">موسع</string>
     <string name="state_collapsed_description" gender="unknown">مطوي</string>
     <string name="state_unselected_description" gender="unknown">غير محدَد</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-bg/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-bg/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">Лента с инструменти</string>
     <string name="summary_description" gender="unknown">Обобщение</string>
     <string name="state_busy_description" gender="unknown">заето</string>
+    <string name="state_invalid_description" gender="unknown">невалидно</string>
     <string name="state_expanded_description" gender="unknown">разширено</string>
     <string name="state_collapsed_description" gender="unknown">свито</string>
     <string name="state_unselected_description" gender="unknown">неизбрано</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-bn/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-bn/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">টুল বার</string>
     <string name="summary_description" gender="unknown">সারসংক্ষেপ</string>
     <string name="state_busy_description" gender="unknown">ব্যস্ত</string>
+    <string name="state_invalid_description" gender="unknown">অবৈধ</string>
     <string name="state_expanded_description" gender="unknown">বাড়ানো হয়েছে</string>
     <string name="state_collapsed_description" gender="unknown">ছোট করা হয়েছে</string>
     <string name="state_unselected_description" gender="unknown">আনসিলেক্ট করা হয়েছে</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-cs/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-cs/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">Panel nástrojů</string>
     <string name="summary_description" gender="unknown">Přehled</string>
     <string name="state_busy_description" gender="unknown">zaneprázdněno</string>
+    <string name="state_invalid_description" gender="unknown">neplatné</string>
     <string name="state_expanded_description" gender="unknown">rozbaleno</string>
     <string name="state_collapsed_description" gender="unknown">sbaleno</string>
     <string name="state_unselected_description" gender="unknown">nevybráno</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-da/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-da/strings.xml
@@ -19,6 +19,7 @@
     <string name="toolbar_description" gender="unknown">Værktøjslinje</string>
     <string name="summary_description" gender="unknown">Oversigt</string>
     <string name="state_busy_description" gender="unknown">optaget</string>
+    <string name="state_invalid_description" gender="unknown">ugyldigt</string>
     <string name="state_expanded_description" gender="unknown">udvidet</string>
     <string name="state_collapsed_description" gender="unknown">skjult</string>
     <string name="state_unselected_description" gender="unknown">fravalgt</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-de/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-de/strings.xml
@@ -19,6 +19,7 @@
     <string name="toolbar_description" gender="unknown">Symbolleiste</string>
     <string name="summary_description" gender="unknown">Übersicht</string>
     <string name="state_busy_description" gender="unknown">in Gebrauch</string>
+    <string name="state_invalid_description" gender="unknown">ungültig</string>
     <string name="state_expanded_description" gender="unknown">eingeblendet</string>
     <string name="state_collapsed_description" gender="unknown">ausgeblendet</string>
     <string name="state_unselected_description" gender="unknown">nicht ausgewählt</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-el/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-el/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">Γραμμή εργαλείων</string>
     <string name="summary_description" gender="unknown">Σύνοψη</string>
     <string name="state_busy_description" gender="unknown">απασχολημένος/η</string>
+    <string name="state_invalid_description" gender="unknown">άκυρος</string>
     <string name="state_expanded_description" gender="unknown">διευρυμένο</string>
     <string name="state_collapsed_description" gender="unknown">συμπτυγμένο</string>
     <string name="state_unselected_description" gender="unknown">μη επιλεγμένα</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-es-rES/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-es-rES/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">Barra de herramientas</string>
     <string name="summary_description" gender="unknown">Resumen</string>
     <string name="state_busy_description" gender="unknown">ocupado</string>
+    <string name="state_invalid_description" gender="unknown">inválido</string>
     <string name="state_expanded_description" gender="unknown">ampliado</string>
     <string name="state_collapsed_description" gender="unknown">contraído</string>
     <string name="state_unselected_description" gender="unknown">sin seleccionar</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-es/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-es/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">Barra de herramientas</string>
     <string name="summary_description" gender="unknown">Resumen</string>
     <string name="state_busy_description" gender="unknown">ocupado</string>
+    <string name="state_invalid_description" gender="unknown">inválido</string>
     <string name="state_expanded_description" gender="unknown">expandido</string>
     <string name="state_collapsed_description" gender="unknown">contraído</string>
     <string name="state_unselected_description" gender="unknown">no seleccionado</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-et/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-et/strings.xml
@@ -21,6 +21,7 @@
     <string name="toolbar_description" gender="unknown">Tööriistariba</string>
     <string name="summary_description" gender="unknown">Kokkuvõte</string>
     <string name="state_busy_description" gender="unknown">hõivatud</string>
+    <string name="state_invalid_description" gender="unknown">vigane</string>
     <string name="state_expanded_description" gender="unknown">laiendatud</string>
     <string name="state_collapsed_description" gender="unknown">ahendatud</string>
     <string name="state_unselected_description" gender="unknown">valimata</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-fa/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-fa/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">نوار ابزار</string>
     <string name="summary_description" gender="unknown">خلاصه</string>
     <string name="state_busy_description" gender="unknown">مشغول</string>
+    <string name="state_invalid_description" gender="unknown">نامعتبر</string>
     <string name="state_expanded_description" gender="unknown">بزرگ‌شده</string>
     <string name="state_collapsed_description" gender="unknown">کوچک‌شده</string>
     <string name="state_unselected_description" gender="unknown">لغو انتخاب شد</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-fi/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-fi/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">Työkalupalkki</string>
     <string name="summary_description" gender="unknown">Yhteenveto</string>
     <string name="state_busy_description" gender="unknown">varattu</string>
+    <string name="state_invalid_description" gender="unknown">virheellinen</string>
     <string name="state_expanded_description" gender="unknown">laajennettu</string>
     <string name="state_collapsed_description" gender="unknown">pienennetty</string>
     <string name="state_unselected_description" gender="unknown">ei valittu</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-fr-rCA/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-fr-rCA/strings.xml
@@ -20,6 +20,7 @@
     <string name="toolbar_description" gender="unknown">Barre d’outils</string>
     <string name="summary_description" gender="unknown">Résumé</string>
     <string name="state_busy_description" gender="unknown">en cours de traitement</string>
+    <string name="state_invalid_description" gender="unknown">invalide</string>
     <string name="state_expanded_description" gender="unknown">agrandi</string>
     <string name="state_collapsed_description" gender="unknown">réduit</string>
     <string name="state_unselected_description" gender="unknown">désélectionné</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-fr/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-fr/strings.xml
@@ -20,6 +20,7 @@
     <string name="toolbar_description" gender="unknown">Barre d’outils</string>
     <string name="summary_description" gender="unknown">Récapitulatif</string>
     <string name="state_busy_description" gender="unknown">opération en cours</string>
+    <string name="state_invalid_description" gender="unknown">invalide</string>
     <string name="state_expanded_description" gender="unknown">agrandi</string>
     <string name="state_collapsed_description" gender="unknown">réduit</string>
     <string name="state_unselected_description" gender="unknown">désélectionné(s)</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-gu/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-gu/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">ટૂલ બાર</string>
     <string name="summary_description" gender="unknown">સારાંશ</string>
     <string name="state_busy_description" gender="unknown">વ્યસ્ત</string>
+    <string name="state_invalid_description" gender="unknown">અમાન</string>
     <string name="state_expanded_description" gender="unknown">વિસ્તૃત</string>
     <string name="state_collapsed_description" gender="unknown">નાનું</string>
     <string name="state_unselected_description" gender="unknown">પસંદગીમાંથી કાઢી નાખ્યું</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-hi/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-hi/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">टूल बार</string>
     <string name="summary_description" gender="unknown">सारांश</string>
     <string name="state_busy_description" gender="unknown">व्यस्त</string>
+    <string name="state_invalid_description" gender="unknown">अवैध</string>
     <string name="state_expanded_description" gender="unknown">बड़ा किया गया</string>
     <string name="state_collapsed_description" gender="unknown">छोटा किया गया</string>
     <string name="state_unselected_description" gender="unknown">नहीं चुने गए</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-hr/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-hr/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">Traka s alatima</string>
     <string name="summary_description" gender="unknown">Sažetak</string>
     <string name="state_busy_description" gender="unknown">zauzeto</string>
+    <string name="state_invalid_description" gender="unknown">nevažeći</string>
     <string name="state_expanded_description" gender="unknown">prošireno</string>
     <string name="state_collapsed_description" gender="unknown">sažeto</string>
     <string name="state_unselected_description" gender="unknown">poništen odabir</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-hu/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-hu/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">Eszköztár</string>
     <string name="summary_description" gender="unknown">Összegzés</string>
     <string name="state_busy_description" gender="unknown">elfoglalt</string>
+    <string name="state_invalid_description" gender="unknown">érvénytelen</string>
     <string name="state_expanded_description" gender="unknown">kibontva</string>
     <string name="state_collapsed_description" gender="unknown">összecsukva</string>
     <string name="state_unselected_description" gender="unknown">nincs kiválasztva</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-it/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-it/strings.xml
@@ -18,6 +18,7 @@
     <string name="toolbar_description" gender="unknown">Barra degli strumenti</string>
     <string name="summary_description" gender="unknown">Riepilogo</string>
     <string name="state_busy_description" gender="unknown">occupato</string>
+    <string name="state_invalid_description" gender="unknown">non valido/a</string>
     <string name="state_expanded_description" gender="unknown">aperto</string>
     <string name="state_collapsed_description" gender="unknown">chiuso</string>
     <string name="state_unselected_description" gender="unknown">non selezionato</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-iw/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-iw/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">סרגל כלים</string>
     <string name="summary_description" gender="unknown">סיכום</string>
     <string name="state_busy_description" gender="unknown">תפוס</string>
+    <string name="state_invalid_description" gender="unknown">לא תקין</string>
     <string name="state_expanded_description" gender="unknown">מורחב</string>
     <string name="state_collapsed_description" gender="unknown">מצומצם</string>
     <string name="state_unselected_description" gender="unknown">הבחירה בוטלה</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-ja/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-ja/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">ツールバー</string>
     <string name="summary_description" gender="unknown">概要</string>
     <string name="state_busy_description" gender="unknown">作業中</string>
+    <string name="state_invalid_description" gender="unknown">無効</string>
     <string name="state_expanded_description" gender="unknown">展開中</string>
     <string name="state_collapsed_description" gender="unknown">縮小中</string>
     <string name="state_unselected_description" gender="unknown">未選択</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-ka/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-ka/strings.xml
@@ -21,6 +21,7 @@
     <string name="toolbar_description" gender="unknown">ხელსაწყოების ზოლი</string>
     <string name="summary_description" gender="unknown">შეჯამება</string>
     <string name="state_busy_description" gender="unknown">დაკავებული</string>
+    <string name="state_invalid_description" gender="unknown">არასწორი</string>
     <string name="state_expanded_description" gender="unknown">გაშლილი</string>
     <string name="state_collapsed_description" gender="unknown">აკეცილი</string>
     <string name="state_unselected_description" gender="unknown">აურჩეველი</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-km/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-km/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">របារ​ឧបករណ៍</string>
     <string name="summary_description" gender="unknown">សេចក្ដីសង្ខេប</string>
     <string name="state_busy_description" gender="unknown">ជាប់រវល់</string>
+    <string name="state_invalid_description" gender="unknown">មិនត្រឹមត្រូវ</string>
     <string name="state_expanded_description" gender="unknown">បានពង្រីក</string>
     <string name="state_collapsed_description" gender="unknown">បានបង្រួម</string>
     <string name="state_unselected_description" gender="unknown">បាបនដោះការជ្រើសរើស</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-kn/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-kn/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">ಟೂಲ್ ಬಾರ್</string>
     <string name="summary_description" gender="unknown">ಸಾರಾಂಶ</string>
     <string name="state_busy_description" gender="unknown">ಕಾರ್ಯನಿರತ</string>
+    <string name="state_invalid_description" gender="unknown">ಅಮಾನ</string>
     <string name="state_expanded_description" gender="unknown">ವಿಸ್ತರಿಸಲಾಗಿದೆ</string>
     <string name="state_collapsed_description" gender="unknown">ಮುಚ್ಚಿದೆ</string>
     <string name="state_unselected_description" gender="unknown">ಆಯ್ಕೆ ರದ್ದುಮಾಡಲಾಗಿದೆ</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-ko/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-ko/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">도구 표시줄</string>
     <string name="summary_description" gender="unknown">요약</string>
     <string name="state_busy_description" gender="unknown">처리 중</string>
+    <string name="state_invalid_description" gender="unknown">유효하지 않음</string>
     <string name="state_expanded_description" gender="unknown">확대됨</string>
     <string name="state_collapsed_description" gender="unknown">숨겨짐</string>
     <string name="state_unselected_description" gender="unknown">선택되지 않음</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-lt/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-lt/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">Įrankių juosta</string>
     <string name="summary_description" gender="unknown">Suvestinė</string>
     <string name="state_busy_description" gender="unknown">naudojama</string>
+    <string name="state_invalid_description" gender="unknown">neteisinga</string>
     <string name="state_expanded_description" gender="unknown">išskleista</string>
     <string name="state_collapsed_description" gender="unknown">sutraukta</string>
     <string name="state_unselected_description" gender="unknown">pasirinkimas atšauktas</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-lv/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-lv/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">Rīkjosla</string>
     <string name="summary_description" gender="unknown">Kopsavilkums</string>
     <string name="state_busy_description" gender="unknown">aizņemts</string>
+    <string name="state_invalid_description" gender="unknown">nepareizs</string>
     <string name="state_expanded_description" gender="unknown">izvērsts</string>
     <string name="state_collapsed_description" gender="unknown">sakļauts</string>
     <string name="state_unselected_description" gender="unknown">nav atlasīts</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-mk/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-mk/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">Лента со алатки</string>
     <string name="summary_description" gender="unknown">Резиме</string>
     <string name="state_busy_description" gender="unknown">зафатено</string>
+    <string name="state_invalid_description" gender="unknown">невалидно</string>
     <string name="state_expanded_description" gender="unknown">проширено</string>
     <string name="state_collapsed_description" gender="unknown">собрано</string>
     <string name="state_unselected_description" gender="unknown">изборот е поништен</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-ml/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-ml/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">ടൂൾ ബാർ</string>
     <string name="summary_description" gender="unknown">സംഗ്രഹം</string>
     <string name="state_busy_description" gender="unknown">തിരക്കിലാണ്</string>
+    <string name="state_invalid_description" gender="unknown">അസാധുവായ</string>
     <string name="state_expanded_description" gender="unknown">വിപുലീകരിച്ചു</string>
     <string name="state_collapsed_description" gender="unknown">ചുരുക്കി</string>
     <string name="state_unselected_description" gender="unknown">തിരഞ്ഞെടുത്തത് മാറ്റി</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-mr/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-mr/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">टूल बार</string>
     <string name="summary_description" gender="unknown">सारांश</string>
     <string name="state_busy_description" gender="unknown">व्यग्र</string>
+    <string name="state_invalid_description" gender="unknown">अवैध</string>
     <string name="state_expanded_description" gender="unknown">विस्तारित केले</string>
     <string name="state_collapsed_description" gender="unknown">संकुचित केले</string>
     <string name="state_unselected_description" gender="unknown">निवड रद्द केलेले</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-ms/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-ms/strings.xml
@@ -20,6 +20,7 @@
     <string name="toolbar_description" gender="unknown">Bar Alat</string>
     <string name="summary_description" gender="unknown">Ringkasan</string>
     <string name="state_busy_description" gender="unknown">sibuk</string>
+    <string name="state_invalid_description" gender="unknown">tidak sah</string>
     <string name="state_expanded_description" gender="unknown">dikembangkan</string>
     <string name="state_collapsed_description" gender="unknown">diruntuhkan</string>
     <string name="state_unselected_description" gender="unknown">dinyahpilih</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-my/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-my/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">ကိရိယာ ဘားတန်း</string>
     <string name="summary_description" gender="unknown">အနှစ်ချုပ်</string>
     <string name="state_busy_description" gender="unknown">လုပ်ဆောင်နေဆဲ</string>
+    <string name="state_invalid_description" gender="unknown">မှန်ကန်မှုမရှိ</string>
     <string name="state_expanded_description" gender="unknown">ချဲ့ထားပြီး</string>
     <string name="state_collapsed_description" gender="unknown">ခေါက်သိမ်းထားပါတယ်</string>
     <string name="state_unselected_description" gender="unknown">ရွေးမထားပါ</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-nl/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-nl/strings.xml
@@ -19,6 +19,7 @@
     <string name="toolbar_description" gender="unknown">Werkbalk</string>
     <string name="summary_description" gender="unknown">Samenvatting</string>
     <string name="state_busy_description" gender="unknown">bezig</string>
+    <string name="state_invalid_description" gender="unknown">ongeldig</string>
     <string name="state_expanded_description" gender="unknown">uitgevouwen</string>
     <string name="state_collapsed_description" gender="unknown">samengevouwen</string>
     <string name="state_unselected_description" gender="unknown">gedeselecteerd</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-pa/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-pa/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">ਟੂਲ ਬਾਰ</string>
     <string name="summary_description" gender="unknown">ਸਾਰ</string>
     <string name="state_busy_description" gender="unknown">ਵਿਅਸਤ</string>
+    <string name="state_invalid_description" gender="unknown">ਅਵੈਧ</string>
     <string name="state_expanded_description" gender="unknown">ਵਿਸਤਾਰ ਕੀਤਾ ਗਿਆ</string>
     <string name="state_collapsed_description" gender="unknown">ਸਮੇਟਿਆ ਗਿਆ</string>
     <string name="state_unselected_description" gender="unknown">ਚੋਣ ਹਟਾਈ ਗਈ</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-pl/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-pl/strings.xml
@@ -19,6 +19,7 @@
     <string name="toolbar_description" gender="unknown">Pasek narzędzi</string>
     <string name="summary_description" gender="unknown">Podsumowanie</string>
     <string name="state_busy_description" gender="unknown">zajęte</string>
+    <string name="state_invalid_description" gender="unknown">nieprawidłowe</string>
     <string name="state_expanded_description" gender="unknown">rozwinięte</string>
     <string name="state_collapsed_description" gender="unknown">zwinięte</string>
     <string name="state_unselected_description" gender="unknown">nie wybrano</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-pt-rPT/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-pt-rPT/strings.xml
@@ -21,6 +21,7 @@
     <string name="toolbar_description" gender="unknown">Barra de ferramentas</string>
     <string name="summary_description" gender="unknown">Resumo</string>
     <string name="state_busy_description" gender="unknown">ocupado</string>
+    <string name="state_invalid_description" gender="unknown">inválido</string>
     <string name="state_expanded_description" gender="unknown">expandido</string>
     <string name="state_collapsed_description" gender="unknown">fechado</string>
     <string name="state_unselected_description" gender="unknown">não selecionado</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-pt/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-pt/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">Barra de ferramentas</string>
     <string name="summary_description" gender="unknown">Resumo</string>
     <string name="state_busy_description" gender="unknown">ocupado</string>
+    <string name="state_invalid_description" gender="unknown">inválido</string>
     <string name="state_expanded_description" gender="unknown">expandido</string>
     <string name="state_collapsed_description" gender="unknown">recolhido</string>
     <string name="state_unselected_description" gender="unknown">desmarcados</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-ro/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-ro/strings.xml
@@ -20,6 +20,7 @@
     <string name="toolbar_description" gender="unknown">Bară de instrumente</string>
     <string name="summary_description" gender="unknown">Rezumat</string>
     <string name="state_busy_description" gender="unknown">ocupat</string>
+    <string name="state_invalid_description" gender="unknown">invalid</string>
     <string name="state_expanded_description" gender="unknown">extins</string>
     <string name="state_collapsed_description" gender="unknown">restrâns</string>
     <string name="state_unselected_description" gender="unknown">neselectat</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-ru/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-ru/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">Панель инструментов</string>
     <string name="summary_description" gender="unknown">Сводка</string>
     <string name="state_busy_description" gender="unknown">занято</string>
+    <string name="state_invalid_description" gender="unknown">недействительно</string>
     <string name="state_expanded_description" gender="unknown">развернуто</string>
     <string name="state_collapsed_description" gender="unknown">свернуто</string>
     <string name="state_unselected_description" gender="unknown">не выбрано</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-si/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-si/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">මෙවලම් තීරුව</string>
     <string name="summary_description" gender="unknown">සාරාංශය</string>
     <string name="state_busy_description" gender="unknown">කාර්යබහුලයි</string>
+    <string name="state_invalid_description" gender="unknown">අවලංගු</string>
     <string name="state_expanded_description" gender="unknown">විහිදුවන ලදි</string>
     <string name="state_collapsed_description" gender="unknown">හකුළන ලදී</string>
     <string name="state_unselected_description" gender="unknown">තේරීම ඉවත් කරන ලද</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-sk/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-sk/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">Panel s nástrojmi</string>
     <string name="summary_description" gender="unknown">Súhrn</string>
     <string name="state_busy_description" gender="unknown">obsadené</string>
+    <string name="state_invalid_description" gender="unknown">neplatné</string>
     <string name="state_expanded_description" gender="unknown">rozbalené</string>
     <string name="state_collapsed_description" gender="unknown">zbalené</string>
     <string name="state_unselected_description" gender="unknown">nevybrané</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-sl/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-sl/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">Vrstica z orodji</string>
     <string name="summary_description" gender="unknown">Povzetek</string>
     <string name="state_busy_description" gender="unknown">zasedeno</string>
+    <string name="state_invalid_description" gender="unknown">neveljavno</string>
     <string name="state_expanded_description" gender="unknown">razširjen</string>
     <string name="state_collapsed_description" gender="unknown">strnjeno</string>
     <string name="state_unselected_description" gender="unknown">neizbrano</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-sq/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-sq/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">Shiriti i mjeteve</string>
     <string name="summary_description" gender="unknown">Përmbledhja</string>
     <string name="state_busy_description" gender="unknown">I zënë</string>
+    <string name="state_invalid_description" gender="unknown">I pavlefshëm</string>
     <string name="state_expanded_description" gender="unknown">zgjeruar</string>
     <string name="state_collapsed_description" gender="unknown">palosur</string>
     <string name="state_unselected_description" gender="unknown">i pazgjedhur</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-sr/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-sr/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">Трака са алаткама</string>
     <string name="summary_description" gender="unknown">Резиме</string>
     <string name="state_busy_description" gender="unknown">заузето</string>
+    <string name="state_invalid_description" gender="unknown">неважећи</string>
     <string name="state_expanded_description" gender="unknown">проширено</string>
     <string name="state_collapsed_description" gender="unknown">скупљено</string>
     <string name="state_unselected_description" gender="unknown">избор опозван</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-sv/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-sv/strings.xml
@@ -21,6 +21,7 @@
     <string name="toolbar_description" gender="unknown">Verktygsfält</string>
     <string name="summary_description" gender="unknown">Sammanfattning</string>
     <string name="state_busy_description" gender="unknown">upptagen</string>
+    <string name="state_invalid_description" gender="unknown">ogiltig</string>
     <string name="state_expanded_description" gender="unknown">utökad</string>
     <string name="state_collapsed_description" gender="unknown">minimerad</string>
     <string name="state_unselected_description" gender="unknown">avmarkerad</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-sw/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-sw/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">Upau wa Zana</string>
     <string name="summary_description" gender="unknown">Muhtasari</string>
     <string name="state_busy_description" gender="unknown">shughulini</string>
+    <string name="state_invalid_description" gender="unknown">batili</string>
     <string name="state_expanded_description" gender="unknown">imepanuliwa</string>
     <string name="state_collapsed_description" gender="unknown">imekunjwa</string>
     <string name="state_unselected_description" gender="unknown">haijateuliwa</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-ta/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-ta/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">கருவிப்பட்டி</string>
     <string name="summary_description" gender="unknown">சுருக்கம்</string>
     <string name="state_busy_description" gender="unknown">பணிமிகுதி</string>
+    <string name="state_invalid_description" gender="unknown">செல்லாதது</string>
     <string name="state_expanded_description" gender="unknown">விரிவாக்கப்பட்டது</string>
     <string name="state_collapsed_description" gender="unknown">சுருக்கப்பட்டது</string>
     <string name="state_unselected_description" gender="unknown">தேர்வுநீக்கப்பட்டது</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-te/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-te/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">టూల్ బార్</string>
     <string name="summary_description" gender="unknown">సమ్మరీ</string>
     <string name="state_busy_description" gender="unknown">బిజీగా ఉన్నారు</string>
+    <string name="state_invalid_description" gender="unknown">చెల్లన</string>
     <string name="state_expanded_description" gender="unknown">విస్తరింపబడింది</string>
     <string name="state_collapsed_description" gender="unknown">కుదించబడింది</string>
     <string name="state_unselected_description" gender="unknown">ఎంపిక తీసివేసారు</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-th/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-th/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">แถบเครื่องมือ</string>
     <string name="summary_description" gender="unknown">สรุป</string>
     <string name="state_busy_description" gender="unknown">ไม่ว่าง</string>
+    <string name="state_invalid_description" gender="unknown">ไม่ถูกต้อง</string>
     <string name="state_expanded_description" gender="unknown">ขยายแล้ว</string>
     <string name="state_collapsed_description" gender="unknown">ยุบแล้ว</string>
     <string name="state_unselected_description" gender="unknown">ไม่ได้เลือก</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-tr/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-tr/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">Araç Çubuğu</string>
     <string name="summary_description" gender="unknown">Özet</string>
     <string name="state_busy_description" gender="unknown">meşgul</string>
+    <string name="state_invalid_description" gender="unknown">geçersiz</string>
     <string name="state_expanded_description" gender="unknown">genişletilmiş</string>
     <string name="state_collapsed_description" gender="unknown">daraltılmış</string>
     <string name="state_unselected_description" gender="unknown">seçili değil</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-uk/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-uk/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">Панель інструментів</string>
     <string name="summary_description" gender="unknown">Зведення</string>
     <string name="state_busy_description" gender="unknown">зайнято</string>
+    <string name="state_invalid_description" gender="unknown">недійсний</string>
     <string name="state_expanded_description" gender="unknown">розгорнуто</string>
     <string name="state_collapsed_description" gender="unknown">згорнуто</string>
     <string name="state_unselected_description" gender="unknown">не вибрано</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-ur/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-ur/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">ٹول بار</string>
     <string name="summary_description" gender="unknown">خلاصہ</string>
     <string name="state_busy_description" gender="unknown">مصروف</string>
+    <string name="state_invalid_description" gender="unknown">غیر معتبر</string>
     <string name="state_expanded_description" gender="unknown">توسیع کیا گیا</string>
     <string name="state_collapsed_description" gender="unknown">سکیڑا گیا</string>
     <string name="state_unselected_description" gender="unknown">غیر منتخب کردہ</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-vi/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-vi/strings.xml
@@ -20,6 +20,7 @@
     <string name="toolbar_description" gender="unknown">Thanh công cụ</string>
     <string name="summary_description" gender="unknown">Tóm tắt</string>
     <string name="state_busy_description" gender="unknown">bận</string>
+    <string name="state_invalid_description" gender="unknown">không hợp lệ</string>
     <string name="state_expanded_description" gender="unknown">đã mở rộng</string>
     <string name="state_collapsed_description" gender="unknown">đã thu gọn</string>
     <string name="state_unselected_description" gender="unknown">không được chọn</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-zh-rCN/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-zh-rCN/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">工具栏</string>
     <string name="summary_description" gender="unknown">摘要</string>
     <string name="state_busy_description" gender="unknown">忙碌中</string>
+    <string name="state_invalid_description" gender="unknown">无效</string>
     <string name="state_expanded_description" gender="unknown">已展开</string>
     <string name="state_collapsed_description" gender="unknown">已收起</string>
     <string name="state_unselected_description" gender="unknown">未选中</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-zh-rHK/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-zh-rHK/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">工具列</string>
     <string name="summary_description" gender="unknown">摘要</string>
     <string name="state_busy_description" gender="unknown">忙碌中</string>
+    <string name="state_invalid_description" gender="unknown">無效</string>
     <string name="state_expanded_description" gender="unknown">已展開</string>
     <string name="state_collapsed_description" gender="unknown">已收合</string>
     <string name="state_unselected_description" gender="unknown">已取消選取</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-zh-rTW/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values-zh-rTW/strings.xml
@@ -22,6 +22,7 @@
     <string name="toolbar_description" gender="unknown">工具列</string>
     <string name="summary_description" gender="unknown">摘要</string>
     <string name="state_busy_description" gender="unknown">忙碌中</string>
+    <string name="state_invalid_description" gender="unknown">無效</string>
     <string name="state_expanded_description" gender="unknown">已展開</string>
     <string name="state_collapsed_description" gender="unknown">已收合</string>
     <string name="state_unselected_description" gender="unknown">已取消選取</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values/strings.xml
@@ -77,6 +77,10 @@
     description="an element currently being updated or modified"
     >busy</string>
   <string
+    name="state_invalid_description"
+    description="input field that has failed validation or does not conform to the expected format"
+    >an input field which has failed validation or does not conform to the expected format</string>
+  <string
     name="state_expanded_description"
     description="a menu, dialog, accordian panel, or other widget which is expanded"
     >expanded</string>

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values/strings.xml
@@ -78,8 +78,8 @@
     >busy</string>
   <string
     name="state_invalid_description"
-    description="input field that has failed validation or does not conform to the expected format"
-    >an input field which has failed validation or does not conform to the expected format</string>
+    description="an input field which has failed validation or does not conform to the expected format"
+    >invalid</string>
   <string
     name="state_expanded_description"
     description="a menu, dialog, accordian panel, or other widget which is expanded"

--- a/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityPrimitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityPrimitives.h
@@ -69,6 +69,7 @@ struct AccessibilityState {
   bool disabled{false};
   bool selected{false};
   bool busy{false};
+  bool invalid{false};
   std::optional<bool> expanded{std::nullopt};
   enum { Unchecked, Checked, Mixed, None } checked{None};
 };
@@ -78,7 +79,7 @@ constexpr bool operator==(
     const AccessibilityState& rhs) {
   return lhs.disabled == rhs.disabled && lhs.selected == rhs.selected &&
       lhs.checked == rhs.checked && lhs.busy == rhs.busy &&
-      lhs.expanded == rhs.expanded;
+      lhs.expanded == rhs.expanded && lhs.invalid == rhs.invalid;
 }
 
 constexpr bool operator!=(

--- a/packages/react-native/ReactCommon/react/renderer/components/view/accessibilityPropsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/accessibilityPropsConversions.h
@@ -170,6 +170,10 @@ inline void fromRawValue(
   if (expanded != map.end()) {
     fromRawValue(context, expanded->second, result.expanded);
   }
+  auto invalid = map.find("invalid");
+  if (invalid != map.end()) {
+    fromRawValue(context, invalid->second, result.invalid);
+  }
 }
 
 inline std::string toString(

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
@@ -454,6 +454,10 @@ inline static void updateAccessibilityStateProp(
     resultState["busy"] = newState->busy;
   }
 
+  if (!oldState.has_value() || newState->invalid != oldState->invalid) {
+    resultState["invalid"] = newState->invalid;
+  }
+
   if (!oldState.has_value() || newState->expanded != oldState->expanded) {
     resultState["expanded"] =
         newState->expanded.has_value() && newState->expanded.value();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
I would like to add support for the aria-invalid property which exists in web but is not currently supported in React Native.

Similar to aria-busy, this implementation will allow components to receive the following properties:
- aria-invalid
- accessibilityState.invalid

I am proposing this enhancement for the following reasons:
- [The RFC for React DOM for Native](https://github.com/react-native-community/discussions-and-proposals/pull/496) proposes support for the aria-invalid property, but it hasn't been implemented yet
- This will enable form testing tools like Maestro and Jest to programmatically identify field errors beyond just string matching, making automated testing more robust
  - Maestro: [assertVisible](https://docs.maestro.dev/api-reference/commands/assertvisible)
  - React Native Testing Library: [Accessibility State](https://github.com/callstack/react-native-testing-library/wiki/Accessibility:-State)

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[GENERAL] [ADDED] - Add `aria-invalid` and `accessibilityState.invalid` to some components

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- `yarn test`
- `yarn lint`
