### PR TITLE
Add status bar offset to New App Screen on Android

### DIFF
--- a/packages/new-app-screen/src/NewAppScreen.js
+++ b/packages/new-app-screen/src/NewAppScreen.js
@@ -13,8 +13,10 @@ import {ThemedText, useTheme} from './Theme';
 import * as React from 'react';
 import {
   Image,
+  Platform,
   SafeAreaView,
   ScrollView,
+  StatusBar,
   StyleSheet,
   Text,
   TouchableHighlight,
@@ -29,6 +31,11 @@ export type NewAppScreenProps = $ReadOnly<{
   templateFileName?: string,
 }>;
 
+const statusBarHeightOffset = Platform.select({
+  android: StatusBar.currentHeight || 0,
+  default: 0,
+});
+
 export default function NewAppScreen({
   templateFileName = 'App.tsx',
 }: NewAppScreenProps): React.Node {
@@ -39,7 +46,7 @@ export default function NewAppScreen({
   return (
     <SafeAreaView style={{backgroundColor: colors.background}}>
       <ScrollView>
-        <View style={styles.container}>
+        <View style={[styles.container, {paddingTop: statusBarHeightOffset}]}>
           <View style={styles.header}>
             <Image
               style={styles.logo}


### PR DESCRIPTION
Summary:
Fix for top padding with Android edge-to-edge (default for current version of the RN template). We add a `statusBarHeightOffset` explicitly, since this is not covered by the builtin `SafeAreaView`.

<img width="796" alt="image" src="https://github.com/user-attachments/assets/209ca15f-2e80-4bac-9827-3358fd4369ad" />

Changelog: [Internal]

Differential Revision: D74142357


