### PR TITLE
migrate deprecated onBackPressed()

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/util/AndroidVersion.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/util/AndroidVersion.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.util
+
+import android.content.Context
+import android.os.Build
+
+/** Helper class for checking Android version-related information. */
+internal object AndroidVersion {
+
+  /**
+   * This is the version code for Android 16 (SDK Level 36). Delete it once we bump up the default
+   * compile SDK version to 36.
+   */
+  private const val VERSION_CODE_BAKLAVA: Int = 36
+
+  /**
+   * This method is used to check if the current device is running Android 16 (SDK Level 36) or
+   * higher and the app is targeting Android 16 (SDK Level 36) or higher.
+   */
+  @JvmStatic
+  fun isAtLeastTargetSdk36(context: Context): Boolean =
+      Build.VERSION.SDK_INT >= VERSION_CODE_BAKLAVA &&
+          context.applicationInfo.targetSdkVersion >= VERSION_CODE_BAKLAVA
+}


### PR DESCRIPTION
Summary:
**Problem:** `Activity.onBackPressed()` has been deprecated and with targetSdk 36, predictive back will be enforced and the API no longer called. We need to migrate to backward compatible `OnBackPressedCallback`.
- https://developer.android.com/about/versions/16/behavior-changes-16#predictive-back.

**Solution:**
`OnBackPressedCallback` is registered conditionally only if it is `targetSdk` 36 or greater.
If the callback in enabled, `onBackPressed()` is not called and callback is used regardless of `android:enableOnBackInvokedCallback` property in <application> or <activity> set in AndroidManifest.xml.

As a workaround callback is manually calling existing `onBackPressed()`.

This is done rather than removing onBackPressed() completely and using only `OnBackPressedCallback` as we are not sure of the impact of removing the implementation entirely. Once we determine it is safe to do so then, we should remove the workaround and fully transition to `OnBackPressedCallback`

NOTE: `ReactDelegate.onHostResume()` sets up the `DefaultHardwareBackBtnHandler` using `ReactActivity` (https://fburl.com/ul47tbeo) and will be called from JS `BackHanderl.exitApp` (https://fburl.com/code/a4l2pjsw).


Changelog:
[Internal]

Differential Revision: D74161428


