### PR TITLE
Fix missing willPerformAsynchronously parameter in calls to MountingCoordinator::pullTransaction

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
@@ -630,7 +630,8 @@ void FabricUIManagerBinding::schedulerShouldRenderTransactions(
     return;
   }
   if (ReactNativeFeatureFlags::enableAccumulatedUpdatesInRawPropsAndroid()) {
-    auto mountingTransaction = mountingCoordinator->pullTransaction();
+    auto mountingTransaction = mountingCoordinator->pullTransaction(
+        /* willPerformAsynchronously = */ true);
     if (mountingTransaction.has_value()) {
       auto transaction = std::move(*mountingTransaction);
       mountingManager->executeMount(transaction);

--- a/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.h
@@ -62,7 +62,6 @@ class MountingCoordinator final {
    * `true` until `didPerformAsyncTransactions` is called.
    */
   std::optional<MountingTransaction> pullTransaction(
-      // TODO: Clean up this parameter when Android migrates to a pull model.
       bool willPerformAsynchronously = false) const;
 
   /*


### PR DESCRIPTION
Summary:
Changelog: [internal]

This sets the argument to `pullTransaction` to `true` in the cases where the call is done from the JS thread and the transactions are mounted asynchronously in the UI thread (basically platforms using the push model for mounting coordinator).

It was missing on an experiment for Android (compatibility mode for Props 2.0)

Differential Revision: D75439105


