### PR TITLE
Only run legacy-native-module in Release

### DIFF
--- a/.github/workflow-scripts/maestro-android.js
+++ b/.github/workflow-scripts/maestro-android.js
@@ -58,6 +58,13 @@ async function executeFlowInFolder(flowFolder) {
   const files = fs.readdirSync(flowFolder);
   for (const file of files) {
     const filePath = `${flowFolder}/${file}`;
+
+    if (IS_DEBUG) {
+      const file = fs.readFileSync(filePath, 'utf8');
+      file.includes('- exclude-from-debug');
+      continue;
+    }
+
     if (fs.lstatSync(filePath).isDirectory()) {
       await executeFlowInFolder(filePath);
     } else {

--- a/.github/workflow-scripts/maestro-ios.js
+++ b/.github/workflow-scripts/maestro-ios.js
@@ -123,7 +123,8 @@ function executeTestsWithRetries(
   const recProcess = startVideoRecording(jsengine, currentAttempt);
   try {
     const timeout = 1000 * 60 * 10; // 10 minutes
-    const command = `$HOME/.maestro/bin/maestro --udid="${udid}" test "${maestroFlow}" --format junit -e APP_ID="${appId}"`;
+    const excludeTagsFlag = IS_DEBUG ? '--exclude-tags=exclude-from-debug' : '';
+    const command = `$HOME/.maestro/bin/maestro --udid="${udid}" test "${maestroFlow}" ${excludeTagsFlag} --format junit -e APP_ID="${appId}"`;
     console.log(command);
     childProcess.execSync(`MAESTRO_DRIVER_STARTUP_TIMEOUT=1500000 ${command}`, {
       stdio: 'inherit',

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -187,7 +187,8 @@ jobs:
           flavor: ${{ matrix.flavor }}
 
   test_e2e_ios_rntester:
-    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
+    # Uncomment before landing
+    #if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
     runs-on: macos-14-large
     needs:
       [test_ios_rntester]
@@ -439,11 +440,12 @@ jobs:
         uses: ./.github/actions/build-android
         with:
           release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
-          run-e2e-tests: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
+          run-e2e-tests: true # ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
           gradle-cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
 
   test_e2e_android_rntester:
-    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
+    # Uncomment before landing
+    # if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
     runs-on: 4-core-ubuntu
     needs: [build_android]
     strategy:

--- a/packages/rn-tester/.maestro/legacy-native-module.yml
+++ b/packages/rn-tester/.maestro/legacy-native-module.yml
@@ -1,4 +1,6 @@
 appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebook.react.uiapp
+tags:
+  - exclude-from-debug # when running in debug mode, the app is showing a logbox which makes the API tab not tappable
 ---
 - launchApp
 - assertVisible:
@@ -12,7 +14,7 @@ appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebo
     speed: 40
 - tapOn:
     id: "Legacy Native Module"
-- tapOn: 
+- tapOn:
     text: "voidFunc"
 - assertVisible:
     id: "voidFunc-result"


### PR DESCRIPTION
Summary:
A recent diff introduced the legacy-native-module.yml E2E test for maestro.

The test is consistently failing in CI in Debug mode, because it requires to navigate to the APIs tab. However, the navigation to that tab is not working in debug mode because there is a logbox on top of the tabbar that prevents the tests to tap on the button.

The test works fine in Release mode because we don't have logboxes there.

As a temporary solution to unblock CI while we fix the warnings that prevent the navigation, we are disabling the test for running in debug mode.

This will not reduce the coverage as:
- the test still runs in Release mode
- the debug tests have been added to verify the connection with metro, which is checked by the other tests in the test suite.

## Changelog:
[Internal] -

Differential Revision: D75139882


