### PR TITLE
manual annotations in preparation of natural inference rollout in xplat/js

### DIFF
--- a/packages/react-native-fantom/src/__tests__/expect-itest.js
+++ b/packages/react-native-fantom/src/__tests__/expect-itest.js
@@ -248,7 +248,7 @@ describe('expect', () => {
     }).toThrow();
   });
 
-  ['toBeCalled', 'toHaveBeenCalled'].map(toHaveBeenCalledAlias =>
+  (['toBeCalled', 'toHaveBeenCalled'] as const).map(toHaveBeenCalledAlias =>
     test(toHaveBeenCalledAlias, () => {
       const fn = jest.fn();
 
@@ -277,87 +277,89 @@ describe('expect', () => {
     }),
   );
 
-  ['toBeCalledTimes', 'toHaveBeenCalledTimes'].map(toHaveBeenCalledTimesAlias =>
-    test(toHaveBeenCalledTimesAlias, () => {
-      const fn = jest.fn();
+  (['toBeCalledTimes', 'toHaveBeenCalledTimes'] as const).map(
+    toHaveBeenCalledTimesAlias =>
+      test(toHaveBeenCalledTimesAlias, () => {
+        const fn = jest.fn();
 
-      expect(fn)[toHaveBeenCalledTimesAlias](0);
-      expect(fn).not[toHaveBeenCalledTimesAlias](1);
-
-      expect(() => {
-        expect(fn).not[toHaveBeenCalledTimesAlias](0);
-      }).toThrow();
-
-      expect(() => {
-        expect(fn)[toHaveBeenCalledTimesAlias](1);
-      }).toThrow();
-
-      fn();
-
-      expect(fn).not[toHaveBeenCalledTimesAlias](0);
-      expect(fn)[toHaveBeenCalledTimesAlias](1);
-
-      expect(() => {
         expect(fn)[toHaveBeenCalledTimesAlias](0);
-      }).toThrow();
-
-      expect(() => {
         expect(fn).not[toHaveBeenCalledTimesAlias](1);
-      }).toThrow();
 
-      // Passing functions that aren't mocks should always fail
-      expect(() => {
-        expect(() => {})[toHaveBeenCalledTimesAlias](0);
-      }).toThrow();
+        expect(() => {
+          expect(fn).not[toHaveBeenCalledTimesAlias](0);
+        }).toThrow();
 
-      expect(() => {
-        expect(() => {}).not[toHaveBeenCalledTimesAlias](1);
-      }).toThrow();
-    }),
+        expect(() => {
+          expect(fn)[toHaveBeenCalledTimesAlias](1);
+        }).toThrow();
+
+        fn();
+
+        expect(fn).not[toHaveBeenCalledTimesAlias](0);
+        expect(fn)[toHaveBeenCalledTimesAlias](1);
+
+        expect(() => {
+          expect(fn)[toHaveBeenCalledTimesAlias](0);
+        }).toThrow();
+
+        expect(() => {
+          expect(fn).not[toHaveBeenCalledTimesAlias](1);
+        }).toThrow();
+
+        // Passing functions that aren't mocks should always fail
+        expect(() => {
+          expect(() => {})[toHaveBeenCalledTimesAlias](0);
+        }).toThrow();
+
+        expect(() => {
+          expect(() => {}).not[toHaveBeenCalledTimesAlias](1);
+        }).toThrow();
+      }),
   );
 
-  ['toBeCalledWith', 'toHaveBeenCalledWith'].map(toHaveBeenCalledWithAlias =>
-    test(toHaveBeenCalledWithAlias, () => {
-      const fn = jest.fn();
+  (['toBeCalledWith', 'toHaveBeenCalledWith'] as const).map(
+    toHaveBeenCalledWithAlias =>
+      test(toHaveBeenCalledWithAlias, () => {
+        const fn = jest.fn();
 
-      expect(fn).not[toHaveBeenCalledWithAlias]();
+        expect(fn).not[toHaveBeenCalledWithAlias]();
 
-      expect(() => {
-        expect(fn)[toHaveBeenCalledWithAlias]();
-      }).toThrow();
+        expect(() => {
+          expect(fn)[toHaveBeenCalledWithAlias]();
+        }).toThrow();
 
-      fn('happy');
-      fn({a: 1}, 2);
-      fn(['fantom'], {isAwesome: true});
+        fn('happy');
+        fn({a: 1}, 2);
+        fn(['fantom'], {isAwesome: true});
 
-      expect(fn)[toHaveBeenCalledWithAlias]('happy');
-      expect(fn)[toHaveBeenCalledWithAlias]({a: 1}, 2);
-      expect(fn)[toHaveBeenCalledWithAlias](['fantom'], {isAwesome: true});
-      expect(fn).not[toHaveBeenCalledWithAlias]();
-      expect(fn).not[toHaveBeenCalledWithAlias]({a: 1});
-      expect(fn).not[toHaveBeenCalledWithAlias]({a: 1}, 2, null);
-      expect(fn).not[toHaveBeenCalledWithAlias]({a: 1, b: 2}, 2);
+        expect(fn)[toHaveBeenCalledWithAlias]('happy');
+        expect(fn)[toHaveBeenCalledWithAlias]({a: 1}, 2);
+        expect(fn)[toHaveBeenCalledWithAlias](['fantom'], {isAwesome: true});
+        expect(fn).not[toHaveBeenCalledWithAlias]();
+        expect(fn).not[toHaveBeenCalledWithAlias]({a: 1});
+        expect(fn).not[toHaveBeenCalledWithAlias]({a: 1}, 2, null);
+        expect(fn).not[toHaveBeenCalledWithAlias]({a: 1, b: 2}, 2);
 
-      expect(() => {
-        expect(fn).not[toHaveBeenCalledWithAlias]({a: 1}, 2);
-      }).toThrow();
+        expect(() => {
+          expect(fn).not[toHaveBeenCalledWithAlias]({a: 1}, 2);
+        }).toThrow();
 
-      expect(() => {
-        expect(fn)[toHaveBeenCalledWithAlias](1);
-      }).toThrow();
+        expect(() => {
+          expect(fn)[toHaveBeenCalledWithAlias](1);
+        }).toThrow();
 
-      // Passing functions that aren't mocks should always fail
-      expect(() => {
-        expect(() => {})[toHaveBeenCalledWithAlias]();
-      }).toThrow();
+        // Passing functions that aren't mocks should always fail
+        expect(() => {
+          expect(() => {})[toHaveBeenCalledWithAlias]();
+        }).toThrow();
 
-      expect(() => {
-        expect(() => {}).not[toHaveBeenCalledWithAlias]();
-      }).toThrow();
-    }),
+        expect(() => {
+          expect(() => {}).not[toHaveBeenCalledWithAlias]();
+        }).toThrow();
+      }),
   );
 
-  ['lastCalledWith', 'toHaveBeenLastCalledWith'].map(
+  (['lastCalledWith', 'toHaveBeenLastCalledWith'] as const).map(
     toHaveBeenLastCalledWithAlias =>
       test(toHaveBeenLastCalledWithAlias, () => {
         const fn = jest.fn();
@@ -404,7 +406,7 @@ describe('expect', () => {
       }),
   );
 
-  ['nthCalledWith', 'toHaveBeenNthCalledWith'].map(
+  (['nthCalledWith', 'toHaveBeenNthCalledWith'] as const).map(
     toHaveBeenNthCalledWithAlias =>
       test(toHaveBeenNthCalledWithAlias, () => {
         const fn = jest.fn();

--- a/packages/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js
+++ b/packages/react-native/Libraries/Components/TextInput/RCTTextInputViewConfig.js
@@ -14,7 +14,7 @@ import {ConditionallyIgnoredEventHandlers} from '../../NativeComponent/ViewConfi
 
 type PartialViewConfigWithoutName = Omit<PartialViewConfig, 'uiViewClassName'>;
 
-const RCTTextInputViewConfig = {
+const RCTTextInputViewConfig: PartialViewConfigWithoutName = {
   bubblingEventTypes: {
     topBlur: {
       phasedRegistrationNames: {

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -784,7 +784,7 @@ const enterKeyHintToReturnTypeMap = {
   previous: 'previous',
   search: 'search',
   send: 'send',
-};
+} as const;
 
 const inputModeToKeyboardTypeMap = {
   none: 'default',
@@ -792,10 +792,11 @@ const inputModeToKeyboardTypeMap = {
   decimal: 'decimal-pad',
   numeric: 'number-pad',
   tel: 'phone-pad',
-  search: Platform.OS === 'ios' ? 'web-search' : 'default',
+  search:
+    Platform.OS === 'ios' ? ('web-search' as const) : ('default' as const),
   email: 'email-address',
   url: 'url',
-};
+} as const;
 
 // Map HTML autocomplete values to Android autoComplete values
 const autoCompleteWebToAutoCompleteAndroidMap = {
@@ -829,7 +830,7 @@ const autoCompleteWebToAutoCompleteAndroidMap = {
   'tel-country-code': 'tel-country-code',
   'tel-national': 'tel-national',
   username: 'username',
-};
+} as const;
 
 // Map HTML autocomplete values to iOS textContentType values
 const autoCompleteWebToTextContentTypeMap = {
@@ -869,7 +870,7 @@ const autoCompleteWebToTextContentTypeMap = {
   tel: 'telephoneNumber',
   url: 'URL',
   username: 'username',
-};
+} as const;
 
 const TextInput: component(
   ref?: React.RefSetter<TextInputInstance>,
@@ -922,8 +923,7 @@ const TextInput: component(
           : Platform.OS === 'ios' &&
               autoComplete &&
               autoComplete in autoCompleteWebToTextContentTypeMap
-            ? // $FlowFixMe[invalid-computed-prop]
-              // $FlowFixMe[prop-missing]
+            ? // $FlowFixMe[prop-missing]
               autoCompleteWebToTextContentTypeMap[autoComplete]
             : textContentType
       }
@@ -962,7 +962,7 @@ const verticalAlignToTextAlignVerticalMap = {
   top: 'top',
   bottom: 'bottom',
   middle: 'center',
-};
+} as const;
 
 // $FlowFixMe[unclear-type] Unclear type. Using `any` type is not safe.
 export default TextInput as any as TextInputType;

--- a/packages/react-native/Libraries/NativeComponent/BaseViewConfig.android.js
+++ b/packages/react-native/Libraries/NativeComponent/BaseViewConfig.android.js
@@ -174,14 +174,14 @@ const validAttributesForNonEventProps = {
   boxShadow:
     NativeReactNativeFeatureFlags != null &&
     ReactNativeFeatureFlags.enableNativeCSSParsing()
-      ? true
+      ? (true as const)
       : {
           process: require('../StyleSheet/processBoxShadow').default,
         },
   filter:
     NativeReactNativeFeatureFlags != null &&
     ReactNativeFeatureFlags.enableNativeCSSParsing()
-      ? true
+      ? (true as const)
       : {
           process: require('../StyleSheet/processFilter').default,
         },
@@ -369,7 +369,7 @@ const validAttributesForNonEventProps = {
   },
   focusable: true,
   backfaceVisibility: true,
-};
+} as const;
 
 // Props for bubbling and direct events
 const validAttributesForEventProps = {
@@ -409,7 +409,7 @@ const validAttributesForEventProps = {
   onPointerOutCapture: true,
   onPointerOver: true,
   onPointerOverCapture: true,
-};
+} as const;
 
 /**
  * On Android, Props are derived from a ViewManager and its ShadowNode.

--- a/packages/react-native/Libraries/NativeComponent/BaseViewConfig.ios.js
+++ b/packages/react-native/Libraries/NativeComponent/BaseViewConfig.ios.js
@@ -232,14 +232,14 @@ const validAttributesForNonEventProps = {
   filter:
     NativeReactNativeFeatureFlags != null &&
     ReactNativeFeatureFlags.enableNativeCSSParsing()
-      ? true
+      ? (true as const)
       : {
           process: require('../StyleSheet/processFilter').default,
         },
   boxShadow:
     NativeReactNativeFeatureFlags != null &&
     ReactNativeFeatureFlags.enableNativeCSSParsing()
-      ? true
+      ? (true as const)
       : {
           process: require('../StyleSheet/processBoxShadow').default,
         },
@@ -369,7 +369,7 @@ const validAttributesForNonEventProps = {
   direction: true,
 
   style: ReactNativeStyleAttributes,
-};
+} as const;
 
 // Props for bubbling and direct events
 const validAttributesForEventProps = ConditionallyIgnoredEventHandlers({

--- a/packages/react-native/Libraries/NativeComponent/ViewConfigIgnore.js
+++ b/packages/react-native/Libraries/NativeComponent/ViewConfigIgnore.js
@@ -34,9 +34,9 @@ export function DynamicallyInjectedByGestureHandler<T: {...}>(object: T): T {
  *
  * TODO(T110872225): Remove this logic, after achieving platform-consistency
  */
-export function ConditionallyIgnoredEventHandlers<T: {[name: string]: true}>(
-  value: T,
-): T | void {
+export function ConditionallyIgnoredEventHandlers<
+  const T: {+[name: string]: true},
+>(value: T): T | void {
   if (Platform.OS === 'ios') {
     return value;
   }

--- a/packages/react-native/Libraries/Pressability/Pressability.js
+++ b/packages/react-native/Libraries/Pressability/Pressability.js
@@ -236,7 +236,7 @@ const Transitions = Object.freeze({
     LEAVE_PRESS_RECT: 'NOT_RESPONDER',
     LONG_PRESS_DETECTED: 'NOT_RESPONDER',
   },
-});
+} as const);
 
 const isActiveSignal = (signal: TouchState) =>
   signal === 'RESPONDER_ACTIVE_PRESS_IN' ||

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -5827,7 +5827,7 @@ exports[`public API should not change unintentionally Libraries/NativeComponent/
   object: T
 ): T;
 declare export function ConditionallyIgnoredEventHandlers<
-  T: { [name: string]: true },
+  const T: { +[name: string]: true },
 >(
   value: T
 ): T | void;


### PR DESCRIPTION
Summary:
The Flow team is improving the way Flow infers type for primitive literals. This diff prepares the codebase for the new behavior by adding type annotations, or annotations of the form `'abc' as const`.

Announcement: https://fb.workplace.com/groups/flowlang/permalink/1725180268087629/

Differential Revision: D75114156


