### PR TITLE
Migrate test to use React.createRef insted of ref functions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -136,7 +136,7 @@ module.exports = {
       },
     },
     {
-      files: ['**/*-itest{.fb,}.js'],
+      files: ['**/__tests__/**'],
       rules: {
         'lint/no-react-native-imports': 'off',
       },

--- a/packages/react-native-fantom/src/__tests__/Fantom-itest.js
+++ b/packages/react-native-fantom/src/__tests__/Fantom-itest.js
@@ -912,26 +912,21 @@ describe('Fantom', () => {
 
     it('change size of <Modal />', () => {
       const root = Fantom.createRoot();
-      let maybeModalNode;
-      let maybeViewNode;
+      const modalNodeRef = React.createRef<HostInstance>();
+      const viewNodeRef = React.createRef<HostInstance>();
 
       Fantom.runTask(() => {
         root.render(
-          <Modal
-            ref={(node: ?HostInstance) => {
-              maybeModalNode = node;
-            }}>
-            <View
-              style={{width: '50%', height: '25%'}}
-              ref={node => {
-                maybeViewNode = node;
-              }}
-            />
+          <Modal ref={modalNodeRef}>
+            <View style={{width: '50%', height: '25%'}} ref={viewNodeRef} />
           </Modal>,
         );
       });
 
-      const modalElement = ensureInstance(maybeModalNode, ReactNativeElement);
+      const modalElement = ensureInstance(
+        modalNodeRef.current,
+        ReactNativeElement,
+      );
 
       Fantom.runOnUIThread(() => {
         Fantom.enqueueModalSizeUpdate(modalElement, {
@@ -942,7 +937,10 @@ describe('Fantom', () => {
 
       Fantom.runWorkLoop();
 
-      const viewElement = ensureInstance(maybeViewNode, ReactNativeElement);
+      const viewElement = ensureInstance(
+        viewNodeRef.current,
+        ReactNativeElement,
+      );
 
       const boundingClientRect = viewElement.getBoundingClientRect();
       expect(boundingClientRect.height).toBe(25);

--- a/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/setUpReactFabricPublicInstanceFantomTests.js
+++ b/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/setUpReactFabricPublicInstanceFantomTests.js
@@ -14,6 +14,7 @@ import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 import type {HostInstance} from 'react-native';
 
 import ReactNativeElement from '../../../../src/private/webapis/dom/nodes/ReactNativeElement';
+import {getRawNativeDOMForTests} from '../../../../src/private/webapis/dom/nodes/specs/NativeDOM';
 import TextInputState from '../../../Components/TextInput/TextInputState';
 import View from '../../../Components/View/View';
 import ReactFabricHostComponent from '../ReactFabricHostComponent';
@@ -395,6 +396,59 @@ export default function setUpTests({isModern}: {isModern: boolean}) {
             .toJSX(),
         ).toEqual(<rn-view testID={'second test id'} />);
       });
+
+      // TODO: delete when NativeDOM.setNativeProps is NOT nullable.
+      // This logic is to ensure compatibility with old app versions without the native module method.
+      if (isModern) {
+        let RawNativeDOM;
+        let originalSetNativeProps;
+
+        beforeAll(() => {
+          RawNativeDOM = nullthrows(getRawNativeDOMForTests());
+          originalSetNativeProps = RawNativeDOM.setNativeProps;
+        });
+
+        beforeEach(() => {
+          // $FlowExpectedError[cannot-write]
+          RawNativeDOM.setNativeProps = originalSetNativeProps;
+        });
+
+        it('should propagate changes to the host component (when NativeDOM.setNativeProps is not available)', () => {
+          // $FlowExpectedError[cannot-write]
+          RawNativeDOM.setNativeProps = null;
+
+          expect(RawNativeDOM.setNativeProps).toBeNull();
+
+          const root = Fantom.createRoot();
+          const nodeRef = React.createRef<HostInstance>();
+
+          Fantom.runTask(() => {
+            root.render(<View ref={nodeRef} testID="first test id" />);
+          });
+
+          expect(
+            root
+              .getRenderedOutput({
+                props: ['testID'],
+              })
+              .toJSX(),
+          ).toEqual(<rn-view testID={'first test id'} />);
+
+          const element = nullthrows(nodeRef.current);
+
+          Fantom.runTask(() => {
+            element.setNativeProps({testID: 'second test id'});
+          });
+
+          expect(
+            root
+              .getRenderedOutput({
+                props: ['testID'],
+              })
+              .toJSX(),
+          ).toEqual(<rn-view testID={'second test id'} />);
+        });
+      }
     });
   });
 }

--- a/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/setUpReactFabricPublicInstanceFantomTests.js
+++ b/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/setUpReactFabricPublicInstanceFantomTests.js
@@ -11,6 +11,8 @@
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
+import type {HostInstance} from 'react-native';
+
 import ReactNativeElement from '../../../../src/private/webapis/dom/nodes/ReactNativeElement';
 import TextInputState from '../../../Components/TextInput/TextInputState';
 import View from '../../../Components/View/View';
@@ -359,6 +361,39 @@ export default function setUpTests({isModern}: {isModern: boolean}) {
         childNode.measureLayout(parentNode, callback);
 
         expect(callback).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('setNativeProps', () => {
+      it('should propagate changes to the host component', () => {
+        const root = Fantom.createRoot();
+        const nodeRef = React.createRef<HostInstance>();
+
+        Fantom.runTask(() => {
+          root.render(<View ref={nodeRef} testID="first test id" />);
+        });
+
+        expect(
+          root
+            .getRenderedOutput({
+              props: ['testID'],
+            })
+            .toJSX(),
+        ).toEqual(<rn-view testID={'first test id'} />);
+
+        const element = nullthrows(nodeRef.current);
+
+        Fantom.runTask(() => {
+          element.setNativeProps({testID: 'second test id'});
+        });
+
+        expect(
+          root
+            .getRenderedOutput({
+              props: ['testID'],
+            })
+            .toJSX(),
+        ).toEqual(<rn-view testID={'second test id'} />);
       });
     });
   });

--- a/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/setUpReactFabricPublicInstanceFantomTests.js
+++ b/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/setUpReactFabricPublicInstanceFantomTests.js
@@ -26,18 +26,14 @@ export default function setUpTests({isModern}: {isModern: boolean}) {
   // TODO: move these tests to the test file for `ReactNativeElement` when the legacy implementation is removed.
   describe(`ReactFabricPublicInstance (${isModern ? 'modern' : 'legacy'})`, () => {
     it('should provide instances of the right class as refs in host components', () => {
-      let node;
+      const nodeRef = React.createRef<HostInstance>();
 
       const root = Fantom.createRoot();
       Fantom.runTask(() => {
-        root.render(
-          <View
-            ref={receivedNode => {
-              node = receivedNode;
-            }}
-          />,
-        );
+        root.render(<View ref={nodeRef} />);
       });
+
+      const node = nullthrows(nodeRef.current);
 
       expect(node).toBeInstanceOf(
         isModern ? ReactNativeElement : ReactFabricHostComponent,
@@ -47,20 +43,13 @@ export default function setUpTests({isModern}: {isModern: boolean}) {
     describe('blur', () => {
       test('blur() invokes TextInputState', () => {
         const root = Fantom.createRoot();
-
-        let maybeNode;
+        const nodeRef = React.createRef<HostInstance>();
 
         Fantom.runTask(() => {
-          root.render(
-            <View
-              ref={node => {
-                maybeNode = node;
-              }}
-            />,
-          );
+          root.render(<View ref={nodeRef} />);
         });
 
-        const node = nullthrows(maybeNode);
+        const node = nullthrows(nodeRef.current);
 
         const blurTextInput = jest.fn();
 
@@ -79,20 +68,13 @@ export default function setUpTests({isModern}: {isModern: boolean}) {
     describe('focus', () => {
       test('focus() invokes TextInputState', () => {
         const root = Fantom.createRoot();
-
-        let maybeNode;
+        const ref = React.createRef<HostInstance>();
 
         Fantom.runTask(() => {
-          root.render(
-            <View
-              ref={node => {
-                maybeNode = node;
-              }}
-            />,
-          );
+          root.render(<View ref={ref} />);
         });
 
-        const node = nullthrows(maybeNode);
+        const node = nullthrows(ref.current);
 
         const focusTextInput = jest.fn();
 
@@ -111,21 +93,18 @@ export default function setUpTests({isModern}: {isModern: boolean}) {
     describe('measure', () => {
       it('component.measure(...) invokes callback', () => {
         const root = Fantom.createRoot();
-
-        let maybeNode;
+        const ref = React.createRef<HostInstance>();
 
         Fantom.runTask(() => {
           root.render(
             <View
               style={{width: 100, height: 100, left: 10, top: 10}}
-              ref={node => {
-                maybeNode = node;
-              }}
+              ref={ref}
             />,
           );
         });
 
-        const node = nullthrows(maybeNode);
+        const node = nullthrows(ref.current);
 
         const callback = jest.fn();
         node.measure(callback);
@@ -136,21 +115,18 @@ export default function setUpTests({isModern}: {isModern: boolean}) {
 
       it('unmounted.measure(...) does nothing', () => {
         const root = Fantom.createRoot();
-
-        let maybeNode;
+        const ref = React.createRef<HostInstance>();
 
         Fantom.runTask(() => {
           root.render(
             <View
               style={{width: 100, height: 100, left: 10, top: 10}}
-              ref={node => {
-                maybeNode = node;
-              }}
+              ref={ref}
             />,
           );
         });
 
-        const node = nullthrows(maybeNode);
+        const node = nullthrows(ref.current);
 
         Fantom.runTask(() => {
           root.render(<></>);
@@ -166,21 +142,18 @@ export default function setUpTests({isModern}: {isModern: boolean}) {
     describe('measureInWindow', () => {
       it('component.measureInWindow(...) invokes callback', () => {
         const root = Fantom.createRoot();
-
-        let maybeNode;
+        const ref = React.createRef<HostInstance>();
 
         Fantom.runTask(() => {
           root.render(
             <View
               style={{width: 100, height: 100, left: 10, top: 10}}
-              ref={node => {
-                maybeNode = node;
-              }}
+              ref={ref}
             />,
           );
         });
 
-        const node = nullthrows(maybeNode);
+        const node = nullthrows(ref.current);
 
         const callback = jest.fn();
         node.measureInWindow(callback);
@@ -191,21 +164,18 @@ export default function setUpTests({isModern}: {isModern: boolean}) {
 
       it('unmounted.measureInWindow(...) does nothing', () => {
         const root = Fantom.createRoot();
-
-        let maybeNode;
+        const ref = React.createRef<HostInstance>();
 
         Fantom.runTask(() => {
           root.render(
             <View
               style={{width: 100, height: 100, left: 10, top: 10}}
-              ref={node => {
-                maybeNode = node;
-              }}
+              ref={ref}
             />,
           );
         });
 
-        const node = nullthrows(maybeNode);
+        const node = nullthrows(ref.current);
 
         Fantom.runTask(() => {
           root.render(<></>);
@@ -221,29 +191,24 @@ export default function setUpTests({isModern}: {isModern: boolean}) {
     describe('measureLayout', () => {
       it('component.measureLayout(component, ...) invokes callback', () => {
         const root = Fantom.createRoot();
-
-        let maybeParentNode;
-        let maybeChildNode;
+        const parentRef = React.createRef<HostInstance>();
+        const childRef = React.createRef<HostInstance>();
 
         Fantom.runTask(() => {
           root.render(
             <View
               style={{width: 100, height: 100, left: 10, top: 10}}
-              ref={node => {
-                maybeParentNode = node;
-              }}>
+              ref={parentRef}>
               <View
                 style={{width: 10, height: 10, left: 20, top: 20}}
-                ref={node => {
-                  maybeChildNode = node;
-                }}
+                ref={childRef}
               />
             </View>,
           );
         });
 
-        const parentNode = nullthrows(maybeParentNode);
-        const childNode = nullthrows(maybeChildNode);
+        const parentNode = nullthrows(parentRef.current);
+        const childNode = nullthrows(childRef.current);
 
         const callback = jest.fn();
         childNode.measureLayout(parentNode, callback);
@@ -254,29 +219,24 @@ export default function setUpTests({isModern}: {isModern: boolean}) {
 
       it('unmounted.measureLayout(component, ...) does nothing', () => {
         const root = Fantom.createRoot();
-
-        let maybeParentNode;
-        let maybeChildNode;
+        const parentRef = React.createRef<HostInstance>();
+        const childRef = React.createRef<HostInstance>();
 
         Fantom.runTask(() => {
           root.render(
             <View
               style={{width: 100, height: 100, left: 10, top: 10}}
-              ref={node => {
-                maybeParentNode = node;
-              }}>
+              ref={parentRef}>
               <View
                 style={{width: 10, height: 10, left: 20, top: 20}}
-                ref={node => {
-                  maybeChildNode = node;
-                }}
+                ref={childRef}
               />
             </View>,
           );
         });
 
-        const parentNode = nullthrows(maybeParentNode);
-        const childNode = nullthrows(maybeChildNode);
+        const parentNode = nullthrows(parentRef.current);
+        const childNode = nullthrows(childRef.current);
 
         Fantom.runTask(() => {
           root.render(
@@ -292,29 +252,24 @@ export default function setUpTests({isModern}: {isModern: boolean}) {
 
       it('component.measureLayout(unmounted, ...) does nothing', () => {
         const root = Fantom.createRoot();
-
-        let maybeParentNode;
-        let maybeChildNode;
+        const parentRef = React.createRef<HostInstance>();
+        const childRef = React.createRef<HostInstance>();
 
         Fantom.runTask(() => {
           root.render(
             <View
               style={{width: 100, height: 100, left: 10, top: 10}}
-              ref={node => {
-                maybeParentNode = node;
-              }}>
+              ref={parentRef}>
               <View
                 style={{width: 10, height: 10, left: 20, top: 20}}
-                ref={node => {
-                  maybeChildNode = node;
-                }}
+                ref={childRef}
               />
             </View>,
           );
         });
 
-        const parentNode = nullthrows(maybeParentNode);
-        const childNode = nullthrows(maybeChildNode);
+        const parentNode = nullthrows(parentRef.current);
+        const childNode = nullthrows(childRef.current);
 
         Fantom.runTask(() => {
           root.render(
@@ -330,29 +285,24 @@ export default function setUpTests({isModern}: {isModern: boolean}) {
 
       it('unmounted.measureLayout(unmounted, ...) does nothing', () => {
         const root = Fantom.createRoot();
-
-        let maybeParentNode;
-        let maybeChildNode;
+        const parentRef = React.createRef<HostInstance>();
+        const childRef = React.createRef<HostInstance>();
 
         Fantom.runTask(() => {
           root.render(
             <View
               style={{width: 100, height: 100, left: 10, top: 10}}
-              ref={node => {
-                maybeParentNode = node;
-              }}>
+              ref={parentRef}>
               <View
                 style={{width: 10, height: 10, left: 20, top: 20}}
-                ref={node => {
-                  maybeChildNode = node;
-                }}
+                ref={childRef}
               />
             </View>,
           );
         });
 
-        const parentNode = nullthrows(maybeParentNode);
-        const childNode = nullthrows(maybeChildNode);
+        const parentNode = nullthrows(parentRef.current);
+        const childNode = nullthrows(childRef.current);
 
         Fantom.runTask(() => {
           root.render(<></>);

--- a/packages/react-native/ReactCommon/react/nativemodule/dom/NativeDOM.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/dom/NativeDOM.cpp
@@ -25,12 +25,15 @@ namespace facebook::react {
 
 #pragma mark - Private helpers
 
+static UIManager& getUIManagerFromRuntime(facebook::jsi::Runtime& runtime) {
+  return UIManagerBinding::getBinding(runtime)->getUIManager();
+}
+
 static RootShadowNode::Shared getCurrentShadowTreeRevision(
     facebook::jsi::Runtime& runtime,
     SurfaceId surfaceId) {
-  auto& uiManager =
-      facebook::react::UIManagerBinding::getBinding(runtime)->getUIManager();
-  auto shadowTreeRevisionProvider = uiManager.getShadowTreeRevisionProvider();
+  auto shadowTreeRevisionProvider =
+      getUIManagerFromRuntime(runtime).getShadowTreeRevisionProvider();
   return shadowTreeRevisionProvider->getCurrentRevision(surfaceId);
 }
 
@@ -457,6 +460,17 @@ void NativeDOM::measureLayout(
        jsi::Value{rt, rect.y},
        jsi::Value{rt, rect.width},
        jsi::Value{rt, rect.height}});
+}
+
+#pragma mark - Legacy direct manipulation APIs (for `ReactNativeElement`).
+
+void NativeDOM::setNativeProps(
+    jsi::Runtime& rt,
+    jsi::Value nativeElementReference,
+    jsi::Value updatePayload) {
+  getUIManagerFromRuntime(rt).setNativeProps_DEPRECATED(
+      shadowNodeFromValue(rt, nativeElementReference),
+      RawProps(rt, updatePayload));
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/dom/NativeDOM.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/dom/NativeDOM.h
@@ -122,6 +122,13 @@ class NativeDOM : public NativeDOMCxxSpec<NativeDOM> {
       jsi::Value relativeToNativeElementReference,
       jsi::Function onFail,
       jsi::Function onSuccess);
+
+#pragma mark - Legacy direct manipulation APIs (for `ReactNativeElement`).
+
+  void setNativeProps(
+      jsi::Runtime& rt,
+      jsi::Value nativeElementReference,
+      jsi::Value updatePayload);
 };
 
 } // namespace facebook::react

--- a/packages/react-native/src/private/webapis/dom/nodes/ReactNativeElement.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/ReactNativeElement.js
@@ -12,7 +12,6 @@
 
 import type {
   InternalInstanceHandle,
-  Node as ShadowNode,
   ViewConfig,
 } from '../../../../../Libraries/Renderer/shims/ReactNativeTypes';
 import type {
@@ -26,7 +25,6 @@ import type {InstanceHandle} from './internals/NodeInternals';
 import type ReactNativeDocument from './ReactNativeDocument';
 
 import TextInputState from '../../../../../Libraries/Components/TextInput/TextInputState';
-import {getFabricUIManager} from '../../../../../Libraries/ReactNative/FabricUIManager';
 import {create as createAttributePayload} from '../../../../../Libraries/ReactNative/ReactFabricPublicInstance/ReactNativeAttributePayload';
 import warnForStyleProps from '../../../../../Libraries/ReactNative/ReactFabricPublicInstance/warnForStyleProps';
 import {
@@ -37,7 +35,6 @@ import {
 } from './internals/NodeInternals';
 import ReadOnlyElement, {getBoundingClientRect} from './ReadOnlyElement';
 import NativeDOM from './specs/NativeDOM';
-import nullthrows from 'nullthrows';
 
 const noop = () => {};
 
@@ -205,12 +202,7 @@ class ReactNativeElement extends ReadOnlyElement implements NativeMethods {
     const node = getNativeElementReference(this);
 
     if (node != null && updatePayload != null) {
-      // $FlowExpectedError[incompatible-type] This is an element instance so the native node reference is always a shadow node.
-      const shadowNode: ShadowNode = node;
-      nullthrows(getFabricUIManager()).setNativeProps(
-        shadowNode,
-        updatePayload,
-      );
+      NativeDOM.setNativeProps(node, updatePayload);
     }
   }
 }

--- a/packages/react-native/src/private/webapis/dom/nodes/ReactNativeElement.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/ReactNativeElement.js
@@ -153,18 +153,14 @@ class ReactNativeElement extends ReadOnlyElement implements NativeMethods {
   measure(callback: MeasureOnSuccessCallback) {
     const node = getNativeElementReference(this);
     if (node != null) {
-      // $FlowExpectedError[incompatible-type] This is an element instance so the native node reference is always a shadow node.
-      const shadowNode: ShadowNode = node;
-      nullthrows(getFabricUIManager()).measure(shadowNode, callback);
+      NativeDOM.measure(node, callback);
     }
   }
 
   measureInWindow(callback: MeasureInWindowOnSuccessCallback) {
     const node = getNativeElementReference(this);
     if (node != null) {
-      // $FlowExpectedError[incompatible-type] This is an element instance so the native node reference is always a shadow node.
-      const shadowNode: ShadowNode = node;
-      nullthrows(getFabricUIManager()).measureInWindow(shadowNode, callback);
+      NativeDOM.measureInWindow(node, callback);
     }
   }
 
@@ -187,14 +183,9 @@ class ReactNativeElement extends ReadOnlyElement implements NativeMethods {
     const fromStateNode = getNativeElementReference(relativeToNativeNode);
 
     if (toStateNode != null && fromStateNode != null) {
-      // $FlowExpectedError[incompatible-type] This is an element instance so the native node reference is always a shadow node.
-      const toStateShadowNode: ShadowNode = toStateNode;
-      // $FlowExpectedError[incompatible-type] This is an element instance so the native node reference is always a shadow node.
-      const fromStateShadowNode: ShadowNode = fromStateNode;
-
-      nullthrows(getFabricUIManager()).measureLayout(
-        toStateShadowNode,
-        fromStateShadowNode,
+      NativeDOM.measureLayout(
+        toStateNode,
+        fromStateNode,
         onFail != null ? onFail : noop,
         onSuccess != null ? onSuccess : noop,
       );


### PR DESCRIPTION
Summary:
Changelog: [internal]

I just realized there were some tests where we didn't migrate to the new recommended pattern.

Differential Revision: D74803018


