### PR TITLE
clean up interface of AnimationDriver

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.cpp
@@ -243,7 +243,7 @@ void NativeAnimatedNodesManager::stopAnimationsForNode(Tag nodeTag) {
   std::vector<int> discardedAnimIds{};
 
   for (const auto& [animationId, driver] : activeAnimations_) {
-    if (driver->animatedValueTag() == nodeTag) {
+    if (driver->getAnimatedValueTag() == nodeTag) {
       discardedAnimIds.emplace_back(animationId);
     }
   }
@@ -612,9 +612,9 @@ bool NativeAnimatedNodesManager::onAnimationFrame(uint64_t timestamp) {
   for (const auto& [_id, driver] : activeAnimations_) {
     driver->runAnimationStep(timestamp);
 
-    if (driver->isComplete()) {
+    if (driver->getIsComplete()) {
       hasFinishedAnimations = true;
-      finishedAnimationValueNodes.insert(driver->animatedValueTag());
+      finishedAnimationValueNodes.insert(driver->getAnimatedValueTag());
     }
   }
 
@@ -625,8 +625,8 @@ bool NativeAnimatedNodesManager::onAnimationFrame(uint64_t timestamp) {
   if (hasFinishedAnimations) {
     std::vector<int> finishedAnimations;
     for (const auto& [animationId, driver] : activeAnimations_) {
-      if (driver->isComplete()) {
-        if (getAnimatedNode<ValueAnimatedNode>(driver->animatedValueTag())) {
+      if (driver->getIsComplete()) {
+        if (getAnimatedNode<ValueAnimatedNode>(driver->getAnimatedValueTag())) {
           driver->stopAnimation();
         }
         finishedAnimations.emplace_back(animationId);

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/drivers/AnimationDriver.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/drivers/AnimationDriver.h
@@ -34,11 +34,11 @@ class AnimationDriver {
   void startAnimation();
   void stopAnimation(bool ignoreCompletedHandlers = false);
 
-  inline constexpr int Id() {
+  inline int getId() const noexcept {
     return id_;
   }
 
-  inline constexpr Tag animatedValueTag() {
+  inline Tag getAnimatedValueTag() const noexcept {
     return animatedValueTag_;
   }
 
@@ -46,11 +46,7 @@ class AnimationDriver {
     return endCallback_;
   }
 
-  virtual double toValue() const noexcept {
-    return 0;
-  }
-
-  bool isComplete() const noexcept {
+  bool getIsComplete() const noexcept {
     return isComplete_;
   }
 

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/drivers/FrameAnimationDriver.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/drivers/FrameAnimationDriver.cpp
@@ -35,10 +35,6 @@ FrameAnimationDriver::FrameAnimationDriver(
   onConfigChanged();
 }
 
-double FrameAnimationDriver::toValue() const noexcept {
-  return toValue_;
-}
-
 void FrameAnimationDriver::updateConfig(folly::dynamic config) {
   AnimationDriver::updateConfig(config);
   onConfigChanged();

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/drivers/FrameAnimationDriver.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/drivers/FrameAnimationDriver.h
@@ -24,8 +24,6 @@ class FrameAnimationDriver : public AnimationDriver {
       const folly::dynamic& config,
       NativeAnimatedNodesManager* manager);
 
-  double toValue() const noexcept override;
-
  protected:
   bool update(double timeDeltaMs, bool restarting) override;
 


### PR DESCRIPTION
Summary:
changelog: [internal]

mark getters as noexcept const and use `get` prefix.

Reviewed By: christophpurrer

Differential Revision: D75531202


