### PR TITLE
Update iOS RNTester build artifacts in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,8 +117,14 @@ vendor/
 /packages/helloworld/ios/build/
 /packages/helloworld/ios/Pods/
 /packages/helloworld/ios/Podfile.lock
+/packages/rn-tester/bin/
+/packages/rn-tester/cache/
+/packages/rn-tester/extensions/
+/packages/rn-tester/gems/
+/packages/rn-tester/specifications/
 /packages/rn-tester/Gemfile.lock
 /packages/**/RCTLegacyInteropComponents.mm
+/packages/sourcemap.ios.map
 
 # Ignore RNTester specific Pods, but keep the __offline_mirrors__ here.
 /packages/rn-tester/Pods/*


### PR DESCRIPTION
## Summary:

Running `yarn prepare-ios` creates some build artifacts folders, which can be added to the .gitignore as they are generated.

## Changelog:

[INTERNAL] - Update iOS RNTester build artifacts in .gitignore

## Test Plan:

N/A