### PR TITLE
Make `ShareModule` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3102,17 +3102,6 @@ public final class com/facebook/react/modules/permissions/PermissionsModule : co
 public final class com/facebook/react/modules/permissions/PermissionsModule$Companion {
 }
 
-public final class com/facebook/react/modules/share/ShareModule : com/facebook/fbreact/specs/NativeShareModuleSpec {
-	public static final field Companion Lcom/facebook/react/modules/share/ShareModule$Companion;
-	public static final field ERROR_INVALID_CONTENT Ljava/lang/String;
-	public static final field NAME Ljava/lang/String;
-	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;)V
-	public fun share (Lcom/facebook/react/bridge/ReadableMap;Ljava/lang/String;Lcom/facebook/react/bridge/Promise;)V
-}
-
-public final class com/facebook/react/modules/share/ShareModule$Companion {
-}
-
 public final class com/facebook/react/modules/systeminfo/AndroidInfoHelpers {
 	public static final field DEVICE_LOCALHOST Ljava/lang/String;
 	public static final field EMULATOR_LOCALHOST Ljava/lang/String;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/share/ShareModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/share/ShareModule.kt
@@ -17,7 +17,7 @@ import com.facebook.react.module.annotations.ReactModule
 
 /** Intent module. Launch other activities or open URLs. */
 @ReactModule(name = NativeShareModuleSpec.NAME)
-public class ShareModule(reactContext: ReactApplicationContext) :
+internal class ShareModule(reactContext: ReactApplicationContext) :
     NativeShareModuleSpec(reactContext) {
 
   /**
@@ -28,7 +28,7 @@ public class ShareModule(reactContext: ReactApplicationContext) :
    * @param content the data to send
    * @param dialogTitle the title of the chooser dialog
    */
-  public override fun share(content: ReadableMap?, dialogTitle: String?, promise: Promise) {
+  override fun share(content: ReadableMap?, dialogTitle: String?, promise: Promise) {
     if (content == null) {
       promise.reject(ERROR_INVALID_CONTENT, "Content cannot be null")
       return
@@ -58,10 +58,10 @@ public class ShareModule(reactContext: ReactApplicationContext) :
     }
   }
 
-  public companion object {
-    public const val NAME: String = NativeShareModuleSpec.NAME
+  companion object {
+    const val NAME: String = NativeShareModuleSpec.NAME
     private const val ACTION_SHARED: String = "sharedAction"
-    public const val ERROR_INVALID_CONTENT: String = "E_INVALID_CONTENT"
+    const val ERROR_INVALID_CONTENT: String = "E_INVALID_CONTENT"
     private const val ERROR_UNABLE_TO_OPEN_DIALOG: String = "E_UNABLE_TO_OPEN_DIALOG"
   }
 }


### PR DESCRIPTION
## Summary:

This class can be internalized as part of the initiative to reduce the public API surface. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.modules.share.ShareModule).

## Changelog:

[INTERNAL] - Make com.facebook.react.modules.share.ShareModule internal

## Test Plan:

```bash
yarn test-android
yarn android
```