### PR TITLE
Make `EventEmitterWrapper` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2397,13 +2397,6 @@ public final class com/facebook/react/fabric/events/EventBeatManager : com/faceb
 	public fun onBatchEventDispatched ()V
 }
 
-public final class com/facebook/react/fabric/events/EventEmitterWrapper : com/facebook/jni/HybridClassBase {
-	public final fun destroy ()V
-	public final fun dispatch (Ljava/lang/String;Lcom/facebook/react/bridge/WritableMap;I)V
-	public final fun dispatchEventSynchronously (Ljava/lang/String;Lcom/facebook/react/bridge/WritableMap;)V
-	public final fun dispatchUnique (Ljava/lang/String;Lcom/facebook/react/bridge/WritableMap;)V
-}
-
 public final class com/facebook/react/fabric/events/FabricEventEmitter : com/facebook/react/uimanager/events/RCTModernEventEmitter {
 	public fun <init> (Lcom/facebook/react/fabric/FabricUIManager;)V
 	public fun receiveEvent (IILjava/lang/String;Lcom/facebook/react/bridge/WritableMap;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/events/EventEmitterWrapper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/events/EventEmitterWrapper.kt
@@ -22,7 +22,7 @@ import com.facebook.react.uimanager.events.EventCategoryDef
  */
 @DoNotStripAny
 @SuppressLint("MissingNativeLoadLibrary")
-public class EventEmitterWrapper private constructor() : HybridClassBase() {
+internal class EventEmitterWrapper private constructor() : HybridClassBase() {
   private external fun dispatchEvent(
       eventName: String,
       params: NativeMap?,
@@ -40,7 +40,7 @@ public class EventEmitterWrapper private constructor() : HybridClassBase() {
    * @param params [WritableMap] payload of the event
    */
   @Synchronized
-  public fun dispatch(
+  fun dispatch(
       eventName: String,
       params: WritableMap?,
       @EventCategoryDef eventCategory: Int
@@ -52,7 +52,7 @@ public class EventEmitterWrapper private constructor() : HybridClassBase() {
   }
 
   @Synchronized
-  public fun dispatchEventSynchronously(eventName: String, params: WritableMap?) {
+  fun dispatchEventSynchronously(eventName: String, params: WritableMap?) {
     if (!isValid) {
       return
     }
@@ -68,7 +68,7 @@ public class EventEmitterWrapper private constructor() : HybridClassBase() {
    * @param params [WritableMap] payload of the event
    */
   @Synchronized
-  public fun dispatchUnique(eventName: String, params: WritableMap?) {
+  fun dispatchUnique(eventName: String, params: WritableMap?) {
     if (!isValid) {
       return
     }
@@ -76,7 +76,7 @@ public class EventEmitterWrapper private constructor() : HybridClassBase() {
   }
 
   @Synchronized
-  public fun destroy() {
+  fun destroy() {
     if (isValid) {
       resetNative()
     }


### PR DESCRIPTION
## Summary:

This class can be internalized as part of the initiative to reduce the public API surface. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.fabric.events.EventEmitterWrapper).

## Changelog:

[INTERNAL] - Make com.facebook.react.fabric.events.EventEmitterWrapper internal

## Test Plan:

```bash
yarn test-android
yarn android
```