### PR TITLE
Legacy Native Module e2e test

### DIFF
--- a/packages/rn-tester/.maestro/legacy-native-module.yml
+++ b/packages/rn-tester/.maestro/legacy-native-module.yml
@@ -7,11 +7,11 @@ appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebo
     id: "apis-tab"
 - scrollUntilVisible:
     element:
-        text: "Legacy Native Module"
+        id: "Legacy Native Module"
     direction: DOWN
-    speed: 60
+    speed: 40
 - tapOn:
-    text: "Legacy Native Module"
+    id: "Legacy Native Module"
 - tapOn: 
     text: "voidFunc"
 - assertVisible:

--- a/packages/rn-tester/.maestro/legacy-native-module.yml
+++ b/packages/rn-tester/.maestro/legacy-native-module.yml
@@ -1,0 +1,46 @@
+appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebook.react.uiapp
+---
+- launchApp
+- assertVisible:
+    text: "APIs"
+- tapOn:
+    id: "apis-tab"
+- scrollUntilVisible:
+    element:
+        text: "Legacy Native Module"
+    direction: DOWN
+    speed: 60
+- tapOn:
+    text: "Legacy Native Module"
+- tapOn: 
+    text: "voidFunc"
+- assertVisible:
+    id: "voidFunc-result"
+- tapOn:
+    text: "getBool"
+- assertVisible:
+    id: "getBool-result"
+- tapOn:
+    text: "getEnum"
+- assertVisible:
+    id: "getEnum-result"
+- tapOn:
+    text: "getInt"
+- assertVisible:
+    id: "getInt-result"
+- tapOn:
+    text: "getString"
+- assertVisible:
+    id: "getString-result"
+- tapOn:
+    text: "getObject"
+- assertVisible:
+    id: "getObject-result"
+- tapOn:
+    text: "getUnsafeObject"
+- assertVisible:
+    id: "getUnsafeObject-result"
+- tapOn:
+    text: "getValue"
+- assertVisible:
+    id: "getValue-result"


### PR DESCRIPTION
## Summary:

Found an issue with the legacy native module calls in old architecture (https://github.com/facebook/react-native/issues/51443) and got the idea of adding some simple e2e tests for the native modules so regressions like this can be captured moving forward.

This doesn't cover all methods, as not all of them are available for both Android and iOS, and also some of them are currently crashing, so it makes no sense to cover them all yet – but this can be used as a good starting point to increase coverage for essential APIs.

## Changelog:

[INTERNAL]  - Legacy Native Module e2e test

## Test Plan:

```sh
cd packages/rn-tester && maestro test .maestro/legacy-native-module.yml -e APP_ID=com.facebook.react.uiapp
```

<img width="594" alt="image" src="https://github.com/user-attachments/assets/6237613d-f5dc-4d8a-9b12-0980177793eb" />

<img width="740" alt="image" src="https://github.com/user-attachments/assets/8bdef368-13ac-494c-a506-88fff01dc8d6" />


