### PR TITLE
[codegen] Fix ImageSource require

### DIFF
--- a/packages/react-native-codegen/src/generators/components/GenerateViewConfigJs.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateViewConfigJs.js
@@ -75,7 +75,7 @@ function getReactDiffProcessValue(typeAnnotation: PropTypeAnnotation) {
           );
         case 'ImageSourcePrimitive':
           return expression(
-            "{ process: require('react-native/Libraries/Image/resolveAssetSource') }",
+            "{ process: ((req) => 'default' in req ? req.default : req)(require('react-native/Libraries/Image/resolveAssetSource')) }",
           );
         case 'ImageRequestPrimitive':
           throw new Error('ImageRequest should not be used in props');


### PR DESCRIPTION
## Summary:

In react-native-svg, I found that the `Image` component stopped working starting with `react-native@0.79`. After some debugging, I traced the issue to the migration of `Libraries/Image` to the new export syntax (see https://github.com/facebook/react-native/commit/8783196ee540f8f78ce60ad20800338cc7645194). To fix this, I updated the import to match other requires, similar to https://github.com/facebook/react-native/blob/main/packages/react-native-codegen/src/generators/components/GenerateViewConfigJs.js#L84.

## Changelog:

[GENERAL] [FIXED] - Fix codegen ImageSource require

## Test Plan:

`validAttributes` process should be a function instead of object with a default property.

Before:
<img width="1041" alt="image" src="https://github.com/user-attachments/assets/9fbc9e9f-6c45-4b0b-adb8-2eb911676fe1" />

After:
<img width="1005" alt="image" src="https://github.com/user-attachments/assets/ee594103-90da-4917-8252-72f4ecfc28e1" />