### PR TITLE
Make use of ref-as-prop support in examples

### DIFF
--- a/packages/rn-tester/js/examples/FlatList/BaseFlatListExample.js
+++ b/packages/rn-tester/js/examples/FlatList/BaseFlatListExample.js
@@ -70,42 +70,39 @@ type Props = $ReadOnly<{
 const BaseFlatListExample: component(
   ref: React.RefSetter<FlatList<string>>,
   ...props: Props
-) = React.forwardRef(
-  // $FlowFixMe[incompatible-call]
-  (props: Props, ref) => {
-    return (
-      <View style={styles.container}>
-        {props.testOutput != null ? (
-          <View testID="test_container" style={styles.testContainer}>
-            <Text style={styles.output} numberOfLines={1} testID="output">
-              {props.testOutput}
-            </Text>
-            {props.onTest != null ? (
-              <Button
-                testID="start_test"
-                onPress={props.onTest}
-                title={props.testLabel ?? 'Test'}
-              />
-            ) : null}
-          </View>
-        ) : null}
-        {props.children}
-        <FlatList
-          {...props.exampleProps}
-          // $FlowFixMe[incompatible-type]
-          ref={ref}
-          testID="flat_list"
-          // $FlowFixMe[incompatible-type]
-          data={DATA}
-          keyExtractor={(item, index) => item + index}
-          style={styles.list}
-          // $FlowFixMe[incompatible-type-arg]
-          renderItem={Item}
-        />
-      </View>
-    );
-  },
-);
+) = ({ref, ...props}: {ref: React.RefSetter<FlatList<string>>, ...Props}) => {
+  return (
+    <View style={styles.container}>
+      {props.testOutput != null ? (
+        <View testID="test_container" style={styles.testContainer}>
+          <Text style={styles.output} numberOfLines={1} testID="output">
+            {props.testOutput}
+          </Text>
+          {props.onTest != null ? (
+            <Button
+              testID="start_test"
+              onPress={props.onTest}
+              title={props.testLabel ?? 'Test'}
+            />
+          ) : null}
+        </View>
+      ) : null}
+      {props.children}
+      <FlatList
+        {...props.exampleProps}
+        // $FlowFixMe[incompatible-type]
+        ref={ref}
+        testID="flat_list"
+        // $FlowFixMe[incompatible-type]
+        data={DATA}
+        keyExtractor={(item, index) => item + index}
+        style={styles.list}
+        // $FlowFixMe[incompatible-type-arg]
+        renderItem={Item}
+      />
+    </View>
+  );
+};
 
 export default BaseFlatListExample;
 

--- a/packages/rn-tester/js/examples/SectionList/SectionListBaseExample.js
+++ b/packages/rn-tester/js/examples/SectionList/SectionListBaseExample.js
@@ -77,7 +77,14 @@ const SectionListBaseExample: component(
   // $FlowIgnore[unclear-type]
   ref: React.RefSetter<SectionList<any>>,
   ...props: Props
-) = React.forwardRef((props: Props, ref): React.Node => {
+) = ({
+  ref,
+  ...props
+}: {
+  // $FlowIgnore[unclear-type]
+  ref: React.RefSetter<SectionList<any>>,
+  ...Props,
+}): React.Node => {
   return (
     <View style={styles.container}>
       {props.testOutput != null ? (
@@ -112,7 +119,7 @@ const SectionListBaseExample: component(
       />
     </View>
   );
-});
+};
 
 const styles = StyleSheet.create({
   item: {

--- a/packages/rn-tester/js/examples/TextInput/ExampleTextInput.js
+++ b/packages/rn-tester/js/examples/TextInput/ExampleTextInput.js
@@ -10,13 +10,19 @@
  */
 
 import {RNTesterThemeContext} from '../../components/RNTesterTheme';
-import React, {forwardRef, useContext} from 'react';
+import React, {useContext} from 'react';
 import {StyleSheet, TextInput} from 'react-native';
 
 const ExampleTextInput: component(
   ref: React.RefSetter<null | React.ElementRef<typeof TextInput>>,
   ...props: React.ElementConfig<typeof TextInput>
-) = forwardRef((props, ref) => {
+) = ({
+  ref,
+  ...props
+}: {
+  ref?: React.RefSetter<null | React.ElementRef<typeof TextInput>>,
+  ...React.ElementConfig<typeof TextInput>,
+}) => {
   const theme = useContext(RNTesterThemeContext);
 
   return (
@@ -34,7 +40,7 @@ const ExampleTextInput: component(
       ]}
     />
   );
-});
+};
 
 const styles = StyleSheet.create({
   input: {


### PR DESCRIPTION
Summary:
Make use of the React 19 feature so that we can remove the remaining `forwardRef` in react native.

Changelog: [Internal]

Differential Revision: D74812747


