### PR TITLE
Introduce ReactSoftExceptionLogger.CategoryMode to warn categories used on soft errors

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1334,6 +1334,9 @@ public final class com/facebook/react/bridge/ReactSoftExceptionLogger$Categories
 	public static final field SURFACE_MOUNTING_MANAGER_MISSING_VIEWSTATE Ljava/lang/String;
 }
 
+public abstract interface annotation class com/facebook/react/bridge/ReactSoftExceptionLogger$CategoryMode : java/lang/annotation/Annotation {
+}
+
 public abstract interface class com/facebook/react/bridge/ReactSoftExceptionLogger$ReactSoftExceptionListener {
 	public abstract fun logSoftException (Ljava/lang/String;Ljava/lang/Throwable;)V
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactSoftExceptionLogger.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactSoftExceptionLogger.kt
@@ -7,13 +7,27 @@
 
 package com.facebook.react.bridge
 
+import androidx.annotation.StringDef
 import com.facebook.common.logging.FLog
 import com.facebook.proguard.annotations.DoNotStrip
+import com.facebook.react.bridge.ReactSoftExceptionLogger.Categories.CLIPPING_PROHIBITED_VIEW
+import com.facebook.react.bridge.ReactSoftExceptionLogger.Categories.RVG_IS_VIEW_CLIPPED
+import com.facebook.react.bridge.ReactSoftExceptionLogger.Categories.RVG_ON_VIEW_REMOVED
+import com.facebook.react.bridge.ReactSoftExceptionLogger.Categories.SOFT_ASSERTIONS
+import com.facebook.react.bridge.ReactSoftExceptionLogger.Categories.SURFACE_MOUNTING_MANAGER_MISSING_VIEWSTATE
 import java.util.concurrent.CopyOnWriteArrayList
-import kotlin.jvm.JvmStatic
 
 @DoNotStrip
 public object ReactSoftExceptionLogger {
+  @Retention(AnnotationRetention.SOURCE)
+  @StringDef(
+      RVG_IS_VIEW_CLIPPED,
+      RVG_ON_VIEW_REMOVED,
+      CLIPPING_PROHIBITED_VIEW,
+      SOFT_ASSERTIONS,
+      SURFACE_MOUNTING_MANAGER_MISSING_VIEWSTATE)
+  public annotation class CategoryMode
+
   /** Constants that listeners can utilize for custom category-based behavior. */
   public object Categories {
     public const val RVG_IS_VIEW_CLIPPED: String = "ReactViewGroup.isViewClipped"
@@ -47,12 +61,12 @@ public object ReactSoftExceptionLogger {
   }
 
   @JvmStatic
-  public fun logSoftExceptionVerbose(category: String, cause: Throwable): Unit {
+  public fun logSoftExceptionVerbose(@CategoryMode category: String, cause: Throwable): Unit {
     logSoftException("${category}|${cause.javaClass.simpleName}:${cause.message}", cause)
   }
 
   @JvmStatic
-  public fun logSoftException(category: String, cause: Throwable): Unit {
+  public fun logSoftException(@CategoryMode category: String, cause: Throwable): Unit {
     if (!listeners.isEmpty()) {
       for (listener in listeners) {
         listener.logSoftException(category, cause)
@@ -64,7 +78,7 @@ public object ReactSoftExceptionLogger {
 
   @JvmStatic
   @DoNotStrip
-  private fun logNoThrowSoftExceptionWithMessage(category: String, message: String) {
+  private fun logNoThrowSoftExceptionWithMessage(@CategoryMode category: String, message: String) {
     logSoftException(category, ReactNoCrashSoftException(message))
   }
 


### PR DESCRIPTION
Summary: This diff introduces ReactSoftExceptionLogger.CategoryMode to limit categories used on soft errors, the limiation will only create a lint warning but won't create a compilation error.

Differential Revision: D74263367


