### PR TITLE
RN: Unbreak Rules of React in `RNTesterPlatformTestEventRecorder`

### DIFF
--- a/packages/react-native/Libraries/Image/AssetRegistry.js
+++ b/packages/react-native/Libraries/Image/AssetRegistry.js
@@ -8,13 +8,7 @@
  * @format
  */
 
-'use strict';
-
-import type {PackagerAsset} from '@react-native/assets-registry/registry';
-
-const AssetRegistry = require('@react-native/assets-registry/registry') as {
-  registerAsset: (asset: PackagerAsset) => number,
-  getAssetByID: (assetId: number) => PackagerAsset,
-};
-
-module.exports = AssetRegistry;
+export {
+  registerAsset,
+  getAssetByID,
+} from '@react-native/assets-registry/registry';

--- a/packages/react-native/Libraries/Image/RelativeImageStub.js
+++ b/packages/react-native/Libraries/Image/RelativeImageStub.js
@@ -27,4 +27,5 @@ const RelativeImageStub = (AssetRegistry.registerAsset({
   type: 'png',
 }): number);
 
+// eslint-disable-next-line lint/no-commonjs-exports
 module.exports = RelativeImageStub;

--- a/packages/react-native/Libraries/Lists/__flowtests__/FlatList-flowtest.js
+++ b/packages/react-native/Libraries/Lists/__flowtests__/FlatList-flowtest.js
@@ -8,8 +8,6 @@
  * @format
  */
 
-'use strict';
-
 const FlatList = require('../FlatList').default;
 const React = require('react');
 
@@ -21,98 +19,96 @@ function renderMyListItem(info: {
   return <span />;
 }
 
-module.exports = {
-  testEverythingIsFine(): React.Node {
-    const data = [
-      {
-        title: 'Title Text',
-        key: 1,
-      },
-    ];
-    return <FlatList renderItem={renderMyListItem} data={data} />;
-  },
+export function testEverythingIsFine(): React.Node {
+  const data = [
+    {
+      title: 'Title Text',
+      key: 1,
+    },
+  ];
+  return <FlatList renderItem={renderMyListItem} data={data} />;
+}
 
-  testBadDataWithTypicalItem(): React.Node {
-    const data = [
-      {
-        title: 6,
-        key: 1,
-      },
-    ];
-    // $FlowExpectedError - bad title type 6, should be string
-    return <FlatList renderItem={renderMyListItem} data={data} />;
-  },
+export function testBadDataWithTypicalItem(): React.Node {
+  const data = [
+    {
+      title: 6,
+      key: 1,
+    },
+  ];
+  // $FlowExpectedError - bad title type 6, should be string
+  return <FlatList renderItem={renderMyListItem} data={data} />;
+}
 
-  testMissingFieldWithTypicalItem(): React.Node {
-    const data = [
-      {
-        key: 1,
-      },
-    ];
-    // $FlowExpectedError - missing title
-    return <FlatList renderItem={renderMyListItem} data={data} />;
-  },
+export function testMissingFieldWithTypicalItem(): React.Node {
+  const data = [
+    {
+      key: 1,
+    },
+  ];
+  // $FlowExpectedError - missing title
+  return <FlatList renderItem={renderMyListItem} data={data} />;
+}
 
-  testGoodDataWithBadCustomRenderItemFunction(): React.Node {
-    const data = [
-      {
-        widget: 6,
-        key: 1,
-      },
-    ];
-    return (
-      <FlatList
-        renderItem={info => (
-          <span>
-            {
-              // $FlowExpectedError - bad widgetCount type 6, should be Object
-              info.item.widget.missingProp
-            }
-          </span>
-        )}
-        data={data}
-      />
-    );
-  },
+export function testGoodDataWithBadCustomRenderItemFunction(): React.Node {
+  const data = [
+    {
+      widget: 6,
+      key: 1,
+    },
+  ];
+  return (
+    <FlatList
+      renderItem={info => (
+        <span>
+          {
+            // $FlowExpectedError - bad widgetCount type 6, should be Object
+            info.item.widget.missingProp
+          }
+        </span>
+      )}
+      data={data}
+    />
+  );
+}
 
-  testBadRenderItemFunction(): $ReadOnlyArray<React.Node> {
-    const data = [
-      {
-        title: 'foo',
-        key: 1,
-      },
-    ];
-    return [
-      // $FlowExpectedError - title should be inside `item`
-      <FlatList renderItem={(info: {title: string}) => <span />} data={data} />,
-      <FlatList
-        // $FlowExpectedError - bad index type string, should be number
-        renderItem={(info: {item: any, index: string}) => <span />}
-        data={data}
-      />,
-      <FlatList
-        // $FlowExpectedError - bad title type number, should be string
-        renderItem={(info: {item: {title: number}}) => <span />}
-        // $FlowExpectedError - bad title type number, should be string
-        data={data}
-      />,
-      // EverythingIsFine
-      <FlatList
-        // $FlowExpectedError - bad title type number, should be string
-        renderItem={(info: {item: {title: string, ...}, ...}) => <span />}
-        data={data}
-      />,
-    ];
-  },
+export function testBadRenderItemFunction(): $ReadOnlyArray<React.Node> {
+  const data = [
+    {
+      title: 'foo',
+      key: 1,
+    },
+  ];
+  return [
+    // $FlowExpectedError - title should be inside `item`
+    <FlatList renderItem={(info: {title: string}) => <span />} data={data} />,
+    <FlatList
+      // $FlowExpectedError - bad index type string, should be number
+      renderItem={(info: {item: any, index: string}) => <span />}
+      data={data}
+    />,
+    <FlatList
+      // $FlowExpectedError - bad title type number, should be string
+      renderItem={(info: {item: {title: number}}) => <span />}
+      // $FlowExpectedError - bad title type number, should be string
+      data={data}
+    />,
+    // EverythingIsFine
+    <FlatList
+      // $FlowExpectedError - bad title type number, should be string
+      renderItem={(info: {item: {title: string, ...}, ...}) => <span />}
+      data={data}
+    />,
+  ];
+}
 
-  testOtherBadProps(): $ReadOnlyArray<React.Node> {
-    return [
-      // $FlowExpectedError - bad numColumns type "lots"
-      <FlatList renderItem={renderMyListItem} data={[]} numColumns="lots" />,
-      // $FlowExpectedError - bad windowSize type "big"
-      <FlatList renderItem={renderMyListItem} data={[]} windowSize="big" />,
-      // $FlowExpectedError - missing `data` prop
-      <FlatList renderItem={renderMyListItem} />,
-    ];
-  },
-};
+export function testOtherBadProps(): $ReadOnlyArray<React.Node> {
+  return [
+    // $FlowExpectedError - bad numColumns type "lots"
+    <FlatList renderItem={renderMyListItem} data={[]} numColumns="lots" />,
+    // $FlowExpectedError - bad windowSize type "big"
+    <FlatList renderItem={renderMyListItem} data={[]} windowSize="big" />,
+    // $FlowExpectedError - missing `data` prop
+    <FlatList renderItem={renderMyListItem} />,
+  ];
+}

--- a/packages/react-native/Libraries/Lists/__flowtests__/SectionList-flowtest.js
+++ b/packages/react-native/Libraries/Lists/__flowtests__/SectionList-flowtest.js
@@ -8,8 +8,6 @@
  * @format
  */
 
-'use strict';
-
 import SectionList from '../SectionList';
 import * as React from 'react';
 
@@ -28,107 +26,105 @@ const renderMyHeader = ({
   ...
 }) => <span />;
 
-module.exports = {
-  testGoodDataWithGoodItem(): React.Node {
-    const sections = [
-      {
-        key: 'a',
-        data: [
-          {
-            title: 'foo',
-            key: 1,
-          },
-        ],
-      },
-    ];
-    return <SectionList renderItem={renderMyListItem} sections={sections} />;
-  },
+export function testGoodDataWithGoodItem(): React.Node {
+  const sections = [
+    {
+      key: 'a',
+      data: [
+        {
+          title: 'foo',
+          key: 1,
+        },
+      ],
+    },
+  ];
+  return <SectionList renderItem={renderMyListItem} sections={sections} />;
+}
 
-  testBadRenderItemFunction(): $ReadOnlyArray<React.Node> {
-    const sections = [
-      {
-        key: 'a',
-        data: [
-          {
-            title: 'foo',
-            key: 1,
-          },
-        ],
-      },
-    ];
-    return [
-      <SectionList
-        // $FlowExpectedError - title should be inside `item`
-        renderItem={(info: {title: string, ...}) => <span />}
-        sections={sections}
-      />,
-      <SectionList
-        // $FlowExpectedError - bad index type string, should be number
-        renderItem={(info: {index: string}) => <span />}
-        sections={sections}
-      />,
-      // EverythingIsFine
-      <SectionList
-        renderItem={(info: {item: {title: string, ...}, ...}) => <span />}
-        sections={sections}
-      />,
-    ];
-  },
+export function testBadRenderItemFunction(): $ReadOnlyArray<React.Node> {
+  const sections = [
+    {
+      key: 'a',
+      data: [
+        {
+          title: 'foo',
+          key: 1,
+        },
+      ],
+    },
+  ];
+  return [
+    <SectionList
+      // $FlowExpectedError - title should be inside `item`
+      renderItem={(info: {title: string, ...}) => <span />}
+      sections={sections}
+    />,
+    <SectionList
+      // $FlowExpectedError - bad index type string, should be number
+      renderItem={(info: {index: string}) => <span />}
+      sections={sections}
+    />,
+    // EverythingIsFine
+    <SectionList
+      renderItem={(info: {item: {title: string, ...}, ...}) => <span />}
+      sections={sections}
+    />,
+  ];
+}
 
-  testBadInheritedDefaultProp(): React.MixedElement {
-    const sections: $FlowFixMe = [];
-    return (
-      <SectionList
-        renderItem={renderMyListItem}
-        sections={sections}
-        // $FlowExpectedError - bad windowSize type "big"
-        windowSize="big"
-      />
-    );
-  },
+export function testBadInheritedDefaultProp(): React.MixedElement {
+  const sections: $FlowFixMe = [];
+  return (
+    <SectionList
+      renderItem={renderMyListItem}
+      sections={sections}
+      // $FlowExpectedError - bad windowSize type "big"
+      windowSize="big"
+    />
+  );
+}
 
-  testMissingData(): React.MixedElement {
-    // $FlowExpectedError - missing `sections` prop
-    return <SectionList renderItem={renderMyListItem} />;
-  },
+export function testMissingData(): React.MixedElement {
+  // $FlowExpectedError - missing `sections` prop
+  return <SectionList renderItem={renderMyListItem} />;
+}
 
-  testBadSectionsShape(): React.MixedElement {
-    const sections = [
-      {
-        key: 'a',
-        items: [
-          {
-            title: 'foo',
-            key: 1,
-          },
-        ],
-      },
-    ];
-    // $FlowExpectedError - section missing `data` field
-    return <SectionList renderItem={renderMyListItem} sections={sections} />;
-  },
+export function testBadSectionsShape(): React.MixedElement {
+  const sections = [
+    {
+      key: 'a',
+      items: [
+        {
+          title: 'foo',
+          key: 1,
+        },
+      ],
+    },
+  ];
+  // $FlowExpectedError - section missing `data` field
+  return <SectionList renderItem={renderMyListItem} sections={sections} />;
+}
 
-  testBadSectionsMetadata(): React.MixedElement {
-    const sections = [
-      {
-        key: 'a',
-        fooNumber: 'string',
-        data: [
-          {
-            title: 'foo',
-            key: 1,
-          },
-        ],
-      },
-    ];
-    return (
-      <SectionList
-        renderSectionHeader={renderMyHeader}
-        renderItem={renderMyListItem}
-        /* $FlowExpectedError - section has bad meta data `fooNumber` field of
-         * type string */
-        sections={sections}
-      />
-    );
-  },
-};
+export function testBadSectionsMetadata(): React.MixedElement {
+  const sections = [
+    {
+      key: 'a',
+      fooNumber: 'string',
+      data: [
+        {
+          title: 'foo',
+          key: 1,
+        },
+      ],
+    },
+  ];
+  return (
+    <SectionList
+      renderSectionHeader={renderMyHeader}
+      renderItem={renderMyListItem}
+      /* $FlowExpectedError - section has bad meta data `fooNumber` field of
+       * type string */
+      sections={sections}
+    />
+  );
+}

--- a/packages/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js
+++ b/packages/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js
@@ -51,6 +51,7 @@ export type {PublicRootInstance} from '../ReactNative/ReactFabricPublicInstance/
 export type PublicTextInstance = ReturnType<createPublicTextInstance>;
 
 // flowlint unsafe-getters-setters:off
+// eslint-disable-next-line lint/no-commonjs-exports
 module.exports = {
   get BatchedBridge(): BatchedBridge {
     return require('../BatchedBridge/BatchedBridge').default;

--- a/packages/react-native/Libraries/StyleSheet/__flowtests__/StyleSheet-flowtest.js
+++ b/packages/react-native/Libraries/StyleSheet/__flowtests__/StyleSheet-flowtest.js
@@ -8,51 +8,47 @@
  * @format
  */
 
-'use strict';
-
 import type {ImageStyleProp, TextStyleProp} from '../StyleSheet';
 
 const StyleSheet = require('../StyleSheet').default;
 const imageStyle = {tintColor: 'rgb(0, 0, 0)'};
 const textStyle = {color: 'rgb(0, 0, 0)'};
 
-module.exports = {
-  testGoodCompose() {
-    (StyleSheet.compose(imageStyle, imageStyle): ImageStyleProp);
+export function testGoodCompose() {
+  (StyleSheet.compose(imageStyle, imageStyle): ImageStyleProp);
 
-    (StyleSheet.compose(textStyle, textStyle): TextStyleProp);
+  (StyleSheet.compose(textStyle, textStyle): TextStyleProp);
 
-    (StyleSheet.compose(null, null): TextStyleProp);
+  (StyleSheet.compose(null, null): TextStyleProp);
 
-    (StyleSheet.compose(textStyle, null): TextStyleProp);
+  (StyleSheet.compose(textStyle, null): TextStyleProp);
 
-    (StyleSheet.compose(
-      textStyle,
-      Math.random() < 0.5 ? textStyle : null,
-    ): TextStyleProp);
+  (StyleSheet.compose(
+    textStyle,
+    Math.random() < 0.5 ? textStyle : null,
+  ): TextStyleProp);
 
-    (StyleSheet.compose([textStyle], null): TextStyleProp);
+  (StyleSheet.compose([textStyle], null): TextStyleProp);
 
-    (StyleSheet.compose([textStyle], null): TextStyleProp);
+  (StyleSheet.compose([textStyle], null): TextStyleProp);
 
-    (StyleSheet.compose([textStyle], [textStyle]): TextStyleProp);
-  },
+  (StyleSheet.compose([textStyle], [textStyle]): TextStyleProp);
+}
 
-  testBadCompose() {
+export function testBadCompose() {
+  // $FlowExpectedError - Incompatible type.
+  (StyleSheet.compose(textStyle, textStyle): ImageStyleProp);
+
+  // $FlowExpectedError - Incompatible type.
+  (StyleSheet.compose(
     // $FlowExpectedError - Incompatible type.
-    (StyleSheet.compose(textStyle, textStyle): ImageStyleProp);
+    [textStyle],
+    null,
+  ): ImageStyleProp);
 
-    // $FlowExpectedError - Incompatible type.
-    (StyleSheet.compose(
-      // $FlowExpectedError - Incompatible type.
-      [textStyle],
-      null,
-    ): ImageStyleProp);
-
-    // $FlowExpectedError - Incompatible type.
-    (StyleSheet.compose(
-      Math.random() < 0.5 ? textStyle : null,
-      null,
-    ): ImageStyleProp);
-  },
-};
+  // $FlowExpectedError - Incompatible type.
+  (StyleSheet.compose(
+    Math.random() < 0.5 ? textStyle : null,
+    null,
+  ): ImageStyleProp);
+}

--- a/packages/react-native/Libraries/Utilities/__mocks__/BackHandler.js
+++ b/packages/react-native/Libraries/Utilities/__mocks__/BackHandler.js
@@ -42,4 +42,4 @@ const BackHandler = {
   },
 };
 
-module.exports = BackHandler;
+export default BackHandler;

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -4219,11 +4219,10 @@ declare export default typeof RCTNativeAppEventEmitter;
 `;
 
 exports[`public API should not change unintentionally Libraries/Image/AssetRegistry.js 1`] = `
-"declare const AssetRegistry: {
-  registerAsset: (asset: PackagerAsset) => number,
-  getAssetByID: (assetId: number) => PackagerAsset,
-};
-declare module.exports: typeof AssetRegistry;
+"export {
+  registerAsset,
+  getAssetByID,
+} from \\"@react-native/assets-registry/registry\\";
 "
 `;
 

--- a/packages/react-native/src/private/devsupport/rndevtools/ReactDevToolsSettingsManager.android.js
+++ b/packages/react-native/src/private/devsupport/rndevtools/ReactDevToolsSettingsManager.android.js
@@ -4,17 +4,16 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow strict-local
+ * @flow strict
  * @format
  */
 
 import NativeReactDevToolsSettingsManager from './specs/NativeReactDevToolsSettingsManager';
 
-module.exports = {
-  setGlobalHookSettings(settings: string) {
-    NativeReactDevToolsSettingsManager?.setGlobalHookSettings(settings);
-  },
-  getGlobalHookSettings(): ?string {
-    return NativeReactDevToolsSettingsManager?.getGlobalHookSettings();
-  },
-};
+export function setGlobalHookSettings(settings: string) {
+  NativeReactDevToolsSettingsManager?.setGlobalHookSettings(settings);
+}
+
+export function getGlobalHookSettings(): ?string {
+  return NativeReactDevToolsSettingsManager?.getGlobalHookSettings();
+}

--- a/packages/react-native/src/private/devsupport/rndevtools/ReactDevToolsSettingsManager.ios.js
+++ b/packages/react-native/src/private/devsupport/rndevtools/ReactDevToolsSettingsManager.ios.js
@@ -12,19 +12,16 @@ import Settings from '../../../../Libraries/Settings/Settings';
 
 const GLOBAL_HOOK_SETTINGS = 'ReactDevTools::HookSettings';
 
-const ReactDevToolsSettingsManager = {
-  setGlobalHookSettings(settings: string): void {
-    Settings.set({
-      [GLOBAL_HOOK_SETTINGS]: settings,
-    });
-  },
-  getGlobalHookSettings(): ?string {
-    const value = Settings.get(GLOBAL_HOOK_SETTINGS);
-    if (typeof value === 'string') {
-      return value;
-    }
-    return null;
-  },
-};
+export function setGlobalHookSettings(settings: string) {
+  Settings.set({
+    [GLOBAL_HOOK_SETTINGS]: settings,
+  });
+}
 
-module.exports = ReactDevToolsSettingsManager;
+export function getGlobalHookSettings(): ?string {
+  const value = Settings.get(GLOBAL_HOOK_SETTINGS);
+  if (typeof value === 'string') {
+    return value;
+  }
+  return null;
+}

--- a/packages/react-native/src/private/devsupport/rndevtools/ReactDevToolsSettingsManager.js.flow
+++ b/packages/react-native/src/private/devsupport/rndevtools/ReactDevToolsSettingsManager.js.flow
@@ -4,13 +4,9 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow strict-local
+ * @flow strict
  * @format
  */
 
-declare const ReactDevToolsSettingsManager: {
-  setGlobalHookSettings(settings: string): void,
-  getGlobalHookSettings(): ?string,
-};
-
-module.exports = ReactDevToolsSettingsManager;
+declare export function setGlobalHookSettings(settings: string): void;
+declare export function getGlobalHookSettings(): ?string;

--- a/packages/rn-tester/js/examples/Experimental/PlatformTest/RNTesterPlatformTestEventRecorder.js
+++ b/packages/rn-tester/js/examples/Experimental/PlatformTest/RNTesterPlatformTestEventRecorder.js
@@ -26,7 +26,7 @@ type EventRecord = {
   event: Object,
 };
 
-class RNTesterPlatformTestEventRecorder {
+export default class RNTesterPlatformTestEventRecorder {
   allRecords: Array<EventRecord> = [];
   relevantEvents: Array<string> = [];
   rawOrder: number = 1;
@@ -101,41 +101,34 @@ class RNTesterPlatformTestEventRecorder {
     };
   }
 
-  useRecorderTestEventHandlers(
+  createRecorderTestEventHandlers(
     targetNames: $ReadOnlyArray<string>,
     callback?: (event: Object, eventType: string, targetName: string) => void,
   ): $ReadOnly<{[targetName: string]: ViewProps}> {
-    // Yes this method exists as a class's prototype method but it will still only be used
-    // in functional components
-    // prettier-ignore
-    // $FlowFixMe[react-rule-hook]
-    return useMemo(() => { // eslint-disable-line react-hooks/rules-of-hooks
-      const result: {[targetName: string]: ViewProps} = {};
-      for (const targetName of targetNames) {
-        const recordedEventHandler =
-          this._generateRecordedEventHandlerWithCallback(
-            targetName,
-            (event, eventType) =>
-              callback && callback(event, eventType, targetName),
-          );
-        // $FlowFixMe[incompatible-call]
-        const eventListenerProps = this.relevantEvents.reduce(
-          (acc: ViewProps, eventName) => {
-            const eventPropName =
-              'on' + eventName[0].toUpperCase() + eventName.slice(1);
-            return {
-              ...acc,
-              [eventPropName]: (e => {
-                recordedEventHandler(e, eventName);
-              }) as $FlowFixMe,
-            };
-          },
-          {},
+    const result: {[targetName: string]: ViewProps} = {};
+    for (const targetName of targetNames) {
+      const recordedEventHandler =
+        this._generateRecordedEventHandlerWithCallback(
+          targetName,
+          (event, eventType) => callback?.(event, eventType, targetName),
         );
-        result[targetName] = eventListenerProps;
-      }
-      return result;
-    }, [callback, targetNames]);
+      // $FlowFixMe[incompatible-call]
+      const eventListenerProps = this.relevantEvents.reduce(
+        (acc: ViewProps, eventName) => {
+          const eventPropName =
+            'on' + eventName[0].toUpperCase() + eventName.slice(1);
+          return {
+            ...acc,
+            [eventPropName]: (e => {
+              recordedEventHandler(e, eventName);
+            }) as $FlowFixMe,
+          };
+        },
+        {},
+      );
+      result[targetName] = eventListenerProps;
+    }
+    return result;
   }
 
   getRecords(): Array<EventRecord> {
@@ -176,4 +169,13 @@ class RNTesterPlatformTestEventRecorder {
   }
 }
 
-export default RNTesterPlatformTestEventRecorder;
+export function useRecorderTestEventHandlers(
+  eventRecorder: RNTesterPlatformTestEventRecorder,
+  targetNames: $ReadOnlyArray<string>,
+  callback?: (event: Object, eventType: string, targetName: string) => void,
+): $ReadOnly<{[targetName: string]: ViewProps}> {
+  return useMemo(
+    () => eventRecorder.createRecorderTestEventHandlers(targetNames, callback),
+    [eventRecorder, targetNames, callback],
+  );
+}

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerMoveAcross.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerMoveAcross.js
@@ -11,7 +11,9 @@
 import type {PlatformTestComponentBaseProps} from '../PlatformTest/RNTesterPlatformTestTypes';
 
 import RNTesterPlatformTest from '../PlatformTest/RNTesterPlatformTest';
-import RNTesterPlatformTestEventRecorder from '../PlatformTest/RNTesterPlatformTestEventRecorder';
+import RNTesterPlatformTestEventRecorder, {
+  useRecorderTestEventHandlers,
+} from '../PlatformTest/RNTesterPlatformTestEventRecorder';
 import * as React from 'react';
 import {useCallback, useState} from 'react';
 import {StyleSheet, View} from 'react-native';
@@ -126,7 +128,8 @@ function PointerEventPointerMoveAcrossTestCase(
     [eventRecorder, pointermove_across],
   );
 
-  const eventProps = eventRecorder.useRecorderTestEventHandlers(
+  const eventProps = useRecorderTestEventHandlers(
+    eventRecorder,
     targetNames,
     eventHandler,
   );

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerMoveBetween.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerMoveBetween.js
@@ -11,7 +11,9 @@
 import type {PlatformTestComponentBaseProps} from '../PlatformTest/RNTesterPlatformTestTypes';
 
 import RNTesterPlatformTest from '../PlatformTest/RNTesterPlatformTest';
-import RNTesterPlatformTestEventRecorder from '../PlatformTest/RNTesterPlatformTestEventRecorder';
+import RNTesterPlatformTestEventRecorder, {
+  useRecorderTestEventHandlers,
+} from '../PlatformTest/RNTesterPlatformTestEventRecorder';
 import * as React from 'react';
 import {useCallback, useState} from 'react';
 import {StyleSheet, View} from 'react-native';
@@ -102,7 +104,8 @@ function PointerEventPointerMoveBetweenTestCase(
     [eventRecorder, pointermove_between],
   );
 
-  const eventProps = eventRecorder.useRecorderTestEventHandlers(
+  const eventProps = useRecorderTestEventHandlers(
+    eventRecorder,
     targetNames,
     eventHandler,
   );

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerMoveEventOrder.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventPointerMoveEventOrder.js
@@ -12,7 +12,9 @@ import type {PlatformTestComponentBaseProps} from '../PlatformTest/RNTesterPlatf
 import type {PointerEvent} from 'react-native';
 
 import RNTesterPlatformTest from '../PlatformTest/RNTesterPlatformTest';
-import RNTesterPlatformTestEventRecorder from '../PlatformTest/RNTesterPlatformTestEventRecorder';
+import RNTesterPlatformTestEventRecorder, {
+  useRecorderTestEventHandlers,
+} from '../PlatformTest/RNTesterPlatformTestEventRecorder';
 import * as React from 'react';
 import {useCallback, useState} from 'react';
 import {StyleSheet, View} from 'react-native';
@@ -111,7 +113,8 @@ function PointerEventPointerMoveEventOrderTestCase(
     [endMoved, eventRecorder, pointer_test, startMoved],
   );
 
-  const eventProps = eventRecorder.useRecorderTestEventHandlers(
+  const eventProps = useRecorderTestEventHandlers(
+    eventRecorder,
     ['start', 'end'],
     eventHandler,
   );


### PR DESCRIPTION
Summary:
Refactors `RNTesterPlatformTestEventRecorder` so that it does not use `useMemo` from an instance method.

Instead, this diff changes the module to export a hook by the same name, `useRecorderTestEventHandlers`.

Changelog:
[Internal]

Differential Revision: D74950333


