### PR TITLE
[android][kotlin] make removeView open in ViewGroupManager

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupManager.kt
@@ -49,7 +49,7 @@ constructor(reactContext: ReactApplicationContext? = null) :
     parent.removeViewAt(index)
   }
 
-  public fun removeView(parent: T, view: View) {
+  public open fun removeView(parent: T, view: View) {
     UiThreadUtil.assertOnUiThread()
 
     for (i in 0 until getChildCount(parent)) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupManager.kt
@@ -49,6 +49,10 @@ constructor(reactContext: ReactApplicationContext? = null) :
     parent.removeViewAt(index)
   }
 
+  /**
+    Expo overrides this function GroupViewManagerWrapper.kt`, which is a replacement view manager adding 
+    support for delegates receiving callbacks whenever one of the methods in the view manager are called.
+  */
   public open fun removeView(parent: T, view: View) {
     UiThreadUtil.assertOnUiThread()
 


### PR DESCRIPTION
## Summary:

After conversion to Kotlin we could no longer override the removeView function since it is no longer open. The rest of this class can be overridden as before, but since functions are final by default this doesn't work for the new `removeView` function.

Expo is overriding the `removeView` functions in `GroupViewManagerWrapper.kt` (a lot of other ViewManager methods are also overridden here, but the `removeView` is introduced in `ViewGroupManager` and needs to be open as well. `GroupViewManagerWrapper.kt` is a replacement view manager that adds support for a delegate that will receive callbacks whenever one of the methods in the view manager are called.

This commit fixes this by making the removeView function explicitly open.

## Changelog:

[ANDROID] [FIXED] - Made function `removeView` open in Kotlin class

## Test Plan:

Verify that Expo can build against this class.