### PR TITLE
Remove unnecessary "using namespace" directives

### DIFF
--- a/packages/react-native/ReactCommon/jserrorhandler/StackTraceParser.cpp
+++ b/packages/react-native/ReactCommon/jserrorhandler/StackTraceParser.cpp
@@ -13,7 +13,7 @@
 #include <sstream>
 #include <string>
 
-using namespace facebook::react;
+namespace facebook::react {
 
 const std::string UNKNOWN_FUNCTION = "<unknown>";
 
@@ -315,3 +315,5 @@ std::vector<JsErrorHandler::ProcessedError::StackFrame> StackTraceParser::parse(
       isHermes ? parseHermes(stackString) : parseOthers(stackString);
   return stackFrames;
 }
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/fantomtestspecificmethods/internal/FantomForcedCloneCommitHook.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/fantomtestspecificmethods/internal/FantomForcedCloneCommitHook.cpp
@@ -9,9 +9,9 @@
 #include <react/renderer/uimanager/UIManagerBinding.h>
 #include <react/renderer/uimanager/primitives.h>
 
-namespace {
+namespace facebook::react {
 
-using namespace facebook::react;
+namespace {
 
 ShadowNode::Shared findAndClone(const ShadowNode::Shared& node) {
   if (node->getProps()->nativeId == "to-be-cloned-in-the-commit-hook") {
@@ -34,8 +34,6 @@ ShadowNode::Shared findAndClone(const ShadowNode::Shared& node) {
 }
 
 } // namespace
-
-namespace facebook::react {
 
 void FantomForcedCloneCommitHook::commitHookWasRegistered(
     const UIManager& /*uiManager*/) noexcept {}

--- a/packages/react-native/ReactCommon/react/renderer/dom/DOM.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/dom/DOM.cpp
@@ -13,14 +13,9 @@
 #include <react/renderer/graphics/Size.h>
 #include <cmath>
 
+namespace facebook::react::dom {
+
 namespace {
-
-using namespace facebook::react;
-
-// To prevent ambiguity with built-in MacOS types.
-using facebook::react::Point;
-using facebook::react::Rect;
-using facebook::react::Size;
 
 ShadowNode::Shared getShadowNodeInRevision(
     const RootShadowNode::Shared& currentRevision,
@@ -156,8 +151,6 @@ Rect getScrollableContentBounds(
 }
 
 } // namespace
-
-namespace facebook::react::dom {
 
 ShadowNode::Shared getParentNode(
     const RootShadowNode::Shared& currentRevision,

--- a/packages/react-native/ReactCommon/react/renderer/dom/DOM.h
+++ b/packages/react-native/ReactCommon/react/renderer/dom/DOM.h
@@ -11,7 +11,6 @@
 #include <react/renderer/core/ShadowNode.h>
 #include <cstdint>
 #include <string>
-#include <tuple>
 #include <vector>
 
 namespace facebook::react::dom {

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBuffer.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBuffer.cpp
@@ -7,8 +7,6 @@
 
 #include "MapBuffer.h"
 
-using namespace facebook::react;
-
 namespace facebook::react {
 
 static inline int32_t bucketOffset(int32_t index) {

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBufferBuilder.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBufferBuilder.cpp
@@ -8,8 +8,6 @@
 #include "MapBufferBuilder.h"
 #include <algorithm>
 
-using namespace facebook::react;
-
 namespace facebook::react {
 
 constexpr uint32_t INT_SIZE = sizeof(uint32_t);


### PR DESCRIPTION
Summary:
Changelog: [internal]

Just a small refactor to remove some unnecessary `using namespace` directives for code in the `facebook::react` namespace.

Differential Revision: D75874213


