### PR TITLE
PerformanceEntryReporter::getMarkTime to return optional DOMHighResTimeStamp

### DIFF
--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.h
@@ -80,6 +80,8 @@ class PerformanceEntryReporter {
     return eventCounts_;
   }
 
+  std::optional<double> getMarkTime(const std::string& markName) const;
+
   PerformanceMark reportMark(
       const std::string& name,
       const std::optional<DOMHighResTimeStamp>& startTime = std::nullopt);
@@ -88,9 +90,6 @@ class PerformanceEntryReporter {
       const std::string& name,
       double startTime,
       double endTime,
-      const std::optional<double>& duration = std::nullopt,
-      const std::optional<std::string>& startMark = std::nullopt,
-      const std::optional<std::string>& endMark = std::nullopt,
       const std::optional<jsinspector_modern::DevToolsTrackEntryPayload>&
           trackMetadata = std::nullopt);
 
@@ -128,8 +127,6 @@ class PerformanceEntryReporter {
   std::unordered_map<std::string, uint32_t> eventCounts_;
 
   std::function<double()> timeStampProvider_ = nullptr;
-
-  double getMarkTime(const std::string& markName) const;
 
   const inline PerformanceEntryBuffer& getBuffer(
       PerformanceEntryType entryType) const {

--- a/packages/react-native/ReactCommon/react/performance/timeline/tests/PerformanceEntryReporterTest.cpp
+++ b/packages/react-native/ReactCommon/react/performance/timeline/tests/PerformanceEntryReporterTest.cpp
@@ -108,38 +108,21 @@ TEST(PerformanceEntryReporter, PerformanceEntryReporterTestReportMeasures) {
   reporter->reportMark("mark2", 2);
 
   reporter->reportMeasure("measure0", 0, 2);
-  reporter->reportMeasure("measure1", 0, 2, 4);
-  reporter->reportMeasure("measure2", 0, 0, std::nullopt, "mark1", "mark2");
-  reporter->reportMeasure("measure3", 0, 0, 5, "mark1");
-  reporter->reportMeasure(
-      "measure4", 1.5, 0, std::nullopt, std::nullopt, "mark2");
-
-  reporter->setTimeStampProvider([]() { return 3.5; });
-  reporter->reportMeasure("measure5", 0, 0, std::nullopt, "mark2");
+  reporter->reportMeasure("measure1", 0, 3);
 
   reporter->reportMark("mark3", 2.5);
-  reporter->reportMeasure("measure6", 2.0, 2.0);
-  reporter->reportMark("mark4", 2.1);
+  reporter->reportMeasure("measure2", 2.0, 2.0);
   reporter->reportMark("mark4", 3.0);
-  // Uses the last reported time for mark4
-  reporter->reportMeasure("measure7", 0, 0, std::nullopt, "mark1", "mark4");
 
   const auto entries = toSorted(reporter->getEntries());
 
   const std::vector<PerformanceEntry> expected = {
       PerformanceMark{{.name = "mark0", .startTime = 0, .duration = 0}},
       PerformanceMeasure{{.name = "measure0", .startTime = 0, .duration = 2}},
-      PerformanceMeasure{{.name = "measure1", .startTime = 0, .duration = 4}},
+      PerformanceMeasure{{.name = "measure1", .startTime = 0, .duration = 3}},
       PerformanceMark{{.name = "mark1", .startTime = 1, .duration = 0}},
-      PerformanceMeasure{{.name = "measure2", .startTime = 1, .duration = 1}},
-      PerformanceMeasure{{.name = "measure7", .startTime = 1, .duration = 2}},
-      PerformanceMeasure{{.name = "measure3", .startTime = 1, .duration = 5}},
-      PerformanceMeasure{
-          {.name = "measure4", .startTime = 1.5, .duration = 0.5}},
       PerformanceMark{{.name = "mark2", .startTime = 2, .duration = 0}},
-      PerformanceMeasure{{.name = "measure6", .startTime = 2, .duration = 0}},
-      PerformanceMeasure{{.name = "measure5", .startTime = 2, .duration = 1.5}},
-      PerformanceMark{{.name = "mark4", .startTime = 2.1, .duration = 0}},
+      PerformanceMeasure{{.name = "measure2", .startTime = 2, .duration = 0}},
       PerformanceMark{{.name = "mark3", .startTime = 2.5, .duration = 0}},
       PerformanceMark{{.name = "mark4", .startTime = 3, .duration = 0}}};
 
@@ -160,11 +143,9 @@ TEST(PerformanceEntryReporter, PerformanceEntryReporterTestGetEntries) {
   reporter->reportMark("mark2", 2);
 
   reporter->reportMeasure("common_name", 0, 2);
-  reporter->reportMeasure("measure1", 0, 2, 4);
-  reporter->reportMeasure("measure2", 0, 0, std::nullopt, "mark1", "mark2");
-  reporter->reportMeasure("measure3", 0, 0, 5, "mark1");
-  reporter->reportMeasure(
-      "measure4", 1.5, 0, std::nullopt, std::nullopt, "mark2");
+  reporter->reportMeasure("measure1", 0, 3);
+  reporter->reportMeasure("measure2", 1, 6);
+  reporter->reportMeasure("measure3", 1.5, 2);
 
   {
     const auto allEntries = toSorted(reporter->getEntries());
@@ -172,12 +153,11 @@ TEST(PerformanceEntryReporter, PerformanceEntryReporterTestGetEntries) {
         PerformanceMark{{.name = "common_name", .startTime = 0, .duration = 0}},
         PerformanceMeasure{
             {.name = "common_name", .startTime = 0, .duration = 2}},
-        PerformanceMeasure{{.name = "measure1", .startTime = 0, .duration = 4}},
+        PerformanceMeasure{{.name = "measure1", .startTime = 0, .duration = 3}},
         PerformanceMark{{.name = "mark1", .startTime = 1, .duration = 0}},
-        PerformanceMeasure{{.name = "measure2", .startTime = 1, .duration = 1}},
-        PerformanceMeasure{{.name = "measure3", .startTime = 1, .duration = 5}},
+        PerformanceMeasure{{.name = "measure2", .startTime = 1, .duration = 5}},
         PerformanceMeasure{
-            {.name = "measure4", .startTime = 1.5, .duration = 0.5}},
+            {.name = "measure3", .startTime = 1.5, .duration = 0.5}},
         PerformanceMark{{.name = "mark2", .startTime = 2, .duration = 0}}};
     ASSERT_EQ(expected, allEntries);
   }
@@ -198,11 +178,10 @@ TEST(PerformanceEntryReporter, PerformanceEntryReporterTestGetEntries) {
     const std::vector<PerformanceEntry> expected = {
         PerformanceMeasure{
             {.name = "common_name", .startTime = 0, .duration = 2}},
-        PerformanceMeasure{{.name = "measure1", .startTime = 0, .duration = 4}},
-        PerformanceMeasure{{.name = "measure2", .startTime = 1, .duration = 1}},
-        PerformanceMeasure{{.name = "measure3", .startTime = 1, .duration = 5}},
+        PerformanceMeasure{{.name = "measure1", .startTime = 0, .duration = 3}},
+        PerformanceMeasure{{.name = "measure2", .startTime = 1, .duration = 5}},
         PerformanceMeasure{
-            {.name = "measure4", .startTime = 1.5, .duration = 0.5}}};
+            {.name = "measure3", .startTime = 1.5, .duration = 0.5}}};
     ASSERT_EQ(expected, measures);
   }
 
@@ -233,11 +212,9 @@ TEST(PerformanceEntryReporter, PerformanceEntryReporterTestClearMarks) {
   reporter->reportMark("mark2", 2);
 
   reporter->reportMeasure("common_name", 0, 2);
-  reporter->reportMeasure("measure1", 0, 2, 4);
-  reporter->reportMeasure("measure2", 0, 0, std::nullopt, "mark1", "mark2");
-  reporter->reportMeasure("measure3", 0, 0, 5, "mark1");
-  reporter->reportMeasure(
-      "measure4", 1.5, 0, std::nullopt, std::nullopt, "mark2");
+  reporter->reportMeasure("measure1", 0, 3);
+  reporter->reportMeasure("measure2", 1, 6);
+  reporter->reportMeasure("measure3", 1.5, 2);
 
   reporter->clearEntries(PerformanceEntryType::MARK, "common_name");
 

--- a/packages/react-native/src/private/webapis/performance/Performance.js
+++ b/packages/react-native/src/private/webapis/performance/Performance.js
@@ -17,6 +17,7 @@ import type {
 } from './PerformanceEntry';
 import type {DetailType, PerformanceMarkOptions} from './UserTiming';
 
+import DOMException from '../errors/DOMException';
 import {setPlatformObject} from '../webidl/PlatformObjects';
 import {EventCounts} from './EventTiming';
 import {
@@ -192,15 +193,22 @@ export default class Performance {
     let computedDuration = duration;
 
     if (NativePerformance?.measureWithResult) {
-      [computedStartTime, computedDuration] =
-        NativePerformance.measureWithResult(
-          measureName,
-          startTime,
-          endTime,
-          duration,
-          startMarkName,
-          endMarkName,
+      try {
+        [computedStartTime, computedDuration] =
+          NativePerformance.measureWithResult(
+            measureName,
+            startTime,
+            endTime,
+            duration,
+            startMarkName,
+            endMarkName,
+          );
+      } catch (error) {
+        throw new DOMException(
+          "Failed to execute 'measure' on 'Performance': " + error.message,
+          'SyntaxError',
         );
+      }
     } else {
       warnNoNativePerformance();
     }

--- a/packages/react-native/src/private/webapis/performance/__tests__/Performance-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/Performance-itest.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type Performance from '../Performance';
+
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
+
+declare var performance: Performance;
+
+describe('Performance', () => {
+  it('measure validates mark names presence in the buffer, if specified', () => {
+    expect(() => {
+      performance.measure('measure', 'start', 'end');
+    }).toThrow(
+      "Failed to execute 'measure' on 'Performance': The mark 'start' does not exist.",
+    ); // This should also check that Error is an instance of DOMException and is SyntaxError,
+    // but toThrow checked currently only supports string argument.
+
+    performance.mark('start');
+    expect(() => {
+      performance.measure('measure', 'start', 'end');
+    }).toThrow(
+      "Failed to execute 'measure' on 'Performance': The mark 'end' does not exist.",
+    ); // This should also check that Error is an instance of DOMException and is SyntaxError,
+    // but toThrow checked currently only supports string argument.
+
+    performance.mark('end');
+    expect(() => {
+      performance.measure('measure', 'start', 'end');
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

This is the pre-requisite for the diff on top, which migrates performance-related classes to start using `HighResTimeStamp`.

Differential Revision: D74837812
