### PR TITLE
use C++ Native Animated from JS if enabled

### DIFF
--- a/packages/react-native/Libraries/Animated/shouldUseTurboAnimatedModule.js
+++ b/packages/react-native/Libraries/Animated/shouldUseTurboAnimatedModule.js
@@ -8,10 +8,15 @@
  * @format
  */
 
+import * as ReactNativeFeatureFlags from '../../src/private/featureflags/ReactNativeFeatureFlags';
 import Platform from '../Utilities/Platform';
 
 function shouldUseTurboAnimatedModule(): boolean {
-  return Platform.OS === 'ios' && global.RN$Bridgeless === true;
+  if (ReactNativeFeatureFlags.cxxNativeAnimatedEnabled()) {
+    return false;
+  } else {
+    return Platform.OS === 'ios' && global.RN$Bridgeless === true;
+  }
 }
 
 export default shouldUseTurboAnimatedModule;

--- a/packages/react-native/React/Fabric/Mounting/RCTMountingManager.h
+++ b/packages/react-native/React/Fabric/Mounting/RCTMountingManager.h
@@ -67,7 +67,7 @@ NS_ASSUME_NONNULL_BEGIN
            forShadowView:(const facebook::react::ShadowView &)shadowView;
 
 - (void)synchronouslyUpdateViewOnUIThread:(ReactTag)reactTag
-                             changedProps:(NSDictionary *)props
+                             changedProps:(folly::dynamic)props
                       componentDescriptor:(const facebook::react::ComponentDescriptor &)componentDescriptor;
 @end
 

--- a/packages/react-native/React/Fabric/RCTScheduler.h
+++ b/packages/react-native/React/Fabric/RCTScheduler.h
@@ -42,6 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
                 blockNativeResponder:(BOOL)blockNativeResponder
                        forShadowView:(const facebook::react::ShadowView &)shadowView;
 
+- (void)schedulerDidSynchronouslyUpdateViewOnUIThread:(facebook::react::Tag)reactTag props:(folly::dynamic)props;
 @end
 
 /**

--- a/packages/react-native/React/Fabric/RCTScheduler.mm
+++ b/packages/react-native/React/Fabric/RCTScheduler.mm
@@ -68,8 +68,8 @@ class SchedulerDelegateProxy : public SchedulerDelegate {
 
   void schedulerShouldSynchronouslyUpdateViewOnUIThread(facebook::react::Tag tag, const folly::dynamic &props) override
   {
-    // Does nothing.
-    // This delegate method is not currently used on iOS.
+    RCTScheduler *scheduler = (__bridge RCTScheduler *)scheduler_;
+    [scheduler.delegate schedulerDidSynchronouslyUpdateViewOnUIThread:tag props:props];
   }
 
  private:

--- a/packages/react-native/React/Fabric/RCTSurfacePresenter.h
+++ b/packages/react-native/React/Fabric/RCTSurfacePresenter.h
@@ -66,6 +66,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable RCTFabricSurface *)surfaceForRootTag:(ReactTag)rootTag;
 
 - (void)synchronouslyUpdateViewOnUIThread:(NSNumber *)reactTag props:(NSDictionary *)props;
+- (void)schedulerDidSynchronouslyUpdateViewOnUIThread:(ReactTag)tag props:(folly::dynamic)props;
 
 - (void)setupAnimationDriverWithSurfaceHandler:(const facebook::react::SurfaceHandler &)surfaceHandler;
 

--- a/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
@@ -150,12 +150,17 @@ using namespace facebook::react;
 
 - (void)synchronouslyUpdateViewOnUIThread:(NSNumber *)reactTag props:(NSDictionary *)props
 {
+  ReactTag tag = [reactTag integerValue];
+  [self schedulerDidSynchronouslyUpdateViewOnUIThread:tag props:convertIdToFollyDynamic(props)];
+}
+
+- (void)schedulerDidSynchronouslyUpdateViewOnUIThread:(ReactTag)tag props:(folly::dynamic)props
+{
   RCTScheduler *scheduler = [self scheduler];
   if (!scheduler) {
     return;
   }
 
-  ReactTag tag = [reactTag integerValue];
   UIView<RCTComponentViewProtocol> *componentView =
       [_mountingManager.componentViewRegistry findComponentViewWithTag:tag];
   if (componentView == nil) {
@@ -168,7 +173,9 @@ using namespace facebook::react;
     return;
   }
 
-  [_mountingManager synchronouslyUpdateViewOnUIThread:tag changedProps:props componentDescriptor:*componentDescriptor];
+  [_mountingManager synchronouslyUpdateViewOnUIThread:tag
+                                         changedProps:std::move(props)
+                                  componentDescriptor:*componentDescriptor];
 }
 
 - (void)setupAnimationDriverWithSurfaceHandler:(const facebook::react::SurfaceHandler &)surfaceHandler

--- a/packages/react-native/ReactCommon/react/utils/platform/ios/react/utils/FollyConvert.h
+++ b/packages/react-native/ReactCommon/react/utils/platform/ios/react/utils/FollyConvert.h
@@ -12,6 +12,7 @@
 namespace facebook::react {
 
 folly::dynamic convertIdToFollyDynamic(id json);
-id convertFollyDynamicToId(const folly::dynamic& dyn);
+id convertFollyDynamicToId(const folly::dynamic &dyn);
+NSArray<NSString *> *extractKeysFromFollyDynamic(const folly::dynamic &dyn);
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/utils/platform/ios/react/utils/FollyConvert.mm
+++ b/packages/react-native/ReactCommon/react/utils/platform/ios/react/utils/FollyConvert.mm
@@ -113,4 +113,20 @@ folly::dynamic convertIdToFollyDynamic(id json)
   return nil;
 }
 
+NSArray<NSString *> *extractKeysFromFollyDynamic(const folly::dynamic &dyn)
+{
+  NSMutableArray<NSString *> *result = [NSMutableArray new];
+
+  if (dyn.type() == folly::dynamic::OBJECT) {
+    for (const auto &elem : dyn.items()) {
+      NSString *key = [[NSString alloc] initWithBytes:elem.first.c_str()
+                                               length:elem.first.size()
+                                             encoding:NSUTF8StringEncoding];
+      [result addObject:key];
+    }
+  }
+
+  return result;
+}
+
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
changelog: [internal]

When C++ Native Animated is used, we can't be using TurboModuleAnimated native module. This diff just add the check to make sure that if C++ Native Animated is used, it will be correctly referenced from JS.

Differential Revision: D74490166
