### PR TITLE
Add support multi-config test runs

### DIFF
--- a/packages/react-native-fantom/__docs__/README.md
+++ b/packages/react-native-fantom/__docs__/README.md
@@ -137,6 +137,45 @@ Available pragmas:
 - `@fantom_react_fb_flags`: used to set overrides for internal React flags set
   in ReactNativeInternalFeatureFlags (Meta use only)
 
+For all pragmas, except non-boolean feature flags, you can use a wildcard (`*`)
+as value to run the test with all possible values for that pragma. For example,
+this test:
+
+```javascript
+/**
+ * @fantom_flags jsOnlyTestFlag:*
+ * @fantom_mode *
+ */
+```
+
+Would be executed with these combinations of options:
+
+| `jsOnlyTestFlag` | `mode`         |
+| ---------------- | -------------- |
+| `false`          | `dev`          |
+| `true`           | `dev`          |
+| `false`          | `dev-bytecode` |
+| `true`           | `dev-bytecode` |
+| `false`          | `opt`          |
+| `true`           | `opt`          |
+
+With an output such as:
+
+```text
+  Test (jsOnlyTestFlag 🛑)
+    [...]
+  Test (jsOnlyTestFlag ✅)
+    [...]
+  Test (mode 🐛🔢, jsOnlyTestFlag 🛑)
+    [...]
+  Test (mode 🐛🔢, jsOnlyTestFlag ✅)
+    [...]
+  Test (mode 🚀, jsOnlyTestFlag 🛑)
+    [...]
+  Test (mode 🚀, jsOnlyTestFlag ✅)
+    [...]
+```
+
 ### Debugging
 
 To debug, run your fantom test with the flag `FANTOM_ENABLE_CPP_DEBUGGING`
@@ -209,6 +248,51 @@ has simple examples you can learn from.
 Fantom tests are currently tied to Meta's infrastructure and do not run outside
 of Meta's CI. We are working on migrating Fantom to Github CI. If you submit a
 PR, the tests will run as part of the PR import process.
+
+#### Can I gate individual tests within a suite to only run, or not run, with a specific feature flag?
+
+Yes, you can use the `@fantom_flags` pragma to customize the flags that are
+going to be used for the entire test suite, and conditionally define or exclude
+the test in the suite depending on the flag value for that run. E.g.:
+
+```javascript
+/**
+ * @fantom_flags commonTestFlag:*
+ */
+
+import * as ReactNativeFeatureFlags from 'react-native/src/private/featureflags/ReactNativeFeatureFlags';
+
+// The entire suite will be run with commonTestFlag set to true and false.
+describe('MyTest', () => {
+  it('should run with all values of the flag', () => {
+    // ...
+  });
+
+  if (ReactNativeFeatureFlags.commonTestFlag()) {
+    it('should only run when the flag is true', () => {
+      // ...
+    });
+  }
+
+  if (!ReactNativeFeatureFlags.commonTestFlag()) {
+    it('should only run when the flag is false', () => {
+      // ...
+    });
+  }
+});
+```
+
+And the result would look like this:
+
+```text
+ PASS  MyTest-itest.js
+  MyTest (commonTestFlag ❌)
+    ✓ should run with all values of the flag
+    ✓ should only run when the flag is false
+  MyTest (commonTestFlag ✅)
+    ✓ should run with all values of the flag
+    ✓ should only run when the flag is true
+```
 
 ---
 

--- a/packages/react-native-fantom/runner/entrypoint-template.js
+++ b/packages/react-native-fantom/runner/entrypoint-template.js
@@ -12,7 +12,7 @@ import type {SnapshotConfig} from '../runtime/snapshotContext';
 import type {
   FantomTestConfigJsOnlyFeatureFlags,
   FantomTestConfigReactInternalFeatureFlags,
-} from './getFantomTestConfig';
+} from './getFantomTestConfigs';
 
 module.exports = function entrypointTemplate({
   testPath,

--- a/packages/react-native-fantom/runner/formatFantomConfig.js
+++ b/packages/react-native-fantom/runner/formatFantomConfig.js
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {FeatureFlagValue} from '../../../packages/react-native/scripts/featureflags/types';
+import type {FantomTestConfig} from '../runner/getFantomTestConfig';
+import type {HermesVariant} from '../runner/utils';
+
+import {
+  DEFAULT_FEATURE_FLAGS,
+  DEFAULT_HERMES_VARIANT,
+  DEFAULT_MODE,
+  FantomTestConfigHermesVariant,
+  FantomTestConfigMode,
+} from '../runner/getFantomTestConfig';
+
+function formatFantomMode(mode: FantomTestConfigMode): string {
+  switch (mode) {
+    case FantomTestConfigMode.DevelopmentWithSource:
+      return 'mode 🐛';
+    case FantomTestConfigMode.DevelopmentWithBytecode:
+      return 'mode 🐛🔢';
+    case FantomTestConfigMode.Optimized:
+      return 'mode 🚀';
+  }
+}
+
+function formatFantomHermesVariant(hermesVariant: HermesVariant): string {
+  switch (hermesVariant) {
+    case FantomTestConfigHermesVariant.Hermes:
+      return 'hermes';
+    case FantomTestConfigHermesVariant.StaticHermes:
+      return 'hermes 🆕';
+    case FantomTestConfigHermesVariant.StaticHermesExperimental:
+      return 'hermes 🧪';
+  }
+}
+
+function formatFantomFeatureFlag(
+  flagName: string,
+  flagValue: FeatureFlagValue,
+): string {
+  if (typeof flagValue === 'boolean') {
+    return `${flagName} ${flagValue ? '✅' : '🛑'}`;
+  }
+
+  return `🔐 ${flagName} = ${flagValue}`;
+}
+
+export default function formatFantomConfig(config: FantomTestConfig): string {
+  const parts = [];
+
+  if (config.mode !== DEFAULT_MODE) {
+    parts.push(formatFantomMode(config.mode));
+  }
+
+  if (config.hermesVariant !== DEFAULT_HERMES_VARIANT) {
+    parts.push(formatFantomHermesVariant(config.hermesVariant));
+  }
+
+  for (const flagType of ['common', 'jsOnly', 'reactInternal'] as const) {
+    for (const [flagName, flagValue] of Object.entries(
+      config.flags[flagType],
+    )) {
+      if (flagValue !== DEFAULT_FEATURE_FLAGS[flagType][flagName]) {
+        parts.push(formatFantomFeatureFlag(flagName, flagValue));
+      }
+    }
+  }
+
+  return parts.join(', ');
+}

--- a/packages/react-native-fantom/runner/formatFantomConfig.js
+++ b/packages/react-native-fantom/runner/formatFantomConfig.js
@@ -9,7 +9,7 @@
  */
 
 import type {FeatureFlagValue} from '../../../packages/react-native/scripts/featureflags/types';
-import type {FantomTestConfig} from '../runner/getFantomTestConfig';
+import type {FantomTestConfig} from '../runner/getFantomTestConfigs';
 import type {HermesVariant} from '../runner/utils';
 
 import {
@@ -18,7 +18,7 @@ import {
   DEFAULT_MODE,
   FantomTestConfigHermesVariant,
   FantomTestConfigMode,
-} from '../runner/getFantomTestConfig';
+} from '../runner/getFantomTestConfigs';
 
 function formatFantomMode(mode: FantomTestConfigMode): string {
   switch (mode) {

--- a/packages/react-native-fantom/runner/getFantomTestConfig.js
+++ b/packages/react-native-fantom/runner/getFantomTestConfig.js
@@ -39,20 +39,32 @@ export type FantomTestConfigReactInternalFeatureFlags = {
   [key: string]: FeatureFlagValue,
 };
 
+export type FantomTestConfigFeatureFlags = {
+  common: FantomTestConfigCommonFeatureFlags,
+  jsOnly: FantomTestConfigJsOnlyFeatureFlags,
+  reactInternal: FantomTestConfigReactInternalFeatureFlags,
+};
+
 export type FantomTestConfig = {
   mode: FantomTestConfigMode,
   hermesVariant: HermesVariant,
-  flags: {
-    common: FantomTestConfigCommonFeatureFlags,
-    jsOnly: FantomTestConfigJsOnlyFeatureFlags,
-    reactInternal: FantomTestConfigReactInternalFeatureFlags,
-  },
+  flags: FantomTestConfigFeatureFlags,
 };
 
-const DEFAULT_MODE: FantomTestConfigMode =
+export const FantomTestConfigHermesVariant = HermesVariant;
+
+export const DEFAULT_MODE: FantomTestConfigMode =
   FantomTestConfigMode.DevelopmentWithSource;
 
-const DEFAULT_HERMES_MODE: HermesVariant = HermesVariant.Hermes;
+export const DEFAULT_HERMES_VARIANT: HermesVariant = HermesVariant.Hermes;
+
+export const DEFAULT_FEATURE_FLAGS: FantomTestConfigFeatureFlags = {
+  common: {},
+  jsOnly: {
+    enableAccessToHostTreeInFabric: true,
+  },
+  reactInternal: {},
+};
 
 const FANTOM_FLAG_FORMAT = /^(\w+):(\w+)$/;
 
@@ -98,13 +110,17 @@ export default function getFantomTestConfig(
 
   const config: FantomTestConfig = {
     mode: DEFAULT_MODE,
-    hermesVariant: DEFAULT_HERMES_MODE,
+    hermesVariant: DEFAULT_HERMES_VARIANT,
     flags: {
-      common: {},
-      jsOnly: {
-        enableAccessToHostTreeInFabric: true,
+      common: {
+        ...DEFAULT_FEATURE_FLAGS.common,
       },
-      reactInternal: {},
+      jsOnly: {
+        ...DEFAULT_FEATURE_FLAGS.jsOnly,
+      },
+      reactInternal: {
+        ...DEFAULT_FEATURE_FLAGS.reactInternal,
+      },
     },
   };
 

--- a/packages/react-native-fantom/runner/getFantomTestConfigs.js
+++ b/packages/react-native-fantom/runner/getFantomTestConfigs.js
@@ -12,7 +12,6 @@ import type {FeatureFlagValue} from '../../../packages/react-native/scripts/feat
 
 import ReactNativeFeatureFlags from '../../../packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config';
 import {HermesVariant} from './utils';
-import fs from 'fs';
 // $FlowExpectedError[untyped-import]
 import {extract, parse} from 'jest-docblock';
 
@@ -51,6 +50,12 @@ export type FantomTestConfig = {
   flags: FantomTestConfigFeatureFlags,
 };
 
+export type PartialFantomTestConfig = {
+  mode?: FantomTestConfigMode,
+  hermesVariant?: HermesVariant,
+  flags?: Partial<FantomTestConfigFeatureFlags>,
+};
+
 export const FantomTestConfigHermesVariant = HermesVariant;
 
 export const DEFAULT_MODE: FantomTestConfigMode =
@@ -66,7 +71,7 @@ export const DEFAULT_FEATURE_FLAGS: FantomTestConfigFeatureFlags = {
   reactInternal: {},
 };
 
-const FANTOM_FLAG_FORMAT = /^(\w+):(\w+)$/;
+const FANTOM_FLAG_FORMAT = /^(\w+):((?:\w+)|\*)$/;
 
 const FANTOM_BENCHMARK_FILENAME_RE = /[Bb]enchmark-itest\./g;
 const FANTOM_BENCHMARK_SUITE_RE =
@@ -75,8 +80,10 @@ const FANTOM_BENCHMARK_SUITE_RE =
 const FANTOM_BENCHMARK_DEFAULT_MODE: FantomTestConfigMode =
   FantomTestConfigMode.Optimized;
 
+const MAX_FANTOM_CONFIGURATION_VARIATIONS = 12;
+
 /**
- * Extracts the Fantom configuration from the test file, specified as part of
+ * Extracts the Fantom configurations from the test file, specified as part of
  * the docblock comment. E.g.:
  *
  * ```
@@ -92,19 +99,22 @@ const FANTOM_BENCHMARK_DEFAULT_MODE: FantomTestConfigMode =
  *
  * The supported options are:
  * - `fantom_mode`: specifies the level of optimization to compile the test
- *  with. Valid values are `dev` and `opt`.
+ *  with. Valid values are `dev`, `dev-bytecode` and `opt`.
  * - `fantom_hermes_variant`: specifies the Hermes variant to use to run the
  *  test. Valid values are `hermes`, `static_hermes` and
  *  `static_hermes_experimental`.
  * - `fantom_flags`: specifies the configuration for common and JS-only feature
  *  flags. They can be specified in the same pragma or in different ones, and
  *  the format is `<flag_name>:<value>`.
+ *
+ * If a wildcard (`*`) is used for any given value, we return a list of
+ * configurations with all the combinations of values for those options (with
+ * a limit of 12 configurations).
  */
-export default function getFantomTestConfig(
+export default function getFantomTestConfigs(
   testPath: string,
-): FantomTestConfig {
-  const testContents = fs.readFileSync(testPath, 'utf8');
-
+  testContents: string,
+): Array<FantomTestConfig> {
   const docblock = extract(testContents);
   const pragmas = parse(docblock) as DocblockPragmas;
 
@@ -126,6 +136,8 @@ export default function getFantomTestConfig(
 
   const maybeMode = pragmas.fantom_mode;
 
+  const configVariations: Array<Array<PartialFantomTestConfig>> = [];
+
   if (maybeMode != null) {
     if (Array.isArray(maybeMode)) {
       throw new Error('Expected a single value for @fantom_mode');
@@ -142,6 +154,13 @@ export default function getFantomTestConfig(
         break;
       case 'opt':
         config.mode = FantomTestConfigMode.Optimized;
+        break;
+      case '*':
+        configVariations.push([
+          {mode: FantomTestConfigMode.DevelopmentWithSource},
+          {mode: FantomTestConfigMode.DevelopmentWithBytecode},
+          {mode: FantomTestConfigMode.Optimized},
+        ]);
         break;
       default:
         throw new Error(`Invalid Fantom mode: ${mode}`);
@@ -174,6 +193,13 @@ export default function getFantomTestConfig(
       case 'static_hermes_experimental':
         config.hermesVariant = HermesVariant.StaticHermesExperimental;
         break;
+      case '*':
+        configVariations.push([
+          {hermesVariant: HermesVariant.Hermes},
+          {hermesVariant: HermesVariant.StaticHermes},
+          {hermesVariant: HermesVariant.StaticHermesExperimental},
+        ]);
+        break;
       default:
         throw new Error(`Invalid Fantom Hermes mode: ${hermesVariant}`);
     }
@@ -200,12 +226,42 @@ export default function getFantomTestConfig(
 
       if (ReactNativeFeatureFlags.common[name]) {
         const flagConfig = ReactNativeFeatureFlags.common[name];
-        const value = parseFeatureFlagValue(flagConfig.defaultValue, rawValue);
-        config.flags.common[name] = value;
+        if (rawValue === '*') {
+          if (typeof flagConfig.defaultValue !== 'boolean') {
+            throw new Error(
+              `Invalid format for Fantom feature flag: ${rawFlagConfig}. Wildcards are not supported for non-boolean feature flags.`,
+            );
+          }
+          configVariations.push([
+            {flags: {common: {[name]: false}}},
+            {flags: {common: {[name]: true}}},
+          ]);
+        } else {
+          const value = parseFeatureFlagValue(
+            flagConfig.defaultValue,
+            rawValue,
+          );
+          config.flags.common[name] = value;
+        }
       } else if (ReactNativeFeatureFlags.jsOnly[name]) {
         const flagConfig = ReactNativeFeatureFlags.jsOnly[name];
-        const value = parseFeatureFlagValue(flagConfig.defaultValue, rawValue);
-        config.flags.jsOnly[name] = value;
+        if (rawValue === '*') {
+          if (typeof flagConfig.defaultValue !== 'boolean') {
+            throw new Error(
+              `Invalid format for Fantom feature flag: ${rawFlagConfig}. Wildcards are not supported for non-boolean feature flags.`,
+            );
+          }
+          configVariations.push([
+            {flags: {jsOnly: {[name]: false}}},
+            {flags: {jsOnly: {[name]: true}}},
+          ]);
+        } else {
+          const value = parseFeatureFlagValue(
+            flagConfig.defaultValue,
+            rawValue,
+          );
+          config.flags.jsOnly[name] = value;
+        }
       } else {
         const validKeys = Object.keys(ReactNativeFeatureFlags.common)
           .concat(Object.keys(ReactNativeFeatureFlags.jsOnly))
@@ -236,12 +292,78 @@ export default function getFantomTestConfig(
       }
 
       const [, name, rawValue] = matches;
-      const value = parseFeatureFlagValue(false, rawValue);
-      config.flags.reactInternal[name] = value;
+      if (rawValue === '*') {
+        configVariations.push([
+          {flags: {reactInternal: {[name]: false}}},
+          {flags: {reactInternal: {[name]: true}}},
+        ]);
+      } else {
+        const value = parseFeatureFlagValue(false, rawValue);
+        config.flags.reactInternal[name] = value;
+      }
     }
   }
 
-  return config;
+  const combinations = configVariations.reduce(
+    (total, current) => total * current.length,
+    1,
+  );
+  if (combinations > MAX_FANTOM_CONFIGURATION_VARIATIONS) {
+    throw new Error(
+      `Cannot define a test with more than ${MAX_FANTOM_CONFIGURATION_VARIATIONS} configuration variations. Please reduce the number of wildcard values (*) used in your test configuration.`,
+    );
+  }
+
+  return getConfigurationVariations(config, configVariations);
+}
+
+function getConfigurationVariations(
+  config: FantomTestConfig,
+  variations: $ReadOnlyArray<$ReadOnlyArray<PartialFantomTestConfig>>,
+): Array<FantomTestConfig> {
+  if (variations.length === 0) {
+    return [config];
+  }
+
+  const results: Array<FantomTestConfig> = [];
+  const [currentConfigVariations, ...remainingVariations] = variations;
+
+  for (const currentConfigVariation of currentConfigVariations) {
+    const currentConfigWithVariation = {
+      mode: currentConfigVariation.mode ?? config.mode,
+      hermesVariant:
+        currentConfigVariation.hermesVariant ?? config.hermesVariant,
+      flags: {
+        common: currentConfigVariation.flags?.common
+          ? {
+              ...config.flags.common,
+              ...currentConfigVariation.flags.common,
+            }
+          : config.flags.common,
+        jsOnly: currentConfigVariation.flags?.jsOnly
+          ? {
+              ...config.flags.jsOnly,
+              ...currentConfigVariation.flags.jsOnly,
+            }
+          : config.flags.jsOnly,
+        reactInternal: currentConfigVariation.flags?.reactInternal
+          ? {
+              ...config.flags.reactInternal,
+              ...currentConfigVariation.flags.reactInternal,
+            }
+          : config.flags.reactInternal,
+      },
+    };
+
+    results.push(
+      ...getConfigurationVariations(
+        currentConfigWithVariation,
+        remainingVariations,
+      ),
+    );
+  }
+
+  return results;
 }
 
 function parseFeatureFlagValue<T: boolean | number | string>(


### PR DESCRIPTION
Changelog: [internal]

This adds support for Fantom to run specific test suites with different combinations of options/flags, using wildcards as values.

See the new documentation for this feature in this diff for more details.

Differential Revision: D75231299
