### PR TITLE
Make time in C++ Animated injectable

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.cpp
@@ -35,6 +35,13 @@
 
 namespace facebook::react {
 
+// Global function pointer for getting current time. Current time
+// can be injected for testing purposes.
+static TimePointFunction g_now = &std::chrono::steady_clock::now;
+void g_setNativeAnimatedNowTimestampFunction(TimePointFunction nowFunction) {
+  g_now = nowFunction;
+}
+
 namespace {
 
 struct NodesQueueItem {
@@ -719,7 +726,7 @@ void NativeAnimatedNodesManager::onRender() {
   // Step through the animation loop
   if (isAnimationUpdateNeeded()) {
     auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                  std::chrono::steady_clock::now().time_since_epoch())
+                  g_now().time_since_epoch())
                   .count();
 
     auto containsChange =

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.h
@@ -14,6 +14,7 @@
 #include <react/renderer/animated/EventEmitterListener.h>
 #include <react/renderer/animated/event_drivers/EventAnimationDriver.h>
 #include <react/renderer/core/ReactPrimitives.h>
+#include <chrono>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -22,6 +23,11 @@
 #include <vector>
 
 namespace facebook::react {
+
+using TimePointFunction = std::chrono::steady_clock::time_point (*)();
+// A way to inject a custom time function for testing purposes.
+// Default is `std::chrono::steady_clock::now`.
+void g_setNativeAnimatedNowTimestampFunction(TimePointFunction nowFunction);
 
 class AnimatedNode;
 class AnimationDriver;
@@ -52,7 +58,7 @@ class NativeAnimatedNodesManager {
 
   explicit NativeAnimatedNodesManager(
       DirectManipulationCallback&& directManipulationCallback,
-      FabricCommitCallback&& fabricCommitCallback = nullptr,
+      FabricCommitCallback&& fabricCommitCallback,
       StartOnRenderCallback&& startOnRenderCallback = nullptr,
       StopOnRenderCallback&& stopOnRenderCallback = nullptr) noexcept;
 


### PR DESCRIPTION
Summary:
changelog: [internal]

Make it possible to inject time via `now` argument to C++ Animated. This will be used in testing.

Differential Revision: D75710463


