### PR TITLE
fix(iOS): enable DEFINES_MODULE in `React-jsc`

### DIFF
--- a/packages/react-native/ReactCommon/jsc/React-jsc.podspec
+++ b/packages/react-native/ReactCommon/jsc/React-jsc.podspec
@@ -32,6 +32,6 @@ Pod::Spec.new do |s|
   s.dependency "React-jsi", version
 
   s.subspec "Fabric" do |ss|
-    ss.pod_target_xcconfig  = { "OTHER_CFLAGS" => "$(inherited)" }
+    ss.pod_target_xcconfig  = { "OTHER_CFLAGS" => "$(inherited)", "DEFINES_MODULE" => "YES" }
   end
 end


### PR DESCRIPTION
## Summary:

Enables `DEFINES_MODULE` in `React-jsc.podspec`

After upgrading app to RN `0.79`, when installing pods with JSC enabled there is an error being thrown that 

`The following Swift pods cannot yet be integrated as static libraries`
`The Swift pod 'RNFlashList' depends upon 'React-jsc', which does not define modules. ...` 
when installing packages that use Swift

## Changelog:

[IOS] [CHANGED] -  enable `DEFINES_MODULE` in `React-jsc.podspec`


## Test Plan:

RNTester runs and builds correctly