### PR TITLE
fix issue #51297 which addresses allWarningsAsErrors type error

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/build.gradle.kts
+++ b/packages/gradle-plugin/react-native-gradle-plugin/build.gradle.kts
@@ -66,8 +66,9 @@ tasks.withType<KotlinCompile>().configureEach {
     apiVersion.set(KotlinVersion.KOTLIN_1_8)
     // See comment above on JDK 11 support
     jvmTarget.set(JvmTarget.JVM_11)
-    allWarningsAsErrors =
+     allWarningsAsErrors.set(
         project.properties["enableWarningsAsErrors"]?.toString()?.toBoolean() ?: false
+    )
   }
 }
 

--- a/packages/gradle-plugin/settings-plugin/build.gradle.kts
+++ b/packages/gradle-plugin/settings-plugin/build.gradle.kts
@@ -56,8 +56,9 @@ tasks.withType<KotlinCompile>().configureEach {
     apiVersion.set(KotlinVersion.KOTLIN_1_8)
     // See comment above on JDK 11 support
     jvmTarget.set(JvmTarget.JVM_11)
-    allWarningsAsErrors =
+     allWarningsAsErrors.set(
         project.properties["enableWarningsAsErrors"]?.toString()?.toBoolean() ?: false
+    )
   }
 }
 

--- a/packages/gradle-plugin/shared-testutil/build.gradle.kts
+++ b/packages/gradle-plugin/shared-testutil/build.gradle.kts
@@ -27,8 +27,9 @@ tasks.withType<KotlinCompile>().configureEach {
     apiVersion.set(KotlinVersion.KOTLIN_1_8)
     // See comment above on JDK 11 support
     jvmTarget.set(JvmTarget.JVM_11)
-    allWarningsAsErrors =
+     allWarningsAsErrors.set(
         project.properties["enableWarningsAsErrors"]?.toString()?.toBoolean() ?: false
+    )
   }
 }
 

--- a/packages/gradle-plugin/shared/build.gradle.kts
+++ b/packages/gradle-plugin/shared/build.gradle.kts
@@ -33,8 +33,9 @@ tasks.withType<KotlinCompile>().configureEach {
     apiVersion.set(KotlinVersion.KOTLIN_1_8)
     // See comment above on JDK 11 support
     jvmTarget.set(JvmTarget.JVM_11)
-    allWarningsAsErrors =
+     allWarningsAsErrors.set(
         project.properties["enableWarningsAsErrors"]?.toString()?.toBoolean() ?: false
+    )
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Resolved a build error [issue #51297](https://github.com/facebook/react-native/issues/51297) caused by assigning a Boolean to a Property<Boolean>.
Switched from direct assignment to using .set(...) to correctly configure allWarningsAsErrors from project properties.

## Changelog:

- Gradle fix: assign allWarningsAsErrors using .set() for Property<Boolean>

<!-- Help reviewers and the release process by writing your own changelog entry.


Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - [ANDROID] [FIXED]

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:
Fixes build failure with React Native v0.79.2 and Gradle v8.0.
```
npm run start
npm run android
```
no more build errors

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
