### PR TITLE
Disallow usage of unprefixed (suffixed) Props type name

### DIFF
--- a/packages/react-native/Libraries/Components/View/View.js
+++ b/packages/react-native/Libraries/Components/View/View.js
@@ -16,8 +16,6 @@ import ViewNativeComponent from './ViewNativeComponent';
 import * as React from 'react';
 import {use} from 'react';
 
-export type Props = ViewProps;
-
 type PropsWithRef = $ReadOnly<{
   ref?: React.RefSetter<React.ElementRef<typeof ViewNativeComponent>>,
   ...ViewProps,

--- a/packages/react-native/Libraries/Image/ImageViewNativeComponent.js
+++ b/packages/react-native/Libraries/Image/ImageViewNativeComponent.js
@@ -26,7 +26,7 @@ import {ConditionallyIgnoredEventHandlers} from '../NativeComponent/ViewConfigIg
 import codegenNativeCommands from '../Utilities/codegenNativeCommands';
 import Platform from '../Utilities/Platform';
 
-type Props = $ReadOnly<{
+type ImageHostComponentProps = $ReadOnly<{
   ...ImageProps,
   ...ViewProps,
 
@@ -162,8 +162,8 @@ export const __INTERNAL_VIEW_CONFIG: PartialViewConfig =
         },
       };
 
-const ImageViewNativeComponent: HostComponent<Props> =
-  NativeComponentRegistry.get<Props>(
+const ImageViewNativeComponent: HostComponent<ImageHostComponentProps> =
+  NativeComponentRegistry.get<ImageHostComponentProps>(
     'RCTImageView',
     () => __INTERNAL_VIEW_CONFIG,
   );

--- a/packages/react-native/Libraries/LogBox/Data/LogBoxData.js
+++ b/packages/react-native/Libraries/LogBox/Data/LogBoxData.js
@@ -413,8 +413,8 @@ export function observe(observer: Observer): Subscription {
   };
 }
 
-type Props = $ReadOnly<{}>;
-type State = $ReadOnly<{
+type LogBoxStateSubscriptionProps = $ReadOnly<{}>;
+type LogBoxStateSubscriptionState = $ReadOnly<{
   logs: LogBoxLogs,
   isDisabled: boolean,
   hasError: boolean,
@@ -432,7 +432,10 @@ type SubscribedComponent = React.ComponentType<
 export function withSubscription(
   WrappedComponent: SubscribedComponent,
 ): React.ComponentType<{}> {
-  class LogBoxStateSubscription extends React.Component<Props, State> {
+  class LogBoxStateSubscription extends React.Component<
+    LogBoxStateSubscriptionProps,
+    LogBoxStateSubscriptionState,
+  > {
     static getDerivedStateFromError(): {hasError: boolean} {
       return {hasError: true};
     }
@@ -446,7 +449,7 @@ export function withSubscription(
 
     _subscription: ?Subscription;
 
-    state: State = {
+    state: LogBoxStateSubscriptionState = {
       logs: new Set(),
       isDisabled: false,
       hasError: false,

--- a/scripts/build-types/transforms/__tests__/ensureNoUnprefixedProps-test.js
+++ b/scripts/build-types/transforms/__tests__/ensureNoUnprefixedProps-test.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+const ensureNoUnprefixedProps = require('../ensureNoUnprefixedProps.js');
+const {parse, print} = require('hermes-transform');
+
+const prettierOptions = {parser: 'babel'};
+
+async function translate(code: string): Promise<string> {
+  const parsed = await parse(code);
+  const result = await ensureNoUnprefixedProps(parsed);
+  return print(result.ast, result.mutatedCode, prettierOptions);
+}
+
+describe('ensureNoUnprefixedProps', () => {
+  test('should throw when encountering unprefixed Props type', async () => {
+    const code = `type Props = {}`;
+    await expect(translate(code)).rejects.toThrow();
+  });
+
+  test('should throw when encountering unprefixed Props interface', async () => {
+    const code = `interface Props {}`;
+    await expect(translate(code)).rejects.toThrow();
+  });
+
+  test('should not throw when encountering prefixed Props type', async () => {
+    const code = `type ViewProps = {}`;
+    await expect(translate(code)).resolves.toBeDefined();
+  });
+
+  test('should not throw when encountering prefixed Props interface', async () => {
+    const code = `interface ViewProps {}`;
+    await expect(translate(code)).resolves.toBeDefined();
+  });
+});

--- a/scripts/build-types/transforms/ensureNoUnprefixedProps.js
+++ b/scripts/build-types/transforms/ensureNoUnprefixedProps.js
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {TransformVisitor} from 'hermes-transform';
+import type {ParseResult} from 'hermes-transform/dist/transform/parse';
+import type {TransformASTResult} from 'hermes-transform/dist/transform/transformAST';
+
+const {transformAST} = require('hermes-transform/dist/transform/transformAST');
+
+const visitors: TransformVisitor = context => ({
+  TypeAlias(node): void {
+    if (node.id.name === 'Props') {
+      throw new Error(
+        `Type alias 'Props' is not allowed. Use more descriptive name.`,
+      );
+    }
+  },
+  InterfaceDeclaration(node): void {
+    if (node.id.name === 'Props') {
+      throw new Error(
+        `Type alias 'Props' is not allowed. Use more descriptive name.`,
+      );
+    }
+  },
+});
+
+/**
+ * flow-api-translator doesn't translate empty type to never due to difference
+ * in semantics between the two. This is desirable behavtior in this case,
+ * as it's the closest approximation of the empty type.
+ */
+async function ensureNoUnprefixedProps(
+  source: ParseResult,
+): Promise<TransformASTResult> {
+  return transformAST(source, visitors);
+}
+
+module.exports = ensureNoUnprefixedProps;

--- a/scripts/build-types/translateSourceFile.js
+++ b/scripts/build-types/translateSourceFile.js
@@ -27,6 +27,7 @@ const preTransforms: Array<PreTransformFn> = [
   require('./transforms/replaceStringishWithString'),
   require('./transforms/replaceNullablePropertiesWithUndefined'),
   require('./transforms/reattachDocComments'),
+  require('./transforms/ensureNoUnprefixedProps'),
 ];
 const postTransforms: Array<PluginObj<mixed>> = [];
 const prettierOptions = {parser: 'babel'};


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Adds a transform that ensures to types and interfaces names `Props` end up in the generated TypeScript definitions. Those are not descriptive and cause duplicate types in the rollup.

Differential Revision: D75508800


