### PR TITLE
Allow links that are entire text views to be focusable when co-opted

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
@@ -202,7 +202,8 @@ using namespace facebook::react;
 
   NSArray<UIAccessibilityElement *> *elements = _accessibilityProvider.accessibilityElements;
   if ([elements count] > 0) {
-    elements[0].isAccessibilityElement = ![self isAccessibilityCoopted];
+    elements[0].isAccessibilityElement =
+        elements[0].accessibilityTraits & UIAccessibilityTraitLink || ![self isAccessibilityCoopted];
   }
   return elements;
 }


### PR DESCRIPTION
Summary:
The co-opting logic failed to account fo the case where the entire text view as a link and therefore turns off ax. In this case I think it makes sense to re-focus that element again so the user can interact with the link.

Changelog: [Internal]

Differential Revision: D74262675


