### PR TITLE
Clean up dp to px conversions

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BackgroundStyleApplicator.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BackgroundStyleApplicator.kt
@@ -89,8 +89,9 @@ public object BackgroundStyleApplicator {
   @JvmStatic
   public fun setBorderWidth(view: View, edge: LogicalEdge, width: Float?): Unit {
     val composite = ensureCompositeBackgroundDrawable(view)
+
     composite.borderInsets = composite.borderInsets ?: BorderInsets()
-    composite.borderInsets?.setBorderWidth(edge, width)
+    composite.borderInsets?.setBorderWidth(edge, width?.dpToPx() ?: Float.NaN)
 
     if (ReactNativeFeatureFlags.enableNewBackgroundAndBorderDrawables()) {
       ensureBorderDrawable(view).setBorderWidth(edge.toSpacingType(), width?.dpToPx() ?: Float.NaN)
@@ -102,9 +103,6 @@ public object BackgroundStyleApplicator {
     } else {
       ensureCSSBackground(view).setBorderWidth(edge.toSpacingType(), width?.dpToPx() ?: Float.NaN)
     }
-
-    composite.borderInsets = composite.borderInsets ?: BorderInsets()
-    composite.borderInsets?.setBorderWidth(edge, width)
 
     if (Build.VERSION.SDK_INT >= MIN_INSET_BOX_SHADOW_SDK_VERSION) {
       for (shadow in composite.innerShadows.filterIsInstance<InsetBoxShadowDrawable>()) {
@@ -361,11 +359,10 @@ public object BackgroundStyleApplicator {
       val computedBorderInsets =
           composite.borderInsets?.resolve(composite.layoutDirection, view.context)
 
-      paddingBoxRect.left = composite.bounds.left + (computedBorderInsets?.left?.dpToPx() ?: 0f)
-      paddingBoxRect.top = composite.bounds.top + (computedBorderInsets?.top?.dpToPx() ?: 0f)
-      paddingBoxRect.right = composite.bounds.right - (computedBorderInsets?.right?.dpToPx() ?: 0f)
-      paddingBoxRect.bottom =
-          composite.bounds.bottom - (computedBorderInsets?.bottom?.dpToPx() ?: 0f)
+      paddingBoxRect.left = composite.bounds.left + (computedBorderInsets?.left ?: 0f)
+      paddingBoxRect.top = composite.bounds.top + (computedBorderInsets?.top ?: 0f)
+      paddingBoxRect.right = composite.bounds.right - (computedBorderInsets?.right ?: 0f)
+      paddingBoxRect.bottom = composite.bounds.bottom - (computedBorderInsets?.bottom ?: 0f)
 
       if (composite.borderRadius?.hasRoundedBorders() == true) {
         val paddingBoxPath =
@@ -529,42 +526,35 @@ public object BackgroundStyleApplicator {
         composite.borderRadius?.resolve(
             composite.layoutDirection,
             view.context,
-            PixelUtil.toDIPFromPixel(composite.bounds.width().toFloat()),
-            PixelUtil.toDIPFromPixel(composite.bounds.height().toFloat()),
-        )
+            composite.bounds.width().toFloat().pxToDp(),
+            composite.bounds.height().toFloat().pxToDp())
 
     val paddingBoxPath = Path()
 
     val innerTopLeftRadiusX =
         getInnerBorderRadius(
-            computedBorderRadius?.topLeft?.horizontal?.dpToPx(),
-            computedBorderInsets?.left?.dpToPx())
+            computedBorderRadius?.topLeft?.horizontal?.dpToPx(), computedBorderInsets?.left)
     val innerTopLeftRadiusY =
         getInnerBorderRadius(
-            computedBorderRadius?.topLeft?.vertical?.dpToPx(), computedBorderInsets?.top?.dpToPx())
+            computedBorderRadius?.topLeft?.vertical?.dpToPx(), computedBorderInsets?.top)
     val innerTopRightRadiusX =
         getInnerBorderRadius(
-            computedBorderRadius?.topRight?.horizontal?.dpToPx(),
-            computedBorderInsets?.right?.dpToPx())
+            computedBorderRadius?.topRight?.horizontal?.dpToPx(), computedBorderInsets?.right)
     val innerTopRightRadiusY =
         getInnerBorderRadius(
-            computedBorderRadius?.topRight?.vertical?.dpToPx(), computedBorderInsets?.top?.dpToPx())
+            computedBorderRadius?.topRight?.vertical?.dpToPx(), computedBorderInsets?.top)
     val innerBottomRightRadiusX =
         getInnerBorderRadius(
-            computedBorderRadius?.bottomRight?.horizontal?.dpToPx(),
-            computedBorderInsets?.right?.dpToPx())
+            computedBorderRadius?.bottomRight?.horizontal?.dpToPx(), computedBorderInsets?.right)
     val innerBottomRightRadiusY =
         getInnerBorderRadius(
-            computedBorderRadius?.bottomRight?.vertical?.dpToPx(),
-            computedBorderInsets?.bottom?.dpToPx())
+            computedBorderRadius?.bottomRight?.vertical?.dpToPx(), computedBorderInsets?.bottom)
     val innerBottomLeftRadiusX =
         getInnerBorderRadius(
-            computedBorderRadius?.bottomLeft?.horizontal?.dpToPx(),
-            computedBorderInsets?.left?.dpToPx())
+            computedBorderRadius?.bottomLeft?.horizontal?.dpToPx(), computedBorderInsets?.left)
     val innerBottomLeftRadiusY =
         getInnerBorderRadius(
-            computedBorderRadius?.bottomLeft?.vertical?.dpToPx(),
-            computedBorderInsets?.bottom?.dpToPx())
+            computedBorderRadius?.bottomLeft?.vertical?.dpToPx(), computedBorderInsets?.bottom)
 
     paddingBoxPath.addRoundRect(
         paddingBoxRect,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/BorderDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/BorderDrawable.kt
@@ -24,7 +24,6 @@ import android.graphics.drawable.Drawable
 import android.os.Build
 import com.facebook.react.uimanager.FloatUtil.floatsEqual
 import com.facebook.react.uimanager.LengthPercentage
-import com.facebook.react.uimanager.PixelUtil.dpToPx
 import com.facebook.react.uimanager.PixelUtil.pxToDp
 import com.facebook.react.uimanager.Spacing
 import com.facebook.react.uimanager.style.BorderColors
@@ -544,10 +543,10 @@ internal class BorderDrawable(
   private fun computeBorderInsets(): RectF {
     borderInsets?.resolve(layoutDirection, context)?.let {
       return RectF(
-          if (it.left.isNaN()) 0f else it.left.dpToPx(),
-          if (it.top.isNaN()) 0f else it.top.dpToPx(),
-          if (it.right.isNaN()) 0f else it.right.dpToPx(),
-          if (it.bottom.isNaN()) 0f else it.bottom.dpToPx(),
+          if (it.left.isNaN()) 0f else it.left,
+          if (it.top.isNaN()) 0f else it.top,
+          if (it.right.isNaN()) 0f else it.right,
+          if (it.bottom.isNaN()) 0f else it.bottom,
       )
     }
     return RectF(0f, 0f, 0f, 0f)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CompositeBackgroundDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CompositeBackgroundDrawable.kt
@@ -15,7 +15,6 @@ import android.graphics.drawable.Drawable
 import android.graphics.drawable.LayerDrawable
 import android.os.Build
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
-import com.facebook.react.uimanager.PixelUtil.dpToPx
 import com.facebook.react.uimanager.style.BorderInsets
 import com.facebook.react.uimanager.style.BorderRadiusStyle
 
@@ -197,14 +196,14 @@ internal class CompositeBackgroundDrawable(
         pathForOutline.addRoundRect(
             RectF(bounds),
             floatArrayOf(
-                (it.topLeft.horizontal + (computedBorderInsets?.left ?: 0f)).dpToPx(),
-                (it.topLeft.vertical + (computedBorderInsets?.top ?: 0f)).dpToPx(),
-                (it.topRight.horizontal + (computedBorderInsets?.right ?: 0f)).dpToPx(),
-                (it.topRight.vertical + (computedBorderInsets?.top ?: 0f)).dpToPx(),
-                (it.bottomRight.horizontal + (computedBorderInsets?.right ?: 0f)).dpToPx(),
-                (it.bottomRight.vertical + (computedBorderInsets?.bottom ?: 0f)).dpToPx(),
-                (it.bottomLeft.horizontal + (computedBorderInsets?.left ?: 0f)).dpToPx(),
-                (it.bottomLeft.vertical + (computedBorderInsets?.bottom ?: 0f)).dpToPx()),
+                it.topLeft.horizontal + (computedBorderInsets?.left ?: 0f),
+                it.topLeft.vertical + (computedBorderInsets?.top ?: 0f),
+                it.topRight.horizontal + (computedBorderInsets?.right ?: 0f),
+                it.topRight.vertical + (computedBorderInsets?.top ?: 0f),
+                it.bottomRight.horizontal + (computedBorderInsets?.right ?: 0f),
+                it.bottomRight.vertical + (computedBorderInsets?.bottom ?: 0f),
+                it.bottomLeft.horizontal + (computedBorderInsets?.left ?: 0f),
+                it.bottomLeft.vertical + (computedBorderInsets?.bottom ?: 0f)),
             Path.Direction.CW)
       }
 


### PR DESCRIPTION
Summary:
Its much easier to reason about insets already being converted to px when set on CompositeBackgroundDrawable.

We also already do this with borderWidths on BorderDrawables

Changelog: [Internal]

Differential Revision: D74080731


