### PR TITLE
fix: make sure RNTester builds with USE_HERMES=0

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
+++ b/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
@@ -66,7 +66,9 @@ Pod::Spec.new do |s|
   s.dependency "React-CoreModules"
   s.dependency "React-RCTFBReactNativeSpec"
   s.dependency "React-defaultsnativemodule"
-  s.dependency 'React-hermes'
+  if use_hermes
+    s.dependency 'React-hermes'
+  end
 
   add_dependency(s, "React-runtimeexecutor", :additional_framework_paths => ["platform/ios"])
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])

--- a/packages/react-native/React-Core.podspec
+++ b/packages/react-native/React-Core.podspec
@@ -122,7 +122,10 @@ Pod::Spec.new do |s|
   s.dependency "React-featureflags"
   s.dependency "React-runtimescheduler"
   s.dependency "Yoga"
-  s.dependency 'React-hermes'
+
+  if use_hermes
+    s.dependency "React-hermes"
+  end
 
   s.resource_bundles = {'React-Core_privacy' => 'React/Resources/PrivacyInfo.xcprivacy'}
 


### PR DESCRIPTION
## Summary:

This PR makes sure React Native still builds with USE_HERMES=0.

## Changelog:

[IOS] [FIXED] - make RNTester build with USE_HERMES=0

## Test Plan:

CI Green
