### PR TITLE
Improve e2e times by using deep links to open examples

### DIFF
--- a/packages/rn-tester/.maestro/button.yml
+++ b/packages/rn-tester/.maestro/button.yml
@@ -2,13 +2,7 @@ appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebo
 ---
 - launchApp
 - assertVisible: "Components"
-- scrollUntilVisible:
-    element:
-      id: "Button"
-    direction: DOWN
-    speed: 40
-- tapOn:
-    id: "Button"
+- openLink: "rntester://example/ButtonExample"
 - tapOn:
     id: "button_default_styling"
 - assertVisible: "Your application has been submitted!"

--- a/packages/rn-tester/.maestro/flatlist.yml
+++ b/packages/rn-tester/.maestro/flatlist.yml
@@ -2,13 +2,7 @@ appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebo
 ---
 - launchApp
 - assertVisible: "Components"
-- scrollUntilVisible:
-    element:
-      id: "Flatlist"
-    direction: DOWN
-    speed: 40
-- tapOn:
-    id: "Flatlist"
+- openLink: "rntester://example/FlatListExample"
 - tapOn:
     id: "Basic"
 - assertVisible:

--- a/packages/rn-tester/.maestro/helpers/launch-app-and-search.yml
+++ b/packages/rn-tester/.maestro/helpers/launch-app-and-search.yml
@@ -1,5 +1,0 @@
-appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebook.react.uiapp
----
-- launchApp
-- assertVisible: "Components"
-- runFlow: ./search.yml

--- a/packages/rn-tester/.maestro/helpers/search.yml
+++ b/packages/rn-tester/.maestro/helpers/search.yml
@@ -1,6 +1,0 @@
-appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebook.react.uiapp
----
-- assertVisible:
-    id: "explorer_search"
-- tapOn:
-    id: "explorer_search"

--- a/packages/rn-tester/.maestro/image.yml
+++ b/packages/rn-tester/.maestro/image.yml
@@ -2,11 +2,5 @@ appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebo
 ---
 - launchApp
 - assertVisible: "Components"
-- scrollUntilVisible:
-    element:
-      id: "Image"
-    direction: DOWN
-    speed: 40
-- tapOn:
-    id: "Image"
+- openLink: "rntester://example/ImageExample"
 - assertVisible: "Plain Network Image with `source` prop."

--- a/packages/rn-tester/.maestro/legacy-native-module.yml
+++ b/packages/rn-tester/.maestro/legacy-native-module.yml
@@ -1,17 +1,8 @@
 appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebook.react.uiapp
 ---
 - launchApp
-- assertVisible:
-    text: "APIs"
-- tapOn:
-    id: "apis-tab"
-- runFlow: ./helpers/search.yml
-- inputText:
-    text: "Legacy Native"
-- assertVisible:
-    id: "Legacy Native Module"
-- tapOn:
-    id: "Legacy Native Module"
+- assertVisible: "Components"
+- openLink: "rntester://example/LegacyModuleExample"
 - tapOn: 
     text: "voidFunc"
 - assertVisible:

--- a/packages/rn-tester/.maestro/modal.yml
+++ b/packages/rn-tester/.maestro/modal.yml
@@ -2,13 +2,7 @@ appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebo
 ---
 - launchApp
 - assertVisible: "Components"
-- scrollUntilVisible:
-    element:
-      id: "Modal"
-    direction: DOWN
-    speed: 60
-- tapOn:
-    id: "Modal"
+- openLink: "rntester://example/ModalExample"
 - assertVisible:
     text: "Show Modal"
 - tapOn:

--- a/packages/rn-tester/.maestro/new-arch-examples.yml
+++ b/packages/rn-tester/.maestro/new-arch-examples.yml
@@ -1,12 +1,8 @@
 appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebook.react.uiapp
 ---
-- runFlow: ./helpers/launch-app-and-search.yml
-- inputText:
-    text: "New Architecture"
-- assertVisible:
-    id: "New Architecture Examples"
-- tapOn:
-    id: "New Architecture Examples"
+- launchApp
+- assertVisible: "Components"
+- openLink: "rntester://example/NewArchitectureExample"
 - assertVisible: "HSBA: h: 0, s: 0, b: 0, a: 0"
 - assertVisible: "Constants From Interop Layer: 3.14"
 - tapOn: "Change Background"

--- a/packages/rn-tester/.maestro/pressable.yml
+++ b/packages/rn-tester/.maestro/pressable.yml
@@ -1,12 +1,8 @@
 appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebook.react.uiapp
 ---
-- runFlow: ./helpers/launch-app-and-search.yml
-- inputText:
-    text: "Pressable"
-- assertVisible:
-    id: "Pressable"
-- tapOn:
-    id: "Pressable"
+- launchApp
+- assertVisible: "Components"
+- openLink: "rntester://example/PressableExample"
 - assertVisible:
     text: "Change content based on Press"
 - assertVisible:

--- a/packages/rn-tester/.maestro/text.yml
+++ b/packages/rn-tester/.maestro/text.yml
@@ -1,12 +1,8 @@
 appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebook.react.uiapp
 ---
-- runFlow: ./helpers/launch-app-and-search.yml
-- inputText:
-    text: "Text"
-- assertVisible:
-    id: "Text"
-- tapOn:
-    id: "Text"
+- launchApp
+- assertVisible: "Components"
+- openLink: "rntester://example/TextExample"
 - assertVisible:
     id: "example_search"
 - tapOn:


### PR DESCRIPTION
## Summary:

This is similar to #51590, but way better as it improves indirectly the flakiness for tests in the API tab. When the logbox is shown in debug mode, it interferes and sometimes makes that test fail, so this prevents that.

Android also takes more advantage of the improvement with this change, the previous PR only improved significantly iOS.

All the screens inside the RNTester seem to have a deeplink, which makes it easier to open the tests as the test cases are intended to check mostly specific behaviour of RN, and it is not necessary to have a middle step to find the specific components.

Maybe it would be good to run this a few times in CI to see if there are no side effects or flakiness added by opening deep links on CI builds.

## Changelog:

[INTERNAL] - Improve e2e times by using deep links to open examples

## Test Plan:

```sh
yarn e2e-test-android
yarn e2e-test-ios
```

iOS:

| Before | After |
|--------|-------|
| <img width="387" alt="image" src="https://github.com/user-attachments/assets/03ccd957-d401-4944-bb5c-d3e7db957b2e" /> | <img width="364" alt="image" src="https://github.com/user-attachments/assets/40a14c95-63f8-441d-b718-b5f57a506393" /> |

Android:

| Before | After |
|--------|-------|
| <img width="455" alt="image" src="https://github.com/user-attachments/assets/c71da8d0-df69-44af-b1b2-580995ce55c7" /> | <img width="449" alt="image" src="https://github.com/user-attachments/assets/7357e670-3510-4bbe-8543-68d3bd8c4bea" /> |


