### PR TITLE
RN: Migrate to ESM - Libraries/Utilities

### DIFF
--- a/packages/react-native/Libraries/Image/AssetRegistry.js
+++ b/packages/react-native/Libraries/Image/AssetRegistry.js
@@ -8,13 +8,7 @@
  * @format
  */
 
-'use strict';
-
-import type {PackagerAsset} from '@react-native/assets-registry/registry';
-
-const AssetRegistry = require('@react-native/assets-registry/registry') as {
-  registerAsset: (asset: PackagerAsset) => number,
-  getAssetByID: (assetId: number) => PackagerAsset,
-};
-
-module.exports = AssetRegistry;
+export {
+  registerAsset,
+  getAssetByID,
+} from '@react-native/assets-registry/registry';

--- a/packages/react-native/Libraries/Image/RelativeImageStub.js
+++ b/packages/react-native/Libraries/Image/RelativeImageStub.js
@@ -27,4 +27,5 @@ const RelativeImageStub = (AssetRegistry.registerAsset({
   type: 'png',
 }): number);
 
+// eslint-disable-next-line lint/no-commonjs-exports
 module.exports = RelativeImageStub;

--- a/packages/react-native/Libraries/Lists/__flowtests__/FlatList-flowtest.js
+++ b/packages/react-native/Libraries/Lists/__flowtests__/FlatList-flowtest.js
@@ -8,8 +8,6 @@
  * @format
  */
 
-'use strict';
-
 const FlatList = require('../FlatList').default;
 const React = require('react');
 
@@ -21,98 +19,96 @@ function renderMyListItem(info: {
   return <span />;
 }
 
-module.exports = {
-  testEverythingIsFine(): React.Node {
-    const data = [
-      {
-        title: 'Title Text',
-        key: 1,
-      },
-    ];
-    return <FlatList renderItem={renderMyListItem} data={data} />;
-  },
+export function testEverythingIsFine(): React.Node {
+  const data = [
+    {
+      title: 'Title Text',
+      key: 1,
+    },
+  ];
+  return <FlatList renderItem={renderMyListItem} data={data} />;
+}
 
-  testBadDataWithTypicalItem(): React.Node {
-    const data = [
-      {
-        title: 6,
-        key: 1,
-      },
-    ];
-    // $FlowExpectedError - bad title type 6, should be string
-    return <FlatList renderItem={renderMyListItem} data={data} />;
-  },
+export function testBadDataWithTypicalItem(): React.Node {
+  const data = [
+    {
+      title: 6,
+      key: 1,
+    },
+  ];
+  // $FlowExpectedError - bad title type 6, should be string
+  return <FlatList renderItem={renderMyListItem} data={data} />;
+}
 
-  testMissingFieldWithTypicalItem(): React.Node {
-    const data = [
-      {
-        key: 1,
-      },
-    ];
-    // $FlowExpectedError - missing title
-    return <FlatList renderItem={renderMyListItem} data={data} />;
-  },
+export function testMissingFieldWithTypicalItem(): React.Node {
+  const data = [
+    {
+      key: 1,
+    },
+  ];
+  // $FlowExpectedError - missing title
+  return <FlatList renderItem={renderMyListItem} data={data} />;
+}
 
-  testGoodDataWithBadCustomRenderItemFunction(): React.Node {
-    const data = [
-      {
-        widget: 6,
-        key: 1,
-      },
-    ];
-    return (
-      <FlatList
-        renderItem={info => (
-          <span>
-            {
-              // $FlowExpectedError - bad widgetCount type 6, should be Object
-              info.item.widget.missingProp
-            }
-          </span>
-        )}
-        data={data}
-      />
-    );
-  },
+export function testGoodDataWithBadCustomRenderItemFunction(): React.Node {
+  const data = [
+    {
+      widget: 6,
+      key: 1,
+    },
+  ];
+  return (
+    <FlatList
+      renderItem={info => (
+        <span>
+          {
+            // $FlowExpectedError - bad widgetCount type 6, should be Object
+            info.item.widget.missingProp
+          }
+        </span>
+      )}
+      data={data}
+    />
+  );
+}
 
-  testBadRenderItemFunction(): $ReadOnlyArray<React.Node> {
-    const data = [
-      {
-        title: 'foo',
-        key: 1,
-      },
-    ];
-    return [
-      // $FlowExpectedError - title should be inside `item`
-      <FlatList renderItem={(info: {title: string}) => <span />} data={data} />,
-      <FlatList
-        // $FlowExpectedError - bad index type string, should be number
-        renderItem={(info: {item: any, index: string}) => <span />}
-        data={data}
-      />,
-      <FlatList
-        // $FlowExpectedError - bad title type number, should be string
-        renderItem={(info: {item: {title: number}}) => <span />}
-        // $FlowExpectedError - bad title type number, should be string
-        data={data}
-      />,
-      // EverythingIsFine
-      <FlatList
-        // $FlowExpectedError - bad title type number, should be string
-        renderItem={(info: {item: {title: string, ...}, ...}) => <span />}
-        data={data}
-      />,
-    ];
-  },
+export function testBadRenderItemFunction(): $ReadOnlyArray<React.Node> {
+  const data = [
+    {
+      title: 'foo',
+      key: 1,
+    },
+  ];
+  return [
+    // $FlowExpectedError - title should be inside `item`
+    <FlatList renderItem={(info: {title: string}) => <span />} data={data} />,
+    <FlatList
+      // $FlowExpectedError - bad index type string, should be number
+      renderItem={(info: {item: any, index: string}) => <span />}
+      data={data}
+    />,
+    <FlatList
+      // $FlowExpectedError - bad title type number, should be string
+      renderItem={(info: {item: {title: number}}) => <span />}
+      // $FlowExpectedError - bad title type number, should be string
+      data={data}
+    />,
+    // EverythingIsFine
+    <FlatList
+      // $FlowExpectedError - bad title type number, should be string
+      renderItem={(info: {item: {title: string, ...}, ...}) => <span />}
+      data={data}
+    />,
+  ];
+}
 
-  testOtherBadProps(): $ReadOnlyArray<React.Node> {
-    return [
-      // $FlowExpectedError - bad numColumns type "lots"
-      <FlatList renderItem={renderMyListItem} data={[]} numColumns="lots" />,
-      // $FlowExpectedError - bad windowSize type "big"
-      <FlatList renderItem={renderMyListItem} data={[]} windowSize="big" />,
-      // $FlowExpectedError - missing `data` prop
-      <FlatList renderItem={renderMyListItem} />,
-    ];
-  },
-};
+export function testOtherBadProps(): $ReadOnlyArray<React.Node> {
+  return [
+    // $FlowExpectedError - bad numColumns type "lots"
+    <FlatList renderItem={renderMyListItem} data={[]} numColumns="lots" />,
+    // $FlowExpectedError - bad windowSize type "big"
+    <FlatList renderItem={renderMyListItem} data={[]} windowSize="big" />,
+    // $FlowExpectedError - missing `data` prop
+    <FlatList renderItem={renderMyListItem} />,
+  ];
+}

--- a/packages/react-native/Libraries/Lists/__flowtests__/SectionList-flowtest.js
+++ b/packages/react-native/Libraries/Lists/__flowtests__/SectionList-flowtest.js
@@ -8,8 +8,6 @@
  * @format
  */
 
-'use strict';
-
 import SectionList from '../SectionList';
 import * as React from 'react';
 
@@ -28,107 +26,105 @@ const renderMyHeader = ({
   ...
 }) => <span />;
 
-module.exports = {
-  testGoodDataWithGoodItem(): React.Node {
-    const sections = [
-      {
-        key: 'a',
-        data: [
-          {
-            title: 'foo',
-            key: 1,
-          },
-        ],
-      },
-    ];
-    return <SectionList renderItem={renderMyListItem} sections={sections} />;
-  },
+export function testGoodDataWithGoodItem(): React.Node {
+  const sections = [
+    {
+      key: 'a',
+      data: [
+        {
+          title: 'foo',
+          key: 1,
+        },
+      ],
+    },
+  ];
+  return <SectionList renderItem={renderMyListItem} sections={sections} />;
+}
 
-  testBadRenderItemFunction(): $ReadOnlyArray<React.Node> {
-    const sections = [
-      {
-        key: 'a',
-        data: [
-          {
-            title: 'foo',
-            key: 1,
-          },
-        ],
-      },
-    ];
-    return [
-      <SectionList
-        // $FlowExpectedError - title should be inside `item`
-        renderItem={(info: {title: string, ...}) => <span />}
-        sections={sections}
-      />,
-      <SectionList
-        // $FlowExpectedError - bad index type string, should be number
-        renderItem={(info: {index: string}) => <span />}
-        sections={sections}
-      />,
-      // EverythingIsFine
-      <SectionList
-        renderItem={(info: {item: {title: string, ...}, ...}) => <span />}
-        sections={sections}
-      />,
-    ];
-  },
+export function testBadRenderItemFunction(): $ReadOnlyArray<React.Node> {
+  const sections = [
+    {
+      key: 'a',
+      data: [
+        {
+          title: 'foo',
+          key: 1,
+        },
+      ],
+    },
+  ];
+  return [
+    <SectionList
+      // $FlowExpectedError - title should be inside `item`
+      renderItem={(info: {title: string, ...}) => <span />}
+      sections={sections}
+    />,
+    <SectionList
+      // $FlowExpectedError - bad index type string, should be number
+      renderItem={(info: {index: string}) => <span />}
+      sections={sections}
+    />,
+    // EverythingIsFine
+    <SectionList
+      renderItem={(info: {item: {title: string, ...}, ...}) => <span />}
+      sections={sections}
+    />,
+  ];
+}
 
-  testBadInheritedDefaultProp(): React.MixedElement {
-    const sections: $FlowFixMe = [];
-    return (
-      <SectionList
-        renderItem={renderMyListItem}
-        sections={sections}
-        // $FlowExpectedError - bad windowSize type "big"
-        windowSize="big"
-      />
-    );
-  },
+export function testBadInheritedDefaultProp(): React.MixedElement {
+  const sections: $FlowFixMe = [];
+  return (
+    <SectionList
+      renderItem={renderMyListItem}
+      sections={sections}
+      // $FlowExpectedError - bad windowSize type "big"
+      windowSize="big"
+    />
+  );
+}
 
-  testMissingData(): React.MixedElement {
-    // $FlowExpectedError - missing `sections` prop
-    return <SectionList renderItem={renderMyListItem} />;
-  },
+export function testMissingData(): React.MixedElement {
+  // $FlowExpectedError - missing `sections` prop
+  return <SectionList renderItem={renderMyListItem} />;
+}
 
-  testBadSectionsShape(): React.MixedElement {
-    const sections = [
-      {
-        key: 'a',
-        items: [
-          {
-            title: 'foo',
-            key: 1,
-          },
-        ],
-      },
-    ];
-    // $FlowExpectedError - section missing `data` field
-    return <SectionList renderItem={renderMyListItem} sections={sections} />;
-  },
+export function testBadSectionsShape(): React.MixedElement {
+  const sections = [
+    {
+      key: 'a',
+      items: [
+        {
+          title: 'foo',
+          key: 1,
+        },
+      ],
+    },
+  ];
+  // $FlowExpectedError - section missing `data` field
+  return <SectionList renderItem={renderMyListItem} sections={sections} />;
+}
 
-  testBadSectionsMetadata(): React.MixedElement {
-    const sections = [
-      {
-        key: 'a',
-        fooNumber: 'string',
-        data: [
-          {
-            title: 'foo',
-            key: 1,
-          },
-        ],
-      },
-    ];
-    return (
-      <SectionList
-        renderSectionHeader={renderMyHeader}
-        renderItem={renderMyListItem}
-        /* $FlowExpectedError - section has bad meta data `fooNumber` field of
-         * type string */
-        sections={sections}
-      />
-    );
-  },
-};
+export function testBadSectionsMetadata(): React.MixedElement {
+  const sections = [
+    {
+      key: 'a',
+      fooNumber: 'string',
+      data: [
+        {
+          title: 'foo',
+          key: 1,
+        },
+      ],
+    },
+  ];
+  return (
+    <SectionList
+      renderSectionHeader={renderMyHeader}
+      renderItem={renderMyListItem}
+      /* $FlowExpectedError - section has bad meta data `fooNumber` field of
+       * type string */
+      sections={sections}
+    />
+  );
+}

--- a/packages/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js
+++ b/packages/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js
@@ -51,6 +51,7 @@ export type {PublicRootInstance} from '../ReactNative/ReactFabricPublicInstance/
 export type PublicTextInstance = ReturnType<createPublicTextInstance>;
 
 // flowlint unsafe-getters-setters:off
+// eslint-disable-next-line lint/no-commonjs-exports
 module.exports = {
   get BatchedBridge(): BatchedBridge {
     return require('../BatchedBridge/BatchedBridge').default;

--- a/packages/react-native/Libraries/StyleSheet/__flowtests__/StyleSheet-flowtest.js
+++ b/packages/react-native/Libraries/StyleSheet/__flowtests__/StyleSheet-flowtest.js
@@ -8,51 +8,47 @@
  * @format
  */
 
-'use strict';
-
 import type {ImageStyleProp, TextStyleProp} from '../StyleSheet';
 
 const StyleSheet = require('../StyleSheet').default;
 const imageStyle = {tintColor: 'rgb(0, 0, 0)'};
 const textStyle = {color: 'rgb(0, 0, 0)'};
 
-module.exports = {
-  testGoodCompose() {
-    (StyleSheet.compose(imageStyle, imageStyle): ImageStyleProp);
+export function testGoodCompose() {
+  (StyleSheet.compose(imageStyle, imageStyle): ImageStyleProp);
 
-    (StyleSheet.compose(textStyle, textStyle): TextStyleProp);
+  (StyleSheet.compose(textStyle, textStyle): TextStyleProp);
 
-    (StyleSheet.compose(null, null): TextStyleProp);
+  (StyleSheet.compose(null, null): TextStyleProp);
 
-    (StyleSheet.compose(textStyle, null): TextStyleProp);
+  (StyleSheet.compose(textStyle, null): TextStyleProp);
 
-    (StyleSheet.compose(
-      textStyle,
-      Math.random() < 0.5 ? textStyle : null,
-    ): TextStyleProp);
+  (StyleSheet.compose(
+    textStyle,
+    Math.random() < 0.5 ? textStyle : null,
+  ): TextStyleProp);
 
-    (StyleSheet.compose([textStyle], null): TextStyleProp);
+  (StyleSheet.compose([textStyle], null): TextStyleProp);
 
-    (StyleSheet.compose([textStyle], null): TextStyleProp);
+  (StyleSheet.compose([textStyle], null): TextStyleProp);
 
-    (StyleSheet.compose([textStyle], [textStyle]): TextStyleProp);
-  },
+  (StyleSheet.compose([textStyle], [textStyle]): TextStyleProp);
+}
 
-  testBadCompose() {
+export function testBadCompose() {
+  // $FlowExpectedError - Incompatible type.
+  (StyleSheet.compose(textStyle, textStyle): ImageStyleProp);
+
+  // $FlowExpectedError - Incompatible type.
+  (StyleSheet.compose(
     // $FlowExpectedError - Incompatible type.
-    (StyleSheet.compose(textStyle, textStyle): ImageStyleProp);
+    [textStyle],
+    null,
+  ): ImageStyleProp);
 
-    // $FlowExpectedError - Incompatible type.
-    (StyleSheet.compose(
-      // $FlowExpectedError - Incompatible type.
-      [textStyle],
-      null,
-    ): ImageStyleProp);
-
-    // $FlowExpectedError - Incompatible type.
-    (StyleSheet.compose(
-      Math.random() < 0.5 ? textStyle : null,
-      null,
-    ): ImageStyleProp);
-  },
-};
+  // $FlowExpectedError - Incompatible type.
+  (StyleSheet.compose(
+    Math.random() < 0.5 ? textStyle : null,
+    null,
+  ): ImageStyleProp);
+}

--- a/packages/react-native/Libraries/Utilities/__mocks__/BackHandler.js
+++ b/packages/react-native/Libraries/Utilities/__mocks__/BackHandler.js
@@ -42,4 +42,4 @@ const BackHandler = {
   },
 };
 
-module.exports = BackHandler;
+export default BackHandler;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -4219,11 +4219,10 @@ declare export default typeof RCTNativeAppEventEmitter;
 `;
 
 exports[`public API should not change unintentionally Libraries/Image/AssetRegistry.js 1`] = `
-"declare const AssetRegistry: {
-  registerAsset: (asset: PackagerAsset) => number,
-  getAssetByID: (assetId: number) => PackagerAsset,
-};
-declare module.exports: typeof AssetRegistry;
+"export {
+  registerAsset,
+  getAssetByID,
+} from \\"@react-native/assets-registry/registry\\";
 "
 `;
 


### PR DESCRIPTION
Summary:
Migrates the `BackHandler` mock to use ESM to mitigate the existing lint warning.

I'm actually not sure this is even used anywhere… and the unmocked `BackHandler` is already using ESM.

Changelog:
[Internal]

Differential Revision: D74949885


