### PR TITLE
Refactor out unused `bundleType` from BundleOptions

### DIFF
--- a/packages/community-cli-plugin/src/commands/bundle/buildBundle.js
+++ b/packages/community-cli-plugin/src/commands/bundle/buildBundle.js
@@ -125,10 +125,10 @@ async function buildBundleWithConfig(
     await bundleImpl.save(bundle, args, console.info);
 
     // Save the assets of the bundle
+    // $FlowFixMe[prop-missing] Fixed by release of Metro 0.82.3
     const outputAssets = await server.getAssets({
       ...Server.DEFAULT_BUNDLE_OPTIONS,
       ...requestOpts,
-      bundleType: 'todo',
     });
 
     // When we're done saving bundle output and the assets, we're done.


### PR DESCRIPTION
Summary:
## Metro
`bundleType` is only used by Metro's reporter upon receipt of a request to Metro server, and is unnecessarily part of `BundleOptions` as passed to serialisers.

Within the server, it's redundant because we've already inspected the `pathname` extension of `.bundle`, etc, before deciding which request processor to use - so we can simply make it part of creating the request processor, instead of passing the same string to every call to the processor.

This diff removes `bundleType` from the `BundleOptions` type while retaining it in the return type of `parseOptionsFromUrl` (a public API) for now.

Callers may continue to pass it - it'll be unused as it always has been - so this is non-breaking

## React Native
Remove `bundleType`, unused in Metro <=0.82.2 and invalid in Metro 0.82.3. The Flow suppression may be removed once 0.82.3 is published, but is temporarily required because the Flow types are different in `main` (Meta-internal CI) vs latest published (OSS CI).

Changelog: [Internal]

Differential Revision: D74150833


