### PR TITLE
[RN][CI] Prebuild React Native core in CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -101,7 +101,7 @@ jobs:
           flavor: ${{ matrix.flavor }}
 
   prebuild_apple_dependencies:
-    uses: ./.github/workflows/prebuild-ios.yml
+    uses: ./.github/workflows/prebuild-ios-dependencies.yml
     secrets: inherit
 
   build_hermesc_linux:

--- a/.github/workflows/prebuild-ios-dependencies.yml
+++ b/.github/workflows/prebuild-ios-dependencies.yml
@@ -1,4 +1,4 @@
-name: Prebuild iOS
+name: Prebuild iOS Dependencies
 
 on:
   workflow_call: # this directive allow us to call this workflow from other workflows

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -96,8 +96,9 @@ jobs:
           hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
           flavor: ${{ matrix.flavor }}
+
   prebuild_apple_dependencies:
-    uses: ./.github/workflows/prebuild-ios.yml
+    uses: ./.github/workflows/prebuild-ios-dependencies.yml
     secrets: inherit
 
   build_hermesc_linux:

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -117,7 +117,7 @@ jobs:
           flavor: ${{ matrix.flavor }}
 
   prebuild_apple_dependencies:
-    uses: ./.github/workflows/prebuild-ios.yml
+    uses: ./.github/workflows/prebuild-ios-dependencies.yml
     secrets: inherit
 
   test_ios_rntester_ruby_3_2_0:


### PR DESCRIPTION
## Summary:

This change adds a workflow that allow to build react-native prebuilds in CI

## Changelog:
[Internal] - build React Native core in CI

## Test Plan:
GHA
