### PR TITLE
Make `ReactModalHostManager` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -5708,47 +5708,6 @@ public final class com/facebook/react/views/imagehelper/ResourceDrawableIdHelper
 	public final fun getInstance ()Lcom/facebook/react/views/imagehelper/ResourceDrawableIdHelper;
 }
 
-public final class com/facebook/react/views/modal/ReactModalHostManager : com/facebook/react/uimanager/ViewGroupManager, com/facebook/react/viewmanagers/ModalHostViewManagerInterface {
-	public static final field Companion Lcom/facebook/react/views/modal/ReactModalHostManager$Companion;
-	public static final field REACT_CLASS Ljava/lang/String;
-	public fun <init> ()V
-	public synthetic fun addEventEmitters (Lcom/facebook/react/uimanager/ThemedReactContext;Landroid/view/View;)V
-	public synthetic fun createViewInstance (Lcom/facebook/react/uimanager/ThemedReactContext;)Landroid/view/View;
-	public fun getDelegate ()Lcom/facebook/react/uimanager/ViewManagerDelegate;
-	public fun getExportedCustomDirectEventTypeConstants ()Ljava/util/Map;
-	public fun getName ()Ljava/lang/String;
-	public synthetic fun onAfterUpdateTransaction (Landroid/view/View;)V
-	public synthetic fun onDropViewInstance (Landroid/view/View;)V
-	public fun onDropViewInstance (Lcom/facebook/react/views/modal/ReactModalHostView;)V
-	public synthetic fun setAnimated (Landroid/view/View;Z)V
-	public fun setAnimated (Lcom/facebook/react/views/modal/ReactModalHostView;Z)V
-	public synthetic fun setAnimationType (Landroid/view/View;Ljava/lang/String;)V
-	public fun setAnimationType (Lcom/facebook/react/views/modal/ReactModalHostView;Ljava/lang/String;)V
-	public synthetic fun setHardwareAccelerated (Landroid/view/View;Z)V
-	public fun setHardwareAccelerated (Lcom/facebook/react/views/modal/ReactModalHostView;Z)V
-	public synthetic fun setIdentifier (Landroid/view/View;I)V
-	public fun setIdentifier (Lcom/facebook/react/views/modal/ReactModalHostView;I)V
-	public synthetic fun setNavigationBarTranslucent (Landroid/view/View;Z)V
-	public fun setNavigationBarTranslucent (Lcom/facebook/react/views/modal/ReactModalHostView;Z)V
-	public synthetic fun setPresentationStyle (Landroid/view/View;Ljava/lang/String;)V
-	public fun setPresentationStyle (Lcom/facebook/react/views/modal/ReactModalHostView;Ljava/lang/String;)V
-	public synthetic fun setStatusBarTranslucent (Landroid/view/View;Z)V
-	public fun setStatusBarTranslucent (Lcom/facebook/react/views/modal/ReactModalHostView;Z)V
-	public synthetic fun setSupportedOrientations (Landroid/view/View;Lcom/facebook/react/bridge/ReadableArray;)V
-	public fun setSupportedOrientations (Lcom/facebook/react/views/modal/ReactModalHostView;Lcom/facebook/react/bridge/ReadableArray;)V
-	public synthetic fun setTestId (Landroid/view/View;Ljava/lang/String;)V
-	public fun setTestId (Lcom/facebook/react/views/modal/ReactModalHostView;Ljava/lang/String;)V
-	public synthetic fun setTransparent (Landroid/view/View;Z)V
-	public fun setTransparent (Lcom/facebook/react/views/modal/ReactModalHostView;Z)V
-	public synthetic fun setVisible (Landroid/view/View;Z)V
-	public fun setVisible (Lcom/facebook/react/views/modal/ReactModalHostView;Z)V
-	public synthetic fun updateState (Landroid/view/View;Lcom/facebook/react/uimanager/ReactStylesDiffMap;Lcom/facebook/react/uimanager/StateWrapper;)Ljava/lang/Object;
-	public fun updateState (Lcom/facebook/react/views/modal/ReactModalHostView;Lcom/facebook/react/uimanager/ReactStylesDiffMap;Lcom/facebook/react/uimanager/StateWrapper;)Ljava/lang/Object;
-}
-
-public final class com/facebook/react/views/modal/ReactModalHostManager$Companion {
-}
-
 public final class com/facebook/react/views/modal/ReactModalHostView : android/view/ViewGroup, com/facebook/react/bridge/LifecycleEventListener {
 	public fun <init> (Lcom/facebook/react/uimanager/ThemedReactContext;)V
 	public fun addChildrenForAccessibility (Ljava/util/ArrayList;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostManager.kt
@@ -23,34 +23,34 @@ import com.facebook.react.views.modal.ReactModalHostView.OnRequestCloseListener
 
 /** View manager for [ReactModalHostView] components. */
 @ReactModule(name = ReactModalHostManager.REACT_CLASS)
-public class ReactModalHostManager :
+internal class ReactModalHostManager :
     ViewGroupManager<ReactModalHostView>(), ModalHostViewManagerInterface<ReactModalHostView> {
   private val delegate: ViewManagerDelegate<ReactModalHostView> = ModalHostViewManagerDelegate(this)
 
-  public override fun getName(): String = REACT_CLASS
+  override fun getName(): String = REACT_CLASS
 
   protected override fun createViewInstance(reactContext: ThemedReactContext): ReactModalHostView =
       ReactModalHostView(reactContext)
 
-  public override fun onDropViewInstance(view: ReactModalHostView) {
+  override fun onDropViewInstance(view: ReactModalHostView) {
     super.onDropViewInstance(view)
     view.onDropInstance()
   }
 
   @ReactProp(name = "animationType")
-  public override fun setAnimationType(view: ReactModalHostView, animationType: String?) {
+  override fun setAnimationType(view: ReactModalHostView, animationType: String?) {
     if (animationType != null) {
       view.animationType = animationType
     }
   }
 
   @ReactProp(name = "transparent")
-  public override fun setTransparent(view: ReactModalHostView, transparent: Boolean) {
+  override fun setTransparent(view: ReactModalHostView, transparent: Boolean) {
     view.transparent = transparent
   }
 
   @ReactProp(name = "statusBarTranslucent")
-  public override fun setStatusBarTranslucent(
+  override fun setStatusBarTranslucent(
       view: ReactModalHostView,
       statusBarTranslucent: Boolean
   ) {
@@ -58,7 +58,7 @@ public class ReactModalHostManager :
   }
 
   @ReactProp(name = "navigationBarTranslucent")
-  public override fun setNavigationBarTranslucent(
+  override fun setNavigationBarTranslucent(
       view: ReactModalHostView,
       navigationBarTranslucent: Boolean
   ) {
@@ -66,7 +66,7 @@ public class ReactModalHostManager :
   }
 
   @ReactProp(name = "hardwareAccelerated")
-  public override fun setHardwareAccelerated(
+  override fun setHardwareAccelerated(
       view: ReactModalHostView,
       hardwareAccelerated: Boolean
   ) {
@@ -74,26 +74,26 @@ public class ReactModalHostManager :
   }
 
   @ReactProp(name = "visible")
-  public override fun setVisible(view: ReactModalHostView, visible: Boolean) {
+  override fun setVisible(view: ReactModalHostView, visible: Boolean) {
     // iOS only
   }
 
   @ReactProp(name = "presentationStyle")
-  public override fun setPresentationStyle(view: ReactModalHostView, value: String?): Unit = Unit
+  override fun setPresentationStyle(view: ReactModalHostView, value: String?): Unit = Unit
 
   @ReactProp(name = "animated")
-  public override fun setAnimated(view: ReactModalHostView, value: Boolean): Unit = Unit
+  override fun setAnimated(view: ReactModalHostView, value: Boolean): Unit = Unit
 
   @ReactProp(name = "supportedOrientations")
-  public override fun setSupportedOrientations(
+  override fun setSupportedOrientations(
       view: ReactModalHostView,
       value: ReadableArray?
   ): Unit = Unit
 
   @ReactProp(name = "identifier")
-  public override fun setIdentifier(view: ReactModalHostView, value: Int): Unit = Unit
+  override fun setIdentifier(view: ReactModalHostView, value: Int): Unit = Unit
 
-  public override fun setTestId(view: ReactModalHostView, value: String?) {
+  override fun setTestId(view: ReactModalHostView, value: String?) {
     super.setTestId(view, value)
     view.setDialogRootViewGroupTestId(value)
   }
@@ -115,7 +115,7 @@ public class ReactModalHostManager :
     }
   }
 
-  public override fun getExportedCustomDirectEventTypeConstants(): Map<String, Any> =
+  override fun getExportedCustomDirectEventTypeConstants(): Map<String, Any> =
       (super.getExportedCustomDirectEventTypeConstants() ?: mutableMapOf()).apply {
         put(RequestCloseEvent.EVENT_NAME, mapOf("registrationName" to "onRequestClose"))
         put(ShowEvent.EVENT_NAME, mapOf("registrationName" to "onShow")) // iOS only
@@ -128,7 +128,7 @@ public class ReactModalHostManager :
     view.showOrUpdate()
   }
 
-  public override fun updateState(
+  override fun updateState(
       view: ReactModalHostView,
       props: ReactStylesDiffMap,
       stateWrapper: StateWrapper
@@ -137,9 +137,9 @@ public class ReactModalHostManager :
     return null
   }
 
-  public override fun getDelegate(): ViewManagerDelegate<ReactModalHostView> = delegate
+  override fun getDelegate(): ViewManagerDelegate<ReactModalHostView> = delegate
 
-  public companion object {
-    public const val REACT_CLASS: String = "RCTModalHostView"
+  companion object {
+    const val REACT_CLASS: String = "RCTModalHostView"
   }
 }


### PR DESCRIPTION
## Summary:

This class can be internalized as part of the initiative to reduce the public API surface. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.views.modal.ReactModalHostManager).

## Changelog:

[INTERNAL] - Make com.facebook.react.views.modal.ReactModalHostManager internal

## Test Plan:

```bash
yarn test-android
yarn android
```