### PR TITLE
migrate deprecated KEYCODE_BACK in Modal

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/util/AndroidVersion.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/util/AndroidVersion.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.util
+
+import android.content.Context
+import android.os.Build
+
+/** Helper class for checking Android version-related information. */
+internal object AndroidVersion {
+
+  /**
+   * This is the version code for Android 16 (SDK Level 36). Delete it once we bump up the default
+   * compile SDK version to 36.
+   */
+  private const val VERSION_CODE_BAKLAVA: Int = 36
+
+  /**
+   * This method is used to check if the current device is running Android 16 (SDK Level 36) or
+   * higher and the app is targeting Android 16 (SDK Level 36) or higher.
+   */
+  @JvmStatic
+  fun isAtLeastTargetSdk36(context: Context): Boolean =
+      Build.VERSION.SDK_INT >= VERSION_CODE_BAKLAVA &&
+          context.applicationInfo.targetSdkVersion >= VERSION_CODE_BAKLAVA
+}


### PR DESCRIPTION
Summary:
**Problem:** `Event.KEYCODE_BACK`has been deprecated with targetSdk 36, predictive back will be enforced and KEYCODE_BACK no longer triggered. We need to migrate to backward compatible `OnBackPressedCallback`.
- https://developer.android.com/about/versions/16/behavior-changes-16#predictive-back.

**Solution:**
Use `OnBackPressedCallback` to handle BACK. Logic for ESC key handling still remains.
To support the callback mechanism, we are using AndroidX ComponentDialog ([src](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:activity/activity/src/main/java/androidx/activity/ComponentDialog.kt)) which is a thin wrapper on the existing Dialog.

Changelog:
[Internal]

Differential Revision: D74162844


