### PR TITLE
make per UI tick calculation more predictable

### DIFF
--- a/packages/react-native/Libraries/Animated/__tests__/Animated-itest.js
+++ b/packages/react-native/Libraries/Animated/__tests__/Animated-itest.js
@@ -61,8 +61,7 @@ test('moving box by 100 points', () => {
     }).start();
   });
 
-  // TODO: this fails with any value below 1022, even though anything above 1000 should be enough.
-  Fantom.unstable_advanceAnimationsByTime(1022);
+  Fantom.unstable_advanceAnimationsByTime(1000);
   boundingClientRect = viewElement.getBoundingClientRect();
   expect(boundingClientRect.x).toBe(100);
 

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.cpp
@@ -610,7 +610,7 @@ void NativeAnimatedNodesManager::updateNodes(
   updatedNodeTags_.clear();
 }
 
-bool NativeAnimatedNodesManager::onAnimationFrame(uint64_t timestamp) {
+bool NativeAnimatedNodesManager::onAnimationFrame(double timestamp) {
   // Run all active animations
   auto hasFinishedAnimations = false;
   std::set<int> finishedAnimationValueNodes;
@@ -723,12 +723,12 @@ void NativeAnimatedNodesManager::onRender() {
 
   // Step through the animation loop
   if (isAnimationUpdateNeeded()) {
-    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                  g_now().time_since_epoch())
-                  .count();
+    auto microseconds = std::chrono::duration_cast<std::chrono::microseconds>(
+                            g_now().time_since_epoch())
+                            .count();
 
     auto containsChange =
-        onAnimationFrame(static_cast<uint64_t>(ms * TicksPerMs));
+        onAnimationFrame(static_cast<double>(microseconds) / 1000.0);
 
     if (!containsChange) {
       // The last animation tick didn't result in any changes to the UI.

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.h
@@ -175,7 +175,7 @@ class NativeAnimatedNodesManager {
  private:
   void stopRenderCallbackIfNeeded() noexcept;
 
-  bool onAnimationFrame(uint64_t timestamp);
+  bool onAnimationFrame(double timestamp);
 
   bool isAnimationUpdateNeeded() const noexcept;
 

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/drivers/AnimationDriver.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/drivers/AnimationDriver.cpp
@@ -70,7 +70,7 @@ void AnimationDriver::runAnimationStep(double renderingTime) {
   }
 
   // ticks are 100 nanoseconds, divide by 10000 to get milliseconds.
-  const auto frameTimeMs = renderingTime / TicksPerMs;
+  const auto frameTimeMs = renderingTime;
   auto restarting = false;
   if (startFrameTimeMs_ < 0) {
     startFrameTimeMs_ = frameTimeMs;

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/drivers/AnimationDriver.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/drivers/AnimationDriver.h
@@ -50,7 +50,7 @@ class AnimationDriver {
     return isComplete_;
   }
 
-  virtual void runAnimationStep(double renderingTime);
+  void runAnimationStep(double renderingTime);
 
   virtual void updateConfig(folly::dynamic config);
 

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/drivers/FrameAnimationDriver.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/drivers/FrameAnimationDriver.cpp
@@ -58,7 +58,7 @@ bool FrameAnimationDriver::update(double timeDeltaMs, bool /*restarting*/) {
     }
 
     const auto startIndex =
-        static_cast<size_t>(timeDeltaMs / SingleFrameIntervalMs);
+        static_cast<size_t>(std::ceil(timeDeltaMs / SingleFrameIntervalMs));
     assert(startIndex >= 0);
     const auto nextIndex = startIndex + 1;
 


### PR DESCRIPTION
Summary:
changelog: [internal]

avoid conversions when dealing with time in C++ Animated. This makes tests more predictable.

Reviewed By: christophpurrer

Differential Revision: D75813200


