### PR TITLE
[ios][prebuild] replaced use of rsync with cp in prebuild scripts

### DIFF
--- a/packages/react-native/third-party-podspecs/ReactNativeDependencies.podspec
+++ b/packages/react-native/third-party-podspecs/ReactNativeDependencies.podspec
@@ -49,9 +49,10 @@ Pod::Spec.new do |spec|
     mkdir -p Headers
     XCFRAMEWORK_PATH=$(find "$CURRENT_PATH" -type d -name "ReactNativeDependencies.xcframework")
     HEADERS_PATH=$(find "$XCFRAMEWORK_PATH" -type d -name "Headers" | head -n 1)
-    rsync -a "$HEADERS_PATH/" Headers
+    cp -R "$HEADERS_PATH/" Headers
     mkdir -p framework/packages/react-native
-    rsync -a --remove-source-files "$XCFRAMEWORK_PATH/.." framework/packages/react-native/
+    cp -R "$XCFRAMEWORK_PATH/.." framework/packages/react-native/
+    find "$XCFRAMEWORK_PATH/.." -type f -exec rm {} +
     find "$CURRENT_PATH" -type d -empty -delete
   CMD
 


### PR DESCRIPTION
## Summary:

When building the RNDependencies XCFrameworks we saw some errors in the CI servers about rsync failing:

`rsync(3031): error: poll: hangup on nonblocking write`

We decided to fix this by changing from using rsync to cp.

This commit fixes this by replacing rsync with cp, and adding a cleanup step after copying the XCFramework files.

## Changelog:

[INTERNAL] [FIXED] - Replacing rsync with cp, and adding a cleanup step after copying the XCFramework files.

## Test Plan:

Run RNDependencies scripts on CI and verify that they're working as expected.