### PR TITLE
Make `DebugServerException` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1688,23 +1688,6 @@ public final class com/facebook/react/bridge/queue/ReactQueueConfigurationSpec$C
 	public final fun createDefault ()Lcom/facebook/react/bridge/queue/ReactQueueConfigurationSpec;
 }
 
-public final class com/facebook/react/common/DebugServerException : java/lang/RuntimeException {
-	public static final field Companion Lcom/facebook/react/common/DebugServerException$Companion;
-	public fun <init> (Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
-	public final fun getOriginalMessage ()Ljava/lang/String;
-	public static final fun makeGeneric (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)Lcom/facebook/react/common/DebugServerException;
-	public static final fun makeGeneric (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)Lcom/facebook/react/common/DebugServerException;
-	public static final fun parse (Ljava/lang/String;Ljava/lang/String;)Lcom/facebook/react/common/DebugServerException;
-}
-
-public final class com/facebook/react/common/DebugServerException$Companion {
-	public final fun makeGeneric (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)Lcom/facebook/react/common/DebugServerException;
-	public final fun makeGeneric (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)Lcom/facebook/react/common/DebugServerException;
-	public final fun parse (Ljava/lang/String;Ljava/lang/String;)Lcom/facebook/react/common/DebugServerException;
-}
-
 public class com/facebook/react/common/JavascriptException : java/lang/RuntimeException {
 	public fun <init> (Ljava/lang/String;)V
 	public final fun getExtraDataAsJson ()Ljava/lang/String;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/DebugServerException.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/DebugServerException.kt
@@ -16,9 +16,9 @@ import org.json.JSONObject
  * Tracks errors connecting to or received from the debug server. The debug server returns errors as
  * json objects. This exception represents that error.
  */
-public class DebugServerException : RuntimeException {
+internal class DebugServerException : RuntimeException {
 
-  public val originalMessage: String
+  val originalMessage: String
 
   private constructor(
       description: String,
@@ -29,18 +29,18 @@ public class DebugServerException : RuntimeException {
     originalMessage = description
   }
 
-  public constructor(description: String) : super(description) {
+  constructor(description: String) : super(description) {
     originalMessage = description
   }
 
-  public constructor(
+  constructor(
       detailMessage: String,
       throwable: Throwable?,
   ) : super(detailMessage, throwable) {
     originalMessage = detailMessage
   }
 
-  public companion object {
+  companion object {
     private val GENERIC_ERROR_MESSAGE =
         """
         |
@@ -57,11 +57,11 @@ public class DebugServerException : RuntimeException {
             .trimMargin()
 
     @JvmStatic
-    public fun makeGeneric(url: String, reason: String, t: Throwable?): DebugServerException =
+    fun makeGeneric(url: String, reason: String, t: Throwable?): DebugServerException =
         makeGeneric(url, reason, "", t)
 
     @JvmStatic
-    public fun makeGeneric(
+    fun makeGeneric(
         url: String,
         reason: String,
         extra: String,
@@ -80,7 +80,7 @@ public class DebugServerException : RuntimeException {
      */
     @JvmStatic
     @Suppress("UNUSED_PARAMETER")
-    public fun parse(url: String?, str: String?): DebugServerException? {
+    fun parse(url: String?, str: String?): DebugServerException? {
       if (str.isNullOrEmpty()) {
         return null
       }


### PR DESCRIPTION
## Summary:

This class can be internalized as part of the initiative to reduce the public API surface. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.common.DebugServerException).

## Changelog:

[INTERNAL] - Make com.facebook.react.common.DebugServerException internal

## Test Plan:

```bash
yarn test-android
yarn android
```