### PR TITLE
rename getters and mark them as const+noexcept in ValueAnimatedNode

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.cpp
@@ -72,7 +72,7 @@ NativeAnimatedNodesManager::~NativeAnimatedNodesManager() noexcept {
 std::optional<double> NativeAnimatedNodesManager::getValue(Tag tag) noexcept {
   auto node = getAnimatedNode<ValueAnimatedNode>(tag);
   if (node) {
-    return node->value();
+    return node->getValue();
   } else {
     LOG(WARNING)
         << "Cannot get value from AnimatedNode, it's not a ValueAnimatedNode";

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/drivers/AnimationDriver.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/drivers/AnimationDriver.cpp
@@ -53,7 +53,7 @@ void AnimationDriver::stopAnimation(bool /*ignoreCompletedHandlers*/) {
   std::optional<double> value = std::nullopt;
   if (auto node =
           manager_->getAnimatedNode<ValueAnimatedNode>(animatedValueTag_)) {
-    value = node->value();
+    value = node->getValue();
   } else {
     LOG(ERROR)
         << "animatedValueTag should be associated with a ValueAnimatedNode";

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/drivers/DecayAnimationDriver.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/drivers/DecayAnimationDriver.cpp
@@ -45,7 +45,7 @@ bool DecayAnimationDriver::update(double timeDeltaMs, bool restarting) {
   if (const auto node =
           manager_->getAnimatedNode<ValueAnimatedNode>(animatedValueTag_)) {
     if (restarting) {
-      const auto value = node->rawValue();
+      const auto value = node->getRawValue();
       if (!fromValue_.has_value()) {
         // First iteration, assign fromValue based on AnimatedValue
         fromValue_ = value;

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/drivers/FrameAnimationDriver.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/drivers/FrameAnimationDriver.cpp
@@ -58,7 +58,7 @@ bool FrameAnimationDriver::update(double timeDeltaMs, bool /*restarting*/) {
   if (auto node =
           manager_->getAnimatedNode<ValueAnimatedNode>(animatedValueTag_)) {
     if (!startValue_) {
-      startValue_ = node->rawValue();
+      startValue_ = node->getRawValue();
     }
 
     const auto startIndex =

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/drivers/SpringAnimationDriver.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/drivers/SpringAnimationDriver.cpp
@@ -82,7 +82,7 @@ bool SpringAnimationDriver::update(double timeDeltaMs, bool restarting) {
           manager_->getAnimatedNode<ValueAnimatedNode>(animatedValueTag_)) {
     if (restarting) {
       if (!fromValue_.has_value()) {
-        fromValue_ = node->rawValue();
+        fromValue_ = node->getRawValue();
       } else {
         if (node->setRawValue(fromValue_.value())) {
           markNodeUpdated(node->tag());

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/AdditionAnimatedNode.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/AdditionAnimatedNode.cpp
@@ -22,7 +22,7 @@ void AdditionAnimatedNode::update() {
     const auto node = manager_->getAnimatedNode<ValueAnimatedNode>(tag);
     react_native_assert(
         node && "Invalid node tag set as input for AdditionAnimatedNode");
-    rawValue += node->value();
+    rawValue += node->getValue();
   }
   setRawValue(rawValue);
 }

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/ColorAnimatedNode.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/ColorAnimatedNode.cpp
@@ -23,9 +23,10 @@ uint8_t getColorValue(
     bool isDecimal = false) {
   if (const auto node = manager.getAnimatedNode<ValueAnimatedNode>(nodeTag)) {
     if (isDecimal) {
-      return std::clamp(static_cast<uint32_t>(node->value() * 255), 0u, 255u);
+      return std::clamp(
+          static_cast<uint32_t>(node->getValue() * 255), 0u, 255u);
     } else {
-      return std::clamp(static_cast<uint32_t>(node->value()), 0u, 255u);
+      return std::clamp(static_cast<uint32_t>(node->getValue()), 0u, 255u);
     }
   }
   return 0;

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/DiffClampAnimatedNode.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/DiffClampAnimatedNode.cpp
@@ -27,10 +27,10 @@ DiffClampAnimatedNode::DiffClampAnimatedNode(
 void DiffClampAnimatedNode::update() {
   if (const auto node =
           manager_->getAnimatedNode<ValueAnimatedNode>(inputNodeTag_)) {
-    const auto value = node->value();
+    const auto value = node->getValue();
     const auto diff = value - lastValue_;
     lastValue_ = value;
-    setRawValue(std::clamp(this->value() + diff, min_, max_));
+    setRawValue(std::clamp(this->getValue() + diff, min_, max_));
   }
 }
 

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/DivisionAnimatedNode.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/DivisionAnimatedNode.cpp
@@ -24,9 +24,9 @@ void DivisionAnimatedNode::update() {
     react_native_assert(
         node && "Invalid node tag set as input for DivisionAnimatedNode");
     if (count == 0) {
-      rawValue = node->value();
+      rawValue = node->getValue();
     } else {
-      rawValue /= node->value();
+      rawValue /= node->getValue();
     }
 
     count++;

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/InterpolationAnimatedNode.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/InterpolationAnimatedNode.cpp
@@ -54,9 +54,9 @@ void InterpolationAnimatedNode::update() {
   if (const auto node =
           manager_->getAnimatedNode<ValueAnimatedNode>(parentTag_)) {
     if (isColorValue_) {
-      setRawValue(interpolateColor(node->value()));
+      setRawValue(interpolateColor(node->getValue()));
     } else {
-      setRawValue(interpolateValue(node->value()));
+      setRawValue(interpolateValue(node->getValue()));
     }
   }
 }

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/ModulusAnimatedNode.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/ModulusAnimatedNode.cpp
@@ -26,7 +26,7 @@ ModulusAnimatedNode::ModulusAnimatedNode(
 void ModulusAnimatedNode::update() {
   if (const auto node =
           manager_->getAnimatedNode<ValueAnimatedNode>(inputNodeTag_)) {
-    setRawValue(std::fmod(node->value(), modulus_));
+    setRawValue(std::fmod(node->getValue(), modulus_));
   }
 }
 

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/MultiplicationAnimatedNode.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/MultiplicationAnimatedNode.cpp
@@ -24,9 +24,9 @@ void MultiplicationAnimatedNode::update() {
     react_native_assert(
         node && "Invalid node tag set as input for MultiplicationAnimatedNode");
     if (count == 0) {
-      rawValue = node->value();
+      rawValue = node->getValue();
     } else {
-      rawValue *= node->value();
+      rawValue *= node->getValue();
     }
     count++;
   }

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/PropsAnimatedNode.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/PropsAnimatedNode.cpp
@@ -111,11 +111,12 @@ void PropsAnimatedNode::update(bool forceFabricCommit) {
         case AnimatedNodeType::Division: {
           if (const auto& valueNode =
                   manager_->getAnimatedNode<ValueAnimatedNode>(nodeTag)) {
-            if (valueNode->isColorValue()) {
+            if (valueNode->getIsColorValue()) {
               props_.insert(
-                  propName.c_str(), static_cast<int32_t>(valueNode->value()));
+                  propName.c_str(),
+                  static_cast<int32_t>(valueNode->getValue()));
             } else {
-              props_.insert(propName.c_str(), valueNode->value());
+              props_.insert(propName.c_str(), valueNode->getValue());
             }
           }
         } break;

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/RoundAnimatedNode.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/RoundAnimatedNode.cpp
@@ -32,7 +32,7 @@ void RoundAnimatedNode::update() {
   auto node = manager_->getAnimatedNode<ValueAnimatedNode>(inputNodeTag_);
   react_native_assert(
       node && "Illegal node ID set as an input for Animated.round node");
-  setRawValue(round(node->value() / nearest_) * nearest_);
+  setRawValue(round(node->getValue() / nearest_) * nearest_);
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/StyleAnimatedNode.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/StyleAnimatedNode.cpp
@@ -53,11 +53,12 @@ void StyleAnimatedNode::update() {
         case AnimatedNodeType::Division: {
           if (const auto valueNode =
                   manager_->getAnimatedNode<ValueAnimatedNode>(nodeTag)) {
-            if (valueNode->isColorValue()) {
+            if (valueNode->getIsColorValue()) {
               props_.insert(
-                  propName.c_str(), static_cast<int32_t>(valueNode->value()));
+                  propName.c_str(),
+                  static_cast<int32_t>(valueNode->getValue()));
             } else {
-              props_.insert(propName.c_str(), valueNode->value());
+              props_.insert(propName.c_str(), valueNode->getValue());
             }
           }
         } break;

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/SubtractionAnimatedNode.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/SubtractionAnimatedNode.cpp
@@ -24,9 +24,9 @@ void SubtractionAnimatedNode::update() {
     react_native_assert(
         node && "Invalid node tag set as input for SubtractionAnimatedNode");
     if (count == 0) {
-      rawValue = node->value();
+      rawValue = node->getValue();
     } else {
-      rawValue -= node->value();
+      rawValue -= node->getValue();
     }
 
     count++;

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/TrackingAnimatedNode.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/TrackingAnimatedNode.cpp
@@ -33,7 +33,7 @@ void TrackingAnimatedNode::update() {
     // manager.
     manager_->stopAnimation(animationId_, true);
     auto animationConfig = getConfig()["animationConfig"];
-    animationConfig["toValue"] = toValueNode->value();
+    animationConfig["toValue"] = toValueNode->getValue();
 
     manager_->startAnimatingNode(
         animationId_, valueNodeId_, animationConfig, std::nullopt);

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/TransformAnimatedNode.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/TransformAnimatedNode.cpp
@@ -43,7 +43,7 @@ void TransformAnimatedNode::update() {
       const auto inputTag = static_cast<Tag>(transform[sNodeTagName].asInt());
       if (const auto node =
               manager_->getAnimatedNode<ValueAnimatedNode>(inputTag)) {
-        value = node->value();
+        value = node->getValue();
       }
     } else {
       value = transform[sValueName].asDouble();

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/ValueAnimatedNode.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/ValueAnimatedNode.cpp
@@ -32,7 +32,7 @@ ValueAnimatedNode::ValueAnimatedNode(
   offset_ = offset;
 }
 
-bool ValueAnimatedNode::setRawValue(double value) {
+bool ValueAnimatedNode::setRawValue(double value) noexcept {
   if (value_ != value) {
     value_ = value;
 
@@ -42,15 +42,15 @@ bool ValueAnimatedNode::setRawValue(double value) {
   return false;
 }
 
-double ValueAnimatedNode::rawValue() {
+double ValueAnimatedNode::getRawValue() const noexcept {
   return value_;
 }
 
-double ValueAnimatedNode::offset() {
+double ValueAnimatedNode::getOffset() const noexcept {
   return offset_;
 }
 
-bool ValueAnimatedNode::setOffset(double offset) {
+bool ValueAnimatedNode::setOffset(double offset) noexcept {
   if (offset_ != offset) {
     offset_ = offset;
 
@@ -60,27 +60,28 @@ bool ValueAnimatedNode::setOffset(double offset) {
   return true;
 }
 
-double ValueAnimatedNode::value() {
-  return value_ + offset();
+double ValueAnimatedNode::getValue() const noexcept {
+  return value_ + getOffset();
 }
 
-void ValueAnimatedNode::flattenOffset() {
-  setRawValue(value_ + offset());
+void ValueAnimatedNode::flattenOffset() noexcept {
+  setRawValue(value_ + getOffset());
   setOffset(0.0f);
 }
 
-void ValueAnimatedNode::extractOffset() {
-  setOffset(value_ + offset());
+void ValueAnimatedNode::extractOffset() noexcept {
+  setOffset(value_ + getOffset());
   setRawValue(0.0f);
 }
 
-void ValueAnimatedNode::onValueUpdate() {
+void ValueAnimatedNode::onValueUpdate() noexcept {
   if (valueListener_) {
-    valueListener_(value());
+    valueListener_(getValue());
   }
 }
 
-void ValueAnimatedNode::setValueListener(ValueListenerCallback&& callback) {
+void ValueAnimatedNode::setValueListener(
+    ValueListenerCallback&& callback) noexcept {
   valueListener_ = std::move(callback);
 }
 

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/ValueAnimatedNode.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/ValueAnimatedNode.h
@@ -25,16 +25,16 @@ class ValueAnimatedNode : public AnimatedNode {
       Tag tag,
       const folly::dynamic& config,
       NativeAnimatedNodesManager& manager);
-  double value();
-  double rawValue();
-  bool setRawValue(double value);
-  double offset();
-  bool setOffset(double offset);
-  void flattenOffset();
-  void extractOffset();
-  void setValueListener(ValueListenerCallback&& callback);
+  double getValue() const noexcept;
+  double getRawValue() const noexcept;
+  bool setRawValue(double value) noexcept;
+  double getOffset() const noexcept;
+  bool setOffset(double offset) noexcept;
+  void flattenOffset() noexcept;
+  void extractOffset() noexcept;
+  void setValueListener(ValueListenerCallback&& callback) noexcept;
 
-  virtual bool isColorValue() {
+  bool getIsColorValue() const noexcept {
     return isColorValue_;
   }
 
@@ -42,7 +42,7 @@ class ValueAnimatedNode : public AnimatedNode {
   bool isColorValue_{false};
 
  private:
-  void onValueUpdate();
+  void onValueUpdate() noexcept;
 
   double value_{0.0};
   double offset_{0.0};


### PR DESCRIPTION
Summary:
changelog: [internal]


rename methods to reflect that they are getters and mark them as noexcept const

Reviewed By: rshest

Differential Revision: D75217535


