### PR TITLE
introduce opt out mechanism for View Culling

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/ModalHostViewShadowNode.h
@@ -30,6 +30,9 @@ class ModalHostViewShadowNode final : public ConcreteViewShadowNode<
   static ShadowNodeTraits BaseTraits() {
     auto traits = ConcreteViewShadowNode::BaseTraits();
     traits.set(ShadowNodeTraits::Trait::RootNodeKind);
+    // <Modal> has a side effect of showing the modal overlay and
+    // must not be culled. Otherwise, the modal overlay will not be shown.
+    traits.set(ShadowNodeTraits::Trait::Unstable_uncullableView);
     return traits;
   }
 };

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
@@ -245,6 +245,15 @@ class ShadowNode : public Sealable,
   void cloneChildrenIfShared();
 
   /*
+   * Updates the node's traits based on its children's traits.
+   * Specifically, if view culling is enabled and any child has the
+   * Unstable_uncullableView or Unstable_uncullableTrace trait, this node will
+   * also be marked as uncullable. This ensures that if a child needs to be
+   * rendered, its parent will be too.
+   */
+  void updateTraitsIfNeccessary();
+
+  /*
    * Pointer to a family object that this shadow node belongs to.
    */
   ShadowNodeFamily::Shared family_;

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeTraits.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeTraits.h
@@ -74,6 +74,14 @@ class ShadowNodeTraits {
 
     // Indicates if the node is keyboard focusable.
     KeyboardFocusable = 1 << 11,
+
+    // Indicates if the node is uncullable. Apply this to your component
+    // if it has side effects beyond just rendering (e.g. it opens a modal).
+    Unstable_uncullableView = 1 << 12,
+
+    // Must not be set directly. It is used by the view culling algorithm to
+    // efficiently determine if a node is uncullable.
+    Unstable_uncullableTrace = 1 << 13,
   };
 
   /*

--- a/packages/react-native/ReactCommon/react/renderer/mounting/internal/sliceChildShadowNodeViewPairs.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/internal/sliceChildShadowNodeViewPairs.cpp
@@ -66,8 +66,12 @@ static void sliceChildShadowNodeViewPairsRecursively(
     auto shadowView = ShadowView(childShadowNode);
 
     if (ReactNativeFeatureFlags::enableViewCulling()) {
-      if (cullingContext.shouldConsiderCulling() &&
-          shadowView.layoutMetrics != EmptyLayoutMetrics) {
+      auto isViewCullable =
+          !shadowView.traits.check(
+              ShadowNodeTraits::Trait::Unstable_uncullableView) &&
+          !shadowView.traits.check(
+              ShadowNodeTraits::Trait::Unstable_uncullableTrace);
+      if (cullingContext.shouldConsiderCulling() && isViewCullable) {
         auto overflowInsetFrame =
             shadowView.layoutMetrics.getOverflowInsetFrame() *
             cullingContext.transform;


### PR DESCRIPTION
Summary:
changelog: [internal]

Introduce a new ShadowNodeTraits: `Unstable_uncullableView` and `Unstable_uncullableTrace`. As the name suggests, this is not stable API yet.

When a shadow node sets this trait, it will be opted out of view culling together with its ancestors all the way to the root.

The trait is propagated to its parent in 4 different places:
1. When node is first created.
2. When node is cloned.
3. When child is appended.
4. When child is replaced.

we can safely do it only in those places because React constructs nodes from bottom up. We are leveraging this implementation detail here but if that changes in the future, a traversal will be required.

Alternative solution considered here was a traversal of shadow tree during commit phase to propagate `Unstable_uncullable` trait. This could be done in a separate traversal or as part of layout phase where layout information is copied out of Yoga tree. Leveraging the fact that React is cloning bottom up makes the implementation simpler. 

If React changes its cloning approach in the future, this will be caught by tests.

Differential Revision: D75476847


