### PR TITLE
Define sampling methods implementations for Hermes fallback target delegate

### DIFF
--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.cpp
@@ -28,13 +28,39 @@ using namespace facebook::hermes;
 
 namespace facebook::react::jsinspector_modern {
 
-#ifdef HERMES_ENABLE_DEBUGGER
 namespace {
 
 const uint16_t HERMES_SAMPLING_FREQUENCY_HZ = 10000;
 
+class HermesRuntimeSamplingProfileDelegate {
+ public:
+  explicit HermesRuntimeSamplingProfileDelegate(
+      std::shared_ptr<HermesRuntime> hermesRuntime)
+      : hermesRuntime_(std::move(hermesRuntime)) {}
+
+  void startSampling() {
+    auto* hermesAPI = castInterface<IHermesRootAPI>(makeHermesRootAPI());
+    hermesAPI->enableSamplingProfiler(HERMES_SAMPLING_FREQUENCY_HZ);
+  }
+
+  void stopSampling() {
+    auto* hermesAPI = castInterface<IHermesRootAPI>(makeHermesRootAPI());
+    hermesAPI->disableSamplingProfiler();
+  }
+
+  tracing::RuntimeSamplingProfile collectSamplingProfile() {
+    return tracing::HermesRuntimeSamplingProfileSerializer::
+        serializeToTracingSamplingProfile(
+            hermesRuntime_->dumpSampledTraceToProfile());
+  }
+
+ private:
+  std::shared_ptr<HermesRuntime> hermesRuntime_;
+};
+
 } // namespace
 
+#ifdef HERMES_ENABLE_DEBUGGER
 class HermesRuntimeTargetDelegate::Impl final : public RuntimeTargetDelegate {
   using HermesStackTrace = debugger::StackTrace;
 
@@ -60,8 +86,11 @@ class HermesRuntimeTargetDelegate::Impl final : public RuntimeTargetDelegate {
       HermesRuntimeTargetDelegate& delegate,
       std::shared_ptr<HermesRuntime> hermesRuntime)
       : delegate_(delegate),
-        runtime_(std::move(hermesRuntime)),
-        cdpDebugAPI_(CDPDebugAPI::create(*runtime_)) {}
+        runtime_(hermesRuntime),
+        cdpDebugAPI_(CDPDebugAPI::create(*runtime_)),
+        samplingProfileDelegate_(
+            std::make_unique<HermesRuntimeSamplingProfileDelegate>(
+                std::move(hermesRuntime))) {}
 
   CDPDebugAPI& getCDPDebugAPI() {
     return *cdpDebugAPI_;
@@ -175,25 +204,23 @@ class HermesRuntimeTargetDelegate::Impl final : public RuntimeTargetDelegate {
   }
 
   void enableSamplingProfiler() override {
-    auto* hermesAPI = castInterface<IHermesRootAPI>(makeHermesRootAPI());
-    hermesAPI->enableSamplingProfiler(HERMES_SAMPLING_FREQUENCY_HZ);
+    samplingProfileDelegate_->startSampling();
   }
 
   void disableSamplingProfiler() override {
-    auto* hermesAPI = castInterface<IHermesRootAPI>(makeHermesRootAPI());
-    hermesAPI->disableSamplingProfiler();
+    samplingProfileDelegate_->stopSampling();
   }
 
   tracing::RuntimeSamplingProfile collectSamplingProfile() override {
-    return tracing::HermesRuntimeSamplingProfileSerializer::
-        serializeToTracingSamplingProfile(
-            runtime_->dumpSampledTraceToProfile());
+    return samplingProfileDelegate_->collectSamplingProfile();
   }
 
  private:
   HermesRuntimeTargetDelegate& delegate_;
   std::shared_ptr<HermesRuntime> runtime_;
   const std::unique_ptr<CDPDebugAPI> cdpDebugAPI_;
+  std::unique_ptr<HermesRuntimeSamplingProfileDelegate>
+      samplingProfileDelegate_;
 };
 
 #else
@@ -208,7 +235,26 @@ class HermesRuntimeTargetDelegate::Impl final
   explicit Impl(
       HermesRuntimeTargetDelegate&,
       std::shared_ptr<HermesRuntime> hermesRuntime)
-      : FallbackRuntimeTargetDelegate{hermesRuntime->description()} {}
+      : FallbackRuntimeTargetDelegate{hermesRuntime->description()},
+        samplingProfileDelegate_(
+            std::make_unique<HermesRuntimeSamplingProfileDelegate>(
+                std::move(hermesRuntime))) {}
+
+  void enableSamplingProfiler() override {
+    samplingProfileDelegate_->startSampling();
+  }
+
+  void disableSamplingProfiler() override {
+    samplingProfileDelegate_->stopSampling();
+  }
+
+  tracing::RuntimeSamplingProfile collectSamplingProfile() override {
+    return samplingProfileDelegate_->collectSamplingProfile();
+  }
+
+ private:
+  std::unique_ptr<HermesRuntimeSamplingProfileDelegate>
+      samplingProfileDelegate_;
 };
 
 #endif // HERMES_ENABLE_DEBUGGER


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

Hermes Sampling Profiler doesn't require debugger to be enabled - we can use it in fallback Hermes Runtime target delegate. That's probably the last thing to make Hermes really run in `opt` mode.

When Hermes Target is compiled with no Debugger support, we can still define implementation for sampling profiler methods and call them on Hermes Runtime.

Differential Revision: D75188276


