### PR TITLE
[android][kotlin] make DevServerHelper open

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.kt
@@ -59,7 +59,7 @@ import okio.Okio
  */
 @SuppressLint(
     "StaticFieldLeak") // TODO: This entire class should be rewritten to don't use AsyncTask
-public class DevServerHelper(
+public open class DevServerHelper(
     private val settings: DeveloperSettings,
     private val applicationContext: Context,
     private val packagerConnectionSettings: PackagerConnectionSettings
@@ -287,20 +287,20 @@ public class DevServerHelper(
         additionalOptionsBuilder.toString())
   }
 
-  public fun getDevServerBundleURL(jsModulePath: String): String =
+  public open fun getDevServerBundleURL(jsModulePath: String): String =
       createBundleURL(jsModulePath, BundleType.BUNDLE, packagerConnectionSettings.debugServerHost)
 
-  public fun getDevServerSplitBundleURL(jsModulePath: String): String =
+  public open fun getDevServerSplitBundleURL(jsModulePath: String): String =
       createSplitBundleURL(jsModulePath, packagerConnectionSettings.debugServerHost)
 
-  public fun isPackagerRunning(callback: PackagerStatusCallback) {
+  public open fun isPackagerRunning(callback: PackagerStatusCallback) {
     packagerStatusCheck.run(packagerConnectionSettings.debugServerHost, callback)
   }
 
-  public fun getSourceMapUrl(mainModuleName: String): String =
+  public open fun getSourceMapUrl(mainModuleName: String): String =
       createBundleURL(mainModuleName, BundleType.MAP)
 
-  public fun getSourceUrl(mainModuleName: String): String =
+  public open fun getSourceUrl(mainModuleName: String): String =
       createBundleURL(mainModuleName, BundleType.BUNDLE)
 
   /**


### PR DESCRIPTION
## Summary:

Expo inherits from the DevServerHelper class, and needs it to be declared as open, the same goes for its public interface.

Expo is using this in `DevLauncherDevServerHelper` and overrides the methods:

- getDevServerBundleURL
- getDevServerSplitBundleURL
- getSourceUrl
- getSourceMapUrl
- isPackagerRunning

This PR fixes this by adding the open to the class and to the methods that should be open

## Changelog:

[ANDROID] [FIXED] - Made DevServerHelper and its method open so that they can be overridden.

## Test Plan:

Verify that we can build against Expo.