### PR TITLE
Fix image source size props in getDiffProps

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
@@ -226,7 +226,8 @@ jni::local_ref<jobject> getProps(
       (strcmp(newShadowView.componentName, "View") == 0 ||
        strcmp(newShadowView.componentName, "Image") == 0 ||
        strcmp(newShadowView.componentName, "ScrollView") == 0 ||
-       strcmp(newShadowView.componentName, "RawText") == 0)) {
+       strcmp(newShadowView.componentName, "RawText") == 0 ||
+       strcmp(newShadowView.componentName, "Text") == 0)) {
     return ReadableNativeMap::newObjectCxxArgs(
         newProps->getDiffProps(oldProps));
   }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
@@ -227,7 +227,8 @@ jni::local_ref<jobject> getProps(
        strcmp(newShadowView.componentName, "Image") == 0 ||
        strcmp(newShadowView.componentName, "ScrollView") == 0 ||
        strcmp(newShadowView.componentName, "RawText") == 0 ||
-       strcmp(newShadowView.componentName, "Text") == 0)) {
+       strcmp(newShadowView.componentName, "Text") == 0 ||
+       strcmp(newShadowView.componentName, "Paragraph") == 0)) {
     return ReadableNativeMap::newObjectCxxArgs(
         newProps->getDiffProps(oldProps));
   }

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
@@ -194,10 +194,8 @@ static folly::dynamic convertImageSource(const ImageSource& imageSource) {
   imageSourceResult["bundle"] = imageSource.bundle;
   imageSourceResult["scale"] = imageSource.scale;
 
-  folly::dynamic size = folly::dynamic::object();
-  size["width"] = imageSource.size.width;
-  size["height"] = imageSource.size.height;
-  imageSourceResult["size"] = size;
+  imageSourceResult["width"] = imageSource.size.width;
+  imageSourceResult["height"] = imageSource.size.height;
 
   imageSourceResult["body"] = imageSource.body;
   imageSourceResult["method"] = imageSource.method;

--- a/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
@@ -356,4 +356,194 @@ SharedDebugStringConvertibleList BaseTextProps::getDebugProps() const {
 }
 #endif
 
+#ifdef ANDROID
+
+static folly::dynamic toDynamic(const Size& size) {
+  folly::dynamic sizeResult = folly::dynamic::object();
+  sizeResult["width"] = size.width;
+  sizeResult["height"] = size.height;
+  return sizeResult;
+}
+
+void BaseTextProps::appendTextAttributesProps(
+    folly::dynamic& result,
+    const BaseTextProps* oldProps) const {
+  if (textAttributes.foregroundColor !=
+      oldProps->textAttributes.foregroundColor) {
+    result["color"] = *textAttributes.foregroundColor;
+  }
+
+  if (textAttributes.fontFamily != oldProps->textAttributes.fontFamily) {
+    result["fontFamily"] = textAttributes.fontFamily;
+  }
+
+  if (textAttributes.fontSize != oldProps->textAttributes.fontSize) {
+    result["fontSize"] = textAttributes.fontSize;
+  }
+
+  if (textAttributes.fontSizeMultiplier !=
+      oldProps->textAttributes.fontSizeMultiplier) {
+    result["fontSizeMultiplier"] = textAttributes.fontSizeMultiplier;
+  }
+
+  if (textAttributes.fontWeight != oldProps->textAttributes.fontWeight) {
+    result["fontWeight"] = textAttributes.fontWeight.has_value()
+        ? toString(textAttributes.fontWeight.value())
+        : nullptr;
+  }
+
+  if (textAttributes.fontStyle != oldProps->textAttributes.fontStyle) {
+    result["fontStyle"] = textAttributes.fontStyle.has_value()
+        ? toString(textAttributes.fontStyle.value())
+        : nullptr;
+  }
+
+  if (textAttributes.fontVariant != oldProps->textAttributes.fontVariant) {
+    result["fontVariant"] = textAttributes.fontVariant.has_value()
+        ? toString(textAttributes.fontVariant.value())
+        : nullptr;
+  }
+
+  if (textAttributes.allowFontScaling !=
+      oldProps->textAttributes.allowFontScaling) {
+    result["allowFontScaling"] = textAttributes.allowFontScaling.has_value()
+        ? textAttributes.allowFontScaling.value()
+        : folly::dynamic(nullptr);
+  }
+
+  if (textAttributes.maxFontSizeMultiplier !=
+      oldProps->textAttributes.maxFontSizeMultiplier) {
+    result["maxFontSizeMultiplier"] = textAttributes.maxFontSizeMultiplier;
+  }
+
+  if (textAttributes.dynamicTypeRamp !=
+      oldProps->textAttributes.dynamicTypeRamp) {
+    result["dynamicTypeRamp"] = textAttributes.dynamicTypeRamp.has_value()
+        ? toString(textAttributes.dynamicTypeRamp.value())
+        : nullptr;
+  }
+
+  if (textAttributes.letterSpacing != oldProps->textAttributes.letterSpacing) {
+    result["letterSpacing"] = textAttributes.letterSpacing;
+  }
+
+  if (textAttributes.textTransform != oldProps->textAttributes.textTransform) {
+    result["textTransform"] = textAttributes.textTransform.has_value()
+        ? toString(textAttributes.textTransform.value())
+        : nullptr;
+  }
+
+  if (textAttributes.textAlignVertical !=
+      oldProps->textAttributes.textAlignVertical) {
+    result["textAlignVertical"] = textAttributes.textAlignVertical.has_value()
+        ? toString(textAttributes.textAlignVertical.value())
+        : nullptr;
+  }
+
+  if (textAttributes.lineHeight != oldProps->textAttributes.lineHeight) {
+    result["lineHeight"] = textAttributes.lineHeight;
+  }
+
+  if (textAttributes.alignment != oldProps->textAttributes.alignment) {
+    result["textAlign"] = textAttributes.alignment.has_value()
+        ? toString(textAttributes.alignment.value())
+        : nullptr;
+  }
+
+  if (textAttributes.baseWritingDirection !=
+      oldProps->textAttributes.baseWritingDirection) {
+    result["baseWritingDirection"] =
+        textAttributes.baseWritingDirection.has_value()
+        ? toString(textAttributes.baseWritingDirection.value())
+        : nullptr;
+  }
+
+  if (textAttributes.lineBreakStrategy !=
+      oldProps->textAttributes.lineBreakStrategy) {
+    result["lineBreakStrategyIOS"] =
+        textAttributes.lineBreakStrategy.has_value()
+        ? toString(textAttributes.lineBreakStrategy.value())
+        : nullptr;
+  }
+
+  if (textAttributes.lineBreakMode != oldProps->textAttributes.lineBreakMode) {
+    result["lineBreakModeIOS"] = textAttributes.lineBreakMode.has_value()
+        ? toString(textAttributes.lineBreakMode.value())
+        : nullptr;
+  }
+
+  if (textAttributes.textDecorationColor !=
+      oldProps->textAttributes.textDecorationColor) {
+    result["textDecorationColor"] = *textAttributes.textDecorationColor;
+  }
+
+  if (textAttributes.textDecorationLineType !=
+      oldProps->textAttributes.textDecorationLineType) {
+    result["textDecorationLine"] =
+        textAttributes.textDecorationLineType.has_value()
+        ? toString(textAttributes.textDecorationLineType.value())
+        : nullptr;
+  }
+
+  if (textAttributes.textDecorationStyle !=
+      oldProps->textAttributes.textDecorationStyle) {
+    result["textDecorationStyle"] =
+        textAttributes.textDecorationStyle.has_value()
+        ? toString(textAttributes.textDecorationStyle.value())
+        : nullptr;
+  }
+
+  if (textAttributes.textShadowOffset !=
+      oldProps->textAttributes.textShadowOffset) {
+    result["textShadowOffset"] = textAttributes.textShadowOffset.has_value()
+        ? toDynamic(textAttributes.textShadowOffset.value())
+        : nullptr;
+  }
+
+  if (textAttributes.textShadowRadius !=
+      oldProps->textAttributes.textShadowRadius) {
+    result["textShadowRadius"] = textAttributes.textShadowRadius;
+  }
+
+  if (textAttributes.textShadowColor !=
+      oldProps->textAttributes.textShadowColor) {
+    result["textShadowColor"] = *textAttributes.textShadowColor;
+  }
+
+  if (textAttributes.isHighlighted != oldProps->textAttributes.isHighlighted) {
+    result["isHighlighted"] = textAttributes.isHighlighted.has_value()
+        ? textAttributes.isHighlighted.value()
+        : folly::dynamic(nullptr);
+  }
+
+  if (textAttributes.isPressable != oldProps->textAttributes.isPressable) {
+    result["isPressable"] = textAttributes.isPressable.has_value()
+        ? textAttributes.isPressable.value()
+        : folly::dynamic(nullptr);
+  }
+
+  if (textAttributes.accessibilityRole !=
+      oldProps->textAttributes.accessibilityRole) {
+    result["accessibilityRole"] = textAttributes.accessibilityRole.has_value()
+        ? toString(textAttributes.accessibilityRole.value())
+        : nullptr;
+  }
+
+  if (textAttributes.role != oldProps->textAttributes.role) {
+    result["role"] = textAttributes.role.has_value()
+        ? toString(textAttributes.role.value())
+        : nullptr;
+  }
+
+  if (textAttributes.opacity != oldProps->textAttributes.opacity) {
+    result["opacity"] = textAttributes.opacity;
+  }
+
+  if (textAttributes.backgroundColor !=
+      oldProps->textAttributes.backgroundColor) {
+    result["backgroundColor"] = *textAttributes.backgroundColor;
+  }
+}
+
+#endif
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.h
@@ -41,6 +41,14 @@ class BaseTextProps {
 #if RN_DEBUG_STRING_CONVERTIBLE
   SharedDebugStringConvertibleList getDebugProps() const;
 #endif
+
+#ifdef ANDROID
+
+  void appendTextAttributesProps(
+      folly::dynamic& result,
+      const BaseTextProps* prevProps) const;
+
+#endif
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.cpp
@@ -152,4 +152,76 @@ SharedDebugStringConvertibleList ParagraphProps::getDebugProps() const {
 }
 #endif
 
+#ifdef ANDROID
+
+folly::dynamic ParagraphProps::getDiffProps(const Props* prevProps) const {
+  static const auto defaultProps = ParagraphProps();
+
+  const ParagraphProps* oldProps = prevProps == nullptr
+      ? &defaultProps
+      : static_cast<const ParagraphProps*>(prevProps);
+
+  folly::dynamic result = ViewProps::getDiffProps(oldProps);
+
+  BaseTextProps::appendTextAttributesProps(result, oldProps);
+
+  if (paragraphAttributes.maximumNumberOfLines !=
+      oldProps->paragraphAttributes.maximumNumberOfLines) {
+    result["numberOfLine"] = paragraphAttributes.maximumNumberOfLines;
+  }
+
+  if (paragraphAttributes.ellipsizeMode !=
+      oldProps->paragraphAttributes.ellipsizeMode) {
+    result["ellipsizeMode"] = toString(paragraphAttributes.ellipsizeMode);
+  }
+
+  if (paragraphAttributes.textBreakStrategy !=
+      oldProps->paragraphAttributes.textBreakStrategy) {
+    result["textBreakStrategy"] =
+        toString(paragraphAttributes.textBreakStrategy);
+  }
+
+  if (paragraphAttributes.adjustsFontSizeToFit !=
+      oldProps->paragraphAttributes.adjustsFontSizeToFit) {
+    result["adjustsFontSizeToFit"] = paragraphAttributes.adjustsFontSizeToFit;
+  }
+
+  if (paragraphAttributes.minimumFontScale !=
+      oldProps->paragraphAttributes.minimumFontScale) {
+    result["minimumFontScale"] = paragraphAttributes.minimumFontScale;
+  }
+
+  if (paragraphAttributes.minimumFontSize !=
+      oldProps->paragraphAttributes.minimumFontSize) {
+    result["minimumFontSize"] = paragraphAttributes.minimumFontSize;
+  }
+
+  if (paragraphAttributes.maximumFontSize !=
+      oldProps->paragraphAttributes.maximumFontSize) {
+    result["maximumFontSize"] = paragraphAttributes.maximumFontSize;
+  }
+
+  if (paragraphAttributes.includeFontPadding !=
+      oldProps->paragraphAttributes.includeFontPadding) {
+    result["includeFontPadding"] = paragraphAttributes.includeFontPadding;
+  }
+
+  if (paragraphAttributes.android_hyphenationFrequency !=
+      oldProps->paragraphAttributes.android_hyphenationFrequency) {
+    result["android_hyphenationFrequency"] =
+        toString(paragraphAttributes.android_hyphenationFrequency);
+  }
+
+  if (isSelectable != oldProps->isSelectable) {
+    result["selectable"] = isSelectable;
+  }
+
+  if (onTextLayout != oldProps->onTextLayout) {
+    result["onTextLayout"] = onTextLayout;
+  }
+
+  return result;
+}
+
+#endif
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.h
@@ -57,6 +57,12 @@ class ParagraphProps : public ViewProps, public BaseTextProps {
 #if RN_DEBUG_STRING_CONVERTIBLE
   SharedDebugStringConvertibleList getDebugProps() const override;
 #endif
+
+#ifdef ANDROID
+
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+
+#endif
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/TextProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/TextProps.cpp
@@ -33,4 +33,21 @@ SharedDebugStringConvertibleList TextProps::getDebugProps() const {
 }
 #endif
 
+#ifdef ANDROID
+
+folly::dynamic TextProps::getDiffProps(const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  static const auto defaultProps = TextProps();
+
+  const TextProps* oldProps = prevProps == nullptr
+      ? &defaultProps
+      : static_cast<const TextProps*>(prevProps);
+
+  BaseTextProps::appendTextAttributesProps(result, oldProps);
+
+  return result;
+}
+
+#endif
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/TextProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/TextProps.h
@@ -34,6 +34,12 @@ class TextProps : public Props, public BaseTextProps {
 #if RN_DEBUG_STRING_CONVERTIBLE
   SharedDebugStringConvertibleList getDebugProps() const override;
 #endif
+
+#ifdef ANDROID
+
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+
+#endif
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
The size parameters are flattened in the source object in the Android image component. This diff converts the `size` object to `width` and `height` props directly set on the source object, fixing image source setting more than one image source.

Changelog: [Internal]

Differential Revision: D74477884


