### PR TITLE
MutationObserver: switch from `ShadowNode` to `ShadowNodeFamily` to prevent leaks

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/mutationobserver/NativeMutationObserver.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/mutationobserver/NativeMutationObserver.cpp
@@ -44,12 +44,19 @@ void NativeMutationObserver::observe(
       mutationObserverId, shadowNode, subtree, uiManager);
 }
 
+// TODO: remove in the next version
 void NativeMutationObserver::unobserve(
-    jsi::Runtime& runtime,
+    jsi::Runtime& /*runtime*/,
     MutationObserverId mutationObserverId,
     jsi::Object targetShadowNode) {
-  auto shadowNode = shadowNodeFromValue(runtime, std::move(targetShadowNode));
-  mutationObserverManager_.unobserve(mutationObserverId, *shadowNode);
+  // This will not be used but cannot be removed yet because the compatibility
+  // check does not allow it.
+}
+
+void NativeMutationObserver::unobserveAll(
+    jsi::Runtime& runtime,
+    MutationObserverId mutationObserverId) {
+  mutationObserverManager_.unobserveAll(mutationObserverId);
 }
 
 void NativeMutationObserver::connect(

--- a/packages/react-native/ReactCommon/react/nativemodule/mutationobserver/NativeMutationObserver.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/mutationobserver/NativeMutationObserver.h
@@ -52,10 +52,16 @@ class NativeMutationObserver
       jsi::Runtime& runtime,
       NativeMutationObserverObserveOptions options);
 
+  // TODO: remove in the next version
+  [[deprecated("use unobserveAll instead")]]
   void unobserve(
       jsi::Runtime& runtime,
       MutationObserverId mutationObserverId,
       jsi::Object targetShadowNode);
+
+  void unobserveAll(
+      jsi::Runtime& runtime,
+      MutationObserverId mutationObserverId);
 
   void connect(
       jsi::Runtime& runtime,

--- a/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserver.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserver.cpp
@@ -15,46 +15,33 @@ MutationObserver::MutationObserver(MutationObserverId mutationObserverId)
     : mutationObserverId_(mutationObserverId) {}
 
 void MutationObserver::observe(
-    ShadowNode::Shared targetShadowNode,
+    std::shared_ptr<const ShadowNodeFamily> targetShadowNodeFamily,
     bool observeSubtree) {
-  if (observeSubtree) {
-    deeplyObservedShadowNodes_.push_back(targetShadowNode);
-  } else {
-    shallowlyObservedShadowNodes_.push_back(targetShadowNode);
+  auto& list = observeSubtree ? deeplyObservedShadowNodeFamilies_
+                              : shallowlyObservedShadowNodeFamilies_;
+  auto& otherList = observeSubtree ? shallowlyObservedShadowNodeFamilies_
+                                   : deeplyObservedShadowNodeFamilies_;
+
+  if (std::find(list.begin(), list.end(), targetShadowNodeFamily) !=
+      list.end()) {
+    // It is already being observed correctly.
+    return;
   }
-}
 
-void MutationObserver::unobserve(const ShadowNode& targetShadowNode) {
-  // We don't know if it's being observed deeply or not, so we need to check
-  // both possibilities.
-  deeplyObservedShadowNodes_.erase(
-      std::remove_if(
-          deeplyObservedShadowNodes_.begin(),
-          deeplyObservedShadowNodes_.end(),
-          [&targetShadowNode](auto shadowNode) {
-            return ShadowNode::sameFamily(*shadowNode, targetShadowNode);
-          }),
-      deeplyObservedShadowNodes_.end());
+  auto it =
+      std::find(otherList.begin(), otherList.end(), targetShadowNodeFamily);
+  if (it != otherList.end()) {
+    // It is being observed incorrectly.
+    otherList.erase(it);
+  }
 
-  shallowlyObservedShadowNodes_.erase(
-      std::remove_if(
-          shallowlyObservedShadowNodes_.begin(),
-          shallowlyObservedShadowNodes_.end(),
-          [&targetShadowNode](const auto shadowNode) {
-            return ShadowNode::sameFamily(*shadowNode, targetShadowNode);
-          }),
-      shallowlyObservedShadowNodes_.end());
-}
-
-bool MutationObserver::isObserving() const {
-  return !deeplyObservedShadowNodes_.empty() ||
-      !shallowlyObservedShadowNodes_.empty();
+  list.push_back(targetShadowNodeFamily);
 }
 
 static ShadowNode::Shared getShadowNodeInTree(
-    const ShadowNode& shadowNode,
+    const ShadowNodeFamily& shadowNodeFamily,
     const ShadowNode& newTree) {
-  auto ancestors = shadowNode.getFamily().getAncestors(newTree);
+  auto ancestors = shadowNodeFamily.getAncestors(newTree);
   if (ancestors.empty()) {
     return nullptr;
   }
@@ -84,9 +71,9 @@ void MutationObserver::recordMutations(
 
   // We go over the deeply observed nodes first to avoid skipping nodes that
   // have only been checked shallowly.
-  for (auto targetShadowNode : deeplyObservedShadowNodes_) {
+  for (const auto& targetShadowNodeFamily : deeplyObservedShadowNodeFamilies_) {
     recordMutationsInTarget(
-        targetShadowNode,
+        *targetShadowNodeFamily,
         oldRootShadowNode,
         newRootShadowNode,
         true,
@@ -94,9 +81,10 @@ void MutationObserver::recordMutations(
         processedNodes);
   }
 
-  for (auto targetShadowNode : shallowlyObservedShadowNodes_) {
+  for (const auto& targetShadowNodeFamily :
+       shallowlyObservedShadowNodeFamilies_) {
     recordMutationsInTarget(
-        targetShadowNode,
+        *targetShadowNodeFamily,
         oldRootShadowNode,
         newRootShadowNode,
         false,
@@ -106,7 +94,7 @@ void MutationObserver::recordMutations(
 }
 
 void MutationObserver::recordMutationsInTarget(
-    ShadowNode::Shared targetShadowNode,
+    const ShadowNodeFamily& targetShadowNodeFamily,
     const RootShadowNode& oldRootShadowNode,
     const RootShadowNode& newRootShadowNode,
     bool observeSubtree,
@@ -117,7 +105,7 @@ void MutationObserver::recordMutationsInTarget(
   //   node itself.
   // - A non-existent node. In that case, there are no new mutations.
   auto oldTargetShadowNode =
-      getShadowNodeInTree(*targetShadowNode, oldRootShadowNode);
+      getShadowNodeInTree(targetShadowNodeFamily, oldRootShadowNode);
   if (!oldTargetShadowNode) {
     return;
   }
@@ -127,7 +115,7 @@ void MutationObserver::recordMutationsInTarget(
   // record any mutations in the node itself (maybe in its parent if there are
   // other observers set up).
   auto newTargetShadowNode =
-      getShadowNodeInTree(*targetShadowNode, newRootShadowNode);
+      getShadowNodeInTree(targetShadowNodeFamily, newRootShadowNode);
   if (!newTargetShadowNode) {
     return;
   }

--- a/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserver.h
+++ b/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserver.h
@@ -9,8 +9,7 @@
 
 #include <react/renderer/components/root/RootShadowNode.h>
 #include <react/renderer/core/ShadowNode.h>
-#include <memory>
-#include <utility>
+#include <react/renderer/core/ShadowNodeFamily.h>
 
 namespace facebook::react {
 
@@ -25,7 +24,7 @@ struct MutationRecord {
 
 class MutationObserver {
  public:
-  MutationObserver(MutationObserverId intersectionObserverId);
+  explicit MutationObserver(MutationObserverId mutationObserverId);
 
   // delete copy constructor
   MutationObserver(const MutationObserver&) = delete;
@@ -39,10 +38,9 @@ class MutationObserver {
   // allow move assignment
   MutationObserver& operator=(MutationObserver&&) = default;
 
-  void observe(ShadowNode::Shared targetShadowNode, bool observeSubtree);
-  void unobserve(const ShadowNode& targetShadowNode);
-
-  bool isObserving() const;
+  void observe(
+      std::shared_ptr<const ShadowNodeFamily> targetShadowNodeFamily,
+      bool observeSubtree);
 
   void recordMutations(
       const RootShadowNode& oldRootShadowNode,
@@ -51,13 +49,15 @@ class MutationObserver {
 
  private:
   MutationObserverId mutationObserverId_;
-  std::vector<ShadowNode::Shared> deeplyObservedShadowNodes_;
-  std::vector<ShadowNode::Shared> shallowlyObservedShadowNodes_;
+  std::vector<std::shared_ptr<const ShadowNodeFamily>>
+      deeplyObservedShadowNodeFamilies_;
+  std::vector<std::shared_ptr<const ShadowNodeFamily>>
+      shallowlyObservedShadowNodeFamilies_;
 
   using SetOfShadowNodePointers = std::unordered_set<const ShadowNode*>;
 
   void recordMutationsInTarget(
-      ShadowNode::Shared targetShadowNode,
+      const ShadowNodeFamily& targetShadowNodeFamily,
       const RootShadowNode& oldRootShadowNode,
       const RootShadowNode& newRootShadowNode,
       bool observeSubtree,

--- a/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserverManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserverManager.h
@@ -26,9 +26,7 @@ class MutationObserverManager final : public UIManagerCommitHook {
       bool observeSubtree,
       const UIManager& uiManager);
 
-  void unobserve(
-      MutationObserverId mutationObserverId,
-      const ShadowNode& shadowNode);
+  void unobserveAll(MutationObserverId mutationObserverId);
 
   void connect(
       UIManager& uiManager,

--- a/packages/react-native/src/private/webapis/mutationobserver/MutationObserver.js
+++ b/packages/react-native/src/private/webapis/mutationobserver/MutationObserver.js
@@ -132,39 +132,23 @@ export default class MutationObserver {
     }
   }
 
-  _unobserve(target: ReactNativeElement): void {
-    if (!(target instanceof ReactNativeElement)) {
-      throw new TypeError(
-        "Failed to execute 'observe' on 'MutationObserver': parameter 1 is not of type 'ReactNativeElement'.",
-      );
-    }
-
-    if (!this._observationTargets.has(target)) {
-      return;
-    }
-
-    const mutationObserverId = this._mutationObserverId;
-    if (mutationObserverId == null) {
-      return;
-    }
-
-    MutationObserverManager.unobserve(mutationObserverId, target);
-    this._observationTargets.delete(target);
-
-    if (this._observationTargets.size === 0) {
-      MutationObserverManager.unregisterObserver(mutationObserverId);
-      this._mutationObserverId = null;
-    }
-  }
-
   /**
    * Tells the observer to stop watching for mutations.
    * The observer can be reused by calling its `observe()` method again.
    */
   disconnect(): void {
-    for (const target of this._observationTargets.keys()) {
-      this._unobserve(target);
+    const mutationObserverId = this._mutationObserverId;
+    if (mutationObserverId == null) {
+      return;
     }
+
+    for (const target of this._observationTargets.keys()) {
+      MutationObserverManager.unobserve(mutationObserverId, target);
+      this._observationTargets.delete(target);
+    }
+
+    MutationObserverManager.unregisterObserver(mutationObserverId);
+    this._mutationObserverId = null;
   }
 
   _getOrCreateMutationObserverId(): MutationObserverId {

--- a/packages/react-native/src/private/webapis/mutationobserver/__tests__/MutationObserver-itest.js
+++ b/packages/react-native/src/private/webapis/mutationobserver/__tests__/MutationObserver-itest.js
@@ -16,6 +16,8 @@ import type MutationObserverType from 'react-native/src/private/webapis/mutation
 import type MutationRecordType from 'react-native/src/private/webapis/mutationobserver/MutationRecord';
 
 import ensureInstance from '../../../__tests__/utilities/ensureInstance';
+import {createShadowNodeReferenceCountingRef} from '../../../__tests__/utilities/ShadowNodeReferenceCounter';
+import NativeMutationObserver from '../specs/NativeMutationObserver';
 import * as Fantom from '@react-native/fantom';
 import nullthrows from 'nullthrows';
 import * as React from 'react';
@@ -40,742 +42,377 @@ function ensureMutationRecordArray(
   );
 }
 
-describe('MutationObserver', () => {
-  describe('constructor(callback)', () => {
-    it('should throw if `callback` is not provided', () => {
-      expect(() => {
-        // $FlowExpectedError[incompatible-call]
-        return new MutationObserver();
-      }).toThrow(
-        "Failed to construct 'MutationObserver': 1 argument required, but only 0 present.",
+const nativeUnobserveAll = nullthrows(NativeMutationObserver?.unobserveAll);
+
+[true, false].forEach(withUnobserveAll => {
+  describe(`MutationObserver (${withUnobserveAll ? 'with' : 'without'} NativeMutationObserver.unobserveAll)`, () => {
+    beforeAll(() => {
+      // $FlowExpectedError[incompatible-use]
+      // $FlowExpectedError[cannot-write]
+      NativeMutationObserver.unobserveAll = withUnobserveAll
+        ? nativeUnobserveAll
+        : null;
+    });
+
+    it(`should ${withUnobserveAll ? 'have' : 'NOT have'} NativeMutationObserver.unobserveAll`, () => {
+      expect(NativeMutationObserver?.unobserveAll).toBe(
+        withUnobserveAll ? nativeUnobserveAll : null,
       );
     });
 
-    it('should throw if `callback` is not a function', () => {
-      expect(() => {
-        // $FlowExpectedError[incompatible-call]
-        return new MutationObserver('not a function!');
-      }).toThrow(
-        "Failed to construct 'MutationObserver': parameter 1 is not of type 'Function'.",
-      );
-    });
-  });
-
-  describe('observe(target, {childList: boolean, subtree: boolean})', () => {
-    it('should throw if `target` is not a `ReactNativeElement`', () => {
-      const observer = new MutationObserver(() => {});
-      expect(() => {
-        // $FlowExpectedError[incompatible-call]
-        observer.observe('something');
-      }).toThrow(
-        "Failed to execute 'observe' on 'MutationObserver': parameter 1 is not of type 'ReactNativeElement'.",
-      );
-    });
-
-    it('should throw if the `childList` option is not provided', () => {
-      const nodeRef = React.createRef<HostInstance>();
-
-      const root = Fantom.createRoot();
-      Fantom.runTask(() => {
-        root.render(<View ref={nodeRef} />);
+    describe('constructor(callback)', () => {
+      it('should throw if `callback` is not provided', () => {
+        expect(() => {
+          // $FlowExpectedError[incompatible-call]
+          return new MutationObserver();
+        }).toThrow(
+          "Failed to construct 'MutationObserver': 1 argument required, but only 0 present.",
+        );
       });
 
-      const node = ensureReactNativeElement(nodeRef.current);
+      it('should throw if `callback` is not a function', () => {
+        expect(() => {
+          // $FlowExpectedError[incompatible-call]
+          return new MutationObserver('not a function!');
+        }).toThrow(
+          "Failed to construct 'MutationObserver': parameter 1 is not of type 'Function'.",
+        );
+      });
+    });
 
-      expect(() => {
+    describe('observe(target, {childList: boolean, subtree: boolean})', () => {
+      it('should throw if `target` is not a `ReactNativeElement`', () => {
         const observer = new MutationObserver(() => {});
-        observer.observe(node);
-      }).toThrow(
-        "Failed to execute 'observe' on 'MutationObserver': The options object must set 'childList' to true.",
-      );
-
-      expect(() => {
-        const observer = new MutationObserver(() => {});
-        // $FlowExpectedError[incompatible-call]
-        observer.observe(node, {childList: false});
-      }).toThrow(
-        "Failed to execute 'observe' on 'MutationObserver': The options object must set 'childList' to true.",
-      );
-
-      expect(() => {
-        const observer = new MutationObserver(() => {});
-        observer.observe(node, {childList: true});
-      }).not.toThrow();
-
-      expect(() => {
-        const observer = new MutationObserver(() => {});
-        // $FlowExpectedError[incompatible-call]
-        observer.observe(node, {childList: 1});
-      }).not.toThrow();
-    });
-
-    it('should throw if the `attributes` option is provided', () => {
-      const nodeRef = React.createRef<HostInstance>();
-
-      const root = Fantom.createRoot();
-      Fantom.runTask(() => {
-        root.render(<View ref={nodeRef} />);
-      });
-
-      const node = ensureReactNativeElement(nodeRef.current);
-
-      expect(() => {
-        const observer = new MutationObserver(() => {});
-        observer.observe(node, {childList: true, attributes: true});
-      }).toThrow(
-        "Failed to execute 'observe' on 'MutationObserver': attributes is not supported",
-      );
-    });
-
-    it('should throw if the `attributeFilter` option is provided', () => {
-      const nodeRef = React.createRef<HostInstance>();
-
-      const root = Fantom.createRoot();
-      Fantom.runTask(() => {
-        root.render(<View ref={nodeRef} />);
-      });
-
-      const node = ensureReactNativeElement(nodeRef.current);
-
-      expect(() => {
-        const observer = new MutationObserver(() => {});
-        observer.observe(node, {childList: true, attributeFilter: []});
-      }).toThrow(
-        "Failed to execute 'observe' on 'MutationObserver': attributeFilter is not supported",
-      );
-    });
-
-    it('should throw if the `attributeOldValue` option is provided', () => {
-      const nodeRef = React.createRef<HostInstance>();
-
-      const root = Fantom.createRoot();
-      Fantom.runTask(() => {
-        root.render(<View ref={nodeRef} />);
-      });
-
-      const node = ensureReactNativeElement(nodeRef.current);
-
-      expect(() => {
-        const observer = new MutationObserver(() => {});
-        // $FlowExpected
-        observer.observe(node, {childList: true, attributeOldValue: true});
-      }).toThrow(
-        "Failed to execute 'observe' on 'MutationObserver': attributeOldValue is not supported",
-      );
-    });
-
-    it('should throw if the `characterData` option is provided', () => {
-      const nodeRef = React.createRef<HostInstance>();
-
-      const root = Fantom.createRoot();
-      Fantom.runTask(() => {
-        root.render(<View ref={nodeRef} />);
-      });
-
-      const node = ensureReactNativeElement(nodeRef.current);
-
-      expect(() => {
-        const observer = new MutationObserver(() => {});
-        observer.observe(node, {childList: true, characterData: true});
-      }).toThrow(
-        "Failed to execute 'observe' on 'MutationObserver': characterData is not supported",
-      );
-    });
-
-    it('should throw if the `characterDataOldValue` option is provided', () => {
-      const nodeRef = React.createRef<HostInstance>();
-
-      const root = Fantom.createRoot();
-      Fantom.runTask(() => {
-        root.render(<View ref={nodeRef} />);
-      });
-
-      const node = ensureReactNativeElement(nodeRef.current);
-
-      expect(() => {
-        const observer = new MutationObserver(() => {});
-        observer.observe(node, {childList: true, characterDataOldValue: true});
-      }).toThrow(
-        "Failed to execute 'observe' on 'MutationObserver': characterDataOldValue is not supported",
-      );
-    });
-
-    it('should ignore calls to observe disconnected targets', () => {
-      const nodeRef = React.createRef<HostInstance>();
-
-      const root = Fantom.createRoot();
-      Fantom.runTask(() => {
-        root.render(<View key="node1" ref={nodeRef} />);
-      });
-
-      const node = ensureReactNativeElement(nodeRef.current);
-
-      Fantom.runTask(() => {
-        root.render(<></>);
-      });
-
-      expect(node.isConnected).toBe(false);
-
-      const observerCallback = () => {};
-      const observer = new MutationObserver(observerCallback);
-
-      expect(() => {
-        observer.observe(node, {childList: true});
-      }).not.toThrow();
-    });
-
-    it('should report direct children added to and removed from an observed node (childList: true, subtree: false) ', () => {
-      const nodeRef = React.createRef<HostInstance>();
-
-      const root = Fantom.createRoot();
-      Fantom.runTask(() => {
-        root.render(<View key="node1" ref={nodeRef} />);
-      });
-
-      const node = ensureReactNativeElement(nodeRef.current);
-
-      const observerCallbackCallArgs = [];
-      const observerCallback = (...args: $ReadOnlyArray<mixed>) => {
-        observerCallbackCallArgs.push(args);
-      };
-      const observer = new MutationObserver(observerCallback);
-      observer.observe(node, {childList: true});
-
-      // Does not report anything initially
-      expect(observerCallbackCallArgs.length).toBe(0);
-
-      const childNode1Ref = React.createRef<HostInstance>();
-      const childNode2Ref = React.createRef<HostInstance>();
-
-      Fantom.runTask(() => {
-        root.render(
-          <View key="node1">
-            <View key="node1-1" ref={childNode1Ref} />
-            <View key="node1-2" ref={childNode2Ref} />
-          </View>,
+        expect(() => {
+          // $FlowExpectedError[incompatible-call]
+          observer.observe('something');
+        }).toThrow(
+          "Failed to execute 'observe' on 'MutationObserver': parameter 1 is not of type 'ReactNativeElement'.",
         );
       });
 
-      const childNode1 = ensureReactNativeElement(childNode1Ref.current);
-      const childNode2 = ensureReactNativeElement(childNode2Ref.current);
-
-      expect(observerCallbackCallArgs.length).toBe(1);
-      const firstCall = nullthrows(observerCallbackCallArgs.at(-1));
-      expect(firstCall.length).toBe(2);
-
-      const firstRecords = ensureMutationRecordArray(firstCall[0]);
-      expect(firstRecords).toBeInstanceOf(Array);
-      expect(firstRecords.length).toBe(1);
-      expect(firstRecords[0]).toBeInstanceOf(MutationRecord);
-
-      const firstRecord = firstRecords[0];
-      expect(firstRecord.type).toBe('childList');
-      expect(firstRecord.target).toBe(node);
-      expect(firstRecord.addedNodes).toBeInstanceOf(NodeList);
-      expect(firstRecord.addedNodes[0]).toBe(childNode1);
-      expect(firstRecord.addedNodes[1]).toBe(childNode2);
-      expect(firstRecord.removedNodes).toBeInstanceOf(NodeList);
-      expect(firstRecord.removedNodes.length).toBe(0);
-
-      expect(firstCall[1]).toBe(observer);
-
-      Fantom.runTask(() => {
-        root.render(
-          <View key="node1">
-            <View key="node1-2" />
-          </View>,
-        );
-      });
-
-      expect(observerCallbackCallArgs.length).toBe(2);
-      const secondCall = nullthrows(observerCallbackCallArgs.at(-1));
-      expect(secondCall.length).toBe(2);
-
-      const secondRecords = ensureMutationRecordArray(secondCall[0]);
-      expect(secondRecords.length).toBe(1);
-      expect(secondRecords[0]).toBeInstanceOf(MutationRecord);
-
-      const secondRecord = secondRecords[0];
-      expect(secondRecord.type).toBe('childList');
-      expect(secondRecord.target).toBe(node);
-      expect(secondRecord.addedNodes).toBeInstanceOf(NodeList);
-      expect([...secondRecord.addedNodes]).toEqual([]);
-      expect(secondRecord.removedNodes).toBeInstanceOf(NodeList);
-      expect([...secondRecord.removedNodes]).toEqual([childNode1]);
-
-      expect(secondCall[1]).toBe(observer);
-    });
-
-    it('should NOT report changes in transitive children when `subtree` is not set to true', () => {
-      const observedNodeRef = React.createRef<HostInstance>();
-
-      const root = Fantom.createRoot();
-      Fantom.runTask(() => {
-        root.render(
-          <View key="node1" ref={observedNodeRef}>
-            <View key="node1-1" />
-          </View>,
-        );
-      });
-
-      const observedNode = ensureReactNativeElement(observedNodeRef.current);
-
-      const observerCallback = jest.fn();
-      const observer = new MutationObserver(observerCallback);
-      observer.observe(observedNode, {childList: true});
-
-      // Does not report anything initially
-      expect(observerCallback).not.toHaveBeenCalled();
-
-      Fantom.runTask(() => {
-        root.render(
-          <View key="node1">
-            <View key="node1-1">
-              <View key="node1-1-1" />
-            </View>
-          </View>,
-        );
-      });
-
-      expect(observerCallback).not.toHaveBeenCalled();
-
-      Fantom.runTask(() => {
-        root.render(
-          <View key="node1">
-            <View key="node1-1" />
-          </View>,
-        );
-      });
-
-      expect(observerCallback).not.toHaveBeenCalled();
-    });
-
-    it('should report changes in transitive children when `subtree` is set to true', () => {
-      const nodeRef = React.createRef<HostInstance>();
-
-      const root = Fantom.createRoot();
-      Fantom.runTask(() => {
-        root.render(
-          <View key="node1" ref={nodeRef}>
-            <View key="node1-1" />
-          </View>,
-        );
-      });
-
-      const node = ensureReactNativeElement(nodeRef.current);
-
-      const observerCallback = jest.fn();
-      const observer = new MutationObserver(observerCallback);
-      observer.observe(node, {childList: true, subtree: true});
-
-      // Does not report anything initially
-      expect(observerCallback).not.toHaveBeenCalled();
-
-      const node111Ref = React.createRef<HostInstance>();
-
-      Fantom.runTask(() => {
-        root.render(
-          <View key="node1">
-            <View key="node1-1">
-              <View key="node1-1-1" ref={node111Ref} />
-            </View>
-          </View>,
-        );
-      });
-
-      const node111 = ensureReactNativeElement(node111Ref.current);
-
-      expect(observerCallback).toHaveBeenCalledTimes(1);
-      const firstCall = observerCallback.mock.lastCall;
-      const firstRecords = ensureMutationRecordArray(firstCall[0]);
-      expect(firstRecords.length).toBe(1);
-      expect([...firstRecords[0].addedNodes]).toEqual([node111]);
-      expect([...firstRecords[0].removedNodes]).toEqual([]);
-
-      Fantom.runTask(() => {
-        root.render(
-          <View key="node1">
-            <View key="node1-1" />
-          </View>,
-        );
-      });
-
-      expect(observerCallback).toHaveBeenCalledTimes(2);
-      const secondRecords = ensureMutationRecordArray(
-        observerCallback.mock.lastCall[0],
-      );
-      expect(secondRecords.length).toBe(1);
-      expect([...secondRecords[0].addedNodes]).toEqual([]);
-      expect([...secondRecords[0].removedNodes]).toEqual([node111]);
-    });
-
-    it('should report changes in different parts of the subtree as separate entries (subtree = true)', () => {
-      const nodeRef = React.createRef<HostInstance>();
-
-      const root = Fantom.createRoot();
-      Fantom.runTask(() => {
-        root.render(
-          <View key="node1" ref={nodeRef}>
-            <View key="node1-1" />
-            <View key="node1-2" />
-          </View>,
-        );
-      });
-
-      const node = ensureReactNativeElement(nodeRef.current);
-
-      const observerCallback = jest.fn();
-      const observer = new MutationObserver(observerCallback);
-      observer.observe(node, {childList: true, subtree: true});
-
-      // Does not report anything initially
-      expect(observerCallback).not.toHaveBeenCalled();
-
-      const node111Ref = React.createRef<HostInstance>();
-      const node121Ref = React.createRef<HostInstance>();
-
-      Fantom.runTask(() => {
-        root.render(
-          <View key="node1">
-            <View key="node1-1">
-              <View key="node1-1-1" ref={node111Ref} />
-            </View>
-            <View key="node1-2">
-              <View key="node1-2-1" ref={node121Ref} />
-            </View>
-          </View>,
-        );
-      });
-
-      const node111 = ensureReactNativeElement(node111Ref.current);
-      const node121 = ensureReactNativeElement(node121Ref.current);
-
-      expect(observerCallback).toHaveBeenCalledTimes(1);
-      const firstCall = observerCallback.mock.lastCall;
-      const firstRecords = ensureMutationRecordArray(firstCall[0]);
-      expect(firstRecords.length).toBe(2);
-      expect([...firstRecords[0].addedNodes]).toEqual([node111]);
-      expect([...firstRecords[0].removedNodes]).toEqual([]);
-      expect([...firstRecords[1].addedNodes]).toEqual([node121]);
-      expect([...firstRecords[1].removedNodes]).toEqual([]);
-
-      Fantom.runTask(() => {
-        root.render(
-          <View key="node1">
-            <View key="node1-1" />
-            <View key="node1-2" />
-          </View>,
-        );
-      });
-
-      expect(observerCallback).toHaveBeenCalledTimes(2);
-      const secondCall = observerCallback.mock.lastCall;
-      const secondRecords = ensureMutationRecordArray(secondCall[0]);
-      expect(secondRecords.length).toBe(2);
-      expect([...secondRecords[0].addedNodes]).toEqual([]);
-      expect([...secondRecords[0].removedNodes]).toEqual([node111]);
-      expect([...secondRecords[1].addedNodes]).toEqual([]);
-      expect([...secondRecords[1].removedNodes]).toEqual([node121]);
-
-      expect(secondCall[1]).toBe(observer);
-    });
-
-    describe('multiple observers', () => {
-      it('should report changes to multiple observers observing different subtrees', () => {
-        const node1Ref = React.createRef<HostInstance>();
-        const node2Ref = React.createRef<HostInstance>();
+      it('should throw if the `childList` option is not provided', () => {
+        const nodeRef = React.createRef<HostInstance>();
 
         const root = Fantom.createRoot();
         Fantom.runTask(() => {
-          root.render(
-            <>
-              <View key="node1" ref={node1Ref} />
-              <View key="node2" ref={node2Ref} />
-            </>,
-          );
+          root.render(<View ref={nodeRef} />);
         });
 
-        const node1 = ensureReactNativeElement(node1Ref.current);
-        const node2 = ensureReactNativeElement(node2Ref.current);
+        const node = ensureReactNativeElement(nodeRef.current);
 
-        const observerCallback1 = jest.fn();
-        const observer1 = new MutationObserver(observerCallback1);
-        observer1.observe(node1, {childList: true, subtree: true});
+        expect(() => {
+          const observer = new MutationObserver(() => {});
+          observer.observe(node);
+        }).toThrow(
+          "Failed to execute 'observe' on 'MutationObserver': The options object must set 'childList' to true.",
+        );
 
-        const observerCallback2 = jest.fn();
-        const observer2 = new MutationObserver(observerCallback2);
-        observer2.observe(node2, {childList: true, subtree: true});
+        expect(() => {
+          const observer = new MutationObserver(() => {});
+          // $FlowExpectedError[incompatible-call]
+          observer.observe(node, {childList: false});
+        }).toThrow(
+          "Failed to execute 'observe' on 'MutationObserver': The options object must set 'childList' to true.",
+        );
+
+        expect(() => {
+          const observer = new MutationObserver(() => {});
+          observer.observe(node, {childList: true});
+        }).not.toThrow();
+
+        expect(() => {
+          const observer = new MutationObserver(() => {});
+          // $FlowExpectedError[incompatible-call]
+          observer.observe(node, {childList: 1});
+        }).not.toThrow();
+      });
+
+      it('should throw if the `attributes` option is provided', () => {
+        const nodeRef = React.createRef<HostInstance>();
+
+        const root = Fantom.createRoot();
+        Fantom.runTask(() => {
+          root.render(<View ref={nodeRef} />);
+        });
+
+        const node = ensureReactNativeElement(nodeRef.current);
+
+        expect(() => {
+          const observer = new MutationObserver(() => {});
+          observer.observe(node, {childList: true, attributes: true});
+        }).toThrow(
+          "Failed to execute 'observe' on 'MutationObserver': attributes is not supported",
+        );
+      });
+
+      it('should throw if the `attributeFilter` option is provided', () => {
+        const nodeRef = React.createRef<HostInstance>();
+
+        const root = Fantom.createRoot();
+        Fantom.runTask(() => {
+          root.render(<View ref={nodeRef} />);
+        });
+
+        const node = ensureReactNativeElement(nodeRef.current);
+
+        expect(() => {
+          const observer = new MutationObserver(() => {});
+          observer.observe(node, {childList: true, attributeFilter: []});
+        }).toThrow(
+          "Failed to execute 'observe' on 'MutationObserver': attributeFilter is not supported",
+        );
+      });
+
+      it('should throw if the `attributeOldValue` option is provided', () => {
+        const nodeRef = React.createRef<HostInstance>();
+
+        const root = Fantom.createRoot();
+        Fantom.runTask(() => {
+          root.render(<View ref={nodeRef} />);
+        });
+
+        const node = ensureReactNativeElement(nodeRef.current);
+
+        expect(() => {
+          const observer = new MutationObserver(() => {});
+          // $FlowExpected
+          observer.observe(node, {childList: true, attributeOldValue: true});
+        }).toThrow(
+          "Failed to execute 'observe' on 'MutationObserver': attributeOldValue is not supported",
+        );
+      });
+
+      it('should throw if the `characterData` option is provided', () => {
+        const nodeRef = React.createRef<HostInstance>();
+
+        const root = Fantom.createRoot();
+        Fantom.runTask(() => {
+          root.render(<View ref={nodeRef} />);
+        });
+
+        const node = ensureReactNativeElement(nodeRef.current);
+
+        expect(() => {
+          const observer = new MutationObserver(() => {});
+          observer.observe(node, {childList: true, characterData: true});
+        }).toThrow(
+          "Failed to execute 'observe' on 'MutationObserver': characterData is not supported",
+        );
+      });
+
+      it('should throw if the `characterDataOldValue` option is provided', () => {
+        const nodeRef = React.createRef<HostInstance>();
+
+        const root = Fantom.createRoot();
+        Fantom.runTask(() => {
+          root.render(<View ref={nodeRef} />);
+        });
+
+        const node = ensureReactNativeElement(nodeRef.current);
+
+        expect(() => {
+          const observer = new MutationObserver(() => {});
+          observer.observe(node, {
+            childList: true,
+            characterDataOldValue: true,
+          });
+        }).toThrow(
+          "Failed to execute 'observe' on 'MutationObserver': characterDataOldValue is not supported",
+        );
+      });
+
+      it('should ignore calls to observe disconnected targets', () => {
+        const nodeRef = React.createRef<HostInstance>();
+
+        const root = Fantom.createRoot();
+        Fantom.runTask(() => {
+          root.render(<View key="node1" ref={nodeRef} />);
+        });
+
+        const node = ensureReactNativeElement(nodeRef.current);
+
+        Fantom.runTask(() => {
+          root.render(<></>);
+        });
+
+        expect(node.isConnected).toBe(false);
+
+        const observerCallback = () => {};
+        const observer = new MutationObserver(observerCallback);
+
+        expect(() => {
+          observer.observe(node, {childList: true});
+        }).not.toThrow();
+      });
+
+      it('should report direct children added to and removed from an observed node (childList: true, subtree: false) ', () => {
+        const nodeRef = React.createRef<HostInstance>();
+
+        const root = Fantom.createRoot();
+        Fantom.runTask(() => {
+          root.render(<View key="node1" ref={nodeRef} />);
+        });
+
+        const node = ensureReactNativeElement(nodeRef.current);
+
+        const observerCallbackCallArgs = [];
+        const observerCallback = (...args: $ReadOnlyArray<mixed>) => {
+          observerCallbackCallArgs.push(args);
+        };
+        const observer = new MutationObserver(observerCallback);
+        observer.observe(node, {childList: true});
 
         // Does not report anything initially
-        expect(observerCallback1).not.toHaveBeenCalled();
-        expect(observerCallback2).not.toHaveBeenCalled();
+        expect(observerCallbackCallArgs.length).toBe(0);
 
-        const childNode11Ref = React.createRef<HostInstance>();
-        const childNode21Ref = React.createRef<HostInstance>();
-
-        Fantom.runTask(() => {
-          root.render(
-            <>
-              <View key="node1">
-                <View key="node1-1" ref={childNode11Ref} />
-              </View>
-              <View key="node2">
-                <View key="node2-1" ref={childNode21Ref} />
-              </View>
-            </>,
-          );
-        });
-
-        const childNode11 = ensureReactNativeElement(childNode11Ref.current);
-        const childNode21 = ensureReactNativeElement(childNode21Ref.current);
-
-        expect(observerCallback1).toHaveBeenCalledTimes(1);
-        const observer1Records1 = ensureMutationRecordArray(
-          observerCallback1.mock.lastCall[0],
-        );
-        expect(observer1Records1.length).toBe(1);
-        expect([...observer1Records1[0].addedNodes]).toEqual([childNode11]);
-        expect([...observer1Records1[0].removedNodes]).toEqual([]);
-
-        expect(observerCallback2).toHaveBeenCalledTimes(1);
-        const observer2Records1 = ensureMutationRecordArray(
-          observerCallback2.mock.lastCall[0],
-        );
-        expect(observer2Records1.length).toBe(1);
-        expect([...observer2Records1[0].addedNodes]).toEqual([childNode21]);
-        expect([...observer2Records1[0].removedNodes]).toEqual([]);
+        const childNode1Ref = React.createRef<HostInstance>();
+        const childNode2Ref = React.createRef<HostInstance>();
 
         Fantom.runTask(() => {
           root.render(
-            <>
-              <View key="node1" />
-              <View key="node2" />
-            </>,
-          );
-        });
-
-        expect(observerCallback1).toHaveBeenCalledTimes(2);
-        const observer1Records2 = ensureMutationRecordArray(
-          observerCallback1.mock.lastCall[0],
-        );
-        expect(observer1Records2.length).toBe(1);
-        expect([...observer1Records2[0].addedNodes]).toEqual([]);
-        expect([...observer1Records2[0].removedNodes]).toEqual([childNode11]);
-
-        expect(observerCallback2).toHaveBeenCalledTimes(2);
-        const observer2Records2 = ensureMutationRecordArray(
-          observerCallback2.mock.lastCall[0],
-        );
-        expect(observer2Records2.length).toBe(1);
-        expect([...observer2Records2[0].addedNodes]).toEqual([]);
-        expect([...observer2Records2[0].removedNodes]).toEqual([childNode21]);
-      });
-
-      it('should report changes to multiple observers observing the same subtree', () => {
-        const node1Ref = React.createRef<HostInstance>();
-        const node2Ref = React.createRef<HostInstance>();
-
-        const root = Fantom.createRoot();
-        Fantom.runTask(() => {
-          root.render(
-            <View key="node1" ref={node1Ref}>
-              <View key="node1-1" ref={node2Ref} />
+            <View key="node1">
+              <View key="node1-1" ref={childNode1Ref} />
+              <View key="node1-2" ref={childNode2Ref} />
             </View>,
           );
         });
 
-        const node1 = ensureReactNativeElement(node1Ref.current);
-        const node2 = ensureReactNativeElement(node2Ref.current);
+        const childNode1 = ensureReactNativeElement(childNode1Ref.current);
+        const childNode2 = ensureReactNativeElement(childNode2Ref.current);
 
-        const observerCallback1 = jest.fn();
-        const observer1 = new MutationObserver(observerCallback1);
-        observer1.observe(node1, {childList: true, subtree: true});
+        expect(observerCallbackCallArgs.length).toBe(1);
+        const firstCall = nullthrows(observerCallbackCallArgs.at(-1));
+        expect(firstCall.length).toBe(2);
 
-        const observerCallback2 = jest.fn();
-        const observer2 = new MutationObserver(observerCallback2);
-        observer2.observe(node2, {childList: true, subtree: true});
+        const firstRecords = ensureMutationRecordArray(firstCall[0]);
+        expect(firstRecords).toBeInstanceOf(Array);
+        expect(firstRecords.length).toBe(1);
+        expect(firstRecords[0]).toBeInstanceOf(MutationRecord);
+
+        const firstRecord = firstRecords[0];
+        expect(firstRecord.type).toBe('childList');
+        expect(firstRecord.target).toBe(node);
+        expect(firstRecord.addedNodes).toBeInstanceOf(NodeList);
+        expect(firstRecord.addedNodes[0]).toBe(childNode1);
+        expect(firstRecord.addedNodes[1]).toBe(childNode2);
+        expect(firstRecord.removedNodes).toBeInstanceOf(NodeList);
+        expect(firstRecord.removedNodes.length).toBe(0);
+
+        expect(firstCall[1]).toBe(observer);
+
+        Fantom.runTask(() => {
+          root.render(
+            <View key="node1">
+              <View key="node1-2" />
+            </View>,
+          );
+        });
+
+        expect(observerCallbackCallArgs.length).toBe(2);
+        const secondCall = nullthrows(observerCallbackCallArgs.at(-1));
+        expect(secondCall.length).toBe(2);
+
+        const secondRecords = ensureMutationRecordArray(secondCall[0]);
+        expect(secondRecords.length).toBe(1);
+        expect(secondRecords[0]).toBeInstanceOf(MutationRecord);
+
+        const secondRecord = secondRecords[0];
+        expect(secondRecord.type).toBe('childList');
+        expect(secondRecord.target).toBe(node);
+        expect(secondRecord.addedNodes).toBeInstanceOf(NodeList);
+        expect([...secondRecord.addedNodes]).toEqual([]);
+        expect(secondRecord.removedNodes).toBeInstanceOf(NodeList);
+        expect([...secondRecord.removedNodes]).toEqual([childNode1]);
+
+        expect(secondCall[1]).toBe(observer);
+      });
+
+      it('should NOT report changes in transitive children when `subtree` is not set to true', () => {
+        const observedNodeRef = React.createRef<HostInstance>();
+
+        const root = Fantom.createRoot();
+        Fantom.runTask(() => {
+          root.render(
+            <View key="node1" ref={observedNodeRef}>
+              <View key="node1-1" />
+            </View>,
+          );
+        });
+
+        const observedNode = ensureReactNativeElement(observedNodeRef.current);
+
+        const observerCallback = jest.fn();
+        const observer = new MutationObserver(observerCallback);
+        observer.observe(observedNode, {childList: true});
 
         // Does not report anything initially
-        expect(observerCallback1).not.toHaveBeenCalled();
-        expect(observerCallback2).not.toHaveBeenCalled();
-
-        const childNode111Ref = React.createRef<HostInstance>();
+        expect(observerCallback).not.toHaveBeenCalled();
 
         Fantom.runTask(() => {
           root.render(
             <View key="node1">
               <View key="node1-1">
-                <View key="node-1-1-1" ref={childNode111Ref} />
+                <View key="node1-1-1" />
               </View>
             </View>,
           );
         });
 
-        const childNode111 = ensureReactNativeElement(childNode111Ref.current);
-
-        expect(observerCallback1).toHaveBeenCalledTimes(1);
-        const observer1Records1 = ensureMutationRecordArray(
-          observerCallback1.mock.lastCall[0],
-        );
-        expect(observer1Records1.length).toBe(1);
-        expect([...observer1Records1[0].addedNodes]).toEqual([childNode111]);
-        expect([...observer1Records1[0].removedNodes]).toEqual([]);
-        expect(observerCallback2).toHaveBeenCalledTimes(1);
-        const observer2Records1 = ensureMutationRecordArray(
-          observerCallback2.mock.lastCall[0],
-        );
-        expect(observer2Records1.length).toBe(1);
-        expect([...observer2Records1[0].addedNodes]).toEqual([childNode111]);
-        expect([...observer2Records1[0].removedNodes]).toEqual([]);
-
-        Fantom.runTask(() => {
-          root.render(
-            <>
-              <View key="node1">
-                <View key="node1-1" />
-              </View>
-            </>,
-          );
-        });
-
-        expect(observerCallback1).toHaveBeenCalledTimes(2);
-        const observer1Records2 = ensureMutationRecordArray(
-          observerCallback1.mock.lastCall[0],
-        );
-        expect(observer1Records2.length).toBe(1);
-        expect([...observer1Records2[0].addedNodes]).toEqual([]);
-        expect([...observer1Records2[0].removedNodes]).toEqual([childNode111]);
-
-        expect(observerCallback2).toHaveBeenCalledTimes(2);
-        const observer2Records2 = ensureMutationRecordArray(
-          observerCallback2.mock.lastCall[0],
-        );
-        expect(observer2Records2.length).toBe(1);
-        expect([...observer2Records2[0].addedNodes]).toEqual([]);
-        expect([...observer2Records2[0].removedNodes]).toEqual([childNode111]);
-      });
-    });
-
-    describe('multiple observed nodes in the same observer', () => {
-      it('should report changes in disjoint observations', () => {
-        const node1Ref = React.createRef<HostInstance>();
-        const node2Ref = React.createRef<HostInstance>();
-
-        const root = Fantom.createRoot();
-        Fantom.runTask(() => {
-          root.render(
-            <>
-              <View key="node1" ref={node1Ref} />
-              <View key="node2" ref={node2Ref} />
-            </>,
-          );
-        });
-
-        const node1 = ensureReactNativeElement(node1Ref.current);
-        const node2 = ensureReactNativeElement(node2Ref.current);
-
-        const observerCallback = jest.fn();
-        const observer = new MutationObserver(observerCallback);
-        observer.observe(node1, {childList: true, subtree: true});
-        observer.observe(node2, {childList: true, subtree: true});
-
-        // Does not report anything initially
         expect(observerCallback).not.toHaveBeenCalled();
 
-        const childNode11Ref = React.createRef<HostInstance>();
-        const childNode21Ref = React.createRef<HostInstance>();
-
         Fantom.runTask(() => {
           root.render(
-            <>
-              <View key="node1">
-                <View key="node1-1" ref={childNode11Ref} />
-              </View>
-              <View key="node2">
-                <View key="node2-1" ref={childNode21Ref} />
-              </View>
-            </>,
-          );
-        });
-
-        const childNode11 = ensureReactNativeElement(childNode11Ref.current);
-        const childNode21 = ensureReactNativeElement(childNode21Ref.current);
-
-        expect(observerCallback).toHaveBeenCalledTimes(1);
-        const records = ensureMutationRecordArray(
-          observerCallback.mock.lastCall[0],
-        );
-        expect(records.length).toBe(2);
-        expect([...records[0].addedNodes]).toEqual([childNode11]);
-        expect([...records[0].removedNodes]).toEqual([]);
-        expect([...records[1].addedNodes]).toEqual([childNode21]);
-        expect([...records[1].removedNodes]).toEqual([]);
-
-        Fantom.runTask(() => {
-          root.render(
-            <>
-              <View key="node1" />
-              <View key="node2" />
-            </>,
-          );
-        });
-
-        expect(observerCallback).toHaveBeenCalledTimes(2);
-        const records2 = ensureMutationRecordArray(
-          observerCallback.mock.lastCall[0],
-        );
-        expect(records2.length).toBe(2);
-        expect([...records2[0].addedNodes]).toEqual([]);
-        expect([...records2[0].removedNodes]).toEqual([childNode11]);
-        expect([...records2[1].addedNodes]).toEqual([]);
-        expect([...records2[1].removedNodes]).toEqual([childNode21]);
-      });
-
-      it('should report changes in joint observations', () => {
-        const node1Ref = React.createRef<HostInstance>();
-        const node11Ref = React.createRef<HostInstance>();
-
-        const root = Fantom.createRoot();
-        Fantom.runTask(() => {
-          root.render(
-            <View key="node1" ref={node1Ref}>
-              <View key="node1-1" ref={node11Ref} />
+            <View key="node1">
+              <View key="node1-1" />
             </View>,
           );
         });
 
-        const node1 = ensureReactNativeElement(node1Ref.current);
-        const node11 = ensureReactNativeElement(node11Ref.current);
+        expect(observerCallback).not.toHaveBeenCalled();
+      });
+
+      it('should report changes in transitive children when `subtree` is set to true', () => {
+        const nodeRef = React.createRef<HostInstance>();
+
+        const root = Fantom.createRoot();
+        Fantom.runTask(() => {
+          root.render(
+            <View key="node1" ref={nodeRef}>
+              <View key="node1-1" />
+            </View>,
+          );
+        });
+
+        const node = ensureReactNativeElement(nodeRef.current);
 
         const observerCallback = jest.fn();
         const observer = new MutationObserver(observerCallback);
-        observer.observe(node1, {childList: true, subtree: true});
-        observer.observe(node11, {childList: true, subtree: true});
+        observer.observe(node, {childList: true, subtree: true});
 
         // Does not report anything initially
         expect(observerCallback).not.toHaveBeenCalled();
 
-        const childNode111Ref = React.createRef<HostInstance>();
+        const node111Ref = React.createRef<HostInstance>();
 
         Fantom.runTask(() => {
           root.render(
             <View key="node1">
               <View key="node1-1">
-                <View key="node1-1-1" ref={childNode111Ref} />
+                <View key="node1-1-1" ref={node111Ref} />
               </View>
             </View>,
           );
         });
 
-        const childNode111 = ensureReactNativeElement(childNode111Ref.current);
+        const node111 = ensureReactNativeElement(node111Ref.current);
 
         expect(observerCallback).toHaveBeenCalledTimes(1);
-        const records = ensureMutationRecordArray(
-          observerCallback.mock.lastCall[0],
-        );
-        expect(records.length).toBe(1);
-        expect([...records[0].addedNodes]).toEqual([childNode111]);
-        expect([...records[0].removedNodes]).toEqual([]);
+        const firstCall = observerCallback.mock.lastCall;
+        const firstRecords = ensureMutationRecordArray(firstCall[0]);
+        expect(firstRecords.length).toBe(1);
+        expect([...firstRecords[0].addedNodes]).toEqual([node111]);
+        expect([...firstRecords[0].removedNodes]).toEqual([]);
 
         Fantom.runTask(() => {
           root.render(
@@ -786,106 +423,546 @@ describe('MutationObserver', () => {
         });
 
         expect(observerCallback).toHaveBeenCalledTimes(2);
-        const records2 = ensureMutationRecordArray(
+        const secondRecords = ensureMutationRecordArray(
           observerCallback.mock.lastCall[0],
         );
-        expect(records2.length).toBe(1);
-        expect([...records2[0].addedNodes]).toEqual([]);
-        expect([...records2[0].removedNodes]).toEqual([childNode111]);
+        expect(secondRecords.length).toBe(1);
+        expect([...secondRecords[0].addedNodes]).toEqual([]);
+        expect([...secondRecords[0].removedNodes]).toEqual([node111]);
       });
+
+      it('should report changes in different parts of the subtree as separate entries (subtree = true)', () => {
+        const nodeRef = React.createRef<HostInstance>();
+
+        const root = Fantom.createRoot();
+        Fantom.runTask(() => {
+          root.render(
+            <View key="node1" ref={nodeRef}>
+              <View key="node1-1" />
+              <View key="node1-2" />
+            </View>,
+          );
+        });
+
+        const node = ensureReactNativeElement(nodeRef.current);
+
+        const observerCallback = jest.fn();
+        const observer = new MutationObserver(observerCallback);
+        observer.observe(node, {childList: true, subtree: true});
+
+        // Does not report anything initially
+        expect(observerCallback).not.toHaveBeenCalled();
+
+        const node111Ref = React.createRef<HostInstance>();
+        const node121Ref = React.createRef<HostInstance>();
+
+        Fantom.runTask(() => {
+          root.render(
+            <View key="node1">
+              <View key="node1-1">
+                <View key="node1-1-1" ref={node111Ref} />
+              </View>
+              <View key="node1-2">
+                <View key="node1-2-1" ref={node121Ref} />
+              </View>
+            </View>,
+          );
+        });
+
+        const node111 = ensureReactNativeElement(node111Ref.current);
+        const node121 = ensureReactNativeElement(node121Ref.current);
+
+        expect(observerCallback).toHaveBeenCalledTimes(1);
+        const firstCall = observerCallback.mock.lastCall;
+        const firstRecords = ensureMutationRecordArray(firstCall[0]);
+        expect(firstRecords.length).toBe(2);
+        expect([...firstRecords[0].addedNodes]).toEqual([node111]);
+        expect([...firstRecords[0].removedNodes]).toEqual([]);
+        expect([...firstRecords[1].addedNodes]).toEqual([node121]);
+        expect([...firstRecords[1].removedNodes]).toEqual([]);
+
+        Fantom.runTask(() => {
+          root.render(
+            <View key="node1">
+              <View key="node1-1" />
+              <View key="node1-2" />
+            </View>,
+          );
+        });
+
+        expect(observerCallback).toHaveBeenCalledTimes(2);
+        const secondCall = observerCallback.mock.lastCall;
+        const secondRecords = ensureMutationRecordArray(secondCall[0]);
+        expect(secondRecords.length).toBe(2);
+        expect([...secondRecords[0].addedNodes]).toEqual([]);
+        expect([...secondRecords[0].removedNodes]).toEqual([node111]);
+        expect([...secondRecords[1].addedNodes]).toEqual([]);
+        expect([...secondRecords[1].removedNodes]).toEqual([node121]);
+
+        expect(secondCall[1]).toBe(observer);
+      });
+
+      describe('multiple observers', () => {
+        it('should report changes to multiple observers observing different subtrees', () => {
+          const node1Ref = React.createRef<HostInstance>();
+          const node2Ref = React.createRef<HostInstance>();
+
+          const root = Fantom.createRoot();
+          Fantom.runTask(() => {
+            root.render(
+              <>
+                <View key="node1" ref={node1Ref} />
+                <View key="node2" ref={node2Ref} />
+              </>,
+            );
+          });
+
+          const node1 = ensureReactNativeElement(node1Ref.current);
+          const node2 = ensureReactNativeElement(node2Ref.current);
+
+          const observerCallback1 = jest.fn();
+          const observer1 = new MutationObserver(observerCallback1);
+          observer1.observe(node1, {childList: true, subtree: true});
+
+          const observerCallback2 = jest.fn();
+          const observer2 = new MutationObserver(observerCallback2);
+          observer2.observe(node2, {childList: true, subtree: true});
+
+          // Does not report anything initially
+          expect(observerCallback1).not.toHaveBeenCalled();
+          expect(observerCallback2).not.toHaveBeenCalled();
+
+          const childNode11Ref = React.createRef<HostInstance>();
+          const childNode21Ref = React.createRef<HostInstance>();
+
+          Fantom.runTask(() => {
+            root.render(
+              <>
+                <View key="node1">
+                  <View key="node1-1" ref={childNode11Ref} />
+                </View>
+                <View key="node2">
+                  <View key="node2-1" ref={childNode21Ref} />
+                </View>
+              </>,
+            );
+          });
+
+          const childNode11 = ensureReactNativeElement(childNode11Ref.current);
+          const childNode21 = ensureReactNativeElement(childNode21Ref.current);
+
+          expect(observerCallback1).toHaveBeenCalledTimes(1);
+          const observer1Records1 = ensureMutationRecordArray(
+            observerCallback1.mock.lastCall[0],
+          );
+          expect(observer1Records1.length).toBe(1);
+          expect([...observer1Records1[0].addedNodes]).toEqual([childNode11]);
+          expect([...observer1Records1[0].removedNodes]).toEqual([]);
+
+          expect(observerCallback2).toHaveBeenCalledTimes(1);
+          const observer2Records1 = ensureMutationRecordArray(
+            observerCallback2.mock.lastCall[0],
+          );
+          expect(observer2Records1.length).toBe(1);
+          expect([...observer2Records1[0].addedNodes]).toEqual([childNode21]);
+          expect([...observer2Records1[0].removedNodes]).toEqual([]);
+
+          Fantom.runTask(() => {
+            root.render(
+              <>
+                <View key="node1" />
+                <View key="node2" />
+              </>,
+            );
+          });
+
+          expect(observerCallback1).toHaveBeenCalledTimes(2);
+          const observer1Records2 = ensureMutationRecordArray(
+            observerCallback1.mock.lastCall[0],
+          );
+          expect(observer1Records2.length).toBe(1);
+          expect([...observer1Records2[0].addedNodes]).toEqual([]);
+          expect([...observer1Records2[0].removedNodes]).toEqual([childNode11]);
+
+          expect(observerCallback2).toHaveBeenCalledTimes(2);
+          const observer2Records2 = ensureMutationRecordArray(
+            observerCallback2.mock.lastCall[0],
+          );
+          expect(observer2Records2.length).toBe(1);
+          expect([...observer2Records2[0].addedNodes]).toEqual([]);
+          expect([...observer2Records2[0].removedNodes]).toEqual([childNode21]);
+        });
+
+        it('should report changes to multiple observers observing the same subtree', () => {
+          const node1Ref = React.createRef<HostInstance>();
+          const node2Ref = React.createRef<HostInstance>();
+
+          const root = Fantom.createRoot();
+          Fantom.runTask(() => {
+            root.render(
+              <View key="node1" ref={node1Ref}>
+                <View key="node1-1" ref={node2Ref} />
+              </View>,
+            );
+          });
+
+          const node1 = ensureReactNativeElement(node1Ref.current);
+          const node2 = ensureReactNativeElement(node2Ref.current);
+
+          const observerCallback1 = jest.fn();
+          const observer1 = new MutationObserver(observerCallback1);
+          observer1.observe(node1, {childList: true, subtree: true});
+
+          const observerCallback2 = jest.fn();
+          const observer2 = new MutationObserver(observerCallback2);
+          observer2.observe(node2, {childList: true, subtree: true});
+
+          // Does not report anything initially
+          expect(observerCallback1).not.toHaveBeenCalled();
+          expect(observerCallback2).not.toHaveBeenCalled();
+
+          const childNode111Ref = React.createRef<HostInstance>();
+
+          Fantom.runTask(() => {
+            root.render(
+              <View key="node1">
+                <View key="node1-1">
+                  <View key="node-1-1-1" ref={childNode111Ref} />
+                </View>
+              </View>,
+            );
+          });
+
+          const childNode111 = ensureReactNativeElement(
+            childNode111Ref.current,
+          );
+
+          expect(observerCallback1).toHaveBeenCalledTimes(1);
+          const observer1Records1 = ensureMutationRecordArray(
+            observerCallback1.mock.lastCall[0],
+          );
+          expect(observer1Records1.length).toBe(1);
+          expect([...observer1Records1[0].addedNodes]).toEqual([childNode111]);
+          expect([...observer1Records1[0].removedNodes]).toEqual([]);
+          expect(observerCallback2).toHaveBeenCalledTimes(1);
+          const observer2Records1 = ensureMutationRecordArray(
+            observerCallback2.mock.lastCall[0],
+          );
+          expect(observer2Records1.length).toBe(1);
+          expect([...observer2Records1[0].addedNodes]).toEqual([childNode111]);
+          expect([...observer2Records1[0].removedNodes]).toEqual([]);
+
+          Fantom.runTask(() => {
+            root.render(
+              <>
+                <View key="node1">
+                  <View key="node1-1" />
+                </View>
+              </>,
+            );
+          });
+
+          expect(observerCallback1).toHaveBeenCalledTimes(2);
+          const observer1Records2 = ensureMutationRecordArray(
+            observerCallback1.mock.lastCall[0],
+          );
+          expect(observer1Records2.length).toBe(1);
+          expect([...observer1Records2[0].addedNodes]).toEqual([]);
+          expect([...observer1Records2[0].removedNodes]).toEqual([
+            childNode111,
+          ]);
+
+          expect(observerCallback2).toHaveBeenCalledTimes(2);
+          const observer2Records2 = ensureMutationRecordArray(
+            observerCallback2.mock.lastCall[0],
+          );
+          expect(observer2Records2.length).toBe(1);
+          expect([...observer2Records2[0].addedNodes]).toEqual([]);
+          expect([...observer2Records2[0].removedNodes]).toEqual([
+            childNode111,
+          ]);
+        });
+      });
+
+      describe('multiple observed nodes in the same observer', () => {
+        it('should report changes in disjoint observations', () => {
+          const node1Ref = React.createRef<HostInstance>();
+          const node2Ref = React.createRef<HostInstance>();
+
+          const root = Fantom.createRoot();
+          Fantom.runTask(() => {
+            root.render(
+              <>
+                <View key="node1" ref={node1Ref} />
+                <View key="node2" ref={node2Ref} />
+              </>,
+            );
+          });
+
+          const node1 = ensureReactNativeElement(node1Ref.current);
+          const node2 = ensureReactNativeElement(node2Ref.current);
+
+          const observerCallback = jest.fn();
+          const observer = new MutationObserver(observerCallback);
+          observer.observe(node1, {childList: true, subtree: true});
+          observer.observe(node2, {childList: true, subtree: true});
+
+          // Does not report anything initially
+          expect(observerCallback).not.toHaveBeenCalled();
+
+          const childNode11Ref = React.createRef<HostInstance>();
+          const childNode21Ref = React.createRef<HostInstance>();
+
+          Fantom.runTask(() => {
+            root.render(
+              <>
+                <View key="node1">
+                  <View key="node1-1" ref={childNode11Ref} />
+                </View>
+                <View key="node2">
+                  <View key="node2-1" ref={childNode21Ref} />
+                </View>
+              </>,
+            );
+          });
+
+          const childNode11 = ensureReactNativeElement(childNode11Ref.current);
+          const childNode21 = ensureReactNativeElement(childNode21Ref.current);
+
+          expect(observerCallback).toHaveBeenCalledTimes(1);
+          const records = ensureMutationRecordArray(
+            observerCallback.mock.lastCall[0],
+          );
+          expect(records.length).toBe(2);
+          expect([...records[0].addedNodes]).toEqual([childNode11]);
+          expect([...records[0].removedNodes]).toEqual([]);
+          expect([...records[1].addedNodes]).toEqual([childNode21]);
+          expect([...records[1].removedNodes]).toEqual([]);
+
+          Fantom.runTask(() => {
+            root.render(
+              <>
+                <View key="node1" />
+                <View key="node2" />
+              </>,
+            );
+          });
+
+          expect(observerCallback).toHaveBeenCalledTimes(2);
+          const records2 = ensureMutationRecordArray(
+            observerCallback.mock.lastCall[0],
+          );
+          expect(records2.length).toBe(2);
+          expect([...records2[0].addedNodes]).toEqual([]);
+          expect([...records2[0].removedNodes]).toEqual([childNode11]);
+          expect([...records2[1].addedNodes]).toEqual([]);
+          expect([...records2[1].removedNodes]).toEqual([childNode21]);
+        });
+
+        it('should report changes in joint observations', () => {
+          const node1Ref = React.createRef<HostInstance>();
+          const node11Ref = React.createRef<HostInstance>();
+
+          const root = Fantom.createRoot();
+          Fantom.runTask(() => {
+            root.render(
+              <View key="node1" ref={node1Ref}>
+                <View key="node1-1" ref={node11Ref} />
+              </View>,
+            );
+          });
+
+          const node1 = ensureReactNativeElement(node1Ref.current);
+          const node11 = ensureReactNativeElement(node11Ref.current);
+
+          const observerCallback = jest.fn();
+          const observer = new MutationObserver(observerCallback);
+          observer.observe(node1, {childList: true, subtree: true});
+          observer.observe(node11, {childList: true, subtree: true});
+
+          // Does not report anything initially
+          expect(observerCallback).not.toHaveBeenCalled();
+
+          const childNode111Ref = React.createRef<HostInstance>();
+
+          Fantom.runTask(() => {
+            root.render(
+              <View key="node1">
+                <View key="node1-1">
+                  <View key="node1-1-1" ref={childNode111Ref} />
+                </View>
+              </View>,
+            );
+          });
+
+          const childNode111 = ensureReactNativeElement(
+            childNode111Ref.current,
+          );
+
+          expect(observerCallback).toHaveBeenCalledTimes(1);
+          const records = ensureMutationRecordArray(
+            observerCallback.mock.lastCall[0],
+          );
+          expect(records.length).toBe(1);
+          expect([...records[0].addedNodes]).toEqual([childNode111]);
+          expect([...records[0].removedNodes]).toEqual([]);
+
+          Fantom.runTask(() => {
+            root.render(
+              <View key="node1">
+                <View key="node1-1" />
+              </View>,
+            );
+          });
+
+          expect(observerCallback).toHaveBeenCalledTimes(2);
+          const records2 = ensureMutationRecordArray(
+            observerCallback.mock.lastCall[0],
+          );
+          expect(records2.length).toBe(1);
+          expect([...records2[0].addedNodes]).toEqual([]);
+          expect([...records2[0].removedNodes]).toEqual([childNode111]);
+        });
+      });
+
+      if (withUnobserveAll) {
+        describe('memory handling', () => {
+          it('should not retain initial children of observed targets', () => {
+            const root = Fantom.createRoot();
+            const observer = new MutationObserver(() => {});
+
+            const [getReferenceCount, childRef] =
+              createShadowNodeReferenceCountingRef();
+
+            const parentRef = React.createRef<HostInstance>();
+
+            Fantom.runTask(() => {
+              root.render(
+                <View ref={parentRef}>
+                  <View ref={childRef} />
+                </View>,
+              );
+            });
+
+            Fantom.runTask(() => {
+              observer.observe(ensureReactNativeElement(parentRef.current), {
+                childList: true,
+              });
+            });
+
+            expect(getReferenceCount()).toBeGreaterThan(0);
+
+            // This updates the working tree in the reconciler
+            Fantom.runTask(() => {
+              // Set style to force a state update
+              root.render(<View style={{width: 1}} />);
+            });
+
+            // This forces swapping the alternate tree in the reconciler
+            Fantom.runTask(() => {
+              // Set style to force a state update
+              root.render(<View style={{width: 2}} />);
+            });
+
+            expect(getReferenceCount()).toBe(0);
+
+            observer.disconnect();
+          });
+        });
+      }
     });
-  });
 
-  describe('disconnect()', () => {
-    it('should stop observing targets', () => {
-      const observedNodeRef = React.createRef<HostInstance>();
+    describe('disconnect()', () => {
+      it('should stop observing targets', () => {
+        const observedNodeRef = React.createRef<HostInstance>();
 
-      const root = Fantom.createRoot();
-      Fantom.runTask(() => {
-        root.render(<View key="node1" ref={observedNodeRef} />);
-      });
+        const root = Fantom.createRoot();
+        Fantom.runTask(() => {
+          root.render(<View key="node1" ref={observedNodeRef} />);
+        });
 
-      const observedNode = ensureReactNativeElement(observedNodeRef.current);
+        const observedNode = ensureReactNativeElement(observedNodeRef.current);
 
-      const observerCallback = jest.fn();
-      const observer = new MutationObserver(observerCallback);
-      observer.observe(observedNode, {childList: true});
+        const observerCallback = jest.fn();
+        const observer = new MutationObserver(observerCallback);
+        observer.observe(observedNode, {childList: true});
 
-      // Does not report anything initially
-      expect(observerCallback).not.toHaveBeenCalled();
+        // Does not report anything initially
+        expect(observerCallback).not.toHaveBeenCalled();
 
-      Fantom.runTask(() => {
-        root.render(
-          <View key="node1">
-            <View key="node1-1" />
-            <View key="node1-2" />
-          </View>,
-        );
-      });
+        Fantom.runTask(() => {
+          root.render(
+            <View key="node1">
+              <View key="node1-1" />
+              <View key="node1-2" />
+            </View>,
+          );
+        });
 
-      expect(observerCallback).toHaveBeenCalledTimes(1);
+        expect(observerCallback).toHaveBeenCalledTimes(1);
 
-      observer.disconnect();
-
-      Fantom.runTask(() => {
-        root.render(
-          <View key="node1">
-            <View key="node1-2" />
-          </View>,
-        );
-      });
-
-      expect(observerCallback).toHaveBeenCalledTimes(1);
-    });
-
-    it('should correctly unobserve targets that are disconnected after observing', () => {
-      const observedNodeRef = React.createRef<HostInstance>();
-
-      const root = Fantom.createRoot();
-      Fantom.runTask(() => {
-        root.render(<View key="node1" ref={observedNodeRef} />);
-      });
-
-      const observedNode = ensureReactNativeElement(observedNodeRef.current);
-
-      const observerCallback = jest.fn();
-      const observer = new MutationObserver(observerCallback);
-      observer.observe(observedNode, {childList: true});
-
-      Fantom.runTask(() => {
-        root.render(<></>);
-      });
-
-      expect(observedNode.isConnected).toBe(false);
-
-      expect(() => {
         observer.disconnect();
-      }).not.toThrow();
-    });
 
-    it('should correctly unobserve targets that are disconnected before observing', () => {
-      const observedNodeRef = React.createRef<HostInstance>();
+        Fantom.runTask(() => {
+          root.render(
+            <View key="node1">
+              <View key="node1-2" />
+            </View>,
+          );
+        });
 
-      const root = Fantom.createRoot();
-      Fantom.runTask(() => {
-        root.render(<View key="node1" ref={observedNodeRef} />);
+        expect(observerCallback).toHaveBeenCalledTimes(1);
       });
 
-      const observedNode = ensureReactNativeElement(observedNodeRef.current);
+      it('should correctly unobserve targets that are disconnected after observing', () => {
+        const observedNodeRef = React.createRef<HostInstance>();
 
-      Fantom.runTask(() => {
-        root.render(<></>);
+        const root = Fantom.createRoot();
+        Fantom.runTask(() => {
+          root.render(<View key="node1" ref={observedNodeRef} />);
+        });
+
+        const observedNode = ensureReactNativeElement(observedNodeRef.current);
+
+        const observerCallback = jest.fn();
+        const observer = new MutationObserver(observerCallback);
+        observer.observe(observedNode, {childList: true});
+
+        Fantom.runTask(() => {
+          root.render(<></>);
+        });
+
+        expect(observedNode.isConnected).toBe(false);
+
+        expect(() => {
+          observer.disconnect();
+        }).not.toThrow();
       });
 
-      expect(observedNode.isConnected).toBe(false);
+      it('should correctly unobserve targets that are disconnected before observing', () => {
+        const observedNodeRef = React.createRef<HostInstance>();
 
-      const observerCallback = jest.fn();
-      const observer = new MutationObserver(observerCallback);
-      observer.observe(observedNode, {childList: true});
+        const root = Fantom.createRoot();
+        Fantom.runTask(() => {
+          root.render(<View key="node1" ref={observedNodeRef} />);
+        });
 
-      expect(() => {
-        observer.disconnect();
-      }).not.toThrow();
+        const observedNode = ensureReactNativeElement(observedNodeRef.current);
+
+        Fantom.runTask(() => {
+          root.render(<></>);
+        });
+
+        expect(observedNode.isConnected).toBe(false);
+
+        const observerCallback = jest.fn();
+        const observer = new MutationObserver(observerCallback);
+        observer.observe(observedNode, {childList: true});
+
+        expect(() => {
+          observer.disconnect();
+        }).not.toThrow();
+      });
     });
   });
 });

--- a/packages/react-native/src/private/webapis/mutationobserver/specs/NativeMutationObserver.js
+++ b/packages/react-native/src/private/webapis/mutationobserver/specs/NativeMutationObserver.js
@@ -36,10 +36,13 @@ export type NativeMutationObserverObserveOptions = {
 
 export interface Spec extends TurboModule {
   +observe: (options: NativeMutationObserverObserveOptions) => void;
-  +unobserve: (
+  // TODO: remove in the next version
+  +unobserve?: (
     mutationObserverId: number,
     targetShadowNode: ShadowNode,
   ) => void;
+  // TODO: remove optionality in the next version
+  +unobserveAll?: (mutationObserverId: number) => void;
   +connect: (
     notifyMutationObservers: () => void,
     // We need this to retain the public instance before React removes the


### PR DESCRIPTION
Summary:
Changelog: [internal]

This replaces the use of `ShadowNode` with `ShadowNodeFamily` in the `MutationObserver` logic to prevent retaining stale subtrees of the nodes being observed.

It refactors some existing logic so we don't need to keep track of the shadow nodes in JS. It was only used to be able to find the node for a target after unmounted, so we could "unobserve" it, but `MutationObserver` doesn't support unobserving individual targets anyway, so we removed that use case and implemented a more general `unobserveAll` method that doesn't require the shadow nodes in the first place.

Differential Revision: D74240834


