### PR TITLE
Make use of ref-as-prop support in ScrollViewStickyHeader

### DIFF
--- a/packages/react-native/Libraries/Components/ScrollView/ScrollViewStickyHeader.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollViewStickyHeader.js
@@ -36,10 +36,16 @@ interface Instance extends React.ElementRef<typeof Animated.View> {
   +setNextHeaderY: number => void;
 }
 
-const ScrollViewStickyHeaderWithForwardedRef: component(
+const ScrollViewStickyHeader: component(
   ref: React.RefSetter<Instance>,
   ...props: ScrollViewStickyHeaderProps
-) = React.forwardRef(function ScrollViewStickyHeader(props, forwardedRef) {
+) = function ScrollViewStickyHeader({
+  ref: forwardedRef,
+  ...props
+}: {
+  ref?: React.RefSetter<Instance>,
+  ...ScrollViewStickyHeaderProps,
+}) {
   const {
     inverted,
     scrollViewHeight,
@@ -295,7 +301,7 @@ const ScrollViewStickyHeaderWithForwardedRef: component(
       })}
     </Animated.View>
   );
-});
+};
 
 const styles = StyleSheet.create({
   header: {
@@ -306,4 +312,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default ScrollViewStickyHeaderWithForwardedRef;
+export default ScrollViewStickyHeader;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -2213,11 +2213,11 @@ exports[`public API should not change unintentionally Libraries/Components/Scrol
 interface Instance extends React.ElementRef<typeof Animated.View> {
   +setNextHeaderY: (number) => void;
 }
-declare const ScrollViewStickyHeaderWithForwardedRef: component(
+declare const ScrollViewStickyHeader: component(
   ref: React.RefSetter<Instance>,
   ...props: ScrollViewStickyHeaderProps
 );
-declare export default typeof ScrollViewStickyHeaderWithForwardedRef;
+declare export default typeof ScrollViewStickyHeader;
 "
 `;
 


### PR DESCRIPTION
Summary:
Make use of the React 19 feature so that we can remove the remaining `forwardRef` in react native.

Changelog: [Internal]

Differential Revision: D74810588


