### PR TITLE
Remove flow libdefs from npm package

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -74,7 +74,6 @@
   "files": [
     "build.gradle.kts",
     "cli.js",
-    "flow",
     "gradle.properties",
     "gradle/libs.versions.toml",
     "index.js",


### PR DESCRIPTION
Summary:
Excludes `packages/react-native/flow/` from being published to npm.

**As far as I know**, we already axed open source Flow support with a similar change in D46313482 (Jun 2023).

Changelog:
[General][Breaking] - The `react-native` package no longer ships with the `flow` directory

Reviewed By: cipolleschi

Differential Revision: D75060845


