### PR TITLE
Implement DOMException

### DIFF
--- a/packages/react-native/src/private/webapis/errors/DOMException.js
+++ b/packages/react-native/src/private/webapis/errors/DOMException.js
@@ -1,0 +1,161 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ * @oncall react_native
+ */
+
+/**
+ * This module implements the `DOMException` interface from WebIDL.
+ * See https://webidl.spec.whatwg.org/#idl-DOMException.
+ */
+
+// flowlint unsafe-getters-setters:off
+
+const ERROR_NAME_TO_ERROR_CODE_MAP: {[string]: number} = {
+  IndexSizeError: 1,
+  HierarchyRequestError: 3,
+  WrongDocumentError: 4,
+  InvalidCharacterError: 5,
+  NoModificationAllowedError: 7,
+  NotFoundError: 8,
+  NotSupportedError: 9,
+  InUseAttributeError: 10,
+  InvalidStateError: 11,
+  SyntaxError: 12,
+  InvalidModificationError: 13,
+  NamespaceError: 14,
+  InvalidAccessError: 15,
+  TypeMismatchError: 17,
+  SecurityError: 18,
+  NetworkError: 19,
+  AbortError: 20,
+  URLMismatchError: 21,
+  QuotaExceededError: 22,
+  TimeoutError: 23,
+  InvalidNodeTypeError: 24,
+  DataCloneError: 25,
+};
+
+const ERROR_CODES: {[string]: number} = {
+  INDEX_SIZE_ERR: 1,
+  DOMSTRING_SIZE_ERR: 2,
+  HIERARCHY_REQUEST_ERR: 3,
+  WRONG_DOCUMENT_ERR: 4,
+  INVALID_CHARACTER_ERR: 5,
+  NO_DATA_ALLOWED_ERR: 6,
+  NO_MODIFICATION_ALLOWED_ERR: 7,
+  NOT_FOUND_ERR: 8,
+  NOT_SUPPORTED_ERR: 9,
+  INUSE_ATTRIBUTE_ERR: 10,
+  INVALID_STATE_ERR: 11,
+  SYNTAX_ERR: 12,
+  INVALID_MODIFICATION_ERR: 13,
+  NAMESPACE_ERR: 14,
+  INVALID_ACCESS_ERR: 15,
+  VALIDATION_ERR: 16,
+  TYPE_MISMATCH_ERR: 17,
+  SECURITY_ERR: 18,
+  NETWORK_ERR: 19,
+  ABORT_ERR: 20,
+  URL_MISMATCH_ERR: 21,
+  QUOTA_EXCEEDED_ERR: 22,
+  TIMEOUT_ERR: 23,
+  INVALID_NODE_TYPE_ERR: 24,
+  DATA_CLONE_ERR: 25,
+};
+
+/* eslint-disable lint/require-extends-error */
+// $FlowExpectedError[incompatible-variance] name is writable in Error but not in DOMException, but this is how it works on Web.
+export default class DOMException extends Error {
+  static +INDEX_SIZE_ERR: 1;
+  static +DOMSTRING_SIZE_ERR: 2;
+  static +HIERARCHY_REQUEST_ERR: 3;
+  static +WRONG_DOCUMENT_ERR: 4;
+  static +INVALID_CHARACTER_ERR: 5;
+  static +NO_DATA_ALLOWED_ERR: 6;
+  static +NO_MODIFICATION_ALLOWED_ERR: 7;
+  static +NOT_FOUND_ERR: 8;
+  static +NOT_SUPPORTED_ERR: 9;
+  static +INUSE_ATTRIBUTE_ERR: 10;
+  static +INVALID_STATE_ERR: 11;
+  static +SYNTAX_ERR: 12;
+  static +INVALID_MODIFICATION_ERR: 13;
+  static +NAMESPACE_ERR: 14;
+  static +INVALID_ACCESS_ERR: 15;
+  static +VALIDATION_ERR: 16;
+  static +TYPE_MISMATCH_ERR: 17;
+  static +SECURITY_ERR: 18;
+  static +NETWORK_ERR: 19;
+  static +ABORT_ERR: 20;
+  static +URL_MISMATCH_ERR: 21;
+  static +QUOTA_EXCEEDED_ERR: 22;
+  static +TIMEOUT_ERR: 23;
+  static +INVALID_NODE_TYPE_ERR: 24;
+  static +DATA_CLONE_ERR: 25;
+
+  +INDEX_SIZE_ERR: 1;
+  +DOMSTRING_SIZE_ERR: 2;
+  +HIERARCHY_REQUEST_ERR: 3;
+  +WRONG_DOCUMENT_ERR: 4;
+  +INVALID_CHARACTER_ERR: 5;
+  +NO_DATA_ALLOWED_ERR: 6;
+  +NO_MODIFICATION_ALLOWED_ERR: 7;
+  +NOT_FOUND_ERR: 8;
+  +NOT_SUPPORTED_ERR: 9;
+  +INUSE_ATTRIBUTE_ERR: 10;
+  +INVALID_STATE_ERR: 11;
+  +SYNTAX_ERR: 12;
+  +INVALID_MODIFICATION_ERR: 13;
+  +NAMESPACE_ERR: 14;
+  +INVALID_ACCESS_ERR: 15;
+  +VALIDATION_ERR: 16;
+  +TYPE_MISMATCH_ERR: 17;
+  +SECURITY_ERR: 18;
+  +NETWORK_ERR: 19;
+  +ABORT_ERR: 20;
+  +URL_MISMATCH_ERR: 21;
+  +QUOTA_EXCEEDED_ERR: 22;
+  +TIMEOUT_ERR: 23;
+  +INVALID_NODE_TYPE_ERR: 24;
+  +DATA_CLONE_ERR: 25;
+
+  #name: string;
+  #code: number;
+
+  constructor(message?: string, name?: string) {
+    super(message);
+
+    if (typeof name === 'undefined') {
+      this.#name = 'Error';
+      this.#code = 0;
+    } else {
+      this.#name = String(name);
+      this.#code = ERROR_NAME_TO_ERROR_CODE_MAP[this.name] ?? 0;
+    }
+  }
+
+  get name(): string {
+    return this.#name;
+  }
+
+  get code(): number {
+    return this.#code;
+  }
+}
+
+for (const code in ERROR_CODES) {
+  Object.defineProperty(DOMException, code, {
+    enumerable: true,
+    value: ERROR_CODES[code],
+  });
+
+  Object.defineProperty(DOMException.prototype, code, {
+    enumerable: true,
+    value: ERROR_CODES[code],
+  });
+}

--- a/packages/react-native/src/private/webapis/errors/__tests__/DOMException-itest.js
+++ b/packages/react-native/src/private/webapis/errors/__tests__/DOMException-itest.js
@@ -1,0 +1,158 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
+
+import DOMException from 'react-native/src/private/webapis/errors/DOMException';
+
+describe('DOMException', () => {
+  it('provides error codes as static fields and instance fields', () => {
+    expect(DOMException.INDEX_SIZE_ERR).toBe(1);
+    expect(DOMException.DOMSTRING_SIZE_ERR).toBe(2);
+    expect(DOMException.HIERARCHY_REQUEST_ERR).toBe(3);
+    expect(DOMException.WRONG_DOCUMENT_ERR).toBe(4);
+    expect(DOMException.INVALID_CHARACTER_ERR).toBe(5);
+    expect(DOMException.NO_DATA_ALLOWED_ERR).toBe(6);
+    expect(DOMException.NO_MODIFICATION_ALLOWED_ERR).toBe(7);
+    expect(DOMException.NOT_FOUND_ERR).toBe(8);
+    expect(DOMException.NOT_SUPPORTED_ERR).toBe(9);
+    expect(DOMException.INUSE_ATTRIBUTE_ERR).toBe(10);
+    expect(DOMException.INVALID_STATE_ERR).toBe(11);
+    expect(DOMException.SYNTAX_ERR).toBe(12);
+    expect(DOMException.INVALID_MODIFICATION_ERR).toBe(13);
+    expect(DOMException.NAMESPACE_ERR).toBe(14);
+    expect(DOMException.INVALID_ACCESS_ERR).toBe(15);
+    expect(DOMException.VALIDATION_ERR).toBe(16);
+    expect(DOMException.TYPE_MISMATCH_ERR).toBe(17);
+    expect(DOMException.SECURITY_ERR).toBe(18);
+    expect(DOMException.NETWORK_ERR).toBe(19);
+    expect(DOMException.ABORT_ERR).toBe(20);
+    expect(DOMException.URL_MISMATCH_ERR).toBe(21);
+    expect(DOMException.QUOTA_EXCEEDED_ERR).toBe(22);
+    expect(DOMException.TIMEOUT_ERR).toBe(23);
+    expect(DOMException.INVALID_NODE_TYPE_ERR).toBe(24);
+    expect(DOMException.DATA_CLONE_ERR).toBe(25);
+
+    expect(new DOMException().INDEX_SIZE_ERR).toBe(1);
+    expect(new DOMException().DOMSTRING_SIZE_ERR).toBe(2);
+    expect(new DOMException().HIERARCHY_REQUEST_ERR).toBe(3);
+    expect(new DOMException().WRONG_DOCUMENT_ERR).toBe(4);
+    expect(new DOMException().INVALID_CHARACTER_ERR).toBe(5);
+    expect(new DOMException().NO_DATA_ALLOWED_ERR).toBe(6);
+    expect(new DOMException().NO_MODIFICATION_ALLOWED_ERR).toBe(7);
+    expect(new DOMException().NOT_FOUND_ERR).toBe(8);
+    expect(new DOMException().NOT_SUPPORTED_ERR).toBe(9);
+    expect(new DOMException().INUSE_ATTRIBUTE_ERR).toBe(10);
+    expect(new DOMException().INVALID_STATE_ERR).toBe(11);
+    expect(new DOMException().SYNTAX_ERR).toBe(12);
+    expect(new DOMException().INVALID_MODIFICATION_ERR).toBe(13);
+    expect(new DOMException().NAMESPACE_ERR).toBe(14);
+    expect(new DOMException().INVALID_ACCESS_ERR).toBe(15);
+    expect(new DOMException().VALIDATION_ERR).toBe(16);
+    expect(new DOMException().TYPE_MISMATCH_ERR).toBe(17);
+    expect(new DOMException().SECURITY_ERR).toBe(18);
+    expect(new DOMException().NETWORK_ERR).toBe(19);
+    expect(new DOMException().ABORT_ERR).toBe(20);
+    expect(new DOMException().URL_MISMATCH_ERR).toBe(21);
+    expect(new DOMException().QUOTA_EXCEEDED_ERR).toBe(22);
+    expect(new DOMException().TIMEOUT_ERR).toBe(23);
+    expect(new DOMException().INVALID_NODE_TYPE_ERR).toBe(24);
+    expect(new DOMException().DATA_CLONE_ERR).toBe(25);
+  });
+
+  it('extends error and provides name and message', () => {
+    const error = new DOMException('test', 'TestError');
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe('TestError');
+    expect(error.message).toBe('test');
+  });
+
+  it('normalizes the name correctly', () => {
+    expect(new DOMException(undefined, undefined).name).toBe('Error');
+    expect(new DOMException(undefined, '').name).toBe('');
+    // $FlowExpectedError[incompatible-call]
+    expect(new DOMException(undefined, null).name).toBe('null');
+    // $FlowExpectedError[incompatible-call]
+    expect(new DOMException(undefined, {}).name).toBe('[object Object]');
+  });
+
+  it('assigns the right code for the given name', () => {
+    // Unknown name is code 0.
+    expect(new DOMException(undefined, 'SomethingElse').code).toBe(0);
+
+    expect(new DOMException(undefined, 'IndexSizeError').code).toBe(
+      DOMException.INDEX_SIZE_ERR,
+    );
+    expect(new DOMException(undefined, 'HierarchyRequestError').code).toBe(
+      DOMException.HIERARCHY_REQUEST_ERR,
+    );
+    expect(new DOMException(undefined, 'WrongDocumentError').code).toBe(
+      DOMException.WRONG_DOCUMENT_ERR,
+    );
+    expect(new DOMException(undefined, 'InvalidCharacterError').code).toBe(
+      DOMException.INVALID_CHARACTER_ERR,
+    );
+    expect(new DOMException(undefined, 'NoModificationAllowedError').code).toBe(
+      DOMException.NO_MODIFICATION_ALLOWED_ERR,
+    );
+    expect(new DOMException(undefined, 'NotFoundError').code).toBe(
+      DOMException.NOT_FOUND_ERR,
+    );
+    expect(new DOMException(undefined, 'NotSupportedError').code).toBe(
+      DOMException.NOT_SUPPORTED_ERR,
+    );
+    expect(new DOMException(undefined, 'InUseAttributeError').code).toBe(
+      DOMException.INUSE_ATTRIBUTE_ERR,
+    );
+    expect(new DOMException(undefined, 'InvalidStateError').code).toBe(
+      DOMException.INVALID_STATE_ERR,
+    );
+    expect(new DOMException(undefined, 'SyntaxError').code).toBe(
+      DOMException.SYNTAX_ERR,
+    );
+    expect(new DOMException(undefined, 'InvalidModificationError').code).toBe(
+      DOMException.INVALID_MODIFICATION_ERR,
+    );
+    expect(new DOMException(undefined, 'NamespaceError').code).toBe(
+      DOMException.NAMESPACE_ERR,
+    );
+    expect(new DOMException(undefined, 'InvalidAccessError').code).toBe(
+      DOMException.INVALID_ACCESS_ERR,
+    );
+    expect(new DOMException(undefined, 'TypeMismatchError').code).toBe(
+      DOMException.TYPE_MISMATCH_ERR,
+    );
+    expect(new DOMException(undefined, 'SecurityError').code).toBe(
+      DOMException.SECURITY_ERR,
+    );
+    expect(new DOMException(undefined, 'NetworkError').code).toBe(
+      DOMException.NETWORK_ERR,
+    );
+    expect(new DOMException(undefined, 'AbortError').code).toBe(
+      DOMException.ABORT_ERR,
+    );
+    expect(new DOMException(undefined, 'URLMismatchError').code).toBe(
+      DOMException.URL_MISMATCH_ERR,
+    );
+    expect(new DOMException(undefined, 'QuotaExceededError').code).toBe(
+      DOMException.QUOTA_EXCEEDED_ERR,
+    );
+    expect(new DOMException(undefined, 'TimeoutError').code).toBe(
+      DOMException.TIMEOUT_ERR,
+    );
+    expect(new DOMException(undefined, 'InvalidNodeTypeError').code).toBe(
+      DOMException.INVALID_NODE_TYPE_ERR,
+    );
+    expect(new DOMException(undefined, 'DataCloneError').code).toBe(
+      DOMException.DATA_CLONE_ERR,
+    );
+  });
+});


### PR DESCRIPTION
Summary:
Changelog: [internal]

This implements an initial version of `DOMException`, but only to be used internally (not exposed as a global yet).

The goal is to make this available to `structuredClone`, which will be added after this.

Differential Revision: D71407318


