### PR TITLE
Extract RN environment setup to a specific module

### DIFF
--- a/packages/react-native/Libraries/Core/InitializeCore.js
+++ b/packages/react-native/Libraries/Core/InitializeCore.js
@@ -28,28 +28,7 @@
 
 const start = Date.now();
 
-require('./setUpGlobals');
-require('../../src/private/setup/setUpDOM').default();
-require('./setUpPerformance');
-require('./polyfillPromise');
-require('./setUpTimers');
-if (__DEV__) {
-  require('./setUpReactDevTools');
-}
-require('./setUpErrorHandling');
-require('./setUpRegeneratorRuntime');
-require('./setUpXHR');
-require('./setUpAlert');
-require('./setUpNavigator');
-require('./setUpBatchedBridge');
-require('./setUpSegmentFetcher');
-if (__DEV__) {
-  require('./checkNativeVersion');
-  require('./setUpDeveloperTools');
-  require('../LogBox/LogBox').default.install();
-}
-
-require('../ReactNative/AppRegistry');
+require('../../src/private/setup/setUpDefaultReactNativeEnvironment').default();
 
 const GlobalPerformanceLogger =
   require('../Utilities/GlobalPerformanceLogger').default;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -9354,6 +9354,13 @@ exports[`public API should not change unintentionally src/private/setup/setUpDOM
 "
 `;
 
+exports[`public API should not change unintentionally src/private/setup/setUpDefaultReactNativeEnvironment.js 1`] = `
+"declare export default function setUpDefaltReactNativeEnvironment(
+  enableDeveloperTools?: boolean
+): void;
+"
+`;
+
 exports[`public API should not change unintentionally src/private/setup/setUpIntersectionObserver.js 1`] = `
 "declare export default function setUpIntersectionObserver(): void;
 "

--- a/packages/react-native/src/private/setup/setUpDefaultReactNativeEnvironment.js
+++ b/packages/react-native/src/private/setup/setUpDefaultReactNativeEnvironment.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+let initialized = false;
+
+export default function setUpDefaltReactNativeEnvironment(
+  enableDeveloperTools: boolean = true,
+) {
+  if (initialized) {
+    return;
+  }
+
+  initialized = true;
+
+  require('../../../Libraries/Core/setUpGlobals');
+  require('./setUpDOM').default();
+  require('../../../Libraries/Core/setUpPerformance');
+  require('../../../Libraries/Core/polyfillPromise');
+  require('../../../Libraries/Core/setUpTimers');
+  if (__DEV__ && enableDeveloperTools) {
+    require('../../../Libraries/Core/setUpReactDevTools');
+  }
+  require('../../../Libraries/Core/setUpErrorHandling');
+  require('../../../Libraries/Core/setUpRegeneratorRuntime');
+  require('../../../Libraries/Core/setUpXHR');
+  require('../../../Libraries/Core/setUpAlert');
+  require('../../../Libraries/Core/setUpNavigator');
+  require('../../../Libraries/Core/setUpBatchedBridge');
+  require('../../../Libraries/Core/setUpSegmentFetcher');
+  if (__DEV__ && enableDeveloperTools) {
+    require('../../../Libraries/Core/checkNativeVersion');
+    require('../../../Libraries/Core/setUpDeveloperTools');
+    require('../../../Libraries/LogBox/LogBox').default.install();
+  }
+
+  require('../../../Libraries/ReactNative/AppRegistry');
+}


### PR DESCRIPTION
Summary:
Changelog: [internal]

This refactors `InitializeCore` to extract the initialization logic to a separate configurable module.

By default, this does the same thing it does now, but the new module could be used without `InitializeCore` to set up the environment forcing disabling developer tools (e.g.: for testing in Fantom in development environments).

Differential Revision: D69003811


