### PR TITLE
Add a custom Jest resolver to opt out from handling "exports" in tests

### DIFF
--- a/packages/react-native/jest-preset.js
+++ b/packages/react-native/jest-preset.js
@@ -14,6 +14,7 @@ module.exports = {
     defaultPlatform: 'ios',
     platforms: ['android', 'ios', 'native'],
   },
+  resolver: require.resolve('./jest/resolver.js'),
   transform: {
     '^.+\\.(js|ts|tsx)$': 'babel-jest',
     '^.+\\.(bmp|gif|jpg|jpeg|mp4|png|psd|svg|webp)$': require.resolve(

--- a/packages/react-native/jest/resolver.js
+++ b/packages/react-native/jest/resolver.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+'use strict';
+
+module.exports = (path, options) => {
+  const originalPackageFilter = options.packageFilter;
+
+  return options.defaultResolver(path, {
+    ...options,
+    packageFilter: pkg => {
+      const filteredPkg = originalPackageFilter
+        ? originalPackageFilter(pkg)
+        : pkg;
+
+      // Temporarily allow any react-native subpaths to be resolved and
+      // mocked by Jest (backwards compatibility around RFC0894)
+      if (filteredPkg.name === 'react-native') {
+        delete filteredPkg.exports;
+      }
+
+      return filteredPkg;
+    },
+  });
+};


### PR DESCRIPTION
Summary: D72228547 added the `exports` field to the main `react-native` package, in which all imports from `./src/*` are explicitly disallowed. This was expected to be a breaking change and to limit the surface area of it, this diff will allow using all imports in jest tests.

Changelog: [General][Added] Added a custom Jest resolver to opt out from handling "exports" in tests

Differential Revision: D74708701


