### PR TITLE
generate-artifacts-executor: fix parsing .class in complex classes

### DIFF
--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/generateRCTThirdPartyComponents.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/generateRCTThirdPartyComponents.js
@@ -193,7 +193,7 @@ function findRCTComponentViewProtocolClass(filepath /*: string */) {
     const lines = fileContent.split('\n');
     const signatureIndex = lines.findIndex(line => regex.test(line));
     const returnRegex = /return (.*)\.class/;
-    const classNameMatch = String(lines.slice(signatureIndex)).match(
+    const classNameMatch = String(lines.slice(signatureIndex).join('\n')).match(
       returnRegex,
     );
     if (classNameMatch) {


### PR DESCRIPTION
## Summary:

There is an edge case in the codegen `findRCTComponentViewProtocolClass` function where the parsing of the Component Class will fail if there is another `.class` call in the same file after the `Class<RCTComponentViewProtocol>` function. This ends up resulting in a `RCTThirdPartyComponentsProvider.mm` file that looks like the image bellow 

<img width="1052" alt="image" src="https://github.com/user-attachments/assets/26ce93be-0370-4852-a949-9da21762ff7f" />
 

You can reproduce this with the following


```
Class<RCTComponentViewProtocol> XYZCls(void)
{
  return XYZ.class;
}
// this comment breaks codegen .class
```

## Changelog:

[IOS] [FIXED] - Fix codegen extracting `.class` from complex component classes

## Test Plan:

Run codegen locally, use this patch in the expo/expo repo and CI should be green