### PR TITLE
Make `EventBeatManager` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2392,11 +2392,6 @@ public final class com/facebook/react/fabric/FabricUIManagerProviderImpl : com/f
 	public fun createUIManager (Lcom/facebook/react/bridge/ReactApplicationContext;)Lcom/facebook/react/bridge/UIManager;
 }
 
-public final class com/facebook/react/fabric/events/EventBeatManager : com/facebook/jni/HybridClassBase, com/facebook/react/uimanager/events/BatchEventDispatchedListener {
-	public fun <init> ()V
-	public fun onBatchEventDispatched ()V
-}
-
 public class com/facebook/react/fabric/mounting/MountItemDispatcher {
 	public fun <init> (Lcom/facebook/react/fabric/mounting/MountingManager;Lcom/facebook/react/fabric/mounting/MountItemDispatcher$ItemDispatchListener;)V
 	public fun addMountItem (Lcom/facebook/react/fabric/mounting/mountitems/MountItem;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/events/EventBeatManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/events/EventBeatManager.kt
@@ -18,7 +18,7 @@ import com.facebook.react.uimanager.events.BatchEventDispatchedListener
  */
 @DoNotStrip
 @SuppressLint("MissingNativeLoadLibrary")
-public final class EventBeatManager() : HybridClassBase(), BatchEventDispatchedListener {
+internal final class EventBeatManager() : HybridClassBase(), BatchEventDispatchedListener {
   init {
     initHybrid()
   }
@@ -27,7 +27,7 @@ public final class EventBeatManager() : HybridClassBase(), BatchEventDispatchedL
 
   private external fun tick()
 
-  public override fun onBatchEventDispatched() {
+  override fun onBatchEventDispatched() {
     tick()
   }
 


### PR DESCRIPTION
## Summary:

This class can be internalized as part of the initiative to reduce the public API surface. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.fabric.events.EventBeatManager).

## Changelog:

[INTERNAL] - Make com.facebook.react.fabric.events.EventBeatManager internal

## Test Plan:

```bash
yarn test-android
yarn android
```