### PR TITLE
Allow Custom ReactNativeFeatureFlags for Shell 2.0

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1895,6 +1895,7 @@ public final class com/facebook/react/defaults/DefaultNewArchitectureEntryPoint 
 	public static final fun load (ZZ)V
 	public static final fun load (ZZZ)V
 	public static synthetic fun load$default (ZZZILjava/lang/Object;)V
+	public static final fun loadWithFeatureFlags (Lcom/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider;)V
 	public final fun setReleaseLevel (Lcom/facebook/react/common/ReleaseLevel;)V
 }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
@@ -15,6 +15,7 @@ import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsOverrides_RNOSS_Canary_Android
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsOverrides_RNOSS_Experimental_Android
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsProvider
 
 /**
  * A utility class that serves as an entry point for users setup the New Architecture.
@@ -64,6 +65,18 @@ public object DefaultNewArchitectureEntryPoint {
     privateTurboModulesEnabled = turboModulesEnabled
     privateConcurrentReactEnabled = fabricEnabled
     privateBridgelessEnabled = bridgelessEnabled
+
+    DefaultSoLoader.maybeLoadSoLibrary()
+  }
+
+  @JvmStatic
+  public fun loadWithFeatureFlags(featureFlags: ReactNativeFeatureFlagsProvider) {
+    ReactNativeFeatureFlags.override(featureFlags)
+
+    privateFabricEnabled = featureFlags.enableFabricRenderer()
+    privateTurboModulesEnabled = featureFlags.useTurboModules()
+    privateConcurrentReactEnabled = featureFlags.enableFabricRenderer()
+    privateBridgelessEnabled = featureFlags.enableBridgelessArchitecture()
 
     DefaultSoLoader.maybeLoadSoLibrary()
   }


### PR DESCRIPTION
Summary: Introduce DefaultNewArchitectureEntryPoint.loadWithFeatureFlags() to allow custom feature flags while using DefaultNewArchitectureEntryPoint

Differential Revision: D74228467


