### PR TITLE
Add a gradle task to download native 3p dependencies.

### DIFF
--- a/packages/react-native-fantom/download.sh
+++ b/packages/react-native-fantom/download.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -e
+
+pushd ../..
+./gradlew prepareNative3pDependencies
+popd

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -407,6 +407,20 @@ val prepareGlog by
       outputDir.set(File(thirdPartyNdkDir, "glog"))
     }
 
+// Tasks used by Fantom to download the Native 3p dependencies used.
+val prepareNative3pDependencies by
+    tasks.registering {
+      dependsOn(
+          prepareBoost,
+          prepareDoubleConversion,
+          prepareFastFloat,
+          prepareFmt,
+          prepareFolly,
+          prepareGlog,
+          prepareGtest,
+      )
+    }
+
 val prepareKotlinBuildScriptModel by
     tasks.registering {
       // This task is run when Gradle Sync is running.
@@ -572,13 +586,7 @@ android {
       .dependsOn(
           buildCodegenCLI,
           "generateCodegenArtifactsFromSchema",
-          prepareBoost,
-          prepareDoubleConversion,
-          prepareFastFloat,
-          prepareFmt,
-          prepareFolly,
-          prepareGlog,
-          prepareGtest,
+          prepareNative3pDependencies,
           preparePrefab)
   tasks.getByName("generateCodegenSchemaFromJavaScript").dependsOn(buildCodegenCLI)
   prepareKotlinBuildScriptModel.dependsOn("preBuild")


### PR DESCRIPTION
Summary:
This adds a `prepareNative3pDependencies` Gradle task that downloads and prepares all the 3p dependecies.
This will be needed before we download native deps for Fantom.

Changelog:
[Internal] [Changed] -

Differential Revision: D74812436


