### PR TITLE
[Android] Fix ConcurrentModificationException in InteropUIBlockListener

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/internal/interop/InteropUiBlockListener.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/internal/interop/InteropUiBlockListener.kt
@@ -38,28 +38,32 @@ internal class InteropUIBlockListener : UIManagerListener {
     afterUIBlocks.add(block)
   }
 
+  @Synchronized
   override fun willMountItems(uiManager: UIManager) {
+    if (beforeUIBlocks.isEmpty()) {
+       return
+     }
     // avoid ConcurrentModificationException by iterating over a copy
-    try {
-      if (uiManager is UIBlockViewResolver) {
-        val snapshot = ArrayList(beforeUIBlocks)
-        beforeUIBlocks.clear()
-        snapshot.forEach { block ->
-          block.execute(uiManager)
-        }
+    val snapshot = ArrayList(beforeUIBlocks)
+    beforeUIBlocks.clear()
+    if (uiManager is UIBlockViewResolver) {
+      snapshot.forEach { block ->
+        block.execute(uiManager)
       }
     }
   }
 
+  @Synchronized
   override fun didMountItems(uiManager: UIManager) {
+    if (afterUIBlocks.isEmpty()) {
+       return
+     }
     // avoid ConcurrentModificationException by iterating over a copy
-    try {
-      if (uiManager is UIBlockViewResolver) {
-        val snapshot = ArrayList(afterUIBlocks)
-        afterUIBlocks.clear()
-        snapshot.forEach { block ->
-          block.execute(uiManager)
-        }
+    val snapshot = ArrayList(afterUIBlocks)
+    afterUIBlocks.clear()
+    if (uiManager is UIBlockViewResolver) {
+      snapshot.forEach { block ->
+        block.execute(uiManager)
       }
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/internal/interop/InteropUiBlockListener.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/internal/interop/InteropUiBlockListener.kt
@@ -43,12 +43,11 @@ internal class InteropUIBlockListener : UIManagerListener {
     try {
       if (uiManager is UIBlockViewResolver) {
         val snapshot = ArrayList(beforeUIBlocks)
+        beforeUIBlocks.clear()
         snapshot.forEach { block ->
           block.execute(uiManager)
         }
       }
-   } finally {
-      beforeUIBlocks.clear()
     }
   }
 
@@ -57,12 +56,11 @@ internal class InteropUIBlockListener : UIManagerListener {
     try {
       if (uiManager is UIBlockViewResolver) {
         val snapshot = ArrayList(afterUIBlocks)
+        afterUIBlocks.clear()
         snapshot.forEach { block ->
           block.execute(uiManager)
         }
       }
-   } finally {
-      afterUIBlocks.clear()
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/internal/interop/InteropUiBlockListener.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/internal/interop/InteropUiBlockListener.kt
@@ -39,39 +39,29 @@ internal class InteropUIBlockListener : UIManagerListener {
   }
 
   override fun willMountItems(uiManager: UIManager) {
-    if (beforeUIBlocks.isEmpty()) {
-      return
-    }
     // avoid ConcurrentModificationException by iterating over a copy
     try {
-      val snapshot = ArrayList(beforeUIBlocks)
-      snapshot.forEach { block ->
-        if (uiManager is UIBlockViewResolver) {
+      if (uiManager is UIBlockViewResolver) {
+        val snapshot = ArrayList(beforeUIBlocks)
+        snapshot.forEach { block ->
           block.execute(uiManager)
         }
       }
-    } catch (e: ConcurrentModificationException) {
-      // ignore any mid-iteration mutations
-    } finally {
+   } finally {
       beforeUIBlocks.clear()
     }
   }
 
   override fun didMountItems(uiManager: UIManager) {
-    if (afterUIBlocks.isEmpty()) {
-      return
-    }
     // avoid ConcurrentModificationException by iterating over a copy
     try {
-      val snapshot = ArrayList(afterUIBlocks)
-      snapshot.forEach { block ->
-        if (uiManager is UIBlockViewResolver) {
+      if (uiManager is UIBlockViewResolver) {
+        val snapshot = ArrayList(afterUIBlocks)
+        snapshot.forEach { block ->
           block.execute(uiManager)
         }
       }
-    } catch (e: ConcurrentModificationException) {
-      // ignore any mid-iteration mutations
-    } finally {
+   } finally {
       afterUIBlocks.clear()
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/internal/interop/InteropUiBlockListener.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/internal/interop/InteropUiBlockListener.kt
@@ -38,31 +38,33 @@ internal class InteropUIBlockListener : UIManagerListener {
     afterUIBlocks.add(block)
   }
 
-  @Synchronized
   override fun willMountItems(uiManager: UIManager) {
-    if (beforeUIBlocks.isEmpty()) {
-       return
-     }
-    // avoid ConcurrentModificationException by iterating over a copy
-    val snapshot = ArrayList(beforeUIBlocks)
-    beforeUIBlocks.clear()
+    val blocksToExecute: List<UIBlock> = synchronized(this) {
+      if (beforeUIBlocks.isEmpty()) {
+        return
+      }
+      // avoid ConcurrentModificationException by iterating over a copy
+      ArrayList(beforeUIBlocks).also { beforeUIBlocks.clear() }
+    }
+
     if (uiManager is UIBlockViewResolver) {
-      snapshot.forEach { block ->
+      blocksToExecute.forEach { block ->
         block.execute(uiManager)
       }
     }
   }
 
-  @Synchronized
   override fun didMountItems(uiManager: UIManager) {
-    if (afterUIBlocks.isEmpty()) {
-       return
-     }
-    // avoid ConcurrentModificationException by iterating over a copy
-    val snapshot = ArrayList(afterUIBlocks)
-    afterUIBlocks.clear()
+    val blocksToExecute: List<UIBlock> = synchronized(this) {
+      if (afterUIBlocks.isEmpty()) {
+        return
+      }
+      // avoid ConcurrentModificationException by iterating over a copy
+      ArrayList(afterUIBlocks).also { afterUIBlocks.clear() }
+    }
+
     if (uiManager is UIBlockViewResolver) {
-      snapshot.forEach { block ->
+      blocksToExecute.forEach { block ->
         block.execute(uiManager)
       }
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/internal/interop/InteropUiBlockListener.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/internal/interop/InteropUiBlockListener.kt
@@ -41,27 +41,31 @@ internal class InteropUIBlockListener : UIManagerListener {
   @Synchronized
   override fun willMountItems(uiManager: UIManager) {
     if (beforeUIBlocks.isEmpty()) {
-      return
-    }
-    beforeUIBlocks.forEach {
-      if (uiManager is UIBlockViewResolver) {
-        it.execute(uiManager)
+       return
+     }
+    // avoid ConcurrentModificationException by iterating over a copy
+    val snapshot = ArrayList(beforeUIBlocks)
+    beforeUIBlocks.clear()
+    if (uiManager is UIBlockViewResolver) {
+      snapshot.forEach { block ->
+        block.execute(uiManager)
       }
     }
-    beforeUIBlocks.clear()
   }
 
   @Synchronized
   override fun didMountItems(uiManager: UIManager) {
     if (afterUIBlocks.isEmpty()) {
-      return
-    }
-    afterUIBlocks.forEach {
-      if (uiManager is UIBlockViewResolver) {
-        it.execute(uiManager)
+       return
+     }
+    // avoid ConcurrentModificationException by iterating over a copy
+    val snapshot = ArrayList(afterUIBlocks)
+    afterUIBlocks.clear()
+    if (uiManager is UIBlockViewResolver) {
+      snapshot.forEach { block ->
+        block.execute(uiManager)
       }
     }
-    afterUIBlocks.clear()
   }
 
   override fun didDispatchMountItems(uiManager: UIManager) = didMountItems(uiManager)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/internal/interop/InteropUiBlockListener.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/internal/interop/InteropUiBlockListener.kt
@@ -41,31 +41,27 @@ internal class InteropUIBlockListener : UIManagerListener {
   @Synchronized
   override fun willMountItems(uiManager: UIManager) {
     if (beforeUIBlocks.isEmpty()) {
-       return
-     }
-    // avoid ConcurrentModificationException by iterating over a copy
-    val snapshot = ArrayList(beforeUIBlocks)
-    beforeUIBlocks.clear()
-    if (uiManager is UIBlockViewResolver) {
-      snapshot.forEach { block ->
-        block.execute(uiManager)
+      return
+    }
+    beforeUIBlocks.forEach {
+      if (uiManager is UIBlockViewResolver) {
+        it.execute(uiManager)
       }
     }
+    beforeUIBlocks.clear()
   }
 
   @Synchronized
   override fun didMountItems(uiManager: UIManager) {
     if (afterUIBlocks.isEmpty()) {
-       return
-     }
-    // avoid ConcurrentModificationException by iterating over a copy
-    val snapshot = ArrayList(afterUIBlocks)
-    afterUIBlocks.clear()
-    if (uiManager is UIBlockViewResolver) {
-      snapshot.forEach { block ->
-        block.execute(uiManager)
+      return
+    }
+    afterUIBlocks.forEach {
+      if (uiManager is UIBlockViewResolver) {
+        it.execute(uiManager)
       }
     }
+    afterUIBlocks.clear()
   }
 
   override fun didDispatchMountItems(uiManager: UIManager) = didMountItems(uiManager)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/internal/interop/InteropUiBlockListener.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/internal/interop/InteropUiBlockListener.kt
@@ -42,24 +42,38 @@ internal class InteropUIBlockListener : UIManagerListener {
     if (beforeUIBlocks.isEmpty()) {
       return
     }
-    beforeUIBlocks.forEach {
-      if (uiManager is UIBlockViewResolver) {
-        it.execute(uiManager)
+    // avoid ConcurrentModificationException by iterating over a copy
+    try {
+      val snapshot = ArrayList(beforeUIBlocks)
+      snapshot.forEach { block ->
+        if (uiManager is UIBlockViewResolver) {
+          block.execute(uiManager)
+        }
       }
+    } catch (e: ConcurrentModificationException) {
+      // ignore any mid-iteration mutations
+    } finally {
+      beforeUIBlocks.clear()
     }
-    beforeUIBlocks.clear()
   }
 
   override fun didMountItems(uiManager: UIManager) {
     if (afterUIBlocks.isEmpty()) {
       return
     }
-    afterUIBlocks.forEach {
-      if (uiManager is UIBlockViewResolver) {
-        it.execute(uiManager)
+    // avoid ConcurrentModificationException by iterating over a copy
+    try {
+      val snapshot = ArrayList(afterUIBlocks)
+      snapshot.forEach { block ->
+        if (uiManager is UIBlockViewResolver) {
+          block.execute(uiManager)
+        }
       }
+    } catch (e: ConcurrentModificationException) {
+      // ignore any mid-iteration mutations
+    } finally {
+      afterUIBlocks.clear()
     }
-    afterUIBlocks.clear()
   }
 
   override fun didDispatchMountItems(uiManager: UIManager) = didMountItems(uiManager)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/internal/interop/InteropUiBlockListener.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/internal/interop/InteropUiBlockListener.kt
@@ -43,11 +43,11 @@ internal class InteropUIBlockListener : UIManagerListener {
       if (beforeUIBlocks.isEmpty()) {
         return
       }
-      // avoid ConcurrentModificationException by iterating over a copy
-      ArrayList(beforeUIBlocks).also { beforeUIBlocks.clear() }
+      beforeUIBlocks.toList().also { beforeUIBlocks.clear() }
     }
 
     if (uiManager is UIBlockViewResolver) {
+      // avoid ConcurrentModificationException by iterating over a copy
       blocksToExecute.forEach { block ->
         block.execute(uiManager)
       }
@@ -59,11 +59,11 @@ internal class InteropUIBlockListener : UIManagerListener {
       if (afterUIBlocks.isEmpty()) {
         return
       }
-      // avoid ConcurrentModificationException by iterating over a copy
-      ArrayList(afterUIBlocks).also { afterUIBlocks.clear() }
+      afterUIBlocks.toList().also { afterUIBlocks.clear() }
     }
 
     if (uiManager is UIBlockViewResolver) {
+      // avoid ConcurrentModificationException by iterating over a copy
       blocksToExecute.forEach { block ->
         block.execute(uiManager)
       }


### PR DESCRIPTION
## Summary:

This React Native Android fix hardens the Fabric `InteropUiBlockListener` against `ConcurrentModificationException` crashes in `willMountItems` and `didMountItems`. By iterating over a shallow copy of the UI‐block lists and catching any mid‐iteration mutations, we ensure the listener never throws during a UI frame and always clears its pending blocks.

The issue was first reported in [React Native Issue #49783](https://github.com/facebook/react-native/issues/49783), and although [React Native PR#50091](https://github.com/facebook/react-native/pull/50091) was closed and not merged, the work in that PR did make it to React Native in [commit 17da3cb](https://github.com/facebook/react-native/commit/17da3cbbf4687f86226c4a80297c4d8abfc9c4f5). However, the fix didn't go far enough. We saw intermittent examples of this exception being thrown when swiping through a carousel from `react-native-reanimated-carousel`. This fix goes right to the exception site itself.

## Changelog:

[ANDROID] [FIXED] -  Hardened the Fabric `InteropUiBlockListener` against `ConcurrentModificationException` crashes in `willMountItems` and `didMountItems`

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

The only way to test this is to develop a standalone app that emulates what we've been seeing in our commercially available RN app. We have done extensive testing of before (intermittent crashes) and after the fix (no crashes) and things have been standing up very well for us.

Here is a the Red Box we see right at the time of the crash, before this fix:

<img width="414" alt="image" src="https://github.com/user-attachments/assets/8d1b6c6d-42f7-48a0-9574-2f05436547d4" />

And here is the beginning of the logcat crash log:

```
2025-05-07 16:01:49.212 unknown:BridgelessReact com.aura.suite                       W  ReactHost{0}.handleHostException(message = "null")
2025-05-07 16:01:49.212 unknown:ReactNative     com.aura.suite                       E  Exception in native call
                                                                                        java.util.ConcurrentModificationException
                                                                                        	at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:1111)
                                                                                        	at java.util.ArrayList$Itr.next(ArrayList.java:1064)
                                                                                        	at com.facebook.react.fabric.internal.interop.InteropUIBlockListener.willMountItems(InteropUiBlockListener.kt:72)
                                                                                        	at com.facebook.react.fabric.FabricUIManager$MountItemDispatchListener.willMountItems(FabricUIManager.java:1235)
                                                                                        	at com.facebook.react.fabric.mounting.MountItemDispatcher.dispatchMountItems(MountItemDispatcher.java:184)
                                                                                        	at com.facebook.react.fabric.mounting.MountItemDispatcher.tryDispatchMountItems(MountItemDispatcher.java:122)
                                                                                        	at com.facebook.react.fabric.FabricUIManager$3.runGuarded(FabricUIManager.java:820)
                                                                                        	at com.facebook.react.bridge.GuardedRunnable.run(GuardedRunnable.java:29)
                                                                                        	at com.facebook.react.fabric.FabricUIManager.scheduleMountItem(FabricUIManager.java:824)
                                                                                        	at com.facebook.react.fabric.FabricUIManagerBinding.reportMount(Native Method)
                                                                                        	at com.facebook.react.fabric.FabricUIManager$MountItemDispatchListener$1.run(FabricUIManager.java:1282)
                                                                                        	at android.os.Handler.handleCallback(Handler.java:959)
                                                                                        	at android.os.Handler.dispatchMessage(Handler.java:100)
                                                                                        	at android.os.Looper.loopOnce(Looper.java:232)
                                                                                        	at android.os.Looper.loop(Looper.java:317)
                                                                                        	at android.app.ActivityThread.main(ActivityThread.java:8592)
                                                                                        	at java.lang.reflect.Method.invoke(Native Method)
                                                                                        	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:580)
                                                                                        	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:878)
```

All of this goes away with this fix. We're using React Native 0.79.2 and this is the first time we've open a PR for react-native. I hope this is enough info as far as testing goes.

Can we see a 0.79.x release with this fix, please?
