### PR TITLE
Fix NaN value comparison for paragraph props diffing

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
@@ -228,7 +228,8 @@ jni::local_ref<jobject> getProps(
        strcmp(newShadowView.componentName, "ScrollView") == 0 ||
        strcmp(newShadowView.componentName, "RawText") == 0 ||
        strcmp(newShadowView.componentName, "Text") == 0 ||
-       strcmp(newShadowView.componentName, "Paragraph") == 0)) {
+       strcmp(newShadowView.componentName, "Paragraph") == 0 ||
+       strcmp(newShadowView.componentName, "TextInput") == 0)) {
     return ReadableNativeMap::newObjectCxxArgs(
         newProps->getDiffProps(oldProps));
   }

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.cpp
@@ -186,18 +186,21 @@ folly::dynamic ParagraphProps::getDiffProps(const Props* prevProps) const {
     result["adjustsFontSizeToFit"] = paragraphAttributes.adjustsFontSizeToFit;
   }
 
-  if (paragraphAttributes.minimumFontScale !=
-      oldProps->paragraphAttributes.minimumFontScale) {
+  if (!floatEquality(
+          paragraphAttributes.minimumFontScale,
+          oldProps->paragraphAttributes.minimumFontScale)) {
     result["minimumFontScale"] = paragraphAttributes.minimumFontScale;
   }
 
-  if (paragraphAttributes.minimumFontSize !=
-      oldProps->paragraphAttributes.minimumFontSize) {
+  if (!floatEquality(
+          paragraphAttributes.minimumFontSize,
+          oldProps->paragraphAttributes.minimumFontSize)) {
     result["minimumFontSize"] = paragraphAttributes.minimumFontSize;
   }
 
-  if (paragraphAttributes.maximumFontSize !=
-      oldProps->paragraphAttributes.maximumFontSize) {
+  if (!floatEquality(
+          paragraphAttributes.maximumFontSize,
+          oldProps->paragraphAttributes.maximumFontSize)) {
     result["maximumFontSize"] = paragraphAttributes.maximumFontSize;
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.cpp
@@ -167,7 +167,7 @@ folly::dynamic ParagraphProps::getDiffProps(const Props* prevProps) const {
 
   if (paragraphAttributes.maximumNumberOfLines !=
       oldProps->paragraphAttributes.maximumNumberOfLines) {
-    result["numberOfLine"] = paragraphAttributes.maximumNumberOfLines;
+    result["numberOfLines"] = paragraphAttributes.maximumNumberOfLines;
   }
 
   if (paragraphAttributes.ellipsizeMode !=

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
@@ -356,4 +356,60 @@ SharedDebugStringConvertibleList AndroidTextInputProps::getDebugProps() const {
 }
 #endif
 
+folly::dynamic AndroidTextInputProps::getDiffProps(
+    const Props* prevProps) const {
+  static const auto defaultProps = AndroidTextInputProps();
+
+  const AndroidTextInputProps* oldProps = prevProps == nullptr
+      ? &defaultProps
+      : static_cast<const AndroidTextInputProps*>(prevProps);
+
+  folly::dynamic result = ViewProps::getDiffProps(oldProps);
+
+  // Base text input paragraph props
+  if (paragraphAttributes.maximumNumberOfLines !=
+      oldProps->paragraphAttributes.maximumNumberOfLines) {
+    result["numberOfLines"] = paragraphAttributes.maximumNumberOfLines;
+  }
+
+  if (paragraphAttributes.ellipsizeMode !=
+      oldProps->paragraphAttributes.ellipsizeMode) {
+    result["ellipsizeMode"] = toString(paragraphAttributes.ellipsizeMode);
+  }
+
+  if (paragraphAttributes.textBreakStrategy !=
+      oldProps->paragraphAttributes.textBreakStrategy) {
+    result["textBreakStrategy"] =
+        toString(paragraphAttributes.textBreakStrategy);
+  }
+
+  if (paragraphAttributes.adjustsFontSizeToFit !=
+      oldProps->paragraphAttributes.adjustsFontSizeToFit) {
+    result["adjustsFontSizeToFit"] = paragraphAttributes.adjustsFontSizeToFit;
+  }
+
+  if (paragraphAttributes.minimumFontSize !=
+      oldProps->paragraphAttributes.minimumFontSize) {
+    result["minimumFontSize"] = paragraphAttributes.minimumFontSize;
+  }
+
+  if (paragraphAttributes.maximumFontSize !=
+      oldProps->paragraphAttributes.maximumFontSize) {
+    result["maximumFontSize"] = paragraphAttributes.maximumFontSize;
+  }
+
+  if (paragraphAttributes.includeFontPadding !=
+      oldProps->paragraphAttributes.includeFontPadding) {
+    result["includeFontPadding"] = paragraphAttributes.includeFontPadding;
+  }
+
+  if (paragraphAttributes.android_hyphenationFrequency !=
+      oldProps->paragraphAttributes.android_hyphenationFrequency) {
+    result["android_hyphenationFrequency"] =
+        toString(paragraphAttributes.android_hyphenationFrequency);
+  }
+
+  return result;
+}
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
@@ -493,6 +493,135 @@ folly::dynamic AndroidTextInputProps::getDiffProps(
         : nullptr;
   }
 
+  // Android text input props
+  if (autoComplete != oldProps->autoComplete) {
+    result["autoComplete"] = autoComplete;
+  }
+
+  if (returnKeyLabel != oldProps->returnKeyLabel) {
+    result["returnKeyLabel"] = returnKeyLabel;
+  }
+
+  if (numberOfLines != oldProps->numberOfLines) {
+    result["numberOfLines"] = numberOfLines;
+  }
+
+  if (disableFullscreenUI != oldProps->disableFullscreenUI) {
+    result["disableFullscreenUI"] = disableFullscreenUI;
+  }
+
+  if (textBreakStrategy != oldProps->textBreakStrategy) {
+    result["textBreakStrategy"] = textBreakStrategy;
+  }
+
+  if (inlineImageLeft != oldProps->inlineImageLeft) {
+    result["inlineImageLeft"] = inlineImageLeft;
+  }
+
+  if (inlineImagePadding != oldProps->inlineImagePadding) {
+    result["inlineImagePadding"] = inlineImagePadding;
+  }
+
+  if (importantForAutofill != oldProps->importantForAutofill) {
+    result["importantForAutofill"] = importantForAutofill;
+  }
+
+  if (showSoftInputOnFocus != oldProps->showSoftInputOnFocus) {
+    result["showSoftInputOnFocus"] = showSoftInputOnFocus;
+  }
+
+  if (autoCorrect != oldProps->autoCorrect) {
+    result["autoCorrect"] = autoCorrect;
+  }
+
+  if (allowFontScaling != oldProps->allowFontScaling) {
+    result["allowFontScaling"] = allowFontScaling;
+  }
+
+  if (maxFontSizeMultiplier != oldProps->maxFontSizeMultiplier) {
+    result["maxFontSizeMultiplier"] = maxFontSizeMultiplier;
+  }
+
+  if (keyboardType != oldProps->keyboardType) {
+    result["keyboardType"] = keyboardType;
+  }
+
+  if (returnKeyType != oldProps->returnKeyType) {
+    result["returnKeyType"] = returnKeyType;
+  }
+
+  if (secureTextEntry != oldProps->secureTextEntry) {
+    result["secureTextEntry"] = secureTextEntry;
+  }
+
+  if (value != oldProps->value) {
+    result["value"] = value;
+  }
+
+  if (selectTextOnFocus != oldProps->selectTextOnFocus) {
+    result["selectTextOnFocus"] = selectTextOnFocus;
+  }
+
+  if (caretHidden != oldProps->caretHidden) {
+    result["caretHidden"] = caretHidden;
+  }
+
+  if (contextMenuHidden != oldProps->contextMenuHidden) {
+    result["contextMenuHidden"] = contextMenuHidden;
+  }
+
+  if (textShadowColor != oldProps->textShadowColor) {
+    result["textShadowColor"] = *textShadowColor;
+  }
+
+  if (textShadowRadius != oldProps->textShadowRadius) {
+    result["textShadowRadius"] = textShadowRadius;
+  }
+
+  if (textDecorationLine != oldProps->textDecorationLine) {
+    result["textDecorationLine"] = textDecorationLine;
+  }
+
+  if (fontStyle != oldProps->fontStyle) {
+    result["fontStyle"] = fontStyle;
+  }
+
+  if (textShadowOffset != oldProps->textShadowOffset) {
+    result["textShadowOffset"] = toDynamic(textShadowOffset);
+  }
+
+  if (lineHeight != oldProps->lineHeight) {
+    result["lineHeight"] = lineHeight;
+  }
+
+  if (textTransform != oldProps->textTransform) {
+    result["textTransform"] = textTransform;
+  }
+
+  if (letterSpacing != oldProps->letterSpacing) {
+    result["letterSpacing"] = letterSpacing;
+  }
+
+  if (fontSize != oldProps->fontSize) {
+    result["fontSize"] = fontSize;
+  }
+
+  if (textAlign != oldProps->textAlign) {
+    result["textAlign"] = textAlign;
+  }
+
+  if (includeFontPadding != oldProps->includeFontPadding) {
+    result["includeFontPadding"] = includeFontPadding;
+  }
+
+  if (fontWeight != oldProps->fontWeight) {
+    result["fontWeight"] = fontWeight;
+  }
+
+  if (fontFamily != oldProps->fontFamily) {
+    result["fontFamily"] = fontFamily;
+  }
+
   return result;
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
@@ -356,6 +356,15 @@ SharedDebugStringConvertibleList AndroidTextInputProps::getDebugProps() const {
 }
 #endif
 
+static folly::dynamic toDynamic(
+    const std::vector<std::string>& acceptDragAndDropTypes) {
+  folly::dynamic acceptDragAndDropTypesArray = folly::dynamic::array();
+  for (const auto& acceptDragAndDropType : acceptDragAndDropTypes) {
+    acceptDragAndDropTypesArray.push_back(acceptDragAndDropType);
+  }
+  return acceptDragAndDropTypesArray;
+}
+
 folly::dynamic AndroidTextInputProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = AndroidTextInputProps();
@@ -407,6 +416,81 @@ folly::dynamic AndroidTextInputProps::getDiffProps(
       oldProps->paragraphAttributes.android_hyphenationFrequency) {
     result["android_hyphenationFrequency"] =
         toString(paragraphAttributes.android_hyphenationFrequency);
+  }
+
+  // Base text input props
+  if (defaultValue != oldProps->defaultValue) {
+    result["defaultValue"] = defaultValue;
+  }
+
+  if (placeholder != oldProps->placeholder) {
+    result["placeholder"] = placeholder;
+  }
+
+  if (placeholderTextColor != oldProps->placeholderTextColor) {
+    result["placeholderTextColor"] = *placeholderTextColor;
+  }
+
+  if (cursorColor != oldProps->cursorColor) {
+    result["cursorColor"] = *cursorColor;
+  }
+
+  if (selectionColor != oldProps->selectionColor) {
+    result["selectionColor"] = *selectionColor;
+  }
+
+  if (selectionHandleColor != oldProps->selectionHandleColor) {
+    result["selectionHandleColor"] = *selectionHandleColor;
+  }
+
+  if (underlineColorAndroid != oldProps->underlineColorAndroid) {
+    result["underlineColorAndroid"] = *underlineColorAndroid;
+  }
+
+  if (maxLength != oldProps->maxLength) {
+    result["maxLength"] = maxLength;
+  }
+
+  if (text != oldProps->text) {
+    result["text"] = text;
+  }
+
+  if (mostRecentEventCount != oldProps->mostRecentEventCount) {
+    result["mostRecentEventCount"] = mostRecentEventCount;
+  }
+
+  if (autoFocus != oldProps->autoFocus) {
+    result["autoFocus"] = autoFocus;
+  }
+
+  if (autoCapitalize != oldProps->autoCapitalize) {
+    result["autoCapitalize"] = autoCapitalize;
+  }
+
+  if (editable != oldProps->editable) {
+    result["editable"] = editable;
+  }
+
+  if (readOnly != oldProps->readOnly) {
+    result["readOnly"] = readOnly;
+  }
+
+  if (submitBehavior != oldProps->submitBehavior) {
+    result["submitBehavior"] = toDynamic(submitBehavior);
+  }
+
+  if (multiline != oldProps->multiline) {
+    result["multiline"] = multiline;
+  }
+
+  if (disableKeyboardShortcuts != oldProps->disableKeyboardShortcuts) {
+    result["disableKeyboardShortcuts"] = disableKeyboardShortcuts;
+  }
+
+  if (acceptDragAndDropTypes != oldProps->acceptDragAndDropTypes) {
+    result["acceptDragAndDropTypes"] = acceptDragAndDropTypes.has_value()
+        ? toDynamic(acceptDragAndDropTypes.value())
+        : nullptr;
   }
 
   return result;

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.h
@@ -27,6 +27,12 @@ struct AndroidTextInputTextShadowOffsetStruct {
   double height;
 };
 
+inline static bool operator==(
+    const AndroidTextInputTextShadowOffsetStruct& lhs,
+    const AndroidTextInputTextShadowOffsetStruct& rhs) {
+  return lhs.width == rhs.width && lhs.height == rhs.height;
+}
+
 static inline void fromRawValue(
     const PropsParserContext& context,
     const RawValue& value,

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.h
@@ -124,8 +124,10 @@ class AndroidTextInputProps final : public BaseTextInputProps {
   bool hasPaddingEnd{};
 
 #if RN_DEBUG_STRING_CONVERTIBLE
-  SharedDebugStringConvertibleList getDebugProps() const;
+  SharedDebugStringConvertibleList getDebugProps() const override;
 #endif
+
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
Because NaN is always different from NaN, these Float props were always included in the diff when set to NaN. This checks for the specific case where both the current and the prev prop value is NaN.

Changelog: [Internal]

Differential Revision: D74647582


