### PR TITLE
Move imported types from `@react-native/assets-registry` and `@react-native/js-polyfills` to `react-native` repo

### DIFF
--- a/packages/react-native/Libraries/Image/AssetSourceResolver.js
+++ b/packages/react-native/Libraries/Image/AssetSourceResolver.js
@@ -18,10 +18,23 @@ export type ResolvedAssetSource = {
   +scale: number,
 };
 
-import type {
-  AssetDestPathResolver,
-  PackagerAsset,
-} from '@react-native/assets-registry/registry';
+// From @react-native/assets-registry
+type AssetDestPathResolver = 'android' | 'generic';
+
+// From @react-native/assets-registry
+type PackagerAsset = $ReadOnly<{
+  __packager_asset: boolean,
+  fileSystemLocation: string,
+  httpServerLocation: string,
+  width: ?number,
+  height: ?number,
+  scales: Array<number>,
+  hash: string,
+  name: string,
+  type: string,
+  resolver?: AssetDestPathResolver,
+  ...
+}>;
 
 const PixelRatio = require('../Utilities/PixelRatio').default;
 const Platform = require('../Utilities/Platform').default;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -4202,6 +4202,19 @@ exports[`public API should not change unintentionally Libraries/Image/AssetSourc
   +uri: string,
   +scale: number,
 };
+type AssetDestPathResolver = \\"android\\" | \\"generic\\";
+type PackagerAsset = $ReadOnly<{
+  fileSystemLocation: string,
+  httpServerLocation: string,
+  width: ?number,
+  height: ?number,
+  scales: Array<number>,
+  hash: string,
+  name: string,
+  type: string,
+  resolver?: AssetDestPathResolver,
+  ...
+}>;
 declare class AssetSourceResolver {
   serverUrl: ?string;
   jsbundleUrl: ?string;
@@ -8915,8 +8928,33 @@ declare export default typeof rejectionTrackingOptions;
 `;
 
 exports[`public API should not change unintentionally Libraries/vendor/core/ErrorUtils.js 1`] = `
-"export type ErrorUtils = ErrorUtilsT;
-declare export default ErrorUtilsT;
+"type ErrorHandler = (error: mixed, isFatal: boolean) => void;
+type Fn<Args, Return> = (...Args) => Return;
+export type ErrorUtils = {
+  applyWithGuard<TArgs: $ReadOnlyArray<mixed>, TOut>(
+    fun: Fn<TArgs, TOut>,
+    context?: mixed,
+    args?: ?TArgs,
+    unused_onError?: null,
+    unused_name?: ?string
+  ): ?TOut,
+  applyWithGuardIfNeeded<TArgs: $ReadOnlyArray<mixed>, TOut>(
+    fun: Fn<TArgs, TOut>,
+    context?: mixed,
+    args?: ?TArgs
+  ): ?TOut,
+  getGlobalHandler(): ErrorHandler,
+  guard<TArgs: $ReadOnlyArray<mixed>, TOut>(
+    fun: Fn<TArgs, TOut>,
+    name?: ?string,
+    context?: mixed
+  ): ?(...TArgs) => ?TOut,
+  inGuard(): boolean,
+  reportError(error: mixed): void,
+  reportFatalError(error: mixed): void,
+  setGlobalHandler(fun: ErrorHandler): void,
+};
+declare export default ErrorUtils;
 "
 `;
 

--- a/packages/react-native/Libraries/vendor/core/ErrorUtils.js
+++ b/packages/react-native/Libraries/vendor/core/ErrorUtils.js
@@ -8,9 +8,33 @@
  * @flow strict
  */
 
-import type {ErrorUtilsT} from '@react-native/js-polyfills/error-guard';
-
-export type ErrorUtils = ErrorUtilsT;
+// From @react-native/js-polyfills
+type ErrorHandler = (error: mixed, isFatal: boolean) => void;
+type Fn<Args, Return> = (...Args) => Return;
+export type ErrorUtils = {
+  applyWithGuard<TArgs: $ReadOnlyArray<mixed>, TOut>(
+    fun: Fn<TArgs, TOut>,
+    context?: mixed,
+    args?: ?TArgs,
+    unused_onError?: null,
+    unused_name?: ?string,
+  ): ?TOut,
+  applyWithGuardIfNeeded<TArgs: $ReadOnlyArray<mixed>, TOut>(
+    fun: Fn<TArgs, TOut>,
+    context?: mixed,
+    args?: ?TArgs,
+  ): ?TOut,
+  getGlobalHandler(): ErrorHandler,
+  guard<TArgs: $ReadOnlyArray<mixed>, TOut>(
+    fun: Fn<TArgs, TOut>,
+    name?: ?string,
+    context?: mixed,
+  ): ?(...TArgs) => ?TOut,
+  inGuard(): boolean,
+  reportError(error: mixed): void,
+  reportFatalError(error: mixed): void,
+  setGlobalHandler(fun: ErrorHandler): void,
+};
 
 /**
  * The particular require runtime that we are using looks for a global
@@ -24,4 +48,4 @@ export type ErrorUtils = ErrorUtilsT;
  * that use it aren't just using a global variable, so simply export the global
  * variable here. ErrorUtils is originally defined in a file named error-guard.js.
  */
-export default (global.ErrorUtils: ErrorUtilsT);
+export default global.ErrorUtils as ErrorUtils;


### PR DESCRIPTION
Summary:
The `build-types` script cannot currently resolve `react-native/assets-registry` and `react-native/js-polyfills`. This diff moves imported types from these packages to `react-native` to include them in generated types.

Changelog:
[Internal]

Differential Revision: D74392568


