### PR TITLE
Narrow file set for no-commonjs-exports lint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,7 +44,8 @@ module.exports = {
     },
     {
       files: [
-        './packages/react-native/**/*.{js,flow}',
+        './packages/react-native/Libraries/**/*.{js,flow}',
+        './packages/react-native/src/**/*.{js,flow}',
         './packages/assets/registry.js',
       ],
       parser: 'hermes-eslint',

--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -9,7 +9,6 @@
  */
 
 // flowlint unsafe-getters-setters:off
-/* eslint-disable lint/no-commonjs-exports */
 
 'use strict';
 'use client';


### PR DESCRIPTION
Summary:
Avoids over-matching non-runtime files such as `packages/react-native/scripts/`.

Changelog: [Internal]

Differential Revision: D74394261


