### PR TITLE
Fix crash when accessing offsetParent from documentElement

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/dom/DOM.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/dom/DOM.cpp
@@ -72,7 +72,13 @@ ShadowNode::Shared getPositionedAncestorOfShadowNodeInRevision(
   auto ancestors = shadowNode.getFamily().getAncestors(*currentRevision);
 
   if (ancestors.empty()) {
+    // The node is no longer part of an active shadow tree, or is the root.
     return nullptr;
+  }
+
+  if (ancestors.size() == 1) {
+    // The parent is the root
+    return currentRevision;
   }
 
   for (auto it = ancestors.rbegin(); it != ancestors.rend(); it++) {
@@ -86,11 +92,9 @@ ShadowNode::Shared getPositionedAncestorOfShadowNodeInRevision(
       // We have found our nearest positioned ancestor, now to get a shared
       // pointer of it
       it++;
-      if (it != ancestors.rend()) {
-        return it->first.get().getChildren().at(it->second);
-      }
-      // else the positioned ancestor is the root which we return outside of the
-      // loop
+      return it == ancestors.rend()
+          ? currentRevision
+          : it->first.get().getChildren().at(it->second);
     }
   }
 

--- a/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeDocument-itest.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeDocument-itest.js
@@ -122,6 +122,10 @@ describe('ReactNativeDocument', () => {
     expect(y).toBe(0);
     expect(width).toBe(200);
     expect(height).toBe(100);
+
+    expect(document.documentElement.offsetParent).toBe(null);
+    expect(document.documentElement.offsetTop).toBe(0);
+    expect(document.documentElement.offsetLeft).toBe(0);
   });
 
   it('implements compareDocumentPosition correctly', () => {

--- a/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeElement-itest.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeElement-itest.js
@@ -1064,7 +1064,7 @@ describe('ReactNativeElement', () => {
     });
 
     describe('offsetParent / offsetTop / offsetLeft', () => {
-      it('retun the rounded offset values and the parent, or null and zeros when disconnected or hidden', () => {
+      it('return the rounded offset values and the parent, or null and zeros when disconnected or hidden', () => {
         const parentRef = createRef<HostInstance>();
         const elementRef = createRef<HostInstance>();
 
@@ -1088,6 +1088,8 @@ describe('ReactNativeElement', () => {
         expect(element.offsetTop).toBe(11);
         expect(element.offsetLeft).toBe(5);
         expect(element.offsetParent).toBe(parentElement);
+
+        expect(parentElement.offsetParent).toBe(root.document.documentElement);
 
         Fantom.runTask(() => {
           root.render(


### PR DESCRIPTION
Summary:
Changelog: [internal]

(This isn't a public API yet so not marking it as a bugfix).

This fixes a crash in the `offsetParent` DOM API when called on a node whose parent is the `documentElement`.

Differential Revision: D75876349


