### PR TITLE
Expose ShadowNodeFamily to RawEvent

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
@@ -171,8 +171,10 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
         std::make_shared<EventTarget>(
             fragment.instanceHandle, fragment.surfaceId),
         eventDispatcher_);
-    return std::make_shared<ShadowNodeFamily>(
-        fragment, std::move(eventEmitter), eventDispatcher_, *this);
+    auto family = std::make_shared<ShadowNodeFamily>(
+        fragment, eventEmitter, eventDispatcher_, *this);
+    eventEmitter->setShadowNodeFamily(family);
+    return family;
   }
 
  protected:

--- a/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.cpp
@@ -98,6 +98,7 @@ void EventEmitter::dispatchEvent(
       normalizeEventType(std::move(type)),
       std::move(payload),
       eventTarget_,
+      shadowNodeFamily_,
       category));
 }
 
@@ -123,6 +124,7 @@ void EventEmitter::dispatchUniqueEvent(
       normalizeEventType(std::move(type)),
       std::move(payload),
       eventTarget_,
+      shadowNodeFamily_,
       RawEvent::Category::Continuous));
 }
 
@@ -147,6 +149,11 @@ void EventEmitter::setEnabled(bool enabled) const {
       eventTarget_.reset();
     }
   }
+}
+
+void EventEmitter::setShadowNodeFamily(
+    std::weak_ptr<const ShadowNodeFamily> shadowNodeFamily) const {
+  shadowNodeFamily_ = std::move(shadowNodeFamily);
 }
 
 const SharedEventTarget& EventEmitter::getEventTarget() const {

--- a/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.h
@@ -57,6 +57,12 @@ class EventEmitter {
    */
   void setEnabled(bool enabled) const;
 
+  /*
+   * Sets a weak reference to the cooresponding ShadowNodeFamily
+   */
+  void setShadowNodeFamily(
+      std::weak_ptr<const ShadowNodeFamily> shadowNodeFamily) const;
+
   const SharedEventTarget& getEventTarget() const;
 
   /*
@@ -106,6 +112,7 @@ class EventEmitter {
   friend class UIManagerBinding;
 
   mutable SharedEventTarget eventTarget_;
+  mutable std::weak_ptr<const ShadowNodeFamily> shadowNodeFamily_;
 
   EventDispatcher::Weak eventDispatcher_;
   mutable int enableCounter_{0};

--- a/packages/react-native/ReactCommon/react/renderer/core/RawEvent.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawEvent.cpp
@@ -13,11 +13,13 @@ RawEvent::RawEvent(
     std::string type,
     SharedEventPayload eventPayload,
     SharedEventTarget eventTarget,
+    std::weak_ptr<const ShadowNodeFamily> shadowNodeFamily,
     Category category,
     bool isUnique)
     : type(std::move(type)),
       eventPayload(std::move(eventPayload)),
       eventTarget(std::move(eventTarget)),
+      shadowNodeFamily(std::move(shadowNodeFamily)),
       category(category),
       isUnique(isUnique) {}
 

--- a/packages/react-native/ReactCommon/react/renderer/core/RawEvent.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawEvent.h
@@ -17,6 +17,8 @@
 
 namespace facebook::react {
 
+class ShadowNodeFamily;
+
 /*
  * Represents ready-to-dispatch event object.
  */
@@ -69,12 +71,14 @@ struct RawEvent {
       std::string type,
       SharedEventPayload eventPayload,
       SharedEventTarget eventTarget,
+      std::weak_ptr<const ShadowNodeFamily> shadowNodeFamily,
       Category category = Category::Unspecified,
       bool isUnique = false);
 
   std::string type;
   SharedEventPayload eventPayload;
   SharedEventTarget eventTarget;
+  std::weak_ptr<const ShadowNodeFamily> shadowNodeFamily;
   Category category;
   EventTag loggingTag{0};
   bool isUnique{false};

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/EventQueueProcessorTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/EventQueueProcessorTest.cpp
@@ -12,6 +12,7 @@
 #include <react/renderer/core/EventPipe.h>
 #include <react/renderer/core/EventQueueProcessor.h>
 #include <react/renderer/core/EventTarget.h>
+#include <react/renderer/core/ShadowNodeFamily.h>
 #include <react/renderer/core/StatePipe.h>
 #include <react/renderer/core/ValueFactoryEventPayload.h>
 
@@ -68,6 +69,7 @@ TEST_F(EventQueueProcessorTest, singleUnspecifiedEvent) {
           "my type",
           std::make_shared<ValueFactoryEventPayload>(dummyValueFactory_),
           nullptr,
+          {},
           RawEvent::Category::Unspecified)});
 
   EXPECT_EQ(eventPriorities_.size(), 1);
@@ -82,21 +84,25 @@ TEST_F(EventQueueProcessorTest, continuousEvent) {
            "touchStart",
            std::make_shared<ValueFactoryEventPayload>(dummyValueFactory_),
            nullptr,
+           {},
            RawEvent::Category::ContinuousStart),
        RawEvent(
            "touchMove",
            std::make_shared<ValueFactoryEventPayload>(dummyValueFactory_),
            nullptr,
+           {},
            RawEvent::Category::Unspecified),
        RawEvent(
            "touchEnd",
            std::make_shared<ValueFactoryEventPayload>(dummyValueFactory_),
            nullptr,
+           {},
            RawEvent::Category::ContinuousEnd),
        RawEvent(
            "custom event",
            std::make_shared<ValueFactoryEventPayload>(dummyValueFactory_),
            nullptr,
+           {},
            RawEvent::Category::Unspecified)});
 
   EXPECT_EQ(eventPriorities_.size(), 4);
@@ -122,6 +128,7 @@ TEST_F(EventQueueProcessorTest, alwaysContinuousEvent) {
               "onScroll",
               std::make_shared<ValueFactoryEventPayload>(dummyValueFactory_),
               nullptr,
+              {},
               RawEvent::Category::Continuous),
       });
 
@@ -139,6 +146,7 @@ TEST_F(EventQueueProcessorTest, alwaysDiscreteEvent) {
               "onChange",
               std::make_shared<ValueFactoryEventPayload>(dummyValueFactory_),
               nullptr,
+              {},
               RawEvent::Category::Discrete),
       });
 


### PR DESCRIPTION
Summary:
Changelog: [Internal]

This diff exposes the corresponding target ShadowNodeFamily to a RawEvent through a weak pointer. This is necessary for the upcoming move of pointer event interception from the JS to main thread.

Differential Revision: D74500630


