### PR TITLE
RN: Simplify `createAnimatedPropsHook-test.js`

### DIFF
--- a/packages/react-native/src/private/animated/__tests__/createAnimatedPropsHook-test.js
+++ b/packages/react-native/src/private/animated/__tests__/createAnimatedPropsHook-test.js
@@ -9,37 +9,13 @@
  * @oncall react_native
  */
 
-import type {ReactNativeFeatureFlagsJsOnlyOverrides} from '../../featureflags/ReactNativeFeatureFlags';
-
 import {create, update} from '../../../../jest/renderer';
+import {AnimatedEvent} from '../../../../Libraries/Animated/AnimatedEvent';
+import createAnimatedPropsHook from '../createAnimatedPropsHook';
 import {useLayoutEffect} from 'react';
 
 describe('useAnimatedProps', () => {
-  function importModules(overrides: ReactNativeFeatureFlagsJsOnlyOverrides) {
-    const ReactNativeFeatureFlags = require('../../featureflags/ReactNativeFeatureFlags');
-
-    // Make sure to setup overrides before importing any modules.
-    ReactNativeFeatureFlags.override(overrides);
-
-    return {
-      // $FlowIgnore[unsafe-getters-setters]
-      get AnimatedEvent() {
-        return require('../../../../Libraries/Animated/AnimatedEvent')
-          .AnimatedEvent;
-      },
-      // $FlowIgnore[unsafe-getters-setters]
-      get createAnimatedPropsHook() {
-        return require('../createAnimatedPropsHook').default;
-      },
-    };
-  }
-
-  beforeEach(() => {
-    jest.resetModules();
-  });
-
   it('returns the same ref callback when `props` changes', async () => {
-    const {createAnimatedPropsHook} = importModules({});
     const useAnimatedProps = createAnimatedPropsHook(null);
 
     const refs = [];
@@ -60,7 +36,6 @@ describe('useAnimatedProps', () => {
   });
 
   it('returns the same ref callback when `AnimatedEvent` is the same', async () => {
-    const {AnimatedEvent, createAnimatedPropsHook} = importModules({});
     const useAnimatedProps = createAnimatedPropsHook(null);
 
     const refs = [];
@@ -83,7 +58,6 @@ describe('useAnimatedProps', () => {
   });
 
   it('returns a new ref callback when `AnimatedEvent` changes', async () => {
-    const {AnimatedEvent, createAnimatedPropsHook} = importModules({});
     const useAnimatedProps = createAnimatedPropsHook(null);
 
     const refs = [];


### PR DESCRIPTION
Summary:
Since `createAnimatedPropsHook-test.js` no longer needs to override feature flags, clean up some of the extra logic.

Changelog:
[Internal]

Differential Revision: D74535116


