### PR TITLE
Fix generated types base on __typetests__

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@babel/plugin-transform-regenerator": "^7.24.7",
     "@babel/preset-env": "^7.25.3",
     "@babel/preset-flow": "^7.24.7",
-    "@definitelytyped/dtslint": "^0.0.127",
+    "@definitelytyped/dtslint": "^0.0.178",
     "@jest/create-cache-key-function": "^29.7.0",
     "@react-native/metro-babel-transformer": "0.80.0-main",
     "@react-native/metro-config": "0.80.0-main",

--- a/packages/react-native/Libraries/Animated/AnimatedExports.js.flow
+++ b/packages/react-native/Libraries/Animated/AnimatedExports.js.flow
@@ -37,7 +37,7 @@ export type {default as AnimatedDivision} from './nodes/AnimatedDivision';
 export type {default as AnimatedModulo} from './nodes/AnimatedModulo';
 export type {default as AnimatedMultiplication} from './nodes/AnimatedMultiplication';
 export type {default as AnimatedSubtraction} from './nodes/AnimatedSubtraction';
-export type {WithAnimatedValue} from './createAnimatedComponent';
+export type {WithAnimatedValue, AnimatedProps} from './createAnimatedComponent';
 export type {AnimatedComponentType as AnimatedComponent} from './createAnimatedComponent';
 
 /**

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js
@@ -22,7 +22,7 @@ import invariant from 'invariant';
 
 export type AnimatedPropsAllowlist = $ReadOnly<{
   style?: ?AnimatedStyleAllowlist,
-  [string]: true,
+  [key: string]: true | AnimatedStyleAllowlist,
 }>;
 
 type TargetView = {

--- a/packages/react-native/Libraries/AppState/AppState.js
+++ b/packages/react-native/Libraries/AppState/AppState.js
@@ -22,7 +22,12 @@ import NativeAppState from './NativeAppState';
  *   - @platform android - on another Activity (even if it was launched by your app)
  * @platform ios - inactive - This is a state that occurs when transitioning between foreground & background, and during periods of inactivity such as entering the multitasking view, opening the Notification Center or in the event of an incoming call.
  */
-export type AppStateStatus = 'inactive' | 'background' | 'active';
+export type AppStateStatus =
+  | 'inactive'
+  | 'background'
+  | 'active'
+  | 'extension'
+  | 'unknown';
 
 /**
  * change - This even is received when the app state has changed.

--- a/packages/react-native/Libraries/Components/ActivityIndicator/ActivityIndicator.js
+++ b/packages/react-native/Libraries/Components/ActivityIndicator/ActivityIndicator.js
@@ -114,6 +114,7 @@ const ActivityIndicator: component(
       style={StyleSheet.compose(styles.container, style)}>
       {Platform.OS === 'android' ? (
         // $FlowFixMe[prop-missing] Flow doesn't know when this is the android component
+        // $FlowFixMe[incompatible-type]
         <PlatformActivityIndicator {...nativeProps} {...androidProps} />
       ) : (
         /* $FlowFixMe[incompatible-type] (>=0.106.0 site=react_native_android_fb) This comment

--- a/packages/react-native/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.js
+++ b/packages/react-native/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.js
@@ -17,6 +17,12 @@ import Platform from '../../Utilities/Platform';
 
 export type {ProgressBarAndroidProps};
 
+// A utility type to preserve the semantics of the union uses in the definition
+// of ProgressBarAndroidProps. TS's Omit does not distribute over unions, so
+// we define our own version which does. This does not affect Flow.
+// $FlowExpectedError[unclear-type]
+type Omit<T, K> = T extends any ? Pick<T, Exclude<$Keys<T>, K>> : T;
+
 /**
  * ProgressBarAndroid has been extracted from react-native core and will be removed in a future release.
  * It can now be installed and imported from `@react-native-community/progress-bar-android` instead of 'react-native'.
@@ -27,7 +33,7 @@ let ProgressBarAndroid: component(
   ref?: React.RefSetter<
     React.ElementRef<ProgressBarAndroidNativeComponentType>,
   >,
-  ...props: ProgressBarAndroidProps
+  ...props: Omit<ProgressBarAndroidProps, empty>
 );
 
 if (Platform.OS === 'android') {

--- a/packages/react-native/Libraries/Components/ProgressBarAndroid/ProgressBarAndroidTypes.js
+++ b/packages/react-native/Libraries/Components/ProgressBarAndroid/ProgressBarAndroidTypes.js
@@ -17,28 +17,25 @@ import type {ViewProps} from '../View/ViewPropTypes';
  * `indeterminate` can only be false if `styleAttr` is Horizontal, and requires a
  * `progress` value.
  */
-type ProgressBarAndroidStyleAttrProp =
-  | {
-      styleAttr: 'Horizontal',
-      indeterminate: false,
-      progress: number,
-    }
-  | {
-      styleAttr:
-        | 'Horizontal'
-        | 'Normal'
-        | 'Small'
-        | 'Large'
-        | 'Inverse'
-        | 'SmallInverse'
-        | 'LargeInverse',
-      indeterminate: true,
-    };
+type DeterminateProgressBarAndroidStyleAttrProp = {
+  styleAttr: 'Horizontal',
+  indeterminate: false,
+  progress: number,
+};
 
-export type ProgressBarAndroidProps = $ReadOnly<{
-  ...ViewProps,
-  ...ProgressBarAndroidStyleAttrProp,
+type IndeterminateProgressBarAndroidStyleAttrProp = {
+  styleAttr:
+    | 'Horizontal'
+    | 'Normal'
+    | 'Small'
+    | 'Large'
+    | 'Inverse'
+    | 'SmallInverse'
+    | 'LargeInverse',
+  indeterminate: true,
+};
 
+type ProgressBarAndroidBaseProps = $ReadOnly<{
   /**
    * Whether to show the ProgressBar (true, the default) or hide it (false).
    */
@@ -52,3 +49,15 @@ export type ProgressBarAndroidProps = $ReadOnly<{
    */
   testID?: ?string,
 }>;
+
+export type ProgressBarAndroidProps =
+  | $ReadOnly<{
+      ...ViewProps,
+      ...ProgressBarAndroidBaseProps,
+      ...DeterminateProgressBarAndroidStyleAttrProp,
+    }>
+  | $ReadOnly<{
+      ...ViewProps,
+      ...ProgressBarAndroidBaseProps,
+      ...IndeterminateProgressBarAndroidStyleAttrProp,
+    }>;

--- a/packages/react-native/Libraries/EventEmitter/NativeEventEmitter.js
+++ b/packages/react-native/Libraries/EventEmitter/NativeEventEmitter.js
@@ -52,7 +52,7 @@ export default class NativeEventEmitter<
 {
   _nativeModule: ?NativeModule;
 
-  constructor(nativeModule: ?NativeModule) {
+  constructor(nativeModule?: ?NativeModule) {
     if (Platform.OS === 'ios') {
       invariant(
         nativeModule != null,

--- a/packages/react-native/Libraries/StyleSheet/StyleSheetExports.js.flow
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetExports.js.flow
@@ -107,4 +107,6 @@ declare export const setStyleAttributePreprocessor: (
  * An identity function for creating style sheets.
  */
 // $FlowFixMe[unsupported-variance-annotation]
-declare export const create: <+S: ____Styles_Internal>(obj: S) => $ReadOnly<S>;
+declare export const create: <+S: ____Styles_Internal>(
+  obj: S & ____Styles_Internal,
+) => $ReadOnly<S>;

--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
@@ -21,6 +21,7 @@ import type {
   ____ViewStyle_InternalOverrides,
 } from './private/_StyleSheetTypesOverrides';
 import type {____TransformStyle_Internal} from './private/_TransformStyle';
+import type {ColorValue} from './StyleSheet';
 
 export type {____TransformStyle_Internal};
 
@@ -1001,7 +1002,7 @@ export type ____ImageStyle_InternalCore = $ReadOnly<{
   resizeMode?: ImageResizeMode,
   objectFit?: 'cover' | 'contain' | 'fill' | 'scale-down' | 'none',
   tintColor?: ____ColorValue_Internal,
-  overlayColor?: string,
+  overlayColor?: ColorValue,
   overflow?: 'visible' | 'hidden',
 }>;
 
@@ -1015,7 +1016,7 @@ export type ____DangerouslyImpreciseStyle_InternalCore = $ReadOnly<{
   resizeMode?: ImageResizeMode,
   objectFit?: 'cover' | 'contain' | 'fill' | 'scale-down' | 'none',
   tintColor?: ____ColorValue_Internal,
-  overlayColor?: string,
+  overlayColor?: ColorValue,
 }>;
 
 export type ____DangerouslyImpreciseStyle_Internal = $ReadOnly<{

--- a/packages/react-native/Libraries/Text/TextProps.js
+++ b/packages/react-native/Libraries/Text/TextProps.js
@@ -13,6 +13,7 @@
 import type {
   AccessibilityActionEvent,
   AccessibilityActionInfo,
+  AccessibilityProps,
   AccessibilityRole,
   AccessibilityState,
   Role,
@@ -124,20 +125,7 @@ export type TextPropsAndroid = {
 };
 
 type TextBaseProps = $ReadOnly<{
-  /**
-   * Indicates whether the view is an accessibility element.
-   *
-   * See https://reactnative.dev/docs/text#accessible
-   */
-  accessible?: ?boolean,
-  accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
   onAccessibilityAction?: ?(event: AccessibilityActionEvent) => mixed,
-  accessibilityHint?: ?Stringish,
-  accessibilityLanguage?: ?Stringish,
-  accessibilityLabel?: ?Stringish,
-  accessibilityRole?: ?AccessibilityRole,
-  accessibilityState?: ?AccessibilityState,
-  'aria-label'?: ?string,
 
   /**
    * Whether fonts should scale to respect Text Size accessibility settings.
@@ -152,24 +140,6 @@ type TextBaseProps = $ReadOnly<{
    *
    */
   android_hyphenationFrequency?: ?('normal' | 'none' | 'full'),
-
-  /**
-   * alias for accessibilityState
-   *
-   * see https://reactnative.dev/docs/accessibility#accessibilitystate
-   */
-  'aria-busy'?: ?boolean,
-  'aria-checked'?: ?boolean | 'mixed',
-  'aria-disabled'?: ?boolean,
-  'aria-expanded'?: ?boolean,
-  'aria-selected'?: ?boolean,
-
-  /**
-   * Represents the nativeID of the associated label text. When the assistive technology focuses on the component with this props, the text is read aloud.
-   * This prop is listed for cross-platform reasons and has no real effect on Android or iOS.
-   */
-  'aria-labelledby'?: ?string,
-
   children?: ?React.Node,
 
   /**
@@ -306,4 +276,5 @@ export type TextProps = $ReadOnly<{
   ...TextPropsIOS,
   ...TextPropsAndroid,
   ...TextBaseProps,
+  ...AccessibilityProps,
 }>;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -190,7 +190,10 @@ export type { default as AnimatedDivision } from \\"./nodes/AnimatedDivision\\";
 export type { default as AnimatedModulo } from \\"./nodes/AnimatedModulo\\";
 export type { default as AnimatedMultiplication } from \\"./nodes/AnimatedMultiplication\\";
 export type { default as AnimatedSubtraction } from \\"./nodes/AnimatedSubtraction\\";
-export type { WithAnimatedValue } from \\"./createAnimatedComponent\\";
+export type {
+  WithAnimatedValue,
+  AnimatedProps,
+} from \\"./createAnimatedComponent\\";
 export type { AnimatedComponentType as AnimatedComponent } from \\"./createAnimatedComponent\\";
 declare export const add: typeof AnimatedImplementation.add;
 declare export const attachNativeEvent: typeof AnimatedImplementation.attachNativeEvent;
@@ -904,7 +907,7 @@ declare export default class AnimatedObject extends AnimatedWithChildren {
 exports[`public API should not change unintentionally Libraries/Animated/nodes/AnimatedProps.js 1`] = `
 "export type AnimatedPropsAllowlist = $ReadOnly<{
   style?: ?AnimatedStyleAllowlist,
-  [string]: true,
+  [key: string]: true | AnimatedStyleAllowlist,
 }>;
 type TargetViewInstance = React.ElementRef<React.ElementType>;
 declare export default class AnimatedProps extends AnimatedNode {
@@ -1077,7 +1080,12 @@ exports[`public API should not change unintentionally Libraries/Animated/useAnim
 `;
 
 exports[`public API should not change unintentionally Libraries/AppState/AppState.js 1`] = `
-"export type AppStateStatus = \\"inactive\\" | \\"background\\" | \\"active\\";
+"export type AppStateStatus =
+  | \\"inactive\\"
+  | \\"background\\"
+  | \\"active\\"
+  | \\"extension\\"
+  | \\"unknown\\";
 type AppStateEventDefinitions = {
   change: [AppStateStatus],
   memoryWarning: [],
@@ -1818,11 +1826,12 @@ declare export default function useAndroidRippleForView(
 
 exports[`public API should not change unintentionally Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.js 1`] = `
 "export type { ProgressBarAndroidProps };
+type Omit<T, K> = T extends any ? Pick<T, Exclude<$Keys<T>, K>> : T;
 declare let ProgressBarAndroid: component(
   ref?: React.RefSetter<
     React.ElementRef<ProgressBarAndroidNativeComponentType>,
   >,
-  ...props: ProgressBarAndroidProps
+  ...props: Omit<ProgressBarAndroidProps, empty>
 );
 declare export default typeof ProgressBarAndroid;
 "
@@ -1835,30 +1844,38 @@ declare export default typeof ProgressBarAndroidNativeComponent;
 `;
 
 exports[`public API should not change unintentionally Libraries/Components/ProgressBarAndroid/ProgressBarAndroidTypes.js 1`] = `
-"type ProgressBarAndroidStyleAttrProp =
-  | {
-      styleAttr: \\"Horizontal\\",
-      indeterminate: false,
-      progress: number,
-    }
-  | {
-      styleAttr:
-        | \\"Horizontal\\"
-        | \\"Normal\\"
-        | \\"Small\\"
-        | \\"Large\\"
-        | \\"Inverse\\"
-        | \\"SmallInverse\\"
-        | \\"LargeInverse\\",
-      indeterminate: true,
-    };
-export type ProgressBarAndroidProps = $ReadOnly<{
-  ...ViewProps,
-  ...ProgressBarAndroidStyleAttrProp,
+"type DeterminateProgressBarAndroidStyleAttrProp = {
+  styleAttr: \\"Horizontal\\",
+  indeterminate: false,
+  progress: number,
+};
+type IndeterminateProgressBarAndroidStyleAttrProp = {
+  styleAttr:
+    | \\"Horizontal\\"
+    | \\"Normal\\"
+    | \\"Small\\"
+    | \\"Large\\"
+    | \\"Inverse\\"
+    | \\"SmallInverse\\"
+    | \\"LargeInverse\\",
+  indeterminate: true,
+};
+type ProgressBarAndroidBaseProps = $ReadOnly<{
   animating?: ?boolean,
   color?: ?ColorValue,
   testID?: ?string,
 }>;
+export type ProgressBarAndroidProps =
+  | $ReadOnly<{
+      ...ViewProps,
+      ...ProgressBarAndroidBaseProps,
+      ...DeterminateProgressBarAndroidStyleAttrProp,
+    }>
+  | $ReadOnly<{
+      ...ViewProps,
+      ...ProgressBarAndroidBaseProps,
+      ...IndeterminateProgressBarAndroidStyleAttrProp,
+    }>;
 "
 `;
 
@@ -4167,7 +4184,7 @@ declare export default class NativeEventEmitter<
   > = $ReadOnly<Record<string, $ReadOnlyArray<UnsafeObject>>>,
 > implements IEventEmitter<TEventToArgsMap>
 {
-  constructor(nativeModule: ?NativeModule): void;
+  constructor(nativeModule?: ?NativeModule): void;
   addListener<TEvent: $Keys<TEventToArgsMap>>(
     eventType: TEvent,
     listener: (...args: TEventToArgsMap[TEvent]) => mixed,
@@ -7108,7 +7125,9 @@ declare export const setStyleAttributePreprocessor: (
   property: string,
   process: (nextProp: any) => any
 ) => void;
-declare export const create: <+S: ____Styles_Internal>(obj: S) => $ReadOnly<S>;
+declare export const create: <+S: ____Styles_Internal>(
+  obj: S & ____Styles_Internal
+) => $ReadOnly<S>;
 "
 `;
 
@@ -7513,7 +7532,7 @@ export type ____ImageStyle_InternalCore = $ReadOnly<{
   resizeMode?: ImageResizeMode,
   objectFit?: \\"cover\\" | \\"contain\\" | \\"fill\\" | \\"scale-down\\" | \\"none\\",
   tintColor?: ____ColorValue_Internal,
-  overlayColor?: string,
+  overlayColor?: ColorValue,
   overflow?: \\"visible\\" | \\"hidden\\",
 }>;
 export type ____ImageStyle_Internal = $ReadOnly<{
@@ -7525,7 +7544,7 @@ export type ____DangerouslyImpreciseStyle_InternalCore = $ReadOnly<{
   resizeMode?: ImageResizeMode,
   objectFit?: \\"cover\\" | \\"contain\\" | \\"fill\\" | \\"scale-down\\" | \\"none\\",
   tintColor?: ____ColorValue_Internal,
-  overlayColor?: string,
+  overlayColor?: ColorValue,
 }>;
 export type ____DangerouslyImpreciseStyle_Internal = $ReadOnly<{
   ...____DangerouslyImpreciseStyle_InternalCore,
@@ -7870,23 +7889,9 @@ export type TextPropsAndroid = {
   minimumFontScale?: ?number,
 };
 type TextBaseProps = $ReadOnly<{
-  accessible?: ?boolean,
-  accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
   onAccessibilityAction?: ?(event: AccessibilityActionEvent) => mixed,
-  accessibilityHint?: ?Stringish,
-  accessibilityLanguage?: ?Stringish,
-  accessibilityLabel?: ?Stringish,
-  accessibilityRole?: ?AccessibilityRole,
-  accessibilityState?: ?AccessibilityState,
-  \\"aria-label\\"?: ?string,
   allowFontScaling?: ?boolean,
   android_hyphenationFrequency?: ?(\\"normal\\" | \\"none\\" | \\"full\\"),
-  \\"aria-busy\\"?: ?boolean,
-  \\"aria-checked\\"?: ?boolean | \\"mixed\\",
-  \\"aria-disabled\\"?: ?boolean,
-  \\"aria-expanded\\"?: ?boolean,
-  \\"aria-selected\\"?: ?boolean,
-  \\"aria-labelledby\\"?: ?string,
   children?: ?React.Node,
   ellipsizeMode?: ?(\\"clip\\" | \\"head\\" | \\"middle\\" | \\"tail\\"),
   id?: string,
@@ -7917,6 +7922,7 @@ export type TextProps = $ReadOnly<{
   ...TextPropsIOS,
   ...TextPropsAndroid,
   ...TextBaseProps,
+  ...AccessibilityProps,
 }>;
 "
 `;
@@ -8945,7 +8951,7 @@ declare export default typeof rejectionTrackingOptions;
 
 exports[`public API should not change unintentionally Libraries/vendor/core/ErrorUtils.js 1`] = `
 "type ErrorHandler = (error: mixed, isFatal: boolean) => void;
-type Fn<Args, Return> = (...Args) => Return;
+type Fn<Args: $ReadOnlyArray<mixed>, Return> = (...Args) => Return;
 export type ErrorUtils = {
   applyWithGuard<TArgs: $ReadOnlyArray<mixed>, TOut>(
     fun: Fn<TArgs, TOut>,
@@ -9087,6 +9093,7 @@ export type {
   SectionListProps,
   SectionListRenderItem,
   SectionListRenderItemInfo,
+  SectionListData,
 } from \\"./Libraries/Lists/SectionList\\";
 export { default as SectionList } from \\"./Libraries/Lists/SectionList\\";
 export type {

--- a/packages/react-native/Libraries/vendor/core/ErrorUtils.js
+++ b/packages/react-native/Libraries/vendor/core/ErrorUtils.js
@@ -10,7 +10,7 @@
 
 // From @react-native/js-polyfills
 type ErrorHandler = (error: mixed, isFatal: boolean) => void;
-type Fn<Args, Return> = (...Args) => Return;
+type Fn<Args: $ReadOnlyArray<mixed>, Return> = (...Args) => Return;
 export type ErrorUtils = {
   applyWithGuard<TArgs: $ReadOnlyArray<mixed>, TOut>(
     fun: Fn<TArgs, TOut>,

--- a/packages/react-native/index.js.flow
+++ b/packages/react-native/index.js.flow
@@ -106,6 +106,7 @@ export type {
   SectionListProps,
   SectionListRenderItem,
   SectionListRenderItemInfo,
+  SectionListData,
 } from './Libraries/Lists/SectionList';
 export {default as SectionList} from './Libraries/Lists/SectionList';
 

--- a/packages/react-native/src/types/globals.d.ts
+++ b/packages/react-native/src/types/globals.d.ts
@@ -57,6 +57,48 @@ declare global {
 
   const HermesInternal: null | {};
 
+  /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly) */
+  interface DOMRectReadOnly {
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/bottom) */
+    readonly bottom: number;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/height) */
+    readonly height: number;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/left) */
+    readonly left: number;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/right) */
+    readonly right: number;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/top) */
+    readonly top: number;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/width) */
+    readonly width: number;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/x) */
+    readonly x: number;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/DOMRectReadOnly/y) */
+    readonly y: number;
+    toJSON(): any;
+  }
+
+  interface DOMRect extends DOMRectReadOnly {
+    height: number;
+    width: number;
+    x: number;
+    y: number;
+  }
+
+  interface DOMRectInit {
+    height?: number | undefined;
+    width?: number | undefined;
+    x?: number | undefined;
+    y?: number | undefined;
+  }
+
+  var DOMRect: {
+    prototype: DOMRect;
+    new (x?: number, y?: number, width?: number, height?: number): DOMRect;
+    /** [MDN Reference](https://developer.mozilla.org/docs/Web/API/DOMRect/fromRect_static) */
+    fromRect(other?: DOMRectInit): DOMRect;
+  };
+
   // #region Timer Functions
 
   function clearInterval(handle: number): void;

--- a/packages/react-native/types/__typetests__/animated.tsx
+++ b/packages/react-native/types/__typetests__/animated.tsx
@@ -14,7 +14,6 @@ import {
   View,
   NativeSyntheticEvent,
   NativeScrollEvent,
-  StyleProp,
   SectionListData,
 } from 'react-native';
 
@@ -43,12 +42,6 @@ const ForwardComp = React.forwardRef<
 });
 
 type X = React.PropsWithoutRef<React.ComponentProps<typeof ForwardComp>>;
-
-type Props = React.ComponentPropsWithRef<typeof Animated.Text>;
-const AnimatedWrapperComponent: React.FunctionComponent<Props> = ({
-  key, // $ExpectType string | number | null | undefined || Key | null | undefined
-  ...props
-}) => <Animated.Text {...props} />;
 
 function TestAnimatedAPI() {
   // Value
@@ -172,9 +165,6 @@ function TestAnimatedAPI() {
 
   const AnimatedView = Animated.createAnimatedComponent(View);
   const ref = React.useRef<React.ComponentRef<typeof View>>(null);
-  const legacyRef =
-    React.useRef<Animated.LegacyRef<React.ComponentRef<typeof View>>>(null);
-
   return (
     <View ref={ref}>
       <Animated.View
@@ -189,8 +179,6 @@ function TestAnimatedAPI() {
       <AnimatedView ref={ref} style={{top: 3}}>
         i has children
       </AnimatedView>
-      <Animated.View ref={legacyRef} />
-      <AnimatedView ref={legacyRef} />
       <AnimatedComp ref={AnimatedCompRef} width={v1} />
       <ForwardComp ref={ForwardCompRef} width={1} />
       <AnimatedForwardComp ref={AnimatedForwardCompRef} width={10} />

--- a/packages/react-native/types/__typetests__/index.tsx
+++ b/packages/react-native/types/__typetests__/index.tsx
@@ -34,7 +34,6 @@ import {
   ColorValue,
   DevSettings,
   DeviceEventEmitter,
-  DeviceEventEmitterStatic,
   Dimensions,
   DrawerLayoutAndroid,
   DrawerSlideEvent,
@@ -50,6 +49,7 @@ import {
   ImageBackground,
   ImageErrorEvent,
   ImageLoadEvent,
+  // @ts-ignore
   ImageResizeMode,
   ImageResolvedAssetSource,
   ImageStyle,
@@ -64,6 +64,7 @@ import {
   Modal,
   MouseEvent,
   NativeEventEmitter,
+  // @ts-ignore
   NativeModule, // Not actually exported, not sure why
   NativeModules,
   NativeScrollEvent,
@@ -75,6 +76,7 @@ import {
   ProgressBarAndroid,
   PushNotificationIOS,
   RefreshControl,
+  // @ts-ignore
   RegisteredStyle,
   ScaledSize,
   ScrollView,
@@ -97,6 +99,7 @@ import {
   TextInputEndEditingEvent,
   TextInputFocusEvent,
   TextInputKeyPressEvent,
+  // @ts-ignore
   TextInputScrollEvent,
   TextInputSelectionChangeEvent,
   TextInputSubmitEditingEvent,
@@ -116,12 +119,14 @@ import {
   requireNativeComponent,
   useColorScheme,
   useWindowDimensions,
+  // @ts-ignore
   SectionListData,
   ToastAndroid,
   Touchable,
   LayoutAnimation,
   processColor,
   experimental_LayoutConformance as LayoutConformance,
+  ViewProps,
 } from 'react-native';
 
 declare module 'react-native' {
@@ -233,10 +238,10 @@ const fontVariantStyle: StyleProp<TextStyle> = {
   fontVariant: ['tabular-nums'],
 };
 
-const viewProperty = StyleSheet.flatten(viewStyle).backgroundColor;
-const textProperty = StyleSheet.flatten(textStyle).fontSize;
-const imageProperty = StyleSheet.flatten(imageStyle).resizeMode;
-const fontVariantProperty = StyleSheet.flatten(fontVariantStyle).fontVariant;
+const viewProperty = StyleSheet.flatten(viewStyle)?.backgroundColor;
+const textProperty = StyleSheet.flatten(textStyle)?.fontSize;
+const imageProperty = StyleSheet.flatten(imageStyle)?.resizeMode;
+const fontVariantProperty = StyleSheet.flatten(fontVariantStyle)?.fontVariant;
 
 // correct use of the StyleSheet.flatten
 const styleArray: StyleProp<ViewStyle>[] = [];
@@ -261,25 +266,6 @@ const styleDimensionValueValidAuto: ViewStyle = {
 
 const styleDimensionValueValidPct: ViewStyle = {
   width: '5%',
-};
-
-const styleDimensionValueValidAnimated: ViewStyle = {
-  width: new Animated.Value(5),
-};
-
-const styleDimensionValueInvalid1: ViewStyle = {
-  // @ts-expect-error
-  width: '5',
-};
-
-const styleDimensionValueInvalid2: ViewStyle = {
-  // @ts-expect-error
-  width: '5px',
-};
-
-const styleDimensionValueInvalid3: ViewStyle = {
-  // @ts-expect-error
-  width: 'A%',
 };
 
 // StyleSheet.compose
@@ -401,10 +387,13 @@ const testNativeSyntheticEvent = <T extends {}>(
   e.isTrusted;
   e.nativeEvent;
   e.target;
-  e.target.measure(() => {});
   e.timeStamp;
   e.type;
   e.nativeEvent;
+
+  if (typeof e.target !== 'number') {
+    e.target?.measure(() => {});
+  }
 };
 
 function eventHandler<T extends React.BaseSyntheticEvent>(e: T) {}
@@ -427,7 +416,7 @@ class CustomView extends React.Component {
 }
 
 class Welcome extends React.Component<
-  ElementProps<View> & {color: string; bgColor?: null | undefined | string}
+  ViewProps & {color: string; bgColor?: null | undefined | string}
 > {
   rootViewRef = React.createRef<React.ComponentRef<typeof View>>();
   customViewRef = React.createRef<React.ComponentRef<typeof CustomView>>();
@@ -637,7 +626,9 @@ export class TouchableNativeFeedbackTest extends React.Component {
 
 // PressableTest
 export class PressableTest extends React.Component<{}> {
-  private readonly myRef: React.RefObject<View | null> = React.createRef();
+  private readonly myRef: React.RefObject<React.ComponentRef<
+    typeof View
+  > | null> = React.createRef();
 
   onPressButton = (e: GestureResponderEvent) => {
     e.persist();
@@ -747,7 +738,7 @@ const AppStateExample = () => {
   React.useEffect(() => {
     const subscription = AppState.addEventListener('change', nextAppState => {
       if (
-        appState.current.match(/inactive|background/) &&
+        appState.current?.match(/inactive|background/) &&
         nextAppState === 'active'
       ) {
         console.log('App has come to the foreground!');
@@ -1155,10 +1146,10 @@ class InputAccessoryViewTest extends React.Component {
   }
 }
 
-// DeviceEventEmitterStatic
-const deviceEventEmitterStatic: DeviceEventEmitterStatic = DeviceEventEmitter;
-deviceEventEmitterStatic.addListener('keyboardWillShow', data => true);
-deviceEventEmitterStatic.addListener('keyboardWillShow', data => true, {});
+// DeviceEventEmitter
+const deviceEventEmitter: typeof DeviceEventEmitter = DeviceEventEmitter;
+deviceEventEmitter.addListener('keyboardWillShow', data => true);
+deviceEventEmitter.addListener('keyboardWillShow', data => true, {});
 
 // NativeEventEmitter - Android
 const androidEventEmitter = new NativeEventEmitter();
@@ -1322,7 +1313,6 @@ class TextTest extends React.Component {
       <Text
         allowFontScaling={false}
         ellipsizeMode="head"
-        lineBreakMode="clip"
         numberOfLines={2}
         onLayout={this.handleOnLayout}
         onTextLayout={this.handleOnTextLayout}
@@ -1423,9 +1413,9 @@ export class ImageTest extends React.Component {
 }
 
 export class ImageBackgroundProps extends React.Component {
-  private _imageRef: Image | null = null;
+  private _imageRef: React.ComponentRef<typeof Image> | null = null;
 
-  setImageRef = (image: Image) => {
+  setImageRef = (image: React.ComponentRef<typeof Image>) => {
     this._imageRef = image;
   };
 
@@ -1854,7 +1844,9 @@ const PlatformTest = () => {
 };
 
 const PlatformConstantsTest = () => {
-  const testing: boolean = Platform.constants.isTesting;
+  if (Platform.OS !== 'web') {
+    const testing: boolean = Platform.constants.isTesting;
+  }
   if (Platform.OS === 'ios') {
     const hasForceTouch: boolean = Platform.constants.forceTouchAvailable;
   } else if (Platform.OS === 'android') {
@@ -1993,6 +1985,7 @@ const ProgressBarAndroidTest = () => {
     color="white"
     styleAttr="Horizontal"
     progress={0.42}
+    indeterminate={false}
   />;
 };
 
@@ -2011,7 +2004,7 @@ const PushNotificationTest = () => {
     alertTitle: 'Hello!',
     applicationIconBadgeNumber: 999,
     category: 'engagement',
-    fireDate: new Date().toISOString(),
+    fireDate: +new Date(),
     isSilent: false,
     repeatInterval: 'minute',
     userInfo: {

--- a/packages/react-native/types/__typetests__/legacy-properties.tsx
+++ b/packages/react-native/types/__typetests__/legacy-properties.tsx
@@ -8,6 +8,7 @@
  */
 
 import * as React from 'react';
+// @ts-ignore
 import {TextInputProperties} from 'react-native';
 
 class Test extends React.Component<TextInputProperties> {}

--- a/packages/react-native/types/__typetests__/stylesheet-create.tsx
+++ b/packages/react-native/types/__typetests__/stylesheet-create.tsx
@@ -8,6 +8,7 @@
  */
 
 import * as React from 'react';
+// @ts-ignore
 import {View, StyleSheet, type ShadowStyleIOS} from 'react-native';
 
 export function App() {

--- a/packages/virtualized-lists/Lists/VirtualizedSectionList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedSectionList.js
@@ -17,6 +17,7 @@ import invariant from 'invariant';
 import * as React from 'react';
 
 type DefaultSectionT = {
+  data: any,
   [key: string]: any,
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1046,30 +1046,32 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@definitelytyped/dts-critic@^0.0.127":
-  version "0.0.127"
-  resolved "https://registry.yarnpkg.com/@definitelytyped/dts-critic/-/dts-critic-0.0.127.tgz#eacdd8fd32bee501d597854e68088e202e01166f"
-  integrity sha512-9atIPvUzleMTnT6mdqSIk4lMYyTCCPW9omKwQx5yDz2BSbCvz2UGzwrYADCkAB+OynOfjefVvzcUIC0M6asVEw==
+"@definitelytyped/dts-critic@^0.0.178":
+  version "0.0.178"
+  resolved "https://registry.yarnpkg.com/@definitelytyped/dts-critic/-/dts-critic-0.0.178.tgz#79e82ef35615b1534da979eb925a6130e1977d94"
+  integrity sha512-1JiY6giD2qLYxDPSWPbZiICzmTX+cHBNMXf09SeY6CJX0kZPcAkX+Uhc64HSqlhutECRWy7SdQCp/NP3xVOt4Q==
   dependencies:
-    "@definitelytyped/header-parser" "^0.0.127"
+    "@definitelytyped/header-parser" "^0.0.178"
     command-exists "^1.2.8"
     rimraf "^3.0.2"
-    semver "^6.2.0"
+    semver "^7.5.2"
     tmp "^0.2.1"
     yargs "^15.3.1"
 
-"@definitelytyped/dtslint@^0.0.127":
-  version "0.0.127"
-  resolved "https://registry.yarnpkg.com/@definitelytyped/dtslint/-/dtslint-0.0.127.tgz#38f8322a0e90d5c01e4a98fcaa05377e9b42100a"
-  integrity sha512-3UAVWRz6G+rbfV/elxMpdpqrDSYPugj4jQjs+SgsJLVLoQOsCXhIv1k2ibgNc5YKWxuw70Z/kRig8jYN49STww==
+"@definitelytyped/dtslint@^0.0.178":
+  version "0.0.178"
+  resolved "https://registry.yarnpkg.com/@definitelytyped/dtslint/-/dtslint-0.0.178.tgz#9e76093ed0913d3b0e78fefb834d2e3d86bb6246"
+  integrity sha512-IK4IqJSIY6wS+8Tg0hIuwAltPs0ZIWibMd3CSurQ8E1gNvuXaR48xjsjFVh2R8pxGrIR75mJ5o6H1GjxFZwK1A==
   dependencies:
-    "@definitelytyped/dts-critic" "^0.0.127"
-    "@definitelytyped/header-parser" "^0.0.127"
-    "@definitelytyped/typescript-versions" "^0.0.127"
-    "@definitelytyped/utils" "^0.0.127"
-    "@typescript-eslint/eslint-plugin" "^5.30.0"
-    "@typescript-eslint/parser" "^5.30.0"
-    "@typescript-eslint/utils" "^5.30.0"
+    "@definitelytyped/dts-critic" "^0.0.178"
+    "@definitelytyped/header-parser" "^0.0.178"
+    "@definitelytyped/typescript-versions" "^0.0.178"
+    "@definitelytyped/utils" "^0.0.178"
+    "@typescript-eslint/eslint-plugin" "^5.55.0"
+    "@typescript-eslint/parser" "^5.55.0"
+    "@typescript-eslint/types" "^5.56.0"
+    "@typescript-eslint/typescript-estree" "^5.55.0"
+    "@typescript-eslint/utils" "^5.55.0"
     eslint "^8.17.0"
     fs-extra "^6.0.1"
     json-stable-stringify "^1.0.1"
@@ -1077,26 +1079,26 @@
     tslint "5.14.0"
     yargs "^15.1.0"
 
-"@definitelytyped/header-parser@^0.0.127":
-  version "0.0.127"
-  resolved "https://registry.yarnpkg.com/@definitelytyped/header-parser/-/header-parser-0.0.127.tgz#2283c5f9acb29a7adaacf09100f851fbb5af127e"
-  integrity sha512-4BvTT/EXZPqkmpw/mhg7inbaLI16Sq1E7K6QeWoTGU60mf8sfB7me7Kta+/EYZptZzyyt/xR6I7MnptWuDCoPw==
+"@definitelytyped/header-parser@^0.0.178":
+  version "0.0.178"
+  resolved "https://registry.yarnpkg.com/@definitelytyped/header-parser/-/header-parser-0.0.178.tgz#2cfd170a33b014d686135673fa7fac837cfe5556"
+  integrity sha512-16FFuaWW2Hq+a0Abyt+9gvPAT0w/ezy4eph3RbtLSqxH3T/UHDla1jgnp1DMvfNeBWaIqHxcr+Vrr7BPquw7mw==
   dependencies:
-    "@definitelytyped/typescript-versions" "^0.0.127"
+    "@definitelytyped/typescript-versions" "^0.0.178"
     "@types/parsimmon" "^1.10.1"
     parsimmon "^1.13.0"
 
-"@definitelytyped/typescript-versions@^0.0.127":
-  version "0.0.127"
-  resolved "https://registry.yarnpkg.com/@definitelytyped/typescript-versions/-/typescript-versions-0.0.127.tgz#40bde1d1e78fea772bef7ff9aacaec94a1113991"
-  integrity sha512-q/vGlB0sVOKeEj4L661MmYPmBBzfZltG/unjsFGBaglu1zz9BIuhSW3NYPeiPrtq8OyrwtR6slet22b2SH/xyw==
+"@definitelytyped/typescript-versions@^0.0.178":
+  version "0.0.178"
+  resolved "https://registry.yarnpkg.com/@definitelytyped/typescript-versions/-/typescript-versions-0.0.178.tgz#98a92f2251f18b32122e808b968ca8e009d3b123"
+  integrity sha512-pPXy3z5gE4xnVgqIRApFcQ6M6kqtRK1gnqyGx/I0Yo1CH8RAsRvumCDB/KiZmQDpCHiy//E9dOIUFdquvC5t7g==
 
-"@definitelytyped/utils@^0.0.127":
-  version "0.0.127"
-  resolved "https://registry.yarnpkg.com/@definitelytyped/utils/-/utils-0.0.127.tgz#d2d485bfbef947af15cfadb7fe9fd55a0db45f70"
-  integrity sha512-EBpYDuYt8T9i63k/jBjWgF7Gr6YebKUiKaNH5kWkIfvGAC1NfyruhxBT40pFTcKICt02/w4Bws/AcjEEekWyww==
+"@definitelytyped/utils@^0.0.178":
+  version "0.0.178"
+  resolved "https://registry.yarnpkg.com/@definitelytyped/utils/-/utils-0.0.178.tgz#f403be41816690246a4e0244d125a0084b16462a"
+  integrity sha512-nYg3E51XpTodS0/5w5r1wM/DhPYhyqa9BP8ili4XgB5s9j4v4mDPX9Jwjns2q24derBvyhdUpzshKDh43aqwZw==
   dependencies:
-    "@definitelytyped/typescript-versions" "^0.0.127"
+    "@definitelytyped/typescript-versions" "^0.0.178"
     "@qiwi/npm-registry-client" "^8.9.1"
     "@types/node" "^14.14.35"
     charm "^1.0.2"
@@ -2091,7 +2093,7 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^5.30.0":
+"@typescript-eslint/eslint-plugin@^5.55.0":
   version "5.62.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz#aeef0328d172b9e37d9bab6dbc13b87ed88977db"
   integrity sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==
@@ -2133,7 +2135,7 @@
     "@typescript-eslint/visitor-keys" "7.2.0"
     debug "^4.3.4"
 
-"@typescript-eslint/parser@^5.30.0":
+"@typescript-eslint/parser@^5.55.0":
   version "5.62.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.62.0.tgz#1b63d082d849a2fcae8a569248fbe2ee1b8a56c7"
   integrity sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==
@@ -2198,7 +2200,7 @@
     debug "^4.3.4"
     ts-api-utils "^1.3.0"
 
-"@typescript-eslint/types@5.62.0":
+"@typescript-eslint/types@5.62.0", "@typescript-eslint/types@^5.56.0":
   version "5.62.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.62.0.tgz#258607e60effa309f067608931c3df6fed41fd2f"
   integrity sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==
@@ -2213,7 +2215,7 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-7.2.0.tgz#0feb685f16de320e8520f13cca30779c8b7c403f"
   integrity sha512-XFtUHPI/abFhm4cbCDc5Ykc8npOKBSJePY3a3s+lwumt7XWJuzP5cZcfZ610MIPHjQjNsOLlYK8ASPaNG8UiyA==
 
-"@typescript-eslint/typescript-estree@5.62.0":
+"@typescript-eslint/typescript-estree@5.62.0", "@typescript-eslint/typescript-estree@^5.55.0":
   version "5.62.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz#7d17794b77fabcac615d6a48fb143330d962eb9b"
   integrity sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==
@@ -2254,7 +2256,7 @@
     semver "^7.5.4"
     ts-api-utils "^1.0.1"
 
-"@typescript-eslint/utils@5.62.0", "@typescript-eslint/utils@^5.10.0", "@typescript-eslint/utils@^5.30.0", "@typescript-eslint/utils@^5.47.1":
+"@typescript-eslint/utils@5.62.0", "@typescript-eslint/utils@^5.10.0", "@typescript-eslint/utils@^5.47.1", "@typescript-eslint/utils@^5.55.0":
   version "5.62.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.62.0.tgz#141e809c71636e4a75daa39faed2fb5f4b10df86"
   integrity sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==
@@ -8020,7 +8022,7 @@ semver@^5.3.0, semver@^5.6.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
   integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
 
-semver@^6.2.0, semver@^6.3.0, semver@^6.3.1:
+semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==


### PR DESCRIPTION
Summary:
This diff is a set of alignments/improvements in generated TS types. It includes:

- extending `AppStateStatus` with `extension` and `unknown`,
- exporting `AnimatedProps` under Animated namespace,
- resolving issue with discriminated unions in `ProgressBarAndroidTypes`,
- fixing `StyleSheet.create` type to accept only specified style properties,
- extending `TextProps` with `AccessibilityProps`,
- extending Fn `Args` generic with `$ReadOnlyArray` in `ErrorUtils`,
- small `__typetests__` adjustments,
- removing type test `styleDimensionValueValidAnimated` as `DimensionValue` no longer accepts `AnimatedNode`,
- removing `styleDimensionValueInvalid` as `DimensionValue` accepts any string now - template literal types in Flow are not supported,
- changing `overlayColor` type to `ColorValue` to align with manual types,
- fixing `AnimatedPropsAllowlist` type which wasn't correct in TS because index signature type was different from style type,
- using `DeviceEventEmitter` instead of `DeviceEventEmitterStatic` in type tests which is equivalent in both new and old types - `DeviceEventEmitterStatic` was only a type of `DeviceEventEmitter`,
- removing type test for checking forwarded key type - doesn't work with new types and that shouldn't be supported,
- removing `Animated.legacyRef` type test - not included in new types,
- adding `DOMRect` from "dom" lib to globals.d.ts to not include "dom" lib in the tsconfig - tries to compare globals with lib.dom.d.ts and produces many errors,
- exporting `SectionListData`,
- bumping `@definitelytyped/dtslint` to `0.0.178` version which removes `testNoTsIgnore` check [here](https://github.com/microsoft/DefinitelyTyped-tools/commit/0e0838aea8f8540a89023389b73b9f637fdcaa4f)

Changelog:
[Internal]

Reviewed By: huntie

Differential Revision: D74246304


