### PR TITLE
feat: process HMR `registerBundle` calls from same origin only

### DIFF
--- a/packages/react-native/Libraries/Utilities/HMRClient.js
+++ b/packages/react-native/Libraries/Utilities/HMRClient.js
@@ -101,7 +101,10 @@ const HMRClient: HMRClientNativeInterface = {
   },
 
   registerBundle(requestUrl: string) {
-    invariant(hmrClient, 'Expected HMRClient.setup() call at startup.');
+    invariant(
+      hmrOrigin != null && hmrClient != null,
+      'Expected HMRClient.setup() call at startup.',
+    );
     // only process registerBundle calls from the same origin
     if (!requestUrl.startsWith(hmrOrigin)) {
       return;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Part of https://github.com/facebook/metro/issues/1480

This PR adds a check in `HMRClient.js` that prevents processing `registerBundle` calls coming from different origin than the one declared in HMR `setup()`. 

This is useful in a Module Federation setup, where we have multiple HMRClients present in runtime - when Host loads external remote, the requestURL will have different origin, but it will be processed by the HMRClient from the Host which in turn causes a runtime error.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[GENERAL] [ADDED] - Process HMR registerBundle calls from the same origin only

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

TBD
