### PR TITLE
remove superclass enable_shared_from_this from AnimationDriver

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/AnimatedMountingOverrideDelegate.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/AnimatedMountingOverrideDelegate.cpp
@@ -9,16 +9,17 @@
 
 #include <react/renderer/componentregistry/ComponentDescriptorRegistry.h>
 #include <react/renderer/components/view/ViewProps.h>
+#include <react/renderer/scheduler/Scheduler.h>
 #include <react/renderer/uimanager/UIManagerBinding.h>
 
 namespace facebook::react {
 
 AnimatedMountingOverrideDelegate::AnimatedMountingOverrideDelegate(
     std::function<folly::dynamic(Tag)> getAnimatedManagedProps,
-    std::weak_ptr<UIManagerBinding> uiManagerBinding)
+    const Scheduler& scheduler)
     : MountingOverrideDelegate(),
       getAnimatedManagedProps_(std::move(getAnimatedManagedProps)),
-      uiManagerBinding_(std::move(uiManagerBinding)){};
+      scheduler_(&scheduler){};
 
 bool AnimatedMountingOverrideDelegate::shouldOverridePullTransaction() const {
   return getAnimatedManagedProps_ != nullptr;
@@ -63,27 +64,22 @@ AnimatedMountingOverrideDelegate::pullTransaction(
     if (modifiedProps.empty()) {
       filteredMutations.emplace_back(mutation);
     } else {
-      if (auto uiManagerBinding = uiManagerBinding_.lock()) {
-        auto* scheduler = static_cast<Scheduler*>(
-            uiManagerBinding->getUIManager().getDelegate());
-        react_native_assert(scheduler);
-        if (const auto* componentDescriptor =
-                scheduler
-                    ->findComponentDescriptorByHandle_DO_NOT_USE_THIS_IS_BROKEN(
-                        mutation.newChildShadowView.componentHandle)) {
-          PropsParserContext propsParserContext{
-              mutation.newChildShadowView.surfaceId,
-              *scheduler->getContextContainer()};
-          auto modifiedNewChildShadowView = mutation.newChildShadowView;
-          modifiedNewChildShadowView.props = componentDescriptor->cloneProps(
-              propsParserContext,
-              mutation.newChildShadowView.props,
-              RawProps(std::move(modifiedProps)));
-          filteredMutations.emplace_back(ShadowViewMutation::UpdateMutation(
-              mutation.oldChildShadowView,
-              std::move(modifiedNewChildShadowView),
-              mutation.parentTag));
-        }
+      if (const auto* componentDescriptor =
+              scheduler_
+                  ->findComponentDescriptorByHandle_DO_NOT_USE_THIS_IS_BROKEN(
+                      mutation.newChildShadowView.componentHandle)) {
+        PropsParserContext propsParserContext{
+            mutation.newChildShadowView.surfaceId,
+            *scheduler_->getContextContainer()};
+        auto modifiedNewChildShadowView = mutation.newChildShadowView;
+        modifiedNewChildShadowView.props = componentDescriptor->cloneProps(
+            propsParserContext,
+            mutation.newChildShadowView.props,
+            RawProps(std::move(modifiedProps)));
+        filteredMutations.emplace_back(ShadowViewMutation::UpdateMutation(
+            mutation.oldChildShadowView,
+            std::move(modifiedNewChildShadowView),
+            mutation.parentTag));
       }
     }
   }

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/AnimatedMountingOverrideDelegate.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/AnimatedMountingOverrideDelegate.h
@@ -11,19 +11,18 @@
 #include <react/renderer/mounting/MountingOverrideDelegate.h>
 #include <react/renderer/mounting/MountingTransaction.h>
 #include <react/renderer/mounting/ShadowViewMutation.h>
-#include <react/renderer/scheduler/Scheduler.h>
 #include <functional>
 #include <optional>
 
 namespace facebook::react {
 
-class UIManagerBinding;
+class Scheduler;
 
 class AnimatedMountingOverrideDelegate : public MountingOverrideDelegate {
  public:
   AnimatedMountingOverrideDelegate(
       std::function<folly::dynamic(Tag)> getAnimatedManagedProps,
-      std::weak_ptr<UIManagerBinding> uiManagerBinding);
+      const Scheduler& scheduler);
 
   bool shouldOverridePullTransaction() const override;
 
@@ -36,7 +35,7 @@ class AnimatedMountingOverrideDelegate : public MountingOverrideDelegate {
  private:
   std::function<folly::dynamic(Tag)> getAnimatedManagedProps_;
 
-  std::weak_ptr<UIManagerBinding> uiManagerBinding_;
+  const Scheduler* scheduler_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManagerProvider.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManagerProvider.h
@@ -35,9 +35,7 @@ class NativeAnimatedNodesManagerProvider {
       NativeAnimatedNodesManager::StopOnRenderCallback stopOnRenderCallback =
           nullptr);
 
-  virtual ~NativeAnimatedNodesManagerProvider() = default;
-
-  virtual std::shared_ptr<NativeAnimatedNodesManager> getOrCreate(
+  std::shared_ptr<NativeAnimatedNodesManager> getOrCreate(
       jsi::Runtime& runtime);
 
   std::shared_ptr<NativeAnimatedNodesManager> get() {
@@ -50,7 +48,7 @@ class NativeAnimatedNodesManagerProvider {
 
   std::shared_ptr<EventEmitterListener> getEventEmitterListener();
 
- protected:
+ private:
   std::shared_ptr<NativeAnimatedNodesManager> nativeAnimatedNodesManager_;
   std::weak_ptr<UIManagerBinding> uiManagerBinding_;
 

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManagerProvider.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManagerProvider.h
@@ -12,8 +12,6 @@
 
 namespace facebook::react {
 
-class UIManagerBinding;
-
 class UIManagerNativeAnimatedDelegateImpl
     : public UIManagerNativeAnimatedDelegate {
  public:
@@ -25,6 +23,7 @@ class UIManagerNativeAnimatedDelegateImpl
  private:
   std::weak_ptr<NativeAnimatedNodesManager> nativeAnimatedNodesManager_;
 };
+
 class AnimatedMountingOverrideDelegate;
 
 class NativeAnimatedNodesManagerProvider {
@@ -50,7 +49,6 @@ class NativeAnimatedNodesManagerProvider {
 
  private:
   std::shared_ptr<NativeAnimatedNodesManager> nativeAnimatedNodesManager_;
-  std::weak_ptr<UIManagerBinding> uiManagerBinding_;
 
   std::shared_ptr<EventEmitterListenerContainer> eventEmitterListenerContainer_;
   std::shared_ptr<EventEmitterListener> eventEmitterListener_;

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/drivers/AnimationDriver.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/drivers/AnimationDriver.h
@@ -22,8 +22,7 @@ enum class AnimationDriverType {
   Decay,
 };
 
-class ValueAnimatedNode;
-class AnimationDriver : public std::enable_shared_from_this<AnimationDriver> {
+class AnimationDriver {
  public:
   AnimationDriver(
       int id,
@@ -47,11 +46,11 @@ class AnimationDriver : public std::enable_shared_from_this<AnimationDriver> {
     return endCallback_;
   }
 
-  virtual double toValue() {
+  virtual double toValue() const noexcept {
     return 0;
   }
 
-  bool isComplete() {
+  bool isComplete() const noexcept {
     return isComplete_;
   }
 

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/drivers/FrameAnimationDriver.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/drivers/FrameAnimationDriver.cpp
@@ -35,7 +35,7 @@ FrameAnimationDriver::FrameAnimationDriver(
   onConfigChanged();
 }
 
-double FrameAnimationDriver::toValue() {
+double FrameAnimationDriver::toValue() const noexcept {
   return toValue_;
 }
 

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/drivers/FrameAnimationDriver.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/drivers/FrameAnimationDriver.h
@@ -24,7 +24,7 @@ class FrameAnimationDriver : public AnimationDriver {
       const folly::dynamic& config,
       NativeAnimatedNodesManager* manager);
 
-  double toValue() override;
+  double toValue() const noexcept override;
 
  protected:
   bool update(double timeDeltaMs, bool restarting) override;


### PR DESCRIPTION
Summary:
changelog: [internal]

AnimationDriver does not use enable_shared_from_this, let's remove it. Also mark a few methods as noexcept and const.

This helps with C++ binary size.

Reviewed By: rshest

Differential Revision: D75172851


