### PR TITLE
Fix string comparison when self has accessibility order reference

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -1161,7 +1161,7 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
   for (auto childId : _props->accessibilityOrder) {
     NSString *nsStringChildId = RCTNSStringFromString(childId);
     // Special case to allow for self-referencing with accessibilityOrder
-    if (nsStringChildId == self.nativeId) {
+    if ([nsStringChildId isEqualToString:self.nativeId]) {
       if (!_axElementDescribingSelf) {
         _axElementDescribingSelf = [[RCTViewAccessibilityElement alloc] initWithView:self];
       }


### PR DESCRIPTION
Summary:
I was informed that we could not reference ourselves with accessibility order when using `useID`. The reason for that ended up being because of this if statement which uses `==`. Note this worked with a normal string like `"foo"` but `useID` has ids like `"<<r0>>"` so I imagine the < and > made this break.

Changelog: [Internal]

Differential Revision: D74601689


