### PR TITLE
Nullability check for stderr from CLI

### DIFF
--- a/packages/react-native-fantom/runner/utils.js
+++ b/packages/react-native-fantom/runner/utils.js
@@ -172,7 +172,7 @@ export function runCommandSync(
     signal: result.signal,
     error: result.error,
     stdout: result.stdout.toString(),
-    stderr: result.stderr.toString(),
+    stderr: result.stderr?.toString() ?? '',
   };
 }
 


### PR DESCRIPTION
Summary:
Changelog: [internal]

Fantom tests are generally very reliable, but a source of flakiness seems to be coming from `result.stderr` being `undefined` and throwing in this callsite. We just add a check to work around it, hoping it's just being set to `undefined` because there really are no errors.

Differential Revision: D75942405


