### PR TITLE
Fix VirtualizeSectionList generic arguments

### DIFF
--- a/packages/virtualized-lists/Lists/VirtualizedSectionList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedSectionList.js
@@ -611,7 +611,7 @@ function ItemWithSeparator<ItemT>(
   );
 }
 
-export default VirtualizedSectionList as component<
+const VirtualizedSectionListComponent = VirtualizedSectionList as component<
   ItemT,
   SectionT: SectionBase<ItemT, DefaultSectionT> = DefaultSectionT,
 >(
@@ -623,3 +623,10 @@ export default VirtualizedSectionList as component<
   >,
   ...VirtualizedSectionListProps<ItemT, SectionT>
 );
+
+export default VirtualizedSectionListComponent;
+
+export type AnyVirtualizedSectionList = typeof VirtualizedSectionListComponent<
+  any,
+  any,
+>;

--- a/packages/virtualized-lists/index.js
+++ b/packages/virtualized-lists/index.js
@@ -13,7 +13,7 @@
 import typeof FillRateHelper from './Lists/FillRateHelper';
 import typeof ViewabilityHelper from './Lists/ViewabilityHelper';
 import typeof VirtualizedList from './Lists/VirtualizedList';
-import typeof VirtualizedSectionList from './Lists/VirtualizedSectionList';
+import type {AnyVirtualizedSectionList} from './Lists/VirtualizedSectionList';
 
 import {typeof VirtualizedListContextResetter} from './Lists/VirtualizedListContext';
 import {keyExtractor} from './Lists/VirtualizeUtils';
@@ -45,7 +45,7 @@ export default {
   get VirtualizedList(): VirtualizedList {
     return require('./Lists/VirtualizedList').default;
   },
-  get VirtualizedSectionList(): VirtualizedSectionList<any, any> {
+  get VirtualizedSectionList(): AnyVirtualizedSectionList {
     return require('./Lists/VirtualizedSectionList').default;
   },
   get VirtualizedListContextResetter(): VirtualizedListContextResetter {


### PR DESCRIPTION
Summary:
Fixes problem with generics passed to `VirtualizedSectionList` in generated types. The `flow-api-translator` creates a re-declaration for `export default` variables which shadows generics.

Changelog:
[Internal]

Differential Revision: D75141051


