### PR TITLE
RN: Create Shadow Node Expiration Checker

### DIFF
--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -567,6 +567,20 @@ if (typeof global.EventTarget === 'undefined') {
 }
 
 /**
+ * Returns a function that returns the current reference count for the supplied
+ * element's shadow node. If the reference count is zero, that means the shadow
+ * node has been deallocated.
+ *
+ * @param node The node for which to create a reference counting function.
+ */
+export function createShadowNodeReferenceCounter(
+  node: ReactNativeElement,
+): () => number {
+  let shadowNode = getNativeNodeReference(node);
+  return NativeFantom.createShadowNodeReferenceCounter(shadowNode);
+}
+
+/**
  * Saves a heap snapshot after forcing garbage collection.
  *
  * The heapsnapshot is saved to the filename supplied as an argument.

--- a/packages/react-native/src/private/__tests__/utilities/ShadowNodeReferenceCounter.js
+++ b/packages/react-native/src/private/__tests__/utilities/ShadowNodeReferenceCounter.js
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import ReactNativeElement from '../../webapis/dom/nodes/ReadOnlyNode';
+import ensureInstance from './ensureInstance';
+import * as Fantom from '@react-native/fantom';
+
+export function createShadowNodeReferenceCounter(
+  element: ReactNativeElement,
+): () => number {
+  const getReferenceCount = Fantom.createShadowNodeReferenceCounter(element);
+  // Create the reference counting function in a helper instead of creating a
+  // closure here, which would unintentionally retain a reference to `element`.
+  return createExpirationChecker(getReferenceCount);
+}
+
+function createExpirationChecker(
+  getReferenceCount: () => number,
+): () => number {
+  return () => {
+    Fantom.runTask(() => {
+      global.gc();
+    });
+    return getReferenceCount();
+  };
+}
+
+export function createShadowNodeReferenceCountingRef(): [
+  () => number,
+  React.RefSetter<mixed>,
+] {
+  let getReferenceCount: ?() => number;
+
+  function getShadowNodeReferenceCount() {
+    if (getReferenceCount == null) {
+      throw new Error('ShadowNode reference counter was not initialized.');
+    }
+    return getReferenceCount();
+  }
+
+  function ref(instance: mixed | null) {
+    if (instance == null) {
+      return;
+    }
+    const element = ensureInstance(instance, ReactNativeElement);
+    if (getReferenceCount != null) {
+      throw new Error('ShadowNode reference counter was already initialized.');
+    }
+    getReferenceCount = createShadowNodeReferenceCounter(element);
+  }
+
+  return [getShadowNodeReferenceCount, ref];
+}

--- a/packages/react-native/src/private/__tests__/utilities/__tests__/ShadowNodeReferenceCounter-itest.js
+++ b/packages/react-native/src/private/__tests__/utilities/__tests__/ShadowNodeReferenceCounter-itest.js
@@ -1,0 +1,210 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import 'react-native/Libraries/Core/InitializeCore';
+
+import type {Node} from '../../../../../Libraries/Renderer/shims/ReactNativeTypes';
+
+import {getNodeFromPublicInstance} from '../../../../../Libraries/ReactPrivate/ReactNativePrivateInterface';
+import ReactNativeElement from '../../../webapis/dom/nodes/ReactNativeElement';
+import ensureInstance from '../ensureInstance';
+import isUnreachable from '../isUnreachable';
+import {
+  createShadowNodeReferenceCounter,
+  createShadowNodeReferenceCountingRef,
+} from '../ShadowNodeReferenceCounter';
+import * as Fantom from '@react-native/fantom';
+import nullthrows from 'nullthrows';
+import * as React from 'react';
+import {View} from 'react-native';
+
+test('shadow node expires when root is destroyed', () => {
+  const root = Fantom.createRoot();
+
+  const [getReferenceCount, ref] = createShadowNodeReferenceCountingRef();
+
+  Fantom.runTask(() => {
+    root.render(<View ref={ref} />);
+  });
+
+  expect(getReferenceCount()).toBeGreaterThan(0);
+
+  Fantom.runTask(() => {
+    root.destroy();
+  });
+
+  expect(getReferenceCount()).toBe(0);
+});
+
+test('element is not retained by `createShadowNodeReferenceCounter`', () => {
+  const root = Fantom.createRoot();
+
+  let elementWeakRef: ?WeakRef<ReactNativeElement>;
+  let getReferenceCount: ?() => number;
+
+  function ref(instance: React.ElementRef<typeof View> | null) {
+    if (instance == null) {
+      return;
+    }
+    const element = ensureInstance(instance, ReactNativeElement);
+    elementWeakRef = new WeakRef(element);
+    getReferenceCount = createShadowNodeReferenceCounter(element);
+  }
+
+  Fantom.runTask(() => {
+    root.render(
+      <View>
+        <View ref={ref} />
+      </View>,
+    );
+  });
+
+  expect(isUnreachable(nullthrows(elementWeakRef))).toBe(false);
+  expect(getReferenceCount?.()).toBeGreaterThan(0);
+
+  Fantom.runTask(() => {
+    root.destroy();
+  });
+
+  expect(isUnreachable(nullthrows(elementWeakRef))).toBe(true);
+  expect(getReferenceCount?.()).toBe(0);
+});
+
+test('shadow node expires when JavaScript element is reachable', () => {
+  const root = Fantom.createRoot();
+
+  let element: ?ReactNativeElement;
+  let getReferenceCount: ?() => number;
+
+  function ref(instance: React.ElementRef<typeof View> | null) {
+    if (instance == null) {
+      return;
+    }
+    element = ensureInstance(instance, ReactNativeElement);
+    getReferenceCount = createShadowNodeReferenceCounter(element);
+  }
+
+  Fantom.runTask(() => {
+    root.render(
+      <View>
+        <View ref={ref} />
+      </View>,
+    );
+  });
+
+  expect(element).not.toBe(undefined);
+  expect(getNodeFromPublicInstance(nullthrows(element))).not.toBe(null);
+  expect(getReferenceCount?.()).toBeGreaterThan(0);
+
+  Fantom.runTask(() => {
+    root.destroy();
+  });
+
+  expect(element).not.toBe(undefined);
+  expect(getNodeFromPublicInstance(nullthrows(element))).toBe(null);
+  expect(getReferenceCount?.()).toBe(0);
+});
+
+test('shadow node is retained when JavaScript node is reachable', () => {
+  const root = Fantom.createRoot();
+
+  let node: ?Node;
+  let getReferenceCount: ?() => number;
+
+  function ref(instance: React.ElementRef<typeof View> | null) {
+    if (instance == null) {
+      return;
+    }
+    const element = ensureInstance(instance, ReactNativeElement);
+    node = getNodeFromPublicInstance(element);
+    getReferenceCount = createShadowNodeReferenceCounter(element);
+  }
+
+  Fantom.runTask(() => {
+    root.render(
+      <View>
+        <View ref={ref} />
+      </View>,
+    );
+  });
+
+  expect(node).not.toBe(undefined);
+  expect(getReferenceCount?.()).toBeGreaterThan(0);
+
+  Fantom.runTask(() => {
+    root.destroy();
+  });
+
+  expect(node).not.toBe(undefined);
+  expect(getReferenceCount?.()).toBeGreaterThan(0);
+});
+
+test('shadow node expires when replaced by null', () => {
+  const root = Fantom.createRoot();
+
+  const [getReferenceCount, ref] = createShadowNodeReferenceCountingRef();
+
+  Fantom.runTask(() => {
+    root.render(
+      <View>
+        <View ref={ref} />
+      </View>,
+    );
+  });
+
+  expect(getReferenceCount()).toBeGreaterThan(0);
+
+  Fantom.runTask(() => {
+    root.render(<View>{null}</View>);
+  });
+
+  // TODO (T223254666): Delete this and figure out why test fails.
+  Fantom.runTask(() => {
+    root.render(<View>{null}</View>);
+  });
+
+  expect(getReferenceCount()).toBe(0);
+});
+
+test('shadow node expires when replaced by another view', () => {
+  const root = Fantom.createRoot();
+
+  const [getReferenceCount, ref] = createShadowNodeReferenceCountingRef();
+
+  Fantom.runTask(() => {
+    root.render(
+      <View>
+        <View key="a" ref={ref} />
+      </View>,
+    );
+  });
+
+  expect(getReferenceCount()).toBeGreaterThan(0);
+
+  Fantom.runTask(() => {
+    root.render(
+      <View>
+        <View key="b" />
+      </View>,
+    );
+  });
+
+  // TODO (T223254666): Delete this and figure out why test fails.
+  Fantom.runTask(() => {
+    root.render(
+      <View>
+        <View key="b" />
+      </View>,
+    );
+  });
+
+  expect(getReferenceCount()).toBe(0);
+});

--- a/packages/react-native/src/private/testing/fantom/specs/NativeFantom.js
+++ b/packages/react-native/src/private/testing/fantom/specs/NativeFantom.js
@@ -93,6 +93,9 @@ interface Spec extends TurboModule {
   validateEmptyMessageQueue: () => void;
   getRenderedOutput: (surfaceId: number, config: RenderFormatOptions) => string;
   reportTestSuiteResultsJSON: (results: string) => void;
+  createShadowNodeReferenceCounter(
+    shadowNode: mixed /* ShadowNode */,
+  ): () => number;
   saveJSMemoryHeapSnapshot: (filePath: string) => void;
 }
 


### PR DESCRIPTION
Summary:
Creates `ShadowNodeExpirationChecker`, a module with utilities for writing unit tests that assert whether a native shadow node has been deallocated.

Changelog:
[Internal]

Differential Revision: D74131710


