### PR TITLE
Add playground benchmark

### DIFF
--- a/packages/react-native-fantom/src/__tests__/Playground-benchmark-itest.js
+++ b/packages/react-native-fantom/src/__tests__/Playground-benchmark-itest.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
+
+import * as Fantom from '@react-native/fantom';
+
+Fantom.unstable_benchmark
+  .suite('Playground benchmark')
+  .test('Variant 1', () => {
+    // Add your tests here, but do NOT commit them.
+  })
+  .test('Variant 2', () => {
+    // Add your tests here, but do NOT commit them.
+  })
+  .test('Variant 3', () => {
+    // Add your tests here, but do NOT commit them.
+  });


### PR DESCRIPTION
Summary:
Changelog: [internal]

We recently added `Playground-itest` as a quick way to test things with Fantom without committing them.

This does the same for benchmarks, so we can quickly answer questions like:

> is `key in obj` faster than `obj[key]`?

Without having to create a new benchmark manually.

Differential Revision: D74578297
