### PR TITLE
[iOS][prebuild] simplify logging in prebuild scripts

### DIFF
--- a/packages/react-native/Package.swift
+++ b/packages/react-native/Package.swift
@@ -514,6 +514,13 @@ let reactRCTLinking = RNTarget(
   dependencies: [.jsi, .reactTurboModuleCore]
 )
 
+let reactSettings = RNTarget(
+  name: .reactSettings,
+  path: "Libraries/Settings",
+  searchPaths: ["ReactCommon", ReactFBReactNativeSpecPath, FBLazyVectorPath],
+  dependencies: [.reactTurboModuleCore, .yoga]
+)
+
 let targets = [
   reactDebug,
   jsi,
@@ -567,6 +574,7 @@ let targets = [
   reactFeatureflagsNativemodule,
   reactNativeModuleDom,
   reactAppDelegate,
+  reactSettings
 ]
 
 let package = Package(
@@ -646,6 +654,7 @@ extension String {
   static let reactFeatureflagsNativemodule = "React-featureflagsnativemodule"
   static let reactNativeModuleDom = "React-domnativemodule"
   static let reactAppDelegate = "React-RCTAppDelegate"
+  static let reactSettings = "React-RCTSettings"
 }
 
 func relativeSearchPath(_ depth: Int, _ path: String) -> String {

--- a/packages/react-native/scripts/ios-prebuild.js
+++ b/packages/react-native/scripts/ios-prebuild.js
@@ -11,7 +11,7 @@
 const {prepareHermesArtifactsAsync} = require('./ios-prebuild/hermes');
 const {
   createFolderIfNotExists,
-  prebuildLog,
+  createLogger,
   throwIfOnEden,
 } = require('./ios-prebuild/utils');
 const {execSync} = require('child_process');
@@ -23,6 +23,8 @@ const packageJsonPath = path.join(
   REACT_NATIVE_PACKAGE_ROOT_FOLDER,
   'package.json',
 );
+
+const prebuildLog = createLogger('Prebuild');
 
 // $FlowIgnore[unsupported-syntax]
 const {version: currentVersion} = require(packageJsonPath);

--- a/packages/react-native/scripts/ios-prebuild/hermes.js
+++ b/packages/react-native/scripts/ios-prebuild/hermes.js
@@ -8,12 +8,15 @@
  * @format
  */
 
+const {createLogger} = require('./utils');
 const {execSync} = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const stream = require('stream');
 const {promisify} = require('util');
+
 const pipeline = promisify(stream.pipeline);
+const hermesLog = createLogger('Hermes');
 
 /**
  * Downloads hermes artifacts from the specified version and build type. If you want to specify a specific
@@ -357,22 +360,6 @@ async function downloadHermesTarball(
 function abort(message /*: string */) {
   hermesLog(message, 'error');
   throw new Error(message);
-}
-
-function hermesLog(
-  message /*: string */,
-  level /*: 'info' | 'warning' | 'error' */ = 'warning',
-) {
-  // Simple log coloring for terminal output
-  const prefix = '[Hermes] ';
-  let colorFn = (x /*:string*/) => x;
-  if (process.stdout.isTTY) {
-    if (level === 'info') colorFn = x => `\x1b[32m${x}\x1b[0m`;
-    else if (level === 'error') colorFn = x => `\x1b[31m${x}\x1b[0m`;
-    else colorFn = x => `\x1b[33m${x}\x1b[0m`;
-  }
-
-  console.log(colorFn(prefix + message));
 }
 
 module.exports = {

--- a/packages/react-native/scripts/ios-prebuild/hermes.js
+++ b/packages/react-native/scripts/ios-prebuild/hermes.js
@@ -116,7 +116,7 @@ function checkExistingVersion(
   const hermesXCFramework = path.join(
     artifactsPath,
     'destroot',
-    'Libraries',
+    'Library',
     'Frameworks',
     'universal',
     'hermes.xcframework',

--- a/packages/react-native/scripts/ios-prebuild/utils.js
+++ b/packages/react-native/scripts/ios-prebuild/utils.js
@@ -37,24 +37,28 @@ function throwIfOnEden() {
   throw new Error('Cannot prepare the iOS prebuilds on an Eden checkout');
 }
 
-function prebuildLog(
-  message /*: string */,
-  level /*: 'info' | 'warning' | 'error' */ = 'warning',
-) {
-  // Simple log coloring for terminal output
-  const prefix = '[Prebuild] ';
-  let colorFn = (x /*:string*/) => x;
-  if (process.stdout.isTTY) {
-    if (level === 'info') colorFn = x => `\x1b[32m${x}\x1b[0m`;
-    else if (level === 'error') colorFn = x => `\x1b[31m${x}\x1b[0m`;
-    else colorFn = x => `\x1b[33m${x}\x1b[0m`;
-  }
+function createLogger(
+  prefix /*: string */,
+) /*: (message: string, level?: 'info' | 'warning' | 'error') => void */ {
+  return function (
+    message /*: string */,
+    level /*: 'info' | 'warning' | 'error' */ = 'info',
+  ) {
+    // Simple log coloring for terminal output
+    const resolvedPrefix = `[${prefix}] `;
+    let colorFn = (x /*:string*/) => x;
+    if (process.stdout.isTTY) {
+      if (level === 'info') colorFn = x => `\x1b[32m${x}\x1b[0m`;
+      else if (level === 'error') colorFn = x => `\x1b[31m${x}\x1b[0m`;
+      else colorFn = x => `\x1b[33m${x}\x1b[0m`;
+    }
 
-  console.log(colorFn(prefix + message));
+    console.log(colorFn(resolvedPrefix) + message);
+  };
 }
 
 module.exports = {
   createFolderIfNotExists,
   throwIfOnEden,
-  prebuildLog,
+  createLogger,
 };


### PR DESCRIPTION
## Summary:

To reduce reduntant code by repeating the logging functionality in each JS module, this commit introduces a factory for creating a logger with a given prefix.

- Create factory `createLogger`
- Remove redundant log implementations
- Changed to use factory in hermes.js and ios-prebuild.js

## Changelog:

[IOS] [CHANGED] - simplified logging in prebuild scripts

## Test Plan:

No tests so far.