### PR TITLE
move RCTFollyConverter to utils module and drop prefix

### DIFF
--- a/packages/react-native/React-Core.podspec
+++ b/packages/react-native/React-Core.podspec
@@ -119,7 +119,6 @@ Pod::Spec.new do |s|
   s.dependency "React-perflogger"
   s.dependency "React-jsi"
   s.dependency "React-jsiexecutor"
-  s.dependency "React-utils"
   s.dependency "React-featureflags"
   s.dependency "React-runtimescheduler"
   s.dependency "Yoga"
@@ -129,6 +128,7 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-jsinspector", :framework_name => 'jsinspector_modern')
   add_dependency(s, "React-jsinspectorcdp", :framework_name => 'jsinspector_moderncdp')
   add_dependency(s, "React-jsitooling", :framework_name => "JSITooling")
+  add_dependency(s, "React-utils", :additional_framework_paths => ["react/utils/platform/ios"])
   add_dependency(s, "RCTDeprecation")
 
   depend_on_js_engine(s)

--- a/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
+++ b/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
@@ -23,7 +23,6 @@
 #import <React/RCTCxxUtils.h>
 #import <React/RCTDevSettings.h>
 #import <React/RCTDisplayLink.h>
-#import <React/RCTFollyConvert.h>
 #import <React/RCTJavaScriptLoader.h>
 #import <React/RCTLog.h>
 #import <React/RCTModuleData.h>
@@ -43,6 +42,7 @@
 #import <cxxreact/ReactMarker.h>
 #import <jsinspector-modern/ReactCdp.h>
 #import <jsireact/JSIExecutor.h>
+#import <react/utils/FollyConvert.h>
 #import <reactperflogger/BridgeNativeModulePerfLogger.h>
 
 #if USE_HERMES

--- a/packages/react-native/React/CxxBridge/RCTObjcExecutor.mm
+++ b/packages/react-native/React/CxxBridge/RCTObjcExecutor.mm
@@ -8,7 +8,6 @@
 #import "RCTObjcExecutor.h"
 
 #import <React/RCTCxxUtils.h>
-#import <React/RCTFollyConvert.h>
 #import <React/RCTJavaScriptExecutor.h>
 #import <React/RCTLog.h>
 #import <React/RCTProfile.h>
@@ -19,6 +18,7 @@
 #import <cxxreact/ModuleRegistry.h>
 #import <cxxreact/RAMBundleRegistry.h>
 #import <folly/json.h>
+#import <react/utils/FollyConvert.h>
 
 namespace facebook::react {
 

--- a/packages/react-native/React/CxxModule/RCTCxxMethod.mm
+++ b/packages/react-native/React/CxxModule/RCTCxxMethod.mm
@@ -10,8 +10,8 @@
 #import <React/RCTBridge+Private.h>
 #import <React/RCTBridge.h>
 #import <React/RCTConvert.h>
-#import <React/RCTFollyConvert.h>
 #import <cxxreact/JsArgumentHelpers.h>
+#import <react/utils/FollyConvert.h>
 
 #import "RCTCxxUtils.h"
 

--- a/packages/react-native/React/CxxModule/RCTCxxModule.mm
+++ b/packages/react-native/React/CxxModule/RCTCxxModule.mm
@@ -8,9 +8,9 @@
 #import "RCTCxxModule.h"
 
 #import <React/RCTBridge.h>
-#import <React/RCTFollyConvert.h>
 #import <React/RCTLog.h>
 #import <cxxreact/CxxModule.h>
+#import <react/utils/FollyConvert.h>
 
 #import "RCTCxxMethod.h"
 

--- a/packages/react-native/React/CxxModule/RCTCxxUtils.mm
+++ b/packages/react-native/React/CxxModule/RCTCxxUtils.mm
@@ -7,7 +7,6 @@
 
 #import "RCTCxxUtils.h"
 
-#import <React/RCTFollyConvert.h>
 #import <React/RCTModuleData.h>
 #import <React/RCTUtils.h>
 #import <cxxreact/CxxNativeModule.h>

--- a/packages/react-native/React/CxxModule/RCTNativeModule.mm
+++ b/packages/react-native/React/CxxModule/RCTNativeModule.mm
@@ -12,10 +12,10 @@
 #import <React/RCTBridgeMethod.h>
 #import <React/RCTBridgeModule.h>
 #import <React/RCTCxxUtils.h>
-#import <React/RCTFollyConvert.h>
 #import <React/RCTLog.h>
 #import <React/RCTProfile.h>
 #import <React/RCTUtils.h>
+#import <react/utils/FollyConvert.h>
 #import <reactperflogger/BridgeNativeModulePerfLogger.h>
 
 #ifdef WITH_FBSYSTRACE

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropCoordinatorAdapter.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropCoordinatorAdapter.mm
@@ -6,8 +6,8 @@
  */
 
 #import "RCTLegacyViewManagerInteropCoordinatorAdapter.h"
-#import <React/RCTFollyConvert.h>
 #import <React/UIView+React.h>
+#import <react/utils/FollyConvert.h>
 
 @implementation RCTLegacyViewManagerInteropCoordinatorAdapter {
   RCTLegacyViewManagerInteropCoordinator *_coordinator;

--- a/packages/react-native/React/Fabric/Mounting/RCTMountingManager.mm
+++ b/packages/react-native/React/Fabric/Mounting/RCTMountingManager.mm
@@ -11,7 +11,6 @@
 
 #import <React/RCTAssert.h>
 #import <React/RCTComponent.h>
-#import <React/RCTFollyConvert.h>
 #import <React/RCTLog.h>
 #import <React/RCTUtils.h>
 #import <cxxreact/TraceSection.h>
@@ -19,6 +18,7 @@
 #import <react/renderer/core/LayoutableShadowNode.h>
 #import <react/renderer/core/RawProps.h>
 #import <react/renderer/mounting/TelemetryController.h>
+#import <react/utils/FollyConvert.h>
 
 #import <React/RCTComponentViewProtocol.h>
 #import <React/RCTComponentViewRegistry.h>

--- a/packages/react-native/React/Fabric/RCTScheduler.mm
+++ b/packages/react-native/React/Fabric/RCTScheduler.mm
@@ -15,8 +15,6 @@
 #import <react/renderer/scheduler/SchedulerDelegate.h>
 #import <react/utils/RunLoopObserver.h>
 
-#import <React/RCTFollyConvert.h>
-
 #import "PlatformRunLoopObserver.h"
 #import "RCTConversions.h"
 

--- a/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePresenter.mm
@@ -16,7 +16,6 @@
 #import <React/RCTComponentViewRegistry.h>
 #import <React/RCTConstants.h>
 #import <React/RCTFabricSurface.h>
-#import <React/RCTFollyConvert.h>
 #import <React/RCTI18nUtil.h>
 #import <React/RCTMountingManager.h>
 #import <React/RCTMountingManagerDelegate.h>
@@ -25,6 +24,7 @@
 #import <React/RCTSurfaceView+Internal.h>
 #import <React/RCTSurfaceView.h>
 #import <React/RCTUtils.h>
+#import <react/utils/FollyConvert.h>
 
 #import <react/featureflags/ReactNativeFeatureFlags.h>
 #import <react/renderer/componentregistry/ComponentDescriptorFactory.h>

--- a/packages/react-native/React/Fabric/Surface/RCTFabricSurface.mm
+++ b/packages/react-native/React/Fabric/Surface/RCTFabricSurface.mm
@@ -12,7 +12,6 @@
 #import <React/RCTAssert.h>
 #import <React/RCTConstants.h>
 #import <React/RCTConversions.h>
-#import <React/RCTFollyConvert.h>
 #import <React/RCTI18nUtil.h>
 #import <React/RCTMountingManager.h>
 #import <React/RCTSurfaceDelegate.h>
@@ -23,6 +22,7 @@
 #import <React/RCTUIManagerUtils.h>
 #import <React/RCTUtils.h>
 #import <react/renderer/mounting/MountingCoordinator.h>
+#import <react/utils/FollyConvert.h>
 
 #import "RCTSurfacePresenter.h"
 

--- a/packages/react-native/React/React-RCTFabric.podspec
+++ b/packages/react-native/React/React-RCTFabric.podspec
@@ -79,7 +79,7 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-ImageManager")
   add_dependency(s, "React-featureflags")
   add_dependency(s, "React-debug")
-  add_dependency(s, "React-utils")
+  add_dependency(s, "React-utils", :additional_framework_paths => ["react/utils/platform/ios"])
   add_dependency(s, "React-performancetimeline")
   add_dependency(s, "React-rendererdebug")
   add_dependency(s, "React-rendererconsistency")

--- a/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/RCTLegacyViewManagerInteropCoordinator.mm
+++ b/packages/react-native/ReactCommon/react/renderer/components/legacyviewmanagerinterop/RCTLegacyViewManagerInteropCoordinator.mm
@@ -11,7 +11,6 @@
 #include <React/RCTBridgeProxy.h>
 #include <React/RCTComponentData.h>
 #include <React/RCTEventDispatcherProtocol.h>
-#include <React/RCTFollyConvert.h>
 #include <React/RCTModuleData.h>
 #include <React/RCTModuleMethod.h>
 #include <React/RCTUIManager.h>
@@ -20,6 +19,7 @@
 #include <React/RCTViewManager.h>
 #include <folly/json.h>
 #include <objc/runtime.h>
+#include <react/utils/FollyConvert.h>
 
 using namespace facebook::react;
 

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/React-RuntimeApple.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/React-RuntimeApple.podspec
@@ -48,7 +48,6 @@ Pod::Spec.new do |s|
   s.dependency "React-callinvoker"
   s.dependency "React-runtimeexecutor"
   s.dependency "React-runtimescheduler"
-  s.dependency "React-utils"
   s.dependency "React-jsi"
   s.dependency "React-Core/Default"
   s.dependency "React-CoreModules"
@@ -61,6 +60,7 @@ Pod::Spec.new do |s|
   s.dependency "React-featureflags"
   add_dependency(s, "React-jsitooling", :framework_name => "JSITooling")
   add_dependency(s, "React-RCTFBReactNativeSpec")
+  add_dependency(s, "React-utils", :additional_framework_paths => ["react/utils/platform/ios"])
 
   if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
     s.dependency "hermes-engine"

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -25,7 +25,6 @@
 #import <React/RCTDevSettings.h>
 #import <React/RCTDisplayLink.h>
 #import <React/RCTEventDispatcherProtocol.h>
-#import <React/RCTFollyConvert.h>
 #import <React/RCTLog.h>
 #import <React/RCTLogBox.h>
 #import <React/RCTModuleData.h>
@@ -41,6 +40,7 @@
 #import <react/featureflags/ReactNativeFeatureFlags.h>
 #import <react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.h>
 #import <react/utils/ContextContainer.h>
+#import <react/utils/FollyConvert.h>
 #import <react/utils/ManagedObjectWrapper.h>
 
 #import "ObjCTimerRegistry.h"

--- a/packages/react-native/ReactCommon/react/utils/platform/ios/react/utils/FollyConvert.h
+++ b/packages/react-native/ReactCommon/react/utils/platform/ios/react/utils/FollyConvert.h
@@ -11,11 +11,7 @@
 
 namespace facebook::react {
 
-[[deprecated(
-    "This function is deprecated, please use /ReactCommon/react/utils/platform/ios/react/utils/FollyConvert.h instead")]]
 folly::dynamic convertIdToFollyDynamic(id json);
-[[deprecated(
-    "This function is deprecated, please use /ReactCommon/react/utils/platform/ios/react/utils/FollyConvert.h instead")]]
 id convertFollyDynamicToId(const folly::dynamic& dyn);
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/utils/platform/ios/react/utils/FollyConvert.mm
+++ b/packages/react-native/ReactCommon/react/utils/platform/ios/react/utils/FollyConvert.mm
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "FollyConvert.h"
+
+#import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+
+namespace facebook::react {
+
+id convertFollyDynamicToId(const folly::dynamic &dyn)
+{
+  // I could imagine an implementation which avoids copies by wrapping the
+  // dynamic in a derived class of NSDictionary.  We can do that if profiling
+  // implies it will help.
+
+  switch (dyn.type()) {
+    case folly::dynamic::NULLT:
+      return (id)kCFNull;
+    case folly::dynamic::BOOL:
+      return dyn.getBool() ? @YES : @NO;
+    case folly::dynamic::INT64:
+      return @(dyn.getInt());
+    case folly::dynamic::DOUBLE:
+      return @(dyn.getDouble());
+    case folly::dynamic::STRING:
+      return [[NSString alloc] initWithBytes:dyn.c_str() length:dyn.size() encoding:NSUTF8StringEncoding];
+    case folly::dynamic::ARRAY: {
+      NSMutableArray *array = [[NSMutableArray alloc] initWithCapacity:dyn.size()];
+      for (const auto &elem : dyn) {
+        id value = convertFollyDynamicToId(elem);
+        if (value) {
+          [array addObject:value];
+        }
+      }
+      return array;
+    }
+    case folly::dynamic::OBJECT: {
+      NSMutableDictionary *dict = [[NSMutableDictionary alloc] initWithCapacity:dyn.size()];
+      for (const auto &elem : dyn.items()) {
+        id key = convertFollyDynamicToId(elem.first);
+        id value = convertFollyDynamicToId(elem.second);
+        if (key && value) {
+          dict[key] = value;
+        }
+      }
+      return dict;
+    }
+  }
+}
+
+folly::dynamic convertIdToFollyDynamic(id json)
+{
+  if (json == nil || json == (id)kCFNull) {
+    return nullptr;
+  } else if ([json isKindOfClass:[NSNumber class]]) {
+    const char *objCType = [json objCType];
+    switch (objCType[0]) {
+      // This is a c++ bool or C99 _Bool.  On some platforms, BOOL is a bool.
+      case _C_BOOL:
+        return (bool)[json boolValue];
+      case _C_CHR:
+        // On some platforms, objc BOOL is a signed char, but it
+        // might also be a small number.  Use the same hack JSC uses
+        // to distinguish them:
+        // https://phabricator.intern.facebook.com/diffusion/FBS/browse/master/fbobjc/xplat/third-party/jsc/safari-600-1-4-17/JavaScriptCore/API/JSValue.mm;b8ee03916489f8b12143cd5c0bca546da5014fc9$901
+        if ([json isKindOfClass:[@YES class]]) {
+          return (bool)[json boolValue];
+        } else {
+          return [json longLongValue];
+        }
+      case _C_UCHR:
+      case _C_SHT:
+      case _C_USHT:
+      case _C_INT:
+      case _C_UINT:
+      case _C_LNG:
+      case _C_ULNG:
+      case _C_LNG_LNG:
+      case _C_ULNG_LNG:
+        return [json longLongValue];
+
+      case _C_FLT:
+      case _C_DBL:
+        return [json doubleValue];
+
+        // default:
+        //   fall through
+    }
+  } else if ([json isKindOfClass:[NSString class]]) {
+    NSData *data = [json dataUsingEncoding:NSUTF8StringEncoding];
+    return std::string(reinterpret_cast<const char *>(data.bytes), data.length);
+  } else if ([json isKindOfClass:[NSArray class]]) {
+    folly::dynamic array = folly::dynamic::array;
+    for (id element in json) {
+      array.push_back(convertIdToFollyDynamic(element));
+    }
+    return array;
+  } else if ([json isKindOfClass:[NSDictionary class]]) {
+    __block folly::dynamic object = folly::dynamic::object();
+
+    [json enumerateKeysAndObjectsUsingBlock:^(NSString *key, NSString *value, __unused BOOL *stop) {
+      object.insert(convertIdToFollyDynamic(key), convertIdToFollyDynamic(value));
+    }];
+
+    return object;
+  }
+
+  return nil;
+}
+
+} // namespace facebook::react


### PR DESCRIPTION
Differential Revision: D74804476

move RCTFollyConverter to utils module so it is more accessible and delete RCTCxxUtils (which only held that one file). Also align on naming and drop RCT prefix.