### PR TITLE
Avoid accessing the MainBundle multiple times

### DIFF
--- a/packages/react-native/React/Base/RCTUtils.mm
+++ b/packages/react-native/React/Base/RCTUtils.mm
@@ -50,9 +50,9 @@ void RCTSetNewArchEnabled(BOOL enabled)
 BOOL RCTAreLegacyLogsEnabled(void)
 {
 #if RCT_DEBUG
-  NSNumber *rctNewArchEnabled =
-      (NSNumber *)[[NSBundle mainBundle] objectForInfoDictionaryKey:@"RCTLegacyWarningsEnabled"];
-  return rctNewArchEnabled.boolValue;
+  static BOOL legacyLogEnabled =
+      ((NSNumber *)[[NSBundle mainBundle] objectForInfoDictionaryKey:@"RCTLegacyWarningsEnabled"]).boolValue;
+  return legacyLogEnabled;
 #else
   return NO;
 #endif

--- a/packages/react-native/React/Base/RCTUtils.mm
+++ b/packages/react-native/React/Base/RCTUtils.mm
@@ -49,9 +49,13 @@ void RCTSetNewArchEnabled(BOOL enabled)
 
 BOOL RCTAreLegacyLogsEnabled(void)
 {
+#if RCT_DEBUG
   NSNumber *rctNewArchEnabled =
       (NSNumber *)[[NSBundle mainBundle] objectForInfoDictionaryKey:@"RCTLegacyWarningsEnabled"];
   return rctNewArchEnabled.boolValue;
+#else
+  return NO;
+#endif
 }
 
 static NSString *__nullable _RCTJSONStringifyNoRetry(id __nullable jsonObject, NSError **error)


### PR DESCRIPTION
Summary:
This change prevents RN from accessing the MainBundle every time a NativeModule is registered by caching the `legacyLogEnabled` property in a static variable.

## Changelog:
[Internal] - Prevent multiple access to mainBundle

Reviewed By: javache

Differential Revision: D73992070


