### PR TITLE
Define PerformanceMark in global

### DIFF
--- a/packages/react-native/Libraries/Core/setUpPerformance.js
+++ b/packages/react-native/Libraries/Core/setUpPerformance.js
@@ -10,12 +10,14 @@
 
 import Performance from '../../src/private/webapis/performance/Performance';
 import NativePerformance from '../../src/private/webapis/performance/specs/NativePerformance';
+import {PerformanceMark} from '../../src/private/webapis/performance/UserTiming';
 
 // In case if the native implementation of the Performance API is available, use it,
 // otherwise fall back to the legacy/default one, which only defines 'Performance.now()'
 if (NativePerformance) {
   // $FlowExpectedError[cannot-write]
   global.performance = new Performance();
+  global.PerformanceMark = PerformanceMark;
 } else {
   if (!global.performance) {
     // $FlowExpectedError[cannot-write]


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

You can actually call `new PerformanceMark(...)` on global: https://w3c.github.io/user-timing/#the-performancemark-constructor

NOTE: Although PerformanceMeasure is also visible on Window, you can't call it. It will throw Illegal Constructor error.

Differential Revision: D75692314


