### PR TITLE
Add snapshot validation to build-types

### DIFF
--- a/scripts/build-types/index.js
+++ b/scripts/build-types/index.js
@@ -20,12 +20,13 @@ const config = {
     debug: {type: 'boolean'},
     help: {type: 'boolean'},
     withSnapshot: {type: 'boolean'},
+    validate: {type: 'boolean'},
   },
 };
 
 async function main() {
   const {
-    values: {debug: debugEnabled, help, withSnapshot},
+    values: {debug: debugEnabled, help, withSnapshot, validate},
     /* $FlowFixMe[incompatible-call] Natural Inference rollout. See
      * https://fburl.com/workplace/6291gfvu */
   } = parseArgs(config);
@@ -68,7 +69,7 @@ async function main() {
         '\n',
     );
 
-    await buildApiSnapshot();
+    await buildApiSnapshot(validate);
   }
 }
 


### PR DESCRIPTION
Summary:
This diff adds `--validate` flag that runs snapshot validation to determine if the `ReactNativeApi.d.ts` rollup has been changed (if JS public API has been touched). There was also an issue with `sortProperties` that reordered some properties (ex. in ImagePropsBase) after removing one of them (ex. accessible) which had negative impact on the displayed result. 

### Motivation
Compare previous snapshot with the one built on the current revision to determine the impact of made changes on the public API surface. Display differences in human readable format using `diffStringsUnified` method from the `jest-diff` library.

For now `--validate` flag is not useful on its own. It should be used with `--withSnapshot` flag (which will be removed shortly and generating snapshot will be a default mechanism).

Changelog:
[General][Added] - Add --validate flag to build-types script for JS API snapshot validation.

Differential Revision: D76135158


