### PR TITLE
RN: Default `featureflags` Script to Update

### DIFF
--- a/packages/react-native/scripts/featureflags/index.js
+++ b/packages/react-native/scripts/featureflags/index.js
@@ -19,6 +19,11 @@ if (require.main === module) {
     command = 'verify-unchanged';
   } else if (process.argv.includes('--print')) {
     command = 'print';
+  } else if (process.argv.includes('--help')) {
+    command = 'help';
+  } else {
+    console.log('Defaulting to `--update`. See all options using `--help`.');
+    command = 'update';
   }
 
   switch (command) {
@@ -31,10 +36,12 @@ if (require.main === module) {
     case 'print':
       require('./print').default(process.argv.includes('--json'));
       break;
-    default:
-      console.error(
-        'Usage: node featureflags.js [--update|--verify-unchanged|--print]',
+    case 'help':
+      console.log(
+        'Usage: node featureflags.js [--update|--verify-unchanged|--print|--help]',
       );
-      process.exit(1);
+      break;
+    default:
+      throw new Error('Unexpected script execution.');
   }
 }

--- a/packages/react-native/scripts/featureflags/templates/common-cxx/ReactNativeFeatureFlagsDynamicProvider.h-template.js
+++ b/packages/react-native/scripts/featureflags/templates/common-cxx/ReactNativeFeatureFlagsDynamicProvider.h-template.js
@@ -16,7 +16,7 @@ import type {
 import {DO_NOT_MODIFY_COMMENT, getCxxTypeFromDefaultValue} from '../../utils';
 import signedsource from 'signedsource';
 
-function getFollyDynamicAccessor(config: CommonFeatureFlagConfig): string {
+function getFollyDynamicAccessor(config: CommonFeatureFlagConfig<>): string {
   switch (typeof config.defaultValue) {
     case 'boolean':
       return 'getBool';

--- a/packages/react-native/scripts/featureflags/types.js
+++ b/packages/react-native/scripts/featureflags/types.js
@@ -28,9 +28,11 @@ export type OSSReleaseStageValue =
   | 'canary'
   | 'stable';
 
-export type CommonFeatureFlagConfig = $ReadOnly<{
-  defaultValue: FeatureFlagValue,
-  metadata: FeatureFlagMetadata,
+export type CommonFeatureFlagConfig<
+  TValue: FeatureFlagValue = FeatureFlagValue,
+> = $ReadOnly<{
+  defaultValue: TValue,
+  metadata: FeatureFlagMetadata<TValue>,
   ossReleaseStage: OSSReleaseStageValue,
   // Indicates if this API should only be defined in JavaScript, only to
   // preserve backwards compatibility with existing native code temporarily.
@@ -38,20 +40,22 @@ export type CommonFeatureFlagConfig = $ReadOnly<{
 }>;
 
 export type CommonFeatureFlagList = $ReadOnly<{
-  [flagName: string]: CommonFeatureFlagConfig,
+  [flagName: string]: CommonFeatureFlagConfig<>,
 }>;
 
-export type JsOnlyFeatureFlagConfig = $ReadOnly<{
-  defaultValue: FeatureFlagValue,
-  metadata: FeatureFlagMetadata,
+export type JsOnlyFeatureFlagConfig<
+  TValue: FeatureFlagValue = FeatureFlagValue,
+> = $ReadOnly<{
+  defaultValue: TValue,
+  metadata: FeatureFlagMetadata<TValue>,
   ossReleaseStage: OSSReleaseStageValue,
 }>;
 
 export type JsOnlyFeatureFlagList = $ReadOnly<{
-  [flagName: string]: JsOnlyFeatureFlagConfig,
+  [flagName: string]: JsOnlyFeatureFlagConfig<>,
 }>;
 
-export type FeatureFlagMetadata =
+export type FeatureFlagMetadata<TValue: FeatureFlagValue = FeatureFlagValue> =
   | $ReadOnly<{
       purpose: 'experimentation',
       /**
@@ -60,12 +64,12 @@ export type FeatureFlagMetadata =
        */
       dateAdded: string,
       description: string,
-      expectedReleaseValue: boolean,
+      expectedReleaseValue: TValue,
     }>
   | $ReadOnly<{
       purpose: 'operational' | 'release',
       description: string,
-      expectedReleaseValue: boolean,
+      expectedReleaseValue: TValue,
     }>;
 
 export type GeneratorConfig = $ReadOnly<{


### PR DESCRIPTION
Summary:
Changes `yarn featureflags` to default to `--update` when no options are supplied.

Provides a way to display the available options with a new `--help` option.

Changelog:
[Internal]

Differential Revision: D75692119


