### PR TITLE
Update loadImageURL signature in RCTImageURLLoader to include metadata in completion callback

### DIFF
--- a/packages/react-native/Libraries/Image/RCTImageLoader.mm
+++ b/packages/react-native/Libraries/Image/RCTImageLoader.mm
@@ -317,6 +317,45 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image, CGSize size, CGFloat scal
   return image;
 }
 
+/*
+ * This function abstracts away the migration from loadImageForURL to loadImageURL by handling checking whether
+ * the interface responds to the new function signature and calling the appropriate function based on the result.
+ */
+static RCTImageLoaderCancellationBlock RCTLoadImageURLFromLoader(
+    id<RCTImageURLLoader> loadHandler,
+    NSURL *imageURL,
+    CGSize size,
+    CGFloat scale,
+    RCTResizeMode resizeMode,
+    RCTImageLoaderProgressBlock progressHandler,
+    RCTImageLoaderPartialLoadBlock partialLoadHandler,
+    RCTImageLoaderCompletionBlockWithMetadata completionHandler)
+{
+  if ([loadHandler respondsToSelector:@selector(loadImageForURL:
+                                                           size:scale:resizeMode:progressHandler:partialLoadHandler
+                                                               :completionHandlerWithMetadata:)]) {
+    return [loadHandler loadImageForURL:imageURL
+                                   size:size
+                                  scale:scale
+                             resizeMode:resizeMode
+                        progressHandler:progressHandler
+                     partialLoadHandler:partialLoadHandler
+          completionHandlerWithMetadata:^(NSError *error, UIImage *image, id metadata) {
+            completionHandler(error, image, metadata);
+          }];
+  } else {
+    return [loadHandler loadImageForURL:imageURL
+                                   size:size
+                                  scale:scale
+                             resizeMode:resizeMode
+                        progressHandler:progressHandler
+                     partialLoadHandler:partialLoadHandler
+                      completionHandler:^(NSError *error, UIImage *image) {
+                        completionHandler(error, image, nil);
+                      }];
+  }
+}
+
 #pragma mark - RCTImageLoaderProtocol 2/3
 
 - (nullable RCTImageLoaderCancellationBlock)loadImageWithURLRequest:(NSURLRequest *)imageURLRequest
@@ -566,15 +605,18 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image, CGSize size, CGFloat scal
              completionHandler(error, image, metadata, nil);
            }];
     }
-    RCTImageLoaderCancellationBlock cb = [loadHandler loadImageForURL:request.URL
-                                                                 size:size
-                                                                scale:scale
-                                                           resizeMode:resizeMode
-                                                      progressHandler:progressHandler
-                                                   partialLoadHandler:partialLoadHandler
-                                                    completionHandler:^(NSError *error, UIImage *image) {
-                                                      completionHandler(error, image, nil, nil);
-                                                    }];
+
+    RCTImageLoaderCancellationBlock cb = RCTLoadImageURLFromLoader(
+        loadHandler,
+        request.URL,
+        size,
+        scale,
+        resizeMode,
+        progressHandler,
+        partialLoadHandler,
+        ^(NSError *error, UIImage *image, id metadata) {
+          completionHandler(error, image, metadata, nil);
+        });
     return [[RCTImageURLLoaderRequest alloc] initWithRequestId:nil imageURL:request.URL cancellationBlock:cb];
   }
 
@@ -608,15 +650,17 @@ static UIImage *RCTResizeImageIfNeeded(UIImage *image, CGSize size, CGFloat scal
              }];
         cancelLoadLocal = loaderRequest.cancellationBlock;
       } else {
-        cancelLoadLocal = [loadHandler loadImageForURL:request.URL
-                                                  size:size
-                                                 scale:scale
-                                            resizeMode:resizeMode
-                                       progressHandler:progressHandler
-                                    partialLoadHandler:partialLoadHandler
-                                     completionHandler:^(NSError *error, UIImage *image) {
-                                       completionHandler(error, image, nil, nil);
-                                     }];
+        cancelLoadLocal = RCTLoadImageURLFromLoader(
+            loadHandler,
+            request.URL,
+            size,
+            scale,
+            resizeMode,
+            progressHandler,
+            partialLoadHandler,
+            ^(NSError *error, UIImage *image, id metadata) {
+              completionHandler(error, image, metadata, nil);
+            });
       }
       [cancelLoadLock lock];
       cancelLoad = cancelLoadLocal;

--- a/packages/react-native/Libraries/Image/RCTImageURLLoader.h
+++ b/packages/react-native/Libraries/Image/RCTImageURLLoader.h
@@ -38,6 +38,8 @@ typedef dispatch_block_t RCTImageLoaderCancellationBlock;
 - (BOOL)canLoadImageURL:(NSURL *)requestURL;
 
 /**
+ * DEPRECATED: Please use updated signature for loadImageForURL which uses
+ * completionHandlerWithMetadata instead.
  * Send a network request to load the request URL. The method should call the
  * progressHandler (if applicable) and the completionHandler when the request
  * has finished. The method should also return a cancellation block, if
@@ -49,9 +51,25 @@ typedef dispatch_block_t RCTImageLoaderCancellationBlock;
                                                  resizeMode:(RCTResizeMode)resizeMode
                                             progressHandler:(RCTImageLoaderProgressBlock)progressHandler
                                          partialLoadHandler:(RCTImageLoaderPartialLoadBlock)partialLoadHandler
-                                          completionHandler:(RCTImageLoaderCompletionBlock)completionHandler;
+                                          completionHandler:(RCTImageLoaderCompletionBlock)completionHandler
+    RCT_DEPRECATED;
 
 @optional
+
+/*
+ * Send a network request to load the request URL. The method should call the
+ * progressHandler (if applicable) and the completionHandler when the request
+ * has finished. The method should also return a cancellation block, if
+ * applicable.
+ */
+- (nullable RCTImageLoaderCancellationBlock)loadImageForURL:(NSURL *)imageURL
+                                                       size:(CGSize)size
+                                                      scale:(CGFloat)scale
+                                                 resizeMode:(RCTResizeMode)resizeMode
+                                            progressHandler:(RCTImageLoaderProgressBlock)progressHandler
+                                         partialLoadHandler:(RCTImageLoaderPartialLoadBlock)partialLoadHandler
+                              completionHandlerWithMetadata:
+                                  (RCTImageLoaderCompletionBlockWithMetadata)completionHandlerWithMetadata;
 
 /**
  * If more than one RCTImageURLLoader responds YES to `-canLoadImageURL:`


### PR DESCRIPTION
Summary:
Changelog: [iOS][Deprecated] Deprecate loadImageForURL in favor of new signature which uses completionHandlerWithMetadata

Updating the signature of completionHandlerWithMetadata to allow passing metadata through the completionHandlerWithMetadata in order to enable better instrumentation of image loading.

Reviewed By: philIip

Differential Revision: D73162738


