### PR TITLE
fix(ios): reset contentInset after centerContent changed

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTEnhancedScrollView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTEnhancedScrollView.mm
@@ -91,6 +91,15 @@
   self.contentInset = UIEdgeInsetsMake(top, left, top, left);
 }
 
+- (void)setCenterContent:(BOOL)centerContent
+{
+  _centerContent = centerContent;
+  if (!_centerContent) {
+    self.contentInset = UIEdgeInsetsZero;
+  }
+  [self centerContentIfNeeded];
+}
+
 - (void)setContentOffset:(CGPoint)contentOffset
 {
   if (_isSetContentOffsetDisabled) {


### PR DESCRIPTION
Reset contentInset after centerContent changed

## Summary:

Pull Request resolved: #50839

## Changelog:

[IOS] [CHANGED] - The content in ScrollView now can be centered/uncentered by changing centerContent property

## Test Plan
Tested with the following code

```javascript
const [centerContent, setCenterContent] = useState(false);
setTimeout(() => {
    setCenterContent(!centerContent);
}, 2000);
return (
  <ScrollView centerContent={centerContent}
    contentContainerStyle={{alignItems: 'center'}}>
      <View style={{width: 200, height: 200, backgroundColor: 'blue'}}>
      </View>
    </ScrollView>
);
```
1. If the initial state is false, the blue rectangle in the ScrollView will be initially located at the top and move to the center after the timer is triggered.
2. If the initial state is true, the blue rectangle in the ScrollView will be centered initially and move to the top after the timer is triggered.
