### PR TITLE
Typo fix in InterpolationAnimatedNode for debugging

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/InterpolationAnimatedNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/InterpolationAnimatedNode.kt
@@ -96,7 +96,7 @@ internal class InterpolationAnimatedNode(config: ReadableMap) : ValueAnimatedNod
   override fun getAnimatedObject(): Any? = objectValue
 
   override fun prettyPrint(): String =
-      "InterpolationAnimatedNode[$tag] super: {super.prettyPrint()}"
+      "InterpolationAnimatedNode[$tag] super: ${super.prettyPrint()}"
 
   companion object {
     const val EXTRAPOLATE_TYPE_IDENTITY: String = "identity"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

I noticed a missing debugging text while working on https://github.com/facebook/react-native/issues/50496. It was a typo. I though I might as well send a PR.

## Changelog:

[Android] [Fixed] - Fixing a typo in InterpolationAnimatedNode for debug text.

<!-- Help reviewers and the release process by writing your own changelog entry.
Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
