### PR TITLE
Remove Broken Caching Logic in AndroidProgressBarMeasurementsManagaer and AndroidSwitchMeasurementsManager

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarMeasurementsManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarMeasurementsManager.cpp
@@ -20,13 +20,6 @@ Size AndroidProgressBarMeasurementsManager::measure(
     SurfaceId surfaceId,
     const AndroidProgressBarProps& props,
     LayoutConstraints layoutConstraints) const {
-  {
-    std::scoped_lock lock(mutex_);
-    if (hasBeenMeasured_) {
-      return cachedMeasurement_;
-    }
-  }
-
   const jni::global_ref<jobject>& fabricUIManager =
       contextContainer_->at<jni::global_ref<jobject>>("FabricUIManager");
 
@@ -54,7 +47,7 @@ Size AndroidProgressBarMeasurementsManager::measure(
   local_ref<ReadableMap::javaobject> propsRM =
       make_local(reinterpret_cast<ReadableMap::javaobject>(propsRNM.get()));
 
-  auto measurement = yogaMeassureToSize(measure(
+  return yogaMeassureToSize(measure(
       fabricUIManager,
       surfaceId,
       componentName.get(),
@@ -65,10 +58,6 @@ Size AndroidProgressBarMeasurementsManager::measure(
       maximumSize.width,
       minimumSize.height,
       maximumSize.height));
-
-  std::scoped_lock lock(mutex_);
-  cachedMeasurement_ = measurement;
-  return measurement;
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarMeasurementsManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/progressbar/android/react/renderer/components/progressbar/AndroidProgressBarMeasurementsManager.h
@@ -27,9 +27,6 @@ class AndroidProgressBarMeasurementsManager {
 
  private:
   const ContextContainer::Shared contextContainer_;
-  mutable std::mutex mutex_;
-  mutable bool hasBeenMeasured_ = false;
-  mutable Size cachedMeasurement_{};
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/switch/androidswitch/react/renderer/components/androidswitch/AndroidSwitchMeasurementsManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/switch/androidswitch/react/renderer/components/androidswitch/AndroidSwitchMeasurementsManager.h
@@ -23,9 +23,6 @@ class AndroidSwitchMeasurementsManager {
 
  private:
   const ContextContainer::Shared contextContainer_;
-  mutable std::mutex mutex_;
-  mutable bool hasBeenMeasured_ = false;
-  mutable Size cachedMeasurement_{};
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
These both have a boolean flag `hasBeenMeasured_` which is never set to true, so the cached measurement is never used, but it would be wrong if it was used, since the cache doesn't respect the content, or measure constraints. Delete the broken code.

Changelog: [Internal]

Differential Revision: D75817999


