### PR TITLE
Mark ReactRawTextManager as @LegacyArchitecture

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/DebugCorePackage.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/DebugCorePackage.kt
@@ -16,11 +16,7 @@ import com.facebook.react.module.model.ReactModuleInfoProvider
 import com.facebook.react.uimanager.ViewManager
 import com.facebook.react.views.debuggingoverlay.DebuggingOverlayManager
 
-/**
- * Package defining core framework modules (e.g. [UIManager]). It should be used for modules that
- * require special integration with other framework parts (e.g. with the list of packages to load
- * view managers from).
- */
+/** Package defining core debugging modules and viewManagers e.g. [DebuggingOverlayManager]). */
 @ReactModuleList(nativeModules = [])
 public class DebugCorePackage public constructor() :
     BaseReactPackage(), ViewManagerOnDemandReactPackage {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -78,6 +78,7 @@ import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.common.annotations.internal.LegacyArchitecture;
 import com.facebook.react.common.annotations.internal.LegacyArchitectureLogLevel;
 import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger;
+import com.facebook.react.common.build.ReactBuildConfig;
 import com.facebook.react.devsupport.DevSupportManagerFactory;
 import com.facebook.react.devsupport.InspectorFlags;
 import com.facebook.react.devsupport.ReactInstanceDevHelper;
@@ -412,15 +413,17 @@ public class ReactInstanceManager {
   }
 
   private void registerCxxErrorHandlerFunc() {
-    Class[] parameterTypes = new Class[1];
-    parameterTypes[0] = Exception.class;
-    Method handleCxxErrorFunc = null;
-    try {
-      handleCxxErrorFunc = ReactInstanceManager.class.getMethod("handleCxxError", parameterTypes);
-    } catch (NoSuchMethodException e) {
-      FLog.e("ReactInstanceHolder", "Failed to set cxx error handler function", e);
+    if (!ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE) {
+      Class[] parameterTypes = new Class[1];
+      parameterTypes[0] = Exception.class;
+      Method handleCxxErrorFunc = null;
+      try {
+        handleCxxErrorFunc = ReactInstanceManager.class.getMethod("handleCxxError", parameterTypes);
+      } catch (NoSuchMethodException e) {
+        FLog.e("ReactInstanceHolder", "Failed to set cxx error handler function", e);
+      }
+      ReactCxxErrorHandler.setHandleErrorFunc(this, handleCxxErrorFunc);
     }
-    ReactCxxErrorHandler.setHandleErrorFunc(this, handleCxxErrorFunc);
   }
 
   private void unregisterCxxErrorHandlerFunc() {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactRawTextManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactRawTextManager.kt
@@ -8,6 +8,7 @@
 package com.facebook.react.views.text
 
 import android.view.View
+import com.facebook.react.common.annotations.internal.LegacyArchitecture
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewManager
@@ -17,6 +18,7 @@ import com.facebook.react.uimanager.ViewManager
  * nodes, any type of native view operation will throw an [IllegalStateException].
  */
 @ReactModule(name = ReactRawTextManager.REACT_CLASS)
+@LegacyArchitecture
 internal class ReactRawTextManager : ViewManager<View, ReactRawTextShadowNode>() {
 
   override fun getName(): String {


### PR DESCRIPTION
Summary:
ReactRawTextManager is not used in new architecture, this diff marks it as so


changelog: [internal] internal

Reviewed By: mlord93, cortinico

Differential Revision: D75150100


