### PR TITLE
trigger animations at time 0 in fantom

### DIFF
--- a/packages/react-native/Libraries/Animated/__tests__/Animated-itest.js
+++ b/packages/react-native/Libraries/Animated/__tests__/Animated-itest.js
@@ -61,8 +61,8 @@ test('moving box by 100 points', () => {
     }).start();
   });
 
-  // TODO: this fails with any value below 1038, even though anything above 1000 should be enough.
-  Fantom.unstable_advanceAnimationsByTime(1038);
+  // TODO: this fails with any value below 1022, even though anything above 1000 should be enough.
+  Fantom.unstable_advanceAnimationsByTime(1022);
   boundingClientRect = viewElement.getBoundingClientRect();
   expect(boundingClientRect.x).toBe(100);
 


### PR DESCRIPTION
Summary:
changelog: [internal]

testing animation must be predictable.
When animation takes 1 second and test calls `unstable_advanceAnimationsByTime(1000)`, the expectation is that the animation would have completed.
Previously it was necessary to wait for at least 38ms over the time it took to complete animation. This diff reduces the delta to 22ms.

Differential Revision: D75813087


