### PR TITLE
Add example for focus events on Android

### DIFF
--- a/packages/react-native/Libraries/Components/Pressable/Pressable.js
+++ b/packages/react-native/Libraries/Components/Pressable/Pressable.js
@@ -18,6 +18,7 @@ import type {ViewProps} from '../View/ViewPropTypes';
 import {PressabilityDebugView} from '../../Pressability/PressabilityDebug';
 import usePressability from '../../Pressability/usePressability';
 import {type RectOrSize} from '../../StyleSheet/Rect';
+import Platform from '../../Utilities/Platform';
 import useMergeRefs from '../../Utilities/useMergeRefs';
 import View from '../View/View';
 import useAndroidRippleForView, {
@@ -192,6 +193,8 @@ function Pressable({
     disabled,
     focusable,
     hitSlop,
+    onBlur,
+    onFocus,
     onHoverIn,
     onHoverOut,
     onLongPress,
@@ -263,6 +266,8 @@ function Pressable({
       delayHoverOut,
       delayLongPress,
       delayPressIn: unstable_pressDelay,
+      onBlur,
+      onFocus,
       onHoverIn,
       onHoverOut,
       onLongPress,
@@ -301,6 +306,8 @@ function Pressable({
       delayLongPress,
       disabled,
       hitSlop,
+      onBlur,
+      onFocus,
       onHoverIn,
       onHoverOut,
       onLongPress,
@@ -314,6 +321,7 @@ function Pressable({
       unstable_pressDelay,
     ],
   );
+
   const eventHandlers = usePressability(config);
 
   return (

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3383,6 +3383,7 @@ public final class com/facebook/react/uimanager/BackgroundStyleApplicator {
 public abstract class com/facebook/react/uimanager/BaseViewManager : com/facebook/react/uimanager/ViewManager, android/view/View$OnLayoutChangeListener {
 	public fun <init> ()V
 	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;)V
+	protected fun addEventEmitters (Lcom/facebook/react/uimanager/ThemedReactContext;Landroid/view/View;)V
 	public fun getExportedCustomBubblingEventTypeConstants ()Ljava/util/Map;
 	public fun getExportedCustomDirectEventTypeConstants ()Ljava/util/Map;
 	protected fun onAfterUpdateTransaction (Landroid/view/View;)V
@@ -6777,12 +6778,9 @@ public class com/facebook/react/views/view/ReactViewManager : com/facebook/react
 	public static final field Companion Lcom/facebook/react/views/view/ReactViewManager$Companion;
 	public static final field REACT_CLASS Ljava/lang/String;
 	public fun <init> ()V
-	public synthetic fun addEventEmitters (Lcom/facebook/react/uimanager/ThemedReactContext;Landroid/view/View;)V
-	protected fun addEventEmitters (Lcom/facebook/react/uimanager/ThemedReactContext;Lcom/facebook/react/views/view/ReactViewGroup;)V
 	public synthetic fun createViewInstance (Lcom/facebook/react/uimanager/ThemedReactContext;)Landroid/view/View;
 	public fun createViewInstance (Lcom/facebook/react/uimanager/ThemedReactContext;)Lcom/facebook/react/views/view/ReactViewGroup;
 	public fun getCommandsMap ()Ljava/util/Map;
-	public fun getExportedCustomBubblingEventTypeConstants ()Ljava/util/Map;
 	public fun getName ()Ljava/lang/String;
 	public fun nextFocusDown (Lcom/facebook/react/views/view/ReactViewGroup;I)V
 	public fun nextFocusForward (Lcom/facebook/react/views/view/ReactViewGroup;I)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -12,6 +12,7 @@ import android.graphics.Paint;
 import android.os.Build;
 import android.text.TextUtils;
 import android.view.View;
+import android.view.View.OnFocusChangeListener;
 import android.view.ViewGroup;
 import android.view.ViewParent;
 import android.view.accessibility.AccessibilityEvent;
@@ -35,6 +36,9 @@ import com.facebook.react.uimanager.ReactAccessibilityDelegate.Role;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.common.UIManagerType;
 import com.facebook.react.uimanager.common.ViewUtil;
+import com.facebook.react.uimanager.events.BlurEvent;
+import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.react.uimanager.events.FocusEvent;
 import com.facebook.react.uimanager.events.PointerEventHelper;
 import com.facebook.react.uimanager.style.OutlineStyle;
 import com.facebook.react.uimanager.util.ReactFindViewUtil;
@@ -163,6 +167,36 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
     view.setForeground(null);
 
     return view;
+  }
+
+  @Override
+  protected void addEventEmitters(@NonNull ThemedReactContext reactContext, @NonNull T view) {
+    super.addEventEmitters(reactContext, view);
+
+    @Nullable OnFocusChangeListener originalFocusChangeListener = view.getOnFocusChangeListener();
+    view.setOnFocusChangeListener(
+        (v, hasFocus) -> {
+          if (originalFocusChangeListener != null) {
+            originalFocusChangeListener.onFocusChange(v, hasFocus);
+          }
+          int surfaceId = UIManagerHelper.getSurfaceId(v.getContext());
+          if (surfaceId == View.NO_ID) {
+            return;
+          }
+          if (view.getContext() instanceof ThemedReactContext) {
+            ThemedReactContext themedReactContext = (ThemedReactContext) v.getContext();
+            @Nullable
+            EventDispatcher eventDispatcher =
+                UIManagerHelper.getEventDispatcherForReactTag(themedReactContext, view.getId());
+            if (eventDispatcher != null) {
+              if (hasFocus) {
+                eventDispatcher.dispatchEvent(new FocusEvent(surfaceId, view.getId()));
+              } else {
+                eventDispatcher.dispatchEvent(new BlurEvent(surfaceId, view.getId()));
+              }
+            }
+          }
+        });
   }
 
   // Currently, layout listener is only attached when transform or transformOrigin is set.
@@ -780,6 +814,16 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
                 MapBuilder.of(
                     "phasedRegistrationNames",
                     MapBuilder.of("bubbled", "onClick", "captured", "onClickCapture")))
+            .put(
+                "topBlur",
+                MapBuilder.of(
+                    "phasedRegistrationNames",
+                    MapBuilder.of("bubbled", "onBlur", "captured", "onBlurCapture")))
+            .put(
+                "topFocus",
+                MapBuilder.of(
+                    "phasedRegistrationNames",
+                    MapBuilder.of("bubbled", "onFocus", "captured", "onFocusCapture")))
             .build());
     return eventTypeConstants;
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.kt
@@ -123,14 +123,6 @@ public open class ReactTextInputManager public constructor() :
                 mapOf(
                     "phasedRegistrationNames" to
                         mapOf("bubbled" to "onEndEditing", "captured" to "onEndEditingCapture")),
-            "topFocus" to
-                mapOf(
-                    "phasedRegistrationNames" to
-                        mapOf("bubbled" to "onFocus", "captured" to "onFocusCapture")),
-            "topBlur" to
-                mapOf(
-                    "phasedRegistrationNames" to
-                        mapOf("bubbled" to "onBlur", "captured" to "onBlurCapture")),
             "topKeyPress" to
                 mapOf(
                     "phasedRegistrationNames" to
@@ -894,6 +886,9 @@ public open class ReactTextInputManager public constructor() :
   override fun addEventEmitters(reactContext: ThemedReactContext, editText: ReactEditText) {
     editText.setEventDispatcher(getEventDispatcher(reactContext, editText))
     editText.addTextChangedListener(ReactTextInputTextWatcher(reactContext, editText))
+
+    // Implements focus/blur dispatching on behalf of BaseViewManager since only one focus listener
+    // can be set on a view instance
     editText.onFocusChangeListener = OnFocusChangeListener { _: View?, hasFocus: Boolean ->
       val surfaceId = reactContext.surfaceId
       val eventDispatcher = getEventDispatcher(reactContext, editText)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.kt
@@ -9,7 +9,6 @@ package com.facebook.react.views.view
 
 import android.graphics.Rect
 import android.view.View
-import android.view.View.OnFocusChangeListener
 import com.facebook.common.logging.FLog
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.DynamicFromObject
@@ -34,8 +33,6 @@ import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.uimanager.annotations.ReactPropGroup
 import com.facebook.react.uimanager.common.UIManagerType
 import com.facebook.react.uimanager.common.ViewUtil
-import com.facebook.react.uimanager.events.BlurEvent
-import com.facebook.react.uimanager.events.FocusEvent
 import com.facebook.react.uimanager.style.BackgroundImageLayer
 import com.facebook.react.uimanager.style.BorderRadiusProp
 import com.facebook.react.uimanager.style.BorderStyle
@@ -344,40 +341,6 @@ public open class ReactViewManager : ReactClippingViewManager<ReactViewGroup>() 
 
   public override fun createViewInstance(context: ThemedReactContext): ReactViewGroup =
       ReactViewGroup(context)
-
-  override fun getExportedCustomBubblingEventTypeConstants(): Map<String, Any> {
-    val baseEventTypeConstants = super.getExportedCustomBubblingEventTypeConstants()
-    val eventTypeConstants = baseEventTypeConstants ?: mutableMapOf()
-    eventTypeConstants.putAll(
-        mapOf(
-            FocusEvent.EVENT_NAME to
-                mapOf(
-                    "phasedRegistrationNames" to
-                        mapOf("bubbled" to "onFocus", "captured" to "onFocusCapture")),
-            BlurEvent.EVENT_NAME to
-                mapOf(
-                    "phasedRegistrationNames" to
-                        mapOf("bubbled" to "onBlur", "captured" to "onBlurCapture")),
-        ))
-    return eventTypeConstants
-  }
-
-  override fun addEventEmitters(reactContext: ThemedReactContext, view: ReactViewGroup) {
-    view.onFocusChangeListener = OnFocusChangeListener { _: View?, hasFocus: Boolean ->
-      val surfaceId = UIManagerHelper.getSurfaceId(view.context)
-      if (surfaceId == View.NO_ID) {
-        return@OnFocusChangeListener
-      }
-      val eventDispatcher =
-          UIManagerHelper.getEventDispatcherForReactTag((view.context as ReactContext), view.id)
-              ?: return@OnFocusChangeListener
-      if (hasFocus) {
-        eventDispatcher.dispatchEvent(FocusEvent(surfaceId, view.id))
-      } else {
-        eventDispatcher.dispatchEvent(BlurEvent(surfaceId, view.id))
-      }
-    }
-  }
 
   override fun getCommandsMap(): MutableMap<String, Int> =
       mutableMapOf(HOTSPOT_UPDATE_KEY to CMD_HOTSPOT_UPDATE, "setPressed" to CMD_SET_PRESSED)

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/BaseViewManagerTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/BaseViewManagerTest.kt
@@ -7,8 +7,10 @@
 
 package com.facebook.react.uimanager
 
+import android.view.View.OnFocusChangeListener
 import com.facebook.react.R
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.BridgeReactContext
 import com.facebook.react.bridge.JavaOnlyArray
 import com.facebook.react.bridge.JavaOnlyMap
 import com.facebook.react.bridge.WritableArray
@@ -23,6 +25,9 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.MockedStatic
 import org.mockito.Mockito
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 
@@ -31,12 +36,15 @@ class BaseViewManagerTest {
   private lateinit var viewManager: BaseViewManager<ReactViewGroup, *>
   private lateinit var view: ReactViewGroup
   private lateinit var arguments: MockedStatic<Arguments>
+  private lateinit var themedReactContext: ThemedReactContext
 
   @Before
   fun setUp() {
     ReactNativeFeatureFlagsForTests.setUp()
     viewManager = ReactViewManager()
-    view = ReactViewGroup(RuntimeEnvironment.getApplication())
+    val context = BridgeReactContext(RuntimeEnvironment.getApplication())
+    themedReactContext = ThemedReactContext(context, context, null, -1)
+    view = ReactViewGroup(themedReactContext)
     arguments = Mockito.mockStatic(Arguments::class.java)
     arguments.`when`<WritableArray> { Arguments.createMap() }.thenAnswer { JavaOnlyArray() }
   }
@@ -74,5 +82,15 @@ class BaseViewManagerTest {
   fun testRoleList() {
     viewManager.setRole(view, "list")
     Assertions.assertThat(view.getTag(R.id.role)).isEqualTo(ReactAccessibilityDelegate.Role.LIST)
+  }
+
+  @Test
+  fun testAddEventEmittersDoesNotOverrideExistingEventEmitters() {
+    val originalFocusListener = mock<OnFocusChangeListener>()
+    view.onFocusChangeListener = originalFocusListener
+    viewManager.addEventEmitters(themedReactContext, view)
+    Assertions.assertThat(view.onFocusChangeListener).isNotEqualTo(originalFocusListener)
+    view.onFocusChangeListener.onFocusChange(view, true)
+    verify(originalFocusListener, times(1)).onFocusChange(view, true)
   }
 }

--- a/packages/rn-tester/js/examples/FocusEventsExample/FocusEventsExample.android.js
+++ b/packages/rn-tester/js/examples/FocusEventsExample/FocusEventsExample.android.js
@@ -1,0 +1,191 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+'use strict';
+
+import RNTesterText from '../../components/RNTesterText';
+import {useState} from 'react';
+import {Alert, Pressable, StyleSheet, TextInput, View} from 'react-native';
+
+type SectionProps = {
+  children: React.Node,
+};
+
+const FocusEventSection = ({children}: SectionProps): React.Node => {
+  const [outerFocused, setOuterFocused] = useState(false);
+
+  return (
+    <View
+      onFocus={() => setOuterFocused(true)}
+      onBlur={() => setOuterFocused(false)}>
+      <RNTesterText style={styles.sectionSubtitle}>
+        Section focused: {outerFocused ? 'true' : 'false'}
+      </RNTesterText>
+      {children}
+    </View>
+  );
+};
+
+const ViewExampleInnerRow = ({focusable}: {focusable: boolean}) => {
+  const [focused, setFocused] = useState(false);
+  return (
+    <View
+      focusable={focusable}
+      onFocus={() => setFocused(true)}
+      onBlur={() => setFocused(false)}
+      style={[styles.viewInnerRow]}>
+      <RNTesterText style={styles.viewInnerRowTextColor}>
+        Focusable: {focusable ? 'true' : 'false'}
+      </RNTesterText>
+      <RNTesterText style={styles.viewInnerRowTextColor}>
+        Focused: {focused ? 'true' : 'false'}
+      </RNTesterText>
+    </View>
+  );
+};
+
+const ViewExample = () => {
+  return (
+    <FocusEventSection>
+      <ViewExampleInnerRow focusable={true} />
+      <ViewExampleInnerRow focusable={true} />
+      <ViewExampleInnerRow focusable={false} />
+      <ViewExampleInnerRow focusable={true} />
+    </FocusEventSection>
+  );
+};
+
+const PressableExample = () => {
+  const [highlightFocused, setHighlightFocused] = useState(false);
+  const [pressableFocused, setPressableFocused] = useState(false);
+  const [disabledPressableFocused, setDisabledPressableFocused] =
+    useState(false);
+
+  return (
+    <FocusEventSection>
+      <Pressable
+        onPress={() => Alert.alert('Pressable pressed!')}
+        onFocus={() => setPressableFocused(true)}
+        onBlur={() => setPressableFocused(false)}>
+        <RNTesterText>
+          Pressable focused: {pressableFocused ? 'true' : 'false'}
+        </RNTesterText>
+      </Pressable>
+      <Pressable
+        disabled={true}
+        onPress={() => Alert.alert('Disabled Pressable pressed!')}
+        onFocus={() => setDisabledPressableFocused(true)}
+        onBlur={() => setDisabledPressableFocused(false)}>
+        <RNTesterText>
+          Disabled Pressable focused:{' '}
+          {disabledPressableFocused ? 'true' : 'false'}
+        </RNTesterText>
+      </Pressable>
+    </FocusEventSection>
+  );
+};
+
+const TextInputExample = () => {
+  const [input1Focused, setInput1Focused] = useState(false);
+  const [input2Focused, setInput2Focused] = useState(false);
+  const [input3Focused, setInput3Focused] = useState(false);
+
+  return (
+    <FocusEventSection>
+      <TextInput
+        onFocus={() => setInput1Focused(true)}
+        onBlur={() => setInput1Focused(false)}
+        style={[styles.textInput, input1Focused && styles.textInputFocused]}
+        placeholder={`Focused: ${input1Focused ? 'true' : 'false'}`}
+      />
+      <TextInput
+        onFocus={() => setInput2Focused(true)}
+        onBlur={() => setInput2Focused(false)}
+        style={[styles.textInput, input2Focused && styles.textInputFocused]}
+        placeholder={`Focused: ${input2Focused ? 'true' : 'false'}`}
+      />
+      <TextInput
+        onFocus={() => setInput3Focused(true)}
+        onBlur={() => setInput3Focused(false)}
+        style={[styles.textInput, input3Focused && styles.textInputFocused]}
+        placeholder={`Not editable focused: ${input3Focused ? 'true' : 'false'}`}
+        editable={false}
+      />
+    </FocusEventSection>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 8,
+    rowGap: 16,
+  },
+  sectionSubtitle: {
+    paddingBottom: 8,
+  },
+  sectionTitle: {
+    paddingBottom: 2,
+    fontSize: 20,
+  },
+  sectionWrapperFocused: {
+    borderColor: 'blue',
+  },
+  textFocused: {
+    backgroundColor: 'lightblue',
+  },
+  textLink: {color: 'blue'},
+  textInput: {
+    borderColor: 'rgba(40, 40, 40, 0.3)',
+    borderRadius: 4,
+    borderWidth: 1,
+    marginTop: 4,
+  },
+  textInputFocused: {
+    borderColor: 'blue',
+  },
+  viewInnerRow: {
+    backgroundColor: '#424B54',
+    borderRadius: 8,
+    borderColor: 'transparent',
+    borderWidth: 2,
+    height: 50,
+    marginTop: 4,
+    padding: 4,
+    width: '100%',
+  },
+  viewInnerRowTextColor: {
+    color: 'white',
+  },
+});
+
+export default {
+  title: 'Focus Events',
+  description: 'Examples that show how Focus events can be used.',
+  examples: [
+    {
+      title: 'View Example',
+      render: function (): React.Node {
+        return <ViewExample />;
+      },
+    },
+    {
+      title: 'TextInput Example',
+      render: function (): React.Node {
+        return <TextInputExample />;
+      },
+    },
+    {
+      title: 'Pressable Example',
+      render: function (): React.Node {
+        return <PressableExample />;
+      },
+    },
+  ],
+};

--- a/packages/rn-tester/js/utils/RNTesterList.android.js
+++ b/packages/rn-tester/js/utils/RNTesterList.android.js
@@ -226,6 +226,11 @@ const APIs: Array<RNTesterModuleInfo> = ([
       .default,
   },
   {
+    key: 'FocusEventsExample',
+    module: require('../examples/FocusEventsExample/FocusEventsExample')
+      .default,
+  },
+  {
     key: 'InvalidPropsExample',
     module: require('../examples/InvalidProps/InvalidPropsExample'),
   },


### PR DESCRIPTION
Summary:
This change builds upon the focus/blur portion showcased in ViewExample but showcases several more components all in one spot. This can be shared with additional platforms or expanded to include more component examples like Image, but the goal is to target Android and not distract from the primary use cases.

Changelog: [Internal]

Differential Revision: D75747410


