### PR TITLE
Use delegate to handle commands when available

### DIFF
--- a/packages/react-native/Libraries/Debugging/DebuggingOverlay.js
+++ b/packages/react-native/Libraries/Debugging/DebuggingOverlay.js
@@ -11,14 +11,14 @@
 import type {
   ElementRectangle,
   TraceUpdate,
-} from './DebuggingOverlayNativeComponent';
+} from '../../src/private/specs_DEPRECATED/components/DebuggingOverlayNativeComponent';
 
+import DebuggingOverlayNativeComponent, {
+  Commands,
+} from '../../src/private/specs_DEPRECATED/components/DebuggingOverlayNativeComponent';
 import View from '../Components/View/View';
 import UIManager from '../ReactNative/UIManager';
 import StyleSheet from '../StyleSheet/StyleSheet';
-import DebuggingOverlayNativeComponent, {
-  Commands,
-} from './DebuggingOverlayNativeComponent';
 import * as React from 'react';
 
 const {useRef, useImperativeHandle} = React;
@@ -26,8 +26,8 @@ const isNativeComponentReady =
   UIManager.hasViewManagerConfig('DebuggingOverlay');
 
 type DebuggingOverlayHandle = {
-  highlightTraceUpdates(updates: TraceUpdate[]): void,
-  highlightElements(elements: ElementRectangle[]): void,
+  highlightTraceUpdates(updates: $ReadOnlyArray<TraceUpdate>): void,
+  highlightElements(elements: $ReadOnlyArray<ElementRectangle>): void,
   clearElementsHighlight(): void,
 };
 

--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -4136,8 +4136,8 @@ declare export default typeof registerCallableModule;
 
 exports[`public API should not change unintentionally Libraries/Debugging/DebuggingOverlay.js 1`] = `
 "type DebuggingOverlayHandle = {
-  highlightTraceUpdates(updates: TraceUpdate[]): void,
-  highlightElements(elements: ElementRectangle[]): void,
+  highlightTraceUpdates(updates: $ReadOnlyArray<TraceUpdate>): void,
+  highlightElements(elements: $ReadOnlyArray<ElementRectangle>): void,
   clearElementsHighlight(): void,
 };
 declare export default component(ref: React.RefSetter<DebuggingOverlayHandle>);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/debuggingoverlay/DebuggingOverlayManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/debuggingoverlay/DebuggingOverlayManager.kt
@@ -30,21 +30,13 @@ internal class DebuggingOverlayManager :
 
   override fun getDelegate(): ViewManagerDelegate<DebuggingOverlay> = delegate
 
-  override fun receiveCommand(view: DebuggingOverlay, commandId: String, args: ReadableArray?) {
-    when (commandId) {
-      "highlightTraceUpdates" -> highlightTraceUpdates(view, args)
-      "highlightElements" -> highlightElements(view, args)
-      "clearElementsHighlights" -> clearElementsHighlights(view)
-      else -> {
-        ReactSoftExceptionLogger.logSoftException(
-            REACT_CLASS,
-            ReactNoCrashSoftException("Received unexpected command in DebuggingOverlayManager"))
-      }
-    }
-  }
+  override fun receiveCommand(view: DebuggingOverlay, commandId: String, args: ReadableArray?) =
+      delegate.receiveCommand(view, commandId, args)
 
-  override fun highlightTraceUpdates(view: DebuggingOverlay, args: ReadableArray?): Unit {
-    val providedTraceUpdates = args?.getArray(0) ?: return
+  override fun highlightTraceUpdates(
+      view: DebuggingOverlay,
+      providedTraceUpdates: ReadableArray
+  ): Unit {
     val formattedTraceUpdates = mutableListOf<TraceUpdate>()
 
     var successfullyParsedPayload = true
@@ -93,8 +85,7 @@ internal class DebuggingOverlayManager :
     }
   }
 
-  override fun highlightElements(view: DebuggingOverlay, args: ReadableArray?): Unit {
-    val providedElements = args?.getArray(0) ?: return
+  override fun highlightElements(view: DebuggingOverlay, providedElements: ReadableArray): Unit {
     val elementsRectangles = mutableListOf<RectF>()
 
     var successfullyParsedPayload = true

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/ReactDrawerLayoutManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/ReactDrawerLayoutManager.kt
@@ -160,26 +160,21 @@ public class ReactDrawerLayoutManager :
           "This method is deprecated. Use receiveCommand(ReactDrawerLayout, String, ReadableArray) instead",
       replaceWith = ReplaceWith("receiveCommand(ReactDrawerLayout, String, ReadableArray)"))
   public override fun receiveCommand(
-      root: ReactDrawerLayout,
+      view: ReactDrawerLayout,
       commandId: Int,
       args: ReadableArray?
-  ) {
+  ): Unit {
     when (commandId) {
-      OPEN_DRAWER -> root.openDrawer()
-      CLOSE_DRAWER -> root.closeDrawer()
+      OPEN_DRAWER -> view.openDrawer()
+      CLOSE_DRAWER -> view.closeDrawer()
     }
   }
 
   public override fun receiveCommand(
-      root: ReactDrawerLayout,
+      view: ReactDrawerLayout,
       commandId: String,
       args: ReadableArray?
-  ) {
-    when (commandId) {
-      COMMAND_OPEN_DRAWER -> root.openDrawer()
-      COMMAND_CLOSE_DRAWER -> root.closeDrawer()
-    }
-  }
+  ): Unit = delegate.receiveCommand(view, commandId, args)
 
   public override fun getExportedViewConstants(): Map<String, Any> =
       mapOf(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/SwipeRefreshLayoutManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/SwipeRefreshLayoutManager.kt
@@ -118,18 +118,10 @@ internal open class SwipeRefreshLayoutManager :
   }
 
   override fun receiveCommand(
-      root: ReactSwipeRefreshLayout,
+      view: ReactSwipeRefreshLayout,
       commandId: String,
       args: ReadableArray?
-  ) {
-    when (commandId) {
-      "setNativeRefreshing" ->
-          if (args != null) {
-            setRefreshing(root, args.getBoolean(0))
-          }
-      else -> {}
-    }
-  }
+  ) = delegate.receiveCommand(view, commandId, args)
 
   override fun getExportedViewConstants(): MutableMap<String, Any> =
       mutableMapOf(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitchManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitchManager.kt
@@ -95,11 +95,8 @@ internal class ReactSwitchManager :
     setValueInternal(view, value)
   }
 
-  override fun receiveCommand(view: ReactSwitch, commandId: String, args: ReadableArray?) {
-    when (commandId) {
-      "setNativeValue" -> setValueInternal(view, args?.getBoolean(0) ?: false)
-    }
-  }
+  override fun receiveCommand(view: ReactSwitch, commandId: String, args: ReadableArray?) =
+      delegate.receiveCommand(view, commandId, args)
 
   override fun addEventEmitters(reactContext: ThemedReactContext, view: ReactSwitch) {
     view.setOnCheckedChangeListener(ON_CHECKED_CHANGE_LISTENER)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.kt
@@ -152,10 +152,10 @@ public open class ReactTextInputManager public constructor() :
   @Deprecated("Deprecated in Java")
   override fun receiveCommand(reactEditText: ReactEditText, commandId: Int, args: ReadableArray?) {
     when (commandId) {
-      FOCUS_TEXT_INPUT -> this.receiveCommand(reactEditText, "focus", args)
-      BLUR_TEXT_INPUT -> this.receiveCommand(reactEditText, "blur", args)
+      FOCUS_TEXT_INPUT -> receiveCommand(reactEditText, "focus", args)
+      BLUR_TEXT_INPUT -> receiveCommand(reactEditText, "blur", args)
       SET_MOST_RECENT_EVENT_COUNT -> {}
-      SET_TEXT_AND_SELECTION -> this.receiveCommand(reactEditText, "setTextAndSelection", args)
+      SET_TEXT_AND_SELECTION -> receiveCommand(reactEditText, "setTextAndSelection", args)
     }
   }
 


### PR DESCRIPTION
Summary:
Generated delegate has this

```
  Override
  public void receiveCommand(T view, String commandName, Nullable ReadableArray args) {
    switch (commandName) {
      case "highlightTraceUpdates":
        mViewManager.highlightTraceUpdates(view, args.getArray(0));
        break;
      case "highlightElements":
        mViewManager.highlightElements(view, args.getArray(0));
        break;
      case "clearElementsHighlights":
        mViewManager.clearElementsHighlights(view);
        break;
    }
  }
````

Changelog: [Internal]

Reviewed By: mdvacca

Differential Revision: D75797948


