### PR TITLE
[ios][prebuild] added missing search path to reactPerfLogger

### DIFF
--- a/packages/react-native/Package.swift
+++ b/packages/react-native/Package.swift
@@ -116,6 +116,7 @@ let reactFeatureFlags = RNTarget(
 let reactPerfLogger = RNTarget(
   name: .reactPerfLogger,
   path: "ReactCommon/reactperflogger",
+  searchPaths: ["ReactCommon"],
   excludedPaths: ["fusebox"]
 )
 


### PR DESCRIPTION
## Summary:

ReactPerfLogger target now has an include file that wasn't in the search path.

This commit fixes this by adding "ReactCommon" as search path to the target.

## Changelog:

[IOS] [FIXED] - Added missing search path to swift package

## Test Plan:

No tests yet.