### PR TITLE
Fix cross-over issue with animatedShouldUseSingleOp and animatedShouldSignalBatch

### DIFF
--- a/packages/react-native/src/private/animated/NativeAnimatedHelper.js
+++ b/packages/react-native/src/private/animated/NativeAnimatedHelper.js
@@ -97,6 +97,10 @@ function createNativeOperations(): $NonMaybeType<typeof NativeAnimatedModule> {
         // is possible because # arguments is fixed for each operation. For more
         // details, see `NativeAnimatedModule.queueAndExecuteBatchedOperations`.
         singleOpQueue.push(operationID, ...args);
+        if (shouldSignalBatch) {
+          clearImmediate(flushQueueImmediate);
+          flushQueueImmediate = setImmediate(API.flushQueue);
+        }
       };
     }
   } else {


### PR DESCRIPTION
Summary:
When using `animatedShouldSignalBatch` in combination with `animatedShouldUseSingleOp`, we were seeing an issue where the queue is not flushed deterministically. It would be flushed in an ad-hoc manner by `createAnimatedPropsHook.js`, but this was only if a mount happened to occur in the same frame.

Adding a deterministic queue flush mechanism to the logic handling `animatedShouldUseSingleOp` appears to resolve the issue.

## Changelog

[Internal]

Differential Revision: D75002657


