### PR TITLE
fix ReactScrollViewHelper.kt remove listeners logic

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
@@ -11,9 +11,11 @@ import android.animation.Animator
 import android.animation.ValueAnimator
 import android.content.Context
 import android.graphics.Point
+import android.os.Build
 import android.view.View
 import android.view.ViewGroup
 import android.widget.OverScroller
+import androidx.annotation.RequiresApi
 import androidx.core.view.ViewCompat.FocusDirection
 import androidx.core.view.ViewCompat.FocusRealDirection
 import com.facebook.common.logging.FLog
@@ -222,9 +224,10 @@ public object ReactScrollViewHelper {
     scrollListeners.add(WeakReference(listener))
   }
 
+  @RequiresApi(Build.VERSION_CODES.N)
   @JvmStatic
   public fun removeScrollListener(listener: ScrollListener) {
-    scrollListeners.remove(WeakReference(listener))
+    scrollListeners.removeIf { it.get() == null || it.get() == listener }
   }
 
   @JvmStatic
@@ -232,9 +235,10 @@ public object ReactScrollViewHelper {
     layoutChangeListeners.add(WeakReference(listener))
   }
 
+  @RequiresApi(Build.VERSION_CODES.N)
   @JvmStatic
   public fun removeLayoutChangeListener(listener: LayoutChangeListener) {
-    layoutChangeListeners.remove(WeakReference(listener))
+    layoutChangeListeners.removeIf { it.get() == null || it.get() == listener }
   }
 
   /**


### PR DESCRIPTION
Summary:
## what

the current removing listeners code is not working. in prod, when removeScrollListener is called, it creates a new weakReference of the scroll listener and it would never match any existing weakreference listeners in the list. The remove action would end up removing nothing from the list. 

This diff fixes the issue by iterating through the list and compare the obj
reference: https://stackoverflow.com/questions/6296051/how-to-remove-a-weakreference-from-a-list

Changelog: [Internal]

Reviewed By: Abbondanzo

Differential Revision: D75716993


