### PR TITLE
Fix missing height constraints when creating Fabric layout for `adjustsFontSizeToFit`

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -673,6 +673,7 @@ public class FabricUIManager
             getYogaSize(minWidth, maxWidth),
             getYogaMeasureMode(minWidth, maxWidth),
             getYogaSize(minHeight, maxHeight),
+            getYogaMeasureMode(minHeight, maxHeight),
             null /* T219881133: Migrate away from ReactTextViewManagerCallback */);
 
     int maximumNumberOfLines =

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
@@ -612,6 +612,7 @@ public class TextLayoutManager {
       float width,
       YogaMeasureMode widthYogaMeasureMode,
       float height,
+      YogaMeasureMode heightYogaMeasureMode,
       @Nullable ReactTextViewManagerCallback reactTextViewManagerCallback) {
     Spannable text =
         getOrCreateSpannableForText(context, attributedString, reactTextViewManagerCallback);
@@ -668,7 +669,7 @@ public class TextLayoutManager {
           width,
           YogaMeasureMode.EXACTLY,
           height,
-          YogaMeasureMode.UNDEFINED,
+          heightYogaMeasureMode,
           minimumFontSize,
           maximumNumberOfLines,
           includeFontPadding,
@@ -799,6 +800,7 @@ public class TextLayoutManager {
             width,
             widthYogaMeasureMode,
             height,
+            heightYogaMeasureMode,
             reactTextViewManagerCallback);
 
     int maximumNumberOfLines =
@@ -1080,6 +1082,7 @@ public class TextLayoutManager {
             width,
             YogaMeasureMode.EXACTLY,
             height,
+            YogaMeasureMode.EXACTLY,
             null);
     return FontMetricsUtil.getFontMetrics(
         layout.getText(), layout, Preconditions.checkNotNull(sTextPaintInstance.get()), context);

--- a/packages/rn-tester/js/examples/Text/TextAdjustsDynamicLayoutExample.js
+++ b/packages/rn-tester/js/examples/Text/TextAdjustsDynamicLayoutExample.js
@@ -20,6 +20,7 @@ export default function TextAdjustsDynamicLayoutExample(props: {}): React.Node {
       <View>
         <View style={[styles.subjectContainer, {height}]}>
           <Text
+            testID="adjusting-text"
             adjustsFontSizeToFit={true}
             numberOfLines={1}
             style={styles.subjectText}>
@@ -28,13 +29,25 @@ export default function TextAdjustsDynamicLayoutExample(props: {}): React.Node {
         </View>
       </View>
       <View style={styles.row}>
-        <Button onPress={() => setHeight(20)} title="Set Height to 20" />
+        <Button
+          testID="set-height-20"
+          onPress={() => setHeight(20)}
+          title="Set Height to 20"
+        />
       </View>
       <View style={styles.row}>
-        <Button onPress={() => setHeight(40)} title="Set Height to 40" />
+        <Button
+          testID="set-height-40"
+          onPress={() => setHeight(40)}
+          title="Set Height to 40"
+        />
       </View>
       <View style={styles.row}>
-        <Button onPress={() => setHeight(60)} title="Set Height to 60" />
+        <Button
+          testID="set-height-60"
+          onPress={() => setHeight(60)}
+          title="Set Height to 60"
+        />
       </View>
     </>
   );


### PR DESCRIPTION
Summary:
`adjustsFontSizeToFit` will adjust font size so that given text fits in both veritcal and horizontal bounds. The algorithm to mutate text to fit is executed during TextLayoutManager during layout creation for Fabric, and then re-executed in `TextView.onDraw()`. See D56134348 which introduced the logic.

In Facsimile, we were not seeing font size adjusted when text is too tall. This is because we are only incorporating the height constraint during Spannable mutation during draw, but not the original layout, which Facsimile uses directly.

This could potentially fix other bugs, where width may not corredpond to the final font size we settle on during drawing.

Changelog:
[Android][Fixed] - Fix missing height constraints when creating Fabric layout for `adjustsFontSizeToFit`

Reviewed By: mdvacca

Differential Revision: D75251391


