### PR TITLE
Add transform that moves comments for default exported variable declarations

### DIFF
--- a/scripts/build-types/transforms/__tests__/reattachDocComments-test.js
+++ b/scripts/build-types/transforms/__tests__/reattachDocComments-test.js
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+const reattachDocComments = require('../reattachDocComments.js');
+const {parse, print} = require('hermes-transform');
+
+const prettierOptions = {parser: 'babel'};
+
+async function translate(code: string): Promise<string> {
+  const parsed = await parse(code);
+  const result = await reattachDocComments(parsed);
+  return print(result.ast, result.mutatedCode, prettierOptions);
+}
+
+describe('reattachDocComments', () => {
+  test('should move component doc block', async () => {
+    const code = `
+        import Bar from './Bar';
+
+        /**
+         * Foo documentation
+         */
+        let Foo: component(
+        ref?: React.RefSetter<
+            React.ElementRef<FooType>,
+        >,
+        ...props: FooProps
+        );
+
+        export default Foo;
+    `;
+
+    const result = await translate(code);
+    expect(result).toMatchInlineSnapshot(`
+      "import Bar from \\"./Bar\\";
+
+      let Foo: component(
+        ref?: React.RefSetter<React.ElementRef<FooType>>,
+        ...props: FooProps
+      );
+
+      /**
+       * Foo documentation
+       */
+      export default Foo;
+      "
+    `);
+  });
+  test('should move variable doc block', async () => {
+    const code = `
+        const bar = 'bar';
+        /**
+         * Foo documentation
+         */
+        const Foo: component(
+        ref?: React.RefSetter<
+            React.ElementRef<FooType>,
+        >,
+        ...props: FooProps
+        ) = () => {};
+
+        export default Foo;
+    `;
+    const result = await translate(code);
+    expect(result).toMatchInlineSnapshot(`
+      "const bar = \\"bar\\";
+      const Foo: component(
+        ref?: React.RefSetter<React.ElementRef<FooType>>,
+        ...props: FooProps
+      ) = () => {};
+
+      /**
+       * Foo documentation
+       */
+      export default Foo;
+      "
+    `);
+  });
+});

--- a/scripts/build-types/transforms/reattachDocComments.js
+++ b/scripts/build-types/transforms/reattachDocComments.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import type {ExportDefaultDeclaration, Program} from 'hermes-estree/dist';
+import type {TransformVisitor} from 'hermes-transform';
+import type {ParseResult} from 'hermes-transform/dist/transform/parse';
+import type {TransformASTResult} from 'hermes-transform/dist/transform/transformAST';
+
+const {transformAST} = require('hermes-transform/dist/transform/transformAST');
+
+const visitors: TransformVisitor = context => ({
+  Program(node): void {
+    const getExportDefaultDeclaration = (
+      programNode: Program,
+    ): [ExportDefaultDeclaration, string] | null => {
+      for (const bodyNode of programNode.body) {
+        if (bodyNode.type === 'ExportDefaultDeclaration') {
+          if (bodyNode.declaration.type === 'Identifier') {
+            return [bodyNode, bodyNode.declaration.name];
+          }
+        }
+      }
+
+      return null;
+    };
+
+    const exportDefaultDeclResult = getExportDefaultDeclaration(node);
+    if (exportDefaultDeclResult == null) {
+      return;
+    }
+
+    const [exportDefaultDecl, exportDefaultDeclName] = exportDefaultDeclResult;
+    for (const bodyNode of node.body) {
+      if (bodyNode.type === 'VariableDeclaration') {
+        for (const decl of bodyNode.declarations) {
+          if (
+            decl.id.type === 'Identifier' &&
+            decl.id.name === exportDefaultDeclName
+          ) {
+            const comments = context.getComments(bodyNode);
+            if (comments != null) {
+              context.addLeadingComments(exportDefaultDecl, comments);
+              context.removeComments(comments);
+            }
+          }
+        }
+      }
+    }
+  },
+});
+
+async function reattachDocComments(
+  source: ParseResult,
+): Promise<TransformASTResult> {
+  return transformAST(source, visitors);
+}
+
+module.exports = reattachDocComments;

--- a/scripts/build-types/translateSourceFile.js
+++ b/scripts/build-types/translateSourceFile.js
@@ -27,6 +27,7 @@ const preTransforms: Array<PreTransformFn> = [
   require('./transforms/replaceEmptyWithNever'),
   require('./transforms/replaceStringishWithString'),
   require('./transforms/replaceNullablePropertiesWithUndefined'),
+  require('./transforms/reattachDocComments'),
 ];
 const postTransforms: Array<PluginObj<mixed>> = [];
 const prettierOptions = {parser: 'babel'};


### PR DESCRIPTION
Summary:
In generated types default exported variables are re-declared which shadows attached tags and doc blocks. This transform moves necessary comments on top of re-declarations to keep them accessible.

Example output for SafeAreaView:

```ts
import type { ViewProps } from "../View/ViewPropTypes";
import View from "../View/View";
import * as React from "react";
declare const exported: (props: Omit<ViewProps, keyof {
  ref?: React.Ref<React.ComponentRef<typeof View>>;
}> & {
  ref?: React.Ref<React.ComponentRef<typeof View>>;
}) => React.ReactNode;
/**
 * Renders nested content and automatically applies paddings reflect the portion
 * of the view that is not covered by navigation bars, tab bars, toolbars, and
 * other ancestor views.
 *
 * Moreover, and most importantly, Safe Area's paddings reflect physical
 * limitation of the screen, such as rounded corners or camera notches (aka
 * sensor housing area on iPhone X).
 */
declare const SafeAreaView_DEFAULT: typeof exported;
declare type SafeAreaView_DEFAULT = typeof SafeAreaView_DEFAULT;
export default SafeAreaView_DEFAULT;
```

Changelog:
[Internal]

Differential Revision: D74249424


