### PR TITLE
Add getBoundingClientRect to TypeScript API

### DIFF
--- a/packages/react-native/types/__typetests__/index.tsx
+++ b/packages/react-native/types/__typetests__/index.tsx
@@ -517,6 +517,8 @@ export class TouchableHighlightTest extends React.Component {
               (x, y, width, height): number => x + y + width + height,
             );
             ref?.setNativeProps({focusable: false});
+            const {x, y, width, height} = ref?.getBoundingClientRect() ?? {};
+            console.log(x, y, width, height);
           }}
         />
       </>

--- a/packages/react-native/types/public/ReactNativeTypes.d.ts
+++ b/packages/react-native/types/public/ReactNativeTypes.d.ts
@@ -7,6 +7,8 @@
  * @format
  */
 
+/// <reference lib="dom" />
+
 import type * as React from 'react';
 
 export type MeasureOnSuccessCallback = (
@@ -109,6 +111,12 @@ export interface NativeMethods {
    * Removes focus from an input or view. This is the opposite of `focus()`.
    */
   blur(): void;
+
+  /**
+   * Returns a DOMRect object providing information about the size of an element
+   * and its position relative to the viewport.
+   */
+  getBoundingClientRect(): DOMRect;
 }
 
 /**


### PR DESCRIPTION
Summary:
Resolves https://github.com/facebook/react-native/issues/50684.

Changelog: [Internal]

Differential Revision: D74002880


