### PR TITLE
fix(iOS): use getNextRootViewTag() on new architecture

### DIFF
--- a/packages/react-native/React/Fabric/Surface/RCTFabricSurface.mm
+++ b/packages/react-native/React/Fabric/Surface/RCTFabricSurface.mm
@@ -23,6 +23,7 @@
 #import <React/RCTUtils.h>
 #import <react/renderer/mounting/MountingCoordinator.h>
 #import <react/utils/FollyConvert.h>
+#import <react/renderer/core/ReactRootViewTagGenerator.h>
 
 #import "RCTSurfacePresenter.h"
 
@@ -57,7 +58,7 @@ using namespace facebook::react;
     _surfacePresenter = surfacePresenter;
 
     _surfaceHandler =
-        SurfaceHandler{RCTStringFromNSString(moduleName), (SurfaceId)[RCTAllocateRootViewTag() integerValue]};
+        SurfaceHandler{RCTStringFromNSString(moduleName), getNextRootViewTag()};
     _surfaceHandler->setProps(convertIdToFollyDynamic(initialProperties));
 
     [_surfacePresenter registerSurface:self];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Sometime ago Fabric specific root view tag allocator was added to the codebase: https://github.com/facebook/react-native/commit/7dec625ecabdc23cbae37e0034d29bb7bff17755 This PR makes sure to use it on iOS. It removes the need for additional conversions.

## Changelog:

[INTERNAL] [CHANGED] -  use getNextRootViewTag() on new architecture


## Test Plan:

CI Green
