### PR TITLE
Deduplicate strings and provide std::string_view

### DIFF
--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeSamplingProfileSerializer.h
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeSamplingProfileSerializer.h
@@ -13,10 +13,20 @@
 
 namespace facebook::react::jsinspector_modern::tracing {
 
+class RawHermesRuntimeProfile : public RawRuntimeProfile {
+ public:
+  explicit RawHermesRuntimeProfile(
+      hermes::sampling_profiler::Profile hermesProfile)
+      : hermesProfile_{std::move(hermesProfile)} {}
+
+ private:
+  hermes::sampling_profiler::Profile hermesProfile_;
+};
+
 class HermesRuntimeSamplingProfileSerializer {
  public:
   static tracing::RuntimeSamplingProfile serializeToTracingSamplingProfile(
-      const hermes::sampling_profiler::Profile& hermesProfile);
+      hermes::sampling_profiler::Profile hermesProfile);
 };
 
 } // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfile.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfile.h
@@ -7,12 +7,22 @@
 
 #pragma once
 
+#include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
 namespace facebook::react::jsinspector_modern::tracing {
+
+/// Opaque class to represent the original runtime profile returned by the
+/// Runtime. RuntimeSamplingProfile class is designed to be agnostic to the
+/// Runtime where sampling occurred.
+class RawRuntimeProfile {
+ public:
+  virtual ~RawRuntimeProfile() = default;
+};
 
 /// Contains relevant information about the sampled runtime from start to
 /// finish.
@@ -33,8 +43,8 @@ struct RuntimeSamplingProfile {
     SampleCallStackFrame(
         const Kind kind,
         const uint32_t scriptId,
-        std::string functionName,
-        std::optional<std::string> url = std::nullopt,
+        std::string_view functionName,
+        std::optional<std::string_view> url = std::nullopt,
         const std::optional<uint32_t>& lineNumber = std::nullopt,
         const std::optional<uint32_t>& columnNumber = std::nullopt)
         : kind_(kind),
@@ -55,7 +65,7 @@ struct RuntimeSamplingProfile {
     }
 
     /// \return name of the function that represents call frame.
-    const std::string& getFunctionName() const {
+    std::string_view getFunctionName() const {
       return functionName_;
     }
 
@@ -64,7 +74,7 @@ struct RuntimeSamplingProfile {
     }
 
     /// \return source url of the corresponding script in the VM.
-    const std::string& getUrl() const {
+    std::string_view getUrl() const {
       return url_.value();
     }
 
@@ -95,8 +105,8 @@ struct RuntimeSamplingProfile {
    private:
     Kind kind_;
     uint32_t scriptId_;
-    std::string functionName_;
-    std::optional<std::string> url_;
+    std::string_view functionName_;
+    std::optional<std::string_view> url_;
     std::optional<uint32_t> lineNumber_;
     std::optional<uint32_t> columnNumber_;
   };
@@ -148,8 +158,13 @@ struct RuntimeSamplingProfile {
     std::vector<SampleCallStackFrame> callStack_;
   };
 
-  RuntimeSamplingProfile(std::string runtimeName, std::vector<Sample> samples)
-      : runtimeName_(std::move(runtimeName)), samples_(std::move(samples)) {}
+  RuntimeSamplingProfile(
+      std::string runtimeName,
+      std::vector<Sample> samples,
+      std::unique_ptr<RawRuntimeProfile> rawRuntimeProfile)
+      : runtimeName_(std::move(runtimeName)),
+        samples_(std::move(samples)),
+        rawRuntimeProfile_(std::move(rawRuntimeProfile)) {}
 
   // Movable.
   RuntimeSamplingProfile& operator=(RuntimeSamplingProfile&&) = default;
@@ -174,6 +189,11 @@ struct RuntimeSamplingProfile {
   std::string runtimeName_;
   /// List of recorded samples, should be chronologically sorted.
   std::vector<Sample> samples_;
+  /// A unique pointer to the original raw runtime profile, collected from the
+  /// runtime in RuntimeTargetDelegate. Keeping a pointer to the original
+  /// profile allows it to remain alive as long as RuntimeSamplingProfile is
+  /// alive, since it may be using the same std::string_view.
+  std::unique_ptr<RawRuntimeProfile> rawRuntimeProfile_;
 };
 
 } // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/tests/RuntimeSamplingProfileTraceEventSerializerTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/tests/RuntimeSamplingProfileTraceEventSerializerTest.cpp
@@ -26,16 +26,16 @@ class RuntimeSamplingProfileTraceEventSerializerTest : public ::testing::Test {
   }
 
   RuntimeSamplingProfile::SampleCallStackFrame createJSCallFrame(
-      std::string functionName,
+      std::string_view functionName,
       uint32_t scriptId = 1,
-      std::optional<std::string> url = std::nullopt,
+      std::optional<std::string_view> url = std::nullopt,
       std::optional<uint32_t> lineNumber = std::nullopt,
       std::optional<uint32_t> columnNumber = std::nullopt) {
     return RuntimeSamplingProfile::SampleCallStackFrame(
         RuntimeSamplingProfile::SampleCallStackFrame::Kind::JSFunction,
         scriptId,
-        std::move(functionName),
-        std::move(url),
+        functionName,
+        url,
         lineNumber,
         columnNumber);
   }
@@ -55,12 +55,12 @@ class RuntimeSamplingProfileTraceEventSerializerTest : public ::testing::Test {
   }
 
   RuntimeSamplingProfile createEmptyProfile() {
-    return {"TestRuntime", {}};
+    return {"TestRuntime", {}, {}};
   }
 
   RuntimeSamplingProfile createProfileWithSamples(
       std::vector<RuntimeSamplingProfile::Sample> samples) {
-    return {"TestRuntime", std::move(samples)};
+    return {"TestRuntime", std::move(samples), {}};
   }
 };
 


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

Depending on the sampling rate, there could be lots of samples recorded. Right now, React Native requests the rate to be 10kHz. In reality, Hermes will be slower. How exactly slower will depend on the platform, because sampling profiler implementation is platform-specific. Windows peaks at ~500Hz, whereas iOS and Android that are using signals can reach up to 5kHz, based on my observations. This means that we could record sample approximately every 0.5ms.

For 30 seconds of sampling, we can get around 150k samples, every one of which may have up to 500 call frames (it is a custom limitation on Hermes side). Previously, every call frame could have a unique copy of function name string and url string.

This diff changes the approach to deduplicate strings, keeping a single copy for every unique string. A new abstraction `UniqueStringEntry` is added that will keep a shared pointer to the string storage and an offset to the entry in this storage.

On React Native side, we are going to re-use these `std::string_view` and keep Hermes' `Profile` alive as long as they are used. We are going to achieve this by keeping unique pointer to the Hermes' `Profile` in React Native's Profile abstraction - `RuntimeSamplingProfile`, which is agnostic to the runtime.

Differential Revision: D73106068


