### PR TITLE
RN: Improve `lint-ci` Script

### DIFF
--- a/.github/workflow-scripts/analyze_code.sh
+++ b/.github/workflow-scripts/analyze_code.sh
@@ -4,12 +4,19 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-GITHUB_OWNER=-facebook
-GITHUB_REPO=-react-native
-export GITHUB_OWNER
-export GITHUB_REPO
+export GITHUB_OWNER=-facebook
+export GITHUB_REPO=-react-native
 
-cat <(echo eslint; npm run lint --silent -- --format=json; echo flow; npm run flow-check --silent --json; echo google-java-format; node scripts/lint-java.js --diff) | node packages/react-native-bots/code-analysis-bot.js
+{
+  echo eslint
+  npm run lint --silent -- --format=json
+
+  echo flow
+  npm run flow-check --silent --json
+
+  echo google-java-format
+  node scripts/lint-java.js --diff
+} | node packages/react-native-bots/code-analysis-bot.js
 
 STATUS=$?
 if [ $STATUS == 0 ]; then
@@ -17,3 +24,4 @@ if [ $STATUS == 0 ]; then
 else
   echo "Code analysis failed, error status $STATUS."
 fi
+exit $STATUS


### PR DESCRIPTION
Summary:
While testing D75988059 with D76047973, I noticed a few opportunities to improve the script used by `yarn lint-ci`:

- The exit code does not currently propagate, meaning `lint-ci` will succeed when it shouldn't.
- The shell script uses some non-idiomatic practices, so this improves it.

Changelog:
[Internal]

Reviewed By: kassens

Differential Revision: D76049502


