### PR TITLE
Added decalaration for  pressRetentionOffset prop to be recognised by typescript

### DIFF
--- a/packages/react-native/Libraries/Text/Text.d.ts
+++ b/packages/react-native/Libraries/Text/Text.d.ts
@@ -213,8 +213,7 @@ export interface TextProps
   pointerEvents?: ViewStyle['pointerEvents'] | undefined;
 
   /**
-   * Insets for press retention.
-   * Example: { top: 20, left: 20, bottom: 20, right: 20 }
+   * Defines how far your touch may move off of the button, before deactivating the button
    */
   pressRetentionOffset?:
    | {top: number; left: number; bottom: number; right: number}

--- a/packages/react-native/Libraries/Text/Text.d.ts
+++ b/packages/react-native/Libraries/Text/Text.d.ts
@@ -211,6 +211,15 @@ export interface TextProps
    * Controls how touch events are handled. Similar to `View`'s `pointerEvents`.
    */
   pointerEvents?: ViewStyle['pointerEvents'] | undefined;
+
+  /**
+   * Insets for press retention.
+   * Example: { top: 20, left: 20, bottom: 20, right: 20 }
+   */
+  pressRetentionOffset?:
+   | {top: number; left: number; bottom: number; right: number}
+   | undefined;
+
 }
 
 /**


### PR DESCRIPTION
## Summary:
Added decalaration for  pressRetentionOffset prop to be recognised by typescript


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:
Added decalaration for  pressRetentionOffset prop to be recognised by typescript in Text.d.ts

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:
[General] [Added] - Add  pressRetentionOffset prop to be recognised by typescript in Text.d.ts

## Test Plan:

Before fix

https://github.com/user-attachments/assets/476364c4-6602-4916-84f2-1ede56bce285

After fix

https://github.com/user-attachments/assets/e5f720d9-cd7d-4cf0-8499-ebe9f83eb17b

Tested here: Related PR: (https://github.com/microsoft/react-native-windows/pull/14596)



