### PR TITLE
Fix bug when dispatching unique and non-unique events of the same type on the same target

### DIFF
--- a/packages/react-native-fantom/src/__tests__/Fantom-itest.js
+++ b/packages/react-native-fantom/src/__tests__/Fantom-itest.js
@@ -497,12 +497,19 @@ describe('Fantom', () => {
       const element = ensureInstance(ref.current, ReactNativeElement);
 
       Fantom.runOnUIThread(() => {
-        Fantom.enqueueNativeEvent(element, 'scroll', {
-          contentOffset: {
-            x: 0,
-            y: 1,
+        Fantom.enqueueNativeEvent(
+          element,
+          'scroll',
+          {
+            contentOffset: {
+              x: 0,
+              y: 1,
+            },
           },
-        });
+          {
+            isUnique: true,
+          },
+        );
         Fantom.enqueueNativeEvent(
           element,
           'scroll',

--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -123,6 +123,8 @@ class Root {
 
 export type {Root};
 
+export {NativeEventCategory} from 'react-native/src/private/testing/fantom/specs/NativeFantom';
+
 const DEFAULT_TASK_PRIORITY = schedulerPriorityImmediate;
 
 /**

--- a/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-itest.js
+++ b/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-itest.js
@@ -83,12 +83,19 @@ describe('onScroll', () => {
     const element = ensureInstance(scrollViewRef.current, ReactNativeElement);
 
     Fantom.runOnUIThread(() => {
-      Fantom.enqueueNativeEvent(element, 'scroll', {
-        contentOffset: {
-          x: 0,
-          y: 1,
+      Fantom.enqueueNativeEvent(
+        element,
+        'scroll',
+        {
+          contentOffset: {
+            x: 0,
+            y: 1,
+          },
         },
-      });
+        {
+          isUnique: true,
+        },
+      );
       Fantom.enqueueNativeEvent(
         element,
         'scroll',

--- a/packages/react-native/Libraries/ReactNative/FabricUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/FabricUIManager.js
@@ -92,6 +92,11 @@ export interface Spec {
     /* width: */ number,
     /* height: */ number,
   ];
+  +unstable_DefaultEventPriority: number;
+  +unstable_DiscreteEventPriority: number;
+  +unstable_ContinuousEventPriority: number;
+  +unstable_IdleEventPriority: number;
+  +unstable_getCurrentEventPriority: () => number;
 }
 
 let nativeFabricUIManagerProxy: ?Spec;
@@ -119,6 +124,11 @@ const CACHED_PROPERTIES = [
   'dispatchCommand',
   'compareDocumentPosition',
   'getBoundingClientRect',
+  'unstable_DefaultEventPriority',
+  'unstable_DiscreteEventPriority',
+  'unstable_ContinuousEventPriority',
+  'unstable_IdleEventPriority',
+  'unstable_getCurrentEventPriority',
 ];
 
 // This is exposed as a getter because apps using the legacy renderer AND

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -6593,6 +6593,11 @@ export interface Spec {
     node: Node | NativeElementReference,
     includeTransform: boolean
   ) => ?[number, number, number, number];
+  +unstable_DefaultEventPriority: number;
+  +unstable_DiscreteEventPriority: number;
+  +unstable_ContinuousEventPriority: number;
+  +unstable_IdleEventPriority: number;
+  +unstable_getCurrentEventPriority: () => number;
 }
 declare export function getFabricUIManager(): ?Spec;
 "

--- a/packages/react-native/ReactCommon/react/renderer/core/EventQueue.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventQueue.cpp
@@ -29,40 +29,40 @@ EventQueue::EventQueue(
 void EventQueue::enqueueEvent(RawEvent&& rawEvent) const {
   {
     std::scoped_lock lock(queueMutex_);
-    eventQueue_.push_back(std::move(rawEvent));
+
+    if (rawEvent.isUnique) {
+      auto repeatedEvent = eventQueue_.rend();
+
+      for (auto it = eventQueue_.rbegin(); it != eventQueue_.rend(); ++it) {
+        if (it->type == rawEvent.type &&
+            it->eventTarget == rawEvent.eventTarget) {
+          repeatedEvent = it;
+          break;
+        } else if (it->eventTarget == rawEvent.eventTarget) {
+          // It is necessary to maintain order of different event types
+          // for the same target. If the same target has event types A1, B1
+          // in the event queue and event A2 occurs. A1 has to stay in the
+          // queue.
+          break;
+        }
+      }
+
+      if (repeatedEvent == eventQueue_.rend()) {
+        eventQueue_.push_back(std::move(rawEvent));
+      } else {
+        *repeatedEvent = std::move(rawEvent);
+      }
+    } else {
+      eventQueue_.push_back(std::move(rawEvent));
+    }
   }
 
   onEnqueue();
 }
 
 void EventQueue::enqueueUniqueEvent(RawEvent&& rawEvent) const {
-  {
-    std::scoped_lock lock(queueMutex_);
-
-    auto repeatedEvent = eventQueue_.rend();
-
-    for (auto it = eventQueue_.rbegin(); it != eventQueue_.rend(); ++it) {
-      if (it->type == rawEvent.type &&
-          it->eventTarget == rawEvent.eventTarget) {
-        repeatedEvent = it;
-        break;
-      } else if (it->eventTarget == rawEvent.eventTarget) {
-        // It is necessary to maintain order of different event types
-        // for the same target. If the same target has event types A1, B1
-        // in the event queue and event A2 occurs. A1 has to stay in the
-        // queue.
-        break;
-      }
-    }
-
-    if (repeatedEvent == eventQueue_.rend()) {
-      eventQueue_.push_back(std::move(rawEvent));
-    } else {
-      *repeatedEvent = std::move(rawEvent);
-    }
-  }
-
-  onEnqueue();
+  rawEvent.isUnique = true;
+  enqueueEvent(std::move(rawEvent));
 }
 
 void EventQueue::enqueueStateUpdate(StateUpdate&& stateUpdate) const {

--- a/packages/react-native/ReactCommon/react/renderer/core/EventQueue.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventQueue.cpp
@@ -35,7 +35,7 @@ void EventQueue::enqueueEvent(RawEvent&& rawEvent) const {
 
       for (auto it = eventQueue_.rbegin(); it != eventQueue_.rend(); ++it) {
         if (it->type == rawEvent.type &&
-            it->eventTarget == rawEvent.eventTarget) {
+            it->eventTarget == rawEvent.eventTarget && it->isUnique) {
           repeatedEvent = it;
           break;
         } else if (it->eventTarget == rawEvent.eventTarget) {

--- a/packages/react-native/ReactCommon/react/renderer/core/RawEvent.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawEvent.cpp
@@ -13,10 +13,12 @@ RawEvent::RawEvent(
     std::string type,
     SharedEventPayload eventPayload,
     SharedEventTarget eventTarget,
-    Category category)
+    Category category,
+    bool isUnique)
     : type(std::move(type)),
       eventPayload(std::move(eventPayload)),
       eventTarget(std::move(eventTarget)),
-      category(category) {}
+      category(category),
+      isUnique(isUnique) {}
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/RawEvent.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawEvent.h
@@ -69,13 +69,15 @@ struct RawEvent {
       std::string type,
       SharedEventPayload eventPayload,
       SharedEventTarget eventTarget,
-      Category category = Category::Unspecified);
+      Category category = Category::Unspecified,
+      bool isUnique = false);
 
   std::string type;
   SharedEventPayload eventPayload;
   SharedEventTarget eventTarget;
   Category category;
   EventTag loggingTag{0};
+  bool isUnique{false};
 
   // The client may specify a platform-specific timestamp for the event start
   // time, for example when MotionEvent was triggered on the Android native

--- a/packages/react-native/src/private/renderer/core/__tests__/EventDispatching-itest.js
+++ b/packages/react-native/src/private/renderer/core/__tests__/EventDispatching-itest.js
@@ -1,0 +1,548 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ * @fantom_flags fixMappingOfEventPrioritiesBetweenFabricAndReact:true
+ */
+
+import 'react-native/Libraries/Core/InitializeCore';
+
+import ensureInstance from '../../../__tests__/utilities/ensureInstance';
+import * as Fantom from '@react-native/fantom';
+import nullthrows from 'nullthrows';
+import * as React from 'react';
+import {View} from 'react-native';
+import * as FabricUIManager from 'react-native/Libraries/ReactNative/FabricUIManager';
+import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
+
+const UIManager = nullthrows(FabricUIManager.getFabricUIManager());
+
+describe('Event Dispatching', () => {
+  it('dispatches events with discrete priority', () => {
+    const root = Fantom.createRoot();
+
+    const ref = React.createRef<React.ElementRef<typeof View>>();
+
+    let onPointerUpPriority;
+
+    const onPointerUp = jest.fn((event: mixed) => {
+      onPointerUpPriority = UIManager.unstable_getCurrentEventPriority();
+    });
+
+    Fantom.runTask(() => {
+      root.render(<View ref={ref} onPointerUp={onPointerUp} />);
+    });
+
+    expect(onPointerUp).toHaveBeenCalledTimes(0);
+
+    const node = ensureInstance(ref.current, ReactNativeElement);
+
+    Fantom.dispatchNativeEvent(
+      node,
+      'onPointerUp',
+      {x: 0, y: 0},
+      {
+        category: Fantom.NativeEventCategory.Discrete,
+      },
+    );
+
+    expect(onPointerUp).toHaveBeenCalledTimes(1);
+    expect(onPointerUpPriority).toBe(UIManager.unstable_DiscreteEventPriority);
+  });
+
+  it('dispatches events with continuous priority', () => {
+    const root = Fantom.createRoot();
+
+    const ref = React.createRef<React.ElementRef<typeof View>>();
+
+    let onPointerMovePriority;
+
+    const onPointerMove = jest.fn((event: mixed) => {
+      onPointerMovePriority = UIManager.unstable_getCurrentEventPriority();
+    });
+
+    Fantom.runTask(() => {
+      root.render(<View ref={ref} onPointerMove={onPointerMove} />);
+    });
+
+    expect(onPointerMove).toHaveBeenCalledTimes(0);
+
+    const node = ensureInstance(ref.current, ReactNativeElement);
+
+    Fantom.dispatchNativeEvent(
+      node,
+      'onPointerMove',
+      {x: 0, y: 0},
+      {
+        category: Fantom.NativeEventCategory.Continuous,
+      },
+    );
+
+    expect(onPointerMove).toHaveBeenCalledTimes(1);
+    expect(onPointerMovePriority).toBe(
+      UIManager.unstable_ContinuousEventPriority,
+    );
+  });
+
+  it('dispatches events with idle priority', () => {
+    const root = Fantom.createRoot();
+
+    const ref = React.createRef<React.ElementRef<typeof View>>();
+
+    let onPointerMovePriority;
+
+    const onPointerMove = jest.fn((event: mixed) => {
+      onPointerMovePriority = UIManager.unstable_getCurrentEventPriority();
+    });
+
+    Fantom.runTask(() => {
+      root.render(<View ref={ref} onPointerMove={onPointerMove} />);
+    });
+
+    expect(onPointerMove).toHaveBeenCalledTimes(0);
+
+    const node = ensureInstance(ref.current, ReactNativeElement);
+
+    Fantom.dispatchNativeEvent(
+      node,
+      'onPointerMove',
+      {x: 0, y: 0},
+      {
+        // This is not the intrinsic category of this event,
+        // but we don't currently dispatch any idle events on View and need a real prop for testing.
+        category: Fantom.NativeEventCategory.Idle,
+      },
+    );
+
+    expect(onPointerMove).toHaveBeenCalledTimes(1);
+    expect(onPointerMovePriority).toBe(UIManager.unstable_IdleEventPriority);
+  });
+
+  describe('when using ContinuousStart and ContinuousEnd', () => {
+    it('uses discrete event priority for both ContinousStart and ContinuousEnd', () => {
+      const root = Fantom.createRoot();
+
+      const ref = React.createRef<React.ElementRef<typeof View>>();
+
+      let onPointerEnterPriority;
+      let onPointerLeavePriority;
+
+      const onPointerEnter = jest.fn((event: mixed) => {
+        onPointerEnterPriority = UIManager.unstable_getCurrentEventPriority();
+      });
+      const onPointerLeave = jest.fn((event: mixed) => {
+        onPointerLeavePriority = UIManager.unstable_getCurrentEventPriority();
+      });
+
+      Fantom.runTask(() => {
+        root.render(
+          <View
+            ref={ref}
+            onPointerEnter={onPointerEnter}
+            onPointerLeave={onPointerLeave}
+          />,
+        );
+      });
+
+      expect(onPointerEnter).toHaveBeenCalledTimes(0);
+      expect(onPointerLeave).toHaveBeenCalledTimes(0);
+
+      const node = ensureInstance(ref.current, ReactNativeElement);
+
+      Fantom.dispatchNativeEvent(
+        node,
+        'onPointerEnter',
+        {x: 0, y: 0},
+        {
+          category: Fantom.NativeEventCategory.ContinuousStart,
+        },
+      );
+
+      expect(onPointerEnter).toHaveBeenCalledTimes(1);
+      expect(onPointerLeave).toHaveBeenCalledTimes(0);
+      expect(onPointerEnterPriority).toBe(
+        UIManager.unstable_DiscreteEventPriority,
+      );
+
+      Fantom.dispatchNativeEvent(
+        node,
+        'onPointerLeave',
+        {x: 0, y: 0},
+        {
+          category: Fantom.NativeEventCategory.ContinuousEnd,
+        },
+      );
+
+      expect(onPointerEnter).toHaveBeenCalledTimes(1);
+      expect(onPointerLeave).toHaveBeenCalledTimes(1);
+      expect(onPointerLeavePriority).toBe(
+        UIManager.unstable_DiscreteEventPriority,
+      );
+    });
+
+    it('uses continuous event priority for unspecified events between ContinuousStart and ContinuousEnd, and default outside of them', () => {
+      const root = Fantom.createRoot();
+
+      const ref = React.createRef<React.ElementRef<typeof View>>();
+
+      let onPointerMovePriority;
+      const onPointerMove = jest.fn((event: mixed) => {
+        onPointerMovePriority = UIManager.unstable_getCurrentEventPriority();
+      });
+
+      Fantom.runTask(() => {
+        root.render(<View ref={ref} onPointerMove={onPointerMove} />);
+      });
+
+      const node = ensureInstance(ref.current, ReactNativeElement);
+      expect(onPointerMove).toHaveBeenCalledTimes(0);
+
+      Fantom.dispatchNativeEvent(
+        node,
+        'onPointerMove',
+        {x: 0, y: 1},
+        {
+          category: Fantom.NativeEventCategory.Unspecified,
+        },
+      );
+
+      expect(onPointerMove).toHaveBeenCalledTimes(1);
+      expect(onPointerMovePriority).toBe(
+        UIManager.unstable_DefaultEventPriority,
+      );
+
+      Fantom.dispatchNativeEvent(
+        node,
+        'onPointerEnter',
+        {x: 0, y: 0},
+        {
+          category: Fantom.NativeEventCategory.ContinuousStart,
+        },
+      );
+
+      expect(onPointerMove).toHaveBeenCalledTimes(1);
+
+      Fantom.dispatchNativeEvent(
+        node,
+        'onPointerMove',
+        {x: 0, y: 1},
+        {
+          category: Fantom.NativeEventCategory.Unspecified,
+        },
+      );
+
+      expect(onPointerMove).toHaveBeenCalledTimes(2);
+      expect(onPointerMovePriority).toBe(
+        UIManager.unstable_ContinuousEventPriority,
+      );
+
+      Fantom.dispatchNativeEvent(
+        node,
+        'onPointerLeave',
+        {x: 0, y: 0},
+        {
+          category: Fantom.NativeEventCategory.ContinuousEnd,
+        },
+      );
+
+      expect(onPointerMove).toHaveBeenCalledTimes(2);
+
+      Fantom.dispatchNativeEvent(
+        node,
+        'onPointerMove',
+        {x: 0, y: 1},
+        {
+          category: Fantom.NativeEventCategory.Unspecified,
+        },
+      );
+
+      expect(onPointerMove).toHaveBeenCalledTimes(3);
+      expect(onPointerMovePriority).toBe(
+        UIManager.unstable_DefaultEventPriority,
+      );
+    });
+
+    it('preserves explicitly set priorities between ContinuousStart and ContinuousEnd', () => {
+      const root = Fantom.createRoot();
+
+      const ref = React.createRef<React.ElementRef<typeof View>>();
+
+      let onPointerMovePriority;
+      const onPointerMove = jest.fn((event: mixed) => {
+        onPointerMovePriority = UIManager.unstable_getCurrentEventPriority();
+      });
+
+      Fantom.runTask(() => {
+        root.render(<View ref={ref} onPointerMove={onPointerMove} />);
+      });
+
+      const node = ensureInstance(ref.current, ReactNativeElement);
+      expect(onPointerMove).toHaveBeenCalledTimes(0);
+
+      Fantom.dispatchNativeEvent(
+        node,
+        'onPointerEnter',
+        {x: 0, y: 0},
+        {
+          category: Fantom.NativeEventCategory.ContinuousStart,
+        },
+      );
+
+      expect(onPointerMove).toHaveBeenCalledTimes(0);
+
+      Fantom.dispatchNativeEvent(
+        node,
+        'onPointerMove',
+        {x: 0, y: 1},
+        {
+          category: Fantom.NativeEventCategory.Idle,
+        },
+      );
+
+      expect(onPointerMove).toHaveBeenCalledTimes(1);
+      expect(onPointerMovePriority).toBe(UIManager.unstable_IdleEventPriority);
+    });
+  });
+
+  describe('unique events', () => {
+    it('are combined and only the last consecutive one is dispatched', () => {
+      const root = Fantom.createRoot();
+
+      const ref = React.createRef<React.ElementRef<typeof View>>();
+
+      const onPointerMove = jest.fn(e => {
+        e.persist();
+      });
+
+      Fantom.runTask(() => {
+        root.render(<View ref={ref} onPointerMove={onPointerMove} />);
+      });
+
+      expect(onPointerMove).toHaveBeenCalledTimes(0);
+
+      const node = ensureInstance(ref.current, ReactNativeElement);
+
+      Fantom.runOnUIThread(() => {
+        Fantom.enqueueNativeEvent(
+          node,
+          'onPointerMove',
+          {x: 0, y: 0},
+          {
+            category: Fantom.NativeEventCategory.Continuous,
+            isUnique: true,
+          },
+        );
+
+        Fantom.enqueueNativeEvent(
+          node,
+          'onPointerMove',
+          {x: 1, y: 0},
+          {
+            category: Fantom.NativeEventCategory.Continuous,
+            isUnique: true,
+          },
+        );
+
+        Fantom.enqueueNativeEvent(
+          node,
+          'onPointerMove',
+          {x: 1, y: 1},
+          {
+            category: Fantom.NativeEventCategory.Continuous,
+            isUnique: true,
+          },
+        );
+      });
+
+      Fantom.runWorkLoop();
+
+      expect(onPointerMove).toHaveBeenCalledTimes(1);
+      expect(onPointerMove.mock.lastCall[0].nativeEvent.x).toBe(1);
+      expect(onPointerMove.mock.lastCall[0].nativeEvent.y).toBe(1);
+    });
+
+    it('are combined if there are different event types in between for a different target', () => {
+      const root = Fantom.createRoot();
+
+      const ref = React.createRef<React.ElementRef<typeof View>>();
+      const otherRef = React.createRef<React.ElementRef<typeof View>>();
+
+      const onPointerMove = jest.fn(e => {
+        e.persist();
+      });
+
+      Fantom.runTask(() => {
+        root.render(
+          <>
+            <View ref={ref} onPointerMove={onPointerMove} />
+            <View ref={otherRef} />
+          </>,
+        );
+      });
+
+      expect(onPointerMove).toHaveBeenCalledTimes(0);
+
+      const node = ensureInstance(ref.current, ReactNativeElement);
+      const otherNode = ensureInstance(otherRef.current, ReactNativeElement);
+
+      Fantom.runOnUIThread(() => {
+        Fantom.enqueueNativeEvent(
+          node,
+          'onPointerMove',
+          {x: 0, y: 0},
+          {
+            category: Fantom.NativeEventCategory.Continuous,
+            isUnique: true,
+          },
+        );
+
+        Fantom.enqueueNativeEvent(
+          otherNode,
+          'onScroll',
+          {x: 1, y: 0},
+          {
+            category: Fantom.NativeEventCategory.Continuous,
+            isUnique: true,
+          },
+        );
+
+        Fantom.enqueueNativeEvent(
+          node,
+          'onPointerMove',
+          {x: 1, y: 1},
+          {
+            category: Fantom.NativeEventCategory.Continuous,
+            isUnique: true,
+          },
+        );
+      });
+
+      Fantom.runWorkLoop();
+
+      expect(onPointerMove).toHaveBeenCalledTimes(1);
+      expect(onPointerMove.mock.lastCall[0].nativeEvent.x).toBe(1);
+      expect(onPointerMove.mock.lastCall[0].nativeEvent.y).toBe(1);
+    });
+
+    it('are NOT combined if there are different event types in between for the same target', () => {
+      const root = Fantom.createRoot();
+
+      const ref = React.createRef<React.ElementRef<typeof View>>();
+
+      const onPointerMove = jest.fn(e => {
+        e.persist();
+      });
+
+      Fantom.runTask(() => {
+        root.render(<View ref={ref} onPointerMove={onPointerMove} />);
+      });
+
+      expect(onPointerMove).toHaveBeenCalledTimes(0);
+
+      const node = ensureInstance(ref.current, ReactNativeElement);
+
+      Fantom.runOnUIThread(() => {
+        Fantom.enqueueNativeEvent(
+          node,
+          'onPointerMove',
+          {x: 0, y: 0},
+          {
+            category: Fantom.NativeEventCategory.Continuous,
+            isUnique: true,
+          },
+        );
+
+        Fantom.enqueueNativeEvent(
+          node,
+          'onScroll',
+          {x: 1, y: 0},
+          {
+            category: Fantom.NativeEventCategory.Continuous,
+            isUnique: true,
+          },
+        );
+
+        Fantom.enqueueNativeEvent(
+          node,
+          'onPointerMove',
+          {x: 1, y: 1},
+          {
+            category: Fantom.NativeEventCategory.Continuous,
+            isUnique: true,
+          },
+        );
+      });
+
+      Fantom.runWorkLoop();
+
+      expect(onPointerMove).toHaveBeenCalledTimes(2);
+    });
+
+    it.skip('are NOT combined with the same type if it is non-unique', () => {
+      const root = Fantom.createRoot();
+
+      const ref = React.createRef<React.ElementRef<typeof View>>();
+
+      const onPointerMove = jest.fn(e => {
+        e.persist();
+      });
+
+      Fantom.runTask(() => {
+        root.render(<View ref={ref} onPointerMove={onPointerMove} />);
+      });
+
+      expect(onPointerMove).toHaveBeenCalledTimes(0);
+
+      const node = ensureInstance(ref.current, ReactNativeElement);
+
+      Fantom.runOnUIThread(() => {
+        Fantom.enqueueNativeEvent(
+          node,
+          'onPointerMove',
+          {x: 0, y: 0},
+          {
+            category: Fantom.NativeEventCategory.Continuous,
+            isUnique: true,
+          },
+        );
+
+        Fantom.enqueueNativeEvent(
+          node,
+          'onPointerMove',
+          {x: 1, y: 0},
+          {
+            category: Fantom.NativeEventCategory.Continuous,
+          },
+        );
+
+        Fantom.enqueueNativeEvent(
+          node,
+          'onPointerMove',
+          {x: 1, y: 1},
+          {
+            category: Fantom.NativeEventCategory.Continuous,
+            isUnique: true,
+          },
+        );
+      });
+
+      Fantom.runWorkLoop();
+
+      expect(onPointerMove).toHaveBeenCalledTimes(3);
+
+      expect(onPointerMove.mock.calls[0][0].nativeEvent.x).toBe(0);
+      expect(onPointerMove.mock.calls[0][0].nativeEvent.y).toBe(0);
+
+      expect(onPointerMove.mock.calls[1][0].nativeEvent.x).toBe(1);
+      expect(onPointerMove.mock.calls[1][0].nativeEvent.y).toBe(0);
+
+      expect(onPointerMove.mock.calls[2][0].nativeEvent.x).toBe(1);
+      expect(onPointerMove.mock.calls[2][0].nativeEvent.y).toBe(1);
+    });
+  });
+});

--- a/packages/react-native/src/private/renderer/core/__tests__/EventDispatching-itest.js
+++ b/packages/react-native/src/private/renderer/core/__tests__/EventDispatching-itest.js
@@ -483,7 +483,7 @@ describe('Event Dispatching', () => {
       expect(onPointerMove).toHaveBeenCalledTimes(2);
     });
 
-    it.skip('are NOT combined with the same type if it is non-unique', () => {
+    it('are NOT combined with the same type if it is non-unique', () => {
       const root = Fantom.createRoot();
 
       const ref = React.createRef<React.ElementRef<typeof View>>();

--- a/packages/react-native/src/private/testing/fantom/specs/NativeFantom.js
+++ b/packages/react-native/src/private/testing/fantom/specs/NativeFantom.js
@@ -49,6 +49,12 @@ export enum NativeEventCategory {
    * isn't ongoing.
    */
   Continuous = 4,
+
+  /*
+   * Priority for events that can be processed in idle times or in the
+   * background.
+   */
+  Idle = 5,
 }
 
 export type ScrollOptions = {


### PR DESCRIPTION
Summary:
Changelog: [internal]

This fixes a potential bug where we coalesce unique events with non-unique ones of the same type and target.

Not marked as a bug fix in the changelog because this wouldn't happen in practice, as we always dispatch events of a given type the same way (all unique or all non-unique).

Differential Revision: D73849222


