### PR TITLE
Allow links in facsimile to be keyboard focusable

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewAccessibilityDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewAccessibilityDelegate.kt
@@ -7,11 +7,10 @@
 
 package com.facebook.react.views.text
 
-import android.graphics.Paint
 import android.graphics.Rect
 import android.os.Bundle
+import android.text.Layout
 import android.text.Spanned
-import android.text.style.AbsoluteSizeSpan
 import android.text.style.ClickableSpan
 import android.view.View
 import android.widget.TextView
@@ -21,7 +20,6 @@ import androidx.core.view.accessibility.AccessibilityNodeProviderCompat
 import com.facebook.react.R
 import com.facebook.react.uimanager.ReactAccessibilityDelegate
 import com.facebook.react.views.text.internal.span.ReactClickableSpan
-import kotlin.math.ceil
 
 internal class ReactTextViewAccessibilityDelegate : ReactAccessibilityDelegate {
   public constructor(
@@ -76,16 +74,19 @@ internal class ReactTextViewAccessibilityDelegate : ReactAccessibilityDelegate {
 
     val link = accessibilityLinks?.getLinkById(virtualViewId) ?: return
 
-    val span = getFirstSpan(link.start, link.end, ClickableSpan::class.java)
-    if (span == null || span !is ReactClickableSpan || hostView !is ReactTextView) {
-      return
-    }
+    val span = getFirstSpan(link.start, link.end, ClickableSpan::class.java) ?: return
 
-    // TODO: When we refactor ReactTextView, implement this using
-    // https://developer.android.com/reference/android/text/Layout
-    span.isKeyboardFocused = hasFocus
-    span.focusBgColor = (hostView as TextView).highlightColor
-    hostView.invalidate()
+    if (span is ReactClickableSpan && hostView is TextView) {
+      span.isKeyboardFocused = hasFocus
+      span.focusBgColor = (hostView as TextView).highlightColor
+      hostView.invalidate()
+    } else if (hostView is PreparedLayoutTextView) {
+      if (hasFocus) {
+        (hostView as PreparedLayoutTextView).setSelection(link.start, link.end)
+      } else {
+        (hostView as PreparedLayoutTextView).clearSelection()
+      }
+    }
   }
 
   override fun onPerformActionForVirtualView(
@@ -99,10 +100,7 @@ internal class ReactTextViewAccessibilityDelegate : ReactAccessibilityDelegate {
 
     val link = accessibilityLinks?.getLinkById(virtualViewId) ?: return false
 
-    val span = getFirstSpan(link.start, link.end, ClickableSpan::class.java)
-    if (span == null || span !is ReactClickableSpan) {
-      return false
-    }
+    val span = getFirstSpan(link.start, link.end, ClickableSpan::class.java) ?: return false
 
     if (action == AccessibilityNodeInfoCompat.ACTION_CLICK) {
       span.onClick(hostView)
@@ -122,32 +120,26 @@ internal class ReactTextViewAccessibilityDelegate : ReactAccessibilityDelegate {
 
   override fun getVirtualViewAt(x: Float, y: Float): Int {
     val accessibilityLinks = accessibilityLinks ?: return INVALID_ID
-    if (accessibilityLinks.size() == 0 || hostView !is TextView) {
+    if (accessibilityLinks.size() == 0 ||
+        (hostView !is TextView && hostView !is PreparedLayoutTextView)) {
       return INVALID_ID
     }
 
-    var x = x
-    var y = y
+    var localX = x
+    var localY = y
+    localX -= hostView.paddingLeft.toFloat()
+    localY -= hostView.paddingTop.toFloat()
+    localX += hostView.scrollX.toFloat()
+    localY += hostView.scrollY.toFloat()
 
-    val textView = hostView as TextView
-    if (textView.text !is Spanned) {
-      return INVALID_ID
-    }
-
-    val layout = textView.layout ?: return INVALID_ID
-
-    x -= textView.totalPaddingLeft.toFloat()
-    y -= textView.totalPaddingTop.toFloat()
-    x += textView.scrollX.toFloat()
-    y += textView.scrollY.toFloat()
-
-    val line = layout.getLineForVertical(y.toInt())
-    val charOffset = layout.getOffsetForHorizontal(line, x)
+    val layout = getLayoutFromHost() ?: return INVALID_ID
+    val line = layout.getLineForVertical(localY.toInt())
+    val charOffset = layout.getOffsetForHorizontal(line, localX)
 
     val clickableSpan =
         getFirstSpan(charOffset, charOffset, ClickableSpan::class.java) ?: return INVALID_ID
 
-    val spanned = textView.text as Spanned
+    val spanned = getSpannedFromHost() ?: return INVALID_ID
     val start = spanned.getSpanStart(clickableSpan)
     val end = spanned.getSpanEnd(clickableSpan)
 
@@ -155,14 +147,31 @@ internal class ReactTextViewAccessibilityDelegate : ReactAccessibilityDelegate {
     return link?.id ?: INVALID_ID
   }
 
-  protected fun <T> getFirstSpan(start: Int, end: Int, classType: Class<T>?): T? {
-    if (hostView !is TextView || (hostView as TextView).text !is Spanned) {
-      return null
+  private fun getLayoutFromHost(): Layout? {
+    return if (hostView is PreparedLayoutTextView) {
+      (hostView as PreparedLayoutTextView).layout
+    } else if (hostView is TextView) {
+      (hostView as TextView).layout
+    } else {
+      null
     }
+  }
 
-    val spanned = (hostView as TextView).text as Spanned
+  protected fun <T> getFirstSpan(start: Int, end: Int, classType: Class<T>?): T? {
+    val spanned = getSpannedFromHost() ?: return null
     val spans = spanned.getSpans(start, end, classType)
     return if (spans.isNotEmpty()) spans[0] else null
+  }
+
+  private fun getSpannedFromHost(): Spanned? {
+    val host = hostView
+    return if (host is PreparedLayoutTextView) {
+      host.layout?.text as? Spanned
+    } else if (host is TextView) {
+      host.text as? Spanned
+    } else {
+      null
+    }
   }
 
   @Suppress("DEPRECATION")
@@ -203,12 +212,11 @@ internal class ReactTextViewAccessibilityDelegate : ReactAccessibilityDelegate {
 
   private fun getBoundsInParent(accessibleLink: AccessibilityLinks.AccessibleLink): Rect? {
     // This view is not a text view, so return the entire views bounds.
-    if (hostView !is TextView) {
+    if (hostView !is TextView && hostView !is PreparedLayoutTextView) {
       return Rect(0, 0, hostView.width, hostView.height)
     }
 
-    val textView = hostView as TextView
-    val textViewLayout = textView.layout ?: return Rect(0, 0, textView.width, textView.height)
+    val textViewLayout = getLayoutFromHost() ?: return Rect(0, 0, hostView.width, hostView.height)
 
     val startOffset = accessibleLink.start
     val endOffset = accessibleLink.end
@@ -225,22 +233,15 @@ internal class ReactTextViewAccessibilityDelegate : ReactAccessibilityDelegate {
 
     val startXCoordinates = textViewLayout.getPrimaryHorizontal(startOffset).toDouble()
 
-    val paint = Paint()
-    val sizeSpan =
-        getFirstSpan(accessibleLink.start, accessibleLink.end, AbsoluteSizeSpan::class.java)
-    val textSize = sizeSpan?.size?.toFloat() ?: textView.textSize
-    paint.textSize = textSize
-    val textWidth = ceil(paint.measureText(accessibleLink.description).toDouble()).toInt()
-
     val endOffsetLineNumber = textViewLayout.getLineForOffset(endOffset)
     val isMultiline = startOffsetLineNumber != endOffsetLineNumber
     textViewLayout.getLineBounds(startOffsetLineNumber, rootRect)
 
-    val verticalOffset = textView.scrollY + textView.totalPaddingTop
+    val verticalOffset = hostView.scrollY + hostView.paddingTop
     rootRect.top += verticalOffset
     rootRect.bottom += verticalOffset
     rootRect.left =
-        (rootRect.left + (startXCoordinates + textView.totalPaddingLeft - textView.scrollX)).toInt()
+        (rootRect.left + (startXCoordinates + hostView.paddingLeft - hostView.scrollX)).toInt()
 
     // The bounds for multi-line strings should *only* include the first line. This is because for
     // API 25 and below, Talkback's click is triggered at the center point of these bounds, and if
@@ -250,8 +251,8 @@ internal class ReactTextViewAccessibilityDelegate : ReactAccessibilityDelegate {
     if (isMultiline) {
       return Rect(rootRect.left, rootRect.top, rootRect.right, rootRect.bottom)
     }
-
-    return Rect(rootRect.left, rootRect.top, rootRect.left + textWidth, rootRect.bottom)
+    val endXCoordinates = textViewLayout.getPrimaryHorizontal(endOffset).toDouble()
+    return Rect(rootRect.left, rootRect.top, endXCoordinates.toInt(), rootRect.bottom)
   }
 
   override fun getAccessibilityNodeProvider(host: View): AccessibilityNodeProviderCompat? {


### PR DESCRIPTION
Summary:
tsia, there is a lot of TextView specific API calls and instance checks in the delegate that need to be modified. Additionally, facsimile has some custom focusing logic we do not need if we have a delegate

I opted to just do a lot of instance specific logic using `is` . That seems easier for the time being with this text view that should replace our other text view over time.

I also expose a new way of focusing a span on facsimile, which may not be the best way to do that, lmk

Changelog: [Internal]

Differential Revision: D74104419


