### PR TITLE
Fix clipToPaddingBox on new Background and Border drawable

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BackgroundStyleApplicator.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BackgroundStyleApplicator.kt
@@ -346,11 +346,16 @@ public object BackgroundStyleApplicator {
 
   @JvmStatic
   public fun clipToPaddingBox(view: View, canvas: Canvas): Unit {
-    // The canvas may be scrolled, so we need to offset
     if (ReactNativeFeatureFlags.enableNewBackgroundAndBorderDrawables()) {
       val drawingRect = Rect()
       view.getDrawingRect(drawingRect)
-      val composite = ensureCompositeBackgroundDrawable(view)
+
+      val composite = getCompositeBackgroundDrawable(view)
+      if (composite == null) {
+        canvas.clipRect(drawingRect)
+        return
+      }
+
       val paddingBoxRect = RectF()
 
       val computedBorderInsets =


### PR DESCRIPTION
Summary:
When clipping to the padding box without a background or border set, we should default to clipping to the drawing rectangle.

This ensures accurate clipping behavior when there is no background or border set. This is because it seems bounds accommodates the contents of the drawables but when no content is present (either a background or a border) the bounds are 0. In which case we want to rely on the drawing rect instead of the bounds for this edge case.



Changelog: [Android][Fixed] - Fix incorrect clip to padding box on new Background and Border drawables

Differential Revision: D74014372


