### PR TITLE
Replace chalk in build scripts

### DIFF
--- a/flow-typed/environment/node.js
+++ b/flow-typed/environment/node.js
@@ -3229,6 +3229,73 @@ declare module 'util' {
     isWebAssemblyCompiledModule: (value: mixed) => boolean,
     ...
   };
+
+  declare type BackgroundColors =
+    | 'bgBlack'
+    | 'bgBlackBright'
+    | 'bgBlue'
+    | 'bgBlueBright'
+    | 'bgCyan'
+    | 'bgCyanBright'
+    | 'bgGray'
+    | 'bgGreen'
+    | 'bgGreenBright'
+    | 'bgGrey'
+    | 'bgMagenta'
+    | 'bgMagentaBright'
+    | 'bgRed'
+    | 'bgRedBright'
+    | 'bgWhite'
+    | 'bgWhiteBright'
+    | 'bgYellow'
+    | 'bgYellowBright';
+
+  declare type ForegroundColors =
+    | 'black'
+    | 'blackBright'
+    | 'blue'
+    | 'blueBright'
+    | 'cyan'
+    | 'cyanBright'
+    | 'gray'
+    | 'green'
+    | 'greenBright'
+    | 'grey'
+    | 'magenta'
+    | 'magentaBright'
+    | 'red'
+    | 'redBright'
+    | 'white'
+    | 'whiteBright'
+    | 'yellow'
+    | 'yellowBright';
+
+  declare type Modifiers =
+    | 'blink'
+    | 'bold'
+    | 'dim'
+    | 'doubleunderline'
+    | 'framed'
+    | 'hidden'
+    | 'inverse'
+    | 'italic'
+    | 'overlined'
+    | 'reset'
+    | 'strikethrough'
+    | 'underline';
+
+  declare function styleText(
+    format:
+      | ForegroundColors
+      | BackgroundColors
+      | Modifiers
+      | $ReadOnlyArray<ForegroundColors | BackgroundColors | Modifiers>,
+    text: string,
+    options?: $ReadOnly<{
+      stream?: ?stream$Stream,
+      validStream?: ?boolean,
+    }>,
+  ): string;
 }
 
 type vm$ScriptOptions = {

--- a/scripts/build-types/index.js
+++ b/scripts/build-types/index.js
@@ -12,9 +12,8 @@ require('../babel-register').registerForScript();
 
 const buildApiSnapshot = require('./BuildApiSnapshot');
 const buildGeneratedTypes = require('./buildGeneratedTypes');
-const chalk = require('chalk');
 const debug = require('debug');
-const {parseArgs} = require('util');
+const {parseArgs, styleText} = require('util');
 
 const config = {
   options: {
@@ -50,7 +49,10 @@ async function main() {
 
   console.log(
     '\n' +
-      chalk.bold.inverse('Building generated react-native package types') +
+      styleText(
+        ['bold', 'inverse'],
+        'Building generated react-native package types',
+      ) +
       '\n',
   );
 
@@ -59,7 +61,10 @@ async function main() {
   if (withSnapshot) {
     console.log(
       '\n' +
-        chalk.bold.inverse.yellow('EXPERIMENTAL - Building API snapshot') +
+        styleText(
+          ['bold', 'inverse', 'yellow'],
+          'EXPERIMENTAL - Building API snapshot',
+        ) +
         '\n',
     );
 

--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -18,7 +18,6 @@ const {
   getTypeScriptCompilerOptions,
 } = require('./config');
 const babel = require('@babel/core');
-const chalk = require('chalk');
 const translate = require('flow-api-translator');
 const {promises: fs} = require('fs');
 const glob = require('glob');
@@ -26,7 +25,7 @@ const micromatch = require('micromatch');
 const path = require('path');
 const prettier = require('prettier');
 const ts = require('typescript');
-const {parseArgs} = require('util');
+const {parseArgs, styleText} = require('util');
 
 const SRC_DIR = 'src';
 const BUILD_DIR = 'dist';
@@ -67,7 +66,9 @@ async function build() {
   }
 
   if (!validate) {
-    console.log('\n' + chalk.bold.inverse('Building packages') + '\n');
+    console.log(
+      '\n' + styleText(['bold', 'inverse'], 'Building packages') + '\n',
+    );
   }
 
   const packagesToBuild = packageNames.length
@@ -90,7 +91,7 @@ async function checkPackage(packageName /*: string */) /*: Promise<boolean> */ {
   const artifacts = await exportedBuildArtifacts(packageName);
   if (artifacts.length > 0) {
     console.log(
-      `${chalk.bgRed(packageName)}: has been built and the ${chalk.bold('build artifacts')} committed to the repository. This will break Flow checks.`,
+      `${styleText('bgRed', packageName)}: has been built and the ${styleText('bold', 'build artifacts')} committed to the repository. This will break Flow checks.`,
     );
     return false;
   }
@@ -113,7 +114,7 @@ async function buildPackage(packageName /*: string */) {
       );
 
     process.stdout.write(
-      `${packageName} ${chalk.dim('.').repeat(72 - packageName.length)} `,
+      `${packageName} ${styleText('dim', '.').repeat(72 - packageName.length)} `,
     );
 
     // Build regular files
@@ -138,9 +139,13 @@ async function buildPackage(packageName /*: string */) {
     // Rewrite package.json "exports" field (src -> dist)
     await rewritePackageExports(packageName);
 
-    process.stdout.write(chalk.reset.inverse.bold.green(' DONE '));
+    process.stdout.write(
+      styleText(['reset', 'inverse', 'bold', 'green'], ' DONE '),
+    );
   } catch (e) {
-    process.stdout.write(chalk.reset.inverse.bold.red(' FAIL ') + '\n');
+    process.stdout.write(
+      styleText(['reset', 'inverse', 'bold', 'red'], ' FAIL ') + '\n',
+    );
     throw e;
   } finally {
     process.stdout.write('\n');
@@ -159,7 +164,7 @@ async function buildFile(
   const logResult = ({copied, desc} /*: {copied: boolean, desc?: string} */) =>
     silent ||
     console.log(
-      chalk.dim('  - ') +
+      styleText('dim', '  - ') +
         path.relative(PACKAGES_DIR, file) +
         (copied ? ' -> ' + path.relative(PACKAGES_DIR, buildPath) : ' ') +
         (desc != null ? ' (' + desc + ')' : ''),
@@ -318,7 +323,7 @@ async function getEntryPoints(
 
       if (target.includes('*')) {
         console.warn(
-          `${chalk.yellow('Warning')}: Encountered subpath pattern ${subpath}` +
+          `${styleText('yellow', 'Warning')}: Encountered subpath pattern ${subpath}` +
             ` in package.json exports for ${packageName}. Matched entry points ` +
             'will not be validated.',
         );


### PR DESCRIPTION
Summary:
Replaces `chalk` with Node's `util.styleText` in `scripts/build/` and `scripts/build-types/`.

Will follow up with replacing across the entire repo at a later point.

Changelog: [Internal]

Differential Revision: D76037191


