### PR TITLE
Make NativeAnimatedNodesManagerProvider not virtual

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManagerProvider.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManagerProvider.h
@@ -35,9 +35,7 @@ class NativeAnimatedNodesManagerProvider {
       NativeAnimatedNodesManager::StopOnRenderCallback stopOnRenderCallback =
           nullptr);
 
-  virtual ~NativeAnimatedNodesManagerProvider() = default;
-
-  virtual std::shared_ptr<NativeAnimatedNodesManager> getOrCreate(
+  std::shared_ptr<NativeAnimatedNodesManager> getOrCreate(
       jsi::Runtime& runtime);
 
   std::shared_ptr<NativeAnimatedNodesManager> get() {
@@ -50,7 +48,7 @@ class NativeAnimatedNodesManagerProvider {
 
   std::shared_ptr<EventEmitterListener> getEventEmitterListener();
 
- protected:
+ private:
   std::shared_ptr<NativeAnimatedNodesManager> nativeAnimatedNodesManager_;
   std::weak_ptr<UIManagerBinding> uiManagerBinding_;
 


### PR DESCRIPTION
Summary:
changelog: [internal]

NativeAnimatedNodesManagerProvider is not subclassed. Let's remove virtual methods and make it a final class.

Reviewed By: lenaic

Differential Revision: D75169108


