### PR TITLE
Fix suggesting components from types_generated directory

### DIFF
--- a/scripts/build-types/transforms/__tests__/replaceDefaultExportName-test.js
+++ b/scripts/build-types/transforms/__tests__/replaceDefaultExportName-test.js
@@ -35,9 +35,9 @@ describe('replaceDefaultExportName', () => {
     const code = `export default Foo;`;
     const result = await translate(code, 'mock/path/to/module/Foo.js');
     expect(result).toMatchInlineSnapshot(`
-      "declare const Foo_DEFAULT: typeof Foo;
-      declare type Foo_DEFAULT = typeof Foo_DEFAULT;
-      export default Foo_DEFAULT;"
+      "declare const $$Foo: typeof Foo;
+      declare type $$Foo = typeof $$Foo;
+      export default $$Foo;"
     `);
   });
 });

--- a/scripts/build-types/transforms/replaceDefaultExportName.js
+++ b/scripts/build-types/transforms/replaceDefaultExportName.js
@@ -19,7 +19,10 @@ function createReplaceDefaultExportName(filePath: string): PluginObj<mixed> {
         const moduleName = fileName.split('.')[0];
 
         if (node.node.name === '$$EXPORT_DEFAULT_DECLARATION$$') {
-          node.node.name = `${moduleName}_DEFAULT`;
+          // Prefixing with $$ prevents the TS LSP server from (incorrectly)
+          // discovering identifiers outside of package.json "exports" in
+          // autocomplete.
+          node.node.name = `$$${moduleName}`;
         }
       },
     },


### PR DESCRIPTION
Summary:
TS LSP suggests importing/using components from `types_generated` directory which are exported under slightly different name than root exports. Prefixing default exports with `$$` fixes the issue.

Changelog:
[Internal]

Differential Revision: D74177107


