### PR TITLE
refactor: Move PerformanceMeasureOptions to UserTiming.js

### DIFF
--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -9738,13 +9738,7 @@ declare export default class MemoryInfo {
 `;
 
 exports[`public API should not change unintentionally src/private/webapis/performance/Performance.js 1`] = `
-"export type PerformanceMeasureOptions = {
-  detail?: DetailType,
-  start?: DOMHighResTimeStamp,
-  duration?: DOMHighResTimeStamp,
-  end?: DOMHighResTimeStamp,
-};
-declare export default class Performance {
+"declare export default class Performance {
   eventCounts: EventCounts;
   get memory(): MemoryInfo;
   get rnStartupTiming(): ReactNativeStartupTiming;
@@ -9860,6 +9854,12 @@ exports[`public API should not change unintentionally src/private/webapis/perfor
 export type PerformanceMarkOptions = {
   detail?: DetailType,
   startTime?: DOMHighResTimeStamp,
+};
+export type PerformanceMeasureOptions = {
+  detail?: DetailType,
+  start?: DOMHighResTimeStamp,
+  duration?: DOMHighResTimeStamp,
+  end?: DOMHighResTimeStamp,
 };
 export type TimeStampOrName = DOMHighResTimeStamp | string;
 export type PerformanceMeasureInit = {

--- a/packages/react-native/src/private/webapis/performance/Performance.js
+++ b/packages/react-native/src/private/webapis/performance/Performance.js
@@ -15,7 +15,10 @@ import type {
   PerformanceEntryList,
   PerformanceEntryType,
 } from './PerformanceEntry';
-import type {DetailType, PerformanceMarkOptions} from './UserTiming';
+import type {
+  PerformanceMarkOptions,
+  PerformanceMeasureOptions,
+} from './UserTiming';
 
 import DOMException from '../errors/DOMException';
 import {setPlatformObject} from '../webidl/PlatformObjects';
@@ -37,13 +40,6 @@ declare var global: {
 
 const getCurrentTimeStamp: () => DOMHighResTimeStamp =
   NativePerformance?.now ?? global.nativePerformanceNow ?? (() => Date.now());
-
-export type PerformanceMeasureOptions = {
-  detail?: DetailType,
-  start?: DOMHighResTimeStamp,
-  duration?: DOMHighResTimeStamp,
-  end?: DOMHighResTimeStamp,
-};
 
 const ENTRY_TYPES_AVAILABLE_FROM_TIMELINE: $ReadOnlyArray<PerformanceEntryType> =
   ['mark', 'measure'];

--- a/packages/react-native/src/private/webapis/performance/UserTiming.js
+++ b/packages/react-native/src/private/webapis/performance/UserTiming.js
@@ -21,6 +21,13 @@ export type PerformanceMarkOptions = {
   startTime?: DOMHighResTimeStamp,
 };
 
+export type PerformanceMeasureOptions = {
+  detail?: DetailType,
+  start?: DOMHighResTimeStamp,
+  duration?: DOMHighResTimeStamp,
+  end?: DOMHighResTimeStamp,
+};
+
 export type TimeStampOrName = DOMHighResTimeStamp | string;
 
 export type PerformanceMeasureInit = {


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

No changes in the actual logic, just moving the type definition to the same file with `PerformanceMarkOptions`, where it makes more sense.

Differential Revision: D75608718


