### PR TITLE
use if statement instead of unordered_map for mapping

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/drivers/AnimationDriver.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/drivers/AnimationDriver.cpp
@@ -20,14 +20,15 @@ namespace facebook::react {
 
 std::optional<AnimationDriverType> AnimationDriver::getDriverTypeByName(
     const std::string& driverTypeName) {
-  static std::unordered_map<std::string, AnimationDriverType> typeNames = {
-      {"frames", AnimationDriverType::Frames},
-      {"spring", AnimationDriverType::Spring},
-      {"decay", AnimationDriverType::Decay}};
-  if (auto iter = typeNames.find(driverTypeName); iter != typeNames.end()) {
-    return iter->second;
+  if (driverTypeName == "frames") {
+    return AnimationDriverType::Frames;
+  } else if (driverTypeName == "spring") {
+    return AnimationDriverType::Spring;
+  } else if (driverTypeName == "decay") {
+    return AnimationDriverType::Decay;
+  } else {
+    return std::nullopt;
   }
-  return std::nullopt;
 }
 
 AnimationDriver::AnimationDriver(

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/AnimatedNode.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/AnimatedNode.cpp
@@ -45,26 +45,37 @@ AnimatedNode* AnimatedNode::getChildNode(Tag tag) {
 
 std::optional<AnimatedNodeType> AnimatedNode::getNodeTypeByName(
     const std::string& nodeTypeName) {
-  static std::unordered_map<std::string, AnimatedNodeType> typeNames = {
-      {"style", AnimatedNodeType::Style},
-      {"value", AnimatedNodeType::Value},
-      {"color", AnimatedNodeType::Color},
-      {"props", AnimatedNodeType::Props},
-      {"interpolation", AnimatedNodeType::Interpolation},
-      {"addition", AnimatedNodeType::Addition},
-      {"subtraction", AnimatedNodeType::Subtraction},
-      {"division", AnimatedNodeType::Division},
-      {"multiplication", AnimatedNodeType::Multiplication},
-      {"modulus", AnimatedNodeType::Modulus},
-      {"diffclamp", AnimatedNodeType::Diffclamp},
-      {"transform", AnimatedNodeType::Transform},
-      {"tracking", AnimatedNodeType::Tracking},
-      {"round", AnimatedNodeType::Round}};
-
-  if (auto iter = typeNames.find(nodeTypeName); iter != typeNames.end()) {
-    return iter->second;
+  if (nodeTypeName == "style") {
+    return AnimatedNodeType::Style;
+  } else if (nodeTypeName == "value") {
+    return AnimatedNodeType::Value;
+  } else if (nodeTypeName == "color") {
+    return AnimatedNodeType::Color;
+  } else if (nodeTypeName == "props") {
+    return AnimatedNodeType::Props;
+  } else if (nodeTypeName == "interpolation") {
+    return AnimatedNodeType::Interpolation;
+  } else if (nodeTypeName == "addition") {
+    return AnimatedNodeType::Addition;
+  } else if (nodeTypeName == "subtraction") {
+    return AnimatedNodeType::Subtraction;
+  } else if (nodeTypeName == "division") {
+    return AnimatedNodeType::Division;
+  } else if (nodeTypeName == "multiplication") {
+    return AnimatedNodeType::Multiplication;
+  } else if (nodeTypeName == "modulus") {
+    return AnimatedNodeType::Modulus;
+  } else if (nodeTypeName == "diffclamp") {
+    return AnimatedNodeType::Diffclamp;
+  } else if (nodeTypeName == "transform") {
+    return AnimatedNodeType::Transform;
+  } else if (nodeTypeName == "tracking") {
+    return AnimatedNodeType::Tracking;
+  } else if (nodeTypeName == "round") {
+    return AnimatedNodeType::Round;
+  } else {
+    return std::nullopt;
   }
-  return std::nullopt;
 }
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
changelog: [internal]

use if/else instead of unordered_map to map types of nodes/drivers from string to a class. This is faster and improves binary size.

Differential Revision: D75676701


