### PR TITLE
RN: Fix Existing Lint Warnings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -64,9 +64,13 @@ module.exports = {
       },
     },
     {
-      files: ['flow-typed/**/*.js'],
+      files: [
+        'flow-typed/**/*.js',
+        'packages/react-native/src/types/*.js.flow',
+      ],
       rules: {
         'lint/valid-flow-typed-signature': 2,
+        'no-shadow': 0,
         'no-unused-vars': 0,
         quotes: 0,
       },

--- a/flow-typed/environment/node.js
+++ b/flow-typed/environment/node.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall flow
  */
 
 // Adapted from https://github.com/flow-typed/flow-typed/blob/main/definitions/environments/node/flow_v0.261.x-/node.js

--- a/flow-typed/npm/@react-native-community/cli-server-api_v19.x.x.js
+++ b/flow-typed/npm/@react-native-community/cli-server-api_v19.x.x.js
@@ -6,7 +6,6 @@
  *
  * @flow strict
  * @format
- * @oncall react_native
  */
 
 declare module '@react-native-community/cli-server-api' {

--- a/flow-typed/npm/@react-native-community/cli-types_v19.x.x.js
+++ b/flow-typed/npm/@react-native-community/cli-types_v19.x.x.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 declare module '@react-native-community/cli-types' {

--- a/flow-typed/npm/actual-request-url_v1.x.x.js
+++ b/flow-typed/npm/actual-request-url_v1.x.x.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 declare module 'actual-request-url' {

--- a/flow-typed/npm/babel-traverse_v7.x.x.js
+++ b/flow-typed/npm/babel-traverse_v7.x.x.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 // The sections between BEGIN GENERATED and END GENERATED are generated

--- a/flow-typed/npm/chalk_v4.x.x.js
+++ b/flow-typed/npm/chalk_v4.x.x.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 // flow-typed signature: 79cfa6bcaa67fdb60f10d320da0470fc

--- a/flow-typed/npm/chrome-launcher_v0.15.x.js
+++ b/flow-typed/npm/chrome-launcher_v0.15.x.js
@@ -6,7 +6,6 @@
  *
  * @flow strict
  * @format
- * @oncall react_native
  */
 
 declare module 'chrome-launcher' {

--- a/flow-typed/npm/chromium-edge-launcher_v0.2.x.js
+++ b/flow-typed/npm/chromium-edge-launcher_v0.2.x.js
@@ -6,7 +6,6 @@
  *
  * @flow strict
  * @format
- * @oncall react_native
  */
 
 declare module 'chromium-edge-launcher' {

--- a/flow-typed/npm/commander_v12.x.x.js
+++ b/flow-typed/npm/commander_v12.x.x.js
@@ -6,7 +6,6 @@
  *
  * @flow strict
  * @format
- * @oncall react_native
  * @generated
  */
 

--- a/flow-typed/npm/connect_v3.x.x.js
+++ b/flow-typed/npm/connect_v3.x.x.js
@@ -6,7 +6,6 @@
  *
  * @flow strict
  * @format
- * @oncall react_native
  */
 
 declare module 'connect' {

--- a/flow-typed/npm/execa_v5.x.x.js
+++ b/flow-typed/npm/execa_v5.x.x.js
@@ -6,7 +6,6 @@
  *
  * @flow strict
  * @format
- * @oncall react_native
  */
 
 // Modified from flow-typed repo:

--- a/flow-typed/npm/jest-diff_v29.x.x.js
+++ b/flow-typed/npm/jest-diff_v29.x.x.js
@@ -3,7 +3,6 @@
  *
  * @flow strict
  * @format
- * @oncall react_native
  */
 
 declare module 'jest-diff' {

--- a/flow-typed/npm/jest-snapshot_v29.x.x.js
+++ b/flow-typed/npm/jest-snapshot_v29.x.x.js
@@ -6,7 +6,6 @@
  *
  * @flow strict
  * @format
- * @oncall react_native
  */
 
 declare module 'jest-snapshot' {

--- a/flow-typed/npm/jest.js
+++ b/flow-typed/npm/jest.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 // Modified from https://raw.githubusercontent.com/flow-typed/flow-typed/master/definitions/npm/jest_v29.x.x/flow_v0.134.x-/jest_v29.x.x.js

--- a/flow-typed/npm/node-fetch_v2.x.x.js
+++ b/flow-typed/npm/node-fetch_v2.x.x.js
@@ -6,7 +6,6 @@
  *
  * @flow strict
  * @format
- * @oncall react_native
  */
 
 // Modified from flow-typed repo:

--- a/flow-typed/npm/open_v7.x.x.js
+++ b/flow-typed/npm/open_v7.x.x.js
@@ -6,7 +6,6 @@
  *
  * @flow strict
  * @format
- * @oncall react_native
  */
 
 declare module 'open' {

--- a/flow-typed/npm/pretty-format_v29.x.x.js
+++ b/flow-typed/npm/pretty-format_v29.x.x.js
@@ -3,7 +3,6 @@
  *
  * @flow strict
  * @format
- * @oncall react_native
  */
 declare type Print = (value: mixed) => string;
 declare type Indent = (value: string) => string;

--- a/flow-typed/npm/selfsigned_v2.x.x.js
+++ b/flow-typed/npm/selfsigned_v2.x.x.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 declare module 'selfsigned' {

--- a/flow-typed/npm/serve-static_v1.x.x.js
+++ b/flow-typed/npm/serve-static_v1.x.x.js
@@ -6,7 +6,6 @@
  *
  * @flow strict
  * @format
- * @oncall react_native
  */
 
 declare module 'serve-static' {

--- a/flow-typed/npm/tinybench_v3.1.x.js
+++ b/flow-typed/npm/tinybench_v3.1.x.js
@@ -6,7 +6,6 @@
  *
  * @flow strict
  * @format
- * @oncall react_native
  */
 
 declare module 'tinybench' {

--- a/flow-typed/npm/undici_v5.x.x.js
+++ b/flow-typed/npm/undici_v5.x.x.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 // Very incomplete types for the undici package.

--- a/flow-typed/npm/wait-for-expect_v3.x.x.js
+++ b/flow-typed/npm/wait-for-expect_v3.x.x.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 declare module 'wait-for-expect' {

--- a/flow-typed/npm/ws_v7.x.x.js
+++ b/flow-typed/npm/ws_v7.x.x.js
@@ -6,7 +6,6 @@
  *
  * @flow strict
  * @format
- * @oncall react_native
  */
 
 declare type ws$PerMessageDeflateOptions = {

--- a/packages/assets/__tests__/path-support-test.js
+++ b/packages/assets/__tests__/path-support-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import {getAndroidResourceFolderName} from '../path-support';

--- a/packages/babel-plugin-codegen/__tests__/index-test.js
+++ b/packages/babel-plugin-codegen/__tests__/index-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/community-cli-plugin/src/commands/bundle/__mocks__/sign.js
+++ b/packages/community-cli-plugin/src/commands/bundle/__mocks__/sign.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 function sign(source) {

--- a/packages/community-cli-plugin/src/commands/bundle/__tests__/filterPlatformAssetScales-test.js
+++ b/packages/community-cli-plugin/src/commands/bundle/__tests__/filterPlatformAssetScales-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import filterPlatformAssetScales from '../filterPlatformAssetScales';

--- a/packages/community-cli-plugin/src/commands/bundle/__tests__/getAssetDestPathAndroid-test.js
+++ b/packages/community-cli-plugin/src/commands/bundle/__tests__/getAssetDestPathAndroid-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import getAssetDestPathAndroid from '../getAssetDestPathAndroid';

--- a/packages/community-cli-plugin/src/commands/bundle/__tests__/getAssetDestPathIOS-test.js
+++ b/packages/community-cli-plugin/src/commands/bundle/__tests__/getAssetDestPathIOS-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import getAssetDestPathIOS from '../getAssetDestPathIOS';

--- a/packages/community-cli-plugin/src/commands/bundle/assetCatalogIOS.js
+++ b/packages/community-cli-plugin/src/commands/bundle/assetCatalogIOS.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {AssetData} from 'metro/src/Assets';

--- a/packages/community-cli-plugin/src/commands/bundle/assetPathUtils.js
+++ b/packages/community-cli-plugin/src/commands/bundle/assetPathUtils.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 export type PackagerAsset = $ReadOnly<{

--- a/packages/community-cli-plugin/src/commands/bundle/buildBundle.js
+++ b/packages/community-cli-plugin/src/commands/bundle/buildBundle.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {Config} from '@react-native-community/cli-types';

--- a/packages/community-cli-plugin/src/commands/bundle/createKeepFileAsync.js
+++ b/packages/community-cli-plugin/src/commands/bundle/createKeepFileAsync.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {AssetData} from 'metro/src/Assets';

--- a/packages/community-cli-plugin/src/commands/bundle/filterPlatformAssetScales.js
+++ b/packages/community-cli-plugin/src/commands/bundle/filterPlatformAssetScales.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 const ALLOWED_SCALES: {[key: string]: number[]} = {

--- a/packages/community-cli-plugin/src/commands/bundle/getAssetDestPathAndroid.js
+++ b/packages/community-cli-plugin/src/commands/bundle/getAssetDestPathAndroid.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {PackagerAsset} from './assetPathUtils';

--- a/packages/community-cli-plugin/src/commands/bundle/getAssetDestPathIOS.js
+++ b/packages/community-cli-plugin/src/commands/bundle/getAssetDestPathIOS.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {PackagerAsset} from './assetPathUtils';

--- a/packages/community-cli-plugin/src/commands/bundle/index.js
+++ b/packages/community-cli-plugin/src/commands/bundle/index.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {Command} from '@react-native-community/cli-types';

--- a/packages/community-cli-plugin/src/commands/bundle/saveAssets.js
+++ b/packages/community-cli-plugin/src/commands/bundle/saveAssets.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {AssetData} from 'metro/src/Assets';

--- a/packages/community-cli-plugin/src/commands/start/OpenDebuggerKeyboardHandler.js
+++ b/packages/community-cli-plugin/src/commands/start/OpenDebuggerKeyboardHandler.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {TerminalReporter} from 'metro';

--- a/packages/community-cli-plugin/src/commands/start/attachKeyHandlers.js
+++ b/packages/community-cli-plugin/src/commands/start/attachKeyHandlers.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {TerminalReporter} from 'metro';

--- a/packages/community-cli-plugin/src/commands/start/index.js
+++ b/packages/community-cli-plugin/src/commands/start/index.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {Command} from '@react-native-community/cli-types';

--- a/packages/community-cli-plugin/src/commands/start/middleware.js
+++ b/packages/community-cli-plugin/src/commands/start/middleware.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {Server} from 'connect';

--- a/packages/community-cli-plugin/src/commands/start/runServer.js
+++ b/packages/community-cli-plugin/src/commands/start/runServer.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {Config} from '@react-native-community/cli-types';

--- a/packages/community-cli-plugin/src/index.flow.js
+++ b/packages/community-cli-plugin/src/index.flow.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 export {default as bundleCommand} from './commands/bundle';

--- a/packages/community-cli-plugin/src/index.js
+++ b/packages/community-cli-plugin/src/index.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 /*::

--- a/packages/community-cli-plugin/src/utils/createDevMiddlewareLogger.js
+++ b/packages/community-cli-plugin/src/utils/createDevMiddlewareLogger.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {TerminalReporter} from 'metro';

--- a/packages/community-cli-plugin/src/utils/errors.js
+++ b/packages/community-cli-plugin/src/utils/errors.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 /**

--- a/packages/community-cli-plugin/src/utils/isDevServerRunning.js
+++ b/packages/community-cli-plugin/src/utils/isDevServerRunning.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import net from 'net';

--- a/packages/community-cli-plugin/src/utils/loadMetroConfig.js
+++ b/packages/community-cli-plugin/src/utils/loadMetroConfig.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {Config} from '@react-native-community/cli-types';

--- a/packages/community-cli-plugin/src/utils/metroPlatformResolver.js
+++ b/packages/community-cli-plugin/src/utils/metroPlatformResolver.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {CustomResolver} from 'metro-resolver';

--- a/packages/community-cli-plugin/src/utils/parseKeyValueParamArray.js
+++ b/packages/community-cli-plugin/src/utils/parseKeyValueParamArray.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 export default function parseKeyValueParamArray(

--- a/packages/community-cli-plugin/src/utils/version.js
+++ b/packages/community-cli-plugin/src/utils/version.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {Config} from '@react-native-community/cli-types';

--- a/packages/core-cli-utils/src/index.flow.js
+++ b/packages/core-cli-utils/src/index.flow.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 // @babel/register doesn't like export {foo} from './bar'; statements,

--- a/packages/core-cli-utils/src/index.js
+++ b/packages/core-cli-utils/src/index.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 /*::

--- a/packages/core-cli-utils/src/private/android.js
+++ b/packages/core-cli-utils/src/private/android.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {Task} from './types';

--- a/packages/core-cli-utils/src/private/app.js
+++ b/packages/core-cli-utils/src/private/app.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {Task} from './types';

--- a/packages/core-cli-utils/src/private/apple.js
+++ b/packages/core-cli-utils/src/private/apple.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {Task} from './types';

--- a/packages/core-cli-utils/src/private/clean.js
+++ b/packages/core-cli-utils/src/private/clean.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {Task} from './types';

--- a/packages/core-cli-utils/src/private/types.js
+++ b/packages/core-cli-utils/src/private/types.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 export type Task<R = mixed> = {

--- a/packages/core-cli-utils/src/private/utils.js
+++ b/packages/core-cli-utils/src/private/utils.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {Task} from './types';

--- a/packages/core-cli-utils/src/public/version.flow.js
+++ b/packages/core-cli-utils/src/public/version.flow.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 // Usage:

--- a/packages/core-cli-utils/src/public/version.js
+++ b/packages/core-cli-utils/src/public/version.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 /*::

--- a/packages/dev-middleware/src/__tests__/FetchUtils.js
+++ b/packages/dev-middleware/src/__tests__/FetchUtils.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {JSONSerializable} from '../inspector-proxy/types';

--- a/packages/dev-middleware/src/__tests__/InspectorDebuggerUtils.js
+++ b/packages/dev-middleware/src/__tests__/InspectorDebuggerUtils.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {JSONSerializable} from '../inspector-proxy/types';

--- a/packages/dev-middleware/src/__tests__/InspectorDeviceUtils.js
+++ b/packages/dev-middleware/src/__tests__/InspectorDeviceUtils.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {

--- a/packages/dev-middleware/src/__tests__/InspectorProtocolUtils.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProtocolUtils.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {

--- a/packages/dev-middleware/src/__tests__/InspectorProxyCdpRewritingHacks-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyCdpRewritingHacks-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import {withFetchSelfSignedCertsForAllTests} from './FetchUtils';

--- a/packages/dev-middleware/src/__tests__/InspectorProxyCdpTransport-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyCdpTransport-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {

--- a/packages/dev-middleware/src/__tests__/InspectorProxyCustomMessageHandler-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyCustomMessageHandler-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import {fetchJson} from './FetchUtils';

--- a/packages/dev-middleware/src/__tests__/InspectorProxyDeviceHandoff-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyDeviceHandoff-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {

--- a/packages/dev-middleware/src/__tests__/InspectorProxyHttpApi-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyHttpApi-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {

--- a/packages/dev-middleware/src/__tests__/InspectorProxyReactNativeReloads-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyReactNativeReloads-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import {fetchJson} from './FetchUtils';

--- a/packages/dev-middleware/src/__tests__/ResourceUtils.js
+++ b/packages/dev-middleware/src/__tests__/ResourceUtils.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 export function withAbortSignalForEachTest(): $ReadOnly<{signal: AbortSignal}> {

--- a/packages/dev-middleware/src/__tests__/ServerUtils.js
+++ b/packages/dev-middleware/src/__tests__/ServerUtils.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {JSONSerializable} from '../inspector-proxy/types';

--- a/packages/dev-middleware/src/__tests__/embedderScriptStub-test.js
+++ b/packages/dev-middleware/src/__tests__/embedderScriptStub-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import {requestLocal} from './FetchUtils';

--- a/packages/dev-middleware/src/__tests__/getBaseUrlFromRequest-test.js
+++ b/packages/dev-middleware/src/__tests__/getBaseUrlFromRequest-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import getBaseUrlFromRequest from '../utils/getBaseUrlFromRequest';

--- a/packages/dev-middleware/src/__tests__/getDevToolsFrontendUrl-test.js
+++ b/packages/dev-middleware/src/__tests__/getDevToolsFrontendUrl-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import getDevToolsFrontendUrl from '../utils/getDevToolsFrontendUrl';

--- a/packages/dev-middleware/src/createDevMiddleware.js
+++ b/packages/dev-middleware/src/createDevMiddleware.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {CreateCustomMessageHandlerFn} from './inspector-proxy/CustomMessageHandler';

--- a/packages/dev-middleware/src/index.flow.js
+++ b/packages/dev-middleware/src/index.flow.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 export {default as createDevMiddleware} from './createDevMiddleware';

--- a/packages/dev-middleware/src/index.js
+++ b/packages/dev-middleware/src/index.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 /*::

--- a/packages/dev-middleware/src/inspector-proxy/CDPMessagesLogging.js
+++ b/packages/dev-middleware/src/inspector-proxy/CDPMessagesLogging.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 // $FlowFixMe[cannot-resolve-module] libdef missing in RN OSS

--- a/packages/dev-middleware/src/inspector-proxy/Device.js
+++ b/packages/dev-middleware/src/inspector-proxy/Device.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {EventReporter} from '../types/EventReporter';

--- a/packages/dev-middleware/src/inspector-proxy/EventLoopPerfTracker.js
+++ b/packages/dev-middleware/src/inspector-proxy/EventLoopPerfTracker.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 // $FlowFixMe[cannot-resolve-module] libdef missing in RN OSS

--- a/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
+++ b/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {DebuggerSessionIDs, EventReporter} from '../types/EventReporter';

--- a/packages/dev-middleware/src/inspector-proxy/InspectorProxyHeartbeat.js
+++ b/packages/dev-middleware/src/inspector-proxy/InspectorProxyHeartbeat.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 // $FlowFixMe[cannot-resolve-module] libdef missing in RN OSS

--- a/packages/dev-middleware/src/inspector-proxy/cdp-types/messages.js
+++ b/packages/dev-middleware/src/inspector-proxy/cdp-types/messages.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {JSONSerializable} from '../types';

--- a/packages/dev-middleware/src/inspector-proxy/cdp-types/protocol.js
+++ b/packages/dev-middleware/src/inspector-proxy/cdp-types/protocol.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 // Adapted from https://github.com/ChromeDevTools/devtools-protocol/blob/master/types/protocol.d.ts

--- a/packages/dev-middleware/src/inspector-proxy/types.js
+++ b/packages/dev-middleware/src/inspector-proxy/types.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 /**

--- a/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
+++ b/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {InspectorProxyQueries} from '../inspector-proxy/InspectorProxy';

--- a/packages/dev-middleware/src/types/BrowserLauncher.js
+++ b/packages/dev-middleware/src/types/BrowserLauncher.js
@@ -6,7 +6,6 @@
  *
  * @flow strict
  * @format
- * @oncall react_native
  */
 
 /**

--- a/packages/dev-middleware/src/types/Logger.js
+++ b/packages/dev-middleware/src/types/Logger.js
@@ -6,7 +6,6 @@
  *
  * @flow strict
  * @format
- * @oncall react_native
  */
 
 export type Logger = $ReadOnly<{

--- a/packages/dev-middleware/src/utils/DefaultBrowserLauncher.js
+++ b/packages/dev-middleware/src/utils/DefaultBrowserLauncher.js
@@ -6,7 +6,6 @@
  *
  * @flow strict
  * @format
- * @oncall react_native
  */
 
 import type {BrowserLauncher} from '../types/BrowserLauncher';

--- a/packages/dev-middleware/src/utils/getBaseUrlFromRequest.js
+++ b/packages/dev-middleware/src/utils/getBaseUrlFromRequest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 // Determine the base URL (scheme and host) used by a client to reach this

--- a/packages/dev-middleware/src/utils/getDevToolsFrontendUrl.js
+++ b/packages/dev-middleware/src/utils/getDevToolsFrontendUrl.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {Experiments} from '../types/Experiments';

--- a/packages/eslint-plugin-react-native/__tests__/no-deep-imports-test.js
+++ b/packages/eslint-plugin-react-native/__tests__/no-deep-imports-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/eslint-plugin-react-native/__tests__/platform-colors-test.js
+++ b/packages/eslint-plugin-react-native/__tests__/platform-colors-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/eslint-plugin-specs/__tests__/react-native-modules-test.js
+++ b/packages/eslint-plugin-specs/__tests__/react-native-modules-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/eslint-plugin-specs/index.js
+++ b/packages/eslint-plugin-specs/index.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/eslint-plugin-specs/react-native-modules.js
+++ b/packages/eslint-plugin-specs/react-native-modules.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/eslint-plugin-specs/with-babel-register/disk-cache.js
+++ b/packages/eslint-plugin-specs/with-babel-register/disk-cache.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 const fs = require('fs');

--- a/packages/eslint-plugin-specs/with-babel-register/index.js
+++ b/packages/eslint-plugin-specs/with-babel-register/index.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 const diskCache = require('./disk-cache');

--- a/packages/helloworld/__tests__/cli-skip.js
+++ b/packages/helloworld/__tests__/cli-skip.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 // TODO(T187224491): js1 jest doesn't install the correct commander, instead

--- a/packages/helloworld/cli.flow.js
+++ b/packages/helloworld/cli.flow.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import {run} from './lib/cli';

--- a/packages/helloworld/cli.js
+++ b/packages/helloworld/cli.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 /*::

--- a/packages/helloworld/lib/cli.js
+++ b/packages/helloworld/lib/cli.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {Task} from '@react-native/core-cli-utils';

--- a/packages/helloworld/lib/filesystem.js
+++ b/packages/helloworld/lib/filesystem.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import {execSync, spawn} from 'child_process';

--- a/packages/helloworld/lib/ios.js
+++ b/packages/helloworld/lib/ios.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {XcodeBuildSettings} from './xcode';

--- a/packages/helloworld/lib/xcode.js
+++ b/packages/helloworld/lib/xcode.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 // For the complete list:

--- a/packages/helloworld/scripts/metro.js
+++ b/packages/helloworld/scripts/metro.js
@@ -6,7 +6,6 @@
  *
  * @noflow
  * @format
- * @oncall react_native
  */
 
 const {startCommand} = require('@react-native/community-cli-plugin');

--- a/packages/helloworld/scripts/monorepo.js
+++ b/packages/helloworld/scripts/monorepo.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 // To be able to execute the cli as a yarn script, we have to strip our yarn types.

--- a/packages/metro-config/src/index.flow.js
+++ b/packages/metro-config/src/index.flow.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {ConfigT} from 'metro-config';

--- a/packages/metro-config/src/index.js
+++ b/packages/metro-config/src/index.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 /*::

--- a/packages/normalize-color/__tests__/normalizeColor-test.js
+++ b/packages/normalize-color/__tests__/normalizeColor-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/polyfills/__tests__/console-itest.js
+++ b/packages/polyfills/__tests__/console-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 const LOG_LEVELS = {

--- a/packages/react-native-babel-preset/src/__mocks__/test-helpers.js
+++ b/packages/react-native-babel-preset/src/__mocks__/test-helpers.js
@@ -6,7 +6,6 @@
  *
  * @format
  * @flow strict
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-babel-preset/src/configs/hmr.js
+++ b/packages/react-native-babel-preset/src/configs/hmr.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-babel-preset/src/configs/lazy-imports.js
+++ b/packages/react-native-babel-preset/src/configs/lazy-imports.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 // This is the set of modules that React Native publicly exports and that we

--- a/packages/react-native-babel-preset/src/configs/main.js
+++ b/packages/react-native-babel-preset/src/configs/main.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-babel-preset/src/index.js
+++ b/packages/react-native-babel-preset/src/index.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-babel-preset/src/passthrough-syntax-plugins.js
+++ b/packages/react-native-babel-preset/src/passthrough-syntax-plugins.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-babel-preset/src/plugin-warn-on-deep-imports.js
+++ b/packages/react-native-babel-preset/src/plugin-warn-on-deep-imports.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-babel-transformer/src/index.js
+++ b/packages/react-native-babel-transformer/src/index.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 // This file uses Flow comment syntax so that it may be used from source as a

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GenerateComponentDescriptorH-test.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GenerateComponentDescriptorH-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GenerateComponentHObjCpp-test.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GenerateComponentHObjCpp-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GenerateEventEmitterCpp-test.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GenerateEventEmitterCpp-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GenerateEventEmitterH-test.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GenerateEventEmitterH-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GeneratePropsCpp-test.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GeneratePropsCpp-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GeneratePropsH-test.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GeneratePropsH-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GeneratePropsJavaDelegate-test.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GeneratePropsJavaDelegate-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GeneratePropsJavaInterface-test.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GeneratePropsJavaInterface-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GenerateShadowNodeCpp-test.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GenerateShadowNodeCpp-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GenerateShadowNodeH-test.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GenerateShadowNodeH-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GenerateViewConfigJs-test.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/GenerateViewConfigJs-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/modules/GenerateModuleCpp-test.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/modules/GenerateModuleCpp-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/modules/GenerateModuleH-test.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/modules/GenerateModuleH-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/modules/GenerateModuleObjCpp-test.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/modules/GenerateModuleObjCpp-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/GenerateComponentDescriptorH-test.js
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/GenerateComponentDescriptorH-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/GenerateComponentHObjCpp-test.js
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/GenerateComponentHObjCpp-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/GenerateEventEmitterCpp-test.js
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/GenerateEventEmitterCpp-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/GenerateEventEmitterH-test.js
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/GenerateEventEmitterH-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/GeneratePropsCpp-test.js
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/GeneratePropsCpp-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/GeneratePropsH-test.js
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/GeneratePropsH-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/GeneratePropsJavaDelegate-test.js
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/GeneratePropsJavaDelegate-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/GeneratePropsJavaInterface-test.js
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/GeneratePropsJavaInterface-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/GenerateShadowNodeCpp-test.js
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/GenerateShadowNodeCpp-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/GenerateShadowNodeH-test.js
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/GenerateShadowNodeH-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/GenerateViewConfigJs-test.js
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/GenerateViewConfigJs-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/__tests__/SchemaValidator-test.js
+++ b/packages/react-native-codegen/src/__tests__/SchemaValidator-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/cli/combine/__tests__/combine-utils-test.js
+++ b/packages/react-native-codegen/src/cli/combine/__tests__/combine-utils-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use-strict';

--- a/packages/react-native-codegen/src/cli/combine/combine-js-to-schema-cli.js
+++ b/packages/react-native-codegen/src/cli/combine/combine-js-to-schema-cli.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/cli/combine/combine-utils.js
+++ b/packages/react-native-codegen/src/cli/combine/combine-utils.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/cli/parser/parser-cli.js
+++ b/packages/react-native-codegen/src/cli/parser/parser-cli.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/generators/TypeUtils/Cxx/index.js
+++ b/packages/react-native-codegen/src/generators/TypeUtils/Cxx/index.js
@@ -6,7 +6,6 @@
  *
  * @flow strict
  * @format
- * @oncall react_native
  */
 
 function wrapOptional(type: string, isRequired: boolean): string {

--- a/packages/react-native-codegen/src/generators/TypeUtils/Java/index.js
+++ b/packages/react-native-codegen/src/generators/TypeUtils/Java/index.js
@@ -6,7 +6,6 @@
  *
  * @flow strict
  * @format
- * @oncall react_native
  */
 
 const objectTypeForPrimitiveType = {

--- a/packages/react-native-codegen/src/generators/TypeUtils/Objective-C/index.js
+++ b/packages/react-native-codegen/src/generators/TypeUtils/Objective-C/index.js
@@ -6,7 +6,6 @@
  *
  * @flow strict
  * @format
- * @oncall react_native
  */
 
 function wrapOptional(type: string, isRequired: boolean): string {

--- a/packages/react-native-codegen/src/generators/__tests__/RNCodegen-test.js
+++ b/packages/react-native-codegen/src/generators/__tests__/RNCodegen-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/generators/components/__tests__/GenerateComponentDescriptorCpp-test.js
+++ b/packages/react-native-codegen/src/generators/components/__tests__/GenerateComponentDescriptorCpp-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/generators/components/__tests__/GenerateComponentDescriptorH-test.js
+++ b/packages/react-native-codegen/src/generators/components/__tests__/GenerateComponentDescriptorH-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/generators/components/__tests__/GenerateComponentHObjCpp-test.js
+++ b/packages/react-native-codegen/src/generators/components/__tests__/GenerateComponentHObjCpp-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/generators/components/__tests__/GenerateEventEmitterCpp-test.js
+++ b/packages/react-native-codegen/src/generators/components/__tests__/GenerateEventEmitterCpp-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/generators/components/__tests__/GenerateEventEmitterH-test.js
+++ b/packages/react-native-codegen/src/generators/components/__tests__/GenerateEventEmitterH-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/generators/components/__tests__/GeneratePropsCpp-test.js
+++ b/packages/react-native-codegen/src/generators/components/__tests__/GeneratePropsCpp-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/generators/components/__tests__/GeneratePropsH-test.js
+++ b/packages/react-native-codegen/src/generators/components/__tests__/GeneratePropsH-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/generators/components/__tests__/GeneratePropsJavaDelegate-test.js
+++ b/packages/react-native-codegen/src/generators/components/__tests__/GeneratePropsJavaDelegate-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/generators/components/__tests__/GeneratePropsJavaInterface-test.js
+++ b/packages/react-native-codegen/src/generators/components/__tests__/GeneratePropsJavaInterface-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/generators/components/__tests__/GeneratePropsJavaPojo-test.js
+++ b/packages/react-native-codegen/src/generators/components/__tests__/GeneratePropsJavaPojo-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/generators/components/__tests__/GenerateShadowNodeCpp-test.js
+++ b/packages/react-native-codegen/src/generators/components/__tests__/GenerateShadowNodeCpp-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/generators/components/__tests__/GenerateShadowNodeH-test.js
+++ b/packages/react-native-codegen/src/generators/components/__tests__/GenerateShadowNodeH-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/generators/components/__tests__/GenerateStateCpp-test.js
+++ b/packages/react-native-codegen/src/generators/components/__tests__/GenerateStateCpp-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/generators/components/__tests__/GenerateStateH-test.js
+++ b/packages/react-native-codegen/src/generators/components/__tests__/GenerateStateH-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/generators/components/__tests__/GenerateTests-test.js
+++ b/packages/react-native-codegen/src/generators/components/__tests__/GenerateTests-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/generators/components/__tests__/GenerateThirdPartyFabricComponentsProviderH-test.js
+++ b/packages/react-native-codegen/src/generators/components/__tests__/GenerateThirdPartyFabricComponentsProviderH-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/generators/components/__tests__/GenerateThirdPartyFabricComponentsProviderObjCpp-test.js
+++ b/packages/react-native-codegen/src/generators/components/__tests__/GenerateThirdPartyFabricComponentsProviderObjCpp-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/generators/components/__tests__/GenerateViewConfigJs-test.js
+++ b/packages/react-native-codegen/src/generators/components/__tests__/GenerateViewConfigJs-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/generators/modules/__tests__/GenerateModuleCpp-test.js
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/GenerateModuleCpp-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/generators/modules/__tests__/GenerateModuleH-test.js
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/GenerateModuleH-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/generators/modules/__tests__/GenerateModuleHObjCpp-test.js
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/GenerateModuleHObjCpp-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/generators/modules/__tests__/GenerateModuleJavaSpec-test.js
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/GenerateModuleJavaSpec-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/generators/modules/__tests__/GenerateModuleJniCpp-test.js
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/GenerateModuleJniCpp-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/generators/modules/__tests__/GenerateModuleJniH-test.js
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/GenerateModuleJniH-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/generators/modules/__tests__/GenerateModuleMm-test.js
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/GenerateModuleMm-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
@@ -6,7 +6,6 @@
  *
  * @format
  * @flow strict-local
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-commons-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use-strict';

--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use-strict';

--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use-strict';

--- a/packages/react-native-codegen/src/parsers/__tests__/utils-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/utils-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/parsers/consistency/__tests__/checkComponentSnaps-test.js
+++ b/packages/react-native-codegen/src/parsers/consistency/__tests__/checkComponentSnaps-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/parsers/consistency/__tests__/checkModuleSnaps-test.js
+++ b/packages/react-native-codegen/src/parsers/consistency/__tests__/checkModuleSnaps-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/parsers/consistency/compareSnaps.js
+++ b/packages/react-native-codegen/src/parsers/consistency/compareSnaps.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/parsers/flow/components/__tests__/component-parser-test.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/__tests__/component-parser-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/module-parser-snapshot-test.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/module-parser-snapshot-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/parsers/typescript/components/__tests__/typescript-component-parser-test.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/__tests__/typescript-component-parser-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/typescript-module-parser-snapshot-test.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/typescript-module-parser-snapshot-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native-compatibility-check/src/__tests__/ErrorFormatting-test.js
+++ b/packages/react-native-compatibility-check/src/__tests__/ErrorFormatting-test.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 import {formatDiffSet} from '../ErrorFormatting.js';

--- a/packages/react-native-compatibility-check/src/__tests__/ErrorFormattingTests.js
+++ b/packages/react-native-compatibility-check/src/__tests__/ErrorFormattingTests.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 export const okayChanges = [

--- a/packages/react-native-compatibility-check/src/__tests__/TypeDiffing-test.js
+++ b/packages/react-native-compatibility-check/src/__tests__/TypeDiffing-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 import convertPropToBasicTypes from '../convertPropToBasicTypes';

--- a/packages/react-native-compatibility-check/src/__tests__/VersionDiffing-test.js
+++ b/packages/react-native-compatibility-check/src/__tests__/VersionDiffing-test.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 import type {SchemaDiff, TypeStore} from '../DiffResults';

--- a/packages/react-native-compatibility-check/src/__tests__/utilities/getTestSchema.js
+++ b/packages/react-native-compatibility-check/src/__tests__/utilities/getTestSchema.js
@@ -6,7 +6,6 @@
  *
  * @format
  * @flow strict-local
- * @oncall react_native
  */
 
 import type {SchemaType} from '@react-native/codegen/src/CodegenSchema';

--- a/packages/react-native-compatibility-check/src/convertPropToBasicTypes.js
+++ b/packages/react-native-compatibility-check/src/convertPropToBasicTypes.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {

--- a/packages/react-native-compatibility-check/src/index.flow.js
+++ b/packages/react-native-compatibility-check/src/index.flow.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 export {compareSchemas} from './index.js';

--- a/packages/react-native-compatibility-check/src/index.js
+++ b/packages/react-native-compatibility-check/src/index.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {

--- a/packages/react-native-fantom/runner/EnvironmentOptions.js
+++ b/packages/react-native-fantom/runner/EnvironmentOptions.js
@@ -6,7 +6,6 @@
  *
  * @flow strict
  * @format
- * @oncall react_native
  */
 
 export const printCLIOutput: boolean = Boolean(process.env.FANTOM_PRINT_OUTPUT);

--- a/packages/react-native-fantom/runner/entrypoint-template.js
+++ b/packages/react-native-fantom/runner/entrypoint-template.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {SnapshotConfig} from '../runtime/snapshotContext';
@@ -41,7 +40,6 @@ module.exports = function entrypointTemplate({
  * ${'@'}generated
  * @noformat
  * @noflow
- * @oncall react_native
  */
 
 import {registerTest} from '${setupModulePath}';

--- a/packages/react-native-fantom/runner/getFantomTestConfig.js
+++ b/packages/react-native-fantom/runner/getFantomTestConfig.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {FeatureFlagValue} from '../../../packages/react-native/scripts/featureflags/types';

--- a/packages/react-native-fantom/runner/index.js
+++ b/packages/react-native-fantom/runner/index.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 require('../../../scripts/babel-register').registerForMonorepo();

--- a/packages/react-native-fantom/runner/runner.js
+++ b/packages/react-native-fantom/runner/runner.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {TestSuiteResult} from '../runtime/setup';

--- a/packages/react-native-fantom/runner/snapshotUtils.js
+++ b/packages/react-native-fantom/runner/snapshotUtils.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {TestSnapshotResults} from '../runtime/snapshotContext';

--- a/packages/react-native-fantom/runner/utils.js
+++ b/packages/react-native-fantom/runner/utils.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import * as EnvironmentOptions from './EnvironmentOptions';

--- a/packages/react-native-fantom/runner/warmup/index.js
+++ b/packages/react-native-fantom/runner/warmup/index.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 require('../../../../scripts/babel-register').registerForMonorepo();

--- a/packages/react-native-fantom/runner/warmup/warmup.js
+++ b/packages/react-native-fantom/runner/warmup/warmup.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import {

--- a/packages/react-native-fantom/runtime/WarmUpEntryPoint.js
+++ b/packages/react-native-fantom/runtime/WarmUpEntryPoint.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 /**

--- a/packages/react-native-fantom/runtime/expect.js
+++ b/packages/react-native-fantom/runtime/expect.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import {ensureMockFunction} from './mocks';

--- a/packages/react-native-fantom/runtime/mocks.js
+++ b/packages/react-native-fantom/runtime/mocks.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 export const MOCK_FN_TAG: symbol = Symbol('mock function');

--- a/packages/react-native-fantom/runtime/mocks/ReactNativeInternalFeatureFlags.js
+++ b/packages/react-native-fantom/runtime/mocks/ReactNativeInternalFeatureFlags.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 module.exports = {

--- a/packages/react-native-fantom/runtime/patchWeakRef.js
+++ b/packages/react-native-fantom/runtime/patchWeakRef.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import * as Fantom from '@react-native/fantom';

--- a/packages/react-native-fantom/runtime/setup.js
+++ b/packages/react-native-fantom/runtime/setup.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {SnapshotConfig, TestSnapshotResults} from './snapshotContext';

--- a/packages/react-native-fantom/runtime/snapshotContext.js
+++ b/packages/react-native-fantom/runtime/snapshotContext.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import {diff} from 'jest-diff';

--- a/packages/react-native-fantom/src/__tests__/Fantom-itest.js
+++ b/packages/react-native-fantom/src/__tests__/Fantom-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';

--- a/packages/react-native-fantom/src/__tests__/FantomFeatureFlags-itest.js
+++ b/packages/react-native-fantom/src/__tests__/FantomFeatureFlags-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  * @fantom_flags commonTestFlag:true jsOnlyTestFlag:true
  */
 

--- a/packages/react-native-fantom/src/__tests__/FantomModeDefault-itest.js
+++ b/packages/react-native-fantom/src/__tests__/FantomModeDefault-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 describe('no "@fantom_mode" in docblock', () => {

--- a/packages/react-native-fantom/src/__tests__/FantomModeDev-itest.js
+++ b/packages/react-native-fantom/src/__tests__/FantomModeDev-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  * @fantom_mode dev
  */
 

--- a/packages/react-native-fantom/src/__tests__/FantomModeDevBytecode-itest.js
+++ b/packages/react-native-fantom/src/__tests__/FantomModeDevBytecode-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  * @fantom_mode dev-bytecode
  */
 

--- a/packages/react-native-fantom/src/__tests__/FantomModeOpt-itest.js
+++ b/packages/react-native-fantom/src/__tests__/FantomModeOpt-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  * @fantom_mode opt
  */
 

--- a/packages/react-native-fantom/src/__tests__/FantomWeakRefs-itest.js
+++ b/packages/react-native-fantom/src/__tests__/FantomWeakRefs-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';

--- a/packages/react-native-fantom/src/__tests__/benchmarks/BenchmarkTests-testMode-benchmark-itest.js
+++ b/packages/react-native-fantom/src/__tests__/benchmarks/BenchmarkTests-testMode-benchmark-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';

--- a/packages/react-native-fantom/src/__tests__/expect-itest.js
+++ b/packages/react-native-fantom/src/__tests__/expect-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import * as React from 'react';

--- a/packages/react-native-fantom/src/__tests__/playground/Playground-benchmark-itest.js
+++ b/packages/react-native-fantom/src/__tests__/playground/Playground-benchmark-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';

--- a/packages/react-native-fantom/src/__tests__/playground/Playground-itest.js
+++ b/packages/react-native-fantom/src/__tests__/playground/Playground-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';

--- a/packages/react-native-fantom/src/__tests__/setup/focused-hooks-itest.js
+++ b/packages/react-native-fantom/src/__tests__/setup/focused-hooks-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 const logs: string[] = [];

--- a/packages/react-native-fantom/src/__tests__/setup/order-of-execution-itest.js
+++ b/packages/react-native-fantom/src/__tests__/setup/order-of-execution-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 const logs: string[] = [];

--- a/packages/react-native-fantom/src/__tests__/setup/order-of-hooks-executions-itest.js
+++ b/packages/react-native-fantom/src/__tests__/setup/order-of-hooks-executions-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 const logs: string[] = [];

--- a/packages/react-native-fantom/src/__tests__/setup/scoping-itest.js
+++ b/packages/react-native-fantom/src/__tests__/setup/scoping-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 const logs: string[] = [];

--- a/packages/react-native-fantom/src/getFantomRenderedOutput.js
+++ b/packages/react-native-fantom/src/getFantomRenderedOutput.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 // $FlowExpectedError[untyped-import]

--- a/packages/react-native/Libraries/Animated/Animated.js
+++ b/packages/react-native/Libraries/Animated/Animated.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import typeof * as AnimatedExports from './AnimatedExports';

--- a/packages/react-native/Libraries/Animated/Animated.js.flow
+++ b/packages/react-native/Libraries/Animated/Animated.js.flow
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 export * as default from './AnimatedExports';

--- a/packages/react-native/Libraries/Animated/AnimatedExports.js
+++ b/packages/react-native/Libraries/Animated/AnimatedExports.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 import typeof AnimatedFlatList from './components/AnimatedFlatList';

--- a/packages/react-native/Libraries/Animated/AnimatedExports.js.flow
+++ b/packages/react-native/Libraries/Animated/AnimatedExports.js.flow
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 import AnimatedImplementation from './AnimatedImplementation';

--- a/packages/react-native/Libraries/Animated/__tests__/Animated-test.js
+++ b/packages/react-native/Libraries/Animated/__tests__/Animated-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 import * as React from 'react';

--- a/packages/react-native/Libraries/Animated/__tests__/Animated-web-test.js
+++ b/packages/react-native/Libraries/Animated/__tests__/Animated-web-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 const StyleSheet = require('../../StyleSheet/StyleSheet').default;

--- a/packages/react-native/Libraries/Animated/__tests__/AnimatedMock-test.js
+++ b/packages/react-native/Libraries/Animated/__tests__/AnimatedMock-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Animated/__tests__/AnimatedObject-test.js
+++ b/packages/react-native/Libraries/Animated/__tests__/AnimatedObject-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 import nullthrows from 'nullthrows';

--- a/packages/react-native/Libraries/Animated/__tests__/AnimatedProps-test.js
+++ b/packages/react-native/Libraries/Animated/__tests__/AnimatedProps-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import AnimatedProps from '../nodes/AnimatedProps';

--- a/packages/react-native/Libraries/Animated/__tests__/AnimatedValue-test.js
+++ b/packages/react-native/Libraries/Animated/__tests__/AnimatedValue-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 describe('AnimatedValue', () => {

--- a/packages/react-native/Libraries/Animated/__tests__/Easing-test.js
+++ b/packages/react-native/Libraries/Animated/__tests__/Easing-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Animated/__tests__/Interpolation-test.js
+++ b/packages/react-native/Libraries/Animated/__tests__/Interpolation-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Animated/__tests__/NativeAnimatedAllowlist-test.js
+++ b/packages/react-native/Libraries/Animated/__tests__/NativeAnimatedAllowlist-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 describe('NativeAnimatedAllowlist', () => {

--- a/packages/react-native/Libraries/Animated/__tests__/TimingAnimation-test.js
+++ b/packages/react-native/Libraries/Animated/__tests__/TimingAnimation-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Animated/__tests__/bezier-test.js
+++ b/packages/react-native/Libraries/Animated/__tests__/bezier-test.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 /**

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedObject.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedObject.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/BatchedBridge/__tests__/MessageQueue-test.js
+++ b/packages/react-native/Libraries/BatchedBridge/__tests__/MessageQueue-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/BatchedBridge/__tests__/NativeModules-test.js
+++ b/packages/react-native/Libraries/BatchedBridge/__tests__/NativeModules-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Blob/__tests__/Blob-test.js
+++ b/packages/react-native/Libraries/Blob/__tests__/Blob-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Blob/__tests__/BlobManager-test.js
+++ b/packages/react-native/Libraries/Blob/__tests__/BlobManager-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Blob/__tests__/BlobRegistry-test.js
+++ b/packages/react-native/Libraries/Blob/__tests__/BlobRegistry-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Blob/__tests__/File-test.js
+++ b/packages/react-native/Libraries/Blob/__tests__/File-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Blob/__tests__/FileReader-test.js
+++ b/packages/react-native/Libraries/Blob/__tests__/FileReader-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Blob/__tests__/URL-test.js
+++ b/packages/react-native/Libraries/Blob/__tests__/URL-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Components/ActivityIndicator/__tests__/ActivityIndicator-test.js
+++ b/packages/react-native/Libraries/Components/ActivityIndicator/__tests__/ActivityIndicator-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Components/DrawerAndroid/__tests__/DrawerAndroid-test.js
+++ b/packages/react-native/Libraries/Components/DrawerAndroid/__tests__/DrawerAndroid-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Components/Keyboard/__tests__/Keyboard-test.js
+++ b/packages/react-native/Libraries/Components/Keyboard/__tests__/Keyboard-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 const LayoutAnimation =

--- a/packages/react-native/Libraries/Components/LayoutConformance/LayoutConformance.js
+++ b/packages/react-native/Libraries/Components/LayoutConformance/LayoutConformance.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import StyleSheet from '../../StyleSheet/StyleSheet';

--- a/packages/react-native/Libraries/Components/Pressable/__tests__/Pressable-test.js
+++ b/packages/react-native/Libraries/Components/Pressable/__tests__/Pressable-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import {expectRendersMatchingSnapshot} from '../../../Utilities/ReactNativeTestTools';

--- a/packages/react-native/Libraries/Components/ProgressBarAndroid/__tests__/ProgressBarAndroid-test.js
+++ b/packages/react-native/Libraries/Components/ProgressBarAndroid/__tests__/ProgressBarAndroid-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Components/SafeAreaView/__tests__/SafeAreaView-test.js
+++ b/packages/react-native/Libraries/Components/SafeAreaView/__tests__/SafeAreaView-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-itest.js
+++ b/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';

--- a/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-test.js
+++ b/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-test.js
@@ -6,7 +6,6 @@
  *
  * @flow-strict
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-viewCulling-itest.js
+++ b/packages/react-native/Libraries/Components/ScrollView/__tests__/ScrollView-viewCulling-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  * @fantom_flags enableViewCulling:true
  * @fantom_flags enableSynchronousStateUpdates:true
  * @fantom_flags enableFixForParentTagDuringReparenting:true

--- a/packages/react-native/Libraries/Components/StatusBar/__tests__/StatusBar-test.js
+++ b/packages/react-native/Libraries/Components/StatusBar/__tests__/StatusBar-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
+++ b/packages/react-native/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
@@ -10,11 +10,7 @@
 
 import type {HostComponent} from '../../../src/private/types/HostComponent';
 import type {PartialViewConfig} from '../../Renderer/shims/ReactNativeTypes';
-import type {
-  ColorValue,
-  TextStyleProp,
-  ViewStyleProp,
-} from '../../StyleSheet/StyleSheet';
+import type {ColorValue, TextStyleProp} from '../../StyleSheet/StyleSheet';
 import type {
   BubblingEventHandler,
   DirectEventHandler,

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
@@ -16,11 +16,7 @@ import type {
 } from '../../Types/CoreEventTypes';
 import type {ViewProps} from '../View/ViewPropTypes';
 
-import {
-  type ColorValue,
-  type TextStyleProp,
-  type ViewStyleProp,
-} from '../../StyleSheet/StyleSheet';
+import {type ColorValue, type TextStyleProp} from '../../StyleSheet/StyleSheet';
 import * as React from 'react';
 
 /**

--- a/packages/react-native/Libraries/Components/TextInput/__tests__/InputAccessoryView-test.js
+++ b/packages/react-native/Libraries/Components/TextInput/__tests__/InputAccessoryView-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-itest.js
+++ b/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';

--- a/packages/react-native/Libraries/Components/Touchable/__tests__/TouchableHighlight-test.js
+++ b/packages/react-native/Libraries/Components/Touchable/__tests__/TouchableHighlight-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Components/Touchable/__tests__/TouchableNativeFeedback-test.js
+++ b/packages/react-native/Libraries/Components/Touchable/__tests__/TouchableNativeFeedback-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Components/Touchable/__tests__/TouchableOpacity-test.js
+++ b/packages/react-native/Libraries/Components/Touchable/__tests__/TouchableOpacity-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Components/Touchable/__tests__/TouchableWithoutFeedback-test.js
+++ b/packages/react-native/Libraries/Components/Touchable/__tests__/TouchableWithoutFeedback-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Components/View/__tests__/View-benchmark-itest.js
+++ b/packages/react-native/Libraries/Components/View/__tests__/View-benchmark-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';

--- a/packages/react-native/Libraries/Components/View/__tests__/View-itest.js
+++ b/packages/react-native/Libraries/Components/View/__tests__/View-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';

--- a/packages/react-native/Libraries/Components/View/__tests__/View-test.js
+++ b/packages/react-native/Libraries/Components/View/__tests__/View-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Core/Devtools/__tests__/loadBundleFromServer-test.js
+++ b/packages/react-native/Libraries/Core/Devtools/__tests__/loadBundleFromServer-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Core/Devtools/__tests__/parseErrorStack-test.js
+++ b/packages/react-native/Libraries/Core/Devtools/__tests__/parseErrorStack-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Core/Devtools/__tests__/parseHermesStack-test.js
+++ b/packages/react-native/Libraries/Core/Devtools/__tests__/parseHermesStack-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Core/Devtools/loadBundleFromServer.js
+++ b/packages/react-native/Libraries/Core/Devtools/loadBundleFromServer.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import Networking from '../../Network/RCTNetworking';

--- a/packages/react-native/Libraries/Core/Timers/__tests__/JSTimers-test.js
+++ b/packages/react-native/Libraries/Core/Timers/__tests__/JSTimers-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Core/__mocks__/NativeExceptionsManager.js
+++ b/packages/react-native/Libraries/Core/__mocks__/NativeExceptionsManager.js
@@ -6,7 +6,6 @@
  *
  * @flow strict
  * @format
- * @oncall react_native
  */
 
 import typeof NativeExceptionsManager from '../NativeExceptionsManager';

--- a/packages/react-native/Libraries/Core/__tests__/ExceptionsManager-test.js
+++ b/packages/react-native/Libraries/Core/__tests__/ExceptionsManager-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Core/__tests__/ReactNativeVersionCheck-test.js
+++ b/packages/react-native/Libraries/Core/__tests__/ReactNativeVersionCheck-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Debugging/DebuggingOverlayRegistry.js
+++ b/packages/react-native/Libraries/Debugging/DebuggingOverlayRegistry.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {HostInstance} from '../../src/private/types/HostInstance';

--- a/packages/react-native/Libraries/Debugging/useSubscribeToDebuggingOverlayRegistry.js
+++ b/packages/react-native/Libraries/Debugging/useSubscribeToDebuggingOverlayRegistry.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {

--- a/packages/react-native/Libraries/Image/__tests__/AssetUtils-test.js
+++ b/packages/react-native/Libraries/Image/__tests__/AssetUtils-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 import {getUrlCacheBreaker, setUrlCacheBreaker} from '../AssetUtils';

--- a/packages/react-native/Libraries/Image/__tests__/Image-test.js
+++ b/packages/react-native/Libraries/Image/__tests__/Image-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Image/__tests__/ImageBackground-test.js
+++ b/packages/react-native/Libraries/Image/__tests__/ImageBackground-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Image/__tests__/ImageSourceUtils-test.js
+++ b/packages/react-native/Libraries/Image/__tests__/ImageSourceUtils-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 const {getImageSourcesFromImageProps} = require('../ImageSourceUtils');

--- a/packages/react-native/Libraries/Image/__tests__/assetRelativePathInSnapshot-test.js
+++ b/packages/react-native/Libraries/Image/__tests__/assetRelativePathInSnapshot-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Image/__tests__/resolveAssetSource-test.js
+++ b/packages/react-native/Libraries/Image/__tests__/resolveAssetSource-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Interaction/__tests__/InteractionManager-test.js
+++ b/packages/react-native/Libraries/Interaction/__tests__/InteractionManager-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Interaction/__tests__/TaskQueue-test.js
+++ b/packages/react-native/Libraries/Interaction/__tests__/TaskQueue-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Lists/__tests__/FlatList-test.js
+++ b/packages/react-native/Libraries/Lists/__tests__/FlatList-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Lists/__tests__/SectionList-test.js
+++ b/packages/react-native/Libraries/Lists/__tests__/SectionList-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/LogBox/Data/__tests__/LogBoxData-test.js
+++ b/packages/react-native/Libraries/LogBox/Data/__tests__/LogBoxData-test.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/LogBox/Data/__tests__/LogBoxLog-test.js
+++ b/packages/react-native/Libraries/LogBox/Data/__tests__/LogBoxLog-test.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/LogBox/Data/__tests__/LogBoxSymbolication-test.js
+++ b/packages/react-native/Libraries/LogBox/Data/__tests__/LogBoxSymbolication-test.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/LogBox/Data/__tests__/parseLogBoxLog-test.js
+++ b/packages/react-native/Libraries/LogBox/Data/__tests__/parseLogBoxLog-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxButton-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxButton-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import Text from '../../../Text/Text';

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspector-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspector-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorCodeFrame-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorCodeFrame-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorFooter-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorFooter-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorHeader-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorHeader-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorMessageHeader-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorMessageHeader-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorReactFrames-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorReactFrames-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorSection-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorSection-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import Text from '../../../Text/Text';

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorSourceMapStatus-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorSourceMapStatus-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorStackFrame-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorStackFrame-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorStackFrames-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxInspectorStackFrames-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {StackFrame} from '../../../Core/NativeExceptionsManager';

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxMessage-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxMessage-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxNotification-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxNotification-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/LogBox/__tests__/LogBox-itest.js
+++ b/packages/react-native/Libraries/LogBox/__tests__/LogBox-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import 'react-native/Libraries/Core/InitializeCore';

--- a/packages/react-native/Libraries/LogBox/__tests__/LogBox-test.js
+++ b/packages/react-native/Libraries/LogBox/__tests__/LogBox-test.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/LogBox/__tests__/LogBoxInspectorContainer-test.js
+++ b/packages/react-native/Libraries/LogBox/__tests__/LogBoxInspectorContainer-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/LogBox/__tests__/LogBoxNotificationContainer-test.js
+++ b/packages/react-native/Libraries/LogBox/__tests__/LogBoxNotificationContainer-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/LogBox/__tests__/fantomHelpers.js
+++ b/packages/react-native/Libraries/LogBox/__tests__/fantomHelpers.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import ensureInstance from '../../../src/private/__tests__/utilities/ensureInstance';

--- a/packages/react-native/Libraries/Modal/__tests__/Modal-test.js
+++ b/packages/react-native/Libraries/Modal/__tests__/Modal-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/NativeComponent/__tests__/StaticViewConfigValidator-test.js
+++ b/packages/react-native/Libraries/NativeComponent/__tests__/StaticViewConfigValidator-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict
  * @format
- * @oncall react_native
  */
 
 import * as ReactNativeFeatureFlags from '../../../src/private/featureflags/ReactNativeFeatureFlags';

--- a/packages/react-native/Libraries/Network/__tests__/FormData-test.js
+++ b/packages/react-native/Libraries/Network/__tests__/FormData-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Network/__tests__/XMLHttpRequest-test.js
+++ b/packages/react-native/Libraries/Network/__tests__/XMLHttpRequest-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Pressability/__tests__/Pressability-test.js
+++ b/packages/react-native/Libraries/Pressability/__tests__/Pressability-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 // TODO(legacy-fake-timers): Fix these tests to work with modern timers.

--- a/packages/react-native/Libraries/ReactNative/AppContainer-dev.js
+++ b/packages/react-native/Libraries/ReactNative/AppContainer-dev.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {

--- a/packages/react-native/Libraries/ReactNative/AppContainer-prod.js
+++ b/packages/react-native/Libraries/ReactNative/AppContainer-prod.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {Props} from './AppContainer';

--- a/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/ReactFabricPublicInstance-Legacy-itest.js
+++ b/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/ReactFabricPublicInstance-Legacy-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  * @fantom_flags enableAccessToHostTreeInFabric:false
  */
 

--- a/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/ReactFabricPublicInstance-Modern-itest.js
+++ b/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/ReactFabricPublicInstance-Modern-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  * @fantom_flags enableAccessToHostTreeInFabric:true
  */
 

--- a/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/ReactFabricPublicInstance-benchmark-itest.js
+++ b/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/ReactFabricPublicInstance-benchmark-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';

--- a/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/setUpReactFabricPublicInstanceFantomTests.js
+++ b/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/setUpReactFabricPublicInstanceFantomTests.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';

--- a/packages/react-native/Libraries/ReactNative/__tests__/FabricUIManager-test.js
+++ b/packages/react-native/Libraries/ReactNative/__tests__/FabricUIManager-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 // flowlint unsafe-getters-setters:off

--- a/packages/react-native/Libraries/ReactNative/__tests__/InterruptibleRendering-itest.js
+++ b/packages/react-native/Libraries/ReactNative/__tests__/InterruptibleRendering-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  * @fantom_flags fixMappingOfEventPrioritiesBetweenFabricAndReact:true
  */
 

--- a/packages/react-native/Libraries/ReactNative/__tests__/ReactFabric-Suspense-itest.js
+++ b/packages/react-native/Libraries/ReactNative/__tests__/ReactFabric-Suspense-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';

--- a/packages/react-native/Libraries/ReactNative/__tests__/State-ForcedCloneCommitHook-itest.js
+++ b/packages/react-native/Libraries/ReactNative/__tests__/State-ForcedCloneCommitHook-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  * @fantom_flags useShadowNodeStateOnClone:true
  */
 

--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
@@ -11,7 +11,6 @@
 'use strict';
 
 import type {WithAnimatedValue} from '../Animated/createAnimatedComponent';
-import type AnimatedNode from '../Animated/nodes/AnimatedNode';
 import type {ImageResizeMode} from './../Image/ImageResizeMode';
 import type {
   ____DangerouslyImpreciseStyle_InternalOverrides,

--- a/packages/react-native/Libraries/StyleSheet/__tests__/StyleSheet-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/StyleSheet-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 import StyleSheet from '../StyleSheet';

--- a/packages/react-native/Libraries/StyleSheet/__tests__/flattenStyle-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/flattenStyle-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/StyleSheet/__tests__/normalizeColor-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/normalizeColor-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/StyleSheet/__tests__/processAspectRatio-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/processAspectRatio-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/StyleSheet/__tests__/processBackgroundImage-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/processBackgroundImage-test.js
@@ -1019,7 +1019,7 @@ describe('processBackgroundImage', () => {
   });
 
   // 4. position syntax: [ [ left | right ] <length-percentage> ] && [ [ top | bottom ] <length-percentage> ]
-  it('should handle left position top position syntax', () => {
+  it('should handle position with separate left and top percentages', () => {
     const input = 'radial-gradient(at top 0% right 10%, red, blue)';
     const result = processBackgroundImage(input);
     expect(result[0].position).toEqual({right: '10%', top: '0%'});
@@ -1137,10 +1137,11 @@ describe('processBackgroundImage', () => {
   });
 
   it('should not process negative radius in radial gradient syntax', () => {
-    const input = 'radial-gradient(circle -100px, red, blue)';
-    const input1 = 'radial-gradient(ellipse 100px -40px, red, blue)';
-    const result = processBackgroundImage(input);
+    const input1 = 'radial-gradient(circle -100px, red, blue)';
+    const input2 = 'radial-gradient(ellipse 100px -40px, red, blue)';
     const result1 = processBackgroundImage(input1);
-    expect(result).toEqual([]);
+    const result2 = processBackgroundImage(input2);
+    expect(result1).toEqual([]);
+    expect(result2).toEqual([]);
   });
 });

--- a/packages/react-native/Libraries/StyleSheet/__tests__/processBackgroundImage-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/processBackgroundImage-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/StyleSheet/__tests__/processBoxShadow-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/processBoxShadow-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import processBoxShadow from '../processBoxShadow';

--- a/packages/react-native/Libraries/StyleSheet/__tests__/processColor-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/processColor-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/StyleSheet/__tests__/processColorArray-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/processColorArray-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/StyleSheet/__tests__/processFilter-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/processFilter-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  * @flow strict-local
  */
 

--- a/packages/react-native/Libraries/StyleSheet/__tests__/processFontVariant-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/processFontVariant-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/StyleSheet/__tests__/processTransform-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/processTransform-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/StyleSheet/__tests__/processTransformOrigin-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/processTransformOrigin-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 import processTransformOrigin from '../processTransformOrigin';

--- a/packages/react-native/Libraries/StyleSheet/__tests__/setNormalizedColorAlpha-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/setNormalizedColorAlpha-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/StyleSheet/__tests__/splitLayoutProps-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/splitLayoutProps-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/StyleSheet/processBoxShadow.js
+++ b/packages/react-native/Libraries/StyleSheet/processBoxShadow.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react-native
  */
 
 import type {ProcessedColorValue} from './processColor';

--- a/packages/react-native/Libraries/StyleSheet/processFilter.js
+++ b/packages/react-native/Libraries/StyleSheet/processFilter.js
@@ -6,7 +6,6 @@
  *
  * @format strict-local
  * @flow
- * @oncall react-native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Text/TextProps.js
+++ b/packages/react-native/Libraries/Text/TextProps.js
@@ -12,10 +12,7 @@
 
 import type {
   AccessibilityActionEvent,
-  AccessibilityActionInfo,
   AccessibilityProps,
-  AccessibilityRole,
-  AccessibilityState,
   Role,
 } from '../Components/View/ViewAccessibility';
 import type {ColorValue, TextStyleProp} from '../StyleSheet/StyleSheet';

--- a/packages/react-native/Libraries/Text/__tests__/Text-itest.js
+++ b/packages/react-native/Libraries/Text/__tests__/Text-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';

--- a/packages/react-native/Libraries/Text/__tests__/Text-test.js
+++ b/packages/react-native/Libraries/Text/__tests__/Text-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Types/ReactDevToolsTypes.js
+++ b/packages/react-native/Libraries/Types/ReactDevToolsTypes.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {HostInstance} from '../../src/private/types/HostInstance';

--- a/packages/react-native/Libraries/Utilities/PlatformTypes.js
+++ b/packages/react-native/Libraries/Utilities/PlatformTypes.js
@@ -17,7 +17,7 @@ export type PlatformOSType =
   | 'native';
 
 type OptionalPlatformSelectSpec<T> = {
-  [_key in PlatformOSType]?: T,
+  [key in PlatformOSType]?: T, // eslint-disable-line no-unused-vars
 };
 
 export type PlatformSelectSpec<T> =

--- a/packages/react-native/Libraries/Utilities/__tests__/DeviceInfo-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/DeviceInfo-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Utilities/__tests__/Dimensions-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/Dimensions-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Utilities/__tests__/PixelRatio-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/PixelRatio-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Utilities/__tests__/Platform-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/Platform-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Utilities/__tests__/ReactNativeTestTools-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/ReactNativeTestTools-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import {create} from '../../../jest/renderer';

--- a/packages/react-native/Libraries/Utilities/__tests__/SceneTracker-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/SceneTracker-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Utilities/__tests__/binaryToBase64-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/binaryToBase64-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Utilities/__tests__/codegenNativeComponent-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/codegenNativeComponent-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Utilities/__tests__/deepFreezeAndThrowOnMutationInDev-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/deepFreezeAndThrowOnMutationInDev-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 const deepFreezeAndThrowOnMutationInDev =

--- a/packages/react-native/Libraries/Utilities/__tests__/infoLog-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/infoLog-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Utilities/__tests__/logError-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/logError-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Utilities/__tests__/mapWithSeparator-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/mapWithSeparator-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Utilities/__tests__/stringifySafe-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/stringifySafe-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import stringifySafe, {createStringifySafeWithLimits} from '../stringifySafe';

--- a/packages/react-native/Libraries/Utilities/__tests__/useColorScheme-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/useColorScheme-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import useColorScheme from '../useColorScheme';

--- a/packages/react-native/Libraries/Utilities/__tests__/useMergeRefs-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/useMergeRefs-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {HostInstance} from '../../../src/private/types/HostInstance';

--- a/packages/react-native/Libraries/Utilities/__tests__/useRefEffect-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/useRefEffect-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {HostInstance} from '../../../src/private/types/HostInstance';

--- a/packages/react-native/Libraries/Utilities/__tests__/warnOnce-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/warnOnce-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Utilities/differ/__tests__/deepDiffer-test.js
+++ b/packages/react-native/Libraries/Utilities/differ/__tests__/deepDiffer-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Utilities/differ/__tests__/matricesDiffer-test.js
+++ b/packages/react-native/Libraries/Utilities/differ/__tests__/matricesDiffer-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/WebSocket/__tests__/WebSocket-test.js
+++ b/packages/react-native/Libraries/WebSocket/__tests__/WebSocket-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -8432,7 +8432,7 @@ exports[`public API should not change unintentionally Libraries/Utilities/Platfo
   | \\"web\\"
   | \\"native\\";
 type OptionalPlatformSelectSpec<T> = {
-  [_key in PlatformOSType]?: T,
+  [key in PlatformOSType]?: T,
 };
 export type PlatformSelectSpec<T> =
   | {

--- a/packages/react-native/Libraries/__tests__/public-api-test.js
+++ b/packages/react-native/Libraries/__tests__/public-api-test.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 import type {TransformVisitor} from 'hermes-transform';

--- a/packages/react-native/Libraries/vendor/emitter/__tests__/EventEmitter-test.js
+++ b/packages/react-native/Libraries/vendor/emitter/__tests__/EventEmitter-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict
  * @format
- * @oncall react_native
  */
 
 import type {EventSubscription} from '../EventEmitter';

--- a/packages/react-native/jest/__tests__/setup-test.js
+++ b/packages/react-native/jest/__tests__/setup-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict
  * @format
- * @oncall react_native
  */
 
 import NativeExceptionsManager from '../../Libraries/Core/NativeExceptionsManager';

--- a/packages/react-native/jest/renderer.js
+++ b/packages/react-native/jest/renderer.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 import type {ReactTestRenderer} from 'react-test-renderer';

--- a/packages/react-native/scripts/bundle.js
+++ b/packages/react-native/scripts/bundle.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/scripts/codegen/__fixtures__/fixtures.js
+++ b/packages/react-native/scripts/codegen/__fixtures__/fixtures.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use-strict';

--- a/packages/react-native/scripts/codegen/__tests__/generate-artifacts-executor-test.js
+++ b/packages/react-native/scripts/codegen/__tests__/generate-artifacts-executor-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/scripts/codegen/__tests__/generate-specs-cli-executor-test.js
+++ b/packages/react-native/scripts/codegen/__tests__/generate-specs-cli-executor-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/react-native/scripts/ios-prebuild.js
+++ b/packages/react-native/scripts/ios-prebuild.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 const {prepareHermesArtifactsAsync} = require('./ios-prebuild/hermes');

--- a/packages/react-native/scripts/ios-prebuild/hermes.js
+++ b/packages/react-native/scripts/ios-prebuild/hermes.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 const {execSync} = require('child_process');

--- a/packages/react-native/scripts/ios-prebuild/utils.js
+++ b/packages/react-native/scripts/ios-prebuild/utils.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 const {execSync} = require('child_process');

--- a/packages/react-native/scripts/prepack.js
+++ b/packages/react-native/scripts/prepack.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 const {

--- a/packages/react-native/src/private/__tests__/utilities/ShadowNodeReferenceCounter.js
+++ b/packages/react-native/src/private/__tests__/utilities/ShadowNodeReferenceCounter.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import ReactNativeElement from '../../webapis/dom/nodes/ReadOnlyNode';

--- a/packages/react-native/src/private/__tests__/utilities/__tests__/ShadowNodeReferenceCounter-itest.js
+++ b/packages/react-native/src/private/__tests__/utilities/__tests__/ShadowNodeReferenceCounter-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';

--- a/packages/react-native/src/private/__tests__/utilities/isUnreachable.js
+++ b/packages/react-native/src/private/__tests__/utilities/isUnreachable.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import * as Fantom from '@react-native/fantom';

--- a/packages/react-native/src/private/animated/__tests__/AnimatedNative-test.js
+++ b/packages/react-native/src/private/animated/__tests__/AnimatedNative-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 import {format} from 'node:util';

--- a/packages/react-native/src/private/animated/__tests__/AnimatedProps-itest.js
+++ b/packages/react-native/src/private/animated/__tests__/AnimatedProps-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';

--- a/packages/react-native/src/private/animated/__tests__/createAnimatedPropsHook-test.js
+++ b/packages/react-native/src/private/animated/__tests__/createAnimatedPropsHook-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import {create, update} from '../../../../jest/renderer';

--- a/packages/react-native/src/private/animated/__tests__/createAnimatedPropsMemoHook-test.js
+++ b/packages/react-native/src/private/animated/__tests__/createAnimatedPropsMemoHook-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import {AnimatedEvent} from '../../../../Libraries/Animated/AnimatedEvent';

--- a/packages/react-native/src/private/animated/createAnimatedPropsMemoHook.js
+++ b/packages/react-native/src/private/animated/createAnimatedPropsMemoHook.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type AnimatedProps from '../../../Libraries/Animated/nodes/AnimatedProps';

--- a/packages/react-native/src/private/components/safeareaview/SafeAreaView_INTERNAL_DO_NOT_USE.js
+++ b/packages/react-native/src/private/components/safeareaview/SafeAreaView_INTERNAL_DO_NOT_USE.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {ViewProps} from '../../../../Libraries/Components/View/ViewPropTypes';

--- a/packages/react-native/src/private/components/scrollview/HScrollViewNativeComponents.js
+++ b/packages/react-native/src/private/components/scrollview/HScrollViewNativeComponents.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {ScrollViewNativeProps} from '../../../../Libraries/Components/ScrollView/ScrollViewNativeComponentType';

--- a/packages/react-native/src/private/components/scrollview/VScrollViewNativeComponents.js
+++ b/packages/react-native/src/private/components/scrollview/VScrollViewNativeComponents.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {ScrollViewNativeProps} from '../../../../Libraries/Components/ScrollView/ScrollViewNativeComponentType';

--- a/packages/react-native/src/private/devsupport/rndevtools/FuseboxSessionObserver.js
+++ b/packages/react-native/src/private/devsupport/rndevtools/FuseboxSessionObserver.js
@@ -6,7 +6,6 @@
  *
  * @flow strict
  * @format
- * @oncall react_native
  */
 
 class FuseboxSessionObserver {

--- a/packages/react-native/src/private/devsupport/rndevtools/setUpFuseboxReactDevToolsDispatcher.js
+++ b/packages/react-native/src/private/devsupport/rndevtools/setUpFuseboxReactDevToolsDispatcher.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 type JSONValue =

--- a/packages/react-native/src/private/devsupport/rndevtools/specs/NativeReactDevToolsRuntimeSettingsModule.js
+++ b/packages/react-native/src/private/devsupport/rndevtools/specs/NativeReactDevToolsRuntimeSettingsModule.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {TurboModule} from '../../../../../Libraries/TurboModule/RCTExport';

--- a/packages/react-native/src/private/featureflags/__tests__/ReactNativeFeatureFlags-test.js
+++ b/packages/react-native/src/private/featureflags/__tests__/ReactNativeFeatureFlags-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 describe('ReactNativeFeatureFlags', () => {

--- a/packages/react-native/src/private/renderer/consistency/__tests__/UIConsistency-itest.js
+++ b/packages/react-native/src/private/renderer/consistency/__tests__/UIConsistency-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  * @fantom_flags enableAccessToHostTreeInFabric:true
  * @fantom_flags enableSynchronousStateUpdates:true
  */

--- a/packages/react-native/src/private/renderer/core/__tests__/EventDispatching-itest.js
+++ b/packages/react-native/src/private/renderer/core/__tests__/EventDispatching-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  * @fantom_flags fixMappingOfEventPrioritiesBetweenFabricAndReact:true
  */
 

--- a/packages/react-native/src/private/renderer/mounting/__tests__/Mounting-itest.js
+++ b/packages/react-native/src/private/renderer/mounting/__tests__/Mounting-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  * @fantom_flags enableFixForParentTagDuringReparenting:true
  */
 

--- a/packages/react-native/src/private/webapis/dom/events/__tests__/CustomEvent-itest.js
+++ b/packages/react-native/src/private/webapis/dom/events/__tests__/CustomEvent-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';

--- a/packages/react-native/src/private/webapis/dom/events/__tests__/Event-itest.js
+++ b/packages/react-native/src/private/webapis/dom/events/__tests__/Event-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';

--- a/packages/react-native/src/private/webapis/dom/events/__tests__/EventHandlerAttributes-itest.js
+++ b/packages/react-native/src/private/webapis/dom/events/__tests__/EventHandlerAttributes-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 // flowlint unsafe-getters-setters:off

--- a/packages/react-native/src/private/webapis/dom/events/__tests__/EventTarget-benchmark-itest.js
+++ b/packages/react-native/src/private/webapis/dom/events/__tests__/EventTarget-benchmark-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';

--- a/packages/react-native/src/private/webapis/dom/events/__tests__/EventTarget-itest.js
+++ b/packages/react-native/src/private/webapis/dom/events/__tests__/EventTarget-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';

--- a/packages/react-native/src/private/webapis/dom/events/__tests__/createEventTargetHierarchyWithDepth.js
+++ b/packages/react-native/src/private/webapis/dom/events/__tests__/createEventTargetHierarchyWithDepth.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import EventTarget from '../EventTarget';

--- a/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeDocument-itest.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeDocument-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';

--- a/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeElement-itest.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeElement-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';

--- a/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReadOnlyText-itest.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReadOnlyText-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';

--- a/packages/react-native/src/private/webapis/dom/oldstylecollections/__tests__/HTMLCollection-test.js
+++ b/packages/react-native/src/private/webapis/dom/oldstylecollections/__tests__/HTMLCollection-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import {createHTMLCollection} from '../HTMLCollection';

--- a/packages/react-native/src/private/webapis/dom/oldstylecollections/__tests__/NodeList-test.js
+++ b/packages/react-native/src/private/webapis/dom/oldstylecollections/__tests__/NodeList-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import {createNodeList} from '../NodeList';

--- a/packages/react-native/src/private/webapis/errors/DOMException.js
+++ b/packages/react-native/src/private/webapis/errors/DOMException.js
@@ -6,7 +6,6 @@
  *
  * @flow strict
  * @format
- * @oncall react_native
  */
 
 /**

--- a/packages/react-native/src/private/webapis/errors/__tests__/DOMException-itest.js
+++ b/packages/react-native/src/private/webapis/errors/__tests__/DOMException-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';

--- a/packages/react-native/src/private/webapis/geometry/__tests__/DOMRectList-test.js
+++ b/packages/react-native/src/private/webapis/geometry/__tests__/DOMRectList-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import {createDOMRectList} from '../DOMRectList';

--- a/packages/react-native/src/private/webapis/idlecallbacks/__tests__/requestIdleCallback-itest.js
+++ b/packages/react-native/src/private/webapis/idlecallbacks/__tests__/requestIdleCallback-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';

--- a/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-benchmark-itest.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-benchmark-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  * @fantom_flags enableAccessToHostTreeInFabric:true
  */
 

--- a/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-itest.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  * @fantom_flags utilizeTokensInIntersectionObserver:true
  */
 

--- a/packages/react-native/src/private/webapis/mutationobserver/__tests__/MutationObserver-itest.js
+++ b/packages/react-native/src/private/webapis/mutationobserver/__tests__/MutationObserver-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';

--- a/packages/react-native/src/private/webapis/performance/MemoryInfo.js
+++ b/packages/react-native/src/private/webapis/performance/MemoryInfo.js
@@ -6,7 +6,6 @@
  *
  * @flow strict
  * @format
- * @oncall react_native
  */
 
 // flowlint unsafe-getters-setters:off

--- a/packages/react-native/src/private/webapis/performance/ReactNativeStartupTiming.js
+++ b/packages/react-native/src/private/webapis/performance/ReactNativeStartupTiming.js
@@ -6,7 +6,6 @@
  *
  * @flow strict
  * @format
- * @oncall react_native
  */
 
 // flowlint unsafe-getters-setters:off

--- a/packages/react-native/src/private/webapis/performance/__tests__/EventTimingAPI-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/EventTimingAPI-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';

--- a/packages/react-native/src/private/webapis/performance/__tests__/LongTasksAPI-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/LongTasksAPI-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';

--- a/packages/react-native/src/private/webapis/performance/__tests__/Performance-benchmark-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/Performance-benchmark-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  * @fantom_mode opt
  */
 

--- a/packages/react-native/src/private/webapis/performance/__tests__/Performance-test.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/Performance-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 // eslint-disable-next-line lint/sort-imports

--- a/packages/react-native/src/private/webapis/performance/__tests__/PerformanceObserver-test.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/PerformanceObserver-test.js
@@ -24,9 +24,8 @@ describe('PerformanceObserver', () => {
   beforeEach(() => {
     jest.resetModules();
 
-    const Performance = require('../Performance').default;
     // $FlowExpectedError[cannot-write]
-    global.performance = new Performance();
+    global.performance = new (require('../Performance').default)();
     PerformanceObserver = require('../PerformanceObserver').PerformanceObserver;
   });
 

--- a/packages/react-native/src/private/webapis/performance/__tests__/PerformanceObserver-test.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/PerformanceObserver-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type Performance from '../Performance';

--- a/packages/react-native/src/private/webapis/performance/__tests__/UserTimingAPI-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/UserTimingAPI-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';

--- a/packages/react-native/src/private/webapis/structuredClone/__tests__/structuredClone-benchmark-itest.js
+++ b/packages/react-native/src/private/webapis/structuredClone/__tests__/structuredClone-benchmark-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';

--- a/packages/react-native/src/private/webapis/structuredClone/__tests__/structuredClone-itest.js
+++ b/packages/react-native/src/private/webapis/structuredClone/__tests__/structuredClone-itest.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';

--- a/packages/react-native/src/private/webapis/structuredClone/structuredClone.js
+++ b/packages/react-native/src/private/webapis/structuredClone/structuredClone.js
@@ -6,7 +6,6 @@
  *
  * @flow strict
  * @format
- * @oncall react_native
  */
 
 import DOMException from '../errors/DOMException';

--- a/packages/react-native/src/types/bom.js.flow
+++ b/packages/react-native/src/types/bom.js.flow
@@ -108,13 +108,10 @@ declare class WebSocket extends EventTarget {
   bufferedAmount: number;
   close(code?: number, reason?: string): void;
   static CLOSED: 3;
-  // eslint-disable-next-line ft-flow/no-dupe-keys
   CLOSED: 3;
   static CLOSING: 2;
-  // eslint-disable-next-line ft-flow/no-dupe-keys
   CLOSING: 2;
   static CONNECTING: 0;
-  // eslint-disable-next-line ft-flow/no-dupe-keys
   CONNECTING: 0;
   constructor(url: string, protocols?: string | Array<string>): void;
   extensions: string;
@@ -123,7 +120,6 @@ declare class WebSocket extends EventTarget {
   onmessage: (ev: MessageEvent) => mixed;
   onopen: (ev: $FlowFixMe) => mixed;
   static OPEN: 1;
-  // eslint-disable-next-line ft-flow/no-dupe-keys
   OPEN: 1;
   protocol: string;
   readyState: number;
@@ -137,15 +133,12 @@ declare class WebSocket extends EventTarget {
 declare class XMLHttpRequest extends EventTarget {
   abort(): void;
   static DONE: number;
-  // eslint-disable-next-line ft-flow/no-dupe-keys
   DONE: number;
   getAllResponseHeaders(): string;
   getResponseHeader(header: string): string;
   static HEADERS_RECEIVED: number;
-  // eslint-disable-next-line ft-flow/no-dupe-keys
   HEADERS_RECEIVED: number;
   static LOADING: number;
-  // eslint-disable-next-line ft-flow/no-dupe-keys
   LOADING: number;
   msCaching: string;
   msCachingEnabled(): boolean;
@@ -165,7 +158,6 @@ declare class XMLHttpRequest extends EventTarget {
     password?: string,
   ): void;
   static OPENED: number;
-  // eslint-disable-next-line ft-flow/no-dupe-keys
   OPENED: number;
   overrideMimeType(mime: string): void;
   readyState: number;
@@ -182,7 +174,6 @@ declare class XMLHttpRequest extends EventTarget {
   statusText: string;
   timeout: number;
   static UNSENT: number;
-  // eslint-disable-next-line ft-flow/no-dupe-keys
   UNSENT: number;
   upload: XMLHttpRequestEventTarget;
 

--- a/packages/react-native/src/types/bom.js.flow
+++ b/packages/react-native/src/types/bom.js.flow
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall flow
  */
 
 /* BOM */

--- a/packages/react-native/src/types/cssom.js.flow
+++ b/packages/react-native/src/types/cssom.js.flow
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall flow
  */
 
 declare class StyleSheet {

--- a/packages/react-native/src/types/dom.js.flow
+++ b/packages/react-native/src/types/dom.js.flow
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall flow
  */
 
 // Adapted from https://github.com/flow-typed/flow-typed/blob/main/definitions/environments/dom/flow_v0.261.x-/dom.js

--- a/packages/react-native/src/types/streams.js.flow
+++ b/packages/react-native/src/types/streams.js.flow
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall flow
  */
 
 // Adapted from https://github.com/flow-typed/flow-typed/blob/main/definitions/environments/streams/flow_v0.261.x-/streams.js

--- a/packages/rn-tester/cli.flow.js
+++ b/packages/rn-tester/cli.flow.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import {run} from './scripts/utils';

--- a/packages/rn-tester/cli.js
+++ b/packages/rn-tester/cli.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 /*::

--- a/packages/rn-tester/js/examples/Animated/PanGestureExample.js
+++ b/packages/rn-tester/js/examples/Animated/PanGestureExample.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';

--- a/packages/rn-tester/js/examples/AppState/AppStateExample.js
+++ b/packages/rn-tester/js/examples/AppState/AppStateExample.js
@@ -15,7 +15,7 @@ import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import RNTesterText from '../../components/RNTesterText';
 import React from 'react';
 import {useEffect, useState} from 'react';
-import {AppState, Platform, View} from 'react-native';
+import {AppState, Platform} from 'react-native';
 
 type Props = {
   detectEvents?: boolean,

--- a/packages/rn-tester/js/examples/FlatList/FlatList-multiColumn.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatList-multiColumn.js
@@ -67,6 +67,7 @@ function MultiColumnExample(): React.Node {
     return {length, offset: length * index, index};
   };
 
+  // eslint-disable-next-line react/no-unstable-nested-components
   const _renderItemComponent = ({
     item,
   }: ListRenderItemInfo<any | Item>): $FlowFixMe => {

--- a/packages/rn-tester/js/examples/MixBlendMode/MixBlendModeExample.js
+++ b/packages/rn-tester/js/examples/MixBlendMode/MixBlendModeExample.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';

--- a/packages/rn-tester/js/examples/Performance/PerformanceComparisonExample.js
+++ b/packages/rn-tester/js/examples/Performance/PerformanceComparisonExample.js
@@ -6,7 +6,6 @@
  *
  * @format
  * @flow strict-local
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/rn-tester/js/examples/Performance/components/ItemList.js
+++ b/packages/rn-tester/js/examples/Performance/components/ItemList.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/rn-tester/js/examples/Performance/components/itemData.js
+++ b/packages/rn-tester/js/examples/Performance/components/itemData.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 const ALL_CHARS =

--- a/packages/rn-tester/js/examples/Performance/performanceComparisonExamples/EffectInRenderExample.js
+++ b/packages/rn-tester/js/examples/Performance/performanceComparisonExamples/EffectInRenderExample.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/rn-tester/js/examples/Performance/performanceComparisonExamples/NotMemoizeExpensiveTaskExample.js
+++ b/packages/rn-tester/js/examples/Performance/performanceComparisonExamples/NotMemoizeExpensiveTaskExample.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/rn-tester/js/examples/Performance/performanceComparisonExamples/ReRenderWithNonPureChildExample.js
+++ b/packages/rn-tester/js/examples/Performance/performanceComparisonExamples/ReRenderWithNonPureChildExample.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/rn-tester/js/examples/Performance/performanceComparisonExamples/ReRenderWithObjectPropExample.js
+++ b/packages/rn-tester/js/examples/Performance/performanceComparisonExamples/ReRenderWithObjectPropExample.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/rn-tester/js/examples/Performance/performanceComparisonExamples/RenderOffscreenContentExample.js
+++ b/packages/rn-tester/js/examples/Performance/performanceComparisonExamples/RenderOffscreenContentExample.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/rn-tester/js/examples/Performance/performanceComparisonExamples/SetStateInWrongEffectExample.js
+++ b/packages/rn-tester/js/examples/Performance/performanceComparisonExamples/SetStateInWrongEffectExample.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/rn-tester/js/examples/Performance/performanceComparisonExamples/SetStateInWrongEffectExample2.js
+++ b/packages/rn-tester/js/examples/Performance/performanceComparisonExamples/SetStateInWrongEffectExample2.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/rn-tester/js/examples/Performance/performanceComparisonExamples/index.js
+++ b/packages/rn-tester/js/examples/Performance/performanceComparisonExamples/index.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 export {default as ReRenderWithNonPureChildExample} from './ReRenderWithNonPureChildExample';

--- a/packages/rn-tester/js/examples/Playground/RNTesterPlayground.js
+++ b/packages/rn-tester/js/examples/Playground/RNTesterPlayground.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';

--- a/packages/rn-tester/js/examples/SectionList/SectionList-inverted.js
+++ b/packages/rn-tester/js/examples/SectionList/SectionList-inverted.js
@@ -11,8 +11,8 @@
 'use strict';
 
 import SectionListBaseExample from './SectionListBaseExample';
-import {useState} from 'react';
 import * as React from 'react';
+import {useState} from 'react';
 
 export function SectionList_inverted(): React.Node {
   const [output, setOutput] = useState('inverted false');

--- a/packages/rn-tester/js/examples/TextInput/ExampleTextInput.js
+++ b/packages/rn-tester/js/examples/TextInput/ExampleTextInput.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import {RNTesterThemeContext} from '../../components/RNTesterTheme';

--- a/packages/rn-tester/js/utils/RNTesterListFbInternal.js
+++ b/packages/rn-tester/js/utils/RNTesterListFbInternal.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {RNTesterModuleInfo} from '../types/RNTesterTypes';

--- a/packages/rn-tester/scripts/monorepo.js
+++ b/packages/rn-tester/scripts/monorepo.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 // To be able to execute the cli as a yarn script, we have to strip our yarn types.

--- a/packages/rn-tester/scripts/utils.js
+++ b/packages/rn-tester/scripts/utils.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {Task} from '@react-native/core-cli-utils';

--- a/packages/virtualized-lists/Lists/__tests__/FillRateHelper-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/FillRateHelper-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/virtualized-lists/Lists/__tests__/ViewabilityHelper-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/ViewabilityHelper-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/virtualized-lists/Lists/__tests__/VirtualizeUtils-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/VirtualizeUtils-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/virtualized-lists/Lists/__tests__/VirtualizedList-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/VirtualizedList-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/virtualized-lists/Lists/__tests__/VirtualizedSectionList-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/VirtualizedSectionList-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/packages/virtualized-lists/Utilities/__tests__/clamp-test.js
+++ b/packages/virtualized-lists/Utilities/__tests__/clamp-test.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/scripts/babel-register.js
+++ b/scripts/babel-register.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 const {

--- a/scripts/build-types/buildGeneratedTypes.js
+++ b/scripts/build-types/buildGeneratedTypes.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 const {PACKAGES_DIR, REPO_ROOT} = require('../consts');

--- a/scripts/build-types/config.js
+++ b/scripts/build-types/config.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 /**

--- a/scripts/build-types/index.js
+++ b/scripts/build-types/index.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 require('../babel-register').registerForScript();

--- a/scripts/build-types/prepare-flow-api-translator.js
+++ b/scripts/build-types/prepare-flow-api-translator.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 require('../babel-register').registerForScript();

--- a/scripts/build-types/resolution/getDependencies.js
+++ b/scripts/build-types/resolution/getDependencies.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {DependencyContext} from './simpleResolve';

--- a/scripts/build-types/resolution/getRequireStack.js
+++ b/scripts/build-types/resolution/getRequireStack.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 type DependencyEdges = Array<[string, string]>;

--- a/scripts/build-types/resolution/resolveTypeInputFile.js
+++ b/scripts/build-types/resolution/resolveTypeInputFile.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 const {REPO_ROOT} = require('../../consts');

--- a/scripts/build-types/resolution/simpleResolve.js
+++ b/scripts/build-types/resolution/simpleResolve.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 const {PACKAGES_DIR} = require('../../consts');

--- a/scripts/build-types/templates/translatedModule.d.ts-template.js
+++ b/scripts/build-types/templates/translatedModule.d.ts-template.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 const signedsource = require('signedsource');

--- a/scripts/build-types/transforms/__tests__/reattachDocComments-test.js
+++ b/scripts/build-types/transforms/__tests__/reattachDocComments-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 const reattachDocComments = require('../reattachDocComments.js');

--- a/scripts/build-types/transforms/__tests__/removeReactNativeImports-test.js
+++ b/scripts/build-types/transforms/__tests__/removeReactNativeImports-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 const removeReactNativeImports = require('../removeReactNativeImports.js');

--- a/scripts/build-types/transforms/__tests__/replaceDefaultExportName-test.js
+++ b/scripts/build-types/transforms/__tests__/replaceDefaultExportName-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 const createReplaceDefaultExportName = require('../replaceDefaultExportName.js');

--- a/scripts/build-types/transforms/__tests__/replaceEmptyWithNever-test.js
+++ b/scripts/build-types/transforms/__tests__/replaceEmptyWithNever-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 const replaceEmptyWithNever = require('../replaceEmptyWithNever.js');

--- a/scripts/build-types/transforms/__tests__/replaceNullablePropertiesWithUndefined-test.js
+++ b/scripts/build-types/transforms/__tests__/replaceNullablePropertiesWithUndefined-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 const replaceNullablePropertiesWithUndefined = require('../replaceNullablePropertiesWithUndefined.js');

--- a/scripts/build-types/transforms/__tests__/replaceRequiresWithImports-test.js
+++ b/scripts/build-types/transforms/__tests__/replaceRequiresWithImports-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 const replaceRequiresWithImports = require('../replaceRequiresWithImports.js');

--- a/scripts/build-types/transforms/__tests__/replaceStringishWithString-test.js
+++ b/scripts/build-types/transforms/__tests__/replaceStringishWithString-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 const replaceStringishWithString = require('../replaceStringishWithString.js');

--- a/scripts/build-types/transforms/__tests__/sortProperties-test.js
+++ b/scripts/build-types/transforms/__tests__/sortProperties-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 const sortPropertiesVisitor = require('../sortProperties.js');

--- a/scripts/build-types/transforms/__tests__/sortTypeDefinitions-test.js
+++ b/scripts/build-types/transforms/__tests__/sortTypeDefinitions-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 const sortTypeDefinitionsVisitor = require('../sortTypeDefinitions.js');

--- a/scripts/build-types/transforms/__tests__/sortUnions-test.js
+++ b/scripts/build-types/transforms/__tests__/sortUnions-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 const sortUnionsVisitor = require('../sortUnions.js');

--- a/scripts/build-types/transforms/__tests__/stripPrivateProperties-test.js
+++ b/scripts/build-types/transforms/__tests__/stripPrivateProperties-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 const stripPrivateProperties = require('../stripPrivateProperties.js');

--- a/scripts/build-types/transforms/reattachDocComments.js
+++ b/scripts/build-types/transforms/reattachDocComments.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {ExportDefaultDeclaration, Program} from 'hermes-estree/dist';

--- a/scripts/build-types/transforms/removeReactNativeImports.js
+++ b/scripts/build-types/transforms/removeReactNativeImports.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {PluginObj} from '@babel/core';

--- a/scripts/build-types/transforms/replaceDefaultExportName.js
+++ b/scripts/build-types/transforms/replaceDefaultExportName.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {PluginObj} from '@babel/core';

--- a/scripts/build-types/transforms/replaceEmptyWithNever.js
+++ b/scripts/build-types/transforms/replaceEmptyWithNever.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {TransformVisitor} from 'hermes-transform';

--- a/scripts/build-types/transforms/replaceNullablePropertiesWithUndefined.js
+++ b/scripts/build-types/transforms/replaceNullablePropertiesWithUndefined.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {ESNode, TypeAnnotationType} from 'hermes-estree';

--- a/scripts/build-types/transforms/replaceRequiresWithImports.js
+++ b/scripts/build-types/transforms/replaceRequiresWithImports.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {TransformVisitor} from 'hermes-transform';

--- a/scripts/build-types/transforms/replaceStringishWithString.js
+++ b/scripts/build-types/transforms/replaceStringishWithString.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {TransformVisitor} from 'hermes-transform';

--- a/scripts/build-types/transforms/sortProperties.js
+++ b/scripts/build-types/transforms/sortProperties.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {PluginObj} from '@babel/core';

--- a/scripts/build-types/transforms/sortTypeDefinitions.js
+++ b/scripts/build-types/transforms/sortTypeDefinitions.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {PluginObj} from '@babel/core';

--- a/scripts/build-types/transforms/sortUnions.js
+++ b/scripts/build-types/transforms/sortUnions.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {PluginObj} from '@babel/core';

--- a/scripts/build-types/transforms/stripPrivateProperties.js
+++ b/scripts/build-types/transforms/stripPrivateProperties.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {TransformVisitor} from 'hermes-transform';

--- a/scripts/build-types/translateSourceFile.js
+++ b/scripts/build-types/translateSourceFile.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 import type {PluginObj} from '@babel/core';

--- a/scripts/build/babel/node.config.js
+++ b/scripts/build/babel/node.config.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 import type {BabelCoreOptions} from '@babel/core';

--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 require('../babel-register').registerForScript();

--- a/scripts/build/clean.js
+++ b/scripts/build/clean.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 require('../babel-register').registerForScript();

--- a/scripts/build/config.js
+++ b/scripts/build/config.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 import type {BabelCoreOptions} from '@babel/core';

--- a/scripts/consts.js
+++ b/scripts/consts.js
@@ -6,7 +6,6 @@
  *
  * @flow strict
  * @format
- * @oncall react_native
  */
 
 const path = require('path');

--- a/scripts/debugger-frontend/sync-and-build.js
+++ b/scripts/debugger-frontend/sync-and-build.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 const {PACKAGES_DIR} = require('../consts');

--- a/scripts/e2e/init-project-e2e.js
+++ b/scripts/e2e/init-project-e2e.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/scripts/e2e/utils/retry.js
+++ b/scripts/e2e/utils/retry.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react-native
  */
 
 const {spawnSync} = require('child_process');

--- a/scripts/e2e/utils/try-n-times.js
+++ b/scripts/e2e/utils/try-n-times.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 /**

--- a/scripts/e2e/utils/verdaccio.js
+++ b/scripts/e2e/utils/verdaccio.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/scripts/release-testing/utils/github-actions-utils.js
+++ b/scripts/release-testing/utils/github-actions-utils.js
@@ -88,7 +88,6 @@ async function _getActionRunsOnBranch() /*: Promise<WorkflowRuns> */ {
   }
 
   const body = await response
-    // eslint-disable-next-line func-call-spacing
     .json /*::<WorkflowRuns>*/
     ();
   return body;
@@ -109,7 +108,6 @@ async function _getArtifacts(run_id /*: number */) /*: Promise<Artifacts> */ {
   }
 
   const body = await response
-    // eslint-disable-next-line func-call-spacing
     .json /*::<Artifacts>*/
     ();
   return body;

--- a/scripts/release-testing/utils/testing-utils.js
+++ b/scripts/release-testing/utils/testing-utils.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/scripts/releases-ci/__tests__/publish-npm-test.js
+++ b/scripts/releases-ci/__tests__/publish-npm-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 const execMock = jest.fn();

--- a/scripts/releases-ci/__tests__/publish-updated-packages-test.js
+++ b/scripts/releases-ci/__tests__/publish-updated-packages-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 const {

--- a/scripts/releases-ci/publish-npm.js
+++ b/scripts/releases-ci/publish-npm.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/scripts/releases-ci/publish-updated-packages.js
+++ b/scripts/releases-ci/publish-updated-packages.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 const {publishPackage} = require('../npm-utils');

--- a/scripts/releases/__tests__/__fixtures__/remove-new-arch-flags-fixture.js
+++ b/scripts/releases/__tests__/__fixtures__/remove-new-arch-flags-fixture.js
@@ -5,7 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @oncall react-native
  */
 
 const validReactNativePodsFile = `

--- a/scripts/releases/__tests__/set-rn-artifacts-version-test.js
+++ b/scripts/releases/__tests__/set-rn-artifacts-version-test.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 const readFileMock = jest.fn();

--- a/scripts/releases/create-release-commit.js
+++ b/scripts/releases/create-release-commit.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 const {setVersion} = require('../releases/set-version');

--- a/scripts/releases/ios-prebuild/build.js
+++ b/scripts/releases/ios-prebuild/build.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 const {execSync} = require('child_process');

--- a/scripts/releases/ios-prebuild/cli.js
+++ b/scripts/releases/ios-prebuild/cli.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 const {dependencies, platforms} = require('./configuration');

--- a/scripts/releases/ios-prebuild/compose-framework.js
+++ b/scripts/releases/ios-prebuild/compose-framework.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 const {HEADERS_FOLDER, TARGET_FOLDER} = require('./constants');

--- a/scripts/releases/ios-prebuild/configuration.js
+++ b/scripts/releases/ios-prebuild/configuration.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 /*::

--- a/scripts/releases/ios-prebuild/constants.js
+++ b/scripts/releases/ios-prebuild/constants.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 module.exports = {

--- a/scripts/releases/ios-prebuild/folders.js
+++ b/scripts/releases/ios-prebuild/folders.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 /*::

--- a/scripts/releases/ios-prebuild/setupDependencies.js
+++ b/scripts/releases/ios-prebuild/setupDependencies.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 const {

--- a/scripts/releases/ios-prebuild/swift-package.js
+++ b/scripts/releases/ios-prebuild/swift-package.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 const {RESOURCES_FOLDER, TARGET_FOLDER} = require('./constants');

--- a/scripts/releases/ios-prebuild/types.js
+++ b/scripts/releases/ios-prebuild/types.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 /*::

--- a/scripts/releases/prepare-ios-prebuilds.js
+++ b/scripts/releases/prepare-ios-prebuilds.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 const {buildDepenencies} = require('./ios-prebuild/build');

--- a/scripts/releases/set-rn-artifacts-version.js
+++ b/scripts/releases/set-rn-artifacts-version.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 /*::

--- a/scripts/releases/set-version.js
+++ b/scripts/releases/set-version.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react-native
  */
 
 'use strict';

--- a/scripts/releases/templates/RCTVersion.m-template.js
+++ b/scripts/releases/templates/RCTVersion.m-template.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 /*::

--- a/scripts/releases/templates/ReactNativeVersion.h-template.js
+++ b/scripts/releases/templates/ReactNativeVersion.h-template.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 /*::

--- a/scripts/releases/templates/ReactNativeVersion.js-template.js
+++ b/scripts/releases/templates/ReactNativeVersion.js-template.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 /*::

--- a/scripts/releases/templates/ReactNativeVersion.kt-template.js
+++ b/scripts/releases/templates/ReactNativeVersion.kt-template.js
@@ -6,7 +6,6 @@
  *
  * @flow
  * @format
- * @oncall react_native
  */
 
 /*::

--- a/scripts/releases/utils/__tests__/version-utils-test.js
+++ b/scripts/releases/utils/__tests__/version-utils-test.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 const {

--- a/scripts/releases/utils/release-utils.js
+++ b/scripts/releases/utils/release-utils.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 'use strict';

--- a/scripts/releases/utils/version-utils.js
+++ b/scripts/releases/utils/version-utils.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 const VERSION_REGEX = /^v?((\d+)\.(\d+)\.(\d+)(?:-(.+))?)$/;

--- a/scripts/utils/monorepo.js
+++ b/scripts/utils/monorepo.js
@@ -6,7 +6,6 @@
  *
  * @flow strict
  * @format
- * @oncall react_native
  */
 
 const {REPO_ROOT} = require('../consts');

--- a/tools/api/ReactNativeCPP.api
+++ b/tools/api/ReactNativeCPP.api
@@ -4,8 +4,6 @@
  *
  * @file_count 1059
  * @generate-command: node tools/api/public-api.js
- *
- * @oncall react_native
  */
 
 

--- a/tools/api/public-api.conf
+++ b/tools/api/public-api.conf
@@ -5,7 +5,6 @@
 ;
 ; @flow strict-local
 ; @format
-; @oncall react_native
 
 ; All [include] and [exclude] globs are run from the react-native project root
 [include]

--- a/tools/api/public-api.js
+++ b/tools/api/public-api.js
@@ -6,7 +6,6 @@
  *
  * @flow strict-local
  * @format
- * @oncall react_native
  */
 
 const chalk = require('chalk');
@@ -287,8 +286,6 @@ function main() {
  *
  * @file_count ${files.length}
  * @generate-command: node tools/api/public-api.js
- *
- * @oncall react_native
  */
 
 `,


### PR DESCRIPTION
Summary:
Fixes a bunch of ESLint warnings across the codebase.

The only remaining warnings are from the `lint/no-commonjs-exports` rule.

Changelog:
[Internal]

Reviewed By: SamChou19815

Differential Revision: D74942686
