### PR TITLE
Improve error messages when enum members are missing

### DIFF
--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/modules/__snapshots__/GenerateModuleH-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/modules/__snapshots__/GenerateModuleH-test.js.snap
@@ -231,7 +231,7 @@ struct Bridging<NativeEnumTurboModuleStatusLowerCaseEnum> {
     } else if (value == \\"off\\") {
       return NativeEnumTurboModuleStatusLowerCaseEnum::Off;
     } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
+      throw jsi::JSError(rt, \\"No appropriate enum member found for value in NativeEnumTurboModuleStatusLowerCaseEnum\\");
     }
   }
 
@@ -243,7 +243,7 @@ struct Bridging<NativeEnumTurboModuleStatusLowerCaseEnum> {
     } else if (value == NativeEnumTurboModuleStatusLowerCaseEnum::Off) {
       return bridging::toJs(rt, \\"off\\");
     } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
+      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value in NativeEnumTurboModuleStatusLowerCaseEnum\\");
     }
   }
 };
@@ -263,7 +263,7 @@ struct Bridging<NativeEnumTurboModuleStatusNumEnum> {
     } else if (value == 0) {
       return NativeEnumTurboModuleStatusNumEnum::Off;
     } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
+      throw jsi::JSError(rt, \\"No appropriate enum member found for value in NativeEnumTurboModuleStatusNumEnum\\");
     }
   }
 
@@ -275,7 +275,7 @@ struct Bridging<NativeEnumTurboModuleStatusNumEnum> {
     } else if (value == NativeEnumTurboModuleStatusNumEnum::Off) {
       return bridging::toJs(rt, 0);
     } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
+      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value in NativeEnumTurboModuleStatusNumEnum\\");
     }
   }
 };
@@ -295,7 +295,7 @@ struct Bridging<NativeEnumTurboModuleStatusRegularEnum> {
     } else if (value == \\"Off\\") {
       return NativeEnumTurboModuleStatusRegularEnum::Off;
     } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
+      throw jsi::JSError(rt, \\"No appropriate enum member found for value in NativeEnumTurboModuleStatusRegularEnum\\");
     }
   }
 
@@ -307,7 +307,7 @@ struct Bridging<NativeEnumTurboModuleStatusRegularEnum> {
     } else if (value == NativeEnumTurboModuleStatusRegularEnum::Off) {
       return bridging::toJs(rt, \\"Off\\");
     } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
+      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value in NativeEnumTurboModuleStatusRegularEnum\\");
     }
   }
 };
@@ -327,7 +327,7 @@ struct Bridging<NativeEnumTurboModuleStatusStrEnum> {
     } else if (value == \\"off\\") {
       return NativeEnumTurboModuleStatusStrEnum::Off;
     } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
+      throw jsi::JSError(rt, \\"No appropriate enum member found for value in NativeEnumTurboModuleStatusStrEnum\\");
     }
   }
 
@@ -339,7 +339,7 @@ struct Bridging<NativeEnumTurboModuleStatusStrEnum> {
     } else if (value == NativeEnumTurboModuleStatusStrEnum::Off) {
       return bridging::toJs(rt, \\"off\\");
     } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
+      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value in NativeEnumTurboModuleStatusStrEnum\\");
     }
   }
 };
@@ -2361,7 +2361,7 @@ struct Bridging<NativeEnumTurboModuleStatusLowerCaseEnum> {
     } else if (value == \\"off\\") {
       return NativeEnumTurboModuleStatusLowerCaseEnum::Off;
     } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
+      throw jsi::JSError(rt, \\"No appropriate enum member found for value in NativeEnumTurboModuleStatusLowerCaseEnum\\");
     }
   }
 
@@ -2373,7 +2373,7 @@ struct Bridging<NativeEnumTurboModuleStatusLowerCaseEnum> {
     } else if (value == NativeEnumTurboModuleStatusLowerCaseEnum::Off) {
       return bridging::toJs(rt, \\"off\\");
     } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
+      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value in NativeEnumTurboModuleStatusLowerCaseEnum\\");
     }
   }
 };
@@ -2393,7 +2393,7 @@ struct Bridging<NativeEnumTurboModuleStatusNumEnum> {
     } else if (value == 0) {
       return NativeEnumTurboModuleStatusNumEnum::Off;
     } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
+      throw jsi::JSError(rt, \\"No appropriate enum member found for value in NativeEnumTurboModuleStatusNumEnum\\");
     }
   }
 
@@ -2405,7 +2405,7 @@ struct Bridging<NativeEnumTurboModuleStatusNumEnum> {
     } else if (value == NativeEnumTurboModuleStatusNumEnum::Off) {
       return bridging::toJs(rt, 0);
     } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
+      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value in NativeEnumTurboModuleStatusNumEnum\\");
     }
   }
 };
@@ -2425,7 +2425,7 @@ struct Bridging<NativeEnumTurboModuleStatusRegularEnum> {
     } else if (value == \\"Off\\") {
       return NativeEnumTurboModuleStatusRegularEnum::Off;
     } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
+      throw jsi::JSError(rt, \\"No appropriate enum member found for value in NativeEnumTurboModuleStatusRegularEnum\\");
     }
   }
 
@@ -2437,7 +2437,7 @@ struct Bridging<NativeEnumTurboModuleStatusRegularEnum> {
     } else if (value == NativeEnumTurboModuleStatusRegularEnum::Off) {
       return bridging::toJs(rt, \\"Off\\");
     } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
+      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value in NativeEnumTurboModuleStatusRegularEnum\\");
     }
   }
 };
@@ -2457,7 +2457,7 @@ struct Bridging<NativeEnumTurboModuleStatusStrEnum> {
     } else if (value == \\"off\\") {
       return NativeEnumTurboModuleStatusStrEnum::Off;
     } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
+      throw jsi::JSError(rt, \\"No appropriate enum member found for value in NativeEnumTurboModuleStatusStrEnum\\");
     }
   }
 
@@ -2469,7 +2469,7 @@ struct Bridging<NativeEnumTurboModuleStatusStrEnum> {
     } else if (value == NativeEnumTurboModuleStatusStrEnum::Off) {
       return bridging::toJs(rt, \\"off\\");
     } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
+      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value in NativeEnumTurboModuleStatusStrEnum\\");
     }
   }
 };

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
@@ -434,7 +434,7 @@ function generateEnum(
       )
       .join(' else ') +
     ` else {
-      throw jsi::JSError(rt, "No appropriate enum member found for value");
+      throw jsi::JSError(rt, "No appropriate enum member found for value in ${enumName}");
     }`;
 
   const toCases =
@@ -446,7 +446,7 @@ function generateEnum(
       )
       .join(' else ') +
     ` else {
-      throw jsi::JSError(rt, "No appropriate enum member found for enum value");
+      throw jsi::JSError(rt, "No appropriate enum member found for enum value in ${enumName}");
     }`;
 
   return EnumTemplate({

--- a/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleH-test.js.snap
@@ -233,7 +233,7 @@ struct Bridging<NativeSampleTurboModuleEnumInt> {
     } else if (value == 42) {
       return NativeSampleTurboModuleEnumInt::IB;
     } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
+      throw jsi::JSError(rt, \\"No appropriate enum member found for value in NativeSampleTurboModuleEnumInt\\");
     }
   }
 
@@ -243,7 +243,7 @@ struct Bridging<NativeSampleTurboModuleEnumInt> {
     } else if (value == NativeSampleTurboModuleEnumInt::IB) {
       return bridging::toJs(rt, 42);
     } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
+      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value in NativeSampleTurboModuleEnumInt\\");
     }
   }
 };
@@ -261,7 +261,7 @@ struct Bridging<NativeSampleTurboModuleEnumFloat> {
     } else if (value == 4.56) {
       return NativeSampleTurboModuleEnumFloat::FB;
     } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
+      throw jsi::JSError(rt, \\"No appropriate enum member found for value in NativeSampleTurboModuleEnumFloat\\");
     }
   }
 
@@ -271,7 +271,7 @@ struct Bridging<NativeSampleTurboModuleEnumFloat> {
     } else if (value == NativeSampleTurboModuleEnumFloat::FB) {
       return bridging::toJs(rt, 4.56);
     } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
+      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value in NativeSampleTurboModuleEnumFloat\\");
     }
   }
 };
@@ -289,7 +289,7 @@ struct Bridging<NativeSampleTurboModuleEnumNone> {
     } else if (value == \\"NB\\") {
       return NativeSampleTurboModuleEnumNone::NB;
     } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
+      throw jsi::JSError(rt, \\"No appropriate enum member found for value in NativeSampleTurboModuleEnumNone\\");
     }
   }
 
@@ -299,7 +299,7 @@ struct Bridging<NativeSampleTurboModuleEnumNone> {
     } else if (value == NativeSampleTurboModuleEnumNone::NB) {
       return bridging::toJs(rt, \\"NB\\");
     } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
+      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value in NativeSampleTurboModuleEnumNone\\");
     }
   }
 };
@@ -317,7 +317,7 @@ struct Bridging<NativeSampleTurboModuleEnumStr> {
     } else if (value == \\"s---b\\") {
       return NativeSampleTurboModuleEnumStr::SB;
     } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
+      throw jsi::JSError(rt, \\"No appropriate enum member found for value in NativeSampleTurboModuleEnumStr\\");
     }
   }
 
@@ -327,7 +327,7 @@ struct Bridging<NativeSampleTurboModuleEnumStr> {
     } else if (value == NativeSampleTurboModuleEnumStr::SB) {
       return bridging::toJs(rt, \\"s---b\\");
     } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
+      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value in NativeSampleTurboModuleEnumStr\\");
     }
   }
 };
@@ -2024,7 +2024,7 @@ struct Bridging<NativeSampleTurboModuleNumEnum> {
     } else if (value == 2) {
       return NativeSampleTurboModuleNumEnum::TWO;
     } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
+      throw jsi::JSError(rt, \\"No appropriate enum member found for value in NativeSampleTurboModuleNumEnum\\");
     }
   }
 
@@ -2034,7 +2034,7 @@ struct Bridging<NativeSampleTurboModuleNumEnum> {
     } else if (value == NativeSampleTurboModuleNumEnum::TWO) {
       return bridging::toJs(rt, 2);
     } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
+      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value in NativeSampleTurboModuleNumEnum\\");
     }
   }
 };
@@ -2054,7 +2054,7 @@ struct Bridging<NativeSampleTurboModuleFloatEnum> {
     } else if (value == 0.2) {
       return NativeSampleTurboModuleFloatEnum::POINT_TWO;
     } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
+      throw jsi::JSError(rt, \\"No appropriate enum member found for value in NativeSampleTurboModuleFloatEnum\\");
     }
   }
 
@@ -2066,7 +2066,7 @@ struct Bridging<NativeSampleTurboModuleFloatEnum> {
     } else if (value == NativeSampleTurboModuleFloatEnum::POINT_TWO) {
       return bridging::toJs(rt, 0.2);
     } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
+      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value in NativeSampleTurboModuleFloatEnum\\");
     }
   }
 };
@@ -2084,7 +2084,7 @@ struct Bridging<NativeSampleTurboModuleStringEnum> {
     } else if (value == \\"goodbye\\") {
       return NativeSampleTurboModuleStringEnum::GoodBye;
     } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for value\\");
+      throw jsi::JSError(rt, \\"No appropriate enum member found for value in NativeSampleTurboModuleStringEnum\\");
     }
   }
 
@@ -2094,7 +2094,7 @@ struct Bridging<NativeSampleTurboModuleStringEnum> {
     } else if (value == NativeSampleTurboModuleStringEnum::GoodBye) {
       return bridging::toJs(rt, \\"goodbye\\");
     } else {
-      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value\\");
+      throw jsi::JSError(rt, \\"No appropriate enum member found for enum value in NativeSampleTurboModuleStringEnum\\");
     }
   }
 };


### PR DESCRIPTION
Summary:
While working on a case for Editor on mac, it took me a while to figure out what enum was the root cause:

 {F1978470518}

Adding the blaming enum name in the error message would have made my life much easier.

## Changelog:

[GENERAL] - Improve error messages when enum members are missing

Differential Revision: D75141414


