### PR TITLE
Basic implementation of structuredClone

### DIFF
--- a/packages/react-native/src/private/webapis/errors/DOMException.js
+++ b/packages/react-native/src/private/webapis/errors/DOMException.js
@@ -1,0 +1,161 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ * @oncall react_native
+ */
+
+/**
+ * This module implements the `DOMException` interface from WebIDL.
+ * See https://webidl.spec.whatwg.org/#idl-DOMException.
+ */
+
+// flowlint unsafe-getters-setters:off
+
+const ERROR_NAME_TO_ERROR_CODE_MAP: {[string]: number} = {
+  IndexSizeError: 1,
+  HierarchyRequestError: 3,
+  WrongDocumentError: 4,
+  InvalidCharacterError: 5,
+  NoModificationAllowedError: 7,
+  NotFoundError: 8,
+  NotSupportedError: 9,
+  InUseAttributeError: 10,
+  InvalidStateError: 11,
+  SyntaxError: 12,
+  InvalidModificationError: 13,
+  NamespaceError: 14,
+  InvalidAccessError: 15,
+  TypeMismatchError: 17,
+  SecurityError: 18,
+  NetworkError: 19,
+  AbortError: 20,
+  URLMismatchError: 21,
+  QuotaExceededError: 22,
+  TimeoutError: 23,
+  InvalidNodeTypeError: 24,
+  DataCloneError: 25,
+};
+
+const ERROR_CODES: {[string]: number} = {
+  INDEX_SIZE_ERR: 1,
+  DOMSTRING_SIZE_ERR: 2,
+  HIERARCHY_REQUEST_ERR: 3,
+  WRONG_DOCUMENT_ERR: 4,
+  INVALID_CHARACTER_ERR: 5,
+  NO_DATA_ALLOWED_ERR: 6,
+  NO_MODIFICATION_ALLOWED_ERR: 7,
+  NOT_FOUND_ERR: 8,
+  NOT_SUPPORTED_ERR: 9,
+  INUSE_ATTRIBUTE_ERR: 10,
+  INVALID_STATE_ERR: 11,
+  SYNTAX_ERR: 12,
+  INVALID_MODIFICATION_ERR: 13,
+  NAMESPACE_ERR: 14,
+  INVALID_ACCESS_ERR: 15,
+  VALIDATION_ERR: 16,
+  TYPE_MISMATCH_ERR: 17,
+  SECURITY_ERR: 18,
+  NETWORK_ERR: 19,
+  ABORT_ERR: 20,
+  URL_MISMATCH_ERR: 21,
+  QUOTA_EXCEEDED_ERR: 22,
+  TIMEOUT_ERR: 23,
+  INVALID_NODE_TYPE_ERR: 24,
+  DATA_CLONE_ERR: 25,
+};
+
+/* eslint-disable lint/require-extends-error */
+// $FlowExpectedError[incompatible-variance] name is writable in Error but not in DOMException, but this is how it works on Web.
+export default class DOMException extends Error {
+  static +INDEX_SIZE_ERR: 1;
+  static +DOMSTRING_SIZE_ERR: 2;
+  static +HIERARCHY_REQUEST_ERR: 3;
+  static +WRONG_DOCUMENT_ERR: 4;
+  static +INVALID_CHARACTER_ERR: 5;
+  static +NO_DATA_ALLOWED_ERR: 6;
+  static +NO_MODIFICATION_ALLOWED_ERR: 7;
+  static +NOT_FOUND_ERR: 8;
+  static +NOT_SUPPORTED_ERR: 9;
+  static +INUSE_ATTRIBUTE_ERR: 10;
+  static +INVALID_STATE_ERR: 11;
+  static +SYNTAX_ERR: 12;
+  static +INVALID_MODIFICATION_ERR: 13;
+  static +NAMESPACE_ERR: 14;
+  static +INVALID_ACCESS_ERR: 15;
+  static +VALIDATION_ERR: 16;
+  static +TYPE_MISMATCH_ERR: 17;
+  static +SECURITY_ERR: 18;
+  static +NETWORK_ERR: 19;
+  static +ABORT_ERR: 20;
+  static +URL_MISMATCH_ERR: 21;
+  static +QUOTA_EXCEEDED_ERR: 22;
+  static +TIMEOUT_ERR: 23;
+  static +INVALID_NODE_TYPE_ERR: 24;
+  static +DATA_CLONE_ERR: 25;
+
+  +INDEX_SIZE_ERR: 1;
+  +DOMSTRING_SIZE_ERR: 2;
+  +HIERARCHY_REQUEST_ERR: 3;
+  +WRONG_DOCUMENT_ERR: 4;
+  +INVALID_CHARACTER_ERR: 5;
+  +NO_DATA_ALLOWED_ERR: 6;
+  +NO_MODIFICATION_ALLOWED_ERR: 7;
+  +NOT_FOUND_ERR: 8;
+  +NOT_SUPPORTED_ERR: 9;
+  +INUSE_ATTRIBUTE_ERR: 10;
+  +INVALID_STATE_ERR: 11;
+  +SYNTAX_ERR: 12;
+  +INVALID_MODIFICATION_ERR: 13;
+  +NAMESPACE_ERR: 14;
+  +INVALID_ACCESS_ERR: 15;
+  +VALIDATION_ERR: 16;
+  +TYPE_MISMATCH_ERR: 17;
+  +SECURITY_ERR: 18;
+  +NETWORK_ERR: 19;
+  +ABORT_ERR: 20;
+  +URL_MISMATCH_ERR: 21;
+  +QUOTA_EXCEEDED_ERR: 22;
+  +TIMEOUT_ERR: 23;
+  +INVALID_NODE_TYPE_ERR: 24;
+  +DATA_CLONE_ERR: 25;
+
+  #name: string;
+  #code: number;
+
+  constructor(message?: string, name?: string) {
+    super(message);
+
+    if (typeof name === 'undefined') {
+      this.#name = 'Error';
+      this.#code = 0;
+    } else {
+      this.#name = String(name);
+      this.#code = ERROR_NAME_TO_ERROR_CODE_MAP[this.name] ?? 0;
+    }
+  }
+
+  get name(): string {
+    return this.#name;
+  }
+
+  get code(): number {
+    return this.#code;
+  }
+}
+
+for (const code in ERROR_CODES) {
+  Object.defineProperty(DOMException, code, {
+    enumerable: true,
+    value: ERROR_CODES[code],
+  });
+
+  Object.defineProperty(DOMException.prototype, code, {
+    enumerable: true,
+    value: ERROR_CODES[code],
+  });
+}

--- a/packages/react-native/src/private/webapis/errors/__tests__/DOMException-itest.js
+++ b/packages/react-native/src/private/webapis/errors/__tests__/DOMException-itest.js
@@ -1,0 +1,158 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
+
+import DOMException from 'react-native/src/private/webapis/errors/DOMException';
+
+describe('DOMException', () => {
+  it('provides error codes as static fields and instance fields', () => {
+    expect(DOMException.INDEX_SIZE_ERR).toBe(1);
+    expect(DOMException.DOMSTRING_SIZE_ERR).toBe(2);
+    expect(DOMException.HIERARCHY_REQUEST_ERR).toBe(3);
+    expect(DOMException.WRONG_DOCUMENT_ERR).toBe(4);
+    expect(DOMException.INVALID_CHARACTER_ERR).toBe(5);
+    expect(DOMException.NO_DATA_ALLOWED_ERR).toBe(6);
+    expect(DOMException.NO_MODIFICATION_ALLOWED_ERR).toBe(7);
+    expect(DOMException.NOT_FOUND_ERR).toBe(8);
+    expect(DOMException.NOT_SUPPORTED_ERR).toBe(9);
+    expect(DOMException.INUSE_ATTRIBUTE_ERR).toBe(10);
+    expect(DOMException.INVALID_STATE_ERR).toBe(11);
+    expect(DOMException.SYNTAX_ERR).toBe(12);
+    expect(DOMException.INVALID_MODIFICATION_ERR).toBe(13);
+    expect(DOMException.NAMESPACE_ERR).toBe(14);
+    expect(DOMException.INVALID_ACCESS_ERR).toBe(15);
+    expect(DOMException.VALIDATION_ERR).toBe(16);
+    expect(DOMException.TYPE_MISMATCH_ERR).toBe(17);
+    expect(DOMException.SECURITY_ERR).toBe(18);
+    expect(DOMException.NETWORK_ERR).toBe(19);
+    expect(DOMException.ABORT_ERR).toBe(20);
+    expect(DOMException.URL_MISMATCH_ERR).toBe(21);
+    expect(DOMException.QUOTA_EXCEEDED_ERR).toBe(22);
+    expect(DOMException.TIMEOUT_ERR).toBe(23);
+    expect(DOMException.INVALID_NODE_TYPE_ERR).toBe(24);
+    expect(DOMException.DATA_CLONE_ERR).toBe(25);
+
+    expect(new DOMException().INDEX_SIZE_ERR).toBe(1);
+    expect(new DOMException().DOMSTRING_SIZE_ERR).toBe(2);
+    expect(new DOMException().HIERARCHY_REQUEST_ERR).toBe(3);
+    expect(new DOMException().WRONG_DOCUMENT_ERR).toBe(4);
+    expect(new DOMException().INVALID_CHARACTER_ERR).toBe(5);
+    expect(new DOMException().NO_DATA_ALLOWED_ERR).toBe(6);
+    expect(new DOMException().NO_MODIFICATION_ALLOWED_ERR).toBe(7);
+    expect(new DOMException().NOT_FOUND_ERR).toBe(8);
+    expect(new DOMException().NOT_SUPPORTED_ERR).toBe(9);
+    expect(new DOMException().INUSE_ATTRIBUTE_ERR).toBe(10);
+    expect(new DOMException().INVALID_STATE_ERR).toBe(11);
+    expect(new DOMException().SYNTAX_ERR).toBe(12);
+    expect(new DOMException().INVALID_MODIFICATION_ERR).toBe(13);
+    expect(new DOMException().NAMESPACE_ERR).toBe(14);
+    expect(new DOMException().INVALID_ACCESS_ERR).toBe(15);
+    expect(new DOMException().VALIDATION_ERR).toBe(16);
+    expect(new DOMException().TYPE_MISMATCH_ERR).toBe(17);
+    expect(new DOMException().SECURITY_ERR).toBe(18);
+    expect(new DOMException().NETWORK_ERR).toBe(19);
+    expect(new DOMException().ABORT_ERR).toBe(20);
+    expect(new DOMException().URL_MISMATCH_ERR).toBe(21);
+    expect(new DOMException().QUOTA_EXCEEDED_ERR).toBe(22);
+    expect(new DOMException().TIMEOUT_ERR).toBe(23);
+    expect(new DOMException().INVALID_NODE_TYPE_ERR).toBe(24);
+    expect(new DOMException().DATA_CLONE_ERR).toBe(25);
+  });
+
+  it('extends error and provides name and message', () => {
+    const error = new DOMException('test', 'TestError');
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe('TestError');
+    expect(error.message).toBe('test');
+  });
+
+  it('normalizes the name correctly', () => {
+    expect(new DOMException(undefined, undefined).name).toBe('Error');
+    expect(new DOMException(undefined, '').name).toBe('');
+    // $FlowExpectedError[incompatible-call]
+    expect(new DOMException(undefined, null).name).toBe('null');
+    // $FlowExpectedError[incompatible-call]
+    expect(new DOMException(undefined, {}).name).toBe('[object Object]');
+  });
+
+  it('assigns the right code for the given name', () => {
+    // Unknown name is code 0.
+    expect(new DOMException(undefined, 'SomethingElse').code).toBe(0);
+
+    expect(new DOMException(undefined, 'IndexSizeError').code).toBe(
+      DOMException.INDEX_SIZE_ERR,
+    );
+    expect(new DOMException(undefined, 'HierarchyRequestError').code).toBe(
+      DOMException.HIERARCHY_REQUEST_ERR,
+    );
+    expect(new DOMException(undefined, 'WrongDocumentError').code).toBe(
+      DOMException.WRONG_DOCUMENT_ERR,
+    );
+    expect(new DOMException(undefined, 'InvalidCharacterError').code).toBe(
+      DOMException.INVALID_CHARACTER_ERR,
+    );
+    expect(new DOMException(undefined, 'NoModificationAllowedError').code).toBe(
+      DOMException.NO_MODIFICATION_ALLOWED_ERR,
+    );
+    expect(new DOMException(undefined, 'NotFoundError').code).toBe(
+      DOMException.NOT_FOUND_ERR,
+    );
+    expect(new DOMException(undefined, 'NotSupportedError').code).toBe(
+      DOMException.NOT_SUPPORTED_ERR,
+    );
+    expect(new DOMException(undefined, 'InUseAttributeError').code).toBe(
+      DOMException.INUSE_ATTRIBUTE_ERR,
+    );
+    expect(new DOMException(undefined, 'InvalidStateError').code).toBe(
+      DOMException.INVALID_STATE_ERR,
+    );
+    expect(new DOMException(undefined, 'SyntaxError').code).toBe(
+      DOMException.SYNTAX_ERR,
+    );
+    expect(new DOMException(undefined, 'InvalidModificationError').code).toBe(
+      DOMException.INVALID_MODIFICATION_ERR,
+    );
+    expect(new DOMException(undefined, 'NamespaceError').code).toBe(
+      DOMException.NAMESPACE_ERR,
+    );
+    expect(new DOMException(undefined, 'InvalidAccessError').code).toBe(
+      DOMException.INVALID_ACCESS_ERR,
+    );
+    expect(new DOMException(undefined, 'TypeMismatchError').code).toBe(
+      DOMException.TYPE_MISMATCH_ERR,
+    );
+    expect(new DOMException(undefined, 'SecurityError').code).toBe(
+      DOMException.SECURITY_ERR,
+    );
+    expect(new DOMException(undefined, 'NetworkError').code).toBe(
+      DOMException.NETWORK_ERR,
+    );
+    expect(new DOMException(undefined, 'AbortError').code).toBe(
+      DOMException.ABORT_ERR,
+    );
+    expect(new DOMException(undefined, 'URLMismatchError').code).toBe(
+      DOMException.URL_MISMATCH_ERR,
+    );
+    expect(new DOMException(undefined, 'QuotaExceededError').code).toBe(
+      DOMException.QUOTA_EXCEEDED_ERR,
+    );
+    expect(new DOMException(undefined, 'TimeoutError').code).toBe(
+      DOMException.TIMEOUT_ERR,
+    );
+    expect(new DOMException(undefined, 'InvalidNodeTypeError').code).toBe(
+      DOMException.INVALID_NODE_TYPE_ERR,
+    );
+    expect(new DOMException(undefined, 'DataCloneError').code).toBe(
+      DOMException.DATA_CLONE_ERR,
+    );
+  });
+});

--- a/packages/react-native/src/private/webapis/structuredClone/__tests__/structuredClone-itest.js
+++ b/packages/react-native/src/private/webapis/structuredClone/__tests__/structuredClone-itest.js
@@ -1,0 +1,292 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
+
+import DOMException from 'react-native/src/private/webapis/errors/DOMException';
+import structuredClone from 'react-native/src/private/webapis/structuredClone/structuredClone';
+
+function expectDataCloneError(fn: () => mixed) {
+  try {
+    fn();
+  } catch (error) {
+    expect(error).toBeInstanceOf(DOMException);
+    expect(error.name).toBe('DataCloneError');
+    expect(error.code).toBe(DOMException.DATA_CLONE_ERR);
+    return;
+  }
+
+  throw new Error('Expected function to throw DataCloneError, but it did not');
+}
+
+describe('structuredClone', () => {
+  it('clones primitive types', () => {
+    expect(structuredClone(undefined)).toBe(undefined);
+    expect(structuredClone(null)).toBe(null);
+
+    expect(structuredClone(0)).toBe(0);
+    expect(structuredClone(1)).toBe(1);
+
+    expect(structuredClone(0n)).toBe(0n);
+    expect(structuredClone(1n)).toBe(1n);
+
+    expect(structuredClone(false)).toBe(false);
+    expect(structuredClone(true)).toBe(true);
+
+    expect(structuredClone('')).toBe('');
+    expect(structuredClone('foo')).toBe('foo');
+  });
+
+  it('clones primitive value wrappers', () => {
+    // eslint-disable-next-line no-new-wrappers
+    const numberValue = new Number(1);
+    const numberClone = structuredClone(numberValue);
+    expect(numberClone).not.toBe(numberValue);
+    expect(numberClone).toBeInstanceOf(Number);
+    expect(numberClone.valueOf()).toBe(1);
+
+    // eslint-disable-next-line no-new-wrappers
+    const stringValue = new String('foo');
+    const stringClone = structuredClone(stringValue);
+    expect(stringClone).not.toBe(stringValue);
+    expect(stringClone).toBeInstanceOf(String);
+    expect(stringClone.valueOf()).toBe('foo');
+
+    // eslint-disable-next-line no-new-wrappers
+    const booleanValue = new Boolean(true);
+    const booleanClone = structuredClone(booleanValue);
+    expect(booleanClone).not.toBe(booleanValue);
+    expect(booleanClone).toBeInstanceOf(Boolean);
+    expect(booleanClone.valueOf()).toBe(true);
+  });
+
+  it('throws with symbols, functions, WeakMap, WeakSet, Promise', () => {
+    expectDataCloneError(() => structuredClone(Symbol()));
+    expectDataCloneError(() => structuredClone(() => {}));
+    expectDataCloneError(() => structuredClone(new WeakMap()));
+    expectDataCloneError(() => structuredClone(new WeakSet()));
+    expectDataCloneError(() => structuredClone(Promise.resolve(4)));
+  });
+
+  it('clones simple objects', () => {
+    const value = {foo: 'bar'};
+    const clone = structuredClone(value);
+    expect(clone).not.toBe(value);
+    expect(clone).toBeInstanceOf(Object);
+    expect(clone).toEqual(value);
+  });
+
+  it('does NOT clone non-enumerable properties', () => {
+    const value = {foo: 'bar'};
+    // $FlowExpectedError[prop-missing]
+    Object.defineProperty(value, 'other', {enumerable: false, value: 'value'});
+
+    const clone = structuredClone(value);
+
+    expect(clone).not.toBe(value);
+    expect(clone).toBeInstanceOf(Object);
+    expect('other' in clone).toBe(false);
+  });
+
+  it('does NOT clone inherited properties', () => {
+    const base = {foo: 'bar'};
+    const value = Object.create(base);
+
+    const clone = structuredClone(value);
+
+    expect(clone).not.toBe(value);
+    expect(clone).toBeInstanceOf(Object);
+    expect('foo' in clone).toBe(false);
+  });
+
+  it('clones arrays', () => {
+    const value = ['foo', 'bar'];
+    const clone = structuredClone(value);
+    expect(clone).not.toBe(value);
+    expect(clone).toBeInstanceOf(Array);
+    expect(clone).toEqual(value);
+  });
+
+  it('clones arbitrary keys in arrays', () => {
+    const value = ['foo', 'bar'];
+    // Also arbitrary keys
+    // $FlowExpectedError[prop-missing]
+    value.key = 'baz';
+    const clone = structuredClone(value);
+    expect(clone).not.toBe(value);
+    expect(clone).toBeInstanceOf(Array);
+    expect(clone).toEqual(value);
+  });
+
+  it('clones maps', () => {
+    const value = new Map([
+      ['key1', 'value1'],
+      ['key2', 'value2'],
+      ['key3', 'value3'],
+    ]);
+    const clone = structuredClone(value);
+    expect(clone).not.toBe(value);
+    expect(clone).toBeInstanceOf(Map);
+    expect(clone).toEqual(value);
+  });
+
+  it('does NOT clone arbitrary keys in maps', () => {
+    const value = new Map([
+      ['key1', 'value1'],
+      ['key2', 'value2'],
+      ['key3', 'value3'],
+    ]);
+    // $FlowExpectedError[prop-missing]
+    value.key = 1;
+    const clone = structuredClone(value);
+    expect(clone).not.toBe(value);
+    expect(clone).toBeInstanceOf(Map);
+    expect(clone.entries()).toEqual(value.entries());
+    // $FlowExpectedError[prop-missing]
+    expect(clone.key).toBeUndefined();
+  });
+
+  it('clones sets', () => {
+    const value = new Set(['key1', 'key2', 'key3']);
+    const clone = structuredClone(value);
+    expect(clone).not.toBe(value);
+    expect(clone).toBeInstanceOf(Set);
+    expect(clone).toEqual(value);
+  });
+
+  it('does NOT clone arbitrary keys in sets', () => {
+    const value = new Set(['key1', 'key2', 'key3']);
+    // $FlowExpectedError[prop-missing]
+    value.key = 1;
+    const clone = structuredClone(value);
+    expect(clone).not.toBe(value);
+    expect(clone).toBeInstanceOf(Set);
+    expect(clone.entries()).toEqual(value.entries());
+    // $FlowExpectedError[prop-missing]
+    expect(clone.key).toBeUndefined();
+  });
+
+  it('clones regular expressions', () => {
+    const value = new RegExp('foo', 'g');
+    const clone = structuredClone(value);
+    expect(clone).not.toBe(value);
+    expect(clone).toBeInstanceOf(RegExp);
+    expect(clone).toEqual(value);
+  });
+
+  it('clones dates', () => {
+    const value = new Date('1993-06-11T14:30:45.123Z');
+    const clone = structuredClone(value);
+    expect(clone).not.toBe(value);
+    expect(clone).toBeInstanceOf(Date);
+    expect(clone).toEqual(value);
+  });
+
+  it('clones errors', () => {
+    const cause = new Error('cause message');
+    const value = new Error('error message', {cause});
+
+    const clone = structuredClone(value);
+
+    expect(clone).not.toBe(value);
+    expect(clone).toBeInstanceOf(Error);
+    expect(clone.message).toBe(value.message);
+    expect(clone.stack).toBe(value.stack);
+
+    // $FlowExpectedError[incompatible-type]
+    const causeClone: Error = clone.cause;
+    expect(causeClone).toBeInstanceOf(Error);
+    expect(causeClone.message).toBe(cause.message);
+    expect(causeClone.stack).toBe(cause.stack);
+
+    // Valid error names
+    value.name = 'Error';
+    expect(structuredClone(value).name).toBe('Error');
+    value.name = 'EvalError';
+    expect(structuredClone(value).name).toBe('EvalError');
+    value.name = 'RangeError';
+    expect(structuredClone(value).name).toBe('RangeError');
+    value.name = 'ReferenceError';
+    expect(structuredClone(value).name).toBe('ReferenceError');
+    value.name = 'SyntaxError';
+    expect(structuredClone(value).name).toBe('SyntaxError');
+    value.name = 'TypeError';
+    expect(structuredClone(value).name).toBe('TypeError');
+    value.name = 'URIError';
+    expect(structuredClone(value).name).toBe('URIError');
+
+    // Invalid error names
+    value.name = 'FooError';
+    expect(structuredClone(value).name).toBe('Error');
+  });
+
+  it('clones values deeply', () => {
+    const value = {
+      obj: {
+        arr: ['baz', 'foobar'],
+      },
+      map: new Map([[new Set(['foo', 'bar']), {key: 'value'}]]),
+    };
+    const clone = structuredClone(value);
+
+    expect(clone).not.toBe(value);
+    expect(clone.obj).not.toBe(value.obj);
+    expect(clone.obj.arr).not.toBe(value.obj.arr);
+    expect(clone.map).not.toBe(value.map);
+    expect([...clone.map.keys()][0]).not.toBe([...value.map.keys()][0]);
+    expect(clone).toEqual(value);
+  });
+
+  it('handles repeated references', () => {
+    const repeatedValue = {foo: 'bar'};
+    // eslint-disable-next-line no-new-wrappers
+    const repeatedNumber = new Number(3);
+    const value = {
+      first: repeatedValue,
+      second: repeatedValue,
+      third: repeatedNumber,
+      fourth: repeatedNumber,
+    };
+    const clone = structuredClone(value);
+
+    expect(clone).not.toBe(value);
+    expect(clone.first).not.toBe(value.first);
+    expect(clone.second).not.toBe(value.second);
+    expect(clone.third).not.toBe(value.third);
+    expect(clone.fourth).not.toBe(value.fourth);
+    expect(clone.first).toBe(clone.second);
+    expect(clone.third).toBe(clone.fourth);
+    expect(clone).toEqual(value);
+  });
+
+  it('handles circular references', () => {
+    const obj: {arr: Array<mixed>} = {arr: []};
+    obj.arr.push(obj);
+    const map = new Map<string, interface {}>();
+    map.set('key', map);
+    const set = new Set([map]);
+    map.set('set', set);
+
+    const value = {
+      obj,
+      map,
+    };
+
+    const clone = structuredClone(value);
+
+    expect(clone).not.toBe(value);
+    expect(clone.obj.arr[0]).toBe(clone.obj);
+    expect(clone.map.get('key')).toBe(clone.map);
+    // $FlowExpectedError[incompatible-type]
+    // $FlowExpectedError[prop-missing]
+    expect([...clone.map.get('set')][0]).toBe(clone.map);
+  });
+});

--- a/packages/react-native/src/private/webapis/structuredClone/structuredClone.js
+++ b/packages/react-native/src/private/webapis/structuredClone/structuredClone.js
@@ -1,0 +1,194 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ * @oncall react_native
+ */
+
+import DOMException from '../errors/DOMException';
+
+const VALID_ERROR_NAMES = new Set([
+  'Error',
+  'EvalError',
+  'RangeError',
+  'ReferenceError',
+  'SyntaxError',
+  'TypeError',
+  'URIError',
+]);
+
+function structuredCloneInternal<T>(value: T, memory: Map<mixed, mixed>): T {
+  // Handles `null` and `undefined`.
+  if (value == null) {
+    return value;
+  }
+
+  // Handles remaining primitive values.
+  switch (typeof value) {
+    case 'boolean':
+    case 'number':
+    case 'string':
+    case 'bigint':
+      return value;
+  }
+
+  // Handles unsupported types (symbols and functions).
+  if (typeof value !== 'object') {
+    // value is symbol or function
+    throw new DOMException(
+      `Failed to execute 'structuredClone' on 'Window': ${String(value)} could not be cloned.`,
+      'DataCloneError',
+    );
+  }
+
+  // Handles circular references.
+  if (memory.has(value)) {
+    // $FlowExpectedError[incompatible-return] we know memory.get(value) is T
+    return memory.get(value);
+  }
+
+  // Known non-serializable objects
+  // TODO: Handle this more holistically.
+  if (
+    value instanceof WeakMap ||
+    value instanceof WeakSet ||
+    value instanceof Promise
+  ) {
+    throw new DOMException(
+      `Failed to execute 'structuredClone' on 'Window': ${String(value)} could not be cloned.`,
+      'DataCloneError',
+    );
+  }
+
+  // Handles primitive wrappers.
+
+  if (value instanceof Number) {
+    // eslint-disable-next-line no-new-wrappers
+    const result = new Number(value);
+    memory.set(value, result);
+
+    // $FlowExpectedError[incompatible-return] we know result is T
+    return result;
+  }
+
+  if (value instanceof Boolean) {
+    // eslint-disable-next-line no-new-wrappers
+    const result = new Boolean(value);
+    memory.set(value, result);
+
+    // $FlowExpectedError[incompatible-return] we know result is T
+    return result;
+  }
+
+  if (value instanceof String) {
+    // eslint-disable-next-line no-new-wrappers
+    const result = new String(value);
+    memory.set(value, result);
+
+    // $FlowExpectedError[incompatible-return] we know result is T
+    return result;
+  }
+
+  // Handles remaining known objects.
+
+  if (value instanceof Date) {
+    const result = new Date(value);
+    memory.set(value, result);
+
+    // $FlowExpectedError[incompatible-return] we know result is T
+    return result;
+  }
+
+  if (value instanceof Error) {
+    const result = value.cause
+      ? new Error(value.message, {cause: value.cause})
+      : new Error(value.message);
+    memory.set(value, result);
+
+    if (VALID_ERROR_NAMES.has(value.name)) {
+      result.name = value.name;
+    } else {
+      result.name = 'Error';
+    }
+
+    result.stack = value.stack;
+
+    // $FlowExpectedError[incompatible-return] we know result is T
+    return result;
+  }
+
+  if (value instanceof Map) {
+    const result = new Map<mixed, mixed>();
+    memory.set(value, result);
+
+    for (const [innerKey, innerValue] of value) {
+      result.set(
+        structuredCloneInternal(innerKey, memory),
+        structuredCloneInternal(innerValue, memory),
+      );
+    }
+
+    // $FlowExpectedError[incompatible-return] we know result is T
+    return result;
+  }
+
+  if (value instanceof Set) {
+    const result = new Set<mixed>();
+    memory.set(value, result);
+
+    for (const innerValue of value) {
+      result.add(structuredCloneInternal(innerValue, memory));
+    }
+
+    // $FlowExpectedError[incompatible-return] we know result is T
+    return result;
+  }
+
+  if (value instanceof RegExp) {
+    const result = new RegExp(value.source, value.flags);
+    memory.set(value, result);
+
+    // $FlowExpectedError[incompatible-return] we know result is T
+    return result;
+  }
+
+  // $FlowExpectedError[incompatible-type] result will be T
+  const result: T = Array.isArray(value) ? [] : {};
+  memory.set(value, result);
+
+  // We need to use Object.keys instead of iterating by indices because we
+  // also need to copy arbitrary fields set in the array.
+  for (const key of Object.keys(value)) {
+    // $FlowExpectedError[incompatible-use]
+    result[key] = structuredCloneInternal(value[key], memory);
+  }
+
+  return result;
+}
+
+/**
+ * Basic implementation of `structuredClone`.
+ * See:
+ * - https://developer.mozilla.org/en-US/docs/Web/API/Window/structuredClone.
+ * - https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
+ * - https://html.spec.whatwg.org/multipage/structured-data.html#structured-cloning
+ *
+ * Supports cloning all built-in types supported by the spec, circular
+ * references and referential equality of the same objects found in the
+ * structure.
+ *
+ * Shortcuts:
+ * - This implementation does NOT serialize and deserialize the value
+ *   but implements the cloning in a single step.
+ *
+ * Known limitations:
+ * - It does not support transfering values.
+ * - it does not support cloning platform objects like `DOMRect` and `DOMException`.
+ */
+export default function structuredClone<T>(value: T): T {
+  return structuredCloneInternal(value, new Map());
+}


### PR DESCRIPTION
Summary:
Changelog: [internal]

This implements an initial version of `structuredClone`, but only to be used internally (not exposed as a global yet).

The goal is to use this implementation to fix the semantics of the `detail` field in performance entries, which is meant to be cloned.

Differential Revision: D71407320


