### PR TITLE
Fix Maestro E2E Tests

### DIFF
--- a/packages/rn-tester/.maestro/new-arch-examples.yml
+++ b/packages/rn-tester/.maestro/new-arch-examples.yml
@@ -6,7 +6,8 @@ appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebo
     element:
       id: "New Architecture Examples"
     direction: DOWN
-    speed: 40
+    speed: 60
+    visibilityPercentage: 100
 - tapOn:
     id: "New Architecture Examples"
 - assertVisible: "HSBA: h: 0, s: 0, b: 0, a: 0"


### PR DESCRIPTION
Summary:
The new warnings on RNTester for the imports are covering the New Architecture list item, as you can see from the video.

This prevents maestro from clicking on the list item, and therefore the test fails.

{F1977997600}

## Changelog:
[Internal] - Fix E2E Tests

Differential Revision: D74803709


