### PR TITLE
[iOS] Fabric: Fixes Text style prop 'writingDirection' not working on  IOS New Architecture

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
@@ -120,7 +120,7 @@ static TextAttributes convertRawProp(
   textAttributes.baseWritingDirection = convertRawProp(
       context,
       rawProps,
-      "baseWritingDirection",
+      "writingDirection",
       sourceTextAttributes.baseWritingDirection,
       defaultTextAttributes.baseWritingDirection);
   textAttributes.lineBreakStrategy = convertRawProp(


### PR DESCRIPTION
## Summary:

Fixes #51235 .

## Changelog:

[IOS] [FIXED] - Fabric: Fixes Text style prop 'writingDirection' not working on  IOS New Architecture


## Test Plan:

Repro please see #51235

