### PR TITLE
Add explanation and suppress unused androidx.core.content.res.use warning

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/DefaultStyleValuesUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/DefaultStyleValuesUtil.kt
@@ -5,6 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// Suppress unused import warning to ensure the correct `use` extension is applied.
+// Removing [androidx.core.content.res.use] import causes Kotlin to fallback to `kotlin.io.use`, which expects `AutoCloseable`.
+// However, `TypedArray` is not `AutoCloseable`, and this mismatch can lead to crashes like
+// IncompatibleClassChangeError.
+@file:Suppress("UnusedImport")
+
 package com.facebook.react.views.text
 
 import android.content.Context


### PR DESCRIPTION
## Summary:

Follow up from https://github.com/facebook/react-native/pull/51170, static code analysis shows androidx.core.content.res.use as unused, it looked pretty harmless to remove it as there was no context about its usage, but it caused some crashes.

I'm suppressing the warning here, plus adding an explanation on why it is needed to prevent a future developer from touching this file and causing the same regression.

## Changelog:

[INTERNAL] - Suppress unused androidx.core.content.res.use warning

## Test Plan:

Static code analysis should not show the import as unused.
