### PR TITLE
Allow parameterizing event types in EventTarget

### DIFF
--- a/packages/react-native/Libraries/Blob/FileReader.js
+++ b/packages/react-native/Libraries/Blob/FileReader.js
@@ -179,51 +179,51 @@ class FileReader extends EventTarget {
     return this._result;
   }
 
-  get onabort(): EventCallback | null {
+  get onabort(): EventCallback<> | null {
     return getEventHandlerAttribute(this, 'abort');
   }
 
-  set onabort(listener: ?EventCallback) {
+  set onabort(listener: ?EventCallback<>) {
     setEventHandlerAttribute(this, 'abort', listener);
   }
 
-  get onerror(): EventCallback | null {
+  get onerror(): EventCallback<> | null {
     return getEventHandlerAttribute(this, 'error');
   }
 
-  set onerror(listener: ?EventCallback) {
+  set onerror(listener: ?EventCallback<>) {
     setEventHandlerAttribute(this, 'error', listener);
   }
 
-  get onload(): EventCallback | null {
+  get onload(): EventCallback<> | null {
     return getEventHandlerAttribute(this, 'load');
   }
 
-  set onload(listener: ?EventCallback) {
+  set onload(listener: ?EventCallback<>) {
     setEventHandlerAttribute(this, 'load', listener);
   }
 
-  get onloadstart(): EventCallback | null {
+  get onloadstart(): EventCallback<> | null {
     return getEventHandlerAttribute(this, 'loadstart');
   }
 
-  set onloadstart(listener: ?EventCallback) {
+  set onloadstart(listener: ?EventCallback<>) {
     setEventHandlerAttribute(this, 'loadstart', listener);
   }
 
-  get onloadend(): EventCallback | null {
+  get onloadend(): EventCallback<> | null {
     return getEventHandlerAttribute(this, 'loadend');
   }
 
-  set onloadend(listener: ?EventCallback) {
+  set onloadend(listener: ?EventCallback<>) {
     setEventHandlerAttribute(this, 'loadend', listener);
   }
 
-  get onprogress(): EventCallback | null {
+  get onprogress(): EventCallback<> | null {
     return getEventHandlerAttribute(this, 'progress');
   }
 
-  set onprogress(listener: ?EventCallback) {
+  set onprogress(listener: ?EventCallback<>) {
     setEventHandlerAttribute(this, 'progress', listener);
   }
 }

--- a/packages/react-native/Libraries/Network/XMLHttpRequest.js
+++ b/packages/react-native/Libraries/Network/XMLHttpRequest.js
@@ -83,46 +83,46 @@ const SUPPORTED_RESPONSE_TYPES = {
 };
 
 class XMLHttpRequestEventTarget extends EventTarget {
-  get onload(): EventCallback | null {
+  get onload(): EventCallback<> | null {
     return getEventHandlerAttribute(this, 'load');
   }
-  set onload(listener: ?EventCallback) {
+  set onload(listener: ?EventCallback<>) {
     setEventHandlerAttribute(this, 'load', listener);
   }
-  get onloadstart(): EventCallback | null {
+  get onloadstart(): EventCallback<> | null {
     return getEventHandlerAttribute(this, 'loadstart');
   }
-  set onloadstart(listener: ?EventCallback) {
+  set onloadstart(listener: ?EventCallback<>) {
     setEventHandlerAttribute(this, 'loadstart', listener);
   }
-  get onprogress(): EventCallback | null {
+  get onprogress(): EventCallback<> | null {
     return getEventHandlerAttribute(this, 'progress');
   }
-  set onprogress(listener: ?EventCallback) {
+  set onprogress(listener: ?EventCallback<>) {
     setEventHandlerAttribute(this, 'progress', listener);
   }
-  get ontimeout(): EventCallback | null {
+  get ontimeout(): EventCallback<> | null {
     return getEventHandlerAttribute(this, 'timeout');
   }
-  set ontimeout(listener: ?EventCallback) {
+  set ontimeout(listener: ?EventCallback<>) {
     setEventHandlerAttribute(this, 'timeout', listener);
   }
-  get onerror(): EventCallback | null {
+  get onerror(): EventCallback<> | null {
     return getEventHandlerAttribute(this, 'error');
   }
-  set onerror(listener: ?EventCallback) {
+  set onerror(listener: ?EventCallback<>) {
     setEventHandlerAttribute(this, 'error', listener);
   }
-  get onabort(): EventCallback | null {
+  get onabort(): EventCallback<> | null {
     return getEventHandlerAttribute(this, 'abort');
   }
-  set onabort(listener: ?EventCallback) {
+  set onabort(listener: ?EventCallback<>) {
     setEventHandlerAttribute(this, 'abort', listener);
   }
-  get onloadend(): EventCallback | null {
+  get onloadend(): EventCallback<> | null {
     return getEventHandlerAttribute(this, 'loadend');
   }
-  set onloadend(listener: ?EventCallback) {
+  set onloadend(listener: ?EventCallback<>) {
     setEventHandlerAttribute(this, 'loadend', listener);
   }
 }
@@ -705,7 +705,7 @@ class XMLHttpRequest extends EventTarget {
     }
   }
 
-  addEventListener(type: string, listener: EventListener | null): void {
+  addEventListener(type: string, listener: EventListener<> | null): void {
     // If we dont' have a 'readystatechange' event handler, we don't
     // have to send repeated LOADING events with incremental updates
     // to responseText, which will avoid a bunch of native -> JS
@@ -726,67 +726,67 @@ class XMLHttpRequest extends EventTarget {
    * `on<event>` event handling (without JS prototype magic).
    */
 
-  get onabort(): EventCallback | null {
+  get onabort(): EventCallback<> | null {
     return getEventHandlerAttribute(this, 'abort');
   }
 
-  set onabort(listener: ?EventCallback) {
+  set onabort(listener: ?EventCallback<>) {
     setEventHandlerAttribute(this, 'abort', listener);
   }
 
-  get onerror(): EventCallback | null {
+  get onerror(): EventCallback<> | null {
     return getEventHandlerAttribute(this, 'error');
   }
 
-  set onerror(listener: ?EventCallback) {
+  set onerror(listener: ?EventCallback<>) {
     setEventHandlerAttribute(this, 'error', listener);
   }
 
-  get onload(): EventCallback | null {
+  get onload(): EventCallback<> | null {
     return getEventHandlerAttribute(this, 'load');
   }
 
-  set onload(listener: ?EventCallback) {
+  set onload(listener: ?EventCallback<>) {
     setEventHandlerAttribute(this, 'load', listener);
   }
 
-  get onloadstart(): EventCallback | null {
+  get onloadstart(): EventCallback<> | null {
     return getEventHandlerAttribute(this, 'loadstart');
   }
 
-  set onloadstart(listener: ?EventCallback) {
+  set onloadstart(listener: ?EventCallback<>) {
     setEventHandlerAttribute(this, 'loadstart', listener);
   }
 
-  get onprogress(): EventCallback | null {
+  get onprogress(): EventCallback<> | null {
     return getEventHandlerAttribute(this, 'progress');
   }
 
-  set onprogress(listener: ?EventCallback) {
+  set onprogress(listener: ?EventCallback<>) {
     setEventHandlerAttribute(this, 'progress', listener);
   }
 
-  get ontimeout(): EventCallback | null {
+  get ontimeout(): EventCallback<> | null {
     return getEventHandlerAttribute(this, 'timeout');
   }
 
-  set ontimeout(listener: ?EventCallback) {
+  set ontimeout(listener: ?EventCallback<>) {
     setEventHandlerAttribute(this, 'timeout', listener);
   }
 
-  get onloadend(): EventCallback | null {
+  get onloadend(): EventCallback<> | null {
     return getEventHandlerAttribute(this, 'loadend');
   }
 
-  set onloadend(listener: ?EventCallback) {
+  set onloadend(listener: ?EventCallback<>) {
     setEventHandlerAttribute(this, 'loadend', listener);
   }
 
-  get onreadystatechange(): EventCallback | null {
+  get onreadystatechange(): EventCallback<> | null {
     return getEventHandlerAttribute(this, 'readystatechange');
   }
 
-  set onreadystatechange(listener: ?EventCallback) {
+  set onreadystatechange(listener: ?EventCallback<>) {
     setEventHandlerAttribute(this, 'readystatechange', listener);
   }
 }

--- a/packages/react-native/Libraries/WebSocket/WebSocket.js
+++ b/packages/react-native/Libraries/WebSocket/WebSocket.js
@@ -289,35 +289,35 @@ class WebSocket extends EventTarget {
     ];
   }
 
-  get onclose(): EventCallback | null {
+  get onclose(): EventCallback<> | null {
     return getEventHandlerAttribute(this, 'close');
   }
 
-  set onclose(listener: ?EventCallback) {
+  set onclose(listener: ?EventCallback<>) {
     setEventHandlerAttribute(this, 'close', listener);
   }
 
-  get onerror(): EventCallback | null {
+  get onerror(): EventCallback<> | null {
     return getEventHandlerAttribute(this, 'error');
   }
 
-  set onerror(listener: ?EventCallback) {
+  set onerror(listener: ?EventCallback<>) {
     setEventHandlerAttribute(this, 'error', listener);
   }
 
-  get onmessage(): EventCallback | null {
+  get onmessage(): EventCallback<> | null {
     return getEventHandlerAttribute(this, 'message');
   }
 
-  set onmessage(listener: ?EventCallback) {
+  set onmessage(listener: ?EventCallback<>) {
     setEventHandlerAttribute(this, 'message', listener);
   }
 
-  get onopen(): EventCallback | null {
+  get onopen(): EventCallback<> | null {
     return getEventHandlerAttribute(this, 'open');
   }
 
-  set onopen(listener: ?EventCallback) {
+  set onopen(listener: ?EventCallback<>) {
     setEventHandlerAttribute(this, 'open', listener);
   }
 }

--- a/packages/react-native/src/private/webapis/dom/events/Event.js
+++ b/packages/react-native/src/private/webapis/dom/events/Event.js
@@ -66,7 +66,7 @@ export default class Event {
   [COMPOSED_PATH_KEY]: boolean = [];
 
   // $FlowExpectedError[unsupported-syntax]
-  [CURRENT_TARGET_KEY]: EventTarget | null = null;
+  [CURRENT_TARGET_KEY]: EventTarget<> | null = null;
 
   // $FlowExpectedError[unsupported-syntax]
   [EVENT_PHASE_KEY]: boolean = Event.NONE;
@@ -84,7 +84,7 @@ export default class Event {
   [STOP_PROPAGATION_FLAG_KEY]: boolean = false;
 
   // $FlowExpectedError[unsupported-syntax]
-  [TARGET_KEY]: EventTarget | null = null;
+  [TARGET_KEY]: EventTarget<> | null = null;
 
   constructor(type: string, options?: ?EventInit) {
     if (arguments.length < 1) {
@@ -123,7 +123,7 @@ export default class Event {
     return this._composed;
   }
 
-  get currentTarget(): EventTarget | null {
+  get currentTarget(): EventTarget<> | null {
     return getCurrentTarget(this);
   }
 
@@ -139,7 +139,7 @@ export default class Event {
     return getIsTrusted(this);
   }
 
-  get target(): EventTarget | null {
+  get target(): EventTarget<> | null {
     return getTarget(this);
   }
 
@@ -151,7 +151,7 @@ export default class Event {
     return this._type;
   }
 
-  composedPath(): $ReadOnlyArray<EventTarget> {
+  composedPath(): $ReadOnlyArray<EventTarget<>> {
     return getComposedPath(this).slice();
   }
 

--- a/packages/react-native/src/private/webapis/dom/events/EventHandlerAttributes.js
+++ b/packages/react-native/src/private/webapis/dom/events/EventHandlerAttributes.js
@@ -40,28 +40,33 @@
  * ```
  */
 
+import type Event from './Event';
 import type EventTarget from './EventTarget';
-import type {EventCallback} from './EventTarget';
+import type {EventCallback, GenericEventMap} from './EventTarget';
 
-type EventHandler = $ReadOnly<{
-  handleEvent: EventCallback,
+type EventHandler<EventTypes: Event> = $ReadOnly<{
+  handleEvent: EventCallback<EventTypes>,
 }>;
-type EventHandlerAttributeMap = Map<string, EventHandler | null>;
+
+type EventHandlerAttributeMap<EventTypes: GenericEventMap> = Map<
+  $Keys<EventTypes>,
+  EventHandler<$Values<EventTypes>> | null,
+>;
 
 const EVENT_HANDLER_CONTENT_ATTRIBUTE_MAP_KEY = Symbol(
   'eventHandlerAttributeMap',
 );
 
-function getEventHandlerAttributeMap(
-  target: EventTarget,
-): ?EventHandlerAttributeMap {
+function getEventHandlerAttributeMap<EventTypes: GenericEventMap>(
+  target: EventTarget<EventTypes>,
+): ?EventHandlerAttributeMap<EventTypes> {
   // $FlowExpectedError[prop-missing]
   return target[EVENT_HANDLER_CONTENT_ATTRIBUTE_MAP_KEY];
 }
 
-function setEventHandlerAttributeMap(
-  target: EventTarget,
-  map: ?EventHandlerAttributeMap,
+function setEventHandlerAttributeMap<EventTypes: GenericEventMap>(
+  target: EventTarget<EventTypes>,
+  map: ?EventHandlerAttributeMap<EventTypes>,
 ) {
   // $FlowExpectedError[prop-missing]
   target[EVENT_HANDLER_CONTENT_ATTRIBUTE_MAP_KEY] = map;
@@ -73,10 +78,13 @@ function setEventHandlerAttributeMap(
  *
  * Should be used to get the current value for `target.on{type}`.
  */
-export function getEventHandlerAttribute(
-  target: EventTarget,
-  type: string,
-): EventCallback | null {
+export function getEventHandlerAttribute<
+  EventTypes: GenericEventMap,
+  EventType: $Keys<EventTypes>,
+>(
+  target: EventTarget<EventTypes>,
+  type: EventType,
+): EventCallback<EventTypes[EventType]> | null {
   const listener = getEventHandlerAttributeMap(target)?.get(type);
   return listener != null ? listener.handleEvent : null;
 }
@@ -87,10 +95,13 @@ export function getEventHandlerAttribute(
  *
  * Should be used to set a value for `target.on{type}`.
  */
-export function setEventHandlerAttribute(
-  target: EventTarget,
-  type: string,
-  callback: ?EventCallback,
+export function setEventHandlerAttribute<
+  EventTypes: GenericEventMap,
+  EventName: $Keys<EventTypes>,
+>(
+  target: EventTarget<EventTypes>,
+  type: EventName,
+  callback: ?EventCallback<EventTypes[EventName]>,
 ): void {
   let map = getEventHandlerAttributeMap(target);
   if (map != null) {

--- a/packages/react-native/src/private/webapis/dom/events/__tests__/EventHandlerAttributes-itest.js
+++ b/packages/react-native/src/private/webapis/dom/events/__tests__/EventHandlerAttributes-itest.js
@@ -21,12 +21,12 @@ import {
 } from 'react-native/src/private/webapis/dom/events/EventHandlerAttributes';
 import EventTarget from 'react-native/src/private/webapis/dom/events/EventTarget';
 
-class EventTargetSubclass extends EventTarget {
-  get oncustomevent(): EventCallback | null {
+class EventTargetSubclass extends EventTarget<{customEvent: Event}> {
+  get oncustomevent(): EventCallback<Event> | null {
     return getEventHandlerAttribute(this, 'customEvent');
   }
 
-  set oncustomevent(listener: ?EventCallback) {
+  set oncustomevent(listener: ?EventCallback<Event>) {
     setEventHandlerAttribute(this, 'customEvent', listener);
   }
 }

--- a/packages/react-native/src/private/webapis/dom/events/__tests__/EventTarget-benchmark-itest.js
+++ b/packages/react-native/src/private/webapis/dom/events/__tests__/EventTarget-benchmark-itest.js
@@ -16,8 +16,8 @@ import Event from 'react-native/src/private/webapis/dom/events/Event';
 import EventTarget from 'react-native/src/private/webapis/dom/events/EventTarget';
 
 let event: Event;
-let eventTarget: EventTarget;
-let eventTargets: $ReadOnlyArray<EventTarget>;
+let eventTarget: EventTarget<>;
+let eventTargets: $ReadOnlyArray<EventTarget<>>;
 
 unstable_benchmark
   .suite('EventTarget', {

--- a/packages/react-native/src/private/webapis/dom/events/__tests__/EventTarget-flowtest.js
+++ b/packages/react-native/src/private/webapis/dom/events/__tests__/EventTarget-flowtest.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import CustomEvent from '../CustomEvent';
+import Event from '../Event';
+import EventTarget from '../EventTarget';
+
+class CustomEventSubclass extends CustomEvent {}
+
+export function testGeneric(target: EventTarget<>) {
+  target.dispatchEvent(new Event('foo'));
+  target.dispatchEvent(new CustomEvent('bar'));
+
+  target.addEventListener('foo', (event: Event) => {});
+  target.addEventListener('bar', (event: Event) => {});
+
+  // $FlowExpectedError[incompatible-call]
+  target.addEventListener('bar', (event: CustomEvent) => {});
+}
+
+export function testCustom(target: EventTarget<{customEvent: CustomEvent}>) {
+  // Good
+  target.dispatchEvent(new CustomEvent('customEvent'));
+
+  // Should this fail?
+  target.dispatchEvent(new CustomEvent('bar'));
+
+  // $FlowExpectedError[incompatible-call]
+  target.dispatchEvent(new Event('customEvent'));
+
+  // Good
+  target.addEventListener('customEvent', (event: CustomEvent) => {});
+
+  // Underconstraining is fine (CustomEvent is a subtype of Event)
+  target.addEventListener('customEvent', (event: Event) => {});
+
+  // Overconstraining is not fine
+  target.addEventListener(
+    'customEvent',
+    // $FlowExpectedError[incompatible-call]
+    (event: CustomEventSubclass) => {},
+  );
+
+  // $FlowExpectedError[prop-missing] Unknown event type
+  // $FlowExpectedError[incompatible-call]
+  target.addEventListener('foo', (event: Event) => {});
+}

--- a/packages/react-native/src/private/webapis/dom/events/__tests__/EventTarget-itest.js
+++ b/packages/react-native/src/private/webapis/dom/events/__tests__/EventTarget-itest.js
@@ -24,7 +24,7 @@ function resetListenerCallOrder() {
 type EventRecordingListener = JestMockFn<[Event], void> & {
   eventData?: {
     callOrder: number,
-    composedPath: $ReadOnlyArray<EventTarget>,
+    composedPath: $ReadOnlyArray<EventTarget<>>,
     currentTarget: Event['currentTarget'],
     eventPhase: Event['eventPhase'],
     target: Event['target'],

--- a/packages/react-native/src/private/webapis/dom/events/__tests__/createEventTargetHierarchyWithDepth.js
+++ b/packages/react-native/src/private/webapis/dom/events/__tests__/createEventTargetHierarchyWithDepth.js
@@ -16,7 +16,7 @@ import {EVENT_TARGET_GET_THE_PARENT_KEY} from '../internals/EventTargetInternals
  */
 export default function createEventTargetHierarchyWithDepth(
   depth: number,
-): Array<EventTarget> {
+): Array<EventTarget<>> {
   if (depth < 1) {
     throw new Error('Depth must be greater or equal to 1');
   }

--- a/packages/react-native/src/private/webapis/dom/events/internals/EventInternals.js
+++ b/packages/react-native/src/private/webapis/dom/events/internals/EventInternals.js
@@ -30,27 +30,27 @@ export const STOP_IMMEDIATE_PROPAGATION_FLAG_KEY: symbol = Symbol(
 export const STOP_PROPAGATION_FLAG_KEY: symbol = Symbol('stopPropagationFlag');
 export const TARGET_KEY: symbol = Symbol('target');
 
-export function getCurrentTarget(event: Event): EventTarget | null {
+export function getCurrentTarget(event: Event): EventTarget<> | null {
   // $FlowExpectedError[prop-missing]
   return event[CURRENT_TARGET_KEY];
 }
 
 export function setCurrentTarget(
   event: Event,
-  currentTarget: EventTarget | null,
+  currentTarget: EventTarget<> | null,
 ): void {
   // $FlowExpectedError[prop-missing]
   event[CURRENT_TARGET_KEY] = currentTarget;
 }
 
-export function getComposedPath(event: Event): $ReadOnlyArray<EventTarget> {
+export function getComposedPath(event: Event): $ReadOnlyArray<EventTarget<>> {
   // $FlowExpectedError[prop-missing]
   return event[COMPOSED_PATH_KEY];
 }
 
 export function setComposedPath(
   event: Event,
-  composedPath: $ReadOnlyArray<EventTarget>,
+  composedPath: $ReadOnlyArray<EventTarget<>>,
 ): void {
   // $FlowExpectedError[prop-missing]
   event[COMPOSED_PATH_KEY] = composedPath;
@@ -109,12 +109,12 @@ export function setStopPropagationFlag(event: Event, value: boolean): void {
   event[STOP_PROPAGATION_FLAG_KEY] = value;
 }
 
-export function getTarget(event: Event): EventTarget | null {
+export function getTarget(event: Event): EventTarget<> | null {
   // $FlowExpectedError[prop-missing]
   return event[TARGET_KEY];
 }
 
-export function setTarget(event: Event, target: EventTarget | null): void {
+export function setTarget(event: Event, target: EventTarget<> | null): void {
   // $FlowExpectedError[prop-missing]
   event[TARGET_KEY] = target;
 }

--- a/packages/react-native/src/private/webapis/dom/events/internals/EventTargetInternals.js
+++ b/packages/react-native/src/private/webapis/dom/events/internals/EventTargetInternals.js
@@ -42,7 +42,7 @@ export const INTERNAL_DISPATCH_METHOD_KEY: symbol = Symbol(
  * JavaScript.
  */
 export function dispatchTrustedEvent(
-  eventTarget: EventTarget,
+  eventTarget: EventTarget<>,
   event: Event,
 ): void {
   setIsTrusted(event, true);


### PR DESCRIPTION
Summary:
Changelog: [internal]

This adds the ability to strongly type `EventTarget` events via generics.

See the next diff for an example of how to use it.

Differential Revision: D75681184


