### PR TITLE
RN: Require `@flow` Annotations

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
+ * @noflow
  * @format
  */
 
@@ -27,6 +28,7 @@ module.exports = {
       files: ['*.js', '*.js.flow', '*.jsx'],
       parser: 'hermes-eslint',
       rules: {
+        'ft-flow/require-valid-file-annotation': [2, 'always'],
         'no-extra-boolean-cast': 0,
         'no-void': 0,
         // These rules are not required with hermes-eslint
@@ -68,6 +70,7 @@ module.exports = {
     {
       files: ['flow-typed/**/*.js', 'packages/react-native/flow/**/*'],
       rules: {
+        'ft-flow/require-valid-file-annotation': 0,
         'lint/valid-flow-typed-signature': 2,
         'no-shadow': 0,
         'no-unused-vars': 0,

--- a/packages/debugger-shell/src/electron/index.js
+++ b/packages/debugger-shell/src/electron/index.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  * @format
  */
 
@@ -12,7 +12,7 @@
 export type * from './index.flow';
 */
 
-if (!process.env.BUILD_EXCLUDE_BABEL_REGISTER) {
+if (!Boolean(process.env.BUILD_EXCLUDE_BABEL_REGISTER)) {
   require('../../../../scripts/babel-register').registerForMonorepo();
 }
 

--- a/packages/debugger-shell/src/electron/preload.js
+++ b/packages/debugger-shell/src/electron/preload.js
@@ -4,9 +4,11 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
+ * @flow strict-local
  * @format
  */
 
+// $FlowFixMe[prop-missing]
 const {contextBridge, ipcRenderer} = require('electron');
 
 contextBridge.executeInMainWorld({
@@ -14,13 +16,15 @@ contextBridge.executeInMainWorld({
     let didDecorateInspectorFrontendHostInstance = false;
     // reactNativeDecorateInspectorFrontendHostInstance was introduced in
     // https://github.com/facebook/react-native-devtools-frontend/pull/168
-    globalThis.reactNativeDecorateInspectorFrontendHostInstance =
-      InspectorFrontendHostInstance => {
-        didDecorateInspectorFrontendHostInstance = true;
-        InspectorFrontendHostInstance.bringToFront = () => {
-          ipcDevTools.bringToFront();
-        };
+    // $FlowIgnore[prop-missing]
+    globalThis.reactNativeDecorateInspectorFrontendHostInstance = (
+      InspectorFrontendHostInstance: $FlowFixMe,
+    ) => {
+      didDecorateInspectorFrontendHostInstance = true;
+      InspectorFrontendHostInstance.bringToFront = () => {
+        ipcDevTools.bringToFront();
       };
+    };
 
     document.addEventListener('DOMContentLoaded', () => {
       if (!didDecorateInspectorFrontendHostInstance) {


### PR DESCRIPTION
Summary:
Configures ESLint to require `flow` (or `noflow`) annotations for JavaScript files in the React Native repository. This ensures that we uphold a high bar for type safety and correctness, or intentionally deviate when it makes sense.

Changelog:
[Internal]

Differential Revision: D75985490


