### PR TITLE
Make AccessibilityOrder also include the host view

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAxOrderHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAxOrderHelper.kt
@@ -122,11 +122,7 @@ private object ReactAxOrderHelper {
       }
     }
 
-    if (root is ViewGroup) {
-      for (i in 0 until root.childCount) {
-        traverseAndDisableAxFromExcludedViews(root.getChildAt(i), root)
-      }
-    }
+    traverseAndDisableAxFromExcludedViews(root, root)
 
     return axOrderViews
   }


### PR DESCRIPTION
Summary:
Simple change to make the host of `experimental_accessibilityOrder` include the view that hosts the property in its order.

Changelog: [Internal]

Reviewed By: joevilches

Differential Revision: D73808337


