### PR TITLE
fix(iOS): allow to interactively swipe down the modal

### DIFF
--- a/packages/react-native/Libraries/Modal/Modal.d.ts
+++ b/packages/react-native/Libraries/Modal/Modal.d.ts
@@ -35,9 +35,9 @@ export interface ModalBaseProps {
    */
   visible?: boolean | undefined;
   /**
-   * The `onRequestClose` callback is called when the user taps the hardware back button on Android or the menu button on Apple TV.
+   * The `onRequestClose` callback is called when the user taps the hardware back button on Android, dismisses the sheet using a gesture on iOS (when `allowSwipeDismissal` is set to true) or the menu button on Apple TV.
    *
-   * This is required on Apple TV and Android.
+   * This is required on iOS and Android.
    */
   onRequestClose?: ((event: NativeSyntheticEvent<any>) => void) | undefined;
   /**
@@ -89,6 +89,12 @@ export interface ModalPropsIOS {
   onOrientationChange?:
     | ((event: NativeSyntheticEvent<any>) => void)
     | undefined;
+
+  /**
+   * Controls whether the modal can be dismissed by swiping down on iOS.
+   * This requires you to implement the `onRequestClose` prop to handle the dismissal.
+   */
+  allowSwipeDismissal?: boolean | undefined;
 }
 
 export interface ModalPropsAndroid {

--- a/packages/react-native/Libraries/Modal/Modal.js
+++ b/packages/react-native/Libraries/Modal/Modal.js
@@ -86,7 +86,7 @@ export type ModalBaseProps = {
    */
   visible?: ?boolean,
   /**
-   * The `onRequestClose` callback is called when the user taps the hardware back button on Android, dismisses the sheet using a gesture on iOS or the menu button on Apple TV.
+   * The `onRequestClose` callback is called when the user taps the hardware back button on Android, dismisses the sheet using a gesture on iOS (when `allowSwipeDismissal` is set to true) or the menu button on Apple TV.
    *
    * This is required on iOS and Android.
    */
@@ -147,6 +147,12 @@ export type ModalPropsIOS = {
   //   | ((event: NativeSyntheticEvent<any>) => void)
   //   | undefined;
   onOrientationChange?: ?DirectEventHandler<OrientationChangeEvent>,
+
+  /**
+   * Controls whether the modal can be dismissed by swiping down on iOS.
+   * This requires you to implement the `onRequestClose` prop to handle the dismissal.
+   */
+  allowSwipeDismissal?: ?boolean,
 };
 
 export type ModalPropsAndroid = {
@@ -193,9 +199,13 @@ function confirmProps(props: ModalProps) {
       );
     }
 
-    if (!props.onRequestClose) {
+    if (
+      Platform.OS === 'ios' &&
+      props.allowSwipeDismissal === true &&
+      !props.onRequestClose
+    ) {
       console.warn(
-        'Modal requires the onRequestClose prop. This is necessary to prevent state corruption.',
+        'Modal requires the onRequestClose prop when used with `allowSwipeDismissal`. This is necessary to prevent state corruption.',
       );
     }
   }
@@ -333,6 +343,7 @@ class Modal extends React.Component<ModalProps, ModalState> {
         onStartShouldSetResponder={this._shouldSetResponder}
         supportedOrientations={this.props.supportedOrientations}
         onOrientationChange={this.props.onOrientationChange}
+        allowSwipeDismissal={this.props.allowSwipeDismissal}
         testID={this.props.testID}>
         <VirtualizedListContextResetter>
           <ScrollView.Context.Provider value={null}>

--- a/packages/react-native/Libraries/Modal/Modal.js
+++ b/packages/react-native/Libraries/Modal/Modal.js
@@ -86,9 +86,9 @@ export type ModalBaseProps = {
    */
   visible?: ?boolean,
   /**
-   * The `onRequestClose` callback is called when the user taps the hardware back button on Android or the menu button on Apple TV.
+   * The `onRequestClose` callback is called when the user taps the hardware back button on Android, dismisses the sheet using a gesture on iOS or the menu button on Apple TV.
    *
-   * This is required on Apple TV and Android.
+   * This is required on iOS and Android.
    */
   // onRequestClose?: (event: NativeSyntheticEvent<any>) => void;
   onRequestClose?: ?DirectEventHandler<null>,
@@ -190,6 +190,12 @@ function confirmProps(props: ModalProps) {
     ) {
       console.warn(
         'Modal with translucent navigation bar and without translucent status bar is not supported.',
+      );
+    }
+
+    if (!props.onRequestClose) {
+      console.warn(
+        'Modal requires the onRequestClose prop. This is necessary to prevent state corruption.',
       );
     }
   }

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTFabricModalHostViewController.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTFabricModalHostViewController.mm
@@ -22,8 +22,6 @@
   }
   _touchHandler = [RCTSurfaceTouchHandler new];
 
-  self.modalInPresentation = YES;
-
   return self;
 }
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.mm
@@ -283,6 +283,13 @@ static ModalHostViewEventEmitter::OnOrientationChange onOrientationChangeStruct(
   }
 }
 
+- (void)presentationControllerDidDismiss:(UIPresentationController *)presentationController {
+  auto eventEmitter = [self modalEventEmitter];
+  if (eventEmitter) {
+    eventEmitter->onRequestClose({});
+  }
+}
+
 @end
 
 #ifdef __cplusplus

--- a/packages/react-native/React/Views/RCTModalHostView.h
+++ b/packages/react-native/React/Views/RCTModalHostView.h
@@ -24,6 +24,7 @@
 
 @property (nonatomic, copy) RCTDirectEventBlock onShow;
 @property (nonatomic, assign) BOOL visible;
+@property (nonatomic, assign) BOOL allowSwipeDismissal;
 
 // Android only
 @property (nonatomic, assign) BOOL statusBarTranslucent;

--- a/packages/react-native/React/Views/RCTModalHostView.m
+++ b/packages/react-native/React/Views/RCTModalHostView.m
@@ -70,6 +70,12 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : coder)
   }
 }
 
+- (void)presentationControllerDidDismiss:(UIPresentationController *)presentationController {
+  if (_onRequestClose != nil) {
+    _onRequestClose(nil);
+  }
+}
+
 - (void)notifyForOrientationChange
 {
   if (!_onOrientationChange) {

--- a/packages/react-native/React/Views/RCTModalHostView.m
+++ b/packages/react-native/React/Views/RCTModalHostView.m
@@ -35,6 +35,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : coder)
   if ((self = [super initWithFrame:CGRectZero])) {
     _bridge = bridge;
     _modalViewController = [RCTModalHostViewController new];
+    _modalViewController.modalInPresentation = YES;
     UIView *containerView = [UIView new];
     containerView.autoresizingMask = UIViewAutoresizingFlexibleHeight | UIViewAutoresizingFlexibleWidth;
     _modalViewController.view = containerView;
@@ -48,6 +49,13 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : coder)
   }
 
   return self;
+}
+
+- (void)setAllowSwipeDismissal:(BOOL)allowSwipeDismissal {
+  if (_allowSwipeDismissal != allowSwipeDismissal) {
+    _allowSwipeDismissal = allowSwipeDismissal;
+    _modalViewController.modalInPresentation = !allowSwipeDismissal;
+  }
 }
 
 - (void)notifyForBoundsChange:(CGRect)newBounds
@@ -71,7 +79,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : coder)
 }
 
 - (void)presentationControllerDidDismiss:(UIPresentationController *)presentationController {
-  if (_onRequestClose != nil) {
+  if (_onRequestClose != nil && _allowSwipeDismissal) {
     _onRequestClose(nil);
   }
 }

--- a/packages/react-native/React/Views/RCTModalHostViewController.m
+++ b/packages/react-native/React/Views/RCTModalHostViewController.m
@@ -22,8 +22,6 @@
     return nil;
   }
 
-  self.modalInPresentation = YES;
-
   _preferredStatusBarStyle = [RCTUIStatusBarManager() statusBarStyle];
   _preferredStatusBarHidden = [RCTUIStatusBarManager() isStatusBarHidden];
 

--- a/packages/react-native/React/Views/RCTModalHostViewManager.m
+++ b/packages/react-native/React/Views/RCTModalHostViewManager.m
@@ -119,6 +119,7 @@ RCT_EXPORT_VIEW_PROPERTY(supportedOrientations, NSArray)
 RCT_EXPORT_VIEW_PROPERTY(onOrientationChange, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(visible, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(onRequestClose, RCTDirectEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(allowSwipeDismissal, BOOL)
 
 // Fabric only
 RCT_EXPORT_VIEW_PROPERTY(onDismiss, RCTDirectEventBlock)

--- a/packages/react-native/src/private/specs_DEPRECATED/components/RCTModalHostViewNativeComponent.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/components/RCTModalHostViewNativeComponent.js
@@ -113,6 +113,12 @@ type NativeProps = $ReadOnly<{
   animated?: WithDefault<boolean, false>,
 
   /**
+   * Controls whether the modal can be dismissed by swiping down on iOS.
+   * This requires you to implement the `onRequestClose` prop to handle the dismissal.
+   */
+  allowSwipeDismissal?: WithDefault<boolean, false>,
+
+  /**
    * The `supportedOrientations` prop allows the modal to be rotated to any of the specified orientations.
    *
    * See https://reactnative.dev/docs/modal#supportedorientations

--- a/packages/rn-tester/js/examples/Modal/ModalPresentation.js
+++ b/packages/rn-tester/js/examples/Modal/ModalPresentation.js
@@ -62,6 +62,7 @@ function ModalPresentation() {
       ios: 'fullScreen',
       default: undefined,
     }),
+    allowSwipeDismissal: false,
     supportedOrientations: Platform.select({
       ios: ['portrait'],
       default: undefined,
@@ -75,6 +76,7 @@ function ModalPresentation() {
   const hardwareAccelerated = props.hardwareAccelerated;
   const statusBarTranslucent = props.statusBarTranslucent;
   const navigationBarTranslucent = props.navigationBarTranslucent;
+  const allowSwipeDismissal = props.allowSwipeDismissal;
   const backdropColor = props.backdropColor;
   const backgroundColor = useContext(RNTesterThemeContext).BackgroundColor;
 
@@ -128,6 +130,21 @@ function ModalPresentation() {
             setProps(prev => ({
               ...prev,
               hardwareAccelerated: enabled,
+            }))
+          }
+        />
+      </View>
+
+      <View style={styles.inlineBlock}>
+        <RNTesterText style={styles.title}>
+          Allow Swipe Dismissal ⚫️
+        </RNTesterText>
+        <Switch
+          value={allowSwipeDismissal}
+          onValueChange={enabled =>
+            setProps(prev => ({
+              ...prev,
+              allowSwipeDismissal: enabled,
             }))
           }
         />

--- a/packages/rn-tester/js/examples/Modal/ModalPresentation.js
+++ b/packages/rn-tester/js/examples/Modal/ModalPresentation.js
@@ -49,6 +49,7 @@ function ModalPresentation() {
 
   const onRequestClose = useCallback(() => {
     console.log('onRequestClose');
+    setProps(prev => ({...prev, visible: false}));
   }, []);
 
   const [props, setProps] = useState<ModalProps>({


### PR DESCRIPTION
## Summary:

This PR allows to interactively close the modal using the swipe down gesture. 

It fixes 5 year old issue: #29319

In short it removes `modalInPresentation` which according to the documentation causes: "UIKit ignores events outside the view controller’s bounds and **prevents the interactive dismissal of the view controller while it is onscreen.**". 

It also adds another delegate event to call onRequestClose whenever modal is closed by gesture.



https://github.com/user-attachments/assets/8849ecba-f762-47ec-a28b-b41c1991a882



## Changelog:

[IOS] [ADDED] - Allow to interactively swipe down the modal. 
Add allowSwipeDismissal prop. 


## Test Plan:

Test if swiping down the modal calls onRequestClose
