### PR TITLE
Make use of ref-as-prop support in ActivityIndicator

### DIFF
--- a/packages/react-native/Libraries/Components/ActivityIndicator/ActivityIndicator.js
+++ b/packages/react-native/Libraries/Components/ActivityIndicator/ActivityIndicator.js
@@ -60,18 +60,22 @@ export type ActivityIndicatorProps = $ReadOnly<{
   size?: ?IndicatorSize,
 }>;
 
-const ActivityIndicator = (
-  {
-    animating = true,
-    color = Platform.OS === 'ios' ? GRAY : null,
-    hidesWhenStopped = true,
-    onLayout,
-    size = 'small',
-    style,
-    ...restProps
-  }: ActivityIndicatorProps,
-  forwardedRef?: any,
-) => {
+const ActivityIndicator: component(
+  ref?: React.RefSetter<HostComponent<empty>>,
+  ...props: ActivityIndicatorProps
+) = ({
+  ref: forwardedRef,
+  animating = true,
+  color = Platform.OS === 'ios' ? GRAY : null,
+  hidesWhenStopped = true,
+  onLayout,
+  size = 'small',
+  style,
+  ...restProps
+}: {
+  ref?: any,
+  ...ActivityIndicatorProps,
+}) => {
   let sizeStyle;
   let sizeProp;
 
@@ -153,11 +157,7 @@ const ActivityIndicator = (
 ```
 */
 
-const ActivityIndicatorWithRef: component(
-  ref?: React.RefSetter<HostComponent<empty>>,
-  ...props: ActivityIndicatorProps
-) = React.forwardRef(ActivityIndicator);
-ActivityIndicatorWithRef.displayName = 'ActivityIndicator';
+ActivityIndicator.displayName = 'ActivityIndicator';
 
 const styles = StyleSheet.create({
   container: {
@@ -174,4 +174,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default ActivityIndicatorWithRef;
+export default ActivityIndicator;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -1485,11 +1485,11 @@ export type ActivityIndicatorProps = $ReadOnly<{
   color?: ?ColorValue,
   size?: ?IndicatorSize,
 }>;
-declare const ActivityIndicatorWithRef: component(
+declare const ActivityIndicator: component(
   ref?: React.RefSetter<HostComponent<empty>>,
   ...props: ActivityIndicatorProps
 );
-declare export default typeof ActivityIndicatorWithRef;
+declare export default typeof ActivityIndicator;
 "
 `;
 


### PR DESCRIPTION
Summary:
Make use of the React 19 feature so that we can remove the remaining `forwardRef` in react native.

Changelog: [Internal]

Differential Revision: D74808564


