### PR TITLE
Set `detail` to null by default to comply with the spec

### DIFF
--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -9738,13 +9738,7 @@ declare export default class MemoryInfo {
 `;
 
 exports[`public API should not change unintentionally src/private/webapis/performance/Performance.js 1`] = `
-"export type PerformanceMeasureOptions = {
-  detail?: DetailType,
-  start?: DOMHighResTimeStamp,
-  duration?: DOMHighResTimeStamp,
-  end?: DOMHighResTimeStamp,
-};
-declare export default class Performance {
+"declare export default class Performance {
   eventCounts: EventCounts;
   get memory(): MemoryInfo;
   get rnStartupTiming(): ReactNativeStartupTiming;
@@ -9860,6 +9854,12 @@ exports[`public API should not change unintentionally src/private/webapis/perfor
 export type PerformanceMarkOptions = {
   detail?: DetailType,
   startTime?: DOMHighResTimeStamp,
+};
+export type PerformanceMeasureOptions = {
+  detail?: DetailType,
+  start?: DOMHighResTimeStamp,
+  duration?: DOMHighResTimeStamp,
+  end?: DOMHighResTimeStamp,
 };
 export type TimeStampOrName = DOMHighResTimeStamp | string;
 export type PerformanceMeasureInit = {

--- a/packages/react-native/src/private/webapis/performance/Performance.js
+++ b/packages/react-native/src/private/webapis/performance/Performance.js
@@ -15,7 +15,10 @@ import type {
   PerformanceEntryList,
   PerformanceEntryType,
 } from './PerformanceEntry';
-import type {DetailType, PerformanceMarkOptions} from './UserTiming';
+import type {
+  PerformanceMarkOptions,
+  PerformanceMeasureOptions,
+} from './UserTiming';
 
 import DOMException from '../errors/DOMException';
 import {setPlatformObject} from '../webidl/PlatformObjects';
@@ -37,13 +40,6 @@ declare var global: {
 
 const getCurrentTimeStamp: () => DOMHighResTimeStamp =
   NativePerformance?.now ?? global.nativePerformanceNow ?? (() => Date.now());
-
-export type PerformanceMeasureOptions = {
-  detail?: DetailType,
-  start?: DOMHighResTimeStamp,
-  duration?: DOMHighResTimeStamp,
-  end?: DOMHighResTimeStamp,
-};
 
 const ENTRY_TYPES_AVAILABLE_FROM_TIMELINE: $ReadOnlyArray<PerformanceEntryType> =
   ['mark', 'measure'];

--- a/packages/react-native/src/private/webapis/performance/UserTiming.js
+++ b/packages/react-native/src/private/webapis/performance/UserTiming.js
@@ -21,6 +21,13 @@ export type PerformanceMarkOptions = {
   startTime?: DOMHighResTimeStamp,
 };
 
+export type PerformanceMeasureOptions = {
+  detail?: DetailType,
+  start?: DOMHighResTimeStamp,
+  duration?: DOMHighResTimeStamp,
+  end?: DOMHighResTimeStamp,
+};
+
 export type TimeStampOrName = DOMHighResTimeStamp | string;
 
 export type PerformanceMeasureInit = {

--- a/packages/react-native/src/private/webapis/performance/UserTiming.js
+++ b/packages/react-native/src/private/webapis/performance/UserTiming.js
@@ -37,7 +37,7 @@ export type PerformanceMeasureInit = {
 };
 
 export class PerformanceMark extends PerformanceEntry {
-  #detail: DetailType;
+  #detail: DetailType = null;
 
   constructor(markName: string, markOptions?: PerformanceMarkOptions) {
     super({
@@ -47,7 +47,7 @@ export class PerformanceMark extends PerformanceEntry {
       duration: 0,
     });
 
-    if (markOptions) {
+    if (markOptions != null && markOptions.detail != null) {
       this.#detail = markOptions.detail;
     }
   }
@@ -58,7 +58,7 @@ export class PerformanceMark extends PerformanceEntry {
 }
 
 export class PerformanceMeasure extends PerformanceEntry {
-  #detail: DetailType;
+  #detail: DetailType = null;
 
   constructor(measureName: string, measureOptions: PerformanceMeasureInit) {
     super({
@@ -68,7 +68,7 @@ export class PerformanceMeasure extends PerformanceEntry {
       duration: measureOptions.duration,
     });
 
-    if (measureOptions) {
+    if (measureOptions != null && measureOptions.detail != null) {
       this.#detail = measureOptions.detail;
     }
   }

--- a/packages/react-native/src/private/webapis/performance/__tests__/Performance-test.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/Performance-test.js
@@ -288,4 +288,30 @@ describe('Performance', () => {
 
     expect(Array.from(eventCounts.values())).toStrictEqual([2, 3, 6]);
   });
+
+  it('detail field is defined as null by default', () => {
+    expect(performance.mark('mark').detail).toBeNull();
+    expect(performance.measure('measure').detail).toBeNull();
+    performance.clearMarks();
+    performance.clearMeasures();
+
+    expect(performance.mark('mark', {}).detail).toBeNull();
+    expect(performance.measure('measure', {start: 0}).detail).toBeNull();
+    performance.clearMarks();
+    performance.clearMeasures();
+
+    expect(performance.mark('mark', {detail: null}).detail).toBeNull();
+    expect(
+      performance.measure('measure', {start: 0, detail: null}).detail,
+    ).toBeNull();
+    performance.clearMarks();
+    performance.clearMeasures();
+
+    expect(performance.mark('mark', {detail: false}).detail).not.toBeNull();
+    expect(
+      performance.measure('measure', {start: 0, detail: false}).detail,
+    ).not.toBeNull();
+    performance.clearMarks();
+    performance.clearMeasures();
+  });
 });


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

This is required by the spec:
- `performance.mark`: https://w3c.github.io/user-timing/#the-performancemark-constructor, see step 7.
- `performance.measure`: https://w3c.github.io/user-timing/#dom-performance-measure, see step 9.

Differential Revision: D75611976


