### PR TITLE
use folly::dynamic without std::optional

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/AnimatedModule.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/AnimatedModule.cpp
@@ -79,20 +79,17 @@ void AnimatedModule::getValue(
 void AnimatedModule::startListeningToAnimatedNodeValue(
     jsi::Runtime& /*rt*/,
     Tag tag) {
-  addOperation([tag, weakThis = weak_from_this()](
-                   NativeAnimatedNodesManager& nodesManager) {
+  addOperation([tag, this](NativeAnimatedNodesManager& nodesManager) {
     nodesManager.startListeningToAnimatedNodeValue(
-        tag, [weakThis, tag](double value) {
-          if (auto strongThis = weakThis.lock()) {
-            strongThis->emitDeviceEvent(
-                "onAnimatedValueUpdate",
-                [tag, value](jsi::Runtime& rt, std::vector<jsi::Value>& args) {
-                  auto arg = jsi::Object(rt);
-                  arg.setProperty(rt, "tag", jsi::Value(tag));
-                  arg.setProperty(rt, "value", jsi::Value(value));
-                  args.emplace_back(rt, arg);
-                });
-          }
+        tag, [this, tag](double value) {
+          emitDeviceEvent(
+              "onAnimatedValueUpdate",
+              [tag, value](jsi::Runtime& rt, std::vector<jsi::Value>& args) {
+                auto arg = jsi::Object(rt);
+                arg.setProperty(rt, "tag", jsi::Value(tag));
+                arg.setProperty(rt, "value", jsi::Value(value));
+                args.emplace_back(rt, arg);
+              });
         });
   });
 }

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/AnimatedModule.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/AnimatedModule.cpp
@@ -54,11 +54,7 @@ void AnimatedModule::updateAnimatedNodeConfig(
     jsi::Runtime& rt,
     Tag tag,
     jsi::Object config) {
-  auto configDynamic = dynamicFromValue(rt, jsi::Value(rt, config));
-  addOperation([tag, configDynamic = std::move(configDynamic)](
-                   NativeAnimatedNodesManager& nodesManager) {
-    nodesManager.updateAnimatedNodeConfig(tag, configDynamic);
-  });
+  // TODO: missing implementation
 }
 
 void AnimatedModule::getValue(
@@ -164,25 +160,19 @@ void AnimatedModule::setAnimatedNodeOffset(
     jsi::Runtime& /*rt*/,
     Tag nodeTag,
     double offset) {
-  addOperation([nodeTag, offset](NativeAnimatedNodesManager& nodesManager) {
-    nodesManager.setAnimatedNodeOffset(nodeTag, offset);
-  });
+  // TODO: missing implementation
 }
 
 void AnimatedModule::flattenAnimatedNodeOffset(
     jsi::Runtime& /*rt*/,
     Tag nodeTag) {
-  addOperation([nodeTag](NativeAnimatedNodesManager& nodesManager) {
-    nodesManager.flattenAnimatedNodeOffset(nodeTag);
-  });
+  // TODO: missing implementation
 }
 
 void AnimatedModule::extractAnimatedNodeOffset(
     jsi::Runtime& /*rt*/,
     Tag nodeTag) {
-  addOperation([nodeTag](NativeAnimatedNodesManager& nodesManager) {
-    nodesManager.extractAnimatedNodeOffset(nodeTag);
-  });
+  // TODO: missing implementation
 }
 
 void AnimatedModule::connectAnimatedNodeToView(

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/AnimatedModule.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/AnimatedModule.h
@@ -18,7 +18,6 @@
 namespace facebook::react {
 
 class AnimatedModule : public NativeAnimatedModuleCxxSpec<AnimatedModule>,
-                       public std::enable_shared_from_this<AnimatedModule>,
                        public TurboModuleWithJSIBindings {
   using Operation =
       std::function<void(NativeAnimatedNodesManager& nodesManager)>;

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/AnimatedMountingOverrideDelegate.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/AnimatedMountingOverrideDelegate.cpp
@@ -14,7 +14,7 @@
 namespace facebook::react {
 
 AnimatedMountingOverrideDelegate::AnimatedMountingOverrideDelegate(
-    std::function<std::optional<folly::dynamic>(Tag)> getAnimatedManagedProps,
+    std::function<folly::dynamic(Tag)> getAnimatedManagedProps,
     std::weak_ptr<UIManagerBinding> uiManagerBinding)
     : MountingOverrideDelegate(),
       getAnimatedManagedProps_(std::move(getAnimatedManagedProps)),
@@ -39,8 +39,9 @@ AnimatedMountingOverrideDelegate::pullTransaction(
   for (const auto& mutation : mutations) {
     if (mutation.type == ShadowViewMutation::Update) {
       const auto tag = mutation.newChildShadowView.tag;
-      if (auto props = getAnimatedManagedProps_(tag)) {
-        animatedManagedProps.insert({tag, std::move(*props)});
+      auto props = getAnimatedManagedProps_(tag);
+      if (!props.isNull()) {
+        animatedManagedProps.insert({tag, std::move(props)});
       }
     }
   }

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/AnimatedMountingOverrideDelegate.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/AnimatedMountingOverrideDelegate.h
@@ -22,7 +22,7 @@ class UIManagerBinding;
 class AnimatedMountingOverrideDelegate : public MountingOverrideDelegate {
  public:
   AnimatedMountingOverrideDelegate(
-      std::function<std::optional<folly::dynamic>(Tag)> getAnimatedManagedProps,
+      std::function<folly::dynamic(Tag)> getAnimatedManagedProps,
       std::weak_ptr<UIManagerBinding> uiManagerBinding);
 
   bool shouldOverridePullTransaction() const override;
@@ -34,7 +34,7 @@ class AnimatedMountingOverrideDelegate : public MountingOverrideDelegate {
       ShadowViewMutationList mutations) const override;
 
  private:
-  std::function<std::optional<folly::dynamic>(Tag)> getAnimatedManagedProps_;
+  std::function<folly::dynamic(Tag)> getAnimatedManagedProps_;
 
   std::weak_ptr<UIManagerBinding> uiManagerBinding_;
 };

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.cpp
@@ -640,8 +640,7 @@ bool NativeAnimatedNodesManager::onAnimationFrame(uint64_t timestamp) {
   return commitProps();
 }
 
-std::optional<folly::dynamic> NativeAnimatedNodesManager::managedProps(
-    Tag tag) noexcept {
+folly::dynamic NativeAnimatedNodesManager::managedProps(Tag tag) noexcept {
   std::lock_guard<std::mutex> lock(connectedAnimatedNodesMutex_);
   const auto iter = connectedAnimatedNodes_.find(tag);
   if (iter != connectedAnimatedNodes_.end()) {
@@ -650,7 +649,7 @@ std::optional<folly::dynamic> NativeAnimatedNodesManager::managedProps(
     }
   }
 
-  return {};
+  return nullptr;
 }
 
 bool NativeAnimatedNodesManager::isOnRenderThread() const noexcept {

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.cpp
@@ -253,28 +253,6 @@ void NativeAnimatedNodesManager::stopAnimationsForNode(Tag nodeTag) {
   }
 }
 
-void NativeAnimatedNodesManager::setAnimatedNodeOffset(
-    Tag /*tag*/,
-    double /*offset*/) noexcept {
-  LOG(WARNING) << "SetAnimatedNodeOffset is unimplemented";
-}
-
-void NativeAnimatedNodesManager::flattenAnimatedNodeOffset(
-    Tag /*tag*/) noexcept {
-  LOG(WARNING) << "FlattenAnimatedNodeOffset is unimplemented";
-}
-
-void NativeAnimatedNodesManager::extractAnimatedNodeOffset(
-    Tag /*tag*/) noexcept {
-  LOG(WARNING) << "ExtractAnimatedNodeOffset is unimplemented";
-}
-
-void NativeAnimatedNodesManager::updateAnimatedNodeConfig(
-    Tag /*tag*/,
-    const folly::dynamic& /*config*/) noexcept {
-  LOG(WARNING) << "UpdateAnimatedNodeConfig is unimplemented";
-}
-
 // drivers
 
 void NativeAnimatedNodesManager::startAnimatingNode(

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.h
@@ -160,7 +160,7 @@ class NativeAnimatedNodesManager {
   void updateNodes(
       const std::set<int>& finishedAnimationValueNodes = {}) noexcept;
 
-  std::optional<folly::dynamic> managedProps(Tag tag) noexcept;
+  folly::dynamic managedProps(Tag tag) noexcept;
 
   bool isOnRenderThread() const noexcept;
 

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.h
@@ -88,17 +88,7 @@ class NativeAnimatedNodesManager {
 
   void dropAnimatedNode(Tag tag) noexcept;
 
-  // mutations
-
   void setAnimatedNodeValue(Tag tag, double value);
-
-  void setAnimatedNodeOffset(Tag tag, double offset) noexcept;
-
-  void flattenAnimatedNodeOffset(Tag tag) noexcept;
-
-  void extractAnimatedNodeOffset(Tag tag) noexcept;
-
-  void updateAnimatedNodeConfig(Tag tag, const folly::dynamic& config) noexcept;
 
   // drivers
 

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManagerProvider.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManagerProvider.cpp
@@ -100,12 +100,12 @@ NativeAnimatedNodesManagerProvider::getOrCreate(jsi::Runtime& runtime) {
               [nativeAnimatedNodesManager =
                    std::weak_ptr<NativeAnimatedNodesManager>(
                        nativeAnimatedNodesManager_)](
-                  Tag tag) -> std::optional<folly::dynamic> {
+                  Tag tag) -> folly::dynamic {
                 if (auto nativeAnimatedNodesManagerStrong =
                         nativeAnimatedNodesManager.lock()) {
                   return nativeAnimatedNodesManagerStrong->managedProps(tag);
                 }
-                return std::nullopt;
+                return nullptr;
               },
               uiManagerBinding_);
 


### PR DESCRIPTION
Summary:
changelog: [internal]

folly::dynamic can be constructed with nullptr and it creates a null folly::dynamic. Let's use that to indicate missing value instead of std::optional to lower C++ binary size.

Reviewed By: rshest

Differential Revision: D75174590


