### PR TITLE
Bump Xcode to version 16.2

### DIFF
--- a/.github/actions/build-hermesc-apple/action.yml
+++ b/.github/actions/build-hermesc-apple/action.yml
@@ -10,6 +10,8 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Setup xcode
+      uses: ./.github/actions/setup-xcode
     - name: Restore Hermes workspace
       uses: ./.github/actions/restore-hermes-workspace
     - name: Hermes apple cache

--- a/.github/actions/setup-xcode/action.yml
+++ b/.github/actions/setup-xcode/action.yml
@@ -4,7 +4,7 @@ inputs:
   xcode-version:
     description: 'The xcode version to use'
     required: false
-    default: '15.2'
+    default: '16.2.0'
 runs:
   using: "composite"
   steps:

--- a/.github/actions/test-ios-helloworld/action.yml
+++ b/.github/actions/test-ios-helloworld/action.yml
@@ -43,7 +43,7 @@ runs:
     - name: Run yarn
       uses: ./.github/actions/yarn-install
     - name: Setup ruby
-      uses: ruby/setup-ruby@v1.170.0
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ inputs.ruby-version }}
     - name: Download ReactNativeDependencies

--- a/.github/actions/test-ios-rntester/action.yml
+++ b/.github/actions/test-ios-rntester/action.yml
@@ -48,7 +48,7 @@ runs:
         name: hermes-darwin-bin-${{ inputs.flavor }}
         path: ${{ inputs.hermes-tarball-artifacts-dir }}
     - name: Setup ruby
-      uses: ruby/setup-ruby@v1.170.0
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ inputs.ruby-version }}
     - name: Prepare IOS Tests

--- a/.github/actions/test-library-on-nightly/action.yml
+++ b/.github/actions/test-library-on-nightly/action.yml
@@ -21,6 +21,10 @@ runs:
         cd /tmp/RNApp
         yarn add ${{ inputs.library-npm-package }}
 
+    # iOS
+    - name: Setup xcode
+      if: ${{ inputs.platform == 'ios' }}
+      uses: ./.github/actions/setup-xcode
     - name: Build iOS
       shell: bash
       if: ${{ inputs.platform == 'ios' }}
@@ -32,6 +36,8 @@ runs:
           -workspace RNApp.xcworkspace \
           -scheme RNApp \
           -sdk iphonesimulator
+
+    # Android
     - name: Setup Java for Android
       if: ${{ inputs.platform == 'android' }}
       uses: actions/setup-java@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,7 +40,7 @@ jobs:
           hermes-version-file: ${{ env.HERMES_VERSION_FILE }}
 
   build_hermesc_apple:
-    runs-on: macos-13
+    runs-on: macos-14
     needs: prepare_hermes_workspace
     env:
       HERMES_WS_DIR: /tmp/hermes
@@ -80,7 +80,7 @@ jobs:
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
 
   build_hermes_macos:
-    runs-on: macos-13
+    runs-on: macos-14
     needs: [build_apple_slices_hermes, prepare_hermes_workspace]
     env:
       HERMES_WS_DIR: /tmp/hermes

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -38,7 +38,7 @@ jobs:
           hermes-version-file: ${{ env.HERMES_VERSION_FILE }}
 
   build_hermesc_apple:
-    runs-on: macos-13
+    runs-on: macos-14
     needs: prepare_hermes_workspace
     env:
       HERMES_WS_DIR: /tmp/hermes
@@ -77,7 +77,7 @@ jobs:
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
 
   build_hermes_macos:
-    runs-on: macos-13
+    runs-on: macos-14
     needs: [build_apple_slices_hermes, prepare_hermes_workspace]
     env:
       HERMES_WS_DIR: /tmp/hermes

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -56,7 +56,7 @@ jobs:
           hermes-version-file: ${{ env.HERMES_VERSION_FILE }}
 
   build_hermesc_apple:
-    runs-on: macos-13
+    runs-on: macos-14
     needs: prepare_hermes_workspace
     env:
       HERMES_WS_DIR: /tmp/hermes
@@ -96,7 +96,7 @@ jobs:
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
 
   build_hermes_macos:
-    runs-on: macos-13
+    runs-on: macos-14
     needs: [build_apple_slices_hermes, prepare_hermes_workspace]
     env:
       HERMES_WS_DIR: /tmp/hermes
@@ -121,7 +121,7 @@ jobs:
     secrets: inherit
 
   test_ios_rntester_ruby_3_2_0:
-    runs-on: macos-13
+    runs-on: macos-14
     needs:
       [build_apple_slices_hermes, prepare_hermes_workspace, build_hermes_macos, prebuild_apple_dependencies]
     env:
@@ -138,7 +138,7 @@ jobs:
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
 
   test_ios_rntester_dynamic_frameworks:
-    runs-on: macos-13
+    runs-on: macos-14
     needs:
       [build_apple_slices_hermes, prepare_hermes_workspace, build_hermes_macos, prebuild_apple_dependencies]
     env:
@@ -161,7 +161,7 @@ jobs:
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
 
   test_ios_rntester:
-    runs-on: macos-13-large
+    runs-on: macos-14-large
     needs:
       [build_apple_slices_hermes, prepare_hermes_workspace, build_hermes_macos, prebuild_apple_dependencies]
     env:
@@ -197,7 +197,7 @@ jobs:
 
   test_e2e_ios_rntester:
     if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
-    runs-on: macos-13-large
+    runs-on: macos-14-large
     needs:
       [test_ios_rntester]
     env:
@@ -220,6 +220,8 @@ jobs:
           path: /tmp/RNTesterBuild/RNTester.app
       - name: Check downloaded folder content
         run: ls -lR /tmp/RNTesterBuild
+      - name: Setup xcode
+        uses: ./.github/actions/setup-xcode
       - name: Run E2E Tests
         uses: ./.github/actions/maestro-ios
         with:
@@ -231,7 +233,7 @@ jobs:
 
   test_e2e_ios_templateapp:
     if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
-    runs-on: macos-13-large
+    runs-on: macos-14-large
     needs: [build_npm_package, prebuild_apple_dependencies]
     env:
       HERMES_WS_DIR: /tmp/hermes
@@ -253,7 +255,7 @@ jobs:
       - name: Run yarn
         uses: ./.github/actions/yarn-install
       - name: Setup ruby
-        uses: ruby/setup-ruby@v1.170.0
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.6.10
       - name: Download Hermes
@@ -589,7 +591,7 @@ jobs:
           compression-level: 0
 
   test_ios_helloworld_with_ruby_3_2_0:
-    runs-on: macos-13
+    runs-on: macos-14
     needs: [prepare_hermes_workspace, build_hermes_macos, prebuild_apple_dependencies] # prepare_hermes_workspace must be there because we need its reference to retrieve a couple of outputs
     env:
       PROJECT_NAME: iOSTemplateProject
@@ -607,7 +609,7 @@ jobs:
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
 
   test_ios_helloworld:
-    runs-on: macos-13
+    runs-on: macos-14
     needs: [prepare_hermes_workspace, build_hermes_macos, prebuild_apple_dependencies] # prepare_hermes_workspace must be there because we need its reference to retrieve a couple of outputs
     strategy:
       matrix:

--- a/.github/workflows/test-libraries-on-nightlies.yml
+++ b/.github/workflows/test-libraries-on-nightlies.yml
@@ -13,7 +13,7 @@ jobs:
   runner-setup:
     runs-on: ubuntu-latest
     outputs:
-      runners: '{"ios":"macos-13-large", "android": "ubuntu-latest"}'
+      runners: '{"ios":"macos-14-large", "android": "ubuntu-latest"}'
     steps:
       - run: echo no-op
 


### PR DESCRIPTION
Summary:
Starting from the [24th of April](https://developer.apple.com/news/upcoming-requirements/?id=02212025a), Apple only accepts app built with Xcode 16.0 or greater

This change bumps our CI to ensure that everything works with Xcode 16.

## Changelog:
[Internal] - Bump CI to Xcode 16.2

Differential Revision: D73924819


