### PR TITLE
Restore the possibility to extend `LayoutAnimationController`

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutAnimationController.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutAnimationController.kt
@@ -29,7 +29,7 @@ import javax.annotation.concurrent.NotThreadSafe
  */
 @NotThreadSafe
 @LegacyArchitecture
-public class LayoutAnimationController {
+public open class LayoutAnimationController {
   private val layoutCreateAnimation: AbstractLayoutAnimation = LayoutCreateAnimation()
   private val layoutUpdateAnimation: AbstractLayoutAnimation = LayoutUpdateAnimation()
   private val layoutDeleteAnimation: AbstractLayoutAnimation = LayoutDeleteAnimation()
@@ -68,7 +68,7 @@ public class LayoutAnimationController {
     }
   }
 
-  public fun reset() {
+  public open fun reset() {
     layoutCreateAnimation.reset()
     layoutUpdateAnimation.reset()
     layoutDeleteAnimation.reset()
@@ -83,7 +83,7 @@ public class LayoutAnimationController {
     }
   }
 
-  public fun shouldAnimateLayout(viewToAnimate: View?): Boolean {
+  public open fun shouldAnimateLayout(viewToAnimate: View?): Boolean {
     // if view parent is null, skip animation: view have been clipped, we don't want animation to
     // resume when view is re-attached to parent, which is the standard android animation behavior.
     // If there's a layout handling animation going on, it should be animated nonetheless since the
@@ -106,7 +106,7 @@ public class LayoutAnimationController {
    * @param width the new width value for the view
    * @param height the new height value for the view
    */
-  public fun applyLayoutUpdate(view: View, x: Int, y: Int, width: Int, height: Int) {
+  public open fun applyLayoutUpdate(view: View, x: Int, y: Int, width: Int, height: Int) {
     assertOnUiThread()
 
     val reactTag = view.id
@@ -167,7 +167,7 @@ public class LayoutAnimationController {
    * @param listener Called once the animation is finished, should be used to completely remove the
    *   view.
    */
-  public fun deleteView(view: View, listener: LayoutAnimationListener) {
+  public open fun deleteView(view: View, listener: LayoutAnimationListener) {
     assertOnUiThread()
 
     val animation =


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

In https://github.com/facebook/react-native/pull/50734, `LayoutAnimationController` was migrated to Kotlin and all of its methods are now marked as final.

However, this class is used and extended by `react-native-reanimated` in order to provide Layout Animations for Android on the Old Architecture. With all its methods being marked as final, the builds are failing.

This PR restores the possibility to extend `LayoutAnimationController`.

## Changelog:

[ANDROID] [FIXED] - Restored the possibility to extend `LayoutAnimationController`

## Test Plan:

I've checked that this PR fixes build errors caused by `LayoutAnimationController` in react-native-reanimated.
