### PR TITLE
hermes-engine should build with target Java version 17

### DIFF
--- a/packages/react-native/ReactAndroid/hermes-engine/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/hermes-engine/build.gradle.kts
@@ -250,6 +250,11 @@ android {
       }
     }
     ndk { abiFilters.addAll(reactNativeArchitectures()) }
+
+    compileOptions {
+      sourceCompatibility = JavaVersion.VERSION_17
+      targetCompatibility = JavaVersion.VERSION_17
+    }
   }
 
   externalNativeBuild {


### PR DESCRIPTION
Summary:
We specify the java target version to 17 for ReactAndroid but not for hermes-engine.
This is causing it to be the default (8) which will cause our build to fail on JDK 21.
This fixes it.

Changelog:
[Internal] [Changed] -

Differential Revision: D74325107


