### PR TITLE
Add test for onScroll events

### DIFF
--- a/packages/react-native/Libraries/Animated/__tests__/Animated-itest.js
+++ b/packages/react-native/Libraries/Animated/__tests__/Animated-itest.js
@@ -15,7 +15,7 @@ import type {HostInstance} from 'react-native';
 import ensureInstance from '../../../src/private/__tests__/utilities/ensureInstance';
 import * as Fantom from '@react-native/fantom';
 import {createRef} from 'react';
-import {Animated, useAnimatedValue} from 'react-native';
+import {Animated, View, useAnimatedValue} from 'react-native';
 import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 
 test('moving box by 100 points', () => {
@@ -81,4 +81,68 @@ test('moving box by 100 points', () => {
   // for synchronisation, even though it doesn't need to.
   Fantom.runWorkLoop();
   expect(viewElement.getBoundingClientRect().x).toBe(100);
+});
+
+test('animation driven by onScroll event', () => {
+  const scrollViewRef = createRef<HostInstance>();
+  const viewRef = createRef<HostInstance>();
+
+  function PressableWithNativeDriver() {
+    const currScroll = useAnimatedValue(0);
+
+    return (
+      <View style={{flex: 1}}>
+        <Animated.View
+          ref={viewRef}
+          style={{
+            position: 'absolute',
+            width: 10,
+            height: 10,
+            transform: [{translateY: currScroll}],
+          }}
+        />
+        <Animated.ScrollView
+          ref={scrollViewRef}
+          onScroll={Animated.event(
+            [
+              {
+                nativeEvent: {
+                  contentOffset: {
+                    y: currScroll,
+                  },
+                },
+              },
+            ],
+            {useNativeDriver: true},
+          )}>
+          <View style={{height: 1000, width: 100}} />
+        </Animated.ScrollView>
+      </View>
+    );
+  }
+
+  const root = Fantom.createRoot();
+  Fantom.runTask(() => {
+    root.render(<PressableWithNativeDriver />);
+  });
+
+  const scrollViewelement = ensureInstance(
+    scrollViewRef.current,
+    ReactNativeElement,
+  );
+  const viewElement = ensureInstance(viewRef.current, ReactNativeElement);
+
+  Fantom.scrollTo(scrollViewelement, {
+    x: 0,
+    y: 100,
+  });
+
+  let transform =
+    // $FlowFixMe[incompatible-use]
+    Fantom.unstable_getDirectManipulationProps(viewElement).transform[0];
+
+  expect(transform.translateY).toBeCloseTo(100, 0.001);
+
+  // TODO(T226364699): this should `toBe(100)` but we are not syncing shadow tree yet.
+  expect(viewElement.getBoundingClientRect().y).toBe(0);
 });

--- a/packages/react-native/src/private/animated/__tests__/AnimatedProps-itest.js
+++ b/packages/react-native/src/private/animated/__tests__/AnimatedProps-itest.js
@@ -54,4 +54,7 @@ test('connects and disconnects views', () => {
 
   expect(mocks.connectAnimatedNodeToView).toBeCalledTimes(1);
   expect(mocks.disconnectAnimatedNodeFromView).toBeCalledTimes(1);
+
+  // TODO: investigate why previous task enqueues more tasks.
+  Fantom.runWorkLoop();
 });


### PR DESCRIPTION
Summary:
changelog: [internal]

To make this possible, we "fake" a UI tick whenever `flushMessageQueue` is called. This was, after every JavaScript task a UI tick happens.
Result:
- Animations are setup right after mounting automatically.
- Animation happens after Fantom.scrollTo is called.

Differential Revision: D75899915


