### PR TITLE
Remove unnecessary receiveCommand overrides

### DIFF
--- a/packages/react-native-codegen/src/generators/components/GeneratePropsJavaDelegate.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsJavaDelegate.js
@@ -74,7 +74,7 @@ const PropSetterTemplate = ({propCases}: {propCases: string}) =>
 const CommandsTemplate = ({commandCases}: {commandCases: string}) =>
   `
   @Override
-  public void receiveCommand(T view, String commandName, @Nullable ReadableArray args) {
+  public void receiveCommand(T view, String commandName, ReadableArray args) {
     switch (commandName) {
       ${commandCases}
     }

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsJavaDelegate-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsJavaDelegate-test.js.snap
@@ -221,7 +221,7 @@ public class CommandNativeComponentManagerDelegate<T extends View, U extends Bas
   }
 
   @Override
-  public void receiveCommand(T view, String commandName, @Nullable ReadableArray args) {
+  public void receiveCommand(T view, String commandName, ReadableArray args) {
     switch (commandName) {
       case \\"flashScrollIndicators\\":
         mViewManager.flashScrollIndicators(view);
@@ -272,7 +272,7 @@ public class CommandNativeComponentManagerDelegate<T extends View, U extends Bas
   }
 
   @Override
-  public void receiveCommand(T view, String commandName, @Nullable ReadableArray args) {
+  public void receiveCommand(T view, String commandName, ReadableArray args) {
     switch (commandName) {
       case \\"handleRootTag\\":
         mViewManager.handleRootTag(view, args.getDouble(0));

--- a/packages/react-native-popup-menu-android/android/src/main/java/com/facebook/react/popupmenu/ReactPopupMenuManager.kt
+++ b/packages/react-native-popup-menu-android/android/src/main/java/com/facebook/react/popupmenu/ReactPopupMenuManager.kt
@@ -39,19 +39,6 @@ public class ReactPopupMenuManager :
     return REACT_CLASS
   }
 
-  override fun receiveCommand(
-      view: ReactPopupMenuContainer,
-      commandId: String,
-      items: ReadableArray?
-  ) {
-    when (commandId) {
-      "show" -> show(view)
-      else -> {
-        // no-op
-      }
-    }
-  }
-
   override fun show(popupMenu: ReactPopupMenuContainer) {
     popupMenu.showPopupMenu()
   }

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -4645,6 +4645,7 @@ public abstract class com/facebook/react/uimanager/ViewManager : com/facebook/re
 
 public abstract interface class com/facebook/react/uimanager/ViewManagerDelegate {
 	public abstract synthetic fun kotlinCompat$receiveCommand (Landroid/view/View;Ljava/lang/String;Lcom/facebook/react/bridge/ReadableArray;)V
+	public synthetic fun kotlinCompat$receiveCommandNullableArgs (Landroid/view/View;Ljava/lang/String;Lcom/facebook/react/bridge/ReadableArray;)V
 	public abstract synthetic fun kotlinCompat$setProperty (Landroid/view/View;Ljava/lang/String;Ljava/lang/Object;)V
 	public fun receiveCommand (Landroid/view/View;Ljava/lang/String;Lcom/facebook/react/bridge/ReadableArray;)V
 	public fun setProperty (Landroid/view/View;Ljava/lang/String;Ljava/lang/Object;)V

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -5446,9 +5446,7 @@ public final class com/facebook/react/views/drawer/ReactDrawerLayoutManager : co
 	public synthetic fun openDrawer (Landroid/view/View;)V
 	public fun openDrawer (Lcom/facebook/react/views/drawer/ReactDrawerLayout;)V
 	public synthetic fun receiveCommand (Landroid/view/View;ILcom/facebook/react/bridge/ReadableArray;)V
-	public synthetic fun receiveCommand (Landroid/view/View;Ljava/lang/String;Lcom/facebook/react/bridge/ReadableArray;)V
 	public fun receiveCommand (Lcom/facebook/react/views/drawer/ReactDrawerLayout;ILcom/facebook/react/bridge/ReadableArray;)V
-	public fun receiveCommand (Lcom/facebook/react/views/drawer/ReactDrawerLayout;Ljava/lang/String;Lcom/facebook/react/bridge/ReadableArray;)V
 	public synthetic fun setDrawerBackgroundColor (Landroid/view/View;Ljava/lang/Integer;)V
 	public fun setDrawerBackgroundColor (Lcom/facebook/react/views/drawer/ReactDrawerLayout;Ljava/lang/Integer;)V
 	public synthetic fun setDrawerLockMode (Landroid/view/View;Ljava/lang/String;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountingManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountingManager.java
@@ -268,14 +268,14 @@ public class MountingManager {
 
   @Deprecated
   public void receiveCommand(
-      int surfaceId, int reactTag, int commandId, @Nullable ReadableArray commandArgs) {
+      int surfaceId, int reactTag, int commandId, ReadableArray commandArgs) {
     UiThreadUtil.assertOnUiThread();
     getSurfaceManagerEnforced(surfaceId, "receiveCommand:int")
         .receiveCommand(reactTag, commandId, commandArgs);
   }
 
   public void receiveCommand(
-      int surfaceId, int reactTag, String commandId, @Nullable ReadableArray commandArgs) {
+      int surfaceId, int reactTag, String commandId, ReadableArray commandArgs) {
     UiThreadUtil.assertOnUiThread();
     getSurfaceManagerEnforced(surfaceId, "receiveCommand:string")
         .receiveCommand(reactTag, commandId, commandArgs);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.java
@@ -698,7 +698,7 @@ public class SurfaceMountingManager {
   }
 
   @Deprecated
-  public void receiveCommand(int reactTag, int commandId, @Nullable ReadableArray commandArgs) {
+  public void receiveCommand(int reactTag, int commandId, ReadableArray commandArgs) {
     if (isStopped()) {
       return;
     }
@@ -726,8 +726,7 @@ public class SurfaceMountingManager {
     viewState.mViewManager.receiveCommand(viewState.mView, commandId, commandArgs);
   }
 
-  public void receiveCommand(
-      int reactTag, @NonNull String commandId, @Nullable ReadableArray commandArgs) {
+  public void receiveCommand(int reactTag, @NonNull String commandId, ReadableArray commandArgs) {
     if (isStopped()) {
       return;
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/DispatchIntCommandMountItem.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/DispatchIntCommandMountItem.kt
@@ -14,7 +14,7 @@ internal class DispatchIntCommandMountItem(
     private val surfaceId: Int,
     private val reactTag: Int,
     private val commandId: Int,
-    private val commandArgs: ReadableArray?
+    private val commandArgs: ReadableArray
 ) : DispatchCommandMountItem() {
 
   override fun getSurfaceId(): Int = surfaceId

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/DispatchStringCommandMountItem.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/DispatchStringCommandMountItem.kt
@@ -14,7 +14,7 @@ internal class DispatchStringCommandMountItem(
     private val surfaceId: Int,
     private val reactTag: Int,
     private val commandId: String,
-    private val commandArgs: ReadableArray?
+    private val commandArgs: ReadableArray
 ) : DispatchCommandMountItem() {
 
   override fun getSurfaceId(): Int = surfaceId

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/MountItemFactory.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/MountItemFactory.kt
@@ -19,7 +19,7 @@ internal object MountItemFactory {
       surfaceId: Int,
       reactTag: Int,
       commandId: Int,
-      commandArgs: ReadableArray?
+      commandArgs: ReadableArray
   ): DispatchCommandMountItem =
       DispatchIntCommandMountItem(surfaceId, reactTag, commandId, commandArgs)
 
@@ -29,7 +29,7 @@ internal object MountItemFactory {
       surfaceId: Int,
       reactTag: Int,
       commandId: String,
-      commandArgs: ReadableArray?
+      commandArgs: ReadableArray
   ): DispatchCommandMountItem =
       DispatchStringCommandMountItem(surfaceId, reactTag, commandId, commandArgs)
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManagerDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManagerDelegate.kt
@@ -149,6 +149,5 @@ public abstract class BaseViewManagerDelegate<
   }
 
   @Suppress("ACCIDENTAL_OVERRIDE")
-  public override fun receiveCommand(view: T, commandName: String, args: ReadableArray?): Unit =
-      Unit
+  public override fun receiveCommand(view: T, commandName: String, args: ReadableArray): Unit = Unit
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
@@ -328,7 +328,7 @@ public abstract class ViewManager<T extends View, C extends ReactShadowNode>
    * @param args optional arguments for the command
    */
   @Deprecated
-  public void receiveCommand(@NonNull T view, int commandId, @Nullable ReadableArray args) {}
+  public void receiveCommand(@NonNull T view, int commandId, ReadableArray args) {}
 
   /**
    * Subclasses may use this method to receive events/commands directly from JS through the {@link
@@ -339,7 +339,7 @@ public abstract class ViewManager<T extends View, C extends ReactShadowNode>
    * @param commandId code of the command
    * @param args optional arguments for the command
    */
-  public void receiveCommand(@NonNull T view, String commandId, @Nullable ReadableArray args) {
+  public void receiveCommand(@NonNull T view, String commandId, ReadableArray args) {
     getOrCreateViewManagerDelegate().receiveCommand(view, commandId, args);
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagerDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagerDelegate.kt
@@ -55,7 +55,17 @@ public interface ViewManagerDelegate<T : View> {
   @Suppress("INAPPLICABLE_JVM_NAME")
   @JvmName("kotlinCompat\$receiveCommand")
   @JvmSynthetic
-  public fun receiveCommand(view: T, commandName: String, args: ReadableArray?)
+  public fun receiveCommand(view: T, commandName: String, args: ReadableArray)
+
+  @Suppress("INAPPLICABLE_JVM_NAME")
+  @Deprecated(
+      message = "args is not nullable, please update your method signature",
+      replaceWith =
+          ReplaceWith("receiveCommand(view: T, commandName: String, args: ReadableArray)"))
+  @JvmName("kotlinCompat\$receiveCommandNullableArgs")
+  @JvmSynthetic
+  public fun receiveCommand(view: T, commandName: String, args: ReadableArray?): Unit =
+      receiveCommand(view, commandName, checkNotNull(args))
 
   @Suppress("INAPPLICABLE_JVM_NAME")
   @Deprecated(
@@ -63,5 +73,5 @@ public interface ViewManagerDelegate<T : View> {
       replaceWith = ReplaceWith("receiveCommand(view, commandName, args)"))
   @JvmName("receiveCommand")
   public fun javaCompat_receiveCommand(view: T, commandName: String?, args: ReadableArray?): Unit =
-      receiveCommand(view, checkNotNull(commandName), args)
+      receiveCommand(view, checkNotNull(commandName), checkNotNull(args))
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagerPropertyUpdater.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagerPropertyUpdater.kt
@@ -186,6 +186,6 @@ public object ViewManagerPropertyUpdater {
     }
 
     @Suppress("ACCIDENTAL_OVERRIDE")
-    override fun receiveCommand(view: T, commandName: String, args: ReadableArray?) = Unit
+    override fun receiveCommand(view: T, commandName: String, args: ReadableArray) = Unit
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/debuggingoverlay/DebuggingOverlayManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/debuggingoverlay/DebuggingOverlayManager.kt
@@ -30,7 +30,7 @@ internal class DebuggingOverlayManager :
 
   override fun getDelegate(): ViewManagerDelegate<DebuggingOverlay> = delegate
 
-  override fun receiveCommand(view: DebuggingOverlay, commandId: String, args: ReadableArray?) =
+  override fun receiveCommand(view: DebuggingOverlay, commandId: String, args: ReadableArray) =
       delegate.receiveCommand(view, commandId, args)
 
   override fun highlightTraceUpdates(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/debuggingoverlay/DebuggingOverlayManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/debuggingoverlay/DebuggingOverlayManager.kt
@@ -30,9 +30,6 @@ internal class DebuggingOverlayManager :
 
   override fun getDelegate(): ViewManagerDelegate<DebuggingOverlay> = delegate
 
-  override fun receiveCommand(view: DebuggingOverlay, commandId: String, args: ReadableArray) =
-      delegate.receiveCommand(view, commandId, args)
-
   override fun highlightTraceUpdates(
       view: DebuggingOverlay,
       providedTraceUpdates: ReadableArray

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/ReactDrawerLayoutManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/ReactDrawerLayoutManager.kt
@@ -173,7 +173,7 @@ public class ReactDrawerLayoutManager :
   public override fun receiveCommand(
       view: ReactDrawerLayout,
       commandId: String,
-      args: ReadableArray?
+      args: ReadableArray
   ): Unit = delegate.receiveCommand(view, commandId, args)
 
   public override fun getExportedViewConstants(): Map<String, Any> =

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/ReactDrawerLayoutManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/ReactDrawerLayoutManager.kt
@@ -170,12 +170,6 @@ public class ReactDrawerLayoutManager :
     }
   }
 
-  public override fun receiveCommand(
-      view: ReactDrawerLayout,
-      commandId: String,
-      args: ReadableArray
-  ): Unit = delegate.receiveCommand(view, commandId, args)
-
   public override fun getExportedViewConstants(): Map<String, Any> =
       mapOf(
           DRAWER_POSITION to

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/SwipeRefreshLayoutManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/SwipeRefreshLayoutManager.kt
@@ -117,12 +117,6 @@ internal open class SwipeRefreshLayoutManager :
     }
   }
 
-  override fun receiveCommand(
-      view: ReactSwipeRefreshLayout,
-      commandId: String,
-      args: ReadableArray
-  ) = delegate.receiveCommand(view, commandId, args)
-
   override fun getExportedViewConstants(): MutableMap<String, Any> =
       mutableMapOf(
           "SIZE" to

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/SwipeRefreshLayoutManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/SwipeRefreshLayoutManager.kt
@@ -120,7 +120,7 @@ internal open class SwipeRefreshLayoutManager :
   override fun receiveCommand(
       view: ReactSwipeRefreshLayout,
       commandId: String,
-      args: ReadableArray?
+      args: ReadableArray
   ) = delegate.receiveCommand(view, commandId, args)
 
   override fun getExportedViewConstants(): MutableMap<String, Any> =

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitchManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitchManager.kt
@@ -95,7 +95,7 @@ internal class ReactSwitchManager :
     setValueInternal(view, value)
   }
 
-  override fun receiveCommand(view: ReactSwitch, commandId: String, args: ReadableArray?) =
+  override fun receiveCommand(view: ReactSwitch, commandId: String, args: ReadableArray) =
       delegate.receiveCommand(view, commandId, args)
 
   override fun addEventEmitters(reactContext: ThemedReactContext, view: ReactSwitch) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitchManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitchManager.kt
@@ -12,7 +12,6 @@ import android.view.View
 import android.widget.CompoundButton
 import androidx.annotation.ColorInt
 import com.facebook.react.bridge.ReactContext
-import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.uimanager.BaseViewManager
 import com.facebook.react.uimanager.PixelUtil
@@ -94,9 +93,6 @@ internal class ReactSwitchManager :
   override fun setNativeValue(view: ReactSwitch, value: Boolean) {
     setValueInternal(view, value)
   }
-
-  override fun receiveCommand(view: ReactSwitch, commandId: String, args: ReadableArray) =
-      delegate.receiveCommand(view, commandId, args)
 
   override fun addEventEmitters(reactContext: ThemedReactContext, view: ReactSwitch) {
     view.setOnCheckedChangeListener(ON_CHECKED_CHANGE_LISTENER)

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/fabric/FabricUIManagerTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/fabric/FabricUIManagerTest.kt
@@ -8,19 +8,19 @@
 package com.facebook.react.fabric
 
 import com.facebook.react.bridge.BridgeReactContext
+import com.facebook.react.bridge.JavaOnlyArray
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsForTests
 import com.facebook.react.uimanager.ViewManagerRegistry
 import com.facebook.react.uimanager.events.BatchEventDispatchedListener
 import com.facebook.testutils.fakes.FakeBatchEventDispatchedListener
 import com.facebook.testutils.shadows.ShadowSoLoader
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.MockedStatic
-import org.mockito.Mockito.mockStatic
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
@@ -37,22 +37,17 @@ class FabricUIManagerTest {
 
   @Before
   fun setup() {
-    featureFlags = mockStatic(ReactNativeFeatureFlags::class.java)
-    featureFlags.`when`<Boolean> { ReactNativeFeatureFlags.enableFabricLogs() }.thenAnswer { false }
+    ReactNativeFeatureFlagsForTests.setUp()
     reactContext = BridgeReactContext(RuntimeEnvironment.getApplication())
     viewManagerRegistry = ViewManagerRegistry(emptyList())
     batchEventDispatchedListener = FakeBatchEventDispatchedListener()
     underTest = FabricUIManager(reactContext, viewManagerRegistry, batchEventDispatchedListener)
   }
 
-  @After
-  fun teardown() {
-    featureFlags.close()
-  }
-
   @Test
   fun createDispatchCommandMountItemForInterop_withValidString_returnsStringEvent() {
-    val command = underTest.createDispatchCommandMountItemForInterop(11, 1, "anEvent", null)
+    val command =
+        underTest.createDispatchCommandMountItemForInterop(11, 1, "anEvent", JavaOnlyArray())
 
     // DispatchStringCommandMountItem is package private so we can `as` check it.
     val className = command::class.java.name.substringAfterLast(".")
@@ -61,7 +56,7 @@ class FabricUIManagerTest {
 
   @Test
   fun createDispatchCommandMountItemForInterop_withValidInt_returnsIntEvent() {
-    val command = underTest.createDispatchCommandMountItemForInterop(11, 1, "42", null)
+    val command = underTest.createDispatchCommandMountItemForInterop(11, 1, "42", JavaOnlyArray())
 
     // DispatchIntCommandMountItem is package private so we can `as` check it.
     val className = command::class.java.name.substringAfterLast(".")

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/component/MyNativeViewManager.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/component/MyNativeViewManager.kt
@@ -37,10 +37,6 @@ internal class MyNativeViewManager :
   override fun createViewInstance(reactContext: ThemedReactContext): MyNativeView =
       MyNativeView(reactContext)
 
-  override fun receiveCommand(view: MyNativeView, commandName: String, args: ReadableArray) {
-    delegate.receiveCommand(view, commandName, args)
-  }
-
   override fun callNativeMethodToChangeBackgroundColor(view: MyNativeView, color: String) {
     view.setBackgroundColor(Color.parseColor(color))
   }

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/component/MyNativeViewManager.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/component/MyNativeViewManager.kt
@@ -37,7 +37,7 @@ internal class MyNativeViewManager :
   override fun createViewInstance(reactContext: ThemedReactContext): MyNativeView =
       MyNativeView(reactContext)
 
-  override fun receiveCommand(view: MyNativeView, commandName: String, args: ReadableArray?) {
+  override fun receiveCommand(view: MyNativeView, commandName: String, args: ReadableArray) {
     delegate.receiveCommand(view, commandName, args)
   }
 


### PR DESCRIPTION
Summary: These just redefine the existing `receiveCommand` from the ViewManagerDelegate which already has this codegen'ed

Reviewed By: cortinico, rshest

Differential Revision: D75869325


