### PR TITLE
Fix up debugger-shell package definition

### DIFF
--- a/packages/debugger-shell/package.json
+++ b/packages/debugger-shell/package.json
@@ -10,8 +10,11 @@
   "bugs": "https://github.com/facebook/react-native/issues",
   "main": "./src/node/index.js",
   "exports": {
-    "node": "./src/node/index.js",
-    "electron": "./src/electron/index.js"
+    ".": {
+      "node": "./src/node/index.js",
+      "electron": "./src/electron/index.js"
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "dev": "electron src/electron"


### PR DESCRIPTION
Summary:
Changelog: [Internal]

D74820232 was missing an `exports` entry for `debugger-shell/package.json`, which is needed for some of our build tooling.

Differential Revision: D75679347


