### PR TITLE
community-cli-plugin: Use `TerminalReporter` type from `metro`, replace deep imports

### DIFF
--- a/packages/community-cli-plugin/src/commands/start/OpenDebuggerKeyboardHandler.js
+++ b/packages/community-cli-plugin/src/commands/start/OpenDebuggerKeyboardHandler.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import type TerminalReporter from 'metro/src/lib/TerminalReporter';
+import type {TerminalReporter} from 'metro';
 
 import chalk from 'chalk';
 

--- a/packages/community-cli-plugin/src/commands/start/attachKeyHandlers.js
+++ b/packages/community-cli-plugin/src/commands/start/attachKeyHandlers.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import type TerminalReporter from 'metro/src/lib/TerminalReporter';
+import type {TerminalReporter} from 'metro';
 
 import OpenDebuggerKeyboardHandler from './OpenDebuggerKeyboardHandler';
 import chalk from 'chalk';

--- a/packages/community-cli-plugin/src/commands/start/runServer.js
+++ b/packages/community-cli-plugin/src/commands/start/runServer.js
@@ -10,9 +10,9 @@
  */
 
 import type {Config} from '@react-native-community/cli-types';
+import type {TerminalReporter} from 'metro';
 import type {Reporter} from 'metro/src/lib/reporting';
 import type {TerminalReportableEvent} from 'metro/src/lib/TerminalReporter';
-import typeof TerminalReporter from 'metro/src/lib/TerminalReporter';
 
 import createDevMiddlewareLogger from '../../utils/createDevMiddlewareLogger';
 import isDevServerRunning from '../../utils/isDevServerRunning';
@@ -176,7 +176,9 @@ async function runServer(
   await version.logIfUpdateAvailable(cliConfig, terminalReporter);
 }
 
-function getReporterImpl(customLogReporterPath?: string): TerminalReporter {
+function getReporterImpl(
+  customLogReporterPath?: string,
+): Class<TerminalReporter> {
   if (customLogReporterPath == null) {
     return require('metro/src/lib/TerminalReporter');
   }

--- a/packages/community-cli-plugin/src/utils/createDevMiddlewareLogger.js
+++ b/packages/community-cli-plugin/src/utils/createDevMiddlewareLogger.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import type TerminalReporter from 'metro/src/lib/TerminalReporter';
+import type {TerminalReporter} from 'metro';
 
 type LoggerFn = (...message: $ReadOnlyArray<string>) => void;
 

--- a/packages/community-cli-plugin/src/utils/version.js
+++ b/packages/community-cli-plugin/src/utils/version.js
@@ -10,7 +10,7 @@
  */
 
 import type {Config} from '@react-native-community/cli-types';
-import type TerminalReporter from 'metro/src/lib/TerminalReporter';
+import type {TerminalReporter} from 'metro';
 
 import chalk from 'chalk';
 import semver from 'semver';


### PR DESCRIPTION
Summary:
`TerminalReporter` is re-exported from `metro` (since [0.76.7](https://github.com/facebook/metro/releases/tag/v0.76.7)), so we can update these deep imports to use public exports.

Changelog: [Internal]

Differential Revision: D74141704


