### PR TITLE
Use unique_ptr instead of shared_ptr in activeAnimations_

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.cpp
@@ -299,30 +299,30 @@ void NativeAnimatedNodesManager::startAnimatingNode(
   if (auto iter = activeAnimations_.find(animationId);
       iter != activeAnimations_.end()) {
     // reset animation config
-    auto animation = iter->second;
+    auto& animation = iter->second;
     animation->updateConfig(config);
   } else if (animatedNodes_.contains(animatedNodeTag)) {
     auto type = config["type"].asString();
     auto typeEnum = AnimationDriver::getDriverTypeByName(type);
-    std::shared_ptr<AnimationDriver> animation = nullptr;
+    std::unique_ptr<AnimationDriver> animation = nullptr;
     if (typeEnum) {
       switch (typeEnum.value()) {
         case AnimationDriverType::Frames: {
-          animation = std::make_shared<FrameAnimationDriver>(
+          animation = std::make_unique<FrameAnimationDriver>(
               animationId, animatedNodeTag, endCallback, config, this);
         } break;
         case AnimationDriverType::Spring: {
-          animation = std::make_shared<SpringAnimationDriver>(
+          animation = std::make_unique<SpringAnimationDriver>(
               animationId, animatedNodeTag, endCallback, config, this);
         } break;
         case AnimationDriverType::Decay: {
-          animation = std::make_shared<DecayAnimationDriver>(
+          animation = std::make_unique<DecayAnimationDriver>(
               animationId, animatedNodeTag, endCallback, config, this);
         } break;
       }
       if (animation) {
-        activeAnimations_.insert({animationId, animation});
         animation->startAnimation();
+        activeAnimations_.insert({animationId, std::move(animation)});
       }
     } else {
       LOG(ERROR) << "Unknown AnimationDriver type " << type;

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.h
@@ -197,7 +197,7 @@ class NativeAnimatedNodesManager
 
   std::unordered_map<Tag, std::unique_ptr<AnimatedNode>> animatedNodes_;
   std::unordered_map<Tag, Tag> connectedAnimatedNodes_;
-  std::unordered_map<int, std::shared_ptr<AnimationDriver>> activeAnimations_;
+  std::unordered_map<int, std::unique_ptr<AnimationDriver>> activeAnimations_;
   std::unordered_map<
       EventAnimationDriverKey,
       std::vector<std::unique_ptr<EventAnimationDriver>>,


### PR DESCRIPTION
Summary:
changelog: [internal]

use unique_ptr instead of shared_ptr to manage memory of activeAnimations_. 

Active animations are only owned by NativeAnimatedNodesManager and their ownership isn't shared with any other class.

This saves a little bit of C++ binary size.

Reviewed By: rshest

Differential Revision: D75142643


