### PR TITLE
Let accessible be std::optional in native

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
@@ -179,7 +179,7 @@ using namespace facebook::react;
   // If the component is not `accessible`, we return an empty array.
   // We do this because logically all nested <Text> components represent the content of the <Paragraph> component;
   // in other words, all nested <Text> components individually have no sense without the <Paragraph>.
-  if (!_textView.state || !paragraphProps.accessible) {
+  if (!_textView.state || !paragraphProps.accessible.value_or(false)) {
     return [NSArray new];
   }
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -344,7 +344,7 @@ const CGFloat BACKGROUND_COLOR_ZPOSITION = -1024.0f;
 
   // `accessible`
   if (oldViewProps.accessible != newViewProps.accessible) {
-    self.accessibilityElement.isAccessibilityElement = newViewProps.accessible;
+    self.accessibilityElement.isAccessibilityElement = newViewProps.accessible.value_or(false);
   }
 
   // `accessibilityLabel`

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FocusOrderingHelper.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FocusOrderingHelper.cpp
@@ -118,7 +118,8 @@ void FocusOrderingHelper::traverseAndUpdateNextFocusableElement(
   // focused and present in the hierarchy
   if (currNode->getTraits().check(ShadowNodeTraits::Trait::KeyboardFocusable) ||
       (props != nullptr &&
-       (props->focusable || props->accessible || props->hasTVPreferredFocus))) {
+       (props->focusable || props->accessible.value_or(false) ||
+        props->hasTVPreferredFocus))) {
     LayoutMetrics nodeLayoutMetrics = uimanager.getRelativeLayoutMetrics(
         *currNode, parentShadowNode.get(), {.includeTransform = true});
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.h
@@ -31,7 +31,7 @@ class AccessibilityProps {
 
 #pragma mark - Props
 
-  bool accessible{false};
+  std::optional<bool> accessible{std::nullopt};
   std::optional<AccessibilityState> accessibilityState{std::nullopt};
   std::string accessibilityLabel;
   std::vector<std::string> accessibilityOrder{};

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ConcreteViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ConcreteViewShadowNode.h
@@ -118,6 +118,7 @@ class ConcreteViewShadowNode : public ConcreteShadowNode<
       BaseShadowNode::orderIndex_ = 0;
     }
 
+    // TODO why is this not needed
     bool isKeyboardFocusable =
         HostPlatformViewTraitsInitializer::isKeyboardFocusable(props) ||
         props.accessible;

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.cpp
@@ -48,7 +48,7 @@ void ViewShadowNode::initialize() noexcept {
 
   bool formsStackingContext = !viewProps.collapsable ||
       viewProps.pointerEvents == PointerEventsMode::None ||
-      !viewProps.nativeId.empty() || viewProps.accessible ||
+      !viewProps.nativeId.empty() || viewProps.accessible.value_or(false) ||
       viewProps.opacity != 1.0 || viewProps.transform != Transform{} ||
       (viewProps.zIndex.has_value() &&
        viewProps.yogaStyle.positionType() != yoga::PositionType::Static) ||

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
@@ -692,7 +692,7 @@ folly::dynamic HostPlatformViewProps::getDiffProps(
   }
 
   if (accessible != oldProps->accessible) {
-    result["accessible"] = accessible;
+    result["accessible"] = accessible.value_or(false);
   }
 
   if (getClipsContentToBounds() != oldProps->getClipsContentToBounds()) {


### PR DESCRIPTION
Summary:
We want to change Text so that if it has links, and no `accessible` value set, it becomes accessible by default for keyboards. To do that we need native to know if "no value is set". This means changing from a `bool` to a `std::optional<bool>`.

This diff does that and fixes any build errors. Runtime should be the same, since the default at all the callsites is false (the default before), and JS overrides will still apply.

Changelog: [Internal]

Reviewed By: javache

Differential Revision: D74914316


