### PR TITLE
Bump AGP to 8.10.x

### DIFF
--- a/packages/gradle-plugin/gradle/libs.versions.toml
+++ b/packages/gradle-plugin/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.9.2"
+agp = "8.10.1"
 gson = "2.8.9"
 guava = "31.0.1-jre"
 javapoet = "1.13.0"

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/AgpConfiguratorUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/AgpConfiguratorUtils.kt
@@ -7,7 +7,8 @@
 
 package com.facebook.react.utils
 
-import com.android.build.api.variant.AndroidComponentsExtension
+import com.android.build.api.variant.ApplicationAndroidComponentsExtension
+import com.android.build.api.variant.LibraryAndroidComponentsExtension
 import com.android.build.gradle.LibraryExtension
 import com.facebook.react.ReactExtension
 import com.facebook.react.utils.ProjectUtils.isHermesEnabled
@@ -28,15 +29,17 @@ internal object AgpConfiguratorUtils {
   fun configureBuildConfigFieldsForApp(project: Project, extension: ReactExtension) {
     val action =
         Action<AppliedPlugin> {
-          project.extensions.getByType(AndroidComponentsExtension::class.java).finalizeDsl { ext ->
-            ext.buildFeatures.buildConfig = true
-            ext.defaultConfig.buildConfigField(
-                "boolean",
-                "IS_NEW_ARCHITECTURE_ENABLED",
-                project.isNewArchEnabled(extension).toString())
-            ext.defaultConfig.buildConfigField(
-                "boolean", "IS_HERMES_ENABLED", project.isHermesEnabled.toString())
-          }
+          project.extensions
+              .getByType(ApplicationAndroidComponentsExtension::class.java)
+              .finalizeDsl { ext ->
+                ext.buildFeatures.buildConfig = true
+                ext.defaultConfig.buildConfigField(
+                    "boolean",
+                    "IS_NEW_ARCHITECTURE_ENABLED",
+                    project.isNewArchEnabled(extension).toString())
+                ext.defaultConfig.buildConfigField(
+                    "boolean", "IS_HERMES_ENABLED", project.isHermesEnabled.toString())
+              }
         }
     project.pluginManager.withPlugin("com.android.application", action)
     project.pluginManager.withPlugin("com.android.library", action)
@@ -45,9 +48,9 @@ internal object AgpConfiguratorUtils {
   fun configureBuildConfigFieldsForLibraries(appProject: Project) {
     appProject.rootProject.allprojects { subproject ->
       subproject.pluginManager.withPlugin("com.android.library") {
-        subproject.extensions.getByType(AndroidComponentsExtension::class.java).finalizeDsl { ext ->
-          ext.buildFeatures.buildConfig = true
-        }
+        subproject.extensions
+            .getByType(LibraryAndroidComponentsExtension::class.java)
+            .finalizeDsl { ext -> ext.buildFeatures.buildConfig = true }
       }
     }
   }
@@ -58,10 +61,13 @@ internal object AgpConfiguratorUtils {
 
     val action =
         Action<AppliedPlugin> {
-          project.extensions.getByType(AndroidComponentsExtension::class.java).finalizeDsl { ext ->
-            ext.defaultConfig.resValue("string", "react_native_dev_server_ip", getHostIpAddress())
-            ext.defaultConfig.resValue("integer", "react_native_dev_server_port", devServerPort)
-          }
+          project.extensions
+              .getByType(ApplicationAndroidComponentsExtension::class.java)
+              .finalizeDsl { ext ->
+                ext.defaultConfig.resValue(
+                    "string", "react_native_dev_server_ip", getHostIpAddress())
+                ext.defaultConfig.resValue("integer", "react_native_dev_server_port", devServerPort)
+              }
         }
 
     project.pluginManager.withPlugin("com.android.application", action)
@@ -71,20 +77,22 @@ internal object AgpConfiguratorUtils {
   fun configureNamespaceForLibraries(appProject: Project) {
     appProject.rootProject.allprojects { subproject ->
       subproject.pluginManager.withPlugin("com.android.library") {
-        subproject.extensions.getByType(AndroidComponentsExtension::class.java).finalizeDsl { ext ->
-          if (ext.namespace == null) {
-            val android = subproject.extensions.getByType(LibraryExtension::class.java)
-            val manifestFile = android.sourceSets.getByName("main").manifest.srcFile
+        subproject.extensions
+            .getByType(LibraryAndroidComponentsExtension::class.java)
+            .finalizeDsl { ext ->
+              if (ext.namespace == null) {
+                val android = subproject.extensions.getByType(LibraryExtension::class.java)
+                val manifestFile = android.sourceSets.getByName("main").manifest.srcFile
 
-            manifestFile
-                .takeIf { it.exists() }
-                ?.let { file ->
-                  getPackageNameFromManifest(file)?.let { packageName ->
-                    ext.namespace = packageName
-                  }
-                }
-          }
-        }
+                manifestFile
+                    .takeIf { it.exists() }
+                    ?.let { file ->
+                      getPackageNameFromManifest(file)?.let { packageName ->
+                        ext.namespace = packageName
+                      }
+                    }
+              }
+            }
       }
     }
   }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/JdkConfiguratorUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/JdkConfiguratorUtils.kt
@@ -7,7 +7,8 @@
 
 package com.facebook.react.utils
 
-import com.android.build.api.variant.AndroidComponentsExtension
+import com.android.build.api.variant.ApplicationAndroidComponentsExtension
+import com.android.build.api.variant.LibraryAndroidComponentsExtension
 import com.facebook.react.utils.PropertyUtils.INTERNAL_DISABLE_JAVA_VERSION_ALIGNMENT
 import org.gradle.api.Action
 import org.gradle.api.JavaVersion
@@ -31,16 +32,27 @@ internal object JdkConfiguratorUtils {
       if (project.hasProperty(INTERNAL_DISABLE_JAVA_VERSION_ALIGNMENT)) {
         return@allprojects
       }
-      val action =
+
+      val applicationAction =
           Action<AppliedPlugin> {
-            project.extensions.getByType(AndroidComponentsExtension::class.java).finalizeDsl { ext
-              ->
-              ext.compileOptions.sourceCompatibility = JavaVersion.VERSION_17
-              ext.compileOptions.targetCompatibility = JavaVersion.VERSION_17
-            }
+            project.extensions
+                .getByType(ApplicationAndroidComponentsExtension::class.java)
+                .finalizeDsl { ext ->
+                  ext.compileOptions.sourceCompatibility = JavaVersion.VERSION_17
+                  ext.compileOptions.targetCompatibility = JavaVersion.VERSION_17
+                }
           }
-      project.pluginManager.withPlugin("com.android.application", action)
-      project.pluginManager.withPlugin("com.android.library", action)
+      val libraryAction =
+          Action<AppliedPlugin> {
+            project.extensions
+                .getByType(LibraryAndroidComponentsExtension::class.java)
+                .finalizeDsl { ext ->
+                  ext.compileOptions.sourceCompatibility = JavaVersion.VERSION_17
+                  ext.compileOptions.targetCompatibility = JavaVersion.VERSION_17
+                }
+          }
+      project.pluginManager.withPlugin("com.android.application", applicationAction)
+      project.pluginManager.withPlugin("com.android.library", libraryAction)
       project.pluginManager.withPlugin("org.jetbrains.kotlin.android") {
         project.kotlinExtension.jvmToolchain(17)
       }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/NdkConfiguratorUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/NdkConfiguratorUtils.kt
@@ -7,7 +7,7 @@
 
 package com.facebook.react.utils
 
-import com.android.build.api.variant.AndroidComponentsExtension
+import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.android.build.api.variant.Variant
 import com.facebook.react.ReactExtension
 import com.facebook.react.utils.ProjectUtils.getReactNativeArchitectures
@@ -19,7 +19,8 @@ internal object NdkConfiguratorUtils {
   @Suppress("UnstableApiUsage")
   fun configureReactNativeNdk(project: Project, extension: ReactExtension) {
     project.pluginManager.withPlugin("com.android.application") {
-      project.extensions.getByType(AndroidComponentsExtension::class.java).finalizeDsl { ext ->
+      project.extensions.getByType(ApplicationAndroidComponentsExtension::class.java).finalizeDsl {
+          ext ->
         if (!project.isNewArchEnabled(extension)) {
           // For Old Arch, we don't need to setup the NDK
           return@finalizeDsl

--- a/packages/react-native/gradle/libs.versions.toml
+++ b/packages/react-native/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ compileSdk = "35"
 buildTools = "35.0.0"
 ndkVersion = "27.1.12297006"
 # Dependencies versions
-agp = "8.9.2"
+agp = "8.10.1"
 androidx-annotation = "1.6.0"
 androidx-appcompat = "1.7.0"
 androidx-autofill = "1.1.0"


### PR DESCRIPTION
Summary:
AGP 8.10.x comes with a source breaking change:
https://issuetracker.google.com/issues/416890061

This shoudl fix it and unblock us for the 0.81 release.

Changelog:
[Android] [Changed] - Bump AGP to 8.10.x

Differential Revision: D76053989


