### PR TITLE
Call onRender inline instead of from startRenderCallbackIfNeeded

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.cpp
@@ -35,6 +35,14 @@
 
 namespace facebook::react {
 
+// Global function pointer for getting current time
+static TimePointFunction g_now = &std::chrono::steady_clock::now;
+
+// Function to set the global now function
+void g_setNativeAnimatedNowTimestampFunction(TimePointFunction nowFunction) {
+  g_now = nowFunction;
+}
+
 namespace {
 
 struct NodesQueueItem {
@@ -719,7 +727,7 @@ void NativeAnimatedNodesManager::onRender() {
   // Step through the animation loop
   if (isAnimationUpdateNeeded()) {
     auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                  std::chrono::steady_clock::now().time_since_epoch())
+                  g_now().time_since_epoch())
                   .count();
 
     auto containsChange =

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.cpp
@@ -405,6 +405,12 @@ void NativeAnimatedNodesManager::handleAnimatedEvent(
       // `startRenderCallbackIfNeeded` will call platform specific code to
       // register UI tick listener.
       startRenderCallbackIfNeeded();
+      // Calling startOnRenderCallback_ will register a UI tick listener.
+      // The UI ticker listener will not be called until the next frame.
+      // That's why, in case this is called from the UI thread, we need to
+      // proactivelly trigger the animation loop to avoid showing stale
+      // frames.
+      onRender();
     }
   }
 }
@@ -427,14 +433,6 @@ NativeAnimatedNodesManager::ensureEventEmitterListener() noexcept {
 void NativeAnimatedNodesManager::startRenderCallbackIfNeeded() {
   if (startOnRenderCallback_) {
     startOnRenderCallback_([this]() { onRender(); });
-
-    if (isOnRenderThread_) {
-      // Calling startOnRenderCallback_ will register a UI tick listener.
-      // The UI ticker listener will not be called until the next frame.
-      // That's why, in case this is called from the UI thread, we need to
-      // proactivelly trigger the animation loop to avoid showing stale frames.
-      onRender();
-    }
   }
 }
 

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.h
@@ -14,6 +14,7 @@
 #include <react/renderer/animated/EventEmitterListener.h>
 #include <react/renderer/animated/event_drivers/EventAnimationDriver.h>
 #include <react/renderer/core/ReactPrimitives.h>
+#include <chrono>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -22,6 +23,11 @@
 #include <vector>
 
 namespace facebook::react {
+
+using TimePointFunction = std::chrono::steady_clock::time_point (*)();
+// A way to inject a custom time function for testing purposes.
+// Default is `std::chrono::steady_clock::now`.
+void g_setNativeAnimatedNowTimestampFunction(TimePointFunction nowFunction);
 
 class AnimatedNode;
 class AnimationDriver;
@@ -52,9 +58,9 @@ class NativeAnimatedNodesManager {
 
   explicit NativeAnimatedNodesManager(
       DirectManipulationCallback&& directManipulationCallback,
-      FabricCommitCallback&& fabricCommitCallback = nullptr,
-      StartOnRenderCallback&& startOnRenderCallback = nullptr,
-      StopOnRenderCallback&& stopOnRenderCallback = nullptr) noexcept;
+      FabricCommitCallback&& fabricCommitCallback,
+      StartOnRenderCallback&& startOnRenderCallback,
+      StopOnRenderCallback&& stopOnRenderCallback) noexcept;
 
   ~NativeAnimatedNodesManager() noexcept;
 


### PR DESCRIPTION
Summary:
changelog: [internal]

inline call `onRender()` instead of calling it from `startRenderCallbackIfNeeded`. This has identical functionality but allows to use Fantom to test C++ Animated. In Fantom, there is only one thread the existing mechanism in C++ Animated uses thread locals to capture which thread in the UI thread. Therefore, some assumptions are broken. This is just an easy workaround around the problem.

Reviewed By: javache, zeyap

Differential Revision: D75787084


