### PR TITLE
Add E2E test for FabricInteropLayer

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
@@ -170,10 +170,24 @@ static NSString *const kRCTLegacyInteropChildIndexKey = @"index";
 
 - (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
 {
-  [_viewsToBeMounted addObject:@{
-    kRCTLegacyInteropChildIndexKey : [NSNumber numberWithInteger:index],
-    kRCTLegacyInteropChildComponentKey : childComponentView
-  }];
+  if (_adapter && index == _adapter.paperView.reactSubviews.count) {
+    // This is a new child view that is being added to the end of the children array.
+    // After the children is added, we need to call didUpdateReactSubviews to make sure that it is rendered.
+    // Without this change, the new child will not be rendered right away because the didUpdateReactSubviews is not
+    // called and the `finalizeUpdate` is not invoked.
+    if ([childComponentView isKindOfClass:[RCTLegacyViewManagerInteropComponentView class]]) {
+      UIView *target = ((RCTLegacyViewManagerInteropComponentView *)childComponentView).contentView;
+      [_adapter.paperView insertReactSubview:target atIndex:index];
+    } else {
+      [_adapter.paperView insertReactSubview:childComponentView atIndex:index];
+    }
+    [_adapter.paperView didUpdateReactSubviews];
+  } else {
+    [_viewsToBeMounted addObject:@{
+      kRCTLegacyInteropChildIndexKey : [NSNumber numberWithInteger:index],
+      kRCTLegacyInteropChildComponentKey : childComponentView
+    }];
+  }
 }
 
 - (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index

--- a/packages/rn-tester/NativeComponentExample/ios/RCTInteropTestView.h
+++ b/packages/rn-tester/NativeComponentExample/ios/RCTInteropTestView.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface InteropTestView : UIView
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/rn-tester/NativeComponentExample/ios/RCTInteropTestView.m
+++ b/packages/rn-tester/NativeComponentExample/ios/RCTInteropTestView.m
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTInteropTestView.h"
+
+@implementation InteropTestView
+
+- (instancetype)initWithFrame:(CGRect)frame
+{
+  self = [super initWithFrame:frame];
+  return self;
+}
+
+@end

--- a/packages/rn-tester/NativeComponentExample/ios/RCTInteropTestViewManager.h
+++ b/packages/rn-tester/NativeComponentExample/ios/RCTInteropTestViewManager.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <React/RCTViewManager.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface InteropTestViewManager : RCTViewManager
+@end
+NS_ASSUME_NONNULL_END

--- a/packages/rn-tester/NativeComponentExample/ios/RCTInteropTestViewManager.m
+++ b/packages/rn-tester/NativeComponentExample/ios/RCTInteropTestViewManager.m
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTInteropTestViewManager.h"
+#import "RCTInteropTestView.h"
+
+@implementation InteropTestViewManager
+
+RCT_EXPORT_MODULE(InteropTestView)
+
+- (UIView *)view
+{
+  return [[InteropTestView alloc] init];
+}
+
+@end

--- a/packages/rn-tester/js/examples/FabricInteropLayer/FabricInteropLayer.js
+++ b/packages/rn-tester/js/examples/FabricInteropLayer/FabricInteropLayer.js
@@ -1,0 +1,149 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+import type {ViewProps} from 'react-native';
+
+import React, {useState} from 'react';
+import {
+  Button,
+  StyleSheet,
+  Text,
+  View,
+  requireNativeComponent,
+  useColorScheme,
+} from 'react-native';
+
+type SectionProps = {
+  title: string,
+  children?: React.Node,
+};
+
+const WHITE = '#ffffff';
+const BLACK = '#000000';
+
+// ========== JS Definition of the Native RCTInteropTestView component ========
+type InteropTestViewProps = {
+  // Add custom props here if needed
+  ...ViewProps,
+};
+
+const NativeInteropTestView =
+  requireNativeComponent<InteropTestViewProps>('InteropTestView');
+
+const InteropTestView = (props: InteropTestViewProps) => {
+  return <NativeInteropTestView {...props} />;
+};
+
+// =============================================================================
+
+function Section({children, title}: SectionProps): React.Node {
+  const isDarkMode = useColorScheme() === 'dark';
+  return (
+    <View style={styles.sectionContainer}>
+      <Text
+        style={[
+          styles.sectionTitle,
+          {
+            color: isDarkMode ? WHITE : BLACK,
+          },
+        ]}>
+        {title}
+      </Text>
+      <Text
+        style={[
+          styles.sectionDescription,
+          {
+            color: isDarkMode ? WHITE : BLACK,
+          },
+        ]}>
+        {children}
+      </Text>
+    </View>
+  );
+}
+
+function AddChildrenForInteropLayer() {
+  const isDarkMode = useColorScheme() === 'dark';
+  const [squares, setSquares] = useState<Array<number>>([0, 1, 2, 3, 4]);
+  const addMarker = () => {
+    setSquares(p => [...p, p.length + 1]);
+  };
+  return (
+    <View
+      style={{
+        backgroundColor: isDarkMode ? BLACK : WHITE,
+      }}>
+      <Section title="Squares">
+        <Button title="Add Marker" onPress={addMarker} />
+        <Text>{`Number of squares: ${squares.length}`}</Text>
+      </Section>
+      <Section title="Custom native view">
+        <InteropTestView style={styles.customView}>
+          {squares.map((_, index) => (
+            <View key={index} style={styles.customViewChild} />
+          ))}
+        </InteropTestView>
+      </Section>
+      <Section title="Regular view">
+        <View style={styles.customView}>
+          {squares.map((_, index) => (
+            <View key={index} style={styles.customViewChild} />
+          ))}
+        </View>
+      </Section>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  sectionContainer: {
+    marginTop: 32,
+    paddingHorizontal: 24,
+  },
+  sectionTitle: {
+    fontSize: 24,
+    fontWeight: '600',
+  },
+  sectionDescription: {
+    marginTop: 8,
+    fontSize: 18,
+    fontWeight: '400',
+  },
+  highlight: {
+    fontWeight: '700',
+  },
+  customView: {
+    width: 300,
+    height: 200,
+    backgroundColor: 'yellow',
+    flexWrap: 'wrap',
+    gap: 10,
+  },
+  customViewChild: {
+    width: 50,
+    height: 50,
+    backgroundColor: 'blue',
+  },
+});
+
+exports.title = 'Fabric Interop Layer';
+exports.category = 'UI';
+exports.description = 'A set test cases for the Fabric Interop Layer.';
+exports.examples = [
+  {
+    title: 'Add children to Interop Layer',
+    description: 'Add children to Interop Layer',
+    name: 'Add Children to interop layer',
+    render(): React.Node {
+      return <AddChildrenForInteropLayer />;
+    },
+  },
+];

--- a/packages/rn-tester/js/examples/FabricInteropLayer/FabricInteropLayer.js
+++ b/packages/rn-tester/js/examples/FabricInteropLayer/FabricInteropLayer.js
@@ -23,6 +23,7 @@ import {
 
 type SectionProps = {
   title: string,
+  testID?: string,
   children?: React.Node,
 };
 
@@ -82,13 +83,21 @@ function AddChildrenForInteropLayer() {
         backgroundColor: isDarkMode ? BLACK : WHITE,
       }}>
       <Section title="Squares">
-        <Button title="Add Marker" onPress={addMarker} />
+        <Button
+          title="Add Marker"
+          onPress={addMarker}
+          testID="add-marker-btn"
+        />
         <Text>{`Number of squares: ${squares.length}`}</Text>
       </Section>
-      <Section title="Custom native view">
+      <Section title="Custom native view" testID="interop-view-content">
         <InteropTestView style={styles.customView}>
           {squares.map((_, index) => (
-            <View key={index} style={styles.customViewChild} />
+            <View
+              key={index}
+              style={styles.customViewChild}
+              testID={`marker_${index}`}
+            />
           ))}
         </InteropTestView>
       </Section>
@@ -134,16 +143,16 @@ const styles = StyleSheet.create({
   },
 });
 
-exports.title = 'Fabric Interop Layer';
+exports.title = 'FabricInteropLayer';
 exports.category = 'UI';
 exports.description = 'A set test cases for the Fabric Interop Layer.';
 exports.examples = [
   {
     title: 'Add children to Interop Layer',
     description: 'Add children to Interop Layer',
-    name: 'Add Children to interop layer',
+    name: 'add-children',
     render(): React.Node {
-      return <AddChildrenForInteropLayer />;
+      return <AddChildrenForInteropLayer testID="add-children" />;
     },
   },
 ];

--- a/packages/rn-tester/js/utils/RNTesterList.ios.js
+++ b/packages/rn-tester/js/utils/RNTesterList.ios.js
@@ -147,6 +147,11 @@ const Components: Array<RNTesterModuleInfo> = [
     module: require('../examples/NewArchitecture/NewArchitectureExample'),
   },
   {
+    key: 'FabricInteropLayer',
+    category: 'UI',
+    module: require('../examples/FabricInteropLayer/FabricInteropLayer'),
+  },
+  {
     key: 'PerformanceComparisonExample',
     category: 'Basic',
     module: require('../examples/Performance/PerformanceComparisonExample'),


### PR DESCRIPTION
Summary:
This adds an E2E Tests for the fabric interop layer in RNTester, so we can make sure that we don't break the mechanism to add children after the view is rendered

## Changelog:
[Internal] - Add E2E test for FabricInteropLayer

Differential Revision: D74590458
