### PR TITLE
fix(types): Devtools.d.ts

### DIFF
--- a/packages/react-native/types/modules/Devtools.d.ts
+++ b/packages/react-native/types/modules/Devtools.d.ts
@@ -9,10 +9,10 @@
 
 declare module 'react-native/Libraries/Core/Devtools/parseErrorStack' {
   export type StackFrame = {
-    column: number | null | undefined,
-    file: string | null | undefined,
-    lineNumber: number | null | undefined,
-    methodName: string,
+    column: number | null | undefined;
+    file: string | null | undefined;
+    lineNumber: number | null | undefined;
+    methodName: string;
   };
 
   export default function parseErrorStack(errorStack?: string): StackFrame[];

--- a/packages/react-native/types/modules/Devtools.d.ts
+++ b/packages/react-native/types/modules/Devtools.d.ts
@@ -9,24 +9,35 @@
 
 declare module 'react-native/Libraries/Core/Devtools/parseErrorStack' {
   export type StackFrame = {
-    file: string;
-    methodName: string;
-    lineNumber: number;
-    column: number | null;
+    column: number | null | undefined,
+    file: string | null | undefined,
+    lineNumber: number | null | undefined,
+    methodName: string,
   };
 
-  export interface ExtendedError extends Error {
-    framesToPop?: number | undefined;
-  }
-
-  export default function parseErrorStack(error: ExtendedError): StackFrame[];
+  export default function parseErrorStack(errorStack?: string): StackFrame[];
 }
 
 declare module 'react-native/Libraries/Core/Devtools/symbolicateStackTrace' {
   import {StackFrame} from 'react-native/Libraries/Core/Devtools/parseErrorStack';
 
+  export type CodeFrame = Readonly<{
+    content: string;
+    location: {
+      row: number;
+      column: number;
+      [key: string]: any;
+    } | null | undefined;
+    fileName: string;
+  }>;
+
+  export type SymbolicatedStackTrace = Readonly<{
+    stack: ReadonlyArray<StackFrame>;
+    codeFrame: CodeFrame | null | undefined;
+  }>;
+
   export default function symbolicateStackTrace(
     stack: ReadonlyArray<StackFrame>,
     extraData?: any,
-  ): Promise<StackFrame[]>;
+  ): Promise<SymbolicatedStackTrace>;
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

- This is similar to https://github.com/facebook/react-native/pull/43566, but include also updated `StackFrame` type.

The current `Devtools.d.ts` doesn't match the `parseErrorStack.js` and `symbolicateStackTrace.js` implementations.

I've tried to run `build-types`, but only `symbolicateStackTrace.d.ts` was generated. I've not checked why.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[GENERAL] [FIXED] - Devtools TS Types

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Call `parseErrorStack` and `symbolicateStackTrace` in TS.