### PR TITLE
RN: Patch `enableEagerAlternateStateNodeCleanup` into Renderers (OSS)

### DIFF
--- a/packages/react-native/Libraries/Renderer/implementations/ReactFabric-dev.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactFabric-dev.js
@@ -7,7 +7,7 @@
  * @noflow
  * @nolint
  * @preventMunge
- * @generated SignedSource<<d944291b21bfca6afd58b1fd5a118042>>
+ * @generated SignedSource<<6b3694149dd8856f0c741d3d94e05646>>
  *
  * This file was sync'd from the facebook/react repository.
  */
@@ -10561,6 +10561,8 @@ __DEV__ &&
             (offscreenSubtreeWasHidden ||
               null === current ||
               safelyDetachRef(current, current.return));
+          null !== finishedWork.alternate &&
+            (finishedWork.alternate.stateNode = finishedWork.stateNode);
           break;
         case 6:
           recursivelyTraverseMutationEffects(root, finishedWork);

--- a/packages/react-native/Libraries/Renderer/implementations/ReactFabric-prod.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactFabric-prod.js
@@ -7,7 +7,7 @@
  * @noflow
  * @nolint
  * @preventMunge
- * @generated SignedSource<<8c6274bec0d166bb311325a3c6c468b5>>
+ * @generated SignedSource<<7430b56dac3186eca669ae53bbf1f23d>>
  *
  * This file was sync'd from the facebook/react repository.
  */
@@ -8075,6 +8075,8 @@ function commitMutationEffectsOnFiber(finishedWork, root) {
         (offscreenSubtreeWasHidden ||
           null === current ||
           safelyDetachRef(current, current.return));
+      null !== finishedWork.alternate &&
+        (finishedWork.alternate.stateNode = finishedWork.stateNode);
       break;
     case 6:
       recursivelyTraverseMutationEffects(root, finishedWork);

--- a/packages/react-native/Libraries/Renderer/implementations/ReactFabric-profiling.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactFabric-profiling.js
@@ -7,7 +7,7 @@
  * @noflow
  * @nolint
  * @preventMunge
- * @generated SignedSource<<49b14f3fcc953f4ddb02c1ef3f6e8c4e>>
+ * @generated SignedSource<<cf19390911979c415bb5e95c5270fba6>>
  *
  * This file was sync'd from the facebook/react repository.
  */
@@ -8530,6 +8530,8 @@ function commitMutationEffectsOnFiber(finishedWork, root) {
         (offscreenSubtreeWasHidden ||
           null === current ||
           safelyDetachRef(current, current.return));
+      null !== finishedWork.alternate &&
+        (finishedWork.alternate.stateNode = finishedWork.stateNode);
       break;
     case 6:
       recursivelyTraverseMutationEffects(root, finishedWork);


### PR DESCRIPTION
Summary:
Enables the `enableEagerAlternateStateNodeCleanup` feature flag in the open source React Native renderers that are currently targeting React 19.1, by manually patching them in the React Native repository.

This feature flag has been found to significantly improve memory management of parent alternate fibers in persistent modes (i.e. Fabric), and we want this to be available to open source users of React Native before the next scheduled public version release of React.

For more details about the fix, see: https://github.com/facebook/react/pull/33161

Changelog:
[General][Changed] - Reduces memory usage by improving memory management of parent alternate fibers.

Differential Revision: D76073900


