### PR TITLE
Make processingStartTime and processingEndTime optional

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/observers/events/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/observers/events/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(react_renderer_observers_events OBJECT ${react_renderer_observers_ev
 
 target_include_directories(react_renderer_observers_events PUBLIC ${REACT_COMMON_DIR})
 target_link_libraries(react_renderer_observers_events
+        react_debug
         react_performance_timeline
         react_timing
         react_renderer_core

--- a/packages/react-native/ReactCommon/react/renderer/observers/events/EventPerformanceLogger.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/observers/events/EventPerformanceLogger.cpp
@@ -7,8 +7,10 @@
 
 #include "EventPerformanceLogger.h"
 
+#include <react/debug/react_native_assert.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/timing/primitives.h>
+
 #include <unordered_map>
 
 namespace facebook::react {
@@ -127,7 +129,7 @@ EventTag EventPerformanceLogger::onEventStart(
   {
     std::lock_guard lock(eventsInFlightMutex_);
     eventsInFlight_.emplace(
-        eventTag, EventEntry{reportedName, target, timeStamp, 0.0});
+        eventTag, EventEntry{reportedName, target, timeStamp});
   }
   return eventTag;
 }
@@ -163,6 +165,9 @@ void EventPerformanceLogger::onEventProcessingEnd(EventTag tag) {
     }
 
     auto& entry = it->second;
+    react_native_assert(
+        entry.processingStartTime.has_value() &&
+        "Attempting to set processingEndTime while processingStartTime is not set.");
     entry.processingEndTime = timeStamp;
   }
 }
@@ -188,12 +193,18 @@ void EventPerformanceLogger::dispatchPendingEventTimingEntries(
       entry.isWaitingForMount = true;
       ++it;
     } else {
+      react_native_assert(
+          entry.processingStartTime.has_value() &&
+          "Attempted to report PerformanceEventTiming, which did not have processingStartTime defined.");
+      react_native_assert(
+          entry.processingEndTime.has_value() &&
+          "Attempted to report PerformanceEventTiming, which did not have processingEndTime defined.");
       performanceEntryReporter->reportEvent(
           std::string(entry.name),
           entry.startTime,
           performanceEntryReporter->getCurrentTimeStamp() - entry.startTime,
-          entry.processingStartTime,
-          entry.processingEndTime,
+          entry.processingStartTime.value(),
+          entry.processingEndTime.value(),
           entry.interactionId);
       it = eventsInFlight_.erase(it);
     }
@@ -214,12 +225,18 @@ void EventPerformanceLogger::shadowTreeDidMount(
     const auto& entry = it->second;
     if (entry.isWaitingForMount &&
         isTargetInRootShadowNode(entry.target, rootShadowNode)) {
+      react_native_assert(
+          entry.processingStartTime.has_value() &&
+          "Attempted to report PerformanceEventTiming, which did not have processingStartTime defined.");
+      react_native_assert(
+          entry.processingEndTime.has_value() &&
+          "Attempted to report PerformanceEventTiming, which did not have processingEndTime defined.");
       performanceEntryReporter->reportEvent(
           std::string(entry.name),
           entry.startTime,
           mountTime - entry.startTime,
-          entry.processingStartTime,
-          entry.processingEndTime,
+          entry.processingStartTime.value(),
+          entry.processingEndTime.value(),
           entry.interactionId);
       it = eventsInFlight_.erase(it);
     } else {

--- a/packages/react-native/ReactCommon/react/renderer/observers/events/EventPerformanceLogger.h
+++ b/packages/react-native/ReactCommon/react/renderer/observers/events/EventPerformanceLogger.h
@@ -11,6 +11,7 @@
 #include <react/renderer/core/EventLogger.h>
 #include <react/renderer/runtimescheduler/RuntimeSchedulerEventTimingDelegate.h>
 #include <react/renderer/uimanager/UIManagerMountHook.h>
+
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -52,9 +53,9 @@ class EventPerformanceLogger : public EventLogger,
   struct EventEntry {
     std::string_view name;
     SharedEventTarget target{nullptr};
-    DOMHighResTimeStamp startTime{0.0};
-    DOMHighResTimeStamp processingStartTime{0.0};
-    DOMHighResTimeStamp processingEndTime{0.0};
+    DOMHighResTimeStamp startTime;
+    std::optional<DOMHighResTimeStamp> processingStartTime;
+    std::optional<DOMHighResTimeStamp> processingEndTime;
 
     bool isWaitingForMount{false};
 
@@ -63,7 +64,7 @@ class EventPerformanceLogger : public EventLogger,
     PerformanceEntryInteractionId interactionId{0};
 
     bool isWaitingForDispatch() {
-      return processingEndTime == 0.0;
+      return !processingEndTime.has_value();
     }
   };
 


### PR DESCRIPTION
Summary:
# Changelong: [Internal]

Ideally, these should not be optional, but these values are set at runtime.

Assertions added to validate that these values are set before reporting to `PerformanceEntryReporter`.

Differential Revision: D74811439
