### PR TITLE
Disable deep import warning on rn-tester package

### DIFF
--- a/packages/rn-tester/.babelrc
+++ b/packages/rn-tester/.babelrc
@@ -1,6 +1,8 @@
 {
     "presets": [
-        "module:@react-native/babel-preset"
+        ["module:@react-native/babel-preset", {
+            "disableDeepImportWarnings": true
+        }]
     ],
     "plugins": [
         "babel-plugin-transform-flow-enums"


### PR DESCRIPTION
Summary:
This diff silence deep import warnings globally for rn-tester package.


Changelog:
[Internal]

Differential Revision: D75291027


