### PR TITLE
RN: Create `virtualViewPrerenderRatio` Feature Flag (#51715)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<d92f20c3ec9183dd2539f41a7b45ad08>>
+ * @generated SignedSource<<7484b716c0cb8d12d307e3b34767e559>>
  */
 
 /**
@@ -347,6 +347,12 @@ public object ReactNativeFeatureFlags {
    */
   @JvmStatic
   public fun useTurboModules(): Boolean = accessor.useTurboModules()
+
+  /**
+   * Initial prerender ratio for VirtualView.
+   */
+  @JvmStatic
+  public fun virtualViewPrerenderRatio(): Double = accessor.virtualViewPrerenderRatio()
 
   /**
    * Overrides the feature flags with the ones provided by the given provider

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<1cd5b56933a6fc03ff2cc3b09fe0c2e8>>
+ * @generated SignedSource<<daf78f5249ed27828d8e2fb83d5e5df3>>
  */
 
 /**
@@ -73,6 +73,7 @@ internal class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAcces
   private var useShadowNodeStateOnCloneCache: Boolean? = null
   private var useTurboModuleInteropCache: Boolean? = null
   private var useTurboModulesCache: Boolean? = null
+  private var virtualViewPrerenderRatioCache: Double? = null
 
   override fun commonTestFlag(): Boolean {
     var cached = commonTestFlagCache
@@ -547,6 +548,15 @@ internal class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAcces
     if (cached == null) {
       cached = ReactNativeFeatureFlagsCxxInterop.useTurboModules()
       useTurboModulesCache = cached
+    }
+    return cached
+  }
+
+  override fun virtualViewPrerenderRatio(): Double {
+    var cached = virtualViewPrerenderRatioCache
+    if (cached == null) {
+      cached = ReactNativeFeatureFlagsCxxInterop.virtualViewPrerenderRatio()
+      virtualViewPrerenderRatioCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<3e0d774f5d727e98bce677e218238eb1>>
+ * @generated SignedSource<<1261be706a0da435a217a88faed53015>>
  */
 
 /**
@@ -133,6 +133,8 @@ public object ReactNativeFeatureFlagsCxxInterop {
   @DoNotStrip @JvmStatic public external fun useTurboModuleInterop(): Boolean
 
   @DoNotStrip @JvmStatic public external fun useTurboModules(): Boolean
+
+  @DoNotStrip @JvmStatic public external fun virtualViewPrerenderRatio(): Double
 
   @DoNotStrip @JvmStatic public external fun override(provider: Any)
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<45f8f8047e5edb8b5c8fd32350246cf6>>
+ * @generated SignedSource<<e3792f1be08a9175b71c3bef175fbb71>>
  */
 
 /**
@@ -128,4 +128,6 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
   override fun useTurboModuleInterop(): Boolean = false
 
   override fun useTurboModules(): Boolean = false
+
+  override fun virtualViewPrerenderRatio(): Double = 5.0
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<2a7cd724a2ce1c9ea796f0b92120072b>>
+ * @generated SignedSource<<aba6b250d4c48029ae96480724c16ed0>>
  */
 
 /**
@@ -77,6 +77,7 @@ internal class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcc
   private var useShadowNodeStateOnCloneCache: Boolean? = null
   private var useTurboModuleInteropCache: Boolean? = null
   private var useTurboModulesCache: Boolean? = null
+  private var virtualViewPrerenderRatioCache: Double? = null
 
   override fun commonTestFlag(): Boolean {
     var cached = commonTestFlagCache
@@ -604,6 +605,16 @@ internal class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcc
       cached = currentProvider.useTurboModules()
       accessedFeatureFlags.add("useTurboModules")
       useTurboModulesCache = cached
+    }
+    return cached
+  }
+
+  override fun virtualViewPrerenderRatio(): Double {
+    var cached = virtualViewPrerenderRatioCache
+    if (cached == null) {
+      cached = currentProvider.virtualViewPrerenderRatio()
+      accessedFeatureFlags.add("virtualViewPrerenderRatio")
+      virtualViewPrerenderRatioCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<e61c6ae173c0399ad549b32fb4914777>>
+ * @generated SignedSource<<3f2600dc760fa878ded68e0e15110904>>
  */
 
 /**
@@ -128,4 +128,6 @@ public interface ReactNativeFeatureFlagsProvider {
   @DoNotStrip public fun useTurboModuleInterop(): Boolean
 
   @DoNotStrip public fun useTurboModules(): Boolean
+
+  @DoNotStrip public fun virtualViewPrerenderRatio(): Double
 }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<bd5d5a0b21816ebd35c06250ba622bb0>>
+ * @generated SignedSource<<fa8099e1d7d94dffcd229b00af5c748a>>
  */
 
 /**
@@ -357,6 +357,12 @@ class ReactNativeFeatureFlagsJavaProvider
     return method(javaProvider_);
   }
 
+  double virtualViewPrerenderRatio() override {
+    static const auto method =
+        getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jdouble()>("virtualViewPrerenderRatio");
+    return method(javaProvider_);
+  }
+
  private:
   jni::global_ref<jobject> javaProvider_;
 };
@@ -626,6 +632,11 @@ bool JReactNativeFeatureFlagsCxxInterop::useTurboModules(
   return ReactNativeFeatureFlags::useTurboModules();
 }
 
+double JReactNativeFeatureFlagsCxxInterop::virtualViewPrerenderRatio(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
+  return ReactNativeFeatureFlags::virtualViewPrerenderRatio();
+}
+
 void JReactNativeFeatureFlagsCxxInterop::override(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/,
     jni::alias_ref<jobject> provider) {
@@ -816,6 +827,9 @@ void JReactNativeFeatureFlagsCxxInterop::registerNatives() {
       makeNativeMethod(
         "useTurboModules",
         JReactNativeFeatureFlagsCxxInterop::useTurboModules),
+      makeNativeMethod(
+        "virtualViewPrerenderRatio",
+        JReactNativeFeatureFlagsCxxInterop::virtualViewPrerenderRatio),
   });
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<5916c20e72c045471b0182b229fa13c7>>
+ * @generated SignedSource<<8ecffdc9571b0f9e89c90b5f53fd17d8>>
  */
 
 /**
@@ -187,6 +187,9 @@ class JReactNativeFeatureFlagsCxxInterop
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool useTurboModules(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
+
+  static double virtualViewPrerenderRatio(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static void override(

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<39a09787285319461afa9de7543d4365>>
+ * @generated SignedSource<<b724dc9b1812a124f4964640b7fca8a1>>
  */
 
 /**
@@ -236,6 +236,10 @@ bool ReactNativeFeatureFlags::useTurboModuleInterop() {
 
 bool ReactNativeFeatureFlags::useTurboModules() {
   return getAccessor().useTurboModules();
+}
+
+double ReactNativeFeatureFlags::virtualViewPrerenderRatio() {
+  return getAccessor().virtualViewPrerenderRatio();
 }
 
 void ReactNativeFeatureFlags::override(

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<cf01214e2de7a6eb948c311b10d272ae>>
+ * @generated SignedSource<<dfad04f9ff620686a1619070f8c19efe>>
  */
 
 /**
@@ -303,6 +303,11 @@ class ReactNativeFeatureFlags {
    * When enabled, NativeModules will be executed by using the TurboModule system
    */
   RN_EXPORT static bool useTurboModules();
+
+  /**
+   * Initial prerender ratio for VirtualView.
+   */
+  RN_EXPORT static double virtualViewPrerenderRatio();
 
   /**
    * Overrides the feature flags with the ones provided by the given provider

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<6030c3b0bc053ef31fddc0cb9b41038e>>
+ * @generated SignedSource<<bea1415ac302c670c4e714ca127a30c1>>
  */
 
 /**
@@ -978,6 +978,24 @@ bool ReactNativeFeatureFlagsAccessor::useTurboModules() {
 
     flagValue = currentProvider_->useTurboModules();
     useTurboModules_ = flagValue;
+  }
+
+  return flagValue.value();
+}
+
+double ReactNativeFeatureFlagsAccessor::virtualViewPrerenderRatio() {
+  auto flagValue = virtualViewPrerenderRatio_.load();
+
+  if (!flagValue.has_value()) {
+    // This block is not exclusive but it is not necessary.
+    // If multiple threads try to initialize the feature flag, we would only
+    // be accessing the provider multiple times but the end state of this
+    // instance and the returned flag value would be the same.
+
+    markFlagAsAccessed(53, "virtualViewPrerenderRatio");
+
+    flagValue = currentProvider_->virtualViewPrerenderRatio();
+    virtualViewPrerenderRatio_ = flagValue;
   }
 
   return flagValue.value();

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<ee78e08d10e34ea7b4b44199f19abdba>>
+ * @generated SignedSource<<7e6dd10f2ccce6e207fd4ce8ed2a3a70>>
  */
 
 /**
@@ -85,6 +85,7 @@ class ReactNativeFeatureFlagsAccessor {
   bool useShadowNodeStateOnClone();
   bool useTurboModuleInterop();
   bool useTurboModules();
+  double virtualViewPrerenderRatio();
 
   void override(std::unique_ptr<ReactNativeFeatureFlagsProvider> provider);
   std::optional<std::string> getAccessedFeatureFlagNames() const;
@@ -96,7 +97,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::unique_ptr<ReactNativeFeatureFlagsProvider> currentProvider_;
   bool wasOverridden_;
 
-  std::array<std::atomic<const char*>, 53> accessedFeatureFlags_;
+  std::array<std::atomic<const char*>, 54> accessedFeatureFlags_;
 
   std::atomic<std::optional<bool>> commonTestFlag_;
   std::atomic<std::optional<bool>> animatedShouldSignalBatch_;
@@ -151,6 +152,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::atomic<std::optional<bool>> useShadowNodeStateOnClone_;
   std::atomic<std::optional<bool>> useTurboModuleInterop_;
   std::atomic<std::optional<bool>> useTurboModules_;
+  std::atomic<std::optional<double>> virtualViewPrerenderRatio_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c98421457ce8d9eca0e3797dab53331d>>
+ * @generated SignedSource<<999bacd5ad8eac2c69f0d7e8d20dcba9>>
  */
 
 /**
@@ -237,6 +237,10 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
 
   bool useTurboModules() override {
     return false;
+  }
+
+  double virtualViewPrerenderRatio() override {
+    return 5.0;
   }
 };
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<5314028389c33ef7e2781e7e43ac6e49>>
+ * @generated SignedSource<<ac09fd0e72e9fa41a5a13578fcd98d03>>
  */
 
 /**
@@ -520,6 +520,15 @@ class ReactNativeFeatureFlagsDynamicProvider : public ReactNativeFeatureFlagsDef
     }
 
     return ReactNativeFeatureFlagsDefaults::useTurboModules();
+  }
+
+  double virtualViewPrerenderRatio() override {
+    auto value = values_["virtualViewPrerenderRatio"];
+    if (!value.isNull()) {
+      return value.getDouble();
+    }
+
+    return ReactNativeFeatureFlagsDefaults::virtualViewPrerenderRatio();
   }
 };
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<16bd6df30a3ea5bcbe1cdb5d82bfca4f>>
+ * @generated SignedSource<<2ae65ebd8470b768fa42f240842d0f87>>
  */
 
 /**
@@ -78,6 +78,7 @@ class ReactNativeFeatureFlagsProvider {
   virtual bool useShadowNodeStateOnClone() = 0;
   virtual bool useTurboModuleInterop() = 0;
   virtual bool useTurboModules() = 0;
+  virtual double virtualViewPrerenderRatio() = 0;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<147254e7f4209e91f9ec00180f5b9c6d>>
+ * @generated SignedSource<<9eaa018054616593369563add66571d1>>
  */
 
 /**
@@ -307,6 +307,11 @@ bool NativeReactNativeFeatureFlags::useTurboModuleInterop(
 bool NativeReactNativeFeatureFlags::useTurboModules(
     jsi::Runtime& /*runtime*/) {
   return ReactNativeFeatureFlags::useTurboModules();
+}
+
+double NativeReactNativeFeatureFlags::virtualViewPrerenderRatio(
+    jsi::Runtime& /*runtime*/) {
+  return ReactNativeFeatureFlags::virtualViewPrerenderRatio();
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<750cb2f00345cd1fd7ad82ed615e82bf>>
+ * @generated SignedSource<<6c313394ffede63dadd06cce03b85550>>
  */
 
 /**
@@ -143,6 +143,8 @@ class NativeReactNativeFeatureFlags
   bool useTurboModuleInterop(jsi::Runtime& runtime);
 
   bool useTurboModules(jsi::Runtime& runtime);
+
+  double virtualViewPrerenderRatio(jsi::Runtime& runtime);
 };
 
 } // namespace facebook::react

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -607,6 +607,16 @@ const definitions: FeatureFlagDefinitions = {
       },
       ossReleaseStage: 'canary',
     },
+    virtualViewPrerenderRatio: {
+      defaultValue: 5,
+      metadata: {
+        dateAdded: '2025-05-30',
+        description: 'Initial prerender ratio for VirtualView.',
+        expectedReleaseValue: 5,
+        purpose: 'experimentation',
+      },
+      ossReleaseStage: 'none',
+    },
   },
 
   jsOnly: {

--- a/packages/react-native/scripts/featureflags/index.js
+++ b/packages/react-native/scripts/featureflags/index.js
@@ -19,6 +19,11 @@ if (require.main === module) {
     command = 'verify-unchanged';
   } else if (process.argv.includes('--print')) {
     command = 'print';
+  } else if (process.argv.includes('--help')) {
+    command = 'help';
+  } else {
+    console.log('Defaulting to `--update`. See all options using `--help`.');
+    command = 'update';
   }
 
   switch (command) {
@@ -31,10 +36,12 @@ if (require.main === module) {
     case 'print':
       require('./print').default(process.argv.includes('--json'));
       break;
-    default:
-      console.error(
-        'Usage: node featureflags.js [--update|--verify-unchanged|--print]',
+    case 'help':
+      console.log(
+        'Usage: node featureflags.js [--update|--verify-unchanged|--print|--help]',
       );
-      process.exit(1);
+      break;
+    default:
+      throw new Error('Unexpected script execution.');
   }
 }

--- a/packages/react-native/scripts/featureflags/templates/android/JReactNativeFeatureFlagsCxxInterop.cpp-template.js
+++ b/packages/react-native/scripts/featureflags/templates/android/JReactNativeFeatureFlagsCxxInterop.cpp-template.js
@@ -10,7 +10,11 @@
 
 import type {FeatureFlagDefinitions} from '../../types';
 
-import {DO_NOT_MODIFY_COMMENT, getCxxTypeFromDefaultValue} from '../../utils';
+import {
+  DO_NOT_MODIFY_COMMENT,
+  getCxxJNITypeFromDefaultValue,
+  getCxxTypeFromDefaultValue,
+} from '../../utils';
 import signedsource from 'signedsource';
 
 export default function (definitions: FeatureFlagDefinitions): string {
@@ -54,7 +58,7 @@ ${Object.entries(definitions.common)
         flagConfig.defaultValue,
       )} ${flagName}() override {
     static const auto method =
-        getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("${flagName}");
+        getReactNativeFeatureFlagsProviderJavaClass()->getMethod<${getCxxJNITypeFromDefaultValue(flagConfig.defaultValue)}()>("${flagName}");
     return method(javaProvider_);
   }`,
   )

--- a/packages/react-native/scripts/featureflags/templates/android/ReactNativeFeatureFlagsCxxAccessor.kt-template.js
+++ b/packages/react-native/scripts/featureflags/templates/android/ReactNativeFeatureFlagsCxxAccessor.kt-template.js
@@ -42,7 +42,12 @@ ${Object.entries(definitions.common)
 
 ${Object.entries(definitions.common)
   .map(
-    ([flagName, flagConfig]) => `  override fun ${flagName}(): Boolean {
+    ([
+      flagName,
+      flagConfig,
+    ]) => `  override fun ${flagName}(): ${getKotlinTypeFromDefaultValue(
+      flagConfig.defaultValue,
+    )} {
     var cached = ${flagName}Cache
     if (cached == null) {
       cached = ReactNativeFeatureFlagsCxxInterop.${flagName}()

--- a/packages/react-native/scripts/featureflags/templates/android/ReactNativeFeatureFlagsDefaults.kt-template.js
+++ b/packages/react-native/scripts/featureflags/templates/android/ReactNativeFeatureFlagsDefaults.kt-template.js
@@ -13,6 +13,7 @@ import type {FeatureFlagDefinitions} from '../../types';
 import {
   DO_NOT_MODIFY_COMMENT,
   getKotlinTypeFromDefaultValue,
+  getKotlinValueFromDefaultValue,
 } from '../../utils';
 import signedsource from 'signedsource';
 
@@ -39,7 +40,7 @@ ${Object.entries(definitions.common)
     ([flagName, flagConfig]) =>
       `  override fun ${flagName}(): ${getKotlinTypeFromDefaultValue(
         flagConfig.defaultValue,
-      )} = ${JSON.stringify(flagConfig.defaultValue)}`,
+      )} = ${getKotlinValueFromDefaultValue(flagConfig.defaultValue)}`,
   )
   .join('\n\n')}
 }

--- a/packages/react-native/scripts/featureflags/templates/android/ReactNativeFeatureFlagsLocalAccessor.kt-template.js
+++ b/packages/react-native/scripts/featureflags/templates/android/ReactNativeFeatureFlagsLocalAccessor.kt-template.js
@@ -46,7 +46,12 @@ ${Object.entries(definitions.common)
 
 ${Object.entries(definitions.common)
   .map(
-    ([flagName, flagConfig]) => `  override fun ${flagName}(): Boolean {
+    ([
+      flagName,
+      flagConfig,
+    ]) => `  override fun ${flagName}(): ${getKotlinTypeFromDefaultValue(
+      flagConfig.defaultValue,
+    )} {
     var cached = ${flagName}Cache
     if (cached == null) {
       cached = currentProvider.${flagName}()

--- a/packages/react-native/scripts/featureflags/templates/android/ReactNativeFeatureFlagsOverrides_RNOSS__Stage__Android.kt-template.js
+++ b/packages/react-native/scripts/featureflags/templates/android/ReactNativeFeatureFlagsOverrides_RNOSS__Stage__Android.kt-template.js
@@ -13,6 +13,7 @@ import type {FeatureFlagDefinitions, OSSReleaseStageValue} from '../../types';
 import {
   DO_NOT_MODIFY_COMMENT,
   getKotlinTypeFromDefaultValue,
+  getKotlinValueFromDefaultValue,
 } from '../../utils';
 import signedsource from 'signedsource';
 
@@ -52,7 +53,7 @@ ${Object.entries(definitions.common)
     if (flagConfig.ossReleaseStage === ossReleaseStage) {
       return `  override fun ${flagName}(): ${getKotlinTypeFromDefaultValue(
         flagConfig.metadata.expectedReleaseValue,
-      )} = ${JSON.stringify(flagConfig.metadata.expectedReleaseValue)}`;
+      )} = ${getKotlinValueFromDefaultValue(flagConfig.metadata.expectedReleaseValue)}`;
     }
   })
   .filter(Boolean)

--- a/packages/react-native/scripts/featureflags/templates/common-cxx/ReactNativeFeatureFlagsDefaults.h-template.js
+++ b/packages/react-native/scripts/featureflags/templates/common-cxx/ReactNativeFeatureFlagsDefaults.h-template.js
@@ -10,7 +10,11 @@
 
 import type {FeatureFlagDefinitions} from '../../types';
 
-import {DO_NOT_MODIFY_COMMENT, getCxxTypeFromDefaultValue} from '../../utils';
+import {
+  DO_NOT_MODIFY_COMMENT,
+  getCxxTypeFromDefaultValue,
+  getCxxValueFromDefaultValue,
+} from '../../utils';
 import signedsource from 'signedsource';
 
 export default function (definitions: FeatureFlagDefinitions): string {
@@ -41,7 +45,7 @@ ${Object.entries(definitions.common)
       `  ${getCxxTypeFromDefaultValue(
         flagConfig.defaultValue,
       )} ${flagName}() override {
-    return ${JSON.stringify(flagConfig.defaultValue)};
+    return ${getCxxValueFromDefaultValue(flagConfig.defaultValue)};
   }`,
   )
   .join('\n\n')}

--- a/packages/react-native/scripts/featureflags/templates/common-cxx/ReactNativeFeatureFlagsDynamicProvider.h-template.js
+++ b/packages/react-native/scripts/featureflags/templates/common-cxx/ReactNativeFeatureFlagsDynamicProvider.h-template.js
@@ -16,7 +16,7 @@ import type {
 import {DO_NOT_MODIFY_COMMENT, getCxxTypeFromDefaultValue} from '../../utils';
 import signedsource from 'signedsource';
 
-function getFollyDynamicAccessor(config: CommonFeatureFlagConfig): string {
+function getFollyDynamicAccessor(config: CommonFeatureFlagConfig<>): string {
   switch (typeof config.defaultValue) {
     case 'boolean':
       return 'getBool';

--- a/packages/react-native/scripts/featureflags/templates/common-cxx/ReactNativeFeatureFlagsDynamicProvider.h-template.js
+++ b/packages/react-native/scripts/featureflags/templates/common-cxx/ReactNativeFeatureFlagsDynamicProvider.h-template.js
@@ -8,26 +8,14 @@
  * @format
  */
 
-import type {
-  CommonFeatureFlagConfig,
-  FeatureFlagDefinitions,
-} from '../../types';
+import type {FeatureFlagDefinitions} from '../../types';
 
-import {DO_NOT_MODIFY_COMMENT, getCxxTypeFromDefaultValue} from '../../utils';
+import {
+  DO_NOT_MODIFY_COMMENT,
+  getCxxFollyDynamicAccessorFromDefaultValue,
+  getCxxTypeFromDefaultValue,
+} from '../../utils';
 import signedsource from 'signedsource';
-
-function getFollyDynamicAccessor(config: CommonFeatureFlagConfig<>): string {
-  switch (typeof config.defaultValue) {
-    case 'boolean':
-      return 'getBool';
-    case 'number':
-      return 'getInt';
-    case 'string':
-      return 'getString';
-    default:
-      throw new Error(`Unsupported type: ${typeof config.defaultValue}`);
-  }
-}
 
 export default function (definitions: FeatureFlagDefinitions): string {
   return signedsource.signFile(`/*
@@ -77,7 +65,7 @@ ${Object.entries(definitions.common)
       )} ${flagName}() override {
     auto value = values_["${flagName}"];
     if (!value.isNull()) {
-      return value.${getFollyDynamicAccessor(flagConfig)}();
+      return value.${getCxxFollyDynamicAccessorFromDefaultValue(flagConfig.defaultValue)}();
     }
 
     return ReactNativeFeatureFlagsDefaults::${flagName}();

--- a/packages/react-native/scripts/featureflags/templates/common-cxx/ReactNativeFeatureFlagsOverridesOSS_Stage_.h-template.js
+++ b/packages/react-native/scripts/featureflags/templates/common-cxx/ReactNativeFeatureFlagsOverridesOSS_Stage_.h-template.js
@@ -10,7 +10,11 @@
 
 import type {FeatureFlagDefinitions, OSSReleaseStageValue} from '../../types';
 
-import {DO_NOT_MODIFY_COMMENT, getCxxTypeFromDefaultValue} from '../../utils';
+import {
+  DO_NOT_MODIFY_COMMENT,
+  getCxxTypeFromDefaultValue,
+  getCxxValueFromDefaultValue,
+} from '../../utils';
 import signedsource from 'signedsource';
 
 function getClassName(ossReleaseStage: OSSReleaseStageValue): string {
@@ -64,7 +68,7 @@ ${Object.entries(definitions.common)
       return `  ${getCxxTypeFromDefaultValue(
         flagConfig.metadata.expectedReleaseValue,
       )} ${flagName}() override {
-    return ${JSON.stringify(flagConfig.metadata.expectedReleaseValue)};
+    return ${getCxxValueFromDefaultValue(flagConfig.metadata.expectedReleaseValue)};
   }`;
     }
   })

--- a/packages/react-native/scripts/featureflags/templates/js/NativeReactNativeFeatureFlags.cpp-template.js
+++ b/packages/react-native/scripts/featureflags/templates/js/NativeReactNativeFeatureFlags.cpp-template.js
@@ -10,7 +10,11 @@
 
 import type {FeatureFlagDefinitions} from '../../types';
 
-import {DO_NOT_MODIFY_COMMENT, getCxxTypeFromDefaultValue} from '../../utils';
+import {
+  DO_NOT_MODIFY_COMMENT,
+  getCxxTypeFromDefaultValue,
+  getCxxValueFromDefaultValue,
+} from '../../utils';
 import signedsource from 'signedsource';
 
 export default function (definitions: FeatureFlagDefinitions): string {
@@ -54,7 +58,7 @@ ${Object.entries(definitions.common)
     jsi::Runtime& /*runtime*/) {
   // This flag is configured with \`skipNativeAPI: true\`.
   // TODO(T204838867): Implement support for optional methods in C++ TM codegen and remove the method definition altogether.
-  return ${JSON.stringify(flagConfig.defaultValue)};
+  return ${getCxxValueFromDefaultValue(flagConfig.defaultValue)};
 }`
       : `${getCxxTypeFromDefaultValue(
           flagConfig.defaultValue,

--- a/packages/react-native/scripts/featureflags/types.js
+++ b/packages/react-native/scripts/featureflags/types.js
@@ -28,9 +28,11 @@ export type OSSReleaseStageValue =
   | 'canary'
   | 'stable';
 
-export type CommonFeatureFlagConfig = $ReadOnly<{
-  defaultValue: FeatureFlagValue,
-  metadata: FeatureFlagMetadata,
+export type CommonFeatureFlagConfig<
+  TValue: FeatureFlagValue = FeatureFlagValue,
+> = $ReadOnly<{
+  defaultValue: TValue,
+  metadata: FeatureFlagMetadata<TValue>,
   ossReleaseStage: OSSReleaseStageValue,
   // Indicates if this API should only be defined in JavaScript, only to
   // preserve backwards compatibility with existing native code temporarily.
@@ -38,20 +40,22 @@ export type CommonFeatureFlagConfig = $ReadOnly<{
 }>;
 
 export type CommonFeatureFlagList = $ReadOnly<{
-  [flagName: string]: CommonFeatureFlagConfig,
+  [flagName: string]: CommonFeatureFlagConfig<>,
 }>;
 
-export type JsOnlyFeatureFlagConfig = $ReadOnly<{
-  defaultValue: FeatureFlagValue,
-  metadata: FeatureFlagMetadata,
+export type JsOnlyFeatureFlagConfig<
+  TValue: FeatureFlagValue = FeatureFlagValue,
+> = $ReadOnly<{
+  defaultValue: TValue,
+  metadata: FeatureFlagMetadata<TValue>,
   ossReleaseStage: OSSReleaseStageValue,
 }>;
 
 export type JsOnlyFeatureFlagList = $ReadOnly<{
-  [flagName: string]: JsOnlyFeatureFlagConfig,
+  [flagName: string]: JsOnlyFeatureFlagConfig<>,
 }>;
 
-export type FeatureFlagMetadata =
+export type FeatureFlagMetadata<TValue: FeatureFlagValue = FeatureFlagValue> =
   | $ReadOnly<{
       purpose: 'experimentation',
       /**
@@ -60,12 +64,12 @@ export type FeatureFlagMetadata =
        */
       dateAdded: string,
       description: string,
-      expectedReleaseValue: boolean,
+      expectedReleaseValue: TValue,
     }>
   | $ReadOnly<{
       purpose: 'operational' | 'release',
       description: string,
-      expectedReleaseValue: boolean,
+      expectedReleaseValue: TValue,
     }>;
 
 export type GeneratorConfig = $ReadOnly<{

--- a/packages/react-native/scripts/featureflags/utils.js
+++ b/packages/react-native/scripts/featureflags/utils.js
@@ -25,6 +25,21 @@ export function getCxxTypeFromDefaultValue(
   }
 }
 
+export function getCxxJNITypeFromDefaultValue(
+  defaultValue: FeatureFlagValue,
+): string {
+  switch (typeof defaultValue) {
+    case 'boolean':
+      return 'jboolean';
+    case 'number':
+      return 'jint';
+    case 'string':
+      return 'jstring';
+    default:
+      throw new Error(`Unsupported default value type: ${typeof defaultValue}`);
+  }
+}
+
 export function getKotlinTypeFromDefaultValue(
   defaultValue: FeatureFlagValue,
 ): string {

--- a/packages/react-native/scripts/featureflags/utils.js
+++ b/packages/react-native/scripts/featureflags/utils.js
@@ -17,9 +17,42 @@ export function getCxxTypeFromDefaultValue(
     case 'boolean':
       return 'bool';
     case 'number':
-      return 'int';
+      return 'double';
     case 'string':
       return 'std::string';
+    default:
+      throw new Error(`Unsupported default value type: ${typeof defaultValue}`);
+  }
+}
+
+export function getCxxValueFromDefaultValue(
+  defaultValue: FeatureFlagValue,
+): string {
+  switch (typeof defaultValue) {
+    case 'boolean':
+      return defaultValue.toString();
+    case 'number':
+      const numericString = defaultValue.toString();
+      // If the number is an integer, we need to append ".0" so that the result
+      // is interpeted as a double in C++.
+      return numericString.includes('.') ? numericString : `${numericString}.0`;
+    case 'string':
+      return JSON.stringify(defaultValue);
+    default:
+      throw new Error(`Unsupported default value type: ${typeof defaultValue}`);
+  }
+}
+
+export function getCxxFollyDynamicAccessorFromDefaultValue(
+  defaultValue: FeatureFlagValue,
+): string {
+  switch (typeof defaultValue) {
+    case 'boolean':
+      return 'getBool';
+    case 'number':
+      return 'getDouble';
+    case 'string':
+      return 'getString';
     default:
       throw new Error(`Unsupported default value type: ${typeof defaultValue}`);
   }
@@ -32,7 +65,7 @@ export function getCxxJNITypeFromDefaultValue(
     case 'boolean':
       return 'jboolean';
     case 'number':
-      return 'jint';
+      return 'jdouble';
     case 'string':
       return 'jstring';
     default:
@@ -47,9 +80,27 @@ export function getKotlinTypeFromDefaultValue(
     case 'boolean':
       return 'Boolean';
     case 'number':
-      return 'Int';
+      return 'Double';
     case 'string':
       return 'String';
+    default:
+      throw new Error(`Unsupported default value type: ${typeof defaultValue}`);
+  }
+}
+
+export function getKotlinValueFromDefaultValue(
+  defaultValue: FeatureFlagValue,
+): string {
+  switch (typeof defaultValue) {
+    case 'boolean':
+      return defaultValue.toString();
+    case 'number':
+      const numericString = defaultValue.toString();
+      // If the number is an integer, we need to append ".0" so that the result
+      // is interpeted as a double in Kotlin.
+      return numericString.includes('.') ? numericString : `${numericString}.0`;
+    case 'string':
+      return JSON.stringify(defaultValue);
     default:
       throw new Error(`Unsupported default value type: ${typeof defaultValue}`);
   }

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<33870be221829e11a7e180b718c3738f>>
+ * @generated SignedSource<<7fe2abc6b638728b09b0194988f0264c>>
  * @flow strict
  * @noformat
  */
@@ -103,6 +103,7 @@ export type ReactNativeFeatureFlags = $ReadOnly<{
   useShadowNodeStateOnClone: Getter<boolean>,
   useTurboModuleInterop: Getter<boolean>,
   useTurboModules: Getter<boolean>,
+  virtualViewPrerenderRatio: Getter<number>,
 }>;
 
 /**
@@ -396,6 +397,10 @@ export const useTurboModuleInterop: Getter<boolean> = createNativeFlagGetter('us
  * When enabled, NativeModules will be executed by using the TurboModule system
  */
 export const useTurboModules: Getter<boolean> = createNativeFlagGetter('useTurboModules', false);
+/**
+ * Initial prerender ratio for VirtualView.
+ */
+export const virtualViewPrerenderRatio: Getter<number> = createNativeFlagGetter('virtualViewPrerenderRatio', 5);
 
 /**
  * Overrides the feature flags with the provided methods.

--- a/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<e07cd5a528549cd9fd1b37d69da13194>>
+ * @generated SignedSource<<afe099f339fe761a3856eb3f43dc6ae7>>
  * @flow strict
  * @noformat
  */
@@ -78,6 +78,7 @@ export interface Spec extends TurboModule {
   +useShadowNodeStateOnClone?: () => boolean;
   +useTurboModuleInterop?: () => boolean;
   +useTurboModules?: () => boolean;
+  +virtualViewPrerenderRatio?: () => number;
 }
 
 const NativeReactNativeFeatureFlags: ?Spec = TurboModuleRegistry.get<Spec>(


### PR DESCRIPTION
Summary:

Adds a feature flag to experiment with different `prerenderRatio` values from the `VirtualView` native component. Notably, this is the first time that the a feature flag has a non-boolean type.

Changelog:
[Internal]

Differential Revision: D75713594
