### PR TITLE
Splitting RN Core into 3

### DIFF
--- a/packages/react-native-codegen/src/cli/combine/combine-js-to-schema-cli.js
+++ b/packages/react-native-codegen/src/cli/combine/combine-js-to-schema-cli.js
@@ -28,6 +28,17 @@ const argv = yargs
     alias: 'exclude',
     default: null,
   })
+  .option('exclude-interface-only', {
+    describe: 'Exclude components with interfaceOnly: true',
+    type: 'boolean',
+    default: false,
+  })
+  .option('exclude-unimplemented', {
+    describe:
+      'Exclude component named UnimplementedNativeViewNativeComponent.js',
+    type: 'boolean',
+    default: false,
+  })
   .parseSync();
 
 const [outfile, ...fileList] = argv._;
@@ -35,10 +46,14 @@ const platform: ?string = argv.platform;
 const exclude: string = argv.exclude;
 const excludeRegExp: ?RegExp =
   exclude != null && exclude !== '' ? new RegExp(exclude) : null;
+const excludeInterfaceOnly: boolean = argv['exclude-interface-only'];
+const excludeUnimplemented: boolean = argv['exclude-unimplemented'];
 
 combineSchemasInFileListAndWriteToFile(
   fileList,
   platform != null ? platform.toLowerCase() : platform,
   outfile,
   excludeRegExp,
+  excludeInterfaceOnly,
+  excludeUnimplemented,
 );


### PR DESCRIPTION
Summary:
In order to avoid the duplicate dependency caused by FAC due to including core components twice, splitting the RN Core into 3 groups:
1. interfaceOnly: true components
2. UnimplementedNativeViewNativeComponent.js
3. Everything Else

Changelog:
[General][Added] Splitting RN Core to interfaceOnly:true, UnimplementedNativeViewNativeComponent.js and everything else

Differential Revision: D75796413


