### PR TITLE
Correctly Pass SurfaceID to TextLayoutManager

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.cpp
@@ -181,8 +181,11 @@ Size ParagraphShadowNode::measureContent(
     attributedString.appendFragment({string, textAttributes, {}});
   }
 
-  TextLayoutContext textLayoutContext{};
-  textLayoutContext.pointScaleFactor = layoutContext.pointScaleFactor;
+  TextLayoutContext textLayoutContext{
+      .pointScaleFactor = layoutContext.pointScaleFactor,
+      .surfaceId = getSurfaceId(),
+  };
+
   return textLayoutManager_
       ->measure(
           AttributedStringBox{attributedString},
@@ -242,8 +245,10 @@ void ParagraphShadowNode::layout(LayoutContext layoutContext) {
 
   updateStateIfNeeded(content);
 
-  TextLayoutContext textLayoutContext{};
-  textLayoutContext.pointScaleFactor = layoutContext.pointScaleFactor;
+  TextLayoutContext textLayoutContext{
+      .pointScaleFactor = layoutContext.pointScaleFactor,
+      .surfaceId = getSurfaceId(),
+  };
   auto measurement = TextMeasurement{};
 
   AttributedStringBox attributedStringBox{content.attributedString};

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <glog/logging.h>
+
 #include <react/renderer/attributedstring/AttributedString.h>
 #include <react/renderer/attributedstring/AttributedStringBox.h>
 #include <react/renderer/components/text/BaseTextShadowNode.h>
@@ -18,6 +20,7 @@
 #include <react/renderer/core/LayoutContext.h>
 #include <react/renderer/textlayoutmanager/TextLayoutContext.h>
 #include <react/renderer/textlayoutmanager/TextLayoutManager.h>
+#include <react/renderer/textlayoutmanager/TextLayoutManagerExtended.h>
 #include <react/utils/ContextContainer.h>
 
 namespace facebook::react {
@@ -106,9 +109,18 @@ class BaseTextInputShadowNode : public ConcreteViewShadowNode<
                    &(YogaLayoutableShadowNode::yogaNode_), YGEdgeTop);
 
     AttributedStringBox attributedStringBox{attributedString};
-    return LineMeasurement::baseline(textLayoutManager_->measureLines(
-               attributedStringBox, props.paragraphAttributes, size)) +
-        top;
+
+    if constexpr (TextLayoutManagerExtended::supportsLineMeasurement()) {
+      auto lines =
+          TextLayoutManagerExtended(*textLayoutManager_)
+              .measureLines(
+                  attributedStringBox, props.paragraphAttributes, size);
+      return LineMeasurement::baseline(lines) + top;
+    } else {
+      LOG(WARNING)
+          << "Baseline alignment is not supported by the current platform";
+      return top;
+    }
   }
 
   /*

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputShadowNode.h
@@ -75,7 +75,9 @@ class BaseTextInputShadowNode : public ConcreteViewShadowNode<
     auto textConstraints = getTextConstraints(layoutConstraints);
 
     TextLayoutContext textLayoutContext{
-        .pointScaleFactor = layoutContext.pointScaleFactor};
+        .pointScaleFactor = layoutContext.pointScaleFactor,
+        .surfaceId = BaseShadowNode::getSurfaceId(),
+    };
     auto textSize = textLayoutManager_
                         ->measure(
                             attributedStringBoxToMeasure(layoutContext),

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.cpp
@@ -31,11 +31,17 @@ Size AndroidTextInputShadowNode::measureContent(
     const LayoutConstraints& layoutConstraints) const {
   auto textConstraints = getTextConstraints(layoutConstraints);
 
+  TextLayoutContext textLayoutContext{
+      .pointScaleFactor = layoutContext.pointScaleFactor,
+      .surfaceId = getSurfaceId(),
+  };
+
   if (getStateData().cachedAttributedStringId != 0) {
     auto textSize = textLayoutManager_
                         ->measureCachedSpannableById(
                             getStateData().cachedAttributedStringId,
                             getConcreteProps().paragraphAttributes,
+                            textLayoutContext,
                             textConstraints)
                         .size;
     return layoutConstraints.clamp(textSize);
@@ -58,8 +64,6 @@ Size AndroidTextInputShadowNode::measureContent(
     return {.width = 0, .height = 0};
   }
 
-  TextLayoutContext textLayoutContext;
-  textLayoutContext.pointScaleFactor = layoutContext.pointScaleFactor;
   auto textSize = textLayoutManager_
                       ->measure(
                           AttributedStringBox{attributedString},

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextLayoutContext.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextLayoutContext.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/graphics/Float.h>
 
 namespace facebook::react {
@@ -23,18 +24,13 @@ struct TextLayoutContext {
    * to `pixel value`.
    */
   Float pointScaleFactor{1.0};
+
+  /**
+   * The ID of the surface being laid out
+   */
+  SurfaceId surfaceId{-1};
+
+  bool operator==(const TextLayoutContext& rhs) const = default;
 };
-
-inline bool operator==(
-    const TextLayoutContext& lhs,
-    const TextLayoutContext& rhs) {
-  return std::tie(lhs.pointScaleFactor) == std::tie(rhs.pointScaleFactor);
-}
-
-inline bool operator!=(
-    const TextLayoutContext& lhs,
-    const TextLayoutContext& rhs) {
-  return !(lhs == rhs);
-}
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextLayoutManagerExtended.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextLayoutManagerExtended.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <glog/logging.h>
+
+#include <react/renderer/attributedstring/AttributedStringBox.h>
+#include <react/renderer/attributedstring/ParagraphAttributes.h>
+#include <react/renderer/graphics/Size.h>
+#include <react/renderer/textlayoutmanager/TextLayoutManager.h>
+#include <react/renderer/textlayoutmanager/TextMeasureCache.h>
+
+namespace facebook::react {
+
+namespace detail {
+/**
+ * TextLayoutManagerExtended acts as an adapter for TextLayoutManager methods
+ * which may not exist for a specific platform. Callers can check at
+ * compile-time whether a method is supported, and calling if it is not will
+ * terminate.
+ */
+template <typename TextLayoutManagerT>
+class TextLayoutManagerExtended {
+ public:
+  static constexpr bool supportsLineMeasurement() {
+    return requires(TextLayoutManagerT textLayoutManager) {
+      {
+        textLayoutManager.measureLines(
+            AttributedStringBox{}, ParagraphAttributes{}, Size{})
+      } -> std::same_as<LinesMeasurements>;
+    };
+  }
+
+  TextLayoutManagerExtended(const TextLayoutManagerT& textLayoutManager)
+      : textLayoutManager_(textLayoutManager) {}
+
+  LinesMeasurements measureLines(
+      const AttributedStringBox& attributedStringBox,
+      const ParagraphAttributes& paragraphAttributes,
+      const Size& size) {
+    if constexpr (supportsLineMeasurement()) {
+      return textLayoutManager_.measureLines(
+          attributedStringBox, paragraphAttributes, size);
+    }
+    LOG(FATAL) << "Platform TextLayoutManager does not support measureLines";
+  }
+
+ private:
+  const TextLayoutManagerT& textLayoutManager_;
+};
+} // namespace detail
+
+using TextLayoutManagerExtended =
+    detail::TextLayoutManagerExtended<TextLayoutManager>;
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.cpp
@@ -91,6 +91,7 @@ TextMeasurement doMeasure(
     const ContextContainer::Shared& contextContainer,
     const AttributedString& attributedString,
     const ParagraphAttributes& paragraphAttributes,
+    const TextLayoutContext& layoutContext,
     const LayoutConstraints& layoutConstraints) {
   const int attachmentCount = countAttachments(attributedString);
   auto env = jni::Environment::current();
@@ -110,7 +111,7 @@ TextMeasurement doMeasure(
 
   auto size = measureAndroidComponent(
       contextContainer,
-      -1, // TODO: we should pass rootTag in
+      layoutContext.surfaceId,
       "RCTText",
       std::move(attributedStringMap),
       std::move(paragraphAttributesMap),
@@ -185,6 +186,7 @@ TextMeasurement TextLayoutManager::measure(
             contextContainer_,
             attributedString,
             paragraphAttributes,
+            layoutContext,
             layoutConstraints);
 
         if (telemetry != nullptr) {
@@ -201,6 +203,7 @@ TextMeasurement TextLayoutManager::measure(
 TextMeasurement TextLayoutManager::measureCachedSpannableById(
     int64_t cacheId,
     const ParagraphAttributes& paragraphAttributes,
+    const TextLayoutContext& layoutContext,
     const LayoutConstraints& layoutConstraints) const {
   auto env = jni::Environment::current();
   auto attachmentPositions = env->NewFloatArray(0);
@@ -214,7 +217,7 @@ TextMeasurement TextLayoutManager::measureCachedSpannableById(
 
   auto size = measureAndroidComponent(
       contextContainer_,
-      -1, // TODO: we should pass rootTag in
+      layoutContext.surfaceId,
       "RCTText",
       localDataBuilder.build(),
       toMapBuffer(paragraphAttributes),

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.h
@@ -26,7 +26,6 @@ class TextLayoutManager;
 class TextLayoutManager {
  public:
   TextLayoutManager(const ContextContainer::Shared& contextContainer);
-  virtual ~TextLayoutManager() = default;
 
   /*
    * Not copyable.
@@ -43,13 +42,12 @@ class TextLayoutManager {
   /*
    * Measures `attributedString` using native text rendering infrastructure.
    */
-  virtual TextMeasurement measure(
+  TextMeasurement measure(
       const AttributedStringBox& attributedStringBox,
       const ParagraphAttributes& paragraphAttributes,
       const TextLayoutContext& layoutContext,
       const LayoutConstraints& layoutConstraints) const;
 
-#ifdef ANDROID
   /**
    * Measures an AttributedString on the platform, as identified by some
    * opaque cache ID.
@@ -58,30 +56,18 @@ class TextLayoutManager {
       int64_t cacheId,
       const ParagraphAttributes& paragraphAttributes,
       const LayoutConstraints& layoutConstraints) const;
-#endif
 
   /*
    * Measures lines of `attributedString` using native text rendering
    * infrastructure.
    */
-  virtual LinesMeasurements measureLines(
+  LinesMeasurements measureLines(
       const AttributedStringBox& attributedStringBox,
       const ParagraphAttributes& paragraphAttributes,
       const Size& size) const;
 
-#ifdef __APPLE__
-  /*
-   * Returns an opaque pointer to platform-specific TextLayoutManager.
-   * Is used on a native views layer to delegate text rendering to the manager.
-   */
-  std::shared_ptr<void> getNativeTextLayoutManager() const;
-#endif
-
- protected:
+ private:
   std::shared_ptr<const ContextContainer> contextContainer_;
-#ifdef __APPLE__
-  std::shared_ptr<void> nativeTextLayoutManager_;
-#endif
   TextMeasureCache textMeasureCache_;
   LineMeasureCache lineMeasureCache_;
 };

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.h
@@ -55,6 +55,7 @@ class TextLayoutManager {
   TextMeasurement measureCachedSpannableById(
       int64_t cacheId,
       const ParagraphAttributes& paragraphAttributes,
+      const TextLayoutContext& layoutContext,
       const LayoutConstraints& layoutConstraints) const;
 
   /*

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/cxx/react/renderer/textlayoutmanager/TextLayoutManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/cxx/react/renderer/textlayoutmanager/TextLayoutManager.cpp
@@ -11,8 +11,7 @@ namespace facebook::react {
 
 TextLayoutManager::TextLayoutManager(
     const ContextContainer::Shared& /*contextContainer*/)
-    : textMeasureCache_(kSimpleThreadSafeCacheSizeCap),
-      lineMeasureCache_(kSimpleThreadSafeCacheSizeCap) {}
+    : textMeasureCache_(kSimpleThreadSafeCacheSizeCap) {}
 
 TextMeasurement TextLayoutManager::measure(
     const AttributedStringBox& attributedStringBox,
@@ -28,21 +27,5 @@ TextMeasurement TextLayoutManager::measure(
   }
   return TextMeasurement{{0, 0}, attachments};
 }
-
-#ifdef ANDROID
-TextMeasurement TextLayoutManager::measureCachedSpannableById(
-    int64_t /*cacheId*/,
-    const ParagraphAttributes& /*paragraphAttributes*/,
-    const LayoutConstraints& /*layoutConstraints*/) const {
-  return {};
-}
-#endif
-
-LinesMeasurements TextLayoutManager::measureLines(
-    const AttributedStringBox& /*attributedStringBox*/,
-    const ParagraphAttributes& /*paragraphAttributes*/,
-    const Size& /*size*/) const {
-  return {};
-};
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/cxx/react/renderer/textlayoutmanager/TextLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/cxx/react/renderer/textlayoutmanager/TextLayoutManager.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/attributedstring/AttributedStringBox.h>
+#include <react/renderer/attributedstring/ParagraphAttributes.h>
+#include <react/renderer/core/LayoutConstraints.h>
+#include <react/renderer/textlayoutmanager/TextLayoutContext.h>
+#include <react/renderer/textlayoutmanager/TextMeasureCache.h>
+#include <react/utils/ContextContainer.h>
+#include <memory>
+
+namespace facebook::react {
+
+class TextLayoutManager;
+
+/*
+ * Cross platform facade for text measurement (e.g. Android-specific
+ * TextLayoutManager)
+ */
+class TextLayoutManager {
+ public:
+  TextLayoutManager(const ContextContainer::Shared& contextContainer);
+  virtual ~TextLayoutManager() = default;
+
+  /*
+   * Not copyable.
+   */
+  TextLayoutManager(const TextLayoutManager&) = delete;
+  TextLayoutManager& operator=(const TextLayoutManager&) = delete;
+
+  /*
+   * Not movable.
+   */
+  TextLayoutManager(TextLayoutManager&&) = delete;
+  TextLayoutManager& operator=(TextLayoutManager&&) = delete;
+
+  /*
+   * Measures `attributedString` using native text rendering infrastructure.
+   */
+  virtual TextMeasurement measure(
+      const AttributedStringBox& attributedStringBox,
+      const ParagraphAttributes& paragraphAttributes,
+      const TextLayoutContext& layoutContext,
+      const LayoutConstraints& layoutConstraints) const;
+
+ protected:
+  std::shared_ptr<const ContextContainer> contextContainer_;
+  TextMeasureCache textMeasureCache_;
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/attributedstring/AttributedStringBox.h>
+#include <react/renderer/attributedstring/ParagraphAttributes.h>
+#include <react/renderer/core/LayoutConstraints.h>
+#include <react/renderer/textlayoutmanager/TextLayoutContext.h>
+#include <react/renderer/textlayoutmanager/TextMeasureCache.h>
+#include <react/utils/ContextContainer.h>
+#include <memory>
+
+namespace facebook::react {
+
+/*
+ * Cross platform facade for text measurement (e.g. Android-specific
+ * TextLayoutManager)
+ */
+class TextLayoutManager {
+ public:
+  TextLayoutManager(const ContextContainer::Shared& contextContainer);
+
+  /*
+   * Not copyable.
+   */
+  TextLayoutManager(const TextLayoutManager&) = delete;
+  TextLayoutManager& operator=(const TextLayoutManager&) = delete;
+
+  /*
+   * Not movable.
+   */
+  TextLayoutManager(TextLayoutManager&&) = delete;
+  TextLayoutManager& operator=(TextLayoutManager&&) = delete;
+
+  /*
+   * Measures `attributedString` using native text rendering infrastructure.
+   */
+  TextMeasurement measure(
+      const AttributedStringBox& attributedStringBox,
+      const ParagraphAttributes& paragraphAttributes,
+      const TextLayoutContext& layoutContext,
+      const LayoutConstraints& layoutConstraints) const;
+
+  /*
+   * Measures lines of `attributedString` using native text rendering
+   * infrastructure.
+   */
+  LinesMeasurements measureLines(
+      const AttributedStringBox& attributedStringBox,
+      const ParagraphAttributes& paragraphAttributes,
+      const Size& size) const;
+
+  /*
+   * Returns an opaque pointer to platform-specific TextLayoutManager.
+   * Is used on a native views layer to delegate text rendering to the manager.
+   */
+  std::shared_ptr<void> getNativeTextLayoutManager() const;
+
+ protected:
+  std::shared_ptr<const ContextContainer> contextContainer_;
+  std::shared_ptr<void> nativeTextLayoutManager_;
+  TextMeasureCache textMeasureCache_;
+  LineMeasureCache lineMeasureCache_;
+};
+
+} // namespace facebook::react


### PR DESCRIPTION
Summary:
We need to get a context corresponding to the root being passed, to be able to resolve things like theme to use. RIght now that's a TODO, that's been around since new arch. Let's pass the real data along.

Changelog:
[Android][Fixed] - Correctly Pass SurfaceID to TextLayoutManager

Reviewed By: javache

Differential Revision: D73819640
