### PR TITLE
Extend getDiffProps method to call HostPlatformViewProps

### DIFF
--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -42,7 +42,7 @@ ArrayPropsNativeComponentViewProps::ArrayPropsNativeComponentViewProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic ArrayPropsNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -83,7 +83,7 @@ BooleanPropNativeComponentViewProps::BooleanPropNativeComponentViewProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic BooleanPropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -123,7 +123,7 @@ ColorPropNativeComponentViewProps::ColorPropNativeComponentViewProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic ColorPropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -164,7 +164,7 @@ DimensionPropNativeComponentViewProps::DimensionPropNativeComponentViewProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic DimensionPropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -204,7 +204,7 @@ EdgeInsetsPropNativeComponentViewProps::EdgeInsetsPropNativeComponentViewProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic EdgeInsetsPropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -245,7 +245,7 @@ EnumPropNativeComponentViewProps::EnumPropNativeComponentViewProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic EnumPropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -285,7 +285,7 @@ EventNestedObjectPropsNativeComponentViewProps::EventNestedObjectPropsNativeComp
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic EventNestedObjectPropsNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -325,7 +325,7 @@ EventPropsNativeComponentViewProps::EventPropsNativeComponentViewProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic EventPropsNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -371,7 +371,7 @@ FloatPropsNativeComponentViewProps::FloatPropsNativeComponentViewProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic FloatPropsNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -412,7 +412,7 @@ ImagePropNativeComponentViewProps::ImagePropNativeComponentViewProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic ImagePropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -454,7 +454,7 @@ IntegerPropNativeComponentViewProps::IntegerPropNativeComponentViewProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic IntegerPropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -494,7 +494,7 @@ InterfaceOnlyNativeComponentViewProps::InterfaceOnlyNativeComponentViewProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic InterfaceOnlyNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -535,7 +535,7 @@ MixedPropNativeComponentViewProps::MixedPropNativeComponentViewProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic MixedPropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -579,7 +579,7 @@ MultiNativePropNativeComponentViewProps::MultiNativePropNativeComponentViewProps
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic MultiNativePropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -619,7 +619,7 @@ NoPropsNoEventsNativeComponentViewProps::NoPropsNoEventsNativeComponentViewProps
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic NoPropsNoEventsNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -662,7 +662,7 @@ ObjectPropsNativeComponentProps::ObjectPropsNativeComponentProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic ObjectPropsNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -702,7 +702,7 @@ PointPropNativeComponentViewProps::PointPropNativeComponentViewProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic PointPropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -743,7 +743,7 @@ StringPropNativeComponentViewProps::StringPropNativeComponentViewProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic StringPropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -37,8 +37,17 @@ ArrayPropsNativeComponentViewProps::ArrayPropsNativeComponentViewProps(
     sizes(convertRawProp(context, rawProps, \\"sizes\\", ArrayPropsNativeComponentViewSizesMaskWrapped{ .value = sourceProps.sizes }, {static_cast<ArrayPropsNativeComponentViewSizesMask>(ArrayPropsNativeComponentViewSizes::Small)}).value),
     object(convertRawProp(context, rawProps, \\"object\\", sourceProps.object, {})),
     arrayOfObjects(convertRawProp(context, rawProps, \\"arrayOfObjects\\", sourceProps.arrayOfObjects, {})),
-    arrayOfMixed(convertRawProp(context, rawProps, \\"arrayOfMixed\\", sourceProps.arrayOfMixed, {}))
-      {}
+    arrayOfMixed(convertRawProp(context, rawProps, \\"arrayOfMixed\\", sourceProps.arrayOfMixed, {})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic ArrayPropsNativeComponentViewProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -69,8 +78,17 @@ BooleanPropNativeComponentViewProps::BooleanPropNativeComponentViewProps(
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
     disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {false})),
-    disabledNullable(convertRawProp(context, rawProps, \\"disabledNullable\\", sourceProps.disabledNullable, {}))
-      {}
+    disabledNullable(convertRawProp(context, rawProps, \\"disabledNullable\\", sourceProps.disabledNullable, {})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic BooleanPropNativeComponentViewProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -100,8 +118,17 @@ ColorPropNativeComponentViewProps::ColorPropNativeComponentViewProps(
     const ColorPropNativeComponentViewProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    tintColor(convertRawProp(context, rawProps, \\"tintColor\\", sourceProps.tintColor, {}))
-      {}
+    tintColor(convertRawProp(context, rawProps, \\"tintColor\\", sourceProps.tintColor, {})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic ColorPropNativeComponentViewProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -132,8 +159,17 @@ DimensionPropNativeComponentViewProps::DimensionPropNativeComponentViewProps(
     const DimensionPropNativeComponentViewProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    marginBack(convertRawProp(context, rawProps, \\"marginBack\\", sourceProps.marginBack, {}))
-      {}
+    marginBack(convertRawProp(context, rawProps, \\"marginBack\\", sourceProps.marginBack, {})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic DimensionPropNativeComponentViewProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -163,8 +199,17 @@ EdgeInsetsPropNativeComponentViewProps::EdgeInsetsPropNativeComponentViewProps(
     const EdgeInsetsPropNativeComponentViewProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps)
 
+     {}
     
-      {}
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic EdgeInsetsPropNativeComponentViewProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -195,8 +240,17 @@ EnumPropNativeComponentViewProps::EnumPropNativeComponentViewProps(
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
     alignment(convertRawProp(context, rawProps, \\"alignment\\", sourceProps.alignment, {EnumPropNativeComponentViewAlignment::Center})),
-    intervals(convertRawProp(context, rawProps, \\"intervals\\", sourceProps.intervals, {EnumPropNativeComponentViewIntervals::Intervals0}))
-      {}
+    intervals(convertRawProp(context, rawProps, \\"intervals\\", sourceProps.intervals, {EnumPropNativeComponentViewIntervals::Intervals0})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic EnumPropNativeComponentViewProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -226,8 +280,17 @@ EventNestedObjectPropsNativeComponentViewProps::EventNestedObjectPropsNativeComp
     const EventNestedObjectPropsNativeComponentViewProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {false}))
-      {}
+    disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {false})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic EventNestedObjectPropsNativeComponentViewProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -257,8 +320,17 @@ EventPropsNativeComponentViewProps::EventPropsNativeComponentViewProps(
     const EventPropsNativeComponentViewProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {false}))
-      {}
+    disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {false})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic EventPropsNativeComponentViewProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -294,8 +366,17 @@ FloatPropsNativeComponentViewProps::FloatPropsNativeComponentViewProps(
     blurRadius4(convertRawProp(context, rawProps, \\"blurRadius4\\", sourceProps.blurRadius4, {0.0})),
     blurRadius5(convertRawProp(context, rawProps, \\"blurRadius5\\", sourceProps.blurRadius5, {1.0})),
     blurRadius6(convertRawProp(context, rawProps, \\"blurRadius6\\", sourceProps.blurRadius6, {0.0})),
-    blurRadiusNullable(convertRawProp(context, rawProps, \\"blurRadiusNullable\\", sourceProps.blurRadiusNullable, {}))
-      {}
+    blurRadiusNullable(convertRawProp(context, rawProps, \\"blurRadiusNullable\\", sourceProps.blurRadiusNullable, {})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic FloatPropsNativeComponentViewProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -326,8 +407,17 @@ ImagePropNativeComponentViewProps::ImagePropNativeComponentViewProps(
     const ImagePropNativeComponentViewProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    thumbImage(convertRawProp(context, rawProps, \\"thumbImage\\", sourceProps.thumbImage, {}))
-      {}
+    thumbImage(convertRawProp(context, rawProps, \\"thumbImage\\", sourceProps.thumbImage, {})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic ImagePropNativeComponentViewProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -359,8 +449,17 @@ IntegerPropNativeComponentViewProps::IntegerPropNativeComponentViewProps(
 
     progress1(convertRawProp(context, rawProps, \\"progress1\\", sourceProps.progress1, {0})),
     progress2(convertRawProp(context, rawProps, \\"progress2\\", sourceProps.progress2, {-1})),
-    progress3(convertRawProp(context, rawProps, \\"progress3\\", sourceProps.progress3, {10}))
-      {}
+    progress3(convertRawProp(context, rawProps, \\"progress3\\", sourceProps.progress3, {10})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic IntegerPropNativeComponentViewProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -390,8 +489,17 @@ InterfaceOnlyNativeComponentViewProps::InterfaceOnlyNativeComponentViewProps(
     const InterfaceOnlyNativeComponentViewProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    title(convertRawProp(context, rawProps, \\"title\\", sourceProps.title, {\\"\\"}))
-      {}
+    title(convertRawProp(context, rawProps, \\"title\\", sourceProps.title, {\\"\\"})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic InterfaceOnlyNativeComponentViewProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -422,8 +530,17 @@ MixedPropNativeComponentViewProps::MixedPropNativeComponentViewProps(
     const MixedPropNativeComponentViewProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    mixedProp(convertRawProp(context, rawProps, \\"mixedProp\\", sourceProps.mixedProp, {}))
-      {}
+    mixedProp(convertRawProp(context, rawProps, \\"mixedProp\\", sourceProps.mixedProp, {})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic MixedPropNativeComponentViewProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -457,8 +574,17 @@ MultiNativePropNativeComponentViewProps::MultiNativePropNativeComponentViewProps
     thumbImage(convertRawProp(context, rawProps, \\"thumbImage\\", sourceProps.thumbImage, {})),
     color(convertRawProp(context, rawProps, \\"color\\", sourceProps.color, {})),
     thumbTintColor(convertRawProp(context, rawProps, \\"thumbTintColor\\", sourceProps.thumbTintColor, {})),
-    point(convertRawProp(context, rawProps, \\"point\\", sourceProps.point, {}))
-      {}
+    point(convertRawProp(context, rawProps, \\"point\\", sourceProps.point, {})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic MultiNativePropNativeComponentViewProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -488,8 +614,17 @@ NoPropsNoEventsNativeComponentViewProps::NoPropsNoEventsNativeComponentViewProps
     const NoPropsNoEventsNativeComponentViewProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps)
 
+     {}
     
-      {}
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic NoPropsNoEventsNativeComponentViewProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -522,8 +657,17 @@ ObjectPropsNativeComponentProps::ObjectPropsNativeComponentProps(
 
     objectProp(convertRawProp(context, rawProps, \\"objectProp\\", sourceProps.objectProp, {})),
     objectArrayProp(convertRawProp(context, rawProps, \\"objectArrayProp\\", sourceProps.objectArrayProp, {})),
-    objectPrimitiveRequiredProp(convertRawProp(context, rawProps, \\"objectPrimitiveRequiredProp\\", sourceProps.objectPrimitiveRequiredProp, {}))
-      {}
+    objectPrimitiveRequiredProp(convertRawProp(context, rawProps, \\"objectPrimitiveRequiredProp\\", sourceProps.objectPrimitiveRequiredProp, {})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic ObjectPropsNativeComponentProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -553,8 +697,17 @@ PointPropNativeComponentViewProps::PointPropNativeComponentViewProps(
     const PointPropNativeComponentViewProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    startPoint(convertRawProp(context, rawProps, \\"startPoint\\", sourceProps.startPoint, {}))
-      {}
+    startPoint(convertRawProp(context, rawProps, \\"startPoint\\", sourceProps.startPoint, {})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic PointPropNativeComponentViewProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -585,8 +738,17 @@ StringPropNativeComponentViewProps::StringPropNativeComponentViewProps(
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
     placeholder(convertRawProp(context, rawProps, \\"placeholder\\", sourceProps.placeholder, {\\"\\"})),
-    defaultValue(convertRawProp(context, rawProps, \\"defaultValue\\", sourceProps.defaultValue, {}))
-      {}
+    defaultValue(convertRawProp(context, rawProps, \\"defaultValue\\", sourceProps.defaultValue, {})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic StringPropNativeComponentViewProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
@@ -163,6 +163,10 @@ class ArrayPropsNativeComponentViewProps final : public ViewProps {
   std::vector<ArrayPropsNativeComponentViewObjectStruct> object{};
   std::vector<ArrayPropsNativeComponentViewArrayOfObjectsStruct> arrayOfObjects{};
   std::vector<folly::dynamic> arrayOfMixed{};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -197,6 +201,10 @@ class BooleanPropNativeComponentViewProps final : public ViewProps {
 
   bool disabled{false};
   bool disabledNullable{};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -231,6 +239,10 @@ class ColorPropNativeComponentViewProps final : public ViewProps {
 #pragma mark - Props
 
   SharedColor tintColor{};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -265,6 +277,10 @@ class DimensionPropNativeComponentViewProps final : public ViewProps {
 #pragma mark - Props
 
   YGValue marginBack{};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -298,6 +314,10 @@ class EdgeInsetsPropNativeComponentViewProps final : public ViewProps {
 #pragma mark - Props
 
   
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -380,6 +400,10 @@ class EnumPropNativeComponentViewProps final : public ViewProps {
 
   EnumPropNativeComponentViewAlignment alignment{EnumPropNativeComponentViewAlignment::Center};
   EnumPropNativeComponentViewIntervals intervals{EnumPropNativeComponentViewIntervals::Intervals0};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -413,6 +437,10 @@ class EventNestedObjectPropsNativeComponentViewProps final : public ViewProps {
 #pragma mark - Props
 
   bool disabled{false};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -446,6 +474,10 @@ class EventPropsNativeComponentViewProps final : public ViewProps {
 #pragma mark - Props
 
   bool disabled{false};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -485,6 +517,10 @@ class FloatPropsNativeComponentViewProps final : public ViewProps {
   Float blurRadius5{1.0};
   Float blurRadius6{0.0};
   Float blurRadiusNullable{};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -519,6 +555,10 @@ class ImagePropNativeComponentViewProps final : public ViewProps {
 #pragma mark - Props
 
   ImageSource thumbImage{};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -554,6 +594,10 @@ class IntegerPropNativeComponentViewProps final : public ViewProps {
   int progress1{0};
   int progress2{-1};
   int progress3{10};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -587,6 +631,10 @@ class InterfaceOnlyNativeComponentViewProps final : public ViewProps {
 #pragma mark - Props
 
   std::string title{\\"\\"};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -620,6 +668,10 @@ class MixedPropNativeComponentViewProps final : public ViewProps {
 #pragma mark - Props
 
   folly::dynamic mixedProp{};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -659,6 +711,10 @@ class MultiNativePropNativeComponentViewProps final : public ViewProps {
   SharedColor color{};
   SharedColor thumbTintColor{};
   Point point{};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -692,6 +748,10 @@ class NoPropsNoEventsNativeComponentViewProps final : public ViewProps {
 #pragma mark - Props
 
   
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -855,6 +915,10 @@ class ObjectPropsNativeComponentProps final : public ViewProps {
   ObjectPropsNativeComponentObjectPropStruct objectProp{};
   ObjectPropsNativeComponentObjectArrayPropStruct objectArrayProp{};
   ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct objectPrimitiveRequiredProp{};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -889,6 +953,10 @@ class PointPropNativeComponentViewProps final : public ViewProps {
 #pragma mark - Props
 
   Point startPoint{};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -923,6 +991,10 @@ class StringPropNativeComponentViewProps final : public ViewProps {
 
   std::string placeholder{\\"\\"};
   std::string defaultValue{};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -42,7 +42,7 @@ ArrayPropsNativeComponentViewProps::ArrayPropsNativeComponentViewProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic ArrayPropsNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -83,7 +83,7 @@ BooleanPropNativeComponentViewProps::BooleanPropNativeComponentViewProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic BooleanPropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -123,7 +123,7 @@ ColorPropNativeComponentViewProps::ColorPropNativeComponentViewProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic ColorPropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -164,7 +164,7 @@ DimensionPropNativeComponentViewProps::DimensionPropNativeComponentViewProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic DimensionPropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -204,7 +204,7 @@ EdgeInsetsPropNativeComponentViewProps::EdgeInsetsPropNativeComponentViewProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic EdgeInsetsPropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -245,7 +245,7 @@ EnumPropNativeComponentViewProps::EnumPropNativeComponentViewProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic EnumPropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -285,7 +285,7 @@ EventNestedObjectPropsNativeComponentViewProps::EventNestedObjectPropsNativeComp
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic EventNestedObjectPropsNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -325,7 +325,7 @@ EventPropsNativeComponentViewProps::EventPropsNativeComponentViewProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic EventPropsNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -371,7 +371,7 @@ FloatPropsNativeComponentViewProps::FloatPropsNativeComponentViewProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic FloatPropsNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -412,7 +412,7 @@ ImagePropNativeComponentViewProps::ImagePropNativeComponentViewProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic ImagePropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -454,7 +454,7 @@ IntegerPropNativeComponentViewProps::IntegerPropNativeComponentViewProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic IntegerPropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -494,7 +494,7 @@ InterfaceOnlyNativeComponentViewProps::InterfaceOnlyNativeComponentViewProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic InterfaceOnlyNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -535,7 +535,7 @@ MixedPropNativeComponentViewProps::MixedPropNativeComponentViewProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic MixedPropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -579,7 +579,7 @@ MultiNativePropNativeComponentViewProps::MultiNativePropNativeComponentViewProps
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic MultiNativePropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -619,7 +619,7 @@ NoPropsNoEventsNativeComponentViewProps::NoPropsNoEventsNativeComponentViewProps
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic NoPropsNoEventsNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -662,7 +662,7 @@ ObjectPropsNativeComponentProps::ObjectPropsNativeComponentProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic ObjectPropsNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -702,7 +702,7 @@ PointPropNativeComponentViewProps::PointPropNativeComponentViewProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic PointPropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -743,7 +743,7 @@ StringPropNativeComponentViewProps::StringPropNativeComponentViewProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic StringPropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -37,8 +37,17 @@ ArrayPropsNativeComponentViewProps::ArrayPropsNativeComponentViewProps(
     sizes(convertRawProp(context, rawProps, \\"sizes\\", ArrayPropsNativeComponentViewSizesMaskWrapped{ .value = sourceProps.sizes }, {static_cast<ArrayPropsNativeComponentViewSizesMask>(ArrayPropsNativeComponentViewSizes::Small)}).value),
     object(convertRawProp(context, rawProps, \\"object\\", sourceProps.object, {})),
     arrayOfObjects(convertRawProp(context, rawProps, \\"arrayOfObjects\\", sourceProps.arrayOfObjects, {})),
-    arrayOfMixed(convertRawProp(context, rawProps, \\"arrayOfMixed\\", sourceProps.arrayOfMixed, {}))
-      {}
+    arrayOfMixed(convertRawProp(context, rawProps, \\"arrayOfMixed\\", sourceProps.arrayOfMixed, {})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic ArrayPropsNativeComponentViewProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -69,8 +78,17 @@ BooleanPropNativeComponentViewProps::BooleanPropNativeComponentViewProps(
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
     disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {false})),
-    disabledNullable(convertRawProp(context, rawProps, \\"disabledNullable\\", sourceProps.disabledNullable, {}))
-      {}
+    disabledNullable(convertRawProp(context, rawProps, \\"disabledNullable\\", sourceProps.disabledNullable, {})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic BooleanPropNativeComponentViewProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -100,8 +118,17 @@ ColorPropNativeComponentViewProps::ColorPropNativeComponentViewProps(
     const ColorPropNativeComponentViewProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    tintColor(convertRawProp(context, rawProps, \\"tintColor\\", sourceProps.tintColor, {}))
-      {}
+    tintColor(convertRawProp(context, rawProps, \\"tintColor\\", sourceProps.tintColor, {})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic ColorPropNativeComponentViewProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -132,8 +159,17 @@ DimensionPropNativeComponentViewProps::DimensionPropNativeComponentViewProps(
     const DimensionPropNativeComponentViewProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    marginBack(convertRawProp(context, rawProps, \\"marginBack\\", sourceProps.marginBack, {}))
-      {}
+    marginBack(convertRawProp(context, rawProps, \\"marginBack\\", sourceProps.marginBack, {})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic DimensionPropNativeComponentViewProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -163,8 +199,17 @@ EdgeInsetsPropNativeComponentViewProps::EdgeInsetsPropNativeComponentViewProps(
     const EdgeInsetsPropNativeComponentViewProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps)
 
+     {}
     
-      {}
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic EdgeInsetsPropNativeComponentViewProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -195,8 +240,17 @@ EnumPropNativeComponentViewProps::EnumPropNativeComponentViewProps(
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
     alignment(convertRawProp(context, rawProps, \\"alignment\\", sourceProps.alignment, {EnumPropNativeComponentViewAlignment::Center})),
-    intervals(convertRawProp(context, rawProps, \\"intervals\\", sourceProps.intervals, {EnumPropNativeComponentViewIntervals::Intervals0}))
-      {}
+    intervals(convertRawProp(context, rawProps, \\"intervals\\", sourceProps.intervals, {EnumPropNativeComponentViewIntervals::Intervals0})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic EnumPropNativeComponentViewProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -226,8 +280,17 @@ EventNestedObjectPropsNativeComponentViewProps::EventNestedObjectPropsNativeComp
     const EventNestedObjectPropsNativeComponentViewProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {false}))
-      {}
+    disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {false})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic EventNestedObjectPropsNativeComponentViewProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -257,8 +320,17 @@ EventPropsNativeComponentViewProps::EventPropsNativeComponentViewProps(
     const EventPropsNativeComponentViewProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {false}))
-      {}
+    disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {false})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic EventPropsNativeComponentViewProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -294,8 +366,17 @@ FloatPropsNativeComponentViewProps::FloatPropsNativeComponentViewProps(
     blurRadius4(convertRawProp(context, rawProps, \\"blurRadius4\\", sourceProps.blurRadius4, {0.0})),
     blurRadius5(convertRawProp(context, rawProps, \\"blurRadius5\\", sourceProps.blurRadius5, {1.0})),
     blurRadius6(convertRawProp(context, rawProps, \\"blurRadius6\\", sourceProps.blurRadius6, {0.0})),
-    blurRadiusNullable(convertRawProp(context, rawProps, \\"blurRadiusNullable\\", sourceProps.blurRadiusNullable, {}))
-      {}
+    blurRadiusNullable(convertRawProp(context, rawProps, \\"blurRadiusNullable\\", sourceProps.blurRadiusNullable, {})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic FloatPropsNativeComponentViewProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -326,8 +407,17 @@ ImagePropNativeComponentViewProps::ImagePropNativeComponentViewProps(
     const ImagePropNativeComponentViewProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    thumbImage(convertRawProp(context, rawProps, \\"thumbImage\\", sourceProps.thumbImage, {}))
-      {}
+    thumbImage(convertRawProp(context, rawProps, \\"thumbImage\\", sourceProps.thumbImage, {})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic ImagePropNativeComponentViewProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -359,8 +449,17 @@ IntegerPropNativeComponentViewProps::IntegerPropNativeComponentViewProps(
 
     progress1(convertRawProp(context, rawProps, \\"progress1\\", sourceProps.progress1, {0})),
     progress2(convertRawProp(context, rawProps, \\"progress2\\", sourceProps.progress2, {-1})),
-    progress3(convertRawProp(context, rawProps, \\"progress3\\", sourceProps.progress3, {10}))
-      {}
+    progress3(convertRawProp(context, rawProps, \\"progress3\\", sourceProps.progress3, {10})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic IntegerPropNativeComponentViewProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -390,8 +489,17 @@ InterfaceOnlyNativeComponentViewProps::InterfaceOnlyNativeComponentViewProps(
     const InterfaceOnlyNativeComponentViewProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    title(convertRawProp(context, rawProps, \\"title\\", sourceProps.title, {\\"\\"}))
-      {}
+    title(convertRawProp(context, rawProps, \\"title\\", sourceProps.title, {\\"\\"})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic InterfaceOnlyNativeComponentViewProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -422,8 +530,17 @@ MixedPropNativeComponentViewProps::MixedPropNativeComponentViewProps(
     const MixedPropNativeComponentViewProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    mixedProp(convertRawProp(context, rawProps, \\"mixedProp\\", sourceProps.mixedProp, {}))
-      {}
+    mixedProp(convertRawProp(context, rawProps, \\"mixedProp\\", sourceProps.mixedProp, {})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic MixedPropNativeComponentViewProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -457,8 +574,17 @@ MultiNativePropNativeComponentViewProps::MultiNativePropNativeComponentViewProps
     thumbImage(convertRawProp(context, rawProps, \\"thumbImage\\", sourceProps.thumbImage, {})),
     color(convertRawProp(context, rawProps, \\"color\\", sourceProps.color, {})),
     thumbTintColor(convertRawProp(context, rawProps, \\"thumbTintColor\\", sourceProps.thumbTintColor, {})),
-    point(convertRawProp(context, rawProps, \\"point\\", sourceProps.point, {}))
-      {}
+    point(convertRawProp(context, rawProps, \\"point\\", sourceProps.point, {})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic MultiNativePropNativeComponentViewProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -488,8 +614,17 @@ NoPropsNoEventsNativeComponentViewProps::NoPropsNoEventsNativeComponentViewProps
     const NoPropsNoEventsNativeComponentViewProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps)
 
+     {}
     
-      {}
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic NoPropsNoEventsNativeComponentViewProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -522,8 +657,17 @@ ObjectPropsNativeComponentProps::ObjectPropsNativeComponentProps(
 
     objectProp(convertRawProp(context, rawProps, \\"objectProp\\", sourceProps.objectProp, {})),
     objectArrayProp(convertRawProp(context, rawProps, \\"objectArrayProp\\", sourceProps.objectArrayProp, {})),
-    objectPrimitiveRequiredProp(convertRawProp(context, rawProps, \\"objectPrimitiveRequiredProp\\", sourceProps.objectPrimitiveRequiredProp, {}))
-      {}
+    objectPrimitiveRequiredProp(convertRawProp(context, rawProps, \\"objectPrimitiveRequiredProp\\", sourceProps.objectPrimitiveRequiredProp, {})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic ObjectPropsNativeComponentProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -553,8 +697,17 @@ PointPropNativeComponentViewProps::PointPropNativeComponentViewProps(
     const PointPropNativeComponentViewProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    startPoint(convertRawProp(context, rawProps, \\"startPoint\\", sourceProps.startPoint, {}))
-      {}
+    startPoint(convertRawProp(context, rawProps, \\"startPoint\\", sourceProps.startPoint, {})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic PointPropNativeComponentViewProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -585,8 +738,17 @@ StringPropNativeComponentViewProps::StringPropNativeComponentViewProps(
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
     placeholder(convertRawProp(context, rawProps, \\"placeholder\\", sourceProps.placeholder, {\\"\\"})),
-    defaultValue(convertRawProp(context, rawProps, \\"defaultValue\\", sourceProps.defaultValue, {}))
-      {}
+    defaultValue(convertRawProp(context, rawProps, \\"defaultValue\\", sourceProps.defaultValue, {})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic StringPropNativeComponentViewProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
@@ -163,6 +163,10 @@ class ArrayPropsNativeComponentViewProps final : public ViewProps {
   std::vector<ArrayPropsNativeComponentViewObjectStruct> object{};
   std::vector<ArrayPropsNativeComponentViewArrayOfObjectsStruct> arrayOfObjects{};
   std::vector<folly::dynamic> arrayOfMixed{};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -197,6 +201,10 @@ class BooleanPropNativeComponentViewProps final : public ViewProps {
 
   bool disabled{false};
   bool disabledNullable{};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -231,6 +239,10 @@ class ColorPropNativeComponentViewProps final : public ViewProps {
 #pragma mark - Props
 
   SharedColor tintColor{};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -265,6 +277,10 @@ class DimensionPropNativeComponentViewProps final : public ViewProps {
 #pragma mark - Props
 
   YGValue marginBack{};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -298,6 +314,10 @@ class EdgeInsetsPropNativeComponentViewProps final : public ViewProps {
 #pragma mark - Props
 
   
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -380,6 +400,10 @@ class EnumPropNativeComponentViewProps final : public ViewProps {
 
   EnumPropNativeComponentViewAlignment alignment{EnumPropNativeComponentViewAlignment::Center};
   EnumPropNativeComponentViewIntervals intervals{EnumPropNativeComponentViewIntervals::Intervals0};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -413,6 +437,10 @@ class EventNestedObjectPropsNativeComponentViewProps final : public ViewProps {
 #pragma mark - Props
 
   bool disabled{false};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -446,6 +474,10 @@ class EventPropsNativeComponentViewProps final : public ViewProps {
 #pragma mark - Props
 
   bool disabled{false};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -485,6 +517,10 @@ class FloatPropsNativeComponentViewProps final : public ViewProps {
   Float blurRadius5{1.0};
   Float blurRadius6{0.0};
   Float blurRadiusNullable{};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -519,6 +555,10 @@ class ImagePropNativeComponentViewProps final : public ViewProps {
 #pragma mark - Props
 
   ImageSource thumbImage{};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -554,6 +594,10 @@ class IntegerPropNativeComponentViewProps final : public ViewProps {
   int progress1{0};
   int progress2{-1};
   int progress3{10};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -587,6 +631,10 @@ class InterfaceOnlyNativeComponentViewProps final : public ViewProps {
 #pragma mark - Props
 
   std::string title{\\"\\"};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -620,6 +668,10 @@ class MixedPropNativeComponentViewProps final : public ViewProps {
 #pragma mark - Props
 
   folly::dynamic mixedProp{};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -659,6 +711,10 @@ class MultiNativePropNativeComponentViewProps final : public ViewProps {
   SharedColor color{};
   SharedColor thumbTintColor{};
   Point point{};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -692,6 +748,10 @@ class NoPropsNoEventsNativeComponentViewProps final : public ViewProps {
 #pragma mark - Props
 
   
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -855,6 +915,10 @@ class ObjectPropsNativeComponentProps final : public ViewProps {
   ObjectPropsNativeComponentObjectPropStruct objectProp{};
   ObjectPropsNativeComponentObjectArrayPropStruct objectArrayProp{};
   ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct objectPrimitiveRequiredProp{};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -889,6 +953,10 @@ class PointPropNativeComponentViewProps final : public ViewProps {
 #pragma mark - Props
 
   Point startPoint{};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -923,6 +991,10 @@ class StringPropNativeComponentViewProps final : public ViewProps {
 
   std::string placeholder{\\"\\"};
   std::string defaultValue{};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
@@ -82,7 +82,7 @@ function generatePropsDiffString(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic ${className}::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsH.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsH.js
@@ -83,6 +83,10 @@ class ${className} final${extendClasses} {
 #pragma mark - Props
 
   ${props}
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 `.trim();
 

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -42,7 +42,7 @@ ArrayPropsNativeComponentProps::ArrayPropsNativeComponentProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic ArrayPropsNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -82,7 +82,7 @@ ArrayPropsNativeComponentProps::ArrayPropsNativeComponentProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic ArrayPropsNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -122,7 +122,7 @@ BooleanPropNativeComponentProps::BooleanPropNativeComponentProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic BooleanPropNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -162,7 +162,7 @@ ColorPropNativeComponentProps::ColorPropNativeComponentProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic ColorPropNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -202,7 +202,7 @@ CommandNativeComponentProps::CommandNativeComponentProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic CommandNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -242,7 +242,7 @@ CommandNativeComponentProps::CommandNativeComponentProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic CommandNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -283,7 +283,7 @@ DimensionPropNativeComponentProps::DimensionPropNativeComponentProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic DimensionPropNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -328,7 +328,7 @@ DoublePropNativeComponentProps::DoublePropNativeComponentProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic DoublePropNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -368,7 +368,7 @@ EventsNestedObjectNativeComponentProps::EventsNestedObjectNativeComponentProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic EventsNestedObjectNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -408,7 +408,7 @@ EventsNativeComponentProps::EventsNativeComponentProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic EventsNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -448,7 +448,7 @@ InterfaceOnlyComponentProps::InterfaceOnlyComponentProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic InterfaceOnlyComponentProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -488,7 +488,7 @@ ExcludedAndroidComponentProps::ExcludedAndroidComponentProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic ExcludedAndroidComponentProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -528,7 +528,7 @@ ExcludedAndroidIosComponentProps::ExcludedAndroidIosComponentProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic ExcludedAndroidIosComponentProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -568,7 +568,7 @@ ExcludedIosComponentProps::ExcludedIosComponentProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic ExcludedIosComponentProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -584,7 +584,7 @@ MultiFileIncludedNativeComponentProps::MultiFileIncludedNativeComponentProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic MultiFileIncludedNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -629,7 +629,7 @@ FloatPropNativeComponentProps::FloatPropNativeComponentProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic FloatPropNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -670,7 +670,7 @@ ImagePropNativeComponentProps::ImagePropNativeComponentProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic ImagePropNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -710,7 +710,7 @@ InsetsPropNativeComponentProps::InsetsPropNativeComponentProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic InsetsPropNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -750,7 +750,7 @@ Int32EnumPropsNativeComponentProps::Int32EnumPropsNativeComponentProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic Int32EnumPropsNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -792,7 +792,7 @@ IntegerPropNativeComponentProps::IntegerPropNativeComponentProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic IntegerPropNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -832,7 +832,7 @@ InterfaceOnlyComponentProps::InterfaceOnlyComponentProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic InterfaceOnlyComponentProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -873,7 +873,7 @@ MixedPropNativeComponentProps::MixedPropNativeComponentProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic MixedPropNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -917,7 +917,7 @@ ImageColorPropNativeComponentProps::ImageColorPropNativeComponentProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic ImageColorPropNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -957,7 +957,7 @@ NoPropsNoEventsComponentProps::NoPropsNoEventsComponentProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic NoPropsNoEventsComponentProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -998,7 +998,7 @@ ObjectPropsProps::ObjectPropsProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic ObjectPropsProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -1038,7 +1038,7 @@ PointPropNativeComponentProps::PointPropNativeComponentProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic PointPropNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -1078,7 +1078,7 @@ StringEnumPropsNativeComponentProps::StringEnumPropsNativeComponentProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic StringEnumPropsNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -1119,7 +1119,7 @@ StringPropComponentProps::StringPropComponentProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic StringPropComponentProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -1159,7 +1159,7 @@ MultiFile1NativeComponentProps::MultiFile1NativeComponentProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic MultiFile1NativeComponentProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -1175,7 +1175,7 @@ MultiFile2NativeComponentProps::MultiFile2NativeComponentProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic MultiFile2NativeComponentProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -1215,7 +1215,7 @@ MultiComponent1NativeComponentProps::MultiComponent1NativeComponentProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic MultiComponent1NativeComponentProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;
@@ -1231,7 +1231,7 @@ MultiComponent2NativeComponentProps::MultiComponent2NativeComponentProps(
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic MultiComponent2NativeComponentProps::getDiffProps(
     const Props* prevProps) const {
-  folly::dynamic result = folly::dynamic::object();
+  folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
 
   // TODO: Implement diffProps
   return result;

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -37,8 +37,17 @@ ArrayPropsNativeComponentProps::ArrayPropsNativeComponentProps(
     object(convertRawProp(context, rawProps, \\"object\\", sourceProps.object, {})),
     array(convertRawProp(context, rawProps, \\"array\\", sourceProps.array, {})),
     arrayOfArrayOfObject(convertRawProp(context, rawProps, \\"arrayOfArrayOfObject\\", sourceProps.arrayOfArrayOfObject, {})),
-    arrayOfMixed(convertRawProp(context, rawProps, \\"arrayOfMixed\\", sourceProps.arrayOfMixed, {}))
-      {}
+    arrayOfMixed(convertRawProp(context, rawProps, \\"arrayOfMixed\\", sourceProps.arrayOfMixed, {})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic ArrayPropsNativeComponentProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -68,8 +77,17 @@ ArrayPropsNativeComponentProps::ArrayPropsNativeComponentProps(
     const ArrayPropsNativeComponentProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    nativePrimitives(convertRawProp(context, rawProps, \\"nativePrimitives\\", sourceProps.nativePrimitives, {}))
-      {}
+    nativePrimitives(convertRawProp(context, rawProps, \\"nativePrimitives\\", sourceProps.nativePrimitives, {})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic ArrayPropsNativeComponentProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -99,8 +117,17 @@ BooleanPropNativeComponentProps::BooleanPropNativeComponentProps(
     const BooleanPropNativeComponentProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {false}))
-      {}
+    disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {false})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic BooleanPropNativeComponentProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -130,8 +157,17 @@ ColorPropNativeComponentProps::ColorPropNativeComponentProps(
     const ColorPropNativeComponentProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    tintColor(convertRawProp(context, rawProps, \\"tintColor\\", sourceProps.tintColor, {}))
-      {}
+    tintColor(convertRawProp(context, rawProps, \\"tintColor\\", sourceProps.tintColor, {})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic ColorPropNativeComponentProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -161,8 +197,17 @@ CommandNativeComponentProps::CommandNativeComponentProps(
     const CommandNativeComponentProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps)
 
+     {}
     
-      {}
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic CommandNativeComponentProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -192,8 +237,17 @@ CommandNativeComponentProps::CommandNativeComponentProps(
     const CommandNativeComponentProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    accessibilityHint(convertRawProp(context, rawProps, \\"accessibilityHint\\", sourceProps.accessibilityHint, {\\"\\"}))
-      {}
+    accessibilityHint(convertRawProp(context, rawProps, \\"accessibilityHint\\", sourceProps.accessibilityHint, {\\"\\"})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic CommandNativeComponentProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -224,8 +278,17 @@ DimensionPropNativeComponentProps::DimensionPropNativeComponentProps(
     const DimensionPropNativeComponentProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    marginBack(convertRawProp(context, rawProps, \\"marginBack\\", sourceProps.marginBack, {}))
-      {}
+    marginBack(convertRawProp(context, rawProps, \\"marginBack\\", sourceProps.marginBack, {})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic DimensionPropNativeComponentProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -260,8 +323,17 @@ DoublePropNativeComponentProps::DoublePropNativeComponentProps(
     blurRadius3(convertRawProp(context, rawProps, \\"blurRadius3\\", sourceProps.blurRadius3, {2.1})),
     blurRadius4(convertRawProp(context, rawProps, \\"blurRadius4\\", sourceProps.blurRadius4, {0.0})),
     blurRadius5(convertRawProp(context, rawProps, \\"blurRadius5\\", sourceProps.blurRadius5, {1.0})),
-    blurRadius6(convertRawProp(context, rawProps, \\"blurRadius6\\", sourceProps.blurRadius6, {0.0}))
-      {}
+    blurRadius6(convertRawProp(context, rawProps, \\"blurRadius6\\", sourceProps.blurRadius6, {0.0})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic DoublePropNativeComponentProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -291,8 +363,17 @@ EventsNestedObjectNativeComponentProps::EventsNestedObjectNativeComponentProps(
     const EventsNestedObjectNativeComponentProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {false}))
-      {}
+    disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {false})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic EventsNestedObjectNativeComponentProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -322,8 +403,17 @@ EventsNativeComponentProps::EventsNativeComponentProps(
     const EventsNativeComponentProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {false}))
-      {}
+    disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {false})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic EventsNativeComponentProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -353,8 +443,17 @@ InterfaceOnlyComponentProps::InterfaceOnlyComponentProps(
     const InterfaceOnlyComponentProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps)
 
+     {}
     
-      {}
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic InterfaceOnlyComponentProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -384,8 +483,17 @@ ExcludedAndroidComponentProps::ExcludedAndroidComponentProps(
     const ExcludedAndroidComponentProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps)
 
+     {}
     
-      {}
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic ExcludedAndroidComponentProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -415,8 +523,17 @@ ExcludedAndroidIosComponentProps::ExcludedAndroidIosComponentProps(
     const ExcludedAndroidIosComponentProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps)
 
+     {}
     
-      {}
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic ExcludedAndroidIosComponentProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -446,15 +563,33 @@ ExcludedIosComponentProps::ExcludedIosComponentProps(
     const ExcludedIosComponentProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps)
 
+     {}
     
-      {}
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic ExcludedIosComponentProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 MultiFileIncludedNativeComponentProps::MultiFileIncludedNativeComponentProps(
     const PropsParserContext &context,
     const MultiFileIncludedNativeComponentProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {true}))
-      {}
+    disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {true})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic MultiFileIncludedNativeComponentProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -489,8 +624,17 @@ FloatPropNativeComponentProps::FloatPropNativeComponentProps(
     blurRadius3(convertRawProp(context, rawProps, \\"blurRadius3\\", sourceProps.blurRadius3, {2.1})),
     blurRadius4(convertRawProp(context, rawProps, \\"blurRadius4\\", sourceProps.blurRadius4, {0.0})),
     blurRadius5(convertRawProp(context, rawProps, \\"blurRadius5\\", sourceProps.blurRadius5, {1.0})),
-    blurRadius6(convertRawProp(context, rawProps, \\"blurRadius6\\", sourceProps.blurRadius6, {0.0}))
-      {}
+    blurRadius6(convertRawProp(context, rawProps, \\"blurRadius6\\", sourceProps.blurRadius6, {0.0})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic FloatPropNativeComponentProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -521,8 +665,17 @@ ImagePropNativeComponentProps::ImagePropNativeComponentProps(
     const ImagePropNativeComponentProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    thumbImage(convertRawProp(context, rawProps, \\"thumbImage\\", sourceProps.thumbImage, {}))
-      {}
+    thumbImage(convertRawProp(context, rawProps, \\"thumbImage\\", sourceProps.thumbImage, {})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic ImagePropNativeComponentProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -552,8 +705,17 @@ InsetsPropNativeComponentProps::InsetsPropNativeComponentProps(
     const InsetsPropNativeComponentProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    contentInset(convertRawProp(context, rawProps, \\"contentInset\\", sourceProps.contentInset, {}))
-      {}
+    contentInset(convertRawProp(context, rawProps, \\"contentInset\\", sourceProps.contentInset, {})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic InsetsPropNativeComponentProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -583,8 +745,17 @@ Int32EnumPropsNativeComponentProps::Int32EnumPropsNativeComponentProps(
     const Int32EnumPropsNativeComponentProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    maxInterval(convertRawProp(context, rawProps, \\"maxInterval\\", sourceProps.maxInterval, {Int32EnumPropsNativeComponentMaxInterval::MaxInterval0}))
-      {}
+    maxInterval(convertRawProp(context, rawProps, \\"maxInterval\\", sourceProps.maxInterval, {Int32EnumPropsNativeComponentMaxInterval::MaxInterval0})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic Int32EnumPropsNativeComponentProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -616,8 +787,17 @@ IntegerPropNativeComponentProps::IntegerPropNativeComponentProps(
 
     progress1(convertRawProp(context, rawProps, \\"progress1\\", sourceProps.progress1, {0})),
     progress2(convertRawProp(context, rawProps, \\"progress2\\", sourceProps.progress2, {-1})),
-    progress3(convertRawProp(context, rawProps, \\"progress3\\", sourceProps.progress3, {10}))
-      {}
+    progress3(convertRawProp(context, rawProps, \\"progress3\\", sourceProps.progress3, {10})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic IntegerPropNativeComponentProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -647,8 +827,17 @@ InterfaceOnlyComponentProps::InterfaceOnlyComponentProps(
     const InterfaceOnlyComponentProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    accessibilityHint(convertRawProp(context, rawProps, \\"accessibilityHint\\", sourceProps.accessibilityHint, {\\"\\"}))
-      {}
+    accessibilityHint(convertRawProp(context, rawProps, \\"accessibilityHint\\", sourceProps.accessibilityHint, {\\"\\"})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic InterfaceOnlyComponentProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -679,8 +868,17 @@ MixedPropNativeComponentProps::MixedPropNativeComponentProps(
     const MixedPropNativeComponentProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    mixedProp(convertRawProp(context, rawProps, \\"mixedProp\\", sourceProps.mixedProp, {}))
-      {}
+    mixedProp(convertRawProp(context, rawProps, \\"mixedProp\\", sourceProps.mixedProp, {})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic MixedPropNativeComponentProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -714,8 +912,17 @@ ImageColorPropNativeComponentProps::ImageColorPropNativeComponentProps(
     thumbImage(convertRawProp(context, rawProps, \\"thumbImage\\", sourceProps.thumbImage, {})),
     color(convertRawProp(context, rawProps, \\"color\\", sourceProps.color, {})),
     thumbTintColor(convertRawProp(context, rawProps, \\"thumbTintColor\\", sourceProps.thumbTintColor, {})),
-    point(convertRawProp(context, rawProps, \\"point\\", sourceProps.point, {}))
-      {}
+    point(convertRawProp(context, rawProps, \\"point\\", sourceProps.point, {})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic ImageColorPropNativeComponentProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -745,8 +952,17 @@ NoPropsNoEventsComponentProps::NoPropsNoEventsComponentProps(
     const NoPropsNoEventsComponentProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps)
 
+     {}
     
-      {}
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic NoPropsNoEventsComponentProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -777,8 +993,17 @@ ObjectPropsProps::ObjectPropsProps(
     const ObjectPropsProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    objectProp(convertRawProp(context, rawProps, \\"objectProp\\", sourceProps.objectProp, {}))
-      {}
+    objectProp(convertRawProp(context, rawProps, \\"objectProp\\", sourceProps.objectProp, {})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic ObjectPropsProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -808,8 +1033,17 @@ PointPropNativeComponentProps::PointPropNativeComponentProps(
     const PointPropNativeComponentProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    startPoint(convertRawProp(context, rawProps, \\"startPoint\\", sourceProps.startPoint, {}))
-      {}
+    startPoint(convertRawProp(context, rawProps, \\"startPoint\\", sourceProps.startPoint, {})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic PointPropNativeComponentProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -839,8 +1073,17 @@ StringEnumPropsNativeComponentProps::StringEnumPropsNativeComponentProps(
     const StringEnumPropsNativeComponentProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    alignment(convertRawProp(context, rawProps, \\"alignment\\", sourceProps.alignment, {StringEnumPropsNativeComponentAlignment::Center}))
-      {}
+    alignment(convertRawProp(context, rawProps, \\"alignment\\", sourceProps.alignment, {StringEnumPropsNativeComponentAlignment::Center})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic StringEnumPropsNativeComponentProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -871,8 +1114,17 @@ StringPropComponentProps::StringPropComponentProps(
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
     accessibilityHint(convertRawProp(context, rawProps, \\"accessibilityHint\\", sourceProps.accessibilityHint, {\\"\\"})),
-    accessibilityRole(convertRawProp(context, rawProps, \\"accessibilityRole\\", sourceProps.accessibilityRole, {}))
-      {}
+    accessibilityRole(convertRawProp(context, rawProps, \\"accessibilityRole\\", sourceProps.accessibilityRole, {})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic StringPropComponentProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -902,15 +1154,33 @@ MultiFile1NativeComponentProps::MultiFile1NativeComponentProps(
     const MultiFile1NativeComponentProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {false}))
-      {}
+    disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {false})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic MultiFile1NativeComponentProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 MultiFile2NativeComponentProps::MultiFile2NativeComponentProps(
     const PropsParserContext &context,
     const MultiFile2NativeComponentProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {true}))
-      {}
+    disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {true})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic MultiFile2NativeComponentProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",
@@ -940,15 +1210,33 @@ MultiComponent1NativeComponentProps::MultiComponent1NativeComponentProps(
     const MultiComponent1NativeComponentProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {false}))
-      {}
+    disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {false})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic MultiComponent1NativeComponentProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 MultiComponent2NativeComponentProps::MultiComponent2NativeComponentProps(
     const PropsParserContext &context,
     const MultiComponent2NativeComponentProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {true}))
-      {}
+    disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {true})) {}
+    
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic MultiComponent2NativeComponentProps::getDiffProps(
+    const Props* prevProps) const {
+  folly::dynamic result = folly::dynamic::object();
+
+  // TODO: Implement diffProps
+  return result;
+}
+#endif
 
 } // namespace facebook::react
 ",

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
@@ -215,6 +215,10 @@ class ArrayPropsNativeComponentProps final : public ViewProps {
   std::vector<ArrayPropsNativeComponentArrayStruct> array{};
   std::vector<std::vector<ArrayPropsNativeComponentArrayOfArrayOfObjectStruct>> arrayOfArrayOfObject{};
   std::vector<folly::dynamic> arrayOfMixed{};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -290,6 +294,10 @@ class ArrayPropsNativeComponentProps final : public ViewProps {
 #pragma mark - Props
 
   std::vector<ArrayPropsNativeComponentNativePrimitivesStruct> nativePrimitives{};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -323,6 +331,10 @@ class BooleanPropNativeComponentProps final : public ViewProps {
 #pragma mark - Props
 
   bool disabled{false};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -357,6 +369,10 @@ class ColorPropNativeComponentProps final : public ViewProps {
 #pragma mark - Props
 
   SharedColor tintColor{};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -390,6 +406,10 @@ class CommandNativeComponentProps final : public ViewProps {
 #pragma mark - Props
 
   
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -423,6 +443,10 @@ class CommandNativeComponentProps final : public ViewProps {
 #pragma mark - Props
 
   std::string accessibilityHint{\\"\\"};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -457,6 +481,10 @@ class DimensionPropNativeComponentProps final : public ViewProps {
 #pragma mark - Props
 
   YGValue marginBack{};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -495,6 +523,10 @@ class DoublePropNativeComponentProps final : public ViewProps {
   double blurRadius4{0.0};
   double blurRadius5{1.0};
   double blurRadius6{0.0};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -528,6 +560,10 @@ class EventsNestedObjectNativeComponentProps final : public ViewProps {
 #pragma mark - Props
 
   bool disabled{false};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -561,6 +597,10 @@ class EventsNativeComponentProps final : public ViewProps {
 #pragma mark - Props
 
   bool disabled{false};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -594,6 +634,10 @@ class InterfaceOnlyComponentProps final : public ViewProps {
 #pragma mark - Props
 
   
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -627,6 +671,10 @@ class ExcludedAndroidComponentProps final : public ViewProps {
 #pragma mark - Props
 
   
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -660,6 +708,10 @@ class ExcludedAndroidIosComponentProps final : public ViewProps {
 #pragma mark - Props
 
   
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -693,6 +745,10 @@ class ExcludedIosComponentProps final : public ViewProps {
 #pragma mark - Props
 
   
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 class MultiFileIncludedNativeComponentProps final : public ViewProps {
@@ -703,6 +759,10 @@ class MultiFileIncludedNativeComponentProps final : public ViewProps {
 #pragma mark - Props
 
   bool disabled{true};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -741,6 +801,10 @@ class FloatPropNativeComponentProps final : public ViewProps {
   Float blurRadius4{0.0};
   Float blurRadius5{1.0};
   Float blurRadius6{0.0};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -775,6 +839,10 @@ class ImagePropNativeComponentProps final : public ViewProps {
 #pragma mark - Props
 
   ImageSource thumbImage{};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -809,6 +877,10 @@ class InsetsPropNativeComponentProps final : public ViewProps {
 #pragma mark - Props
 
   EdgeInsets contentInset{};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -869,6 +941,10 @@ class Int32EnumPropsNativeComponentProps final : public ViewProps {
 #pragma mark - Props
 
   Int32EnumPropsNativeComponentMaxInterval maxInterval{Int32EnumPropsNativeComponentMaxInterval::MaxInterval0};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -904,6 +980,10 @@ class IntegerPropNativeComponentProps final : public ViewProps {
   int progress1{0};
   int progress2{-1};
   int progress3{10};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -937,6 +1017,10 @@ class InterfaceOnlyComponentProps final : public ViewProps {
 #pragma mark - Props
 
   std::string accessibilityHint{\\"\\"};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -970,6 +1054,10 @@ class MixedPropNativeComponentProps final : public ViewProps {
 #pragma mark - Props
 
   folly::dynamic mixedProp{};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -1009,6 +1097,10 @@ class ImageColorPropNativeComponentProps final : public ViewProps {
   SharedColor color{};
   SharedColor thumbTintColor{};
   Point point{};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -1042,6 +1134,10 @@ class NoPropsNoEventsComponentProps final : public ViewProps {
 #pragma mark - Props
 
   
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -1315,6 +1411,10 @@ class ObjectPropsProps final : public ViewProps {
 #pragma mark - Props
 
   ObjectPropsObjectPropStruct objectProp{};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -1349,6 +1449,10 @@ class PointPropNativeComponentProps final : public ViewProps {
 #pragma mark - Props
 
   Point startPoint{};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -1400,6 +1504,10 @@ class StringEnumPropsNativeComponentProps final : public ViewProps {
 #pragma mark - Props
 
   StringEnumPropsNativeComponentAlignment alignment{StringEnumPropsNativeComponentAlignment::Center};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -1434,6 +1542,10 @@ class StringPropComponentProps final : public ViewProps {
 
   std::string accessibilityHint{\\"\\"};
   std::string accessibilityRole{};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -1467,6 +1579,10 @@ class MultiFile1NativeComponentProps final : public ViewProps {
 #pragma mark - Props
 
   bool disabled{false};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 class MultiFile2NativeComponentProps final : public ViewProps {
@@ -1477,6 +1593,10 @@ class MultiFile2NativeComponentProps final : public ViewProps {
 #pragma mark - Props
 
   bool disabled{true};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react
@@ -1510,6 +1630,10 @@ class MultiComponent1NativeComponentProps final : public ViewProps {
 #pragma mark - Props
 
   bool disabled{false};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 class MultiComponent2NativeComponentProps final : public ViewProps {
@@ -1520,6 +1644,10 @@ class MultiComponent2NativeComponentProps final : public ViewProps {
 #pragma mark - Props
 
   bool disabled{true};
+
+  #ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+  #endif
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
Extend getDiffProps method to call HostPlatformViewProps

changelog: [internal] internal

Reviewed By: lenaic

Differential Revision: D69487495


