### PR TITLE
Override `useShadowNodeStateOnClone` for OSS

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android.kt
@@ -19,4 +19,6 @@ public class ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android(
   override fun useTurboModules(): Boolean = bridgelessEnabled || turboModulesEnabled
 
   override fun updateRuntimeShadowNodeReferencesOnCommit(): Boolean = true
+
+  override fun useShadowNodeStateOnClone(): Boolean = true
 }

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSStable.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSStable.h
@@ -29,5 +29,8 @@ class ReactNativeFeatureFlagsOverridesOSSStable
   bool updateRuntimeShadowNodeReferencesOnCommit() override {
     return true;
   }
+  bool useShadowNodeStateOnClone() override {
+    return true;
+  }
 };
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
Enabling `useShadowNodeStateOnClone` by default on OSS to resolve https://github.com/facebook/react-native/issues/49694

Changelog: [Internal]

Differential Revision: D73970421


