### PR TITLE
Make `JSResponderHandler` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3382,13 +3382,6 @@ public final class com/facebook/react/soloader/OpenSourceMergedSoMapping : com/f
 	public fun mapLibName (Ljava/lang/String;)Ljava/lang/String;
 }
 
-public final class com/facebook/react/touch/JSResponderHandler : com/facebook/react/touch/OnInterceptTouchEventListener {
-	public fun <init> ()V
-	public final fun clearJSResponder ()V
-	public fun onInterceptTouchEvent (Landroid/view/ViewGroup;Landroid/view/MotionEvent;)Z
-	public final fun setJSResponder (ILandroid/view/ViewParent;)V
-}
-
 public abstract interface class com/facebook/react/touch/ReactHitSlopView {
 	public abstract fun getHitSlopRect ()Landroid/graphics/Rect;
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/touch/JSResponderHandler.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/touch/JSResponderHandler.kt
@@ -20,7 +20,7 @@ import android.view.ViewParent
  *
  * Single [com.facebook.react.bridge.CatalystInstance] should reuse same instance of this class.
  */
-public class JSResponderHandler : OnInterceptTouchEventListener {
+internal class JSResponderHandler : OnInterceptTouchEventListener {
 
   @Volatile private var currentJSResponder = JS_RESPONDER_UNSET
   // We're holding on to the ViewParent that blocked native responders so that we can clear it
@@ -28,7 +28,7 @@ public class JSResponderHandler : OnInterceptTouchEventListener {
 
   private var viewParentBlockingNativeResponder: ViewParent? = null
 
-  public fun setJSResponder(tag: Int, viewParentBlockingNativeResponder: ViewParent?) {
+  fun setJSResponder(tag: Int, viewParentBlockingNativeResponder: ViewParent?) {
     currentJSResponder = tag
     // We need to unblock the native responder first, otherwise we can get in a bad state: a
     // ViewParent sets requestDisallowInterceptTouchEvent to true, which sets this setting to true
@@ -42,7 +42,7 @@ public class JSResponderHandler : OnInterceptTouchEventListener {
     }
   }
 
-  public fun clearJSResponder() {
+  fun clearJSResponder() {
     currentJSResponder = JS_RESPONDER_UNSET
     maybeUnblockNativeResponder()
   }


### PR DESCRIPTION
## Summary:

This class can be internalized as part of the initiative to reduce the public API surface. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.touch.JSResponderHandler).

## Changelog:

[INTERNAL] - Make com.facebook.react.touch.JSResponderHandler internal

## Test Plan:

```bash
yarn test-android
yarn android
```