### PR TITLE
Allow platforms to provide custom IsColorMeaningful implementation

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/graphics/Color.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Color.cpp
@@ -14,7 +14,7 @@ bool isColorMeaningful(const SharedColor& color) noexcept {
     return false;
   }
 
-  return colorComponentsFromColor(color).alpha > 0;
+  return hostPlatformColorIsColorMeaningful(*color);
 }
 
 // Create Color from float RGBA values in [0, 1] range

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/HostPlatformColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/HostPlatformColor.h
@@ -24,10 +24,6 @@ hostPlatformColorFromRGBA(uint8_t r, uint8_t g, uint8_t b, uint8_t a) {
   return (a & 0xff) << 24 | (r & 0xff) << 16 | (g & 0xff) << 8 | (b & 0xff);
 }
 
-bool hostPlatformColorIsColorMeaningful(Color color) noexcept {
-  return colorComponentsFromHostPlatformColor(color).alpha > 0;
-}
-
 inline Color hostPlatformColorFromComponents(ColorComponents components) {
   float ratio = 255;
   return ((int)round(components.alpha * ratio) & 0xff) << 24 |
@@ -43,6 +39,10 @@ inline ColorComponents colorComponentsFromHostPlatformColor(Color color) {
       (float)((color >> 8) & 0xff) / ratio,
       (float)((color >> 0) & 0xff) / ratio,
       (float)((color >> 24) & 0xff) / ratio};
+}
+
+bool hostPlatformColorIsColorMeaningful(Color color) noexcept {
+  return colorComponentsFromHostPlatformColor(color).alpha > 0;
 }
 
 inline float alphaFromHostPlatformColor(Color color) {

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/HostPlatformColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/HostPlatformColor.h
@@ -41,7 +41,7 @@ inline ColorComponents colorComponentsFromHostPlatformColor(Color color) {
       (float)((color >> 24) & 0xff) / ratio};
 }
 
-bool hostPlatformColorIsColorMeaningful(Color color) noexcept {
+inline bool hostPlatformColorIsColorMeaningful(Color color) noexcept {
   return colorComponentsFromHostPlatformColor(color).alpha > 0;
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/HostPlatformColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/HostPlatformColor.h
@@ -24,6 +24,10 @@ hostPlatformColorFromRGBA(uint8_t r, uint8_t g, uint8_t b, uint8_t a) {
   return (a & 0xff) << 24 | (r & 0xff) << 16 | (g & 0xff) << 8 | (b & 0xff);
 }
 
+bool hostPlatformColorIsColorMeaningful(Color color) noexcept {
+  return colorComponentsFromHostPlatformColor(color).alpha > 0;
+}
+
 inline Color hostPlatformColorFromComponents(ColorComponents components) {
   float ratio = 255;
   return ((int)round(components.alpha * ratio) & 0xff) << 24 |

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/cxx/react/renderer/graphics/HostPlatformColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/cxx/react/renderer/graphics/HostPlatformColor.h
@@ -59,7 +59,7 @@ inline ColorComponents colorComponentsFromHostPlatformColor(Color color) {
       static_cast<float>(alphaFromHostPlatformColor(color)) / ratio};
 }
 
-bool hostPlatformColorIsColorMeaningful(Color color) noexcept {
+inline bool hostPlatformColorIsColorMeaningful(Color color) noexcept {
   return colorComponentsFromHostPlatformColor(color).alpha > 0;
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/cxx/react/renderer/graphics/HostPlatformColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/cxx/react/renderer/graphics/HostPlatformColor.h
@@ -25,10 +25,6 @@ hostPlatformColorFromRGBA(uint8_t r, uint8_t g, uint8_t b, uint8_t a) {
   return (a & 0xff) << 24 | (r & 0xff) << 16 | (g & 0xff) << 8 | (b & 0xff);
 }
 
-bool hostPlatformColorIsColorMeaningful(Color color) noexcept {
-  return colorComponentsFromHostPlatformColor(color).alpha > 0;
-}
-
 inline Color hostPlatformColorFromComponents(ColorComponents components) {
   float ratio = 255;
   return hostPlatformColorFromRGBA(
@@ -61,6 +57,10 @@ inline ColorComponents colorComponentsFromHostPlatformColor(Color color) {
       static_cast<float>(greenFromHostPlatformColor(color)) / ratio,
       static_cast<float>(blueFromHostPlatformColor(color)) / ratio,
       static_cast<float>(alphaFromHostPlatformColor(color)) / ratio};
+}
+
+bool hostPlatformColorIsColorMeaningful(Color color) noexcept {
+  return colorComponentsFromHostPlatformColor(color).alpha > 0;
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/cxx/react/renderer/graphics/HostPlatformColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/cxx/react/renderer/graphics/HostPlatformColor.h
@@ -25,6 +25,10 @@ hostPlatformColorFromRGBA(uint8_t r, uint8_t g, uint8_t b, uint8_t a) {
   return (a & 0xff) << 24 | (r & 0xff) << 16 | (g & 0xff) << 8 | (b & 0xff);
 }
 
+bool hostPlatformColorIsColorMeaningful(Color color) noexcept {
+  return colorComponentsFromHostPlatformColor(color).alpha > 0;
+}
+
 inline Color hostPlatformColorFromComponents(ColorComponents components) {
   float ratio = 255;
   return hostPlatformColorFromRGBA(

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/HostPlatformColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/HostPlatformColor.h
@@ -80,6 +80,10 @@ hostPlatformColorFromRGBA(uint8_t r, uint8_t g, uint8_t b, uint8_t a) {
   return Color(colorComponents);
 }
 
+bool hostPlatformColorIsColorMeaningful(Color color) noexcept {
+  return colorComponentsFromHostPlatformColor(color).alpha > 0;
+}
+
 inline Color hostPlatformColorFromComponents(ColorComponents components) {
   return Color(components);
 }

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/HostPlatformColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/HostPlatformColor.h
@@ -88,7 +88,7 @@ inline ColorComponents colorComponentsFromHostPlatformColor(Color color) {
   return color.getColorComponents();
 }
 
-bool hostPlatformColorIsColorMeaningful(Color color) noexcept {
+inline bool hostPlatformColorIsColorMeaningful(Color color) noexcept {
   return colorComponentsFromHostPlatformColor(color).alpha > 0;
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/HostPlatformColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/HostPlatformColor.h
@@ -80,16 +80,16 @@ hostPlatformColorFromRGBA(uint8_t r, uint8_t g, uint8_t b, uint8_t a) {
   return Color(colorComponents);
 }
 
-bool hostPlatformColorIsColorMeaningful(Color color) noexcept {
-  return colorComponentsFromHostPlatformColor(color).alpha > 0;
-}
-
 inline Color hostPlatformColorFromComponents(ColorComponents components) {
   return Color(components);
 }
 
 inline ColorComponents colorComponentsFromHostPlatformColor(Color color) {
   return color.getColorComponents();
+}
+
+bool hostPlatformColorIsColorMeaningful(Color color) noexcept {
+  return colorComponentsFromHostPlatformColor(color).alpha > 0;
 }
 
 inline float alphaFromHostPlatformColor(Color color) {


### PR DESCRIPTION
## Summary:

On windows, not all PlatformColors are convertible directly into colorComponents.  For PlatformColors, the Color.isColorMeaningful may need to do something other than check the alpha component of the color. 

Here I'm moving the implementation of isColorMeaningful into the HostPlatformColor implemantion to allow the host platform to customize the implemenation of isColorMeaningful.

## Changelog:

[INTERNAL] [ADDED] - Allow platforms to override isColorMeaningful

## Test Plan:

No behavior change in core. -- Will be used in react-native-windows to fix https://github.com/microsoft/react-native-windows/issues/14006