### PR TITLE
Kotlin: Clean up redundant constructs

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/NativeModuleRegistryBuilder.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/NativeModuleRegistryBuilder.kt
@@ -28,7 +28,7 @@ public class NativeModuleRegistryBuilder(
   public constructor(
       reactApplicationContext: ReactApplicationContext,
       @Suppress("UNUSED_PARAMETER") reactInstanceManager: ReactInstanceManager
-  ) : this(reactApplicationContext) {}
+  ) : this(reactApplicationContext)
 
   public fun processPackage(reactPackage: ReactPackage) {
     // We use an iterable instead of an iterator here to ensure thread safety, and that this list

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/MessageQueueThreadHandler.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/MessageQueueThreadHandler.kt
@@ -12,8 +12,7 @@ import android.os.Looper
 import android.os.Message
 
 /** Handler that can catch and dispatch Exceptions to an Exception handler. */
-internal class MessageQueueThreadHandler
-constructor(looper: Looper, private val exceptionHandler: QueueThreadExceptionHandler) :
+internal class MessageQueueThreadHandler(looper: Looper, private val exceptionHandler: QueueThreadExceptionHandler) :
     Handler(looper) {
   override fun dispatchMessage(msg: Message) {
     try {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/LogBoxModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/LogBoxModule.kt
@@ -17,7 +17,7 @@ import com.facebook.react.module.annotations.ReactModule
 @ReactModule(name = NativeLogBoxSpec.NAME)
 internal class LogBoxModule(
     reactContext: ReactApplicationContext?,
-    private val devSupportManager: DevSupportManager
+    devSupportManager: DevSupportManager
 ) : NativeLogBoxSpec(reactContext) {
   private val surfaceDelegate: SurfaceDelegate =
       devSupportManager.createSurfaceDelegate(NAME)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobProvider.kt
@@ -18,7 +18,7 @@ import java.io.IOException
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
-public final class BlobProvider : ContentProvider() {
+public class BlobProvider : ContentProvider() {
   private val executor: ExecutorService = Executors.newSingleThreadExecutor()
 
   override fun onCreate(): Boolean = true

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/fresco/ReactOkHttpNetworkFetcher.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/fresco/ReactOkHttpNetworkFetcher.kt
@@ -17,7 +17,7 @@ import okhttp3.CacheControl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 
-internal class ReactOkHttpNetworkFetcher(private val okHttpClient: OkHttpClient) :
+internal class ReactOkHttpNetworkFetcher(okHttpClient: OkHttpClient) :
     OkHttpNetworkFetcher(okHttpClient) {
   private fun getHeaders(readableMap: ReadableMap?): Map<String, String>? {
     if (readableMap == null) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/ForwardingCookieHandler.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/ForwardingCookieHandler.kt
@@ -23,7 +23,7 @@ import java.net.URI
 public class ForwardingCookieHandler() : CookieHandler() {
 
   @Deprecated("Use the default constructor", ReplaceWith("ForwardingCookieHandler()"))
-  public constructor(@Suppress("UNUSED_PARAMETER") reactContext: ReactContext) : this() {}
+  public constructor(@Suppress("UNUSED_PARAMETER") reactContext: ReactContext) : this()
 
   @Throws(IOException::class)
   override fun get(uri: URI, headers: Map<String, List<String>>): Map<String, List<String>> {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.kt
@@ -164,11 +164,11 @@ public class NetworkingModule(
         https://github.com/facebook/react-native/pull/37798#pullrequestreview-1518338914""")
   public interface CustomClientBuilder : com.facebook.react.modules.network.CustomClientBuilder
 
-  override final fun initialize() {
+  override fun initialize() {
     cookieJarContainer?.setCookieJar(JavaNetCookieJar(cookieHandler))
   }
 
-  override final fun invalidate() {
+  override fun invalidate() {
     shuttingDown = true
     cancelAllRequests()
 
@@ -204,7 +204,7 @@ public class NetworkingModule(
     responseHandlers.remove(handler)
   }
 
-  override final fun sendRequest(
+  override fun sendRequest(
       method: String,
       url: String,
       requestIdAsDouble: Double,
@@ -663,7 +663,7 @@ public class NetworkingModule(
     requestIds.clear()
   }
 
-  final override fun abortRequest(requestIdAsDouble: Double) {
+  override fun abortRequest(requestIdAsDouble: Double) {
     val requestId = requestIdAsDouble.toInt()
     cancelRequest(requestId)
     removeRequest(requestId)
@@ -674,13 +674,13 @@ public class NetworkingModule(
   }
 
   @ReactMethod
-  public final override fun clearCookies(callback: com.facebook.react.bridge.Callback): Unit {
+  public override fun clearCookies(callback: com.facebook.react.bridge.Callback): Unit {
     cookieHandler.clearCookies(callback)
   }
 
-  public final override fun addListener(eventName: String?): Unit = Unit
+  public override fun addListener(eventName: String?): Unit = Unit
 
-  public final override fun removeListeners(count: Double): Unit = Unit
+  public override fun removeListeners(count: Double): Unit = Unit
 
   private fun constructMultipartBody(
       body: ReadableArray,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostInspectorTarget.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostInspectorTarget.kt
@@ -15,7 +15,7 @@ import java.io.Closeable
 import java.util.concurrent.Executor
 
 @DoNotStripAny
-internal class ReactHostInspectorTarget(private val reactHostImpl: ReactHostImpl) : Closeable {
+internal class ReactHostInspectorTarget(reactHostImpl: ReactHostImpl) : Closeable {
   // fbjni looks for the exact name "mHybridData":
   // https://github.com/facebookincubator/fbjni/blob/5587a7fd2b191656be9391a3832ce04c034009a5/cxx/fbjni/detail/Hybrid.h#L310
   @Suppress("NoHungarianNotation")

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/TaskCompletionSource.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/TaskCompletionSource.kt
@@ -13,7 +13,7 @@ package com.facebook.react.runtime.internal.bolts
  * access to the consumer side through the getTask() method while isolating the Task's completion
  * mechanisms from the consumer.
  */
-internal class TaskCompletionSource<TResult>() {
+internal class TaskCompletionSource<TResult> {
 
   /** @return the Task associated with this TaskCompletionSource. */
   val task: Task<TResult> = Task()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/OnLayoutEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/OnLayoutEvent.kt
@@ -39,7 +39,7 @@ public class OnLayoutEvent private constructor() : Event<OnLayoutEvent>() {
 
   override fun getEventName(): String = "topLayout"
 
-  override fun getEventData(): WritableMap? {
+  override fun getEventData(): WritableMap {
     val layout =
         Arguments.createMap().apply {
           putDouble("x", toDIPFromPixel(x.toFloat()).toDouble())

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/Spacing.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/Spacing.kt
@@ -19,9 +19,9 @@ public class Spacing(private val defaultValue: Float, private val spacing: Float
   private var valueFlags = 0
   private var hasAliasesSet = false
 
-  public constructor() : this(0f, newFullSpacingArray()) {}
+  public constructor() : this(0f, newFullSpacingArray())
 
-  public constructor(defaultValue: Float) : this(defaultValue, newFullSpacingArray()) {}
+  public constructor(defaultValue: Float) : this(defaultValue, newFullSpacingArray())
 
   /**
    * Copy constructor.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/events/DrawerClosedEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/events/DrawerClosedEvent.kt
@@ -21,7 +21,7 @@ internal class DrawerClosedEvent : Event<DrawerClosedEvent> {
 
   override fun getEventName(): String = EVENT_NAME
 
-  protected override fun getEventData(): WritableMap? = Arguments.createMap()
+  protected override fun getEventData(): WritableMap = Arguments.createMap()
 
   companion object {
     const val EVENT_NAME: String = "topDrawerClose"

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/events/DrawerOpenedEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/events/DrawerOpenedEvent.kt
@@ -21,7 +21,7 @@ internal class DrawerOpenedEvent : Event<DrawerOpenedEvent> {
 
   override fun getEventName(): String = EVENT_NAME
 
-  protected override fun getEventData(): WritableMap? = Arguments.createMap()
+  protected override fun getEventData(): WritableMap = Arguments.createMap()
 
   companion object {
     const val EVENT_NAME: String = "topDrawerOpen"

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/events/DrawerSlideEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/events/DrawerSlideEvent.kt
@@ -29,7 +29,7 @@ internal class DrawerSlideEvent : Event<DrawerSlideEvent> {
 
   override fun getEventName(): String = EVENT_NAME
 
-  protected override fun getEventData(): WritableMap? {
+  protected override fun getEventData(): WritableMap {
     val eventData: WritableMap = Arguments.createMap()
     eventData.putDouble("offset", getOffset().toDouble())
     return eventData

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ImageLoadEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ImageLoadEvent.kt
@@ -35,7 +35,7 @@ private constructor(
   // enough to fit into short.
   override fun getCoalescingKey(): Short = eventType.toShort()
 
-  override fun getEventData(): WritableMap? =
+  override fun getEventData(): WritableMap =
       Arguments.createMap().apply {
         when (eventType) {
           ON_PROGRESS -> {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ShowEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ShowEvent.kt
@@ -22,7 +22,7 @@ internal class ShowEvent(surfaceId: Int, viewTag: Int) : Event<ShowEvent>(surfac
 
   override fun getEventName(): String = EVENT_NAME
 
-  override fun getEventData(): WritableMap? = Arguments.createMap()
+  override fun getEventData(): WritableMap = Arguments.createMap()
 
   companion object {
     const val EVENT_NAME: String = "topShow"

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/safeareaview/ReactSafeAreaViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/safeareaview/ReactSafeAreaViewManager.kt
@@ -19,7 +19,7 @@ import com.facebook.react.viewmanagers.SafeAreaViewManagerInterface
 
 /** View manager for [ReactSafeAreaView] components. */
 @ReactModule(name = ReactSafeAreaViewManager.REACT_CLASS)
-internal class ReactSafeAreaViewManager() :
+internal class ReactSafeAreaViewManager :
     ViewGroupManager<ReactSafeAreaView>(), SafeAreaViewManagerInterface<ReactSafeAreaView> {
 
   private val delegate: ViewManagerDelegate<ReactSafeAreaView> = SafeAreaViewManagerDelegate(this)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/safeareaview/ReactSafeAreaViewShadowNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/safeareaview/ReactSafeAreaViewShadowNode.kt
@@ -10,4 +10,4 @@ package com.facebook.react.views.safeareaview
 import com.facebook.react.common.annotations.internal.LegacyArchitecture
 import com.facebook.react.uimanager.LayoutShadowNode
 
-@LegacyArchitecture internal class ReactSafeAreaViewShadowNode() : LayoutShadowNode() {}
+@LegacyArchitecture internal class ReactSafeAreaViewShadowNode : LayoutShadowNode() {}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/RefreshEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/RefreshEvent.kt
@@ -23,7 +23,7 @@ internal class RefreshEvent : Event<RefreshEvent> {
     return "topRefresh"
   }
 
-  override fun getEventData(): WritableMap? {
+  override fun getEventData(): WritableMap {
     return Arguments.createMap()
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitchEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitchEvent.kt
@@ -23,7 +23,7 @@ internal class ReactSwitchEvent(surfaceId: Int, viewId: Int, private val isCheck
 
   override fun getEventName(): String = EVENT_NAME
 
-  public override fun getEventData(): WritableMap? =
+  public override fun getEventData(): WritableMap =
       Arguments.createMap().apply {
         putInt("target", viewTag)
         putBoolean("value", isChecked)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactContentSizeChangedEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactContentSizeChangedEvent.kt
@@ -31,7 +31,7 @@ internal class ReactContentSizeChangedEvent(
 
   override fun getEventName(): String = EVENT_NAME
 
-  override fun getEventData(): WritableMap? {
+  override fun getEventData(): WritableMap {
     val contentSize =
         Arguments.createMap().apply {
           putDouble("width", contentWidth.toDouble())

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextChangedEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextChangedEvent.kt
@@ -30,7 +30,7 @@ internal class ReactTextChangedEvent(
 
   override fun getEventName(): String = EVENT_NAME
 
-  override fun getEventData(): WritableMap? {
+  override fun getEventData(): WritableMap {
     return Arguments.createMap().apply {
       putString("text", text)
       putInt("eventCount", eventCount)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputBlurEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputBlurEvent.kt
@@ -24,7 +24,7 @@ internal class ReactTextInputBlurEvent(surfaceId: Int, viewId: Int) :
 
   override fun canCoalesce(): Boolean = false
 
-  override fun getEventData(): WritableMap? {
+  override fun getEventData(): WritableMap {
     return Arguments.createMap().apply { putInt("target", viewTag) }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputEndEditingEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputEndEditingEvent.kt
@@ -30,7 +30,7 @@ internal class ReactTextInputEndEditingEvent(
 
   override fun canCoalesce(): Boolean = false
 
-  override fun getEventData(): WritableMap? {
+  override fun getEventData(): WritableMap {
     return Arguments.createMap().apply {
       putInt("target", viewTag)
       putString("text", text)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputFocusEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputFocusEvent.kt
@@ -22,7 +22,7 @@ internal class ReactTextInputFocusEvent(surfaceId: Int, viewId: Int) :
 
   override fun getEventName(): String = EVENT_NAME
 
-  override fun getEventData(): WritableMap? {
+  override fun getEventData(): WritableMap {
     return Arguments.createMap().apply { putInt("target", viewTag) }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputKeyPressEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputKeyPressEvent.kt
@@ -22,7 +22,7 @@ internal class ReactTextInputKeyPressEvent(surfaceId: Int, viewId: Int, private 
 
   override fun getEventName(): String = EVENT_NAME
 
-  override fun getEventData(): WritableMap? {
+  override fun getEventData(): WritableMap {
     return Arguments.createMap().apply { putString("key", key) }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputSelectionEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputSelectionEvent.kt
@@ -30,7 +30,7 @@ internal class ReactTextInputSelectionEvent(
 
   override fun getEventName(): String = EVENT_NAME
 
-  override fun getEventData(): WritableMap? {
+  override fun getEventData(): WritableMap {
     val selectionData =
         Arguments.createMap().apply {
           putInt("end", selectionEnd)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputSubmitEditingEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputSubmitEditingEvent.kt
@@ -25,7 +25,7 @@ internal class ReactTextInputSubmitEditingEvent(
 
   override fun getEventName(): String = EVENT_NAME
 
-  override fun getEventData(): WritableMap? {
+  override fun getEventData(): WritableMap {
     return Arguments.createMap().apply {
       putInt("target", viewTag)
       putString("text", text)

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/layoutanimation/AbstractLayoutAnimationTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/layoutanimation/AbstractLayoutAnimationTest.kt
@@ -53,7 +53,7 @@ class AbstractLayoutAnimationTest {
               y: Int,
               width: Int,
               height: Int
-          ): Animation? {
+          ): Animation {
             return mock()
           }
         }
@@ -102,7 +102,7 @@ class AbstractLayoutAnimationTest {
               y: Int,
               width: Int,
               height: Int
-          ): Animation? = mock()
+          ): Animation = mock()
         }
 
     val result = invalidAnimation.createAnimation(view, 0, 0, 100, 100)
@@ -126,7 +126,7 @@ class AbstractLayoutAnimationTest {
               y: Int,
               width: Int,
               height: Int
-          ): Animation? = mock()
+          ): Animation = mock()
         }
 
     val exception =


### PR DESCRIPTION
## Summary:

Static code analysis detected several redundant constructs across the codebase. Most of the ones fixed here are marked as warnings/weak warnings, likely code smells post-migration from Java.

Doing a small round to clean up some of them.

## Changelog:

[INTERNAL] - Kotlin: Clean up redundant constructs

## Test Plan:

```sh
yarn android
yarn test-android
```