### PR TITLE
Refactor InterruptibleRendering Fantom test to use dispatchNativeEvent

### DIFF
--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -348,7 +348,9 @@ export function dispatchNativeEvent(
     enqueueNativeEvent(node, type, payload, options);
   });
 
-  runWorkLoop();
+  if (!flushingQueue) {
+    runWorkLoop();
+  }
 }
 
 export type ScrollEventOptions = {

--- a/packages/react-native/Libraries/ReactNative/__tests__/InterruptibleRendering-itest.js
+++ b/packages/react-native/Libraries/ReactNative/__tests__/InterruptibleRendering-itest.js
@@ -43,18 +43,16 @@ describe('discrete event category', () => {
       if (interruptRendering) {
         interruptRendering = false;
         const element = ensureReactNativeElement(textInputRef.current);
-        Fantom.runOnUIThread(() => {
-          Fantom.enqueueNativeEvent(
-            element,
-            'change',
-            {
-              text: 'update from native',
-            },
-            {
-              category: NativeEventCategory.Discrete,
-            },
-          );
-        });
+        Fantom.dispatchNativeEvent(
+          element,
+          'change',
+          {
+            text: 'update from native',
+          },
+          {
+            category: NativeEventCategory.Discrete,
+          },
+        );
         // We must schedule a task that is run right after the above native event is
         // processed to be able to observe the results of rendering.
         Fantom.scheduleTask(afterUpdate);
@@ -149,21 +147,19 @@ describe('continuous event category', () => {
       if (interruptRendering) {
         interruptRendering = false;
         const element = ensureReactNativeElement(textInputRef.current);
-        Fantom.runOnUIThread(() => {
-          Fantom.enqueueNativeEvent(
-            element,
-            'selectionChange',
-            {
-              selection: {
-                start: 1,
-                end: 5,
-              },
+        Fantom.dispatchNativeEvent(
+          element,
+          'selectionChange',
+          {
+            selection: {
+              start: 1,
+              end: 5,
             },
-            {
-              category: NativeEventCategory.Continuous,
-            },
-          );
-        });
+          },
+          {
+            category: NativeEventCategory.Continuous,
+          },
+        );
       }
       useEffect(() => {
         effectMock({text, deferredText});


### PR DESCRIPTION
Summary:
Changelog: [internal]

Now we can use the higher level API for event dispatching in this test.

Differential Revision: D73663626


