### PR TITLE
Stop building JSC inside RN-Tester

### DIFF
--- a/packages/rn-tester/android/app/build.gradle.kts
+++ b/packages/rn-tester/android/app/build.gradle.kts
@@ -37,7 +37,7 @@ react {
   //   The list of variants to that are debuggable. For those we're going to
   //   skip the bundling of the JS bundle and the assets. By default is just 'debug'.
   //   If you add flavors like lite, prod, etc. you'll have to list your debuggableVariants.
-  debuggableVariants = listOf("hermesDebug", "jscDebug")
+  // debuggableVariants = listOf("debug")
 
   /* Bundling */
   //   A list containing the node command and its flags. Default is just 'node'.
@@ -62,19 +62,12 @@ react {
   /* Hermes Commands */
   //   The hermes compiler command to run. By default it is 'hermesc'
   hermesCommand = "$reactNativeDirPath/ReactAndroid/hermes-engine/build/hermes/bin/hermesc"
-  enableHermesOnlyInVariants = listOf("hermesDebug", "hermesRelease")
 
   autolinkLibrariesWithApp()
 }
 
 /** Run Proguard to shrink the Java bytecode in release builds. */
 val enableProguardInReleaseBuilds = true
-
-/**
- * The preferred build flavor of JavaScriptCore (JSC) For example, to use the international variant,
- * you can use: `def jscFlavor = "io.github.react-native-community:jsc-android-intl:2026004.+"`
- */
-val jscFlavor = "io.github.react-native-community:jsc-android:2026004.+"
 
 /** This allows to customized the CMake version used for compiling RN Tester. */
 val cmakeVersion =
@@ -99,18 +92,6 @@ android {
   }
   if (rootProject.hasProperty("ndkVersion") && rootProject.properties["ndkVersion"] != null) {
     ndkVersion = rootProject.properties["ndkVersion"].toString()
-  }
-
-  flavorDimensions.add("vm")
-  productFlavors {
-    create("hermes") {
-      dimension = "vm"
-      buildConfigField("boolean", "IS_HERMES_ENABLED_IN_FLAVOR", "true")
-    }
-    create("jsc") {
-      dimension = "vm"
-      buildConfigField("boolean", "IS_HERMES_ENABLED_IN_FLAVOR", "false")
-    }
   }
 
   defaultConfig {
@@ -160,9 +141,8 @@ dependencies {
   // Build React Native from source
   implementation(project(":packages:react-native:ReactAndroid"))
 
-  // Consume Hermes as built from source only for the Hermes variant.
-  "hermesImplementation"(project(":packages:react-native:ReactAndroid:hermes-engine"))
-  "jscImplementation"(jscFlavor)
+  // Consume Hermes as built from source.
+  implementation(project(":packages:react-native:ReactAndroid:hermes-engine"))
 
   testImplementation(libs.junit)
   implementation(libs.androidx.profileinstaller)
@@ -200,18 +180,8 @@ afterEvaluate {
     // As we're consuming Hermes from source, we want to make sure
     // `hermesc` is built before we actually invoke the `emit*HermesResource` task
     tasks
-        .getByName("createBundleHermesReleaseJsAndAssets")
+        .getByName("createBundleReleaseJsAndAssets")
         .dependsOn(":packages:react-native:ReactAndroid:hermes-engine:buildHermesC")
-  }
-
-  // As we're building 4 native flavors in parallel, there is clash on the `.cxx/Debug` and
-  // `.cxx/Release` folder where the CMake intermediates are stored.
-  // We fixing this by instructing Gradle to always mergeLibs after they've been built.
-  if (isNewArchEnabled) {
-    tasks.getByName("mergeHermesDebugNativeLibs").mustRunAfter("externalNativeBuildJscDebug")
-    tasks.getByName("mergeHermesReleaseNativeLibs").mustRunAfter("externalNativeBuildJscRelease")
-    tasks.getByName("mergeJscDebugNativeLibs").mustRunAfter("externalNativeBuildHermesDebug")
-    tasks.getByName("mergeJscReleaseNativeLibs").mustRunAfter("externalNativeBuildHermesRelease")
   }
 
   // As RN-Tester consumes the codegen from source, we need to make sure the codegen exists before
@@ -220,9 +190,6 @@ afterEvaluate {
       .getByName("generateCodegenSchemaFromJavaScript")
       .dependsOn(":packages:react-native:ReactAndroid:buildCodegenCLI")
   tasks
-      .getByName("createBundleJscReleaseJsAndAssets")
-      .dependsOn(":packages:react-native:ReactAndroid:buildCodegenCLI")
-  tasks
-      .getByName("createBundleHermesReleaseJsAndAssets")
+      .getByName("createBundleReleaseJsAndAssets")
       .dependsOn(":packages:react-native:ReactAndroid:buildCodegenCLI")
 }

--- a/packages/rn-tester/android/app/gradle.properties
+++ b/packages/rn-tester/android/app/gradle.properties
@@ -5,5 +5,5 @@ android.useAndroidX=true
 
 # RN-Tester is building with NewArch always enabled
 newArchEnabled=true
-# RN-Tester is running with Hermes enabled and filtering variants with enableHermesOnlyInVariants
+# RN-Tester is running with Hermes always enabled
 hermesEnabled=true

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.kt
@@ -114,7 +114,7 @@ internal class RNTesterApplication : Application(), ReactApplication {
       }
 
       override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
-      override val isHermesEnabled: Boolean = BuildConfig.IS_HERMES_ENABLED_IN_FLAVOR
+      override val isHermesEnabled: Boolean = true
     }
   }
 

--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -14,13 +14,13 @@
   },
   "scripts": {
     "start": "react-native start",
-    "android": "react-native run-android --mode HermesDebug",
-    "install-android-jsc": "../../gradlew :packages:rn-tester:android:app:installJscDebug",
-    "install-android-hermes": "../../gradlew :packages:rn-tester:android:app:installHermesDebug",
+    "android": "react-native run-android",
+    "install-android-jsc": "../../gradlew :packages:rn-tester:android:app:installDebug",
+    "install-android-hermes": "../../gradlew :packages:rn-tester:android:app:installDebug",
     "clean-android": "rm -rf android/app/build",
     "prepare-ios": "node ./cli.js bootstrap ios",
     "clean-ios": "rm -rf build/generated/ios Pods Podfile.lock RNTesterPods.xcworkspace/ ../react-native-codegen/lib/",
-    "e2e-build-android": "../../gradlew :packages:rn-tester:android:app:installHermesRelease -PreactNativeArchitectures=arm64-v8a",
+    "e2e-build-android": "../../gradlew :packages:rn-tester:android:app:installRelease -PreactNativeArchitectures=arm64-v8a",
     "e2e-build-ios": "./scripts/maestro-build-ios.sh",
     "e2e-test-android": "maestro test .maestro/ -e APP_ID=com.facebook.react.uiapp",
     "e2e-test-ios": "./scripts/maestro-test-ios.sh"

--- a/packages/rn-tester/react-native.config.js
+++ b/packages/rn-tester/react-native.config.js
@@ -27,7 +27,6 @@ module.exports = {
       manifestPath:
         'packages/rn-tester/android/app/src/main/AndroidManifest.xml',
       packageName: 'com.facebook.react.uiapp',
-      watchModeCommandParams: ['--mode HermesDebug'],
     },
   },
 };

--- a/scripts/release-testing/test-e2e-local.js
+++ b/scripts/release-testing/test-e2e-local.js
@@ -188,18 +188,11 @@ async function testRNTesterAndroid(
     const unzipFolder = path.join(ciArtifacts.baseTmpPath(), 'rntester-apks');
     exec(`rm -rf ${unzipFolder}`);
     exec(`unzip ${downloadPath} -d ${unzipFolder}`);
-    let apkPath = path.join(
-      unzipFolder,
-      `app-${argv.hermes === true ? 'hermes' : 'jsc'}-${emulatorArch}-debug.apk`,
-    );
+    let apkPath = path.join(unzipFolder, `app-${emulatorArch}-debug.apk`);
 
     exec(`adb install ${apkPath}`);
   } else {
-    exec(
-      `../../gradlew :packages:rn-tester:android:app:${
-        argv.hermes === true ? 'installHermesDebug' : 'installJscDebug'
-      } --quiet`,
-    );
+    exec(`../../gradlew :packages:rn-tester:android:app:installDebug --quiet`);
   }
 
   // launch the app


### PR DESCRIPTION
Summary:
As in 0.81 we're stopping 1st party support for JSC, we can now cleanup the RNTester
flavor for JSC and simplify the setup here.

Changelog:
[Internal] [Changed] -

Reviewed By: rshest

Differential Revision: D76051319


