### PR TITLE
Remove the "Newer Patch Available" logic from @react-native-bot

### DIFF
--- a/.github/workflow-scripts/actOnLabel.js
+++ b/.github/workflow-scripts/actOnLabel.js
@@ -95,12 +95,6 @@ module.exports = async (github, context, labelWithContext) => {
       );
       await requestAuthorFeedback();
       return;
-    case 'Newer Patch Available':
-      await addComment(
-        `> [!TIP]\n` +
-          `> **Newer version available**: You are on a supported minor version, but it looks like there's a newer patch available - ${labelWithContext.newestPatch}. Please [upgrade](https://reactnative.dev/docs/upgrading) to the highest patch for your minor or latest and verify if the issue persists (alternatively, create a new project and repro the issue in it). If it does not repro, please let us know so we can close out this issue. This helps us ensure we are looking at issues that still exist in the most recent releases.`,
-      );
-      return;
     case 'Needs: Version Info':
       await addComment(
         `> [!WARNING]\n` +

--- a/.github/workflow-scripts/verifyVersion.js
+++ b/.github/workflow-scripts/verifyVersion.js
@@ -45,18 +45,6 @@ module.exports = async (github, context) => {
   if (!isVersionSupported(issueVersion, latestVersion)) {
     return {label: 'Type: Unsupported Version'};
   }
-
-  // We want to encourage users to repro the issue on the highest available patch for the given minor.
-  const latestPatchForVersion = getLatestPatchForVersion(
-    issueVersion,
-    recentReleases,
-  );
-  if (latestPatchForVersion > issueVersion.patch) {
-    return {
-      label: 'Newer Patch Available',
-      newestPatch: `${issueVersion.major}.${issueVersion.minor}.${latestPatchForVersion}`,
-    };
-  }
 };
 
 /**
@@ -85,22 +73,6 @@ function isVersionTooOld(actualVersion, latestVersion) {
     latestVersion.major - actualVersion.major >= 1 ||
     latestVersion.minor - actualVersion.minor >= 5
   );
-}
-
-// Assumes that releases are sorted in the order of recency (i.e. most recent releases are earlier in the list)
-// This enables us to stop looking as soon as we find the first release with a matching major/minor version, since
-// we know it's the most recent release, therefore the highest patch available.
-function getLatestPatchForVersion(version, releases) {
-  for (releaseName of releases) {
-    const release = parseVersionFromString(releaseName);
-    if (
-      release &&
-      release.major == version.major &&
-      release.minor == version.minor
-    ) {
-      return release.patch;
-    }
-  }
 }
 
 function getReactNativeVersionFromIssueBodyIfExists(issue) {


### PR DESCRIPTION
Summary:
This bog action is not really useful. It's currently buggy and spams the user twice + we agreed it provide little value for the user.
Therefore we're removing this message for the time being.

Changelog:
[Internal] [Changed] -

Differential Revision: D74645716


