### PR TITLE
WIP [RN][JS Stable API] Verify built types in Github CI (#50292)

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -50,6 +50,9 @@ runs:
     - name: Lint markdown
       shell: bash
       run: yarn run lint-markdown
-    - name: Validate typegen
+    - name: Build types
       shell: bash
       run: yarn build-types
+    - name: Run typescript check of generated types
+      shell: bash
+      run: yarn test-generated-typescript

--- a/flow-typed/npm/typescript_v5.x.x.js
+++ b/flow-typed/npm/typescript_v5.x.x.js
@@ -48,6 +48,11 @@ declare module 'typescript' {
       file: SourceFile,
       start?: number,
     ): $ReadOnly<{line: number, character: number}>,
+    convertCompilerOptionsFromJson(
+      jsonOptions: any,
+      basePath: string,
+      configFileName?: string,
+    ): {options: Object, errors: Diagnostic[]},
     ModuleResolutionKind: typeof ModuleResolutionKind,
     ...
   };

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test-e2e-local": "node ./scripts/release-testing/test-e2e-local.js",
     "test-ios": "./scripts/objc-test.sh test",
     "test-typescript": "tsc -p packages/react-native/types/tsconfig.json",
+    "test-generated-typescript": "tsc -p packages/react-native/types_generated/tsconfig.test.json",
     "test": "jest",
     "fantom": "JS_DIR='..' yarn jest --config packages/react-native-fantom/config/jest.config.js",
     "trigger-react-native-release": "node ./scripts/releases-local/trigger-react-native-release.js",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "supports-color": "^7.1.0",
     "temp-dir": "^2.0.0",
     "tinybench": "^3.1.0",
-    "typescript": "5.0.4",
+    "typescript": "5.8.3",
     "ws": "^6.2.3"
   },
   "resolutions": {

--- a/scripts/build-types/buildGeneratedTypes.js
+++ b/scripts/build-types/buildGeneratedTypes.js
@@ -54,10 +54,26 @@ async function buildGeneratedTypes(): Promise<void> {
     }
   }
 
-  await fs.copyFile(
-    path.join(__dirname, 'templates/tsconfig.json'),
-    path.join(PACKAGES_DIR, 'react-native', TYPES_OUTPUT_DIR, 'tsconfig.json'),
-  );
+  await Promise.all([
+    fs.copyFile(
+      path.join(__dirname, 'templates/tsconfig.json'),
+      path.join(
+        PACKAGES_DIR,
+        'react-native',
+        TYPES_OUTPUT_DIR,
+        'tsconfig.json',
+      ),
+    ),
+    fs.copyFile(
+      path.join(__dirname, 'templates/tsconfig.test.json'),
+      path.join(
+        PACKAGES_DIR,
+        'react-native',
+        TYPES_OUTPUT_DIR,
+        'tsconfig.test.json',
+      ),
+    ),
+  ]);
 
   if (allErrors.length > 0) {
     process.exitCode = 1;

--- a/scripts/build-types/templates/tsconfig.test.json
+++ b/scripts/build-types/templates/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "lib": ["es2020"],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "types": [],
+    "jsx": "react",
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true,
+    "paths": {"react-native": ["."]},
+    "moduleResolution": "bundler",
+    "customConditions": ["react-native-strict-api"]
+  },
+  "include": ["**/*.d.ts", "../types/__typetests__/**/*"]
+}

--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -432,7 +432,13 @@ function validateTypeScriptDefs(packageName /*: string */) {
     noEmit: true,
     skipLibCheck: false,
   };
-  const program = ts.createProgram(files, compilerOptions);
+  const program = ts.createProgram(
+    files,
+    ts.convertCompilerOptionsFromJson(
+      compilerOptions,
+      path.resolve(PACKAGES_DIR, packageName),
+    ),
+  );
   const emitResult = program.emit();
 
   if (emitResult.diagnostics.length) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8613,11 +8613,6 @@ typed-array-length@^1.0.6:
     is-typed-array "^1.1.13"
     possible-typed-array-names "^1.0.0"
 
-typescript@5.0.4:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
-  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
-
 typescript@5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.2.tgz#00d1c7c1c46928c5845c1ee8d0cc2791031d4c43"
@@ -8627,6 +8622,11 @@ typescript@5.8.2:
   version "5.8.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.2.tgz#8170b3702f74b79db2e5a96207c15e65807999e4"
   integrity sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==
+
+typescript@5.8.3:
+  version "5.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.3.tgz#92f8a3e5e3cf497356f4178c34cd65a7f5e8440e"
+  integrity sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==
 
 uc.micro@^2.0.0, uc.micro@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Summary:

## This diff
Generates types via `yarn build-types` and verifies them on the basis of react-native/types/__typetests.

Changelog: [Internal]

Differential Revision: D71902007


