### PR TITLE
Mark methods in NativeAnimatedNodesManager as noexcept

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.cpp
@@ -69,7 +69,7 @@ NativeAnimatedNodesManager::~NativeAnimatedNodesManager() noexcept {
   stopRenderCallbackIfNeeded();
 }
 
-std::optional<double> NativeAnimatedNodesManager::getValue(Tag tag) {
+std::optional<double> NativeAnimatedNodesManager::getValue(Tag tag) noexcept {
   auto node = getAnimatedNode<ValueAnimatedNode>(tag);
   if (node) {
     return node->value();
@@ -84,7 +84,7 @@ std::optional<double> NativeAnimatedNodesManager::getValue(Tag tag) {
 
 std::unique_ptr<AnimatedNode> NativeAnimatedNodesManager::animatedNode(
     Tag tag,
-    const folly::dynamic& config) {
+    const folly::dynamic& config) noexcept {
   auto typeName = config["type"].asString();
 
   auto type = AnimatedNode::getNodeTypeByName(typeName);
@@ -145,7 +145,7 @@ std::unique_ptr<AnimatedNode> NativeAnimatedNodesManager::animatedNode(
 
 void NativeAnimatedNodesManager::createAnimatedNode(
     Tag tag,
-    const folly::dynamic& config) {
+    const folly::dynamic& config) noexcept {
   auto node = animatedNode(tag, config);
   if (node) {
     std::lock_guard<std::mutex> lock(connectedAnimatedNodesMutex_);
@@ -156,7 +156,7 @@ void NativeAnimatedNodesManager::createAnimatedNode(
 
 void NativeAnimatedNodesManager::connectAnimatedNodes(
     Tag parentTag,
-    Tag childTag) {
+    Tag childTag) noexcept {
   react_native_assert(parentTag);
   react_native_assert(childTag);
 
@@ -175,7 +175,7 @@ void NativeAnimatedNodesManager::connectAnimatedNodes(
 
 void NativeAnimatedNodesManager::connectAnimatedNodeToView(
     Tag propsNodeTag,
-    Tag viewTag) {
+    Tag viewTag) noexcept {
   react_native_assert(propsNodeTag);
   react_native_assert(viewTag);
 
@@ -195,7 +195,7 @@ void NativeAnimatedNodesManager::connectAnimatedNodeToView(
 
 void NativeAnimatedNodesManager::disconnectAnimatedNodeFromView(
     Tag propsNodeTag,
-    Tag viewTag) {
+    Tag viewTag) noexcept {
   react_native_assert(propsNodeTag);
   react_native_assert(viewTag);
 
@@ -215,7 +215,7 @@ void NativeAnimatedNodesManager::disconnectAnimatedNodeFromView(
 
 void NativeAnimatedNodesManager::disconnectAnimatedNodes(
     Tag parentTag,
-    Tag childTag) {
+    Tag childTag) noexcept {
   react_native_assert(parentTag);
   react_native_assert(childTag);
 
@@ -231,13 +231,13 @@ void NativeAnimatedNodesManager::disconnectAnimatedNodes(
   }
 }
 
-void NativeAnimatedNodesManager::restoreDefaultValues(Tag tag) {
+void NativeAnimatedNodesManager::restoreDefaultValues(Tag tag) noexcept {
   if (auto propsNode = getAnimatedNode<PropsAnimatedNode>(tag)) {
     propsNode->restoreDefaultValues();
   }
 }
 
-void NativeAnimatedNodesManager::dropAnimatedNode(Tag tag) {
+void NativeAnimatedNodesManager::dropAnimatedNode(Tag tag) noexcept {
   std::lock_guard<std::mutex> lock(connectedAnimatedNodesMutex_);
   animatedNodes_.erase(tag);
 }
@@ -269,21 +269,23 @@ void NativeAnimatedNodesManager::stopAnimationsForNode(Tag nodeTag) {
 
 void NativeAnimatedNodesManager::setAnimatedNodeOffset(
     Tag /*tag*/,
-    double /*offset*/) {
+    double /*offset*/) noexcept {
   LOG(WARNING) << "SetAnimatedNodeOffset is unimplemented";
 }
 
-void NativeAnimatedNodesManager::flattenAnimatedNodeOffset(Tag /*tag*/) {
+void NativeAnimatedNodesManager::flattenAnimatedNodeOffset(
+    Tag /*tag*/) noexcept {
   LOG(WARNING) << "FlattenAnimatedNodeOffset is unimplemented";
 }
 
-void NativeAnimatedNodesManager::extractAnimatedNodeOffset(Tag /*tag*/) {
+void NativeAnimatedNodesManager::extractAnimatedNodeOffset(
+    Tag /*tag*/) noexcept {
   LOG(WARNING) << "ExtractAnimatedNodeOffset is unimplemented";
 }
 
 void NativeAnimatedNodesManager::updateAnimatedNodeConfig(
     Tag /*tag*/,
-    const folly::dynamic& /*config*/) {
+    const folly::dynamic& /*config*/) noexcept {
   LOG(WARNING) << "UpdateAnimatedNodeConfig is unimplemented";
 }
 
@@ -293,7 +295,7 @@ void NativeAnimatedNodesManager::startAnimatingNode(
     int animationId,
     Tag animatedNodeTag,
     const folly::dynamic& config,
-    const std::optional<AnimationEndCallback>& endCallback) {
+    const std::optional<AnimationEndCallback>& endCallback) noexcept {
   if (auto iter = activeAnimations_.find(animationId);
       iter != activeAnimations_.end()) {
     // reset animation config
@@ -330,7 +332,7 @@ void NativeAnimatedNodesManager::startAnimatingNode(
 
 void NativeAnimatedNodesManager::stopAnimation(
     int animationId,
-    bool /*isTrackingAnimation*/) {
+    bool /*isTrackingAnimation*/) noexcept {
   if (auto iter = activeAnimations_.find(animationId);
       iter != activeAnimations_.end()) {
     iter->second->stopAnimation();
@@ -341,7 +343,7 @@ void NativeAnimatedNodesManager::stopAnimation(
 void NativeAnimatedNodesManager::addAnimatedEventToView(
     Tag viewTag,
     const std::string& eventName,
-    const folly::dynamic& eventMapping) {
+    const folly::dynamic& eventMapping) noexcept {
   const auto animatedValueTag = (eventMapping.count("animatedValueTag") != 0u)
       ? static_cast<Tag>(eventMapping["animatedValueTag"].asInt())
       : 0;
@@ -370,7 +372,7 @@ void NativeAnimatedNodesManager::addAnimatedEventToView(
 void NativeAnimatedNodesManager::removeAnimatedEventFromView(
     Tag viewTag,
     const std::string& eventName,
-    Tag animatedValueTag) {
+    Tag animatedValueTag) noexcept {
   const auto key = EventAnimationDriverKey{
       viewTag, EventEmitter::normalizeEventType(eventName)};
   auto driversIter = eventDrivers_.find(key);
@@ -387,7 +389,7 @@ static thread_local bool isOnRenderThread_{false};
 void NativeAnimatedNodesManager::handleAnimatedEvent(
     Tag viewTag,
     const std::string& eventName,
-    const EventPayload& eventPayload) {
+    const EventPayload& eventPayload) noexcept {
   // We currently reject events that are not on the same thread as `onRender`
   // callbacks, as the assumption is these events can synchronously update
   // UI components or otherwise Animated nodes with single-threaded assumptions.
@@ -436,7 +438,7 @@ void NativeAnimatedNodesManager::handleAnimatedEvent(
 }
 
 std::shared_ptr<EventEmitterListener>
-NativeAnimatedNodesManager::ensureEventEmitterListener() {
+NativeAnimatedNodesManager::ensureEventEmitterListener() noexcept {
   if (!eventEmitterListener_) {
     eventEmitterListener_ = std::make_shared<EventEmitterListener>(
         [weakSelf = weak_from_this()](
@@ -476,13 +478,13 @@ void NativeAnimatedNodesManager::stopRenderCallbackIfNeeded() noexcept {
   }
 }
 
-bool NativeAnimatedNodesManager::isAnimationUpdateNeeded() const {
+bool NativeAnimatedNodesManager::isAnimationUpdateNeeded() const noexcept {
   return !activeAnimations_.empty() || !updatedNodeTags_.empty() ||
       isGestureAnimationInProgress_;
 }
 
 void NativeAnimatedNodesManager::updateNodes(
-    const std::set<int>& finishedAnimationValueNodes) {
+    const std::set<int>& finishedAnimationValueNodes) noexcept {
   auto nodesQueue = std::deque<NodesQueueItem>{};
 
   const auto is_node_connected_to_finished_animation =
@@ -682,7 +684,7 @@ bool NativeAnimatedNodesManager::onAnimationFrame(uint64_t timestamp) {
 }
 
 std::optional<folly::dynamic> NativeAnimatedNodesManager::managedProps(
-    Tag tag) {
+    Tag tag) noexcept {
   std::lock_guard<std::mutex> lock(connectedAnimatedNodesMutex_);
   const auto iter = connectedAnimatedNodes_.find(tag);
   if (iter != connectedAnimatedNodes_.end()) {
@@ -694,14 +696,14 @@ std::optional<folly::dynamic> NativeAnimatedNodesManager::managedProps(
   return {};
 }
 
-bool NativeAnimatedNodesManager::isOnRenderThread() const {
+bool NativeAnimatedNodesManager::isOnRenderThread() const noexcept {
   return isOnRenderThread_;
 }
 
 // listeners
 void NativeAnimatedNodesManager::startListeningToAnimatedNodeValue(
     Tag tag,
-    ValueListenerCallback&& callback) {
+    ValueListenerCallback&& callback) noexcept {
   if (auto iter = animatedNodes_.find(tag); iter != animatedNodes_.end() &&
       iter->second->type() == AnimatedNodeType::Value) {
     static_pointer_cast<ValueAnimatedNode>(iter->second)
@@ -712,7 +714,8 @@ void NativeAnimatedNodesManager::startListeningToAnimatedNodeValue(
   }
 }
 
-void NativeAnimatedNodesManager::stopListeningToAnimatedNodeValue(Tag tag) {
+void NativeAnimatedNodesManager::stopListeningToAnimatedNodeValue(
+    Tag tag) noexcept {
   if (auto iter = animatedNodes_.find(tag); iter != animatedNodes_.end() &&
       iter->second->type() == AnimatedNodeType::Value) {
     static_pointer_cast<ValueAnimatedNode>(iter->second)
@@ -727,7 +730,7 @@ void NativeAnimatedNodesManager::schedulePropsCommit(
     Tag viewTag,
     const folly::dynamic& props,
     bool layoutStyleUpdated,
-    bool forceFabricCommit) {
+    bool forceFabricCommit) noexcept {
   // When fabricCommitCallback_ & directManipulationCallback_ are both
   // available, we commit layout props via Fabric and the other using direct
   // manipulation; if only one is available, we commit all props using that

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.cpp
@@ -65,6 +65,10 @@ NativeAnimatedNodesManager::NativeAnimatedNodesManager(
       startOnRenderCallback_(std::move(startOnRenderCallback)),
       stopOnRenderCallback_(std::move(stopOnRenderCallback)) {}
 
+NativeAnimatedNodesManager::~NativeAnimatedNodesManager() noexcept {
+  stopRenderCallbackIfNeeded();
+}
+
 std::optional<double> NativeAnimatedNodesManager::getValue(Tag tag) {
   auto node = getAnimatedNode<ValueAnimatedNode>(tag);
   if (node) {
@@ -466,7 +470,7 @@ void NativeAnimatedNodesManager::startRenderCallbackIfNeeded() {
   }
 }
 
-void NativeAnimatedNodesManager::stopRenderCallbackIfNeeded() {
+void NativeAnimatedNodesManager::stopRenderCallbackIfNeeded() noexcept {
   if (stopOnRenderCallback_) {
     stopOnRenderCallback_();
   }

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.h
@@ -71,35 +71,35 @@ class NativeAnimatedNodesManager
     return nullptr;
   }
 
-  std::optional<double> getValue(Tag tag);
+  std::optional<double> getValue(Tag tag) noexcept;
 
   // graph
 
-  void createAnimatedNode(Tag tag, const folly::dynamic& config);
+  void createAnimatedNode(Tag tag, const folly::dynamic& config) noexcept;
 
-  void connectAnimatedNodes(Tag parentTag, Tag childTag);
+  void connectAnimatedNodes(Tag parentTag, Tag childTag) noexcept;
 
-  void connectAnimatedNodeToView(Tag propsNodeTag, Tag viewTag);
+  void connectAnimatedNodeToView(Tag propsNodeTag, Tag viewTag) noexcept;
 
-  void disconnectAnimatedNodes(Tag parentTag, Tag childTag);
+  void disconnectAnimatedNodes(Tag parentTag, Tag childTag) noexcept;
 
-  void disconnectAnimatedNodeFromView(Tag propsNodeTag, Tag viewTag);
+  void disconnectAnimatedNodeFromView(Tag propsNodeTag, Tag viewTag) noexcept;
 
-  void restoreDefaultValues(Tag tag);
+  void restoreDefaultValues(Tag tag) noexcept;
 
-  void dropAnimatedNode(Tag tag);
+  void dropAnimatedNode(Tag tag) noexcept;
 
   // mutations
 
   void setAnimatedNodeValue(Tag tag, double value);
 
-  void setAnimatedNodeOffset(Tag tag, double offset);
+  void setAnimatedNodeOffset(Tag tag, double offset) noexcept;
 
-  void flattenAnimatedNodeOffset(Tag tag);
+  void flattenAnimatedNodeOffset(Tag tag) noexcept;
 
-  void extractAnimatedNodeOffset(Tag tag);
+  void extractAnimatedNodeOffset(Tag tag) noexcept;
 
-  void updateAnimatedNodeConfig(Tag tag, const folly::dynamic& config);
+  void updateAnimatedNodeConfig(Tag tag, const folly::dynamic& config) noexcept;
 
   // drivers
 
@@ -107,36 +107,38 @@ class NativeAnimatedNodesManager
       int animationId,
       Tag animatedNodeTag,
       const folly::dynamic& config,
-      const std::optional<AnimationEndCallback>& endCallback);
+      const std::optional<AnimationEndCallback>& endCallback) noexcept;
 
-  void stopAnimation(int animationId, bool isTrackingAnimation = false);
+  void stopAnimation(
+      int animationId,
+      bool isTrackingAnimation = false) noexcept;
 
   void addAnimatedEventToView(
       Tag viewTag,
       const std::string& eventName,
-      const folly::dynamic& eventMapping);
+      const folly::dynamic& eventMapping) noexcept;
 
   void removeAnimatedEventFromView(
       Tag viewTag,
       const std::string& eventName,
-      Tag animatedValueTag);
+      Tag animatedValueTag) noexcept;
 
-  std::shared_ptr<EventEmitterListener> getEventEmitterListener() {
+  std::shared_ptr<EventEmitterListener> getEventEmitterListener() noexcept {
     return ensureEventEmitterListener();
   }
   // listeners
 
   void startListeningToAnimatedNodeValue(
       Tag tag,
-      ValueListenerCallback&& callback);
+      ValueListenerCallback&& callback) noexcept;
 
-  void stopListeningToAnimatedNodeValue(Tag tag);
+  void stopListeningToAnimatedNodeValue(Tag tag) noexcept;
 
   void schedulePropsCommit(
       Tag viewTag,
       const folly::dynamic& props,
       bool layoutStyleUpdated,
-      bool forceFabricCommit);
+      bool forceFabricCommit) noexcept;
 
   /**
    * Commits all pending animated property updates to their respective views.
@@ -166,31 +168,32 @@ class NativeAnimatedNodesManager
 
   void startRenderCallbackIfNeeded();
 
-  void updateNodes(const std::set<int>& finishedAnimationValueNodes = {});
+  void updateNodes(
+      const std::set<int>& finishedAnimationValueNodes = {}) noexcept;
 
-  std::optional<folly::dynamic> managedProps(Tag tag);
+  std::optional<folly::dynamic> managedProps(Tag tag) noexcept;
 
-  bool isOnRenderThread() const;
+  bool isOnRenderThread() const noexcept;
 
  private:
   void stopRenderCallbackIfNeeded() noexcept;
 
   bool onAnimationFrame(uint64_t timestamp);
 
-  bool isAnimationUpdateNeeded() const;
+  bool isAnimationUpdateNeeded() const noexcept;
 
   void stopAnimationsForNode(Tag nodeTag);
 
-  std::shared_ptr<EventEmitterListener> ensureEventEmitterListener();
+  std::shared_ptr<EventEmitterListener> ensureEventEmitterListener() noexcept;
 
   void handleAnimatedEvent(
       Tag tag,
       const std::string& eventName,
-      const EventPayload& payload);
+      const EventPayload& payload) noexcept;
 
   std::unique_ptr<AnimatedNode> animatedNode(
       Tag tag,
-      const folly::dynamic& config);
+      const folly::dynamic& config) noexcept;
 
   std::unordered_map<Tag, std::shared_ptr<AnimatedNode>> animatedNodes_;
   std::unordered_map<Tag, Tag> connectedAnimatedNodes_;

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.h
@@ -57,7 +57,7 @@ class NativeAnimatedNodesManager
       StartOnRenderCallback&& startOnRenderCallback = nullptr,
       StopOnRenderCallback&& stopOnRenderCallback = nullptr) noexcept;
 
-  ~NativeAnimatedNodesManager() = default;
+  ~NativeAnimatedNodesManager() noexcept;
 
   template <
       typename T,
@@ -173,7 +173,7 @@ class NativeAnimatedNodesManager
   bool isOnRenderThread() const;
 
  private:
-  void stopRenderCallbackIfNeeded();
+  void stopRenderCallbackIfNeeded() noexcept;
 
   bool onAnimationFrame(uint64_t timestamp);
 

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/PropsAnimatedNode.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/PropsAnimatedNode.cpp
@@ -11,6 +11,7 @@
 
 #include "PropsAnimatedNode.h"
 
+#include <react/debug/react_native_assert.h>
 #include <react/renderer/animated/NativeAnimatedAllowlist.h>
 #include <react/renderer/animated/NativeAnimatedNodesManager.h>
 #include <react/renderer/animated/nodes/ColorAnimatedNode.h>
@@ -57,23 +58,16 @@ PropsAnimatedNode::PropsAnimatedNode(
 }
 
 void PropsAnimatedNode::connectToView(Tag viewTag) {
-  if (connectedViewTag_) {
-    throw std::invalid_argument(
-        "Animated node " + std::to_string(tag_) +
-        " has already been attached to a view already exists.");
-    return;
-  }
+  react_native_assert(
+      connectedViewTag_ == animated::undefinedAnimatedNodeIdentifier &&
+      "Animated node has already been attached to a view already exists.");
   connectedViewTag_ = viewTag;
 }
 
 void PropsAnimatedNode::disconnectFromView(Tag viewTag) {
-  if (connectedViewTag_ == animated::undefinedAnimatedNodeIdentifier) {
-    return;
-  } else if (connectedViewTag_ != viewTag) {
-    throw std::invalid_argument(
-        "Attempting to disconnect view that has not been connected with the given animated node.");
-    return;
-  }
+  react_native_assert(
+      connectedViewTag_ == viewTag &&
+      "Attempting to disconnect view that has not been connected with the given animated node.");
   connectedViewTag_ = animated::undefinedAnimatedNodeIdentifier;
 }
 


### PR DESCRIPTION
Summary:
changelog: [internal]

use noexcept in NativeAnimatedNodesManager whenever feasible to lower C++ binary size.

Reviewed By: rshest

Differential Revision: D75149555


