### PR TITLE
Clean up compatibility code for MutationObserver

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/mutationobserver/NativeMutationObserver.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/mutationobserver/NativeMutationObserver.cpp
@@ -44,15 +44,6 @@ void NativeMutationObserver::observe(
       mutationObserverId, shadowNode, subtree, uiManager);
 }
 
-// TODO: remove in the next version
-void NativeMutationObserver::unobserve(
-    jsi::Runtime& /*runtime*/,
-    MutationObserverId mutationObserverId,
-    jsi::Object targetShadowNode) {
-  // This will not be used but cannot be removed yet because the compatibility
-  // check does not allow it.
-}
-
 void NativeMutationObserver::unobserveAll(
     jsi::Runtime& runtime,
     MutationObserverId mutationObserverId) {

--- a/packages/react-native/ReactCommon/react/nativemodule/mutationobserver/NativeMutationObserver.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/mutationobserver/NativeMutationObserver.h
@@ -52,13 +52,6 @@ class NativeMutationObserver
       jsi::Runtime& runtime,
       NativeMutationObserverObserveOptions options);
 
-  // TODO: remove in the next version
-  [[deprecated("use unobserveAll instead")]]
-  void unobserve(
-      jsi::Runtime& runtime,
-      MutationObserverId mutationObserverId,
-      jsi::Object targetShadowNode);
-
   void unobserveAll(
       jsi::Runtime& runtime,
       MutationObserverId mutationObserverId);

--- a/packages/react-native/src/private/webapis/mutationobserver/MutationObserver.js
+++ b/packages/react-native/src/private/webapis/mutationobserver/MutationObserver.js
@@ -118,15 +118,11 @@ export default class MutationObserver {
 
     const mutationObserverId = this._getOrCreateMutationObserverId();
 
-    const didStartObserving = MutationObserverManager.observe({
+    MutationObserverManager.observe({
       mutationObserverId,
       target,
       subtree: Boolean(options?.subtree),
     });
-
-    if (didStartObserving && !MutationObserverManager.unobserveAll) {
-      this._observationTargets.add(target);
-    }
   }
 
   /**
@@ -139,17 +135,7 @@ export default class MutationObserver {
       return;
     }
 
-    if (MutationObserverManager.unobserveAll) {
-      MutationObserverManager.unobserveAll(mutationObserverId);
-    } else if (MutationObserverManager.unobserve) {
-      for (const target of this._observationTargets.keys()) {
-        nullthrows(MutationObserverManager.unobserve)(
-          mutationObserverId,
-          target,
-        );
-      }
-      this._observationTargets.clear();
-    }
+    MutationObserverManager.unobserveAll(mutationObserverId);
 
     MutationObserverManager.unregisterObserver(mutationObserverId);
     this._mutationObserverId = null;

--- a/packages/react-native/src/private/webapis/mutationobserver/__tests__/MutationObserver-itest.js
+++ b/packages/react-native/src/private/webapis/mutationobserver/__tests__/MutationObserver-itest.js
@@ -16,7 +16,6 @@ import type MutationRecordType from 'react-native/src/private/webapis/mutationob
 
 import ensureInstance from '../../../__tests__/utilities/ensureInstance';
 import {createShadowNodeReferenceCountingRef} from '../../../__tests__/utilities/ShadowNodeReferenceCounter';
-import NativeMutationObserver from '../specs/NativeMutationObserver';
 import * as Fantom from '@react-native/fantom';
 import nullthrows from 'nullthrows';
 import * as React from 'react';
@@ -42,921 +41,891 @@ function ensureMutationRecordArray(
   );
 }
 
-const nativeUnobserveAll = nullthrows(NativeMutationObserver?.unobserveAll);
-
-[true, false].forEach(withUnobserveAll => {
-  describe(`MutationObserver (${withUnobserveAll ? 'with' : 'without'} NativeMutationObserver.unobserveAll)`, () => {
-    beforeAll(() => {
-      // $FlowExpectedError[incompatible-use]
-      // $FlowExpectedError[cannot-write]
-      NativeMutationObserver.unobserveAll = withUnobserveAll
-        ? nativeUnobserveAll
-        : null;
-    });
-
-    it(`should ${withUnobserveAll ? 'have' : 'NOT have'} NativeMutationObserver.unobserveAll`, () => {
-      expect(NativeMutationObserver?.unobserveAll).toBe(
-        withUnobserveAll ? nativeUnobserveAll : null,
+describe('MutationObserver', () => {
+  describe('constructor(callback)', () => {
+    it('should throw if `callback` is not provided', () => {
+      expect(() => {
+        // $FlowExpectedError[incompatible-call]
+        return new MutationObserver();
+      }).toThrow(
+        "Failed to construct 'MutationObserver': 1 argument required, but only 0 present.",
       );
     });
 
-    describe('constructor(callback)', () => {
-      it('should throw if `callback` is not provided', () => {
-        expect(() => {
-          // $FlowExpectedError[incompatible-call]
-          return new MutationObserver();
-        }).toThrow(
-          "Failed to construct 'MutationObserver': 1 argument required, but only 0 present.",
-        );
-      });
+    it('should throw if `callback` is not a function', () => {
+      expect(() => {
+        // $FlowExpectedError[incompatible-call]
+        return new MutationObserver('not a function!');
+      }).toThrow(
+        "Failed to construct 'MutationObserver': parameter 1 is not of type 'Function'.",
+      );
+    });
+  });
 
-      it('should throw if `callback` is not a function', () => {
-        expect(() => {
-          // $FlowExpectedError[incompatible-call]
-          return new MutationObserver('not a function!');
-        }).toThrow(
-          "Failed to construct 'MutationObserver': parameter 1 is not of type 'Function'.",
-        );
-      });
+  describe('observe(target, {childList: boolean, subtree: boolean})', () => {
+    it('should throw if `target` is not a `ReactNativeElement`', () => {
+      const observer = new MutationObserver(() => {});
+      expect(() => {
+        // $FlowExpectedError[incompatible-call]
+        observer.observe('something');
+      }).toThrow(
+        "Failed to execute 'observe' on 'MutationObserver': parameter 1 is not of type 'ReactNativeElement'.",
+      );
     });
 
-    describe('observe(target, {childList: boolean, subtree: boolean})', () => {
-      it('should throw if `target` is not a `ReactNativeElement`', () => {
+    it('should throw if the `childList` option is not provided', () => {
+      const nodeRef = createRef<HostInstance>();
+
+      const root = Fantom.createRoot();
+      Fantom.runTask(() => {
+        root.render(<View ref={nodeRef} />);
+      });
+
+      const node = ensureReactNativeElement(nodeRef.current);
+
+      expect(() => {
         const observer = new MutationObserver(() => {});
-        expect(() => {
-          // $FlowExpectedError[incompatible-call]
-          observer.observe('something');
-        }).toThrow(
-          "Failed to execute 'observe' on 'MutationObserver': parameter 1 is not of type 'ReactNativeElement'.",
-        );
-      });
+        observer.observe(node);
+      }).toThrow(
+        "Failed to execute 'observe' on 'MutationObserver': The options object must set 'childList' to true.",
+      );
 
-      it('should throw if the `childList` option is not provided', () => {
-        const nodeRef = createRef<HostInstance>();
+      expect(() => {
+        const observer = new MutationObserver(() => {});
+        // $FlowExpectedError[incompatible-call]
+        observer.observe(node, {childList: false});
+      }).toThrow(
+        "Failed to execute 'observe' on 'MutationObserver': The options object must set 'childList' to true.",
+      );
 
-        const root = Fantom.createRoot();
-        Fantom.runTask(() => {
-          root.render(<View ref={nodeRef} />);
-        });
-
-        const node = ensureReactNativeElement(nodeRef.current);
-
-        expect(() => {
-          const observer = new MutationObserver(() => {});
-          observer.observe(node);
-        }).toThrow(
-          "Failed to execute 'observe' on 'MutationObserver': The options object must set 'childList' to true.",
-        );
-
-        expect(() => {
-          const observer = new MutationObserver(() => {});
-          // $FlowExpectedError[incompatible-call]
-          observer.observe(node, {childList: false});
-        }).toThrow(
-          "Failed to execute 'observe' on 'MutationObserver': The options object must set 'childList' to true.",
-        );
-
-        expect(() => {
-          const observer = new MutationObserver(() => {});
-          observer.observe(node, {childList: true});
-        }).not.toThrow();
-
-        expect(() => {
-          const observer = new MutationObserver(() => {});
-          // $FlowExpectedError[incompatible-call]
-          observer.observe(node, {childList: 1});
-        }).not.toThrow();
-      });
-
-      it('should throw if the `attributes` option is provided', () => {
-        const nodeRef = createRef<HostInstance>();
-
-        const root = Fantom.createRoot();
-        Fantom.runTask(() => {
-          root.render(<View ref={nodeRef} />);
-        });
-
-        const node = ensureReactNativeElement(nodeRef.current);
-
-        expect(() => {
-          const observer = new MutationObserver(() => {});
-          observer.observe(node, {childList: true, attributes: true});
-        }).toThrow(
-          "Failed to execute 'observe' on 'MutationObserver': attributes is not supported",
-        );
-      });
-
-      it('should throw if the `attributeFilter` option is provided', () => {
-        const nodeRef = createRef<HostInstance>();
-
-        const root = Fantom.createRoot();
-        Fantom.runTask(() => {
-          root.render(<View ref={nodeRef} />);
-        });
-
-        const node = ensureReactNativeElement(nodeRef.current);
-
-        expect(() => {
-          const observer = new MutationObserver(() => {});
-          observer.observe(node, {childList: true, attributeFilter: []});
-        }).toThrow(
-          "Failed to execute 'observe' on 'MutationObserver': attributeFilter is not supported",
-        );
-      });
-
-      it('should throw if the `attributeOldValue` option is provided', () => {
-        const nodeRef = createRef<HostInstance>();
-
-        const root = Fantom.createRoot();
-        Fantom.runTask(() => {
-          root.render(<View ref={nodeRef} />);
-        });
-
-        const node = ensureReactNativeElement(nodeRef.current);
-
-        expect(() => {
-          const observer = new MutationObserver(() => {});
-          // $FlowExpected
-          observer.observe(node, {childList: true, attributeOldValue: true});
-        }).toThrow(
-          "Failed to execute 'observe' on 'MutationObserver': attributeOldValue is not supported",
-        );
-      });
-
-      it('should throw if the `characterData` option is provided', () => {
-        const nodeRef = createRef<HostInstance>();
-
-        const root = Fantom.createRoot();
-        Fantom.runTask(() => {
-          root.render(<View ref={nodeRef} />);
-        });
-
-        const node = ensureReactNativeElement(nodeRef.current);
-
-        expect(() => {
-          const observer = new MutationObserver(() => {});
-          observer.observe(node, {childList: true, characterData: true});
-        }).toThrow(
-          "Failed to execute 'observe' on 'MutationObserver': characterData is not supported",
-        );
-      });
-
-      it('should throw if the `characterDataOldValue` option is provided', () => {
-        const nodeRef = createRef<HostInstance>();
-
-        const root = Fantom.createRoot();
-        Fantom.runTask(() => {
-          root.render(<View ref={nodeRef} />);
-        });
-
-        const node = ensureReactNativeElement(nodeRef.current);
-
-        expect(() => {
-          const observer = new MutationObserver(() => {});
-          observer.observe(node, {
-            childList: true,
-            characterDataOldValue: true,
-          });
-        }).toThrow(
-          "Failed to execute 'observe' on 'MutationObserver': characterDataOldValue is not supported",
-        );
-      });
-
-      it('should ignore calls to observe disconnected targets', () => {
-        const nodeRef = createRef<HostInstance>();
-
-        const root = Fantom.createRoot();
-        Fantom.runTask(() => {
-          root.render(<View key="node1" ref={nodeRef} />);
-        });
-
-        const node = ensureReactNativeElement(nodeRef.current);
-
-        Fantom.runTask(() => {
-          root.render(<></>);
-        });
-
-        expect(node.isConnected).toBe(false);
-
-        const observerCallback = () => {};
-        const observer = new MutationObserver(observerCallback);
-
-        expect(() => {
-          observer.observe(node, {childList: true});
-        }).not.toThrow();
-      });
-
-      it('should report direct children added to and removed from an observed node (childList: true, subtree: false) ', () => {
-        const nodeRef = createRef<HostInstance>();
-
-        const root = Fantom.createRoot();
-        Fantom.runTask(() => {
-          root.render(<View key="node1" ref={nodeRef} />);
-        });
-
-        const node = ensureReactNativeElement(nodeRef.current);
-
-        const observerCallbackCallArgs = [];
-        const observerCallback = (...args: $ReadOnlyArray<mixed>) => {
-          observerCallbackCallArgs.push(args);
-        };
-        const observer = new MutationObserver(observerCallback);
+      expect(() => {
+        const observer = new MutationObserver(() => {});
         observer.observe(node, {childList: true});
+      }).not.toThrow();
 
-        // Does not report anything initially
-        expect(observerCallbackCallArgs.length).toBe(0);
+      expect(() => {
+        const observer = new MutationObserver(() => {});
+        // $FlowExpectedError[incompatible-call]
+        observer.observe(node, {childList: 1});
+      }).not.toThrow();
+    });
 
-        const childNode1Ref = createRef<HostInstance>();
-        const childNode2Ref = createRef<HostInstance>();
+    it('should throw if the `attributes` option is provided', () => {
+      const nodeRef = createRef<HostInstance>();
 
-        Fantom.runTask(() => {
-          root.render(
-            <View key="node1">
-              <View key="node1-1" ref={childNode1Ref} />
-              <View key="node1-2" ref={childNode2Ref} />
-            </View>,
-          );
-        });
-
-        const childNode1 = ensureReactNativeElement(childNode1Ref.current);
-        const childNode2 = ensureReactNativeElement(childNode2Ref.current);
-
-        expect(observerCallbackCallArgs.length).toBe(1);
-        const firstCall = nullthrows(observerCallbackCallArgs.at(-1));
-        expect(firstCall.length).toBe(2);
-
-        const firstRecords = ensureMutationRecordArray(firstCall[0]);
-        expect(firstRecords).toBeInstanceOf(Array);
-        expect(firstRecords.length).toBe(1);
-        expect(firstRecords[0]).toBeInstanceOf(MutationRecord);
-
-        const firstRecord = firstRecords[0];
-        expect(firstRecord.type).toBe('childList');
-        expect(firstRecord.target).toBe(node);
-        expect(firstRecord.addedNodes).toBeInstanceOf(NodeList);
-        expect(firstRecord.addedNodes[0]).toBe(childNode1);
-        expect(firstRecord.addedNodes[1]).toBe(childNode2);
-        expect(firstRecord.removedNodes).toBeInstanceOf(NodeList);
-        expect(firstRecord.removedNodes.length).toBe(0);
-
-        expect(firstCall[1]).toBe(observer);
-
-        Fantom.runTask(() => {
-          root.render(
-            <View key="node1">
-              <View key="node1-2" />
-            </View>,
-          );
-        });
-
-        expect(observerCallbackCallArgs.length).toBe(2);
-        const secondCall = nullthrows(observerCallbackCallArgs.at(-1));
-        expect(secondCall.length).toBe(2);
-
-        const secondRecords = ensureMutationRecordArray(secondCall[0]);
-        expect(secondRecords.length).toBe(1);
-        expect(secondRecords[0]).toBeInstanceOf(MutationRecord);
-
-        const secondRecord = secondRecords[0];
-        expect(secondRecord.type).toBe('childList');
-        expect(secondRecord.target).toBe(node);
-        expect(secondRecord.addedNodes).toBeInstanceOf(NodeList);
-        expect([...secondRecord.addedNodes]).toEqual([]);
-        expect(secondRecord.removedNodes).toBeInstanceOf(NodeList);
-        expect([...secondRecord.removedNodes]).toEqual([childNode1]);
-
-        expect(secondCall[1]).toBe(observer);
+      const root = Fantom.createRoot();
+      Fantom.runTask(() => {
+        root.render(<View ref={nodeRef} />);
       });
 
-      it('should NOT report changes in transitive children when `subtree` is not set to true', () => {
-        const observedNodeRef = createRef<HostInstance>();
+      const node = ensureReactNativeElement(nodeRef.current);
 
-        const root = Fantom.createRoot();
-        Fantom.runTask(() => {
-          root.render(
-            <View key="node1" ref={observedNodeRef}>
-              <View key="node1-1" />
-            </View>,
-          );
-        });
+      expect(() => {
+        const observer = new MutationObserver(() => {});
+        observer.observe(node, {childList: true, attributes: true});
+      }).toThrow(
+        "Failed to execute 'observe' on 'MutationObserver': attributes is not supported",
+      );
+    });
 
-        const observedNode = ensureReactNativeElement(observedNodeRef.current);
+    it('should throw if the `attributeFilter` option is provided', () => {
+      const nodeRef = createRef<HostInstance>();
 
-        const observerCallback = jest.fn();
-        const observer = new MutationObserver(observerCallback);
-        observer.observe(observedNode, {childList: true});
-
-        // Does not report anything initially
-        expect(observerCallback).not.toHaveBeenCalled();
-
-        Fantom.runTask(() => {
-          root.render(
-            <View key="node1">
-              <View key="node1-1">
-                <View key="node1-1-1" />
-              </View>
-            </View>,
-          );
-        });
-
-        expect(observerCallback).not.toHaveBeenCalled();
-
-        Fantom.runTask(() => {
-          root.render(
-            <View key="node1">
-              <View key="node1-1" />
-            </View>,
-          );
-        });
-
-        expect(observerCallback).not.toHaveBeenCalled();
+      const root = Fantom.createRoot();
+      Fantom.runTask(() => {
+        root.render(<View ref={nodeRef} />);
       });
 
-      it('should report changes in transitive children when `subtree` is set to true', () => {
-        const nodeRef = createRef<HostInstance>();
+      const node = ensureReactNativeElement(nodeRef.current);
 
-        const root = Fantom.createRoot();
-        Fantom.runTask(() => {
-          root.render(
-            <View key="node1" ref={nodeRef}>
-              <View key="node1-1" />
-            </View>,
-          );
+      expect(() => {
+        const observer = new MutationObserver(() => {});
+        observer.observe(node, {childList: true, attributeFilter: []});
+      }).toThrow(
+        "Failed to execute 'observe' on 'MutationObserver': attributeFilter is not supported",
+      );
+    });
+
+    it('should throw if the `attributeOldValue` option is provided', () => {
+      const nodeRef = createRef<HostInstance>();
+
+      const root = Fantom.createRoot();
+      Fantom.runTask(() => {
+        root.render(<View ref={nodeRef} />);
+      });
+
+      const node = ensureReactNativeElement(nodeRef.current);
+
+      expect(() => {
+        const observer = new MutationObserver(() => {});
+        // $FlowExpected
+        observer.observe(node, {childList: true, attributeOldValue: true});
+      }).toThrow(
+        "Failed to execute 'observe' on 'MutationObserver': attributeOldValue is not supported",
+      );
+    });
+
+    it('should throw if the `characterData` option is provided', () => {
+      const nodeRef = createRef<HostInstance>();
+
+      const root = Fantom.createRoot();
+      Fantom.runTask(() => {
+        root.render(<View ref={nodeRef} />);
+      });
+
+      const node = ensureReactNativeElement(nodeRef.current);
+
+      expect(() => {
+        const observer = new MutationObserver(() => {});
+        observer.observe(node, {childList: true, characterData: true});
+      }).toThrow(
+        "Failed to execute 'observe' on 'MutationObserver': characterData is not supported",
+      );
+    });
+
+    it('should throw if the `characterDataOldValue` option is provided', () => {
+      const nodeRef = createRef<HostInstance>();
+
+      const root = Fantom.createRoot();
+      Fantom.runTask(() => {
+        root.render(<View ref={nodeRef} />);
+      });
+
+      const node = ensureReactNativeElement(nodeRef.current);
+
+      expect(() => {
+        const observer = new MutationObserver(() => {});
+        observer.observe(node, {
+          childList: true,
+          characterDataOldValue: true,
         });
+      }).toThrow(
+        "Failed to execute 'observe' on 'MutationObserver': characterDataOldValue is not supported",
+      );
+    });
 
-        const node = ensureReactNativeElement(nodeRef.current);
+    it('should ignore calls to observe disconnected targets', () => {
+      const nodeRef = createRef<HostInstance>();
 
-        const observerCallback = jest.fn();
-        const observer = new MutationObserver(observerCallback);
-        observer.observe(node, {childList: true, subtree: true});
+      const root = Fantom.createRoot();
+      Fantom.runTask(() => {
+        root.render(<View key="node1" ref={nodeRef} />);
+      });
 
-        // Does not report anything initially
-        expect(observerCallback).not.toHaveBeenCalled();
+      const node = ensureReactNativeElement(nodeRef.current);
 
-        const node111Ref = createRef<HostInstance>();
+      Fantom.runTask(() => {
+        root.render(<></>);
+      });
 
-        Fantom.runTask(() => {
-          root.render(
-            <View key="node1">
-              <View key="node1-1">
-                <View key="node1-1-1" ref={node111Ref} />
-              </View>
-            </View>,
-          );
-        });
+      expect(node.isConnected).toBe(false);
 
-        const node111 = ensureReactNativeElement(node111Ref.current);
+      const observerCallback = () => {};
+      const observer = new MutationObserver(observerCallback);
 
-        expect(observerCallback).toHaveBeenCalledTimes(1);
-        const firstCall = observerCallback.mock.lastCall;
-        const firstRecords = ensureMutationRecordArray(firstCall[0]);
-        expect(firstRecords.length).toBe(1);
-        expect([...firstRecords[0].addedNodes]).toEqual([node111]);
-        expect([...firstRecords[0].removedNodes]).toEqual([]);
+      expect(() => {
+        observer.observe(node, {childList: true});
+      }).not.toThrow();
+    });
 
-        Fantom.runTask(() => {
-          root.render(
-            <View key="node1">
-              <View key="node1-1" />
-            </View>,
-          );
-        });
+    it('should report direct children added to and removed from an observed node (childList: true, subtree: false) ', () => {
+      const nodeRef = createRef<HostInstance>();
 
-        expect(observerCallback).toHaveBeenCalledTimes(2);
-        const secondRecords = ensureMutationRecordArray(
-          observerCallback.mock.lastCall[0],
+      const root = Fantom.createRoot();
+      Fantom.runTask(() => {
+        root.render(<View key="node1" ref={nodeRef} />);
+      });
+
+      const node = ensureReactNativeElement(nodeRef.current);
+
+      const observerCallbackCallArgs = [];
+      const observerCallback = (...args: $ReadOnlyArray<mixed>) => {
+        observerCallbackCallArgs.push(args);
+      };
+      const observer = new MutationObserver(observerCallback);
+      observer.observe(node, {childList: true});
+
+      // Does not report anything initially
+      expect(observerCallbackCallArgs.length).toBe(0);
+
+      const childNode1Ref = createRef<HostInstance>();
+      const childNode2Ref = createRef<HostInstance>();
+
+      Fantom.runTask(() => {
+        root.render(
+          <View key="node1">
+            <View key="node1-1" ref={childNode1Ref} />
+            <View key="node1-2" ref={childNode2Ref} />
+          </View>,
         );
-        expect(secondRecords.length).toBe(1);
-        expect([...secondRecords[0].addedNodes]).toEqual([]);
-        expect([...secondRecords[0].removedNodes]).toEqual([node111]);
       });
 
-      it('should report changes in different parts of the subtree as separate entries (subtree = true)', () => {
-        const nodeRef = createRef<HostInstance>();
+      const childNode1 = ensureReactNativeElement(childNode1Ref.current);
+      const childNode2 = ensureReactNativeElement(childNode2Ref.current);
+
+      expect(observerCallbackCallArgs.length).toBe(1);
+      const firstCall = nullthrows(observerCallbackCallArgs.at(-1));
+      expect(firstCall.length).toBe(2);
+
+      const firstRecords = ensureMutationRecordArray(firstCall[0]);
+      expect(firstRecords).toBeInstanceOf(Array);
+      expect(firstRecords.length).toBe(1);
+      expect(firstRecords[0]).toBeInstanceOf(MutationRecord);
+
+      const firstRecord = firstRecords[0];
+      expect(firstRecord.type).toBe('childList');
+      expect(firstRecord.target).toBe(node);
+      expect(firstRecord.addedNodes).toBeInstanceOf(NodeList);
+      expect(firstRecord.addedNodes[0]).toBe(childNode1);
+      expect(firstRecord.addedNodes[1]).toBe(childNode2);
+      expect(firstRecord.removedNodes).toBeInstanceOf(NodeList);
+      expect(firstRecord.removedNodes.length).toBe(0);
+
+      expect(firstCall[1]).toBe(observer);
+
+      Fantom.runTask(() => {
+        root.render(
+          <View key="node1">
+            <View key="node1-2" />
+          </View>,
+        );
+      });
+
+      expect(observerCallbackCallArgs.length).toBe(2);
+      const secondCall = nullthrows(observerCallbackCallArgs.at(-1));
+      expect(secondCall.length).toBe(2);
+
+      const secondRecords = ensureMutationRecordArray(secondCall[0]);
+      expect(secondRecords.length).toBe(1);
+      expect(secondRecords[0]).toBeInstanceOf(MutationRecord);
+
+      const secondRecord = secondRecords[0];
+      expect(secondRecord.type).toBe('childList');
+      expect(secondRecord.target).toBe(node);
+      expect(secondRecord.addedNodes).toBeInstanceOf(NodeList);
+      expect([...secondRecord.addedNodes]).toEqual([]);
+      expect(secondRecord.removedNodes).toBeInstanceOf(NodeList);
+      expect([...secondRecord.removedNodes]).toEqual([childNode1]);
+
+      expect(secondCall[1]).toBe(observer);
+    });
+
+    it('should NOT report changes in transitive children when `subtree` is not set to true', () => {
+      const observedNodeRef = createRef<HostInstance>();
+
+      const root = Fantom.createRoot();
+      Fantom.runTask(() => {
+        root.render(
+          <View key="node1" ref={observedNodeRef}>
+            <View key="node1-1" />
+          </View>,
+        );
+      });
+
+      const observedNode = ensureReactNativeElement(observedNodeRef.current);
+
+      const observerCallback = jest.fn();
+      const observer = new MutationObserver(observerCallback);
+      observer.observe(observedNode, {childList: true});
+
+      // Does not report anything initially
+      expect(observerCallback).not.toHaveBeenCalled();
+
+      Fantom.runTask(() => {
+        root.render(
+          <View key="node1">
+            <View key="node1-1">
+              <View key="node1-1-1" />
+            </View>
+          </View>,
+        );
+      });
+
+      expect(observerCallback).not.toHaveBeenCalled();
+
+      Fantom.runTask(() => {
+        root.render(
+          <View key="node1">
+            <View key="node1-1" />
+          </View>,
+        );
+      });
+
+      expect(observerCallback).not.toHaveBeenCalled();
+    });
+
+    it('should report changes in transitive children when `subtree` is set to true', () => {
+      const nodeRef = createRef<HostInstance>();
+
+      const root = Fantom.createRoot();
+      Fantom.runTask(() => {
+        root.render(
+          <View key="node1" ref={nodeRef}>
+            <View key="node1-1" />
+          </View>,
+        );
+      });
+
+      const node = ensureReactNativeElement(nodeRef.current);
+
+      const observerCallback = jest.fn();
+      const observer = new MutationObserver(observerCallback);
+      observer.observe(node, {childList: true, subtree: true});
+
+      // Does not report anything initially
+      expect(observerCallback).not.toHaveBeenCalled();
+
+      const node111Ref = createRef<HostInstance>();
+
+      Fantom.runTask(() => {
+        root.render(
+          <View key="node1">
+            <View key="node1-1">
+              <View key="node1-1-1" ref={node111Ref} />
+            </View>
+          </View>,
+        );
+      });
+
+      const node111 = ensureReactNativeElement(node111Ref.current);
+
+      expect(observerCallback).toHaveBeenCalledTimes(1);
+      const firstCall = observerCallback.mock.lastCall;
+      const firstRecords = ensureMutationRecordArray(firstCall[0]);
+      expect(firstRecords.length).toBe(1);
+      expect([...firstRecords[0].addedNodes]).toEqual([node111]);
+      expect([...firstRecords[0].removedNodes]).toEqual([]);
+
+      Fantom.runTask(() => {
+        root.render(
+          <View key="node1">
+            <View key="node1-1" />
+          </View>,
+        );
+      });
+
+      expect(observerCallback).toHaveBeenCalledTimes(2);
+      const secondRecords = ensureMutationRecordArray(
+        observerCallback.mock.lastCall[0],
+      );
+      expect(secondRecords.length).toBe(1);
+      expect([...secondRecords[0].addedNodes]).toEqual([]);
+      expect([...secondRecords[0].removedNodes]).toEqual([node111]);
+    });
+
+    it('should report changes in different parts of the subtree as separate entries (subtree = true)', () => {
+      const nodeRef = createRef<HostInstance>();
+
+      const root = Fantom.createRoot();
+      Fantom.runTask(() => {
+        root.render(
+          <View key="node1" ref={nodeRef}>
+            <View key="node1-1" />
+            <View key="node1-2" />
+          </View>,
+        );
+      });
+
+      const node = ensureReactNativeElement(nodeRef.current);
+
+      const observerCallback = jest.fn();
+      const observer = new MutationObserver(observerCallback);
+      observer.observe(node, {childList: true, subtree: true});
+
+      // Does not report anything initially
+      expect(observerCallback).not.toHaveBeenCalled();
+
+      const node111Ref = createRef<HostInstance>();
+      const node121Ref = createRef<HostInstance>();
+
+      Fantom.runTask(() => {
+        root.render(
+          <View key="node1">
+            <View key="node1-1">
+              <View key="node1-1-1" ref={node111Ref} />
+            </View>
+            <View key="node1-2">
+              <View key="node1-2-1" ref={node121Ref} />
+            </View>
+          </View>,
+        );
+      });
+
+      const node111 = ensureReactNativeElement(node111Ref.current);
+      const node121 = ensureReactNativeElement(node121Ref.current);
+
+      expect(observerCallback).toHaveBeenCalledTimes(1);
+      const firstCall = observerCallback.mock.lastCall;
+      const firstRecords = ensureMutationRecordArray(firstCall[0]);
+      expect(firstRecords.length).toBe(2);
+      expect([...firstRecords[0].addedNodes]).toEqual([node111]);
+      expect([...firstRecords[0].removedNodes]).toEqual([]);
+      expect([...firstRecords[1].addedNodes]).toEqual([node121]);
+      expect([...firstRecords[1].removedNodes]).toEqual([]);
+
+      Fantom.runTask(() => {
+        root.render(
+          <View key="node1">
+            <View key="node1-1" />
+            <View key="node1-2" />
+          </View>,
+        );
+      });
+
+      expect(observerCallback).toHaveBeenCalledTimes(2);
+      const secondCall = observerCallback.mock.lastCall;
+      const secondRecords = ensureMutationRecordArray(secondCall[0]);
+      expect(secondRecords.length).toBe(2);
+      expect([...secondRecords[0].addedNodes]).toEqual([]);
+      expect([...secondRecords[0].removedNodes]).toEqual([node111]);
+      expect([...secondRecords[1].addedNodes]).toEqual([]);
+      expect([...secondRecords[1].removedNodes]).toEqual([node121]);
+
+      expect(secondCall[1]).toBe(observer);
+    });
+
+    describe('multiple observers', () => {
+      it('should report changes to multiple observers observing different subtrees', () => {
+        const node1Ref = createRef<HostInstance>();
+        const node2Ref = createRef<HostInstance>();
 
         const root = Fantom.createRoot();
         Fantom.runTask(() => {
           root.render(
-            <View key="node1" ref={nodeRef}>
-              <View key="node1-1" />
-              <View key="node1-2" />
+            <>
+              <View key="node1" ref={node1Ref} />
+              <View key="node2" ref={node2Ref} />
+            </>,
+          );
+        });
+
+        const node1 = ensureReactNativeElement(node1Ref.current);
+        const node2 = ensureReactNativeElement(node2Ref.current);
+
+        const observerCallback1 = jest.fn();
+        const observer1 = new MutationObserver(observerCallback1);
+        observer1.observe(node1, {childList: true, subtree: true});
+
+        const observerCallback2 = jest.fn();
+        const observer2 = new MutationObserver(observerCallback2);
+        observer2.observe(node2, {childList: true, subtree: true});
+
+        // Does not report anything initially
+        expect(observerCallback1).not.toHaveBeenCalled();
+        expect(observerCallback2).not.toHaveBeenCalled();
+
+        const childNode11Ref = createRef<HostInstance>();
+        const childNode21Ref = createRef<HostInstance>();
+
+        Fantom.runTask(() => {
+          root.render(
+            <>
+              <View key="node1">
+                <View key="node1-1" ref={childNode11Ref} />
+              </View>
+              <View key="node2">
+                <View key="node2-1" ref={childNode21Ref} />
+              </View>
+            </>,
+          );
+        });
+
+        const childNode11 = ensureReactNativeElement(childNode11Ref.current);
+        const childNode21 = ensureReactNativeElement(childNode21Ref.current);
+
+        expect(observerCallback1).toHaveBeenCalledTimes(1);
+        const observer1Records1 = ensureMutationRecordArray(
+          observerCallback1.mock.lastCall[0],
+        );
+        expect(observer1Records1.length).toBe(1);
+        expect([...observer1Records1[0].addedNodes]).toEqual([childNode11]);
+        expect([...observer1Records1[0].removedNodes]).toEqual([]);
+
+        expect(observerCallback2).toHaveBeenCalledTimes(1);
+        const observer2Records1 = ensureMutationRecordArray(
+          observerCallback2.mock.lastCall[0],
+        );
+        expect(observer2Records1.length).toBe(1);
+        expect([...observer2Records1[0].addedNodes]).toEqual([childNode21]);
+        expect([...observer2Records1[0].removedNodes]).toEqual([]);
+
+        Fantom.runTask(() => {
+          root.render(
+            <>
+              <View key="node1" />
+              <View key="node2" />
+            </>,
+          );
+        });
+
+        expect(observerCallback1).toHaveBeenCalledTimes(2);
+        const observer1Records2 = ensureMutationRecordArray(
+          observerCallback1.mock.lastCall[0],
+        );
+        expect(observer1Records2.length).toBe(1);
+        expect([...observer1Records2[0].addedNodes]).toEqual([]);
+        expect([...observer1Records2[0].removedNodes]).toEqual([childNode11]);
+
+        expect(observerCallback2).toHaveBeenCalledTimes(2);
+        const observer2Records2 = ensureMutationRecordArray(
+          observerCallback2.mock.lastCall[0],
+        );
+        expect(observer2Records2.length).toBe(1);
+        expect([...observer2Records2[0].addedNodes]).toEqual([]);
+        expect([...observer2Records2[0].removedNodes]).toEqual([childNode21]);
+      });
+
+      it('should report changes to multiple observers observing the same subtree', () => {
+        const node1Ref = createRef<HostInstance>();
+        const node2Ref = createRef<HostInstance>();
+
+        const root = Fantom.createRoot();
+        Fantom.runTask(() => {
+          root.render(
+            <View key="node1" ref={node1Ref}>
+              <View key="node1-1" ref={node2Ref} />
             </View>,
           );
         });
 
-        const node = ensureReactNativeElement(nodeRef.current);
+        const node1 = ensureReactNativeElement(node1Ref.current);
+        const node2 = ensureReactNativeElement(node2Ref.current);
 
-        const observerCallback = jest.fn();
-        const observer = new MutationObserver(observerCallback);
-        observer.observe(node, {childList: true, subtree: true});
+        const observerCallback1 = jest.fn();
+        const observer1 = new MutationObserver(observerCallback1);
+        observer1.observe(node1, {childList: true, subtree: true});
+
+        const observerCallback2 = jest.fn();
+        const observer2 = new MutationObserver(observerCallback2);
+        observer2.observe(node2, {childList: true, subtree: true});
 
         // Does not report anything initially
-        expect(observerCallback).not.toHaveBeenCalled();
+        expect(observerCallback1).not.toHaveBeenCalled();
+        expect(observerCallback2).not.toHaveBeenCalled();
 
-        const node111Ref = createRef<HostInstance>();
-        const node121Ref = createRef<HostInstance>();
+        const childNode111Ref = createRef<HostInstance>();
 
         Fantom.runTask(() => {
           root.render(
             <View key="node1">
               <View key="node1-1">
-                <View key="node1-1-1" ref={node111Ref} />
-              </View>
-              <View key="node1-2">
-                <View key="node1-2-1" ref={node121Ref} />
+                <View key="node-1-1-1" ref={childNode111Ref} />
               </View>
             </View>,
           );
         });
 
-        const node111 = ensureReactNativeElement(node111Ref.current);
-        const node121 = ensureReactNativeElement(node121Ref.current);
+        const childNode111 = ensureReactNativeElement(childNode111Ref.current);
 
-        expect(observerCallback).toHaveBeenCalledTimes(1);
-        const firstCall = observerCallback.mock.lastCall;
-        const firstRecords = ensureMutationRecordArray(firstCall[0]);
-        expect(firstRecords.length).toBe(2);
-        expect([...firstRecords[0].addedNodes]).toEqual([node111]);
-        expect([...firstRecords[0].removedNodes]).toEqual([]);
-        expect([...firstRecords[1].addedNodes]).toEqual([node121]);
-        expect([...firstRecords[1].removedNodes]).toEqual([]);
+        expect(observerCallback1).toHaveBeenCalledTimes(1);
+        const observer1Records1 = ensureMutationRecordArray(
+          observerCallback1.mock.lastCall[0],
+        );
+        expect(observer1Records1.length).toBe(1);
+        expect([...observer1Records1[0].addedNodes]).toEqual([childNode111]);
+        expect([...observer1Records1[0].removedNodes]).toEqual([]);
+        expect(observerCallback2).toHaveBeenCalledTimes(1);
+        const observer2Records1 = ensureMutationRecordArray(
+          observerCallback2.mock.lastCall[0],
+        );
+        expect(observer2Records1.length).toBe(1);
+        expect([...observer2Records1[0].addedNodes]).toEqual([childNode111]);
+        expect([...observer2Records1[0].removedNodes]).toEqual([]);
 
         Fantom.runTask(() => {
           root.render(
-            <View key="node1">
-              <View key="node1-1" />
-              <View key="node1-2" />
-            </View>,
-          );
-        });
-
-        expect(observerCallback).toHaveBeenCalledTimes(2);
-        const secondCall = observerCallback.mock.lastCall;
-        const secondRecords = ensureMutationRecordArray(secondCall[0]);
-        expect(secondRecords.length).toBe(2);
-        expect([...secondRecords[0].addedNodes]).toEqual([]);
-        expect([...secondRecords[0].removedNodes]).toEqual([node111]);
-        expect([...secondRecords[1].addedNodes]).toEqual([]);
-        expect([...secondRecords[1].removedNodes]).toEqual([node121]);
-
-        expect(secondCall[1]).toBe(observer);
-      });
-
-      describe('multiple observers', () => {
-        it('should report changes to multiple observers observing different subtrees', () => {
-          const node1Ref = createRef<HostInstance>();
-          const node2Ref = createRef<HostInstance>();
-
-          const root = Fantom.createRoot();
-          Fantom.runTask(() => {
-            root.render(
-              <>
-                <View key="node1" ref={node1Ref} />
-                <View key="node2" ref={node2Ref} />
-              </>,
-            );
-          });
-
-          const node1 = ensureReactNativeElement(node1Ref.current);
-          const node2 = ensureReactNativeElement(node2Ref.current);
-
-          const observerCallback1 = jest.fn();
-          const observer1 = new MutationObserver(observerCallback1);
-          observer1.observe(node1, {childList: true, subtree: true});
-
-          const observerCallback2 = jest.fn();
-          const observer2 = new MutationObserver(observerCallback2);
-          observer2.observe(node2, {childList: true, subtree: true});
-
-          // Does not report anything initially
-          expect(observerCallback1).not.toHaveBeenCalled();
-          expect(observerCallback2).not.toHaveBeenCalled();
-
-          const childNode11Ref = createRef<HostInstance>();
-          const childNode21Ref = createRef<HostInstance>();
-
-          Fantom.runTask(() => {
-            root.render(
-              <>
-                <View key="node1">
-                  <View key="node1-1" ref={childNode11Ref} />
-                </View>
-                <View key="node2">
-                  <View key="node2-1" ref={childNode21Ref} />
-                </View>
-              </>,
-            );
-          });
-
-          const childNode11 = ensureReactNativeElement(childNode11Ref.current);
-          const childNode21 = ensureReactNativeElement(childNode21Ref.current);
-
-          expect(observerCallback1).toHaveBeenCalledTimes(1);
-          const observer1Records1 = ensureMutationRecordArray(
-            observerCallback1.mock.lastCall[0],
-          );
-          expect(observer1Records1.length).toBe(1);
-          expect([...observer1Records1[0].addedNodes]).toEqual([childNode11]);
-          expect([...observer1Records1[0].removedNodes]).toEqual([]);
-
-          expect(observerCallback2).toHaveBeenCalledTimes(1);
-          const observer2Records1 = ensureMutationRecordArray(
-            observerCallback2.mock.lastCall[0],
-          );
-          expect(observer2Records1.length).toBe(1);
-          expect([...observer2Records1[0].addedNodes]).toEqual([childNode21]);
-          expect([...observer2Records1[0].removedNodes]).toEqual([]);
-
-          Fantom.runTask(() => {
-            root.render(
-              <>
-                <View key="node1" />
-                <View key="node2" />
-              </>,
-            );
-          });
-
-          expect(observerCallback1).toHaveBeenCalledTimes(2);
-          const observer1Records2 = ensureMutationRecordArray(
-            observerCallback1.mock.lastCall[0],
-          );
-          expect(observer1Records2.length).toBe(1);
-          expect([...observer1Records2[0].addedNodes]).toEqual([]);
-          expect([...observer1Records2[0].removedNodes]).toEqual([childNode11]);
-
-          expect(observerCallback2).toHaveBeenCalledTimes(2);
-          const observer2Records2 = ensureMutationRecordArray(
-            observerCallback2.mock.lastCall[0],
-          );
-          expect(observer2Records2.length).toBe(1);
-          expect([...observer2Records2[0].addedNodes]).toEqual([]);
-          expect([...observer2Records2[0].removedNodes]).toEqual([childNode21]);
-        });
-
-        it('should report changes to multiple observers observing the same subtree', () => {
-          const node1Ref = createRef<HostInstance>();
-          const node2Ref = createRef<HostInstance>();
-
-          const root = Fantom.createRoot();
-          Fantom.runTask(() => {
-            root.render(
-              <View key="node1" ref={node1Ref}>
-                <View key="node1-1" ref={node2Ref} />
-              </View>,
-            );
-          });
-
-          const node1 = ensureReactNativeElement(node1Ref.current);
-          const node2 = ensureReactNativeElement(node2Ref.current);
-
-          const observerCallback1 = jest.fn();
-          const observer1 = new MutationObserver(observerCallback1);
-          observer1.observe(node1, {childList: true, subtree: true});
-
-          const observerCallback2 = jest.fn();
-          const observer2 = new MutationObserver(observerCallback2);
-          observer2.observe(node2, {childList: true, subtree: true});
-
-          // Does not report anything initially
-          expect(observerCallback1).not.toHaveBeenCalled();
-          expect(observerCallback2).not.toHaveBeenCalled();
-
-          const childNode111Ref = createRef<HostInstance>();
-
-          Fantom.runTask(() => {
-            root.render(
-              <View key="node1">
-                <View key="node1-1">
-                  <View key="node-1-1-1" ref={childNode111Ref} />
-                </View>
-              </View>,
-            );
-          });
-
-          const childNode111 = ensureReactNativeElement(
-            childNode111Ref.current,
-          );
-
-          expect(observerCallback1).toHaveBeenCalledTimes(1);
-          const observer1Records1 = ensureMutationRecordArray(
-            observerCallback1.mock.lastCall[0],
-          );
-          expect(observer1Records1.length).toBe(1);
-          expect([...observer1Records1[0].addedNodes]).toEqual([childNode111]);
-          expect([...observer1Records1[0].removedNodes]).toEqual([]);
-          expect(observerCallback2).toHaveBeenCalledTimes(1);
-          const observer2Records1 = ensureMutationRecordArray(
-            observerCallback2.mock.lastCall[0],
-          );
-          expect(observer2Records1.length).toBe(1);
-          expect([...observer2Records1[0].addedNodes]).toEqual([childNode111]);
-          expect([...observer2Records1[0].removedNodes]).toEqual([]);
-
-          Fantom.runTask(() => {
-            root.render(
-              <>
-                <View key="node1">
-                  <View key="node1-1" />
-                </View>
-              </>,
-            );
-          });
-
-          expect(observerCallback1).toHaveBeenCalledTimes(2);
-          const observer1Records2 = ensureMutationRecordArray(
-            observerCallback1.mock.lastCall[0],
-          );
-          expect(observer1Records2.length).toBe(1);
-          expect([...observer1Records2[0].addedNodes]).toEqual([]);
-          expect([...observer1Records2[0].removedNodes]).toEqual([
-            childNode111,
-          ]);
-
-          expect(observerCallback2).toHaveBeenCalledTimes(2);
-          const observer2Records2 = ensureMutationRecordArray(
-            observerCallback2.mock.lastCall[0],
-          );
-          expect(observer2Records2.length).toBe(1);
-          expect([...observer2Records2[0].addedNodes]).toEqual([]);
-          expect([...observer2Records2[0].removedNodes]).toEqual([
-            childNode111,
-          ]);
-        });
-      });
-
-      describe('multiple observed nodes in the same observer', () => {
-        it('should report changes in disjoint observations', () => {
-          const node1Ref = createRef<HostInstance>();
-          const node2Ref = createRef<HostInstance>();
-
-          const root = Fantom.createRoot();
-          Fantom.runTask(() => {
-            root.render(
-              <>
-                <View key="node1" ref={node1Ref} />
-                <View key="node2" ref={node2Ref} />
-              </>,
-            );
-          });
-
-          const node1 = ensureReactNativeElement(node1Ref.current);
-          const node2 = ensureReactNativeElement(node2Ref.current);
-
-          const observerCallback = jest.fn();
-          const observer = new MutationObserver(observerCallback);
-          observer.observe(node1, {childList: true, subtree: true});
-          observer.observe(node2, {childList: true, subtree: true});
-
-          // Does not report anything initially
-          expect(observerCallback).not.toHaveBeenCalled();
-
-          const childNode11Ref = createRef<HostInstance>();
-          const childNode21Ref = createRef<HostInstance>();
-
-          Fantom.runTask(() => {
-            root.render(
-              <>
-                <View key="node1">
-                  <View key="node1-1" ref={childNode11Ref} />
-                </View>
-                <View key="node2">
-                  <View key="node2-1" ref={childNode21Ref} />
-                </View>
-              </>,
-            );
-          });
-
-          const childNode11 = ensureReactNativeElement(childNode11Ref.current);
-          const childNode21 = ensureReactNativeElement(childNode21Ref.current);
-
-          expect(observerCallback).toHaveBeenCalledTimes(1);
-          const records = ensureMutationRecordArray(
-            observerCallback.mock.lastCall[0],
-          );
-          expect(records.length).toBe(2);
-          expect([...records[0].addedNodes]).toEqual([childNode11]);
-          expect([...records[0].removedNodes]).toEqual([]);
-          expect([...records[1].addedNodes]).toEqual([childNode21]);
-          expect([...records[1].removedNodes]).toEqual([]);
-
-          Fantom.runTask(() => {
-            root.render(
-              <>
-                <View key="node1" />
-                <View key="node2" />
-              </>,
-            );
-          });
-
-          expect(observerCallback).toHaveBeenCalledTimes(2);
-          const records2 = ensureMutationRecordArray(
-            observerCallback.mock.lastCall[0],
-          );
-          expect(records2.length).toBe(2);
-          expect([...records2[0].addedNodes]).toEqual([]);
-          expect([...records2[0].removedNodes]).toEqual([childNode11]);
-          expect([...records2[1].addedNodes]).toEqual([]);
-          expect([...records2[1].removedNodes]).toEqual([childNode21]);
-        });
-
-        it('should report changes in joint observations', () => {
-          const node1Ref = createRef<HostInstance>();
-          const node11Ref = createRef<HostInstance>();
-
-          const root = Fantom.createRoot();
-          Fantom.runTask(() => {
-            root.render(
-              <View key="node1" ref={node1Ref}>
-                <View key="node1-1" ref={node11Ref} />
-              </View>,
-            );
-          });
-
-          const node1 = ensureReactNativeElement(node1Ref.current);
-          const node11 = ensureReactNativeElement(node11Ref.current);
-
-          const observerCallback = jest.fn();
-          const observer = new MutationObserver(observerCallback);
-          observer.observe(node1, {childList: true, subtree: true});
-          observer.observe(node11, {childList: true, subtree: true});
-
-          // Does not report anything initially
-          expect(observerCallback).not.toHaveBeenCalled();
-
-          const childNode111Ref = createRef<HostInstance>();
-
-          Fantom.runTask(() => {
-            root.render(
-              <View key="node1">
-                <View key="node1-1">
-                  <View key="node1-1-1" ref={childNode111Ref} />
-                </View>
-              </View>,
-            );
-          });
-
-          const childNode111 = ensureReactNativeElement(
-            childNode111Ref.current,
-          );
-
-          expect(observerCallback).toHaveBeenCalledTimes(1);
-          const records = ensureMutationRecordArray(
-            observerCallback.mock.lastCall[0],
-          );
-          expect(records.length).toBe(1);
-          expect([...records[0].addedNodes]).toEqual([childNode111]);
-          expect([...records[0].removedNodes]).toEqual([]);
-
-          Fantom.runTask(() => {
-            root.render(
+            <>
               <View key="node1">
                 <View key="node1-1" />
-              </View>,
-            );
-          });
-
-          expect(observerCallback).toHaveBeenCalledTimes(2);
-          const records2 = ensureMutationRecordArray(
-            observerCallback.mock.lastCall[0],
+              </View>
+            </>,
           );
-          expect(records2.length).toBe(1);
-          expect([...records2[0].addedNodes]).toEqual([]);
-          expect([...records2[0].removedNodes]).toEqual([childNode111]);
         });
+
+        expect(observerCallback1).toHaveBeenCalledTimes(2);
+        const observer1Records2 = ensureMutationRecordArray(
+          observerCallback1.mock.lastCall[0],
+        );
+        expect(observer1Records2.length).toBe(1);
+        expect([...observer1Records2[0].addedNodes]).toEqual([]);
+        expect([...observer1Records2[0].removedNodes]).toEqual([childNode111]);
+
+        expect(observerCallback2).toHaveBeenCalledTimes(2);
+        const observer2Records2 = ensureMutationRecordArray(
+          observerCallback2.mock.lastCall[0],
+        );
+        expect(observer2Records2.length).toBe(1);
+        expect([...observer2Records2[0].addedNodes]).toEqual([]);
+        expect([...observer2Records2[0].removedNodes]).toEqual([childNode111]);
       });
-
-      if (withUnobserveAll) {
-        describe('memory handling', () => {
-          it('should not retain initial children of observed targets', () => {
-            const root = Fantom.createRoot();
-            const observer = new MutationObserver(() => {});
-
-            const [getReferenceCount, childRef] =
-              createShadowNodeReferenceCountingRef();
-
-            const parentRef = createRef<HostInstance>();
-
-            Fantom.runTask(() => {
-              root.render(
-                <View ref={parentRef}>
-                  <View ref={childRef} />
-                </View>,
-              );
-            });
-
-            Fantom.runTask(() => {
-              observer.observe(ensureReactNativeElement(parentRef.current), {
-                childList: true,
-              });
-            });
-
-            expect(getReferenceCount()).toBeGreaterThan(0);
-
-            // This updates the working tree in the reconciler
-            Fantom.runTask(() => {
-              // Set style to force a state update
-              root.render(<View style={{width: 1}} />);
-            });
-
-            expect(getReferenceCount()).toBe(0);
-
-            observer.disconnect();
-          });
-        });
-      }
     });
 
-    describe('disconnect()', () => {
-      it('should stop observing targets', () => {
-        const observedNodeRef = createRef<HostInstance>();
+    describe('multiple observed nodes in the same observer', () => {
+      it('should report changes in disjoint observations', () => {
+        const node1Ref = createRef<HostInstance>();
+        const node2Ref = createRef<HostInstance>();
 
         const root = Fantom.createRoot();
         Fantom.runTask(() => {
-          root.render(<View key="node1" ref={observedNodeRef} />);
+          root.render(
+            <>
+              <View key="node1" ref={node1Ref} />
+              <View key="node2" ref={node2Ref} />
+            </>,
+          );
         });
 
-        const observedNode = ensureReactNativeElement(observedNodeRef.current);
+        const node1 = ensureReactNativeElement(node1Ref.current);
+        const node2 = ensureReactNativeElement(node2Ref.current);
 
         const observerCallback = jest.fn();
         const observer = new MutationObserver(observerCallback);
-        observer.observe(observedNode, {childList: true});
+        observer.observe(node1, {childList: true, subtree: true});
+        observer.observe(node2, {childList: true, subtree: true});
 
         // Does not report anything initially
         expect(observerCallback).not.toHaveBeenCalled();
+
+        const childNode11Ref = createRef<HostInstance>();
+        const childNode21Ref = createRef<HostInstance>();
+
+        Fantom.runTask(() => {
+          root.render(
+            <>
+              <View key="node1">
+                <View key="node1-1" ref={childNode11Ref} />
+              </View>
+              <View key="node2">
+                <View key="node2-1" ref={childNode21Ref} />
+              </View>
+            </>,
+          );
+        });
+
+        const childNode11 = ensureReactNativeElement(childNode11Ref.current);
+        const childNode21 = ensureReactNativeElement(childNode21Ref.current);
+
+        expect(observerCallback).toHaveBeenCalledTimes(1);
+        const records = ensureMutationRecordArray(
+          observerCallback.mock.lastCall[0],
+        );
+        expect(records.length).toBe(2);
+        expect([...records[0].addedNodes]).toEqual([childNode11]);
+        expect([...records[0].removedNodes]).toEqual([]);
+        expect([...records[1].addedNodes]).toEqual([childNode21]);
+        expect([...records[1].removedNodes]).toEqual([]);
+
+        Fantom.runTask(() => {
+          root.render(
+            <>
+              <View key="node1" />
+              <View key="node2" />
+            </>,
+          );
+        });
+
+        expect(observerCallback).toHaveBeenCalledTimes(2);
+        const records2 = ensureMutationRecordArray(
+          observerCallback.mock.lastCall[0],
+        );
+        expect(records2.length).toBe(2);
+        expect([...records2[0].addedNodes]).toEqual([]);
+        expect([...records2[0].removedNodes]).toEqual([childNode11]);
+        expect([...records2[1].addedNodes]).toEqual([]);
+        expect([...records2[1].removedNodes]).toEqual([childNode21]);
+      });
+
+      it('should report changes in joint observations', () => {
+        const node1Ref = createRef<HostInstance>();
+        const node11Ref = createRef<HostInstance>();
+
+        const root = Fantom.createRoot();
+        Fantom.runTask(() => {
+          root.render(
+            <View key="node1" ref={node1Ref}>
+              <View key="node1-1" ref={node11Ref} />
+            </View>,
+          );
+        });
+
+        const node1 = ensureReactNativeElement(node1Ref.current);
+        const node11 = ensureReactNativeElement(node11Ref.current);
+
+        const observerCallback = jest.fn();
+        const observer = new MutationObserver(observerCallback);
+        observer.observe(node1, {childList: true, subtree: true});
+        observer.observe(node11, {childList: true, subtree: true});
+
+        // Does not report anything initially
+        expect(observerCallback).not.toHaveBeenCalled();
+
+        const childNode111Ref = createRef<HostInstance>();
+
+        Fantom.runTask(() => {
+          root.render(
+            <View key="node1">
+              <View key="node1-1">
+                <View key="node1-1-1" ref={childNode111Ref} />
+              </View>
+            </View>,
+          );
+        });
+
+        const childNode111 = ensureReactNativeElement(childNode111Ref.current);
+
+        expect(observerCallback).toHaveBeenCalledTimes(1);
+        const records = ensureMutationRecordArray(
+          observerCallback.mock.lastCall[0],
+        );
+        expect(records.length).toBe(1);
+        expect([...records[0].addedNodes]).toEqual([childNode111]);
+        expect([...records[0].removedNodes]).toEqual([]);
 
         Fantom.runTask(() => {
           root.render(
             <View key="node1">
               <View key="node1-1" />
-              <View key="node1-2" />
             </View>,
           );
         });
 
-        expect(observerCallback).toHaveBeenCalledTimes(1);
+        expect(observerCallback).toHaveBeenCalledTimes(2);
+        const records2 = ensureMutationRecordArray(
+          observerCallback.mock.lastCall[0],
+        );
+        expect(records2.length).toBe(1);
+        expect([...records2[0].addedNodes]).toEqual([]);
+        expect([...records2[0].removedNodes]).toEqual([childNode111]);
+      });
+    });
 
-        observer.disconnect();
+    describe('memory handling', () => {
+      it('should not retain initial children of observed targets', () => {
+        const root = Fantom.createRoot();
+        const observer = new MutationObserver(() => {});
+
+        const [getReferenceCount, childRef] =
+          createShadowNodeReferenceCountingRef();
+
+        const parentRef = createRef<HostInstance>();
 
         Fantom.runTask(() => {
           root.render(
-            <View key="node1">
-              <View key="node1-2" />
+            <View ref={parentRef}>
+              <View ref={childRef} />
             </View>,
           );
         });
 
-        expect(observerCallback).toHaveBeenCalledTimes(1);
+        Fantom.runTask(() => {
+          observer.observe(ensureReactNativeElement(parentRef.current), {
+            childList: true,
+          });
+        });
+
+        expect(getReferenceCount()).toBeGreaterThan(0);
+
+        Fantom.runTask(() => {
+          root.render(<View />);
+        });
+
+        expect(getReferenceCount()).toBe(0);
+
+        observer.disconnect();
+      });
+    });
+  });
+
+  describe('disconnect()', () => {
+    it('should stop observing targets', () => {
+      const observedNodeRef = createRef<HostInstance>();
+
+      const root = Fantom.createRoot();
+      Fantom.runTask(() => {
+        root.render(<View key="node1" ref={observedNodeRef} />);
       });
 
-      it('should correctly unobserve targets that are disconnected after observing', () => {
-        const observedNodeRef = createRef<HostInstance>();
+      const observedNode = ensureReactNativeElement(observedNodeRef.current);
 
-        const root = Fantom.createRoot();
-        Fantom.runTask(() => {
-          root.render(<View key="node1" ref={observedNodeRef} />);
-        });
+      const observerCallback = jest.fn();
+      const observer = new MutationObserver(observerCallback);
+      observer.observe(observedNode, {childList: true});
 
-        const observedNode = ensureReactNativeElement(observedNodeRef.current);
+      // Does not report anything initially
+      expect(observerCallback).not.toHaveBeenCalled();
 
-        const observerCallback = jest.fn();
-        const observer = new MutationObserver(observerCallback);
-        observer.observe(observedNode, {childList: true});
-
-        Fantom.runTask(() => {
-          root.render(<></>);
-        });
-
-        expect(observedNode.isConnected).toBe(false);
-
-        expect(() => {
-          observer.disconnect();
-        }).not.toThrow();
+      Fantom.runTask(() => {
+        root.render(
+          <View key="node1">
+            <View key="node1-1" />
+            <View key="node1-2" />
+          </View>,
+        );
       });
 
-      it('should correctly unobserve targets that are disconnected before observing', () => {
-        const observedNodeRef = createRef<HostInstance>();
+      expect(observerCallback).toHaveBeenCalledTimes(1);
 
-        const root = Fantom.createRoot();
-        Fantom.runTask(() => {
-          root.render(<View key="node1" ref={observedNodeRef} />);
-        });
+      observer.disconnect();
 
-        const observedNode = ensureReactNativeElement(observedNodeRef.current);
-
-        Fantom.runTask(() => {
-          root.render(<></>);
-        });
-
-        expect(observedNode.isConnected).toBe(false);
-
-        const observerCallback = jest.fn();
-        const observer = new MutationObserver(observerCallback);
-        observer.observe(observedNode, {childList: true});
-
-        expect(() => {
-          observer.disconnect();
-        }).not.toThrow();
+      Fantom.runTask(() => {
+        root.render(
+          <View key="node1">
+            <View key="node1-2" />
+          </View>,
+        );
       });
+
+      expect(observerCallback).toHaveBeenCalledTimes(1);
+    });
+
+    it('should correctly unobserve targets that are disconnected after observing', () => {
+      const observedNodeRef = createRef<HostInstance>();
+
+      const root = Fantom.createRoot();
+      Fantom.runTask(() => {
+        root.render(<View key="node1" ref={observedNodeRef} />);
+      });
+
+      const observedNode = ensureReactNativeElement(observedNodeRef.current);
+
+      const observerCallback = jest.fn();
+      const observer = new MutationObserver(observerCallback);
+      observer.observe(observedNode, {childList: true});
+
+      Fantom.runTask(() => {
+        root.render(<></>);
+      });
+
+      expect(observedNode.isConnected).toBe(false);
+
+      expect(() => {
+        observer.disconnect();
+      }).not.toThrow();
+    });
+
+    it('should correctly unobserve targets that are disconnected before observing', () => {
+      const observedNodeRef = createRef<HostInstance>();
+
+      const root = Fantom.createRoot();
+      Fantom.runTask(() => {
+        root.render(<View key="node1" ref={observedNodeRef} />);
+      });
+
+      const observedNode = ensureReactNativeElement(observedNodeRef.current);
+
+      Fantom.runTask(() => {
+        root.render(<></>);
+      });
+
+      expect(observedNode.isConnected).toBe(false);
+
+      const observerCallback = jest.fn();
+      const observer = new MutationObserver(observerCallback);
+      observer.observe(observedNode, {childList: true});
+
+      expect(() => {
+        observer.disconnect();
+      }).not.toThrow();
     });
   });
 });

--- a/packages/react-native/src/private/webapis/mutationobserver/specs/NativeMutationObserver.js
+++ b/packages/react-native/src/private/webapis/mutationobserver/specs/NativeMutationObserver.js
@@ -36,13 +36,7 @@ export type NativeMutationObserverObserveOptions = {
 
 export interface Spec extends TurboModule {
   +observe: (options: NativeMutationObserverObserveOptions) => void;
-  // TODO: remove in the next version
-  +unobserve?: (
-    mutationObserverId: number,
-    targetShadowNode: ShadowNode,
-  ) => void;
-  // TODO: remove optionality in the next version
-  +unobserveAll?: (mutationObserverId: number) => void;
+  +unobserveAll: (mutationObserverId: number) => void;
   +connect: (
     notifyMutationObservers: () => void,
     // We need this to retain the public instance before React removes the


### PR DESCRIPTION
Summary:
Changelog: [internal]

Clean up old compatibility code for when NativeMutationObserver.unobserveAll isn't available.

Reviewed By: lenaic

Differential Revision: D74313204


