### PR TITLE
Define reporter that includes information about the Fantom config used in test

### DIFF
--- a/packages/react-native-fantom/runner/formatFantomConfig.js
+++ b/packages/react-native-fantom/runner/formatFantomConfig.js
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {FeatureFlagValue} from '../../../packages/react-native/scripts/featureflags/types';
+import type {FantomTestConfig} from '../runner/getFantomTestConfig';
+import type {HermesVariant} from '../runner/utils';
+
+import {
+  DEFAULT_FEATURE_FLAGS,
+  DEFAULT_HERMES_VARIANT,
+  DEFAULT_MODE,
+  FantomTestConfigHermesVariant,
+  FantomTestConfigMode,
+} from '../runner/getFantomTestConfig';
+
+function formatFantomMode(mode: FantomTestConfigMode): string {
+  switch (mode) {
+    case FantomTestConfigMode.DevelopmentWithSource:
+      return 'mode 🐛';
+    case FantomTestConfigMode.DevelopmentWithBytecode:
+      return 'mode 🐛🔢';
+    case FantomTestConfigMode.Optimized:
+      return 'mode 🚀';
+  }
+}
+
+function formatFantomHermesVariant(hermesVariant: HermesVariant): string {
+  switch (hermesVariant) {
+    case FantomTestConfigHermesVariant.Hermes:
+      return 'hermes';
+    case FantomTestConfigHermesVariant.StaticHermes:
+      return 'hermes 🆕';
+    case FantomTestConfigHermesVariant.StaticHermesExperimental:
+      return 'hermes 🧪';
+  }
+}
+
+function formatFantomFeatureFlag(
+  flagName: string,
+  flagValue: FeatureFlagValue,
+): string {
+  if (typeof flagValue === 'boolean') {
+    return `${flagName} ${flagValue ? '✅' : '🛑'}`;
+  }
+
+  return `🔐 ${flagName} = ${flagValue}`;
+}
+
+export default function formatFantomConfig(config: FantomTestConfig): string {
+  const parts = [];
+
+  if (config.mode !== DEFAULT_MODE) {
+    parts.push(formatFantomMode(config.mode));
+  }
+
+  if (config.hermesVariant !== DEFAULT_HERMES_VARIANT) {
+    parts.push(formatFantomHermesVariant(config.hermesVariant));
+  }
+
+  for (const flagType of ['common', 'jsOnly', 'reactInternal'] as const) {
+    for (const [flagName, flagValue] of Object.entries(
+      config.flags[flagType],
+    )) {
+      if (flagValue !== DEFAULT_FEATURE_FLAGS[flagType][flagName]) {
+        parts.push(formatFantomFeatureFlag(flagName, flagValue));
+      }
+    }
+  }
+
+  return parts.join(', ');
+}

--- a/packages/react-native-fantom/runner/getFantomTestConfig.js
+++ b/packages/react-native-fantom/runner/getFantomTestConfig.js
@@ -39,20 +39,32 @@ export type FantomTestConfigReactInternalFeatureFlags = {
   [key: string]: FeatureFlagValue,
 };
 
+export type FantomTestConfigFeatureFlags = {
+  common: FantomTestConfigCommonFeatureFlags,
+  jsOnly: FantomTestConfigJsOnlyFeatureFlags,
+  reactInternal: FantomTestConfigReactInternalFeatureFlags,
+};
+
 export type FantomTestConfig = {
   mode: FantomTestConfigMode,
   hermesVariant: HermesVariant,
-  flags: {
-    common: FantomTestConfigCommonFeatureFlags,
-    jsOnly: FantomTestConfigJsOnlyFeatureFlags,
-    reactInternal: FantomTestConfigReactInternalFeatureFlags,
-  },
+  flags: FantomTestConfigFeatureFlags,
 };
 
-const DEFAULT_MODE: FantomTestConfigMode =
+export const FantomTestConfigHermesVariant = HermesVariant;
+
+export const DEFAULT_MODE: FantomTestConfigMode =
   FantomTestConfigMode.DevelopmentWithSource;
 
-const DEFAULT_HERMES_MODE: HermesVariant = HermesVariant.Hermes;
+export const DEFAULT_HERMES_VARIANT: HermesVariant = HermesVariant.Hermes;
+
+export const DEFAULT_FEATURE_FLAGS: FantomTestConfigFeatureFlags = {
+  common: {},
+  jsOnly: {
+    enableAccessToHostTreeInFabric: true,
+  },
+  reactInternal: {},
+};
 
 const FANTOM_FLAG_FORMAT = /^(\w+):(\w+)$/;
 
@@ -98,13 +110,17 @@ export default function getFantomTestConfig(
 
   const config: FantomTestConfig = {
     mode: DEFAULT_MODE,
-    hermesVariant: DEFAULT_HERMES_MODE,
+    hermesVariant: DEFAULT_HERMES_VARIANT,
     flags: {
-      common: {},
-      jsOnly: {
-        enableAccessToHostTreeInFabric: true,
+      common: {
+        ...DEFAULT_FEATURE_FLAGS.common,
       },
-      reactInternal: {},
+      jsOnly: {
+        ...DEFAULT_FEATURE_FLAGS.jsOnly,
+      },
+      reactInternal: {
+        ...DEFAULT_FEATURE_FLAGS.reactInternal,
+      },
     },
   };
 


### PR DESCRIPTION
Summary:
Changelog: [internal]

This implements a custom reporter for Jest/Fantom to display the test configuration with the test results.

Differential Revision: D75063176


