### PR TITLE
fix: run monitor-new-issues only in the main repo

### DIFF
--- a/.github/workflows/monitor-new-issues.yml
+++ b/.github/workflows/monitor-new-issues.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   monitor-issues:
     runs-on: ubuntu-latest
+    if: github.repository == 'facebook/react-native'
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary:

This PR makes sure that monitor-new-issues runs only in the main repo. It was failing on my fork and spamming notifications. 

## Changelog:

[INTERNAL] [FIXED] - run monitor-new-issues only in the main repo

## Test Plan:

CI Green
