### PR TITLE
Remove `YogaLayoutableShadowNode::cleanLayout()` and Fix ParagraphShadowNode Font Size Invalidation Logic

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.cpp
@@ -58,26 +58,13 @@ ParagraphShadowNode::ParagraphShadowNode(
     const ShadowNode& sourceShadowNode,
     const ShadowNodeFragment& fragment)
     : ConcreteViewShadowNode(sourceShadowNode, fragment) {
-  auto& sourceParagraphShadowNode =
-      static_cast<const ParagraphShadowNode&>(sourceShadowNode);
-  auto& state = getStateData();
-  const auto& sourceContent = sourceParagraphShadowNode.content_;
-
-  if (!fragment.children && !fragment.props &&
-      sourceParagraphShadowNode.getIsLayoutClean() &&
-      (!ReactNativeFeatureFlags::enableFontScaleChangesUpdatingLayout() ||
-       (sourceContent.has_value() &&
-        sourceContent.value()
-                .attributedString.getBaseTextAttributes()
-                .fontSizeMultiplier ==
-            state.attributedString.getBaseTextAttributes()
-                .fontSizeMultiplier))) {
-    // This ParagraphShadowNode was cloned but did not change
-    // in a way that affects its layout. Let's mark it clean
-    // to stop Yoga from traversing it.
-    cleanLayout();
-  }
   initialize();
+}
+
+bool ParagraphShadowNode::shouldNewRevisionDirtyMeasurement(
+    const ShadowNode& /*sourceShadowNode*/,
+    const ShadowNodeFragment& fragment) const {
+  return fragment.props != nullptr;
 }
 
 const Content& ParagraphShadowNode::getContent(

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.h
@@ -90,6 +90,11 @@ class ParagraphShadowNode final : public ConcreteViewShadowNode<
     Attachments attachments;
   };
 
+ protected:
+  bool shouldNewRevisionDirtyMeasurement(
+      const ShadowNode& sourceShadowNode,
+      const ShadowNodeFragment& fragment) const override;
+
  private:
   void initialize() noexcept;
   /*

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
@@ -37,6 +37,10 @@ class YogaLayoutableShadowNode : public LayoutableShadowNode {
       const ShadowNode& sourceShadowNode,
       const ShadowNodeFragment& fragment);
 
+  void completeClone(
+      const ShadowNode& sourceShadowNode,
+      const ShadowNodeFragment& fragment) override;
+
 #pragma mark - Mutating Methods
 
   /*
@@ -69,7 +73,6 @@ class YogaLayoutableShadowNode : public LayoutableShadowNode {
 
 #pragma mark - LayoutableShadowNode
 
-  void cleanLayout() override;
   void dirtyLayout() override;
   bool getIsLayoutClean() const override;
 
@@ -86,6 +89,14 @@ class YogaLayoutableShadowNode : public LayoutableShadowNode {
   Rect getContentBounds() const;
 
  protected:
+  /**
+   * Subclasses which provide MeasurableYogaNode may override to signal that a
+   * new ShadowNode revision does not need to invalidate existing measurements.
+   */
+  virtual bool shouldNewRevisionDirtyMeasurement(
+      const ShadowNode& sourceShadowNode,
+      const ShadowNodeFragment& fragment) const;
+
   /*
    * Yoga config associated (only) with this particular node.
    */

--- a/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
@@ -80,6 +80,7 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
       const ShadowNode& sourceShadowNode,
       const ShadowNodeFragment& fragment) const override {
     auto shadowNode = std::make_shared<ShadowNodeT>(sourceShadowNode, fragment);
+    shadowNode->completeClone(sourceShadowNode, fragment);
     sourceShadowNode.transferRuntimeShadowNodeReference(shadowNode, fragment);
 
     adopt(*shadowNode);

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.h
@@ -146,7 +146,6 @@ class LayoutableShadowNode : public ShadowNode {
    * Indicates whether all nodes (and possibly their subtrees) along the path
    * to the root node should be re-laid out.
    */
-  virtual void cleanLayout() = 0;
   virtual void dirtyLayout() = 0;
   virtual bool getIsLayoutClean() const = 0;
 

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
@@ -95,7 +95,7 @@ class ShadowNode : public Sealable,
   virtual ~ShadowNode() override = default;
 
   /*
-   * Clones the shadow node using stored `cloneFunction`.
+   * Clones the shadow node using the ShadowNode's ComponentDescriptor.
    */
   std::shared_ptr<ShadowNode> clone(const ShadowNodeFragment& fragment) const;
 
@@ -123,6 +123,14 @@ class ShadowNode : public Sealable,
       const std::function<std::shared_ptr<ShadowNode>(
           const ShadowNode& oldShadowNode,
           const ShadowNodeFragment& fragment)>& callback) const;
+
+  /**
+   * Called, once a fully derived ShadowNode clone has been created via
+   * ComponentDescriptor::cloneShadowNode.
+   */
+  virtual void completeClone(
+      const ShadowNode& sourceShadowNode,
+      const ShadowNodeFragment& fragment) {}
 
 #pragma mark - Getters
 


### PR DESCRIPTION
Summary:
This API is evil.

Yoga's public API never allows a dirty node to become clean again, until its laid out, but this API requires doing that, since we will otherwise automatically dirty by default.

Let's replace it with `YogaLayoutableShadowNode::shouldNewRevisionDirtyMeasurement()`, which lets individual ShadowNodes represent whether a new revision's state and props should cause dirtying, defaulting to true.

Changelog:
[General][Removed] - Remove `YogaLayoutableShadowNode::cleanLayout()`

Reviewed By: lenaic

Differential Revision: D75479902


