### PR TITLE
Enable RSNRU only for React commits

### DIFF
--- a/packages/react-native/Libraries/ReactNative/__tests__/State-ForcedCloneCommitHook-itest.js
+++ b/packages/react-native/Libraries/ReactNative/__tests__/State-ForcedCloneCommitHook-itest.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @fantom_flags useShadowNodeStateOnClone:true
+ * @fantom_flags updateRuntimeShadowNodeReferencesOnCommit:*
  * @flow strict-local
  * @format
  */

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
@@ -318,7 +318,8 @@ CommitStatus ShadowTree::tryCommit(
       std::scoped_lock dispatchLock(EventEmitter::DispatchMutex());
       updateMountedFlag(
           currentRevision_.rootShadowNode->getChildren(),
-          newRootShadowNode->getChildren());
+          newRootShadowNode->getChildren(),
+          commitOptions.source);
     }
 
     telemetry.didCommit();

--- a/packages/react-native/ReactCommon/react/renderer/mounting/updateMountedFlag.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/updateMountedFlag.cpp
@@ -12,7 +12,8 @@
 namespace facebook::react {
 void updateMountedFlag(
     const ShadowNode::ListOfShared& oldChildren,
-    const ShadowNode::ListOfShared& newChildren) {
+    const ShadowNode::ListOfShared& newChildren,
+    ShadowTreeCommitSource commitSource) {
   // This is a simplified version of Diffing algorithm that only updates
   // `mounted` flag on `ShadowNode`s. The algorithm sets "mounted" flag before
   // "unmounted" to allow `ShadowNode` detect a situation where the node was
@@ -49,11 +50,13 @@ void updateMountedFlag(
     newChild->setMounted(true);
     oldChild->setMounted(false);
 
-    if (ReactNativeFeatureFlags::updateRuntimeShadowNodeReferencesOnCommit()) {
+    if (commitSource == ShadowTreeCommitSource::React &&
+        ReactNativeFeatureFlags::updateRuntimeShadowNodeReferencesOnCommit()) {
       newChild->updateRuntimeShadowNodeReference(newChild);
     }
 
-    updateMountedFlag(oldChild->getChildren(), newChild->getChildren());
+    updateMountedFlag(
+        oldChild->getChildren(), newChild->getChildren(), commitSource);
   }
 
   size_t lastIndexAfterFirstStage = index;
@@ -62,14 +65,14 @@ void updateMountedFlag(
   for (index = lastIndexAfterFirstStage; index < newChildren.size(); index++) {
     const auto& newChild = newChildren[index];
     newChild->setMounted(true);
-    updateMountedFlag({}, newChild->getChildren());
+    updateMountedFlag({}, newChild->getChildren(), commitSource);
   }
 
   // State 3: Unmount old children.
   for (index = lastIndexAfterFirstStage; index < oldChildren.size(); index++) {
     const auto& oldChild = oldChildren[index];
     oldChild->setMounted(false);
-    updateMountedFlag(oldChild->getChildren(), {});
+    updateMountedFlag(oldChild->getChildren(), {}, commitSource);
   }
 }
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/mounting/updateMountedFlag.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/updateMountedFlag.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <react/renderer/core/ShadowNode.h>
+#include <react/renderer/mounting/ShadowTree.h>
 
 namespace facebook::react {
 /*
@@ -15,5 +16,6 @@ namespace facebook::react {
  */
 void updateMountedFlag(
     const ShadowNode::ListOfShared& oldChildren,
-    const ShadowNode::ListOfShared& newChildren);
+    const ShadowNode::ListOfShared& newChildren,
+    ShadowTreeCommitSource commitSource);
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
Changelog: [Internal]

To avoid corrupting the React fiber tree when committing from multiple threads this diff only updates shadow node references within the fiber tree for commits originating from React.

This guarantees that during the update of the references no React render will start or is running, making the update of the shadow node reference safe to execute.

S527994

Differential Revision: D76043845


