### PR TITLE
Update Metro imports to use package root exports

### DIFF
--- a/packages/community-cli-plugin/src/commands/bundle/assetCatalogIOS.js
+++ b/packages/community-cli-plugin/src/commands/bundle/assetCatalogIOS.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-import type {AssetData} from 'metro/src/Assets';
+import type {AssetData} from 'metro';
 
 import assetPathUtils from './assetPathUtils';
 import fs from 'fs';

--- a/packages/community-cli-plugin/src/commands/bundle/createKeepFileAsync.js
+++ b/packages/community-cli-plugin/src/commands/bundle/createKeepFileAsync.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-import type {AssetData} from 'metro/src/Assets';
+import type {AssetData} from 'metro';
 
 import assetPathUtils from './assetPathUtils';
 import fs from 'fs';

--- a/packages/community-cli-plugin/src/commands/bundle/saveAssets.js
+++ b/packages/community-cli-plugin/src/commands/bundle/saveAssets.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-import type {AssetData} from 'metro/src/Assets';
+import type {AssetData} from 'metro';
 
 import {
   cleanAssetCatalog,

--- a/packages/community-cli-plugin/src/commands/start/middleware.js
+++ b/packages/community-cli-plugin/src/commands/start/middleware.js
@@ -9,7 +9,7 @@
  */
 
 import type {Server} from 'connect';
-import type {TerminalReportableEvent} from 'metro/src/lib/TerminalReporter';
+import type {TerminalReportableEvent} from 'metro';
 
 import {typeof createDevServerMiddleware as CreateDevServerMiddleware} from '@react-native-community/cli-server-api';
 

--- a/packages/community-cli-plugin/src/commands/start/runServer.js
+++ b/packages/community-cli-plugin/src/commands/start/runServer.js
@@ -9,9 +9,7 @@
  */
 
 import type {Config} from '@react-native-community/cli-types';
-import type {TerminalReporter} from 'metro';
-import type {Reporter} from 'metro/src/lib/reporting';
-import type {TerminalReportableEvent} from 'metro/src/lib/TerminalReporter';
+import type {Reporter, TerminalReportableEvent, TerminalReporter} from 'metro';
 
 import createDevMiddlewareLogger from '../../utils/createDevMiddlewareLogger';
 import isDevServerRunning from '../../utils/isDevServerRunning';
@@ -179,7 +177,7 @@ function getReporterImpl(
   customLogReporterPath?: string,
 ): Class<TerminalReporter> {
   if (customLogReporterPath == null) {
-    return require('metro/src/lib/TerminalReporter');
+    return require('metro').TerminalReporter;
   }
   try {
     // First we let require resolve it, so we can require packages in node_modules


### PR DESCRIPTION
Summary:
Cleanup to use the new public type / API exports from `metro` landed in Metro 0.82.3, which is RN's minimum as of D74181990 / [PR](https://github.com/facebook/react-native/pull/51122), in preference to deep imports.

Changelog: [Internal]

Differential Revision: D74141939


