### PR TITLE
Fix issue where text inputs cannot blur on <= Android 8.1

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -6553,6 +6553,7 @@ public class com/facebook/react/views/textinput/ReactEditText : androidx/appcomp
 	public fun onTextContextMenuItem (I)Z
 	public fun onTouchEvent (Landroid/view/MotionEvent;)Z
 	public fun removeTextChangedListener (Landroid/text/TextWatcher;)V
+	public fun requestFocus (ILandroid/graphics/Rect;)Z
 	public final fun requestFocusFromJS ()V
 	public final fun setAllowFontScaling (Z)V
 	public final fun setAutoFocus (Z)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.kt
@@ -364,9 +364,23 @@ public open class ReactEditText public constructor(context: Context) : AppCompat
     hideSoftKeyboard()
   }
 
+  override fun requestFocus(direction: Int, previouslyFocusedRect: Rect?): Boolean {
+    // On some older versions of Android there is a bug where `clearFocus` will try to focus the
+    // first focusable View in the hierarchy after clearing focus. This is intended behavior, but
+    // only if you are not in touch mode per
+    // https://developer.android.com/reference/android/view/View#clearFocus(), yet this happens in
+    // both. Therefore, we are swallowing Android-based focus calls if we are in touch mode.
+    // If we are not in touch mode (using a hardware keyboard) then we will allow this to happen.
+    // Note this only happens for Android-origin focus calls, as opposed to JS-origin (like tapping)
+    // since those go through `requestFocusProgrammatically`
+    if (isInTouchMode) {
+      return isFocused
+    }
+    return super.requestFocus(direction, previouslyFocusedRect)
+  }
+
   // For cases like autoFocus, or ref.focus() where we request focus programmatically and not
-  // through
-  // interacting with the EditText directly (like clicking on it). We cannot use stock
+  // through interacting with the EditText directly (like clicking on it). We cannot use stock
   // requestFocus() because it will not pop up the soft keyboard, only clicking the input will do
   // that. This method will eventually replace requestFocusInternal()
   private fun requestFocusProgrammatically(): Boolean {


### PR DESCRIPTION
Summary:
We got https://github.com/facebook/react-native/issues/51072#issue-3035616801 which demonstrates that if we have 2 text inputs on a screen we cannot blur them. If you try to blur any, focus jumps to the first one. 

This seems to be a bug with Android's `clearFocus` per https://developer.android.com/reference/android/view/View#clearFocus(), this behavior is intended when we are not in touch mode, yet it happens regardless of what mode we are in on this version.

I modified this a bit to swallow `requestFocus` calls if we are in touch mode. This should be fine as no JS focus calls will go through this path. On hardware keyboard focus and focus from `clearFocus`

Changelog: [Android][Bugfix] - Fix bug where focus would jump to top text input upon clearing a separate text input.

Differential Revision: D74678847


