### PR TITLE
Fix nativeID and testID prop diffing for View component

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
@@ -583,11 +583,11 @@ folly::dynamic HostPlatformViewProps::getDiffProps(
   }
 
   if (nativeId != oldProps->nativeId) {
-    result["nativeId"] = nativeId;
+    result["nativeID"] = nativeId;
   }
 
   if (testId != oldProps->testId) {
-    result["testId"] = testId;
+    result["testID"] = testId;
   }
 
   if (accessible != oldProps->accessible) {


### PR DESCRIPTION
Summary:
The nativeID and testID prop mapping on the native Java side use full caps `ID` in the setter mapping. Fixing the props diffing result to use the right key in the result for both.

Changelog: [Internal]

Differential Revision: D74724759


