### PR TITLE
Migrate `rn-tester` codegen types imports to use root exported `CodegenTypes` namespace

### DIFF
--- a/packages/rn-tester/NativeComponentExample/js/MyNativeViewNativeComponent.js
+++ b/packages/rn-tester/NativeComponentExample/js/MyNativeViewNativeComponent.js
@@ -8,26 +8,20 @@
  * @format
  */
 
-import type {HostComponent, ViewProps} from 'react-native';
-import type {
-  BubblingEventHandler,
-  Double,
-  Float,
-  Int32,
-} from 'react-native/Libraries/Types/CodegenTypes';
+import type {CodegenTypes, HostComponent, ViewProps} from 'react-native';
 
 import * as React from 'react';
 import {codegenNativeCommands, codegenNativeComponent} from 'react-native';
 
 type Event = $ReadOnly<{
-  values: $ReadOnlyArray<Int32>,
+  values: $ReadOnlyArray<CodegenTypes.Int32>,
   boolValues: $ReadOnlyArray<boolean>,
-  floats: $ReadOnlyArray<Float>,
-  doubles: $ReadOnlyArray<Double>,
+  floats: $ReadOnlyArray<CodegenTypes.Float>,
+  doubles: $ReadOnlyArray<CodegenTypes.Double>,
   yesNos: $ReadOnlyArray<'yep' | 'nope'>,
   strings: $ReadOnlyArray<string>,
-  latLons: $ReadOnlyArray<{lat: Double, lon: Double}>,
-  multiArrays: $ReadOnlyArray<$ReadOnlyArray<Int32>>,
+  latLons: $ReadOnlyArray<{lat: CodegenTypes.Double, lon: CodegenTypes.Double}>,
+  multiArrays: $ReadOnlyArray<$ReadOnlyArray<CodegenTypes.Int32>>,
 }>;
 
 type LegacyStyleEvent = $ReadOnly<{
@@ -36,12 +30,12 @@ type LegacyStyleEvent = $ReadOnly<{
 
 type NativeProps = $ReadOnly<{
   ...ViewProps,
-  opacity?: Float,
-  values: $ReadOnlyArray<Int32>,
+  opacity?: CodegenTypes.Float,
+  values: $ReadOnlyArray<CodegenTypes.Int32>,
 
   // Events
-  onIntArrayChanged?: ?BubblingEventHandler<Event>,
-  onLegacyStyleEvent?: ?BubblingEventHandler<
+  onIntArrayChanged?: ?CodegenTypes.BubblingEventHandler<Event>,
+  onLegacyStyleEvent?: ?CodegenTypes.BubblingEventHandler<
     LegacyStyleEvent,
     'alternativeLegacyName',
   >,

--- a/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.js
+++ b/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.js
@@ -8,8 +8,7 @@
  * @format
  */
 
-import type {TurboModule} from 'react-native';
-import type {EventEmitter} from 'react-native/Libraries/Types/CodegenTypes';
+import type {CodegenTypes, TurboModule} from 'react-native';
 
 import {TurboModuleRegistry} from 'react-native';
 
@@ -77,11 +76,11 @@ export type CustomDeviceEvent = {
 };
 
 export interface Spec extends TurboModule {
-  +onPress: EventEmitter<void>;
-  +onClick: EventEmitter<string>;
-  +onChange: EventEmitter<ObjectStruct>;
-  +onSubmit: EventEmitter<ObjectStruct[]>;
-  +onEvent: EventEmitter<EnumNone>;
+  +onPress: CodegenTypes.EventEmitter<void>;
+  +onClick: CodegenTypes.EventEmitter<string>;
+  +onChange: CodegenTypes.EventEmitter<ObjectStruct>;
+  +onSubmit: CodegenTypes.EventEmitter<ObjectStruct[]>;
+  +onEvent: CodegenTypes.EventEmitter<EnumNone>;
   +getArray: (arg: Array<ObjectStruct | null>) => Array<ObjectStruct | null>;
   +getBool: (arg: boolean) => boolean;
   +getConstants: () => ConstantsStruct;

--- a/packages/rn-tester/NativeModuleExample/NativeScreenshotManager.js
+++ b/packages/rn-tester/NativeModuleExample/NativeScreenshotManager.js
@@ -8,12 +8,11 @@
  * @format
  */
 
-import type {TurboModule} from 'react-native';
-import type {UnsafeObject} from 'react-native/Libraries/Types/CodegenTypes';
+import type {CodegenTypes, TurboModule} from 'react-native';
 
 import {TurboModuleRegistry} from 'react-native';
 
-export type ScreenshotManagerOptions = UnsafeObject;
+export type ScreenshotManagerOptions = CodegenTypes.UnsafeObject;
 
 export interface Spec extends TurboModule {
   +getConstants: () => {};


### PR DESCRIPTION
Summary:
This is the second part of the migration of `rn-tester` package to use root imports. In this diff the `CodegenTypes` namespace is used to define Codegen primitives. 

Changelog:
[Internal]

Reviewed By: huntie

Differential Revision: D73780584


