### PR TITLE
Fix generated types in @react-native/virtualized-lists being used without opt-in

### DIFF
--- a/packages/virtualized-lists/package.json
+++ b/packages/virtualized-lists/package.json
@@ -21,7 +21,8 @@
   },
   "exports": {
     ".": {
-      "types": "./types_generated/index.d.ts",
+      "react-native-strict-api": "./types_generated/index.d.ts",
+      "types": "./index.d.ts",
       "default": "./index.js"
     },
     "./*": {


### PR DESCRIPTION
Summary:
Changelog: [General][Fixed] Fix generated types in react-native/virtualized-lists being used without opt-in

D71969602 introduces `exports` field to `package.json` files in `react-native` and `virtualized-lists`. In that diff, the `types` in `virtualized-lists` by default pointed to the new generated types without requiring the opt-in.

This fixes that by requiring the opt-in before using the generated types.

Differential Revision: D74573321


