### PR TITLE
[iOS][prebuild] fix hermes nightly download

### DIFF
--- a/packages/react-native/Package.swift
+++ b/packages/react-native/Package.swift
@@ -38,13 +38,15 @@ class RNTarget: BaseTarget {
   let dependencies: [String]
   let sources: [String]?
   let publicHeadersPath: String?
+  let defines: [CXXSetting]
 
-  init(name: String, path: String, searchPaths: [String] = [], linkedFrameworks: [String] = [], excludedPaths: [String] = [], dependencies: [String] = [], sources: [String]? = nil, publicHeadersPath: String? = ".") {
+  init(name: String, path: String, searchPaths: [String] = [], linkedFrameworks: [String] = [], excludedPaths: [String] = [], dependencies: [String] = [], sources: [String]? = nil, publicHeadersPath: String? = ".", defines: [CXXSetting] = []) {
     self.linkedFrameworks = linkedFrameworks
     self.excludedPaths = excludedPaths
     self.dependencies = dependencies
     self.sources = sources
     self.publicHeadersPath = publicHeadersPath
+    self.defines = defines
 
     super.init(name: name, path: path, searchPaths: searchPaths)
   }
@@ -65,7 +67,8 @@ class RNTarget: BaseTarget {
       dependencies: self.dependencies,
       sources: self.sources,
       publicHeadersPath: self.publicHeadersPath,
-      linkerSettings: linkerSettings
+      linkerSettings: linkerSettings,
+      defines: self.defines
     )
   }
 }
@@ -165,7 +168,11 @@ let reactJsInspectorNetwork = RNTarget(
   name: .reactJsInspectorNetwork,
   path: "ReactCommon/jsinspector-modern/network",
   searchPaths: ["ReactCommon", RuntimeExecutorPath],
-  dependencies: [.reactNativeDependencies]
+  dependencies: [.reactNativeDependencies],
+  defines: [
+    CXXSetting.define("REACT_NATIVE_DEBUGGER_ENABLED", to: "1", .when(configuration: BuildConfiguration.debug)),
+    CXXSetting.define("REACT_NATIVE_DEBUGGER_ENABLED_DEVONLY", to: "1", .when(configuration: BuildConfiguration.debug)),
+  ]
 )
 
 let reactJsInspector = RNTarget(
@@ -173,7 +180,11 @@ let reactJsInspector = RNTarget(
   path: "ReactCommon/jsinspector-modern",
   searchPaths: ["ReactCommon", RuntimeExecutorPath],
   excludedPaths: ["tracing", "network", "tests"],
-  dependencies: [.reactNativeDependencies, .reactFeatureFlags, .jsi, .reactJsInspectorTracing, .reactJsInspectorNetwork]
+  dependencies: [.reactNativeDependencies, .reactFeatureFlags, .jsi, .reactJsInspectorTracing, .reactJsInspectorNetwork],
+  defines: [
+    CXXSetting.define("REACT_NATIVE_DEBUGGER_ENABLED", to: "1", .when(configuration: BuildConfiguration.debug)),
+    CXXSetting.define("REACT_NATIVE_DEBUGGER_ENABLED_DEVONLY", to: "1", .when(configuration: BuildConfiguration.debug)),
+  ]
 )
 
 let reactCxxReact = RNTarget(
@@ -203,7 +214,10 @@ let reactHermes = RNTarget(
   path: "ReactCommon/hermes",
   searchPaths: ["ReactCommon", RuntimeExecutorPath],
   excludedPaths: ["inspector-modern/chrome/tests"],
-  dependencies: [.reactNativeDependencies, .reactCxxReact, .reactJsiExecutor, .reactJsInspector, .reactJsInspectorTracing, .reactPerfLogger, .hermesPrebuilt, .jsi]
+  dependencies: [.reactNativeDependencies, .reactCxxReact, .reactJsiExecutor, .reactJsInspector, .reactJsInspectorTracing, .reactPerfLogger, .hermesPrebuilt, .jsi],
+  defines: [
+    CXXSetting.define("HERMES_ENABLE_DEBUGGER", to: "1", .when(configuration: BuildConfiguration.debug))
+  ]
 )
 
 let reactPerformanceTimeline = RNTarget(
@@ -648,7 +662,8 @@ extension Target {
     dependencies: [String] = [],
     sources: [String]? = nil,
     publicHeadersPath: String? = ".",
-    linkerSettings: [LinkerSetting] = []
+    linkerSettings: [LinkerSetting] = [],
+    defines: [CXXSetting] = []
   ) -> Target {
     let dependencies = dependencies.map { Dependency.byNameItem(name: $0, condition: nil) }
     let excludes = excludedPaths
@@ -666,10 +681,9 @@ extension Target {
       [
         .unsafeFlags(["-std=c++20"]),
         .define("DEBUG", .when(configuration: .debug)),
-        .define("USE_HERMES", to: "1"),
-        // TODO: T223727527 Why doesn't it pick up this when DEBUG is set??
-        .define("RCT_ENABLE_INSPECTOR", to: "1", .when(configuration: .debug)),
-      ] + cxxCommonHeaderPaths
+        .define("NDEBUG", .when(configuration: .release)),
+        .define("USE_HERMES", to: "1")
+      ] + defines + cxxCommonHeaderPaths
 
     return .target(
       name: name,

--- a/packages/react-native/scripts/ios-prebuild.js
+++ b/packages/react-native/scripts/ios-prebuild.js
@@ -12,7 +12,6 @@
 const {prepareHermesArtifactsAsync} = require('./ios-prebuild/hermes');
 const {
   createFolderIfNotExists,
-  prebuild_log,
   throwIfOnEden,
 } = require('./ios-prebuild/utils');
 const {execSync} = require('child_process');
@@ -29,8 +28,8 @@ const packageJsonPath = path.join(
 const {version: currentVersion} = require(packageJsonPath);
 
 async function main() {
-  prebuild_log('Prebuilding React Native iOS...');
-  prebuild_log('');
+  console.log('Prebuilding React Native iOS...');
+  console.log('');
 
   throwIfOnEden();
 
@@ -58,10 +57,9 @@ async function main() {
     const link = (fromPath /*:string*/, includePath /*:string*/) => {
       const source = path.resolve(root, fromPath);
       const target = path.resolve(linksFolder, includePath);
+      console.log(`Linking ${source} to ${target}...`);
 
       createFolderIfNotExists(target);
-
-      let copiedFiles = 0;
 
       // get subfolders in source - make sure we only copy folders with header files
       const entries = fs.readdirSync(source, {withFileTypes: true});
@@ -85,7 +83,6 @@ async function main() {
             }
             try {
               fs.linkSync(sourceFile, targetFile);
-              copiedFiles++;
             } catch (e) {
               console.error(
                 `Failed to create link for ${sourceFile} to ${targetFile}: ${e}`,
@@ -93,10 +90,6 @@ async function main() {
             }
           }
         });
-      }
-
-      if (copiedFiles > 0) {
-        prebuild_log(`Linking ${source} to ${target}...`);
       }
 
       const subfolders = entries
@@ -118,16 +111,15 @@ async function main() {
     );
 
     // CODEGEN
-    prebuild_log('Running codegen...');
+    console.log('Running codegen...');
     const codegenPath = path.join(root, '.build/codegen');
     createFolderIfNotExists(codegenPath);
 
     const command = `node scripts/generate-codegen-artifacts -p "${root}" -o "${codegenPath}"  -t ios`;
-    prebuild_log(command);
+    console.log(command);
     execSync(command, {stdio: 'inherit'});
 
     // LINKING
-    prebuild_log('Linking header files...');
     link('Libraries/WebSocket/', 'React');
     link('React/Base', 'React');
     link('React/Base/Surface', 'React');
@@ -169,7 +161,7 @@ async function main() {
     );
 
     // Done!
-    prebuild_log('🏁 Done!');
+    console.log('🏁 Done!');
   } catch (err) {
     console.error(err);
     process.exitCode = 1;

--- a/packages/react-native/scripts/ios-prebuild.js
+++ b/packages/react-native/scripts/ios-prebuild.js
@@ -110,11 +110,7 @@ async function main() {
     };
 
     // HERMES ARTIFACTS
-    await prepareHermesArtifactsAsync(
-      currentVersion,
-      'release',
-      REACT_NATIVE_PACKAGE_ROOT_FOLDER,
-    );
+    await prepareHermesArtifactsAsync(currentVersion, 'debug');
 
     // CODEGEN
     const codegenPath = path.join(root, '.build/codegen');

--- a/packages/react-native/scripts/ios-prebuild/hermes.js
+++ b/packages/react-native/scripts/ios-prebuild/hermes.js
@@ -13,10 +13,23 @@ const {execSync} = require('child_process');
 const fs = require('fs');
 const path = require('path');
 
+/**
+ * Downloads hermes artifacts from the specified version and build type. If you want to specify a specific
+ * version of hermes, use the HERMES_VERSION environment variable. The path to the artifacts will be inside
+ * the .build/artifacts/hermes folder, but this can be overridden by setting the HERMES_ENGINE_TARBALL_PATH
+ * environment variable. If this varuable is set, the script will use the local tarball instead of downloading it.
+ * @param {*} version
+ * @param {*} buildType
+ * @returns
+ */
 async function prepareHermesArtifactsAsync(
   version /*:string*/,
   buildType /*:string*/,
+  reactNativePath /*:string*/,
 ) /*: Promise<string> */ {
+  const resolved_version = process.env.HERMES_VERSION ?? version;
+  hermes_log(`Preparing Hermes v.${resolved_version}...`);
+
   // Check if the Hermes artifacts are already downloaded
   const artifactsPath /*: string*/ = path.resolve(
     process.cwd(),
@@ -24,64 +37,278 @@ async function prepareHermesArtifactsAsync(
     'artifacts',
     'hermes',
   );
-  if (fs.existsSync(artifactsPath)) {
-    return artifactsPath;
+
+  fs.mkdirSync(artifactsPath, {recursive: true});
+
+  let local_path = process.env.HERMES_ENGINE_TARBALL_PATH ?? '';
+
+  // Only check if the artifacts folder exists if we are not using a local tarball
+  if (!local_path) {
+    if (fs.existsSync(artifactsPath)) {
+      // Check hermes version file
+      const versionFilePath = path.join(artifactsPath, 'version.txt');
+      if (fs.existsSync(versionFilePath)) {
+        const versionFileContent = fs.readFileSync(versionFilePath, 'utf8');
+        if (versionFileContent.trim() === resolved_version) {
+          hermes_log(
+            `Hermes artifacts already downloaded and up to date: ${artifactsPath}`,
+          );
+          return artifactsPath;
+        }
+      }
+      // If the version file does not exist or the version does not match, delete the artifacts folder
+      fs.rmSync(artifactsPath, {recursive: true, force: true});
+      hermes_log(
+        `Hermes artifacts folder already exists, but version does not match. Deleting: ${artifactsPath}`,
+      );
+      // Lets create the veresion.txt file
+      fs.mkdirSync(artifactsPath, {recursive: true});
+      fs.writeFileSync(versionFilePath, resolved_version, 'utf8');
+      hermes_log(
+        `Hermes artifacts folder created: ${artifactsPath} with version: ${resolved_version}`,
+      );
+    }
+
+    const sourceType = hermesSourceType(resolved_version, reactNativePath);
+    local_path = resolve_source_type(
+      sourceType,
+      resolved_version,
+      reactNativePath,
+      artifactsPath,
+    );
+  } else {
+    hermes_log('Using local tarball, skipping artifacts folder check');
   }
 
-  // Download the Hermes artifacts
-  const url = getHermesArtifactsUrl(version, buildType);
-  console.log(`Downloading Hermes artifacts from ${url}...`);
+  // Extract the tar.gz
+  execSync(`tar -xzf "${local_path}" -C "${artifactsPath}"`, {
+    stdio: 'inherit',
+  });
 
-  // download the file pointed to by the URL and store it in the ./.build/artifacts folder on disk
-  await downloadAndExtract(url, artifactsPath);
+  // Delete the tarball after extraction
+  if (!process.env.HERMES_ENGINE_TARBALL_PATH) {
+    fs.unlinkSync(local_path);
+  }
+
   return artifactsPath;
 }
 
-async function downloadAndExtract(url /*:string*/, targetFolder /*:string*/) {
-  const buildDir = path.resolve('.build', 'artifacts');
-  const tarballPath = path.join(buildDir, 'artifact.tar.gz');
+/*::
+type HermesEngineSourceTypeT =
+  | 'local_prebuilt_tarball'
+  | 'download_prebuild_release_tarball'
+  | 'download_prebuilt_nightly_tarball'
+  | 'build_from_github_commit'
+  | 'build_from_github_tag'
+  | 'build_from_github_main'
+  | 'build_from_local_source_dir';
 
-  // Ensure build directory exists
-  fs.mkdirSync(targetFolder, {recursive: true});
+*/
 
-  console.log(`Downloading file from ${url} to ${tarballPath}...`);
+const HermesEngineSourceType = {
+  LOCAL_PREBUILT_TARBALL: 'local_prebuilt_tarball',
+  DOWNLOAD_PREBUILD_RELEASE_TARBALL: 'download_prebuild_release_tarball',
+  DOWNLOAD_PREBUILT_NIGHTLY_TARBALL: 'download_prebuilt_nightly_tarball',
+};
 
+function hermesEngineTarballEnvvarDefined() /*: boolean */ {
+  return !!process.env.HERMES_ENGINE_TARBALL_PATH;
+}
+
+function releaseTarballUrl(
+  version /*: string */,
+  buildType /*: 'debug' | 'release' */,
+) /*: string */ {
+  const mavenRepoUrl = 'https://repo1.maven.org/maven2';
+  const namespace = 'com/facebook/react';
+  return `${mavenRepoUrl}/${namespace}/react-native-artifacts/${version}/react-native-artifacts-${version}-hermes-ios-${buildType}.tar.gz`;
+}
+
+function nightlyTarballUrl(version /*: string */) /*: string */ {
+  const params = `r=snapshots&g=com.facebook.react&a=react-native-artifacts&c=hermes-ios-debug&e=tar.gz&v=${version}-SNAPSHOT`;
+  return resolveUrlRedirects(
+    `http://oss.sonatype.org/service/local/artifact/maven/redirect?${params}`,
+  );
+}
+
+function resolveUrlRedirects(url /*: string */) /*: string */ {
+  // Synchronously resolve the final URL after redirects using curl
   try {
-    // Download the file using curl via execSync
-    execSync(`curl -L "${url}" -o "${tarballPath}"`, {stdio: 'inherit'});
-
-    console.log('Download complete. Extracting...');
-
-    // Extract the tar.gz using execSync
-    execSync(`tar -xzf "${tarballPath}" -C "${targetFolder}"`, {
-      stdio: 'inherit',
-    });
-
-    // Delete the tarball after extraction
-    fs.unlinkSync(tarballPath);
-
-    console.log('Download and extraction complete.');
-  } catch (error) {
-    if (fs.existsSync(tarballPath)) {
-      fs.unlinkSync(tarballPath);
-    }
-    throw new Error(`Failed to download or extract: ${error.message}`);
+    return execSync(`curl -Ls -o /dev/null -w '%{url_effective}' "${url}"`)
+      .toString()
+      .trim();
+  } catch (e) {
+    hermes_log(`Failed to resolve URL redirects\n${e}`, 'error');
+    return url;
   }
 }
 
-function getHermesArtifactsUrl(
-  version /*:string*/,
-  buildType /*:string*/,
-) /*:string*/ {
-  // Define the URL for the Hermes artifacts
-  // The URL format is:
-  // https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/<version>/react-native-artifacts-<version>-hermes-ios-<buildType>.tar.gz
-  // where <version> is the version of React Native and <buildType> is the build type (e.g., "debug" or "release")
-  // The Maven repository URL and namespace
-  // are hardcoded for simplicity, but they could be parameterized if needed
-  const maven_repo_url = 'https://repo1.maven.org/maven2';
-  const namespace = 'com/facebook/react';
-  return `${maven_repo_url}/${namespace}/react-native-artifacts/${version}/react-native-artifacts-${version}-hermes-ios-${buildType}.tar.gz`;
+function hermesArtifactExists(tarballUrl /*: string */) /*: boolean */ {
+  try {
+    const code = execSync(
+      `curl -o /dev/null --silent -Iw '%{http_code}' -L "${tarballUrl}"`,
+    )
+      .toString()
+      .trim();
+    return code === '200';
+  } catch (e) {
+    return false;
+  }
+}
+
+function releaseArtifactExists(version /*: string */) /*: boolean */ {
+  return hermesArtifactExists(releaseTarballUrl(version, 'debug'));
+}
+
+function nightlyArtifactExists(version /*: string */) /*: boolean */ {
+  return hermesArtifactExists(nightlyTarballUrl(version).replace(/\\/g, ''));
+}
+
+function hermesSourceType(
+  version /*: string */,
+  reactNativePath /*: string */,
+) /*: HermesEngineSourceTypeT */ {
+  if (hermesEngineTarballEnvvarDefined()) {
+    hermes_log('Using local prebuild tarball');
+    return HermesEngineSourceType.LOCAL_PREBUILT_TARBALL;
+  }
+  if (releaseArtifactExists(version)) {
+    hermes_log('Using download prebuild release tarball');
+    return HermesEngineSourceType.DOWNLOAD_PREBUILD_RELEASE_TARBALL;
+  }
+  if (nightlyArtifactExists(version)) {
+    hermes_log('Using download prebuild nightly tarball');
+    return HermesEngineSourceType.DOWNLOAD_PREBUILT_NIGHTLY_TARBALL;
+  }
+  //return HermesEngineSourceType.BUILD_FROM_GITHUB_MAIN;
+  hermes_log(
+    'Using download prebuild nightly tarball - this is a fallback and might not work.',
+  );
+  return HermesEngineSourceType.DOWNLOAD_PREBUILT_NIGHTLY_TARBALL;
+}
+
+function resolve_source_type(
+  sourceType /*: HermesEngineSourceTypeT */,
+  version /*: string */,
+  reactNativePath /*: string */,
+  artifactsPath /*: string*/,
+) /*: string */ {
+  switch (sourceType) {
+    case HermesEngineSourceType.LOCAL_PREBUILT_TARBALL:
+      return local_prebuilt_tarball(artifactsPath);
+    case HermesEngineSourceType.DOWNLOAD_PREBUILD_RELEASE_TARBALL:
+      return _download_prebuild_release_tarball(
+        reactNativePath,
+        version,
+        artifactsPath,
+      );
+    case HermesEngineSourceType.DOWNLOAD_PREBUILT_NIGHTLY_TARBALL:
+      return _download_prebuilt_nightly_tarball(version, artifactsPath);
+    default:
+      abort(
+        `[Hermes] Unsupported or invalid source type provided: ${sourceType}`,
+      );
+      return '';
+  }
+}
+
+function local_prebuilt_tarball(artifactsPath /*: string*/) /*: string */ {
+  const tarballPath = process.env.HERMES_ENGINE_TARBALL_PATH;
+  if (tarballPath && fs.existsSync(tarballPath)) {
+    hermes_log(
+      `Using pre-built binary from local path defined by HERMES_ENGINE_TARBALL_PATH envvar: ${tarballPath}`,
+    );
+    return `file://${tarballPath}`;
+  }
+  abort(
+    `[Hermes] HERMES_ENGINE_TARBALL_PATH is set, but points to a non-existing file: "${tarballPath ?? 'unknown'}"\nIf you don't want to use tarball, run 'unset HERMES_ENGINE_TARBALL_PATH'`,
+  );
+  return '';
+}
+
+function _download_prebuild_release_tarball(
+  reactNativePath /*: string */,
+  version /*: string */,
+  artifactsPath /*: string*/,
+) /*: string */ {
+  const url = releaseTarballUrl(version, 'debug');
+  hermes_log(`Using release tarball from URL: ${url}`);
+  return download_stable_hermes(
+    reactNativePath,
+    version,
+    'release',
+    artifactsPath,
+  );
+}
+
+function _download_prebuilt_nightly_tarball(
+  version /*: string */,
+  artifactsPath /*: string*/,
+) /*: string */ {
+  const url = nightlyTarballUrl(version);
+  hermes_log(`Using nightly tarball from URL: ${url}`);
+  return download_stable_hermes('', version, 'release', artifactsPath);
+}
+
+function download_stable_hermes(
+  reactNativePath /*: string */,
+  version /*: string */,
+  buildType /*: 'debug' | 'release' */,
+  artifactsPath /*: string */,
+) /*: string */ {
+  const tarballUrl = releaseTarballUrl(version, buildType);
+  return download_hermes_tarball(
+    reactNativePath,
+    tarballUrl,
+    version,
+    buildType,
+    artifactsPath,
+  );
+}
+
+function download_hermes_tarball(
+  reactNativePath /*: string */,
+  tarballUrl /*: string */,
+  version /*: string */,
+  configuration /*: string */,
+  artifactsPath /*: string */,
+) /*: string */ {
+  const destPath = configuration
+    ? `${artifactsPath}/hermes-ios-${version}-${configuration}.tar.gz`
+    : `${artifactsPath}/hermes-ios-${version}.tar.gz`;
+  if (!fs.existsSync(destPath)) {
+    const tmpFile = `${artifactsPath}/hermes-ios.download`;
+    try {
+      fs.mkdirSync(artifactsPath, {recursive: true});
+      execSync(
+        `curl "${tarballUrl}" -Lo "${tmpFile}" && mv "${tmpFile}" "${destPath}"`,
+      );
+    } catch (e) {
+      abort(`Failed to download Hermes tarball from ${tarballUrl}`);
+    }
+  }
+  return destPath;
+}
+
+function abort(message /*: string */) {
+  hermes_log(message, 'error');
+  throw new Error(message);
+}
+
+function hermes_log(
+  message /*: string */,
+  level /*: 'info' | 'warning' | 'error' */ = 'warning',
+) {
+  // Simple log coloring for terminal output
+  const prefix = '[Hermes] ';
+  let colorFn = (x /*:string*/) => x;
+  if (process.stdout.isTTY) {
+    if (level === 'info') colorFn = x => `\x1b[32m${x}\x1b[0m`;
+    else if (level === 'error') colorFn = x => `\x1b[31m${x}\x1b[0m`;
+    else colorFn = x => `\x1b[33m${x}\x1b[0m`;
+  }
+
+  console.log(colorFn(prefix + message));
 }
 
 module.exports = {

--- a/packages/react-native/scripts/ios-prebuild/hermes.js
+++ b/packages/react-native/scripts/ios-prebuild/hermes.js
@@ -29,23 +29,23 @@ async function prepareHermesArtifactsAsync(
   // See if the user has set the HERMES_ENGINE_TARBALL_PATH environment variable
   let localPath = process.env.HERMES_ENGINE_TARBALL_PATH ?? '';
 
+  // Create artifacts folder
+  const artifactsPath /*: string*/ = path.resolve(
+    process.cwd(),
+    '.build',
+    'artifacts',
+    'hermes',
+  );
+
+  // Ensure that the artifacts folder exists
+  fs.mkdirSync(artifactsPath, {recursive: true});
+
   // Only check if the artifacts folder exists if we are not using a local tarball
   if (!localPath) {
     // Resolve the version from the environment variable or use the default version
     const resolvedVersion = process.env.HERMES_VERSION ?? version;
 
     // Check if the Hermes artifacts are already downloaded
-    const artifactsPath /*: string*/ = path.resolve(
-      process.cwd(),
-      '.build',
-      'artifacts',
-      'hermes',
-    );
-
-    // Ensure that the artifacts folder exists
-    fs.mkdirSync(artifactsPath, {recursive: true});
-
-    // Check hermes version file
     if (checkExistingVersion(resolvedVersion, artifactsPath)) {
       return artifactsPath;
     }

--- a/packages/react-native/scripts/ios-prebuild/hermes.js
+++ b/packages/react-native/scripts/ios-prebuild/hermes.js
@@ -86,7 +86,7 @@ type HermesEngineSourceType =
 
 */
 
-const HermesEngineSourceType = {
+const HermesEngineSourceTypes = {
   LOCAL_PREBUILT_TARBALL: 'local_prebuilt_tarball',
   DOWNLOAD_PREBUILD_RELEASE_TARBALL: 'download_prebuild_release_tarball',
   DOWNLOAD_PREBUILT_NIGHTLY_TARBALL: 'download_prebuilt_nightly_tarball',
@@ -183,20 +183,20 @@ function hermesSourceType(
 ) /*: HermesEngineSourceType */ {
   if (hermesEngineTarballEnvvarDefined()) {
     hermesLog('Using local prebuild tarball');
-    return HermesEngineSourceType.LOCAL_PREBUILT_TARBALL;
+    return HermesEngineSourceTypes.LOCAL_PREBUILT_TARBALL;
   }
   if (releaseArtifactExists(version)) {
     hermesLog('Using download prebuild release tarball');
-    return HermesEngineSourceType.DOWNLOAD_PREBUILD_RELEASE_TARBALL;
+    return HermesEngineSourceTypes.DOWNLOAD_PREBUILD_RELEASE_TARBALL;
   }
   if (nightlyArtifactExists(version)) {
     hermesLog('Using download prebuild nightly tarball');
-    return HermesEngineSourceType.DOWNLOAD_PREBUILT_NIGHTLY_TARBALL;
+    return HermesEngineSourceTypes.DOWNLOAD_PREBUILT_NIGHTLY_TARBALL;
   }
   hermesLog(
     'Using download prebuild nightly tarball - this is a fallback and might not work.',
   );
-  return HermesEngineSourceType.DOWNLOAD_PREBUILT_NIGHTLY_TARBALL;
+  return HermesEngineSourceTypes.DOWNLOAD_PREBUILT_NIGHTLY_TARBALL;
 }
 
 function resolveSourceFromSourceType(
@@ -206,15 +206,15 @@ function resolveSourceFromSourceType(
   artifactsPath /*: string*/,
 ) /*: string */ {
   switch (sourceType) {
-    case HermesEngineSourceType.LOCAL_PREBUILT_TARBALL:
+    case HermesEngineSourceTypes.LOCAL_PREBUILT_TARBALL:
       return localPrebuiltTarball();
-    case HermesEngineSourceType.DOWNLOAD_PREBUILD_RELEASE_TARBALL:
+    case HermesEngineSourceTypes.DOWNLOAD_PREBUILD_RELEASE_TARBALL:
       return downloadPrebuildReleaseTarball(
         reactNativePath,
         version,
         artifactsPath,
       );
-    case HermesEngineSourceType.DOWNLOAD_PREBUILT_NIGHTLY_TARBALL:
+    case HermesEngineSourceTypes.DOWNLOAD_PREBUILT_NIGHTLY_TARBALL:
       return downloadPrebuiltNightlyTarball(version, artifactsPath);
     default:
       abort(
@@ -245,12 +245,7 @@ function downloadPrebuildReleaseTarball(
 ) /*: string */ {
   const url = releaseTarballUrl(version, 'debug');
   hermesLog(`Using release tarball from URL: ${url}`);
-  return downloadStableHermes(
-    reactNativePath,
-    version,
-    'release',
-    artifactsPath,
-  );
+  return downloadStableHermes(version, 'release', artifactsPath);
 }
 
 function downloadPrebuiltNightlyTarball(

--- a/packages/react-native/scripts/ios-prebuild/hermes.js
+++ b/packages/react-native/scripts/ios-prebuild/hermes.js
@@ -18,9 +18,6 @@ const path = require('path');
  * version of hermes, use the HERMES_VERSION environment variable. The path to the artifacts will be inside
  * the .build/artifacts/hermes folder, but this can be overridden by setting the HERMES_ENGINE_TARBALL_PATH
  * environment variable. If this varuable is set, the script will use the local tarball instead of downloading it.
- * @param {*} version
- * @param {*} buildType
- * @returns
  */
 async function prepareHermesArtifactsAsync(
   version /*:string*/,

--- a/packages/react-native/scripts/ios-prebuild/hermes.js
+++ b/packages/react-native/scripts/ios-prebuild/hermes.js
@@ -61,7 +61,7 @@ async function prepareHermesArtifactsAsync(
       hermes_log(
         `Hermes artifacts folder already exists, but version does not match. Deleting: ${artifactsPath}`,
       );
-      // Lets create the veresion.txt file
+      // Lets create the version.txt file
       fs.mkdirSync(artifactsPath, {recursive: true});
       fs.writeFileSync(versionFilePath, resolved_version, 'utf8');
       hermes_log(

--- a/packages/react-native/scripts/ios-prebuild/hermes.js
+++ b/packages/react-native/scripts/ios-prebuild/hermes.js
@@ -21,7 +21,7 @@ const path = require('path');
  */
 async function prepareHermesArtifactsAsync(
   version /*:string*/,
-  buildType /*:string*/,
+  buildType /*: 'debug' | 'release' */,
 ) /*: Promise<string> */ {
   hermesLog(`Preparing Hermes...`);
 
@@ -107,7 +107,7 @@ const HermesEngineSourceTypes = {
 function checkExistingVersion(
   versionFilePath /*: string */,
   version /*: string */,
-  buildType /*: string */,
+  buildType /*: 'debug' | 'release' */,
   artifactsPath /*: string */,
 ) {
   const resolvedVersion = `${version}-${buildType}`;
@@ -189,7 +189,7 @@ function nightlyArtifactExists(version /*: string */) /*: boolean */ {
 
 function hermesSourceType(
   version /*: string */,
-  buildType /*: string */,
+  buildType /*: 'debug' | 'release' */,
 ) /*: HermesEngineSourceType */ {
   if (hermesEngineTarballEnvvarDefined()) {
     hermesLog('Using local prebuild tarball');
@@ -212,7 +212,7 @@ function hermesSourceType(
 function resolveSourceFromSourceType(
   sourceType /*: HermesEngineSourceType */,
   version /*: string */,
-  buildType /*: string */,
+  buildType /*: 'debug' | 'release' */,
   artifactsPath /*: string*/,
 ) /*: string */ {
   switch (sourceType) {
@@ -246,7 +246,7 @@ function localPrebuiltTarball() /*: string */ {
 
 function downloadPrebuildTarball(
   version /*: string */,
-  buildType /*: string */,
+  buildType /*: 'debug' | 'release' */,
   artifactsPath /*: string*/,
 ) /*: string */ {
   const url = getTarballUrl(version, buildType);

--- a/packages/react-native/scripts/ios-prebuild/utils.js
+++ b/packages/react-native/scripts/ios-prebuild/utils.js
@@ -17,7 +17,7 @@ const fs = require('fs');
  * @param {string} folderPath - The path to the folder
  * @returns {string} The path to the created or existing folder
  */
-function createFolderIfNotExists(folderPath /*:string*/) /*: string*/ {
+function createFolderIfNotExists(folderPath /*:string*/) /*: string */ {
   if (!fs.existsSync(folderPath)) {
     fs.mkdirSync(folderPath, {recursive: true});
     if (!fs.existsSync(folderPath)) {
@@ -38,7 +38,20 @@ function throwIfOnEden() {
   throw new Error('Cannot prepare the iOS prebuilds on an Eden checkout');
 }
 
-module.exports = {
-  createFolderIfNotExists,
-  throwIfOnEden,
-};
+function prebuild_log(
+  message /*: string */,
+  level /*: 'info' | 'warning' | 'error' */ = 'warning',
+) {
+  // Simple log coloring for terminal output
+  const prefix = '[Prebuild] ';
+  let colorFn = (x /*:string*/) => x;
+  if (process.stdout.isTTY) {
+    if (level === 'info') colorFn = x => `\x1b[32m${x}\x1b[0m`;
+    else if (level === 'error') colorFn = x => `\x1b[31m${x}\x1b[0m`;
+    else colorFn = x => `\x1b[33m${x}\x1b[0m`;
+  }
+
+  console.log(colorFn(prefix + message));
+}
+
+module.exports = {createFolderIfNotExists, throwIfOnEden, prebuild_log};

--- a/packages/react-native/scripts/ios-prebuild/utils.js
+++ b/packages/react-native/scripts/ios-prebuild/utils.js
@@ -38,20 +38,4 @@ function throwIfOnEden() {
   throw new Error('Cannot prepare the iOS prebuilds on an Eden checkout');
 }
 
-function prebuild_log(
-  message /*: string */,
-  level /*: 'info' | 'warning' | 'error' */ = 'warning',
-) {
-  // Simple log coloring for terminal output
-  const prefix = '[Prebuild] ';
-  let colorFn = (x /*:string*/) => x;
-  if (process.stdout.isTTY) {
-    if (level === 'info') colorFn = x => `\x1b[32m${x}\x1b[0m`;
-    else if (level === 'error') colorFn = x => `\x1b[31m${x}\x1b[0m`;
-    else colorFn = x => `\x1b[33m${x}\x1b[0m`;
-  }
-
-  console.log(colorFn(prefix + message));
-}
-
-module.exports = {createFolderIfNotExists, throwIfOnEden, prebuild_log};
+module.exports = {createFolderIfNotExists, throwIfOnEden};

--- a/packages/react-native/scripts/ios-prebuild/utils.js
+++ b/packages/react-native/scripts/ios-prebuild/utils.js
@@ -29,7 +29,7 @@ function createFolderIfNotExists(folderPath /*:string*/) /*: string */ {
 
 function throwIfOnEden() {
   try {
-    execSync('eden info');
+    execSync('eden info', {stdio: 'ignore'});
   } catch (error) {
     // eden info failed, we are not on Eden, do nothing
     return;
@@ -38,4 +38,24 @@ function throwIfOnEden() {
   throw new Error('Cannot prepare the iOS prebuilds on an Eden checkout');
 }
 
-module.exports = {createFolderIfNotExists, throwIfOnEden};
+function prebuildLog(
+  message /*: string */,
+  level /*: 'info' | 'warning' | 'error' */ = 'warning',
+) {
+  // Simple log coloring for terminal output
+  const prefix = '[Prebuild] ';
+  let colorFn = (x /*:string*/) => x;
+  if (process.stdout.isTTY) {
+    if (level === 'info') colorFn = x => `\x1b[32m${x}\x1b[0m`;
+    else if (level === 'error') colorFn = x => `\x1b[31m${x}\x1b[0m`;
+    else colorFn = x => `\x1b[33m${x}\x1b[0m`;
+  }
+
+  console.log(colorFn(prefix + message));
+}
+
+module.exports = {
+  createFolderIfNotExists,
+  throwIfOnEden,
+  prebuildLog,
+};


### PR DESCRIPTION
## Summary:

The download of nightlies used the wrong inner function to download.

This commit fixes this by simplifying the download functions a bit, and also bring the buildType along all the way.

## Changelog:

[IOS] [FIXED] - fix hermes nightly download

## Test Plan:

Run prebuild scripts:

`HERMES_VERSION=0.81.0-nightly-20250516-249a24ac7 node scripts/ios-prebuild`

&& 

`HERMES_VERSION=0.80.0-rc.1  node scripts/ios-prebuild.js`

a few times after each other and verify that the correct hermes builds are downloaded.