### PR TITLE
Add "./scripts/*" exports subpath

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -47,6 +47,7 @@
       "react-native-strict-api": null,
       "default": "./Libraries/*.d.ts"
     },
+    "./scripts/*": "./scripts/*",
     "./types/*.d.ts": {
       "react-native-strict-api": null,
       "default": "./types/*.d.ts"


### PR DESCRIPTION
Summary:
Should fix non-`.js` script resolution using `require.resolve` (currently breaking CI).

Changelog: [Internal]

Reviewed By: mdvacca, cipolleschi, rshest

Differential Revision: D73786668


