### PR TITLE
Make use of ref-as-prop support in Animated

### DIFF
--- a/packages/react-native/Libraries/Animated/components/AnimatedScrollView.js
+++ b/packages/react-native/Libraries/Animated/components/AnimatedScrollView.js
@@ -9,7 +9,10 @@
  */
 
 import type {____ViewStyle_Internal} from '../../StyleSheet/StyleSheetTypes';
-import type {AnimatedComponentType} from '../createAnimatedComponent';
+import type {
+  AnimatedComponentType,
+  AnimatedProps,
+} from '../createAnimatedComponent';
 
 import RefreshControl from '../../Components/RefreshControl/RefreshControl';
 import ScrollView from '../../Components/ScrollView/ScrollView';
@@ -32,55 +35,54 @@ type AnimatedScrollViewInstance = React.ElementRef<typeof ScrollView>;
 const AnimatedScrollView: AnimatedComponentType<
   AnimatedScrollViewProps,
   AnimatedScrollViewInstance,
-> = React.forwardRef(
-  function AnimatedScrollViewWithOrWithoutInvertedRefreshControl(
-    props,
-    forwardedRef,
+> = function AnimatedScrollViewWithOrWithoutInvertedRefreshControl({
+  ref: forwardedRef,
+  ...props
+}: {
+  ref?: React.RefSetter<AnimatedScrollViewInstance>,
+  ...AnimatedProps<AnimatedScrollViewProps>,
+}) {
+  // (Android only) When a ScrollView has a RefreshControl and
+  // any `style` property set with an Animated.Value, the CSS
+  // gets incorrectly applied twice. This is because ScrollView
+  // swaps the parent/child relationship of itself and the
+  // RefreshControl component (see ScrollView.js for more details).
+  if (
+    Platform.OS === 'android' &&
+    props.refreshControl != null &&
+    props.style != null
   ) {
-    // (Android only) When a ScrollView has a RefreshControl and
-    // any `style` property set with an Animated.Value, the CSS
-    // gets incorrectly applied twice. This is because ScrollView
-    // swaps the parent/child relationship of itself and the
-    // RefreshControl component (see ScrollView.js for more details).
-    if (
-      Platform.OS === 'android' &&
-      props.refreshControl != null &&
-      props.style != null
-    ) {
-      return (
-        // $FlowFixMe - It should return an Animated ScrollView but it returns a ScrollView with Animated props applied.
-        <AnimatedScrollViewWithInvertedRefreshControl
-          scrollEventThrottle={0.0001}
-          {...props}
-          ref={forwardedRef}
-          // $FlowFixMe[incompatible-type]
-          refreshControl={props.refreshControl}
-        />
-      );
-    } else {
-      return (
-        <AnimatedScrollViewWithoutInvertedRefreshControl
-          scrollEventThrottle={0.0001}
-          {...props}
-          ref={forwardedRef}
-        />
-      );
-    }
-  },
-);
+    return (
+      // $FlowFixMe - It should return an Animated ScrollView but it returns a ScrollView with Animated props applied.
+      <AnimatedScrollViewWithInvertedRefreshControl
+        scrollEventThrottle={0.0001}
+        {...props}
+        ref={forwardedRef}
+        // $FlowFixMe[incompatible-type]
+        refreshControl={props.refreshControl}
+      />
+    );
+  } else {
+    return (
+      <AnimatedScrollViewWithoutInvertedRefreshControl
+        scrollEventThrottle={0.0001}
+        {...props}
+        ref={forwardedRef}
+      />
+    );
+  }
+};
 
-const AnimatedScrollViewWithInvertedRefreshControl = React.forwardRef(
-  // $FlowFixMe[incompatible-call]
-  function AnimatedScrollViewWithInvertedRefreshControl(
-    props: {
-      ...React.ElementConfig<typeof ScrollView>,
-      // $FlowFixMe[unclear-type] Same Flow type as `refreshControl` in ScrollView
-      refreshControl: ExactReactElement_DEPRECATED<any>,
-    },
-    forwardedRef:
-      | {current: AnimatedScrollViewInstance | null, ...}
-      | ((AnimatedScrollViewInstance | null) => mixed),
-  ) {
+const AnimatedScrollViewWithInvertedRefreshControl =
+  function AnimatedScrollViewWithInvertedRefreshControl({
+    ref: forwardedRef,
+    ...props
+  }: {
+    ref?: React.RefSetter<AnimatedScrollViewInstance>,
+    ...React.ElementConfig<typeof ScrollView>,
+    // $FlowFixMe[unclear-type] Same Flow type as `refreshControl` in ScrollView
+    refreshControl: ExactReactElement_DEPRECATED<any>,
+  }) {
     // Split `props` into the animate-able props for the parent (RefreshControl)
     // and child (ScrollView).
     const {intermediatePropsForRefreshControl, intermediatePropsForScrollView} =
@@ -134,8 +136,7 @@ const AnimatedScrollViewWithInvertedRefreshControl = React.forwardRef(
         )}
       />
     );
-  },
-);
+  };
 
 const AnimatedScrollViewWithoutInvertedRefreshControl =
   createAnimatedComponent(ScrollView);

--- a/packages/react-native/Libraries/Animated/createAnimatedComponent.js
+++ b/packages/react-native/Libraries/Animated/createAnimatedComponent.js
@@ -105,41 +105,45 @@ export function unstable_createAnimatedComponentWithAllowlist<
   const AnimatedComponent: AnimatedComponentType<
     TProps,
     React.ElementRef<TInstance>,
-  > = React.forwardRef<AnimatedProps<TProps>, React.ElementRef<TInstance>>(
-    (props, forwardedRef) => {
-      const [reducedProps, callbackRef] = useAnimatedProps<
-        TProps,
-        React.ElementRef<TInstance>,
-      >(props);
-      const ref = useMergeRefs<React.ElementRef<TInstance>>(
-        callbackRef,
-        forwardedRef,
-      );
+  > = ({
+    ref: forwardedRef,
+    ...props
+  }: {
+    ref?: React.RefSetter<React.ElementRef<TInstance>>,
+    ...AnimatedProps<TProps>,
+  }) => {
+    const [reducedProps, callbackRef] = useAnimatedProps<
+      TProps,
+      React.ElementRef<TInstance>,
+    >(props);
+    const ref = useMergeRefs<React.ElementRef<TInstance>>(
+      callbackRef,
+      forwardedRef,
+    );
 
-      // Some components require explicit passthrough values for animation
-      // to work properly. For example, if an animated component is
-      // transformed and Pressable, onPress will not work after transform
-      // without these passthrough values.
-      // $FlowFixMe[prop-missing]
-      const {passthroughAnimatedPropExplicitValues, style} = reducedProps;
-      const passthroughStyle = passthroughAnimatedPropExplicitValues?.style;
-      const mergedStyle = useMemo(
-        () => composeStyles(style, passthroughStyle),
-        [passthroughStyle, style],
-      );
+    // Some components require explicit passthrough values for animation
+    // to work properly. For example, if an animated component is
+    // transformed and Pressable, onPress will not work after transform
+    // without these passthrough values.
+    // $FlowFixMe[prop-missing]
+    const {passthroughAnimatedPropExplicitValues, style} = reducedProps;
+    const passthroughStyle = passthroughAnimatedPropExplicitValues?.style;
+    const mergedStyle = useMemo(
+      () => composeStyles(style, passthroughStyle),
+      [passthroughStyle, style],
+    );
 
-      // NOTE: It is important that `passthroughAnimatedPropExplicitValues` is
-      // spread after `reducedProps` but before `style`.
-      return (
-        <Component
-          {...reducedProps}
-          {...passthroughAnimatedPropExplicitValues}
-          style={mergedStyle}
-          ref={ref}
-        />
-      );
-    },
-  );
+    // NOTE: It is important that `passthroughAnimatedPropExplicitValues` is
+    // spread after `reducedProps` but before `style`.
+    return (
+      <Component
+        {...reducedProps}
+        {...passthroughAnimatedPropExplicitValues}
+        style={mergedStyle}
+        ref={ref}
+      />
+    );
+  };
 
   AnimatedComponent.displayName = `Animated(${
     Component.displayName || 'Anonymous'


### PR DESCRIPTION
Summary:
Make use of the React 19 feature so that we can remove the remaining `forwardRef` in react native.

Changelog: [Internal]

Differential Revision: D74815987


