### PR TITLE
Bring back @flow strict to composeStyles and fix Flow errors

### DIFF
--- a/packages/react-native/src/private/styles/composeStyles.js
+++ b/packages/react-native/src/private/styles/composeStyles.js
@@ -4,26 +4,19 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
+ * @flow strict
  * @format
  */
-
-import type {
-  ImageStyle,
-  TextStyle,
-  ViewStyle,
-} from '../../../Libraries/StyleSheet/StyleSheet';
-import type {StyleProp} from '../../../Libraries/StyleSheet/StyleSheetTypes';
 
 /**
  * Combines two styles such that `style2` will override any styles in `style1`.
  * If either style is null or undefined, the other one is returned without
  * allocating an array, saving allocations and enabling memoization.
  */
-export default function composeStyles<
-  T: ViewStyle | ImageStyle | TextStyle,
-  U: T,
-  V: T,
->(style1: ?StyleProp<U>, style2: ?StyleProp<V>): ?StyleProp<T> {
+export default function composeStyles<T, U: T, V: T>(
+  style1: ?U,
+  style2: ?V,
+): ?(T | $ReadOnlyArray<T>) {
   if (style1 == null) {
     return style2;
   }


### PR DESCRIPTION
Summary:
The `flow strict` annotation was accidently removed in D74574293. This diff brings it back and fixes flow errors caused by this change. This makes generated TS types for `composeStyles` more relaxed but the main idea of inferring inputs base on output type annotation is preserved. 

Changelog:
[Internal]

Reviewed By: huntie

Differential Revision: D75945388


