### PR TITLE
Fully remove LOG_TAG from Buck/CMake

### DIFF
--- a/packages/react-native/ReactCommon/cmake-utils/react-native-flags.cmake
+++ b/packages/react-native/ReactCommon/cmake-utils/react-native-flags.cmake
@@ -20,7 +20,7 @@ SET(reactnative_FLAGS
 )
 
 # This function can be used to configure the reactnative flags for a specific target in
-# a conveniente way. The usage is:
+# a convenient way. The usage is:
 #
 # target_compile_reactnative_options(target_name scope)
 #


### PR DESCRIPTION
Summary:
We should be able to clean this up as we're not using it directly.
It would be used via the NDK logging utilities from Android, that we don't use.

Changelog:
[Internal] [Changed] -

Differential Revision: D75531640
