### PR TITLE
Use correct scriptId

### DIFF
--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeSamplingProfileSerializer.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeSamplingProfileSerializer.cpp
@@ -5,11 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <variant>
+
 #include "HermesRuntimeSamplingProfileSerializer.h"
 
 namespace facebook::react::jsinspector_modern::tracing {
 
 namespace {
+
+namespace fhsp = facebook::hermes::sampling_profiler;
 
 /// Fallback script ID for call frames, when Hermes didn't provide one or when
 /// this frame is part of the VM, like native functions, used for parity with
@@ -21,123 +25,114 @@ const std::string GARBAGE_COLLECTOR_FRAME_NAME = "(garbage collector)";
 /// Filters out Hermes Suspend frames related to Debugger.
 /// Even though Debugger domain is expected to be disabled, Hermes might run
 /// Debugger loop while recording sampling profile. We only allow GC frames.
-bool shouldIgnoreHermesFrame(
-    hermes::sampling_profiler::ProfileSampleCallStackFrame* hermesFrame) {
-  if (hermesFrame->getKind() !=
-      hermes::sampling_profiler::ProfileSampleCallStackFrame::Kind::Suspend) {
-    return false;
-  }
-
-  auto* suspendFrame = static_cast<
-      hermes::sampling_profiler::ProfileSampleCallStackSuspendFrame*>(
-      hermesFrame);
-  auto suspendFrameKind = suspendFrame->getSuspendFrameKind();
-  return suspendFrameKind !=
-      hermes::sampling_profiler::ProfileSampleCallStackSuspendFrame::
-          SuspendFrameKind::GC;
+inline bool shouldIgnoreHermesFrame(
+    const fhsp::ProfileSampleCallStackSuspendFrame& suspendFrame) {
+  return suspendFrame.getSuspendFrameKind() !=
+      fhsp::ProfileSampleCallStackSuspendFrame::SuspendFrameKind::GC;
 }
 
-RuntimeSamplingProfile::SampleCallStackFrame convertHermesFrameToTracingFrame(
-    hermes::sampling_profiler::ProfileSampleCallStackFrame* hermesFrame) {
-  switch (hermesFrame->getKind()) {
-    case hermes::sampling_profiler::ProfileSampleCallStackFrame::Kind::
-        JSFunction: {
-      auto* jsFunctionFrame = static_cast<
-          hermes::sampling_profiler::ProfileSampleCallStackJSFunctionFrame*>(
-          hermesFrame);
-      return RuntimeSamplingProfile::SampleCallStackFrame{
-          RuntimeSamplingProfile::SampleCallStackFrame::Kind::JSFunction,
-          jsFunctionFrame->hasScriptId() ? jsFunctionFrame->getScriptId()
-                                         : FALLBACK_SCRIPT_ID,
-          jsFunctionFrame->getFunctionName(),
-          jsFunctionFrame->hasUrl()
-              ? std::optional<std::string>{jsFunctionFrame->getUrl()}
-              : std::nullopt,
-          jsFunctionFrame->hasLineNumber()
-              ? std::optional<uint32_t>{jsFunctionFrame->getLineNumber() - 1}
-              // Hermes VM keeps line numbers as 1-based. Convert to
-              // 0-based.
-              : std::nullopt,
-          jsFunctionFrame->hasColumnNumber()
-              ? std::optional<uint32_t>{jsFunctionFrame->getColumnNumber() - 1}
-              // Hermes VM keeps column numbers as 1-based. Convert to
-              // 0-based.
-              : std::nullopt,
-      };
-    }
-    case hermes::sampling_profiler::ProfileSampleCallStackFrame::Kind::
-        NativeFunction: {
-      auto* nativeFunctionFrame =
-          static_cast<hermes::sampling_profiler::
-                          ProfileSampleCallStackNativeFunctionFrame*>(
-              hermesFrame);
+RuntimeSamplingProfile::SampleCallStackFrame convertNativeHermesFrame(
+    const fhsp::ProfileSampleCallStackNativeFunctionFrame& frame) {
+  return RuntimeSamplingProfile::SampleCallStackFrame{
+      RuntimeSamplingProfile::SampleCallStackFrame::Kind::NativeFunction,
+      FALLBACK_SCRIPT_ID, // JavaScript Runtime defines the implementation
+                          // for native function, no script ID to reference.
+      frame.getFunctionName(),
+  };
+}
 
-      return RuntimeSamplingProfile::SampleCallStackFrame{
-          RuntimeSamplingProfile::SampleCallStackFrame::Kind::NativeFunction,
-          FALLBACK_SCRIPT_ID, // JavaScript Runtime defines the implementation
-                              // for native function, no script ID to reference.
-          nativeFunctionFrame->getFunctionName(),
-      };
-    }
-    case hermes::sampling_profiler::ProfileSampleCallStackFrame::Kind::
-        HostFunction: {
-      auto* hostFunctionFrame = static_cast<
-          hermes::sampling_profiler::ProfileSampleCallStackHostFunctionFrame*>(
-          hermesFrame);
+RuntimeSamplingProfile::SampleCallStackFrame convertHostFunctionHermesFrame(
+    const fhsp::ProfileSampleCallStackHostFunctionFrame& frame) {
+  return RuntimeSamplingProfile::SampleCallStackFrame{
+      RuntimeSamplingProfile::SampleCallStackFrame::Kind::HostFunction,
+      FALLBACK_SCRIPT_ID, // JavaScript Runtime defines the implementation
+                          // for host function, no script ID to reference.
+      frame.getFunctionName(),
+  };
+}
 
-      return RuntimeSamplingProfile::SampleCallStackFrame{
-          RuntimeSamplingProfile::SampleCallStackFrame::Kind::HostFunction,
-          FALLBACK_SCRIPT_ID, // JavaScript Runtime defines the implementation
-                              // for host function, no script ID to reference.
-          hostFunctionFrame->getFunctionName(),
-      };
-    }
-    case hermes::sampling_profiler::ProfileSampleCallStackFrame::Kind::
-        Suspend: {
-      auto* suspendFrame = static_cast<
-          hermes::sampling_profiler::ProfileSampleCallStackSuspendFrame*>(
-          hermesFrame);
-      auto suspendFrameKind = suspendFrame->getSuspendFrameKind();
-      if (suspendFrameKind ==
-          hermes::sampling_profiler::ProfileSampleCallStackSuspendFrame::
-              SuspendFrameKind::GC) {
-        return RuntimeSamplingProfile::SampleCallStackFrame{
-            RuntimeSamplingProfile::SampleCallStackFrame::Kind::
-                GarbageCollector,
-            FALLBACK_SCRIPT_ID, // GC frames are part of the VM, no script ID to
-                                // reference.
-            GARBAGE_COLLECTOR_FRAME_NAME,
-        };
-      }
-
-      // We should have filtered out Debugger Suspend frames before in
-      // shouldFilterOutHermesFrame().
-      throw std::logic_error{
-          "Unexpected Suspend frame found in Hermes call stack"};
-    }
-
-    default:
-      throw std::logic_error{"Unknown Hermes stack frame kind"};
+RuntimeSamplingProfile::SampleCallStackFrame convertSuspendHermesFrame(
+    const fhsp::ProfileSampleCallStackSuspendFrame& frame) {
+  if (frame.getSuspendFrameKind() ==
+      fhsp::ProfileSampleCallStackSuspendFrame::SuspendFrameKind::GC) {
+    return RuntimeSamplingProfile::SampleCallStackFrame{
+        RuntimeSamplingProfile::SampleCallStackFrame::Kind::GarbageCollector,
+        FALLBACK_SCRIPT_ID, // GC frames are part of the VM, no script ID to
+                            // reference.
+        GARBAGE_COLLECTOR_FRAME_NAME,
+    };
   }
+
+  // We should have filtered out Debugger Suspend frames before in
+  // shouldFilterOutHermesFrame().
+  throw std::logic_error{"Unexpected Suspend frame found in Hermes call stack"};
+}
+
+RuntimeSamplingProfile::SampleCallStackFrame convertJSFunctionHermesFrame(
+    const fhsp::ProfileSampleCallStackJSFunctionFrame& frame) {
+  return RuntimeSamplingProfile::SampleCallStackFrame{
+      RuntimeSamplingProfile::SampleCallStackFrame::Kind::JSFunction,
+      frame.hasScriptId() ? frame.getScriptId() : FALLBACK_SCRIPT_ID,
+      frame.getFunctionName(),
+      frame.hasUrl() ? std::optional<std::string>{frame.getUrl()}
+                     : std::nullopt,
+      frame.hasLineNumber() ? std::optional<uint32_t>{frame.getLineNumber() - 1}
+                            // Hermes VM keeps line numbers as 1-based. Convert
+                            // to 0-based.
+                            : std::nullopt,
+      frame.hasColumnNumber()
+          ? std::optional<uint32_t>{frame.getColumnNumber() - 1}
+          // Hermes VM keeps column numbers as 1-based. Convert to
+          // 0-based.
+          : std::nullopt,
+  };
 }
 
 RuntimeSamplingProfile::Sample convertHermesSampleToTracingSample(
-    const hermes::sampling_profiler::ProfileSample& hermesSample) {
+    const fhsp::ProfileSample& hermesSample) {
   uint64_t reconciledTimestamp = hermesSample.getTimestamp();
-  std::vector<hermes::sampling_profiler::ProfileSampleCallStackFrame*>
-      hermesSampleCallStack = hermesSample.getCallStack();
+  const std::vector<fhsp::ProfileSampleCallStackFrame>& hermesSampleCallStack =
+      hermesSample.getCallStack();
 
   std::vector<RuntimeSamplingProfile::SampleCallStackFrame>
       reconciledSampleCallStack;
   reconciledSampleCallStack.reserve(hermesSampleCallStack.size());
 
-  for (auto* hermesFrame : hermesSampleCallStack) {
-    if (shouldIgnoreHermesFrame(hermesFrame)) {
-      continue;
+  for (const auto& hermesFrame : hermesSampleCallStack) {
+    if (std::holds_alternative<fhsp::ProfileSampleCallStackSuspendFrame>(
+            hermesFrame)) {
+      const auto& suspendFrame =
+          std::get<fhsp::ProfileSampleCallStackSuspendFrame>(hermesFrame);
+      if (shouldIgnoreHermesFrame(suspendFrame)) {
+        continue;
+      }
+
+      reconciledSampleCallStack.emplace_back(
+          convertSuspendHermesFrame(suspendFrame));
+    } else if (std::holds_alternative<
+                   fhsp::ProfileSampleCallStackNativeFunctionFrame>(
+                   hermesFrame)) {
+      const auto& nativeFunctionFrame =
+          std::get<fhsp::ProfileSampleCallStackNativeFunctionFrame>(
+              hermesFrame);
+      reconciledSampleCallStack.emplace_back(
+          convertNativeHermesFrame(nativeFunctionFrame));
+    } else if (std::holds_alternative<
+                   fhsp::ProfileSampleCallStackHostFunctionFrame>(
+                   hermesFrame)) {
+      const auto& hostFunctionFrame =
+          std::get<fhsp::ProfileSampleCallStackHostFunctionFrame>(hermesFrame);
+      reconciledSampleCallStack.emplace_back(
+          convertHostFunctionHermesFrame(hostFunctionFrame));
+    } else if (std::holds_alternative<
+                   fhsp::ProfileSampleCallStackJSFunctionFrame>(hermesFrame)) {
+      const auto& jsFunctionFrame =
+          std::get<fhsp::ProfileSampleCallStackJSFunctionFrame>(hermesFrame);
+      reconciledSampleCallStack.emplace_back(
+          convertJSFunctionHermesFrame(jsFunctionFrame));
+    } else {
+      throw std::logic_error{"Unknown Hermes stack frame kind"};
     }
-    RuntimeSamplingProfile::SampleCallStackFrame reconciledFrame =
-        convertHermesFrameToTracingFrame(hermesFrame);
-    reconciledSampleCallStack.push_back(std::move(reconciledFrame));
   }
 
   return RuntimeSamplingProfile::Sample{
@@ -156,7 +151,7 @@ HermesRuntimeSamplingProfileSerializer::serializeToTracingSamplingProfile(
   std::vector<RuntimeSamplingProfile::Sample> reconciledSamples;
   reconciledSamples.reserve(hermesSamples.size());
 
-  for (auto& hermesSample : hermesSamples) {
+  for (const auto& hermesSample : hermesSamples) {
     RuntimeSamplingProfile::Sample reconciledSample =
         convertHermesSampleToTracingSample(hermesSample);
     reconciledSamples.push_back(std::move(reconciledSample));

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeSamplingProfileSerializer.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeSamplingProfileSerializer.cpp
@@ -72,7 +72,7 @@ RuntimeSamplingProfile::SampleCallStackFrame convertJSFunctionHermesFrame(
     const fhsp::ProfileSampleCallStackJSFunctionFrame& frame) {
   return RuntimeSamplingProfile::SampleCallStackFrame{
       RuntimeSamplingProfile::SampleCallStackFrame::Kind::JSFunction,
-      frame.hasScriptId() ? frame.getScriptId() : FALLBACK_SCRIPT_ID,
+      frame.getScriptId(),
       frame.getFunctionName(),
       frame.hasUrl() ? std::optional<std::string>{frame.getUrl()}
                      : std::nullopt,

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeSamplingProfileSerializer.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeSamplingProfileSerializer.cpp
@@ -91,14 +91,13 @@ RuntimeSamplingProfile::SampleCallStackFrame convertJSFunctionHermesFrame(
 RuntimeSamplingProfile::Sample convertHermesSampleToTracingSample(
     const fhsp::ProfileSample& hermesSample) {
   uint64_t reconciledTimestamp = hermesSample.getTimestamp();
-  const std::vector<fhsp::ProfileSampleCallStackFrame>& hermesSampleCallStack =
-      hermesSample.getCallStack();
+  const auto callStackRange = hermesSample.getCallStackFramesRange();
 
   std::vector<RuntimeSamplingProfile::SampleCallStackFrame>
       reconciledSampleCallStack;
-  reconciledSampleCallStack.reserve(hermesSampleCallStack.size());
+  reconciledSampleCallStack.reserve(hermesSample.getCallStackFramesCount());
 
-  for (const auto& hermesFrame : hermesSampleCallStack) {
+  for (const auto& hermesFrame : callStackRange) {
     if (std::holds_alternative<fhsp::ProfileSampleCallStackSuspendFrame>(
             hermesFrame)) {
       const auto& suspendFrame =
@@ -146,12 +145,11 @@ RuntimeSamplingProfile::Sample convertHermesSampleToTracingSample(
 /* static */ RuntimeSamplingProfile
 HermesRuntimeSamplingProfileSerializer::serializeToTracingSamplingProfile(
     const hermes::sampling_profiler::Profile& hermesProfile) {
-  const std::vector<hermes::sampling_profiler::ProfileSample>& hermesSamples =
-      hermesProfile.getSamples();
+  const auto samplesRange = hermesProfile.getSamplesRange();
   std::vector<RuntimeSamplingProfile::Sample> reconciledSamples;
-  reconciledSamples.reserve(hermesSamples.size());
+  reconciledSamples.reserve(hermesProfile.getSamplesCount());
 
-  for (const auto& hermesSample : hermesSamples) {
+  for (const auto& hermesSample : samplesRange) {
     RuntimeSamplingProfile::Sample reconciledSample =
         convertHermesSampleToTracingSample(hermesSample);
     reconciledSamples.push_back(std::move(reconciledSample));

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/ProfileTreeNode.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/ProfileTreeNode.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <memory>
 #include <utility>
 
 #include <jsinspector-modern/tracing/RuntimeSamplingProfile.h>
@@ -28,14 +27,16 @@ class ProfileTreeNode {
     Other,
   };
 
+  static constexpr uint32_t NO_PARENT = UINT32_MAX;
+
   ProfileTreeNode(
       uint32_t id,
       CodeType codeType,
-      std::shared_ptr<ProfileTreeNode> parent,
-      RuntimeSamplingProfile::SampleCallStackFrame callFrame)
+      RuntimeSamplingProfile::SampleCallStackFrame callFrame,
+      uint32_t parentId = NO_PARENT)
       : id_(id),
         codeType_(codeType),
-        parent_(parent),
+        parentId_(parentId),
         callFrame_(std::move(callFrame)) {}
 
   uint32_t getId() const {
@@ -46,11 +47,12 @@ class ProfileTreeNode {
     return codeType_;
   }
 
-  /**
-   * \return pointer to the parent node, nullptr if this is the root node.
-   */
-  ProfileTreeNode* getParent() const {
-    return parent_.get();
+  inline bool hasParent() const {
+    return parentId_ != NO_PARENT;
+  }
+
+  uint32_t getParentId() const {
+    return parentId_;
   }
 
   /**
@@ -61,36 +63,37 @@ class ProfileTreeNode {
   }
 
   /**
-   * Will only add unique child node.
-   * \return shared pointer to the already existing child node, nullptr if the
-   * added child node is unique.
+   * \return a pointer if the node already contains a child with the same
+   * codeType and callFrame, nullptr otherwise.
    */
-  std::shared_ptr<ProfileTreeNode> addChild(
-      std::shared_ptr<ProfileTreeNode> child) {
-    for (const auto& existingChild : children_) {
-      if (*existingChild == child.get()) {
-        return existingChild;
+  ProfileTreeNode* getIfAlreadyExists(
+      CodeType childCodeType,
+      const RuntimeSamplingProfile::SampleCallStackFrame& childCallFrame) {
+    for (auto& existingChild : children_) {
+      if (existingChild.getCodeType() == childCodeType &&
+          existingChild.getCallFrame() == childCallFrame) {
+        return &existingChild;
       }
     }
 
-    children_.push_back(child);
     return nullptr;
   }
 
-  bool operator==(const ProfileTreeNode* rhs) const {
-    if (this->parent_ != rhs->parent_) {
-      return false;
-    }
-    if (this->codeType_ != rhs->codeType_) {
-      return false;
-    }
-
-    return this->getCallFrame() == rhs->getCallFrame();
+  /**
+   * Creates a ProfileTreeNode and links it as a child to this node.
+   * \return a pointer to the child node.
+   */
+  ProfileTreeNode* addChild(
+      uint32_t childId,
+      CodeType childCodeType,
+      RuntimeSamplingProfile::SampleCallStackFrame childCallFrame) {
+    return &children_.emplace_back(
+        childId, childCodeType, std::move(childCallFrame), id_);
   }
 
  private:
   /**
-   *  Unique id of the node.
+   * Unique id of the node.
    */
   uint32_t id_;
   /**
@@ -99,13 +102,14 @@ class ProfileTreeNode {
    */
   CodeType codeType_;
   /**
-   * Shared pointer to the parent node. Can be nullptr only for root node.
+   * Unique id of the parent node. NO_PARENT if this is root node.
    */
-  std::shared_ptr<ProfileTreeNode> parent_;
+  uint32_t parentId_;
   /**
-   * Lst of shared pointers to children nodes.
+   * List of children nodes, should be unique by codeType and callFrame among
+   * each other.
    */
-  std::vector<std::shared_ptr<ProfileTreeNode>> children_;
+  std::vector<ProfileTreeNode> children_;
   /**
    * Information about the corresponding call frame that is represented by this
    * node.

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.cpp
@@ -14,12 +14,12 @@ namespace {
 
 // Right now we only emit single Profile. We might revisit this decision in the
 // future, once we support multiple VMs being sampled at the same time.
-const uint16_t PROFILE_ID = 1;
+constexpr uint16_t PROFILE_ID = 1;
 
 /// Fallback script ID for artificial call frames, such as (root), (idle) or
 /// (program). Required for emulating the payload in a format that is expected
 /// by Chrome DevTools.
-const uint32_t FALLBACK_SCRIPT_ID = 0;
+constexpr uint32_t FALLBACK_SCRIPT_ID = 0;
 
 uint64_t formatTimePointToUnixTimestamp(
     std::chrono::steady_clock::time_point timestamp) {
@@ -29,15 +29,13 @@ uint64_t formatTimePointToUnixTimestamp(
 }
 
 TraceEventProfileChunk::CPUProfile::Node convertToTraceEventProfileNode(
-    std::shared_ptr<ProfileTreeNode> node) {
-  ProfileTreeNode* nodeParent = node->getParent();
+    const ProfileTreeNode& node) {
   const RuntimeSamplingProfile::SampleCallStackFrame& callFrame =
-      node->getCallFrame();
+      node.getCallFrame();
   auto traceEventCallFrame =
       TraceEventProfileChunk::CPUProfile::Node::CallFrame{
-          node->getCodeType() == ProfileTreeNode::CodeType::JavaScript
-              ? "JS"
-              : "other",
+          node.getCodeType() == ProfileTreeNode::CodeType::JavaScript ? "JS"
+                                                                      : "other",
           callFrame.getScriptId(),
           callFrame.getFunctionName(),
           callFrame.hasUrl() ? std::optional<std::string>(callFrame.getUrl())
@@ -50,10 +48,10 @@ TraceEventProfileChunk::CPUProfile::Node convertToTraceEventProfileNode(
               : std::nullopt};
 
   return TraceEventProfileChunk::CPUProfile::Node{
-      node->getId(),
+      node.getId(),
       traceEventCallFrame,
-      nodeParent != nullptr ? std::optional<uint32_t>(nodeParent->getId())
-                            : std::nullopt};
+      node.hasParent() ? std::optional<uint32_t>(node.getParentId())
+                       : std::nullopt};
 }
 
 RuntimeSamplingProfile::SampleCallStackFrame createArtificialCallFrame(
@@ -71,42 +69,14 @@ RuntimeSamplingProfile::SampleCallStackFrame createGarbageCollectorCallFrame() {
       "(garbage collector)"};
 };
 
-std::shared_ptr<ProfileTreeNode> createNode(
-    NodeIdGenerator& nodeIdGenerator,
-    ProfileTreeNode::CodeType codeType,
-    std::shared_ptr<ProfileTreeNode> parent,
-    const RuntimeSamplingProfile::SampleCallStackFrame& callFrame) {
-  return std::make_shared<ProfileTreeNode>(
-      nodeIdGenerator.getNext(), codeType, parent, callFrame);
-}
-
-std::shared_ptr<ProfileTreeNode> createArtificialNode(
-    NodeIdGenerator& nodeIdGenerator,
-    std::shared_ptr<ProfileTreeNode> parent,
-    std::string callFrameName) {
-  RuntimeSamplingProfile::SampleCallStackFrame callFrame =
-      createArtificialCallFrame(std::move(callFrameName));
-
-  return createNode(
-      nodeIdGenerator, ProfileTreeNode::CodeType::Other, parent, callFrame);
-}
-
-std::shared_ptr<ProfileTreeNode> createRootNode(
-    NodeIdGenerator& nodeIdGenerator) {
-  return createArtificialNode(nodeIdGenerator, nullptr, "(root)");
-}
-
-std::shared_ptr<ProfileTreeNode> createProgramNode(
-    NodeIdGenerator& nodeIdGenerator,
-    std::shared_ptr<ProfileTreeNode> rootNode) {
-  return createArtificialNode(nodeIdGenerator, rootNode, "(program)");
-}
-
-std::shared_ptr<ProfileTreeNode> createIdleNode(
-    NodeIdGenerator& nodeIdGenerator,
-    std::shared_ptr<ProfileTreeNode> rootNode) {
-  return createArtificialNode(nodeIdGenerator, rootNode, "(idle)");
-}
+class ProfileTreeRootNode : public ProfileTreeNode {
+ public:
+  explicit ProfileTreeRootNode(uint32_t id)
+      : ProfileTreeNode(
+            id,
+            CodeType::Other,
+            createArtificialCallFrame("(root)")) {}
+};
 
 } // namespace
 
@@ -159,36 +129,37 @@ void RuntimeSamplingProfileTraceEventSerializer::bufferProfileChunkTraceEvent(
 void RuntimeSamplingProfileTraceEventSerializer::processCallStack(
     const std::vector<RuntimeSamplingProfile::SampleCallStackFrame>& callStack,
     ProfileChunk& chunk,
-    std::shared_ptr<ProfileTreeNode> rootNode,
-    std::shared_ptr<ProfileTreeNode> idleNode,
+    ProfileTreeNode& rootNode,
+    uint32_t idleNodeId,
     long long samplesTimeDelta,
     NodeIdGenerator& nodeIdGenerator) {
   if (callStack.empty()) {
-    chunkEmptySample(chunk, idleNode->getId(), samplesTimeDelta);
+    chunkEmptySample(chunk, idleNodeId, samplesTimeDelta);
     return;
   }
 
-  auto previousNode = rootNode;
+  ProfileTreeNode* previousNode = &rootNode;
   for (auto it = callStack.rbegin(); it != callStack.rend(); ++it) {
     const RuntimeSamplingProfile::SampleCallStackFrame& callFrame = *it;
     bool isGarbageCollectorFrame = callFrame.getKind() ==
         RuntimeSamplingProfile::SampleCallStackFrame::Kind::GarbageCollector;
+
+    ProfileTreeNode::CodeType childCodeType = isGarbageCollectorFrame
+        ? ProfileTreeNode::CodeType::Other
+        : ProfileTreeNode::CodeType::JavaScript;
     // We don't need real garbage collector call frame, we change it to
     // what Chrome DevTools expects.
-    auto currentNode = createNode(
-        nodeIdGenerator,
-        isGarbageCollectorFrame ? ProfileTreeNode::CodeType::Other
-                                : ProfileTreeNode::CodeType::JavaScript,
-        previousNode,
-        isGarbageCollectorFrame ? createGarbageCollectorCallFrame()
-                                : callFrame);
+    RuntimeSamplingProfile::SampleCallStackFrame childCallFrame =
+        isGarbageCollectorFrame ? createGarbageCollectorCallFrame() : callFrame;
 
-    auto alreadyExistingNode = previousNode->addChild(currentNode);
-    if (alreadyExistingNode != nullptr) {
-      previousNode = alreadyExistingNode;
+    ProfileTreeNode* maybeExistingChild =
+        previousNode->getIfAlreadyExists(childCodeType, childCallFrame);
+    if (maybeExistingChild != nullptr) {
+      previousNode = maybeExistingChild;
     } else {
-      chunk.nodes.push_back(currentNode);
-      previousNode = currentNode;
+      previousNode = previousNode->addChild(
+          nodeIdGenerator.getNext(), childCodeType, childCallFrame);
+      chunk.nodes.push_back(*previousNode);
     }
   }
 
@@ -220,20 +191,28 @@ void RuntimeSamplingProfileTraceEventSerializer::serializeAndNotify(
   sendProfileTraceEvent(
       firstChunkThreadId, PROFILE_ID, tracingStartUnixTimestamp);
 
-  NodeIdGenerator nodeIdGenerator{};
-  auto rootNode = createRootNode(nodeIdGenerator);
-  auto programNode = createProgramNode(nodeIdGenerator, rootNode);
-  auto idleNode = createIdleNode(nodeIdGenerator, rootNode);
-  rootNode->addChild(programNode);
-  rootNode->addChild(idleNode);
-
   // There could be any number of new nodes in this chunk. Empty if all nodes
   // are already emitted in previous chunks.
   ProfileChunk chunk{
       profileChunkSize_, firstChunkThreadId, currentChunkUnixTimestamp};
+
+  NodeIdGenerator nodeIdGenerator{};
+
+  ProfileTreeRootNode rootNode(nodeIdGenerator.getNext());
   chunk.nodes.push_back(rootNode);
-  chunk.nodes.push_back(programNode);
-  chunk.nodes.push_back(idleNode);
+
+  ProfileTreeNode* programNode = rootNode.addChild(
+      nodeIdGenerator.getNext(),
+      ProfileTreeNode::CodeType::Other,
+      createArtificialCallFrame("(program)"));
+  chunk.nodes.push_back(*programNode);
+
+  ProfileTreeNode* idleNode = rootNode.addChild(
+      nodeIdGenerator.getNext(),
+      ProfileTreeNode::CodeType::Other,
+      createArtificialCallFrame("(idle)"));
+  chunk.nodes.push_back(*idleNode);
+  uint32_t idleNodeId = idleNode->getId();
 
   for (const auto& sample : samples) {
     uint64_t currentSampleThreadId = sample.getThreadId();
@@ -257,7 +236,7 @@ void RuntimeSamplingProfileTraceEventSerializer::serializeAndNotify(
         sample.getCallStack(),
         chunk,
         rootNode,
-        idleNode,
+        idleNodeId,
         currentSampleUnixTimestamp - previousSampleUnixTimestamp,
         nodeIdGenerator);
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.h
@@ -50,7 +50,7 @@ class RuntimeSamplingProfileTraceEventSerializer {
       return samples.empty();
     }
 
-    std::vector<std::shared_ptr<ProfileTreeNode>> nodes;
+    std::vector<ProfileTreeNode> nodes;
     std::vector<uint32_t> samples;
     std::vector<long long> timeDeltas;
     uint16_t size;
@@ -128,11 +128,10 @@ class RuntimeSamplingProfileTraceEventSerializer {
    * \param callStack The call stack that will be processed.
    * \param chunk The profile chunk, which will buffer the sample with the
    * provided call stack.
-   * \param rootNode Shared pointer to the (root) node. Will be the parent node
-   * of the corresponding profile tree branch.
-   * \param idleNode Shared pointer to the (idle) node. Will be the only node
-   * that is used for the corresponding profile tree branch, in case of an empty
-   * call stack.
+   * \param rootNode The (root) node. Will be the parent node of the
+   * corresponding profile tree branch.
+   * \param idleNodeId Id of the (idle) node. Will be the only node that is used
+   * for the corresponding profile tree branch, in case of an empty call stack.
    * \param samplesTimeDelta Delta between the current sample and the previous
    * one.
    * \param nodeIdGenerator NodeIdGenerator instance that will be used for
@@ -142,8 +141,8 @@ class RuntimeSamplingProfileTraceEventSerializer {
       const std::vector<RuntimeSamplingProfile::SampleCallStackFrame>&
           callStack,
       ProfileChunk& chunk,
-      std::shared_ptr<ProfileTreeNode> rootNode,
-      std::shared_ptr<ProfileTreeNode> idleNode,
+      ProfileTreeNode& rootNode,
+      uint32_t idleNodeId,
       long long samplesTimeDelta,
       NodeIdGenerator& nodeIdGenerator);
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/tests/ProfileTreeNodeTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/tests/ProfileTreeNodeTest.cpp
@@ -12,56 +12,39 @@
 
 namespace facebook::react::jsinspector_modern::tracing {
 
-TEST(ProfileTreeNodeTest, EqualityOperator) {
-  auto callFrame = RuntimeSamplingProfile::SampleCallStackFrame{
+TEST(ProfileTreeNodeTest, OnlyAddsUniqueChildren) {
+  auto fooCallFrame = RuntimeSamplingProfile::SampleCallStackFrame{
       RuntimeSamplingProfile::SampleCallStackFrame::Kind::JSFunction, 0, "foo"};
-  ProfileTreeNode* node1;
-  ProfileTreeNode* node2;
+  auto barCallFrame = RuntimeSamplingProfile::SampleCallStackFrame{
+      RuntimeSamplingProfile::SampleCallStackFrame::Kind::JSFunction, 0, "bar"};
 
-  node1 = new ProfileTreeNode(
-      1, ProfileTreeNode::CodeType::JavaScript, nullptr, callFrame);
-  node2 = new ProfileTreeNode(
-      2, ProfileTreeNode::CodeType::JavaScript, nullptr, callFrame);
-  EXPECT_EQ(*node1 == node2, true);
+  ProfileTreeNode parent(
+      1, ProfileTreeNode::CodeType::JavaScript, fooCallFrame);
+  ProfileTreeNode* child =
+      parent.addChild(2, ProfileTreeNode::CodeType::JavaScript, barCallFrame);
 
-  node1 = new ProfileTreeNode(
-      3,
-      ProfileTreeNode::CodeType::JavaScript,
-      std::shared_ptr<ProfileTreeNode>(node1),
-      callFrame);
-  node2 = new ProfileTreeNode(
-      4, ProfileTreeNode::CodeType::JavaScript, nullptr, callFrame);
-  EXPECT_EQ(*node1 == node2, false);
+  auto maybeAlreadyExistingChild = parent.getIfAlreadyExists(
+      ProfileTreeNode::CodeType::JavaScript, barCallFrame);
+  EXPECT_NE(maybeAlreadyExistingChild, nullptr);
 
-  node1 = new ProfileTreeNode(
-      5,
-      ProfileTreeNode::CodeType::JavaScript,
-      std::shared_ptr<ProfileTreeNode>(node2),
-      callFrame);
-  node2 = new ProfileTreeNode(
-      6,
-      ProfileTreeNode::CodeType::JavaScript,
-      std::shared_ptr<ProfileTreeNode>(node2),
-      callFrame);
-  EXPECT_EQ(*node1 == node2, true);
+  auto maybeExistingChildOfChild = child->getIfAlreadyExists(
+      ProfileTreeNode::CodeType::JavaScript, barCallFrame);
+  EXPECT_EQ(maybeExistingChildOfChild, nullptr);
 }
 
-TEST(ProfileTreeNodeTest, OnlyAddsUniqueChildren) {
-  auto callFrame = RuntimeSamplingProfile::SampleCallStackFrame{
+TEST(ProfileTreeNodeTest, ConsidersCodeTypeOfChild) {
+  auto parentCallFrame = RuntimeSamplingProfile::SampleCallStackFrame{
       RuntimeSamplingProfile::SampleCallStackFrame::Kind::JSFunction, 0, "foo"};
-  auto parent = std::make_shared<ProfileTreeNode>(
-      1, ProfileTreeNode::CodeType::JavaScript, nullptr, callFrame);
-  auto existingChild = std::make_shared<ProfileTreeNode>(
-      2, ProfileTreeNode::CodeType::JavaScript, parent, callFrame);
+  auto childCallFrame = RuntimeSamplingProfile::SampleCallStackFrame{
+      RuntimeSamplingProfile::SampleCallStackFrame::Kind::JSFunction, 0, "bar"};
 
-  auto maybeAlreadyExistingChild = parent->addChild(existingChild);
-  EXPECT_EQ(maybeAlreadyExistingChild, nullptr);
+  ProfileTreeNode parent(
+      1, ProfileTreeNode::CodeType::JavaScript, parentCallFrame);
+  parent.addChild(2, ProfileTreeNode::CodeType::JavaScript, childCallFrame);
 
-  auto copyOfExistingChild = std::make_shared<ProfileTreeNode>(
-      3, ProfileTreeNode::CodeType::JavaScript, parent, callFrame);
-
-  maybeAlreadyExistingChild = parent->addChild(copyOfExistingChild);
-  EXPECT_EQ(maybeAlreadyExistingChild, existingChild);
+  auto maybeExistingChild = parent.getIfAlreadyExists(
+      ProfileTreeNode::CodeType::Other, childCallFrame);
+  EXPECT_EQ(maybeExistingChild, nullptr);
 }
 
 } // namespace facebook::react::jsinspector_modern::tracing


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

I've been using the wrong thing this whole time, because it is referenced in `ChromeTraceSerializer.cpp`:
https://www.internalfb.com/code/fbsource/[b422eeb3bb6334ef95e8cf01b18e32ba8ab72bbe]/xplat/hermes-snapshot/lib/VM/Profiler/ChromeTraceSerializer.cpp?lines=439

Turns out, there is a real `scriptId`, defined by the Runtime and which is unique for every script. This also aligns with other parts of the CDP stack in Hermes. Since this scriptId is always available, there is no need to make it optional.

Reviewed By: dannysu

Differential Revision: D73185984


