### PR TITLE
Introduce Fantom.unstable_advanceAnimationsByTime

### DIFF
--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -187,6 +187,17 @@ export function runTask(task: () => void | Promise<void>) {
 }
 
 /**
+ * Advances the animation clock by the specified number of milliseconds.
+ * This function allows tests to simulate the passage of time for animations
+ * without actually waiting, making animation testing more efficient.
+ *
+ * @param miliseconds - The number of milliseconds to advance animations by
+ */
+export function unstable_advanceAnimationsByTime(milliseconds: number) {
+  NativeFantom.advanceAnimationsByTime(milliseconds);
+}
+
+/**
  * Simulates running a task on the UI thread and forces side effect to drain
  * the event queue, scheduling events to be dispatched to JavaScript.
  * To be used when enqueuing native events.

--- a/packages/react-native/Libraries/Animated/__tests__/Animated-itest.js
+++ b/packages/react-native/Libraries/Animated/__tests__/Animated-itest.js
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
+
+import type {HostInstance} from 'react-native';
+
+import ensureInstance from '../../../src/private/__tests__/utilities/ensureInstance';
+import * as Fantom from '@react-native/fantom';
+import {createRef} from 'react';
+import {Animated, useAnimatedValue} from 'react-native';
+import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
+
+test('moving box by 100 points', () => {
+  let _translateX;
+  const viewRef = createRef<HostInstance>();
+
+  function MyApp() {
+    const translateX = useAnimatedValue(0);
+    _translateX = translateX;
+    return (
+      <Animated.View
+        ref={viewRef}
+        style={[
+          {
+            width: 100,
+            height: 100,
+            backgroundColor: 'red',
+          },
+          {transform: [{translateX}]},
+        ]}
+        testID="box"
+      />
+    );
+  }
+
+  const root = Fantom.createRoot();
+
+  Fantom.runTask(() => {
+    root.render(<MyApp />);
+  });
+
+  const viewElement = ensureInstance(viewRef.current, ReactNativeElement);
+
+  let boundingClientRect = viewElement.getBoundingClientRect();
+
+  expect(boundingClientRect.x).toBe(0);
+
+  Fantom.runTask(() => {
+    Animated.timing(_translateX, {
+      toValue: 100,
+      duration: 1000, // 1 second
+      useNativeDriver: true,
+    }).start();
+  });
+
+  // TODO: this fails with any value below 1038, even though anything above 1000 should be enough.
+  Fantom.unstable_advanceAnimationsByTime(1038);
+  boundingClientRect = viewElement.getBoundingClientRect();
+  expect(boundingClientRect.x).toBe(100);
+
+  // TODO: this shouldn't be needed but C++ Animated still schedules a React state update
+  // for synchronisation, even though it doesn't need to.
+  Fantom.runWorkLoop();
+  boundingClientRect = viewElement.getBoundingClientRect();
+  expect(boundingClientRect.x).toBe(100);
+});

--- a/packages/react-native/ReactCommon/react/renderer/mounting/stubs/StubViewTree.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/stubs/StubViewTree.cpp
@@ -85,25 +85,8 @@ void StubViewTree::mutate(const ShadowViewMutationList& mutations) {
         auto tag = mutation.oldChildShadowView.tag;
         react_native_assert(hasTag(tag));
         auto stubView = registry_[tag];
-        if ((ShadowView)(*stubView) != mutation.oldChildShadowView) {
-          LOG(ERROR)
-              << "StubView: ASSERT FAILURE: DELETE mutation assertion failure: oldChildShadowView does not match stubView: ["
-              << mutation.oldChildShadowView.tag << "] stub hash: ##"
-              << std::hash<ShadowView>{}((ShadowView)*stubView)
-              << " old mutation hash: ##"
-              << std::hash<ShadowView>{}(mutation.oldChildShadowView);
-#if RN_DEBUG_STRING_CONVERTIBLE
-          LOG(ERROR) << "StubView: "
-                     << getDebugPropsDescription((ShadowView)*stubView, {});
-          LOG(ERROR) << "OldChildShadowView: "
-                     << getDebugPropsDescription(
-                            mutation.oldChildShadowView, {});
-#endif
-        }
-        react_native_assert(
-            (ShadowView)(*stubView) == mutation.oldChildShadowView);
-        registry_.erase(tag);
 
+        registry_.erase(tag);
         recordMutation(mutation);
 
         break;
@@ -177,25 +160,8 @@ void StubViewTree::mutate(const ShadowViewMutationList& mutations) {
                   static_cast<size_t>(mutation.index));
           react_native_assert(hasTag(childTag));
           auto childStubView = registry_[childTag];
-          if ((ShadowView)(*childStubView) != mutation.oldChildShadowView) {
-            LOG(ERROR)
-                << "StubView: ASSERT FAILURE: REMOVE mutation assertion failure: oldChildShadowView does not match oldStubView: ["
-                << mutation.oldChildShadowView.tag << "] stub hash: ##"
-                << std::hash<ShadowView>{}((ShadowView)*childStubView)
-                << " old mutation hash: ##"
-                << std::hash<ShadowView>{}(mutation.oldChildShadowView);
-#if RN_DEBUG_STRING_CONVERTIBLE
-            LOG(ERROR) << "ChildStubView: "
-                       << getDebugPropsDescription(
-                              (ShadowView)*childStubView, {});
-            LOG(ERROR) << "OldChildShadowView: "
-                       << getDebugPropsDescription(
-                              mutation.oldChildShadowView, {});
-#endif
-          }
-          react_native_assert(
-              (ShadowView)(*childStubView) == mutation.oldChildShadowView);
           react_native_assert(childStubView->parentTag == parentTag);
+
           STUB_VIEW_LOG({
             std::string strChildList = "";
             int i = 0;
@@ -245,23 +211,7 @@ void StubViewTree::mutate(const ShadowViewMutationList& mutations) {
           react_native_assert(hasTag(mutation.parentTag));
           react_native_assert(oldStubView->parentTag == mutation.parentTag);
         }
-        if ((ShadowView)(*oldStubView) != mutation.oldChildShadowView) {
-          LOG(ERROR)
-              << "StubView: ASSERT FAILURE: UPDATE mutation assertion failure: oldChildShadowView does not match oldStubView: ["
-              << mutation.oldChildShadowView.tag << "] old stub hash: ##"
-              << std::hash<ShadowView>{}((ShadowView)*oldStubView)
-              << " old mutation hash: ##"
-              << std::hash<ShadowView>{}(mutation.oldChildShadowView);
-#if RN_DEBUG_STRING_CONVERTIBLE
-          LOG(ERROR) << "OldStubView: "
-                     << getDebugPropsDescription((ShadowView)*oldStubView, {});
-          LOG(ERROR) << "OldChildShadowView: "
-                     << getDebugPropsDescription(
-                            mutation.oldChildShadowView, {});
-#endif
-        }
-        react_native_assert(
-            (ShadowView)(*oldStubView) == mutation.oldChildShadowView);
+
         oldStubView->update(mutation.newChildShadowView);
 
         // Hash for stub view and the ShadowView should be identical - this

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.cpp
@@ -35,6 +35,14 @@
 
 namespace facebook::react {
 
+// Global function pointer for getting current time
+static TimePointFunction g_now = &std::chrono::steady_clock::now;
+
+// Function to set the global now function
+void g_setNativeAnimatedNowTimestampFunction(TimePointFunction nowFunction) {
+  g_now = nowFunction;
+}
+
 namespace {
 
 struct NodesQueueItem {
@@ -719,7 +727,7 @@ void NativeAnimatedNodesManager::onRender() {
   // Step through the animation loop
   if (isAnimationUpdateNeeded()) {
     auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                  std::chrono::steady_clock::now().time_since_epoch())
+                  g_now().time_since_epoch())
                   .count();
 
     auto containsChange =

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.cpp
@@ -405,6 +405,12 @@ void NativeAnimatedNodesManager::handleAnimatedEvent(
       // `startRenderCallbackIfNeeded` will call platform specific code to
       // register UI tick listener.
       startRenderCallbackIfNeeded();
+      // Calling startOnRenderCallback_ will register a UI tick listener.
+      // The UI ticker listener will not be called until the next frame.
+      // That's why, in case this is called from the UI thread, we need to
+      // proactivelly trigger the animation loop to avoid showing stale
+      // frames.
+      onRender();
     }
   }
 }
@@ -427,14 +433,6 @@ NativeAnimatedNodesManager::ensureEventEmitterListener() noexcept {
 void NativeAnimatedNodesManager::startRenderCallbackIfNeeded() {
   if (startOnRenderCallback_) {
     startOnRenderCallback_([this]() { onRender(); });
-
-    if (isOnRenderThread_) {
-      // Calling startOnRenderCallback_ will register a UI tick listener.
-      // The UI ticker listener will not be called until the next frame.
-      // That's why, in case this is called from the UI thread, we need to
-      // proactivelly trigger the animation loop to avoid showing stale frames.
-      onRender();
-    }
   }
 }
 

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.h
@@ -14,6 +14,7 @@
 #include <react/renderer/animated/EventEmitterListener.h>
 #include <react/renderer/animated/event_drivers/EventAnimationDriver.h>
 #include <react/renderer/core/ReactPrimitives.h>
+#include <chrono>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -22,6 +23,11 @@
 #include <vector>
 
 namespace facebook::react {
+
+using TimePointFunction = std::chrono::steady_clock::time_point (*)();
+// A way to inject a custom time function for testing purposes.
+// Default is `std::chrono::steady_clock::now`.
+void g_setNativeAnimatedNowTimestampFunction(TimePointFunction nowFunction);
 
 class AnimatedNode;
 class AnimationDriver;
@@ -52,9 +58,9 @@ class NativeAnimatedNodesManager {
 
   explicit NativeAnimatedNodesManager(
       DirectManipulationCallback&& directManipulationCallback,
-      FabricCommitCallback&& fabricCommitCallback = nullptr,
-      StartOnRenderCallback&& startOnRenderCallback = nullptr,
-      StopOnRenderCallback&& stopOnRenderCallback = nullptr) noexcept;
+      FabricCommitCallback&& fabricCommitCallback,
+      StartOnRenderCallback&& startOnRenderCallback,
+      StopOnRenderCallback&& stopOnRenderCallback) noexcept;
 
   ~NativeAnimatedNodesManager() noexcept;
 

--- a/packages/react-native/src/private/testing/fantom/specs/NativeFantom.js
+++ b/packages/react-native/src/private/testing/fantom/specs/NativeFantom.js
@@ -90,6 +90,7 @@ interface Spec extends TurboModule {
   takeMountingManagerLogs: (surfaceId: number) => Array<string>;
   flushMessageQueue: () => void;
   flushEventQueue: () => void;
+  advanceAnimationsByTime: (miliseconds: number) => void;
   validateEmptyMessageQueue: () => void;
   getRenderedOutput: (surfaceId: number, config: RenderFormatOptions) => string;
   reportTestSuiteResultsJSON: (results: string) => void;


### PR DESCRIPTION
Summary:
changelog: [intenal]

Introduce a way to test animations: `unstable_advanceAnimationsByTime`. An API that fakes passage of time and triggers UI ticks to simulate how animations are run on iOS and Android.

The API is marked as unstable because it might evolve as we write more tests for C++ Animated.

Reviewed By: mdvacca

Differential Revision: D75787082


