### PR TITLE
Add automatic retry of failed workflows to improve E2E stability

### DIFF
--- a/.github/workflows/retry-workflow.yml
+++ b/.github/workflows/retry-workflow.yml
@@ -1,0 +1,19 @@
+name: Retry workflow
+# Based on https://stackoverflow.com/a/78314483
+
+on:
+    workflow_dispatch:
+        inputs:
+            run_id:
+                required: true
+jobs:
+    rerun:
+        runs-on: ubuntu-latest
+        steps:
+            - name: rerun ${{ inputs.run_id }}
+              env:
+                  GH_REPO: ${{ github.repository }}
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  gh run watch ${{ inputs.run_id }} > /dev/null 2>&1
+                  gh run rerun ${{ inputs.run_id }} --failed

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -632,3 +632,24 @@ jobs:
         uses: ./.github/actions/lint
         with:
           github-token: ${{ env.GH_TOKEN }}
+
+  # This job should help with the E2E flakyness.
+  # In case E2E tests fails, it launches a new retry-workflow workflow, passing the current run_id as input.
+  # The retry-workflow reruns only the failed jobs of the current test-all workflow using
+  # ```
+  # gh run rerun ${{ inputs.run_id }} --failed
+  # ```
+  # From https://stackoverflow.com/a/78314483 it seems like that adding the extra workflow
+  # rather then calling directly this command should improve stability of this solution.
+  # This is exactly the same as rerunning failed tests from the GH UI, but automated.
+  rerun-failed-jobs:
+    runs-on: ubuntu-latest
+    needs: [test_e2e_ios_rntester, test_e2e_android_rntester,test_e2e_ios_templateapp, test_e2e_android_templateapp]
+    if: failure() && fromJSON(github.run_attempt) < 3 && ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Rerun failed jobs in the current workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run retry-workflow.yml -F run_id=${{ github.run_id }}


### PR DESCRIPTION
Summary:
This cdhanges are inspired by https://stackoverflow.com/a/78314483 and they should help with the stability of E2E tests on main.
Most of the time, those tests fails because of flakyness in the E2E infrastructure on GHA. Usually, rerunning the tests manually makes the workflow pass.

These couple of jobs automatically reruns the workflow up to 3 times in case one of the E2E tests fails

## Changelog:
[Internal] - improve CI by rerunning the workflow if the E2E tests fails

Differential Revision: D75449445


