### PR TITLE
Incorporate maxLines and ellipsization into text layout

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -6533,6 +6533,7 @@ public class com/facebook/react/views/text/TextAttributeProps {
 	public fun getEffectiveFontSize ()I
 	public fun getEffectiveLetterSpacing ()F
 	public fun getEffectiveLineHeight ()F
+	public static fun getEllipsizeMode (Ljava/lang/String;)Landroid/text/TextUtils$TruncateAt;
 	public fun getFontFamily ()Ljava/lang/String;
 	public fun getFontFeatureSettings ()Ljava/lang/String;
 	public fun getFontStyle ()I

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<519e6095d6c91fbbb4225a066c9cbe26>>
+ * @generated SignedSource<<1172f5f2fda3a7d7835f619376f65b3a>>
  */
 
 /**
@@ -221,6 +221,12 @@ public object ReactNativeFeatureFlags {
    */
   @JvmStatic
   public fun fuseboxNetworkInspectionEnabled(): Boolean = accessor.fuseboxNetworkInspectionEnabled()
+
+  /**
+   * Set maxLines and ellipsization during Android layout creation
+   */
+  @JvmStatic
+  public fun incorporateMaxLinesDuringAndroidLayout(): Boolean = accessor.incorporateMaxLinesDuringAndroidLayout()
 
   /**
    * Enables storing js caller stack when creating promise in native module. This is useful in case of Promise rejection and tracing the cause.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<a70b3ffda510a41144b061036d4f1d48>>
+ * @generated SignedSource<<b045498e0c54e6c12cdf6a6dc25fd109>>
  */
 
 /**
@@ -52,6 +52,7 @@ internal class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAcces
   private var fixMappingOfEventPrioritiesBetweenFabricAndReactCache: Boolean? = null
   private var fuseboxEnabledReleaseCache: Boolean? = null
   private var fuseboxNetworkInspectionEnabledCache: Boolean? = null
+  private var incorporateMaxLinesDuringAndroidLayoutCache: Boolean? = null
   private var traceTurboModulePromiseRejectionsOnAndroidCache: Boolean? = null
   private var updateRuntimeShadowNodeReferencesOnCommitCache: Boolean? = null
   private var useAlwaysAvailableJSErrorHandlingCache: Boolean? = null
@@ -348,6 +349,15 @@ internal class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAcces
     if (cached == null) {
       cached = ReactNativeFeatureFlagsCxxInterop.fuseboxNetworkInspectionEnabled()
       fuseboxNetworkInspectionEnabledCache = cached
+    }
+    return cached
+  }
+
+  override fun incorporateMaxLinesDuringAndroidLayout(): Boolean {
+    var cached = incorporateMaxLinesDuringAndroidLayoutCache
+    if (cached == null) {
+      cached = ReactNativeFeatureFlagsCxxInterop.incorporateMaxLinesDuringAndroidLayout()
+      incorporateMaxLinesDuringAndroidLayoutCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<6107b2e4611a6cd6ad67420eee468601>>
+ * @generated SignedSource<<007721988dfdf572f8ac218744341e60>>
  */
 
 /**
@@ -91,6 +91,8 @@ public object ReactNativeFeatureFlagsCxxInterop {
   @DoNotStrip @JvmStatic public external fun fuseboxEnabledRelease(): Boolean
 
   @DoNotStrip @JvmStatic public external fun fuseboxNetworkInspectionEnabled(): Boolean
+
+  @DoNotStrip @JvmStatic public external fun incorporateMaxLinesDuringAndroidLayout(): Boolean
 
   @DoNotStrip @JvmStatic public external fun traceTurboModulePromiseRejectionsOnAndroid(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<ad976c46e40f6d8a945041388865ec60>>
+ * @generated SignedSource<<6b10c147b3f1753448f599ae4fb43387>>
  */
 
 /**
@@ -86,6 +86,8 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
   override fun fuseboxEnabledRelease(): Boolean = false
 
   override fun fuseboxNetworkInspectionEnabled(): Boolean = false
+
+  override fun incorporateMaxLinesDuringAndroidLayout(): Boolean = true
 
   override fun traceTurboModulePromiseRejectionsOnAndroid(): Boolean = false
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<580a0bc36f98e9680387089a9740bba8>>
+ * @generated SignedSource<<b64966fc245f53645726747ec93a15d1>>
  */
 
 /**
@@ -56,6 +56,7 @@ internal class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcc
   private var fixMappingOfEventPrioritiesBetweenFabricAndReactCache: Boolean? = null
   private var fuseboxEnabledReleaseCache: Boolean? = null
   private var fuseboxNetworkInspectionEnabledCache: Boolean? = null
+  private var incorporateMaxLinesDuringAndroidLayoutCache: Boolean? = null
   private var traceTurboModulePromiseRejectionsOnAndroidCache: Boolean? = null
   private var updateRuntimeShadowNodeReferencesOnCommitCache: Boolean? = null
   private var useAlwaysAvailableJSErrorHandlingCache: Boolean? = null
@@ -384,6 +385,16 @@ internal class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcc
       cached = currentProvider.fuseboxNetworkInspectionEnabled()
       accessedFeatureFlags.add("fuseboxNetworkInspectionEnabled")
       fuseboxNetworkInspectionEnabledCache = cached
+    }
+    return cached
+  }
+
+  override fun incorporateMaxLinesDuringAndroidLayout(): Boolean {
+    var cached = incorporateMaxLinesDuringAndroidLayoutCache
+    if (cached == null) {
+      cached = currentProvider.incorporateMaxLinesDuringAndroidLayout()
+      accessedFeatureFlags.add("incorporateMaxLinesDuringAndroidLayout")
+      incorporateMaxLinesDuringAndroidLayoutCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<b4a944a07650cf46f90d86419b11bbee>>
+ * @generated SignedSource<<1e9beb93c98a0a82d030b7a3ea1cf7e4>>
  */
 
 /**
@@ -86,6 +86,8 @@ public interface ReactNativeFeatureFlagsProvider {
   @DoNotStrip public fun fuseboxEnabledRelease(): Boolean
 
   @DoNotStrip public fun fuseboxNetworkInspectionEnabled(): Boolean
+
+  @DoNotStrip public fun incorporateMaxLinesDuringAndroidLayout(): Boolean
 
   @DoNotStrip public fun traceTurboModulePromiseRejectionsOnAndroid(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.java
@@ -788,4 +788,24 @@ public class TextAttributeProps {
     }
     return androidHyphenationFrequency;
   }
+
+  public static @Nullable TextUtils.TruncateAt getEllipsizeMode(@Nullable String ellipsizeMode) {
+    @Nullable TextUtils.TruncateAt truncateAt = TextUtils.TruncateAt.START;
+    if (ellipsizeMode != null) {
+      switch (ellipsizeMode) {
+        case "head":
+          truncateAt = TextUtils.TruncateAt.START;
+          break;
+        case "middle":
+          truncateAt = TextUtils.TruncateAt.MIDDLE;
+          break;
+        case "tail":
+          truncateAt = TextUtils.TruncateAt.END;
+          break;
+        case "clip":
+          truncateAt = null;
+      }
+    }
+    return truncateAt;
+  }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
@@ -19,6 +19,7 @@ import android.text.Spanned;
 import android.text.StaticLayout;
 import android.text.TextDirectionHeuristics;
 import android.text.TextPaint;
+import android.text.TextUtils;
 import android.util.LayoutDirection;
 import android.view.Gravity;
 import android.view.View;
@@ -32,6 +33,7 @@ import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.common.build.ReactBuildConfig;
 import com.facebook.react.common.mapbuffer.MapBuffer;
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags;
 import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.uimanager.ReactAccessibilityDelegate.AccessibilityRole;
 import com.facebook.react.uimanager.ReactAccessibilityDelegate.Role;
@@ -385,6 +387,8 @@ public class TextLayoutManager {
       int hyphenationFrequency,
       Layout.Alignment alignment,
       int justificationMode,
+      @Nullable TextUtils.TruncateAt ellipsizeMode,
+      int maxNumberOfLines,
       TextPaint paint) {
     Layout layout;
 
@@ -413,6 +417,11 @@ public class TextLayoutManager {
               .setHyphenationFrequency(hyphenationFrequency)
               .setTextDirection(
                   isScriptRTL ? TextDirectionHeuristics.RTL : TextDirectionHeuristics.LTR);
+
+      if (ReactNativeFeatureFlags.incorporateMaxLinesDuringAndroidLayout()
+          && maxNumberOfLines != ReactConstants.UNSET) {
+        builder.setEllipsize(ellipsizeMode).setMaxLines(maxNumberOfLines);
+      }
 
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
         builder.setUseLineSpacingFromFallbacks(true);
@@ -446,6 +455,11 @@ public class TextLayoutManager {
               .setHyphenationFrequency(hyphenationFrequency)
               .setTextDirection(
                   isScriptRTL ? TextDirectionHeuristics.RTL : TextDirectionHeuristics.LTR);
+
+      if (ReactNativeFeatureFlags.incorporateMaxLinesDuringAndroidLayout()
+          && maxNumberOfLines != ReactConstants.UNSET) {
+        builder.setEllipsize(ellipsizeMode).setMaxLines(maxNumberOfLines);
+      }
 
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
         builder.setJustificationMode(justificationMode);
@@ -536,6 +550,12 @@ public class TextLayoutManager {
         paragraphAttributes.contains(PA_KEY_MAX_NUMBER_OF_LINES)
             ? paragraphAttributes.getInt(PA_KEY_MAX_NUMBER_OF_LINES)
             : ReactConstants.UNSET;
+    @Nullable
+    TextUtils.TruncateAt ellipsizeMode =
+        paragraphAttributes.contains(PA_KEY_ELLIPSIZE_MODE)
+            ? TextAttributeProps.getEllipsizeMode(
+                paragraphAttributes.getString(PA_KEY_ELLIPSIZE_MODE))
+            : null;
 
     @Nullable String alignmentAttr = getTextAlignmentAttr(attributedString);
     Layout.Alignment alignment = getTextAlignment(attributedString, text, alignmentAttr);
@@ -573,6 +593,8 @@ public class TextLayoutManager {
         hyphenationFrequency,
         alignment,
         justificationMode,
+        ellipsizeMode,
+        maximumNumberOfLines,
         paint);
   }
 
@@ -602,6 +624,8 @@ public class TextLayoutManager {
             hyphenationFrequency,
             alignment,
             justificationMode,
+            null,
+            ReactConstants.UNSET,
             paint);
 
     // Minimum font size is 4pts to match the iOS implementation.
@@ -654,6 +678,8 @@ public class TextLayoutManager {
               hyphenationFrequency,
               alignment,
               justificationMode,
+              null,
+              ReactConstants.UNSET,
               paint);
     }
   }
@@ -677,7 +703,7 @@ public class TextLayoutManager {
             width,
             height,
             reactTextViewManagerCallback);
-    Spannable text = (Spannable) layout.getText();
+    Spanned text = (Spanned) layout.getText();
 
     if (text == null) {
       return 0;
@@ -726,6 +752,8 @@ public class TextLayoutManager {
 
     float calculatedHeight = height;
     if (heightYogaMeasureMode != YogaMeasureMode.EXACTLY) {
+      // StaticLayout only seems to change its height in response to maxLines when ellipsizing, so
+      // we must truncate
       calculatedHeight = layout.getLineBottom(calculatedLineCount - 1);
       if (heightYogaMeasureMode == YogaMeasureMode.AT_MOST && calculatedHeight > height) {
         calculatedHeight = height;

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<b07fb300852699f3066090549af0b994>>
+ * @generated SignedSource<<ac6b60d9d2062eda500e291fb2167076>>
  */
 
 /**
@@ -228,6 +228,12 @@ class ReactNativeFeatureFlagsJavaProvider
   bool fuseboxNetworkInspectionEnabled() override {
     static const auto method =
         getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("fuseboxNetworkInspectionEnabled");
+    return method(javaProvider_);
+  }
+
+  bool incorporateMaxLinesDuringAndroidLayout() override {
+    static const auto method =
+        getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("incorporateMaxLinesDuringAndroidLayout");
     return method(javaProvider_);
   }
 
@@ -461,6 +467,11 @@ bool JReactNativeFeatureFlagsCxxInterop::fuseboxNetworkInspectionEnabled(
   return ReactNativeFeatureFlags::fuseboxNetworkInspectionEnabled();
 }
 
+bool JReactNativeFeatureFlagsCxxInterop::incorporateMaxLinesDuringAndroidLayout(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
+  return ReactNativeFeatureFlags::incorporateMaxLinesDuringAndroidLayout();
+}
+
 bool JReactNativeFeatureFlagsCxxInterop::traceTurboModulePromiseRejectionsOnAndroid(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
   return ReactNativeFeatureFlags::traceTurboModulePromiseRejectionsOnAndroid();
@@ -643,6 +654,9 @@ void JReactNativeFeatureFlagsCxxInterop::registerNatives() {
       makeNativeMethod(
         "fuseboxNetworkInspectionEnabled",
         JReactNativeFeatureFlagsCxxInterop::fuseboxNetworkInspectionEnabled),
+      makeNativeMethod(
+        "incorporateMaxLinesDuringAndroidLayout",
+        JReactNativeFeatureFlagsCxxInterop::incorporateMaxLinesDuringAndroidLayout),
       makeNativeMethod(
         "traceTurboModulePromiseRejectionsOnAndroid",
         JReactNativeFeatureFlagsCxxInterop::traceTurboModulePromiseRejectionsOnAndroid),

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<963cdfe340c23ca3ca6e43020a3ab608>>
+ * @generated SignedSource<<e1f86665fe4df2f2ee9fb82261760a69>>
  */
 
 /**
@@ -124,6 +124,9 @@ class JReactNativeFeatureFlagsCxxInterop
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool fuseboxNetworkInspectionEnabled(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
+
+  static bool incorporateMaxLinesDuringAndroidLayout(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool traceTurboModulePromiseRejectionsOnAndroid(

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<da8e7e537e16a1338c7a56b1d17b2c6e>>
+ * @generated SignedSource<<17feaf7e1ce72109e0f99902ac8ad1e2>>
  */
 
 /**
@@ -152,6 +152,10 @@ bool ReactNativeFeatureFlags::fuseboxEnabledRelease() {
 
 bool ReactNativeFeatureFlags::fuseboxNetworkInspectionEnabled() {
   return getAccessor().fuseboxNetworkInspectionEnabled();
+}
+
+bool ReactNativeFeatureFlags::incorporateMaxLinesDuringAndroidLayout() {
+  return getAccessor().incorporateMaxLinesDuringAndroidLayout();
 }
 
 bool ReactNativeFeatureFlags::traceTurboModulePromiseRejectionsOnAndroid() {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<43fcd5c23c1eb9b91d3bc26d5543a4b7>>
+ * @generated SignedSource<<28265b23648f7634587376b9f0320f7b>>
  */
 
 /**
@@ -198,6 +198,11 @@ class ReactNativeFeatureFlags {
    * Enable network inspection support in the React Native DevTools CDP backend. Requires `enableBridgelessArchitecture`. This flag is global and should not be changed across React Host lifetimes.
    */
   RN_EXPORT static bool fuseboxNetworkInspectionEnabled();
+
+  /**
+   * Set maxLines and ellipsization during Android layout creation
+   */
+  RN_EXPORT static bool incorporateMaxLinesDuringAndroidLayout();
 
   /**
    * Enables storing js caller stack when creating promise in native module. This is useful in case of Promise rejection and tracing the cause.

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<18b19e4eef226bc502f31d36ada48a53>>
+ * @generated SignedSource<<da4f2f13d1cf90e63e65365a5f5a92e4>>
  */
 
 /**
@@ -605,6 +605,24 @@ bool ReactNativeFeatureFlagsAccessor::fuseboxNetworkInspectionEnabled() {
   return flagValue.value();
 }
 
+bool ReactNativeFeatureFlagsAccessor::incorporateMaxLinesDuringAndroidLayout() {
+  auto flagValue = incorporateMaxLinesDuringAndroidLayout_.load();
+
+  if (!flagValue.has_value()) {
+    // This block is not exclusive but it is not necessary.
+    // If multiple threads try to initialize the feature flag, we would only
+    // be accessing the provider multiple times but the end state of this
+    // instance and the returned flag value would be the same.
+
+    markFlagAsAccessed(32, "incorporateMaxLinesDuringAndroidLayout");
+
+    flagValue = currentProvider_->incorporateMaxLinesDuringAndroidLayout();
+    incorporateMaxLinesDuringAndroidLayout_ = flagValue;
+  }
+
+  return flagValue.value();
+}
+
 bool ReactNativeFeatureFlagsAccessor::traceTurboModulePromiseRejectionsOnAndroid() {
   auto flagValue = traceTurboModulePromiseRejectionsOnAndroid_.load();
 
@@ -614,7 +632,7 @@ bool ReactNativeFeatureFlagsAccessor::traceTurboModulePromiseRejectionsOnAndroid
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(32, "traceTurboModulePromiseRejectionsOnAndroid");
+    markFlagAsAccessed(33, "traceTurboModulePromiseRejectionsOnAndroid");
 
     flagValue = currentProvider_->traceTurboModulePromiseRejectionsOnAndroid();
     traceTurboModulePromiseRejectionsOnAndroid_ = flagValue;
@@ -632,7 +650,7 @@ bool ReactNativeFeatureFlagsAccessor::updateRuntimeShadowNodeReferencesOnCommit(
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(33, "updateRuntimeShadowNodeReferencesOnCommit");
+    markFlagAsAccessed(34, "updateRuntimeShadowNodeReferencesOnCommit");
 
     flagValue = currentProvider_->updateRuntimeShadowNodeReferencesOnCommit();
     updateRuntimeShadowNodeReferencesOnCommit_ = flagValue;
@@ -650,7 +668,7 @@ bool ReactNativeFeatureFlagsAccessor::useAlwaysAvailableJSErrorHandling() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(34, "useAlwaysAvailableJSErrorHandling");
+    markFlagAsAccessed(35, "useAlwaysAvailableJSErrorHandling");
 
     flagValue = currentProvider_->useAlwaysAvailableJSErrorHandling();
     useAlwaysAvailableJSErrorHandling_ = flagValue;
@@ -668,7 +686,7 @@ bool ReactNativeFeatureFlagsAccessor::useEditTextStockAndroidFocusBehavior() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(35, "useEditTextStockAndroidFocusBehavior");
+    markFlagAsAccessed(36, "useEditTextStockAndroidFocusBehavior");
 
     flagValue = currentProvider_->useEditTextStockAndroidFocusBehavior();
     useEditTextStockAndroidFocusBehavior_ = flagValue;
@@ -686,7 +704,7 @@ bool ReactNativeFeatureFlagsAccessor::useFabricInterop() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(36, "useFabricInterop");
+    markFlagAsAccessed(37, "useFabricInterop");
 
     flagValue = currentProvider_->useFabricInterop();
     useFabricInterop_ = flagValue;
@@ -704,7 +722,7 @@ bool ReactNativeFeatureFlagsAccessor::useNativeViewConfigsInBridgelessMode() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(37, "useNativeViewConfigsInBridgelessMode");
+    markFlagAsAccessed(38, "useNativeViewConfigsInBridgelessMode");
 
     flagValue = currentProvider_->useNativeViewConfigsInBridgelessMode();
     useNativeViewConfigsInBridgelessMode_ = flagValue;
@@ -722,7 +740,7 @@ bool ReactNativeFeatureFlagsAccessor::useOptimizedEventBatchingOnAndroid() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(38, "useOptimizedEventBatchingOnAndroid");
+    markFlagAsAccessed(39, "useOptimizedEventBatchingOnAndroid");
 
     flagValue = currentProvider_->useOptimizedEventBatchingOnAndroid();
     useOptimizedEventBatchingOnAndroid_ = flagValue;
@@ -740,7 +758,7 @@ bool ReactNativeFeatureFlagsAccessor::useRawPropsJsiValue() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(39, "useRawPropsJsiValue");
+    markFlagAsAccessed(40, "useRawPropsJsiValue");
 
     flagValue = currentProvider_->useRawPropsJsiValue();
     useRawPropsJsiValue_ = flagValue;
@@ -758,7 +776,7 @@ bool ReactNativeFeatureFlagsAccessor::useShadowNodeStateOnClone() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(40, "useShadowNodeStateOnClone");
+    markFlagAsAccessed(41, "useShadowNodeStateOnClone");
 
     flagValue = currentProvider_->useShadowNodeStateOnClone();
     useShadowNodeStateOnClone_ = flagValue;
@@ -776,7 +794,7 @@ bool ReactNativeFeatureFlagsAccessor::useTurboModuleInterop() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(41, "useTurboModuleInterop");
+    markFlagAsAccessed(42, "useTurboModuleInterop");
 
     flagValue = currentProvider_->useTurboModuleInterop();
     useTurboModuleInterop_ = flagValue;
@@ -794,7 +812,7 @@ bool ReactNativeFeatureFlagsAccessor::useTurboModules() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(42, "useTurboModules");
+    markFlagAsAccessed(43, "useTurboModules");
 
     flagValue = currentProvider_->useTurboModules();
     useTurboModules_ = flagValue;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<4be34538399efc2c7190f35b57d99aec>>
+ * @generated SignedSource<<0267ee6a1b8f1beae0860d132dd2402d>>
  */
 
 /**
@@ -64,6 +64,7 @@ class ReactNativeFeatureFlagsAccessor {
   bool fixMappingOfEventPrioritiesBetweenFabricAndReact();
   bool fuseboxEnabledRelease();
   bool fuseboxNetworkInspectionEnabled();
+  bool incorporateMaxLinesDuringAndroidLayout();
   bool traceTurboModulePromiseRejectionsOnAndroid();
   bool updateRuntimeShadowNodeReferencesOnCommit();
   bool useAlwaysAvailableJSErrorHandling();
@@ -86,7 +87,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::unique_ptr<ReactNativeFeatureFlagsProvider> currentProvider_;
   bool wasOverridden_;
 
-  std::array<std::atomic<const char*>, 43> accessedFeatureFlags_;
+  std::array<std::atomic<const char*>, 44> accessedFeatureFlags_;
 
   std::atomic<std::optional<bool>> commonTestFlag_;
   std::atomic<std::optional<bool>> animatedShouldSignalBatch_;
@@ -120,6 +121,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::atomic<std::optional<bool>> fixMappingOfEventPrioritiesBetweenFabricAndReact_;
   std::atomic<std::optional<bool>> fuseboxEnabledRelease_;
   std::atomic<std::optional<bool>> fuseboxNetworkInspectionEnabled_;
+  std::atomic<std::optional<bool>> incorporateMaxLinesDuringAndroidLayout_;
   std::atomic<std::optional<bool>> traceTurboModulePromiseRejectionsOnAndroid_;
   std::atomic<std::optional<bool>> updateRuntimeShadowNodeReferencesOnCommit_;
   std::atomic<std::optional<bool>> useAlwaysAvailableJSErrorHandling_;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<82cdae47f241f17524ce1b4cbaf5d7e2>>
+ * @generated SignedSource<<78ca4b2bee31ff4813301019618fcc11>>
  */
 
 /**
@@ -153,6 +153,10 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
 
   bool fuseboxNetworkInspectionEnabled() override {
     return false;
+  }
+
+  bool incorporateMaxLinesDuringAndroidLayout() override {
+    return true;
   }
 
   bool traceTurboModulePromiseRejectionsOnAndroid() override {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<f9749a9af3dff2d030ff401915f46ece>>
+ * @generated SignedSource<<314d2aad3f4449406d3a9f78135424d8>>
  */
 
 /**
@@ -331,6 +331,15 @@ class ReactNativeFeatureFlagsDynamicProvider : public ReactNativeFeatureFlagsDef
     }
 
     return ReactNativeFeatureFlagsDefaults::fuseboxNetworkInspectionEnabled();
+  }
+
+  bool incorporateMaxLinesDuringAndroidLayout() override {
+    auto value = values_["incorporateMaxLinesDuringAndroidLayout"];
+    if (!value.isNull()) {
+      return value.getBool();
+    }
+
+    return ReactNativeFeatureFlagsDefaults::incorporateMaxLinesDuringAndroidLayout();
   }
 
   bool traceTurboModulePromiseRejectionsOnAndroid() override {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<cbd205716995b7d53e0426d821cf381e>>
+ * @generated SignedSource<<3328b8a878572bb64517a8320a5c1fac>>
  */
 
 /**
@@ -57,6 +57,7 @@ class ReactNativeFeatureFlagsProvider {
   virtual bool fixMappingOfEventPrioritiesBetweenFabricAndReact() = 0;
   virtual bool fuseboxEnabledRelease() = 0;
   virtual bool fuseboxNetworkInspectionEnabled() = 0;
+  virtual bool incorporateMaxLinesDuringAndroidLayout() = 0;
   virtual bool traceTurboModulePromiseRejectionsOnAndroid() = 0;
   virtual bool updateRuntimeShadowNodeReferencesOnCommit() = 0;
   virtual bool useAlwaysAvailableJSErrorHandling() = 0;

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7aa76d7bbd51de2cc1e3da0ac88e7b56>>
+ * @generated SignedSource<<9f00c0fc715cca4ea3fc6f7fe0b288c7>>
  */
 
 /**
@@ -202,6 +202,11 @@ bool NativeReactNativeFeatureFlags::fuseboxEnabledRelease(
 bool NativeReactNativeFeatureFlags::fuseboxNetworkInspectionEnabled(
     jsi::Runtime& /*runtime*/) {
   return ReactNativeFeatureFlags::fuseboxNetworkInspectionEnabled();
+}
+
+bool NativeReactNativeFeatureFlags::incorporateMaxLinesDuringAndroidLayout(
+    jsi::Runtime& /*runtime*/) {
+  return ReactNativeFeatureFlags::incorporateMaxLinesDuringAndroidLayout();
 }
 
 bool NativeReactNativeFeatureFlags::traceTurboModulePromiseRejectionsOnAndroid(

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<b5b7e8a4b0eb26b5ceea212700ae6efe>>
+ * @generated SignedSource<<9620cd29be36a46d4a80fdfb0600970d>>
  */
 
 /**
@@ -100,6 +100,8 @@ class NativeReactNativeFeatureFlags
   bool fuseboxEnabledRelease(jsi::Runtime& runtime);
 
   bool fuseboxNetworkInspectionEnabled(jsi::Runtime& runtime);
+
+  bool incorporateMaxLinesDuringAndroidLayout(jsi::Runtime& runtime);
 
   bool traceTurboModulePromiseRejectionsOnAndroid(jsi::Runtime& runtime);
 

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.cpp
@@ -181,8 +181,11 @@ Size ParagraphShadowNode::measureContent(
     attributedString.appendFragment({string, textAttributes, {}});
   }
 
-  TextLayoutContext textLayoutContext{};
-  textLayoutContext.pointScaleFactor = layoutContext.pointScaleFactor;
+  TextLayoutContext textLayoutContext{
+      .pointScaleFactor = layoutContext.pointScaleFactor,
+      .surfaceId = getSurfaceId(),
+  };
+
   return textLayoutManager_
       ->measure(
           AttributedStringBox{attributedString},
@@ -242,8 +245,10 @@ void ParagraphShadowNode::layout(LayoutContext layoutContext) {
 
   updateStateIfNeeded(content);
 
-  TextLayoutContext textLayoutContext{};
-  textLayoutContext.pointScaleFactor = layoutContext.pointScaleFactor;
+  TextLayoutContext textLayoutContext{
+      .pointScaleFactor = layoutContext.pointScaleFactor,
+      .surfaceId = getSurfaceId(),
+  };
   auto measurement = TextMeasurement{};
 
   AttributedStringBox attributedStringBox{content.attributedString};

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputShadowNode.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <glog/logging.h>
+
 #include <react/renderer/attributedstring/AttributedString.h>
 #include <react/renderer/attributedstring/AttributedStringBox.h>
 #include <react/renderer/components/text/BaseTextShadowNode.h>
@@ -18,6 +20,7 @@
 #include <react/renderer/core/LayoutContext.h>
 #include <react/renderer/textlayoutmanager/TextLayoutContext.h>
 #include <react/renderer/textlayoutmanager/TextLayoutManager.h>
+#include <react/renderer/textlayoutmanager/TextLayoutManagerExtended.h>
 #include <react/utils/ContextContainer.h>
 
 namespace facebook::react {
@@ -106,9 +109,18 @@ class BaseTextInputShadowNode : public ConcreteViewShadowNode<
                    &(YogaLayoutableShadowNode::yogaNode_), YGEdgeTop);
 
     AttributedStringBox attributedStringBox{attributedString};
-    return LineMeasurement::baseline(textLayoutManager_->measureLines(
-               attributedStringBox, props.paragraphAttributes, size)) +
-        top;
+
+    if constexpr (TextLayoutManagerExtended::supportsLineMeasurement()) {
+      auto lines =
+          TextLayoutManagerExtended(*textLayoutManager_)
+              .measureLines(
+                  attributedStringBox, props.paragraphAttributes, size);
+      return LineMeasurement::baseline(lines) + top;
+    } else {
+      LOG(WARNING)
+          << "Baseline alignment is not supported by the current platform";
+      return top;
+    }
   }
 
   /*

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputShadowNode.h
@@ -75,7 +75,9 @@ class BaseTextInputShadowNode : public ConcreteViewShadowNode<
     auto textConstraints = getTextConstraints(layoutConstraints);
 
     TextLayoutContext textLayoutContext{
-        .pointScaleFactor = layoutContext.pointScaleFactor};
+        .pointScaleFactor = layoutContext.pointScaleFactor,
+        .surfaceId = BaseShadowNode::getSurfaceId(),
+    };
     auto textSize = textLayoutManager_
                         ->measure(
                             attributedStringBoxToMeasure(layoutContext),

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.cpp
@@ -31,11 +31,17 @@ Size AndroidTextInputShadowNode::measureContent(
     const LayoutConstraints& layoutConstraints) const {
   auto textConstraints = getTextConstraints(layoutConstraints);
 
+  TextLayoutContext textLayoutContext{
+      .pointScaleFactor = layoutContext.pointScaleFactor,
+      .surfaceId = getSurfaceId(),
+  };
+
   if (getStateData().cachedAttributedStringId != 0) {
     auto textSize = textLayoutManager_
                         ->measureCachedSpannableById(
                             getStateData().cachedAttributedStringId,
                             getConcreteProps().paragraphAttributes,
+                            textLayoutContext,
                             textConstraints)
                         .size;
     return layoutConstraints.clamp(textSize);
@@ -58,8 +64,6 @@ Size AndroidTextInputShadowNode::measureContent(
     return {.width = 0, .height = 0};
   }
 
-  TextLayoutContext textLayoutContext;
-  textLayoutContext.pointScaleFactor = layoutContext.pointScaleFactor;
   auto textSize = textLayoutManager_
                       ->measure(
                           AttributedStringBox{attributedString},

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextLayoutContext.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextLayoutContext.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/graphics/Float.h>
 
 namespace facebook::react {
@@ -23,18 +24,13 @@ struct TextLayoutContext {
    * to `pixel value`.
    */
   Float pointScaleFactor{1.0};
+
+  /**
+   * The ID of the surface being laid out
+   */
+  SurfaceId surfaceId{-1};
+
+  bool operator==(const TextLayoutContext& rhs) const = default;
 };
-
-inline bool operator==(
-    const TextLayoutContext& lhs,
-    const TextLayoutContext& rhs) {
-  return std::tie(lhs.pointScaleFactor) == std::tie(rhs.pointScaleFactor);
-}
-
-inline bool operator!=(
-    const TextLayoutContext& lhs,
-    const TextLayoutContext& rhs) {
-  return !(lhs == rhs);
-}
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextLayoutManagerExtended.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextLayoutManagerExtended.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <glog/logging.h>
+
+#include <react/renderer/attributedstring/AttributedStringBox.h>
+#include <react/renderer/attributedstring/ParagraphAttributes.h>
+#include <react/renderer/graphics/Size.h>
+#include <react/renderer/textlayoutmanager/TextLayoutManager.h>
+#include <react/renderer/textlayoutmanager/TextMeasureCache.h>
+
+namespace facebook::react {
+
+namespace detail {
+/**
+ * TextLayoutManagerExtended acts as an adapter for TextLayoutManager methods
+ * which may not exist for a specific platform. Callers can check at
+ * compile-time whether a method is supported, and calling if it is not will
+ * terminate.
+ */
+template <typename TextLayoutManagerT>
+class TextLayoutManagerExtended {
+ public:
+  static constexpr bool supportsLineMeasurement() {
+    return requires(TextLayoutManagerT textLayoutManager) {
+      {
+        textLayoutManager.measureLines(
+            AttributedStringBox{}, ParagraphAttributes{}, Size{})
+      } -> std::same_as<LinesMeasurements>;
+    };
+  }
+
+  TextLayoutManagerExtended(const TextLayoutManagerT& textLayoutManager)
+      : textLayoutManager_(textLayoutManager) {}
+
+  LinesMeasurements measureLines(
+      const AttributedStringBox& attributedStringBox,
+      const ParagraphAttributes& paragraphAttributes,
+      const Size& size) {
+    if constexpr (supportsLineMeasurement()) {
+      return textLayoutManager_.measureLines(
+          attributedStringBox, paragraphAttributes, size);
+    }
+    LOG(FATAL) << "Platform TextLayoutManager does not support measureLines";
+  }
+
+ private:
+  const TextLayoutManagerT& textLayoutManager_;
+};
+} // namespace detail
+
+using TextLayoutManagerExtended =
+    detail::TextLayoutManagerExtended<TextLayoutManager>;
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.cpp
@@ -91,6 +91,7 @@ TextMeasurement doMeasure(
     const ContextContainer::Shared& contextContainer,
     const AttributedString& attributedString,
     const ParagraphAttributes& paragraphAttributes,
+    const TextLayoutContext& layoutContext,
     const LayoutConstraints& layoutConstraints) {
   const int attachmentCount = countAttachments(attributedString);
   auto env = jni::Environment::current();
@@ -110,7 +111,7 @@ TextMeasurement doMeasure(
 
   auto size = measureAndroidComponent(
       contextContainer,
-      -1, // TODO: we should pass rootTag in
+      layoutContext.surfaceId,
       "RCTText",
       std::move(attributedStringMap),
       std::move(paragraphAttributesMap),
@@ -185,6 +186,7 @@ TextMeasurement TextLayoutManager::measure(
             contextContainer_,
             attributedString,
             paragraphAttributes,
+            layoutContext,
             layoutConstraints);
 
         if (telemetry != nullptr) {
@@ -201,6 +203,7 @@ TextMeasurement TextLayoutManager::measure(
 TextMeasurement TextLayoutManager::measureCachedSpannableById(
     int64_t cacheId,
     const ParagraphAttributes& paragraphAttributes,
+    const TextLayoutContext& layoutContext,
     const LayoutConstraints& layoutConstraints) const {
   auto env = jni::Environment::current();
   auto attachmentPositions = env->NewFloatArray(0);
@@ -214,7 +217,7 @@ TextMeasurement TextLayoutManager::measureCachedSpannableById(
 
   auto size = measureAndroidComponent(
       contextContainer_,
-      -1, // TODO: we should pass rootTag in
+      layoutContext.surfaceId,
       "RCTText",
       localDataBuilder.build(),
       toMapBuffer(paragraphAttributes),

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.h
@@ -26,7 +26,6 @@ class TextLayoutManager;
 class TextLayoutManager {
  public:
   TextLayoutManager(const ContextContainer::Shared& contextContainer);
-  virtual ~TextLayoutManager() = default;
 
   /*
    * Not copyable.
@@ -43,13 +42,12 @@ class TextLayoutManager {
   /*
    * Measures `attributedString` using native text rendering infrastructure.
    */
-  virtual TextMeasurement measure(
+  TextMeasurement measure(
       const AttributedStringBox& attributedStringBox,
       const ParagraphAttributes& paragraphAttributes,
       const TextLayoutContext& layoutContext,
       const LayoutConstraints& layoutConstraints) const;
 
-#ifdef ANDROID
   /**
    * Measures an AttributedString on the platform, as identified by some
    * opaque cache ID.
@@ -58,30 +56,18 @@ class TextLayoutManager {
       int64_t cacheId,
       const ParagraphAttributes& paragraphAttributes,
       const LayoutConstraints& layoutConstraints) const;
-#endif
 
   /*
    * Measures lines of `attributedString` using native text rendering
    * infrastructure.
    */
-  virtual LinesMeasurements measureLines(
+  LinesMeasurements measureLines(
       const AttributedStringBox& attributedStringBox,
       const ParagraphAttributes& paragraphAttributes,
       const Size& size) const;
 
-#ifdef __APPLE__
-  /*
-   * Returns an opaque pointer to platform-specific TextLayoutManager.
-   * Is used on a native views layer to delegate text rendering to the manager.
-   */
-  std::shared_ptr<void> getNativeTextLayoutManager() const;
-#endif
-
- protected:
+ private:
   std::shared_ptr<const ContextContainer> contextContainer_;
-#ifdef __APPLE__
-  std::shared_ptr<void> nativeTextLayoutManager_;
-#endif
   TextMeasureCache textMeasureCache_;
   LineMeasureCache lineMeasureCache_;
 };

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.h
@@ -55,6 +55,7 @@ class TextLayoutManager {
   TextMeasurement measureCachedSpannableById(
       int64_t cacheId,
       const ParagraphAttributes& paragraphAttributes,
+      const TextLayoutContext& layoutContext,
       const LayoutConstraints& layoutConstraints) const;
 
   /*

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/cxx/react/renderer/textlayoutmanager/TextLayoutManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/cxx/react/renderer/textlayoutmanager/TextLayoutManager.cpp
@@ -11,8 +11,7 @@ namespace facebook::react {
 
 TextLayoutManager::TextLayoutManager(
     const ContextContainer::Shared& /*contextContainer*/)
-    : textMeasureCache_(kSimpleThreadSafeCacheSizeCap),
-      lineMeasureCache_(kSimpleThreadSafeCacheSizeCap) {}
+    : textMeasureCache_(kSimpleThreadSafeCacheSizeCap) {}
 
 TextMeasurement TextLayoutManager::measure(
     const AttributedStringBox& attributedStringBox,
@@ -28,21 +27,5 @@ TextMeasurement TextLayoutManager::measure(
   }
   return TextMeasurement{{0, 0}, attachments};
 }
-
-#ifdef ANDROID
-TextMeasurement TextLayoutManager::measureCachedSpannableById(
-    int64_t /*cacheId*/,
-    const ParagraphAttributes& /*paragraphAttributes*/,
-    const LayoutConstraints& /*layoutConstraints*/) const {
-  return {};
-}
-#endif
-
-LinesMeasurements TextLayoutManager::measureLines(
-    const AttributedStringBox& /*attributedStringBox*/,
-    const ParagraphAttributes& /*paragraphAttributes*/,
-    const Size& /*size*/) const {
-  return {};
-};
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/cxx/react/renderer/textlayoutmanager/TextLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/cxx/react/renderer/textlayoutmanager/TextLayoutManager.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/attributedstring/AttributedStringBox.h>
+#include <react/renderer/attributedstring/ParagraphAttributes.h>
+#include <react/renderer/core/LayoutConstraints.h>
+#include <react/renderer/textlayoutmanager/TextLayoutContext.h>
+#include <react/renderer/textlayoutmanager/TextMeasureCache.h>
+#include <react/utils/ContextContainer.h>
+#include <memory>
+
+namespace facebook::react {
+
+class TextLayoutManager;
+
+/*
+ * Cross platform facade for text measurement (e.g. Android-specific
+ * TextLayoutManager)
+ */
+class TextLayoutManager {
+ public:
+  TextLayoutManager(const ContextContainer::Shared& contextContainer);
+  virtual ~TextLayoutManager() = default;
+
+  /*
+   * Not copyable.
+   */
+  TextLayoutManager(const TextLayoutManager&) = delete;
+  TextLayoutManager& operator=(const TextLayoutManager&) = delete;
+
+  /*
+   * Not movable.
+   */
+  TextLayoutManager(TextLayoutManager&&) = delete;
+  TextLayoutManager& operator=(TextLayoutManager&&) = delete;
+
+  /*
+   * Measures `attributedString` using native text rendering infrastructure.
+   */
+  virtual TextMeasurement measure(
+      const AttributedStringBox& attributedStringBox,
+      const ParagraphAttributes& paragraphAttributes,
+      const TextLayoutContext& layoutContext,
+      const LayoutConstraints& layoutConstraints) const;
+
+ protected:
+  std::shared_ptr<const ContextContainer> contextContainer_;
+  TextMeasureCache textMeasureCache_;
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/attributedstring/AttributedStringBox.h>
+#include <react/renderer/attributedstring/ParagraphAttributes.h>
+#include <react/renderer/core/LayoutConstraints.h>
+#include <react/renderer/textlayoutmanager/TextLayoutContext.h>
+#include <react/renderer/textlayoutmanager/TextMeasureCache.h>
+#include <react/utils/ContextContainer.h>
+#include <memory>
+
+namespace facebook::react {
+
+/*
+ * Cross platform facade for text measurement (e.g. Android-specific
+ * TextLayoutManager)
+ */
+class TextLayoutManager {
+ public:
+  TextLayoutManager(const ContextContainer::Shared& contextContainer);
+
+  /*
+   * Not copyable.
+   */
+  TextLayoutManager(const TextLayoutManager&) = delete;
+  TextLayoutManager& operator=(const TextLayoutManager&) = delete;
+
+  /*
+   * Not movable.
+   */
+  TextLayoutManager(TextLayoutManager&&) = delete;
+  TextLayoutManager& operator=(TextLayoutManager&&) = delete;
+
+  /*
+   * Measures `attributedString` using native text rendering infrastructure.
+   */
+  TextMeasurement measure(
+      const AttributedStringBox& attributedStringBox,
+      const ParagraphAttributes& paragraphAttributes,
+      const TextLayoutContext& layoutContext,
+      const LayoutConstraints& layoutConstraints) const;
+
+  /*
+   * Measures lines of `attributedString` using native text rendering
+   * infrastructure.
+   */
+  LinesMeasurements measureLines(
+      const AttributedStringBox& attributedStringBox,
+      const ParagraphAttributes& paragraphAttributes,
+      const Size& size) const;
+
+  /*
+   * Returns an opaque pointer to platform-specific TextLayoutManager.
+   * Is used on a native views layer to delegate text rendering to the manager.
+   */
+  std::shared_ptr<void> getNativeTextLayoutManager() const;
+
+ protected:
+  std::shared_ptr<const ContextContainer> contextContainer_;
+  std::shared_ptr<void> nativeTextLayoutManager_;
+  TextMeasureCache textMeasureCache_;
+  LineMeasureCache lineMeasureCache_;
+};
+
+} // namespace facebook::react

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -385,6 +385,16 @@ const definitions: FeatureFlagDefinitions = {
       },
       ossReleaseStage: 'none',
     },
+    incorporateMaxLinesDuringAndroidLayout: {
+      defaultValue: true,
+      metadata: {
+        description:
+          'Set maxLines and ellipsization during Android layout creation',
+        expectedReleaseValue: true,
+        purpose: 'release',
+      },
+      ossReleaseStage: 'stable',
+    },
     traceTurboModulePromiseRejectionsOnAndroid: {
       defaultValue: false,
       metadata: {

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7d8d9fdc5a0a3133890ae00bb7a1436c>>
+ * @generated SignedSource<<ed6d94dd3369073c3dba6eba354101e2>>
  * @flow strict
  */
 
@@ -78,6 +78,7 @@ export type ReactNativeFeatureFlags = $ReadOnly<{
   fixMappingOfEventPrioritiesBetweenFabricAndReact: Getter<boolean>,
   fuseboxEnabledRelease: Getter<boolean>,
   fuseboxNetworkInspectionEnabled: Getter<boolean>,
+  incorporateMaxLinesDuringAndroidLayout: Getter<boolean>,
   traceTurboModulePromiseRejectionsOnAndroid: Getter<boolean>,
   updateRuntimeShadowNodeReferencesOnCommit: Getter<boolean>,
   useAlwaysAvailableJSErrorHandling: Getter<boolean>,
@@ -283,6 +284,10 @@ export const fuseboxEnabledRelease: Getter<boolean> = createNativeFlagGetter('fu
  * Enable network inspection support in the React Native DevTools CDP backend. Requires `enableBridgelessArchitecture`. This flag is global and should not be changed across React Host lifetimes.
  */
 export const fuseboxNetworkInspectionEnabled: Getter<boolean> = createNativeFlagGetter('fuseboxNetworkInspectionEnabled', false);
+/**
+ * Set maxLines and ellipsization during Android layout creation
+ */
+export const incorporateMaxLinesDuringAndroidLayout: Getter<boolean> = createNativeFlagGetter('incorporateMaxLinesDuringAndroidLayout', true);
 /**
  * Enables storing js caller stack when creating promise in native module. This is useful in case of Promise rejection and tracing the cause.
  */

--- a/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7e9029f654b8454e5d0f878d3196341b>>
+ * @generated SignedSource<<c95c93d2845a0b4555b8da4ede06fa43>>
  * @flow strict
  */
 
@@ -56,6 +56,7 @@ export interface Spec extends TurboModule {
   +fixMappingOfEventPrioritiesBetweenFabricAndReact?: () => boolean;
   +fuseboxEnabledRelease?: () => boolean;
   +fuseboxNetworkInspectionEnabled?: () => boolean;
+  +incorporateMaxLinesDuringAndroidLayout?: () => boolean;
   +traceTurboModulePromiseRejectionsOnAndroid?: () => boolean;
   +updateRuntimeShadowNodeReferencesOnCommit?: () => boolean;
   +useAlwaysAvailableJSErrorHandling?: () => boolean;


### PR DESCRIPTION
Summary:
Right now, we fully layout text, then use max lines to determine  a metric to use when calculating size.

Android API 23+ which we fully target allows incorporating ellipsization and maxlines directly into the layout. This will let us directly draw the layout when using maxLines later. This may also let Android optimize line-breaking a bit, when we hit truncation.

Special care is taken not to set this when we are in `adjustsFontSizeToFit` path, so that line count will flow over, signifing overflow.

I think the main user-facing change is that `onTextLayout` events will have measures post-ellipsization.

Changelog:
[Android][Changed] - Incorporate maxLines and ellipsization into text layout

Reviewed By: joevilches

Differential Revision: D73811573
