### PR TITLE
fix(types): Reference `global.d.ts` using `path` not `types`

### DIFF
--- a/packages/react-native/types/index.d.ts
+++ b/packages/react-native/types/index.d.ts
@@ -68,7 +68,7 @@
 /// <reference path="modules/BatchedBridge.d.ts" />
 /// <reference path="modules/Codegen.d.ts" />
 /// <reference path="modules/Devtools.d.ts" />
-/// <reference types="../src/types/globals.d.ts" />
+/// <reference path="../src/types/globals.d.ts" />
 
 export * from '../Libraries/ActionSheetIOS/ActionSheetIOS';
 export * from '../Libraries/Alert/Alert';

--- a/packages/react-native/types/index.d.ts
+++ b/packages/react-native/types/index.d.ts
@@ -68,6 +68,7 @@
 /// <reference path="modules/BatchedBridge.d.ts" />
 /// <reference path="modules/Codegen.d.ts" />
 /// <reference path="modules/Devtools.d.ts" />
+// dtslint:skip no-bad-reference
 /// <reference path="../src/types/globals.d.ts" />
 
 export * from '../Libraries/ActionSheetIOS/ActionSheetIOS';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

After https://github.com/facebook/react-native/pull/49516 TSC would not find the global types.

Types reference expect a package name but was given a path to a declaration. 

TS doc: https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-path-

This PR changes `types` to `path` to fix the issue.

`dtslint` fails with `no-bad-reference` rule, but the `../src` lives in the same package in `react-native` package.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[GENERAL] [FIXED] - Reference `global.d.ts` using `path` so they can be resolved by TSC


## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Before the change with current RN 0.79.2 TSC would fail on resolving the global types (example from [Sentry RN SDK build](https://github.com/getsentry/sentry-react-native/commit/134d810cf95416091779806e00d3a3cc6cbace89)):

![Screenshot 2025-05-05 at 17 18 04](https://github.com/user-attachments/assets/b264c8da-aa21-49d8-9597-82586291a01a)

After the change to path TSC finds the global types.

Using TSC Version 4.9.5 
