### PR TITLE
Improved the description of the error shown when a previous debugger is closed when a new one is opened

### DIFF
--- a/packages/dev-middleware/src/inspector-proxy/Device.js
+++ b/packages/dev-middleware/src/inspector-proxy/Device.js
@@ -43,11 +43,14 @@ const WS_CLOSURE_CODE = {
   INTERNAL_ERROR: 1011,
 };
 
+// should be aligned with
+// https://github.com/facebook/react-native-devtools-frontend/blob/3d17e0fd462dc698db34586697cce2371b25e0d3/front_end/ui/legacy/components/utils/TargetDetachedDialog.ts#L50-L64
 export const WS_CLOSE_REASON = {
-  PAGE_NOT_FOUND: '[PAGE_NOT_FOUND] Debugger Page Not Found',
+  PAGE_NOT_FOUND: '[PAGE_NOT_FOUND] Debugger page not found',
   CONNECTION_LOST: '[CONNECTION_LOST] Connection lost to corresponding device',
-  RECREATING_DEVICE: '[RECREATING_DEVICE] Recreating Device Connection',
-  RECREATING_DEBUGGER: '[RECREATING_DEBUGGER] Recreating Debugger Connection',
+  RECREATING_DEVICE: '[RECREATING_DEVICE] Recreating device connection',
+  NEW_DEBUGGER_OPENED:
+    '[NEW_DEBUGGER_OPENED] New debugger opened for the same app instance',
 };
 
 // Prefix for script URLs that are alphanumeric IDs. See comment in #processMessageFromDeviceLegacy method for
@@ -336,7 +339,7 @@ export default class Device {
     // Disconnect current debugger if we already have debugger connected.
     this.#terminateDebuggerConnection(
       WS_CLOSURE_CODE.NORMAL,
-      WS_CLOSE_REASON.RECREATING_DEBUGGER,
+      WS_CLOSE_REASON.NEW_DEBUGGER_OPENED,
     );
 
     this.#deviceEventReporter?.logConnection('debugger', {

--- a/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
+++ b/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
@@ -48,7 +48,7 @@ const MIN_EVENT_LOOP_DELAY_PERCENT_TO_REPORT = 20;
 const INTERNAL_ERROR_CODE = 1011;
 
 // should be aligned with
-// https://github.com/facebook/react-native-devtools-frontend/blob/fa273092fbc8edc94d4a0a3621735f4677a99ba8/front_end/ui/legacy/components/utils/TargetDetachedDialog.ts#L50
+// https://github.com/facebook/react-native-devtools-frontend/blob/3d17e0fd462dc698db34586697cce2371b25e0d3/front_end/ui/legacy/components/utils/TargetDetachedDialog.ts#L50-L64
 const INTERNAL_ERROR_MESSAGES = {
   UREGISTERED_DEVICE:
     '[UREGISTERED_DEVICE] Debugger connection attempted for a device that was not registered',


### PR DESCRIPTION
Summary:
Changelog: [General][Internal] Improved the description of the error shown when a previous debugger is closed when a new one is opened

Corresponding DevTools PR:
https://github.com/facebook/react-native-devtools-frontend/pull/162

Differential Revision: D74657572


