### PR TITLE
Remove reactnative_unittest target and setup

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -70,7 +70,6 @@ val FAST_FLOAT_VERSION = libs.versions.fastFloat.get()
 val FMT_VERSION = libs.versions.fmt.get()
 val FOLLY_VERSION = libs.versions.folly.get()
 val GLOG_VERSION = libs.versions.glog.get()
-val GTEST_VERSION = libs.versions.gtest.get()
 
 val preparePrefab by
     tasks.registering(PreparePrefabHeadersTask::class) {
@@ -378,26 +377,6 @@ val downloadGlog by
       dest(downloadGlogDest)
     }
 
-val downloadGtestDest = File(downloadsDir, "gtest.tar.gz")
-val downloadGtest by
-    tasks.registering(Download::class) {
-      dependsOn(createNativeDepsDirectories)
-      src("https://github.com/google/googletest/archive/refs/tags/release-${GTEST_VERSION}.tar.gz")
-      onlyIfModified(true)
-      overwrite(false)
-      retries(5)
-      quiet(true)
-      dest(downloadGtestDest)
-    }
-
-val prepareGtest by
-    tasks.registering(Copy::class) {
-      dependsOn(if (dependenciesPath != null) emptyList() else listOf(downloadGtest))
-      from(dependenciesPath ?: tarTree(downloadGtestDest))
-      eachFile { path = path.substringAfter("/") }
-      into(File(thirdPartyNdkDir, "googletest"))
-    }
-
 val prepareGlog by
     tasks.registering(PrepareGlogTask::class) {
       dependsOn(if (dependenciesPath != null) emptyList() else listOf(downloadGlog))
@@ -417,7 +396,6 @@ val prepareNative3pDependencies by
           prepareFmt,
           prepareFolly,
           prepareGlog,
-          prepareGtest,
       )
     }
 
@@ -567,17 +545,6 @@ android {
     cmake {
       version = cmakeVersion
       path("src/main/jni/CMakeLists.txt")
-    }
-  }
-
-  buildTypes {
-    debug {
-      externalNativeBuild {
-        cmake {
-          // We want to build Gtest suite only for the debug variant.
-          targets("reactnative_unittest")
-        }
-      }
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
@@ -62,7 +62,6 @@ add_react_third_party_ndk_subdir(double-conversion)
 add_react_third_party_ndk_subdir(fast_float)
 add_react_third_party_ndk_subdir(fmt)
 add_react_third_party_ndk_subdir(folly)
-add_react_third_party_ndk_subdir(googletest)
 
 # Common targets
 add_react_common_subdir(yoga)
@@ -331,95 +330,4 @@ target_include_directories(reactnative
         $<TARGET_PROPERTY:turbomodulejsijni,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:uimanagerjni,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:yoga,INTERFACE_INCLUDE_DIRECTORIES>
-)
-
-# GTest dependencies
-add_executable(reactnative_unittest
-  ${REACT_COMMON_DIR}/cxxreact/tests/jsarg_helpers.cpp
-  ${REACT_COMMON_DIR}/cxxreact/tests/jsbigstring.cpp
-  ${REACT_COMMON_DIR}/cxxreact/tests/methodcall.cpp
-  ${REACT_COMMON_DIR}/cxxreact/tests/RecoverableErrorTest.cpp
-  ${REACT_COMMON_DIR}/react/bridging/tests/BridgingTest.cpp
-  ${REACT_COMMON_DIR}/react/renderer/attributedstring/tests/AttributedStringBoxTest.cpp
-  ${REACT_COMMON_DIR}/react/renderer/components/image/tests/ImageTest.cpp
-  ${REACT_COMMON_DIR}/react/renderer/components/root/tests/RootShadowNodeTest.cpp
-  ${REACT_COMMON_DIR}/react/renderer/components/scrollview/tests/ScrollViewTest.cpp
-  ${REACT_COMMON_DIR}/react/renderer/components/view/tests/LayoutTest.cpp
-  ${REACT_COMMON_DIR}/react/renderer/components/view/tests/ViewTest.cpp
-  ${REACT_COMMON_DIR}/react/renderer/core/tests/DynamicPropsUtilitiesTest.cpp
-  ${REACT_COMMON_DIR}/react/renderer/core/tests/EventQueueProcessorTest.cpp
-  ${REACT_COMMON_DIR}/react/renderer/core/tests/FindNodeAtPointTest.cpp
-  ${REACT_COMMON_DIR}/react/renderer/core/tests/LayoutableShadowNodeTest.cpp
-  ${REACT_COMMON_DIR}/react/renderer/core/tests/PrimitivesTest.cpp
-  ${REACT_COMMON_DIR}/react/renderer/core/tests/RawPropsTest.cpp
-  ${REACT_COMMON_DIR}/react/renderer/core/tests/ShadowNodeFamilyTest.cpp
-  ${REACT_COMMON_DIR}/react/renderer/debug/tests/DebugStringConvertibleTest.cpp
-  ${REACT_COMMON_DIR}/react/renderer/element/tests/ElementTest.cpp
-  ${REACT_COMMON_DIR}/react/renderer/graphics/tests/GraphicsTest.cpp
-  ${REACT_COMMON_DIR}/react/renderer/graphics/tests/TransformTest.cpp
-  ${REACT_COMMON_DIR}/react/renderer/imagemanager/tests/ImageManagerTest.cpp
-  ${REACT_COMMON_DIR}/react/renderer/mapbuffer/tests/MapBufferTest.cpp
-  ${REACT_COMMON_DIR}/react/renderer/mounting/tests/StackingContextTest.cpp
-  ${REACT_COMMON_DIR}/react/renderer/mounting/tests/StateReconciliationTest.cpp
-  ${REACT_COMMON_DIR}/react/renderer/runtimescheduler/tests/RuntimeSchedulerTest.cpp
-  ${REACT_COMMON_DIR}/react/renderer/runtimescheduler/tests/SchedulerPriorityTest.cpp
-  ${REACT_COMMON_DIR}/react/renderer/telemetry/tests/TransactionTelemetryTest.cpp
-  ${REACT_COMMON_DIR}/react/renderer/textlayoutmanager/tests/TextLayoutManagerTest.cpp
-  ${REACT_COMMON_DIR}/react/renderer/uimanager/tests/FabricUIManagerTest.cpp
-
-  ########## (COMPILE BUT FAIL ON ASSERTS) ###########
-  # ${REACT_COMMON_DIR}/react/renderer/animations/tests/LayoutAnimationTest.cpp
-  # ${REACT_COMMON_DIR}/react/renderer/mounting/tests/MountingTest.cpp
-  # ${REACT_COMMON_DIR}/react/renderer/mounting/tests/ShadowTreeLifeCycleTest.cpp
-
-  ########## (COMPILE BUT FAIL WITH RUNTIME EXCEPTIONS) ###########
-  # ${REACT_COMMON_DIR}/hermes/inspector-modern/chrome/tests/ConnectionDemuxTests.cpp
-
-  ########## (DO NOT COMPILE) ###########
-  # ${REACT_COMMON_DIR}/react/renderer/core/tests/ShadowNodeTest.cpp
-  # ${REACT_COMMON_DIR}/react/renderer/core/tests/ConcreteShadowNodeTest.cpp
-  # ${REACT_COMMON_DIR}/react/renderer/core/tests/ComponentDescriptorTest.cpp
-  )
-
-target_compile_reactnative_options(reactnative_unittest PRIVATE)
-target_compile_options(reactnative_unittest PRIVATE -DHERMES_ENABLE_DEBUGGER)
-
-target_link_libraries(reactnative_unittest
-  fabricjni
-  folly_runtime
-  glog
-  glog_init
-  gtest_main
-  hermes-engine::libhermes
-  hermes_inspector_modern
-  jserrorhandler
-  jsi
-  mapbufferjni
-  react_codegen_rncore
-  react_cxxreact
-  react_debug
-  react_renderer_animations
-  react_renderer_attributedstring
-  react_renderer_core
-  react_renderer_css
-  react_renderer_debug
-  react_renderer_dom
-  react_renderer_element
-  react_renderer_graphics
-  react_renderer_mapbuffer
-  react_renderer_mounting
-  react_renderer_telemetry
-  react_renderer_textlayoutmanager
-  react_renderer_uimanager
-  react_renderer_uimanager_consistency
-  react_utils
-  reactnative
-  rrc_legacyviewmanagerinterop
-  rrc_modal
-  rrc_root
-  rrc_scrollview
-  rrc_text
-  rrc_textinput
-  rrc_view
-  yoga
 )

--- a/packages/react-native/gradle/libs.versions.toml
+++ b/packages/react-native/gradle/libs.versions.toml
@@ -46,7 +46,6 @@ fastFloat="8.0.0"
 fmt="11.0.2"
 folly="2024.11.18.00"
 glog="0.3.5"
-gtest="1.12.1"
 
 [libraries]
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "androidx-annotation" }


### PR DESCRIPTION
Summary:
We're not really running those tests in OSS. They would require an emulator in OSS CI which
is costly and flaky. I'd rather remove the build logic for them and rely on Fantom for those kind
of tests in the future.

Changelog:
[Internal] [Changed] -

Differential Revision: D76050039


