### PR TITLE
fix(promise): Swallowed rejections warnings, use `console.error` for logging rejections in dev and prod

### DIFF
--- a/packages/react-native/Libraries/promiseRejectionTrackingOptions.js
+++ b/packages/react-native/Libraries/promiseRejectionTrackingOptions.js
@@ -41,30 +41,17 @@ let rejectionTrackingOptions: $NonMaybeType<Parameters<enable>[0]> = {
       }
     }
 
-    const warning = `Possible unhandled promise rejection (id: ${id}):\n${
-      message ?? ''
-    }`;
-    if (__DEV__) {
-      LogBox.addLog({
-        level: 'warn',
-        message: {
-          content: warning,
-          substitutions: [],
-        },
-        componentStack: [],
-        componentStackType: null,
-        stack,
-        category: 'possible_unhandled_promise_rejection',
-      });
-    } else {
-      console.warn(warning);
-    }
+    // We overwrite the stack by the extracted rejection stack if available
+    const rejectionPrefix = `Uncaught (in promise, id ${id})`;
+    const rejectionError = new Error(`${rejectionPrefix} ${message ?? ''}`);
+    rejectionError.stack = `${rejectionPrefix} ${stack ?? ''}`;
+    console.error(rejectionError);
   },
   onHandled: id => {
     const warning =
       `Promise rejection handled (id: ${id})\n` +
       'This means you can ignore any previous messages of the form ' +
-      `"Possible unhandled promise rejection (id: ${id}):"`;
+      `"Uncaught (in promise, id ${id})"`;
     console.warn(warning);
   },
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This PR fixes logging of rejections, which stopped working with the transition from using LogBox for warnings to directing users to use React Native Debugger, where warnings can be viewed in the Console tab.

Rejected promises before this PR used LogBox.addLog with the level: warn directly without console.warn, which notified users to open debugger to view a warning (after rejected promise) without actually printing any warnings to the console.

This PR uses `ExceptionsManager.handleException(error, false /* isFatal */); for promise rejections that correctly raising an error to the console if needed.

### Rejected Promise in Chrome

<img width="749" alt="Screenshot 2025-05-25 at 14 50 25" src="https://github.com/user-attachments/assets/7f61eec6-63d8-4db6-8666-a2d415808ccc" />

### Rejected Promise in React Native after this PR

<img width="1236" alt="Screenshot 2025-05-26 at 0 07 07" src="https://github.com/user-attachments/assets/fd223e75-5a06-4359-b26d-133d2514c023" />

### LogBox After This PR

<img width="236" src="https://github.com/user-attachments/assets/c0cd384c-9724-4f91-b0e7-7c005e29e653" />

<img width="236" src="https://github.com/user-attachments/assets/04004f73-ebad-4d45-a4ba-62e3c4b92099" />


## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[GENERAL] [FIXED] - Swallowed promise rejections warnings

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Use `Promise.reject` and observe that the rejection is now shown symbolicated in LogBox and also printed in React Native Debugger Console.

```
<Button
  title="Uncaught Promise Rejection"
  onPress={() => {
    Promise.reject(new Error('This is an uncaught promise rejection!'));
  }}
/>
```

## Future

Ideally the rejection stack is symbolicated in dev, but I would prefer that to be solved in a separate PR.

### Example

<img width="1236" alt="Screenshot 2025-05-26 at 0 22 54" src="https://github.com/user-attachments/assets/088e519a-79ca-4cb2-bf07-a9cedc40cfe5" />


