### PR TITLE
Use native .isNaN instead of java.lang.Float.isNaN

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/FloatUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/FloatUtil.kt
@@ -14,8 +14,8 @@ public object FloatUtil {
 
   @JvmStatic
   public fun floatsEqual(f1: Float, f2: Float): Boolean {
-    return if (java.lang.Float.isNaN(f1) || java.lang.Float.isNaN(f2)) {
-      java.lang.Float.isNaN(f1) && java.lang.Float.isNaN(f2)
+    return if (f1.isNaN() || f2.isNaN()) {
+      f1.isNaN() && f2.isNaN()
     } else abs(f2 - f1) < EPSILON
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.kt
@@ -254,7 +254,7 @@ constructor(private val fpsListener: FpsListener? = null) :
   public fun setBorderRadius(view: ReactHorizontalScrollView?, index: Int, borderRadius: Float) {
     if (view != null) {
       val radius =
-          if (java.lang.Float.isNaN(borderRadius)) null
+          if (borderRadius.isNaN()) null
           else LengthPercentage(borderRadius, LengthPercentageType.POINT)
       setBorderRadius(view, BorderRadiusProp.entries[index], radius)
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.kt
@@ -225,7 +225,7 @@ constructor(private val fpsListener: FpsListener? = null) :
   public fun setBorderRadius(view: ReactScrollView?, index: Int, borderRadius: Float) {
     if (view != null) {
       val radius =
-          if (java.lang.Float.isNaN(borderRadius)) null
+          if (borderRadius.isNaN()) null
           else LengthPercentage(borderRadius, LengthPercentageType.POINT)
       setBorderRadius(view, BorderRadiusProp.entries[index], radius)
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextAnchorViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextAnchorViewManager.kt
@@ -129,7 +129,7 @@ internal abstract class ReactTextAnchorViewManager<C : ReactBaseTextShadowNode?>
       defaultFloat = Float.NaN)
   public fun setBorderRadius(view: ReactTextView, index: Int, borderRadius: Float) {
     val radius =
-        if (java.lang.Float.isNaN(borderRadius)) {
+        if (borderRadius.isNaN()) {
           null
         } else {
           LengthPercentage(borderRadius, LengthPercentageType.POINT)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.kt
@@ -803,7 +803,7 @@ public open class ReactEditText public constructor(context: Context) : AppCompat
     }
 
     val effectiveLetterSpacing = textAttributes.effectiveLetterSpacing
-    if (!java.lang.Float.isNaN(effectiveLetterSpacing)) {
+    if (!effectiveLetterSpacing.isNaN()) {
       workingText.setSpan(
           CustomLetterSpacingSpan(effectiveLetterSpacing), 0, workingText.length, spanFlags)
     }
@@ -820,7 +820,7 @@ public open class ReactEditText public constructor(context: Context) : AppCompat
     }
 
     val lineHeight = textAttributes.effectiveLineHeight
-    if (!java.lang.Float.isNaN(lineHeight)) {
+    if (!lineHeight.isNaN()) {
       workingText.setSpan(CustomLineHeightSpan(lineHeight), 0, workingText.length, spanFlags)
     }
   }
@@ -995,7 +995,7 @@ public open class ReactEditText public constructor(context: Context) : AppCompat
 
   public fun setBorderRadius(borderRadius: Float, position: Int) {
     val radius =
-        if (java.lang.Float.isNaN(borderRadius)) {
+        if (borderRadius.isNaN()) {
           null
         } else {
           LengthPercentage(toDIPFromPixel(borderRadius), LengthPercentageType.POINT)
@@ -1052,7 +1052,7 @@ public open class ReactEditText public constructor(context: Context) : AppCompat
     setTextSize(TypedValue.COMPLEX_UNIT_PX, textAttributes.effectiveFontSize.toFloat())
 
     val effectiveLetterSpacing = textAttributes.effectiveLetterSpacing
-    if (!java.lang.Float.isNaN(effectiveLetterSpacing)) {
+    if (!effectiveLetterSpacing.isNaN()) {
       letterSpacing = effectiveLetterSpacing
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.kt
@@ -807,7 +807,7 @@ public open class ReactTextInputManager public constructor() :
       defaultFloat = Float.NaN)
   public fun setBorderRadius(view: ReactEditText, index: Int, borderRadius: Float) {
     val radius =
-        if (java.lang.Float.isNaN(borderRadius)) {
+        if (borderRadius.isNaN()) {
           null
         } else {
           LengthPercentage(borderRadius, LengthPercentageType.POINT)


### PR DESCRIPTION
Summary:
# Changelog:
[Internal] - 

Based on review discussions in on of the previous PRs, it's a better style to use native Kotlin's `.isNaN` instead of `java.lang.Float.isNaN()`.

This makes sure that we uniformly do so throughout the codebase.

Differential Revision: D75215199


