### PR TITLE
make FabricUIManagerBinding::getScheduler private method

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.h
@@ -21,7 +21,6 @@
 #include <react/renderer/uimanager/LayoutAnimationStatusDelegate.h>
 #include <react/renderer/uimanager/primitives.h>
 
-#include "EventEmitterWrapper.h"
 #include "JFabricUIManager.h"
 #include "SurfaceHandlerBinding.h"
 
@@ -43,6 +42,9 @@ class FabricUIManagerBinding : public jni::HybridClass<FabricUIManagerBinding>,
 
   static void registerNatives();
 
+  // Must be kept public even though it is not used by any other class in React
+  // Native. Used by 3rd party libraries, for example Reanimated:
+  // https://github.com/software-mansion/react-native-reanimated/
   std::shared_ptr<Scheduler> getScheduler();
 
  private:


### PR DESCRIPTION
Summary:
changelog: [internal]

Make it private to make sure ownership of scheduler_ is not shared with any other class.

Differential Revision: D75902518


