### PR TITLE
Remove static from the local scoped variable for getConstants - part 2

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTLegacyUIManagerConstantsProvider.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTLegacyUIManagerConstantsProvider.mm
@@ -19,7 +19,7 @@ namespace {
 
 jsi::Value getConstants(facebook::jsi::Runtime &runtime)
 {
-  static NSMutableDictionary<NSString *, NSObject *> *result = [NSMutableDictionary new];
+  NSMutableDictionary<NSString *, NSObject *> *result = [NSMutableDictionary new];
   auto directEvents = [NSMutableDictionary new];
   auto bubblingEvents = [NSMutableDictionary new];
   for (Class moduleClass in RCTGetModuleClasses()) {


### PR DESCRIPTION
Summary:
Changelog [Internal]:

Remove unnecessary `static` in a local scoped variable.

Reviewed By: RSNara

Differential Revision: D75306776
