### PR TITLE
Remove unused `forwardRef` import in `SectionListModern`

### DIFF
--- a/packages/react-native/Libraries/Lists/SectionListModern.js
+++ b/packages/react-native/Libraries/Lists/SectionListModern.js
@@ -21,7 +21,7 @@ import type {
 import Platform from '../Utilities/Platform';
 import VirtualizedLists from '@react-native/virtualized-lists';
 import * as React from 'react';
-import {forwardRef, useImperativeHandle, useRef} from 'react';
+import {useImperativeHandle, useRef} from 'react';
 
 const VirtualizedSectionList = VirtualizedLists.VirtualizedSectionList;
 


### PR DESCRIPTION
Summary:
Followup of https://github.com/facebook/react-native/pull/51360

Changelog: [Internal]

Reviewed By: marcoww6

Differential Revision: D74825642


