### PR TITLE
Annotate deprecated APIs

### DIFF
--- a/packages/react-native/Libraries/Interaction/InteractionManager.js
+++ b/packages/react-native/Libraries/Interaction/InteractionManager.js
@@ -31,55 +31,6 @@ const _emitter = new EventEmitter<{
 const DEBUG_DELAY: 0 = 0;
 const DEBUG: false = false;
 
-/**
- * InteractionManager allows long-running work to be scheduled after any
- * interactions/animations have completed. In particular, this allows JavaScript
- * animations to run smoothly.
- *
- * Applications can schedule tasks to run after interactions with the following:
- *
- * ```
- * InteractionManager.runAfterInteractions(() => {
- *   // ...long-running synchronous task...
- * });
- * ```
- *
- * Compare this to other scheduling alternatives:
- *
- * - requestAnimationFrame(): for code that animates a view over time.
- * - setImmediate/setTimeout(): run code later, note this may delay animations.
- * - runAfterInteractions(): run code later, without delaying active animations.
- *
- * The touch handling system considers one or more active touches to be an
- * 'interaction' and will delay `runAfterInteractions()` callbacks until all
- * touches have ended or been cancelled.
- *
- * InteractionManager also allows applications to register animations by
- * creating an interaction 'handle' on animation start, and clearing it upon
- * completion:
- *
- * ```
- * var handle = InteractionManager.createInteractionHandle();
- * // run animation... (`runAfterInteractions` tasks are queued)
- * // later, on animation completion:
- * InteractionManager.clearInteractionHandle(handle);
- * // queued tasks run if all handles were cleared
- * ```
- *
- * `runAfterInteractions` takes either a plain callback function, or a
- * `PromiseTask` object with a `gen` method that returns a `Promise`.  If a
- * `PromiseTask` is supplied, then it is fully resolved (including asynchronous
- * dependencies that also schedule more tasks via `runAfterInteractions`) before
- * starting on the next task that might have been queued up synchronously
- * earlier.
- *
- * By default, queued tasks are executed together in a loop in one
- * `setImmediate` batch. If `setDeadline` is called with a positive number, then
- * tasks will only be executed until the deadline (in terms of js event loop run
- * time) approaches, at which point execution will yield via setTimeout,
- * allowing events such as touches to start interactions and block queued tasks
- * from executing, making apps more responsive.
- */
 const InteractionManagerImpl = {
   Events: {
     interactionStart: 'interactionStart',
@@ -226,6 +177,57 @@ function _processUpdate() {
   _deleteInteractionSet.clear();
 }
 
+/**
+ * InteractionManager allows long-running work to be scheduled after any
+ * interactions/animations have completed. In particular, this allows JavaScript
+ * animations to run smoothly.
+ *
+ * Applications can schedule tasks to run after interactions with the following:
+ *
+ * ```
+ * InteractionManager.runAfterInteractions(() => {
+ *   // ...long-running synchronous task...
+ * });
+ * ```
+ *
+ * Compare this to other scheduling alternatives:
+ *
+ * - requestAnimationFrame(): for code that animates a view over time.
+ * - setImmediate/setTimeout(): run code later, note this may delay animations.
+ * - runAfterInteractions(): run code later, without delaying active animations.
+ *
+ * The touch handling system considers one or more active touches to be an
+ * 'interaction' and will delay `runAfterInteractions()` callbacks until all
+ * touches have ended or been cancelled.
+ *
+ * InteractionManager also allows applications to register animations by
+ * creating an interaction 'handle' on animation start, and clearing it upon
+ * completion:
+ *
+ * ```
+ * var handle = InteractionManager.createInteractionHandle();
+ * // run animation... (`runAfterInteractions` tasks are queued)
+ * // later, on animation completion:
+ * InteractionManager.clearInteractionHandle(handle);
+ * // queued tasks run if all handles were cleared
+ * ```
+ *
+ * `runAfterInteractions` takes either a plain callback function, or a
+ * `PromiseTask` object with a `gen` method that returns a `Promise`.  If a
+ * `PromiseTask` is supplied, then it is fully resolved (including asynchronous
+ * dependencies that also schedule more tasks via `runAfterInteractions`) before
+ * starting on the next task that might have been queued up synchronously
+ * earlier.
+ *
+ * By default, queued tasks are executed together in a loop in one
+ * `setImmediate` batch. If `setDeadline` is called with a positive number, then
+ * tasks will only be executed until the deadline (in terms of js event loop run
+ * time) approaches, at which point execution will yield via setTimeout,
+ * allowing events such as touches to start interactions and block queued tasks
+ * from executing, making apps more responsive.
+ *
+ * @deprecated
+ */
 const InteractionManager = (
   ReactNativeFeatureFlags.disableInteractionManager()
     ? require('./InteractionManagerStub').default

--- a/packages/react-native/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/packages/react-native/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -167,10 +167,11 @@ export interface PushNotification {
 }
 
 /**
- *
  * Handle notifications for your app, including scheduling and permissions.
  *
  * See https://reactnative.dev/docs/pushnotificationios
+ *
+ * @deprecated Use [@react-native-community/push-notification-ios](https://www.npmjs.com/package/@react-native-community/push-notification-ios) instead
  */
 class PushNotificationIOS {
   _data: Object;


### PR DESCRIPTION
Summary:
Adds `@deprecated` to 2x API exports via `index.js.flow`. This will flag these APIs appropriately to the developer under TypeScript.

Changelog: [Internal]

Differential Revision: D75403796


