### PR TITLE
Override `updateRuntimeShadowNodeReferencesOnCommit` for OSS

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android.kt
@@ -17,4 +17,6 @@ public class ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android(
   override fun enableFabricRenderer(): Boolean = bridgelessEnabled || fabricEnabled
 
   override fun useTurboModules(): Boolean = bridgelessEnabled || turboModulesEnabled
+
+  override fun updateRuntimeShadowNodeReferencesOnCommit(): Boolean = true
 }

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSStable.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSStable.h
@@ -26,5 +26,8 @@ class ReactNativeFeatureFlagsOverridesOSSStable
   bool useNativeViewConfigsInBridgelessMode() override {
     return true;
   }
+  bool updateRuntimeShadowNodeReferencesOnCommit() override {
+    return true;
+  }
 };
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
OSS is affected by https://github.com/facebook/react-native/issues/49694 and it is endangering the migration of multiple apps to the New Architecture.

We fixed the issue but it is hidden behind feature flag while we are experimenting with it internally, to make sure it does not causes regressions.

However, the fix has been verified for the reproducer code and the OSS will be beneficial for the community.

We are overriding the featureFlag, enabling it for OSS.

## Changelog:
[Internal] - Enable `updateRuntimeShadowNodeReferencesOnCommit` for OSS

Differential Revision: D73771648


