### PR TITLE
Add RCTJermesInstance

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/React-RuntimeApple.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/React-RuntimeApple.podspec
@@ -73,5 +73,7 @@ Pod::Spec.new do |s|
     s.exclude_files = "ReactCommon/RCTHermesInstance.{mm,h}"
   end
 
+  s.exclude_files += "ReactCommon/RCTJermesInstance.{mm,h}"
+
   add_rn_third_party_dependencies(s)
 end

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTJermesInstance.h
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTJermesInstance.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <UIKit/UIKit.h>
+
+#import <cxxreact/MessageQueueThread.h>
+#import <hermes/Public/CrashManager.h>
+#import <jsi/jsi.h>
+#import <react/runtime/JSRuntimeFactory.h>
+#import <react/runtime/hermes/JermesInstance.h>
+
+namespace facebook::react {
+
+using CrashManagerProvider =
+    std::function<std::shared_ptr<::hermes::vm::CrashManager>()>;
+
+// ObjC++ wrapper for HermesInstance.cpp
+class RCTJermesInstance : public JSRuntimeFactory {
+ public:
+  RCTJermesInstance();
+  RCTJermesInstance(CrashManagerProvider crashManagerProvider);
+  RCTJermesInstance(
+      CrashManagerProvider crashManagerProvider,
+      bool allocInOldGenBeforeTTI);
+
+  std::unique_ptr<JSRuntime> createJSRuntime(
+      std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept override;
+
+  ~RCTJermesInstance() override{};
+
+ private:
+  CrashManagerProvider _crashManagerProvider;
+  std::unique_ptr<JermesInstance> _hermesInstance;
+  bool _allocInOldGenBeforeTTI;
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTJermesInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTJermesInstance.mm
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTJermesInstance.h"
+
+namespace facebook::react {
+
+RCTJermesInstance::RCTJermesInstance() : RCTJermesInstance(nullptr, false) {}
+
+RCTJermesInstance::RCTJermesInstance(CrashManagerProvider crashManagerProvider)
+    : RCTJermesInstance(std::move(crashManagerProvider), false)
+{
+}
+
+RCTJermesInstance::RCTJermesInstance(CrashManagerProvider crashManagerProvider, bool allocInOldGenBeforeTTI)
+    : _crashManagerProvider(std::move(crashManagerProvider)),
+      _hermesInstance(std::make_unique<JermesInstance>()),
+      _allocInOldGenBeforeTTI(allocInOldGenBeforeTTI)
+{
+}
+
+std::unique_ptr<JSRuntime> RCTJermesInstance::createJSRuntime(
+    std::shared_ptr<MessageQueueThread> msgQueueThread) noexcept
+{
+  return _hermesInstance->createJSRuntime(
+      _crashManagerProvider ? _crashManagerProvider() : nullptr, std::move(msgQueueThread), _allocInOldGenBeforeTTI);
+}
+
+} // namespace facebook::react


### PR DESCRIPTION
Summary:
Add `RCTJermesInstance` that uses `JermesInstance`. This will only be included in the target `runtime-platform` on iOS when `react_native.enable_hermes_experimental=True` is passed.

Changelog: [Internal]

Differential Revision: D74339977
