### PR TITLE
add fantom tests for pointerevents

### DIFF
--- a/packages/react-native/Libraries/Components/View/__tests__/View-itest.js
+++ b/packages/react-native/Libraries/Components/View/__tests__/View-itest.js
@@ -170,6 +170,68 @@ describe('<View>', () => {
   });
 
   describe('props', () => {
+    describe('pointerEvents', () => {
+      it('auto does not propagate to the mounting layer, it is the default', () => {
+        const root = Fantom.createRoot();
+
+        Fantom.runTask(() => {
+          root.render(<View collapsable={false} pointerEvents="auto" />);
+        });
+
+        expect(
+          root.getRenderedOutput({props: ['pointerEvents']}).toJSX(),
+        ).toEqual(<rn-view />);
+      });
+      it('box-none propagates to the mounting layer, does not unflatten', () => {
+        const root = Fantom.createRoot();
+
+        Fantom.runTask(() => {
+          root.render(<View collapsable={false} pointerEvents="box-none" />);
+        });
+
+        expect(
+          root.getRenderedOutput({props: ['pointerEvents']}).toJSX(),
+        ).toEqual(<rn-view pointerEvents="box-none" />);
+
+        Fantom.runTask(() => {
+          root.render(<View pointerEvents="box-none" />);
+        });
+
+        expect(
+          root.getRenderedOutput({props: ['pointerEvents']}).toJSX(),
+        ).toEqual(null);
+      });
+      it('box-only propagates to the mounting layer, does not unflatten', () => {
+        const root = Fantom.createRoot();
+
+        Fantom.runTask(() => {
+          root.render(<View collapsable={false} pointerEvents="box-only" />);
+        });
+
+        expect(
+          root.getRenderedOutput({props: ['pointerEvents']}).toJSX(),
+        ).toEqual(<rn-view pointerEvents="box-only" />);
+
+        Fantom.runTask(() => {
+          root.render(<View pointerEvents="box-only" />);
+        });
+
+        expect(
+          root.getRenderedOutput({props: ['pointerEvents']}).toJSX(),
+        ).toEqual(null);
+      });
+      it('none propagates to the mounting layer, unflattens', () => {
+        const root = Fantom.createRoot();
+
+        Fantom.runTask(() => {
+          root.render(<View pointerEvents="none" />);
+        });
+
+        expect(
+          root.getRenderedOutput({props: ['pointerEvents']}).toJSX(),
+        ).toEqual(<rn-view pointerEvents="none" />);
+      });
+    });
     describe('accessibility', () => {
       describe('accessibilityActions', () => {
         it('is propagated to the mounting layer', () => {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
@@ -602,6 +602,10 @@ SharedDebugStringConvertibleList BaseViewProps::getDebugProps() const {
               defaultBaseViewProps.backgroundColor),
           debugStringConvertibleItem(
               "zIndex", zIndex, defaultBaseViewProps.zIndex.value_or(0)),
+          debugStringConvertibleItem(
+              "pointerEvents",
+              pointerEvents,
+              defaultBaseViewProps.pointerEvents),
       };
 }
 #endif

--- a/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
@@ -848,6 +848,19 @@ inline void fromRawValue(
   react_native_expect(false);
 }
 
+inline std::string toString(const PointerEventsMode& value) {
+  switch (value) {
+    case PointerEventsMode::Auto:
+      return "auto";
+    case PointerEventsMode::None:
+      return "none";
+    case PointerEventsMode::BoxNone:
+      return "box-none";
+    case PointerEventsMode::BoxOnly:
+      return "box-only";
+  }
+}
+
 inline void fromRawValue(
     const PropsParserContext& context,
     const RawValue& value,


### PR DESCRIPTION
Summary:
changelog: [internal]

add tests for pointerevents props.

Reviewed By: rshest

Differential Revision: D75991670


