### PR TITLE
Add comment to clarify how I18nManager works

### DIFF
--- a/packages/react-native/React/Modules/RCTI18nUtil.m
+++ b/packages/react-native/React/Modules/RCTI18nUtil.m
@@ -95,7 +95,9 @@
   return direction == NSLocaleLanguageDirectionRightToLeft;
 }
 
-// Check if the current application language is RTL
+// Intersect Xcode "Localization" languages with the system languages and checks if the result is using RTL
+// For RTL support, app must add an RTL lang to .pbxproj's knownRegions = ( ... )
+// and user must have chosen an RTL language
 - (BOOL)isApplicationPreferredLanguageRTL
 {
   NSWritingDirection direction = [NSParagraphStyle defaultWritingDirectionForLanguage:nil];


### PR DESCRIPTION
iOS I18nManager.isRTL is not wrong but often misinterpreted.
This PR adds a comment to clarify what the native call does, since Apple doesn't.

## Summary:

Undocumented behavior made me waste several hours hunting for an i18n issue that incorrectly made me think RN had a bug. It's impossible to know this code is working as intended as original commit does not state why the code exist, only that it was changed, no mentions in changelogs, and no official docs from neither RN nor from Apple explains the combined or individual behavior.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[iOS] [Added] - Added comment to clarify why i18nManager.isRTL may not return the expected value

## Test Plan:

This project demonstrates that compiling and running will give you the "wrong"/unexpected isRTL value when using Hebrew
https://github.com/scarlac/rtl-test

When Hebrew is added to the Xcode project under "Internationalization" then you will observe that `.isRTL` starts returning `true`.

Note that Xcode has a nasty caching bug that means that removing Hebrew:
1. Will Not remove Hebrew (you need to remove it twice)
2. Will Not cause `.isRTL` to revert behavior

The solution is to remove Hebrew 2x, and then to clear DerivedData (or Product -> Clean Build Folder..., or CMD+Shift+K)

In addition to these issues, it's important to note that calling .forceRTL or .allowRTL are persisted across restarts. This is clearly intentional but also not clearly documented, so you cannot "clear" these states. A reinstall is necessary, or a counter-value call is necessary. The demo project does not use these calls, so it's not an issue there.