### PR TITLE
remove enable_shared_from_this from AnimatedModule

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/AnimatedModule.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/AnimatedModule.cpp
@@ -79,20 +79,17 @@ void AnimatedModule::getValue(
 void AnimatedModule::startListeningToAnimatedNodeValue(
     jsi::Runtime& /*rt*/,
     Tag tag) {
-  addOperation([tag, weakThis = weak_from_this()](
-                   NativeAnimatedNodesManager& nodesManager) {
+  addOperation([tag, this](NativeAnimatedNodesManager& nodesManager) {
     nodesManager.startListeningToAnimatedNodeValue(
-        tag, [weakThis, tag](double value) {
-          if (auto strongThis = weakThis.lock()) {
-            strongThis->emitDeviceEvent(
-                "onAnimatedValueUpdate",
-                [tag, value](jsi::Runtime& rt, std::vector<jsi::Value>& args) {
-                  auto arg = jsi::Object(rt);
-                  arg.setProperty(rt, "tag", jsi::Value(tag));
-                  arg.setProperty(rt, "value", jsi::Value(value));
-                  args.emplace_back(rt, arg);
-                });
-          }
+        tag, [this, tag](double value) {
+          emitDeviceEvent(
+              "onAnimatedValueUpdate",
+              [tag, value](jsi::Runtime& rt, std::vector<jsi::Value>& args) {
+                auto arg = jsi::Object(rt);
+                arg.setProperty(rt, "tag", jsi::Value(tag));
+                arg.setProperty(rt, "value", jsi::Value(value));
+                args.emplace_back(rt, arg);
+              });
         });
   });
 }

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/AnimatedModule.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/AnimatedModule.cpp
@@ -54,11 +54,7 @@ void AnimatedModule::updateAnimatedNodeConfig(
     jsi::Runtime& rt,
     Tag tag,
     jsi::Object config) {
-  auto configDynamic = dynamicFromValue(rt, jsi::Value(rt, config));
-  addOperation([tag, configDynamic = std::move(configDynamic)](
-                   NativeAnimatedNodesManager& nodesManager) {
-    nodesManager.updateAnimatedNodeConfig(tag, configDynamic);
-  });
+  // TODO: missing implementation
 }
 
 void AnimatedModule::getValue(
@@ -164,25 +160,19 @@ void AnimatedModule::setAnimatedNodeOffset(
     jsi::Runtime& /*rt*/,
     Tag nodeTag,
     double offset) {
-  addOperation([nodeTag, offset](NativeAnimatedNodesManager& nodesManager) {
-    nodesManager.setAnimatedNodeOffset(nodeTag, offset);
-  });
+  // TODO: missing implementation
 }
 
 void AnimatedModule::flattenAnimatedNodeOffset(
     jsi::Runtime& /*rt*/,
     Tag nodeTag) {
-  addOperation([nodeTag](NativeAnimatedNodesManager& nodesManager) {
-    nodesManager.flattenAnimatedNodeOffset(nodeTag);
-  });
+  // TODO: missing implementation
 }
 
 void AnimatedModule::extractAnimatedNodeOffset(
     jsi::Runtime& /*rt*/,
     Tag nodeTag) {
-  addOperation([nodeTag](NativeAnimatedNodesManager& nodesManager) {
-    nodesManager.extractAnimatedNodeOffset(nodeTag);
-  });
+  // TODO: missing implementation
 }
 
 void AnimatedModule::connectAnimatedNodeToView(

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/AnimatedModule.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/AnimatedModule.h
@@ -18,7 +18,6 @@
 namespace facebook::react {
 
 class AnimatedModule : public NativeAnimatedModuleCxxSpec<AnimatedModule>,
-                       public std::enable_shared_from_this<AnimatedModule>,
                        public TurboModuleWithJSIBindings {
   using Operation =
       std::function<void(NativeAnimatedNodesManager& nodesManager)>;

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.cpp
@@ -253,28 +253,6 @@ void NativeAnimatedNodesManager::stopAnimationsForNode(Tag nodeTag) {
   }
 }
 
-void NativeAnimatedNodesManager::setAnimatedNodeOffset(
-    Tag /*tag*/,
-    double /*offset*/) noexcept {
-  LOG(WARNING) << "SetAnimatedNodeOffset is unimplemented";
-}
-
-void NativeAnimatedNodesManager::flattenAnimatedNodeOffset(
-    Tag /*tag*/) noexcept {
-  LOG(WARNING) << "FlattenAnimatedNodeOffset is unimplemented";
-}
-
-void NativeAnimatedNodesManager::extractAnimatedNodeOffset(
-    Tag /*tag*/) noexcept {
-  LOG(WARNING) << "ExtractAnimatedNodeOffset is unimplemented";
-}
-
-void NativeAnimatedNodesManager::updateAnimatedNodeConfig(
-    Tag /*tag*/,
-    const folly::dynamic& /*config*/) noexcept {
-  LOG(WARNING) << "UpdateAnimatedNodeConfig is unimplemented";
-}
-
 // drivers
 
 void NativeAnimatedNodesManager::startAnimatingNode(

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.h
@@ -88,17 +88,7 @@ class NativeAnimatedNodesManager {
 
   void dropAnimatedNode(Tag tag) noexcept;
 
-  // mutations
-
   void setAnimatedNodeValue(Tag tag, double value);
-
-  void setAnimatedNodeOffset(Tag tag, double offset) noexcept;
-
-  void flattenAnimatedNodeOffset(Tag tag) noexcept;
-
-  void extractAnimatedNodeOffset(Tag tag) noexcept;
-
-  void updateAnimatedNodeConfig(Tag tag, const folly::dynamic& config) noexcept;
 
   // drivers
 


### PR DESCRIPTION
Summary:
changelog: [internal]

When native module is destroyed, ui queue is also torn down.

this helps with C++ binary size a little bit

Reviewed By: rshest

Differential Revision: D75149437


