### PR TITLE
Use methodSignatureForSelector instead of instanceMethodSignatureForSelector

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
@@ -686,7 +686,7 @@ NSInvocation *ObjCTurboModule::createMethodInvocation(
     NSMutableArray *retainedObjectsForInvocation)
 {
   const char *moduleName = name_.c_str();
-  const id<RCTBridgeModule> module = instance_;
+  const NSObject<RCTBridgeModule> *module = instance_;
 
   if (isSync) {
     TurboModulePerfLogger::syncMethodCallArgConversionStart(moduleName, methodName);
@@ -694,11 +694,9 @@ NSInvocation *ObjCTurboModule::createMethodInvocation(
     TurboModulePerfLogger::asyncMethodCallArgConversionStart(moduleName, methodName);
   }
 
-  NSInvocation *inv =
-      [NSInvocation invocationWithMethodSignature:[[module class] instanceMethodSignatureForSelector:selector]];
+  NSMethodSignature *methodSignature = [module methodSignatureForSelector:selector];
+  NSInvocation *inv = [NSInvocation invocationWithMethodSignature:methodSignature];
   [inv setSelector:selector];
-
-  NSMethodSignature *methodSignature = [[module class] instanceMethodSignatureForSelector:selector];
 
   for (size_t i = 0; i < count; i++) {
     const jsi::Value &arg = args[i];


### PR DESCRIPTION
Summary:
We inherited this from the legacy native module infra, where we didn't have access to the module instance. Instead we can use the simpler `methodSignatureForSelector` which works correctly with OCMock (needed in D74815079).

Changelog: [Internal]

Differential Revision: D74817191


