### PR TITLE
Fixup tests for ReactHostImpl Kotlin migration

### DIFF
--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/runtime/BridgelessReactContextTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/runtime/BridgelessReactContextTest.kt
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 @file:Suppress("DEPRECATION") // Suppressing as we want to test getFabricUIManager here
 
 package com.facebook.react.runtime
@@ -11,6 +12,7 @@ package com.facebook.react.runtime
 import android.app.Activity
 import android.content.Context
 import com.facebook.react.bridge.WritableNativeArray
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.fabric.FabricUIManager
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsForTests
 import com.facebook.react.uimanager.UIManagerModule
@@ -23,13 +25,14 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentCaptor
-import org.mockito.ArgumentMatchers
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
@@ -43,6 +46,7 @@ import org.robolectric.annotation.Config
             ShadowNativeLoader::class,
             ShadowArguments::class,
             ShadowWritableNativeArray::class])
+@OptIn(UnstableReactNativeAPI::class)
 class BridgelessReactContextTest {
   private lateinit var context: Context
   private lateinit var reactHost: ReactHostImpl
@@ -52,24 +56,22 @@ class BridgelessReactContextTest {
   fun setUp() {
     ReactNativeFeatureFlagsForTests.setUp()
     context = Robolectric.buildActivity(Activity::class.java).create().get()
-    reactHost = mock<ReactHostImpl>()
+    reactHost = mock()
     bridgelessReactContext = BridgelessReactContext(context, reactHost)
   }
 
   @Test
   fun getNativeModuleTest() {
-    val mUiManagerModule = mock<UIManagerModule>()
-    doReturn(mUiManagerModule)
-        .`when`(reactHost)
-        .getNativeModule(ArgumentMatchers.any<Class<UIManagerModule>>())
+    val uiManagerModuleMock: UIManagerModule = mock()
+    whenever(reactHost.getNativeModule(any<Class<UIManagerModule>>())).doReturn(uiManagerModuleMock)
     val uiManagerModule = bridgelessReactContext.getNativeModule(UIManagerModule::class.java)
-    assertThat(uiManagerModule).isEqualTo(mUiManagerModule)
+    assertThat(uiManagerModule).isEqualTo(uiManagerModuleMock)
   }
 
   @Test
   fun getFabricUIManagerTest() {
     val fabricUiManager = mock<FabricUIManager>()
-    doReturn(fabricUiManager).`when`(reactHost).uiManager
+    whenever(reactHost.uiManager).doReturn(fabricUiManager)
     assertThat(bridgelessReactContext.getFabricUIManager()).isEqualTo(fabricUiManager)
   }
 
@@ -84,11 +86,11 @@ class BridgelessReactContextTest {
   fun testEmitDeviceEvent() {
     bridgelessReactContext.emitDeviceEvent("onNetworkResponseReceived", mapOf("foo" to "bar"))
 
-    val argsCapture = ArgumentCaptor.forClass(WritableNativeArray::class.java)
+    val argsCapture = argumentCaptor<WritableNativeArray>()
     verify(reactHost, times(1))
         .callFunctionOnModule(eq("RCTDeviceEventEmitter"), eq("emit"), argsCapture.capture())
 
-    val argsList = ShadowNativeArray.getContents(argsCapture.value)
+    val argsList = ShadowNativeArray.getContents(argsCapture.firstValue)
     assertThat(argsList[0]).isEqualTo("onNetworkResponseReceived")
     @Suppress("UNCHECKED_CAST") assertThat((argsList[1] as Map<Any, Any>)["foo"]).isEqualTo("bar")
   }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/runtime/ReactSurfaceTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/runtime/ReactSurfaceTest.kt
@@ -23,8 +23,8 @@ import org.assertj.core.api.Assertions
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentMatchers.any
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify


### PR DESCRIPTION
Summary:
Splitting of from D73846053 to reduce size.

Changelog: [Internal]

Differential Revision: D73923280


