### PR TITLE
Remove continue-on-error from e2e test in GHA

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -194,7 +194,6 @@ jobs:
     env:
       HERMES_WS_DIR: /tmp/hermes
       HERMES_TARBALL_ARTIFACTS_DIR: /tmp/hermes/hermes-runtime-darwin
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
@@ -227,7 +226,6 @@ jobs:
     env:
       HERMES_WS_DIR: /tmp/hermes
       HERMES_TARBALL_ARTIFACTS_DIR: /tmp/hermes/hermes-runtime-darwin
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
@@ -315,7 +313,6 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
     runs-on: 4-core-ubuntu
     needs: build_npm_package
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Summary:
I observed that when continue-on-error is set to true, Github reports the outcome of a job as success even if it fails.

With this change, we should ensure that when an E2E test fails, the pipeline fails, so that we can retry the jobs properly.

## Changelog:
[Internal] - Remove continue-on-error from e2e tests in GHA

Differential Revision: D75796284


