### PR TITLE
[kotlin][android] adding accessor for backing map

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactStylesDiffMap.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactStylesDiffMap.kt
@@ -60,4 +60,10 @@ public class ReactStylesDiffMap(props: ReadableMap) {
   public fun getDynamic(name: String): Dynamic = backingMap.getDynamic(name)
 
   override fun toString(): String = "{ ${javaClass.simpleName}: $backingMap }"
+
+  /**
+   * Access the package private property for faster access to the underlying values.
+   This is used in Expo to override setting properties in some subclassed view-managers
+  */
+  public fun getBackingMap(): ReadableMap = backingMap
 }


### PR DESCRIPTION
## Summary:

Expo is using the backingmap to be able to update properties in a fast and performant way in two overridden view manager subclasses (ViewGroupManager subclass is one of them). This was previously done by exposing a helper method accessing the inner field in java due to the inner field being accessible from the same package. This no longer works in 0.80.

This commit fixes this by exposing a public function that returns the backingMap directly.

## Changelog:

[ANDROID] [FIXED] - Add accessor to backing map in ReactStylesDiffMap.kt

## Test Plan:

Build with Expo modules