### PR TITLE
Add missing ScrollView props to ScrollProps

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
@@ -222,8 +222,9 @@ jni::local_ref<jobject> getProps(
   // is enabled.
   auto* oldProps = oldShadowView.props.get();
   auto* newProps = newShadowView.props.get();
-  if (ReactNativeFeatureFlags::enablePropsUpdateReconciliationAndroid() &&
-      strcmp(newShadowView.componentName, "View") == 0) {
+  if ((ReactNativeFeatureFlags::enablePropsUpdateReconciliationAndroid()) &&
+      (strcmp(newShadowView.componentName, "View") == 0 ||
+       strcmp(newShadowView.componentName, "Image") == 0)) {
     return ReadableNativeMap::newObjectCxxArgs(
         newProps->getDiffProps(oldProps));
   }

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
@@ -45,6 +45,12 @@ class ImageProps final : public ViewProps {
   SharedColor overlayColor{};
   Float fadeDuration{};
   bool progressiveRenderingEnabled{};
+
+#ifdef ANDROID
+
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+
+#endif
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.cpp
@@ -371,7 +371,27 @@ ScrollViewProps::ScrollViewProps(
                     rawProps,
                     "isInvertedVirtualizedList",
                     sourceProps.isInvertedVirtualizedList,
-                    {})) {}
+                    {})),
+      sendMomentumEvents(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.sendMomentumEvents
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "sendMomentumEvents",
+                    sourceProps.sendMomentumEvents,
+                    true)),
+      nestedScrollEnabled(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.nestedScrollEnabled
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "nestedScrollEnabled",
+                    sourceProps.nestedScrollEnabled,
+                    true))
+
+{}
 
 void ScrollViewProps::setProp(
     const PropsParserContext& context,
@@ -424,6 +444,8 @@ void ScrollViewProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(contentInsetAdjustmentBehavior);
     RAW_SET_PROP_SWITCH_CASE_BASIC(scrollToOverflowEnabled);
     RAW_SET_PROP_SWITCH_CASE_BASIC(isInvertedVirtualizedList);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(sendMomentumEvents);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(nestedScrollEnabled);
   }
 }
 
@@ -558,7 +580,15 @@ SharedDebugStringConvertibleList ScrollViewProps::getDebugProps() const {
           debugStringConvertibleItem(
               "isInvertedVirtualizedList",
               snapToEnd,
-              defaultScrollViewProps.isInvertedVirtualizedList)};
+              defaultScrollViewProps.isInvertedVirtualizedList),
+          debugStringConvertibleItem(
+              "sendMomentumEvents",
+              sendMomentumEvents,
+              defaultScrollViewProps.sendMomentumEvents),
+          debugStringConvertibleItem(
+              "nestedScrollEnabled",
+              nestedScrollEnabled,
+              defaultScrollViewProps.nestedScrollEnabled)};
 }
 #endif
 

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewProps.h
@@ -74,6 +74,9 @@ class ScrollViewProps final : public ViewProps {
   bool scrollToOverflowEnabled{false};
   bool isInvertedVirtualizedList{false};
 
+  bool sendMomentumEvents{};
+  bool nestedScrollEnabled{};
+
 #pragma mark - DebugStringConvertible
 
 #if RN_DEBUG_STRING_CONVERTIBLE

--- a/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/UnimplementedViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/UnimplementedViewProps.cpp
@@ -17,4 +17,23 @@ ComponentName UnimplementedViewProps::getComponentName() const {
   return componentName_;
 }
 
+#ifdef ANDROID
+folly::dynamic UnimplementedViewProps::getDiffProps(
+    const Props* prevProps) const {
+  static const auto defaultProps = UnimplementedViewProps();
+
+  const UnimplementedViewProps* oldProps = prevProps == nullptr
+      ? &defaultProps
+      : static_cast<const UnimplementedViewProps*>(prevProps);
+
+  folly::dynamic result = ViewProps::getDiffProps(oldProps);
+
+  if (componentName_ != oldProps->componentName_) {
+    result["name"] = componentName_;
+  }
+
+  return result;
+}
+#endif
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/UnimplementedViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/unimplementedview/UnimplementedViewProps.h
@@ -27,6 +27,12 @@ class UnimplementedViewProps final : public ViewProps {
   void setComponentName(ComponentName componentName);
   ComponentName getComponentName() const;
 
+#ifdef ANDROID
+
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+
+#endif
+
  private:
   mutable ComponentName componentName_{};
 };


### PR DESCRIPTION
Summary:
Adding the ScrollView properties that are android specific to the common ScrollView props so that they can be diffed in a getDiffProps implementation.

Changelog: [Internal]

Differential Revision: D74327335


