### PR TITLE
[RN][CI] Fix workflow-retry for android

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -644,12 +644,31 @@ jobs:
   # This is exactly the same as rerunning failed tests from the GH UI, but automated.
   rerun-failed-jobs:
     runs-on: ubuntu-latest
-    needs: [test_e2e_ios_rntester, test_e2e_android_rntester,test_e2e_ios_templateapp, test_e2e_android_templateapp]
-    if: failure() && fromJSON(github.run_attempt) < 3 && ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
+    needs: [test_e2e_ios_rntester, test_e2e_android_rntester, test_e2e_ios_templateapp, test_e2e_android_templateapp]
+    if: always()
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Rerun failed jobs in the current workflow
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh workflow run retry-workflow.yml -F run_id=${{ github.run_id }}
+        run: |
+          SHOULD_RETRY=${{fromJSON(github.run_attempt) < 3}}
+          if [[ $SHOULD_RETRY == "false" ]]; then
+            exit 0
+          fi
+
+          RNTESTER_ANDROID_FAILED=${{ needs.test_e2e_android_rntester.result == 'failure' }}
+          TEMPLATE_ANDROID_FAILED=${{ needs.test_e2e_android_templateapp.result == 'failure' }}
+          RNTESTER_IOS_FAILED=${{ needs.test_e2e_ios_rntester.result == 'failure' }}
+          TEMPLATE_IOS_FAILED=${{ needs.test_e2e_ios_templateapp.result == 'failure' }}
+
+          echo "RNTESTER_ANDROID_FAILED: $RNTESTER_ANDROID_FAILED"
+          echo "TEMPLATE_ANDROID_FAILED: $TEMPLATE_ANDROID_FAILED"
+          echo "RNTESTER_IOS_FAILED: $RNTESTER_IOS_FAILED"
+          echo "TEMPLATE_IOS_FAILED: $TEMPLATE_IOS_FAILED"
+
+          if [[ $RNTESTER_ANDROID_FAILED == "true" || $TEMPLATE_ANDROID_FAILED == "true" || $RNTESTER_IOS_FAILED == "true" || $TEMPLATE_IOS_FAILED == "true" ]]; then
+            echo "Rerunning failed jobs in the current workflow"
+            gh workflow run retry-workflow.yml -F run_id=${{ github.run_id }}
+          fi

--- a/packages/rn-tester/.maestro/button.yml
+++ b/packages/rn-tester/.maestro/button.yml
@@ -9,7 +9,7 @@ appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebo
     speed: 40
 - tapOn:
     id: "Button"
-- tapOn: 
+- tapOn:
     id: "button_default_styling"
 - assertVisible: "Your application has been submitted!"
 - tapOn: "OK"


### PR DESCRIPTION
## Summary:
The retry mechanism introduced in [this commit]() works for iOS e2e failures but it is skipped if android e2e tests fails.
This change should fix that

## Changelog:
[Internal] - Fix retry for Android E2E tests

## Test Plan:
GHA
