### PR TITLE
fix: make RCTScreenSize take horizontal orientation into account

### DIFF
--- a/packages/react-native/React/Base/RCTUtils.mm
+++ b/packages/react-native/React/Base/RCTUtils.mm
@@ -383,21 +383,27 @@ CGFloat RCTFontSizeMultiplier(void)
   return mapping[RCTSharedApplication().preferredContentSizeCategory].floatValue;
 }
 
+UIDeviceOrientation RCTDeviceOrientation(void) {
+  return [[UIDevice currentDevice] orientation];
+}
+
 CGSize RCTScreenSize(void)
 {
-  // FIXME: this caches whatever the bounds were when it was first called, and then
-  // doesn't update when the device is rotated. We need to find another thread-
-  // safe way to get the screen size.
-
-  static CGSize size;
+  static CGSize portraitSize;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
     RCTUnsafeExecuteOnMainQueueSync(^{
-      size = [UIScreen mainScreen].bounds.size;
+      CGSize screenSize = [UIScreen mainScreen].bounds.size;
+      portraitSize = CGSizeMake(MIN(screenSize.width, screenSize.height),
+                                MAX(screenSize.width, screenSize.height));
     });
   });
-
-  return size;
+  
+  if (UIDeviceOrientationIsLandscape(RCTDeviceOrientation())) {
+    return CGSizeMake(portraitSize.height, portraitSize.width);
+  } else {
+    return CGSizeMake(portraitSize.width, portraitSize.height);
+  }
 }
 
 CGSize RCTViewportSize(void)


### PR DESCRIPTION
## Summary:

This PR improves `RCTScreenSize` to handle horizontal orientations. This was causing a flicker whenever opening a Modal in horizontal orientation. Currently, `RCTScreenSize` is used to supply initial state for `ModalHostViewState`: 

https://github.com/facebook/react-native/blob/f1697544cd720df21bd7dc8ca993d95a41321e3f/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewState.h#L31

This works great in portrait mode, but causes onLayout the be called twice in horizontal orientation (first with screen size and then with actual size..)

## Changelog:

[IOS] [FIXED] - make RCTScreenSize take horizontal orientation into account


## Test Plan:

Open modal in horizontal orientation
