### PR TITLE
fix crash when host pause called and mCurrentActivity is null

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -646,9 +646,7 @@ public class ReactInstanceManager {
   public void onHostPause(@Nullable Activity activity) {
     if (mRequireActivity) {
       if (mCurrentActivity == null) {
-        String message =
-            "ReactInstanceManager.onHostPause called with null activity, expected:"
-                + mCurrentActivity.getClass().getSimpleName();
+        String message = "ReactInstanceManager.onHostPause called with null activity";
         FLog.e(TAG, message);
         StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
         for (StackTraceElement element : stackTrace) {


### PR DESCRIPTION
Summary:
shouldnt happen but when it does it shouldnt crash some more

fix for P1798860939

Reviewed By: cortinico

Differential Revision: D73852655


