### PR TITLE
Refactor PerformanceEntry as std::variant

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.cpp
@@ -8,8 +8,8 @@
 #include "NativePerformance.h"
 
 #include <memory>
-#include <mutex>
 #include <unordered_map>
+#include <variant>
 
 #include <cxxreact/JSExecutor.h>
 #include <cxxreact/ReactMarker.h>
@@ -45,6 +45,40 @@ class PerformanceObserverWrapper : public jsi::NativeState {
 void sortEntries(std::vector<PerformanceEntry>& entries) {
   return std::stable_sort(
       entries.begin(), entries.end(), PerformanceEntrySorter{});
+}
+
+NativePerformanceEntry toNativePerformanceEntry(const PerformanceEntry& entry) {
+  auto nativeEntry = std::visit(
+      [](const auto& entryData) -> NativePerformanceEntry {
+        return {
+            .name = entryData.name,
+            .entryType = entryData.entryType,
+            .startTime = entryData.startTime,
+            .duration = entryData.duration,
+        };
+      },
+      entry);
+
+  if (std::holds_alternative<PerformanceEventTiming>(entry)) {
+    auto eventEntry = std::get<PerformanceEventTiming>(entry);
+    nativeEntry.processingStart = eventEntry.processingStart;
+    nativeEntry.processingEnd = eventEntry.processingEnd;
+    nativeEntry.interactionId = eventEntry.interactionId;
+  }
+
+  return nativeEntry;
+}
+
+std::vector<NativePerformanceEntry> toNativePerformanceEntries(
+    std::vector<PerformanceEntry>& entries) {
+  std::vector<NativePerformanceEntry> result;
+  result.reserve(entries.size());
+
+  for (auto& entry : entries) {
+    result.emplace_back(toNativePerformanceEntry(entry));
+  }
+
+  return result;
 }
 
 const std::array<PerformanceEntryType, 2> ENTRY_TYPES_AVAILABLE_FROM_TIMELINE{
@@ -122,7 +156,7 @@ void NativePerformance::clearMeasures(
   }
 }
 
-std::vector<PerformanceEntry> NativePerformance::getEntries(
+std::vector<NativePerformanceEntry> NativePerformance::getEntries(
     jsi::Runtime& /*rt*/) {
   std::vector<PerformanceEntry> entries;
 
@@ -132,10 +166,10 @@ std::vector<PerformanceEntry> NativePerformance::getEntries(
 
   sortEntries(entries);
 
-  return entries;
+  return toNativePerformanceEntries(entries);
 }
 
-std::vector<PerformanceEntry> NativePerformance::getEntriesByName(
+std::vector<NativePerformanceEntry> NativePerformance::getEntriesByName(
     jsi::Runtime& /*rt*/,
     std::string entryName,
     std::optional<PerformanceEntryType> entryType) {
@@ -155,10 +189,10 @@ std::vector<PerformanceEntry> NativePerformance::getEntriesByName(
 
   sortEntries(entries);
 
-  return entries;
+  return toNativePerformanceEntries(entries);
 }
 
-std::vector<PerformanceEntry> NativePerformance::getEntriesByType(
+std::vector<NativePerformanceEntry> NativePerformance::getEntriesByType(
     jsi::Runtime& /*rt*/,
     PerformanceEntryType entryType) {
   std::vector<PerformanceEntry> entries;
@@ -169,7 +203,7 @@ std::vector<PerformanceEntry> NativePerformance::getEntriesByType(
 
   sortEntries(entries);
 
-  return entries;
+  return toNativePerformanceEntries(entries);
 }
 
 std::vector<std::pair<std::string, uint32_t>> NativePerformance::getEventCounts(
@@ -304,7 +338,7 @@ void NativePerformance::disconnect(jsi::Runtime& rt, jsi::Object observerObj) {
   observer->disconnect();
 }
 
-std::vector<PerformanceEntry> NativePerformance::takeRecords(
+std::vector<NativePerformanceEntry> NativePerformance::takeRecords(
     jsi::Runtime& rt,
     jsi::Object observerObj,
     bool sort) {
@@ -320,7 +354,7 @@ std::vector<PerformanceEntry> NativePerformance::takeRecords(
   if (sort) {
     sortEntries(records);
   }
-  return records;
+  return toNativePerformanceEntries(records);
 }
 
 std::vector<PerformanceEntryType>

--- a/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.h
@@ -49,9 +49,23 @@ struct Bridging<PerformanceEntryType> {
   }
 };
 
+// Our Native Module codegen does not support JS type unions, so we use a
+// flattened object here as an intermediate format.
+struct NativePerformanceEntry {
+  std::string name;
+  PerformanceEntryType entryType;
+  DOMHighResTimeStamp startTime;
+  DOMHighResTimeStamp duration;
+
+  // For PerformanceEventTiming only
+  std::optional<DOMHighResTimeStamp> processingStart;
+  std::optional<DOMHighResTimeStamp> processingEnd;
+  std::optional<PerformanceEntryInteractionId> interactionId;
+};
+
 template <>
-struct Bridging<PerformanceEntry>
-    : NativePerformanceRawPerformanceEntryBridging<PerformanceEntry> {};
+struct Bridging<NativePerformanceEntry>
+    : NativePerformanceRawPerformanceEntryBridging<NativePerformanceEntry> {};
 
 template <>
 struct Bridging<NativePerformancePerformanceObserverObserveOptions>
@@ -98,15 +112,15 @@ class NativePerformance : public NativePerformanceCxxSpec<NativePerformance> {
 #pragma mark - Performance Timeline (https://w3c.github.io/performance-timeline/#performance-timeline)
 
   // https://www.w3.org/TR/performance-timeline/#getentries-method
-  std::vector<PerformanceEntry> getEntries(jsi::Runtime& rt);
+  std::vector<NativePerformanceEntry> getEntries(jsi::Runtime& rt);
 
   // https://www.w3.org/TR/performance-timeline/#getentriesbytype-method
-  std::vector<PerformanceEntry> getEntriesByType(
+  std::vector<NativePerformanceEntry> getEntriesByType(
       jsi::Runtime& rt,
       PerformanceEntryType entryType);
 
   // https://www.w3.org/TR/performance-timeline/#getentriesbyname-method
-  std::vector<PerformanceEntry> getEntriesByName(
+  std::vector<NativePerformanceEntry> getEntriesByName(
       jsi::Runtime& rt,
       std::string entryName,
       std::optional<PerformanceEntryType> entryType = std::nullopt);
@@ -125,7 +139,7 @@ class NativePerformance : public NativePerformanceCxxSpec<NativePerformance> {
       jsi::Object observer,
       NativePerformancePerformanceObserverObserveOptions options);
   void disconnect(jsi::Runtime& rt, jsi::Object observer);
-  std::vector<PerformanceEntry> takeRecords(
+  std::vector<NativePerformanceEntry> takeRecords(
       jsi::Runtime& rt,
       jsi::Object observerObj,
       // When called via `observer.takeRecords` it should be in insertion order.

--- a/packages/react-native/ReactCommon/react/performance/timeline/CircularBuffer.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/CircularBuffer.h
@@ -10,7 +10,6 @@
 #include <algorithm>
 #include <functional>
 #include <vector>
-#include "PerformanceEntry.h"
 
 namespace facebook::react {
 

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntry.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntry.h
@@ -8,9 +8,8 @@
 #pragma once
 
 #include <react/timing/primitives.h>
-#include <optional>
 #include <string>
-#include <unordered_set>
+#include <variant>
 
 namespace facebook::react {
 
@@ -25,28 +24,50 @@ enum class PerformanceEntryType {
   _NEXT = 5,
 };
 
-struct PerformanceEntry {
+struct AbstractPerformanceEntry {
   std::string name;
-  PerformanceEntryType entryType;
   DOMHighResTimeStamp startTime;
   DOMHighResTimeStamp duration = 0;
-
-  // For "event" entries only:
-  std::optional<DOMHighResTimeStamp> processingStart;
-  std::optional<DOMHighResTimeStamp> processingEnd;
-  std::optional<PerformanceEntryInteractionId> interactionId;
 };
 
-constexpr size_t NUM_PERFORMANCE_ENTRY_TYPES =
-    (size_t)PerformanceEntryType::_NEXT - 1; // Valid types start from 1.
+struct PerformanceMark : AbstractPerformanceEntry {
+  static constexpr PerformanceEntryType entryType = PerformanceEntryType::MARK;
+};
+
+struct PerformanceMeasure : AbstractPerformanceEntry {
+  static constexpr PerformanceEntryType entryType =
+      PerformanceEntryType::MEASURE;
+};
+
+struct PerformanceEventTiming : AbstractPerformanceEntry {
+  static constexpr PerformanceEntryType entryType = PerformanceEntryType::EVENT;
+  DOMHighResTimeStamp processingStart;
+  DOMHighResTimeStamp processingEnd;
+  PerformanceEntryInteractionId interactionId;
+};
+
+struct PerformanceLongTaskTiming : AbstractPerformanceEntry {
+  static constexpr PerformanceEntryType entryType =
+      PerformanceEntryType::LONGTASK;
+};
+
+using PerformanceEntry = std::variant<
+    PerformanceMark,
+    PerformanceMeasure,
+    PerformanceEventTiming,
+    PerformanceLongTaskTiming>;
 
 struct PerformanceEntrySorter {
   bool operator()(const PerformanceEntry& lhs, const PerformanceEntry& rhs) {
-    if (lhs.startTime != rhs.startTime) {
-      return lhs.startTime < rhs.startTime;
-    } else {
-      return lhs.duration < rhs.duration;
-    }
+    return std::visit(
+        [](const auto& left, const auto& right) {
+          if (left.startTime != right.startTime) {
+            return left.startTime < right.startTime;
+          }
+          return left.duration < right.duration;
+        },
+        lhs,
+        rhs);
   }
 };
 

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryCircularBuffer.cpp
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryCircularBuffer.cpp
@@ -7,6 +7,8 @@
 
 #include "PerformanceEntryCircularBuffer.h"
 
+#include <variant>
+
 namespace facebook::react {
 
 void PerformanceEntryCircularBuffer::add(const PerformanceEntry& entry) {
@@ -23,8 +25,11 @@ void PerformanceEntryCircularBuffer::getEntries(
 void PerformanceEntryCircularBuffer::getEntries(
     std::vector<PerformanceEntry>& target,
     const std::string& name) const {
-  buffer_.getEntries(
-      target, [&](const PerformanceEntry& e) { return e.name == name; });
+  buffer_.getEntries(target, [&](const PerformanceEntry& entry) {
+    return std::visit(
+        [&name](const auto& entryData) { return entryData.name == name; },
+        entry);
+  });
 }
 
 void PerformanceEntryCircularBuffer::clear() {
@@ -32,7 +37,11 @@ void PerformanceEntryCircularBuffer::clear() {
 }
 
 void PerformanceEntryCircularBuffer::clear(const std::string& name) {
-  buffer_.clear([&](const PerformanceEntry& e) { return e.name == name; });
+  buffer_.clear([&](const PerformanceEntry& entry) {
+    return std::visit(
+        [&name](const auto& entryData) { return entryData.name == name; },
+        entry);
+  });
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryKeyedBuffer.cpp
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryKeyedBuffer.cpp
@@ -11,12 +11,15 @@
 namespace facebook::react {
 
 void PerformanceEntryKeyedBuffer::add(const PerformanceEntry& entry) {
-  auto node = entryMap_.find(entry.name);
+  auto name =
+      std::visit([](const auto& entryData) { return entryData.name; }, entry);
+
+  auto node = entryMap_.find(name);
 
   if (node != entryMap_.end()) {
     node->second.push_back(entry);
   } else {
-    entryMap_.emplace(entry.name, std::vector<PerformanceEntry>{entry});
+    entryMap_.emplace(name, std::vector<PerformanceEntry>{entry});
   }
 }
 

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryKeyedBuffer.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryKeyedBuffer.h
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <optional>
-#include <string_view>
 #include <unordered_map>
 #include <vector>
 #include "PerformanceEntryBuffer.h"

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.cpp
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.cpp
@@ -16,6 +16,8 @@
 #include <reactperflogger/ReactPerfetto.h>
 #endif
 
+#include <variant>
+
 namespace facebook::react {
 
 namespace {
@@ -165,15 +167,12 @@ void PerformanceEntryReporter::clearEntries(
   getBufferRef(entryType).clear(entryName);
 }
 
-PerformanceEntry PerformanceEntryReporter::reportMark(
+PerformanceMark PerformanceEntryReporter::reportMark(
     const std::string& name,
     const std::optional<DOMHighResTimeStamp>& startTime) {
   // Resolve timings
   auto startTimeVal = startTime ? *startTime : getCurrentTimeStamp();
-  const auto entry = PerformanceEntry{
-      .name = name,
-      .entryType = PerformanceEntryType::MARK,
-      .startTime = startTimeVal};
+  const auto entry = PerformanceMark{{.name = name, .startTime = startTimeVal}};
 
   traceMark(entry);
 
@@ -188,7 +187,7 @@ PerformanceEntry PerformanceEntryReporter::reportMark(
   return entry;
 }
 
-PerformanceEntry PerformanceEntryReporter::reportMeasure(
+PerformanceMeasure PerformanceEntryReporter::reportMeasure(
     const std::string& name,
     DOMHighResTimeStamp startTime,
     DOMHighResTimeStamp endTime,
@@ -210,11 +209,10 @@ PerformanceEntry PerformanceEntryReporter::reportMeasure(
   DOMHighResTimeStamp durationVal =
       duration ? *duration : endTimeVal - startTimeVal;
 
-  const auto entry = PerformanceEntry{
-      .name = std::string(name),
-      .entryType = PerformanceEntryType::MEASURE,
-      .startTime = startTimeVal,
-      .duration = durationVal};
+  const auto entry = PerformanceMeasure{
+      {.name = std::string(name),
+       .startTime = startTimeVal,
+       .duration = durationVal}};
 
   traceMeasure(entry);
 
@@ -234,7 +232,8 @@ DOMHighResTimeStamp PerformanceEntryReporter::getMarkTime(
   std::shared_lock lock(buffersMutex_);
 
   if (auto it = markBuffer_.find(markName); it) {
-    return it->startTime;
+    return std::visit(
+        [](const auto& entryData) { return entryData.startTime; }, *it);
   } else {
     return 0.0;
   }
@@ -255,14 +254,11 @@ void PerformanceEntryReporter::reportEvent(
     return;
   }
 
-  const auto entry = PerformanceEntry{
-      .name = std::move(name),
-      .entryType = PerformanceEntryType::EVENT,
-      .startTime = startTime,
-      .duration = duration,
-      .processingStart = processingStart,
-      .processingEnd = processingEnd,
-      .interactionId = interactionId};
+  const auto entry = PerformanceEventTiming{
+      {.name = std::move(name), .startTime = startTime, .duration = duration},
+      processingStart,
+      processingEnd,
+      interactionId};
 
   {
     std::unique_lock lock(buffersMutex_);
@@ -276,11 +272,10 @@ void PerformanceEntryReporter::reportEvent(
 void PerformanceEntryReporter::reportLongTask(
     DOMHighResTimeStamp startTime,
     DOMHighResTimeStamp duration) {
-  const auto entry = PerformanceEntry{
-      .name = std::string{"self"},
-      .entryType = PerformanceEntryType::LONGTASK,
-      .startTime = startTime,
-      .duration = duration};
+  const auto entry = PerformanceLongTaskTiming{
+      {.name = std::string{"self"},
+       .startTime = startTime,
+       .duration = duration}};
 
   {
     std::unique_lock lock(buffersMutex_);
@@ -290,7 +285,7 @@ void PerformanceEntryReporter::reportLongTask(
   observerRegistry_->queuePerformanceEntry(entry);
 }
 
-void PerformanceEntryReporter::traceMark(const PerformanceEntry& entry) const {
+void PerformanceEntryReporter::traceMark(const PerformanceMark& entry) const {
   auto& performanceTracer =
       jsinspector_modern::PerformanceTracer::getInstance();
   if (ReactPerfettoLogger::isTracing() || performanceTracer.isTracing()) {
@@ -308,7 +303,7 @@ void PerformanceEntryReporter::traceMark(const PerformanceEntry& entry) const {
 }
 
 void PerformanceEntryReporter::traceMeasure(
-    const PerformanceEntry& entry) const {
+    const PerformanceMeasure& entry) const {
   auto& performanceTracer =
       jsinspector_modern::PerformanceTracer::getInstance();
   if (performanceTracer.isTracing() || ReactPerfettoLogger::isTracing()) {

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.h
@@ -77,11 +77,11 @@ class PerformanceEntryReporter {
     return eventCounts_;
   }
 
-  PerformanceEntry reportMark(
+  PerformanceMark reportMark(
       const std::string& name,
       const std::optional<DOMHighResTimeStamp>& startTime = std::nullopt);
 
-  PerformanceEntry reportMeasure(
+  PerformanceMeasure reportMeasure(
       const std::string& name,
       double startTime,
       double endTime,
@@ -149,8 +149,8 @@ class PerformanceEntryReporter {
     throw std::logic_error("Unhandled PerformanceEntryType");
   }
 
-  void traceMark(const PerformanceEntry& entry) const;
-  void traceMeasure(const PerformanceEntry& entry) const;
+  void traceMark(const PerformanceMark& entry) const;
+  void traceMeasure(const PerformanceMeasure& entry) const;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceObserver.cpp
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceObserver.cpp
@@ -8,13 +8,18 @@
 #include "PerformanceObserver.h"
 #include "PerformanceEntryReporter.h"
 
+#include <variant>
+
 namespace facebook::react {
 
 void PerformanceObserver::handleEntry(const PerformanceEntry& entry) {
-  if (observedTypes_.contains(entry.entryType)) {
+  auto entryType = std::visit(
+      [](const auto& entryData) { return entryData.entryType; }, entry);
+
+  if (observedTypes_.contains(entryType)) {
     // https://www.w3.org/TR/event-timing/#should-add-performanceeventtiming
-    if (entry.entryType == PerformanceEntryType::EVENT &&
-        entry.duration < durationThreshold_) {
+    if (std::holds_alternative<PerformanceEventTiming>(entry) &&
+        std::get<PerformanceEventTiming>(entry).duration < durationThreshold_) {
       // The entries duration is lower than the desired reporting threshold,
       // skip
       return;

--- a/packages/react-native/ReactCommon/react/performance/timeline/tests/PerformanceEntryReporterTest.cpp
+++ b/packages/react-native/ReactCommon/react/performance/timeline/tests/PerformanceEntryReporterTest.cpp
@@ -11,6 +11,8 @@
 
 #include "../PerformanceEntryReporter.h"
 
+#include <variant>
+
 using namespace facebook::react;
 
 namespace facebook::react {
@@ -18,11 +20,27 @@ namespace facebook::react {
 [[maybe_unused]] static bool operator==(
     const PerformanceEntry& lhs,
     const PerformanceEntry& rhs) {
-  return lhs.name == rhs.name && lhs.entryType == rhs.entryType &&
-      lhs.startTime == rhs.startTime && lhs.duration == rhs.duration &&
-      lhs.processingStart == rhs.processingStart &&
-      lhs.processingEnd == rhs.processingEnd &&
-      lhs.interactionId == rhs.interactionId;
+  return std::visit(
+      [&](const auto& left, const auto& right) {
+        bool baseMatch = left.name == right.name &&
+            left.entryType == right.entryType &&
+            left.startTime == right.startTime &&
+            left.duration == right.duration;
+
+        if (baseMatch && left.entryType == PerformanceEntryType::EVENT) {
+          auto leftEventTiming = std::get<PerformanceEventTiming>(lhs);
+          auto rightEventTiming = std::get<PerformanceEventTiming>(rhs);
+
+          return leftEventTiming.processingStart ==
+              rightEventTiming.processingStart &&
+              leftEventTiming.processingEnd == rightEventTiming.processingEnd &&
+              leftEventTiming.interactionId == rightEventTiming.interactionId;
+        }
+
+        return baseMatch;
+      },
+      lhs,
+      rhs);
 }
 
 [[maybe_unused]] static std::ostream& operator<<(
@@ -34,11 +52,18 @@ namespace facebook::react {
       "PerformanceEntryType::MEASURE",
       "PerformanceEntryType::EVENT",
   };
-  return os << "{ .name = \"" << entry.name << "\"" << ", .entryType = "
-            << entryTypeNames[static_cast<int>(entry.entryType)]
-            << ", .startTime = " << entry.startTime
-            << ", .duration = " << entry.duration << " }";
+
+  return std::visit(
+      [&](const auto& entryDetails) -> std::ostream& {
+        os << "{ .name = \"" << entryDetails.name << "\"" << ", .entryType = "
+           << entryTypeNames[static_cast<int>(entryDetails.entryType) - 1]
+           << ", .startTime = " << entryDetails.startTime
+           << ", .duration = " << entryDetails.duration << " }";
+        return os;
+      },
+      entry);
 }
+
 } // namespace facebook::react
 
 namespace {
@@ -65,22 +90,10 @@ TEST(PerformanceEntryReporter, PerformanceEntryReporterTestReportMarks) {
   ASSERT_EQ(4, entries.size());
 
   const std::vector<PerformanceEntry> expected = {
-      {.name = "mark0",
-       .entryType = PerformanceEntryType::MARK,
-       .startTime = 0,
-       .duration = 0},
-      {.name = "mark1",
-       .entryType = PerformanceEntryType::MARK,
-       .startTime = 1,
-       .duration = 0},
-      {.name = "mark2",
-       .entryType = PerformanceEntryType::MARK,
-       .startTime = 2,
-       .duration = 0},
-      {.name = "mark0",
-       .entryType = PerformanceEntryType::MARK,
-       .startTime = 3,
-       .duration = 0}};
+      PerformanceMark{{.name = "mark0", .startTime = 0, .duration = 0}},
+      PerformanceMark{{.name = "mark1", .startTime = 1, .duration = 0}},
+      PerformanceMark{{.name = "mark2", .startTime = 2, .duration = 0}},
+      PerformanceMark{{.name = "mark0", .startTime = 3, .duration = 0}}};
 
   ASSERT_EQ(expected, entries);
 }
@@ -113,62 +126,21 @@ TEST(PerformanceEntryReporter, PerformanceEntryReporterTestReportMeasures) {
   const auto entries = toSorted(reporter->getEntries());
 
   const std::vector<PerformanceEntry> expected = {
-      {.name = "mark0",
-       .entryType = PerformanceEntryType::MARK,
-       .startTime = 0,
-       .duration = 0},
-      {.name = "measure0",
-       .entryType = PerformanceEntryType::MEASURE,
-       .startTime = 0,
-       .duration = 2},
-      {.name = "measure1",
-       .entryType = PerformanceEntryType::MEASURE,
-       .startTime = 0,
-       .duration = 4},
-      {.name = "mark1",
-       .entryType = PerformanceEntryType::MARK,
-       .startTime = 1,
-       .duration = 0},
-      {.name = "measure2",
-       .entryType = PerformanceEntryType::MEASURE,
-       .startTime = 1,
-       .duration = 1},
-      {.name = "measure7",
-       .entryType = PerformanceEntryType::MEASURE,
-       .startTime = 1,
-       .duration = 2},
-      {.name = "measure3",
-       .entryType = PerformanceEntryType::MEASURE,
-       .startTime = 1,
-       .duration = 5},
-      {.name = "measure4",
-       .entryType = PerformanceEntryType::MEASURE,
-       .startTime = 1.5,
-       .duration = 0.5},
-      {.name = "mark2",
-       .entryType = PerformanceEntryType::MARK,
-       .startTime = 2,
-       .duration = 0},
-      {.name = "measure6",
-       .entryType = PerformanceEntryType::MEASURE,
-       .startTime = 2,
-       .duration = 0},
-      {.name = "measure5",
-       .entryType = PerformanceEntryType::MEASURE,
-       .startTime = 2,
-       .duration = 1.5},
-      {.name = "mark4",
-       .entryType = PerformanceEntryType::MARK,
-       .startTime = 2.1,
-       .duration = 0},
-      {.name = "mark3",
-       .entryType = PerformanceEntryType::MARK,
-       .startTime = 2.5,
-       .duration = 0},
-      {.name = "mark4",
-       .entryType = PerformanceEntryType::MARK,
-       .startTime = 3,
-       .duration = 0}};
+      PerformanceMark{{.name = "mark0", .startTime = 0, .duration = 0}},
+      PerformanceMeasure{{.name = "measure0", .startTime = 0, .duration = 2}},
+      PerformanceMeasure{{.name = "measure1", .startTime = 0, .duration = 4}},
+      PerformanceMark{{.name = "mark1", .startTime = 1, .duration = 0}},
+      PerformanceMeasure{{.name = "measure2", .startTime = 1, .duration = 1}},
+      PerformanceMeasure{{.name = "measure7", .startTime = 1, .duration = 2}},
+      PerformanceMeasure{{.name = "measure3", .startTime = 1, .duration = 5}},
+      PerformanceMeasure{
+          {.name = "measure4", .startTime = 1.5, .duration = 0.5}},
+      PerformanceMark{{.name = "mark2", .startTime = 2, .duration = 0}},
+      PerformanceMeasure{{.name = "measure6", .startTime = 2, .duration = 0}},
+      PerformanceMeasure{{.name = "measure5", .startTime = 2, .duration = 1.5}},
+      PerformanceMark{{.name = "mark4", .startTime = 2.1, .duration = 0}},
+      PerformanceMark{{.name = "mark3", .startTime = 2.5, .duration = 0}},
+      PerformanceMark{{.name = "mark4", .startTime = 3, .duration = 0}}};
 
   ASSERT_EQ(expected, entries);
 }
@@ -196,38 +168,16 @@ TEST(PerformanceEntryReporter, PerformanceEntryReporterTestGetEntries) {
   {
     const auto allEntries = toSorted(reporter->getEntries());
     const std::vector<PerformanceEntry> expected = {
-        {.name = "common_name",
-         .entryType = PerformanceEntryType::MARK,
-         .startTime = 0,
-         .duration = 0},
-        {.name = "common_name",
-         .entryType = PerformanceEntryType::MEASURE,
-         .startTime = 0,
-         .duration = 2},
-        {.name = "measure1",
-         .entryType = PerformanceEntryType::MEASURE,
-         .startTime = 0,
-         .duration = 4},
-        {.name = "mark1",
-         .entryType = PerformanceEntryType::MARK,
-         .startTime = 1,
-         .duration = 0},
-        {.name = "measure2",
-         .entryType = PerformanceEntryType::MEASURE,
-         .startTime = 1,
-         .duration = 1},
-        {.name = "measure3",
-         .entryType = PerformanceEntryType::MEASURE,
-         .startTime = 1,
-         .duration = 5},
-        {.name = "measure4",
-         .entryType = PerformanceEntryType::MEASURE,
-         .startTime = 1.5,
-         .duration = 0.5},
-        {.name = "mark2",
-         .entryType = PerformanceEntryType::MARK,
-         .startTime = 2,
-         .duration = 0}};
+        PerformanceMark{{.name = "common_name", .startTime = 0, .duration = 0}},
+        PerformanceMeasure{
+            {.name = "common_name", .startTime = 0, .duration = 2}},
+        PerformanceMeasure{{.name = "measure1", .startTime = 0, .duration = 4}},
+        PerformanceMark{{.name = "mark1", .startTime = 1, .duration = 0}},
+        PerformanceMeasure{{.name = "measure2", .startTime = 1, .duration = 1}},
+        PerformanceMeasure{{.name = "measure3", .startTime = 1, .duration = 5}},
+        PerformanceMeasure{
+            {.name = "measure4", .startTime = 1.5, .duration = 0.5}},
+        PerformanceMark{{.name = "mark2", .startTime = 2, .duration = 0}}};
     ASSERT_EQ(expected, allEntries);
   }
 
@@ -235,18 +185,9 @@ TEST(PerformanceEntryReporter, PerformanceEntryReporterTestGetEntries) {
     const auto marks =
         toSorted(reporter->getEntries(PerformanceEntryType::MARK));
     const std::vector<PerformanceEntry> expected = {
-        {.name = "common_name",
-         .entryType = PerformanceEntryType::MARK,
-         .startTime = 0,
-         .duration = 0},
-        {.name = "mark1",
-         .entryType = PerformanceEntryType::MARK,
-         .startTime = 1,
-         .duration = 0},
-        {.name = "mark2",
-         .entryType = PerformanceEntryType::MARK,
-         .startTime = 2,
-         .duration = 0}};
+        PerformanceMark{{.name = "common_name", .startTime = 0, .duration = 0}},
+        PerformanceMark{{.name = "mark1", .startTime = 1, .duration = 0}},
+        PerformanceMark{{.name = "mark2", .startTime = 2, .duration = 0}}};
     ASSERT_EQ(expected, marks);
   }
 
@@ -254,45 +195,27 @@ TEST(PerformanceEntryReporter, PerformanceEntryReporterTestGetEntries) {
     const auto measures =
         toSorted(reporter->getEntries(PerformanceEntryType::MEASURE));
     const std::vector<PerformanceEntry> expected = {
-        {.name = "common_name",
-         .entryType = PerformanceEntryType::MEASURE,
-         .startTime = 0,
-         .duration = 2},
-        {.name = "measure1",
-         .entryType = PerformanceEntryType::MEASURE,
-         .startTime = 0,
-         .duration = 4},
-        {.name = "measure2",
-         .entryType = PerformanceEntryType::MEASURE,
-         .startTime = 1,
-         .duration = 1},
-        {.name = "measure3",
-         .entryType = PerformanceEntryType::MEASURE,
-         .startTime = 1,
-         .duration = 5},
-        {.name = "measure4",
-         .entryType = PerformanceEntryType::MEASURE,
-         .startTime = 1.5,
-         .duration = 0.5}};
+        PerformanceMeasure{
+            {.name = "common_name", .startTime = 0, .duration = 2}},
+        PerformanceMeasure{{.name = "measure1", .startTime = 0, .duration = 4}},
+        PerformanceMeasure{{.name = "measure2", .startTime = 1, .duration = 1}},
+        PerformanceMeasure{{.name = "measure3", .startTime = 1, .duration = 5}},
+        PerformanceMeasure{
+            {.name = "measure4", .startTime = 1.5, .duration = 0.5}}};
     ASSERT_EQ(expected, measures);
   }
 
   {
     const std::vector<PerformanceEntry> expected = {
-        {.name = "common_name",
-         .entryType = PerformanceEntryType::MARK,
-         .startTime = 0}};
+        PerformanceMark{{.name = "common_name", .startTime = 0}}};
     const auto commonName =
         reporter->getEntries(PerformanceEntryType::MARK, "common_name");
     ASSERT_EQ(expected, commonName);
   }
 
   {
-    const std::vector<PerformanceEntry> expected = {
-        {.name = "common_name",
-         .entryType = PerformanceEntryType::MEASURE,
-         .startTime = 0,
-         .duration = 2}};
+    const std::vector<PerformanceEntry> expected = {PerformanceMeasure{
+        {.name = "common_name", .startTime = 0, .duration = 2}}};
     const auto commonName =
         reporter->getEntries(PerformanceEntryType::MEASURE, "common_name");
     ASSERT_EQ(expected, commonName);
@@ -320,18 +243,9 @@ TEST(PerformanceEntryReporter, PerformanceEntryReporterTestClearMarks) {
   {
     auto entries = toSorted(reporter->getEntries(PerformanceEntryType::MARK));
     std::vector<PerformanceEntry> expected = {
-        {.name = "mark1",
-         .entryType = PerformanceEntryType::MARK,
-         .startTime = 1,
-         .duration = 0},
-        {.name = "mark2",
-         .entryType = PerformanceEntryType::MARK,
-         .startTime = 2,
-         .duration = 0},
-        {.name = "mark1",
-         .entryType = PerformanceEntryType::MARK,
-         .startTime = 2.1,
-         .duration = 0},
+        PerformanceMark{{.name = "mark1", .startTime = 1, .duration = 0}},
+        PerformanceMark{{.name = "mark2", .startTime = 2, .duration = 0}},
+        PerformanceMark{{.name = "mark1", .startTime = 2.1, .duration = 0}},
     };
     ASSERT_EQ(expected, entries);
   }

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/RuntimeSchedulerTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/tests/RuntimeSchedulerTest.cpp
@@ -14,6 +14,7 @@
 #include <react/renderer/runtimescheduler/RuntimeScheduler.h>
 #include <memory>
 #include <semaphore>
+#include <variant>
 
 #include "StubClock.h"
 #include "StubErrorUtils.h"
@@ -1247,9 +1248,14 @@ TEST_P(RuntimeSchedulerTest, reportsLongTasks) {
   EXPECT_EQ(stubQueue_->size(), 0);
   pendingEntries = performanceEntryReporter_->getEntries();
   EXPECT_EQ(pendingEntries.size(), 1);
-  EXPECT_EQ(pendingEntries[0].entryType, PerformanceEntryType::LONGTASK);
-  EXPECT_EQ(pendingEntries[0].startTime, 100);
-  EXPECT_EQ(pendingEntries[0].duration, 50);
+  auto entry = pendingEntries[0];
+  std::visit(
+      [](const auto& entryDetails) {
+        EXPECT_EQ(entryDetails.entryType, PerformanceEntryType::LONGTASK);
+        EXPECT_EQ(entryDetails.startTime, 100);
+        EXPECT_EQ(entryDetails.duration, 50);
+      },
+      entry);
 }
 
 TEST_P(RuntimeSchedulerTest, reportsLongTasksWithYielding) {
@@ -1327,9 +1333,14 @@ TEST_P(RuntimeSchedulerTest, reportsLongTasksWithYielding) {
   EXPECT_EQ(stubQueue_->size(), 0);
   pendingEntries = performanceEntryReporter_->getEntries();
   EXPECT_EQ(pendingEntries.size(), 1);
-  EXPECT_EQ(pendingEntries[0].entryType, PerformanceEntryType::LONGTASK);
-  EXPECT_EQ(pendingEntries[0].startTime, 100);
-  EXPECT_EQ(pendingEntries[0].duration, 120);
+  auto entry = pendingEntries[0];
+  std::visit(
+      [](const auto& entryDetails) {
+        EXPECT_EQ(entryDetails.entryType, PerformanceEntryType::LONGTASK);
+        EXPECT_EQ(entryDetails.startTime, 100);
+        EXPECT_EQ(entryDetails.duration, 120);
+      },
+      entry);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/packages/react-native/src/private/webapis/performance/specs/NativePerformance.js
+++ b/packages/react-native/src/private/webapis/performance/specs/NativePerformance.js
@@ -24,7 +24,7 @@ export type RawPerformanceEntry = {
   startTime: number,
   duration: number,
 
-  // For "event" entries only:
+  // For PerformanceEventTiming only
   processingStart?: number,
   processingEnd?: number,
   interactionId?: number,


### PR DESCRIPTION
Summary:
Refactors our previous single-struct representation for `PerformanceEntry` ([see MDN](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceEntry)) as a `std::variant` — to precisely switch between the possible `PerformanceEntry` variations.

This maps closely to the `PerformanceEntry` type inheritance in the web spec, and makes this type substantially cleaner to extend and work with in D73861431.

Changelog: [Internal]

Differential Revision: D73860532


