### PR TITLE
Fixup focusability logic of PreparedLayoutTextView

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextView.kt
@@ -52,11 +52,6 @@ internal class PreparedLayoutTextView(context: Context) : ViewGroup(context) {
 
         clickableSpans = value?.text?.let { filterClickableSpans(it) } ?: emptyList()
 
-        // T221698736: This and `accessible` prop can clobber each other, and ShadowTree does not
-        // know
-        // about this. Need to figure out desired behavior for controlling implicit focusability.
-        isFocusable = clickableSpans.isNotEmpty()
-
         field = value
         invalidate()
       }
@@ -92,7 +87,6 @@ internal class PreparedLayoutTextView(context: Context) : ViewGroup(context) {
   public fun recycleView(): Unit {
     initView()
     BackgroundStyleApplicator.reset(this)
-    isFocusable = false
     overflow = Overflow.HIDDEN
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewAccessibilityDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewAccessibilityDelegate.kt
@@ -174,6 +174,15 @@ internal class ReactTextViewAccessibilityDelegate : ReactAccessibilityDelegate {
     }
   }
 
+  override fun onInitializeAccessibilityNodeInfo(host: View, info: AccessibilityNodeInfoCompat) {
+    super.onInitializeAccessibilityNodeInfo(host, info)
+    // PreparedLayoutTextView isn't actually a TextView, so we need to teach it about its text that
+    // it is holding so TalkBack knows what to announce when focusing it.
+    if (host is PreparedLayoutTextView) {
+      info.text = host.text
+    }
+  }
+
   @Suppress("DEPRECATION")
   override fun onPopulateNodeForVirtualView(virtualViewId: Int, node: AccessibilityNodeInfoCompat) {
     // If we get an invalid virtualViewId for some reason (which is known to happen in API 19 and


### PR DESCRIPTION
Summary:
For now, we are opting to not auto-focus `PreparedLayoutTextViews` if they have links. The reason being this would not work well with Text nested in a View which is also accessible. If that Text had links, and was set to focusable, then TalkBack would individually focus that Text, which users may not want.

So this diff removes that link detection, and fixes up accessibility in general. Since this isn't a TextView, we need to explicitly set the `text` on the `AccessibilityNodeInfo` object in the delegate so TalkBack know what to annouce.

In the future we aim to bring back auto-focusing with links, but only if a screen reader is not on, so that keyboard users can benefit from this.

Changelog: [Internal]

Differential Revision: D75103779


