### PR TITLE
Add HighResTimeStamp::toChronoSteadyClockTimePoint

### DIFF
--- a/packages/react-native/ReactCommon/react/timing/primitives.h
+++ b/packages/react-native/ReactCommon/react/timing/primitives.h
@@ -238,6 +238,20 @@ class HighResTimeStamp {
         .toDOMHighResTimeStamp();
   }
 
+  // This method is expected to be used only when converting time stamps from
+  // external systems.
+  static constexpr HighResTimeStamp fromChronoSteadyClockTimePoint(
+      std::chrono::steady_clock::time_point chronoTimePoint) {
+    return HighResTimeStamp(chronoTimePoint);
+  }
+
+  // This method is provided for convenience, if you need to convert
+  // HighResTimeStamp to some common epoch with time stamps from other sources.
+  constexpr std::chrono::steady_clock::time_point toChronoSteadyClockTimePoint()
+      const {
+    return chronoTimePoint_;
+  }
+
   constexpr bool operator==(const HighResTimeStamp& rhs) const {
     return chronoTimePoint_ == rhs.chronoTimePoint_;
   }

--- a/packages/react-native/ReactCommon/react/timing/tests/PrimitivesTest.cpp
+++ b/packages/react-native/ReactCommon/react/timing/tests/PrimitivesTest.cpp
@@ -128,4 +128,11 @@ TEST(HighResTimeStamp, ComparisonOperators) {
   EXPECT_FALSE(now >= later);
 }
 
+TEST(HighResTimeStamp, SteadyClockTimePointConversion) {
+  [[maybe_unused]] auto timestamp =
+      HighResTimeStamp::now().toChronoSteadyClockTimePoint();
+
+  EXPECT_TRUE(decltype(timestamp)::clock::is_steady);
+}
+
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

The main idea is that subsystems who might use a different time origin (the starting point of the whole timeline of events), can use this method to get raw `std::chrono::steady_clock::time_point` and then offset it by some arbitrary epoch: be it unix time origin or `std::chrono::steady_clock::epoch`.

Differential Revision: D74892329


