### PR TITLE
preventing future build failures

### DIFF
--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.cpp
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <jsi/jsi.h>
 #include <jsinspector-modern/RuntimeTarget.h>
 
 #include "HermesRuntimeSamplingProfileSerializer.h"
@@ -39,12 +40,12 @@ class HermesRuntimeSamplingProfileDelegate {
       : hermesRuntime_(std::move(hermesRuntime)) {}
 
   void startSampling() {
-    auto* hermesAPI = castInterface<IHermesRootAPI>(makeHermesRootAPI());
+    auto* hermesAPI = jsi::castInterface<IHermesRootAPI>(makeHermesRootAPI());
     hermesAPI->enableSamplingProfiler(HERMES_SAMPLING_FREQUENCY_HZ);
   }
 
   void stopSampling() {
-    auto* hermesAPI = castInterface<IHermesRootAPI>(makeHermesRootAPI());
+    auto* hermesAPI = jsi::castInterface<IHermesRootAPI>(makeHermesRootAPI());
     hermesAPI->disableSamplingProfiler();
   }
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkReporter.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkReporter.h
@@ -15,6 +15,7 @@
 #include <functional>
 #include <mutex>
 #include <string>
+#include <unordered_map>
 
 namespace facebook::react::jsinspector_modern {
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/NativeDrawable.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/NativeDrawable.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <glog/logging.h>
 #include <react/debug/react_native_expect.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/graphics/Float.h>


### PR DESCRIPTION
Summary:
changelog: [internal]

Fixing possible build failures when targets are built in different context:
- Adding includes to used std functions.
- Using explicit jsi namespace.
- Declaring dependency.

Reviewed By: javache

Differential Revision: D74878821


