### PR TITLE
enable enableEagerAlternateStateNodeCleanup in tests

### DIFF
--- a/packages/react-native-fantom/runtime/mocks/ReactNativeInternalFeatureFlags.js
+++ b/packages/react-native-fantom/runtime/mocks/ReactNativeInternalFeatureFlags.js
@@ -9,4 +9,11 @@
  * @oncall react_native
  */
 
-module.exports = {};
+module.exports = {
+  // When enableEagerAlternateStateNodeCleanup is enabled, alternate.stateNode is proactively
+  // pointed towards finishedWork's stateNode, releasing resources sooner.
+  // With enableEagerAlternateStateNodeCleanup enabled, we can remove workarounds in tests
+  // and have predictable memory model.
+  // See https://github.com/facebook/react/pull/33161 for details.
+  enableEagerAlternateStateNodeCleanup: true,
+};

--- a/packages/react-native/src/private/__tests__/utilities/__tests__/ShadowNodeReferenceCounter-itest.js
+++ b/packages/react-native/src/private/__tests__/utilities/__tests__/ShadowNodeReferenceCounter-itest.js
@@ -166,11 +166,6 @@ test('shadow node expires when replaced by null', () => {
     root.render(<View>{null}</View>);
   });
 
-  // TODO (T223254666): Delete this and figure out why test fails.
-  Fantom.runTask(() => {
-    root.render(<View>{null}</View>);
-  });
-
   expect(getReferenceCount()).toBe(0);
 });
 
@@ -189,15 +184,6 @@ test('shadow node expires when replaced by another view', () => {
 
   expect(getReferenceCount()).toBeGreaterThan(0);
 
-  Fantom.runTask(() => {
-    root.render(
-      <View>
-        <View key="b" />
-      </View>,
-    );
-  });
-
-  // TODO (T223254666): Delete this and figure out why test fails.
   Fantom.runTask(() => {
     root.render(
       <View>

--- a/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-itest.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-itest.js
@@ -879,11 +879,6 @@ describe('IntersectionObserver', () => {
         root.render(<Observe />);
       });
 
-      // TODO (T223254666): Delete this and figure out why test fails.
-      Fantom.runTask(() => {
-        root.render(<Observe />);
-      });
-
       expect(getReferenceCount()).toBe(0);
     });
 

--- a/packages/react-native/src/private/webapis/mutationobserver/__tests__/MutationObserver-itest.js
+++ b/packages/react-native/src/private/webapis/mutationobserver/__tests__/MutationObserver-itest.js
@@ -858,12 +858,6 @@ const nativeUnobserveAll = nullthrows(NativeMutationObserver?.unobserveAll);
               root.render(<View style={{width: 1}} />);
             });
 
-            // This forces swapping the alternate tree in the reconciler
-            Fantom.runTask(() => {
-              // Set style to force a state update
-              root.render(<View style={{width: 2}} />);
-            });
-
             expect(getReferenceCount()).toBe(0);
 
             observer.disconnect();


### PR DESCRIPTION
Summary:
changelog: [internal]

enable enableEagerAlternateStateNodeCleanup in tests and remove workarounds.

Reviewed By: rubennorte

Differential Revision: D74643973


