### PR TITLE
Ensure LogBox is disabled in Fantom tests

### DIFF
--- a/packages/react-native-fantom/config/metro.config.js
+++ b/packages/react-native-fantom/config/metro.config.js
@@ -51,6 +51,10 @@ const config = {
     // using babel-register.
     babelTransformerPath: path.resolve(__dirname, 'metro-babel-transformer.js'),
   },
+  serializer: {
+    // Force an empty list so Metro doesn't inject InitializeCore in tests.
+    getModulesRunBeforeMainModule: () => [],
+  },
   watchFolders: JS_DIR
     ? [
         path.join(JS_DIR, 'RKJSModules', 'vendor', 'react'),

--- a/packages/react-native-fantom/runtime/WarmUpEntryPoint.js
+++ b/packages/react-native-fantom/runtime/WarmUpEntryPoint.js
@@ -13,6 +13,6 @@
  * This is just an entrypoint to warm up the Metro cache before the tests run.
  */
 
-import 'react-native/Libraries/Core/InitializeCore.js';
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 import '@react-native/fantom/src/__tests__/Fantom-itest';
 import './setup';

--- a/packages/react-native-fantom/src/__tests__/Fantom-itest.js
+++ b/packages/react-native-fantom/src/__tests__/Fantom-itest.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import 'react-native/Libraries/Core/InitializeCore';
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import type {Root} from '@react-native/fantom';
 import type {HostInstance} from 'react-native';

--- a/packages/react-native-fantom/src/__tests__/FantomWeakRefs-itest.js
+++ b/packages/react-native-fantom/src/__tests__/FantomWeakRefs-itest.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import 'react-native/Libraries/Core/InitializeCore';
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import * as Fantom from '@react-native/fantom';
 

--- a/packages/react-native-fantom/src/__tests__/benchmarks/BenchmarkTests-testMode-benchmark-itest.js
+++ b/packages/react-native-fantom/src/__tests__/benchmarks/BenchmarkTests-testMode-benchmark-itest.js
@@ -9,6 +9,7 @@
  * @oncall react_native
  */
 
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 import * as Fantom from '@react-native/fantom';
 
 let runs = 0;

--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -20,7 +20,6 @@ import ReactNativeElement from '../../react-native/src/private/webapis/dom/nodes
 import * as Benchmark from './Benchmark';
 import getFantomRenderedOutput from './getFantomRenderedOutput';
 import {createRootTag} from 'react-native/Libraries/ReactNative/RootTag';
-import ReactFabric from 'react-native/Libraries/Renderer/shims/ReactFabric';
 import NativeFantom, {
   NativeEventCategory,
 } from 'react-native/src/private/testing/fantom/specs/NativeFantom';
@@ -89,6 +88,10 @@ class Root {
       this.#hasRendered = true;
     }
 
+    // Require Fabric lazily to prevent it from running InitializeCore before the test
+    // has a change to do its environment setup.
+    const ReactFabric =
+      require('react-native/Libraries/Renderer/shims/ReactFabric').default;
     ReactFabric.render(element, this.#surfaceId, null, true);
 
     if (this.#document == null) {

--- a/packages/react-native-fantom/src/setUpDefaultReactNativeEnvironment.js
+++ b/packages/react-native-fantom/src/setUpDefaultReactNativeEnvironment.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import setUpDefaultReactNativeEnvironment from 'react-native/src/private/setup/setUpDefaultReactNativeEnvironment';
+
+// Do NOT enable developer tools for Fantom.
+setUpDefaultReactNativeEnvironment(false);

--- a/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-itest.js
+++ b/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-itest.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import 'react-native/Libraries/Core/InitializeCore';
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import type {HostInstance} from 'react-native';
 

--- a/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-viewCulling-itest.js
+++ b/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-viewCulling-itest.js
@@ -12,7 +12,7 @@
  * @fantom_flags enableFixForParentTagDuringReparenting:true
  */
 
-import 'react-native/Libraries/Core/InitializeCore.js';
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import type {HostInstance} from 'react-native';
 

--- a/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-itest.js
+++ b/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-itest.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import 'react-native/Libraries/Core/InitializeCore';
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import type {HostInstance} from 'react-native';
 

--- a/packages/react-native/Libraries/Components/View/__tests__/View-benchmark-itest.js
+++ b/packages/react-native/Libraries/Components/View/__tests__/View-benchmark-itest.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import 'react-native/Libraries/Core/InitializeCore';
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import * as Fantom from '@react-native/fantom';
 import * as React from 'react';

--- a/packages/react-native/Libraries/Components/View/__tests__/View-itest.js
+++ b/packages/react-native/Libraries/Components/View/__tests__/View-itest.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import 'react-native/Libraries/Core/InitializeCore';
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import * as Fantom from '@react-native/fantom';
 import * as React from 'react';

--- a/packages/react-native/Libraries/Core/InitializeCore.js
+++ b/packages/react-native/Libraries/Core/InitializeCore.js
@@ -28,28 +28,7 @@
 
 const start = Date.now();
 
-require('./setUpGlobals');
-require('../../src/private/setup/setUpDOM').default();
-require('./setUpPerformance');
-require('./polyfillPromise');
-require('./setUpTimers');
-if (__DEV__) {
-  require('./setUpReactDevTools');
-}
-require('./setUpErrorHandling');
-require('./setUpRegeneratorRuntime');
-require('./setUpXHR');
-require('./setUpAlert');
-require('./setUpNavigator');
-require('./setUpBatchedBridge');
-require('./setUpSegmentFetcher');
-if (__DEV__) {
-  require('./checkNativeVersion');
-  require('./setUpDeveloperTools');
-  require('../LogBox/LogBox').default.install();
-}
-
-require('../ReactNative/AppRegistry');
+require('../../src/private/setup/setUpDefaultReactNativeEnvironment').default();
 
 const GlobalPerformanceLogger =
   require('../Utilities/GlobalPerformanceLogger').default;

--- a/packages/react-native/Libraries/LogBox/__tests__/LogBox-itest.js
+++ b/packages/react-native/Libraries/LogBox/__tests__/LogBox-itest.js
@@ -21,6 +21,9 @@ import {LogBox, Text, View} from 'react-native';
 // This is a bug we'll fix in a followup.
 const BUG_WITH_COMPONENT_FRAMES: [] = [];
 
+// Disable the logic to make sure that LogBox is not installed in tests.
+Fantom.setLogBoxCheckEnabled(false);
+
 describe('LogBox', () => {
   let originalConsoleError;
   let originalConsoleWarn;

--- a/packages/react-native/Libraries/LogBox/__tests__/fantomHelpers.js
+++ b/packages/react-native/Libraries/LogBox/__tests__/fantomHelpers.js
@@ -18,8 +18,6 @@ import * as Fantom from '@react-native/fantom';
 import nullthrows from 'nullthrows';
 import * as React from 'react';
 
-import '../../Core/InitializeCore.js';
-
 interface InspectorUI {
   header: ?string;
   title: ?string;

--- a/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/ReactFabricPublicInstance-benchmark-itest.js
+++ b/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/ReactFabricPublicInstance-benchmark-itest.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import 'react-native/Libraries/Core/InitializeCore';
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import type {
   InternalInstanceHandle,

--- a/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/setUpReactFabricPublicInstanceFantomTests.js
+++ b/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/setUpReactFabricPublicInstanceFantomTests.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import '../../../Core/InitializeCore.js';
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import ReactNativeElement from '../../../../src/private/webapis/dom/nodes/ReactNativeElement';
 import TextInputState from '../../../Components/TextInput/TextInputState';

--- a/packages/react-native/Libraries/ReactNative/__tests__/InterruptibleRendering-itest.js
+++ b/packages/react-native/Libraries/ReactNative/__tests__/InterruptibleRendering-itest.js
@@ -10,7 +10,7 @@
  * @fantom_flags fixMappingOfEventPrioritiesBetweenFabricAndReact:true
  */
 
-import 'react-native/Libraries/Core/InitializeCore';
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import type {HostInstance} from 'react-native';
 

--- a/packages/react-native/Libraries/ReactNative/__tests__/ReactFabric-Suspense-itest.js
+++ b/packages/react-native/Libraries/ReactNative/__tests__/ReactFabric-Suspense-itest.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import 'react-native/Libraries/Core/InitializeCore';
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import * as Fantom from '@react-native/fantom';
 import * as React from 'react';

--- a/packages/react-native/Libraries/ReactNative/__tests__/State-ForcedCloneCommitHook-itest.js
+++ b/packages/react-native/Libraries/ReactNative/__tests__/State-ForcedCloneCommitHook-itest.js
@@ -10,7 +10,7 @@
  * @fantom_flags useShadowNodeStateOnClone:true
  */
 
-import 'react-native/Libraries/Core/InitializeCore';
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import type {HostInstance} from 'react-native';
 

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -9354,6 +9354,13 @@ exports[`public API should not change unintentionally src/private/setup/setUpDOM
 "
 `;
 
+exports[`public API should not change unintentionally src/private/setup/setUpDefaultReactNativeEnvironment.js 1`] = `
+"declare export default function setUpDefaltReactNativeEnvironment(
+  enableDeveloperTools?: boolean
+): void;
+"
+`;
+
 exports[`public API should not change unintentionally src/private/setup/setUpIntersectionObserver.js 1`] = `
 "declare export default function setUpIntersectionObserver(): void;
 "

--- a/packages/react-native/src/private/__tests__/utilities/__tests__/ShadowNodeReferenceCounter-itest.js
+++ b/packages/react-native/src/private/__tests__/utilities/__tests__/ShadowNodeReferenceCounter-itest.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import 'react-native/Libraries/Core/InitializeCore';
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import type {Node} from '../../../../../Libraries/Renderer/shims/ReactNativeTypes';
 

--- a/packages/react-native/src/private/animated/__tests__/AnimatedProps-itest.js
+++ b/packages/react-native/src/private/animated/__tests__/AnimatedProps-itest.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import 'react-native/Libraries/Core/InitializeCore';
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import * as Fantom from '@react-native/fantom';
 import * as React from 'react';

--- a/packages/react-native/src/private/renderer/consistency/__tests__/UIConsistency-itest.js
+++ b/packages/react-native/src/private/renderer/consistency/__tests__/UIConsistency-itest.js
@@ -11,7 +11,7 @@
  * @fantom_flags enableSynchronousStateUpdates:true
  */
 
-import 'react-native/Libraries/Core/InitializeCore';
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import type {HostInstance} from 'react-native';
 

--- a/packages/react-native/src/private/renderer/core/__tests__/EventDispatching-itest.js
+++ b/packages/react-native/src/private/renderer/core/__tests__/EventDispatching-itest.js
@@ -10,7 +10,7 @@
  * @fantom_flags fixMappingOfEventPrioritiesBetweenFabricAndReact:true
  */
 
-import 'react-native/Libraries/Core/InitializeCore';
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import ensureInstance from '../../../__tests__/utilities/ensureInstance';
 import * as Fantom from '@react-native/fantom';

--- a/packages/react-native/src/private/renderer/mounting/__tests__/Mounting-itest.js
+++ b/packages/react-native/src/private/renderer/mounting/__tests__/Mounting-itest.js
@@ -10,7 +10,7 @@
  * @fantom_flags enableFixForParentTagDuringReparenting:true
  */
 
-import 'react-native/Libraries/Core/InitializeCore';
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import type {HostInstance} from 'react-native';
 

--- a/packages/react-native/src/private/setup/setUpDefaultReactNativeEnvironment.js
+++ b/packages/react-native/src/private/setup/setUpDefaultReactNativeEnvironment.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+let initialized = false;
+
+export default function setUpDefaltReactNativeEnvironment(
+  enableDeveloperTools: boolean = true,
+) {
+  if (initialized) {
+    return;
+  }
+
+  initialized = true;
+
+  require('../../../Libraries/Core/setUpGlobals');
+  require('./setUpDOM').default();
+  require('../../../Libraries/Core/setUpPerformance');
+  require('../../../Libraries/Core/polyfillPromise');
+  require('../../../Libraries/Core/setUpTimers');
+  if (__DEV__ && enableDeveloperTools) {
+    require('../../../Libraries/Core/setUpReactDevTools');
+  }
+  require('../../../Libraries/Core/setUpErrorHandling');
+  require('../../../Libraries/Core/setUpRegeneratorRuntime');
+  require('../../../Libraries/Core/setUpXHR');
+  require('../../../Libraries/Core/setUpAlert');
+  require('../../../Libraries/Core/setUpNavigator');
+  require('../../../Libraries/Core/setUpBatchedBridge');
+  require('../../../Libraries/Core/setUpSegmentFetcher');
+  if (__DEV__ && enableDeveloperTools) {
+    require('../../../Libraries/Core/checkNativeVersion');
+    require('../../../Libraries/Core/setUpDeveloperTools');
+    require('../../../Libraries/LogBox/LogBox').default.install();
+  }
+
+  require('../../../Libraries/ReactNative/AppRegistry');
+}

--- a/packages/react-native/src/private/webapis/dom/events/__tests__/CustomEvent-itest.js
+++ b/packages/react-native/src/private/webapis/dom/events/__tests__/CustomEvent-itest.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import 'react-native/Libraries/Core/InitializeCore';
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import CustomEvent from 'react-native/src/private/webapis/dom/events/CustomEvent';
 import Event from 'react-native/src/private/webapis/dom/events/Event';

--- a/packages/react-native/src/private/webapis/dom/events/__tests__/Event-itest.js
+++ b/packages/react-native/src/private/webapis/dom/events/__tests__/Event-itest.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import 'react-native/Libraries/Core/InitializeCore';
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import Event from 'react-native/src/private/webapis/dom/events/Event';
 import {setInPassiveListenerFlag} from 'react-native/src/private/webapis/dom/events/internals/EventInternals';

--- a/packages/react-native/src/private/webapis/dom/events/__tests__/EventHandlerAttributes-itest.js
+++ b/packages/react-native/src/private/webapis/dom/events/__tests__/EventHandlerAttributes-itest.js
@@ -11,7 +11,7 @@
 
 // flowlint unsafe-getters-setters:off
 
-import 'react-native/Libraries/Core/InitializeCore';
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import type {EventCallback} from 'react-native/src/private/webapis/dom/events/EventTarget';
 

--- a/packages/react-native/src/private/webapis/dom/events/__tests__/EventTarget-benchmark-itest.js
+++ b/packages/react-native/src/private/webapis/dom/events/__tests__/EventTarget-benchmark-itest.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import 'react-native/Libraries/Core/InitializeCore';
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import createEventTargetHierarchyWithDepth from './createEventTargetHierarchyWithDepth';
 import {unstable_benchmark} from '@react-native/fantom';

--- a/packages/react-native/src/private/webapis/dom/events/__tests__/EventTarget-itest.js
+++ b/packages/react-native/src/private/webapis/dom/events/__tests__/EventTarget-itest.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import 'react-native/Libraries/Core/InitializeCore';
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import createEventTargetHierarchyWithDepth from './createEventTargetHierarchyWithDepth';
 import Event from 'react-native/src/private/webapis/dom/events/Event';

--- a/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeDocument-itest.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeDocument-itest.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import 'react-native/Libraries/Core/InitializeCore';
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import type {HostInstance} from 'react-native';
 

--- a/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeElement-itest.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeElement-itest.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import 'react-native/Libraries/Core/InitializeCore';
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import type {HostInstance} from 'react-native';
 

--- a/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReadOnlyText-itest.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReadOnlyText-itest.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import 'react-native/Libraries/Core/InitializeCore';
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import type {HostInstance} from 'react-native';
 

--- a/packages/react-native/src/private/webapis/idlecallbacks/__tests__/requestIdleCallback-itest.js
+++ b/packages/react-native/src/private/webapis/idlecallbacks/__tests__/requestIdleCallback-itest.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import 'react-native/Libraries/Core/InitializeCore';
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import * as Fantom from '@react-native/fantom';
 

--- a/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-benchmark-itest.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-benchmark-itest.js
@@ -10,7 +10,7 @@
  * @fantom_flags enableAccessToHostTreeInFabric:true
  */
 
-import 'react-native/Libraries/Core/InitializeCore';
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import type {Root} from '@react-native/fantom';
 import type {HostInstance} from 'react-native';

--- a/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-itest.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-itest.js
@@ -10,7 +10,7 @@
  * @fantom_flags utilizeTokensInIntersectionObserver:true
  */
 
-import 'react-native/Libraries/Core/InitializeCore';
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import type {HostInstance} from 'react-native';
 import type IntersectionObserverType from 'react-native/src/private/webapis/intersectionobserver/IntersectionObserver';

--- a/packages/react-native/src/private/webapis/mutationobserver/__tests__/MutationObserver-itest.js
+++ b/packages/react-native/src/private/webapis/mutationobserver/__tests__/MutationObserver-itest.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import 'react-native/Libraries/Core/InitializeCore';
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import type {HostInstance} from 'react-native';
 import type MutationObserverType from 'react-native/src/private/webapis/mutationobserver/MutationObserver';

--- a/packages/react-native/src/private/webapis/performance/__tests__/EventTimingAPI-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/EventTimingAPI-itest.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import 'react-native/Libraries/Core/InitializeCore';
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import type {PerformanceObserverEntryList} from 'react-native/src/private/webapis/performance/PerformanceObserver';
 

--- a/packages/react-native/src/private/webapis/performance/__tests__/LongTasksAPI-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/LongTasksAPI-itest.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import 'react-native/Libraries/Core/InitializeCore';
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import type {
   PerformanceObserverCallbackOptions,

--- a/packages/react-native/src/private/webapis/performance/__tests__/Performance-benchmark-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/Performance-benchmark-itest.js
@@ -10,7 +10,7 @@
  * @fantom_mode opt
  */
 
-import 'react-native/Libraries/Core/InitializeCore';
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import type Performance from 'react-native/src/private/webapis/performance/Performance';
 

--- a/packages/react-native/src/private/webapis/performance/__tests__/UserTimingAPI-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/UserTimingAPI-itest.js
@@ -9,7 +9,7 @@
  * @oncall react_native
  */
 
-import 'react-native/Libraries/Core/InitializeCore';
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import type Performance from 'react-native/src/private/webapis/performance/Performance';
 


### PR DESCRIPTION
Summary:
Changelog: [internal]

This adds a safety mechanism to Fantom tests to prevent LogBox from swallowing errors.

Now we validate that LogBox isn't installed when running tasks, so we can properly fix error reporting in tests.

Differential Revision: D74464749
