### PR TITLE
Make `SoftAssertions` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1474,13 +1474,6 @@ public final class com/facebook/react/bridge/RuntimeExecutor : com/facebook/jni/
 public final class com/facebook/react/bridge/RuntimeScheduler : com/facebook/jni/HybridClassBase {
 }
 
-public final class com/facebook/react/bridge/SoftAssertions {
-	public static final field INSTANCE Lcom/facebook/react/bridge/SoftAssertions;
-	public static final fun assertCondition (ZLjava/lang/String;)V
-	public static final fun assertNotNull (Ljava/lang/Object;)Ljava/lang/Object;
-	public static final fun assertUnreachable (Ljava/lang/String;)V
-}
-
 public abstract interface class com/facebook/react/bridge/UIManager : com/facebook/react/bridge/PerformanceCounter {
 	public abstract fun addRootView (Landroid/view/View;Lcom/facebook/react/bridge/WritableMap;)I
 	public abstract fun addUIManagerEventListener (Lcom/facebook/react/bridge/UIManagerListener;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/SoftAssertions.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/SoftAssertions.kt
@@ -15,7 +15,7 @@ import com.facebook.react.bridge.ReactSoftExceptionLogger.Categories.SOFT_ASSERT
  * opinion on when these assertions should be used as opposed to assertions that might throw
  * AssertionError Throwables that will cause the app to hard crash.
  */
-public object SoftAssertions {
+internal object SoftAssertions {
 
   /**
    * Throw [AssertionException] with a given message. Use this method surrounded with `if` block
@@ -24,7 +24,7 @@ public object SoftAssertions {
    * throw.
    */
   @JvmStatic
-  public fun assertUnreachable(message: String): Unit {
+  fun assertUnreachable(message: String): Unit {
     ReactSoftExceptionLogger.logSoftException(SOFT_ASSERTIONS, AssertionException(message))
   }
 
@@ -34,7 +34,7 @@ public object SoftAssertions {
    * throw.
    */
   @JvmStatic
-  public fun assertCondition(condition: Boolean, message: String): Unit {
+  fun assertCondition(condition: Boolean, message: String): Unit {
     if (!condition) {
       ReactSoftExceptionLogger.logSoftException(SOFT_ASSERTIONS, AssertionException(message))
     }
@@ -45,7 +45,7 @@ public object SoftAssertions {
    * an assertion with ReactSoftExceptionLogger, which decides whether or not to actually throw.
    */
   @JvmStatic
-  public fun <T> assertNotNull(instance: T?): T? {
+  fun <T> assertNotNull(instance: T?): T? {
     if (instance == null) {
       ReactSoftExceptionLogger.logSoftException(
           SOFT_ASSERTIONS, AssertionException("Expected object to not be null!"))


### PR DESCRIPTION
## Summary:

This class can be internalized as part of the initiative to reduce the public API surface. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.bridge.SoftAssertions).

## Changelog:

[INTERNAL] - Make com.facebook.react.bridge.SoftAssertions internal

## Test Plan:

```bash
yarn test-android
yarn android
```