### PR TITLE
Correct Link for Networking

### DIFF
--- a/packages/new-app-screen/src/Links.js
+++ b/packages/new-app-screen/src/Links.js
@@ -51,7 +51,7 @@ const Links: Array<{
   {
     title: 'Networking',
     description: 'Use the Fetch API',
-    url: 'https://reactnative.dev/docs/navigation',
+    url: 'https://reactnative.dev/docs/network',
   },
   {
     title: 'Showcase',


### PR DESCRIPTION


## Summary:
I noticed the link to networking in new app screen is wrong. So correcting it here

## Changelog:
[GENERAL][FIXED] - Fix Networking URL in New app screen

## Test Plan:
Click on the link to open
