### PR TITLE
fix: ignore build/ and DerivedData/ dirs in when reading infoPlistFiles

### DIFF
--- a/packages/react-native/scripts/cocoapods/new_architecture.rb
+++ b/packages/react-native/scripts/cocoapods/new_architecture.rb
@@ -161,7 +161,7 @@ class NewArchitectureHelper
             .uniq{ |p| p.path }
             .map{ |p| p.path }
 
-        excluded_info_plist = ["/Pods", "Tests", "metainternal", ".bundle"]
+        excluded_info_plist = ["/Pods", "Tests", "metainternal", ".bundle", "build/", "DerivedData/"]
         projectPaths.each do |projectPath|
             projectFolderPath = File.dirname(projectPath)
             infoPlistFiles = `find #{projectFolderPath} -name "Info.plist"`


### PR DESCRIPTION
## Summary:

https://github.com/facebook/react-native/pull/49927 introduced a regression where a Ruby script would read compilation artifacts and fail, when the user has relative build directories set in XCode.

After successful compilation `build/` dir and `DerivedData/` dir have `.plist` files that aren't in UTF-8 encoding and shouldn't be read by the script. If the user tries to reinstall pods at this point, he gets the following error:

![image](https://github.com/user-attachments/assets/6bd31907-66af-4ea5-b2a6-2847e0ee18e1)

This is how you enable relative build directories in XCode.

![Screenshot 2025-06-05 at 11 08 31](https://github.com/user-attachments/assets/22a555b4-a468-481d-8492-02c3b36bfa25)

## Changelog:

[IOS] [FIXED] - Ignore `build/` and `DerivedData/` directories when reading `.plist` files.

## Test Plan:

After applying this patch the problem doesn't occur anymore on my machine.
