### PR TITLE
Fix reporting of errors during test setup

### DIFF
--- a/packages/react-native-fantom/runtime/setup.js
+++ b/packages/react-native-fantom/runtime/setup.js
@@ -190,18 +190,13 @@ global.jest = {
 
 global.expect = expect;
 
+let testSetupError: ?Error;
+
 function runWithGuard(fn: () => void) {
   try {
     fn();
   } catch (error) {
-    let reportedError =
-      error instanceof Error ? error : new Error(String(error));
-    reportTestSuiteResult({
-      error: {
-        message: reportedError.message,
-        stack: reportedError.stack,
-      },
-    });
+    testSetupError = error instanceof Error ? error : new Error(String(error));
   }
 }
 
@@ -400,9 +395,18 @@ function validateEmptyMessageQueue(): void {
 }
 
 global.$$RunTests$$ = () => {
-  reportTestSuiteResult({
-    testResults: runSuite(currentContext),
-  });
+  if (testSetupError != null) {
+    reportTestSuiteResult({
+      error: {
+        message: testSetupError.message,
+        stack: testSetupError.stack,
+      },
+    });
+  } else {
+    reportTestSuiteResult({
+      testResults: runSuite(currentContext),
+    });
+  }
 };
 
 export function registerTest(


### PR DESCRIPTION
Summary:
Changelog: [internal]

If you create a Fantom test that throws an error during its setup (not during the execution of specific tests), Fantom fails with an error saying there are no tests defined, which isn't useful.

This fixes the problem and shows where the error in the test setup happened exactly.

Differential Revision: D75689283


