### PR TITLE
RN: Represent Numeric Feature Flags as Double

### DIFF
--- a/packages/react-native/scripts/featureflags/templates/android/JReactNativeFeatureFlagsCxxInterop.cpp-template.js
+++ b/packages/react-native/scripts/featureflags/templates/android/JReactNativeFeatureFlagsCxxInterop.cpp-template.js
@@ -10,7 +10,11 @@
 
 import type {FeatureFlagDefinitions} from '../../types';
 
-import {DO_NOT_MODIFY_COMMENT, getCxxTypeFromDefaultValue} from '../../utils';
+import {
+  DO_NOT_MODIFY_COMMENT,
+  getCxxJNITypeFromDefaultValue,
+  getCxxTypeFromDefaultValue,
+} from '../../utils';
 import signedsource from 'signedsource';
 
 export default function (definitions: FeatureFlagDefinitions): string {
@@ -54,7 +58,7 @@ ${Object.entries(definitions.common)
         flagConfig.defaultValue,
       )} ${flagName}() override {
     static const auto method =
-        getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("${flagName}");
+        getReactNativeFeatureFlagsProviderJavaClass()->getMethod<${getCxxJNITypeFromDefaultValue(flagConfig.defaultValue)}()>("${flagName}");
     return method(javaProvider_);
   }`,
   )

--- a/packages/react-native/scripts/featureflags/templates/android/ReactNativeFeatureFlagsCxxAccessor.kt-template.js
+++ b/packages/react-native/scripts/featureflags/templates/android/ReactNativeFeatureFlagsCxxAccessor.kt-template.js
@@ -42,7 +42,12 @@ ${Object.entries(definitions.common)
 
 ${Object.entries(definitions.common)
   .map(
-    ([flagName, flagConfig]) => `  override fun ${flagName}(): Boolean {
+    ([
+      flagName,
+      flagConfig,
+    ]) => `  override fun ${flagName}(): ${getKotlinTypeFromDefaultValue(
+      flagConfig.defaultValue,
+    )} {
     var cached = ${flagName}Cache
     if (cached == null) {
       cached = ReactNativeFeatureFlagsCxxInterop.${flagName}()

--- a/packages/react-native/scripts/featureflags/templates/android/ReactNativeFeatureFlagsDefaults.kt-template.js
+++ b/packages/react-native/scripts/featureflags/templates/android/ReactNativeFeatureFlagsDefaults.kt-template.js
@@ -13,6 +13,7 @@ import type {FeatureFlagDefinitions} from '../../types';
 import {
   DO_NOT_MODIFY_COMMENT,
   getKotlinTypeFromDefaultValue,
+  getKotlinValueFromDefaultValue,
 } from '../../utils';
 import signedsource from 'signedsource';
 
@@ -39,7 +40,7 @@ ${Object.entries(definitions.common)
     ([flagName, flagConfig]) =>
       `  override fun ${flagName}(): ${getKotlinTypeFromDefaultValue(
         flagConfig.defaultValue,
-      )} = ${JSON.stringify(flagConfig.defaultValue)}`,
+      )} = ${getKotlinValueFromDefaultValue(flagConfig.defaultValue)}`,
   )
   .join('\n\n')}
 }

--- a/packages/react-native/scripts/featureflags/templates/android/ReactNativeFeatureFlagsLocalAccessor.kt-template.js
+++ b/packages/react-native/scripts/featureflags/templates/android/ReactNativeFeatureFlagsLocalAccessor.kt-template.js
@@ -46,7 +46,12 @@ ${Object.entries(definitions.common)
 
 ${Object.entries(definitions.common)
   .map(
-    ([flagName, flagConfig]) => `  override fun ${flagName}(): Boolean {
+    ([
+      flagName,
+      flagConfig,
+    ]) => `  override fun ${flagName}(): ${getKotlinTypeFromDefaultValue(
+      flagConfig.defaultValue,
+    )} {
     var cached = ${flagName}Cache
     if (cached == null) {
       cached = currentProvider.${flagName}()

--- a/packages/react-native/scripts/featureflags/templates/android/ReactNativeFeatureFlagsOverrides_RNOSS__Stage__Android.kt-template.js
+++ b/packages/react-native/scripts/featureflags/templates/android/ReactNativeFeatureFlagsOverrides_RNOSS__Stage__Android.kt-template.js
@@ -13,6 +13,7 @@ import type {FeatureFlagDefinitions, OSSReleaseStageValue} from '../../types';
 import {
   DO_NOT_MODIFY_COMMENT,
   getKotlinTypeFromDefaultValue,
+  getKotlinValueFromDefaultValue,
 } from '../../utils';
 import signedsource from 'signedsource';
 
@@ -52,7 +53,7 @@ ${Object.entries(definitions.common)
     if (flagConfig.ossReleaseStage === ossReleaseStage) {
       return `  override fun ${flagName}(): ${getKotlinTypeFromDefaultValue(
         flagConfig.metadata.expectedReleaseValue,
-      )} = ${JSON.stringify(flagConfig.metadata.expectedReleaseValue)}`;
+      )} = ${getKotlinValueFromDefaultValue(flagConfig.metadata.expectedReleaseValue)}`;
     }
   })
   .filter(Boolean)

--- a/packages/react-native/scripts/featureflags/templates/common-cxx/ReactNativeFeatureFlagsDefaults.h-template.js
+++ b/packages/react-native/scripts/featureflags/templates/common-cxx/ReactNativeFeatureFlagsDefaults.h-template.js
@@ -10,7 +10,11 @@
 
 import type {FeatureFlagDefinitions} from '../../types';
 
-import {DO_NOT_MODIFY_COMMENT, getCxxTypeFromDefaultValue} from '../../utils';
+import {
+  DO_NOT_MODIFY_COMMENT,
+  getCxxTypeFromDefaultValue,
+  getCxxValueFromDefaultValue,
+} from '../../utils';
 import signedsource from 'signedsource';
 
 export default function (definitions: FeatureFlagDefinitions): string {
@@ -41,7 +45,7 @@ ${Object.entries(definitions.common)
       `  ${getCxxTypeFromDefaultValue(
         flagConfig.defaultValue,
       )} ${flagName}() override {
-    return ${JSON.stringify(flagConfig.defaultValue)};
+    return ${getCxxValueFromDefaultValue(flagConfig.defaultValue)};
   }`,
   )
   .join('\n\n')}

--- a/packages/react-native/scripts/featureflags/templates/common-cxx/ReactNativeFeatureFlagsDynamicProvider.h-template.js
+++ b/packages/react-native/scripts/featureflags/templates/common-cxx/ReactNativeFeatureFlagsDynamicProvider.h-template.js
@@ -16,7 +16,7 @@ import type {
 import {DO_NOT_MODIFY_COMMENT, getCxxTypeFromDefaultValue} from '../../utils';
 import signedsource from 'signedsource';
 
-function getFollyDynamicAccessor(config: CommonFeatureFlagConfig): string {
+function getFollyDynamicAccessor(config: CommonFeatureFlagConfig<>): string {
   switch (typeof config.defaultValue) {
     case 'boolean':
       return 'getBool';

--- a/packages/react-native/scripts/featureflags/templates/common-cxx/ReactNativeFeatureFlagsDynamicProvider.h-template.js
+++ b/packages/react-native/scripts/featureflags/templates/common-cxx/ReactNativeFeatureFlagsDynamicProvider.h-template.js
@@ -8,26 +8,14 @@
  * @format
  */
 
-import type {
-  CommonFeatureFlagConfig,
-  FeatureFlagDefinitions,
-} from '../../types';
+import type {FeatureFlagDefinitions} from '../../types';
 
-import {DO_NOT_MODIFY_COMMENT, getCxxTypeFromDefaultValue} from '../../utils';
+import {
+  DO_NOT_MODIFY_COMMENT,
+  getCxxFollyDynamicAccessorFromDefaultValue,
+  getCxxTypeFromDefaultValue,
+} from '../../utils';
 import signedsource from 'signedsource';
-
-function getFollyDynamicAccessor(config: CommonFeatureFlagConfig<>): string {
-  switch (typeof config.defaultValue) {
-    case 'boolean':
-      return 'getBool';
-    case 'number':
-      return 'getInt';
-    case 'string':
-      return 'getString';
-    default:
-      throw new Error(`Unsupported type: ${typeof config.defaultValue}`);
-  }
-}
 
 export default function (definitions: FeatureFlagDefinitions): string {
   return signedsource.signFile(`/*
@@ -77,7 +65,7 @@ ${Object.entries(definitions.common)
       )} ${flagName}() override {
     auto value = values_["${flagName}"];
     if (!value.isNull()) {
-      return value.${getFollyDynamicAccessor(flagConfig)}();
+      return value.${getCxxFollyDynamicAccessorFromDefaultValue(flagConfig.defaultValue)}();
     }
 
     return ReactNativeFeatureFlagsDefaults::${flagName}();

--- a/packages/react-native/scripts/featureflags/templates/common-cxx/ReactNativeFeatureFlagsOverridesOSS_Stage_.h-template.js
+++ b/packages/react-native/scripts/featureflags/templates/common-cxx/ReactNativeFeatureFlagsOverridesOSS_Stage_.h-template.js
@@ -10,7 +10,11 @@
 
 import type {FeatureFlagDefinitions, OSSReleaseStageValue} from '../../types';
 
-import {DO_NOT_MODIFY_COMMENT, getCxxTypeFromDefaultValue} from '../../utils';
+import {
+  DO_NOT_MODIFY_COMMENT,
+  getCxxTypeFromDefaultValue,
+  getCxxValueFromDefaultValue,
+} from '../../utils';
 import signedsource from 'signedsource';
 
 function getClassName(ossReleaseStage: OSSReleaseStageValue): string {
@@ -64,7 +68,7 @@ ${Object.entries(definitions.common)
       return `  ${getCxxTypeFromDefaultValue(
         flagConfig.metadata.expectedReleaseValue,
       )} ${flagName}() override {
-    return ${JSON.stringify(flagConfig.metadata.expectedReleaseValue)};
+    return ${getCxxValueFromDefaultValue(flagConfig.metadata.expectedReleaseValue)};
   }`;
     }
   })

--- a/packages/react-native/scripts/featureflags/templates/js/NativeReactNativeFeatureFlags.cpp-template.js
+++ b/packages/react-native/scripts/featureflags/templates/js/NativeReactNativeFeatureFlags.cpp-template.js
@@ -10,7 +10,11 @@
 
 import type {FeatureFlagDefinitions} from '../../types';
 
-import {DO_NOT_MODIFY_COMMENT, getCxxTypeFromDefaultValue} from '../../utils';
+import {
+  DO_NOT_MODIFY_COMMENT,
+  getCxxTypeFromDefaultValue,
+  getCxxValueFromDefaultValue,
+} from '../../utils';
 import signedsource from 'signedsource';
 
 export default function (definitions: FeatureFlagDefinitions): string {
@@ -54,7 +58,7 @@ ${Object.entries(definitions.common)
     jsi::Runtime& /*runtime*/) {
   // This flag is configured with \`skipNativeAPI: true\`.
   // TODO(T204838867): Implement support for optional methods in C++ TM codegen and remove the method definition altogether.
-  return ${JSON.stringify(flagConfig.defaultValue)};
+  return ${getCxxValueFromDefaultValue(flagConfig.defaultValue)};
 }`
       : `${getCxxTypeFromDefaultValue(
           flagConfig.defaultValue,

--- a/packages/react-native/scripts/featureflags/types.js
+++ b/packages/react-native/scripts/featureflags/types.js
@@ -28,9 +28,11 @@ export type OSSReleaseStageValue =
   | 'canary'
   | 'stable';
 
-export type CommonFeatureFlagConfig = $ReadOnly<{
-  defaultValue: FeatureFlagValue,
-  metadata: FeatureFlagMetadata,
+export type CommonFeatureFlagConfig<
+  TValue: FeatureFlagValue = FeatureFlagValue,
+> = $ReadOnly<{
+  defaultValue: TValue,
+  metadata: FeatureFlagMetadata<TValue>,
   ossReleaseStage: OSSReleaseStageValue,
   // Indicates if this API should only be defined in JavaScript, only to
   // preserve backwards compatibility with existing native code temporarily.
@@ -38,20 +40,22 @@ export type CommonFeatureFlagConfig = $ReadOnly<{
 }>;
 
 export type CommonFeatureFlagList = $ReadOnly<{
-  [flagName: string]: CommonFeatureFlagConfig,
+  [flagName: string]: CommonFeatureFlagConfig<>,
 }>;
 
-export type JsOnlyFeatureFlagConfig = $ReadOnly<{
-  defaultValue: FeatureFlagValue,
-  metadata: FeatureFlagMetadata,
+export type JsOnlyFeatureFlagConfig<
+  TValue: FeatureFlagValue = FeatureFlagValue,
+> = $ReadOnly<{
+  defaultValue: TValue,
+  metadata: FeatureFlagMetadata<TValue>,
   ossReleaseStage: OSSReleaseStageValue,
 }>;
 
 export type JsOnlyFeatureFlagList = $ReadOnly<{
-  [flagName: string]: JsOnlyFeatureFlagConfig,
+  [flagName: string]: JsOnlyFeatureFlagConfig<>,
 }>;
 
-export type FeatureFlagMetadata =
+export type FeatureFlagMetadata<TValue: FeatureFlagValue = FeatureFlagValue> =
   | $ReadOnly<{
       purpose: 'experimentation',
       /**
@@ -60,12 +64,12 @@ export type FeatureFlagMetadata =
        */
       dateAdded: string,
       description: string,
-      expectedReleaseValue: boolean,
+      expectedReleaseValue: TValue,
     }>
   | $ReadOnly<{
       purpose: 'operational' | 'release',
       description: string,
-      expectedReleaseValue: boolean,
+      expectedReleaseValue: TValue,
     }>;
 
 export type GeneratorConfig = $ReadOnly<{

--- a/packages/react-native/scripts/featureflags/utils.js
+++ b/packages/react-native/scripts/featureflags/utils.js
@@ -25,6 +25,21 @@ export function getCxxTypeFromDefaultValue(
   }
 }
 
+export function getCxxJNITypeFromDefaultValue(
+  defaultValue: FeatureFlagValue,
+): string {
+  switch (typeof defaultValue) {
+    case 'boolean':
+      return 'jboolean';
+    case 'number':
+      return 'jint';
+    case 'string':
+      return 'jstring';
+    default:
+      throw new Error(`Unsupported default value type: ${typeof defaultValue}`);
+  }
+}
+
 export function getKotlinTypeFromDefaultValue(
   defaultValue: FeatureFlagValue,
 ): string {

--- a/packages/react-native/scripts/featureflags/utils.js
+++ b/packages/react-native/scripts/featureflags/utils.js
@@ -17,9 +17,42 @@ export function getCxxTypeFromDefaultValue(
     case 'boolean':
       return 'bool';
     case 'number':
-      return 'int';
+      return 'double';
     case 'string':
       return 'std::string';
+    default:
+      throw new Error(`Unsupported default value type: ${typeof defaultValue}`);
+  }
+}
+
+export function getCxxValueFromDefaultValue(
+  defaultValue: FeatureFlagValue,
+): string {
+  switch (typeof defaultValue) {
+    case 'boolean':
+      return defaultValue.toString();
+    case 'number':
+      const numericString = defaultValue.toString();
+      // If the number is an integer, we need to append ".0" so that the result
+      // is interpeted as a double in C++.
+      return numericString.includes('.') ? numericString : `${numericString}.0`;
+    case 'string':
+      return JSON.stringify(defaultValue);
+    default:
+      throw new Error(`Unsupported default value type: ${typeof defaultValue}`);
+  }
+}
+
+export function getCxxFollyDynamicAccessorFromDefaultValue(
+  defaultValue: FeatureFlagValue,
+): string {
+  switch (typeof defaultValue) {
+    case 'boolean':
+      return 'getBool';
+    case 'number':
+      return 'getDouble';
+    case 'string':
+      return 'getString';
     default:
       throw new Error(`Unsupported default value type: ${typeof defaultValue}`);
   }
@@ -32,7 +65,7 @@ export function getCxxJNITypeFromDefaultValue(
     case 'boolean':
       return 'jboolean';
     case 'number':
-      return 'jint';
+      return 'jdouble';
     case 'string':
       return 'jstring';
     default:
@@ -47,9 +80,27 @@ export function getKotlinTypeFromDefaultValue(
     case 'boolean':
       return 'Boolean';
     case 'number':
-      return 'Int';
+      return 'Double';
     case 'string':
       return 'String';
+    default:
+      throw new Error(`Unsupported default value type: ${typeof defaultValue}`);
+  }
+}
+
+export function getKotlinValueFromDefaultValue(
+  defaultValue: FeatureFlagValue,
+): string {
+  switch (typeof defaultValue) {
+    case 'boolean':
+      return defaultValue.toString();
+    case 'number':
+      const numericString = defaultValue.toString();
+      // If the number is an integer, we need to append ".0" so that the result
+      // is interpeted as a double in Kotlin.
+      return numericString.includes('.') ? numericString : `${numericString}.0`;
+    case 'string':
+      return JSON.stringify(defaultValue);
     default:
       throw new Error(`Unsupported default value type: ${typeof defaultValue}`);
   }


### PR DESCRIPTION
Summary:
Changes the React Native Feature Flags system so that numeric feature flags are represented in native languages as double instead of int, in order to avoid loss of precision for non-integral JavaScript numbers.

Changelog:
[Internal]

Differential Revision: D75709111


