### PR TITLE
Add Hermes Root API in all other versions of Hermes

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/hermes/instrumentation/HermesSamplingProfiler.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/hermes/instrumentation/HermesSamplingProfiler.cpp
@@ -14,17 +14,23 @@ namespace jsi {
 namespace jni {
 
 void HermesSamplingProfiler::enable(jni::alias_ref<jclass>) {
-  hermes::HermesRuntime::enableSamplingProfiler();
+  auto* hermesAPI =
+      castInterface<hermes::IHermesRootAPI>(hermes::makeHermesRootAPI());
+  hermesAPI->enableSamplingProfiler();
 }
 
 void HermesSamplingProfiler::disable(jni::alias_ref<jclass>) {
-  hermes::HermesRuntime::disableSamplingProfiler();
+  auto* hermesAPI =
+      castInterface<hermes::IHermesRootAPI>(hermes::makeHermesRootAPI());
+  hermesAPI->disableSamplingProfiler();
 }
 
 void HermesSamplingProfiler::dumpSampledTraceToFile(
     jni::alias_ref<jclass>,
     std::string filename) {
-  hermes::HermesRuntime::dumpSampledTraceToFile(filename);
+  auto* hermesAPI =
+      castInterface<hermes::IHermesRootAPI>(hermes::makeHermesRootAPI());
+  hermesAPI->dumpSampledTraceToFile(filename);
 }
 
 void HermesSamplingProfiler::registerNatives() {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/hermes/reactexecutor/OnLoad.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/hermes/reactexecutor/OnLoad.cpp
@@ -57,7 +57,12 @@ class HermesExecutorHolder
     JReactMarker::setLogPerfMarkerIfNeeded();
 
     std::call_once(flag, []() {
-      facebook::hermes::HermesRuntime::setFatalHandler(hermesFatalHandler);
+      auto* fatalHandlerInterface =
+          castInterface<facebook::hermes::ISetFatalHandler>(
+              facebook::hermes::makeHermesRootAPI());
+      if (fatalHandlerInterface) {
+        fatalHandlerInterface->setFatalHandler(hermesFatalHandler);
+      }
     });
     auto factory = std::make_unique<HermesExecutorFactory>(installBindings);
     factory->setEnableDebugger(enableDebugger);
@@ -75,7 +80,10 @@ class HermesExecutorHolder
     JReactMarker::setLogPerfMarkerIfNeeded();
     auto runtimeConfig = makeRuntimeConfig(heapSizeMB);
     std::call_once(flag, []() {
-      facebook::hermes::HermesRuntime::setFatalHandler(hermesFatalHandler);
+      auto fatalHandlerInterface =
+          castInterface<facebook::hermes::ISetFatalHandler>(
+              facebook::hermes::makeHermesRootAPI());
+      fatalHandlerInterface->setFatalHandler(hermesFatalHandler);
     });
     auto factory = std::make_unique<HermesExecutorFactory>(
         installBindings, JSIExecutor::defaultTimeoutInvoker, runtimeConfig);

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.cpp
@@ -175,11 +175,13 @@ class HermesRuntimeTargetDelegate::Impl final : public RuntimeTargetDelegate {
   }
 
   void enableSamplingProfiler() override {
-    runtime_->enableSamplingProfiler(HERMES_SAMPLING_FREQUENCY_HZ);
+    auto* hermesAPI = castInterface<IHermesRootAPI>(makeHermesRootAPI());
+    hermesAPI->enableSamplingProfiler(HERMES_SAMPLING_FREQUENCY_HZ);
   }
 
   void disableSamplingProfiler() override {
-    runtime_->disableSamplingProfiler();
+    auto* hermesAPI = castInterface<IHermesRootAPI>(makeHermesRootAPI());
+    hermesAPI->disableSamplingProfiler();
   }
 
   tracing::RuntimeSamplingProfile collectSamplingProfile() override {

--- a/packages/react-native/ReactCommon/jsi/jsi/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsi/jsi/CMakeLists.txt
@@ -3,7 +3,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_library(jsi

--- a/packages/react-native/ReactCommon/jsi/jsi/decorator.h
+++ b/packages/react-native/ReactCommon/jsi/jsi/decorator.h
@@ -112,6 +112,10 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
     return plain_;
   }
 
+  ICast* castInterface(const UUID& interfaceUUID) override {
+    return plain().castInterface(interfaceUUID);
+  }
+
   Value evaluateJavaScript(
       const std::shared_ptr<const Buffer>& buffer,
       const std::string& sourceURL) override {
@@ -575,6 +579,11 @@ class WithRuntimeDecorator : public RuntimeDecorator<Plain, Base> {
   // the ctor, and there is no ctor, so they can be passed members of
   // the derived class.
   WithRuntimeDecorator(Plain& plain, With& with) : RD(plain), with_(with) {}
+
+  ICast* castInterface(const UUID& interfaceUUID) override {
+    Around around{with_};
+    return RD::castInterface(interfaceUUID);
+  }
 
   Value evaluateJavaScript(
       const std::shared_ptr<const Buffer>& buffer,

--- a/packages/react-native/ReactCommon/jsi/jsi/jsi.cpp
+++ b/packages/react-native/ReactCommon/jsi/jsi/jsi.cpp
@@ -227,6 +227,10 @@ NativeState::~NativeState() {}
 
 Runtime::~Runtime() {}
 
+ICast* Runtime::castInterface(const UUID& /*interfaceUUID*/) {
+  return nullptr;
+}
+
 Instrumentation& Runtime::instrumentation() {
   class NoInstrumentation : public Instrumentation {
     std::string getRecordedGCStats() override {

--- a/packages/react-native/ReactCommon/jsi/jsi/test/testlib.cpp
+++ b/packages/react-native/ReactCommon/jsi/jsi/test/testlib.cpp
@@ -1773,6 +1773,25 @@ TEST_P(JSITest, ObjectCreateWithPrototype) {
   EXPECT_TRUE(child.getPrototype(rd).isNull());
 }
 
+TEST_P(JSITest, CastInterface) {
+  // This Runtime Decorator is used to test the default implementation of
+  // jsi::Runtime::castInterface
+  class RD : public RuntimeDecorator<Runtime, Runtime> {
+   public:
+    explicit RD(Runtime& rt) : RuntimeDecorator(rt) {}
+
+    ICast* castInterface(const UUID& interfaceUuid) override {
+      return Runtime::castInterface(interfaceUuid);
+    }
+  };
+
+  RD rd = RD(rt);
+  auto randomUuid = UUID{0xf2cd96cf, 0x455e, 0x42d9, 0x850a, 0x13e2cde59b8b};
+  auto ptr = rd.castInterface(randomUuid);
+
+  EXPECT_EQ(ptr, nullptr);
+}
+
 INSTANTIATE_TEST_CASE_P(
     Runtimes,
     JSITest,

--- a/packages/react-native/ReactCommon/jsi/jsi/test/testlib.cpp
+++ b/packages/react-native/ReactCommon/jsi/jsi/test/testlib.cpp
@@ -1173,7 +1173,7 @@ TEST_P(JSITest, DecoratorTest) {
 
   class CountRuntime final : public WithRuntimeDecorator<Count> {
    public:
-    explicit CountRuntime(std::unique_ptr<Runtime> rt)
+    explicit CountRuntime(std::shared_ptr<Runtime> rt)
         : WithRuntimeDecorator<Count>(*rt, count_),
           rt_(std::move(rt)),
           count_(kInit) {}
@@ -1183,7 +1183,7 @@ TEST_P(JSITest, DecoratorTest) {
     }
 
    private:
-    std::unique_ptr<Runtime> rt_;
+    std::shared_ptr<Runtime> rt_;
     Count count_;
   };
 
@@ -1222,7 +1222,7 @@ TEST_P(JSITest, MultiDecoratorTest) {
   class MultiRuntime final
       : public WithRuntimeDecorator<std::tuple<Inc, Nest>> {
    public:
-    explicit MultiRuntime(std::unique_ptr<Runtime> rt)
+    explicit MultiRuntime(std::shared_ptr<Runtime> rt)
         : WithRuntimeDecorator<std::tuple<Inc, Nest>>(*rt, tuple_),
           rt_(std::move(rt)) {}
 
@@ -1234,7 +1234,7 @@ TEST_P(JSITest, MultiDecoratorTest) {
     }
 
    private:
-    std::unique_ptr<Runtime> rt_;
+    std::shared_ptr<Runtime> rt_;
     std::tuple<Inc, Nest> tuple_;
   };
 

--- a/packages/react-native/ReactCommon/jsi/jsi/test/testlib.h
+++ b/packages/react-native/ReactCommon/jsi/jsi/test/testlib.h
@@ -19,7 +19,7 @@ namespace jsi {
 
 class Runtime;
 
-using RuntimeFactory = std::function<std::unique_ptr<Runtime>()>;
+using RuntimeFactory = std::function<std::shared_ptr<Runtime>()>;
 
 std::vector<RuntimeFactory> runtimeGenerators();
 
@@ -42,7 +42,7 @@ class JSITestBase : public ::testing::TestWithParam<RuntimeFactory> {
   }
 
   RuntimeFactory factory;
-  std::unique_ptr<Runtime> runtime;
+  std::shared_ptr<Runtime> runtime;
   Runtime& rt;
 };
 } // namespace jsi

--- a/packages/react-native/ReactCommon/reactperflogger/reactperflogger/FuseboxPerfettoDataSource.cpp
+++ b/packages/react-native/ReactCommon/reactperflogger/reactperflogger/FuseboxPerfettoDataSource.cpp
@@ -115,14 +115,18 @@ void logHermesProfileToFusebox(const std::string& traceStr) {
 
 void FuseboxPerfettoDataSource::OnStart(const StartArgs&) {
   FuseboxTracer::getFuseboxTracer().startTracing();
-  facebook::hermes::HermesRuntime::enableSamplingProfiler(SAMPLING_HZ);
+  auto* hermesAPI =
+      castInterface<hermes::IHermesRootAPI>(hermes::makeHermesRootAPI());
+  hermesAPI->enableSamplingProfiler(SAMPLING_HZ);
 }
 
 void FuseboxPerfettoDataSource::OnFlush(const FlushArgs&) {}
 
 void FuseboxPerfettoDataSource::OnStop(const StopArgs& a) {
   std::stringstream stream;
-  facebook::hermes::HermesRuntime::dumpSampledTraceToStream(stream);
+  auto* hermesAPI =
+      castInterface<hermes::IHermesRootAPI>(hermes::makeHermesRootAPI());
+  hermesAPI->dumpSampledTraceToStream(stream);
   std::string trace = stream.str();
   logHermesProfileToFusebox(trace);
 

--- a/packages/react-native/ReactCommon/reactperflogger/reactperflogger/HermesPerfettoDataSource.cpp
+++ b/packages/react-native/ReactCommon/reactperflogger/reactperflogger/HermesPerfettoDataSource.cpp
@@ -106,7 +106,9 @@ void logHermesProfileToPerfetto(const std::string& traceStr) {
 } // namespace
 
 void HermesPerfettoDataSource::OnStart(const StartArgs&) {
-  facebook::hermes::HermesRuntime::enableSamplingProfiler(SAMPLING_HZ);
+  auto* hermesAPI =
+      castInterface<hermes::IHermesRootAPI>(hermes::makeHermesRootAPI());
+  hermesAPI->enableSamplingProfiler(SAMPLING_HZ);
   TRACE_EVENT_INSTANT(
       "react-native",
       perfetto::DynamicString{"Profiling Started"},
@@ -117,14 +119,18 @@ void HermesPerfettoDataSource::OnStart(const StartArgs&) {
 void HermesPerfettoDataSource::OnFlush(const FlushArgs&) {
   // NOTE: We write data during OnFlush and not OnStop because we can't
   //       use the TRACE_EVENT macros in OnStop.
+  auto* hermesAPI =
+      castInterface<hermes::IHermesRootAPI>(hermes::makeHermesRootAPI());
   std::stringstream stream;
-  facebook::hermes::HermesRuntime::dumpSampledTraceToStream(stream);
+  hermesAPI->dumpSampledTraceToStream(stream);
   std::string trace = stream.str();
   logHermesProfileToPerfetto(trace);
 }
 
 void HermesPerfettoDataSource::OnStop(const StopArgs& a) {
-  facebook::hermes::HermesRuntime::disableSamplingProfiler();
+  auto* hermesAPI =
+      castInterface<hermes::IHermesRootAPI>(hermes::makeHermesRootAPI());
+  hermesAPI->disableSamplingProfiler();
 }
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
Introduces the `IHermesRootAPI` interface and a class implementation.
This root API will contain the previously static methods on
`HermesRuntime`.

The root API will serve as an entry point for users to create the Hermes
runtime and invoke methods that do not necessarily require a runtime.

Diff also moves all usages of the static methods on `HermesRuntime` to
getting the methods from the root API. 

Multiple places are depending on Hermes, Hermes snapshot, and Shermes,
so this diff will also update all of these verions of Hermes at once.

Differential Revision: D71132855


