### PR TITLE
Fix extraneous blank space at the bottom of multiline `TextInput` with different line heights on iOS

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.h
@@ -41,6 +41,8 @@ NSString *RCTNSStringFromStringApplyingTextTransform(NSString *string, facebook:
 
 void RCTApplyBaselineOffset(NSMutableAttributedString *attributedText);
 
+void RCTApplyBaselineOffsetForRange(NSMutableAttributedString *attributedText, NSRange attributedTextRange);
+
 /*
  * Whether two `NSAttributedString` lead to the same underlying displayed text, even if they are not strictly equal.
  * I.e. is one string substitutable for the other when backing a control (which may have some ignorable attributes

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTAttributedTextUtils.mm
@@ -293,10 +293,18 @@ NSMutableDictionary<NSAttributedStringKey, id> *RCTNSTextAttributesFromTextAttri
 
 void RCTApplyBaselineOffset(NSMutableAttributedString *attributedText)
 {
+  [attributedText.string enumerateSubstringsInRange:NSMakeRange(0, attributedText.length)
+                                            options:NSStringEnumerationByLines | NSStringEnumerationSubstringNotRequired
+                                         usingBlock:^(NSString * _Nullable substring, NSRange substringRange, NSRange enclosingRange, BOOL * _Nonnull stop) {
+    RCTApplyBaselineOffsetForRange(attributedText, enclosingRange);
+  }];
+}
+
+void RCTApplyBaselineOffsetForRange(NSMutableAttributedString *attributedText, NSRange attributedTextRange)
   __block CGFloat maximumLineHeight = 0;
 
   [attributedText enumerateAttribute:NSParagraphStyleAttributeName
-                             inRange:NSMakeRange(0, attributedText.length)
+                             inRange:attributedTextRange
                              options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired
                           usingBlock:^(NSParagraphStyle *paragraphStyle, __unused NSRange range, __unused BOOL *stop) {
                             if (!paragraphStyle) {
@@ -314,7 +322,7 @@ void RCTApplyBaselineOffset(NSMutableAttributedString *attributedText)
   __block CGFloat maximumFontLineHeight = 0;
 
   [attributedText enumerateAttribute:NSFontAttributeName
-                             inRange:NSMakeRange(0, attributedText.length)
+                             inRange:attributedTextRange
                              options:NSAttributedStringEnumerationLongestEffectiveRangeNotRequired
                           usingBlock:^(UIFont *font, NSRange range, __unused BOOL *stop) {
                             if (!font) {
@@ -332,7 +340,7 @@ void RCTApplyBaselineOffset(NSMutableAttributedString *attributedText)
 
   [attributedText addAttribute:NSBaselineOffsetAttributeName
                          value:@(baseLineOffset)
-                         range:NSMakeRange(0, attributedText.length)];
+                         range:attributedTextRange];
 }
 
 static NSMutableAttributedString *RCTNSAttributedStringFragmentFromFragment(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

This PR removes extraneous blank space at the bottom of multiline `TextInput` when using nested `Text` with different font sizes on iOS with the New Architecture enabled.

| Before | After |
|:-:|:-:|
| <img width="283" alt="Screenshot 2025-05-15 at 12 16 05" src="https://github.com/user-attachments/assets/47256267-86ff-45f9-9e60-162d444a4b9d" /> | <img width="286" alt="Screenshot 2025-05-15 at 12 01 32" src="https://github.com/user-attachments/assets/43ce4b0b-6410-4ca5-be37-59c6374ea15c" /> |

The proposed solution is to call `RCTApplyBaselineOffset` separately for each line of text.

Ideally, we would call it separately for each part of text with different font size.

## Changelog:

[IOS] [FIXED] - Fixed extraneous blank space at the bottom of multiline `TextInput` with different line heights on iOS

## Test Plan:

```tsx
<TextInput
  multiline
  style={{borderWidth: 1, width: 300, fontSize: 20}}
  ref={ref}
  placeholder="Type here...">
  First line{'\n'}
  <Text style={{fontSize: 30, lineHeight: 60}}>Second line</Text>
  {'\n'}Third line{'\n'}Fourth line
  {'\n'}
  Fifth line
</TextInput>
```
