### PR TITLE
simplify searchPaths for CallInvoker

### DIFF
--- a/packages/react-native/Package.swift
+++ b/packages/react-native/Package.swift
@@ -29,10 +29,10 @@ import PackageDescription
 
 // MARK: Constants declaration
 let react = "React"
-let RuntimeExecutorPath = "ReactCommon/runtimeexecutor"
-let CallInvokerPath = "ReactCommon/callinvoker"
-let ReactFBReactNativeSpecPath = "React/FBReactNativeSpec"
-let FBLazyVectorPath = "Libraries/FBLazyVector"
+let RuntimeExecutorPath = "ReactCommon/runtimeexecutor" // header only target
+let CallInvokerPath = "ReactCommon/callinvoker" // header only target
+let ReactFBReactNativeSpecPath = "React/FBReactNativeSpec" // generated
+let FBLazyVectorPath = "Libraries/FBLazyVector" // header only
 
 // MARK: Prebuilt Dependencies declaration
 let reactNativeDependencies = BinaryTarget(
@@ -51,8 +51,7 @@ let hermesPrebuilt = BinaryTarget(
 /// RCTDeprecation.podspec
 let rctDeprecation = RNTarget(
   name: .rctDeprecation,
-  path: "ReactApple/Libraries/RCTFoundation/RCTDeprecation",
-  searchPaths: ["ReactApple"]
+  path: "ReactApple/Libraries/RCTFoundation/RCTDeprecation"
 )
 
 // To avoid having to delete the cmake folder at the same level we provide a "wrong" public header path and instead include it using header search paths.
@@ -60,36 +59,31 @@ let rctDeprecation = RNTarget(
 let yoga = RNTarget(
   name: .yoga,
   path: "ReactCommon/yoga",
-  searchPaths: ["ReactCommon/yoga"],
   publicHeadersPath: "yoga"
 )
 
 // React-oscompat.podspec
 let reactOSCompat = RNTarget(
   name: .reactOSCompat,
-  path: "ReactCommon/oscompat",
-  searchPaths: ["ReactCommon"]
+  path: "ReactCommon/oscompat"
 )
 
 // React-rendererconsistency.podspec
 let reactRendererConsistency = RNTarget(
   name: .reactRendererConsistency,
-  path: "ReactCommon/react/renderer/consistency",
-  searchPaths: ["ReactCommon"]
+  path: "ReactCommon/react/renderer/consistency"
 )
 
 // React-debug.podspec
 let reactDebug = RNTarget(
   name: .reactDebug,
   path: "ReactCommon/react/debug",
-  searchPaths: ["ReactCommon"],
   dependencies: [.reactNativeDependencies]
 )
 /// React-jsi.podspec
 let jsi = RNTarget(
   name: .jsi,
   path: "ReactCommon/jsi",
-  searchPaths: ["ReactCommon"],
   excludedPaths: ["jsi/test", "CMakeLists.txt", "jsi/CMakeLists.txt"],
   dependencies: [.reactNativeDependencies]
 )
@@ -98,7 +92,7 @@ let jsi = RNTarget(
 let reactUtils = RNTarget(
   name: .reactUtils,
   path: "ReactCommon/react/utils",
-  searchPaths: ["ReactCommon", "ReactCommon/react/utils/platform/ios"],
+  searchPaths: ["ReactCommon/react/utils/platform/ios"],
   linkedFrameworks: ["CoreFoundation"],
   excludedPaths: ["tests", "platform/android", "platform/cxx", "platform/windows"],
   dependencies: [.reactDebug, .jsi, .reactNativeDependencies]
@@ -108,7 +102,6 @@ let reactUtils = RNTarget(
 let reactFeatureFlags = RNTarget(
   name: .reactFeatureFlags,
   path: "ReactCommon/react/featureflags",
-  searchPaths: ["ReactCommon"],
   excludedPaths: ["tests"]
 )
 
@@ -116,7 +109,6 @@ let reactFeatureFlags = RNTarget(
 let reactPerfLogger = RNTarget(
   name: .reactPerfLogger,
   path: "ReactCommon/reactperflogger",
-  searchPaths: ["ReactCommon"],
   excludedPaths: ["fusebox"]
 )
 
@@ -139,7 +131,6 @@ let mapbuffer = RNTarget(
 let reactRendererDebug = RNTarget(
   name: .reactRendererDebug,
   path: "ReactCommon/react/renderer/debug",
-  searchPaths: ["ReactCommon"],
   excludedPaths: ["tests"],
   dependencies: [.reactDebug, .reactNativeDependencies]
 )
@@ -155,7 +146,6 @@ let reactRuntimeExecutor = RNTarget(
 let reactJsInspectorTracing = RNTarget(
   name: .reactJsInspectorTracing,
   path: "ReactCommon/jsinspector-modern/tracing",
-  searchPaths: ["ReactCommon"],
   excludedPaths: ["tests"],
   dependencies: [.reactNativeDependencies, .reactFeatureFlags, .jsi, .reactOSCompat]
 )
@@ -164,7 +154,7 @@ let reactJsInspectorTracing = RNTarget(
 let reactJsInspectorNetwork = RNTarget(
   name: .reactJsInspectorNetwork,
   path: "ReactCommon/jsinspector-modern/network",
-  searchPaths: ["ReactCommon", RuntimeExecutorPath],
+  searchPaths: [RuntimeExecutorPath],
   dependencies: [.reactNativeDependencies],
   defines: [
     CXXSetting.define("REACT_NATIVE_DEBUGGER_ENABLED", to: "1", .when(configuration: BuildConfiguration.debug)),
@@ -176,7 +166,7 @@ let reactJsInspectorNetwork = RNTarget(
 let reactJsInspector = RNTarget(
   name: .reactJsInspector,
   path: "ReactCommon/jsinspector-modern",
-  searchPaths: ["ReactCommon", RuntimeExecutorPath],
+  searchPaths: [RuntimeExecutorPath],
   excludedPaths: ["tracing", "network", "tests"],
   dependencies: [.reactNativeDependencies, .reactFeatureFlags, .jsi, .reactJsInspectorTracing, .reactJsInspectorNetwork],
   defines: [
@@ -189,7 +179,7 @@ let reactJsInspector = RNTarget(
 let reactCxxReact = RNTarget(
   name: .reactCxxReact,
   path: "ReactCommon/cxxreact",
-  searchPaths: ["ReactCommon", RuntimeExecutorPath, CallInvokerPath],
+  searchPaths: [RuntimeExecutorPath, CallInvokerPath],
   excludedPaths: ["tests", "SampleCXXModule.cpp"],
   dependencies: [.reactNativeDependencies, .jsi, .reactPerfLogger, .logger, .reactDebug, .reactJsInspector]
 )
@@ -198,7 +188,7 @@ let reactCxxReact = RNTarget(
 let reactJsiExecutor = RNTarget(
   name: .reactJsiExecutor,
   path: "ReactCommon/jsiexecutor",
-  searchPaths: ["ReactCommon", RuntimeExecutorPath],
+  searchPaths: [RuntimeExecutorPath],
   dependencies: [.reactNativeDependencies, .jsi, .reactPerfLogger, .reactCxxReact, .reactJsInspector]
 )
 
@@ -206,7 +196,7 @@ let reactJsiExecutor = RNTarget(
 let reactJsiTooling = RNTarget(
   name: .reactJsiTooling,
   path: "ReactCommon/jsitooling",
-  searchPaths: ["ReactCommon", RuntimeExecutorPath],
+  searchPaths: [RuntimeExecutorPath],
   dependencies: [.reactNativeDependencies, .reactJsInspector, .reactJsInspectorTracing, .reactCxxReact, .jsi]
 )
 
@@ -214,7 +204,7 @@ let reactJsiTooling = RNTarget(
 let reactHermes = RNTarget(
   name: .reactHermes,
   path: "ReactCommon/hermes",
-  searchPaths: ["ReactCommon", RuntimeExecutorPath],
+  searchPaths: [RuntimeExecutorPath],
   excludedPaths: ["inspector-modern/chrome/tests"],
   dependencies: [.reactNativeDependencies, .reactCxxReact, .reactJsiExecutor, .reactJsInspector, .reactJsInspectorTracing, .reactPerfLogger, .hermesPrebuilt, .jsi],
   defines: [
@@ -226,7 +216,7 @@ let reactHermes = RNTarget(
 let reactPerformanceTimeline = RNTarget(
   name: .reactPerformanceTimeline,
   path: "ReactCommon/react/performance/timeline",
-  searchPaths: ["ReactCommon", RuntimeExecutorPath],
+  searchPaths: [RuntimeExecutorPath],
   excludedPaths: ["tests"],
   dependencies: [.reactNativeDependencies, .reactFeatureFlags, .reactJsInspectorTracing, .reactCxxReact, .reactPerfLogger]
 )
@@ -235,7 +225,7 @@ let reactPerformanceTimeline = RNTarget(
 let reactRuntimeScheduler = RNTarget(
   name: .reactRuntimeScheduler,
   path: "ReactCommon/react/renderer/runtimescheduler",
-  searchPaths: ["ReactCommon", RuntimeExecutorPath, CallInvokerPath],
+  searchPaths: [RuntimeExecutorPath, CallInvokerPath],
   excludedPaths: ["tests"],
   dependencies: [.reactNativeDependencies, .reactFeatureFlags, .reactCxxReact, .reactPerfLogger, .reactPerformanceTimeline, .reactRendererConsistency, .reactUtils, .reactRuntimeExecutor]
 )
@@ -245,7 +235,7 @@ let reactRuntimeScheduler = RNTarget(
 let reactTurboModuleBridging = RNTarget(
   name: .reactTurboModuleBridging,
   path: "ReactCommon/react/bridging",
-  searchPaths: ["ReactCommon", CallInvokerPath],
+  searchPaths: [CallInvokerPath],
   excludedPaths: ["tests"],
   dependencies: [.reactNativeDependencies, .reactPerfLogger, .reactCxxReact, .jsi, .logger]
 )
@@ -254,7 +244,7 @@ let reactTurboModuleBridging = RNTarget(
 let reactJsErrorHandler = RNTarget(
   name: .reactJsErrorHandler,
   path: "ReactCommon/jserrorhandler",
-  searchPaths: ["ReactCommon", CallInvokerPath],
+  searchPaths: [CallInvokerPath],
   excludedPaths: ["tests"],
   dependencies: [.reactNativeDependencies, .jsi, .reactCxxReact, .reactFeatureFlags, .reactDebug, .reactTurboModuleBridging]
 )
@@ -264,7 +254,6 @@ let reactJsErrorHandler = RNTarget(
 let reactGraphicsApple = RNTarget(
   name: .reactGraphicsApple,
   path: "ReactCommon/react/renderer/graphics/platform/ios",
-  searchPaths: ["ReactCommon"],
   linkedFrameworks: ["UIKit", "CoreGraphics"],
   dependencies: [.reactDebug, .jsi, .reactUtils, .reactNativeDependencies]
 )
@@ -273,7 +262,6 @@ let reactGraphicsApple = RNTarget(
 let reactGraphics = RNTarget(
   name: .reactGraphics,
   path: "ReactCommon/react/renderer/graphics",
-  searchPaths: ["ReactCommon"],
   excludedPaths: ["platform", "tests"],
   dependencies: [.reactNativeDependencies, .jsi, .reactJsiExecutor, .reactRendererDebug, .reactUtils, .reactGraphicsApple]
 )
@@ -283,7 +271,7 @@ let reactGraphics = RNTarget(
 let reactTurboModuleCore = RNTarget(
   name: .reactTurboModuleCore,
   path: "ReactCommon/react/nativemodule/core",
-  searchPaths: ["ReactCommon", CallInvokerPath, "ReactCommon/react/nativemodule/core", "ReactCommon/react/nativemodule/core/platform/ios"],
+  searchPaths: [CallInvokerPath, "ReactCommon/react/nativemodule/core/platform/ios"],
   excludedPaths: ["platform/android", "iostests"],
   dependencies: [.reactNativeDependencies, .reactDebug, .reactFeatureFlags, .reactUtils, .reactPerfLogger, .reactCxxReact, .reactTurboModuleBridging, .yoga]
 )
@@ -292,7 +280,7 @@ let reactTurboModuleCore = RNTarget(
 let reactTurboModuleCoreDefaults = RNTarget(
   name: .reactTurboModuleCoreDefaults,
   path: "ReactCommon/react/nativemodule/defaults",
-  searchPaths: ["ReactCommon", CallInvokerPath, ReactFBReactNativeSpecPath],
+  searchPaths: [CallInvokerPath, ReactFBReactNativeSpecPath],
   dependencies: [.reactNativeDependencies, .jsi, .reactJsiExecutor, .reactTurboModuleCore]
 )
 
@@ -300,7 +288,7 @@ let reactTurboModuleCoreDefaults = RNTarget(
 let reactTurboModuleCoreMicrotasks = RNTarget(
   name: .reactTurboModuleCoreMicrotasks,
   path: "ReactCommon/react/nativemodule/microtasks",
-  searchPaths: ["ReactCommon", CallInvokerPath, ReactFBReactNativeSpecPath],
+  searchPaths: [CallInvokerPath, ReactFBReactNativeSpecPath],
   dependencies: [.reactNativeDependencies, .reactDebug, .reactFeatureFlags, .reactUtils, .reactPerfLogger, .reactCxxReact, .reactTurboModuleCore]
 )
 
@@ -308,7 +296,7 @@ let reactTurboModuleCoreMicrotasks = RNTarget(
 let reactIdleCallbacksNativeModule = RNTarget(
   name: .reactIdleCallbacksNativeModule,
   path: "ReactCommon/react/nativemodule/idlecallbacks",
-  searchPaths: ["ReactCommon", CallInvokerPath, RuntimeExecutorPath, ReactFBReactNativeSpecPath],
+  searchPaths: [CallInvokerPath, RuntimeExecutorPath, ReactFBReactNativeSpecPath],
   dependencies: [.reactNativeDependencies, .reactDebug, .reactFeatureFlags, .reactUtils, .reactPerfLogger, .reactCxxReact, .reactTurboModuleCore]
 )
 
@@ -316,7 +304,7 @@ let reactIdleCallbacksNativeModule = RNTarget(
 let reactFeatureflagsNativemodule = RNTarget(
   name: .reactFeatureflagsNativemodule,
   path: "ReactCommon/react/nativemodule/featureflags",
-  searchPaths: ["ReactCommon", CallInvokerPath, RuntimeExecutorPath, ReactFBReactNativeSpecPath],
+  searchPaths: [CallInvokerPath, RuntimeExecutorPath, ReactFBReactNativeSpecPath],
   dependencies: [.reactNativeDependencies, .reactDebug, .reactFeatureFlags, .reactUtils, .reactPerfLogger, .reactCxxReact, .reactTurboModuleCore]
 )
 
@@ -324,7 +312,7 @@ let reactFeatureflagsNativemodule = RNTarget(
 let reactNativeModuleDom = RNTarget(
   name: .reactNativeModuleDom,
   path: "ReactCommon/react/nativemodule/dom",
-  searchPaths: ["ReactCommon", CallInvokerPath, RuntimeExecutorPath, ReactFBReactNativeSpecPath],
+  searchPaths: [CallInvokerPath, RuntimeExecutorPath, ReactFBReactNativeSpecPath],
   dependencies: [.reactNativeDependencies, .reactDebug, .reactFeatureFlags, .reactUtils, .reactPerfLogger, .reactCxxReact, .reactTurboModuleCore, .yoga, .reactGraphicsApple, .reactFabric]
 )
 
@@ -332,7 +320,7 @@ let reactNativeModuleDom = RNTarget(
 let rctTypesafety = RNTarget(
   name: .rctTypesafety,
   path: "Libraries/Typesafety",
-  searchPaths: ["ReactCommon", FBLazyVectorPath],
+  searchPaths: [FBLazyVectorPath],
   dependencies: [.reactNativeDependencies, .yoga]
 )
 
@@ -347,7 +335,7 @@ let reactCoreRCTWebsocket = RNTarget(
 let reactCoreModules = RNTarget(
   name: .reactCoreModules,
   path: "React/CoreModules",
-  searchPaths: ["ReactCommon", ReactFBReactNativeSpecPath, FBLazyVectorPath, RuntimeExecutorPath, CallInvokerPath],
+  searchPaths: [ReactFBReactNativeSpecPath, FBLazyVectorPath, RuntimeExecutorPath, CallInvokerPath],
   excludedPaths: ["PlatformStubs/RCTStatusBarManager.mm"],
   dependencies: [.reactNativeDependencies, .jsi, .yoga, .reactTurboModuleCore]
 )
@@ -357,7 +345,7 @@ let reactCoreModules = RNTarget(
 let reactRuntime = RNTarget(
   name: .reactRuntime,
   path: "ReactCommon/react/runtime",
-  searchPaths: ["ReactCommon", RuntimeExecutorPath, CallInvokerPath],
+  searchPaths: [RuntimeExecutorPath, CallInvokerPath],
   excludedPaths: ["tests", "iostests", "platform"],
   dependencies: [.reactNativeDependencies, .jsi, .reactJsiExecutor, .reactCxxReact, .reactJsErrorHandler, .reactPerformanceTimeline, .reactUtils, .reactFeatureFlags, .reactJsInspector, .reactJsiTooling, .reactHermes, .reactRuntimeScheduler, .hermesPrebuilt]
 )
@@ -366,7 +354,7 @@ let reactRuntime = RNTarget(
 let reactRuntimeApple = RNTarget(
   name: .reactRuntimeApple,
   path: "ReactCommon/react/runtime/platform/ios",
-  searchPaths: ["ReactCommon", RuntimeExecutorPath, CallInvokerPath, ReactFBReactNativeSpecPath, FBLazyVectorPath],
+  searchPaths: [RuntimeExecutorPath, CallInvokerPath, ReactFBReactNativeSpecPath, FBLazyVectorPath],
   excludedPaths: ["ReactCommon/RCTJscInstance.mm", "ReactCommon/metainternal"],
   dependencies: [.reactNativeDependencies, .jsi, .reactPerfLogger, .reactCxxReact, .rctDeprecation, .yoga, .reactRuntime, .reactRCTFabric, .reactCoreModules, .reactTurboModuleCore, .hermesPrebuilt, .reactUtils]
 )
@@ -375,7 +363,15 @@ let reactRuntimeApple = RNTarget(
 let reactCore = RNTarget(
   name: .reactCore,
   path: "React",
-  searchPaths: ["ReactCommon", RuntimeExecutorPath, CallInvokerPath, ReactFBReactNativeSpecPath, FBLazyVectorPath, "React/I18n", "React/Profiler", "ReactCommon/react/runtime/platform/ios"],
+  searchPaths: [
+    RuntimeExecutorPath,
+    CallInvokerPath,
+    ReactFBReactNativeSpecPath,
+    FBLazyVectorPath,
+    "React/I18n",
+    "React/Profiler",
+    "ReactCommon/react/runtime/platform/ios", // explicit header search path to break circular dependency. RCTHost imports `RCTDefines.h` in ReactCore, ReacCore needs to import RCTHost
+  ],
   linkedFrameworks: ["CoreServices"],
   excludedPaths: ["Fabric", "Tests", "Resources", "Runtime/RCTJscInstanceFactory.mm", "I18n/strings", "CxxBridge/JSCExecutorFactory.mm", "CoreModules"],
   dependencies: [.reactNativeDependencies, .reactCxxReact, .reactPerfLogger, .jsi, .reactJsiExecutor, .reactUtils, .reactFeatureFlags, .reactRuntimeScheduler, .yoga, .reactJsInspector, .reactJsiTooling, .rctDeprecation, .reactCoreRCTWebsocket, .reactRCTImage, .reactTurboModuleCore, .reactRCTText, .reactRCTBlob, .reactRCTAnimation, .reactRCTNetwork, .reactFabric, .hermesPrebuilt],
@@ -387,14 +383,8 @@ let reactFabric = RNTarget(
   name: .reactFabric,
   path: "ReactCommon/react/renderer",
   searchPaths: [
-    "ReactCommon",
     RuntimeExecutorPath,
     CallInvokerPath,
-    "ReactCommon/react/renderer/components/view",
-    "ReactCommon/react/renderer/components/view/platform/cxx",
-    "ReactCommon/react/renderer/imagemanager/platform/ios",
-    "ReactCommon/react/renderer/components/scrollview/",
-    "ReactCommon/react/renderer/components/scrollview/platform/cxx",
   ],
   excludedPaths: [
     "animations/tests",
@@ -427,14 +417,14 @@ let reactFabric = RNTarget(
     "components/root/tests",
   ],
   dependencies: [.reactNativeDependencies, .reactJsiExecutor, .rctTypesafety, .reactTurboModuleCore, .jsi, .logger, .reactDebug, .reactFeatureFlags, .reactUtils, .reactRuntimeScheduler, .reactCxxReact, .reactRendererDebug, .reactGraphics, .yoga],
-  sources: ["animations", "attributedstring", "core", "componentregistry", "componentregistry/native", "components/root", "components/view", "components/scrollview", "components/legacyviewmanagerinterop", "dom", "scheduler", "mounting", "observers/events", "telemetry", "consistency", "leakchecker", "uimanager", "uimanager/consistency"]
+  sources: ["animations", "attributedstring", "core", "componentregistry", "componentregistry/native", "components/root", "components/view", "components/view/platform/cxx", "components/scrollview", "components/scrollview/platform/cxx", "components/legacyviewmanagerinterop", "dom", "scheduler", "mounting", "observers/events", "telemetry", "consistency", "leakchecker", "uimanager", "uimanager/consistency"]
 )
 
 /// React-RCTFabric.podspec
 let reactRCTFabric = RNTarget(
   name: .reactRCTFabric,
   path: "React/Fabric",
-  searchPaths: ["ReactCommon", RuntimeExecutorPath, CallInvokerPath],
+  searchPaths: [RuntimeExecutorPath, CallInvokerPath],
   dependencies: [.reactNativeDependencies, .reactCore, .reactRCTImage, .yoga, .reactRCTText, .jsi, .reactFabricComponents, .reactGraphics, .reactImageManager, .reactDebug, .reactUtils, .reactPerformanceTimeline, .reactRendererDebug, .reactRendererConsistency, .reactRuntimeScheduler, .reactRCTAnimation, .reactJsInspector, .reactJsInspectorNetwork, .reactJsInspectorTracing, .reactFabric, .reactFabricImage]
 )
 
@@ -442,15 +432,6 @@ let reactRCTFabric = RNTarget(
 let reactFabricComponents = RNTarget(
   name: .reactFabricComponents,
   path: "ReactCommon/react/renderer",
-  searchPaths: [
-    "ReactCommon",
-    "ReactCommon/react/renderer/components/view/platform/cxx",
-    "ReactCommon/react/renderer/components/text",
-    "ReactCommon/react/renderer/components/text/platform/cxx",
-    "ReactCommon/react/renderer/components/textinput/platform/ios",
-    "ReactCommon/react/renderer/textlayoutmanager/platform/ios",
-    "ReactCommon/react/renderer/textlayoutmanager",
-  ],
   excludedPaths: [
     "components/view/platform/android",
     "components/view/platform/windows",
@@ -473,7 +454,6 @@ let reactFabricComponents = RNTarget(
 let reactFabricImage = RNTarget(
   name: .reactFabricImage,
   path: "ReactCommon/react/renderer/components/image",
-  searchPaths: ["ReactCommon"],
   excludedPaths: ["tests"],
   dependencies: [.reactNativeDependencies, .reactFabric, .reactCore, .reactJsiExecutor, .reactTurboModuleCore, .jsi, .logger, .reactDebug, .reactFeatureFlags, .reactUtils, .reactRuntimeScheduler, .reactCxxReact, .yoga, .reactRendererDebug, .reactGraphics, .reactTurboModuleBridging, .reactImageManagerApple]
 )
@@ -482,7 +462,6 @@ let reactFabricImage = RNTarget(
 let reactImageManagerApple = RNTarget(
   name: .reactImageManagerApple,
   path: "ReactCommon/react/renderer/imagemanager/platform/ios",
-  searchPaths: ["ReactCommon"],
   dependencies: [.reactNativeDependencies, .reactGraphics, .reactDebug, .reactUtils, .reactRendererDebug, .reactImageManager, .reactRCTImage, .reactCore, .yoga]
 )
 
@@ -490,7 +469,6 @@ let reactImageManagerApple = RNTarget(
 let reactImageManager = RNTarget(
   name: .reactImageManager,
   path: "ReactCommon/react/renderer/imagemanager",
-  searchPaths: ["ReactCommon"],
   excludedPaths: ["platform", "tests"],
   dependencies: [.reactNativeDependencies, .reactGraphics, .reactDebug, .reactUtils, .reactRendererDebug, .yoga]
 )
@@ -499,7 +477,7 @@ let reactImageManager = RNTarget(
 let reactRCTAnimation = RNTarget(
   name: .reactRCTAnimation,
   path: "Libraries/NativeAnimation",
-  searchPaths: ["ReactCommon", ReactFBReactNativeSpecPath, FBLazyVectorPath, CallInvokerPath],
+  searchPaths: [ReactFBReactNativeSpecPath, FBLazyVectorPath, CallInvokerPath],
   dependencies: [.reactNativeDependencies, .rctTypesafety, .jsi, .reactFeatureFlags, .yoga, .reactTurboModuleCore, .reactUtils]
 )
 
@@ -507,7 +485,7 @@ let reactRCTAnimation = RNTarget(
 let reactRCTImage = RNTarget(
   name: .reactRCTImage,
   path: "Libraries/Image",
-  searchPaths: ["ReactCommon", CallInvokerPath, ReactFBReactNativeSpecPath, FBLazyVectorPath],
+  searchPaths: [CallInvokerPath, ReactFBReactNativeSpecPath, FBLazyVectorPath],
   linkedFrameworks: ["Accelerate"],
   dependencies: [.rctTypesafety, .jsi, .yoga, .reactTurboModuleBridging, .reactTurboModuleCore]
 )
@@ -516,7 +494,7 @@ let reactRCTImage = RNTarget(
 let reactRCTText = RNTarget(
   name: .reactRCTText,
   path: "Libraries/Text",
-  searchPaths: ["ReactCommon", CallInvokerPath, ReactFBReactNativeSpecPath, FBLazyVectorPath],
+  searchPaths: [CallInvokerPath, ReactFBReactNativeSpecPath, FBLazyVectorPath],
   dependencies: [.yoga, .reactTurboModuleCore]
 )
 
@@ -524,7 +502,7 @@ let reactRCTText = RNTarget(
 let reactRCTBlob = RNTarget(
   name: .reactRCTBlob,
   path: "Libraries/Blob",
-  searchPaths: ["ReactCommon", CallInvokerPath, ReactFBReactNativeSpecPath, FBLazyVectorPath],
+  searchPaths: [CallInvokerPath, ReactFBReactNativeSpecPath, FBLazyVectorPath],
   dependencies: [.yoga, .jsi, .reactTurboModuleCore]
 )
 
@@ -532,7 +510,7 @@ let reactRCTBlob = RNTarget(
 let reactRCTNetwork = RNTarget(
   name: .reactRCTNetwork,
   path: "Libraries/Network",
-  searchPaths: ["ReactCommon", CallInvokerPath, ReactFBReactNativeSpecPath, FBLazyVectorPath],
+  searchPaths: [CallInvokerPath, ReactFBReactNativeSpecPath, FBLazyVectorPath],
   dependencies: [.yoga, .jsi, .reactTurboModuleCore]
 )
 
@@ -540,7 +518,7 @@ let reactRCTNetwork = RNTarget(
 let reactAppDelegate = RNTarget(
   name: .reactAppDelegate,
   path: "Libraries/AppDelegate",
-  searchPaths: ["ReactCommon", RuntimeExecutorPath, CallInvokerPath],
+  searchPaths: [RuntimeExecutorPath, CallInvokerPath],
   dependencies: [.reactNativeDependencies, .jsi, .reactJsiExecutor, .reactRuntime, .reactRCTImage, .reactHermes, .reactCore, .reactFabric, .reactTurboModuleCore, .hermesPrebuilt, .yoga]
 )
 
@@ -548,7 +526,7 @@ let reactAppDelegate = RNTarget(
 let reactRCTLinking = RNTarget(
   name: .reactRCTLinking,
   path: "Libraries/LinkingIOS",
-  searchPaths: ["ReactCommon", CallInvokerPath, ReactFBReactNativeSpecPath, FBLazyVectorPath],
+  searchPaths: [CallInvokerPath, ReactFBReactNativeSpecPath, FBLazyVectorPath],
   dependencies: [.jsi, .reactTurboModuleCore]
 )
 
@@ -556,7 +534,7 @@ let reactRCTLinking = RNTarget(
 let reactSettings = RNTarget(
   name: .reactSettings,
   path: "Libraries/Settings",
-  searchPaths: ["ReactCommon", ReactFBReactNativeSpecPath, FBLazyVectorPath],
+  searchPaths: [ReactFBReactNativeSpecPath, FBLazyVectorPath],
   dependencies: [.reactTurboModuleCore, .yoga]
 )
 

--- a/packages/react-native/Package.swift
+++ b/packages/react-native/Package.swift
@@ -180,6 +180,7 @@ let reactCxxReact = RNTarget(
   searchPaths: [CallInvokerPath],
   excludedPaths: ["tests", "SampleCXXModule.cpp"],
   dependencies: [.reactNativeDependencies, .jsi, .reactPerfLogger, .logger, .reactDebug, .reactJsInspector]
+
 )
 
 /// React-jsiexecutor.podspec
@@ -219,7 +220,6 @@ let reactPerformanceTimeline = RNTarget(
 let reactRuntimeScheduler = RNTarget(
   name: .reactRuntimeScheduler,
   path: "ReactCommon/react/renderer/runtimescheduler",
-  searchPaths: [CallInvokerPath],
   excludedPaths: ["tests"],
   dependencies: [.reactNativeDependencies, .reactFeatureFlags, .reactCxxReact, .reactPerfLogger, .reactPerformanceTimeline, .reactRendererConsistency, .reactUtils, .reactRuntimeExecutor]
 )
@@ -229,7 +229,6 @@ let reactRuntimeScheduler = RNTarget(
 let reactTurboModuleBridging = RNTarget(
   name: .reactTurboModuleBridging,
   path: "ReactCommon/react/bridging",
-  searchPaths: [CallInvokerPath],
   excludedPaths: ["tests"],
   dependencies: [.reactNativeDependencies, .reactPerfLogger, .reactCxxReact, .jsi, .logger]
 )
@@ -238,7 +237,6 @@ let reactTurboModuleBridging = RNTarget(
 let reactJsErrorHandler = RNTarget(
   name: .reactJsErrorHandler,
   path: "ReactCommon/jserrorhandler",
-  searchPaths: [CallInvokerPath],
   excludedPaths: ["tests"],
   dependencies: [.reactNativeDependencies, .jsi, .reactCxxReact, .reactFeatureFlags, .reactDebug, .reactTurboModuleBridging]
 )
@@ -265,7 +263,7 @@ let reactGraphics = RNTarget(
 let reactTurboModuleCore = RNTarget(
   name: .reactTurboModuleCore,
   path: "ReactCommon/react/nativemodule/core",
-  searchPaths: [CallInvokerPath, "ReactCommon/react/nativemodule/core/platform/ios"],
+  searchPaths: ["ReactCommon/react/nativemodule/core/platform/ios"],
   excludedPaths: ["platform/android", "iostests"],
   dependencies: [.reactNativeDependencies, .reactDebug, .reactFeatureFlags, .reactUtils, .reactPerfLogger, .reactCxxReact, .reactTurboModuleBridging, .yoga, .reactRuntimeExecutor]
 )
@@ -274,7 +272,7 @@ let reactTurboModuleCore = RNTarget(
 let reactTurboModuleCoreDefaults = RNTarget(
   name: .reactTurboModuleCoreDefaults,
   path: "ReactCommon/react/nativemodule/defaults",
-  searchPaths: [CallInvokerPath, ReactFBReactNativeSpecPath],
+  searchPaths: [ReactFBReactNativeSpecPath],
   dependencies: [.reactNativeDependencies, .jsi, .reactJsiExecutor, .reactTurboModuleCore]
 )
 
@@ -282,7 +280,7 @@ let reactTurboModuleCoreDefaults = RNTarget(
 let reactTurboModuleCoreMicrotasks = RNTarget(
   name: .reactTurboModuleCoreMicrotasks,
   path: "ReactCommon/react/nativemodule/microtasks",
-  searchPaths: [CallInvokerPath, ReactFBReactNativeSpecPath],
+  searchPaths: [ReactFBReactNativeSpecPath],
   dependencies: [.reactNativeDependencies, .reactDebug, .reactFeatureFlags, .reactUtils, .reactPerfLogger, .reactCxxReact, .reactTurboModuleCore]
 )
 
@@ -290,7 +288,7 @@ let reactTurboModuleCoreMicrotasks = RNTarget(
 let reactIdleCallbacksNativeModule = RNTarget(
   name: .reactIdleCallbacksNativeModule,
   path: "ReactCommon/react/nativemodule/idlecallbacks",
-  searchPaths: [CallInvokerPath, ReactFBReactNativeSpecPath],
+  searchPaths: [ReactFBReactNativeSpecPath],
   dependencies: [.reactNativeDependencies, .reactDebug, .reactFeatureFlags, .reactUtils, .reactPerfLogger, .reactCxxReact, .reactTurboModuleCore]
 )
 
@@ -298,7 +296,7 @@ let reactIdleCallbacksNativeModule = RNTarget(
 let reactFeatureflagsNativemodule = RNTarget(
   name: .reactFeatureflagsNativemodule,
   path: "ReactCommon/react/nativemodule/featureflags",
-  searchPaths: [CallInvokerPath, ReactFBReactNativeSpecPath],
+  searchPaths: [ReactFBReactNativeSpecPath],
   dependencies: [.reactNativeDependencies, .reactDebug, .reactFeatureFlags, .reactUtils, .reactPerfLogger, .reactCxxReact, .reactTurboModuleCore]
 )
 
@@ -306,7 +304,7 @@ let reactFeatureflagsNativemodule = RNTarget(
 let reactNativeModuleDom = RNTarget(
   name: .reactNativeModuleDom,
   path: "ReactCommon/react/nativemodule/dom",
-  searchPaths: [CallInvokerPath, ReactFBReactNativeSpecPath],
+  searchPaths: [ReactFBReactNativeSpecPath],
   dependencies: [.reactNativeDependencies, .reactDebug, .reactFeatureFlags, .reactUtils, .reactPerfLogger, .reactCxxReact, .reactTurboModuleCore, .yoga, .reactGraphicsApple, .reactFabric]
 )
 
@@ -329,7 +327,7 @@ let reactCoreRCTWebsocket = RNTarget(
 let reactCoreModules = RNTarget(
   name: .reactCoreModules,
   path: "React/CoreModules",
-  searchPaths: [ReactFBReactNativeSpecPath, FBLazyVectorPath, CallInvokerPath],
+  searchPaths: [ReactFBReactNativeSpecPath, FBLazyVectorPath],
   excludedPaths: ["PlatformStubs/RCTStatusBarManager.mm"],
   dependencies: [.reactNativeDependencies, .jsi, .yoga, .reactTurboModuleCore]
 )
@@ -339,7 +337,6 @@ let reactCoreModules = RNTarget(
 let reactRuntime = RNTarget(
   name: .reactRuntime,
   path: "ReactCommon/react/runtime",
-  searchPaths: [CallInvokerPath],
   excludedPaths: ["tests", "iostests", "platform"],
   dependencies: [.reactNativeDependencies, .jsi, .reactJsiExecutor, .reactCxxReact, .reactJsErrorHandler, .reactPerformanceTimeline, .reactUtils, .reactFeatureFlags, .reactJsInspector, .reactJsiTooling, .reactHermes, .reactRuntimeScheduler, .hermesPrebuilt]
 )
@@ -348,7 +345,7 @@ let reactRuntime = RNTarget(
 let reactRuntimeApple = RNTarget(
   name: .reactRuntimeApple,
   path: "ReactCommon/react/runtime/platform/ios",
-  searchPaths: [CallInvokerPath, ReactFBReactNativeSpecPath, FBLazyVectorPath],
+  searchPaths: [ReactFBReactNativeSpecPath, FBLazyVectorPath],
   excludedPaths: ["ReactCommon/RCTJscInstance.mm", "ReactCommon/metainternal"],
   dependencies: [.reactNativeDependencies, .jsi, .reactPerfLogger, .reactCxxReact, .rctDeprecation, .yoga, .reactRuntime, .reactRCTFabric, .reactCoreModules, .reactTurboModuleCore, .hermesPrebuilt, .reactUtils]
 )
@@ -358,7 +355,6 @@ let reactCore = RNTarget(
   name: .reactCore,
   path: "React",
   searchPaths: [
-    CallInvokerPath,
     ReactFBReactNativeSpecPath,
     FBLazyVectorPath,
     "React/I18n",
@@ -375,9 +371,6 @@ let reactCore = RNTarget(
 let reactFabric = RNTarget(
   name: .reactFabric,
   path: "ReactCommon/react/renderer",
-  searchPaths: [
-    CallInvokerPath
-  ],
   excludedPaths: [
     "animations/tests",
     "attributedstring/tests",
@@ -416,7 +409,6 @@ let reactFabric = RNTarget(
 let reactRCTFabric = RNTarget(
   name: .reactRCTFabric,
   path: "React/Fabric",
-  searchPaths: [CallInvokerPath],
   dependencies: [.reactNativeDependencies, .reactCore, .reactRCTImage, .yoga, .reactRCTText, .jsi, .reactFabricComponents, .reactGraphics, .reactImageManager, .reactDebug, .reactUtils, .reactPerformanceTimeline, .reactRendererDebug, .reactRendererConsistency, .reactRuntimeScheduler, .reactRCTAnimation, .reactJsInspector, .reactJsInspectorNetwork, .reactJsInspectorTracing, .reactFabric, .reactFabricImage]
 )
 
@@ -469,7 +461,7 @@ let reactImageManager = RNTarget(
 let reactRCTAnimation = RNTarget(
   name: .reactRCTAnimation,
   path: "Libraries/NativeAnimation",
-  searchPaths: [ReactFBReactNativeSpecPath, FBLazyVectorPath, CallInvokerPath],
+  searchPaths: [ReactFBReactNativeSpecPath, FBLazyVectorPath],
   dependencies: [.reactNativeDependencies, .rctTypesafety, .jsi, .reactFeatureFlags, .yoga, .reactTurboModuleCore, .reactUtils]
 )
 
@@ -477,7 +469,7 @@ let reactRCTAnimation = RNTarget(
 let reactRCTImage = RNTarget(
   name: .reactRCTImage,
   path: "Libraries/Image",
-  searchPaths: [CallInvokerPath, ReactFBReactNativeSpecPath, FBLazyVectorPath],
+  searchPaths: [ReactFBReactNativeSpecPath, FBLazyVectorPath],
   linkedFrameworks: ["Accelerate"],
   dependencies: [.rctTypesafety, .jsi, .yoga, .reactTurboModuleBridging, .reactTurboModuleCore]
 )
@@ -486,7 +478,7 @@ let reactRCTImage = RNTarget(
 let reactRCTText = RNTarget(
   name: .reactRCTText,
   path: "Libraries/Text",
-  searchPaths: [CallInvokerPath, ReactFBReactNativeSpecPath, FBLazyVectorPath],
+  searchPaths: [ReactFBReactNativeSpecPath, FBLazyVectorPath],
   dependencies: [.yoga, .reactTurboModuleCore]
 )
 
@@ -494,7 +486,7 @@ let reactRCTText = RNTarget(
 let reactRCTBlob = RNTarget(
   name: .reactRCTBlob,
   path: "Libraries/Blob",
-  searchPaths: [CallInvokerPath, ReactFBReactNativeSpecPath, FBLazyVectorPath],
+  searchPaths: [ReactFBReactNativeSpecPath, FBLazyVectorPath],
   dependencies: [.yoga, .jsi, .reactTurboModuleCore]
 )
 
@@ -502,7 +494,7 @@ let reactRCTBlob = RNTarget(
 let reactRCTNetwork = RNTarget(
   name: .reactRCTNetwork,
   path: "Libraries/Network",
-  searchPaths: [CallInvokerPath, ReactFBReactNativeSpecPath, FBLazyVectorPath],
+  searchPaths: [ReactFBReactNativeSpecPath, FBLazyVectorPath],
   dependencies: [.yoga, .jsi, .reactTurboModuleCore]
 )
 
@@ -510,7 +502,6 @@ let reactRCTNetwork = RNTarget(
 let reactAppDelegate = RNTarget(
   name: .reactAppDelegate,
   path: "Libraries/AppDelegate",
-  searchPaths: [CallInvokerPath],
   dependencies: [.reactNativeDependencies, .jsi, .reactJsiExecutor, .reactRuntime, .reactRCTImage, .reactHermes, .reactCore, .reactFabric, .reactTurboModuleCore, .hermesPrebuilt, .yoga]
 )
 
@@ -518,7 +509,7 @@ let reactAppDelegate = RNTarget(
 let reactRCTLinking = RNTarget(
   name: .reactRCTLinking,
   path: "Libraries/LinkingIOS",
-  searchPaths: [CallInvokerPath, ReactFBReactNativeSpecPath, FBLazyVectorPath],
+  searchPaths: [ReactFBReactNativeSpecPath, FBLazyVectorPath],
   dependencies: [.jsi, .reactTurboModuleCore]
 )
 

--- a/packages/react-native/Package.swift
+++ b/packages/react-native/Package.swift
@@ -393,6 +393,8 @@ let reactFabric = RNTarget(
     "ReactCommon/react/renderer/components/view",
     "ReactCommon/react/renderer/components/view/platform/cxx",
     "ReactCommon/react/renderer/imagemanager/platform/ios",
+    "ReactCommon/react/renderer/components/scrollview/",
+    "ReactCommon/react/renderer/components/scrollview/platform/cxx",
   ],
   excludedPaths: [
     "animations/tests",
@@ -402,6 +404,8 @@ let reactFabric = RNTarget(
     "components/view/platform/android",
     "components/view/platform/windows",
     "components/view/platform/macos",
+    "components/scrollview/tests",
+    "components/scrollview/platform/android",
     "mounting/tests",
     "uimanager/tests",
     "telemetry/tests",
@@ -416,7 +420,6 @@ let reactFabric = RNTarget(
     "components/modal",
     "components/rncore",
     "components/safeareaview",
-    "components/scrollview",
     "components/text",
     "components/textinput",
     "components/textinput/platform/ios/",
@@ -452,8 +455,6 @@ let reactFabricComponents = RNTarget(
     "components/view/platform/android",
     "components/view/platform/windows",
     "components/view/platform/macos",
-    "components/scrollview/tests",
-    "components/scrollview/platform/android",
     "components/textinput/platform/android",
     "components/text/platform/android",
     "components/textinput/platform/macos",
@@ -465,7 +466,7 @@ let reactFabricComponents = RNTarget(
     "textlayoutmanager/platform/macos",
   ],
   dependencies: [.reactNativeDependencies, .reactCore, .reactJsiExecutor, .reactTurboModuleCore, .jsi, .logger, .reactDebug, .reactFeatureFlags, .reactUtils, .reactRuntimeScheduler, .reactCxxReact, .yoga, .reactRendererDebug, .reactGraphics, .reactFabric, .reactTurboModuleBridging],
-  sources: ["components/inputaccessory", "components/modal", "components/rncore", "components/safeareaview", "components/scrollview", "components/text", "components/text/platform/cxx", "components/textinput", "components/textinput/platform/ios/", "components/unimplementedview", "textlayoutmanager", "textlayoutmanager/platform/ios"]
+  sources: ["components/inputaccessory", "components/modal", "components/rncore", "components/safeareaview", "components/text", "components/text/platform/cxx", "components/textinput", "components/textinput/platform/ios/", "components/unimplementedview", "textlayoutmanager", "textlayoutmanager/platform/ios"]
 )
 
 /// React-FabricImage.podspec

--- a/packages/react-native/Package.swift
+++ b/packages/react-native/Package.swift
@@ -154,7 +154,6 @@ let reactJsInspectorTracing = RNTarget(
 let reactJsInspectorNetwork = RNTarget(
   name: .reactJsInspectorNetwork,
   path: "ReactCommon/jsinspector-modern/network",
-  searchPaths: [RuntimeExecutorPath],
   dependencies: [.reactNativeDependencies],
   defines: [
     CXXSetting.define("REACT_NATIVE_DEBUGGER_ENABLED", to: "1", .when(configuration: BuildConfiguration.debug)),
@@ -166,9 +165,8 @@ let reactJsInspectorNetwork = RNTarget(
 let reactJsInspector = RNTarget(
   name: .reactJsInspector,
   path: "ReactCommon/jsinspector-modern",
-  searchPaths: [RuntimeExecutorPath],
   excludedPaths: ["tracing", "network", "tests"],
-  dependencies: [.reactNativeDependencies, .reactFeatureFlags, .jsi, .reactJsInspectorTracing, .reactJsInspectorNetwork],
+  dependencies: [.reactNativeDependencies, .reactFeatureFlags, .jsi, .reactJsInspectorTracing, .reactJsInspectorNetwork, .reactRuntimeExecutor],
   defines: [
     CXXSetting.define("REACT_NATIVE_DEBUGGER_ENABLED", to: "1", .when(configuration: BuildConfiguration.debug)),
     CXXSetting.define("REACT_NATIVE_DEBUGGER_ENABLED_DEVONLY", to: "1", .when(configuration: BuildConfiguration.debug)),
@@ -179,7 +177,7 @@ let reactJsInspector = RNTarget(
 let reactCxxReact = RNTarget(
   name: .reactCxxReact,
   path: "ReactCommon/cxxreact",
-  searchPaths: [RuntimeExecutorPath, CallInvokerPath],
+  searchPaths: [CallInvokerPath],
   excludedPaths: ["tests", "SampleCXXModule.cpp"],
   dependencies: [.reactNativeDependencies, .jsi, .reactPerfLogger, .logger, .reactDebug, .reactJsInspector]
 )
@@ -188,7 +186,6 @@ let reactCxxReact = RNTarget(
 let reactJsiExecutor = RNTarget(
   name: .reactJsiExecutor,
   path: "ReactCommon/jsiexecutor",
-  searchPaths: [RuntimeExecutorPath],
   dependencies: [.reactNativeDependencies, .jsi, .reactPerfLogger, .reactCxxReact, .reactJsInspector]
 )
 
@@ -196,15 +193,13 @@ let reactJsiExecutor = RNTarget(
 let reactJsiTooling = RNTarget(
   name: .reactJsiTooling,
   path: "ReactCommon/jsitooling",
-  searchPaths: [RuntimeExecutorPath],
-  dependencies: [.reactNativeDependencies, .reactJsInspector, .reactJsInspectorTracing, .reactCxxReact, .jsi]
+  dependencies: [.reactNativeDependencies, .reactJsInspector, .reactJsInspectorTracing, .reactCxxReact, .jsi, .reactRuntimeExecutor]
 )
 
 /// React-hermes.podspec
 let reactHermes = RNTarget(
   name: .reactHermes,
   path: "ReactCommon/hermes",
-  searchPaths: [RuntimeExecutorPath],
   excludedPaths: ["inspector-modern/chrome/tests"],
   dependencies: [.reactNativeDependencies, .reactCxxReact, .reactJsiExecutor, .reactJsInspector, .reactJsInspectorTracing, .reactPerfLogger, .hermesPrebuilt, .jsi],
   defines: [
@@ -216,7 +211,6 @@ let reactHermes = RNTarget(
 let reactPerformanceTimeline = RNTarget(
   name: .reactPerformanceTimeline,
   path: "ReactCommon/react/performance/timeline",
-  searchPaths: [RuntimeExecutorPath],
   excludedPaths: ["tests"],
   dependencies: [.reactNativeDependencies, .reactFeatureFlags, .reactJsInspectorTracing, .reactCxxReact, .reactPerfLogger]
 )
@@ -225,7 +219,7 @@ let reactPerformanceTimeline = RNTarget(
 let reactRuntimeScheduler = RNTarget(
   name: .reactRuntimeScheduler,
   path: "ReactCommon/react/renderer/runtimescheduler",
-  searchPaths: [RuntimeExecutorPath, CallInvokerPath],
+  searchPaths: [CallInvokerPath],
   excludedPaths: ["tests"],
   dependencies: [.reactNativeDependencies, .reactFeatureFlags, .reactCxxReact, .reactPerfLogger, .reactPerformanceTimeline, .reactRendererConsistency, .reactUtils, .reactRuntimeExecutor]
 )
@@ -273,7 +267,7 @@ let reactTurboModuleCore = RNTarget(
   path: "ReactCommon/react/nativemodule/core",
   searchPaths: [CallInvokerPath, "ReactCommon/react/nativemodule/core/platform/ios"],
   excludedPaths: ["platform/android", "iostests"],
-  dependencies: [.reactNativeDependencies, .reactDebug, .reactFeatureFlags, .reactUtils, .reactPerfLogger, .reactCxxReact, .reactTurboModuleBridging, .yoga]
+  dependencies: [.reactNativeDependencies, .reactDebug, .reactFeatureFlags, .reactUtils, .reactPerfLogger, .reactCxxReact, .reactTurboModuleBridging, .yoga, .reactRuntimeExecutor]
 )
 
 /// React-defaultsnativemodule.podspec
@@ -296,7 +290,7 @@ let reactTurboModuleCoreMicrotasks = RNTarget(
 let reactIdleCallbacksNativeModule = RNTarget(
   name: .reactIdleCallbacksNativeModule,
   path: "ReactCommon/react/nativemodule/idlecallbacks",
-  searchPaths: [CallInvokerPath, RuntimeExecutorPath, ReactFBReactNativeSpecPath],
+  searchPaths: [CallInvokerPath, ReactFBReactNativeSpecPath],
   dependencies: [.reactNativeDependencies, .reactDebug, .reactFeatureFlags, .reactUtils, .reactPerfLogger, .reactCxxReact, .reactTurboModuleCore]
 )
 
@@ -304,7 +298,7 @@ let reactIdleCallbacksNativeModule = RNTarget(
 let reactFeatureflagsNativemodule = RNTarget(
   name: .reactFeatureflagsNativemodule,
   path: "ReactCommon/react/nativemodule/featureflags",
-  searchPaths: [CallInvokerPath, RuntimeExecutorPath, ReactFBReactNativeSpecPath],
+  searchPaths: [CallInvokerPath, ReactFBReactNativeSpecPath],
   dependencies: [.reactNativeDependencies, .reactDebug, .reactFeatureFlags, .reactUtils, .reactPerfLogger, .reactCxxReact, .reactTurboModuleCore]
 )
 
@@ -312,7 +306,7 @@ let reactFeatureflagsNativemodule = RNTarget(
 let reactNativeModuleDom = RNTarget(
   name: .reactNativeModuleDom,
   path: "ReactCommon/react/nativemodule/dom",
-  searchPaths: [CallInvokerPath, RuntimeExecutorPath, ReactFBReactNativeSpecPath],
+  searchPaths: [CallInvokerPath, ReactFBReactNativeSpecPath],
   dependencies: [.reactNativeDependencies, .reactDebug, .reactFeatureFlags, .reactUtils, .reactPerfLogger, .reactCxxReact, .reactTurboModuleCore, .yoga, .reactGraphicsApple, .reactFabric]
 )
 
@@ -335,7 +329,7 @@ let reactCoreRCTWebsocket = RNTarget(
 let reactCoreModules = RNTarget(
   name: .reactCoreModules,
   path: "React/CoreModules",
-  searchPaths: [ReactFBReactNativeSpecPath, FBLazyVectorPath, RuntimeExecutorPath, CallInvokerPath],
+  searchPaths: [ReactFBReactNativeSpecPath, FBLazyVectorPath, CallInvokerPath],
   excludedPaths: ["PlatformStubs/RCTStatusBarManager.mm"],
   dependencies: [.reactNativeDependencies, .jsi, .yoga, .reactTurboModuleCore]
 )
@@ -345,7 +339,7 @@ let reactCoreModules = RNTarget(
 let reactRuntime = RNTarget(
   name: .reactRuntime,
   path: "ReactCommon/react/runtime",
-  searchPaths: [RuntimeExecutorPath, CallInvokerPath],
+  searchPaths: [CallInvokerPath],
   excludedPaths: ["tests", "iostests", "platform"],
   dependencies: [.reactNativeDependencies, .jsi, .reactJsiExecutor, .reactCxxReact, .reactJsErrorHandler, .reactPerformanceTimeline, .reactUtils, .reactFeatureFlags, .reactJsInspector, .reactJsiTooling, .reactHermes, .reactRuntimeScheduler, .hermesPrebuilt]
 )
@@ -354,7 +348,7 @@ let reactRuntime = RNTarget(
 let reactRuntimeApple = RNTarget(
   name: .reactRuntimeApple,
   path: "ReactCommon/react/runtime/platform/ios",
-  searchPaths: [RuntimeExecutorPath, CallInvokerPath, ReactFBReactNativeSpecPath, FBLazyVectorPath],
+  searchPaths: [CallInvokerPath, ReactFBReactNativeSpecPath, FBLazyVectorPath],
   excludedPaths: ["ReactCommon/RCTJscInstance.mm", "ReactCommon/metainternal"],
   dependencies: [.reactNativeDependencies, .jsi, .reactPerfLogger, .reactCxxReact, .rctDeprecation, .yoga, .reactRuntime, .reactRCTFabric, .reactCoreModules, .reactTurboModuleCore, .hermesPrebuilt, .reactUtils]
 )
@@ -364,7 +358,6 @@ let reactCore = RNTarget(
   name: .reactCore,
   path: "React",
   searchPaths: [
-    RuntimeExecutorPath,
     CallInvokerPath,
     ReactFBReactNativeSpecPath,
     FBLazyVectorPath,
@@ -383,8 +376,7 @@ let reactFabric = RNTarget(
   name: .reactFabric,
   path: "ReactCommon/react/renderer",
   searchPaths: [
-    RuntimeExecutorPath,
-    CallInvokerPath,
+    CallInvokerPath
   ],
   excludedPaths: [
     "animations/tests",
@@ -424,7 +416,7 @@ let reactFabric = RNTarget(
 let reactRCTFabric = RNTarget(
   name: .reactRCTFabric,
   path: "React/Fabric",
-  searchPaths: [RuntimeExecutorPath, CallInvokerPath],
+  searchPaths: [CallInvokerPath],
   dependencies: [.reactNativeDependencies, .reactCore, .reactRCTImage, .yoga, .reactRCTText, .jsi, .reactFabricComponents, .reactGraphics, .reactImageManager, .reactDebug, .reactUtils, .reactPerformanceTimeline, .reactRendererDebug, .reactRendererConsistency, .reactRuntimeScheduler, .reactRCTAnimation, .reactJsInspector, .reactJsInspectorNetwork, .reactJsInspectorTracing, .reactFabric, .reactFabricImage]
 )
 
@@ -518,7 +510,7 @@ let reactRCTNetwork = RNTarget(
 let reactAppDelegate = RNTarget(
   name: .reactAppDelegate,
   path: "Libraries/AppDelegate",
-  searchPaths: [RuntimeExecutorPath, CallInvokerPath],
+  searchPaths: [CallInvokerPath],
   dependencies: [.reactNativeDependencies, .jsi, .reactJsiExecutor, .reactRuntime, .reactRCTImage, .reactHermes, .reactCore, .reactFabric, .reactTurboModuleCore, .hermesPrebuilt, .yoga]
 )
 


### PR DESCRIPTION
Summary:
Previously we were spreading the searchPath on the CallInvoker everywhere, but that's not needed.

This change ensure that only the targets that nedds visibility over the CallInvoker depends on them.

## Changelog:
[Internal] -

Differential Revision: D75756303


