### PR TITLE
Release cached images when image component gets recycled on iOS

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.mm
@@ -118,6 +118,12 @@ using namespace facebook::react;
 - (void)prepareForRecycle
 {
   [super prepareForRecycle];
+  if (_state) {
+    const auto &imageRequest = _state->getData().getImageRequest();
+    auto &observerCoordinator = imageRequest.getObserverCoordinator();
+    observerCoordinator.reset();
+  }
+
   [self _setStateAndResubscribeImageResponseObserver:nullptr];
   _imageView.image = nil;
 }

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponseObserverCoordinator.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponseObserverCoordinator.cpp
@@ -116,4 +116,13 @@ void ImageResponseObserverCoordinator::nativeImageResponseFailed(
   }
 }
 
+void ImageResponseObserverCoordinator::reset() const {
+  mutex_.lock();
+  status_ = ImageResponse::Status::Loading;
+  imageData_.reset();
+  imageMetadata_.reset();
+  imageErrorData_.reset();
+  mutex_.unlock();
+}
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponseObserverCoordinator.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponseObserverCoordinator.h
@@ -60,6 +60,11 @@ class ImageResponseObserverCoordinator {
    */
   void nativeImageResponseFailed(const ImageLoadError& loadError) const;
 
+  /*
+   * Releases image data and metadata pointers.
+   */
+  void reset() const;
+
  private:
   /*
    * List of observers.


### PR DESCRIPTION
Summary:
Changelog: [IOS][FIXED] Don't retain cached images in state after `RCTImageComponentView` gets recycled

Fixes https://github.com/facebook/react-native/issues/51198

Crosspost from the task comment:
From what I've been able to figure out, it seems like the image shadow nodes (keeping the loaded image in state) are being kept in memory by shadow node reference wrappers. It doesn't seem strictly like a memory leak - manually triggering garbage collection causes those nodes to be deallocated, but since Hermes isn't aware of the memory they are retaining, I think, it doesn't trigger it automatically.

This diff explicitly releases the retained memory when image component gets recycled.

Differential Revision: D75137263


