### PR TITLE
RN: Fix Typing for Non-Boolean Feature Flags

### DIFF
--- a/packages/react-native/scripts/featureflags/templates/android/JReactNativeFeatureFlagsCxxInterop.cpp-template.js
+++ b/packages/react-native/scripts/featureflags/templates/android/JReactNativeFeatureFlagsCxxInterop.cpp-template.js
@@ -10,7 +10,11 @@
 
 import type {FeatureFlagDefinitions} from '../../types';
 
-import {DO_NOT_MODIFY_COMMENT, getCxxTypeFromDefaultValue} from '../../utils';
+import {
+  DO_NOT_MODIFY_COMMENT,
+  getCxxJNITypeFromDefaultValue,
+  getCxxTypeFromDefaultValue,
+} from '../../utils';
 import signedsource from 'signedsource';
 
 export default function (definitions: FeatureFlagDefinitions): string {
@@ -54,7 +58,7 @@ ${Object.entries(definitions.common)
         flagConfig.defaultValue,
       )} ${flagName}() override {
     static const auto method =
-        getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("${flagName}");
+        getReactNativeFeatureFlagsProviderJavaClass()->getMethod<${getCxxJNITypeFromDefaultValue(flagConfig.defaultValue)}()>("${flagName}");
     return method(javaProvider_);
   }`,
   )

--- a/packages/react-native/scripts/featureflags/templates/android/ReactNativeFeatureFlagsCxxAccessor.kt-template.js
+++ b/packages/react-native/scripts/featureflags/templates/android/ReactNativeFeatureFlagsCxxAccessor.kt-template.js
@@ -42,7 +42,12 @@ ${Object.entries(definitions.common)
 
 ${Object.entries(definitions.common)
   .map(
-    ([flagName, flagConfig]) => `  override fun ${flagName}(): Boolean {
+    ([
+      flagName,
+      flagConfig,
+    ]) => `  override fun ${flagName}(): ${getKotlinTypeFromDefaultValue(
+      flagConfig.defaultValue,
+    )} {
     var cached = ${flagName}Cache
     if (cached == null) {
       cached = ReactNativeFeatureFlagsCxxInterop.${flagName}()

--- a/packages/react-native/scripts/featureflags/templates/android/ReactNativeFeatureFlagsLocalAccessor.kt-template.js
+++ b/packages/react-native/scripts/featureflags/templates/android/ReactNativeFeatureFlagsLocalAccessor.kt-template.js
@@ -46,7 +46,12 @@ ${Object.entries(definitions.common)
 
 ${Object.entries(definitions.common)
   .map(
-    ([flagName, flagConfig]) => `  override fun ${flagName}(): Boolean {
+    ([
+      flagName,
+      flagConfig,
+    ]) => `  override fun ${flagName}(): ${getKotlinTypeFromDefaultValue(
+      flagConfig.defaultValue,
+    )} {
     var cached = ${flagName}Cache
     if (cached == null) {
       cached = currentProvider.${flagName}()

--- a/packages/react-native/scripts/featureflags/templates/common-cxx/ReactNativeFeatureFlagsDynamicProvider.h-template.js
+++ b/packages/react-native/scripts/featureflags/templates/common-cxx/ReactNativeFeatureFlagsDynamicProvider.h-template.js
@@ -16,7 +16,7 @@ import type {
 import {DO_NOT_MODIFY_COMMENT, getCxxTypeFromDefaultValue} from '../../utils';
 import signedsource from 'signedsource';
 
-function getFollyDynamicAccessor(config: CommonFeatureFlagConfig): string {
+function getFollyDynamicAccessor(config: CommonFeatureFlagConfig<>): string {
   switch (typeof config.defaultValue) {
     case 'boolean':
       return 'getBool';

--- a/packages/react-native/scripts/featureflags/types.js
+++ b/packages/react-native/scripts/featureflags/types.js
@@ -28,9 +28,11 @@ export type OSSReleaseStageValue =
   | 'canary'
   | 'stable';
 
-export type CommonFeatureFlagConfig = $ReadOnly<{
-  defaultValue: FeatureFlagValue,
-  metadata: FeatureFlagMetadata,
+export type CommonFeatureFlagConfig<
+  TValue: FeatureFlagValue = FeatureFlagValue,
+> = $ReadOnly<{
+  defaultValue: TValue,
+  metadata: FeatureFlagMetadata<TValue>,
   ossReleaseStage: OSSReleaseStageValue,
   // Indicates if this API should only be defined in JavaScript, only to
   // preserve backwards compatibility with existing native code temporarily.
@@ -38,20 +40,22 @@ export type CommonFeatureFlagConfig = $ReadOnly<{
 }>;
 
 export type CommonFeatureFlagList = $ReadOnly<{
-  [flagName: string]: CommonFeatureFlagConfig,
+  [flagName: string]: CommonFeatureFlagConfig<>,
 }>;
 
-export type JsOnlyFeatureFlagConfig = $ReadOnly<{
-  defaultValue: FeatureFlagValue,
-  metadata: FeatureFlagMetadata,
+export type JsOnlyFeatureFlagConfig<
+  TValue: FeatureFlagValue = FeatureFlagValue,
+> = $ReadOnly<{
+  defaultValue: TValue,
+  metadata: FeatureFlagMetadata<TValue>,
   ossReleaseStage: OSSReleaseStageValue,
 }>;
 
 export type JsOnlyFeatureFlagList = $ReadOnly<{
-  [flagName: string]: JsOnlyFeatureFlagConfig,
+  [flagName: string]: JsOnlyFeatureFlagConfig<>,
 }>;
 
-export type FeatureFlagMetadata =
+export type FeatureFlagMetadata<TValue: FeatureFlagValue = FeatureFlagValue> =
   | $ReadOnly<{
       purpose: 'experimentation',
       /**
@@ -60,12 +64,12 @@ export type FeatureFlagMetadata =
        */
       dateAdded: string,
       description: string,
-      expectedReleaseValue: boolean,
+      expectedReleaseValue: TValue,
     }>
   | $ReadOnly<{
       purpose: 'operational' | 'release',
       description: string,
-      expectedReleaseValue: boolean,
+      expectedReleaseValue: TValue,
     }>;
 
 export type GeneratorConfig = $ReadOnly<{

--- a/packages/react-native/scripts/featureflags/utils.js
+++ b/packages/react-native/scripts/featureflags/utils.js
@@ -25,6 +25,21 @@ export function getCxxTypeFromDefaultValue(
   }
 }
 
+export function getCxxJNITypeFromDefaultValue(
+  defaultValue: FeatureFlagValue,
+): string {
+  switch (typeof defaultValue) {
+    case 'boolean':
+      return 'jboolean';
+    case 'number':
+      return 'jint';
+    case 'string':
+      return 'jstring';
+    default:
+      throw new Error(`Unsupported default value type: ${typeof defaultValue}`);
+  }
+}
+
 export function getKotlinTypeFromDefaultValue(
   defaultValue: FeatureFlagValue,
 ): string {


### PR DESCRIPTION
Summary:
Currently, the type definitions for feature flags assumes `boolean` values in the `expectedReleaseValue` field.

This diff fixes them so `expectedReleaseValue` must match the type of `defaultValue`.

Changelog:
[Internal]

Differential Revision: D75690997


