### PR TITLE
[RN][CI] Bump windows to latests as GH will remove windows-2019 EOM

### DIFF
--- a/.github/actions/build-hermesc-windows/action.yml
+++ b/.github/actions/build-hermesc-windows/action.yml
@@ -25,7 +25,7 @@ runs:
     - name: Windows cache
       uses: actions/cache@v4
       with:
-        key: v2-hermes-${{ github.job }}-windows-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}
+        key: v3-hermes-${{ github.job }}-windows-${{ inputs.hermes-version }}-${{ inputs.react-native-version }}
         path: |
           D:\tmp\hermes\win64-bin\
           D:\tmp\hermes\hermes\icu\
@@ -63,7 +63,7 @@ runs:
           $Env:PATH += ";$Env:CMAKE_DIR;$Env:MSBUILD_DIR"
           $Env:ICU_ROOT = "$Env:HERMES_WS_DIR\icu"
 
-          cmake -S hermes -B build_release -G 'Visual Studio 16 2019' -Ax64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=True -DHERMES_ENABLE_WIN10_ICU_FALLBACK=OFF
+          cmake -S hermes -B build_release -G 'Visual Studio 17 2022' -Ax64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=True -DHERMES_ENABLE_WIN10_ICU_FALLBACK=OFF
           if (-not $?) { throw "Failed to configure Hermes" }
           echo "Running windows build..."
           cd build_release

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -120,7 +120,7 @@ jobs:
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
 
   build_hermesc_windows:
-    runs-on: windows-2019
+    runs-on: windows-2025
     needs: prepare_hermes_workspace
     env:
       HERMES_WS_DIR: 'D:\tmp\hermes'

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -116,7 +116,7 @@ jobs:
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
 
   build_hermesc_windows:
-    runs-on: windows-2019
+    runs-on: windows-2025
     needs: prepare_hermes_workspace
     env:
       HERMES_WS_DIR: 'D:\tmp\hermes'

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -382,7 +382,7 @@ jobs:
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
 
   build_hermesc_windows:
-    runs-on: windows-2019
+    runs-on: windows-2025
     needs: prepare_hermes_workspace
     env:
       HERMES_WS_DIR: 'D:\tmp\hermes'


### PR DESCRIPTION
## Summary:
As per title, GH is [removing windows-2019](https://github.com/facebook/react-native/actions/runs/15421451006/job/43403215354) at the end of the month. We need to migrate away from them.

## Changelog:
[Internal] - Bump windows runners

## Test Plan:
GHA
