### PR TITLE
Fix "detected text" annoucement

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAxOrderHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAxOrderHelper.kt
@@ -9,6 +9,7 @@ package com.facebook.react.uimanager
 
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import com.facebook.react.R
 import com.facebook.react.bridge.ReadableArray
@@ -90,7 +91,11 @@ private object ReactAxOrderHelper {
   ): Array<View?> {
     val axOrderViews = arrayOfNulls<View?>(axOrderIds.size)
 
-    fun traverseAndDisableAxFromExcludedViews(view: View, parent: View) {
+    fun traverseAndDisableAxFromExcludedViews(
+        view: View,
+        parent: View,
+        hasCooptingAncestor: Boolean
+    ) {
       val nativeId = view.getTag(R.id.view_tag_native_id) as String?
 
       val isIncluded = nativeId != null && axOrderSet.contains(nativeId)
@@ -101,28 +106,40 @@ private object ReactAxOrderHelper {
             view, view.isFocusable, view.importantForAccessibility)
       }
 
+      // There is a strange bug with TalkBack where if a focused view has nothing to announce, and
+      // there are no accessibility node's below it, then it will run OCR model on its bounds and
+      // announce any text it sees. Also, if there is a TextView below the View backing the node,
+      // it will announce that text too. This can happen frequently with our implementation here
+      // we change importantForAccessibility for TextView's that are not included in
+      // accessibilityOrder thus kicking off the logic described. To avoid this double announcement
+      // we just do not set importantForAccessibility on TextView's in the case where someone is
+      // coopting them. We will not focus the text since they got coopted.
       if (isIncluded) {
         axOrderViews[axOrderIds.indexOf(nativeId)] = view
-      } else {
+      } else if (!(view is TextView && hasCooptingAncestor)) {
         // Save original state before disabling
         view.setTag(R.id.original_important_for_ax, view.importantForAccessibility)
         view.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
       }
 
+      val wantsToCoopt = isIncluded && view.contentDescription.isNullOrEmpty()
+
       if (view is ViewGroup) {
-        // Continue to try to disable children if this view is not included and is focusable.
-        // This view being focusable means it's an element, and not a container which means its
-        // presence doesn't imply all its children should be focusable. And if its not included we
-        // still want to attempt to disable the children of the container
+        // Continue to try to disable children if this view is not included and is
+        // focusable. This view being focusable means it's an element, and not a container which
+        // means its presence doesn't imply all its children should be focusable. And if its not
+        // included we still want to attempt to disable the children of the container
         if (!isIncluded || view.isFocusable()) {
           for (i in 0 until view.childCount) {
-            traverseAndDisableAxFromExcludedViews(view.getChildAt(i), parent)
+            traverseAndDisableAxFromExcludedViews(view.getChildAt(i), parent, wantsToCoopt)
           }
         }
       }
     }
 
-    traverseAndDisableAxFromExcludedViews(root, root)
+    // Technically we don't know if there is a coopting ancestor here, as it could be above the root
+    // but those cases should be fairly rare
+    traverseAndDisableAxFromExcludedViews(root, root, false)
 
     return axOrderViews
   }


### PR DESCRIPTION
Summary:
There was a strange bug reported to us with `accessibilityOrder` where an OCR model would announce text on the screen sometimes. This would happen if a focused `View` without a label would wrap `Text` that was was not included in the `accessibilityOrder` array. What happens under the hood is we have a focused `View` trying to coopt a label. It finds no accessibility nodes under it (because the `Text` has `importantForAccessibility` set to `NO`) so it falls back to this weird TalkBack behavior. It both reads the text from the TextView and announces an OCR announcement - leading to repeating the text. 

To fix this we just check if we are going to coopt text and if we do then we do not set `importantForAccessibility`. Behavior here changes a bit. Links are not accessible without having to reference the Text, setting `accessible={true}` on non-referenced `Text` will lead to be focusable.

These are both less bad than what we had before though, so I think this tradeoff is fine.

Changelog: [Internal]

Reviewed By: jorge-cab

Differential Revision: D74101530


