### PR TITLE
remove ATOMIC_VAR_INIT

### DIFF
--- a/packages/react-native/React/Profiler/RCTProfile.m
+++ b/packages/react-native/React/Profiler/RCTProfile.m
@@ -42,7 +42,7 @@ static NSString *const kProfilePrefix = @"rct_profile_";
 
 #pragma mark - Variables
 
-static atomic_bool RCTProfileProfiling = ATOMIC_VAR_INIT(NO);
+static atomic_bool RCTProfileProfiling = NO;
 
 static NSDictionary *RCTProfileInfo;
 static NSMutableDictionary *RCTProfileOngoingEvents;


### PR DESCRIPTION
Summary: ATOMIC_VAR_INIT is deprecated in C17, and does nothing anyway.

Reviewed By: NSProgrammer

Differential Revision: D74002901


