### PR TITLE
Move textAlignVertical to paragraph props

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextView.kt
@@ -41,19 +41,20 @@ internal class PreparedLayoutTextView(context: Context) : ViewGroup(context), Re
   private var clickableSpans: List<ClickableSpan> = emptyList()
   private var selection: TextSelection? = null
 
-  public var layout: Layout? = null
+  public var preparedLayout: PreparedLayout? = null
     set(value) {
       if (field != value) {
         val lastSelection = selection
         if (lastSelection != null) {
-          if (value != null && field?.text.toString() == value.text.toString()) {
-            value.getSelectionPath(lastSelection.start, lastSelection.end, lastSelection.path)
+          if (value != null && field?.layout?.text.toString() == value.layout.text.toString()) {
+            value.layout.getSelectionPath(
+                lastSelection.start, lastSelection.end, lastSelection.path)
           } else {
             clearSelection()
           }
         }
 
-        clickableSpans = value?.text?.let { filterClickableSpans(it) } ?: emptyList()
+        clickableSpans = value?.layout?.text?.let { filterClickableSpans(it) } ?: emptyList()
 
         field = value
         invalidate()
@@ -73,7 +74,7 @@ internal class PreparedLayoutTextView(context: Context) : ViewGroup(context), Re
   public @ColorInt var selectionColor: Int? = null
 
   public val text: CharSequence?
-    get() = layout?.text
+    get() = preparedLayout?.layout?.text
 
   init {
     initView()
@@ -84,7 +85,7 @@ internal class PreparedLayoutTextView(context: Context) : ViewGroup(context), Re
   private fun initView() {
     clickableSpans = emptyList()
     selection = null
-    layout = null
+    preparedLayout = null
   }
 
   public fun recycleView(): Unit {
@@ -101,17 +102,17 @@ internal class PreparedLayoutTextView(context: Context) : ViewGroup(context), Re
     super.onDraw(canvas)
     canvas.translate(paddingLeft.toFloat(), paddingTop.toFloat())
 
-    val textLayout = layout
-    if (textLayout != null) {
+    val layout = preparedLayout?.layout
+    if (layout != null) {
       if (selection != null) {
         selectionPaint.setColor(
             selectionColor ?: DefaultStyleValuesUtil.getDefaultTextColorHighlight(context))
       }
 
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-        Api34Utils.draw(textLayout, canvas, selection?.path, selectionPaint)
+        Api34Utils.draw(layout, canvas, selection?.path, selectionPaint)
       } else {
-        textLayout.draw(canvas, selection?.path, selectionPaint, 0)
+        layout.draw(canvas, selection?.path, selectionPaint, 0)
       }
     }
   }
@@ -121,21 +122,21 @@ internal class PreparedLayoutTextView(context: Context) : ViewGroup(context), Re
   }
 
   public fun setSelection(start: Int, end: Int) {
-    val textLayout = checkNotNull(layout)
-    if (start < 0 || end > textLayout.text.length || start >= end) {
+    val layout = checkNotNull(preparedLayout).layout
+    if (start < 0 || end > layout.text.length || start >= end) {
       throw IllegalArgumentException(
-          "setSelection start and end are not in valid range. start: $start, end: $end, text length: ${textLayout.text.length}")
+          "setSelection start and end are not in valid range. start: $start, end: $end, text length: ${layout.text.length}")
     }
 
     val textSelection = selection
     if (textSelection == null) {
       val selectionPath = Path()
-      textLayout.getSelectionPath(start, end, selectionPath)
+      layout.getSelectionPath(start, end, selectionPath)
       selection = TextSelection(start, end, selectionPath)
     } else {
       textSelection.start = start
       textSelection.end = end
-      textLayout.getSelectionPath(start, end, textSelection.path)
+      layout.getSelectionPath(start, end, textSelection.path)
     }
 
     invalidate()
@@ -171,9 +172,9 @@ internal class PreparedLayoutTextView(context: Context) : ViewGroup(context), Re
       clearSelection()
       clickableSpan.onClick(this)
     } else if (action == MotionEvent.ACTION_DOWN) {
-      val textLayout = checkNotNull(layout)
-      val start = (textLayout.text as Spanned).getSpanStart(clickableSpan)
-      val end = (textLayout.text as Spanned).getSpanEnd(clickableSpan)
+      val layout = checkNotNull(preparedLayout).layout
+      val start = (layout.text as Spanned).getSpanStart(clickableSpan)
+      val end = (layout.text as Spanned).getSpanEnd(clickableSpan)
       setSelection(start, end)
     }
 
@@ -205,19 +206,19 @@ internal class PreparedLayoutTextView(context: Context) : ViewGroup(context), Re
   }
 
   private fun getTextOffsetAt(x: Int, y: Int): Int {
-    val textLayout = layout ?: return -1
-    val line = textLayout.getLineForVertical(y)
+    val layout = preparedLayout?.layout ?: return -1
+    val line = layout.getLineForVertical(y)
 
     val left: Float
     val right: Float
 
-    if (textLayout.alignment == Layout.Alignment.ALIGN_CENTER) {
+    if (layout.alignment == Layout.Alignment.ALIGN_CENTER) {
       /**
        * [Layout#getLineLeft] and [Layout#getLineRight] properly account for paragraph margins on
        * centered text.
        */
-      left = textLayout.getLineLeft(line)
-      right = textLayout.getLineRight(line)
+      left = layout.getLineLeft(line)
+      right = layout.getLineRight(line)
     } else {
       /**
        * [Layout#getLineLeft] and [Layout#getLineRight] do NOT properly account for paragraph
@@ -229,11 +230,11 @@ internal class PreparedLayoutTextView(context: Context) : ViewGroup(context), Re
        * [Layout#getLineMax] gives the extent *plus* the leading margin, so we can figure out the
        * rest from there.
        */
-      val rtl = textLayout.getParagraphDirection(line) == Layout.DIR_RIGHT_TO_LEFT
+      val rtl = layout.getParagraphDirection(line) == Layout.DIR_RIGHT_TO_LEFT
       left =
-          if (rtl) (textLayout.width - textLayout.getLineMax(line))
-          else textLayout.getParagraphLeft(line).toFloat()
-      right = if (rtl) textLayout.getParagraphRight(line).toFloat() else textLayout.getLineMax(line)
+          if (rtl) (layout.width - layout.getLineMax(line))
+          else layout.getParagraphLeft(line).toFloat()
+      right = if (rtl) layout.getParagraphRight(line).toFloat() else layout.getLineMax(line)
     }
 
     if (x < left || x > right) {
@@ -241,7 +242,7 @@ internal class PreparedLayoutTextView(context: Context) : ViewGroup(context), Re
     }
 
     return try {
-      textLayout.getOffsetForHorizontal(line, x.toFloat())
+      layout.getOffsetForHorizontal(line, x.toFloat())
     } catch (e: ArrayIndexOutOfBoundsException) {
       // This happens for bidi text on Android 7-8.
       // See

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextViewManager.kt
@@ -62,13 +62,13 @@ internal class PreparedLayoutTextViewManager :
 
   override fun updateExtraData(view: PreparedLayoutTextView, extraData: Any) {
     SystraceSection("PreparedLayoutTextViewManager.updateExtraData").use { _ ->
-      val layout = (extraData as PreparedLayout).layout
-      view.layout = layout
+      val preparedLayout = extraData as PreparedLayout
+      view.preparedLayout = preparedLayout
 
       // If this text view contains any clickable spans, set a view tag and reset the accessibility
       // delegate so that these can be picked up by the accessibility system.
-      if (layout.text is Spanned) {
-        val spannedText = layout.text as Spanned
+      if (preparedLayout.layout.text is Spanned) {
+        val spannedText = preparedLayout.layout.text as Spanned
         val accessibilityLinks = AccessibilityLinks(spannedText)
         view.setTag(
             R.id.accessibility_links,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewAccessibilityDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewAccessibilityDelegate.kt
@@ -149,7 +149,7 @@ internal class ReactTextViewAccessibilityDelegate : ReactAccessibilityDelegate {
 
   private fun getLayoutFromHost(): Layout? {
     return if (hostView is PreparedLayoutTextView) {
-      (hostView as PreparedLayoutTextView).layout
+      (hostView as PreparedLayoutTextView).preparedLayout?.layout
     } else if (hostView is TextView) {
       (hostView as TextView).layout
     } else {
@@ -166,7 +166,7 @@ internal class ReactTextViewAccessibilityDelegate : ReactAccessibilityDelegate {
   private fun getSpannedFromHost(): Spanned? {
     val host = hostView
     return if (host is PreparedLayoutTextView) {
-      host.layout?.text as? Spanned
+      host.preparedLayout?.layout?.text as? Spanned
     } else if (host is TextView) {
       host.text as? Spanned
     } else {

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/ParagraphAttributes.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/ParagraphAttributes.cpp
@@ -21,14 +21,16 @@ bool ParagraphAttributes::operator==(const ParagraphAttributes& rhs) const {
              textBreakStrategy,
              adjustsFontSizeToFit,
              includeFontPadding,
-             android_hyphenationFrequency) ==
+             android_hyphenationFrequency,
+             textAlignVertical) ==
       std::tie(
              rhs.maximumNumberOfLines,
              rhs.ellipsizeMode,
              rhs.textBreakStrategy,
              rhs.adjustsFontSizeToFit,
              rhs.includeFontPadding,
-             rhs.android_hyphenationFrequency) &&
+             rhs.android_hyphenationFrequency,
+             rhs.textAlignVertical) &&
       floatEquality(minimumFontSize, rhs.minimumFontSize) &&
       floatEquality(maximumFontSize, rhs.maximumFontSize) &&
       floatEquality(minimumFontScale, rhs.minimumFontScale);
@@ -73,7 +75,11 @@ SharedDebugStringConvertibleList ParagraphAttributes::getDebugProps() const {
       debugStringConvertibleItem(
           "android_hyphenationFrequency",
           android_hyphenationFrequency,
-          paragraphAttributes.android_hyphenationFrequency)};
+          paragraphAttributes.android_hyphenationFrequency),
+      debugStringConvertibleItem(
+          "textAlignVertical",
+          textAlignVertical,
+          paragraphAttributes.textAlignVertical)};
 }
 #endif
 

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/ParagraphAttributes.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/ParagraphAttributes.h
@@ -76,6 +76,12 @@ class ParagraphAttributes : public DebugStringConvertible {
    */
   Float minimumFontScale{std::numeric_limits<Float>::quiet_NaN()};
 
+  /*
+   * The vertical alignment of the text, causing the glyphs to be vertically
+   * aligned in its container.
+   */
+  std::optional<TextAlignmentVertical> textAlignVertical{};
+
   bool operator==(const ParagraphAttributes&) const;
   bool operator!=(const ParagraphAttributes&) const;
 
@@ -103,7 +109,8 @@ struct hash<facebook::react::ParagraphAttributes> {
         attributes.maximumFontSize,
         attributes.includeFontPadding,
         attributes.android_hyphenationFrequency,
-        attributes.minimumFontScale);
+        attributes.minimumFontScale,
+        attributes.textAlignVertical);
   }
 };
 } // namespace std

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp
@@ -114,10 +114,6 @@ void TextAttributes::apply(TextAttributes textAttributes) {
       ? textAttributes.accessibilityRole
       : accessibilityRole;
   role = textAttributes.role.has_value() ? textAttributes.role : role;
-
-  textAlignVertical = textAttributes.textAlignVertical.has_value()
-      ? textAttributes.textAlignVertical
-      : textAlignVertical;
 }
 
 #pragma mark - Operators
@@ -133,7 +129,6 @@ bool TextAttributes::operator==(const TextAttributes& rhs) const {
              allowFontScaling,
              dynamicTypeRamp,
              alignment,
-             textAlignVertical,
              baseWritingDirection,
              lineBreakStrategy,
              textDecorationColor,
@@ -146,8 +141,7 @@ bool TextAttributes::operator==(const TextAttributes& rhs) const {
              layoutDirection,
              accessibilityRole,
              role,
-             textTransform,
-             textAlignVertical) ==
+             textTransform) ==
       std::tie(
              rhs.foregroundColor,
              rhs.backgroundColor,
@@ -158,7 +152,6 @@ bool TextAttributes::operator==(const TextAttributes& rhs) const {
              rhs.allowFontScaling,
              rhs.dynamicTypeRamp,
              rhs.alignment,
-             rhs.textAlignVertical,
              rhs.baseWritingDirection,
              rhs.lineBreakStrategy,
              rhs.textDecorationColor,
@@ -171,8 +164,7 @@ bool TextAttributes::operator==(const TextAttributes& rhs) const {
              rhs.layoutDirection,
              rhs.accessibilityRole,
              rhs.role,
-             rhs.textTransform,
-             rhs.textAlignVertical) &&
+             rhs.textTransform) &&
       floatEquality(maxFontSizeMultiplier, rhs.maxFontSizeMultiplier) &&
       floatEquality(opacity, rhs.opacity) &&
       floatEquality(fontSize, rhs.fontSize) &&
@@ -289,11 +281,6 @@ SharedDebugStringConvertibleList TextAttributes::getDebugProps() const {
           accessibilityRole,
           textAttributes.accessibilityRole),
       debugStringConvertibleItem("role", role, textAttributes.role),
-
-      debugStringConvertibleItem(
-          "textAlignVertical",
-          textAlignVertical,
-          textAttributes.textAlignVertical),
   };
 }
 #endif

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.h
@@ -86,8 +86,6 @@ class TextAttributes : public DebugStringConvertible {
   std::optional<AccessibilityRole> accessibilityRole{};
   std::optional<Role> role{};
 
-  std::optional<TextAlignmentVertical> textAlignVertical{};
-
 #pragma mark - Operations
 
   void apply(TextAttributes textAttributes);
@@ -127,7 +125,6 @@ struct hash<facebook::react::TextAttributes> {
         textAttributes.textTransform,
         textAttributes.lineHeight,
         textAttributes.alignment,
-        textAttributes.textAlignVertical,
         textAttributes.baseWritingDirection,
         textAttributes.lineBreakStrategy,
         textAttributes.lineBreakMode,
@@ -141,8 +138,7 @@ struct hash<facebook::react::TextAttributes> {
         textAttributes.isPressable,
         textAttributes.layoutDirection,
         textAttributes.accessibilityRole,
-        textAttributes.role,
-        textAttributes.textAlignVertical);
+        textAttributes.role);
   }
 };
 } // namespace std

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/conversions.h
@@ -21,7 +21,6 @@
 #include <react/renderer/core/conversions.h>
 #include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/core/propsConversions.h>
-#include <cmath>
 #include <unordered_map>
 
 #ifdef RN_SERIALIZABLE_STATE
@@ -978,6 +977,12 @@ inline ParagraphAttributes convertRawProp(
       "android_hyphenationFrequency",
       sourceParagraphAttributes.android_hyphenationFrequency,
       defaultParagraphAttributes.android_hyphenationFrequency);
+  paragraphAttributes.textAlignVertical = convertRawProp(
+      context,
+      rawProps,
+      "textAlignVertical",
+      sourceParagraphAttributes.textAlignVertical,
+      defaultParagraphAttributes.textAlignVertical);
 
   return paragraphAttributes;
 }
@@ -1060,6 +1065,7 @@ constexpr static MapBuffer::Key PA_KEY_INCLUDE_FONT_PADDING = 4;
 constexpr static MapBuffer::Key PA_KEY_HYPHENATION_FREQUENCY = 5;
 constexpr static MapBuffer::Key PA_KEY_MINIMUM_FONT_SIZE = 6;
 constexpr static MapBuffer::Key PA_KEY_MAXIMUM_FONT_SIZE = 7;
+constexpr static MapBuffer::Key PA_KEY_TEXT_ALIGN_VERTICAL = 8;
 
 inline MapBuffer toMapBuffer(const ParagraphAttributes& paragraphAttributes) {
   auto builder = MapBufferBuilder();
@@ -1077,6 +1083,11 @@ inline MapBuffer toMapBuffer(const ParagraphAttributes& paragraphAttributes) {
   builder.putString(
       PA_KEY_HYPHENATION_FREQUENCY,
       toString(paragraphAttributes.android_hyphenationFrequency));
+  if (paragraphAttributes.textAlignVertical.has_value()) {
+    builder.putString(
+        PA_KEY_TEXT_ALIGN_VERTICAL,
+        toString(*paragraphAttributes.textAlignVertical));
+  }
   builder.putDouble(
       PA_KEY_MINIMUM_FONT_SIZE, paragraphAttributes.minimumFontSize);
   builder.putDouble(
@@ -1219,10 +1230,6 @@ inline MapBuffer toMapBuffer(const TextAttributes& textAttributes) {
   }
   if (textAttributes.role.has_value()) {
     builder.putInt(TA_KEY_ROLE, static_cast<int32_t>(*textAttributes.role));
-  }
-  if (textAttributes.textAlignVertical.has_value()) {
-    builder.putString(
-        TA_KEY_ALIGNMENT_VERTICAL, toString(*textAttributes.textAlignVertical));
   }
   return builder.build();
 }

--- a/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
@@ -98,12 +98,6 @@ static TextAttributes convertRawProp(
       "textTransform",
       sourceTextAttributes.textTransform,
       defaultTextAttributes.textTransform);
-  textAttributes.textAlignVertical = convertRawProp(
-      context,
-      rawProps,
-      "textAlignVertical",
-      sourceTextAttributes.textAlignVertical,
-      defaultTextAttributes.textAlignVertical);
 
   // Paragraph
   textAttributes.lineHeight = convertRawProp(
@@ -291,12 +285,6 @@ void BaseTextProps::setProp(
         defaults,
         value,
         textAttributes,
-        textAlignVertical,
-        "textAlignVertical");
-    REBUILD_FIELD_SWITCH_CASE(
-        defaults,
-        value,
-        textAttributes,
         baseWritingDirection,
         "baseWritingDirection");
     REBUILD_FIELD_SWITCH_CASE(
@@ -436,13 +424,6 @@ void BaseTextProps::appendTextAttributesProps(
   if (textAttributes.textTransform != oldProps->textAttributes.textTransform) {
     result["textTransform"] = textAttributes.textTransform.has_value()
         ? toString(textAttributes.textTransform.value())
-        : nullptr;
-  }
-
-  if (textAttributes.textAlignVertical !=
-      oldProps->textAttributes.textAlignVertical) {
-    result["textAlignVertical"] = textAttributes.textAlignVertical.has_value()
-        ? toString(textAttributes.textAlignVertical.value())
         : nullptr;
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphProps.cpp
@@ -126,6 +126,12 @@ void ParagraphProps::setProp(
         paragraphAttributes,
         android_hyphenationFrequency,
         "android_hyphenationFrequency");
+    REBUILD_FIELD_SWITCH_CASE(
+        paDefaults,
+        value,
+        paragraphAttributes,
+        textAlignVertical,
+        "textAlignVertical");
   }
 
   switch (hash) {
@@ -217,6 +223,14 @@ folly::dynamic ParagraphProps::getDiffProps(const Props* prevProps) const {
       oldProps->paragraphAttributes.android_hyphenationFrequency) {
     result["android_hyphenationFrequency"] =
         toString(paragraphAttributes.android_hyphenationFrequency);
+  }
+
+  if (paragraphAttributes.textAlignVertical !=
+      oldProps->paragraphAttributes.textAlignVertical) {
+    result["textAlignVertical"] =
+        paragraphAttributes.textAlignVertical.has_value()
+        ? toString(paragraphAttributes.textAlignVertical.value())
+        : nullptr;
   }
 
   if (isSelectable != oldProps->isSelectable) {

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.cpp
@@ -201,6 +201,12 @@ void BaseTextInputProps::setProp(
         paragraphAttributes,
         android_hyphenationFrequency,
         "android_hyphenationFrequency");
+    REBUILD_FIELD_SWITCH_CASE(
+        paDefaults,
+        value,
+        paragraphAttributes,
+        textAlignVertical,
+        "textAlignVertical");
   }
 
   switch (hash) {

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
@@ -425,6 +425,16 @@ folly::dynamic AndroidTextInputProps::getDiffProps(
         toString(paragraphAttributes.android_hyphenationFrequency);
   }
 
+  if (paragraphAttributes.textAlignVertical !=
+      oldProps->paragraphAttributes.textAlignVertical) {
+    if (!paragraphAttributes.textAlignVertical.has_value()) {
+      result["textAlignVertical"] = nullptr;
+    } else {
+      result["textAlignVertical"] =
+          toString(*paragraphAttributes.textAlignVertical);
+    }
+  }
+
   // Base text input props
   if (defaultValue != oldProps->defaultValue) {
     result["defaultValue"] = defaultValue;


### PR DESCRIPTION
Summary:
This prop only works on top level text components, yet it is stored as a TextAttribute. It should be a ParagraphAttribute, so I moved it there.

Changelog: [Internal]

Differential Revision: D75684576


