### PR TITLE
Do not flush Animated operation queue on mount for some feature flags

### DIFF
--- a/packages/react-native/src/private/animated/NativeAnimatedHelper.js
+++ b/packages/react-native/src/private/animated/NativeAnimatedHelper.js
@@ -57,7 +57,7 @@ const eventListenerAnimationFinishedCallbacks: {
 let globalEventEmitterGetValueListener: ?EventSubscription = null;
 let globalEventEmitterAnimationFinishedListener: ?EventSubscription = null;
 
-const shouldSignalBatch =
+const shouldSignalBatch: boolean =
   ReactNativeFeatureFlags.animatedShouldSignalBatch() ||
   ReactNativeFeatureFlags.cxxNativeAnimatedEnabled();
 
@@ -440,6 +440,7 @@ export default {
   generateNewAnimationId,
   assertNativeAnimatedModule,
   shouldUseNativeDriver,
+  shouldSignalBatch,
   transformDataType,
   // $FlowExpectedError[unsafe-getters-setters] - unsafe getter lint suppression
   // $FlowExpectedError[missing-type-arg] - unsafe getter lint suppression

--- a/packages/react-native/src/private/animated/NativeAnimatedHelper.js
+++ b/packages/react-native/src/private/animated/NativeAnimatedHelper.js
@@ -97,6 +97,10 @@ function createNativeOperations(): $NonMaybeType<typeof NativeAnimatedModule> {
         // is possible because # arguments is fixed for each operation. For more
         // details, see `NativeAnimatedModule.queueAndExecuteBatchedOperations`.
         singleOpQueue.push(operationID, ...args);
+        if (shouldSignalBatch) {
+          clearImmediate(flushQueueImmediate);
+          flushQueueImmediate = setImmediate(API.flushQueue);
+        }
       };
     }
   } else {

--- a/packages/react-native/src/private/animated/createAnimatedPropsHook.js
+++ b/packages/react-native/src/private/animated/createAnimatedPropsHook.js
@@ -66,9 +66,13 @@ export default function createAnimatedPropsHook(
     );
 
     useEffect(() => {
-      // If multiple components call `flushQueue`, the first one will flush the
-      // queue and subsequent ones will do nothing.
-      NativeAnimatedHelper.API.flushQueue();
+      // Animated queue flush is handled deterministically in setImmediate for the following feature flags:
+      // animatedShouldSignalBatch, cxxNativeAnimatedEnabled
+      if (!NativeAnimatedHelper.shouldSignalBatch) {
+        // If multiple components call `flushQueue`, the first one will flush the
+        // queue and subsequent ones will do nothing.
+        NativeAnimatedHelper.API.flushQueue();
+      }
       let drivenAnimationEndedListener: ?EventSubscription = null;
       if (node.__isNative) {
         drivenAnimationEndedListener =


### PR DESCRIPTION
Summary:
We are trying to minimize the amount of non-determinism in flushing Animated operation queues. Initiallly the `ReactNativeFeatureFlags.animatedShouldSignalBatch` handled non-determinism on the native side, eliminating the use of native mount hooks to trigger operation batch flushes in the native module. However, there is additional non-determinism introduced by JS, where the set of pending Animated operations may be flushed as a result of an effect.

This change eliminates the flushing of Animated operations in the `useEffect` for `createAnimatedPropsHook.js`.

## Changelog

[Internal]

Differential Revision: D75003751


