### PR TITLE
[iOS][prebuild] fix wrong path in prebuild hermes check

### DIFF
--- a/packages/react-native/Package.swift
+++ b/packages/react-native/Package.swift
@@ -514,6 +514,13 @@ let reactRCTLinking = RNTarget(
   dependencies: [.jsi, .reactTurboModuleCore]
 )
 
+let reactSettings = RNTarget(
+  name: .reactSettings,
+  path: "Libraries/Settings",
+  searchPaths: ["ReactCommon", ReactFBReactNativeSpecPath, FBLazyVectorPath],
+  dependencies: [.reactTurboModuleCore, .yoga]
+)
+
 let targets = [
   reactDebug,
   jsi,
@@ -567,6 +574,7 @@ let targets = [
   reactFeatureflagsNativemodule,
   reactNativeModuleDom,
   reactAppDelegate,
+  reactSettings
 ]
 
 let package = Package(
@@ -646,6 +654,7 @@ extension String {
   static let reactFeatureflagsNativemodule = "React-featureflagsnativemodule"
   static let reactNativeModuleDom = "React-domnativemodule"
   static let reactAppDelegate = "React-RCTAppDelegate"
+  static let reactSettings = "React-RCTSettings"
 }
 
 func relativeSearchPath(_ depth: Int, _ path: String) -> String {

--- a/packages/react-native/scripts/ios-prebuild/hermes.js
+++ b/packages/react-native/scripts/ios-prebuild/hermes.js
@@ -116,7 +116,7 @@ function checkExistingVersion(
   const hermesXCFramework = path.join(
     artifactsPath,
     'destroot',
-    'Libraries',
+    'Library',
     'Frameworks',
     'universal',
     'hermes.xcframework',


### PR DESCRIPTION
## Summary:

When checking if we should download hermes artifacts, the path to the folder we're checking was wrong, causing hermes to always be downloaded.

This commit fixes this by renaming it from `Libraries` -> `Library`

## Changelog:

[IOS] [FIXED] - fixed wrong path in prebuild hermes check

## Test Plan:

Test to run the prebuild script twice with the same hermes version. Hermes should only be downloaded the first time.