### PR TITLE
Fix all active ESLint warnings

### DIFF
--- a/flow-typed/npm/jest.js
+++ b/flow-typed/npm/jest.js
@@ -12,7 +12,6 @@
 // Modifications are explained inline by comments beginning with `// MODIFIED`.
 
 // MODIFIED: Added ESLint suppression comment - no-unused-vars doesn't understand declaration files
-/* eslint-disable no-unused-vars */
 
 type JestMockFn<TArguments: $ReadOnlyArray<mixed>, TReturn> = {
   (...args: TArguments): TReturn,

--- a/packages/assets/registry.js
+++ b/packages/assets/registry.js
@@ -40,4 +40,5 @@ function getAssetByID(assetId /*: number */) /*: PackagerAsset */ {
   return assets[assetId - 1];
 }
 
+// eslint-disable-next-line lint/no-commonjs-exports
 module.exports = {registerAsset, getAssetByID};

--- a/packages/dev-middleware/src/inspector-proxy/Device.js
+++ b/packages/dev-middleware/src/inspector-proxy/Device.js
@@ -37,7 +37,6 @@ import WS from 'ws';
 const debug = require('debug')('Metro:InspectorProxy');
 
 const PAGES_POLLING_INTERVAL = 1000;
-const MIN_MESSAGE_QUEUE_BYTES_TO_REPORT = 2 * 1024 * 1024; // 2 MiB
 
 const WS_CLOSURE_CODE = {
   NORMAL: 1000,

--- a/packages/polyfills/console.js
+++ b/packages/polyfills/console.js
@@ -11,7 +11,7 @@
 
 'use client';
 
-/* eslint-disable no-shadow, eqeqeq, curly, no-unused-vars, no-void, no-control-regex  */
+/* eslint-disable no-shadow, eqeqeq, no-unused-vars, no-void, no-control-regex  */
 
 /**
  * This pipes all of our console logging functions to native logging so that

--- a/packages/react-native-compatibility-check/src/__tests__/TypeDiffing-test.js
+++ b/packages/react-native-compatibility-check/src/__tests__/TypeDiffing-test.js
@@ -82,7 +82,7 @@ const [
   nativeTypeDiffingTypesAliases,
   nativeTypeDiffingTypesMethodParamLookup,
   nativeTypeDiffingTypesMethodLookup,
-  _,
+  ,
   nativeTypeDiffingTypesEnums,
 ] = getModule(
   'native-module-type-diffing-types',

--- a/packages/react-native/Libraries/Animated/animations/Animation.js
+++ b/packages/react-native/Libraries/Animated/animations/Animation.js
@@ -13,7 +13,6 @@ import type AnimatedNode from '../nodes/AnimatedNode';
 import type AnimatedValue from '../nodes/AnimatedValue';
 
 import NativeAnimatedHelper from '../../../src/private/animated/NativeAnimatedHelper';
-import * as ReactNativeFeatureFlags from '../../../src/private/featureflags/ReactNativeFeatureFlags';
 import AnimatedProps from '../nodes/AnimatedProps';
 
 export type EndResult = {finished: boolean, value?: number, ...};

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedValue.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedValue.js
@@ -52,7 +52,6 @@ const NativeAnimatedAPI = NativeAnimatedHelper.API;
  * transform which can receive values from multiple parents.
  */
 export function flushValue(rootNode: AnimatedNode): void {
-  // eslint-disable-next-line func-call-spacing
   const leaves = new Set<{update: () => void, ...}>();
   function findAnimatedStyles(node: AnimatedNode) {
     // $FlowFixMe[prop-missing]

--- a/packages/react-native/Libraries/BatchedBridge/__mocks__/MessageQueueTestConfig.js
+++ b/packages/react-native/Libraries/BatchedBridge/__mocks__/MessageQueueTestConfig.js
@@ -35,4 +35,5 @@ const MessageQueueTestConfig = {
   remoteModuleConfig: remoteModulesConfig,
 };
 
+// eslint-disable-next-line lint/no-commonjs-exports
 module.exports = MessageQueueTestConfig;

--- a/packages/react-native/Libraries/BatchedBridge/__mocks__/MessageQueueTestModule.js
+++ b/packages/react-native/Libraries/BatchedBridge/__mocks__/MessageQueueTestModule.js
@@ -19,4 +19,5 @@ const MessageQueueTestModule = {
   testHook2: function () {},
 };
 
+// eslint-disable-next-line lint/no-commonjs-exports
 module.exports = MessageQueueTestModule;


### PR DESCRIPTION
Summary:
Address/supress ESLint warnings across the codebase, currently flagged on every PR via GitHub's "Unchanged files with check annotations" check.

{F1977480883}

Changelog: [Internal]

Differential Revision: D73778510


