### PR TITLE
Assume full container width when ellipsizing line

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
@@ -753,9 +753,19 @@ public class TextLayoutManager {
       for (int lineIndex = 0; lineIndex < calculatedLineCount; lineIndex++) {
         boolean endsWithNewLine =
             text.length() > 0 && text.charAt(layout.getLineEnd(lineIndex) - 1) == '\n';
-        if (!endsWithNewLine && lineIndex + 1 < layout.getLineCount()) {
-          calculatedWidth = width;
-          break;
+        // Line-wrapping or ellipsizing to truncate should result in taking the full available width
+        // of the container, instead of width after line-breaking/ellipsizing.
+        if (ReactNativeFeatureFlags.incorporateMaxLinesDuringAndroidLayout()) {
+          if ((!endsWithNewLine && lineIndex + 1 < layout.getLineCount())
+              || layout.getEllipsisCount(lineIndex) > 0) {
+            calculatedWidth = width;
+            break;
+          }
+        } else {
+          if (!endsWithNewLine && lineIndex + 1 < layout.getLineCount()) {
+            calculatedWidth = width;
+            break;
+          }
         }
         float lineWidth =
             endsWithNewLine ? layout.getLineMax(lineIndex) : layout.getLineWidth(lineIndex);


### PR DESCRIPTION
Summary:
We calculate the width of text to be the full width of the container, if the text overflows the bounds of the container, instead of the wrapped width, to match the behavior on web.

Incorporating line count into layout defeats this logic, since the final layout never overflows. We need to also check to see if we are ellipsized (had overflow) instead.

Changelog:
[Android][Fixed] - Assume full container width when ellipsizing line

Reviewed By: joevilches

Differential Revision: D74204041


