### PR TITLE
Do not access to main bundle when running in prod

### DIFF
--- a/packages/react-native/React/Base/RCTUtils.mm
+++ b/packages/react-native/React/Base/RCTUtils.mm
@@ -49,9 +49,13 @@ void RCTSetNewArchEnabled(BOOL enabled)
 
 BOOL RCTAreLegacyLogsEnabled(void)
 {
+#if RCT_DEBUG
   NSNumber *rctNewArchEnabled =
       (NSNumber *)[[NSBundle mainBundle] objectForInfoDictionaryKey:@"RCTLegacyWarningsEnabled"];
   return rctNewArchEnabled.boolValue;
+#else
+  return NO;
+#endif
 }
 
 static NSString *__nullable _RCTJSONStringifyNoRetry(id __nullable jsonObject, NSError **error)


### PR DESCRIPTION
Summary:
The call to the mainBundle to read the `RCTLegacyWarningsEnabled` key can sometime deadlock in prod.
However, these are development logs that we don't want to run in Prod.

This change should disable the logs in prod, skipping the access to the `mainBundle`, and avoid the deadlock completely.

## Changelog:
[Internal] - Fix deadlock at startup to read `RCTLegacyWarningsEnabled`

Reviewed By: philIip, javache

Differential Revision: D73987454


