### PR TITLE
Fix TextLayoutManager MeasureMode Regression

### DIFF
--- a/packages/react-native-codegen/src/generators/components/GenerateStateH.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateStateH.js
@@ -33,7 +33,7 @@ const FileTemplate = ({
  */
 #pragma once
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
 #endif
 
@@ -50,7 +50,7 @@ class ${stateName}State {
 public:
   ${stateName}State() = default;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   ${stateName}State(${stateName}State const &previousState, folly::dynamic data){};
   folly::dynamic getDynamic() const {
     return {};

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateStateH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateStateH-test.js.snap
@@ -12,7 +12,7 @@ Map {
  */
 #pragma once
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
 #endif
 
@@ -22,7 +22,7 @@ class ArrayPropsNativeComponentState {
 public:
   ArrayPropsNativeComponentState() = default;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   ArrayPropsNativeComponentState(ArrayPropsNativeComponentState const &previousState, folly::dynamic data){};
   folly::dynamic getDynamic() const {
     return {};
@@ -46,7 +46,7 @@ Map {
  */
 #pragma once
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
 #endif
 
@@ -56,7 +56,7 @@ class ArrayPropsNativeComponentState {
 public:
   ArrayPropsNativeComponentState() = default;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   ArrayPropsNativeComponentState(ArrayPropsNativeComponentState const &previousState, folly::dynamic data){};
   folly::dynamic getDynamic() const {
     return {};
@@ -80,7 +80,7 @@ Map {
  */
 #pragma once
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
 #endif
 
@@ -90,7 +90,7 @@ class BooleanPropNativeComponentState {
 public:
   BooleanPropNativeComponentState() = default;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   BooleanPropNativeComponentState(BooleanPropNativeComponentState const &previousState, folly::dynamic data){};
   folly::dynamic getDynamic() const {
     return {};
@@ -114,7 +114,7 @@ Map {
  */
 #pragma once
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
 #endif
 
@@ -124,7 +124,7 @@ class ColorPropNativeComponentState {
 public:
   ColorPropNativeComponentState() = default;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   ColorPropNativeComponentState(ColorPropNativeComponentState const &previousState, folly::dynamic data){};
   folly::dynamic getDynamic() const {
     return {};
@@ -148,7 +148,7 @@ Map {
  */
 #pragma once
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
 #endif
 
@@ -158,7 +158,7 @@ class CommandNativeComponentState {
 public:
   CommandNativeComponentState() = default;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   CommandNativeComponentState(CommandNativeComponentState const &previousState, folly::dynamic data){};
   folly::dynamic getDynamic() const {
     return {};
@@ -182,7 +182,7 @@ Map {
  */
 #pragma once
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
 #endif
 
@@ -192,7 +192,7 @@ class CommandNativeComponentState {
 public:
   CommandNativeComponentState() = default;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   CommandNativeComponentState(CommandNativeComponentState const &previousState, folly::dynamic data){};
   folly::dynamic getDynamic() const {
     return {};
@@ -216,7 +216,7 @@ Map {
  */
 #pragma once
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
 #endif
 
@@ -226,7 +226,7 @@ class DimensionPropNativeComponentState {
 public:
   DimensionPropNativeComponentState() = default;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   DimensionPropNativeComponentState(DimensionPropNativeComponentState const &previousState, folly::dynamic data){};
   folly::dynamic getDynamic() const {
     return {};
@@ -250,7 +250,7 @@ Map {
  */
 #pragma once
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
 #endif
 
@@ -260,7 +260,7 @@ class DoublePropNativeComponentState {
 public:
   DoublePropNativeComponentState() = default;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   DoublePropNativeComponentState(DoublePropNativeComponentState const &previousState, folly::dynamic data){};
   folly::dynamic getDynamic() const {
     return {};
@@ -284,7 +284,7 @@ Map {
  */
 #pragma once
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
 #endif
 
@@ -294,7 +294,7 @@ class EventsNestedObjectNativeComponentState {
 public:
   EventsNestedObjectNativeComponentState() = default;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   EventsNestedObjectNativeComponentState(EventsNestedObjectNativeComponentState const &previousState, folly::dynamic data){};
   folly::dynamic getDynamic() const {
     return {};
@@ -318,7 +318,7 @@ Map {
  */
 #pragma once
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
 #endif
 
@@ -328,7 +328,7 @@ class EventsNativeComponentState {
 public:
   EventsNativeComponentState() = default;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   EventsNativeComponentState(EventsNativeComponentState const &previousState, folly::dynamic data){};
   folly::dynamic getDynamic() const {
     return {};
@@ -352,7 +352,7 @@ Map {
  */
 #pragma once
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
 #endif
 
@@ -376,7 +376,7 @@ Map {
  */
 #pragma once
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
 #endif
 
@@ -386,7 +386,7 @@ class ExcludedAndroidComponentState {
 public:
   ExcludedAndroidComponentState() = default;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   ExcludedAndroidComponentState(ExcludedAndroidComponentState const &previousState, folly::dynamic data){};
   folly::dynamic getDynamic() const {
     return {};
@@ -410,7 +410,7 @@ Map {
  */
 #pragma once
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
 #endif
 
@@ -420,7 +420,7 @@ class ExcludedAndroidIosComponentState {
 public:
   ExcludedAndroidIosComponentState() = default;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   ExcludedAndroidIosComponentState(ExcludedAndroidIosComponentState const &previousState, folly::dynamic data){};
   folly::dynamic getDynamic() const {
     return {};
@@ -444,7 +444,7 @@ Map {
  */
 #pragma once
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
 #endif
 
@@ -454,7 +454,7 @@ class ExcludedIosComponentState {
 public:
   ExcludedIosComponentState() = default;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   ExcludedIosComponentState(ExcludedIosComponentState const &previousState, folly::dynamic data){};
   folly::dynamic getDynamic() const {
     return {};
@@ -466,7 +466,7 @@ class MultiFileIncludedNativeComponentState {
 public:
   MultiFileIncludedNativeComponentState() = default;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   MultiFileIncludedNativeComponentState(MultiFileIncludedNativeComponentState const &previousState, folly::dynamic data){};
   folly::dynamic getDynamic() const {
     return {};
@@ -490,7 +490,7 @@ Map {
  */
 #pragma once
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
 #endif
 
@@ -500,7 +500,7 @@ class FloatPropNativeComponentState {
 public:
   FloatPropNativeComponentState() = default;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   FloatPropNativeComponentState(FloatPropNativeComponentState const &previousState, folly::dynamic data){};
   folly::dynamic getDynamic() const {
     return {};
@@ -524,7 +524,7 @@ Map {
  */
 #pragma once
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
 #endif
 
@@ -534,7 +534,7 @@ class ImagePropNativeComponentState {
 public:
   ImagePropNativeComponentState() = default;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   ImagePropNativeComponentState(ImagePropNativeComponentState const &previousState, folly::dynamic data){};
   folly::dynamic getDynamic() const {
     return {};
@@ -558,7 +558,7 @@ Map {
  */
 #pragma once
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
 #endif
 
@@ -568,7 +568,7 @@ class InsetsPropNativeComponentState {
 public:
   InsetsPropNativeComponentState() = default;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   InsetsPropNativeComponentState(InsetsPropNativeComponentState const &previousState, folly::dynamic data){};
   folly::dynamic getDynamic() const {
     return {};
@@ -592,7 +592,7 @@ Map {
  */
 #pragma once
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
 #endif
 
@@ -602,7 +602,7 @@ class Int32EnumPropsNativeComponentState {
 public:
   Int32EnumPropsNativeComponentState() = default;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   Int32EnumPropsNativeComponentState(Int32EnumPropsNativeComponentState const &previousState, folly::dynamic data){};
   folly::dynamic getDynamic() const {
     return {};
@@ -626,7 +626,7 @@ Map {
  */
 #pragma once
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
 #endif
 
@@ -636,7 +636,7 @@ class IntegerPropNativeComponentState {
 public:
   IntegerPropNativeComponentState() = default;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   IntegerPropNativeComponentState(IntegerPropNativeComponentState const &previousState, folly::dynamic data){};
   folly::dynamic getDynamic() const {
     return {};
@@ -660,7 +660,7 @@ Map {
  */
 #pragma once
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
 #endif
 
@@ -684,7 +684,7 @@ Map {
  */
 #pragma once
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
 #endif
 
@@ -694,7 +694,7 @@ class MixedPropNativeComponentState {
 public:
   MixedPropNativeComponentState() = default;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   MixedPropNativeComponentState(MixedPropNativeComponentState const &previousState, folly::dynamic data){};
   folly::dynamic getDynamic() const {
     return {};
@@ -718,7 +718,7 @@ Map {
  */
 #pragma once
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
 #endif
 
@@ -728,7 +728,7 @@ class ImageColorPropNativeComponentState {
 public:
   ImageColorPropNativeComponentState() = default;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   ImageColorPropNativeComponentState(ImageColorPropNativeComponentState const &previousState, folly::dynamic data){};
   folly::dynamic getDynamic() const {
     return {};
@@ -752,7 +752,7 @@ Map {
  */
 #pragma once
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
 #endif
 
@@ -762,7 +762,7 @@ class NoPropsNoEventsComponentState {
 public:
   NoPropsNoEventsComponentState() = default;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   NoPropsNoEventsComponentState(NoPropsNoEventsComponentState const &previousState, folly::dynamic data){};
   folly::dynamic getDynamic() const {
     return {};
@@ -786,7 +786,7 @@ Map {
  */
 #pragma once
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
 #endif
 
@@ -796,7 +796,7 @@ class ObjectPropsState {
 public:
   ObjectPropsState() = default;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   ObjectPropsState(ObjectPropsState const &previousState, folly::dynamic data){};
   folly::dynamic getDynamic() const {
     return {};
@@ -820,7 +820,7 @@ Map {
  */
 #pragma once
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
 #endif
 
@@ -830,7 +830,7 @@ class PointPropNativeComponentState {
 public:
   PointPropNativeComponentState() = default;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   PointPropNativeComponentState(PointPropNativeComponentState const &previousState, folly::dynamic data){};
   folly::dynamic getDynamic() const {
     return {};
@@ -854,7 +854,7 @@ Map {
  */
 #pragma once
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
 #endif
 
@@ -864,7 +864,7 @@ class StringEnumPropsNativeComponentState {
 public:
   StringEnumPropsNativeComponentState() = default;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   StringEnumPropsNativeComponentState(StringEnumPropsNativeComponentState const &previousState, folly::dynamic data){};
   folly::dynamic getDynamic() const {
     return {};
@@ -888,7 +888,7 @@ Map {
  */
 #pragma once
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
 #endif
 
@@ -898,7 +898,7 @@ class StringPropComponentState {
 public:
   StringPropComponentState() = default;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   StringPropComponentState(StringPropComponentState const &previousState, folly::dynamic data){};
   folly::dynamic getDynamic() const {
     return {};
@@ -922,7 +922,7 @@ Map {
  */
 #pragma once
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
 #endif
 
@@ -932,7 +932,7 @@ class MultiFile1NativeComponentState {
 public:
   MultiFile1NativeComponentState() = default;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   MultiFile1NativeComponentState(MultiFile1NativeComponentState const &previousState, folly::dynamic data){};
   folly::dynamic getDynamic() const {
     return {};
@@ -944,7 +944,7 @@ class MultiFile2NativeComponentState {
 public:
   MultiFile2NativeComponentState() = default;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   MultiFile2NativeComponentState(MultiFile2NativeComponentState const &previousState, folly::dynamic data){};
   folly::dynamic getDynamic() const {
     return {};
@@ -968,7 +968,7 @@ Map {
  */
 #pragma once
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
 #endif
 
@@ -978,7 +978,7 @@ class MultiComponent1NativeComponentState {
 public:
   MultiComponent1NativeComponentState() = default;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   MultiComponent1NativeComponentState(MultiComponent1NativeComponentState const &previousState, folly::dynamic data){};
   folly::dynamic getDynamic() const {
     return {};
@@ -990,7 +990,7 @@ class MultiComponent2NativeComponentState {
 public:
   MultiComponent2NativeComponentState() = default;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   MultiComponent2NativeComponentState(MultiComponent2NativeComponentState const &previousState, folly::dynamic data){};
   folly::dynamic getDynamic() const {
     return {};

--- a/packages/react-native-popup-menu-android/android/src/main/jni/react/renderer/components/ReactPopupMenuAndroidSpecs/States.h
+++ b/packages/react-native-popup-menu-android/android/src/main/jni/react/renderer/components/ReactPopupMenuAndroidSpecs/States.h
@@ -8,7 +8,7 @@
  */
 #pragma once
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
 #include <react/renderer/mapbuffer/MapBuffer.h>
 #include <react/renderer/mapbuffer/MapBufferBuilder.h>
@@ -20,7 +20,7 @@ class AndroidPopupMenuState {
 public:
   AndroidPopupMenuState() = default;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   AndroidPopupMenuState(AndroidPopupMenuState const &previousState, folly::dynamic data){};
   folly::dynamic getDynamic() const {
     return {};

--- a/packages/react-native-test-library/android/src/main/jni/react/renderer/components/OSSLibraryExampleSpec/States.h
+++ b/packages/react-native-test-library/android/src/main/jni/react/renderer/components/OSSLibraryExampleSpec/States.h
@@ -8,7 +8,7 @@
  */
 #pragma once
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
 #endif
 
@@ -18,7 +18,7 @@ class SampleNativeComponentState {
 public:
   SampleNativeComponentState() = default;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   SampleNativeComponentState(SampleNativeComponentState const &previousState, folly::dynamic data){};
   folly::dynamic getDynamic() const {
     return {};

--- a/packages/react-native-test-library/ios/OSSLibraryExampleSpec/States.h
+++ b/packages/react-native-test-library/ios/OSSLibraryExampleSpec/States.h
@@ -8,7 +8,7 @@
  */
 #pragma once
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
 #endif
 
@@ -18,7 +18,7 @@ class SampleNativeComponentState {
 public:
   SampleNativeComponentState() = default;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   SampleNativeComponentState(SampleNativeComponentState const &previousState, folly::dynamic data){};
   folly::dynamic getDynamic() const {
     return {};

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2370,14 +2370,12 @@ public class com/facebook/react/fabric/FabricUIManager : com/facebook/react/brid
 	public fun initialize ()V
 	public fun invalidate ()V
 	public fun markActiveTouchForTag (II)V
-	public fun measurePreparedLayout (Lcom/facebook/react/views/text/PreparedLayout;FFFF)[F
 	public fun onAllAnimationsComplete ()V
 	public fun onAnimationStarted ()V
 	public fun onHostDestroy ()V
 	public fun onHostPause ()V
 	public fun onHostResume ()V
 	public fun onRequestEventBeat ()V
-	public fun prepareLayout (ILcom/facebook/react/common/mapbuffer/ReadableMapBuffer;Lcom/facebook/react/common/mapbuffer/ReadableMapBuffer;FF)Lcom/facebook/react/views/text/PreparedLayout;
 	public fun prependUIBlock (Lcom/facebook/react/fabric/interop/UIBlock;)V
 	public fun profileNextBatch ()V
 	public fun receiveEvent (IILjava/lang/String;Lcom/facebook/react/bridge/WritableMap;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -654,11 +654,14 @@ public class FabricUIManager
 
   @AnyThread
   @ThreadConfined(ANY)
+  @UnstableReactNativeAPI
   public PreparedLayout prepareLayout(
       int surfaceId,
       ReadableMapBuffer attributedString,
       ReadableMapBuffer paragraphAttributes,
+      float minWidth,
       float maxWidth,
+      float minHeight,
       float maxHeight) {
     SurfaceMountingManager surfaceMountingManager =
         mMountingManager.getSurfaceManagerEnforced(surfaceId, "prepareLayout");
@@ -667,8 +670,9 @@ public class FabricUIManager
             Preconditions.checkNotNull(surfaceMountingManager.getContext()),
             attributedString,
             paragraphAttributes,
-            PixelUtil.toPixelFromDIP(maxWidth),
-            PixelUtil.toPixelFromDIP(maxHeight),
+            getYogaSize(minWidth, maxWidth),
+            getYogaMeasureMode(minWidth, maxWidth),
+            getYogaSize(minHeight, maxHeight),
             null /* T219881133: Migrate away from ReactTextViewManagerCallback */);
 
     int maximumNumberOfLines =
@@ -681,6 +685,7 @@ public class FabricUIManager
 
   @AnyThread
   @ThreadConfined(ANY)
+  @UnstableReactNativeAPI
   public float[] measurePreparedLayout(
       PreparedLayout preparedLayout,
       float minWidth,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/shell/MainReactPackage.kt
@@ -55,6 +55,7 @@ import com.facebook.react.views.scroll.ReactHorizontalScrollViewManager
 import com.facebook.react.views.scroll.ReactScrollViewManager
 import com.facebook.react.views.swiperefresh.SwipeRefreshLayoutManager
 import com.facebook.react.views.switchview.ReactSwitchManager
+import com.facebook.react.views.text.PreparedLayoutTextViewManager
 import com.facebook.react.views.text.ReactRawTextManager
 import com.facebook.react.views.text.ReactTextViewManager
 import com.facebook.react.views.text.ReactVirtualTextViewManager
@@ -148,7 +149,8 @@ constructor(private val config: MainPackageConfig? = null) :
           ReactModalHostManager(),
           ReactRawTextManager(),
           ReactTextInputManager(),
-          ReactTextViewManager(),
+          if (ReactNativeFeatureFlags.enablePreparedTextLayout()) PreparedLayoutTextViewManager()
+          else ReactTextViewManager(),
           ReactViewManager(),
           ReactVirtualTextViewManager(),
           ReactUnimplementedViewManager())
@@ -183,7 +185,12 @@ constructor(private val config: MainPackageConfig? = null) :
           ReactRawTextManager.REACT_CLASS to ModuleSpec.viewManagerSpec { ReactRawTextManager() },
           ReactTextInputManager.REACT_CLASS to
               ModuleSpec.viewManagerSpec { ReactTextInputManager() },
-          ReactTextViewManager.REACT_CLASS to ModuleSpec.viewManagerSpec { ReactTextViewManager() },
+          ReactTextViewManager.REACT_CLASS to
+              ModuleSpec.viewManagerSpec {
+                if (ReactNativeFeatureFlags.enablePreparedTextLayout())
+                    PreparedLayoutTextViewManager()
+                else ReactTextViewManager()
+              },
           ReactViewManager.REACT_CLASS to ModuleSpec.viewManagerSpec { ReactViewManager() },
           ReactVirtualTextViewManager.REACT_CLASS to
               ModuleSpec.viewManagerSpec { ReactVirtualTextViewManager() },

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextViewManager.kt
@@ -7,7 +7,6 @@
 
 package com.facebook.react.views.text
 
-import android.text.Layout
 import android.text.Spanned
 import android.view.View
 import com.facebook.react.R
@@ -63,7 +62,7 @@ internal class PreparedLayoutTextViewManager :
 
   override fun updateExtraData(view: PreparedLayoutTextView, extraData: Any) {
     SystraceSection("PreparedLayoutTextViewManager.updateExtraData").use { _ ->
-      val layout = extraData as Layout
+      val layout = (extraData as PreparedLayout).layout
       view.layout = layout
 
       // If this text view contains any clickable spans, set a view tag and reset the accessibility

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
@@ -52,7 +52,6 @@ import com.facebook.react.views.text.internal.span.ReactUnderlineSpan;
 import com.facebook.react.views.text.internal.span.SetSpanOperation;
 import com.facebook.react.views.text.internal.span.ShadowStyleSpan;
 import com.facebook.react.views.text.internal.span.TextInlineViewPlaceholderSpan;
-import com.facebook.yoga.YogaConstants;
 import com.facebook.yoga.YogaMeasureMode;
 import com.facebook.yoga.YogaMeasureOutput;
 import java.util.ArrayList;
@@ -390,8 +389,7 @@ public class TextLayoutManager {
     boolean isScriptRTL = TextDirectionHeuristics.FIRSTSTRONG_LTR.isRtl(text, 0, spanLength);
 
     if (boring == null
-        && (unconstrainedWidth
-            || (!YogaConstants.isUndefined(desiredWidth) && desiredWidth <= width))) {
+        && (unconstrainedWidth || (!Float.isNaN(desiredWidth) && desiredWidth <= width))) {
       // Is used when the width is not known and the text is not boring, ie. if it contains
       // unicode characters.
 
@@ -510,6 +508,7 @@ public class TextLayoutManager {
       MapBuffer attributedString,
       MapBuffer paragraphAttributes,
       float width,
+      YogaMeasureMode widthYogaMeasureMode,
       float height,
       @Nullable ReactTextViewManagerCallback reactTextViewManagerCallback) {
     Spannable text =
@@ -582,7 +581,7 @@ public class TextLayoutManager {
         text,
         boring,
         width,
-        YogaMeasureMode.EXACTLY,
+        widthYogaMeasureMode,
         includeFontPadding,
         textBreakStrategy,
         hyphenationFrequency,
@@ -696,6 +695,7 @@ public class TextLayoutManager {
             attributedString,
             paragraphAttributes,
             width,
+            widthYogaMeasureMode,
             height,
             reactTextViewManagerCallback);
 
@@ -961,7 +961,14 @@ public class TextLayoutManager {
       float width,
       float height) {
     Layout layout =
-        createLayout(context, attributedString, paragraphAttributes, width, height, null);
+        createLayout(
+            context,
+            attributedString,
+            paragraphAttributes,
+            width,
+            YogaMeasureMode.EXACTLY,
+            height,
+            null);
     return FontMetricsUtil.getFontMetrics(
         layout.getText(), layout, Preconditions.checkNotNull(sTextPaintInstance.get()), context);
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
@@ -825,7 +825,7 @@ public class TextLayoutManager {
     // where the container is measured smaller than text. Math.ceil prevents it
     // See T136756103 for investigation
     if (android.os.Build.VERSION.SDK_INT > Build.VERSION_CODES.Q) {
-      calculatedWidth = (float) Math.ceil(calculatedWidth);
+      calculatedWidth = Math.min((float) Math.ceil(calculatedWidth), width);
     }
     return calculatedWidth;
   }

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
@@ -24,7 +24,7 @@
 #include <cmath>
 #include <unordered_map>
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <react/renderer/mapbuffer/MapBuffer.h>
 #include <react/renderer/mapbuffer/MapBufferBuilder.h>
 #endif
@@ -1003,7 +1003,7 @@ inline std::string toString(const AttributedString::Range& range) {
       ", length: " + std::to_string(range.length) + "}";
 }
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 
 // constants for AttributedString serialization
 constexpr static MapBuffer::Key AS_KEY_HASH = 0;

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewState.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewState.cpp
@@ -9,7 +9,7 @@
 
 namespace facebook::react {
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 folly::dynamic ModalHostViewState::getDynamic() const {
   return folly::dynamic::object("screenWidth", screenSize.width)(
       "screenHeight", screenSize.height);

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewState.h
@@ -10,7 +10,7 @@
 #include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/graphics/Float.h>
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
 #endif
 
@@ -35,7 +35,7 @@ class ModalHostViewState final {
   };
   ModalHostViewState(Size screenSize_) : screenSize(screenSize_){};
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   ModalHostViewState(
       const ModalHostViewState& previousState,
       folly::dynamic data)
@@ -46,7 +46,7 @@ class ModalHostViewState final {
 
   const Size screenSize{};
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   folly::dynamic getDynamic() const;
 #endif
 

--- a/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/conversions.h
@@ -13,7 +13,7 @@
 
 namespace facebook::react {
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 inline folly::dynamic toDynamic(const AndroidProgressBarProps& props) {
   folly::dynamic serializedProps = folly::dynamic::object();
   serializedProps["styleAttr"] = props.styleAttr;

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/ScrollViewState.h
@@ -12,7 +12,7 @@
 #include <react/renderer/graphics/Rect.h>
 #include <react/renderer/graphics/Size.h>
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
 #endif
 
@@ -38,7 +38,7 @@ class ScrollViewState final {
    */
   Size getContentSize() const;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   ScrollViewState(const ScrollViewState& previousState, folly::dynamic data)
       : contentOffset(
             {(Float)data["contentOffsetLeft"].getDouble(),

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.h
@@ -108,7 +108,22 @@ class ParagraphShadowNode final : public ConcreteViewShadowNode<
    * Creates a `State` object (with `AttributedText` and
    * `TextLayoutManager`) if needed.
    */
+  template <typename ParagraphStateT>
+  void updateStateIfNeeded(
+      const Content& content,
+      const MeasuredPreparedLayout& layout);
+
+  /*
+   * Creates a `State` object (with `AttributedText` and
+   * `TextLayoutManager`) if needed.
+   */
   void updateStateIfNeeded(const Content& content);
+
+  /**
+   * Returns any previously prepared layout, generated for measurement, which
+   * may be used, given the currently assigned layout to the ShadowNode
+   */
+  MeasuredPreparedLayout* findUsableLayout();
 
   std::shared_ptr<const TextLayoutManager> textLayoutManager_;
 
@@ -121,13 +136,7 @@ class ParagraphShadowNode final : public ConcreteViewShadowNode<
    * Intermediate layout results generated during measurement, that may be
    * reused by the platform.
    */
-  struct PreparedLayoutResult {
-    LayoutConstraints layoutConstraints;
-    Size measureSize;
-    TextLayoutManagerExtended::PreparedLayout preparedLayout{};
-  };
-
-  mutable std::vector<PreparedLayoutResult> preparedLayouts_;
+  mutable std::vector<MeasuredPreparedLayout> measuredLayouts_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/conversions.h
@@ -10,14 +10,14 @@
 #include <folly/dynamic.h>
 #include <react/renderer/attributedstring/conversions.h>
 #include <react/renderer/components/text/ParagraphState.h>
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <react/renderer/mapbuffer/MapBuffer.h>
 #include <react/renderer/mapbuffer/MapBufferBuilder.h>
 #endif
 
 namespace facebook::react {
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 inline MapBuffer toMapBuffer(const ParagraphState& paragraphState) {
   auto builder = MapBufferBuilder();
   auto attStringMapBuffer = toMapBuffer(paragraphState.attributedString);

--- a/packages/react-native/ReactCommon/react/renderer/components/text/platform/android/react/renderer/components/text/ParagraphState.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/platform/android/react/renderer/components/text/ParagraphState.cpp
@@ -8,9 +8,13 @@
 #include "ParagraphState.h"
 
 #include <react/renderer/components/text/conversions.h>
+#include <react/renderer/core/ConcreteState.h>
 #include <react/renderer/debug/debugStringConvertibleUtils.h>
 
 namespace facebook::react {
+
+static_assert(StateDataWithMapBuffer<ParagraphState>);
+static_assert(StateDataWithJNIReference<ParagraphState>);
 
 folly::dynamic ParagraphState::getDynamic() const {
   LOG(FATAL) << "ParagraphState may only be serialized to MapBuffer";
@@ -18,6 +22,10 @@ folly::dynamic ParagraphState::getDynamic() const {
 
 MapBuffer ParagraphState::getMapBuffer() const {
   return toMapBuffer(*this);
+}
+
+jni::local_ref<jobject> ParagraphState::getJNIReference() const {
+  return jni::make_local(measuredLayout.preparedLayout.get());
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/platform/android/react/renderer/components/text/ParagraphState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/platform/android/react/renderer/components/text/ParagraphState.h
@@ -11,6 +11,7 @@
 #include <react/renderer/attributedstring/AttributedString.h>
 #include <react/renderer/attributedstring/ParagraphAttributes.h>
 #include <react/renderer/textlayoutmanager/TextLayoutManager.h>
+#include <react/renderer/textlayoutmanager/TextLayoutManagerExtended.h>
 
 #include <fbjni/fbjni.h>
 #include <folly/dynamic.h>
@@ -51,13 +52,31 @@ class ParagraphState final {
    */
   std::weak_ptr<const TextLayoutManager> layoutManager;
 
+  /**
+   * A fully prepared representation of a text layout to mount
+   */
+  MeasuredPreparedLayout measuredLayout;
+
   ParagraphState(
       AttributedString attributedString,
       ParagraphAttributes paragraphAttributes,
-      const std::weak_ptr<const TextLayoutManager>& layoutManager)
+      std::weak_ptr<const TextLayoutManager> layoutManager,
+      MeasuredPreparedLayout measuredLayout)
       : attributedString(std::move(attributedString)),
         paragraphAttributes(std::move(paragraphAttributes)),
-        layoutManager(layoutManager) {}
+        layoutManager(std::move(layoutManager)),
+        measuredLayout(std::move(measuredLayout)) {}
+
+  ParagraphState(
+      AttributedString attributedString,
+      ParagraphAttributes paragraphAttributes,
+      std::weak_ptr<const TextLayoutManager> layoutManager)
+      : ParagraphState(
+            std::move(attributedString),
+            std::move(paragraphAttributes),
+            std::move(layoutManager),
+            {}) {}
+
   ParagraphState() = default;
   ParagraphState(
       const ParagraphState& /*previousState*/,
@@ -67,6 +86,7 @@ class ParagraphState final {
 
   folly::dynamic getDynamic() const;
   MapBuffer getMapBuffer() const;
+  jni::local_ref<jobject> getJNIReference() const;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/platform/android/react/renderer/components/text/ParagraphState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/platform/android/react/renderer/components/text/ParagraphState.h
@@ -12,6 +12,7 @@
 #include <react/renderer/attributedstring/ParagraphAttributes.h>
 #include <react/renderer/textlayoutmanager/TextLayoutManager.h>
 
+#include <fbjni/fbjni.h>
 #include <folly/dynamic.h>
 #include <react/renderer/mapbuffer/MapBuffer.h>
 

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputComponentDescriptor.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "AndroidTextInputShadowNode.h"
+#include "AndroidTextInputState.h"
 
 #include <fbjni/fbjni.h>
 
@@ -68,7 +69,8 @@ class AndroidTextInputComponentDescriptor final
     }
 
     return std::make_shared<AndroidTextInputShadowNode::ConcreteState>(
-        std::make_shared<const TextInputState>(TextInputState({}, {}, {}, 0)),
+        std::make_shared<const AndroidTextInputState>(
+            AndroidTextInputState({}, {}, {}, 0)),
         family);
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.cpp
@@ -154,7 +154,7 @@ void AndroidTextInputShadowNode::updateStateIfNeeded(
       : props.mostRecentEventCount;
   auto newAttributedString = getMostRecentAttributedString(layoutContext);
 
-  setStateData(TextInputState{
+  setStateData(AndroidTextInputState{
       AttributedStringBox(newAttributedString),
       reactTreeAttributedString,
       props.paragraphAttributes,

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.h
@@ -9,9 +9,9 @@
 
 #include "AndroidTextInputEventEmitter.h"
 #include "AndroidTextInputProps.h"
+#include "AndroidTextInputState.h"
 
 #include <react/renderer/attributedstring/AttributedString.h>
-#include <react/renderer/components/textinput/TextInputState.h>
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 #include <react/utils/ContextContainer.h>
 
@@ -26,7 +26,7 @@ class AndroidTextInputShadowNode final : public ConcreteViewShadowNode<
                                              AndroidTextInputComponentName,
                                              AndroidTextInputProps,
                                              AndroidTextInputEventEmitter,
-                                             TextInputState> {
+                                             AndroidTextInputState> {
  public:
   using ConcreteViewShadowNode::ConcreteViewShadowNode;
 

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputState.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputState.cpp
@@ -5,46 +5,18 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "TextInputState.h"
+#include "AndroidTextInputState.h"
 
-#ifdef ANDROID
 #include <react/renderer/attributedstring/conversions.h>
 #include <react/renderer/components/text/ParagraphState.h>
-#endif
 
 namespace facebook::react {
 
-TextInputState::TextInputState(
-    AttributedStringBox attributedStringBox,
-    AttributedString reactTreeAttributedString,
-    ParagraphAttributes paragraphAttributes,
-    int64_t mostRecentEventCount)
-    : attributedStringBox(std::move(attributedStringBox)),
-      reactTreeAttributedString(std::move(reactTreeAttributedString)),
-      paragraphAttributes(std::move(paragraphAttributes)),
-      mostRecentEventCount(mostRecentEventCount) {}
-
-#ifdef ANDROID
-TextInputState::TextInputState(
-    const TextInputState& previousState,
-    const folly::dynamic& data)
-    : attributedStringBox(previousState.attributedStringBox),
-      reactTreeAttributedString(previousState.reactTreeAttributedString),
-      paragraphAttributes(previousState.paragraphAttributes),
-      mostRecentEventCount(data.getDefault(
-                                   "mostRecentEventCount",
-                                   previousState.mostRecentEventCount)
-                               .getInt()),
-      cachedAttributedStringId(data.getDefault(
-                                       "opaqueCacheId",
-                                       previousState.cachedAttributedStringId)
-                                   .getInt()){};
-
-folly::dynamic TextInputState::getDynamic() const {
+folly::dynamic AndroidTextInputState::getDynamic() const {
   LOG(FATAL) << "TextInputState state should only be read using MapBuffer";
 }
 
-MapBuffer TextInputState::getMapBuffer() const {
+MapBuffer AndroidTextInputState::getMapBuffer() const {
   auto builder = MapBufferBuilder();
   // If we have a `cachedAttributedStringId` we know that we're (1) not trying
   // to set a new string, so we don't need to pass it along; (2) setState was
@@ -66,6 +38,5 @@ MapBuffer TextInputState::getMapBuffer() const {
   }
   return builder.build();
 }
-#endif
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputState.h
@@ -11,16 +11,19 @@
 #include <react/renderer/attributedstring/ParagraphAttributes.h>
 #include <react/renderer/textlayoutmanager/TextLayoutManager.h>
 
+#include <folly/dynamic.h>
+#include <react/renderer/mapbuffer/MapBuffer.h>
+
 namespace facebook::react {
 
 /*
  * State for <TextInput> component.
  */
-class TextInputState final {
+class AndroidTextInputState final {
  public:
-  TextInputState() = default;
+  AndroidTextInputState() = default;
 
-  TextInputState(
+  AndroidTextInputState(
       AttributedStringBox attributedStringBox,
       AttributedString reactTreeAttributedString,
       ParagraphAttributes paragraphAttributes,
@@ -29,6 +32,24 @@ class TextInputState final {
         reactTreeAttributedString(std::move(reactTreeAttributedString)),
         paragraphAttributes(std::move(paragraphAttributes)),
         mostRecentEventCount(mostRecentEventCount) {}
+
+  AndroidTextInputState(
+      const AndroidTextInputState& previousState,
+      const folly::dynamic& data)
+      : attributedStringBox(previousState.attributedStringBox),
+        reactTreeAttributedString(previousState.reactTreeAttributedString),
+        paragraphAttributes(previousState.paragraphAttributes),
+        mostRecentEventCount(data.getDefault(
+                                     "mostRecentEventCount",
+                                     previousState.mostRecentEventCount)
+                                 .getInt()),
+        cachedAttributedStringId(data.getDefault(
+                                         "opaqueCacheId",
+                                         previousState.cachedAttributedStringId)
+                                     .getInt()) {}
+
+  folly::dynamic getDynamic() const;
+  MapBuffer getMapBuffer() const;
 
   /*
    * All content of <TextInput> component.
@@ -51,6 +72,12 @@ class TextInputState final {
   ParagraphAttributes paragraphAttributes;
 
   int64_t mostRecentEventCount{0};
+
+  /**
+   * Stores an opaque cache ID used on the Java side to refer to a specific
+   * AttributedString for measurement purposes only.
+   */
+  int64_t cachedAttributedStringId{0};
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -15,9 +15,11 @@
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/components/view/ViewShadowNode.h>
 #include <react/renderer/components/view/conversions.h>
+#include <react/renderer/core/ComponentDescriptor.h>
 #include <react/renderer/core/LayoutConstraints.h>
 #include <react/renderer/core/LayoutContext.h>
 #include <react/renderer/debug/DebugStringConvertibleItem.h>
+#include <react/utils/FloatComparison.h>
 #include <yoga/Yoga.h>
 #include <algorithm>
 #include <limits>
@@ -836,6 +838,21 @@ YGSize YogaLayoutableShadowNode::yogaNodeMeasureCallbackConnector(
 
   auto size = shadowNode.measureContent(
       threadLocalLayoutContext, {minimumSize, maximumSize});
+
+#ifdef REACT_NATIVE_DEBUG
+  bool widthInBounds = size.width + kDefaultEpsilon >= minimumSize.width &&
+      size.width - kDefaultEpsilon <= maximumSize.width;
+  bool heightInBounds = size.height + kDefaultEpsilon >= minimumSize.height &&
+      size.height - kDefaultEpsilon <= maximumSize.height;
+
+  if (!widthInBounds || !heightInBounds) {
+    LOG(FATAL) << shadowNode.getComponentDescriptor().getComponentName()
+               << " returned in invalid measurement. Min: ["
+               << minimumSize.width << "," << minimumSize.height << "] Max: ["
+               << maximumSize.width << "," << maximumSize.height
+               << "] Actual: [" << size.width << "," << size.height << "]";
+  }
+#endif
 
   return YGSize{
       yogaFloatFromFloat(size.width), yogaFloatFromFloat(size.height)};

--- a/packages/react-native/ReactCommon/react/renderer/core/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/core/CMakeLists.txt
@@ -26,4 +26,5 @@ target_link_libraries(react_renderer_core
         react_utils
         runtimeexecutor)
 target_compile_reactnative_options(react_renderer_core PRIVATE "Fabric")
+target_compile_definitions(react_renderer_core PUBLIC REACT_NATIVE_HAS_SERIALIZABLE_STATE)
 target_compile_options(react_renderer_core PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/core/ConcreteState.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ConcreteState.h
@@ -13,7 +13,7 @@
 #include <react/debug/react_native_assert.h>
 #include <react/renderer/core/State.h>
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <fbjni/fbjni.h>
 #include <react/renderer/mapbuffer/MapBuffer.h>
 #include <react/renderer/mapbuffer/MapBufferBuilder.h>
@@ -21,7 +21,7 @@
 
 namespace facebook::react {
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 template <typename StateDataT>
 concept StateDataWithMapBuffer = requires(StateDataT stateData) {
   { stateData.getMapBuffer() } -> std::same_as<MapBuffer>;
@@ -107,7 +107,7 @@ class ConcreteState : public State {
     family->dispatchRawState(std::move(stateUpdate));
   }
 
-#ifdef ANDROID
+#if defined(REACT_NATIVE_HAS_SERIALIZABLE_STATE)
   folly::dynamic getDynamic() const override {
     return getData().getDynamic();
   }

--- a/packages/react-native/ReactCommon/react/renderer/core/State.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/State.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <fbjni/fbjni.h>
 #include <folly/dynamic.h>
 #include <react/renderer/mapbuffer/MapBuffer.h>
@@ -62,7 +62,7 @@ class State {
    */
   size_t getRevision() const;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   virtual folly::dynamic getDynamic() const = 0;
   virtual MapBuffer getMapBuffer() const = 0;
   virtual jni::local_ref<jobject> getJNIReference() const = 0;

--- a/packages/react-native/ReactCommon/react/renderer/core/StateData.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/StateData.h
@@ -9,7 +9,7 @@
 
 #include <memory>
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
 #include <folly/dynamic.h>
 #include <react/renderer/mapbuffer/MapBuffer.h>
 #include <react/renderer/mapbuffer/MapBufferBuilder.h>
@@ -24,7 +24,7 @@ namespace facebook::react {
 struct StateData final {
   using Shared = std::shared_ptr<const void>;
 
-#ifdef ANDROID
+#ifdef REACT_NATIVE_HAS_SERIALIZABLE_STATE
   StateData() = default;
   StateData(const StateData& previousState, folly::dynamic data) {}
   folly::dynamic getDynamic() const;

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextLayoutManagerExtended.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextLayoutManagerExtended.h
@@ -121,4 +121,10 @@ class TextLayoutManagerExtended {
 using TextLayoutManagerExtended =
     detail::TextLayoutManagerExtended<TextLayoutManager>;
 
+struct MeasuredPreparedLayout {
+  LayoutConstraints layoutConstraints;
+  TextMeasurement measurement;
+  TextLayoutManagerExtended::PreparedLayout preparedLayout{};
+};
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.cpp
@@ -308,12 +308,17 @@ TextLayoutManager::PreparedLayout TextLayoutManager::prepareLayout(
               JReadableMapBuffer::javaobject,
               JReadableMapBuffer::javaobject,
               jfloat,
+              jfloat,
+              jfloat,
               jfloat)>("prepareLayout");
 
   auto attributedStringMB =
       JReadableMapBuffer::createWithContents(toMapBuffer(attributedString));
   auto paragraphAttributesMB =
       JReadableMapBuffer::createWithContents(toMapBuffer(paragraphAttributes));
+
+  auto minimumSize = layoutConstraints.minimumSize;
+  auto maximumSize = layoutConstraints.maximumSize;
 
   // T222682416: We don't have any global cache here. We should investigate
   // whether that is desirable
@@ -322,8 +327,10 @@ TextLayoutManager::PreparedLayout TextLayoutManager::prepareLayout(
       layoutContext.surfaceId,
       attributedStringMB.get(),
       paragraphAttributesMB.get(),
-      layoutConstraints.maximumSize.width,
-      layoutConstraints.maximumSize.height))};
+      minimumSize.width,
+      maximumSize.width,
+      minimumSize.height,
+      maximumSize.height))};
 }
 
 TextMeasurement TextLayoutManager::measurePreparedLayout(

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/cxx/react/renderer/textlayoutmanager/TextLayoutManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/cxx/react/renderer/textlayoutmanager/TextLayoutManager.cpp
@@ -17,7 +17,7 @@ TextMeasurement TextLayoutManager::measure(
     const AttributedStringBox& attributedStringBox,
     const ParagraphAttributes& /*paragraphAttributes*/,
     const TextLayoutContext& /*layoutContext*/,
-    const LayoutConstraints& /*layoutConstraints*/) const {
+    const LayoutConstraints& layoutConstraints) const {
   TextMeasurement::Attachments attachments;
   for (const auto& fragment : attributedStringBox.getValue().getFragments()) {
     if (fragment.isAttachment()) {
@@ -25,7 +25,10 @@ TextMeasurement TextLayoutManager::measure(
           TextMeasurement::Attachment{{{0, 0}, {0, 0}}, false});
     }
   }
-  return TextMeasurement{{0, 0}, attachments};
+  return TextMeasurement{
+      {layoutConstraints.minimumSize.width,
+       layoutConstraints.minimumSize.height},
+      attachments};
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/utils/FloatComparison.h
+++ b/packages/react-native/ReactCommon/react/utils/FloatComparison.h
@@ -9,7 +9,9 @@
 
 namespace facebook::react {
 
-inline bool floatEquality(float a, float b, float epsilon = 0.005f) {
+constexpr float kDefaultEpsilon = 0.005f;
+
+inline bool floatEquality(float a, float b, float epsilon = kDefaultEpsilon) {
   return (std::isnan(a) && std::isnan(b)) ||
       (!std::isnan(a) && !std::isnan(b) && fabs(a - b) < epsilon);
 }

--- a/packages/react-native/ReactCommon/yoga/yoga/YGNodeLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGNodeLayout.cpp
@@ -90,3 +90,11 @@ float YGNodeLayoutGetPadding(YGNodeConstRef node, YGEdge edge) {
   return getResolvedLayoutProperty<&LayoutResults::padding>(
       node, scopedEnum(edge));
 }
+
+float YGNodeLayoutGetRawHeight(YGNodeConstRef node) {
+  return resolveRef(node)->getLayout().rawDimension(Dimension::Height);
+}
+
+float YGNodeLayoutGetRawWidth(YGNodeConstRef node) {
+  return resolveRef(node)->getLayout().rawDimension(Dimension::Width);
+}

--- a/packages/react-native/ReactCommon/yoga/yoga/YGNodeLayout.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGNodeLayout.h
@@ -32,4 +32,14 @@ YG_EXPORT float YGNodeLayoutGetMargin(YGNodeConstRef node, YGEdge edge);
 YG_EXPORT float YGNodeLayoutGetBorder(YGNodeConstRef node, YGEdge edge);
 YG_EXPORT float YGNodeLayoutGetPadding(YGNodeConstRef node, YGEdge edge);
 
+/**
+ * Return the measured height of the node, before layout rounding
+ */
+YG_EXPORT float YGNodeLayoutGetRawHeight(YGNodeConstRef node);
+
+/**
+ * Return the measured width of the node, before layout rounding
+ */
+YG_EXPORT float YGNodeLayoutGetRawWidth(YGNodeConstRef node);
+
 YG_EXTERN_C_END

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/PixelGrid.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/PixelGrid.cpp
@@ -106,25 +106,25 @@ void roundLayoutResultsToPixelGrid(
     const bool hasFractionalHeight =
         !yoga::inexactEquals(round(scaledNodeHeight), scaledNodeHeight);
 
-    node->setLayoutDimension(
+    node->getLayout().setDimension(
+        Dimension::Width,
         roundValueToPixelGrid(
             absoluteNodeRight,
             pointScaleFactor,
             (textRounding && hasFractionalWidth),
             (textRounding && !hasFractionalWidth)) -
             roundValueToPixelGrid(
-                absoluteNodeLeft, pointScaleFactor, false, textRounding),
-        Dimension::Width);
+                absoluteNodeLeft, pointScaleFactor, false, textRounding));
 
-    node->setLayoutDimension(
+    node->getLayout().setDimension(
+        Dimension::Height,
         roundValueToPixelGrid(
             absoluteNodeBottom,
             pointScaleFactor,
             (textRounding && hasFractionalHeight),
             (textRounding && !hasFractionalHeight)) -
             roundValueToPixelGrid(
-                absoluteNodeTop, pointScaleFactor, false, textRounding),
-        Dimension::Height);
+                absoluteNodeTop, pointScaleFactor, false, textRounding));
   }
 
   for (yoga::Node* child : node->getChildren()) {

--- a/packages/react-native/ReactCommon/yoga/yoga/node/LayoutResults.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/LayoutResults.h
@@ -66,8 +66,16 @@ struct LayoutResults {
     return measuredDimensions_[yoga::to_underlying(axis)];
   }
 
+  float rawDimension(Dimension axis) const {
+    return rawDimensions_[yoga::to_underlying(axis)];
+  }
+
   void setMeasuredDimension(Dimension axis, float dimension) {
     measuredDimensions_[yoga::to_underlying(axis)] = dimension;
+  }
+
+  void setRawDimension(Dimension axis, float dimension) {
+    rawDimensions_[yoga::to_underlying(axis)] = dimension;
   }
 
   float position(PhysicalEdge physicalEdge) const {
@@ -113,6 +121,7 @@ struct LayoutResults {
 
   std::array<float, 2> dimensions_ = {{YGUndefined, YGUndefined}};
   std::array<float, 2> measuredDimensions_ = {{YGUndefined, YGUndefined}};
+  std::array<float, 2> rawDimensions_ = {{YGUndefined, YGUndefined}};
   std::array<float, 4> position_ = {};
   std::array<float, 4> margin_ = {};
   std::array<float, 4> border_ = {};

--- a/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/node/Node.cpp
@@ -247,6 +247,7 @@ void Node::setLayoutHadOverflow(bool hadOverflow) {
 
 void Node::setLayoutDimension(float lengthValue, Dimension dimension) {
   layout_.setDimension(dimension, lengthValue);
+  layout_.setRawDimension(dimension, lengthValue);
 }
 
 // If both left and right are defined, then use left. Otherwise return +left or


### PR DESCRIPTION
Summary:
D58818560 tried to deduplicate some code, but introduced an error, where we no longer correctly incorporate the width MeasureMode into the text layout that we create, instead, passing `YogaMeasureMode.EXACTLY`.

In effect, this means the Android layout created always takes up the maximum allowable space, even if content is smaller. This is later masked, because our returned measure when `AT_MOST` is based on maximum line length, and the layout is then recreated when drawing a TextView, but means:

1. Attachments may not be positioned correctly, when using a non-left-aligned paragraph alignment
2. Directly drawing the layout shows the wrong thing

Changelog:
[Android][Fixed] - Fix TextLayoutManager MeasureMode Regression

Differential Revision: D74366936
