### PR TITLE
Remove hard-coded component name listing for Props 2.0 support testing

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp
@@ -223,13 +223,9 @@ jni::local_ref<jobject> getProps(
   auto* oldProps = oldShadowView.props.get();
   auto* newProps = newShadowView.props.get();
   if ((ReactNativeFeatureFlags::enablePropsUpdateReconciliationAndroid()) &&
-      (strcmp(newShadowView.componentName, "View") == 0 ||
-       strcmp(newShadowView.componentName, "Image") == 0 ||
-       strcmp(newShadowView.componentName, "ScrollView") == 0 ||
-       strcmp(newShadowView.componentName, "RawText") == 0 ||
-       strcmp(newShadowView.componentName, "Text") == 0 ||
-       strcmp(newShadowView.componentName, "Paragraph") == 0 ||
-       strcmp(newShadowView.componentName, "TextInput") == 0)) {
+      strcmp(
+          newShadowView.componentName,
+          newProps->getDiffPropsImplementationTarget()) == 0) {
     return ReadableNativeMap::newObjectCxxArgs(
         newProps->getDiffProps(oldProps));
   }

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
@@ -232,6 +232,10 @@ static folly::dynamic convertEdgeInsets(const EdgeInsets& edgeInsets) {
   return edgeInsetsResult;
 }
 
+ComponentName ImageProps::getDiffPropsImplementationTarget() const {
+  return "Image";
+}
+
 folly::dynamic ImageProps::getDiffProps(const Props* prevProps) const {
   static const auto defaultProps = ImageProps();
 

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
@@ -47,6 +47,7 @@ class ImageProps final : public ViewProps {
   bool progressiveRenderingEnabled{};
 
 #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
   folly::dynamic getDiffProps(const Props* prevProps) const override;
 #endif
 };

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/android/react/renderer/components/scrollview/HostPlatformScrollViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/android/react/renderer/components/scrollview/HostPlatformScrollViewProps.cpp
@@ -106,6 +106,11 @@ static folly::dynamic convertPoint(const Point& point) {
   return pointResult;
 }
 
+ComponentName HostPlatformScrollViewProps::getDiffPropsImplementationTarget()
+    const {
+  return "ScrollView";
+}
+
 folly::dynamic HostPlatformScrollViewProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = HostPlatformScrollViewProps();

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/android/react/renderer/components/scrollview/HostPlatformScrollViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/android/react/renderer/components/scrollview/HostPlatformScrollViewProps.h
@@ -39,6 +39,7 @@ class HostPlatformScrollViewProps final : public BaseScrollViewProps {
   SharedDebugStringConvertibleList getDebugProps() const override;
 #endif
 
+  ComponentName getDiffPropsImplementationTarget() const override;
   folly::dynamic getDiffProps(const Props* prevProps) const override;
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.cpp
@@ -154,6 +154,10 @@ SharedDebugStringConvertibleList ParagraphProps::getDebugProps() const {
 
 #ifdef RN_SERIALIZABLE_STATE
 
+ComponentName ParagraphProps::getDiffPropsImplementationTarget() const {
+  return "Paragraph";
+}
+
 folly::dynamic ParagraphProps::getDiffProps(const Props* prevProps) const {
   static const auto defaultProps = ParagraphProps();
 

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.h
@@ -59,6 +59,7 @@ class ParagraphProps : public ViewProps, public BaseTextProps {
 #endif
 
 #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
   folly::dynamic getDiffProps(const Props* prevProps) const override;
 #endif
 };

--- a/packages/react-native/ReactCommon/react/renderer/components/text/RawTextProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/RawTextProps.cpp
@@ -30,6 +30,10 @@ SharedDebugStringConvertibleList RawTextProps::getDebugProps() const {
 
 #ifdef RN_SERIALIZABLE_STATE
 
+ComponentName RawTextProps::getDiffPropsImplementationTarget() const {
+  return "RawText";
+}
+
 folly::dynamic RawTextProps::getDiffProps(const Props* prevProps) const {
   folly::dynamic result = folly::dynamic::object();
 

--- a/packages/react-native/ReactCommon/react/renderer/components/text/RawTextProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/RawTextProps.h
@@ -38,6 +38,7 @@ class RawTextProps : public Props {
 #endif
 
 #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
   folly::dynamic getDiffProps(const Props* prevProps) const override;
 #endif
 };

--- a/packages/react-native/ReactCommon/react/renderer/components/text/TextProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/TextProps.cpp
@@ -35,6 +35,10 @@ SharedDebugStringConvertibleList TextProps::getDebugProps() const {
 
 #ifdef RN_SERIALIZABLE_STATE
 
+ComponentName TextProps::getDiffPropsImplementationTarget() const {
+  return "Text";
+}
+
 folly::dynamic TextProps::getDiffProps(const Props* prevProps) const {
   folly::dynamic result = folly::dynamic::object();
 

--- a/packages/react-native/ReactCommon/react/renderer/components/text/TextProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/TextProps.h
@@ -36,6 +36,7 @@ class TextProps : public Props, public BaseTextProps {
 #endif
 
 #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
   folly::dynamic getDiffProps(const Props* prevProps) const override;
 #endif
 };

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
@@ -366,6 +366,10 @@ static folly::dynamic toDynamic(
   return acceptDragAndDropTypesArray;
 }
 
+ComponentName AndroidTextInputProps::getDiffPropsImplementationTarget() const {
+  return "TextInput";
+}
+
 folly::dynamic AndroidTextInputProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = AndroidTextInputProps();

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.h
@@ -133,6 +133,7 @@ class AndroidTextInputProps final : public BaseTextInputProps {
   SharedDebugStringConvertibleList getDebugProps() const override;
 #endif
 
+  ComponentName getDiffPropsImplementationTarget() const override;
   folly::dynamic getDiffProps(const Props* prevProps) const override;
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
@@ -539,6 +539,10 @@ static folly::dynamic toDynamic(const EdgeInsets& edgeInsets) {
   return edgeInsetsResult;
 }
 
+ComponentName HostPlatformViewProps::getDiffPropsImplementationTarget() const {
+  return "View";
+}
+
 folly::dynamic HostPlatformViewProps::getDiffProps(
     const Props* prevProps) const {
   folly::dynamic result = folly::dynamic::object();

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.h
@@ -58,6 +58,7 @@ class HostPlatformViewProps : public BaseViewProps {
 #endif
 
 #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
   folly::dynamic getDiffProps(const Props* prevProps) const override;
 #endif
 };

--- a/packages/react-native/ReactCommon/react/renderer/core/Props.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/Props.h
@@ -66,6 +66,10 @@ class Props : public virtual Sealable, public virtual DebugStringConvertible {
 #ifdef RN_SERIALIZABLE_STATE
   folly::dynamic rawProps = folly::dynamic::object();
 
+  virtual ComponentName getDiffPropsImplementationTarget() const {
+    return "";
+  }
+
   virtual folly::dynamic getDiffProps(const Props* prevProps) const {
     return folly::dynamic::object();
   }


### PR DESCRIPTION
Summary:
To fully support props diffing for a component, the component's Props implementation needs to implement the prop diffing for the derived class.

Because all Props classes extend the ViewProps, all Props classes implement the `getDiffProps` function. To support testing that the props diffing implementation support all properties of the derived Props class for the component being mounted, this diff adds the virtual function `getDiffPropsImplementationTarget` which returns the `ComponentName` that the `getDiffProps` function supports.

This removes the need for a hard-coded list of components that support props diffing and enables the use of codegen to conditionally enable props diffing.

Changelog: [Internal]

Differential Revision: D75465020


