### PR TITLE
Fix the `use` import on `DefaultStyleValuesUtil`

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/DefaultStyleValuesUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/DefaultStyleValuesUtil.kt
@@ -9,6 +9,7 @@ package com.facebook.react.views.text
 
 import android.content.Context
 import android.content.res.ColorStateList
+import androidx.core.content.res.use
 
 /** Utility class that access default values from style */
 public object DefaultStyleValuesUtil {


### PR DESCRIPTION
Summary:
D74381864 caused a series of crashes to spike due to .IncompatibleClassChangeError: Class 'android.content.res.TypedArray' does not implement interface 'java.lang.AutoCloseable'

This fixes it.

Changelog:
[Internal] [Changed] -

Differential Revision: D74468593


