### PR TITLE
introduce more tests for edge cases for view culling

### DIFF
--- a/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-viewCulling-itest.js
+++ b/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-viewCulling-itest.js
@@ -1193,6 +1193,81 @@ describe('reparenting', () => {
     ]);
   });
 
+  test('parent-child flattening with child culled', () => {
+    const root = Fantom.createRoot({viewportWidth: 100, viewportHeight: 100});
+    const nodeRef = React.createRef<HostInstance>();
+
+    Fantom.runTask(() => {
+      root.render(
+        <ScrollView
+          style={{height: 100, width: 100}}
+          ref={nodeRef}
+          contentOffset={{x: 0, y: 50}}>
+          <View
+            style={{
+              marginTop: 100,
+              opacity: 0.5,
+            }}>
+            <View
+              style={{
+                marginTop: 50,
+                opacity: 0.1,
+              }}>
+              <View
+                nativeID={'child'}
+                style={{height: 10, width: 10, marginTop: 5}}
+              />
+            </View>
+          </View>
+        </ScrollView>,
+      );
+    });
+
+    expect(root.takeMountingManagerLogs()).toEqual([
+      'Update {type: "RootView", nativeID: (root)}',
+      'Create {type: "ScrollView", nativeID: (N/A)}',
+      'Create {type: "View", nativeID: (N/A)}',
+      'Create {type: "View", nativeID: (N/A)}',
+      'Create {type: "View", nativeID: (N/A)}',
+      'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+      'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+      'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+      'Insert {type: "ScrollView", parentNativeID: (root), index: 0, nativeID: (N/A)}',
+    ]);
+
+    // force parent-child to be flattened.
+    Fantom.runTask(() => {
+      root.render(
+        <ScrollView
+          style={{height: 100, width: 100}}
+          ref={nodeRef}
+          contentOffset={{x: 0, y: 50}}>
+          <View
+            style={{
+              marginTop: 100,
+            }}>
+            <View
+              style={{
+                marginTop: 50,
+              }}>
+              <View
+                nativeID={'child'}
+                style={{height: 10, width: 10, marginTop: 5}}
+              />
+            </View>
+          </View>
+        </ScrollView>,
+      );
+    });
+
+    expect(root.takeMountingManagerLogs()).toEqual([
+      'Remove {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+      'Remove {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+      'Delete {type: "View", nativeID: (N/A)}',
+      'Delete {type: "View", nativeID: (N/A)}',
+    ]);
+  });
+
   test('parent-child switching from unflattened-flattened to flattened-unflattened', () => {
     const root = Fantom.createRoot({viewportWidth: 100, viewportHeight: 100});
 
@@ -1346,6 +1421,179 @@ describe('reparenting', () => {
       'Update {type: "ScrollView", nativeID: (N/A)}',
       'Create {type: "View", nativeID: "grandchild"}',
       'Insert {type: "View", parentNativeID: "child", index: 0, nativeID: "grandchild"}',
+    ]);
+  });
+
+  test('unflattening and creating a deeper subtree that is partially culled', () => {
+    const root = Fantom.createRoot({viewportWidth: 100, viewportHeight: 100});
+
+    // First render with a flattened view container that is visible.
+    Fantom.runTask(() => {
+      root.render(
+        <ScrollView
+          style={{height: 100, width: 100}}
+          contentOffset={{x: 0, y: 115}}>
+          <View style={{marginTop: 200}} />
+        </ScrollView>,
+      );
+    });
+
+    expect(root.takeMountingManagerLogs()).toEqual([
+      'Update {type: "RootView", nativeID: (root)}',
+      'Create {type: "ScrollView", nativeID: (N/A)}',
+      'Create {type: "View", nativeID: (N/A)}',
+      'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+      'Insert {type: "ScrollView", parentNativeID: (root), index: 0, nativeID: (N/A)}',
+    ]);
+
+    const nodeRef = React.createRef<HostInstance>();
+
+    // Now update opacity to unflattned the container and add a child that has a culled descendant.
+    Fantom.runTask(() => {
+      root.render(
+        <ScrollView
+          style={{height: 100, width: 100}}
+          ref={nodeRef}
+          contentOffset={{x: 0, y: 115}}>
+          <View
+            style={{
+              marginTop: 200,
+              opacity: 0.5, // Force unflattening
+            }}>
+            <View
+              nativeID="child"
+              style={{
+                marginTop: 10,
+                height: 10,
+                width: 10,
+              }}>
+              <View
+                nativeID="grandchild"
+                style={{
+                  marginTop: 5, // 215
+                  height: 5,
+                  width: 5,
+                }}>
+                <View
+                  nativeID="grandgrandchild"
+                  style={{
+                    marginTop: 2.5, // 217.5
+                    height: 2.5,
+                    width: 2.5,
+                  }}
+                />
+              </View>
+            </View>
+          </View>
+        </ScrollView>,
+      );
+    });
+
+    expect(root.takeMountingManagerLogs()).toEqual([
+      'Update {type: "ScrollView", nativeID: (N/A)}',
+      'Update {type: "View", nativeID: (N/A)}',
+      'Create {type: "View", nativeID: (N/A)}',
+      'Create {type: "View", nativeID: "child"}',
+      'Create {type: "View", nativeID: "grandchild"}',
+      'Insert {type: "View", parentNativeID: "child", index: 0, nativeID: "grandchild"}',
+      'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+      'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: "child"}',
+    ]);
+
+    const element = ensureInstance(nodeRef.current, ReactNativeElement);
+
+    // Scroll down to see the grandchild.
+    Fantom.scrollTo(element, {
+      x: 0,
+      y: 118,
+    });
+
+    expect(root.takeMountingManagerLogs()).toEqual([
+      'Update {type: "ScrollView", nativeID: (N/A)}',
+      'Create {type: "View", nativeID: "grandgrandchild"}',
+      'Insert {type: "View", parentNativeID: "grandchild", index: 0, nativeID: "grandgrandchild"}',
+    ]);
+  });
+
+  test('flattening and deleting a deeper subtree that is partially culled', () => {
+    const root = Fantom.createRoot({viewportWidth: 100, viewportHeight: 100});
+
+    // First render with a unflattened view container that is visible and a subtree that is partially culled.
+    Fantom.runTask(() => {
+      root.render(
+        <ScrollView
+          style={{height: 100, width: 100}}
+          contentOffset={{x: 0, y: 115}}>
+          <View style={{marginTop: 200, opacity: 0.5}}>
+            <View
+              nativeID="child"
+              style={{
+                marginTop: 10,
+                height: 10,
+                width: 10,
+              }}>
+              <View
+                nativeID="grandchild"
+                style={{
+                  marginTop: 5,
+                  height: 5,
+                  width: 5,
+                }}>
+                <View
+                  nativeID="grandgrandchild"
+                  style={{
+                    marginTop: 2.5,
+                    height: 2.5,
+                    width: 2.5,
+                  }}
+                />
+              </View>
+            </View>
+          </View>
+        </ScrollView>,
+      );
+    });
+
+    // All views are mounted, except for the grandchild.
+    expect(root.takeMountingManagerLogs()).toEqual([
+      'Update {type: "RootView", nativeID: (root)}',
+      'Create {type: "ScrollView", nativeID: (N/A)}',
+      'Create {type: "View", nativeID: (N/A)}',
+      'Create {type: "View", nativeID: (N/A)}',
+      'Create {type: "View", nativeID: "child"}',
+      'Create {type: "View", nativeID: "grandchild"}',
+      'Insert {type: "View", parentNativeID: "child", index: 0, nativeID: "grandchild"}',
+      'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: "child"}',
+      'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+      'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+      'Insert {type: "ScrollView", parentNativeID: (root), index: 0, nativeID: (N/A)}',
+    ]);
+
+    // Now change opacity to the default to flatten the container and delete container's subtree.
+    Fantom.runTask(() => {
+      root.render(
+        <ScrollView
+          style={{height: 100, width: 100}}
+          contentOffset={{x: 0, y: 115}}>
+          <View
+            style={{
+              marginTop: 200,
+            }}
+          />
+        </ScrollView>,
+      );
+    });
+
+    // Note that the grandchild is not deleted because it was not previously mounted.
+    expect(root.takeMountingManagerLogs()).toEqual([
+      'Update {type: "ScrollView", nativeID: (N/A)}',
+      'Update {type: "View", nativeID: (N/A)}',
+      'Remove {type: "View", parentNativeID: "child", index: 0, nativeID: "grandchild"}',
+      'Delete {type: "View", nativeID: "grandchild"}',
+      'Remove {type: "View", parentNativeID: (N/A), index: 0, nativeID: "child"}',
+      'Remove {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+      'Delete {type: "View", nativeID: (N/A)}',
+      'Delete {type: "View", nativeID: "child"}',
     ]);
   });
 
@@ -1668,6 +1916,244 @@ describe('reparenting', () => {
       'Create {type: "View", nativeID: (N/A)}',
       'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
       'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: "grandchild"}',
+    ]);
+  });
+
+  test('nested scroll view with unflattened wrapper', () => {
+    const root = Fantom.createRoot({viewportWidth: 100, viewportHeight: 100});
+
+    Fantom.runTask(() => {
+      root.render(
+        <ScrollView style={{width: 100, height: 100}}>
+          <View>
+            <ScrollView
+              contentOffset={{x: 15, y: 0}}
+              style={{height: 100, width: 100}}
+              horizontal={true}>
+              <View nativeID="child" style={{width: 10, height: 10}} />
+            </ScrollView>
+          </View>
+        </ScrollView>,
+      );
+    });
+
+    expect(root.takeMountingManagerLogs()).toEqual([
+      'Update {type: "RootView", nativeID: (root)}',
+      'Create {type: "ScrollView", nativeID: (N/A)}',
+      'Create {type: "View", nativeID: (N/A)}',
+      'Create {type: "ScrollView", nativeID: (N/A)}',
+      'Insert {type: "ScrollView", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+      'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+      'Insert {type: "ScrollView", parentNativeID: (root), index: 0, nativeID: (N/A)}',
+    ]);
+
+    Fantom.runTask(() => {
+      root.render(
+        <ScrollView style={{height: 100, width: 100, padding: 1}}>
+          <View nativeID="unflattened">
+            <ScrollView
+              contentOffset={{x: 15, y: 0}}
+              style={{height: 100, width: 100}}
+              horizontal={true}>
+              <View nativeID="child" style={{width: 10, height: 10}} />
+            </ScrollView>
+          </View>
+        </ScrollView>,
+      );
+    });
+
+    expect(root.takeMountingManagerLogs()).toEqual([
+      'Update {type: "ScrollView", nativeID: (N/A)}',
+      'Update {type: "View", nativeID: (N/A)}',
+      'Remove {type: "ScrollView", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+      'Create {type: "View", nativeID: "unflattened"}',
+      'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: "unflattened"}',
+      'Insert {type: "ScrollView", parentNativeID: "unflattened", index: 0, nativeID: (N/A)}',
+    ]);
+  });
+
+  test('reparenting with reparented subtree changing its marginTop', () => {
+    const root = Fantom.createRoot({viewportWidth: 100, viewportHeight: 100});
+    const nodeRef = React.createRef<HostInstance>();
+
+    Fantom.runTask(() => {
+      root.render(
+        <ScrollView ref={nodeRef} style={{width: 100, height: 100}}>
+          <View>
+            <View
+              style={{
+                height: 100,
+                width: 100,
+              }}
+              collapsableChildren={false}>
+              <View nativeID="child" style={{width: 10, height: 10}}>
+                <View
+                  nativeID="grandchild"
+                  style={{width: 5, height: 5, marginTop: 5}}
+                />
+              </View>
+            </View>
+          </View>
+        </ScrollView>,
+      );
+    });
+
+    expect(root.takeMountingManagerLogs()).toEqual([
+      'Update {type: "RootView", nativeID: (root)}',
+      'Create {type: "ScrollView", nativeID: (N/A)}',
+      'Create {type: "View", nativeID: (N/A)}',
+      'Create {type: "View", nativeID: "child"}',
+      'Create {type: "View", nativeID: "grandchild"}',
+      'Insert {type: "View", parentNativeID: "child", index: 0, nativeID: "grandchild"}',
+      'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: "child"}',
+      'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+      'Insert {type: "ScrollView", parentNativeID: (root), index: 0, nativeID: (N/A)}',
+    ]);
+
+    Fantom.runTask(() => {
+      root.render(
+        <ScrollView ref={nodeRef} style={{height: 100, width: 100}}>
+          <View nativeID="unflattened">
+            <View
+              style={{
+                height: 100,
+                width: 100,
+                marginTop: 97,
+              }}
+              collapsableChildren={false}>
+              <View nativeID="child" style={{width: 10, height: 10}}>
+                <View
+                  nativeID="grandchild"
+                  style={{width: 5, height: 5, marginTop: 5}}
+                />
+              </View>
+            </View>
+          </View>
+        </ScrollView>,
+      );
+    });
+
+    expect(root.takeMountingManagerLogs()).toEqual([
+      'Update {type: "ScrollView", nativeID: (N/A)}',
+      'Update {type: "View", nativeID: (N/A)}',
+      'Update {type: "View", nativeID: "child"}',
+      'Remove {type: "View", parentNativeID: (N/A), index: 0, nativeID: "child"}',
+      'Create {type: "View", nativeID: "unflattened"}',
+      'Remove {type: "View", parentNativeID: "child", index: 0, nativeID: "grandchild"}',
+      'Delete {type: "View", nativeID: "grandchild"}',
+      'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: "unflattened"}',
+      'Insert {type: "View", parentNativeID: "unflattened", index: 0, nativeID: "child"}',
+    ]);
+
+    const element = ensureInstance(nodeRef.current, ReactNativeElement);
+
+    Fantom.scrollTo(element, {
+      x: 0,
+      y: 50,
+    });
+
+    expect(root.takeMountingManagerLogs()).toEqual([
+      'Update {type: "ScrollView", nativeID: (N/A)}',
+      'Create {type: "View", nativeID: "grandchild"}',
+      'Insert {type: "View", parentNativeID: "child", index: 0, nativeID: "grandchild"}',
+    ]);
+  });
+
+  test('reparenting deep tree with reparented subtree changing its marginTop', () => {
+    const root = Fantom.createRoot({viewportWidth: 100, viewportHeight: 100});
+    const nodeRef = React.createRef<HostInstance>();
+
+    Fantom.runTask(() => {
+      root.render(
+        <ScrollView ref={nodeRef} style={{width: 100, height: 100}}>
+          <View>
+            <View
+              style={{
+                height: 100,
+                width: 100,
+              }}
+              collapsableChildren={false}>
+              <View nativeID="child" style={{width: 10, height: 10}}>
+                <View
+                  nativeID="grandchild"
+                  style={{width: 5, height: 5, marginTop: 5}}>
+                  <View
+                    nativeID="grandgrandchild"
+                    style={{width: 5, height: 5, marginTop: 5}}
+                  />
+                </View>
+              </View>
+            </View>
+          </View>
+        </ScrollView>,
+      );
+    });
+
+    expect(root.takeMountingManagerLogs()).toEqual([
+      'Update {type: "RootView", nativeID: (root)}',
+      'Create {type: "ScrollView", nativeID: (N/A)}',
+      'Create {type: "View", nativeID: (N/A)}',
+      'Create {type: "View", nativeID: "child"}',
+      'Create {type: "View", nativeID: "grandchild"}',
+      'Create {type: "View", nativeID: "grandgrandchild"}',
+      'Insert {type: "View", parentNativeID: "grandchild", index: 0, nativeID: "grandgrandchild"}',
+      'Insert {type: "View", parentNativeID: "child", index: 0, nativeID: "grandchild"}',
+      'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: "child"}',
+      'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: (N/A)}',
+      'Insert {type: "ScrollView", parentNativeID: (root), index: 0, nativeID: (N/A)}',
+    ]);
+
+    Fantom.runTask(() => {
+      root.render(
+        <ScrollView ref={nodeRef} style={{height: 100, width: 100}}>
+          <View nativeID="unflattened">
+            <View
+              style={{
+                height: 100,
+                width: 100,
+                marginTop: 94,
+              }}
+              collapsableChildren={false}>
+              <View nativeID="child" style={{width: 10, height: 10}}>
+                <View
+                  nativeID="grandchild"
+                  style={{width: 5, height: 5, marginTop: 5}}>
+                  <View
+                    nativeID="grandgrandchild"
+                    style={{width: 2.5, height: 2.5, marginTop: 2.5}}
+                  />
+                </View>
+              </View>
+            </View>
+          </View>
+        </ScrollView>,
+      );
+    });
+
+    expect(root.takeMountingManagerLogs()).toEqual([
+      'Update {type: "ScrollView", nativeID: (N/A)}',
+      'Update {type: "View", nativeID: (N/A)}',
+      'Update {type: "View", nativeID: "child"}',
+      'Remove {type: "View", parentNativeID: (N/A), index: 0, nativeID: "child"}',
+      'Create {type: "View", nativeID: "unflattened"}',
+      'Remove {type: "View", parentNativeID: "grandchild", index: 0, nativeID: "grandgrandchild"}',
+      'Delete {type: "View", nativeID: "grandgrandchild"}',
+      'Update {type: "View", nativeID: "grandchild"}',
+      'Insert {type: "View", parentNativeID: (N/A), index: 0, nativeID: "unflattened"}',
+      'Insert {type: "View", parentNativeID: "unflattened", index: 0, nativeID: "child"}',
+    ]);
+
+    const element = ensureInstance(nodeRef.current, ReactNativeElement);
+
+    Fantom.scrollTo(element, {
+      x: 0,
+      y: 50,
+    });
+
+    expect(root.takeMountingManagerLogs()).toEqual([
+      'Update {type: "ScrollView", nativeID: (N/A)}',
+      'Create {type: "View", nativeID: "grandgrandchild"}',
+      'Insert {type: "View", parentNativeID: "grandchild", index: 0, nativeID: "grandgrandchild"}',
     ]);
   });
 });


### PR DESCRIPTION
Summary:
changelog: [internal]


# Why so many tests?
Differentiator has two modes: regular and reparenting. The reparenting one is almost a completely separate Differentiator, effectively doubling the complexity. It handles quite a few different special cases and is not covered by any reasonable tests, so here I am adding the tests to make sure every branch of the reparenting Differentiator is traversed.

Reviewed By: lenaic

Differential Revision: D73845746


