### PR TITLE
Fix wrong I18nManager.isRTL value on iOS

### DIFF
--- a/packages/react-native/React/Modules/RCTI18nUtil.m
+++ b/packages/react-native/React/Modules/RCTI18nUtil.m
@@ -98,7 +98,8 @@
 // Check if the current application language is RTL
 - (BOOL)isApplicationPreferredLanguageRTL
 {
-  NSWritingDirection direction = [NSParagraphStyle defaultWritingDirectionForLanguage:nil];
+  NSString *language = [[NSLocale preferredLanguages] firstObject];
+  NSWritingDirection direction = [NSParagraphStyle defaultWritingDirectionForLanguage:language];
   return direction == NSWritingDirectionRightToLeft;
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Fixes #51647 

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[iOS] [Fixed] Fix wrong I18nManager.isRTL value on iOS

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Ran this change in English (US, LTR), Hebrew (RTL), and Arabic (RTL) to confirm that they appear correctly.