### PR TITLE
Stop render callback on destruction to prevent crash

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.cpp
@@ -65,6 +65,10 @@ NativeAnimatedNodesManager::NativeAnimatedNodesManager(
       startOnRenderCallback_(std::move(startOnRenderCallback)),
       stopOnRenderCallback_(std::move(stopOnRenderCallback)) {}
 
+NativeAnimatedNodesManager::~NativeAnimatedNodesManager() noexcept {
+  stopRenderCallbackIfNeeded();
+}
+
 std::optional<double> NativeAnimatedNodesManager::getValue(Tag tag) {
   auto node = getAnimatedNode<ValueAnimatedNode>(tag);
   if (node) {
@@ -466,7 +470,7 @@ void NativeAnimatedNodesManager::startRenderCallbackIfNeeded() {
   }
 }
 
-void NativeAnimatedNodesManager::stopRenderCallbackIfNeeded() {
+void NativeAnimatedNodesManager::stopRenderCallbackIfNeeded() noexcept {
   if (stopOnRenderCallback_) {
     stopOnRenderCallback_();
   }

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.h
@@ -57,7 +57,7 @@ class NativeAnimatedNodesManager
       StartOnRenderCallback&& startOnRenderCallback = nullptr,
       StopOnRenderCallback&& stopOnRenderCallback = nullptr) noexcept;
 
-  ~NativeAnimatedNodesManager() = default;
+  ~NativeAnimatedNodesManager() noexcept;
 
   template <
       typename T,
@@ -173,7 +173,7 @@ class NativeAnimatedNodesManager
   bool isOnRenderThread() const;
 
  private:
-  void stopRenderCallbackIfNeeded();
+  void stopRenderCallbackIfNeeded() noexcept;
 
   bool onAnimationFrame(uint64_t timestamp);
 


### PR DESCRIPTION
Summary:
changelog: [internal]

we must call stopRenderCallbackIfNeeded to prevent UI tick from being called when 
`NativeAnimatedNodesManager` is deallocated.

Reviewed By: mdvacca

Differential Revision: D75140890


