### PR TITLE
Migrate already root exported deep imports in rn-tester.

### DIFF
--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -9256,6 +9256,7 @@ export type {
   LayoutChangeEvent,
   LayoutRectangle,
   MouseEvent,
+  PointerEvent,
   NativeMouseEvent,
   NativePointerEvent,
   NativeScrollEvent,

--- a/packages/react-native/index.js.flow
+++ b/packages/react-native/index.js.flow
@@ -411,6 +411,7 @@ export type {
   LayoutChangeEvent,
   LayoutRectangle,
   MouseEvent,
+  PointerEvent,
   NativeMouseEvent,
   NativePointerEvent,
   NativeScrollEvent,

--- a/packages/rn-tester/IntegrationTests/ImageCachePolicyTest.js
+++ b/packages/rn-tester/IntegrationTests/ImageCachePolicyTest.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-import type {ImageURISource} from 'react-native/Libraries/Image/ImageSource';
+import type {ImageURISource} from 'react-native';
 
 import * as React from 'react';
 import {useEffect, useState} from 'react';

--- a/packages/rn-tester/IntegrationTests/LayoutEventsTest.js
+++ b/packages/rn-tester/IntegrationTests/LayoutEventsTest.js
@@ -10,11 +10,8 @@
 
 'use strict';
 
+import type {LayoutChangeEvent, LayoutRectangle} from 'react-native';
 import type {ViewStyleProp} from 'react-native/Libraries/StyleSheet/StyleSheet';
-import type {
-  LayoutChangeEvent,
-  LayoutRectangle,
-} from 'react-native/Libraries/Types/CoreEventTypes';
 
 const React = require('react');
 const ReactNative = require('react-native');

--- a/packages/rn-tester/NativeComponentExample/js/MyLegacyViewNativeComponent.js
+++ b/packages/rn-tester/NativeComponentExample/js/MyLegacyViewNativeComponent.js
@@ -8,8 +8,7 @@
  * @format
  */
 
-import type {HostComponent} from 'react-native';
-import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
+import type {HostComponent, ViewProps} from 'react-native';
 
 import ReactNative from '../../../react-native/Libraries/Renderer/shims/ReactNative';
 import * as React from 'react';

--- a/packages/rn-tester/NativeComponentExample/js/MyNativeViewNativeComponent.js
+++ b/packages/rn-tester/NativeComponentExample/js/MyNativeViewNativeComponent.js
@@ -8,8 +8,7 @@
  * @format
  */
 
-import type {HostComponent} from 'react-native';
-import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
+import type {HostComponent, ViewProps} from 'react-native';
 import type {
   BubblingEventHandler,
   Double,
@@ -18,8 +17,7 @@ import type {
 } from 'react-native/Libraries/Types/CodegenTypes';
 
 import * as React from 'react';
-import codegenNativeCommands from 'react-native/Libraries/Utilities/codegenNativeCommands';
-import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+import {codegenNativeCommands, codegenNativeComponent} from 'react-native';
 
 type Event = $ReadOnly<{
   values: $ReadOnlyArray<Int32>,

--- a/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.js
+++ b/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
+import type {TurboModule} from 'react-native';
 import type {EventEmitter} from 'react-native/Libraries/Types/CodegenTypes';
 
 import {TurboModuleRegistry} from 'react-native';

--- a/packages/rn-tester/NativeModuleExample/NativeScreenshotManager.js
+++ b/packages/rn-tester/NativeModuleExample/NativeScreenshotManager.js
@@ -8,10 +8,10 @@
  * @format
  */
 
-import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
+import type {TurboModule} from 'react-native';
 import type {UnsafeObject} from 'react-native/Libraries/Types/CodegenTypes';
 
-import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';
+import {TurboModuleRegistry} from 'react-native';
 
 export type ScreenshotManagerOptions = UnsafeObject;
 

--- a/packages/rn-tester/RCTTest/RCTSnapshotNativeComponent.js
+++ b/packages/rn-tester/RCTTest/RCTSnapshotNativeComponent.js
@@ -10,9 +10,11 @@
 
 'use strict';
 
-import type {HostComponent} from 'react-native';
-import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
-import type {NativeSyntheticEvent} from 'react-native/Libraries/Types/CoreEventTypes';
+import type {
+  HostComponent,
+  NativeSyntheticEvent,
+  ViewProps,
+} from 'react-native';
 
 const {requireNativeComponent} = require('react-native');
 

--- a/packages/rn-tester/ReportFullyDrawnView/ReportFullyDrawnViewNativeComponent.js
+++ b/packages/rn-tester/ReportFullyDrawnView/ReportFullyDrawnViewNativeComponent.js
@@ -9,9 +9,9 @@
  */
 
 import type {HostComponent} from 'react-native';
-import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
+import type {ViewProps} from 'react-native';
 
-import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
+import {codegenNativeComponent} from 'react-native';
 
 type NativeProps = $ReadOnly<{
   ...ViewProps,

--- a/packages/rn-tester/js/components/RNTOption.js
+++ b/packages/rn-tester/js/components/RNTOption.js
@@ -10,8 +10,8 @@
 
 'use strict';
 
+import type {GestureResponderEvent} from 'react-native';
 import type {ViewStyleProp} from 'react-native/Libraries/StyleSheet/StyleSheet';
-import type {GestureResponderEvent} from 'react-native/Libraries/Types/CoreEventTypes';
 
 import {RNTesterThemeContext} from './RNTesterTheme';
 import * as React from 'react';

--- a/packages/rn-tester/js/components/RNTesterButton.js
+++ b/packages/rn-tester/js/components/RNTesterButton.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-import type {GestureResponderEvent} from 'react-native/Libraries/Types/CoreEventTypes';
+import type {GestureResponderEvent} from 'react-native';
 
 import React from 'react';
 import {Pressable, StyleSheet, Text} from 'react-native';

--- a/packages/rn-tester/js/components/RNTesterText.js
+++ b/packages/rn-tester/js/components/RNTesterText.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-import type {TextProps} from 'react-native/Libraries/Text/TextProps';
+import type {TextProps} from 'react-native';
 
 import {RNTesterThemeContext} from './RNTesterTheme';
 import React, {useContext, useMemo} from 'react';

--- a/packages/rn-tester/js/components/RNTesterTheme.js
+++ b/packages/rn-tester/js/components/RNTesterTheme.js
@@ -8,8 +8,7 @@
  * @format
  */
 
-import type {ImageSource} from 'react-native/Libraries/Image/ImageSource';
-import type {ColorValue} from 'react-native/Libraries/StyleSheet/StyleSheet';
+import type {ColorValue, ImageSource} from 'react-native';
 
 import * as React from 'react';
 import {Appearance} from 'react-native';

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
@@ -10,8 +10,7 @@
 
 'use strict';
 
-import type {GestureResponderEvent} from 'react-native/Libraries/Types/CoreEventTypes';
-import type {EventSubscription} from 'react-native/Libraries/vendor/emitter/EventEmitter';
+import type {EventSubscription, GestureResponderEvent} from 'react-native';
 
 import RNTesterBlock from '../../components/RNTesterBlock';
 import RNTesterText from '../../components/RNTesterText';

--- a/packages/rn-tester/js/examples/AnimatedGratuitousApp/AnExChained.js
+++ b/packages/rn-tester/js/examples/AnimatedGratuitousApp/AnExChained.js
@@ -10,8 +10,10 @@
 
 'use strict';
 
-import type {PanResponderGestureState} from 'react-native/Libraries/Interaction/PanResponder';
-import type {GestureResponderEvent} from 'react-native/Libraries/Types/CoreEventTypes';
+import type {
+  GestureResponderEvent,
+  PanResponderGestureState,
+} from 'react-native';
 
 import React from 'react';
 import {Animated, PanResponder, StyleSheet, View} from 'react-native';

--- a/packages/rn-tester/js/examples/Appearance/AppearanceExample.js
+++ b/packages/rn-tester/js/examples/Appearance/AppearanceExample.js
@@ -8,7 +8,7 @@
  * @flow
  */
 
-import type {ColorSchemeName} from 'react-native/Libraries/Utilities/NativeAppearance';
+import type {ColorSchemeName} from 'react-native';
 
 import RNTesterText from '../../components/RNTesterText';
 import {RNTesterThemeContext, themes} from '../../components/RNTesterTheme';

--- a/packages/rn-tester/js/examples/Experimental/Compatibility/ManyPointersPropertiesExample.js
+++ b/packages/rn-tester/js/examples/Experimental/Compatibility/ManyPointersPropertiesExample.js
@@ -9,7 +9,7 @@
  */
 
 import type {RNTesterModuleExample} from '../../../types/RNTesterTypes';
-import type {PointerEvent} from 'react-native/Libraries/Types/CoreEventTypes';
+import type {PointerEvent} from 'react-native';
 
 import * as React from 'react';
 import {StyleSheet, Text, View} from 'react-native';

--- a/packages/rn-tester/js/examples/Experimental/PlatformTest/RNTesterPlatformTestEventRecorder.js
+++ b/packages/rn-tester/js/examples/Experimental/PlatformTest/RNTesterPlatformTestEventRecorder.js
@@ -8,7 +8,7 @@
  * @flow
  */
 
-import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
+import type {ViewProps} from 'react-native';
 
 import {useMemo} from 'react';
 

--- a/packages/rn-tester/js/examples/Experimental/PlatformTest/RNTesterPlatformTestResultView.js
+++ b/packages/rn-tester/js/examples/Experimental/PlatformTest/RNTesterPlatformTestResultView.js
@@ -12,11 +12,8 @@ import type {
   PlatformTestResult,
   PlatformTestResultStatus,
 } from './RNTesterPlatformTestTypes';
-import type {ListRenderItemInfo} from 'react-native/Libraries/Lists/VirtualizedList';
-import type {
-  TextStyle,
-  ViewStyleProp,
-} from 'react-native/Libraries/StyleSheet/StyleSheet';
+import type {ListRenderItemInfo, TextStyle} from 'react-native';
+import type {ViewStyleProp} from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 import RNTesterPlatformTestMinimizedResultView from './RNTesterPlatformTestMinimizedResultView';
 import RNTesterPlatformTestResultsText from './RNTesterPlatformTestResultsText';

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventAccessibility.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventAccessibility.js
@@ -9,7 +9,7 @@
  */
 
 import type {EventOccurrence} from './PointerEventSupport';
-import type {PointerEvent} from 'react-native/Libraries/Types/CoreEventTypes';
+import type {PointerEvent} from 'react-native';
 
 import {EventTracker} from './PointerEventSupport';
 import * as React from 'react';

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventAttributesHoverablePointers.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventAttributesHoverablePointers.js
@@ -9,11 +9,7 @@
  */
 
 import type {PlatformTestComponentBaseProps} from '../PlatformTest/RNTesterPlatformTestTypes';
-import type {HostInstance} from 'react-native';
-import type {
-  LayoutRectangle,
-  PointerEvent,
-} from 'react-native/Libraries/Types/CoreEventTypes';
+import type {HostInstance, LayoutRectangle, PointerEvent} from 'react-native';
 
 import RNTesterPlatformTest from '../PlatformTest/RNTesterPlatformTest';
 import {check_PointerEvent, useTestEventHandler} from './PointerEventSupport';

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventAttributesNoHoverPointers.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventAttributesNoHoverPointers.js
@@ -9,11 +9,7 @@
  */
 
 import type {PlatformTestComponentBaseProps} from '../PlatformTest/RNTesterPlatformTestTypes';
-import type {HostInstance} from 'react-native';
-import type {
-  LayoutRectangle,
-  PointerEvent,
-} from 'react-native/Libraries/Types/CoreEventTypes';
+import type {HostInstance, LayoutRectangle, PointerEvent} from 'react-native';
 
 import RNTesterPlatformTest from '../PlatformTest/RNTesterPlatformTest';
 import {check_PointerEvent, useTestEventHandler} from './PointerEventSupport';

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventCaptureMouse.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventCaptureMouse.js
@@ -10,7 +10,7 @@
 
 import type {PlatformTestComponentBaseProps} from '../PlatformTest/RNTesterPlatformTestTypes';
 import type {ElementRef} from 'react';
-import type {PointerEvent} from 'react-native/Libraries/Types/CoreEventTypes';
+import type {PointerEvent} from 'react-native';
 
 import RNTesterPlatformTest from '../PlatformTest/RNTesterPlatformTest';
 import * as React from 'react';

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventClickTouch.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventClickTouch.js
@@ -10,7 +10,7 @@
 
 import type {PlatformTestComponentBaseProps} from '../PlatformTest/RNTesterPlatformTestTypes';
 import type {PlatformTestContext} from '../PlatformTest/RNTesterPlatformTestTypes';
-import type {PointerEvent} from 'react-native/Libraries/Types/CoreEventTypes';
+import type {PointerEvent} from 'react-native';
 
 import RNTesterPlatformTest from '../PlatformTest/RNTesterPlatformTest';
 import {check_PointerEvent} from './PointerEventSupport';

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventClickTouchHierarchyPointerEvents.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventClickTouchHierarchyPointerEvents.js
@@ -10,7 +10,7 @@
 
 import type {PlatformTestComponentBaseProps} from '../PlatformTest/RNTesterPlatformTestTypes';
 import type {EventOccurrence, EventTrackerProps} from './PointerEventSupport';
-import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
+import type {ViewProps} from 'react-native';
 
 import RNTesterPlatformTest from '../PlatformTest/RNTesterPlatformTest';
 import {EventTracker, mkEvent} from './PointerEventSupport';

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventLayoutChangeShouldFirePointerOver.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventLayoutChangeShouldFirePointerOver.js
@@ -9,7 +9,7 @@
  */
 
 import type {PlatformTestComponentBaseProps} from '../PlatformTest/RNTesterPlatformTestTypes';
-import type {PointerEvent} from 'react-native/Libraries/Types/CoreEventTypes';
+import type {PointerEvent} from 'react-native';
 
 import RNTesterPlatformTest from '../PlatformTest/RNTesterPlatformTest';
 import * as React from 'react';

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerCancelTouch.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerCancelTouch.js
@@ -9,7 +9,7 @@
  */
 
 import type {PlatformTestComponentBaseProps} from '../PlatformTest/RNTesterPlatformTestTypes';
-import type {PointerEvent} from 'react-native/Libraries/Types/CoreEventTypes';
+import type {PointerEvent} from 'react-native';
 
 import RNTesterPlatformTest from '../PlatformTest/RNTesterPlatformTest';
 import {check_PointerEvent} from './PointerEventSupport';

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerMove.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerMove.js
@@ -11,7 +11,7 @@
 // adapted from https://github.com/web-platform-tests/wpt/blob/master/pointerevents/pointerevent_pointermove.html
 
 import type {PlatformTestComponentBaseProps} from '../PlatformTest/RNTesterPlatformTestTypes';
-import type {PointerEvent} from 'react-native/Libraries/Types/CoreEventTypes';
+import type {PointerEvent} from 'react-native';
 
 import RNTesterPlatformTest from '../PlatformTest/RNTesterPlatformTest';
 import {useTestEventHandler} from './PointerEventSupport';

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerMoveEventOrder.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerMoveEventOrder.js
@@ -9,7 +9,7 @@
  */
 
 import type {PlatformTestComponentBaseProps} from '../PlatformTest/RNTesterPlatformTestTypes';
-import type {PointerEvent} from 'react-native/Libraries/Types/CoreEventTypes';
+import type {PointerEvent} from 'react-native';
 
 import RNTesterPlatformTest from '../PlatformTest/RNTesterPlatformTest';
 import RNTesterPlatformTestEventRecorder from '../PlatformTest/RNTesterPlatformTestEventRecorder';

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerMoveOnChordedMouseButton.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerMoveOnChordedMouseButton.js
@@ -9,7 +9,7 @@
  */
 
 import type {PlatformTestComponentBaseProps} from '../PlatformTest/RNTesterPlatformTestTypes';
-import type {PointerEvent} from 'react-native/Libraries/Types/CoreEventTypes';
+import type {PointerEvent} from 'react-native';
 
 import RNTesterPlatformTest from '../PlatformTest/RNTesterPlatformTest';
 import * as React from 'react';

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerOverOut.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerOverOut.js
@@ -9,8 +9,7 @@
  */
 
 import type {PlatformTestComponentBaseProps} from '../PlatformTest/RNTesterPlatformTestTypes';
-import type {HostInstance} from 'react-native';
-import type {PointerEvent} from 'react-native/Libraries/Types/CoreEventTypes';
+import type {HostInstance, PointerEvent} from 'react-native';
 
 import RNTesterPlatformTest from '../PlatformTest/RNTesterPlatformTest';
 import * as React from 'react';

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPrimaryTouchPointer.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPrimaryTouchPointer.js
@@ -9,7 +9,7 @@
  */
 
 import type {PlatformTestComponentBaseProps} from '../PlatformTest/RNTesterPlatformTestTypes';
-import type {PointerEvent} from 'react-native/Libraries/Types/CoreEventTypes';
+import type {PointerEvent} from 'react-native';
 
 import RNTesterPlatformTest from '../PlatformTest/RNTesterPlatformTest';
 import {useTestEventHandler} from './PointerEventSupport';

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventSupport.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventSupport.js
@@ -9,8 +9,7 @@
  */
 
 import type {PlatformTestHarness} from '../PlatformTest/RNTesterPlatformTestTypes';
-import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
-import type {PointerEvent} from 'react-native/Libraries/Types/CoreEventTypes';
+import type {PointerEvent, ViewProps} from 'react-native';
 
 import * as React from 'react';
 import {useMemo} from 'react';

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventsEventfulView.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventsEventfulView.js
@@ -8,8 +8,7 @@
  * @flow
  */
 
-import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
-import type {PointerEvent} from 'react-native/Libraries/Types/CoreEventTypes';
+import type {PointerEvent, ViewProps} from 'react-native';
 
 import * as React from 'react';
 import {StyleSheet, Text, View} from 'react-native';

--- a/packages/rn-tester/js/examples/FlatList/BaseFlatListExample.js
+++ b/packages/rn-tester/js/examples/FlatList/BaseFlatListExample.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-import type {ListRenderItemInfo} from 'react-native/Libraries/Lists/VirtualizedList';
+import type {ListRenderItemInfo} from 'react-native';
 
 import * as React from 'react';
 import {

--- a/packages/rn-tester/js/examples/FlatList/FlatList-basic.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatList-basic.js
@@ -12,8 +12,7 @@
 
 import type {Item} from '../../components/ListExampleShared';
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
-import type FlatList from 'react-native/Libraries/Lists/FlatList';
-import type {ListRenderItemInfo} from 'react-native/Libraries/Lists/VirtualizedList';
+import type {FlatList, ListRenderItemInfo} from 'react-native';
 
 import {
   FooterComponent,

--- a/packages/rn-tester/js/examples/FlatList/FlatList-multiColumn.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatList-multiColumn.js
@@ -12,7 +12,7 @@
 
 import type {Item} from '../../components/ListExampleShared';
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
-import type {ListRenderItemInfo} from 'react-native/Libraries/Lists/VirtualizedList';
+import type {ListRenderItemInfo} from 'react-native';
 
 import {
   FooterComponent,

--- a/packages/rn-tester/js/examples/FlatList/FlatList-nested.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatList-nested.js
@@ -11,8 +11,8 @@
 'use strict';
 
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+import type {ListRenderItemInfo} from 'react-native';
 import type {ViewToken} from 'react-native/Libraries/Lists/ViewabilityHelper';
-import type {ListRenderItemInfo} from 'react-native/Libraries/Lists/VirtualizedList';
 
 import RNTesterPage from '../../components/RNTesterPage';
 import RNTesterText from '../../components/RNTesterText';

--- a/packages/rn-tester/js/examples/FlatList/FlatList-stickyHeaders.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatList-stickyHeaders.js
@@ -9,7 +9,7 @@
  */
 
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
-import type {ListRenderItemInfo} from 'react-native/Libraries/Lists/VirtualizedList';
+import type {ListRenderItemInfo} from 'react-native';
 
 import * as React from 'react';
 import {FlatList, StyleSheet, Text, View} from 'react-native';

--- a/packages/rn-tester/js/examples/Image/ImageExample.js
+++ b/packages/rn-tester/js/examples/Image/ImageExample.js
@@ -11,8 +11,7 @@
 'use strict';
 
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
-import type {ImageProps} from 'react-native/Libraries/Image/ImageProps';
-import type {LayoutChangeEvent} from 'react-native/Libraries/Types/CoreEventTypes';
+import type {ImageProps, LayoutChangeEvent} from 'react-native';
 
 import RNTesterButton from '../../components/RNTesterButton';
 import RNTesterText from '../../components/RNTesterText';

--- a/packages/rn-tester/js/examples/Keyboard/KeyboardExample.js
+++ b/packages/rn-tester/js/examples/Keyboard/KeyboardExample.js
@@ -14,7 +14,7 @@ import type {
   RNTesterModule,
   RNTesterModuleExample,
 } from '../../types/RNTesterTypes';
-import type {KeyboardEvent} from 'react-native/Libraries/Components/Keyboard/Keyboard';
+import type {KeyboardEvent} from 'react-native';
 
 import RNTesterText from '../../components/RNTesterText';
 import * as React from 'react';

--- a/packages/rn-tester/js/examples/Modal/ModalPresentation.js
+++ b/packages/rn-tester/js/examples/Modal/ModalPresentation.js
@@ -11,7 +11,7 @@
 /* eslint-disable no-alert */
 
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
-import type {ModalProps} from 'react-native/Libraries/Modal/Modal';
+import type {ModalProps} from 'react-native';
 
 import RNTesterButton from '../../components/RNTesterButton';
 import RNTesterText from '../../components/RNTesterText';

--- a/packages/rn-tester/js/examples/Performance/components/ItemList.js
+++ b/packages/rn-tester/js/examples/Performance/components/ItemList.js
@@ -12,7 +12,7 @@
 'use strict';
 
 import type {ItemDataType} from './itemData';
-import type {ScrollEvent} from 'react-native/Libraries/Types/CoreEventTypes';
+import type {ScrollEvent} from 'react-native';
 
 import * as React from 'react';
 import {FlatList, ScrollView, StyleSheet, Text, View} from 'react-native';

--- a/packages/rn-tester/js/examples/Performance/performanceComparisonExamples/ReRenderWithNonPureChildExample.js
+++ b/packages/rn-tester/js/examples/Performance/performanceComparisonExamples/ReRenderWithNonPureChildExample.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-import type {ScrollEvent} from 'react-native/Libraries/Types/CoreEventTypes';
+import type {ScrollEvent} from 'react-native';
 
 import {LIST_100_ITEMS} from '../components/itemData';
 import ItemList from '../components/ItemList';

--- a/packages/rn-tester/js/examples/Performance/performanceComparisonExamples/ReRenderWithObjectPropExample.js
+++ b/packages/rn-tester/js/examples/Performance/performanceComparisonExamples/ReRenderWithObjectPropExample.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-import type {ScrollEvent} from 'react-native/Libraries/Types/CoreEventTypes';
+import type {ScrollEvent} from 'react-native';
 
 import {LIST_100_ITEMS} from '../components/itemData';
 import ItemList from '../components/ItemList';

--- a/packages/rn-tester/js/examples/PermissionsAndroid/PermissionsExample.js
+++ b/packages/rn-tester/js/examples/PermissionsAndroid/PermissionsExample.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-import type {Permission} from 'react-native/Libraries/PermissionsAndroid/PermissionsAndroid';
+import type {Permission} from 'react-native';
 
 import RNTesterButton from '../../components/RNTesterButton';
 import RNTesterText from '../../components/RNTesterText';

--- a/packages/rn-tester/js/examples/PlatformColor/PlatformColorExample.js
+++ b/packages/rn-tester/js/examples/PlatformColor/PlatformColorExample.js
@@ -10,8 +10,13 @@
 
 import RNTesterText from '../../components/RNTesterText';
 import React from 'react';
-import {DynamicColorIOS, PlatformColor, StyleSheet, View} from 'react-native';
-import Platform from 'react-native/Libraries/Utilities/Platform';
+import {
+  DynamicColorIOS,
+  Platform,
+  PlatformColor,
+  StyleSheet,
+  View,
+} from 'react-native';
 
 function PlatformColorsExample() {
   function createTable() {

--- a/packages/rn-tester/js/examples/SectionList/SectionList-scrollable.js
+++ b/packages/rn-tester/js/examples/SectionList/SectionList-scrollable.js
@@ -11,7 +11,7 @@
 'use strict';
 
 import type {Item} from '../../components/ListExampleShared';
-import type {SectionBase} from 'react-native/Libraries/Lists/SectionList';
+import type {SectionBase} from 'react-native';
 
 import {
   FooterComponent,

--- a/packages/rn-tester/js/examples/Snapshot/SnapshotViewIOS.ios.js
+++ b/packages/rn-tester/js/examples/Snapshot/SnapshotViewIOS.ios.js
@@ -10,8 +10,7 @@
 
 'use strict';
 
-import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
-import type {NativeSyntheticEvent} from 'react-native/Libraries/Types/CoreEventTypes';
+import type {NativeSyntheticEvent, ViewProps} from 'react-native';
 
 const React = require('react');
 const {NativeModules, StyleSheet, UIManager, View} = require('react-native');

--- a/packages/rn-tester/js/examples/SwipeableCardExample/SwipeableCardExample.js
+++ b/packages/rn-tester/js/examples/SwipeableCardExample/SwipeableCardExample.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-import type {ListRenderItemInfo} from 'react-native/Libraries/Lists/VirtualizedList';
+import type {ListRenderItemInfo} from 'react-native';
 
 import * as React from 'react';
 import {

--- a/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputExample.ios.js
@@ -14,7 +14,7 @@ import type {
   RNTesterModule,
   RNTesterModuleExample,
 } from '../../types/RNTesterTypes';
-import type {KeyboardTypeOptions} from 'react-native/Libraries/Components/TextInput/TextInput';
+import type {KeyboardTypeOptions} from 'react-native';
 
 import RNTesterText from '../../components/RNTesterText';
 import ExampleTextInput from './ExampleTextInput';

--- a/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputSharedExamples.js
@@ -11,7 +11,7 @@
 'use strict';
 
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
-import type {TextStyle} from 'react-native/Libraries/StyleSheet/StyleSheet';
+import type {TextStyle} from 'react-native';
 
 import RNTesterButton from '../../components/RNTesterButton';
 import RNTesterText from '../../components/RNTesterText';

--- a/packages/rn-tester/js/examples/TurboModule/NativeCxxModuleExampleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/NativeCxxModuleExampleExample.js
@@ -8,8 +8,7 @@
  * @flow strict-local
  */
 
-import type {RootTag} from 'react-native/Libraries/ReactNative/RootTag';
-import type {EventSubscription} from 'react-native/Libraries/vendor/emitter/EventEmitter';
+import type {EventSubscription, RootTag} from 'react-native';
 
 import NativeCxxModuleExample, {
   EnumInt,

--- a/packages/rn-tester/js/examples/TurboModule/SampleLegacyModuleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/SampleLegacyModuleExample.js
@@ -8,7 +8,7 @@
  * @flow strict-local
  */
 
-import type {RootTag} from 'react-native/Libraries/ReactNative/RootTag';
+import type {RootTag} from 'react-native';
 
 import RNTesterText from '../../components/RNTesterText';
 import styles from './TurboModuleExampleCommon';

--- a/packages/rn-tester/js/examples/TurboModule/SampleTurboModuleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/SampleTurboModuleExample.js
@@ -8,8 +8,7 @@
  * @flow strict-local
  */
 
-import type {RootTag} from 'react-native/Libraries/ReactNative/RootTag';
-import type {EventSubscription} from 'react-native/Libraries/vendor/emitter/EventEmitter';
+import type {EventSubscription, RootTag} from 'react-native';
 
 import RNTesterText from '../../components/RNTesterText';
 import styles from './TurboModuleExampleCommon';


### PR DESCRIPTION
Summary:
In rn-tester package there are many react-native deep imports which will be deprecated in the future. It is a starter for migrating rn-tester to using root imports instead. Only deep imports that are already root exported are changed. This diff avoids using `CodegenTypes` as it causes build errors and will be resolved in next stages.

Besides import changes, `PointerEvent` type is now also exported from the root.

Changelog:
[Internal]

Differential Revision: D73656526
