### PR TITLE
remove use of shared_ptr from NativeAnimatedNodesManager::animatedNodes_ and NodesQueueItem

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.h
@@ -62,11 +62,11 @@ class NativeAnimatedNodesManager
   template <
       typename T,
       typename = std::enable_if_t<std::is_base_of_v<AnimatedNode, T>>>
-  std::shared_ptr<T> getAnimatedNode(Tag tag) const
+  T* getAnimatedNode(Tag tag) const
     requires(std::is_base_of_v<AnimatedNode, T>)
   {
     if (auto it = animatedNodes_.find(tag); it != animatedNodes_.end()) {
-      return std::static_pointer_cast<T>(it->second);
+      return static_cast<T*>(it->second.get());
     }
     return nullptr;
   }
@@ -195,7 +195,7 @@ class NativeAnimatedNodesManager
       Tag tag,
       const folly::dynamic& config) noexcept;
 
-  std::unordered_map<Tag, std::shared_ptr<AnimatedNode>> animatedNodes_;
+  std::unordered_map<Tag, std::unique_ptr<AnimatedNode>> animatedNodes_;
   std::unordered_map<Tag, Tag> connectedAnimatedNodes_;
   std::unordered_map<int, std::shared_ptr<AnimationDriver>> activeAnimations_;
   std::unordered_map<

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/AnimatedNode.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/AnimatedNode.cpp
@@ -35,7 +35,7 @@ void AnimatedNode::removeChild(const Tag tag) {
   }
 }
 
-std::shared_ptr<AnimatedNode> AnimatedNode::getChildNode(Tag tag) {
+AnimatedNode* AnimatedNode::getChildNode(Tag tag) {
   if (const auto manager = manager_.lock()) {
     if (children_.find(tag) != children_.end()) {
       return manager->getAnimatedNode<AnimatedNode>(tag);

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/AnimatedNode.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/AnimatedNode.h
@@ -97,7 +97,7 @@ class AnimatedNode {
   static constexpr int INITIAL_BFS_COLOR = 0;
 
  protected:
-  std::shared_ptr<AnimatedNode> getChildNode(Tag tag);
+  AnimatedNode* getChildNode(Tag tag);
   Tag tag_{0};
   std::weak_ptr<NativeAnimatedNodesManager> manager_;
   AnimatedNodeType type_;


### PR DESCRIPTION
Summary:
changelog: [internal]

using shared_ptr here is not necessary because AnimatedNodes are not shared between multiple entities, they are only owned by NativeAnimatedNodesManager.

This saves a little bit C++ binary size.

Reviewed By: rshest

Differential Revision: D75148952


