### PR TITLE
rename advanceAnimationsByTime to produceFramesForDuration for clarify

### DIFF
--- a/packages/react-native-fantom/src/index.js
+++ b/packages/react-native-fantom/src/index.js
@@ -187,14 +187,24 @@ export function runTask(task: () => void | Promise<void>) {
 }
 
 /**
- * Advances the animation clock by the specified number of milliseconds.
- * This function allows tests to simulate the passage of time for animations
- * without actually waiting, making animation testing more efficient.
+ * Simulates the production of animation frames for a specified duration.
+ * This function is useful for testing animations or time-dependent behaviors
+ * by advancing the animation frame timeline without waiting for real time to pass.
  *
- * @param miliseconds - The number of milliseconds to advance animations by
+ * @param milliseconds - The duration in milliseconds for which to produce animation frames
+ *
+ * @example
+ * ```
+ * // Simulate 500ms of animation frames
+ * Fantom.unstable_produceFramesForDuration(500);
+ *
+ * // Now you can test the state of your UI after those frames have been produced
+ * ```
+ *
+ * Note: This API is marked as unstable and may change in future versions.
  */
-export function unstable_advanceAnimationsByTime(milliseconds: number) {
-  NativeFantom.advanceAnimationsByTime(milliseconds);
+export function unstable_produceFramesForDuration(milliseconds: number) {
+  NativeFantom.produceFramesForDuration(milliseconds);
 }
 
 /**

--- a/packages/react-native/Libraries/Animated/__tests__/Animated-itest.js
+++ b/packages/react-native/Libraries/Animated/__tests__/Animated-itest.js
@@ -61,7 +61,7 @@ test('moving box by 100 points', () => {
     }).start();
   });
 
-  Fantom.unstable_advanceAnimationsByTime(1000);
+  Fantom.unstable_produceFramesForDuration(1000);
   boundingClientRect = viewElement.getBoundingClientRect();
   expect(boundingClientRect.x).toBe(100);
 

--- a/packages/react-native/src/private/testing/fantom/specs/NativeFantom.js
+++ b/packages/react-native/src/private/testing/fantom/specs/NativeFantom.js
@@ -90,7 +90,7 @@ interface Spec extends TurboModule {
   takeMountingManagerLogs: (surfaceId: number) => Array<string>;
   flushMessageQueue: () => void;
   flushEventQueue: () => void;
-  advanceAnimationsByTime: (miliseconds: number) => void;
+  produceFramesForDuration: (miliseconds: number) => void;
   validateEmptyMessageQueue: () => void;
   getRenderedOutput: (surfaceId: number, config: RenderFormatOptions) => string;
   reportTestSuiteResultsJSON: (results: string) => void;


### PR DESCRIPTION
Summary:
changelog: [internal]

after a bit of discussion it was clear the name of this method was confusing. Let's rename it to `produceFramesForDuration` to make it more obvious what happens under the hood.

Reviewed By: rubennorte

Differential Revision: D75953355


