### PR TITLE
Make ShadowNode::transferRuntimeShadowNodeReference private

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
@@ -221,13 +221,6 @@ class ShadowNode : public Sealable,
       const Shared& destinationShadowNode) const;
 
   /*
-   * Transfer the runtime reference to this `ShadowNode` to a new instance,
-   * updating the reference to point to the new `ShadowNode` referencing it.
-   */
-  void transferRuntimeShadowNodeReference(
-      const Shared& destinationShadowNode) const;
-
-  /*
    * Transfer the runtime reference based on the fragment instructions.
    */
   void transferRuntimeShadowNodeReference(
@@ -273,6 +266,13 @@ class ShadowNode : public Sealable,
    * rendered, its parent will be too.
    */
   void updateTraitsIfNeccessary();
+
+  /*
+   * Transfer the runtime reference to this `ShadowNode` to a new instance,
+   * updating the reference to point to the new `ShadowNode` referencing it.
+   */
+  void transferRuntimeShadowNodeReference(
+      const Shared& destinationShadowNode) const;
 
   /*
    * Pointer to a family object that this shadow node belongs to.


### PR DESCRIPTION
Summary:
changelog: [internal]


this overload of transferRuntimeShadowNodeReference is only used within ShadowNode, let's make it private.

Differential Revision: D75903646


