### PR TITLE
Fix compose views crashing inside RN Modal component.

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
@@ -54,6 +54,13 @@ import com.facebook.react.views.modal.ReactModalHostView.DialogRootViewGroup
 import com.facebook.react.views.view.ReactViewGroup
 import com.facebook.react.views.view.setStatusBarTranslucency
 import com.facebook.react.views.view.setSystemBarsTranslucency
+import androidx.lifecycle.setViewTreeLifecycleOwner
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.setViewTreeViewModelStoreOwner
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.savedstate.setViewTreeSavedStateRegistryOwner
+import androidx.savedstate.SavedStateRegistryOwner
+import androidx.appcompat.app.AppCompatActivity
 
 /**
  * ReactModalHostView is a view that sits in the view hierarchy representing a Modal view.
@@ -143,6 +150,7 @@ public class ReactModalHostView(context: ThemedReactContext) :
 
   protected override fun onAttachedToWindow() {
     super.onAttachedToWindow()
+    dialog?.enableComposeViewSupport(getCurrentActivity())
     (context as ThemedReactContext).addLifecycleEventListener(this)
   }
 
@@ -593,5 +601,14 @@ public class ReactModalHostView(context: ThemedReactContext) :
       // No-op - override in order to still receive events to onInterceptTouchEvent
       // even when some other view disallow that
     }
+  }
+}
+
+public fun Dialog.enableComposeViewSupport(activity: Activity?) {
+  val decorView = getWindow()?.getDecorView()
+  if (decorView != null && activity != null) {
+    decorView.setViewTreeLifecycleOwner(activity as LifecycleOwner)
+    decorView.setViewTreeViewModelStoreOwner(activity as ViewModelStoreOwner)
+    decorView.setViewTreeSavedStateRegistryOwner(activity as SavedStateRegistryOwner)
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

This PR enables using [ComposeView](https://developer.android.com/reference/kotlin/androidx/compose/ui/platform/ComposeView), in particular as used in expo-ui and other compose libraries, inside RN modals.

Without it, apps crash with a a client crash related to the ViewTreeLifecycleOwner.

With it, components inside expo-ui render correctly inside modals.

This change is applied inside RN Modal, instead of expo-ui internals, since we to set the appropriate fields on every new dialog mounted.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID][FIXED] – Fix compose views crashing inside RN Modal component.

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
