### PR TITLE
Fix data race in usage of ShadowTreeRevisionConsistencyManager

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.h
@@ -182,8 +182,8 @@ class RuntimeScheduler_Legacy final : public RuntimeSchedulerBase {
    */
   std::atomic_bool isPerformingWork_{false};
 
-  ShadowTreeRevisionConsistencyManager* shadowTreeRevisionConsistencyManager_{
-      nullptr};
+  std::atomic<ShadowTreeRevisionConsistencyManager*>
+      shadowTreeRevisionConsistencyManager_{nullptr};
 
   RuntimeSchedulerTaskErrorHandler onTaskError_;
 };

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.h
@@ -225,8 +225,8 @@ class RuntimeScheduler_Modern final : public RuntimeSchedulerBase {
   std::queue<RuntimeSchedulerRenderingUpdate> pendingRenderingUpdates_;
   std::unordered_set<SurfaceId> surfaceIdsWithPendingRenderingUpdates_;
 
-  ShadowTreeRevisionConsistencyManager* shadowTreeRevisionConsistencyManager_{
-      nullptr};
+  std::atomic<ShadowTreeRevisionConsistencyManager*>
+      shadowTreeRevisionConsistencyManager_{nullptr};
 
   PerformanceEntryReporter* performanceEntryReporter_{nullptr};
   RuntimeSchedulerEventTimingDelegate* eventTimingDelegate_{nullptr};


### PR DESCRIPTION
Summary:
# Changelog: 
[Internal] - 

Indirect consequence of https://github.com/facebook/react-native/pull/50484, TSAN started to detect a data race in some configurations.


It's possible to have the data race between the `ShadowTreeRevisionConsistencyManager` being set in `RuntimeScheduler` and it being already used in the executor thread (as these things are generally done from different threads).

Differential Revision: D74651070


