### PR TITLE
fix: call delete instead of free in imagefetcher

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/ImageManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/ImageManager.cpp
@@ -16,8 +16,7 @@ ImageManager::ImageManager(const ContextContainer::Shared& contextContainer)
     : self_(new ImageFetcher(contextContainer)) {}
 
 ImageManager::~ImageManager() {
-  // @lint-ignore CLANGTIDY cppcoreguidelines-no-malloc
-  free(self_);
+  delete reinterpret_cast<ImageFetcher *>(self_);
 }
 
 ImageRequest ImageManager::requestImage(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

I've been digging into memleaks in RN for some time and noticed that instances of `FabricUIManager` are leaking on reload action even on an empty app. I managed to pinpoint it to [ContextContainer](https://github.com/facebook/react-native/blob/36df97f500aa0aa8031098caf7526db358b6ddc1/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp#L522) (which holds `FabricUIManager` on the cpp side) not being deallocated after reload. After much much digging (since contextContainer is passed around in many places) I found that destructor of `ImageFetcher` never runs on reload, and its instance holds `contextContainer`. It turns out that `ImageManager`, which holds `ImageFetcher`, was calling `free` instead of `delete` and the former does not call destructor. After applying it, `contextContainer` does not leak making `FabricUIManager` instances not to leak too :tada:.

## Changelog:

[ANDROID] [FIXED] - Change `free` to `delete` to call destructor of `ImageFetcher` and release `contextContainer`.

## Test Plan:

Run empty RN app in AS, do reload multiple times and see in AS profiler that instances of `FabricUIManager` are kept in memory without this change.
