### PR TITLE
RN: Add `@noflow` to Node.js Scripts

### DIFF
--- a/flow-typed/environment/node.js
+++ b/flow-typed/environment/node.js
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
+ * @flow
  * @format
  */
 

--- a/flow-typed/npm/jest.js
+++ b/flow-typed/npm/jest.js
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
+ * @flow
  * @format
  */
 

--- a/packages/community-cli-plugin/src/commands/bundle/__mocks__/sign.js
+++ b/packages/community-cli-plugin/src/commands/bundle/__mocks__/sign.js
@@ -4,10 +4,11 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
+ * @flow strict-local
  * @format
  */
 
-function sign(source) {
+function sign(source: string): string {
   return source;
 }
 

--- a/packages/eslint-config-react-native/__tests__/prettier-config-test.js
+++ b/packages/eslint-config-react-native/__tests__/prettier-config-test.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 import eslintConfigReactNative from '..';

--- a/packages/eslint-config-react-native/index.js
+++ b/packages/eslint-config-react-native/index.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 module.exports = {

--- a/packages/eslint-plugin-react-native/__tests__/eslint-tester.js
+++ b/packages/eslint-plugin-react-native/__tests__/eslint-tester.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/packages/eslint-plugin-react-native/__tests__/no-deep-imports-test.js
+++ b/packages/eslint-plugin-react-native/__tests__/no-deep-imports-test.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/packages/eslint-plugin-react-native/__tests__/platform-colors-test.js
+++ b/packages/eslint-plugin-react-native/__tests__/platform-colors-test.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/packages/eslint-plugin-react-native/index.js
+++ b/packages/eslint-plugin-react-native/index.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 exports.rules = {

--- a/packages/eslint-plugin-react-native/no-deep-imports.js
+++ b/packages/eslint-plugin-react-native/no-deep-imports.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/packages/eslint-plugin-react-native/platform-colors.js
+++ b/packages/eslint-plugin-react-native/platform-colors.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 module.exports = {

--- a/packages/eslint-plugin-react-native/utils.js
+++ b/packages/eslint-plugin-react-native/utils.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/packages/eslint-plugin-specs/__tests__/eslint-tester.js
+++ b/packages/eslint-plugin-specs/__tests__/eslint-tester.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/packages/eslint-plugin-specs/__tests__/react-native-modules-test.js
+++ b/packages/eslint-plugin-specs/__tests__/react-native-modules-test.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/packages/eslint-plugin-specs/index.js
+++ b/packages/eslint-plugin-specs/index.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/packages/eslint-plugin-specs/postpack.js
+++ b/packages/eslint-plugin-specs/postpack.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 const fs = require('fs');

--- a/packages/eslint-plugin-specs/prepack.js
+++ b/packages/eslint-plugin-specs/prepack.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 const fs = require('fs');

--- a/packages/eslint-plugin-specs/react-native-modules.js
+++ b/packages/eslint-plugin-specs/react-native-modules.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/packages/eslint-plugin-specs/with-babel-register/disk-cache.js
+++ b/packages/eslint-plugin-specs/with-babel-register/disk-cache.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 const fs = require('fs');

--- a/packages/eslint-plugin-specs/with-babel-register/index.js
+++ b/packages/eslint-plugin-specs/with-babel-register/index.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 const diskCache = require('./disk-cache');

--- a/packages/react-native-babel-preset/src/__tests__/plugin-warn-on-deep-imports-test.js
+++ b/packages/react-native-babel-preset/src/__tests__/plugin-warn-on-deep-imports-test.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/packages/react-native-babel-preset/src/configs/hmr.js
+++ b/packages/react-native-babel-preset/src/configs/hmr.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/packages/react-native-babel-preset/src/configs/lazy-imports.js
+++ b/packages/react-native-babel-preset/src/configs/lazy-imports.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 // This is the set of modules that React Native publicly exports and that we

--- a/packages/react-native-babel-preset/src/configs/main.js
+++ b/packages/react-native-babel-preset/src/configs/main.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/packages/react-native-babel-preset/src/index.js
+++ b/packages/react-native-babel-preset/src/index.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/packages/react-native-babel-preset/src/passthrough-syntax-plugins.js
+++ b/packages/react-native-babel-preset/src/passthrough-syntax-plugins.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/packages/react-native-babel-preset/src/plugin-warn-on-deep-imports.js
+++ b/packages/react-native-babel-preset/src/plugin-warn-on-deep-imports.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/packages/react-native-bots/code-analysis-bot.js
+++ b/packages/react-native-bots/code-analysis-bot.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/packages/react-native-bots/dangerfile.js
+++ b/packages/react-native-bots/dangerfile.js
@@ -5,9 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';
+
 const {danger, fail, warn} = require('danger');
 
 const body = danger.github.pr.body?.toLowerCase() ?? '';

--- a/packages/react-native-codegen-typescript-test/scripts/build.js
+++ b/packages/react-native-codegen-typescript-test/scripts/build.js
@@ -6,6 +6,7 @@
  *
  * @format
  * @lint-ignore-every LICENSELINT
+ * @noflow
  */
 
 const fs = require('fs');

--- a/packages/react-native-codegen/scripts/build.js
+++ b/packages/react-native-codegen/scripts/build.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 /**

--- a/packages/react-native-popup-menu-android/react-native.config.js
+++ b/packages/react-native-popup-menu-android/react-native.config.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 module.exports = {

--- a/packages/react-native-popup-menu-android/scripts/prepublish-popup-menu-android.js
+++ b/packages/react-native-popup-menu-android/scripts/prepublish-popup-menu-android.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 /*

--- a/packages/react-native-test-library/babel.config.js
+++ b/packages/react-native-test-library/babel.config.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 module.exports = {

--- a/packages/react-native-test-library/react-native.config.js
+++ b/packages/react-native-test-library/react-native.config.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 module.exports = {

--- a/packages/rn-tester/metro.config.js
+++ b/packages/rn-tester/metro.config.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/packages/rn-tester/react-native.config.js
+++ b/packages/rn-tester/react-native.config.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/scripts/clean-gha-cache.js
+++ b/scripts/clean-gha-cache.js
@@ -3,11 +3,14 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @noflow
  */
 
 const {execSync} = require('node:child_process');
 
-const CACHE_LIMIT = (10 * 1024 ** 3) * 0.9;
+const CACHE_LIMIT = 10 * 1024 ** 3 * 0.9;
 // Doing this to capture node-modules- and the pre-existing node-cache-<platform>-yarn-<sha> entries
 const NODE_CACHE_KEY = 'node-';
 const NODE_CACHE_KEY_FULL = 'node-modules-';
@@ -15,14 +18,16 @@ const NODE_CACHE_KEY_FULL = 'node-modules-';
 function cleanData(rawStr) {
   const now = new Date();
   const json = JSON.parse(rawStr);
-  return json
-    .map(raw => ({
-      ...raw,
-      createdAt: now - new Date(raw.createdAt),
-      msSinceLastAccessed: now - new Date(raw.lastAccessedAt),
-    }))
-    // Order: oldest last access time first
-    .sort((a, b) => b.msSinceLastAccessed - a.msSinceLastAccessed);
+  return (
+    json
+      .map(raw => ({
+        ...raw,
+        createdAt: now - new Date(raw.createdAt),
+        msSinceLastAccessed: now - new Date(raw.lastAccessedAt),
+      }))
+      // Order: oldest last access time first
+      .sort((a, b) => b.msSinceLastAccessed - a.msSinceLastAccessed)
+  );
 }
 
 const mb = bytes => (bytes / 1024 ** 2).toFixed(2) + 'MB';
@@ -37,7 +42,7 @@ function cacheToString(entry) {
 function cleanCache(cmd) {
   try {
     const msg = execSync(cmd, 'utf8');
-    return (msg.trim().length > 0) ? msg.trim() : '🪓';
+    return msg.trim().length > 0 ? msg.trim() : '🪓';
   } catch (e) {
     // There can be race conditions between github cache cleanups and this script.
     if (/Could not find a cache matching/.test(e.message)) {
@@ -48,10 +53,12 @@ function cleanCache(cmd) {
 }
 
 function main() {
-  const cacheUsage = cleanData(execSync(
-    'gh cache list --sort last_accessed_at --json id,key,createdAt,lastAccessedAt,sizeInBytes --limit 1000',
-    'utf8'
-  ));
+  const cacheUsage = cleanData(
+    execSync(
+      'gh cache list --sort last_accessed_at --json id,key,createdAt,lastAccessedAt,sizeInBytes --limit 1000',
+      'utf8',
+    ),
+  );
 
   let total = 0;
   let remove = [];
@@ -60,25 +67,38 @@ function main() {
   // Be aggressive with node cache entries. Ignore entries < 1MB and only keep most
   // recently created entry.
   const nodeCacheUsage = cacheUsage
-    .filter(({key, sizeInBytes}) =>
-      // I've observed some noisy entries, ignore anything that isn't > 1MB
-      key.startsWith(NODE_CACHE_KEY) && sizeInBytes > 1024 * 1024
+    .filter(
+      ({key, sizeInBytes}) =>
+        // I've observed some noisy entries, ignore anything that isn't > 1MB
+        key.startsWith(NODE_CACHE_KEY) && sizeInBytes > 1024 * 1024,
     )
     .sort((a, b) => b.createdAt - a.createdAt);
   // Find the oldest version of node-modules-*. It's still possible that we have legacy node-yarn-*
   // entries if there are commits on branches of RN < 0.75-stable, so guard for this:
-  const idx = nodeCacheUsage.findLastIndex(({key}) => key.startsWith(NODE_CACHE_KEY_FULL));
-  const keeping = ((idx === -1) ? nodeCacheUsage : nodeCacheUsage.splice(idx, 1)).pop();
+  const idx = nodeCacheUsage.findLastIndex(({key}) =>
+    key.startsWith(NODE_CACHE_KEY_FULL),
+  );
+  const keeping = (
+    idx === -1 ? nodeCacheUsage : nodeCacheUsage.splice(idx, 1)
+  ).pop();
 
-  console.log('TASK: clean up old node_modules cache entries.', keeping ? `\nkeeping ${cacheToString(keeping)}` : ' Skipping, no cache entries.');
+  console.log(
+    'TASK: clean up old node_modules cache entries.',
+    keeping
+      ? `\nkeeping ${cacheToString(keeping)}`
+      : ' Skipping, no cache entries.',
+  );
   for (const entry of nodeCacheUsage) {
-      console.warn(`removing ${cacheToString(entry)}`);
-      cleaned += entry.sizeInBytes;
-      remove.push(entry.id);
+    console.warn(`removing ${cacheToString(entry)}`);
+    cleaned += entry.sizeInBytes;
+    remove.push(entry.id);
   }
 
   // Cleanup everything else
-  console.log('TASK: clean up everything else that takes us over our threshold: ' + mb(CACHE_LIMIT));
+  console.log(
+    'TASK: clean up everything else that takes us over our threshold: ' +
+      mb(CACHE_LIMIT),
+  );
   for (let i = cacheUsage.length - 1; i > 0; i--) {
     const cache = cacheUsage[i];
     total += cache.sizeInBytes;
@@ -89,12 +109,18 @@ function main() {
       cleaned += cache.sizeInBytes;
       remove.push(cache.id);
     } else {
-      console.warn(`skip ${cacheUsage.length - i} ${mb(cache.sizeInBytes)} ${hrs(cache.msSinceLastAccessed)}`);
+      console.warn(
+        `skip ${cacheUsage.length - i} ${mb(cache.sizeInBytes)} ${hrs(cache.msSinceLastAccessed)}`,
+      );
     }
   }
-  console.warn(`Identifed ${remove.length} cache keys for removal, reducing cache from ${mb(total)} -> ${mb(total - cleaned)}`);
+  console.warn(
+    `Identifed ${remove.length} cache keys for removal, reducing cache from ${mb(total)} -> ${mb(total - cleaned)}`,
+  );
 
-  const cleanup = remove.map(id => `gh cache delete ${id} --repo facebook/react-native`);
+  const cleanup = remove.map(
+    id => `gh cache delete ${id} --repo facebook/react-native`,
+  );
   for (const cmd of cleanup) {
     if (dryRun) {
       console.warn(`Skip: ${cmd}`);

--- a/scripts/e2e/utils/retry.js
+++ b/scripts/e2e/utils/retry.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 const {spawnSync} = require('child_process');

--- a/scripts/lint-java.js
+++ b/scripts/lint-java.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/scripts/monorepo/print/index.js
+++ b/scripts/monorepo/print/index.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 const {getVersionsBySpec} = require('../../npm-utils');

--- a/scripts/run-ci-javascript-tests.js
+++ b/scripts/run-ci-javascript-tests.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/tools/eslint/rules/__tests__/no-commonjs-exports-test.js
+++ b/tools/eslint/rules/__tests__/no-commonjs-exports-test.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/tools/eslint/rules/__tests__/no-haste-imports-test.js
+++ b/tools/eslint/rules/__tests__/no-haste-imports-test.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/tools/eslint/rules/__tests__/no-react-default-imports.js
+++ b/tools/eslint/rules/__tests__/no-react-default-imports.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/tools/eslint/rules/__tests__/no-react-named-type-imports.js
+++ b/tools/eslint/rules/__tests__/no-react-named-type-imports.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/tools/eslint/rules/__tests__/no-react-native-imports-test.js
+++ b/tools/eslint/rules/__tests__/no-react-native-imports-test.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/tools/eslint/rules/__tests__/no-react-node-imports-test.js
+++ b/tools/eslint/rules/__tests__/no-react-node-imports-test.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/tools/eslint/rules/__tests__/react-native-manifest-test.js
+++ b/tools/eslint/rules/__tests__/react-native-manifest-test.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/tools/eslint/rules/__tests__/require-extends-error-test.js
+++ b/tools/eslint/rules/__tests__/require-extends-error-test.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/tools/eslint/rules/__tests__/valid-flow-typed-signature-test.js
+++ b/tools/eslint/rules/__tests__/valid-flow-typed-signature-test.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/tools/eslint/rules/no-commonjs-exports.js
+++ b/tools/eslint/rules/no-commonjs-exports.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/tools/eslint/rules/no-haste-imports.js
+++ b/tools/eslint/rules/no-haste-imports.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/tools/eslint/rules/no-react-default-imports.js
+++ b/tools/eslint/rules/no-react-default-imports.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/tools/eslint/rules/no-react-named-type-imports.js
+++ b/tools/eslint/rules/no-react-named-type-imports.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/tools/eslint/rules/no-react-native-imports.js
+++ b/tools/eslint/rules/no-react-native-imports.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/tools/eslint/rules/no-react-node-imports.js
+++ b/tools/eslint/rules/no-react-node-imports.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/tools/eslint/rules/react-native-manifest.js
+++ b/tools/eslint/rules/react-native-manifest.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/tools/eslint/rules/require-extends-error.js
+++ b/tools/eslint/rules/require-extends-error.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';

--- a/tools/eslint/rules/valid-flow-typed-signature.js
+++ b/tools/eslint/rules/valid-flow-typed-signature.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
+ * @noflow
  */
 
 'use strict';


### PR DESCRIPTION
Summary:
Adds `noflow` to a bunch of Node.js script files.

In the future, these files could be migrated to use `flow strict-local` or `flow strict` using comment syntax for type annotations. But for now, adding `noflow` makes it explicit that these are known to not be typechecked.

Changelog:
[Internal]

Differential Revision: D75883703
