### PR TITLE
Tweak visibility of fields inside NativeModuleRegistry

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1003,15 +1003,11 @@ public abstract interface class com/facebook/react/bridge/NativeModule {
 public final class com/facebook/react/bridge/NativeModuleRegistry {
 	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;Ljava/util/Map;)V
 	public final fun getAllModules ()Ljava/util/List;
-	public final fun getCxxModules ()Ljava/util/List;
 	public final fun getModule (Ljava/lang/Class;)Lcom/facebook/react/bridge/NativeModule;
 	public final fun getModule (Ljava/lang/String;)Lcom/facebook/react/bridge/NativeModule;
 	public final fun hasModule (Ljava/lang/Class;)Z
 	public final fun hasModule (Ljava/lang/String;)Z
-	public final fun notifyJSInstanceDestroy ()V
-	public final fun notifyJSInstanceInitialized ()V
 	public final fun onBatchComplete ()V
-	public final fun registerModules (Lcom/facebook/react/bridge/NativeModuleRegistry;)V
 }
 
 public final class com/facebook/react/bridge/NoSuchKeyException : java/lang/RuntimeException {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeModuleRegistry.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NativeModuleRegistry.kt
@@ -35,7 +35,10 @@ public class NativeModuleRegistry(
     }
   }
 
-  public val cxxModules: List<ModuleHolder>
+  @get:JvmName(
+      "getCxxModules") // This is needed till there are Java Consumer of this API inside React
+  // Native
+  internal val cxxModules: List<ModuleHolder>
     get() = buildList {
       for ((_, value) in modules) {
         if (value.isCxxModule) {
@@ -45,7 +48,10 @@ public class NativeModuleRegistry(
     }
 
   /** Adds any new modules to the current module registry */
-  public fun registerModules(newRegister: NativeModuleRegistry) {
+  @JvmName(
+      "registerModules") // This is needed till there are Java Consumer of this API inside React
+  // Native
+  internal fun registerModules(newRegister: NativeModuleRegistry) {
     check(reactApplicationContext == newRegister.reactApplicationContext) {
       "Extending native modules with non-matching application contexts."
     }
@@ -59,7 +65,10 @@ public class NativeModuleRegistry(
     }
   }
 
-  public fun notifyJSInstanceDestroy() {
+  @JvmName(
+      "notifyJSInstanceDestroy") // This is needed till there are Java Consumer of this API inside
+  // React Native
+  internal fun notifyJSInstanceDestroy() {
     reactApplicationContext.assertOnNativeModulesQueueThread()
     beginSection(Systrace.TRACE_TAG_REACT, "NativeModuleRegistry_notifyJSInstanceDestroy")
     try {
@@ -71,7 +80,9 @@ public class NativeModuleRegistry(
     }
   }
 
-  public fun notifyJSInstanceInitialized() {
+  @JvmName("notifyJSInstanceInitialized") // This is needed till there are Java Consumer of this API
+  // inside React Native
+  internal fun notifyJSInstanceInitialized() {
     reactApplicationContext.assertOnNativeModulesQueueThread(
         "From version React Native v0.44, " +
             "native modules are explicitly not initialized on the UI thread.")


### PR DESCRIPTION
Summary:
Tweaking the visiblity of some of the fields `NativeModuleRegistry` after the Kotlin migration
of that class.

Changelog:
[Internal] [Changed] -

Differential Revision: D75959962


