### PR TITLE
prevent deadlock in C++ Animated

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.h
@@ -144,8 +144,10 @@ class NativeAnimatedNodesManager {
   bool commitProps();
 
   void scheduleOnUI(UiTask&& task) {
-    std::lock_guard<std::mutex> lock(uiTasksMutex_);
-    operations_.push_back(std::move(task));
+    {
+      std::lock_guard<std::mutex> lock(uiTasksMutex_);
+      operations_.push_back(std::move(task));
+    }
 
     // Whenever a batch is flushed to the UI thread, start the onRender
     // callbacks to guarantee they run at least once. E.g., to execute


### PR DESCRIPTION
Summary:
changelog: [internal]

as a general rule of thumb, do not call outside of your class when holding a mutex. It is easy to cause a deadlock because the outside code may end up trying to acquire the mutex down the stack, leading to deadlock.

Here, it happens because `startRenderCallbackIfNeeded` may end up calling onRender and in onRender, we try to acquire the mutex again

Reviewed By: javache

Differential Revision: D75675465


