### PR TITLE
improve disconnection reasons reporting

### DIFF
--- a/packages/dev-middleware/src/inspector-proxy/Device.js
+++ b/packages/dev-middleware/src/inspector-proxy/Device.js
@@ -44,10 +44,10 @@ const WS_CLOSURE_CODE = {
 };
 
 export const WS_CLOSE_REASON = {
-  PAGE_NOT_FOUND: 'Debugger Page Not Found',
-  DEVICE_DISCONNECTED: 'Corresponding Device Disconnected',
-  RECREATING_DEVICE: 'Recreating Device Connection',
-  RECREATING_DEBUGGER: 'Recreating Debugger Connection',
+  PAGE_NOT_FOUND: '[PAGE_NOT_FOUND] Debugger Page Not Found',
+  CONNECTION_LOST: '[CONNECTION_LOST] Connection lost to corresponding device',
+  RECREATING_DEVICE: '[RECREATING_DEVICE] Recreating Device Connection',
+  RECREATING_DEBUGGER: '[RECREATING_DEBUGGER] Recreating Debugger Connection',
 };
 
 // Prefix for script URLs that are alphanumeric IDs. See comment in #processMessageFromDeviceLegacy method for
@@ -219,7 +219,7 @@ export default class Device {
         // Device disconnected - close debugger connection.
         this.#terminateDebuggerConnection(
           WS_CLOSURE_CODE.NORMAL,
-          WS_CLOSE_REASON.DEVICE_DISCONNECTED,
+          WS_CLOSE_REASON.CONNECTION_LOST,
         );
         clearInterval(this.#pagesPollingIntervalId);
       }

--- a/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
+++ b/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
@@ -47,6 +47,15 @@ const MIN_EVENT_LOOP_DELAY_PERCENT_TO_REPORT = 20;
 
 const INTERNAL_ERROR_CODE = 1011;
 
+// should be aligned with
+// https://github.com/facebook/react-native-devtools-frontend/blob/fa273092fbc8edc94d4a0a3621735f4677a99ba8/front_end/ui/legacy/components/utils/TargetDetachedDialog.ts#L50
+const INTERNAL_ERROR_MESSAGES = {
+  UREGISTERED_DEVICE:
+    '[UREGISTERED_DEVICE] Debugger connection attempted for a device that was not registered',
+  INCORRECT_URL:
+    '[INCORRECT_URL] Incorrect URL - device and page IDs must be provided',
+};
+
 export type GetPageDescriptionsConfig = {
   requestorRelativeBaseUrl: URL,
   logNoPagesForConnectedDevice?: boolean,
@@ -507,13 +516,11 @@ export default class InspectorProxy implements InspectorProxyQueries {
 
       try {
         if (deviceId == null || pageId == null) {
-          throw new Error('Incorrect URL - must provide device and page IDs');
+          throw new Error(INTERNAL_ERROR_MESSAGES.INCORRECT_URL);
         }
 
         if (device == null) {
-          throw new Error(
-            'Debugger connection attempted for a non registered device',
-          );
+          throw new Error(INTERNAL_ERROR_MESSAGES.UREGISTERED_DEVICE);
         }
 
         this.#logger?.info(


### PR DESCRIPTION
Summary:
Corresponding OS PR:
https://github.com/facebook/react-native-devtools-frontend/pull/160

Improve termination dialog with the following:
* Commit 1- add a session ID, if it exists, to the feedback message.
* Commit 2- add the option to display why devtools got disconnected.
* Commit 3- add a custom message to be displayed to users in certain cases when a disconnection happens.

Differential Revision: D74484316


