### PR TITLE
Create src/fb_internal/ directory, initially migrate VirtualView

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -2,6 +2,9 @@
 ; Ignore build cache folder
 <PROJECT_ROOT>/packages/react-native/sdks/.*
 
+; Ignore fb_internal modules
+<PROJECT_ROOT>/packages/react-native/src/fb_internal/.*
+
 ; Ignore the codegen e2e tests
 <PROJECT_ROOT>/packages/react-native-codegen/e2e/__test_fixtures__/modules/NativeEnumTurboModule.js
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -58,6 +58,7 @@
     "./ReactApple/*": null,
     "./ReactCommon/*": null,
     "./sdks/*": null,
+    "./src/fb_internal/*": "./src/fb_internal/*",
     "./src/*": null,
     "./third-party-podspecs/*": null,
     "./types/*": null,


### PR DESCRIPTION
Summary:
While D72228547 has recently disallowed all `./src/*` subpath imports from React Native (functionally, `./src/private/*`), we have a number of APIs that are imported from Meta product code legitimately — e.g. as part of validating under-development React Native features internally in real Meta apps.

This diff defines a new, exported `./src/fb_internal/*` subpath via `package.json#exports`, which will allow us to expose select entry points for this purpose.

Changelog: [Internal]

Differential Revision: D73770609


