### PR TITLE
Fix: KeyboardAvoidingView Android behavior fix.

### DIFF
--- a/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -94,6 +94,11 @@ class KeyboardAvoidingView extends React.Component<
       return 0;
     }
 
+    // On the Android platform, the keyboard height is 0 during the keyboard close event.
+    if (Platform.OS === 'android' && keyboardFrame?.height === 0) {
+      return 0;
+    }
+
     const keyboardY =
       keyboardFrame.screenY - (this.props.keyboardVerticalOffset ?? 0);
 


### PR DESCRIPTION
Try to resolve Android compatibility for KeyboardAvoidingView component.

## Summary:

On Android devices, KeyboardAvoidingView causes various space errors after opening / closing.

The main reason for this is that when I examine the values ​​in the KeyboardAvoidingView component, in some cases the area covered by the keyboard does not equal 0.

This change resolves the following issues.

https://github.com/facebook/react-native/issues/29614 https://github.com/facebook/react-native/issues/47140 https://github.com/facebook/react-native/issues/50444 https://github.com/facebook/react-native/issues/50728

## Changelog:

[ANDROID] [FIXED] - Fixed issues with KeyboardAvoidingView after keyboard on/off.

## Test Plan:
1- Implement the change.
2- Try the steps of the referenced issues again.
3- Verify that everything works correctly.

