### PR TITLE
RN: Fix Lint for `FocusEventsExample.android.js`

### DIFF
--- a/packages/rn-tester/js/examples/FocusEventsExample/FocusEventsExample.android.js
+++ b/packages/rn-tester/js/examples/FocusEventsExample/FocusEventsExample.android.js
@@ -4,11 +4,9 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  * @format
  */
-
-'use strict';
 
 import RNTesterText from '../../components/RNTesterText';
 import {useState} from 'react';
@@ -63,7 +61,6 @@ const ViewExample = () => {
 };
 
 const PressableExample = () => {
-  const [highlightFocused, setHighlightFocused] = useState(false);
   const [pressableFocused, setPressableFocused] = useState(false);
   const [disabledPressableFocused, setDisabledPressableFocused] =
     useState(false);


### PR DESCRIPTION
Summary:
Fixes lint warnings for `FocusEventsExample.android.js`.

Changelog:
[Internal]

Differential Revision: D76074712


