### PR TITLE
Back out "Improve e2e times by using deep links to open examples"

### DIFF
--- a/packages/rn-tester/.maestro/button.yml
+++ b/packages/rn-tester/.maestro/button.yml
@@ -2,7 +2,13 @@ appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebo
 ---
 - launchApp
 - assertVisible: "Components"
-- openLink: "rntester://example/ButtonExample"
+- scrollUntilVisible:
+    element:
+      id: "Button"
+    direction: DOWN
+    speed: 40
+- tapOn:
+    id: "Button"
 - tapOn:
     id: "button_default_styling"
 - assertVisible: "Your application has been submitted!"

--- a/packages/rn-tester/.maestro/flatlist.yml
+++ b/packages/rn-tester/.maestro/flatlist.yml
@@ -2,7 +2,13 @@ appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebo
 ---
 - launchApp
 - assertVisible: "Components"
-- openLink: "rntester://example/FlatListExample"
+- scrollUntilVisible:
+    element:
+      id: "Flatlist"
+    direction: DOWN
+    speed: 40
+- tapOn:
+    id: "Flatlist"
 - tapOn:
     id: "Basic"
 - assertVisible:

--- a/packages/rn-tester/.maestro/helpers/launch-app-and-search.yml
+++ b/packages/rn-tester/.maestro/helpers/launch-app-and-search.yml
@@ -1,0 +1,5 @@
+appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebook.react.uiapp
+---
+- launchApp
+- assertVisible: "Components"
+- runFlow: ./search.yml

--- a/packages/rn-tester/.maestro/helpers/search.yml
+++ b/packages/rn-tester/.maestro/helpers/search.yml
@@ -1,0 +1,6 @@
+appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebook.react.uiapp
+---
+- assertVisible:
+    id: "explorer_search"
+- tapOn:
+    id: "explorer_search"

--- a/packages/rn-tester/.maestro/image.yml
+++ b/packages/rn-tester/.maestro/image.yml
@@ -2,5 +2,11 @@ appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebo
 ---
 - launchApp
 - assertVisible: "Components"
-- openLink: "rntester://example/ImageExample"
+- scrollUntilVisible:
+    element:
+      id: "Image"
+    direction: DOWN
+    speed: 40
+- tapOn:
+    id: "Image"
 - assertVisible: "Plain Network Image with `source` prop."

--- a/packages/rn-tester/.maestro/legacy-native-module.yml
+++ b/packages/rn-tester/.maestro/legacy-native-module.yml
@@ -1,8 +1,17 @@
 appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebook.react.uiapp
 ---
 - launchApp
-- assertVisible: "Components"
-- openLink: "rntester://example/LegacyModuleExample"
+- assertVisible:
+    text: "APIs"
+- tapOn:
+    id: "apis-tab"
+- runFlow: ./helpers/search.yml
+- inputText:
+    text: "Legacy Native"
+- assertVisible:
+    id: "Legacy Native Module"
+- tapOn:
+    id: "Legacy Native Module"
 - tapOn: 
     text: "voidFunc"
 - assertVisible:

--- a/packages/rn-tester/.maestro/modal.yml
+++ b/packages/rn-tester/.maestro/modal.yml
@@ -2,7 +2,13 @@ appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebo
 ---
 - launchApp
 - assertVisible: "Components"
-- openLink: "rntester://example/ModalExample"
+- scrollUntilVisible:
+    element:
+      id: "Modal"
+    direction: DOWN
+    speed: 60
+- tapOn:
+    id: "Modal"
 - assertVisible:
     text: "Show Modal"
 - tapOn:

--- a/packages/rn-tester/.maestro/new-arch-examples.yml
+++ b/packages/rn-tester/.maestro/new-arch-examples.yml
@@ -1,8 +1,12 @@
 appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebook.react.uiapp
 ---
-- launchApp
-- assertVisible: "Components"
-- openLink: "rntester://example/NewArchitectureExample"
+- runFlow: ./helpers/launch-app-and-search.yml
+- inputText:
+    text: "New Architecture"
+- assertVisible:
+    id: "New Architecture Examples"
+- tapOn:
+    id: "New Architecture Examples"
 - assertVisible: "HSBA: h: 0, s: 0, b: 0, a: 0"
 - assertVisible: "Constants From Interop Layer: 3.14"
 - tapOn: "Change Background"

--- a/packages/rn-tester/.maestro/pressable.yml
+++ b/packages/rn-tester/.maestro/pressable.yml
@@ -1,8 +1,12 @@
 appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebook.react.uiapp
 ---
-- launchApp
-- assertVisible: "Components"
-- openLink: "rntester://example/PressableExample"
+- runFlow: ./helpers/launch-app-and-search.yml
+- inputText:
+    text: "Pressable"
+- assertVisible:
+    id: "Pressable"
+- tapOn:
+    id: "Pressable"
 - assertVisible:
     text: "Change content based on Press"
 - assertVisible:

--- a/packages/rn-tester/.maestro/text.yml
+++ b/packages/rn-tester/.maestro/text.yml
@@ -1,8 +1,12 @@
 appId: ${APP_ID} # iOS: com.meta.RNTester.localDevelopment | Android: com.facebook.react.uiapp
 ---
-- launchApp
-- assertVisible: "Components"
-- openLink: "rntester://example/TextExample"
+- runFlow: ./helpers/launch-app-and-search.yml
+- inputText:
+    text: "Text"
+- assertVisible:
+    id: "Text"
+- tapOn:
+    id: "Text"
 - assertVisible:
     id: "example_search"
 - tapOn:


### PR DESCRIPTION
Summary:
Commit [8960d9ea2c](https://github.com/facebook/react-native/commit/8960d9ea2cea22451e8f7c9d6c22ed1ed6de131f) fully broke the iOS tests on RNTester in CI.

All 8 of them consistently fails 5 times out of 5 within the workflow and for each retry.

Reverting the change to get CI back to green

## Changelog:
[Internal] - Reverting [8960d9ea2c](https://github.com/facebook/react-native/commit/8960d9ea2cea22451e8f7c9d6c22ed1ed6de131f)

Differential Revision: D75960750


