### PR TITLE
Unbreak build_android due to broken `StateReconciliationTest.cpp`

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/mounting/tests/StateReconciliationTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/tests/StateReconciliationTest.cpp
@@ -277,7 +277,7 @@ TEST_F(StateReconciliationTest, testCloneslessStateReconciliationDoesntClone) {
 
   // ==== Creact clones tree ====
 
-  ShadowNode::Unshared newlyClonedShadowNode;
+  std::shared_ptr<ShadowNode> newlyClonedShadowNode;
 
   auto rootShadowNodeClonedFromReact = rootShadowNode2->cloneTree(
       scrollViewFamily, [&](const ShadowNode& oldShadowNode) {
@@ -369,7 +369,7 @@ TEST_F(StateReconciliationTest, testStateReconciliationScrollViewChildUpdate) {
 
   // ==== React starts cloning but does not commit ====
 
-  ShadowNode::Unshared newlyClonedViewShadowNode;
+  std::shared_ptr<ShadowNode> newlyClonedViewShadowNode;
 
   auto rootShadowNodeClonedFromReact = initialRootShadowNode->cloneTree(
       initialChildViewShadowNode->getFamily(),


### PR DESCRIPTION
Summary:
This unbreaks the CI after D74245228

Changelog:
[Internal] [Changed] -

Differential Revision: D74324800


