### PR TITLE
Set default XMLHttpRequest trackingName to undefined

### DIFF
--- a/packages/react-native/Libraries/Network/XMLHttpRequest.js
+++ b/packages/react-native/Libraries/Network/XMLHttpRequest.js
@@ -170,7 +170,7 @@ class XMLHttpRequest extends EventTarget {
   _sent: boolean;
   _url: ?string = null;
   _timedOut: boolean = false;
-  _trackingName: ?string = null;
+  _trackingName: string | void = undefined;
   _incrementalEvents: boolean = false;
   _startTime: ?number = null;
   _performanceLogger: IPerformanceLogger = GlobalPerformanceLogger;
@@ -534,7 +534,7 @@ class XMLHttpRequest extends EventTarget {
   /**
    * Custom extension for tracking origins of request.
    */
-  setTrackingName(trackingName: ?string): XMLHttpRequest {
+  setTrackingName(trackingName: string | void): XMLHttpRequest {
     this._trackingName = trackingName;
     return this;
   }

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -6009,7 +6009,7 @@ declare class XMLHttpRequest extends EventTarget {
   getAllResponseHeaders(): ?string;
   getResponseHeader(header: string): ?string;
   setRequestHeader(header: string, value: any): void;
-  setTrackingName(trackingName: ?string): XMLHttpRequest;
+  setTrackingName(trackingName: string | void): XMLHttpRequest;
   setPerformanceLogger(performanceLogger: IPerformanceLogger): XMLHttpRequest;
   open(method: string, url: string, async: ?boolean): void;
   send(data: any): void;


### PR DESCRIPTION
Summary:
This fixes an issue with the internal networking layer when `enableModuleArgumentNSNullConversionIOS` is enabled, as we'd try to  pass `NSNull` as trackingName instead of omitting it.
`
Changelog: [Internal]

Differential Revision: D75516619


