### PR TITLE
Move RefreshControlMock into Jest preset files

### DIFF
--- a/packages/react-native/jest/RefreshControlMock.js
+++ b/packages/react-native/jest/RefreshControlMock.js
@@ -10,9 +10,9 @@
 
 'use strict';
 
-import type {HostComponent} from '../../../../src/private/types/HostComponent';
+import type {HostComponent} from '../src/private/types/HostComponent';
 
-import requireNativeComponent from '../../../ReactNative/requireNativeComponent';
+import requireNativeComponent from '../Libraries/ReactNative/requireNativeComponent';
 import * as React from 'react';
 
 const RCTRefreshControl: HostComponent<{}> = requireNativeComponent<{}>(

--- a/packages/react-native/jest/setup.js
+++ b/packages/react-native/jest/setup.js
@@ -201,9 +201,7 @@ jest
   }))
   .mock('../Libraries/Components/RefreshControl/RefreshControl', () => ({
     __esModule: true,
-    default: jest.requireActual(
-      '../Libraries/Components/RefreshControl/__mocks__/RefreshControlMock',
-    ).default,
+    default: jest.requireActual('./RefreshControlMock').default,
   }))
   .mock('../Libraries/Components/ScrollView/ScrollView', () => {
     const baseComponent = mockComponent(


### PR DESCRIPTION
Summary:
Alternative to https://github.com/facebook/react-native/pull/50784.

`__mocks__` (and other underscored dirs) are correctly excluded from our npm package via `package.json#files`. But in this instance, this is a source file for the `jest/` directory (Jest preset within `react-native`), and should be included — fix by relocating.

Changelog:
[General][Fixed] - Fix missing RefreshControlMock source in Jest preset

Reviewed By: rshest

Differential Revision: D75215731
