### PR TITLE
Make `FabricEventEmitter` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2404,14 +2404,6 @@ public final class com/facebook/react/fabric/events/EventEmitterWrapper : com/fa
 	public final fun dispatchUnique (Ljava/lang/String;Lcom/facebook/react/bridge/WritableMap;)V
 }
 
-public final class com/facebook/react/fabric/events/FabricEventEmitter : com/facebook/react/uimanager/events/RCTModernEventEmitter {
-	public fun <init> (Lcom/facebook/react/fabric/FabricUIManager;)V
-	public fun receiveEvent (IILjava/lang/String;Lcom/facebook/react/bridge/WritableMap;)V
-	public fun receiveEvent (IILjava/lang/String;ZILcom/facebook/react/bridge/WritableMap;I)V
-	public fun receiveEvent (ILjava/lang/String;Lcom/facebook/react/bridge/WritableMap;)V
-	public fun receiveTouches (Ljava/lang/String;Lcom/facebook/react/bridge/WritableArray;Lcom/facebook/react/bridge/WritableArray;)V
-}
-
 public class com/facebook/react/fabric/mounting/MountItemDispatcher {
 	public fun <init> (Lcom/facebook/react/fabric/mounting/MountingManager;Lcom/facebook/react/fabric/mounting/MountItemDispatcher$ItemDispatchListener;)V
 	public fun addMountItem (Lcom/facebook/react/fabric/mounting/mountitems/MountItem;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/events/FabricEventEmitter.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/events/FabricEventEmitter.kt
@@ -15,13 +15,13 @@ import com.facebook.react.uimanager.events.EventCategoryDef
 import com.facebook.react.uimanager.events.RCTModernEventEmitter
 import com.facebook.systrace.Systrace
 
-public class FabricEventEmitter(private val uiManager: FabricUIManager) : RCTModernEventEmitter {
+internal class FabricEventEmitter(private val uiManager: FabricUIManager) : RCTModernEventEmitter {
   @Deprecated("Deprecated in Java")
-  public override fun receiveEvent(targetTag: Int, eventName: String, params: WritableMap?): Unit {
+  override fun receiveEvent(targetTag: Int, eventName: String, params: WritableMap?): Unit {
     receiveEvent(ViewUtil.NO_SURFACE_ID, targetTag, eventName, params)
   }
 
-  public override fun receiveEvent(
+  override fun receiveEvent(
       surfaceId: Int,
       targetTag: Int,
       eventName: String,
@@ -30,7 +30,7 @@ public class FabricEventEmitter(private val uiManager: FabricUIManager) : RCTMod
     receiveEvent(surfaceId, targetTag, eventName, false, 0, params, EventCategoryDef.UNSPECIFIED)
   }
 
-  public override fun receiveEvent(
+  override fun receiveEvent(
       surfaceId: Int,
       targetTag: Int,
       eventName: String,
@@ -49,7 +49,7 @@ public class FabricEventEmitter(private val uiManager: FabricUIManager) : RCTMod
 
   /** Touches are dispatched by [.receiveTouches] */
   @Deprecated("Deprecated in Java")
-  public override fun receiveTouches(
+  override fun receiveTouches(
       eventName: String,
       touches: WritableArray,
       changedIndices: WritableArray


### PR DESCRIPTION
## Summary:

This class can be internalized as part of the initiative to reduce the public API surface. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.fabric.events.FabricEventEmitter).

## Changelog:

[INTERNAL] - Make com.facebook.react.fabric.events.FabricEventEmitter internal

## Test Plan:

```bash
yarn test-android
yarn android
```