### PR TITLE
Add missing view events to View prop diffing

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
@@ -407,7 +407,9 @@ void BaseViewProps::setProp(
     VIEW_EVENT_CASE(PointerLeave);
     VIEW_EVENT_CASE(PointerLeaveCapture);
     VIEW_EVENT_CASE(PointerOver);
+    VIEW_EVENT_CASE(PointerOverCapture);
     VIEW_EVENT_CASE(PointerOut);
+    VIEW_EVENT_CASE(PointerOutCapture);
     VIEW_EVENT_CASE(MoveShouldSetResponder);
     VIEW_EVENT_CASE(MoveShouldSetResponderCapture);
     VIEW_EVENT_CASE(StartShouldSetResponder);

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
@@ -691,10 +691,28 @@ folly::dynamic HostPlatformViewProps::getDiffProps(
         result,
         events,
         oldProps->events,
+        ViewEvents::Offset::PointerOverCapture,
+        "onPointerOverCapture");
+    updateEventProp(
+        result,
+        events,
+        oldProps->events,
         ViewEvents::Offset::PointerOut,
         "onPointerOut");
     updateEventProp(
+        result,
+        events,
+        oldProps->events,
+        ViewEvents::Offset::PointerOutCapture,
+        "onPointerOutCapture");
+    updateEventProp(
         result, events, oldProps->events, ViewEvents::Offset::Click, "onClick");
+    updateEventProp(
+        result,
+        events,
+        oldProps->events,
+        ViewEvents::Offset::ClickCapture,
+        "onClickCapture");
     updateEventProp(
         result,
         events,

--- a/packages/react-native/ReactCommon/react/renderer/components/view/propsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/propsConversions.h
@@ -289,12 +289,24 @@ static inline ViewEvents convertRawProp(
       "onPointerOver",
       sourceValue[Offset::PointerOver],
       defaultValue[Offset::PointerOver]);
+  result[Offset::PointerOverCapture] = convertRawProp(
+      context,
+      rawProps,
+      "onPointerOverCapture",
+      sourceValue[Offset::PointerOverCapture],
+      defaultValue[Offset::PointerOverCapture]);
   result[Offset::PointerOut] = convertRawProp(
       context,
       rawProps,
       "onPointerOut",
       sourceValue[Offset::PointerOut],
       defaultValue[Offset::PointerOut]);
+  result[Offset::PointerOutCapture] = convertRawProp(
+      context,
+      rawProps,
+      "onPointerOutCapture",
+      sourceValue[Offset::PointerOutCapture],
+      defaultValue[Offset::PointerOutCapture]);
   result[Offset::Click] = convertRawProp(
       context,
       rawProps,


### PR DESCRIPTION
Summary:
Adding parsing and diffing for
- `onClickCapture`
- `onPointerOutCapture`
- `onPointerOverCapture`

Changelog: [Internal]

Differential Revision: D74732872


