### PR TITLE
Remove unneeded folly deps

### DIFF
--- a/packages/react-native/ReactCommon/cxxreact/JSBigString.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/JSBigString.cpp
@@ -9,12 +9,12 @@
 
 #include <glog/logging.h>
 
-#include <folly/Memory.h>
 #include <folly/portability/Fcntl.h>
 #include <folly/portability/SysMman.h>
 #include <folly/portability/SysStat.h>
 #include <folly/portability/Unistd.h>
 
+#include <cstring>
 #include <memory>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/cxxreact/JSBigString.h
+++ b/packages/react-native/ReactCommon/cxxreact/JSBigString.h
@@ -7,7 +7,8 @@
 
 #pragma once
 
-#include <folly/Exception.h>
+#include <memory>
+#include <string>
 
 #ifndef RN_EXPORT
 #ifdef _MSC_VER

--- a/packages/react-native/ReactCommon/cxxreact/JSIndexedRAMBundle.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/JSIndexedRAMBundle.cpp
@@ -7,10 +7,11 @@
 
 #include "JSIndexedRAMBundle.h"
 
-#include <glog/logging.h>
 #include <fstream>
-#include <memory>
 #include <sstream>
+
+#include <folly/lang/Bits.h>
+#include <glog/logging.h>
 
 namespace facebook::react {
 

--- a/packages/react-native/ReactCommon/cxxreact/JSIndexedRAMBundle.h
+++ b/packages/react-native/ReactCommon/cxxreact/JSIndexedRAMBundle.h
@@ -7,8 +7,10 @@
 
 #pragma once
 
+#include <functional>
 #include <istream>
 #include <memory>
+#include <string>
 
 #include <cxxreact/JSBigString.h>
 #include <cxxreact/JSModulesUnbundle.h>


### PR DESCRIPTION
Summary:
Remove unneeded deps from the build graph. Especially `//xplat/folly:logging_logging` ends up adding 418KB in development which is unused here.

Changelog: [Internal]

Differential Revision: D71316272


