### PR TITLE
Used shared_ptr<Runtime> in jsi testlib

### DIFF
--- a/packages/react-native/ReactCommon/jsi/jsi/decorator.h
+++ b/packages/react-native/ReactCommon/jsi/jsi/decorator.h
@@ -112,6 +112,10 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
     return plain_;
   }
 
+  ICast* castInterface(const UUID& interfaceUUID) override {
+    return plain().castInterface(interfaceUUID);
+  }
+
   Value evaluateJavaScript(
       const std::shared_ptr<const Buffer>& buffer,
       const std::string& sourceURL) override {
@@ -586,6 +590,11 @@ class WithRuntimeDecorator : public RuntimeDecorator<Plain, Base> {
   // the ctor, and there is no ctor, so they can be passed members of
   // the derived class.
   WithRuntimeDecorator(Plain& plain, With& with) : RD(plain), with_(with) {}
+
+  ICast* castInterface(const UUID& interfaceUUID) override {
+    Around around{with_};
+    return RD::castInterface(interfaceUUID);
+  }
 
   Value evaluateJavaScript(
       const std::shared_ptr<const Buffer>& buffer,

--- a/packages/react-native/ReactCommon/jsi/jsi/jsi.cpp
+++ b/packages/react-native/ReactCommon/jsi/jsi/jsi.cpp
@@ -286,6 +286,10 @@ NativeState::~NativeState() {}
 
 Runtime::~Runtime() {}
 
+ICast* Runtime::castInterface(const UUID& /*interfaceUUID*/) {
+  return nullptr;
+}
+
 Instrumentation& Runtime::instrumentation() {
   class NoInstrumentation : public Instrumentation {
     std::string getRecordedGCStats() override {

--- a/packages/react-native/ReactCommon/jsi/jsi/jsi.h
+++ b/packages/react-native/ReactCommon/jsi/jsi/jsi.h
@@ -113,6 +113,25 @@ class JSI_EXPORT UUID {
   uint64_t low;
 };
 
+/// Base interface that all JSI interfaces inherit from. Users should not try to
+/// manipulate this base type directly, and should use castInterface to get the
+/// appropriate subtype.
+struct JSI_EXPORT ICast {
+  /// If the current object can be cast into the interface specified by \p
+  /// interfaceUUID, return a pointer to the object. Otherwise, return a null
+  /// pointer.
+  /// The returned interface has the same lifetime as the underlying object. It
+  /// does not need to be released when not needed.
+  virtual ICast* castInterface(const UUID& interfaceUUID) = 0;
+
+ protected:
+  /// Interfaces are not destructible, thus the destructor is intentionally
+  /// protected to prevent delete calls on the interface.
+  /// Additionally, the destructor is non-virtual to reduce the vtable
+  /// complexity from inheritance.
+  ~ICast() = default;
+};
+
 /// Base class for buffers of data or bytecode that need to be passed to the
 /// runtime. The buffer is expected to be fully immutable, so the result of
 /// size(), data(), and the contents of the pointer returned by data() must not
@@ -251,9 +270,11 @@ class JSI_EXPORT NativeState {
 /// in a non-Runtime-managed object, and not clean it up before the Runtime
 /// is shut down.  If your lifecycle is such that avoiding this is hard,
 /// you will probably need to do use your own locks.
-class JSI_EXPORT Runtime {
+class JSI_EXPORT Runtime : public ICast {
  public:
   virtual ~Runtime();
+
+  ICast* castInterface(const UUID& interfaceUUID) override;
 
   /// Evaluates the given JavaScript \c buffer.  \c sourceURL is used
   /// to annotate the stack trace if there is an exception.  The
@@ -1762,6 +1783,32 @@ class JSI_EXPORT JSError : public JSIException {
   std::string message_;
   std::string stack_;
 };
+
+/// Helper function to cast the object pointed to by \p ptr into an interface
+/// specified by \c U. If cast is successful, return a pointer to the object
+/// as a raw pointer of \c U. Otherwise, return nullptr.
+/// The returned interface same lifetime as the object referenced by \p ptr.
+template <typename U, typename T>
+U* castInterface(T* ptr) {
+  if (ptr) {
+    return static_cast<U*>(ptr->castInterface(U::uuid));
+  }
+  return nullptr;
+};
+
+/// Helper function to cast the object managed by the shared_ptr \p ptr into an
+/// interface specified by \c U. If the cast is successful, return a shared_ptr
+/// of type \c U to the object. Otherwise, return an empty pointer.
+/// The returned shared_ptr shares ownership of the object with \p ptr.
+template <typename U, typename T>
+std::shared_ptr<U> dynamicInterfaceCast(T&& ptr) {
+  auto* p = ptr->castInterface(U::uuid);
+  U* res = static_cast<U*>(p);
+  if (res) {
+    return std::shared_ptr<U>(std::forward<T>(ptr), res);
+  }
+  return nullptr;
+}
 
 } // namespace jsi
 } // namespace facebook

--- a/packages/react-native/ReactCommon/jsi/jsi/test/testlib.cpp
+++ b/packages/react-native/ReactCommon/jsi/jsi/test/testlib.cpp
@@ -1173,7 +1173,7 @@ TEST_P(JSITest, DecoratorTest) {
 
   class CountRuntime final : public WithRuntimeDecorator<Count> {
    public:
-    explicit CountRuntime(std::unique_ptr<Runtime> rt)
+    explicit CountRuntime(std::shared_ptr<Runtime> rt)
         : WithRuntimeDecorator<Count>(*rt, count_),
           rt_(std::move(rt)),
           count_(kInit) {}
@@ -1183,7 +1183,7 @@ TEST_P(JSITest, DecoratorTest) {
     }
 
    private:
-    std::unique_ptr<Runtime> rt_;
+    std::shared_ptr<Runtime> rt_;
     Count count_;
   };
 
@@ -1222,7 +1222,7 @@ TEST_P(JSITest, MultiDecoratorTest) {
   class MultiRuntime final
       : public WithRuntimeDecorator<std::tuple<Inc, Nest>> {
    public:
-    explicit MultiRuntime(std::unique_ptr<Runtime> rt)
+    explicit MultiRuntime(std::shared_ptr<Runtime> rt)
         : WithRuntimeDecorator<std::tuple<Inc, Nest>>(*rt, tuple_),
           rt_(std::move(rt)) {}
 
@@ -1234,7 +1234,7 @@ TEST_P(JSITest, MultiDecoratorTest) {
     }
 
    private:
-    std::unique_ptr<Runtime> rt_;
+    std::shared_ptr<Runtime> rt_;
     std::tuple<Inc, Nest> tuple_;
   };
 

--- a/packages/react-native/ReactCommon/jsi/jsi/test/testlib.cpp
+++ b/packages/react-native/ReactCommon/jsi/jsi/test/testlib.cpp
@@ -1861,6 +1861,25 @@ TEST_P(JSITest, SetRuntimeData) {
   EXPECT_EQ(weakObj3.use_count(), 0);
 }
 
+TEST_P(JSITest, CastInterface) {
+  // This Runtime Decorator is used to test the default implementation of
+  // jsi::Runtime::castInterface
+  class RD : public RuntimeDecorator<Runtime, Runtime> {
+   public:
+    explicit RD(Runtime& rt) : RuntimeDecorator(rt) {}
+
+    ICast* castInterface(const UUID& interfaceUuid) override {
+      return Runtime::castInterface(interfaceUuid);
+    }
+  };
+
+  RD rd = RD(rt);
+  auto randomUuid = UUID{0xf2cd96cf, 0x455e, 0x42d9, 0x850a, 0x13e2cde59b8b};
+  auto ptr = rd.castInterface(randomUuid);
+
+  EXPECT_EQ(ptr, nullptr);
+}
+
 INSTANTIATE_TEST_CASE_P(
     Runtimes,
     JSITest,

--- a/packages/react-native/ReactCommon/jsi/jsi/test/testlib.h
+++ b/packages/react-native/ReactCommon/jsi/jsi/test/testlib.h
@@ -19,7 +19,7 @@ namespace jsi {
 
 class Runtime;
 
-using RuntimeFactory = std::function<std::unique_ptr<Runtime>()>;
+using RuntimeFactory = std::function<std::shared_ptr<Runtime>()>;
 
 std::vector<RuntimeFactory> runtimeGenerators();
 
@@ -42,7 +42,7 @@ class JSITestBase : public ::testing::TestWithParam<RuntimeFactory> {
   }
 
   RuntimeFactory factory;
-  std::unique_ptr<Runtime> runtime;
+  std::shared_ptr<Runtime> runtime;
   Runtime& rt;
 };
 } // namespace jsi


### PR DESCRIPTION
Summary:
After introducing the interfaces, runtime should be managed through a
shared pointer instead of a unique pointer.

This diff will change the usage in JSI testlib. Later diffs will
actually change the HermesRuntime usages.

Reviewed By: lavenzg

Differential Revision: D70113190


