### PR TITLE
deprecate type aliases ShadowNode::Unshared and ShadowNode::Weak

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.cpp
@@ -313,7 +313,7 @@ void ParagraphShadowNode::layout(LayoutContext layoutContext) {
   // `paragraphOwningShadowNode` is owning pointer to`paragraphShadowNode`
   // (besides the initial case when `paragraphShadowNode == this`), we need
   // this only to keep it in memory for a while.
-  auto paragraphOwningShadowNode = ShadowNode::Unshared{};
+  auto paragraphOwningShadowNode = std::shared_ptr<ShadowNode>{};
 
   react_native_assert(
       content.attachments.size() == measurement.attachments.size());
@@ -327,7 +327,7 @@ void ParagraphShadowNode::layout(LayoutContext layoutContext) {
       continue;
     }
 
-    auto clonedShadowNode = ShadowNode::Unshared{};
+    auto clonedShadowNode = std::shared_ptr<ShadowNode>{};
 
     paragraphOwningShadowNode = paragraphShadowNode->cloneTree(
         attachment.shadowNode->getFamily(),

--- a/packages/react-native/ReactCommon/react/renderer/core/ComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ComponentDescriptor.h
@@ -85,7 +85,7 @@ class ComponentDescriptor {
   /*
    * Clones a `ShadowNode` with optionally new `props` and/or `children`.
    */
-  virtual ShadowNode::Unshared cloneShadowNode(
+  virtual std::shared_ptr<ShadowNode> cloneShadowNode(
       const ShadowNode& sourceShadowNode,
       const ShadowNodeFragment& fragment) const = 0;
 

--- a/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
@@ -76,7 +76,7 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
     return shadowNode;
   }
 
-  ShadowNode::Unshared cloneShadowNode(
+  std::shared_ptr<ShadowNode> cloneShadowNode(
       const ShadowNode& sourceShadowNode,
       const ShadowNodeFragment& fragment) const override {
     auto shadowNode = std::make_shared<ShadowNodeT>(sourceShadowNode, fragment);

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -133,7 +133,7 @@ ShadowNode::ShadowNode(
   }
 }
 
-ShadowNode::Unshared ShadowNode::clone(
+std::shared_ptr<ShadowNode> ShadowNode::clone(
     const ShadowNodeFragment& fragment) const {
   const auto& family = *family_;
   const auto& componentDescriptor = family.componentDescriptor_;
@@ -340,14 +340,14 @@ ShadowNodeFamily::Shared ShadowNode::getFamilyShared() const {
   return family_;
 }
 
-ShadowNode::Unshared ShadowNode::cloneTree(
+std::shared_ptr<ShadowNode> ShadowNode::cloneTree(
     const ShadowNodeFamily& shadowNodeFamily,
-    const std::function<ShadowNode::Unshared(const ShadowNode& oldShadowNode)>&
-        callback) const {
+    const std::function<std::shared_ptr<ShadowNode>(
+        const ShadowNode& oldShadowNode)>& callback) const {
   auto ancestors = shadowNodeFamily.getAncestors(*this);
 
   if (ancestors.empty()) {
-    return ShadowNode::Unshared{nullptr};
+    return std::shared_ptr<ShadowNode>{nullptr};
   }
 
   auto& parent = ancestors.back();

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
@@ -33,10 +33,14 @@ class ShadowNode : public Sealable,
                    public jsi::NativeState {
  public:
   using Shared = std::shared_ptr<const ShadowNode>;
-  using Weak = std::weak_ptr<const ShadowNode>;
-  using Unshared = std::shared_ptr<ShadowNode>;
+  // TODO(T223558094): delete this in the next version.
+  using Weak [[deprecated("Use std::weak_ptr<const ShadowNode> instead")]] =
+      std::weak_ptr<const ShadowNode>;
+  // TODO(T223558094): delete this in the next version.
+  using Unshared [[deprecated("Use std::weak_ptr<const ShadowNode> instead")]] =
+      std::shared_ptr<ShadowNode>;
   using ListOfShared = std::vector<Shared>;
-  using ListOfWeak = std::vector<Weak>;
+  using ListOfWeak = std::vector<std::weak_ptr<const ShadowNode>>;
   using SharedListOfShared = std::shared_ptr<const ListOfShared>;
   using UnsharedListOfShared = std::shared_ptr<ListOfShared>;
   using UnsharedListOfWeak = std::shared_ptr<ListOfWeak>;
@@ -93,7 +97,7 @@ class ShadowNode : public Sealable,
   /*
    * Clones the shadow node using stored `cloneFunction`.
    */
-  Unshared clone(const ShadowNodeFragment& fragment) const;
+  std::shared_ptr<ShadowNode> clone(const ShadowNodeFragment& fragment) const;
 
   /*
    * Clones the node (and partially the tree starting from the node) by
@@ -102,10 +106,10 @@ class ShadowNode : public Sealable,
    *
    * Returns `nullptr` if the operation cannot be performed successfully.
    */
-  Unshared cloneTree(
+  std::shared_ptr<ShadowNode> cloneTree(
       const ShadowNodeFamily& shadowNodeFamily,
-      const std::function<Unshared(const ShadowNode& oldShadowNode)>& callback)
-      const;
+      const std::function<std::shared_ptr<ShadowNode>(
+          const ShadowNode& oldShadowNode)>& callback) const;
 
 #pragma mark - Getters
 

--- a/packages/react-native/ReactCommon/react/renderer/element/ComponentBuilder.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/element/ComponentBuilder.cpp
@@ -15,7 +15,7 @@ ComponentBuilder::ComponentBuilder(
     ComponentDescriptorRegistry::Shared componentDescriptorRegistry)
     : componentDescriptorRegistry_(std::move(componentDescriptorRegistry)){};
 
-ShadowNode::Unshared ComponentBuilder::build(
+std::shared_ptr<ShadowNode> ComponentBuilder::build(
     const ElementFragment& elementFragment) const {
   auto& componentDescriptor =
       componentDescriptorRegistry_->at(elementFragment.componentHandle);

--- a/packages/react-native/ReactCommon/react/renderer/element/ComponentBuilder.h
+++ b/packages/react-native/ReactCommon/react/renderer/element/ComponentBuilder.h
@@ -48,7 +48,8 @@ class ComponentBuilder final {
   /*
    * Internal, type-erased version of `build`.
    */
-  ShadowNode::Unshared build(const ElementFragment& elementFragment) const;
+  std::shared_ptr<ShadowNode> build(
+      const ElementFragment& elementFragment) const;
 
   ComponentDescriptorRegistry::Shared componentDescriptorRegistry_;
 };

--- a/packages/react-native/ReactCommon/react/renderer/element/ElementFragment.h
+++ b/packages/react-native/ReactCommon/react/renderer/element/ElementFragment.h
@@ -27,7 +27,7 @@ class ElementFragment final {
   using List = std::vector<ElementFragment>;
   using ListOfShared = std::vector<Shared>;
   using ReferenceCallback =
-      std::function<void(const ShadowNode::Unshared& shadowNode)>;
+      std::function<void(const std::shared_ptr<ShadowNode>& shadowNode)>;
   using FinalizeCallback = std::function<void(ShadowNode& shadowNode)>;
   using StateCallback =
       std::function<StateData::Shared(const State::Shared& state)>;

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
@@ -31,7 +31,7 @@ using CommitMode = ShadowTree::CommitMode;
  * of calling, the function returns `nullptr` (as an indication that no
  * additional work is required).
  */
-static ShadowNode::Unshared progressState(const ShadowNode& shadowNode) {
+static std::shared_ptr<ShadowNode> progressState(const ShadowNode& shadowNode) {
   auto isStateChanged = false;
   auto areChildrenChanged = false;
 
@@ -78,7 +78,7 @@ static ShadowNode::Unshared progressState(const ShadowNode& shadowNode) {
  * The function uses a given base tree to exclude unchanged (equal) parts
  * of the three from the traversing.
  */
-static ShadowNode::Unshared progressState(
+static std::shared_ptr<ShadowNode> progressState(
     const ShadowNode& shadowNode,
     const ShadowNode& baseShadowNode) {
   // The intuition behind the complexity:
@@ -357,7 +357,8 @@ void ShadowTree::mount(ShadowTreeRevision revision, bool mountSynchronously)
 
 void ShadowTree::commitEmptyTree() const {
   commit(
-      [](const RootShadowNode& oldRootShadowNode) -> RootShadowNode::Unshared {
+      [](const RootShadowNode& oldRootShadowNode)
+          -> std::shared_ptr<RootShadowNode> {
         return std::make_shared<RootShadowNode>(
             oldRootShadowNode,
             ShadowNodeFragment{

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceHandler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceHandler.cpp
@@ -248,8 +248,7 @@ std::shared_ptr<const ShadowNode> SurfaceHandler::dirtyMeasurableNodesRecursive(
       ShadowNodeFragment::childrenPlaceholder();
 
   if (nodeHasChildren) {
-    ShadowNode::UnsharedListOfShared newChildrenMutable = nullptr;
-
+    std::shared_ptr<ShadowNode::ListOfShared> newChildrenMutable = nullptr;
     for (size_t i = 0; i < node->getChildren().size(); i++) {
       const auto& child = node->getChildren()[i];
 

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/PointerEventsProcessor.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/PointerEventsProcessor.cpp
@@ -119,7 +119,7 @@ static ShadowNode::Shared getCaptureTargetOverride(
     return nullptr;
   }
 
-  ShadowNode::Weak maybeTarget = pendingPointerItr->second;
+  std::weak_ptr<const ShadowNode> maybeTarget = pendingPointerItr->second;
   if (maybeTarget.expired()) {
     // target has expired so it should functionally behave the same as if it
     // was removed from the override list.

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/PointerEventsProcessor.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/PointerEventsProcessor.h
@@ -42,7 +42,7 @@ using DispatchEvent = std::function<void(
 
 using PointerIdentifier = int32_t;
 using CaptureTargetOverrideRegistry =
-    std::unordered_map<PointerIdentifier, ShadowNode::Weak>;
+    std::unordered_map<PointerIdentifier, std::weak_ptr<const ShadowNode>>;
 
 using ActivePointerRegistry =
     std::unordered_map<PointerIdentifier, ActivePointer>;

--- a/packages/react-native/ReactCommon/react/test_utils/shadowTreeGeneration.h
+++ b/packages/react-native/ReactCommon/react/test_utils/shadowTreeGeneration.h
@@ -103,7 +103,7 @@ static ShadowNode::ListOfShared cloneSharedShadowNodeList(
   return result;
 }
 
-static inline ShadowNode::Unshared messWithChildren(
+static inline std::shared_ptr<ShadowNode> messWithChildren(
     const Entropy& entropy,
     const ShadowNode& shadowNode) {
   auto children = shadowNode.getChildren();
@@ -114,7 +114,7 @@ static inline ShadowNode::Unshared messWithChildren(
        std::make_shared<const ShadowNode::ListOfShared>(children)});
 }
 
-static inline ShadowNode::Unshared messWithLayoutableOnlyFlag(
+static inline std::shared_ptr<ShadowNode> messWithLayoutableOnlyFlag(
     const Entropy& entropy,
     const ShadowNode& shadowNode) {
   auto oldProps = shadowNode.getProps();
@@ -171,7 +171,7 @@ static inline ShadowNode::Unshared messWithLayoutableOnlyFlag(
 
 // Similar to `messWithLayoutableOnlyFlag` but has a 50/50 chance of flattening
 // (or unflattening) a node's children.
-static inline ShadowNode::Unshared messWithNodeFlattenednessFlags(
+static inline std::shared_ptr<ShadowNode> messWithNodeFlattenednessFlags(
     const Entropy& entropy,
     const ShadowNode& shadowNode) {
   ContextContainer contextContainer{};
@@ -212,7 +212,7 @@ static inline ShadowNode::Unshared messWithNodeFlattenednessFlags(
   return shadowNode.clone({newProps});
 }
 
-static inline ShadowNode::Unshared messWithYogaStyles(
+static inline std::shared_ptr<ShadowNode> messWithYogaStyles(
     const Entropy& entropy,
     const ShadowNode& shadowNode) {
   folly::dynamic dynamic = folly::dynamic::object();
@@ -250,8 +250,9 @@ static inline ShadowNode::Unshared messWithYogaStyles(
   return shadowNode.clone({newProps});
 }
 
-using ShadowNodeAlteration = std::function<
-    ShadowNode::Unshared(const Entropy& entropy, const ShadowNode& shadowNode)>;
+using ShadowNodeAlteration = std::function<std::shared_ptr<ShadowNode>(
+    const Entropy& entropy,
+    const ShadowNode& shadowNode)>;
 
 static inline void alterShadowTree(
     const Entropy& entropy,


### PR DESCRIPTION
Summary:
changelog: [General][Deprecated] - deprecate type aliases ShadowNode::Unshared and ShadowNode::Weak in favour of std::shared_ptr<ShadowNode> and std::weak_ptr<ShadowNode>

migrate away from using these type aliases to avoid confusion.

It is unclear from ShadowNode::Unshared what it means. This can be avoided by using std::shared_ptr<ShadowNode> directly. The same applies to ShadowNode::Weak.

Reviewed By: rubennorte

Differential Revision: D74245228


