### PR TITLE
fix: exclusion of selectively disabled libraries from codegen generation

### DIFF
--- a/packages/react-native/scripts/codegen/__tests__/generate-artifacts-executor-test.js
+++ b/packages/react-native/scripts/codegen/__tests__/generate-artifacts-executor-test.js
@@ -96,6 +96,7 @@ const packageJson = JSON.stringify({
           jsSrcsDir: '.',
         },
         libraryPath: rootPath,
+        name: 'react-native',
       });
     });
 
@@ -112,6 +113,7 @@ const packageJson = JSON.stringify({
           jsSrcsDir: '.',
         },
         libraryPath: myDependencyPath,
+        name: 'react-native',
       });
       expect(libraries[1]).toEqual({
         config: {
@@ -120,6 +122,7 @@ const packageJson = JSON.stringify({
           jsSrcsDir: 'component/js',
         },
         libraryPath: myDependencyPath,
+        name: 'my-component',
       });
       expect(libraries[2]).toEqual({
         config: {
@@ -128,6 +131,7 @@ const packageJson = JSON.stringify({
           jsSrcsDir: 'module/js',
         },
         libraryPath: myDependencyPath,
+        name: 'my-module',
       });
     });
   });

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/utils.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/utils.js
@@ -236,6 +236,7 @@ function extractLibrariesFromJSON(
     const config = configFile.codegenConfig;
     return [
       {
+        name: configFile.name,
         config,
         libraryPath: dependencyPath,
       },
@@ -290,6 +291,7 @@ function extractLibrariesFromConfigurationArray(
 ) {
   return configFile.codegenConfig.libraries.map(config => {
     return {
+      name: config.name,
       config,
       libraryPath: dependencyPath,
     };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
PR #51078 Implemented finding disabled libraries but the code (below) didn't actually filter any libraries out because destructured name is `undefined`. This pr adds the name to codegenEnabledLibraries so filtering would work.

```js
const libraries = codegenEnabledLibraries.filter(
  ({name}) => !disabledLibraries.includes(name),
);
```

## Changelog:

[IOS] [FIXED] - Skip codegen for selectively disabled libraries in react-native.config.js


## Test Plan:

1. Install a library that has the componentProvider field set in the codegen config (for example: react-native-safe-area-context and react-native-screens or see [reproducer](https://github.com/aattola/rn-codegen-exclude)) 
2. Exclude library with react-native.config.js
3. install pods / run codegen
4. Check that codegen actually excluded the specified dependencies from: `ios/build/generated/ios/RCTThirdPartyComponentsProvider.mm`
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
