### PR TITLE
Make use of ref-as-prop support in ProgressBarAndroid

### DIFF
--- a/packages/react-native/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.android.js
+++ b/packages/react-native/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.android.js
@@ -39,23 +39,24 @@ export type {ProgressBarAndroidProps};
  * },
  * ```
  */
-const ProgressBarAndroidWithForwardedRef: component(
+const ProgressBarAndroid: component(
   ref?: React.RefSetter<
     React.ElementRef<typeof ProgressBarAndroidNativeComponent>,
   >,
   ...props: ProgressBarAndroidProps
-) = React.forwardRef(function ProgressBarAndroid(
-  {
-    // $FlowFixMe[incompatible-type]
-    styleAttr = 'Normal',
-    indeterminate = true,
-    animating = true,
-    ...restProps
-  }: ProgressBarAndroidProps,
-  forwardedRef: ?React.RefSetter<
+) = function ProgressBarAndroid({
+  ref: forwardedRef,
+  // $FlowFixMe[incompatible-type]
+  styleAttr = 'Normal',
+  indeterminate = true,
+  animating = true,
+  ...restProps
+}: {
+  ref?: React.RefSetter<
     React.ElementRef<typeof ProgressBarAndroidNativeComponent>,
   >,
-) {
+  ...ProgressBarAndroidProps,
+}) {
   return (
     <ProgressBarAndroidNativeComponent
       styleAttr={styleAttr}
@@ -65,6 +66,6 @@ const ProgressBarAndroidWithForwardedRef: component(
       ref={forwardedRef}
     />
   );
-});
+};
 
-export default ProgressBarAndroidWithForwardedRef;
+export default ProgressBarAndroid;


### PR DESCRIPTION
Summary:
Make use of the React 19 feature so that we can remove the remaining `forwardRef` in react native.

Changelog: [Internal]

Differential Revision: D74814465


