### PR TITLE
Re-expose src/ paths via exports (default)

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -50,6 +50,11 @@
       "default": "./Libraries/*.d.ts"
     },
     "./scripts/*": "./scripts/*",
+    "./src/*": {
+      "react-native-strict-api": null,
+      "react-native-strict-api-UNSAFE-ALLOW-SUBPATHS": "./types_generated/src/*.d.ts",
+      "default": "./src/*.js"
+    },
     "./types/*.d.ts": {
       "react-native-strict-api": null,
       "default": "./types/*.d.ts"
@@ -61,7 +66,6 @@
     "./ReactCommon/*": null,
     "./sdks/*": null,
     "./src/fb_internal/*": "./src/fb_internal/*",
-    "./src/*": null,
     "./third-party-podspecs/*": null,
     "./types/*": null,
     "./types_generated/*": null,


### PR DESCRIPTION
Summary:
Re-expose **all `"./src/*"` paths via `package.json#exports`.

Follows D72228547 — as we'd attempted to be proactive with hiding `src/`, but are now reverting — essentially reducing this change as much as possible (read: most defensive/safer effect on OSS).

**Motivation**

Mitigates a warning emitted by Metro that may surface in new bare React Native template projects.

![image](https://github.com/user-attachments/assets/582ea18b-6570-43a5-880c-2513793d9db0)

This is due to a 1P reference to `'react-native/src/private/featureflags/ReactNativeFeatureFlags` in `@react-native/virtualized-lists`. 

This is enough motivation to undo part of our change with introducing `"exports"` on `react-native` in 0.80.

**Especially**, to avoid confusion with other warnings we've intentionally introduced in 0.80 around subpath imports.

- The key difference is the above screenshot is from Metro and covers **any** import from any `node_modules` file — as opposed to just the immediate project.

Changelog:
[General][Changed] - Re-expose `src/*` subpaths when not using the Strict TypeScript API

The net breaking change for 0.80, once picked, is simply the presence of `"exports"` (only very edge case effects on expanding per-platform extensions, which we've mitigated). **All exported paths equivalent**.

Differential Revision: D75682566


