### PR TITLE
properly set dependencies on JSI and React-hermes

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
+++ b/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
@@ -66,6 +66,7 @@ Pod::Spec.new do |s|
   s.dependency "React-CoreModules"
   s.dependency "React-RCTFBReactNativeSpec"
   s.dependency "React-defaultsnativemodule"
+  s.dependency 'React-hermes'
 
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
   add_dependency(s, "React-NativeModulesApple")

--- a/packages/react-native/React-Core.podspec
+++ b/packages/react-native/React-Core.podspec
@@ -122,6 +122,7 @@ Pod::Spec.new do |s|
   s.dependency "React-featureflags"
   s.dependency "React-runtimescheduler"
   s.dependency "Yoga"
+  s.dependency 'React-hermes'
 
   s.resource_bundles = {'React-Core_privacy' => 'React/Resources/PrivacyInfo.xcprivacy'}
 
@@ -130,6 +131,7 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-jsitooling", :framework_name => "JSITooling")
   add_dependency(s, "React-utils", :additional_framework_paths => ["react/utils/platform/ios"])
   add_dependency(s, "RCTDeprecation")
+
 
   depend_on_js_engine(s)
   add_rn_third_party_dependencies(s)

--- a/packages/react-native/scripts/cocoapods/jsengine.rb
+++ b/packages/react-native/scripts/cocoapods/jsengine.rb
@@ -36,7 +36,6 @@ end
 def depend_on_js_engine(s)
   if ENV["USE_HERMES"] == nil || ENV["USE_HERMES"] == "1"
     s.dependency 'hermes-engine'
-    s.dependency 'React-hermes'
   elsif ENV['USE_THIRD_PARTY_JSC'] != '1'
     s.dependency 'React-jsc'
   end


### PR DESCRIPTION
Summary:
This fix relaxes some dependencies on React-hermes that should not be in the code.

## Changelog:
[Internal] - Remove dependencies from React-Hermes when they are not needed.

Differential Revision: D75447910


