### PR TITLE
Do not log warning for missing feature flags native module in tests

### DIFF
--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlagsBase.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlagsBase.js
@@ -102,6 +102,8 @@ const hasTurboModules =
 function maybeLogUnavailableNativeModuleError(configName: string): void {
   if (
     !NativeReactNativeFeatureFlags &&
+    // Don't log in tests.
+    process.env.NODE_ENV !== 'test' &&
     // Don't log more than once per config
     !reportedConfigNames.has(configName) &&
     // Don't log in the legacy architecture.

--- a/packages/react-native/src/private/featureflags/__tests__/ReactNativeFeatureFlags-test.js
+++ b/packages/react-native/src/private/featureflags/__tests__/ReactNativeFeatureFlags-test.js
@@ -8,6 +8,10 @@
  * @format
  */
 
+// Pretend to not run in a testing environment so we log the warning for the
+// missing native module to the console.
+process.env.NODE_ENV = 'development';
+
 describe('ReactNativeFeatureFlags', () => {
   beforeEach(() => {
     jest.unmock('../specs/NativeReactNativeFeatureFlags');


### PR DESCRIPTION
Summary:
Changelog: [internal]

The native module will never be defined in tests, so there's no point in logging this warning there.

Differential Revision: D75451414


