### PR TITLE
Remove react-native-exit-app from nightly testing

### DIFF
--- a/.github/workflows/test-libraries-on-nightlies.yml
+++ b/.github/workflows/test-libraries-on-nightlies.yml
@@ -48,7 +48,6 @@ jobs:
           "react-native-contacts",
           "react-native-device-info",
           "react-native-email-link",
-          "react-native-exit-app",
           "@dr.pogodin/react-native-fs",
           "react-native-permissions",
           "react-native-vector-icons",


### PR DESCRIPTION
Summary:
react-native-exit-app last commit is from 2 years ago.
Removing it as it is broken with our nightly integration

## Changelog:
[Internal] - Remove react-native-exit-app from nightly testing

Differential Revision: D74527792


