### PR TITLE
Manually set all fields on scratch TextPaint

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/FontMetricsUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/FontMetricsUtil.kt
@@ -22,12 +22,7 @@ internal object FontMetricsUtil {
   private const val AMPLIFICATION_FACTOR = 100f
 
   @JvmStatic
-  fun getFontMetrics(
-      text: CharSequence,
-      layout: Layout,
-      paint: TextPaint,
-      context: Context
-  ): WritableArray {
+  fun getFontMetrics(text: CharSequence, layout: Layout, context: Context): WritableArray {
     val dm = context.resources.displayMetrics
     val lines = Arguments.createArray()
 
@@ -35,7 +30,7 @@ internal object FontMetricsUtil {
     // their height. In order to get more precision than Android offers, we blow up the text size by
     // 100 and
     // measure it. Luckily, text size affects rendering linearly, so we can do this trick.
-    val paintCopy = TextPaint(paint).apply { textSize *= AMPLIFICATION_FACTOR }
+    val paintCopy = TextPaint(layout.paint).apply { textSize *= AMPLIFICATION_FACTOR }
 
     val capHeightBounds = Rect()
     paintCopy.getTextBounds(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
@@ -112,9 +112,7 @@ public class ReactTextShadowNode extends ReactBaseTextShadowNode {
 
           if (mShouldNotifyOnTextLayout) {
             ThemedReactContext themedReactContext = getThemedContext();
-            WritableArray lines =
-                FontMetricsUtil.getFontMetrics(
-                    text, layout, sTextPaintInstance, themedReactContext);
+            WritableArray lines = FontMetricsUtil.getFontMetrics(text, layout, themedReactContext);
             WritableMap event = Arguments.createMap();
             event.putArray("lines", lines);
             if (themedReactContext.hasActiveReactInstance()) {


### PR DESCRIPTION
Summary:
`TextPaint.reset()` is buggy, and doesn't always reset all the state. D64535719 fixed this for resetting typeface, but a bug showed up, where we seem to sometimes leak `fakeBoldText` as well.

Let's remove the `reset()`, and explicitly set every field, every time.

Changelog:
[Android][Fixed] - Manually set all fields on scratch TextPaint

Differential Revision: D75987605


