### PR TITLE
Simplify StubViewTree creation

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/animations/tests/LayoutAnimationTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animations/tests/LayoutAnimationTest.cpp
@@ -121,7 +121,7 @@ static void testShadowNodeTreeLifeCycleLayoutAnimations(
                 ShadowNode::ListOfShared{singleRootChildNode})}));
 
     // Building an initial view hierarchy.
-    auto viewTree = buildStubViewTreeWithoutUsingDifferentiator(*emptyRootNode);
+    auto viewTree = StubViewTree(ShadowView(*emptyRootNode));
     viewTree.mutate(
         calculateShadowViewMutations(*emptyRootNode, *currentRootNode));
 

--- a/packages/react-native/ReactCommon/react/renderer/mounting/tests/ShadowTreeLifeCycleTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/tests/ShadowTreeLifeCycleTest.cpp
@@ -80,7 +80,7 @@ static void testShadowNodeTreeLifeCycle(
                 ShadowNode::ListOfShared{singleRootChildNode})}));
 
     // Building an initial view hierarchy.
-    auto viewTree = buildStubViewTreeWithoutUsingDifferentiator(*emptyRootNode);
+    auto viewTree = StubViewTree(ShadowView(*emptyRootNode));
     viewTree.mutate(
         calculateShadowViewMutations(*emptyRootNode, *currentRootNode));
 


### PR DESCRIPTION
Summary:
In the case of an empty root node, we don't need `buildStubViewTreeWithoutUsingDifferentiator` to create the initial `StubViewTree`

When testing with Fantom, this caused an additional unnecessary clone of RootShadowNode.

Differential Revision: D74472766

Changelog: [Internal]


