### PR TITLE
Back out "Override `updateRuntimeShadowNodeReferencesOnCommit` for OSS"

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android.kt
@@ -18,7 +18,5 @@ public class ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android(
 
   override fun useTurboModules(): Boolean = bridgelessEnabled || turboModulesEnabled
 
-  override fun updateRuntimeShadowNodeReferencesOnCommit(): Boolean = true
-
   override fun useShadowNodeStateOnClone(): Boolean = true
 }

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSStable.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSStable.h
@@ -26,9 +26,6 @@ class ReactNativeFeatureFlagsOverridesOSSStable
   bool useNativeViewConfigsInBridgelessMode() override {
     return true;
   }
-  bool updateRuntimeShadowNodeReferencesOnCommit() override {
-    return true;
-  }
   bool useShadowNodeStateOnClone() override {
     return true;
   }


### PR DESCRIPTION
Summary:
Original commit changeset: 4394a2370d9e

Original Phabricator Diff: D73771648

Differential Revision: D76038710


