### PR TITLE
Root export `PublicRootInstance` and `PublicTextInstance` for `ReactNativeTypes` to use

### DIFF
--- a/packages/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js.flow
+++ b/packages/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js.flow
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict-local
+ */
+
+import typeof {createPublicTextInstance} from '../ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance';
+
+export type {
+  HostInstance as PublicInstance,
+
+  // These types are only necessary for Paper
+  NativeMethods as LegacyPublicInstance,
+  MeasureOnSuccessCallback,
+  MeasureInWindowOnSuccessCallback,
+  MeasureLayoutOnSuccessCallback,
+} from '../../src/private/types/HostInstance';
+
+export type {PublicRootInstance} from '../ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance';
+export type PublicTextInstance = ReturnType<createPublicTextInstance>;
+
+export {default as BatchedBridge} from '../BatchedBridge/BatchedBridge';
+export {default as ExceptionsManager} from '../Core/ExceptionsManager';
+export {default as Platform} from '../Utilities/Platform';
+export {default as RCTEventEmitter} from '../EventEmitter/RCTEventEmitter';
+export * as ReactNativeViewConfigRegistry from '../Renderer/shims/ReactNativeViewConfigRegistry';
+export {default as TextInputState} from '../Components/TextInput/TextInputState';
+export {default as UIManager} from '../ReactNative/UIManager';
+export {default as deepDiffer} from '../Utilities/differ/deepDiffer';
+export {default as deepFreezeAndThrowOnMutationInDev} from '../Utilities/deepFreezeAndThrowOnMutationInDev';
+export {default as flattenStyle} from '../StyleSheet/flattenStyle';
+export {default as ReactFiberErrorDialog} from '../Core/ReactFiberErrorDialog';
+export {default as legacySendAccessibilityEvent} from '../Components/AccessibilityInfo/legacySendAccessibilityEvent';
+export {default as RawEventEmitter} from '../Core/RawEventEmitter';
+export {default as CustomEvent} from '../../src/private/webapis/dom/events/CustomEvent';
+export {
+  create as createAttributePayload,
+  diff as diffAttributePayloads,
+} from '../ReactNative/ReactFabricPublicInstance/ReactNativeAttributePayload';
+export {
+  createPublicRootInstance,
+  createPublicInstance,
+  createPublicTextInstance,
+  getNativeTagFromPublicInstance,
+  getNodeFromPublicInstance,
+  getInternalInstanceHandleFromPublicInstance,
+} from '../ReactNative/ReactFabricPublicInstance/ReactFabricPublicInstance';

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -9281,6 +9281,10 @@ export type {
 export type { HostComponent } from \\"./src/private/types/HostComponent\\";
 export type { ColorSchemeName } from \\"./src/private/specs_DEPRECATED/modules/NativeAppearance\\";
 export type { ErrorUtils } from \\"./Libraries/vendor/core/ErrorUtils\\";
+export type {
+  PublicRootInstance,
+  PublicTextInstance,
+} from \\"./Libraries/ReactPrivate/ReactNativePrivateInterface\\";
 "
 `;
 

--- a/packages/react-native/index.js.flow
+++ b/packages/react-native/index.js.flow
@@ -438,5 +438,9 @@ export type {
 export type {HostComponent} from './src/private/types/HostComponent';
 export type {ColorSchemeName} from './src/private/specs_DEPRECATED/modules/NativeAppearance';
 export type {ErrorUtils} from './Libraries/vendor/core/ErrorUtils';
+export type {
+  PublicRootInstance,
+  PublicTextInstance,
+} from './Libraries/ReactPrivate/ReactNativePrivateInterface';
 
 // #endregion


### PR DESCRIPTION
Summary:
`ReactNativeTypes` deep imports  `MeasureOnSuccessCallback`, `PublicInstance`, `PublicRootInstance` and `PublicTextInstance`. The `MeasureOnSuccessCallback` type  is already root exported, `PublicInstance` is exported as `HostInstance` and there are two types left to export to root import all of them from react-native. This is needed for `simpleResolve` to properly resolve and build types located in `ReactNativePrivateInterface`.

This cannot be fixed on the resolver level because that would also involve change in the `exports` field in `package.json` to enable types resolution for deep paths which should be strict by design.

Changelog:
[Internal]

Differential Revision: D73926160


