### PR TITLE
Make `ModuleDataCleaner` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2671,15 +2671,6 @@ public final class com/facebook/react/modules/blob/FileReaderModule$Companion {
 	public final fun getNAME ()Ljava/lang/String;
 }
 
-public final class com/facebook/react/modules/common/ModuleDataCleaner {
-	public static final field INSTANCE Lcom/facebook/react/modules/common/ModuleDataCleaner;
-	public static final fun cleanDataFromModules (Lcom/facebook/react/bridge/ReactContext;)V
-}
-
-public abstract interface class com/facebook/react/modules/common/ModuleDataCleaner$Cleanable {
-	public abstract fun clearSensitiveData ()V
-}
-
 public abstract interface class com/facebook/react/modules/core/DefaultHardwareBackBtnHandler {
 	public abstract fun invokeDefaultOnBackPressed ()V
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/common/ModuleDataCleaner.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/common/ModuleDataCleaner.kt
@@ -15,10 +15,10 @@ import com.facebook.react.common.ReactConstants
  * Cleans sensitive user data from native modules that implement the [Cleanable] interface. This is
  * useful e.g. when a user logs out from an app.
  */
-public object ModuleDataCleaner {
+internal object ModuleDataCleaner {
 
   @JvmStatic
-  public fun cleanDataFromModules(reactContext: ReactContext) {
+  fun cleanDataFromModules(reactContext: ReactContext) {
     reactContext.nativeModules.forEach { nativeModule ->
       if (nativeModule is Cleanable) {
         FLog.d(ReactConstants.TAG, "Cleaning data from ${nativeModule.getName()}")
@@ -40,7 +40,7 @@ public object ModuleDataCleaner {
    * instance is destroyed. This is because logout implies that the instance is destroyed. Apps
    * should enforce this.
    */
-  public fun interface Cleanable {
-    public fun clearSensitiveData()
+  fun interface Cleanable {
+    fun clearSensitiveData()
   }
 }


### PR DESCRIPTION
## Summary:

This class can be internalized as part of the initiative to reduce the public API surface. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.modules.common.ModuleDataCleaner).

Only one library uses it (https://github.com/jbrodriguez/react-native-android-sqlite), but it's hasn't been updated for 10 years. Marking it as breaking, but it's unlikely that the library is used nowadays. See: 

## Changelog:

[ANDROID][BREAKING] - Make com.facebook.react.modules.common.ModuleDataCleaner internal

## Test Plan:

```bash
yarn test-android
yarn android
```