### PR TITLE
Improve e2e times and flakiness by using the search

### DIFF
--- a/packages/rn-tester/.maestro/button.yml
+++ b/packages/rn-tester/.maestro/button.yml
@@ -2,11 +2,14 @@ appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebo
 ---
 - launchApp
 - assertVisible: "Components"
-- scrollUntilVisible:
-    element:
-      id: "Button"
-    direction: DOWN
-    speed: 40
+- assertVisible:
+    id: "explorer_search"
+- tapOn:
+    id: "explorer_search"
+- inputText:
+    text: "Button"
+- assertVisible:
+    id: "Button"
 - tapOn:
     id: "Button"
 - tapOn: 

--- a/packages/rn-tester/.maestro/flatlist.yml
+++ b/packages/rn-tester/.maestro/flatlist.yml
@@ -2,11 +2,14 @@ appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebo
 ---
 - launchApp
 - assertVisible: "Components"
-- scrollUntilVisible:
-    element:
-      id: "Flatlist"
-    direction: DOWN
-    speed: 40
+- assertVisible:
+    id: "explorer_search"
+- tapOn:
+    id: "explorer_search"
+- inputText:
+    text: "Flatlist"
+- assertVisible:
+    id: "Flatlist"
 - tapOn:
     id: "Flatlist"
 - tapOn:

--- a/packages/rn-tester/.maestro/image.yml
+++ b/packages/rn-tester/.maestro/image.yml
@@ -2,11 +2,14 @@ appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebo
 ---
 - launchApp
 - assertVisible: "Components"
-- scrollUntilVisible:
-    element:
-      id: "Image"
-    direction: DOWN
-    speed: 40
+- assertVisible:
+    id: "explorer_search"
+- tapOn:
+    id: "explorer_search"
+- inputText:
+    text: "Image"
+- assertVisible:
+    id: "Image"
 - tapOn:
     id: "Image"
 - assertVisible: "Plain Network Image with `source` prop."

--- a/packages/rn-tester/.maestro/legacy-native-module.yml
+++ b/packages/rn-tester/.maestro/legacy-native-module.yml
@@ -5,11 +5,14 @@ appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebo
     text: "APIs"
 - tapOn:
     id: "apis-tab"
-- scrollUntilVisible:
-    element:
-        id: "Legacy Native Module"
-    direction: DOWN
-    speed: 40
+- assertVisible:
+    id: "explorer_search"
+- tapOn:
+    id: "explorer_search"
+- inputText:
+    text: "Legacy Native Module"
+- assertVisible:
+    id: "Legacy Native Module"
 - tapOn:
     id: "Legacy Native Module"
 - tapOn: 

--- a/packages/rn-tester/.maestro/modal.yml
+++ b/packages/rn-tester/.maestro/modal.yml
@@ -2,11 +2,14 @@ appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebo
 ---
 - launchApp
 - assertVisible: "Components"
-- scrollUntilVisible:
-    element:
-      id: "Modal"
-    direction: DOWN
-    speed: 60
+- assertVisible:
+    id: "explorer_search"
+- tapOn:
+    id: "explorer_search"
+- inputText:
+    text: "Modal"
+- assertVisible:
+    id: "Modal"
 - tapOn:
     id: "Modal"
 - assertVisible:

--- a/packages/rn-tester/.maestro/new-arch-examples.yml
+++ b/packages/rn-tester/.maestro/new-arch-examples.yml
@@ -2,12 +2,14 @@ appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebo
 ---
 - launchApp
 - assertVisible: "Components"
-- scrollUntilVisible:
-    element:
-      id: "New Architecture Examples"
-    direction: DOWN
-    speed: 60
-    visibilityPercentage: 100
+- assertVisible:
+    id: "explorer_search"
+- tapOn:
+    id: "explorer_search"
+- inputText:
+    text: "New Architecture Examples"
+- assertVisible:
+    id: "New Architecture Examples"
 - tapOn:
     id: "New Architecture Examples"
 - assertVisible: "HSBA: h: 0, s: 0, b: 0, a: 0"

--- a/packages/rn-tester/.maestro/pressable.yml
+++ b/packages/rn-tester/.maestro/pressable.yml
@@ -2,11 +2,14 @@ appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebo
 ---
 - launchApp
 - assertVisible: "Components"
-- scrollUntilVisible:
-    element:
-      id: "Pressable"
-    direction: DOWN
-    speed: 40
+- assertVisible:
+    id: "explorer_search"
+- tapOn:
+    id: "explorer_search"
+- inputText:
+    text: "Pressable"
+- assertVisible:
+    id: "Pressable"
 - tapOn:
     id: "Pressable"
 - assertVisible:

--- a/packages/rn-tester/.maestro/text.yml
+++ b/packages/rn-tester/.maestro/text.yml
@@ -2,23 +2,22 @@ appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebo
 ---
 - launchApp
 - assertVisible: "Components"
-- scrollUntilVisible:
-    element:
-      id: "Text"
-    direction: DOWN
-    speed: 60
-    timeout: 60000 #ms
-    visibilityPercentage: 100
+- assertVisible:
+    id: "explorer_search"
+- tapOn:
+    id: "explorer_search"
+- inputText:
+    text: "Text"
+- assertVisible:
+    id: "Text"
 - tapOn:
     id: "Text"
-- assertVisible: "Text"
-- scrollUntilVisible:
-    element:
-      id: "background-border-width"
-    direction: DOWN
-    speed: 20
-    timeout: 60000 #ms
-    visibilityPercentage: 100
+- assertVisible:
+    id: "example_search"
+- tapOn:
+    id: "example_search"
+- inputText:
+    text: "Background Color and Border Width"
 - assertVisible: "Text with background color only"
 - assertVisible: "Text with background color and uniform borderRadii"
 - assertVisible: "Text with background color and non-uniform borders"


### PR DESCRIPTION
## Summary:

I'm writing some tests for some APIs/components, and I see some opportunity for improvement in the way how we can write e2e cases for the RNTester.

This diff improves two things:

1. e2e execution times: right now as we are using the `scrollUntilVisible` functionality, it takes quite some time, as some of the items are not very up in the lists and getting to them it's not always very fast.
2. Flakiness: I ran the tests multiple times locally, and in multiple occasions, the `scrollUntilVisible ` did not find anything as the scroll was too fast so the test ended up failing.

Instead of using `scrollUntilVisible`, we can simply use the search bar which we have in both Components and APIs tabs. This runs faster and we can also share the search flow across multiple test cases, so writing the tests becomes a bit simpler as well.

## Changelog:

[INTERNAL] - Improve e2e times and flakiness by using the search

## Test Plan:

TODO
