### PR TITLE
Make `ReactSoftExceptionLogger` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1321,31 +1321,6 @@ public class com/facebook/react/bridge/ReactNoCrashSoftException : java/lang/Run
 	public fun <init> (Ljava/lang/Throwable;)V
 }
 
-public final class com/facebook/react/bridge/ReactSoftExceptionLogger {
-	public static final field INSTANCE Lcom/facebook/react/bridge/ReactSoftExceptionLogger;
-	public static final fun addListener (Lcom/facebook/react/bridge/ReactSoftExceptionLogger$ReactSoftExceptionListener;)V
-	public static final fun clearListeners ()V
-	public static final fun logSoftException (Ljava/lang/String;Ljava/lang/Throwable;)V
-	public static final fun logSoftExceptionVerbose (Ljava/lang/String;Ljava/lang/Throwable;)V
-	public static final fun removeListener (Lcom/facebook/react/bridge/ReactSoftExceptionLogger$ReactSoftExceptionListener;)V
-}
-
-public final class com/facebook/react/bridge/ReactSoftExceptionLogger$Categories {
-	public static final field CLIPPING_PROHIBITED_VIEW Ljava/lang/String;
-	public static final field INSTANCE Lcom/facebook/react/bridge/ReactSoftExceptionLogger$Categories;
-	public static final field RVG_IS_VIEW_CLIPPED Ljava/lang/String;
-	public static final field RVG_ON_VIEW_REMOVED Ljava/lang/String;
-	public static final field SOFT_ASSERTIONS Ljava/lang/String;
-	public static final field SURFACE_MOUNTING_MANAGER_MISSING_VIEWSTATE Ljava/lang/String;
-}
-
-public abstract interface annotation class com/facebook/react/bridge/ReactSoftExceptionLogger$CategoryMode : java/lang/annotation/Annotation {
-}
-
-public abstract interface class com/facebook/react/bridge/ReactSoftExceptionLogger$ReactSoftExceptionListener {
-	public abstract fun logSoftException (Ljava/lang/String;Ljava/lang/Throwable;)V
-}
-
 public abstract interface class com/facebook/react/bridge/ReadableArray {
 	public abstract fun getArray (I)Lcom/facebook/react/bridge/ReadableArray;
 	public abstract fun getBoolean (I)Z

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactSoftExceptionLogger.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactSoftExceptionLogger.kt
@@ -18,7 +18,7 @@ import com.facebook.react.bridge.ReactSoftExceptionLogger.Categories.SURFACE_MOU
 import java.util.concurrent.CopyOnWriteArrayList
 
 @DoNotStrip
-public object ReactSoftExceptionLogger {
+internal object ReactSoftExceptionLogger {
   @Retention(AnnotationRetention.SOURCE)
   @StringDef(
       RVG_IS_VIEW_CLIPPED,
@@ -26,15 +26,15 @@ public object ReactSoftExceptionLogger {
       CLIPPING_PROHIBITED_VIEW,
       SOFT_ASSERTIONS,
       SURFACE_MOUNTING_MANAGER_MISSING_VIEWSTATE)
-  public annotation class CategoryMode
+  annotation class CategoryMode
 
   /** Constants that listeners can utilize for custom category-based behavior. */
-  public object Categories {
-    public const val RVG_IS_VIEW_CLIPPED: String = "ReactViewGroup.isViewClipped"
-    public const val RVG_ON_VIEW_REMOVED: String = "ReactViewGroup.onViewRemoved"
-    public const val CLIPPING_PROHIBITED_VIEW: String = "ReactClippingProhibitedView"
-    public const val SOFT_ASSERTIONS: String = "SoftAssertions"
-    public const val SURFACE_MOUNTING_MANAGER_MISSING_VIEWSTATE: String =
+  object Categories {
+    const val RVG_IS_VIEW_CLIPPED: String = "ReactViewGroup.isViewClipped"
+    const val RVG_ON_VIEW_REMOVED: String = "ReactViewGroup.onViewRemoved"
+    const val CLIPPING_PROHIBITED_VIEW: String = "ReactClippingProhibitedView"
+    const val SOFT_ASSERTIONS: String = "SoftAssertions"
+    const val SURFACE_MOUNTING_MANAGER_MISSING_VIEWSTATE: String =
         "SurfaceMountingManager:MissingViewState"
   }
 
@@ -44,29 +44,29 @@ public object ReactSoftExceptionLogger {
   private val listeners: MutableList<ReactSoftExceptionListener> = CopyOnWriteArrayList()
 
   @JvmStatic
-  public fun addListener(listener: ReactSoftExceptionListener): Unit {
+  fun addListener(listener: ReactSoftExceptionListener): Unit {
     if (!listeners.contains(listener)) {
       listeners.add(listener)
     }
   }
 
   @JvmStatic
-  public fun removeListener(listener: ReactSoftExceptionListener): Unit {
+  fun removeListener(listener: ReactSoftExceptionListener): Unit {
     listeners.remove(listener)
   }
 
   @JvmStatic
-  public fun clearListeners(): Unit {
+  fun clearListeners(): Unit {
     listeners.clear()
   }
 
   @JvmStatic
-  public fun logSoftExceptionVerbose(@CategoryMode category: String, cause: Throwable): Unit {
+  fun logSoftExceptionVerbose(@CategoryMode category: String, cause: Throwable): Unit {
     logSoftException("${category}|${cause.javaClass.simpleName}:${cause.message}", cause)
   }
 
   @JvmStatic
-  public fun logSoftException(@CategoryMode category: String, cause: Throwable): Unit {
+  fun logSoftException(@CategoryMode category: String, cause: Throwable): Unit {
     if (!listeners.isEmpty()) {
       for (listener in listeners) {
         listener.logSoftException(category, cause)
@@ -82,7 +82,7 @@ public object ReactSoftExceptionLogger {
     logSoftException(category, ReactNoCrashSoftException(message))
   }
 
-  public fun interface ReactSoftExceptionListener {
-    public fun logSoftException(category: String, cause: Throwable)
+  fun interface ReactSoftExceptionListener {
+    fun logSoftException(category: String, cause: Throwable)
   }
 }


### PR DESCRIPTION
## Summary:

This class can be internalized as part of the initiative to reduce the public API surface. I've checked there are [no relevant OSS usages](https://github.com/search?type=code&q=NOT+is%3Afork+NOT+org%3Afacebook+NOT+repo%3Areact-native-tvos%2Freact-native-tvos+NOT+repo%3Anuagoz%2Freact-native+NOT+repo%3A2lambda123%2Freact-native+NOT+repo%3Abeanchips%2Ffacebookreactnative+NOT+repo%3AfabOnReact%2Freact-native-notes+NOT+user%3Ahuntie+NOT+user%3Acortinico+NOT+repo%3AMaxdev18%2Fpowersync_app+NOT+repo%3Acarter-0%2Finstagram-decompiled+NOT+repo%3Am0mosenpai%2Finstadamn+NOT+repo%3AA-Star100%2FA-Star100-AUG2-2024+NOT+repo%3Alclnrd%2Fdetox-scrollview-reproductible+NOT+repo%3ADionisisChytiris%2FWorldWiseTrivia_Main+NOT+repo%3Apast3l%2Fhi2+NOT+repo%3AoneDotpy%2FCaribouQuest+NOT+repo%3Abejayoharen%2Fdailytodo+NOT+repo%3Amolangning%2Freversing-discord+NOT+repo%3AScottPrzy%2Freact-native+NOT+repo%3Agabrieldonadel%2Freact-native-visionos+NOT+repo%3AGabriel2308%2FTestes-Soft+NOT+repo%3Adawnzs03%2FflakyBuild+NOT+repo%3Acga2351%2Fcode+NOT+repo%3Astreeg%2Ftcc+NOT+repo%3Asoftware-mansion-labs%2Freact-native-swiftui+NOT+repo%3Apkcsecurity%2Fdecompiled-lightbulb+com.facebook.react.bridge.ReactSoftExceptionLogger).

## Changelog:

[INTERNAL] - Make com.facebook.react.bridge.ReactSoftExceptionLogger internal

## Test Plan:

```bash
yarn test-android
yarn android
```