### PR TITLE
IntersectionObserver: Clean up shadow nodes after unobserve

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/NativeIntersectionObserver.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/NativeIntersectionObserver.cpp
@@ -37,7 +37,7 @@ void NativeIntersectionObserver::observe(
 
   intersectionObserverManager_.observe(
       intersectionObserverId,
-      shadowNode,
+      shadowNode->getFamilyShared(),
       thresholds,
       rootThresholds,
       uiManager);
@@ -48,7 +48,8 @@ void NativeIntersectionObserver::unobserve(
     IntersectionObserverObserverId intersectionObserverId,
     jsi::Object targetShadowNode) {
   auto shadowNode = shadowNodeFromValue(runtime, std::move(targetShadowNode));
-  intersectionObserverManager_.unobserve(intersectionObserverId, *shadowNode);
+  intersectionObserverManager_.unobserve(
+      intersectionObserverId, shadowNode->getFamilyShared());
 }
 
 void NativeIntersectionObserver::connect(

--- a/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/NativeIntersectionObserver.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/NativeIntersectionObserver.cpp
@@ -21,6 +21,27 @@ NativeIntersectionObserverModuleProvider(
 
 namespace facebook::react {
 
+namespace {
+
+jsi::Object tokenFromShadowNodeFamily(
+    jsi::Runtime& runtime,
+    ShadowNodeFamily::Shared shadowNodeFamily) {
+  jsi::Object obj(runtime);
+  // Need to const_cast since JSI only allows non-const pointees
+  obj.setNativeState(
+      runtime,
+      std::const_pointer_cast<ShadowNodeFamily>(std::move(shadowNodeFamily)));
+  return obj;
+}
+
+ShadowNodeFamily::Shared shadowNodeFamilyFromToken(
+    jsi::Runtime& runtime,
+    jsi::Object token) {
+  return token.getNativeState<ShadowNodeFamily>(runtime);
+}
+
+} // namespace
+
 NativeIntersectionObserver::NativeIntersectionObserver(
     std::shared_ptr<CallInvoker> jsInvoker)
     : NativeIntersectionObserverCxxSpec(std::move(jsInvoker)) {}
@@ -28,19 +49,7 @@ NativeIntersectionObserver::NativeIntersectionObserver(
 void NativeIntersectionObserver::observe(
     jsi::Runtime& runtime,
     NativeIntersectionObserverObserveOptions options) {
-  auto intersectionObserverId = options.intersectionObserverId;
-  auto shadowNode =
-      shadowNodeFromValue(runtime, std::move(options.targetShadowNode));
-  auto thresholds = options.thresholds;
-  auto rootThresholds = options.rootThresholds;
-  auto& uiManager = getUIManagerFromRuntime(runtime);
-
-  intersectionObserverManager_.observe(
-      intersectionObserverId,
-      shadowNode->getFamilyShared(),
-      thresholds,
-      rootThresholds,
-      uiManager);
+  observeV2(runtime, std::move(options));
 }
 
 void NativeIntersectionObserver::unobserve(
@@ -48,8 +57,40 @@ void NativeIntersectionObserver::unobserve(
     IntersectionObserverObserverId intersectionObserverId,
     jsi::Object targetShadowNode) {
   auto shadowNode = shadowNodeFromValue(runtime, std::move(targetShadowNode));
+  auto token =
+      tokenFromShadowNodeFamily(runtime, shadowNode->getFamilyShared());
+  unobserveV2(runtime, intersectionObserverId, std::move(token));
+}
+
+jsi::Object NativeIntersectionObserver::observeV2(
+    jsi::Runtime& runtime,
+    NativeIntersectionObserverObserveOptions options) {
+  auto intersectionObserverId = options.intersectionObserverId;
+  auto shadowNode =
+      shadowNodeFromValue(runtime, std::move(options.targetShadowNode));
+  auto shadowNodeFamily = shadowNode->getFamilyShared();
+  auto thresholds = options.thresholds;
+  auto rootThresholds = options.rootThresholds;
+  auto& uiManager = getUIManagerFromRuntime(runtime);
+
+  intersectionObserverManager_.observe(
+      intersectionObserverId,
+      shadowNodeFamily,
+      thresholds,
+      rootThresholds,
+      uiManager);
+
+  return tokenFromShadowNodeFamily(runtime, shadowNodeFamily);
+}
+
+void NativeIntersectionObserver::unobserveV2(
+    jsi::Runtime& runtime,
+    IntersectionObserverObserverId intersectionObserverId,
+    jsi::Object targetToken) {
+  auto shadowNodeFamily =
+      shadowNodeFamilyFromToken(runtime, std::move(targetToken));
   intersectionObserverManager_.unobserve(
-      intersectionObserverId, shadowNode->getFamilyShared());
+      intersectionObserverId, shadowNodeFamily);
 }
 
 void NativeIntersectionObserver::connect(

--- a/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/NativeIntersectionObserver.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/NativeIntersectionObserver.h
@@ -61,14 +61,27 @@ class NativeIntersectionObserver
  public:
   NativeIntersectionObserver(std::shared_ptr<CallInvoker> jsInvoker);
 
+  // TODO(T223605846): Remove legacy observe method
+  [[deprecated("Please use observeV2")]]
   void observe(
       jsi::Runtime& runtime,
       NativeIntersectionObserverObserveOptions options);
 
+  // TODO(T223605846): Remove legacy unobserve method
+  [[deprecated("Please use unobserveV2")]]
   void unobserve(
       jsi::Runtime& runtime,
       IntersectionObserverObserverId intersectionObserverId,
       jsi::Object targetShadowNode);
+
+  jsi::Object observeV2(
+      jsi::Runtime& runtime,
+      NativeIntersectionObserverObserveOptions options);
+
+  void unobserveV2(
+      jsi::Runtime& runtime,
+      IntersectionObserverObserverId intersectionObserverId,
+      jsi::Object targetToken);
 
   void connect(
       jsi::Runtime& runtime,

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFamily.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFamily.h
@@ -39,7 +39,7 @@ struct ShadowNodeFamilyFragment {
  * Represents all things that shadow nodes from the same family have in common.
  * To be used inside `ShadowNode` class *only*.
  */
-class ShadowNodeFamily final {
+class ShadowNodeFamily final : public jsi::NativeState {
  public:
   using Shared = std::shared_ptr<const ShadowNodeFamily>;
   using Weak = std::weak_ptr<const ShadowNodeFamily>;

--- a/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserverManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserverManager.h
@@ -22,14 +22,14 @@ class IntersectionObserverManager final : public UIManagerMountHook {
 
   void observe(
       IntersectionObserverObserverId intersectionObserverId,
-      const ShadowNode::Shared& shadowNode,
+      const ShadowNodeFamily::Shared& shadowNode,
       std::vector<Float> thresholds,
       std::optional<std::vector<Float>> rootThresholds,
       const UIManager& uiManager);
 
   void unobserve(
       IntersectionObserverObserverId intersectionObserverId,
-      const ShadowNode& shadowNode);
+      const ShadowNodeFamily::Shared& shadowNode);
 
   void connect(
       UIManager& uiManager,

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -663,6 +663,16 @@ const definitions: FeatureFlagDefinitions = {
       },
       ossReleaseStage: 'none',
     },
+    utilizeTokensInIntersectionObserver: {
+      defaultValue: true,
+      metadata: {
+        dateAdded: '2025-05-06',
+        description: 'Use tokens in IntersectionObserver vs ShadowNode.',
+        expectedReleaseValue: true,
+        purpose: 'experimentation',
+      },
+      ossReleaseStage: 'none',
+    },
   },
 };
 

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<6667fc8e4fdd2db0b54c908155b110cf>>
+ * @generated SignedSource<<17fa5e03fe52ed129cf731bba6e9869c>>
  * @flow strict
  */
 
@@ -39,6 +39,7 @@ export type ReactNativeFeatureFlagsJsOnly = $ReadOnly<{
   shouldUseAnimatedObjectForTransform: Getter<boolean>,
   shouldUseRemoveClippedSubviewsAsDefaultOnIOS: Getter<boolean>,
   shouldUseSetNativePropsInFabric: Getter<boolean>,
+  utilizeTokensInIntersectionObserver: Getter<boolean>,
 }>;
 
 export type ReactNativeFeatureFlagsJsOnlyOverrides = OverridesFor<ReactNativeFeatureFlagsJsOnly>;
@@ -154,6 +155,11 @@ export const shouldUseRemoveClippedSubviewsAsDefaultOnIOS: Getter<boolean> = cre
  * Enables use of setNativeProps in JS driven animations.
  */
 export const shouldUseSetNativePropsInFabric: Getter<boolean> = createJavaScriptFlagGetter('shouldUseSetNativePropsInFabric', true);
+
+/**
+ * Use tokens in IntersectionObserver vs ShadowNode.
+ */
+export const utilizeTokensInIntersectionObserver: Getter<boolean> = createJavaScriptFlagGetter('utilizeTokensInIntersectionObserver', true);
 
 /**
  * Common flag for testing. Do NOT modify.

--- a/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-itest.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-itest.js
@@ -7,6 +7,7 @@
  * @flow strict-local
  * @format
  * @oncall react_native
+ * @fantom_flags utilizeTokensInIntersectionObserver:true
  */
 
 import 'react-native/Libraries/Core/InitializeCore';
@@ -844,8 +845,7 @@ describe('IntersectionObserver', () => {
       });
     });
 
-    // TODO (T223234714): Fix memory leak and enable this test.
-    it.skip('should not retain initial children of observed targets', () => {
+    it('should not retain initial children of observed targets', () => {
       const root = Fantom.createRoot();
       observer = new IntersectionObserver(() => {});
 

--- a/packages/react-native/src/private/webapis/intersectionobserver/internals/IntersectionObserverManager.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/internals/IntersectionObserverManager.js
@@ -232,6 +232,7 @@ export function unobserve(
       );
       return;
     }
+    targetToShadowNodeMap.delete(target);
 
     NativeIntersectionObserver.unobserve(
       intersectionObserverId,
@@ -245,6 +246,7 @@ export function unobserve(
       );
       return;
     }
+    targetToTokenMap.delete(target);
 
     modernNativeIntersectionObserver.unobserve(
       intersectionObserverId,

--- a/packages/react-native/src/private/webapis/intersectionobserver/specs/NativeIntersectionObserver.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/specs/NativeIntersectionObserver.js
@@ -30,9 +30,20 @@ export type NativeIntersectionObserverObserveOptions = {
   rootThresholds?: ?$ReadOnlyArray<number>,
 };
 
+export type NativeIntersectionObserverToken = mixed;
+
 export interface Spec extends TurboModule {
+  // TODO(T223605846): Remove legacy observe method
   +observe: (options: NativeIntersectionObserverObserveOptions) => void;
+  // TODO(T223605846): Remove legacy unobserve method
   +unobserve: (intersectionObserverId: number, targetShadowNode: mixed) => void;
+  +observeV2?: (
+    options: NativeIntersectionObserverObserveOptions,
+  ) => NativeIntersectionObserverToken;
+  +unobserveV2?: (
+    intersectionObserverId: number,
+    token: NativeIntersectionObserverToken,
+  ) => void;
   +connect: (notifyIntersectionObserversCallback: () => void) => void;
   +disconnect: () => void;
   +takeRecords: () => $ReadOnlyArray<NativeIntersectionObserverEntry>;


### PR DESCRIPTION
Summary:
After unobserve is called, the shadow node actually isn't deleted from the `targetToShadowNode` WeakMap. So, if the element is kept around, the shadow node will leak.

We suspect this doesn't happen in practice. But, still it's good to just do this cleanup, just in case.

Changelog: [General][Fixed] Fix potential leak inside IntersectionObserver

Reviewed By: lunaleaps, yungsters

Differential Revision: D74361644


