### PR TITLE
Fix Custom Focus Ordering for FocusForwar, FocusBackwards and nested children

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -29,7 +29,7 @@ import androidx.annotation.AnyThread;
 import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 import androidx.core.util.Preconditions;
-import androidx.core.view.ViewCompat.FocusRealDirection;
+import androidx.core.view.ViewCompat.FocusDirection;
 import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.infer.annotation.Nullsafe;
@@ -275,7 +275,7 @@ public class FabricUIManager
    *     view, returns null if no view could be found
    */
   public @Nullable Integer findNextFocusableElement(
-      int parentTag, int focusedTag, @FocusRealDirection int direction) {
+      int parentTag, int focusedTag, @FocusDirection int direction) {
     if (mBinding == null) {
       return null;
     }
@@ -294,6 +294,12 @@ public class FabricUIManager
         break;
       case View.FOCUS_LEFT:
         generalizedDirection = 3;
+        break;
+      case View.FOCUS_FORWARD:
+        generalizedDirection = 4;
+        break;
+      case View.FOCUS_BACKWARD:
+        generalizedDirection = 5;
         break;
       default:
         return null;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -32,7 +32,7 @@ import android.widget.HorizontalScrollView;
 import android.widget.OverScroller;
 import androidx.annotation.Nullable;
 import androidx.core.view.ViewCompat;
-import androidx.core.view.ViewCompat.FocusRealDirection;
+import androidx.core.view.ViewCompat.FocusDirection;
 import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.infer.annotation.Nullsafe;
@@ -816,16 +816,22 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
   }
 
   @Override
-  public @Nullable View focusSearch(View focused, @FocusRealDirection int direction) {
+  public @Nullable View focusSearch(View focused, @FocusDirection int direction) {
+    View nextFocus = super.focusSearch(focused, direction);
+
+    if (nextFocus != null && this.findViewById(nextFocus.getId()) != null) {
+      return nextFocus;
+    }
+
     if (ReactNativeFeatureFlags.enableCustomFocusSearchOnClippedElementsAndroid()) {
-      @Nullable View nextfocusableView = findNextFocusableView(this, focused, direction, true);
+      @Nullable View nextfocusableView = findNextFocusableView(this, focused, direction);
 
       if (nextfocusableView != null) {
         return nextfocusableView;
       }
     }
 
-    return super.focusSearch(focused, direction);
+    return nextFocus;
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -32,7 +32,7 @@ import android.widget.ScrollView;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.view.ViewCompat;
-import androidx.core.view.ViewCompat.FocusRealDirection;
+import androidx.core.view.ViewCompat.FocusDirection;
 import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.infer.annotation.Nullsafe;
@@ -396,16 +396,22 @@ public class ReactScrollView extends ScrollView
   }
 
   @Override
-  public @Nullable View focusSearch(View focused, @FocusRealDirection int direction) {
+  public @Nullable View focusSearch(View focused, @FocusDirection int direction) {
+    View nextFocus = super.focusSearch(focused, direction);
+
+    if (nextFocus != null && this.findViewById(nextFocus.getId()) != null) {
+      return nextFocus;
+    }
+
     if (ReactNativeFeatureFlags.enableCustomFocusSearchOnClippedElementsAndroid()) {
-      @Nullable View nextfocusableView = findNextFocusableView(this, focused, direction, false);
+      @Nullable View nextfocusableView = findNextFocusableView(this, focused, direction);
 
       if (nextfocusableView != null) {
         return nextfocusableView;
       }
     }
 
-    return super.focusSearch(focused, direction);
+    return nextFocus;
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
@@ -11,10 +11,10 @@ import android.animation.Animator
 import android.animation.ValueAnimator
 import android.content.Context
 import android.graphics.Point
-import android.view.FocusFinder
 import android.view.View
 import android.view.ViewGroup
 import android.widget.OverScroller
+import androidx.core.view.ViewCompat.FocusDirection
 import androidx.core.view.ViewCompat.FocusRealDirection
 import com.facebook.common.logging.FLog
 import com.facebook.react.bridge.ReactContext
@@ -470,23 +470,8 @@ public object ReactScrollViewHelper {
   public fun findNextFocusableView(
       host: ViewGroup,
       focused: View,
-      @FocusRealDirection direction: Int,
-      horizontal: Boolean
+      @FocusDirection direction: Int,
   ): View? {
-    val absDir = resolveAbsoluteDirection(direction, horizontal, host.getLayoutDirection())
-
-    /*
-     * Check if we can focus the next element in the absolute direction within the ScrollView this
-     * would mean the view is not clipped, if we can't, look into the shadow tree to find the next
-     * focusable element
-     */
-    val ff = FocusFinder.getInstance()
-    val result = ff.findNextFocus(host, focused, absDir)
-
-    if (result != null) {
-      return result
-    }
-
     if (host !is ReactClippingViewGroup) {
       return null
     }
@@ -496,8 +481,8 @@ public object ReactScrollViewHelper {
             ?: return null
 
     val nextFocusableViewId =
-        (uimanager as FabricUIManager).findNextFocusableElement(
-            host.getChildAt(0).id, focused.id, absDir) ?: return null
+        (uimanager as FabricUIManager).findNextFocusableElement(host.id, focused.id, direction)
+            ?: return null
 
     val ancestorIdList =
         uimanager

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FocusOrderingHelper.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FocusOrderingHelper.cpp
@@ -28,6 +28,8 @@ int majorAxisDistanceRaw(
     case FocusDirection::FocusDown:
       return static_cast<int>(
           dest.origin.y - (source.origin.y + source.size.height));
+    default:
+      return INT_MAX;
   }
 }
 
@@ -45,6 +47,8 @@ int minorAxisDistance(FocusDirection direction, Rect source, Rect dest) {
     case FocusDirection::FocusDown:
       // the distance between the center horizontals
       return static_cast<int>(abs((source.getMidX() - dest.getMidX())));
+    default:
+      return INT_MAX;
   }
 }
 
@@ -79,6 +83,24 @@ bool isCandidate(Rect source, Rect dest, FocusDirection focusDirection) {
               (source.origin.y + source.size.height) <= dest.origin.y) &&
           ((source.origin.y + source.size.height) <
            (dest.origin.y + dest.size.height));
+    case FocusDirection::FocusForward:
+      return ((source.origin.y < dest.origin.y ||
+               (source.origin.y + source.size.height) <= dest.origin.y) &&
+              ((source.origin.y + source.size.height) <
+               (dest.origin.y + dest.size.height))) ||
+          ((source.origin.x < dest.origin.x ||
+            (source.origin.x + source.size.width) <= dest.origin.x) &&
+           (source.origin.x + source.size.width) <
+               (dest.origin.x + dest.size.width));
+    case FocusDirection::FocusBackward:
+      return (((source.origin.y + source.size.height) >
+                   (dest.origin.y + dest.size.height) ||
+               source.origin.y >= (dest.origin.y + dest.size.height)) &&
+              source.origin.y > dest.origin.y) ||
+          (((source.origin.x + source.size.width) >
+                (dest.origin.x + dest.size.width) ||
+            source.origin.x >= (dest.origin.x + dest.size.width)) &&
+           source.origin.x > dest.origin.x);
   }
 }
 
@@ -91,15 +113,80 @@ bool isBetterCandidate(
     return false;
   }
 
-  int candidateWeightedDistance = getWeightedDistanceFor(
-      majorAxisDistance(focusDirection, source, candidate),
-      minorAxisDistance(focusDirection, source, candidate));
+  int candidateWeightedDistance = 0;
+  int currentWeightedDistance = 0;
 
-  int currentWeightedDistance = getWeightedDistanceFor(
-      majorAxisDistance(focusDirection, source, current),
-      minorAxisDistance(focusDirection, source, current));
+  switch (focusDirection) {
+    case FocusDirection::FocusLeft:
+    case FocusDirection::FocusRight:
+    case FocusDirection::FocusUp:
+    case FocusDirection::FocusDown:
+      candidateWeightedDistance = getWeightedDistanceFor(
+          majorAxisDistance(focusDirection, source, candidate),
+          minorAxisDistance(focusDirection, source, candidate));
 
-  return candidateWeightedDistance < currentWeightedDistance;
+      currentWeightedDistance = getWeightedDistanceFor(
+          majorAxisDistance(focusDirection, source, current),
+          minorAxisDistance(focusDirection, source, current));
+
+      return candidateWeightedDistance < currentWeightedDistance;
+    /*
+     * For forward and backward, Android uses a different algorithm to tell the
+     * order in which to focus. It sorts the children of the root by top to
+     * bottom and then groups the views into "rows". Then, it looks for the
+     * index of the current focused, and focuses the next or previous element.
+     *
+     * We are not implementing this algorithm, but instead, we are using the
+     * same comparison logic android uses to sort the children to find the next
+     * focusable.
+     *
+     * See:
+     * https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/core/java/android/view/FocusFinder.java;l=833;drc=61197364367c9e404c7da6900658f1b16c42d0da
+     */
+    case FocusDirection::FocusForward: {
+      int currentRowBottom = source.origin.y + source.size.height;
+      int candidateRowBottom = candidate.origin.y + candidate.size.height;
+
+      if (candidate.origin.y < currentRowBottom &&
+          candidateRowBottom > source.origin.y) {
+        int result = candidate.origin.x - current.origin.x;
+        if (result == 0) {
+          result = (candidate.origin.x + candidate.size.width) -
+              (current.origin.x + current.size.width);
+        }
+        return result < 0;
+      } else {
+        int result = candidate.origin.y - current.origin.y;
+        if (result == 0) {
+          result = (candidate.origin.y + candidate.size.height) -
+              (current.origin.y + current.size.height);
+        }
+        return result < 0;
+      }
+    }
+    case FocusDirection::FocusBackward: {
+      int currentRowBottom = source.origin.y + source.size.height;
+      int candidateRowBottom = candidate.origin.y + candidate.size.height;
+
+      if (candidate.origin.y < currentRowBottom &&
+          candidateRowBottom > source.origin.y) {
+        int result = current.origin.x - candidate.origin.x;
+        if (result == 0) {
+          result = (current.origin.x + current.size.width) -
+              (candidate.origin.x + candidate.size.width);
+        }
+        return result < 0;
+      } else {
+        int result = current.origin.y - candidate.origin.y;
+        if (result == 0) {
+          result = (current.origin.y + current.size.height) -
+              (candidate.origin.y + candidate.size.height);
+        }
+        return result < 0;
+      }
+    }
+  }
+  return false;
 }
 
 void FocusOrderingHelper::traverseAndUpdateNextFocusableElement(
@@ -178,6 +265,8 @@ std::optional<FocusDirection> FocusOrderingHelper::resolveFocusDirection(
     case FocusDirection::FocusUp:
     case FocusDirection::FocusRight:
     case FocusDirection::FocusLeft:
+    case FocusDirection::FocusForward:
+    case FocusDirection::FocusBackward:
       return static_cast<FocusDirection>(direction);
   }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FocusOrderingHelper.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FocusOrderingHelper.h
@@ -15,6 +15,8 @@ enum class FocusDirection {
   FocusUp = 1,
   FocusRight = 2,
   FocusLeft = 3,
+  FocusForward = 4,
+  FocusBackward = 5,
 };
 
 class FocusOrderingHelper {


### PR DESCRIPTION
Summary:
Before we were relying on absolute focus direction to determine the next focusable view inspired by Recycler View's implementation. This turned out to be inaccurate since FocusForward and FocusBackward do the ordering differently.

For FocusForward and FocusBackwards the children of the root node are ordered first from top to bottom then, row groups are created by getting views with the same vertical position and then everything else is sorted left to right. 

Android creates an array with this order and then just focuses the next or previous element of this list. We don't do this but now FocusForward and FocusBackward follow the some comparisons used to build this array on Android.

Also, there was an issue with nested children within an accessible view, this just needed a bit of refactor on the focusSearch function so that we can tell when we actually need to trigger our custom focus search

Differential Revision: D75301251


