### PR TITLE
Implement size for URLSearchParams

### DIFF
--- a/packages/react-native/Libraries/Blob/URLSearchParams.js
+++ b/packages/react-native/Libraries/Blob/URLSearchParams.js
@@ -13,6 +13,10 @@
 export class URLSearchParams {
   _searchParams: Map<string, string[]> = new Map();
 
+  get size(): number {
+    return this._searchParams.size;
+  }
+
   constructor(params?: Record<string, string> | string | [string, string][]) {
     if (params === null) {
       return;

--- a/packages/react-native/Libraries/Blob/URLSearchParams.js.flow
+++ b/packages/react-native/Libraries/Blob/URLSearchParams.js.flow
@@ -10,6 +10,7 @@
 
 declare export class URLSearchParams {
   _searchParams: Array<[string, string]>;
+  +size: number;
   constructor(
     params?: Record<string, string> | string | Array<[string, string]>,
   ): void;

--- a/packages/react-native/Libraries/Blob/__tests__/URL-test.js
+++ b/packages/react-native/Libraries/Blob/__tests__/URL-test.js
@@ -59,6 +59,7 @@ describe('URL', function () {
 
     // Test searchParams
     const searchParams = url.searchParams;
+    expect(searchParams.size).toBe(2);
     expect(searchParams.get('query')).toBe('testQuery');
     expect(searchParams.get('key')).toBe('value');
 
@@ -69,6 +70,7 @@ describe('URL', function () {
         '&param3=value3+with+spaces+legacy',
       ].join(''),
     );
+    expect(paramsFromString.size).toBe(3);
     expect(paramsFromString.get('param1')).toBe('value1');
     expect(paramsFromString.get('param2')).toBe('value2 with spaces');
     expect(paramsFromString.get('param3')).toBe('value3 with spaces legacy');
@@ -82,6 +84,7 @@ describe('URL', function () {
       active: 'true',
     });
 
+    expect(paramsFromObject.size).toBe(3);
     expect(paramsFromObject.get('user')).toBe('john');
     expect(paramsFromObject.get('age')).toBe('30');
     expect(paramsFromObject.get('active')).toBe('true');
@@ -97,6 +100,7 @@ describe('URL', function () {
 
     // URLSearchParams: Empty
     const emptyParams = new URLSearchParams('');
+    expect(emptyParams.size).toBe(0);
     expect([...emptyParams.entries()]).toEqual([]);
 
     // URLSearchParams: Array (for multiple values of the same key)
@@ -105,6 +109,7 @@ describe('URL', function () {
       ['key1', 'value2'],
       ['key2', 'value3'],
     ]);
+    expect(paramsFromArray.size).toBe(2);
     expect(paramsFromArray.getAll('key1')).toEqual(['value1', 'value2']);
     expect(paramsFromArray.get('key2')).toBe('value3');
 
@@ -115,10 +120,12 @@ describe('URL', function () {
 
     // Adding a new param
     urlParams.append('newKey', 'newValue');
+    expect(urlParams.size).toBe(3);
     expect(urlParams.get('newKey')).toBe('newValue');
 
     // Deleting a param
     urlParams.delete('key');
+    expect(urlParams.size).toBe(2);
     expect(urlParams.get('key')).toBeNull();
 
     // Checking if a param exists

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -1343,6 +1343,7 @@ declare export class URL {
 
 exports[`public API should not change unintentionally Libraries/Blob/URLSearchParams.js.flow 1`] = `
 "declare export class URLSearchParams {
+  +size: number;
   constructor(
     params?: Record<string, string> | string | Array<[string, string]>
   ): void;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

The current `URLSearchParams` is missing the readonly `size` property defined in the [whatwg spec](https://url.spec.whatwg.org/#interface-urlsearchparams), and attempting to use it returns `undefined`. This PR adds it.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:
[GENERAL] [FIXED] - Added size property to URLSearchParams implementation
<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

I've modified the [tests](packages/react-native/Libraries/Blob/__tests__/URL-test.js) to assert the `size` property is correct.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
