### PR TITLE
[RN][Release] Fix set-rn-version to account for codegen snapshot test files

### DIFF
--- a/3077396185.mdt
+++ b/3077396185.mdt
@@ -1,0 +1,10 @@
+## Summary:
+This change fixes the script that updates the RN Version to also update the Codegen snapshots so that they are in sync with the current version of React Native.
+It also updates the Snapshot as it was failing in rc.0
+
+## Changelog:
+[Internal] - Fixed script that updates the react native versions
+
+## Test Plan:
+Tested locally by running `node ./scripts/releases/set-rn-artifacts-version --built-type release --to-version 0.80.0-rc.0` and verifying that the snapshot file was getting updated. I then run the `yarn test  
+generate-artifacts-executor-test.js` command to verify that the tests were passing.

--- a/packages/react-native/scripts/codegen/__tests__/__snapshots__/generate-artifacts-executor-test.js.snap
+++ b/packages/react-native/scripts/codegen/__tests__/__snapshots__/generate-artifacts-executor-test.js.snap
@@ -363,7 +363,7 @@ exports[`execute "ReactAppDependencyProvider.podspec" should match snapshot 1`] 
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-version = \\"1000.0.0\\"
+version = \\"0.80.0-rc.0\\"
 source = { :git => 'https://github.com/facebook/react-native.git' }
 if version == '1000.0.0'
   # This is an unpublished version, use the latest commit hash of the react-native repo, which we’re presumably in.
@@ -401,7 +401,7 @@ exports[`execute "ReactCodegen.podspec" should match snapshot 1`] = `
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-version = \\"1000.0.0\\"
+version = \\"0.80.0-rc.0\\"
 source = { :git => 'https://github.com/facebook/react-native.git' }
 if version == '1000.0.0'
   # This is an unpublished version, use the latest commit hash of the react-native repo, which we’re presumably in.

--- a/scripts/releases/__tests__/__snapshots__/set-rn-artifacts-version-test.js.snap
+++ b/scripts/releases/__tests__/__snapshots__/set-rn-artifacts-version-test.js.snap
@@ -121,6 +121,12 @@ constexpr struct {
 "
 `;
 
+exports[`updateReactNativeArtifacts should set nightly version: packages/react-native/scripts/codegen/__tests__/__snapshots__/generate-artifacts-executor-test.js.snap 1`] = `
+"version = \\"0.81.0-nightly-29282302-abcd1234\\\\
+other text
+version = \\"0.81.0-nightly-29282302-abcd1234\\\\"
+`;
+
 exports[`updateReactNativeArtifacts should set release version: packages/react-native/Libraries/Core/ReactNativeVersion.js 1`] = `
 "/**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
@@ -240,4 +246,10 @@ constexpr struct {
 
 } // namespace facebook::react
 "
+`;
+
+exports[`updateReactNativeArtifacts should set release version: packages/react-native/scripts/codegen/__tests__/__snapshots__/generate-artifacts-executor-test.js.snap 1`] = `
+"version = \\"0.81.0\\\\
+other text
+version = \\"0.81.0\\\\"
 `;

--- a/scripts/releases/__tests__/__snapshots__/set-version-test.js.snap
+++ b/scripts/releases/__tests__/__snapshots__/set-version-test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`setVersion updates monorepo for nightly: ../../../../packages/react-native/scripts/codegen/__tests__/__snapshots__/generate-artifacts-executor-test.js.snap 1`] = `"[omitted]"`;
+
 exports[`setVersion updates monorepo for nightly: set-version/package.json 1`] = `
 "{
   \\"name\\": \\"@react-native/monorepo\\",
@@ -81,6 +83,8 @@ exports[`setVersion updates monorepo for nightly: set-version/packages/react-nat
 "
 `;
 
+exports[`setVersion updates monorepo for release-candidate: ../../../../packages/react-native/scripts/codegen/__tests__/__snapshots__/generate-artifacts-executor-test.js.snap 1`] = `"[omitted]"`;
+
 exports[`setVersion updates monorepo for release-candidate: set-version/package.json 1`] = `
 "{
   \\"name\\": \\"@react-native/monorepo\\",
@@ -161,6 +165,8 @@ exports[`setVersion updates monorepo for release-candidate: set-version/packages
 }
 "
 `;
+
+exports[`setVersion updates monorepo for stable version: ../../../../packages/react-native/scripts/codegen/__tests__/__snapshots__/generate-artifacts-executor-test.js.snap 1`] = `"[omitted]"`;
 
 exports[`setVersion updates monorepo for stable version: set-version/package.json 1`] = `
 "{

--- a/scripts/releases/__tests__/set-rn-artifacts-version-test.js
+++ b/scripts/releases/__tests__/set-rn-artifacts-version-test.js
@@ -37,6 +37,20 @@ describe('updateReactNativeArtifacts', () => {
       ) {
         return 'VERSION_NAME=1000.0.0\n';
       }
+
+      if (
+        filePath ===
+        path.join(
+          REPO_ROOT,
+          'packages/react-native/scripts/codegen/__tests__/__snapshots__/generate-artifacts-executor-test.js.snap',
+        )
+      ) {
+        return `
+version = "1000.0.0\\
+other text
+version = "1000.0.0\\
+        `;
+      }
     });
   });
 

--- a/scripts/releases/set-rn-artifacts-version.js
+++ b/scripts/releases/set-rn-artifacts-version.js
@@ -79,6 +79,7 @@ async function updateReactNativeArtifacts(
   const versionInfo = parseVersion(version, buildType);
 
   await updateSourceFiles(versionInfo);
+  await updateTestFiles(versionInfo);
   await updateGradleFile(versionInfo.version);
 }
 
@@ -114,6 +115,40 @@ function updateSourceFiles(
       require('./templates/ReactNativeVersion.js-template')(templateData),
     ),
   ]);
+}
+
+function updateTestFiles(
+  versionInfo /*: Version */,
+) /*: Promise<Array<void>>*/ {
+  const oldVersion = /"\d+\.\d+\.\d+(-rc\.\d+)?\\/g;
+  const newVersion = `"${versionInfo.version}\\`;
+
+  const snapshotTestPath = path.join(
+    __dirname,
+    '..',
+    '..',
+    'packages',
+    'react-native',
+    'scripts',
+    'codegen',
+    '__tests__',
+    '__snapshots__',
+    'generate-artifacts-executor-test.js.snap',
+  );
+
+  const promise /*: Promise<void> */ = new Promise(async (resolve, reject) => {
+    try {
+      let snapshot = String(await fs.readFile(snapshotTestPath, 'utf8')).trim();
+      // Replace all occurrences of the old version pattern with the new version
+      snapshot = snapshot.replaceAll(oldVersion, newVersion);
+      await fs.writeFile(snapshotTestPath, snapshot, {encoding: 'utf8'});
+      resolve();
+    } catch (error) {
+      reject(error);
+    }
+  });
+
+  return Promise.all([promise]);
 }
 
 async function updateGradleFile(version /*: string */) /*: Promise<void> */ {


### PR DESCRIPTION
## Summary:
test-js jobs are failing because the codegen snapshot tests generates a Podspecs withan hardcoded version that does not matches the version we are about to release.

This fix updates the script that set the RN version to make sure it also updates the Codegen snapshots.

This change also fixes the currently broken snapshots.

## Changelog:
[Internal] - Fix set-rn-version script to update codegen snapshots

## Test Plan:
Tested locally by
```
node scripts/release/set-rn-version --built-type release --to-version 0.80.0-rc.0
```
And verifying that only the snapshot got updated.

Tested that the jest test were passing by running

```
yarn test generate-artifacts-executor-test
```
