### PR TITLE
fix crash on non-critical path, e.g., setTimeout

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
@@ -109,7 +109,7 @@ ReactInstance::ReactInstance(
         runtimeExecutorThatExecutesAfterInspectorSetup,
         [jsErrorHandler = jsErrorHandler_](
             jsi::Runtime& runtime, jsi::JSError& error) {
-          jsErrorHandler->handleError(runtime, error, true);
+          jsErrorHandler->handleError(runtime, error, false);
         });
 
     auto runtimeExecutorThatGoesThroughRuntimeScheduler =
@@ -143,7 +143,7 @@ ReactInstance::ReactInstance(
         runtimeExecutor,
         [jsErrorHandler = jsErrorHandler_](
             jsi::Runtime& runtime, jsi::JSError& error) {
-          jsErrorHandler->handleError(runtime, error, true);
+          jsErrorHandler->handleError(runtime, error, false);
         });
   }
 


### PR DESCRIPTION
## Summary:

Issue: https://github.com/facebook/react-native/issues/51664

Exceptions on non-critical path crash the app. This happened locations such as callback in `setTimeout`, onPress callback of `<Pressable>`, less defensive 3rd-parties libraries (on code level) can also crash the app on these paths.

Exception in `ReactFabric::extractEvents` crashes the app.

The above behaviors does not exist in older versions. In React web, exceptions on those paths are treated same way as async operations and are handled by global handler.

## Changelog:

[IOS] [FIXED] - Fix crash on non-critical path

## Test Plan:

1. Callback in `setTimeout`:
```
setTimeout(() => {
  throw new Error('SWW');
}, 10000);
```

2. Callback in `Pressable`:
```
<Pressable onPress={() => {
  throw new Error('SWW');
}}/>
```

3. Simulated exception in `ReactFabric::extractEvents`
```
let deathCount = 0; // use this variable to pass the bootstrap

var ResponderEventPlugin = {
    _getResponder: function () {
      return responderInst;
    },
    eventTypes: eventTypes,
    extractEvents: function (
      topLevelType,
      targetInst,
      nativeEvent,
      nativeEventTarget
    ) {   
...
      if (deathCount++ === 300) { // use `===` to simulate an one-off exception, e.g., `Unsupported top level event type ...` 
        throw new Error('SWW');
      }
...
```

