### PR TITLE
Extract out core components from auto-generated registry

### DIFF
--- a/packages/react-native-codegen/src/cli/combine/combine-schemas-cli.js
+++ b/packages/react-native-codegen/src/cli/combine/combine-schemas-cli.js
@@ -35,6 +35,9 @@ const argv = yargs
   .option('e', {
     alias: 'exclude',
   })
+  .option('f', {
+    alias: 'filter',
+  })
   .parseSync();
 
 const platform: string = argv.platform.toLowerCase();
@@ -42,6 +45,7 @@ const output: string = argv.output;
 const schemaQuery: string = argv.s;
 
 const exclude: string = argv.e;
+const filter: ?Array<string> = argv.filter;
 
 if (!['ios', 'android'].includes(platform)) {
   throw new Error(`Invalid platform ${platform}`);
@@ -91,6 +95,9 @@ for (const file of schemaFiles) {
       }
 
       if (!(exclude && exclude === specName)) {
+        if (module.type === 'Component' && filter?.includes(specName)) {
+          continue;
+        }
         modules[specName] = module;
         specNameToFile[specName] = file;
       }

--- a/packages/react-native-codegen/src/cli/combine/combine-schemas-cli.js
+++ b/packages/react-native-codegen/src/cli/combine/combine-schemas-cli.js
@@ -32,11 +32,16 @@ const argv = yargs
   .option('s', {
     alias: 'schema-query',
   })
+  .option('e', {
+    alias: 'exclude',
+  })
   .parseSync();
 
 const platform: string = argv.platform.toLowerCase();
 const output: string = argv.output;
 const schemaQuery: string = argv.s;
+
+const exclude: string = argv.e;
 
 if (!['ios', 'android'].includes(platform)) {
   throw new Error(`Invalid platform ${platform}`);
@@ -85,10 +90,11 @@ for (const file of schemaFiles) {
         }
       }
 
-      modules[specName] = module;
-      specNameToFile[specName] = file;
+      if (!(exclude && exclude === specName)) {
+        modules[specName] = module;
+        specNameToFile[specName] = file;
+      }
     }
   }
 }
-
 fs.writeFileSync(output, JSON.stringify({modules}));


### PR DESCRIPTION
Summary:
In order to avoid duplicates, extracting out the  core components from the auto-generated registry of FAC i.e. ComponentDescriptors.cpp

All of the existing FAC apps already get it via DefaultComponentsRegistry -> CoreComponentsRegistry

**Changelog**:
[Android] [Fixed] - Extract out core components from auto-generated registry for FAC

Differential Revision: D76078460


