### PR TITLE
Fix E2E tests for Android (both ci and release testing)

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -87,12 +87,12 @@ runs:
       uses: actions/upload-artifact@v4.3.4
       with:
         name: rntester-debug
-        path: packages/rn-tester/android/app/build/outputs/apk/hermes/debug/
+        path: packages/rn-tester/android/app/build/outputs/apk/debug/
         compression-level: 0
     - name: Upload RNTester APK - hermes-release
       if: ${{ always() }}
       uses: actions/upload-artifact@v4.3.4
       with:
         name: rntester-release
-        path: packages/rn-tester/android/app/build/outputs/apk/hermes/release/
+        path: packages/rn-tester/android/app/build/outputs/apk/release/
         compression-level: 0

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -439,14 +439,14 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: rntester-${{ matrix.flavor }}
-          path: ./packages/rn-tester/android/app/build/outputs/apk/hermes/${{ matrix.flavor }}/
+          path: ./packages/rn-tester/android/app/build/outputs/apk/${{ matrix.flavor }}/
       - name: Print folder structure
-        run: ls -lR ./packages/rn-tester/android/app/build/outputs/apk/hermes/${{ matrix.flavor }}/
+        run: ls -lR ./packages/rn-tester/android/app/build/outputs/apk/${{ matrix.flavor }}/
       - name: Run E2E Tests
         uses: ./.github/actions/maestro-android
         timeout-minutes: 60
         with:
-          app-path: ./packages/rn-tester/android/app/build/outputs/apk/hermes/${{ matrix.flavor }}/app-hermes-x86-${{ matrix.flavor }}.apk
+          app-path: ./packages/rn-tester/android/app/build/outputs/apk/${{ matrix.flavor }}/app-x86-${{ matrix.flavor }}.apk
           app-id: com.facebook.react.uiapp
           maestro-flow: ./packages/rn-tester/.maestro
           flavor: ${{ matrix.flavor }}


### PR DESCRIPTION
Summary:
After [51865](https://github.com/facebook/react-native/pull/51865), the path were the apk are generated changed. That broke the e2E tests in ci and the local script to test E2E, because the artefacts were not uploaded to CI properly.

This change should fix it

## Changelog:
[Internal] -

Differential Revision: D76133191


