### PR TITLE
chore: convert View to React 19

### DIFF
--- a/packages/react-native/Libraries/Components/View/View.js
+++ b/packages/react-native/Libraries/Components/View/View.js
@@ -14,10 +14,10 @@ import TextAncestor from '../../Text/TextAncestor';
 import ViewNativeComponent from './ViewNativeComponent';
 import * as React from 'react';
 
-export type Props = {
+export type Props = $ReadOnly<{
   ...ViewProps,
-  ref?: React.RefSetter<React.ElementRef<typeof ViewNativeComponent>>,
-};
+  ref?: React.Ref<typeof ViewNativeComponent>,
+}>;
 
 /**
  * The most fundamental component for building a UI, View is a container that

--- a/packages/react-native/Libraries/Components/View/View.js
+++ b/packages/react-native/Libraries/Components/View/View.js
@@ -14,7 +14,10 @@ import TextAncestor from '../../Text/TextAncestor';
 import ViewNativeComponent from './ViewNativeComponent';
 import * as React from 'react';
 
-export type Props = ViewProps;
+export type Props = {
+  ...ViewProps,
+  ref?: React.RefSetter<React.ElementRef<typeof ViewNativeComponent>>,
+};
 
 /**
  * The most fundamental component for building a UI, View is a container that
@@ -23,108 +26,93 @@ export type Props = ViewProps;
  *
  * @see https://reactnative.dev/docs/view
  */
-const View: component(
-  ref?: React.RefSetter<React.ElementRef<typeof ViewNativeComponent>>,
-  ...props: ViewProps
-) = React.forwardRef(
-  (
-    {
-      accessibilityElementsHidden,
-      accessibilityLabel,
-      accessibilityLabelledBy,
-      accessibilityLiveRegion,
-      accessibilityState,
-      accessibilityValue,
-      'aria-busy': ariaBusy,
-      'aria-checked': ariaChecked,
-      'aria-disabled': ariaDisabled,
-      'aria-expanded': ariaExpanded,
-      'aria-hidden': ariaHidden,
-      'aria-label': ariaLabel,
-      'aria-labelledby': ariaLabelledBy,
-      'aria-live': ariaLive,
-      'aria-selected': ariaSelected,
-      'aria-valuemax': ariaValueMax,
-      'aria-valuemin': ariaValueMin,
-      'aria-valuenow': ariaValueNow,
-      'aria-valuetext': ariaValueText,
-      focusable,
-      id,
-      importantForAccessibility,
-      nativeID,
-      tabIndex,
-      ...otherProps
-    }: ViewProps,
-    forwardedRef,
-  ) => {
-    const hasTextAncestor = React.useContext(TextAncestor);
-    const _accessibilityLabelledBy =
-      ariaLabelledBy?.split(/\s*,\s*/g) ?? accessibilityLabelledBy;
+function View({
+  ref,
+  accessibilityElementsHidden,
+  accessibilityLabel,
+  accessibilityLabelledBy,
+  accessibilityLiveRegion,
+  accessibilityState,
+  accessibilityValue,
+  'aria-busy': ariaBusy,
+  'aria-checked': ariaChecked,
+  'aria-disabled': ariaDisabled,
+  'aria-expanded': ariaExpanded,
+  'aria-hidden': ariaHidden,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledBy,
+  'aria-live': ariaLive,
+  'aria-selected': ariaSelected,
+  'aria-valuemax': ariaValueMax,
+  'aria-valuemin': ariaValueMin,
+  'aria-valuenow': ariaValueNow,
+  'aria-valuetext': ariaValueText,
+  focusable,
+  id,
+  importantForAccessibility,
+  nativeID,
+  tabIndex,
+  ...otherProps
+}: Props): React.Node {
+  const hasTextAncestor = React.use(TextAncestor);
+  const _accessibilityLabelledBy =
+    ariaLabelledBy?.split(/\s*,\s*/g) ?? accessibilityLabelledBy;
 
-    const _accessibilityState =
-      accessibilityState != null ||
-      ariaBusy != null ||
-      ariaChecked != null ||
-      ariaDisabled != null ||
-      ariaExpanded != null ||
-      ariaSelected != null
-        ? {
-            busy: ariaBusy ?? accessibilityState?.busy,
-            checked: ariaChecked ?? accessibilityState?.checked,
-            disabled: ariaDisabled ?? accessibilityState?.disabled,
-            expanded: ariaExpanded ?? accessibilityState?.expanded,
-            selected: ariaSelected ?? accessibilityState?.selected,
-          }
-        : undefined;
-
-    const _accessibilityValue =
-      accessibilityValue != null ||
-      ariaValueMax != null ||
-      ariaValueMin != null ||
-      ariaValueNow != null ||
-      ariaValueText != null
-        ? {
-            max: ariaValueMax ?? accessibilityValue?.max,
-            min: ariaValueMin ?? accessibilityValue?.min,
-            now: ariaValueNow ?? accessibilityValue?.now,
-            text: ariaValueText ?? accessibilityValue?.text,
-          }
-        : undefined;
-
-    const actualView = (
-      <ViewNativeComponent
-        {...otherProps}
-        accessibilityLiveRegion={
-          ariaLive === 'off' ? 'none' : ariaLive ?? accessibilityLiveRegion
+  const _accessibilityState =
+    accessibilityState != null ||
+    ariaBusy != null ||
+    ariaChecked != null ||
+    ariaDisabled != null ||
+    ariaExpanded != null ||
+    ariaSelected != null
+      ? {
+          busy: ariaBusy ?? accessibilityState?.busy,
+          checked: ariaChecked ?? accessibilityState?.checked,
+          disabled: ariaDisabled ?? accessibilityState?.disabled,
+          expanded: ariaExpanded ?? accessibilityState?.expanded,
+          selected: ariaSelected ?? accessibilityState?.selected,
         }
-        accessibilityLabel={ariaLabel ?? accessibilityLabel}
-        focusable={tabIndex !== undefined ? !tabIndex : focusable}
-        accessibilityState={_accessibilityState}
-        accessibilityElementsHidden={ariaHidden ?? accessibilityElementsHidden}
-        accessibilityLabelledBy={_accessibilityLabelledBy}
-        accessibilityValue={_accessibilityValue}
-        importantForAccessibility={
-          ariaHidden === true
-            ? 'no-hide-descendants'
-            : importantForAccessibility
+      : undefined;
+
+  const _accessibilityValue =
+    accessibilityValue != null ||
+    ariaValueMax != null ||
+    ariaValueMin != null ||
+    ariaValueNow != null ||
+    ariaValueText != null
+      ? {
+          max: ariaValueMax ?? accessibilityValue?.max,
+          min: ariaValueMin ?? accessibilityValue?.min,
+          now: ariaValueNow ?? accessibilityValue?.now,
+          text: ariaValueText ?? accessibilityValue?.text,
         }
-        nativeID={id ?? nativeID}
-        ref={forwardedRef}
-      />
-    );
+      : undefined;
 
-    if (hasTextAncestor) {
-      return (
-        <TextAncestor.Provider value={false}>
-          {actualView}
-        </TextAncestor.Provider>
-      );
-    }
+  const actualView = (
+    <ViewNativeComponent
+      {...otherProps}
+      accessibilityLiveRegion={
+        ariaLive === 'off' ? 'none' : ariaLive ?? accessibilityLiveRegion
+      }
+      accessibilityLabel={ariaLabel ?? accessibilityLabel}
+      focusable={tabIndex !== undefined ? !tabIndex : focusable}
+      accessibilityState={_accessibilityState}
+      accessibilityElementsHidden={ariaHidden ?? accessibilityElementsHidden}
+      accessibilityLabelledBy={_accessibilityLabelledBy}
+      accessibilityValue={_accessibilityValue}
+      importantForAccessibility={
+        ariaHidden === true ? 'no-hide-descendants' : importantForAccessibility
+      }
+      nativeID={id ?? nativeID}
+      ref={ref}
+    />
+  );
 
-    return actualView;
-  },
-);
+  if (hasTextAncestor) {
+    return <TextAncestor value={false}>{actualView}</TextAncestor>;
+  }
 
-View.displayName = 'View';
+  return actualView;
+}
 
 export default View;

--- a/packages/react-native/Libraries/Components/View/View.js
+++ b/packages/react-native/Libraries/Components/View/View.js
@@ -15,8 +15,8 @@ import ViewNativeComponent from './ViewNativeComponent';
 import * as React from 'react';
 
 export type Props = $ReadOnly<{
+  ref?: React.RefSetter<typeof ViewNativeComponent>,
   ...ViewProps,
-  ref?: React.Ref<typeof ViewNativeComponent>,
 }>;
 
 /**
@@ -27,7 +27,6 @@ export type Props = $ReadOnly<{
  * @see https://reactnative.dev/docs/view
  */
 function View({
-  ref,
   accessibilityElementsHidden,
   accessibilityLabel,
   accessibilityLabelledBy,
@@ -104,7 +103,6 @@ function View({
         ariaHidden === true ? 'no-hide-descendants' : importantForAccessibility
       }
       nativeID={id ?? nativeID}
-      ref={ref}
     />
   );
 

--- a/packages/react-native/Libraries/Components/View/View.js
+++ b/packages/react-native/Libraries/Components/View/View.js
@@ -113,4 +113,7 @@ function View({
   return actualView;
 }
 
-export default View;
+export default View as component(
+  ref?: React.RefSetter<React.ElementRef<typeof ViewNativeComponent>>,
+  ...props: ViewProps
+);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

- Convert View implementation to React 19:
  - Remove legacy `forwardRef` in favor of built-in `ref` prop.
  - Use `use` API instead of `useContext`.
  - Drop the extraneous `.Provider` for `TextAncestor` context.
  - Remove `displayName` in favor of component name. I'm not 100% sure this is a full fallback but it is valid according to `react/display-name` eslint rule—https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/display-name.md
- Based on discussion with Nicola Carti and Riccardo Cipolleschi.
- I tried using flow `component` keyword but it's not enabled in this project. Given the `react-native` package is shipped untranspiled, it's probably safer to avoid newer flow types.
- Overall matched the component style of LogBox.
- It's unclear the exact right way to type a ref since it should be optional for external users of the component but required inside the component. Erring on the side of caution and using optional types so users don't get type errors when `ref` isn't defined.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[GENERAL] [BREAKING] Upgrade `View` component to React 19.

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

- Type checks should pass.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
