### PR TITLE
Kotlin: Clean up redundant constructs (2/n)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/TurboReactPackage.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/TurboReactPackage.kt
@@ -10,4 +10,4 @@ package com.facebook.react
 @Deprecated(
     message = "Use BaseReactPackage instead",
     replaceWith = ReplaceWith(expression = "BaseReactPackage"))
-public abstract class TurboReactPackage : BaseReactPackage() {}
+public abstract class TurboReactPackage : BaseReactPackage()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.kt
@@ -190,7 +190,7 @@ public class NativeAnimatedModule(reactContext: ReactApplicationContext?) :
   }
 
   private val animatedFrameCallback: GuardedFrameCallback
-  private val reactChoreographer: ReactChoreographer = ReactChoreographer.getInstance()
+  private val reactChoreographer: ReactChoreographer? = ReactChoreographer.getInstance()
 
   private val operations = ConcurrentOperationQueue()
   private val preOperations = ConcurrentOperationQueue()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.kt
@@ -190,7 +190,7 @@ public class NativeAnimatedModule(reactContext: ReactApplicationContext?) :
   }
 
   private val animatedFrameCallback: GuardedFrameCallback
-  private val reactChoreographer: ReactChoreographer? = ReactChoreographer.getInstance()
+  private val reactChoreographer: ReactChoreographer = ReactChoreographer.getInstance()
 
   private val operations = ConcurrentOperationQueue()
   private val preOperations = ConcurrentOperationQueue()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/internal/InteropLegacyArchitecture.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/annotations/internal/InteropLegacyArchitecture.kt
@@ -13,4 +13,4 @@ package com.facebook.react.common.annotations.internal
  */
 @Retention(AnnotationRetention.SOURCE)
 @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
-public annotation class InteropLegacyArchitecture()
+public annotation class InteropLegacyArchitecture

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/events/EventBeatManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/events/EventBeatManager.kt
@@ -18,7 +18,7 @@ import com.facebook.react.uimanager.events.BatchEventDispatchedListener
  */
 @DoNotStrip
 @SuppressLint("MissingNativeLoadLibrary")
-internal final class EventBeatManager() : HybridClassBase(), BatchEventDispatchedListener {
+internal class EventBeatManager : HybridClassBase(), BatchEventDispatchedListener {
   init {
     initHybrid()
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/DialogModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/DialogModule.kt
@@ -8,8 +8,6 @@
 package com.facebook.react.modules.dialog
 
 import android.content.DialogInterface
-import android.content.DialogInterface.OnClickListener
-import android.content.DialogInterface.OnDismissListener
 import android.os.Bundle
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/toast/ToastModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/toast/ToastModule.kt
@@ -31,19 +31,19 @@ internal class ToastModule(reactContext: ReactApplicationContext) :
 
   override fun show(message: String?, durationDouble: Double) {
     val duration = durationDouble.toInt()
-    UiThreadUtil.runOnUiThread(
-        Runnable { Toast.makeText(getReactApplicationContext(), message, duration).show() })
+    UiThreadUtil.runOnUiThread {
+      Toast.makeText(getReactApplicationContext(), message, duration).show()
+    }
   }
 
   override fun showWithGravity(message: String?, durationDouble: Double, gravityDouble: Double) {
     val duration = durationDouble.toInt()
     val gravity = gravityDouble.toInt()
-    UiThreadUtil.runOnUiThread(
-        Runnable {
-          val toast = Toast.makeText(getReactApplicationContext(), message, duration)
-          toast.setGravity(gravity, 0, 0)
-          toast.show()
-        })
+    UiThreadUtil.runOnUiThread {
+      val toast = Toast.makeText(getReactApplicationContext(), message, duration)
+      toast.setGravity(gravity, 0, 0)
+      toast.show()
+    }
   }
 
   override fun showWithGravityAndOffset(
@@ -57,12 +57,11 @@ internal class ToastModule(reactContext: ReactApplicationContext) :
     val gravity = gravityDouble.toInt()
     val xOffset = xOffsetDouble.toInt()
     val yOffset = yOffsetDouble.toInt()
-    UiThreadUtil.runOnUiThread(
-        Runnable {
-          val toast = Toast.makeText(getReactApplicationContext(), message, duration)
-          toast.setGravity(gravity, xOffset, yOffset)
-          toast.show()
-        })
+    UiThreadUtil.runOnUiThread {
+      val toast = Toast.makeText(getReactApplicationContext(), message, duration)
+      toast.setGravity(gravity, xOffset, yOffset)
+      toast.show()
+    }
   }
 
   companion object {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessCatalystInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessCatalystInstance.kt
@@ -125,14 +125,14 @@ internal class BridgelessCatalystInstance(private val reactHost: ReactHostImpl) 
   public override val runtimeExecutor: RuntimeExecutor?
     get() = reactHost.getRuntimeExecutor()
 
-  public override val runtimeScheduler: RuntimeScheduler?
+  public override val runtimeScheduler: RuntimeScheduler
     get() = throw UnsupportedOperationException("Unimplemented method 'getRuntimeScheduler'")
 
   public override fun extendNativeModules(modules: NativeModuleRegistry) {
     throw UnsupportedOperationException("Unimplemented method 'extendNativeModules'")
   }
 
-  public override val sourceURL: String?
+  public override val sourceURL: String
     get() = throw UnsupportedOperationException("Unimplemented method 'getSourceURL'")
 
   override fun addBridgeIdleDebugListener(listener: NotThreadSafeBridgeIdleDebugListener) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.kt
@@ -136,7 +136,7 @@ internal class BridgelessReactContext(context: Context, private val reactHost: R
   override fun <T : NativeModule> hasNativeModule(nativeModuleInterface: Class<T>): Boolean =
       reactHost.hasNativeModule(nativeModuleInterface)
 
-  override fun getNativeModules(): MutableCollection<NativeModule>? = reactHost.nativeModules
+  override fun getNativeModules(): MutableCollection<NativeModule> = reactHost.nativeModules
 
   override fun <T : NativeModule> getNativeModule(nativeModuleInterface: Class<T>): T? =
       reactHost.getNativeModule(nativeModuleInterface)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.kt
@@ -211,27 +211,27 @@ internal class ReactInstance(
           // 2. genericBubblingEventTypes.
           // 3. genericDirectEventTypes.
           // We want to match this beahavior.
-          DefaultEventTypesProvider {
-            Arguments.makeNativeMap(UIManagerModuleConstantsHelper.getDefaultExportableEventTypes())
-          },
+        {
+          Arguments.makeNativeMap(UIManagerModuleConstantsHelper.getDefaultExportableEventTypes())
+        },
           ConstantsForViewManagerProvider { viewManagerName: String ->
             val viewManager =
                 viewManagerResolver.getViewManager(viewManagerName)
                     ?: return@ConstantsForViewManagerProvider null
             getConstantsForViewManager(viewManager, customDirectEvents)
           },
-          ConstantsProvider {
-            val viewManagers: List<ViewManager<*, *>> =
-                ArrayList(viewManagerResolver.eagerViewManagerMap.values)
-            val constants = createConstants(viewManagers, customDirectEvents)
+        {
+          val viewManagers: List<ViewManager<*, *>> =
+              ArrayList(viewManagerResolver.eagerViewManagerMap.values)
+          val constants = createConstants(viewManagers, customDirectEvents)
 
-            val lazyViewManagers = viewManagerResolver.lazyViewManagerNames
-            if (!lazyViewManagers.isEmpty()) {
-              constants["ViewManagerNames"] = ArrayList(lazyViewManagers)
-              constants["LazyViewManagersEnabled"] = true
-            }
-            Arguments.makeNativeMap(constants)
-          })
+          val lazyViewManagers = viewManagerResolver.lazyViewManagerNames
+          if (!lazyViewManagers.isEmpty()) {
+            constants["ViewManagerNames"] = ArrayList(lazyViewManagers)
+            constants["LazyViewManagersEnabled"] = true
+          }
+          Arguments.makeNativeMap(constants)
+        })
     }
 
     val eventBeatManager = EventBeatManager()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/ExecutorException.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/internal/bolts/ExecutorException.kt
@@ -12,4 +12,4 @@ package com.facebook.react.runtime.internal.bolts
  * the continuation block it self.
  */
 internal class ExecutorException(e: Exception?) :
-    RuntimeException("An exception was thrown by an Executor", e) {}
+    RuntimeException("An exception was thrown by an Executor", e)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/CallInvokerHolderImpl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/CallInvokerHolderImpl.kt
@@ -17,4 +17,4 @@ import com.facebook.react.turbomodule.core.interfaces.CallInvokerHolder
  * pass it from CatalystInstance, through Java, to TurboModuleManager::initHybrid.
  */
 @FrameworkAPI
-public class CallInvokerHolderImpl private constructor() : HybridClassBase(), CallInvokerHolder {}
+public class CallInvokerHolderImpl private constructor() : HybridClassBase(), CallInvokerHolder

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/NativeMethodCallInvokerHolderImpl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/turbomodule/core/NativeMethodCallInvokerHolderImpl.kt
@@ -19,4 +19,4 @@ import com.facebook.react.turbomodule.core.interfaces.NativeMethodCallInvokerHol
  */
 @FrameworkAPI
 public class NativeMethodCallInvokerHolderImpl private constructor() :
-    HybridClassBase(), NativeMethodCallInvokerHolder {}
+    HybridClassBase(), NativeMethodCallInvokerHolder

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactStylesDiffMap.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactStylesDiffMap.kt
@@ -57,7 +57,7 @@ public class ReactStylesDiffMap(props: ReadableMap) {
 
   public fun getMap(name: String): ReadableMap? = backingMap.getMap(name)
 
-  public fun getDynamic(name: String): Dynamic? = backingMap.getDynamic(name)
+  public fun getDynamic(name: String): Dynamic = backingMap.getDynamic(name)
 
   override fun toString(): String = "{ ${javaClass.simpleName}: $backingMap }"
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstants.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstants.kt
@@ -10,7 +10,6 @@ package com.facebook.react.uimanager
 import android.view.accessibility.AccessibilityEvent
 import android.widget.ImageView
 import com.facebook.react.uimanager.events.TouchEventType
-import com.facebook.react.uimanager.events.TouchEventType.Companion.getJSEventName
 
 /** Constants exposed to JS from [UIManagerModule]. */
 internal object UIManagerModuleConstants {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupDrawingOrderHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupDrawingOrderHelper.kt
@@ -76,12 +76,11 @@ public class ViewGroupDrawingOrderHelper(private val viewGroup: ViewGroup) {
       }
 
       // Sort the views by zIndex
-      viewsToSort.sortWith(
-          Comparator { view1, view2 ->
-            val view1ZIndex = ViewGroupManager.getViewZIndex(view1) ?: 0
-            val view2ZIndex = ViewGroupManager.getViewZIndex(view2) ?: 0
-            view1ZIndex - view2ZIndex
-          })
+      viewsToSort.sortWith { view1, view2 ->
+        val view1ZIndex = ViewGroupManager.getViewZIndex(view1) ?: 0
+        val view2ZIndex = ViewGroupManager.getViewZIndex(view2) ?: 0
+        view1ZIndex - view2ZIndex
+      }
 
       currentDrawingOrderIndices = IntArray(childCount)
       for (i in 0 until childCount) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagerWithGeneratedInterface.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagerWithGeneratedInterface.kt
@@ -8,4 +8,4 @@
 package com.facebook.react.uimanager
 
 /** Marker interface to be extended by all code-generated ViewManagerInterface. */
-public interface ViewManagerWithGeneratedInterface {}
+public interface ViewManagerWithGeneratedInterface

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/FabricEventDispatcher.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/FabricEventDispatcher.kt
@@ -221,7 +221,7 @@ internal class FabricEventDispatcher(
       if (reactContext.isOnUiQueueThread()) {
         maybeDispatchBatchedEvents()
       } else {
-        reactContext.runOnUiQueueThread(Runnable { maybeDispatchBatchedEvents() })
+        reactContext.runOnUiQueueThread { maybeDispatchBatchedEvents() }
       }
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/events/DrawerStateChangedEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/events/DrawerStateChangedEvent.kt
@@ -29,7 +29,7 @@ internal class DrawerStateChangedEvent : Event<DrawerStateChangedEvent> {
 
   override fun getEventName(): String = EVENT_NAME
 
-  protected override fun getEventData(): WritableMap? {
+  protected override fun getEventData(): WritableMap {
     val eventData: WritableMap = Arguments.createMap()
     eventData.putInt("drawerState", getDrawerState())
     return eventData

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/safeareaview/ReactSafeAreaViewShadowNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/safeareaview/ReactSafeAreaViewShadowNode.kt
@@ -10,4 +10,4 @@ package com.facebook.react.views.safeareaview
 import com.facebook.react.common.annotations.internal.LegacyArchitecture
 import com.facebook.react.uimanager.LayoutShadowNode
 
-@LegacyArchitecture internal class ReactSafeAreaViewShadowNode : LayoutShadowNode() {}
+@LegacyArchitecture internal class ReactSafeAreaViewShadowNode : LayoutShadowNode()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
@@ -566,7 +566,7 @@ public object ReactScrollViewHelper {
     }
   }
 
-  public class ReactScrollViewScrollState() {
+  public class ReactScrollViewScrollState {
 
     /** Get the position after current animation is finished */
     public val finalAnimatedPositionScroll: Point = Point()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/DefaultStyleValuesUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/DefaultStyleValuesUtil.kt
@@ -9,7 +9,6 @@ package com.facebook.react.views.text
 
 import android.content.Context
 import android.content.res.ColorStateList
-import androidx.core.content.res.use
 
 /** Utility class that access default values from style */
 public object DefaultStyleValuesUtil {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextViewManager.kt
@@ -86,7 +86,7 @@ internal class PreparedLayoutTextViewManager :
       stateWrapper: StateWrapper
   ): Any? = (stateWrapper as? ReferenceStateWrapper)?.stateDataReference
 
-  override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any>? {
+  override fun getExportedCustomDirectEventTypeConstants(): MutableMap<String, Any> {
     val baseEventTypeConstants = super.getExportedCustomDirectEventTypeConstants()
     val eventTypeConstants = baseEventTypeConstants ?: HashMap()
     eventTypeConstants.put("topTextLayout", mapOf("registrationName" to "onTextLayout"))

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactRawTextManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactRawTextManager.kt
@@ -26,7 +26,7 @@ internal class ReactRawTextManager : ViewManager<View, ReactRawTextShadowNode>()
   public override fun createViewInstance(context: ThemedReactContext): ReactTextView =
       throw IllegalStateException("Attempt to create a native view for RCTRawText")
 
-  override fun prepareToRecycleView(reactContext: ThemedReactContext, view: View): View? =
+  override fun prepareToRecycleView(reactContext: ThemedReactContext, view: View): View =
       throw IllegalStateException("Attempt to recycle a native view for RCTRawText")
 
   override fun updateExtraData(view: View, extraData: Any): Unit = Unit


### PR DESCRIPTION
## Summary:

Follow up from #51061 – Static code analysis detected several redundant constructs across the codebase. Most of the ones fixed here are marked as warnings/weak warnings, likely code smells post-migration from Java.

Doing another small round to clean up some of them.

## Changelog:

[INTERNAL] - Kotlin: Clean up redundant constructs

## Test Plan:

```sh
yarn android
yarn test-android
```