### PR TITLE
Avoid copying samples list when serializing

### DIFF
--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeSamplingProfileSerializer.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeSamplingProfileSerializer.cpp
@@ -122,7 +122,7 @@ RuntimeSamplingProfile::SampleCallStackFrame convertHermesFrameToTracingFrame(
 }
 
 RuntimeSamplingProfile::Sample convertHermesSampleToTracingSample(
-    hermes::sampling_profiler::ProfileSample& hermesSample) {
+    const hermes::sampling_profiler::ProfileSample& hermesSample) {
   uint64_t reconciledTimestamp = hermesSample.getTimestamp();
   std::vector<hermes::sampling_profiler::ProfileSampleCallStackFrame*>
       hermesSampleCallStack = hermesSample.getCallStack();

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeSamplingProfileSerializer.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeSamplingProfileSerializer.cpp
@@ -151,7 +151,7 @@ RuntimeSamplingProfile::Sample convertHermesSampleToTracingSample(
 /* static */ RuntimeSamplingProfile
 HermesRuntimeSamplingProfileSerializer::serializeToTracingSamplingProfile(
     const hermes::sampling_profiler::Profile& hermesProfile) {
-  std::vector<hermes::sampling_profiler::ProfileSample> hermesSamples =
+  const std::vector<hermes::sampling_profiler::ProfileSample>& hermesSamples =
       hermesProfile.getSamples();
   std::vector<RuntimeSamplingProfile::Sample> reconciledSamples;
   reconciledSamples.reserve(hermesSamples.size());

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
@@ -320,7 +320,7 @@ folly::dynamic PerformanceTracer::getSerializedRuntimeProfileChunkTraceEvent(
       .pid = processId_,
       .tid = threadId,
       .args =
-          folly::dynamic::object("data", traceEventProfileChunk.asDynamic()),
+          folly::dynamic::object("data", traceEventProfileChunk.toDynamic()),
   });
 }
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.cpp
@@ -148,9 +148,11 @@ void RuntimeSamplingProfileTraceEventSerializer::bufferProfileChunkTraceEvent(
           chunk.threadId,
           chunk.timestamp,
           TraceEventProfileChunk{
-              TraceEventProfileChunk::CPUProfile{
-                  traceEventNodes, chunk.samples},
-              TraceEventProfileChunk::TimeDeltas{chunk.timeDeltas},
+              .cpuProfile =
+                  TraceEventProfileChunk::CPUProfile{
+                      traceEventNodes, chunk.samples},
+              .timeDeltas =
+                  TraceEventProfileChunk::TimeDeltas{chunk.timeDeltas},
           }));
 }
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEventProfile.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEventProfile.h
@@ -9,8 +9,6 @@
 
 #include <folly/dynamic.h>
 
-#include <utility>
-
 namespace facebook::react::jsinspector_modern::tracing {
 
 /// Arbitrary data structure, which represents payload of the "ProfileChunk"
@@ -19,21 +17,11 @@ struct TraceEventProfileChunk {
   /// Deltas between timestamps of chronolocigally sorted samples.
   /// Will be sent as part of the "ProfileChunk" trace event.
   struct TimeDeltas {
-   public:
-    explicit TimeDeltas(std::vector<long long> deltas)
-        : deltas_(std::move(deltas)) {}
-
-    folly::dynamic asDynamic() const {
-      folly::dynamic value = folly::dynamic::array();
-      for (auto delta : deltas_) {
-        value.push_back(delta);
-      }
-
-      return value;
+    folly::dynamic toDynamic() const {
+      return folly::dynamic::array(deltas.begin(), deltas.end());
     }
 
-   private:
-    std::vector<long long> deltas_;
+    std::vector<long long> deltas;
   };
 
   /// Contains Profile information that will be emitted in this chunk: nodes and
@@ -45,113 +33,73 @@ struct TraceEventProfileChunk {
     struct Node {
       /// Unique call frame in the call stack.
       struct CallFrame {
-       public:
-        CallFrame(
-            std::string codeType,
-            uint32_t scriptId,
-            std::string functionName,
-            std::optional<std::string> url = std::nullopt,
-            std::optional<uint32_t> lineNumber = std::nullopt,
-            std::optional<uint32_t> columnNumber = std::nullopt)
-            : codeType_(std::move(codeType)),
-              scriptId_(scriptId),
-              functionName_(std::move(functionName)),
-              url_(std::move(url)),
-              lineNumber_(lineNumber),
-              columnNumber_(columnNumber) {}
-
-        folly::dynamic asDynamic() const {
+        folly::dynamic toDynamic() const {
           folly::dynamic dynamicCallFrame = folly::dynamic::object();
-          dynamicCallFrame["codeType"] = codeType_;
-          dynamicCallFrame["scriptId"] = scriptId_;
-          dynamicCallFrame["functionName"] = functionName_;
-          if (url_.has_value()) {
-            dynamicCallFrame["url"] = url_.value();
+          dynamicCallFrame["codeType"] = codeType;
+          dynamicCallFrame["scriptId"] = scriptId;
+          dynamicCallFrame["functionName"] = functionName;
+          if (url.has_value()) {
+            dynamicCallFrame["url"] = url.value();
           }
-          if (lineNumber_.has_value()) {
-            dynamicCallFrame["lineNumber"] = lineNumber_.value();
+          if (lineNumber.has_value()) {
+            dynamicCallFrame["lineNumber"] = lineNumber.value();
           }
-          if (columnNumber_.has_value()) {
-            dynamicCallFrame["columnNumber"] = columnNumber_.value();
+          if (columnNumber.has_value()) {
+            dynamicCallFrame["columnNumber"] = columnNumber.value();
           }
 
           return dynamicCallFrame;
         }
 
-       private:
-        std::string codeType_;
-        uint32_t scriptId_;
-        std::string functionName_;
-        std::optional<std::string> url_;
-        std::optional<uint32_t> lineNumber_;
-        std::optional<uint32_t> columnNumber_;
+        std::string codeType;
+        uint32_t scriptId;
+        std::string functionName;
+        std::optional<std::string> url;
+        std::optional<uint32_t> lineNumber;
+        std::optional<uint32_t> columnNumber;
       };
 
-     public:
-      Node(
-          uint32_t id,
-          CallFrame callFrame,
-          std::optional<uint32_t> parentId = std::nullopt)
-          : id_(id), callFrame_(std::move(callFrame)), parentId_(parentId) {}
-
-      folly::dynamic asDynamic() const {
+      folly::dynamic toDynamic() const {
         folly::dynamic dynamicNode = folly::dynamic::object();
 
-        dynamicNode["callFrame"] = callFrame_.asDynamic();
-        dynamicNode["id"] = id_;
-        if (parentId_.has_value()) {
-          dynamicNode["parent"] = parentId_.value();
+        dynamicNode["callFrame"] = callFrame.toDynamic();
+        dynamicNode["id"] = id;
+        if (parentId.has_value()) {
+          dynamicNode["parent"] = parentId.value();
         }
 
         return dynamicNode;
       }
 
-     private:
-      uint32_t id_;
-      CallFrame callFrame_;
-      std::optional<uint32_t> parentId_;
+      uint32_t id;
+      CallFrame callFrame;
+      std::optional<uint32_t> parentId;
     };
 
-   public:
-    CPUProfile(std::vector<Node> nodes, std::vector<uint32_t> samples)
-        : nodes_(std::move(nodes)), samples_(std::move(samples)) {}
-
-    folly::dynamic asDynamic() const {
+    folly::dynamic toDynamic() const {
       folly::dynamic dynamicNodes = folly::dynamic::array();
-      for (const auto& node : nodes_) {
-        dynamicNodes.push_back(node.asDynamic());
+      dynamicNodes.reserve(nodes.size());
+      for (const auto& node : nodes) {
+        dynamicNodes.push_back(node.toDynamic());
       }
-
-      folly::dynamic dynamicSamples = folly::dynamic::array();
-      for (auto sample : samples_) {
-        dynamicSamples.push_back(sample);
-      }
+      folly::dynamic dynamicSamples =
+          folly::dynamic::array(samples.begin(), samples.end());
 
       return folly::dynamic::object("nodes", dynamicNodes)(
           "samples", dynamicSamples);
     }
 
-   private:
-    std::vector<Node> nodes_;
-    std::vector<uint32_t> samples_;
+    std::vector<Node> nodes;
+    std::vector<uint32_t> samples;
   };
 
- public:
-  TraceEventProfileChunk(CPUProfile cpuProfile, TimeDeltas timeDeltas)
-      : cpuProfile_(std::move(cpuProfile)),
-        timeDeltas_(std::move(timeDeltas)) {}
-
-  folly::dynamic asDynamic() const {
-    folly::dynamic value = folly::dynamic::object;
-    value["cpuProfile"] = cpuProfile_.asDynamic();
-    value["timeDeltas"] = timeDeltas_.asDynamic();
-
-    return value;
+  folly::dynamic toDynamic() const {
+    return folly::dynamic::object("cpuProfile", cpuProfile.toDynamic())(
+        "timeDeltas", timeDeltas.toDynamic());
   }
 
- private:
-  CPUProfile cpuProfile_;
-  TimeDeltas timeDeltas_;
+  CPUProfile cpuProfile;
+  TimeDeltas timeDeltas;
 };
 
 } // namespace facebook::react::jsinspector_modern::tracing


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

There may be tens of thousands of samples stored, so we should avoid copying it. I don't think we should restrict it from being copied, though, but we don't need it to copy in this case.

Reviewed By: huntie, dannysu

Differential Revision: D73106950


