### PR TITLE
Make use of ref-as-prop support in DebuggingOverlay

### DIFF
--- a/packages/react-native/Libraries/Debugging/DebuggingOverlay.js
+++ b/packages/react-native/Libraries/Debugging/DebuggingOverlay.js
@@ -31,10 +31,11 @@ type DebuggingOverlayHandle = {
   clearElementsHighlight(): void,
 };
 
-function DebuggingOverlay(
-  _props: {},
+function DebuggingOverlay({
+  ref,
+}: {
   ref: React.RefSetter<DebuggingOverlayHandle>,
-): React.Node {
+}): React.Node {
   useImperativeHandle(
     ref,
     () => ({
@@ -102,9 +103,6 @@ const styles = StyleSheet.create({
   },
 });
 
-const DebuggingOverlayWithForwardedRef: component(
+export default DebuggingOverlay as component(
   ref: React.RefSetter<DebuggingOverlayHandle>,
-  ...props: {}
-) = React.forwardRef(DebuggingOverlay);
-
-export default DebuggingOverlayWithForwardedRef;
+);

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -4118,11 +4118,7 @@ exports[`public API should not change unintentionally Libraries/Debugging/Debugg
   highlightElements(elements: ElementRectangle[]): void,
   clearElementsHighlight(): void,
 };
-declare const DebuggingOverlayWithForwardedRef: component(
-  ref: React.RefSetter<DebuggingOverlayHandle>,
-  ...props: {}
-);
-declare export default typeof DebuggingOverlayWithForwardedRef;
+declare export default component(ref: React.RefSetter<DebuggingOverlayHandle>);
 "
 `;
 


### PR DESCRIPTION
Summary:
Make use of the React 19 feature so that we can remove the remaining `forwardRef` in react native.

Changelog: [Internal]

Differential Revision: D74808254


