### PR TITLE
Support running tests with different hermes variants

### DIFF
--- a/packages/react-native-fantom/runner/getFantomTestConfig.js
+++ b/packages/react-native-fantom/runner/getFantomTestConfig.js
@@ -56,6 +56,9 @@ const FANTOM_BENCHMARK_FILENAME_RE = /[Bb]enchmark-itest\./g;
 const FANTOM_BENCHMARK_SUITE_RE =
   /\n(Fantom\.)?unstable_benchmark(\s*)\.suite\(/g;
 
+const FANTOM_BENCHMARK_DEFAULT_MODE: FantomTestConfigMode =
+  FantomTestConfigMode.Optimized;
+
 /**
  * Extracts the Fantom configuration from the test file, specified as part of
  * the docblock comment. E.g.:
@@ -123,7 +126,7 @@ export default function getFantomTestConfig(
       FANTOM_BENCHMARK_FILENAME_RE.test(testPath) ||
       FANTOM_BENCHMARK_SUITE_RE.test(testContents)
     ) {
-      config.mode = FantomTestConfigMode.Optimized;
+      config.mode = FANTOM_BENCHMARK_DEFAULT_MODE;
     }
   }
 

--- a/packages/react-native-fantom/runner/getFantomTestConfig.js
+++ b/packages/react-native-fantom/runner/getFantomTestConfig.js
@@ -11,6 +11,7 @@
 import type {FeatureFlagValue} from '../../../packages/react-native/scripts/featureflags/types';
 
 import ReactNativeFeatureFlags from '../../../packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config';
+import {HermesVariant} from './utils';
 import fs from 'fs';
 // $FlowExpectedError[untyped-import]
 import {extract, parse} from 'jest-docblock';
@@ -40,6 +41,7 @@ export type FantomTestConfigReactInternalFeatureFlags = {
 
 export type FantomTestConfig = {
   mode: FantomTestConfigMode,
+  hermesVariant: HermesVariant,
   flags: {
     common: FantomTestConfigCommonFeatureFlags,
     jsOnly: FantomTestConfigJsOnlyFeatureFlags,
@@ -49,6 +51,8 @@ export type FantomTestConfig = {
 
 const DEFAULT_MODE: FantomTestConfigMode =
   FantomTestConfigMode.DevelopmentWithSource;
+
+const DEFAULT_HERMES_MODE: HermesVariant = HermesVariant.Hermes;
 
 const FANTOM_FLAG_FORMAT = /^(\w+):(\w+)$/;
 
@@ -67,6 +71,7 @@ const FANTOM_BENCHMARK_DEFAULT_MODE: FantomTestConfigMode =
  * /**
  *  * @flow strict-local
  *  * @fantom_mode opt
+ *  * @fantom_hermes_variant static_hermes
  *  * @fantom_flags commonTestFlag:true
  *  * @fantom_flags jsOnlyTestFlag:true
  *  * @fantom_react_fb_flags reactInternalFlag:true
@@ -76,6 +81,8 @@ const FANTOM_BENCHMARK_DEFAULT_MODE: FantomTestConfigMode =
  * The supported options are:
  * - `fantom_mode`: specifies the level of optimization to compile the test
  *  with. Valid values are `dev` and `opt`.
+ * - `fantom_hermes_variant`: specifies the Hermes variant to use to run the
+ *  test. Valid values are `hermes`, `static_hermes` and `static_hermes_trunk`.
  * - `fantom_flags`: specifies the configuration for common and JS-only feature
  *  flags. They can be specified in the same pragma or in different ones, and
  *  the format is `<flag_name>:<value>`.
@@ -90,6 +97,7 @@ export default function getFantomTestConfig(
 
   const config: FantomTestConfig = {
     mode: DEFAULT_MODE,
+    hermesVariant: DEFAULT_HERMES_MODE,
     flags: {
       common: {},
       jsOnly: {
@@ -127,6 +135,31 @@ export default function getFantomTestConfig(
       FANTOM_BENCHMARK_SUITE_RE.test(testContents)
     ) {
       config.mode = FANTOM_BENCHMARK_DEFAULT_MODE;
+    }
+  }
+
+  const maybeHermesVariant = pragmas.fantom_hermes_variant;
+
+  if (maybeHermesVariant != null) {
+    if (Array.isArray(maybeHermesVariant)) {
+      throw new Error('Expected a single value for @fantom_hermes_variant');
+    }
+
+    const hermesVariant = maybeHermesVariant;
+
+    switch (hermesVariant) {
+      case 'hermes':
+        config.hermesVariant = HermesVariant.Hermes;
+        break;
+      case 'static_hermes':
+      case 'static_hermes_stable':
+        config.hermesVariant = HermesVariant.StaticHermesStable;
+        break;
+      case 'static_hermes_trunk':
+        config.hermesVariant = HermesVariant.StaticHermesTrunk;
+        break;
+      default:
+        throw new Error(`Invalid Fantom Hermes mode: ${hermesVariant}`);
     }
   }
 

--- a/packages/react-native-fantom/runner/utils.js
+++ b/packages/react-native-fantom/runner/utils.js
@@ -18,6 +18,36 @@ import {SourceMapConsumer} from 'source-map';
 
 const BUCK_ISOLATION_DIR = 'react-native-fantom-buck-out';
 
+export enum HermesVariant {
+  Hermes,
+  StaticHermesStable,
+  StaticHermesTrunk,
+}
+
+export function getBuckOptionsForHermes(
+  variant: HermesVariant,
+): $ReadOnlyArray<string> {
+  switch (variant) {
+    case HermesVariant.Hermes:
+      return [];
+    case HermesVariant.StaticHermesStable:
+      return ['-c hermes.static_hermes=stable'];
+    case HermesVariant.StaticHermesTrunk:
+      return ['-c hermes.static_hermes=trunk'];
+  }
+}
+
+export function getHermesCompilerTarget(variant: HermesVariant): string {
+  switch (variant) {
+    case HermesVariant.Hermes:
+      return '//xplat/hermes/tools/hermesc:hermesc';
+    case HermesVariant.StaticHermesStable:
+      return '//xplat/shermes/stable:hermesc';
+    case HermesVariant.StaticHermesTrunk:
+      return '//xplat/static_h:hermesc';
+  }
+}
+
 export function getBuckModesForPlatform(
   enableRelease: boolean = false,
 ): $ReadOnlyArray<string> {


### PR DESCRIPTION
Summary:
This diff adds the `fantom_hermes_variant` pragma which can be set to:
- `hermes` for the default Hermes runtime used by RN
- `static_hermes` for the stable version of Static Hermes
- `static_hermes_trunk` for the "trunk" version of Static Hermes

Each variant will set up the correct build options for the runner and the correct compiler to use for the bundle.

Changelog: [Internal]

Reviewed By: rshest

Differential Revision: D74959718


