### PR TITLE
Fix Networking url in NewAppScreen

### DIFF
--- a/packages/new-app-screen/src/Links.js
+++ b/packages/new-app-screen/src/Links.js
@@ -51,7 +51,7 @@ const Links: Array<{
   {
     title: 'Networking',
     description: 'Use the Fetch API',
-    url: 'https://reactnative.dev/docs/navigation',
+    url: 'https://reactnative.dev/docs/network',
   },
   {
     title: 'Showcase',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This pull request fixes an incorrect URL assigned to the "Networking" button in the NewAppScreen component. The previous link was missing the proper path segment for the networking documentation. This update ensures that users are directed to the correct page for React Native's networking features.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

GENERAL FIXED - Corrected the target URL of the "Networking" button in NewAppScreen.

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->


1. Initialize an Application with Community CLI
2. Tap the "Networking" button.
3. Confirm that it now opens the correct React Native networking documentation page.
4. Verified the behavior on both Android and iOS.