### PR TITLE
Make ResourceDrawableIdHelper an object

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -5688,17 +5688,13 @@ public final class com/facebook/react/views/imagehelper/ImageSource$Companion {
 }
 
 public final class com/facebook/react/views/imagehelper/ResourceDrawableIdHelper {
-	public static final field Companion Lcom/facebook/react/views/imagehelper/ResourceDrawableIdHelper$Companion;
-	public final fun clear ()V
-	public static final fun getInstance ()Lcom/facebook/react/views/imagehelper/ResourceDrawableIdHelper;
-	public final fun getResourceDrawable (Landroid/content/Context;Ljava/lang/String;)Landroid/graphics/drawable/Drawable;
-	public final fun getResourceDrawableId (Landroid/content/Context;Ljava/lang/String;)I
-	public final fun getResourceDrawableUri (Landroid/content/Context;Ljava/lang/String;)Landroid/net/Uri;
-}
-
-public final class com/facebook/react/views/imagehelper/ResourceDrawableIdHelper$Companion {
+	public static final field INSTANCE Lcom/facebook/react/views/imagehelper/ResourceDrawableIdHelper;
 	public final fun DEPRECATED$getInstance ()Lcom/facebook/react/views/imagehelper/ResourceDrawableIdHelper;
-	public final fun getInstance ()Lcom/facebook/react/views/imagehelper/ResourceDrawableIdHelper;
+	public static final fun clear ()V
+	public static final fun getInstance ()Lcom/facebook/react/views/imagehelper/ResourceDrawableIdHelper;
+	public static final fun getResourceDrawable (Landroid/content/Context;Ljava/lang/String;)Landroid/graphics/drawable/Drawable;
+	public static final fun getResourceDrawableId (Landroid/content/Context;Ljava/lang/String;)I
+	public static final fun getResourceDrawableUri (Landroid/content/Context;Ljava/lang/String;)Landroid/net/Uri;
 }
 
 public final class com/facebook/react/views/modal/ReactModalHostManager : com/facebook/react/uimanager/ViewGroupManager, com/facebook/react/viewmanagers/ModalHostViewManagerInterface {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.kt
@@ -73,7 +73,7 @@ import com.facebook.react.views.image.MultiPostprocessor.Companion.from
 import com.facebook.react.views.imagehelper.ImageSource
 import com.facebook.react.views.imagehelper.ImageSource.Companion.getTransparentBitmapImageSource
 import com.facebook.react.views.imagehelper.MultiSourceHelper.getBestSourceForSize
-import com.facebook.react.views.imagehelper.ResourceDrawableIdHelper.Companion.instance
+import com.facebook.react.views.imagehelper.ResourceDrawableIdHelper
 import kotlin.math.abs
 
 /**
@@ -326,7 +326,7 @@ public class ReactImageView(
   }
 
   public fun setDefaultSource(name: String?) {
-    val newDefaultDrawable = instance.getResourceDrawable(context, name)
+    val newDefaultDrawable = ResourceDrawableIdHelper.getResourceDrawable(context, name)
     if (defaultImageDrawable != newDefaultDrawable) {
       defaultImageDrawable = newDefaultDrawable
       isDirty = true
@@ -334,7 +334,7 @@ public class ReactImageView(
   }
 
   public fun setLoadingIndicatorSource(name: String?) {
-    val drawable = instance.getResourceDrawable(context, name)
+    val drawable = ResourceDrawableIdHelper.getResourceDrawable(context, name)
     val newLoadingIndicatorSource = drawable?.let { AutoRotateDrawable(it, 1000) }
     if (loadingImageDrawable != newLoadingIndicatorSource) {
       loadingImageDrawable = newLoadingIndicatorSource

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/imagehelper/ImageSource.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/imagehelper/ImageSource.kt
@@ -64,7 +64,7 @@ constructor(
 
   private fun computeLocalUri(context: Context): Uri {
     _isResource = true
-    return ResourceDrawableIdHelper.instance.getResourceDrawableUri(context, source)
+    return ResourceDrawableIdHelper.getResourceDrawableUri(context, source)
   }
 
   public companion object {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/imagehelper/ResourceDrawableIdHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/imagehelper/ResourceDrawableIdHelper.kt
@@ -15,14 +15,16 @@ import javax.annotation.concurrent.ThreadSafe
 
 /** Helper class for obtaining information about local images. */
 @ThreadSafe
-public class ResourceDrawableIdHelper private constructor() {
+public object ResourceDrawableIdHelper {
   private val resourceDrawableIdMap: MutableMap<String, Int> = HashMap()
 
   @Synchronized
+  @JvmStatic
   public fun clear() {
     resourceDrawableIdMap.clear()
   }
 
+  @JvmStatic
   public fun getResourceDrawableId(context: Context, name: String?): Int {
     if (name.isNullOrEmpty()) {
       return 0
@@ -47,11 +49,13 @@ public class ResourceDrawableIdHelper private constructor() {
     return newId
   }
 
+  @JvmStatic
   public fun getResourceDrawable(context: Context, name: String?): Drawable? {
     val resId = getResourceDrawableId(context, name)
     return if (resId > 0) ResourcesCompat.getDrawable(context.resources, resId, null) else null
   }
 
+  @JvmStatic
   public fun getResourceDrawableUri(context: Context, name: String?): Uri {
     val resId = getResourceDrawableId(context, name)
     return if (resId > 0) {
@@ -61,21 +65,20 @@ public class ResourceDrawableIdHelper private constructor() {
     }
   }
 
-  public companion object {
-    private const val LOCAL_RESOURCE_SCHEME = "res"
-    private val resourceDrawableIdHelper: ResourceDrawableIdHelper = ResourceDrawableIdHelper()
-    @JvmStatic
-    public val instance: ResourceDrawableIdHelper
-      get() = resourceDrawableIdHelper
+  @JvmStatic
+  @Deprecated("Use object methods instead, this API is for backward compat")
+  public val instance: ResourceDrawableIdHelper
+    get() = this
 
-    /**
-     * We're just re-adding this to reduce a breaking change for libraries in React Native 0.75.
-     *
-     * @deprecated Use instance instead
-     */
-    @Deprecated("Use .instance instead, this API is for backward compat", ReplaceWith("instance"))
-    @JvmName(
-        "DEPRECATED\$getInstance") // We intentionally don't want to expose this accessor to Java.
-    public fun getInstance(): ResourceDrawableIdHelper = instance
-  }
+  private const val LOCAL_RESOURCE_SCHEME = "res"
+
+  /**
+   * We're just re-adding this to reduce a breaking change for libraries in React Native 0.75.
+   *
+   * @deprecated Use instance instead
+   */
+  @Deprecated("Use .instance instead, this API is for backward compat", ReplaceWith("instance"))
+  @JvmName(
+      "DEPRECATED\$getInstance") // We intentionally don't want to expose this accessor to Java.
+  public fun getInstance(): ResourceDrawableIdHelper = this
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.kt
@@ -56,7 +56,7 @@ import com.facebook.react.uimanager.events.EventDispatcher
 import com.facebook.react.uimanager.style.BorderRadiusProp
 import com.facebook.react.uimanager.style.BorderStyle.Companion.fromString
 import com.facebook.react.uimanager.style.LogicalEdge
-import com.facebook.react.views.imagehelper.ResourceDrawableIdHelper.Companion.instance
+import com.facebook.react.views.imagehelper.ResourceDrawableIdHelper
 import com.facebook.react.views.scroll.ScrollEventType
 import com.facebook.react.views.scroll.ScrollEventType.Companion.getJSEventName
 import com.facebook.react.views.text.DefaultStyleValuesUtil.getDefaultTextColor
@@ -598,7 +598,7 @@ public open class ReactTextInputManager public constructor() :
 
   @ReactProp(name = "inlineImageLeft")
   public fun setInlineImageLeft(view: ReactEditText, resource: String?) {
-    val id = instance.getResourceDrawableId(view.context, resource)
+    val id = ResourceDrawableIdHelper.getResourceDrawableId(view.context, resource)
     view.setCompoundDrawablesWithIntrinsicBounds(id, 0, 0, 0)
   }
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/runtime/BridgelessReactContextTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/runtime/BridgelessReactContextTest.kt
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 @file:Suppress("DEPRECATION") // Suppressing as we want to test getFabricUIManager here
 
 package com.facebook.react.runtime
@@ -11,6 +12,7 @@ package com.facebook.react.runtime
 import android.app.Activity
 import android.content.Context
 import com.facebook.react.bridge.WritableNativeArray
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.fabric.FabricUIManager
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsForTests
 import com.facebook.react.uimanager.UIManagerModule
@@ -23,13 +25,14 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentCaptor
-import org.mockito.ArgumentMatchers
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
@@ -43,6 +46,7 @@ import org.robolectric.annotation.Config
             ShadowNativeLoader::class,
             ShadowArguments::class,
             ShadowWritableNativeArray::class])
+@OptIn(UnstableReactNativeAPI::class)
 class BridgelessReactContextTest {
   private lateinit var context: Context
   private lateinit var reactHost: ReactHostImpl
@@ -52,24 +56,22 @@ class BridgelessReactContextTest {
   fun setUp() {
     ReactNativeFeatureFlagsForTests.setUp()
     context = Robolectric.buildActivity(Activity::class.java).create().get()
-    reactHost = mock<ReactHostImpl>()
+    reactHost = mock()
     bridgelessReactContext = BridgelessReactContext(context, reactHost)
   }
 
   @Test
   fun getNativeModuleTest() {
-    val mUiManagerModule = mock<UIManagerModule>()
-    doReturn(mUiManagerModule)
-        .`when`(reactHost)
-        .getNativeModule(ArgumentMatchers.any<Class<UIManagerModule>>())
+    val uiManagerModuleMock: UIManagerModule = mock()
+    whenever(reactHost.getNativeModule(any<Class<UIManagerModule>>())).doReturn(uiManagerModuleMock)
     val uiManagerModule = bridgelessReactContext.getNativeModule(UIManagerModule::class.java)
-    assertThat(uiManagerModule).isEqualTo(mUiManagerModule)
+    assertThat(uiManagerModule).isEqualTo(uiManagerModuleMock)
   }
 
   @Test
   fun getFabricUIManagerTest() {
     val fabricUiManager = mock<FabricUIManager>()
-    doReturn(fabricUiManager).`when`(reactHost).uiManager
+    whenever(reactHost.uiManager).doReturn(fabricUiManager)
     assertThat(bridgelessReactContext.getFabricUIManager()).isEqualTo(fabricUiManager)
   }
 
@@ -84,11 +86,11 @@ class BridgelessReactContextTest {
   fun testEmitDeviceEvent() {
     bridgelessReactContext.emitDeviceEvent("onNetworkResponseReceived", mapOf("foo" to "bar"))
 
-    val argsCapture = ArgumentCaptor.forClass(WritableNativeArray::class.java)
+    val argsCapture = argumentCaptor<WritableNativeArray>()
     verify(reactHost, times(1))
         .callFunctionOnModule(eq("RCTDeviceEventEmitter"), eq("emit"), argsCapture.capture())
 
-    val argsList = ShadowNativeArray.getContents(argsCapture.value)
+    val argsList = ShadowNativeArray.getContents(argsCapture.firstValue)
     assertThat(argsList[0]).isEqualTo("onNetworkResponseReceived")
     @Suppress("UNCHECKED_CAST") assertThat((argsList[1] as Map<Any, Any>)["foo"]).isEqualTo("bar")
   }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/runtime/ReactSurfaceTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/runtime/ReactSurfaceTest.kt
@@ -23,8 +23,8 @@ import org.assertj.core.api.Assertions
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentMatchers.any
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify


### PR DESCRIPTION
Summary:
There's no need to use a singleton pattern here, we can just use a Kotlin object.

Changelog: [Android][Removed] Deprecated `ResourceDrawableIdHelper.instance`

Differential Revision: D73923281


