### PR TITLE
small changes to ctor of State and ConcreteState

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/ConcreteState.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ConcreteState.h
@@ -49,17 +49,15 @@ class ConcreteState : public State {
   /*
    * Creates an updated `State` object with given previous one and `data`.
    */
-  explicit ConcreteState(const SharedData& data, const State& previousState)
-      : State(data, previousState) {}
+  explicit ConcreteState(SharedData data, const State& previousState)
+      : State(std::move(data), previousState) {}
 
   /*
    * Creates a first-of-its-family `State` object with given `family` and
    * `data`.
    */
-  explicit ConcreteState(
-      const SharedData& data,
-      const ShadowNodeFamily::Shared& family)
-      : State(data, family) {}
+  explicit ConcreteState(SharedData data, ShadowNodeFamily::Weak family)
+      : State(std::move(data), std::move(family)) {}
 
   ~ConcreteState() override = default;
 

--- a/packages/react-native/ReactCommon/react/renderer/core/State.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/State.cpp
@@ -21,8 +21,8 @@ State::State(StateData::Shared data, const State& previousState)
       data_(std::move(data)),
       revision_(previousState.revision_ + 1){};
 
-State::State(StateData::Shared data, const ShadowNodeFamily::Shared& family)
-    : family_(family),
+State::State(StateData::Shared data, ShadowNodeFamily::Weak family)
+    : family_(std::move(family)),
       data_(std::move(data)),
       revision_{State::initialRevisionValue} {};
 

--- a/packages/react-native/ReactCommon/react/renderer/core/State.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/State.h
@@ -34,9 +34,7 @@ class State {
    * type-erasured arguments impossible.
    */
   explicit State(StateData::Shared data, const State& previousState);
-  explicit State(
-      StateData::Shared data,
-      const ShadowNodeFamily::Shared& family);
+  explicit State(StateData::Shared data, ShadowNodeFamily::Weak family);
 
  public:
   virtual ~State() = default;


### PR DESCRIPTION
Summary:
changelog: [internal]

1. `ConcreteState` and `State` were taking shared_ptr to family even though they only use weak_ptr.
2. `ConcreteState` was taking a const& to `data`. It unconditionally takes ownership of data, make it obvious in the interface.

Reviewed By: lenaic

Differential Revision: D74024980


