### PR TITLE
RuntimeExecutor: Refine the variables and comments again

### DIFF
--- a/packages/react-native/React/Base/RCTUtils.h
+++ b/packages/react-native/React/Base/RCTUtils.h
@@ -49,7 +49,7 @@ RCT_EXTERN void RCTExecuteOnMainQueue(dispatch_block_t block);
 // Legacy function to execute the specified block on the main queue synchronously.
 // Please do not use this unless you know what you're doing.
 RCT_EXTERN void RCTUnsafeExecuteOnMainQueueSync(dispatch_block_t block);
-RCT_EXTERN void RCTUnsafeExecuteOnMainQueueSyncWithError(dispatch_block_t block, NSString *context);
+RCT_EXTERN void RCTUnsafeExecuteOnMainQueueSyncWithError(dispatch_block_t block, NSString *_Nullable context);
 
 // Get screen metrics in a thread-safe way
 RCT_EXTERN CGFloat RCTScreenScale(void);

--- a/packages/react-native/React/Base/RCTUtils.mm
+++ b/packages/react-native/React/Base/RCTUtils.mm
@@ -299,32 +299,27 @@ void RCTExecuteOnMainQueue(dispatch_block_t block)
 // unless you know what you are doing.
 void RCTUnsafeExecuteOnMainQueueSync(dispatch_block_t block)
 {
-  if (RCTIsMainQueue()) {
-    block();
-  } else {
-    if (facebook::react::ReactNativeFeatureFlags::disableMainQueueSyncDispatchIOS()) {
-      RCTLogError(@"RCTUnsafeExecuteOnMainQueueSync: Sync dispatches to the main queue can deadlock React Native.");
-    }
-    dispatch_sync(dispatch_get_main_queue(), ^{
-      block();
-    });
-  }
+  RCTUnsafeExecuteOnMainQueueSyncWithError(block, nil);
 }
 
 // Please do not use this method
 // unless you know what you are doing.
-void RCTUnsafeExecuteOnMainQueueSyncWithError(dispatch_block_t block, NSString *context)
+void RCTUnsafeExecuteOnMainQueueSyncWithError(dispatch_block_t block, NSString *_Nullable context)
 {
   if (RCTIsMainQueue()) {
     block();
-  } else {
-    if (facebook::react::ReactNativeFeatureFlags::disableMainQueueSyncDispatchIOS()) {
-      RCTLogError(@"RCTUnsafeExecuteOnMainQueueSync: %@", context);
-    }
-    dispatch_sync(dispatch_get_main_queue(), ^{
-      block();
-    });
+    return;
   }
+
+  if (facebook::react::ReactNativeFeatureFlags::disableMainQueueSyncDispatchIOS()) {
+    RCTLogError(
+        @"RCTUnsafeExecuteOnMainQueueSync: %@",
+        context ?: @"Sync dispatches to the main queue can deadlock React Native.");
+  }
+
+  dispatch_sync(dispatch_get_main_queue(), ^{
+    block();
+  });
 }
 
 static void RCTUnsafeExecuteOnMainQueueOnceSync(dispatch_once_t *onceToken, dispatch_block_t block)
@@ -332,19 +327,24 @@ static void RCTUnsafeExecuteOnMainQueueOnceSync(dispatch_once_t *onceToken, disp
   // The solution was borrowed from a post by Sophie Alpert:
   // https://sophiebits.com/2014/04/02/dispatch-once-initialization-on-the-main-thread
   // See also: https://www.mikeash.com/pyblog/friday-qa-2014-06-06-secrets-of-dispatch_once.html
-  if (RCTIsMainQueue()) {
+  auto executeOnce = ^{
     dispatch_once(onceToken, block);
-  } else {
-    if (DISPATCH_EXPECT(*onceToken == 0L, NO)) {
-      if (facebook::react::ReactNativeFeatureFlags::disableMainQueueSyncDispatchIOS()) {
-        RCTLogError(
-            @"RCTUnsafeExecuteOnMainQueueOnceSync: Sync dispatches to the main queue can deadlock React Native.");
-      }
-      dispatch_sync(dispatch_get_main_queue(), ^{
-        dispatch_once(onceToken, block);
-      });
-    }
+  };
+
+  if (RCTIsMainQueue()) {
+    executeOnce();
+    return;
   }
+
+  if (!DISPATCH_EXPECT(*onceToken == 0L, NO)) {
+    return;
+  }
+
+  if (facebook::react::ReactNativeFeatureFlags::disableMainQueueSyncDispatchIOS()) {
+    RCTLogError(@"RCTUnsafeExecuteOnMainQueueOnceSync: Sync dispatches to the main queue can deadlock React Native.");
+  }
+
+  dispatch_sync(dispatch_get_main_queue(), executeOnce);
 }
 
 CGFloat RCTScreenScale(void)

--- a/packages/react-native/ReactCommon/runtimeexecutor/ReactCommon/RuntimeExecutor.h
+++ b/packages/react-native/ReactCommon/runtimeexecutor/ReactCommon/RuntimeExecutor.h
@@ -25,61 +25,60 @@ namespace facebook::react {
 using RuntimeExecutor =
     std::function<void(std::function<void(jsi::Runtime& runtime)>&& callback)>;
 
-/*
- * Executes a `callback` in a *synchronous* manner on the same thread using
- * given `RuntimeExecutor`.
- * Use this method when the caller needs to *be blocked* by executing the
- * `callback` and requires that the callback will be executed on the same
- * thread.
- * Example order of events (when not a sync call in runtimeExecutor callback):
+/**
+ * Example order of events (when not a sync call in runtimeExecutor
+ * jsWork):
  * - [UI thread] Lock all mutexes at start
- * - [UI thread] runtimeCaptured.lock before callback
- * - [JS thread] Set runtimePtr in runtimeExecutor callback
- * - [JS thread] runtimeCaptured.unlock in runtimeExecutor callback
- * - [UI thread] Call callback
- * - [JS thread] callbackExecuted.lock in runtimeExecutor callback
- * - [UI thread] callbackExecuted.unlock after callback
- * - [UI thread] jsBlockExecuted.lock after callback
- * - [JS thread] jsBlockExecuted.unlock in runtimeExecutor callback
+ * - [UI thread] Schedule "runtime capture block" on js thread
+ * - [UI thread] Wait for runtime capture: runtimeCaptured.lock()
+ * - [JS thread] Capture runtime by setting runtimePtr
+ * - [JS thread] Signal runtime captured: runtimeCaptured.unlock()
+ * - [UI thread] Call jsWork using runtimePtr
+ * - [JS thread] Wait until jsWork done: jsWorkDone.lock()
+ * - [UI thread] Signal jsWork done: jsWorkDone.unlock()
+ * - [UI thread] Wait until runtime capture block finished:
+ *               runtimeCaptureBlockDone.lock()
+ * - [JS thread] Signal runtime capture block is finished:
+ *               runtimeCaptureBlockDone.unlock()
  */
 inline static void executeSynchronouslyOnSameThread_CAN_DEADLOCK(
     const RuntimeExecutor& runtimeExecutor,
-    std::function<void(jsi::Runtime& runtime)>&& callback) noexcept {
+    std::function<void(jsi::Runtime& runtime)>&& jsWork) noexcept {
   // Note: We need the third mutex to get back to the main thread before
   // the lambda is finished (because all mutexes are allocated on the stack).
 
   std::mutex runtimeCaptured;
-  std::mutex callbackExecuted;
-  std::mutex jsBlockExecuted;
+  std::mutex jsWorkDone;
+  std::mutex runtimeCaptureBlockDone;
 
   runtimeCaptured.lock();
-  callbackExecuted.lock();
-  jsBlockExecuted.lock();
+  jsWorkDone.lock();
+  runtimeCaptureBlockDone.lock();
 
   jsi::Runtime* runtimePtr;
 
   auto threadId = std::this_thread::get_id();
-
-  runtimeExecutor([&](jsi::Runtime& runtime) {
+  auto runtimeCaptureBlock = [&](jsi::Runtime& runtime) {
     runtimePtr = &runtime;
 
     if (threadId == std::this_thread::get_id()) {
       // In case of a synchronous call, we should unlock mutexes and return.
       runtimeCaptured.unlock();
-      jsBlockExecuted.unlock();
+      runtimeCaptureBlockDone.unlock();
       return;
     }
 
     runtimeCaptured.unlock();
-    // `callback` is called somewhere here.
-    callbackExecuted.lock();
-    jsBlockExecuted.unlock();
-  });
+    // `jsWork` is called somewhere here.
+    jsWorkDone.lock();
+    runtimeCaptureBlockDone.unlock();
+  };
+  runtimeExecutor(std::move(runtimeCaptureBlock));
 
   runtimeCaptured.lock();
-  callback(*runtimePtr);
-  callbackExecuted.unlock();
-  jsBlockExecuted.lock();
+  jsWork(*runtimePtr);
+  jsWorkDone.unlock();
+  runtimeCaptureBlockDone.lock();
 }
 
 template <typename DataT>


### PR DESCRIPTION
Summary:
Just refactoring an renaming the variables inside RuntimeExecutor again (in a separate diff). Just so that the logic in the subsequent diffs is easier to read: D74769326

Changelog: [Internal]

Differential Revision: D74941734


