### PR TITLE
Expose event priorities in Fantom and JS

### DIFF
--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -123,6 +123,8 @@ class Root {
 
 export type {Root};
 
+export {NativeEventCategory} from 'react-native/src/private/testing/fantom/specs/NativeFantom';
+
 const DEFAULT_TASK_PRIORITY = schedulerPriorityImmediate;
 
 /**

--- a/packages/react-native/Libraries/ReactNative/FabricUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/FabricUIManager.js
@@ -92,6 +92,11 @@ export interface Spec {
     /* width: */ number,
     /* height: */ number,
   ];
+  +unstable_DefaultEventPriority: number;
+  +unstable_DiscreteEventPriority: number;
+  +unstable_ContinuousEventPriority: number;
+  +unstable_IdleEventPriority: number;
+  +unstable_getCurrentEventPriority: () => number;
 }
 
 let nativeFabricUIManagerProxy: ?Spec;
@@ -119,6 +124,11 @@ const CACHED_PROPERTIES = [
   'dispatchCommand',
   'compareDocumentPosition',
   'getBoundingClientRect',
+  'unstable_DefaultEventPriority',
+  'unstable_DiscreteEventPriority',
+  'unstable_ContinuousEventPriority',
+  'unstable_IdleEventPriority',
+  'unstable_getCurrentEventPriority',
 ];
 
 // This is exposed as a getter because apps using the legacy renderer AND

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -6593,6 +6593,11 @@ export interface Spec {
     node: Node | NativeElementReference,
     includeTransform: boolean
   ) => ?[number, number, number, number];
+  +unstable_DefaultEventPriority: number;
+  +unstable_DiscreteEventPriority: number;
+  +unstable_ContinuousEventPriority: number;
+  +unstable_IdleEventPriority: number;
+  +unstable_getCurrentEventPriority: () => number;
 }
 declare export function getFabricUIManager(): ?Spec;
 "

--- a/packages/react-native/src/private/testing/fantom/specs/NativeFantom.js
+++ b/packages/react-native/src/private/testing/fantom/specs/NativeFantom.js
@@ -49,6 +49,12 @@ export enum NativeEventCategory {
    * isn't ongoing.
    */
   Continuous = 4,
+
+  /*
+   * Priority for events that can be processed in idle times or in the
+   * background.
+   */
+  Idle = 5,
 }
 
 export type ScrollOptions = {


### PR DESCRIPTION
Summary:
Changelog: [internal]

This just exposes some enum values and methods that we forgot to expose in a few interfaces.

Differential Revision: D73849221


