### PR TITLE
Text: Fix selectable prop mapping (was isSelectable) for Fabric - ensure correct macro conversion

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
@@ -105,8 +105,8 @@ using namespace facebook::react;
   _paragraphAttributes = newParagraphProps.paragraphAttributes;
   _textView.paragraphAttributes = _paragraphAttributes;
 
-  if (newParagraphProps.isSelectable != oldParagraphProps.isSelectable) {
-    if (newParagraphProps.isSelectable) {
+  if (newParagraphProps.selectable != oldParagraphProps.selectable) {
+    if (newParagraphProps.selectable) {
       [self enableContextMenu];
     } else {
       [self disableContextMenu];
@@ -329,14 +329,14 @@ using namespace facebook::react;
 - (BOOL)canBecomeFirstResponder
 {
   const auto &paragraphProps = static_cast<const ParagraphProps &>(*_props);
-  return paragraphProps.isSelectable;
+  return paragraphProps.selectable;
 }
 
 - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
 {
   const auto &paragraphProps = static_cast<const ParagraphProps &>(*_props);
 
-  if (paragraphProps.isSelectable && action == @selector(copy:)) {
+  if (paragraphProps.selectable && action == @selector(copy:)) {
     return YES;
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.cpp
@@ -31,14 +31,14 @@ ParagraphProps::ParagraphProps(
                     rawProps,
                     sourceProps.paragraphAttributes,
                     {})),
-      isSelectable(
+      selectable(
           ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
-              ? sourceProps.isSelectable
+              ? sourceProps.selectable
               : convertRawProp(
                     context,
                     rawProps,
                     "selectable",
-                    sourceProps.isSelectable,
+                    sourceProps.selectable,
                     false)),
       onTextLayout(
           ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
@@ -129,7 +129,7 @@ void ParagraphProps::setProp(
   }
 
   switch (hash) {
-    RAW_SET_PROP_SWITCH_CASE_BASIC(isSelectable);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(selectable);
     RAW_SET_PROP_SWITCH_CASE_BASIC(onTextLayout);
   }
 
@@ -148,7 +148,7 @@ SharedDebugStringConvertibleList ParagraphProps::getDebugProps() const {
   return ViewProps::getDebugProps() + BaseTextProps::getDebugProps() +
       paragraphAttributes.getDebugProps() +
       SharedDebugStringConvertibleList{
-          debugStringConvertibleItem("isSelectable", isSelectable)};
+          debugStringConvertibleItem("selectable", selectable)};
 }
 #endif
 

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.h
@@ -48,7 +48,7 @@ class ParagraphProps : public ViewProps, public BaseTextProps {
   /*
    * Defines can the text be selected (and copied) or not.
    */
-  bool isSelectable{};
+  bool selectable{};
 
   bool onTextLayout{};
 

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.cpp
@@ -29,7 +29,7 @@ const char ParagraphComponentName[] = "Paragraph";
 
 void ParagraphShadowNode::initialize() noexcept {
 #ifdef ANDROID
-  if (getConcreteProps().isSelectable) {
+  if (getConcreteProps().selectable) {
     traits_.set(ShadowNodeTraits::Trait::KeyboardFocusable);
   }
 #endif


### PR DESCRIPTION
## Summary:
for IOS and React native windows we can observe that the macro conversion is incorrect in ParagraphProps particularly for selectable prop.


current conversion 
```
case ([]() constexpr -> RawPropsPropNameHash {   return facebook::react::fnv1a("isSelectable");  }()): fromRawValue(context, value, isSelectable, defaults.isSelectable); return;
```
issue is that isSelectable is not the raw prop therefore JS to native flow for the prop is not correct .
(Note : this works for Android as @ReactProp(name = "selectable"):  https://github.com/facebook/react-native/blob/bbc1e121c71d14803d29a931f642bf8ea6ee2023/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextAnchorViewManager.kt#L97-L100 )

after fix 

```
case ([]() constexpr -> RawPropsPropNameHash {   return facebook::react::fnv1a("selectable");  }()): fromRawValue(context, value, selectable, defaults.selectable); return;
```


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Current implementation selectable prop is not working for IOS and React native windows as the macro conversion is incorrect in ParagraphProps particularly for selectable prop.

## Changelog:
Updated ParagraphProps declaration .h/.cpp file for selectable raw prop and then refactoring their respective implementations 
all places required .
 
<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:
[IOS] [FIXED] - Fix selectable prop not working correctly 
[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

Tested on react native windows playground 

Sample code 

```
export default class Bootstrap extends React.Component {
  render() {
    return (
      <View style={styles.container}>
        <Text style={styles.header}>Selectable vs Non-Selectable Text</Text>

        <Text selectable={true} style={styles.text}>
          ✅ This text is selectable. You can long-press and copy it.
        </Text>

        <Text selectable={false} style={styles.text}>
          ❌ This text is not selectable. You cannot copy it.
        </Text>
      </View>
    );
  }
}


```
before fix debug output  , native unaware of selectable prop values from JS
```
ReactNative ['Samples\text'] (info): ''[Text.js] NativeText _selectable:', true'
ReactNative ['Samples\text'] (info): ''[Text.js] NativeText _selectable:', false'
[ParagraphComponentView] updateProps - old isSelectable: 0, new isSelectable: 0
[ParagraphComponentView] DrawText - isSelectable: 0
[ParagraphComponentView] DrawText - selection logic would be DISABLED here.
[ParagraphComponentView] updateProps - old isSelectable: 0, new isSelectable: 0
[ParagraphComponentView] DrawText - isSelectable: 0
[ParagraphComponentView] DrawText - selection logic would be DISABLED here.
[ParagraphComponentView] updateProps - old isSelectable: 0, new isSelectable: 0
[ParagraphComponentView] DrawText - isSelectable: 0
[ParagraphComponentView] DrawText - selection logic would be DISABLED here.

```

after fix debug output , native picks up selectable prop values from JS correctly 
```
ReactNative ['Samples\text'] (info): ''[Text.js] NativeText _selectable:', true'
ReactNative ['Samples\text'] (info): ''[Text.js] NativeText _selectable:', false'
[ParagraphComponentView] updateProps - old selectable: 0, new selectable: 0
[ParagraphComponentView] DrawText - selectable: 0
[ParagraphComponentView] DrawText - selection logic would be DISABLED here.
[ParagraphComponentView] updateProps - old selectable: 0, new selectable: 1
[ParagraphComponentView] DrawText - selectable: 1
[ParagraphComponentView] DrawText - selection logic would be enabled here.
[ParagraphComponentView] updateProps - old selectable: 0, new selectable: 0
[ParagraphComponentView] DrawText - selectable: 0
[ParagraphComponentView] DrawText - selection logic would be DISABLED here.
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
