### PR TITLE
[0.80] Fix broken focus behavior for TextInput in older Android versions (< 9)

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -6565,7 +6565,6 @@ public class com/facebook/react/views/textinput/ReactEditText : androidx/appcomp
 	public fun addTextChangedListener (Landroid/text/TextWatcher;)V
 	protected final fun applyTextAttributes ()V
 	public final fun canUpdateWithEventCount (I)Z
-	public fun clearFocus ()V
 	protected final fun finalize ()V
 	public final fun getBorderColor (I)I
 	protected final fun getContainsImages ()Z

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.kt
@@ -926,7 +926,7 @@ public open class ReactTextInputManager public constructor() :
         }
 
         if (shouldBlur) {
-          editText.clearFocus()
+          editText.clearFocusAndMaybeRefocus()
         }
 
         // Prevent default behavior except when we want it to insert a newline.


### PR DESCRIPTION
I am picking https://github.com/facebook/react-native/commit/d07b2a9d992c7240006d7d3607a109215deff5c6 into 0.80. There are several merge conflicts so doing this as a PR per @cortinico's recommendation in https://github.com/reactwg/react-native-releases/issues/952. 

This change addresses this issue: https://github.com/facebook/react-native/issues/51072

A change I made in 0.79 broke some blurring behavior on older Android versions. 

Fix commit: facebook/react-native@d07b2a9 


## Changelog:

[Android] [Fixed] - Fix broken focus behavior for TextInput in older Android versions (< 9)