### PR TITLE
build (Android): allow for additional sdkmanager paths

### DIFF
--- a/packages/react-native/ReactAndroid/hermes-engine/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/hermes-engine/build.gradle.kts
@@ -39,12 +39,28 @@ fun getSDKManagerPath(): String {
   val ossSdkManagerPath = File("${getSDKPath()}/tools/bin/sdkmanager")
   val windowsMetaSdkManagerPath = File("${getSDKPath()}/cmdline-tools/latest/bin/sdkmanager.bat")
   val windowsOssSdkManagerPath = File("${getSDKPath()}/tools/bin/sdkmanager.bat")
+  val easSdkManagerPath = File("${getSDKPath()}/cmdline-tools/tools/bin/sdkmanager")
   return when {
     metaSdkManagerPath.exists() -> metaSdkManagerPath.absolutePath
     windowsMetaSdkManagerPath.exists() -> windowsMetaSdkManagerPath.absolutePath
     ossSdkManagerPath.exists() -> ossSdkManagerPath.absolutePath
     windowsOssSdkManagerPath.exists() -> windowsOssSdkManagerPath.absolutePath
-    else -> throw GradleException("Could not find sdkmanager executable.")
+    easSdkManagerPath.exists() -> easSdkManagerPath.absolutePath
+    else -> getCustomSDKManagerPath()
+  }
+}
+
+fun getCustomSDKManagerPath(): String {
+  val customSdkManagerEnv = System.getenv("ANDROID_CUSTOM_SDKMANAGER_PATH")
+  return when {
+    customSdkManagerEnv.isNullOrBlank() -> throw GradleException("Could not find sdkmanager executable.")
+    else -> {
+      val customSdkManagerPath = File(customSdkManagerEnv)
+      when {
+        customSdkManagerPath.exists() -> customSdkManagerPath.absolutePath
+        else -> throw GradleException("Could not find sdkmanager executable.")
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary:

When building Android in cloud environments, it turns out that in some of the environments, `sdkmanager` is not in any of the paths checked in `packages/react-native/ReactAndroid/hermes-engine/build.gradle.kts`, so the build fails.

I have added the path for the Linux cloud build environments I have been using (EAS).

I have also added the ability to insert a custom value for the path, in case this problem occurs again in future.

## Changelog:

[Internal][Fixed] - Allow more sdkmanager paths in hermes-engine Android build.

## Test Plan:

Tested the changes in CI builds in EAS.