### PR TITLE
Support bridging for Class methods return types

### DIFF
--- a/packages/react-native/ReactCommon/react/bridging/Class.h
+++ b/packages/react-native/ReactCommon/react/bridging/Class.h
@@ -41,7 +41,7 @@ T callFromJs(
         rt, fromJs<Args>(rt, std::forward<JSArgs>(args), jsInvoker)...);
     return jsi::Value();
 
-  } else if constexpr (is_jsi_v<T>) {
+  } else if constexpr (is_jsi_v<T> || supportsToJs<R, T>) {
     static_assert(supportsToJs<R, T>, "Incompatible return type");
 
     return toJs(
@@ -49,7 +49,6 @@ T callFromJs(
         (instance->*method)(
             rt, fromJs<Args>(rt, std::forward<JSArgs>(args), jsInvoker)...),
         jsInvoker);
-
   } else if constexpr (is_optional_jsi_v<T>) {
     static_assert(
         is_optional_v<R>


### PR DESCRIPTION
Summary:
Changelog:
[General][Added] - Added support for bridging Class methods return types

Previously, this wouldn't work, unless you define your C++ implementation of the TM to have primitive return type that can be converted to JavaScript's type.

Differential Revision: D74478572


