### PR TITLE
Replace chalk in packages

### DIFF
--- a/flow-typed/environment/node.js
+++ b/flow-typed/environment/node.js
@@ -3229,6 +3229,73 @@ declare module 'util' {
     isWebAssemblyCompiledModule: (value: mixed) => boolean,
     ...
   };
+
+  declare type BackgroundColors =
+    | 'bgBlack'
+    | 'bgBlackBright'
+    | 'bgBlue'
+    | 'bgBlueBright'
+    | 'bgCyan'
+    | 'bgCyanBright'
+    | 'bgGray'
+    | 'bgGreen'
+    | 'bgGreenBright'
+    | 'bgGrey'
+    | 'bgMagenta'
+    | 'bgMagentaBright'
+    | 'bgRed'
+    | 'bgRedBright'
+    | 'bgWhite'
+    | 'bgWhiteBright'
+    | 'bgYellow'
+    | 'bgYellowBright';
+
+  declare type ForegroundColors =
+    | 'black'
+    | 'blackBright'
+    | 'blue'
+    | 'blueBright'
+    | 'cyan'
+    | 'cyanBright'
+    | 'gray'
+    | 'green'
+    | 'greenBright'
+    | 'grey'
+    | 'magenta'
+    | 'magentaBright'
+    | 'red'
+    | 'redBright'
+    | 'white'
+    | 'whiteBright'
+    | 'yellow'
+    | 'yellowBright';
+
+  declare type Modifiers =
+    | 'blink'
+    | 'bold'
+    | 'dim'
+    | 'doubleunderline'
+    | 'framed'
+    | 'hidden'
+    | 'inverse'
+    | 'italic'
+    | 'overlined'
+    | 'reset'
+    | 'strikethrough'
+    | 'underline';
+
+  declare function styleText(
+    format:
+      | ForegroundColors
+      | BackgroundColors
+      | Modifiers
+      | $ReadOnlyArray<ForegroundColors | BackgroundColors | Modifiers>,
+    text: string,
+    options?: $ReadOnly<{
+      stream?: ?stream$Stream,
+      validStream?: ?boolean,
+    }>,
+  ): string;
 }
 
 type vm$ScriptOptions = {

--- a/packages/community-cli-plugin/package.json
+++ b/packages/community-cli-plugin/package.json
@@ -23,7 +23,6 @@
   ],
   "dependencies": {
     "@react-native/dev-middleware": "0.80.0-main",
-    "chalk": "^4.0.0",
     "debug": "^4.4.0",
     "invariant": "^2.2.4",
     "metro": "^0.82.4",

--- a/packages/community-cli-plugin/src/commands/bundle/buildBundle.js
+++ b/packages/community-cli-plugin/src/commands/bundle/buildBundle.js
@@ -15,10 +15,10 @@ import type {ConfigT} from 'metro-config';
 import loadMetroConfig from '../../utils/loadMetroConfig';
 import parseKeyValueParamArray from '../../utils/parseKeyValueParamArray';
 import saveAssets from './saveAssets';
-import chalk from 'chalk';
 import {promises as fs} from 'fs';
 import {runBuild} from 'metro';
 import path from 'path';
+import {styleText} from 'util';
 
 export type BundleCommandArgs = {
   assetsDest?: string,
@@ -69,14 +69,14 @@ async function buildBundleWithConfig(
 
   if (config.resolver.platforms.indexOf(args.platform) === -1) {
     console.error(
-      `${chalk.red('error')}: Invalid platform ${
-        args.platform ? `"${chalk.bold(args.platform)}" ` : ''
+      `${styleText('red', 'error')}: Invalid platform ${
+        args.platform ? `"${styleText('bold', args.platform)}" ` : ''
       }selected.`,
     );
 
     console.info(
       `Available platforms are: ${config.resolver.platforms
-        .map(x => `"${chalk.bold(x)}"`)
+        .map(x => `"${styleText('bold', x)}"`)
         .join(
           ', ',
         )}. If you are trying to bundle for an out-of-tree platform, it may not be installed.`,

--- a/packages/community-cli-plugin/src/commands/bundle/saveAssets.js
+++ b/packages/community-cli-plugin/src/commands/bundle/saveAssets.js
@@ -20,9 +20,9 @@ import createKeepFileAsync from './createKeepFileAsync';
 import filterPlatformAssetScales from './filterPlatformAssetScales';
 import getAssetDestPathAndroid from './getAssetDestPathAndroid';
 import getAssetDestPathIOS from './getAssetDestPathIOS';
-import chalk from 'chalk';
 import fs from 'fs';
 import path from 'path';
+import {styleText} from 'util';
 
 type CopiedFiles = {
   [src: string]: string,
@@ -65,7 +65,7 @@ async function saveAssets(
     const catalogDir = path.join(assetCatalogDest, 'RNAssets.xcassets');
     if (!fs.existsSync(catalogDir)) {
       console.error(
-        `${chalk.red('error')}: Could not find asset catalog 'RNAssets.xcassets' in ${assetCatalogDest}. Make sure to create it if it does not exist.`,
+        `${styleText('red', 'error')}: Could not find asset catalog 'RNAssets.xcassets' in ${assetCatalogDest}. Make sure to create it if it does not exist.`,
       );
       return;
     }

--- a/packages/community-cli-plugin/src/commands/start/OpenDebuggerKeyboardHandler.js
+++ b/packages/community-cli-plugin/src/commands/start/OpenDebuggerKeyboardHandler.js
@@ -10,7 +10,7 @@
 
 import type {TerminalReporter} from 'metro';
 
-import chalk from 'chalk';
+import {styleText} from 'util';
 
 type PageDescription = $ReadOnly<{
   id: string,
@@ -108,7 +108,7 @@ export default class OpenDebuggerKeyboardHandler {
             .slice(0, 9)
             .map(
               ({title}, i) =>
-                `${chalk.white.inverse(` ${i + 1} `)} - "${title}"`,
+                `${styleText(['white', 'inverse'], ` ${i + 1} `)} - "${title}"`,
             )
             .join('\n  ')}`,
         );

--- a/packages/community-cli-plugin/src/commands/start/attachKeyHandlers.js
+++ b/packages/community-cli-plugin/src/commands/start/attachKeyHandlers.js
@@ -11,10 +11,10 @@
 import type {TerminalReporter} from 'metro';
 
 import OpenDebuggerKeyboardHandler from './OpenDebuggerKeyboardHandler';
-import chalk from 'chalk';
 import invariant from 'invariant';
 import readline from 'readline';
 import {ReadStream} from 'tty';
+import {styleText} from 'util';
 
 const CTRL_C = '\u0003';
 const CTRL_D = '\u0004';
@@ -117,9 +117,9 @@ export default function attachKeyHandlers({
     level: 'info',
     data: `Key commands available:
 
-  ${chalk.bold.inverse(' r ')} - reload app(s)
-  ${chalk.bold.inverse(' d ')} - open Dev Menu
-  ${chalk.bold.inverse(' j ')} - open DevTools
+  ${styleText(['bold', 'inverse'], ' r ')} - reload app(s)
+  ${styleText(['bold', 'inverse'], ' d ')} - open Dev Menu
+  ${styleText(['bold', 'inverse'], ' j ')} - open DevTools
 `,
   });
 }

--- a/packages/community-cli-plugin/src/commands/start/runServer.js
+++ b/packages/community-cli-plugin/src/commands/start/runServer.js
@@ -18,11 +18,11 @@ import * as version from '../../utils/version';
 import attachKeyHandlers from './attachKeyHandlers';
 import {createDevServerMiddleware} from './middleware';
 import {createDevMiddleware} from '@react-native/dev-middleware';
-import chalk from 'chalk';
 import Metro from 'metro';
 import {Terminal} from 'metro-core';
 import path from 'path';
 import url from 'url';
+import {styleText} from 'util';
 
 export type StartCommandArgs = {
   assetPlugins?: string[],
@@ -68,7 +68,10 @@ async function runServer(
   const devServerUrl = url.format({protocol, hostname, port});
 
   console.info(
-    chalk.blue(`\nWelcome to React Native v${cliConfig.reactNativeVersion}`),
+    styleText(
+      'blue',
+      `\nWelcome to React Native v${cliConfig.reactNativeVersion}`,
+    ),
   );
 
   const serverStatus = await isDevServerRunning(devServerUrl, projectRoot);
@@ -80,7 +83,7 @@ async function runServer(
     return;
   } else if (serverStatus === 'port_taken') {
     console.error(
-      `${chalk.red('error')}: Another process is running on port ${port}. Please terminate this ` +
+      `${styleText('red', 'error')}: Another process is running on port ${port}. Please terminate this ` +
         'process and try again, or use another port with "--port".',
     );
     return;
@@ -131,7 +134,7 @@ async function runServer(
         terminalReporter.update({
           type: 'unstable_server_log',
           level: 'info',
-          data: `Dev server ready. ${chalk.dim('Press Ctrl+C to exit.')}`,
+          data: `Dev server ready. ${styleText('dim', 'Press Ctrl+C to exit.')}`,
         });
         attachKeyHandlers({
           devServerUrl,

--- a/packages/community-cli-plugin/src/utils/version.js
+++ b/packages/community-cli-plugin/src/utils/version.js
@@ -11,8 +11,8 @@
 import type {Config} from '@react-native-community/cli-types';
 import type {TerminalReporter} from 'metro';
 
-import chalk from 'chalk';
 import semver from 'semver';
+import {styleText} from 'util';
 
 const debug = require('debug')('ReactNative:CommunityCliPlugin');
 
@@ -81,8 +81,8 @@ export async function logIfUpdateAvailable(
       type: 'unstable_server_log',
       level: 'info',
       data: `React Native v${newVersion.stable} is now available (your project is running on v${currentVersion}).
-Changelog: ${chalk.dim.underline(newVersion?.changelogUrl ?? 'none')}
-Diff: ${chalk.dim.underline(newVersion?.diffUrl ?? 'none')}
+Changelog: ${styleText(['dim', 'underline'], newVersion?.changelogUrl ?? 'none')}
+Diff: ${styleText(['dim', 'underline'], newVersion?.diffUrl ?? 'none')}
 `,
     });
   }

--- a/packages/helloworld/lib/cli.js
+++ b/packages/helloworld/lib/cli.js
@@ -13,9 +13,9 @@ import type {Result} from 'execa';
 import type {ExecaPromise} from 'execa';
 import type {TaskResult, TaskSpec} from 'listr2';
 
-import chalk from 'chalk';
 import {Listr} from 'listr2';
 import {Observable} from 'rxjs';
+import {styleText} from 'util';
 
 export function trim(
   line: string,
@@ -57,7 +57,7 @@ export function observe(result: ExecaPromiseMetaized): TaskResult<{}, string> {
       error =>
         observer.error(
           new Error(
-            `${chalk.red.bold(error.shortMessage)}\n${
+            `${styleText(['red', 'bold'], error.shortMessage)}\n${
               error.stderr || error.stdout
             }`,
           ),

--- a/packages/helloworld/package.json
+++ b/packages/helloworld/package.json
@@ -25,7 +25,6 @@
     "@react-native/metro-config": "0.80.0-main",
     "@react-native/typescript-config": "0.80.0-main",
     "@types/jest": "^29.5.14",
-    "chalk": "^4.1.2",
     "commander": "^12.0.0",
     "eslint": "^8.19.0",
     "jest": "^29.7.0",

--- a/packages/react-native-codegen/package.json
+++ b/packages/react-native-codegen/package.json
@@ -43,7 +43,6 @@
     "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7",
     "@babel/plugin-transform-optional-chaining": "^7.24.8",
     "@babel/preset-env": "^7.25.3",
-    "chalk": "^4.0.0",
     "hermes-estree": "0.28.1",
     "micromatch": "^4.0.4",
     "prettier": "2.8.8",

--- a/packages/react-native-codegen/scripts/build.js
+++ b/packages/react-native-codegen/scripts/build.js
@@ -24,12 +24,13 @@
 'use strict';
 
 const babel = require('@babel/core');
-const chalk = require('chalk');
 const fs = require('fs');
 const glob = require('glob');
 const micromatch = require('micromatch');
 const path = require('path');
 const prettier = require('prettier');
+const {styleText} = require('util');
+
 const prettierConfig = JSON.parse(
   fs.readFileSync(path.resolve(__dirname, '..', '.prettierrc'), 'utf8'),
 );
@@ -45,7 +46,7 @@ const fixedWidth = str => {
   const strs = str.match(new RegExp(`(.{1,${WIDTH}})`, 'g')) || [str];
   let lastString = strs[strs.length - 1];
   if (lastString.length < WIDTH) {
-    lastString += Array(WIDTH - lastString.length).join(chalk.dim('.'));
+    lastString += Array(WIDTH - lastString.length).join(styleText('dim', '.'));
   }
   return strs.slice(0, -1).concat(lastString).join('\n');
 };
@@ -65,7 +66,7 @@ function buildFile(file, silent) {
   if (micromatch.isMatch(file, IGNORE_PATTERN)) {
     silent ||
       process.stdout.write(
-        chalk.dim('  \u2022 ') +
+        styleText('dim', '  \u2022 ') +
           path.relative(PACKAGE_DIR, file) +
           ' (ignore)\n',
       );
@@ -73,9 +74,9 @@ function buildFile(file, silent) {
     fs.createReadStream(file).pipe(fs.createWriteStream(destPath));
     silent ||
       process.stdout.write(
-        chalk.red('  \u2022 ') +
+        styleText('red', '  \u2022 ') +
           path.relative(PACKAGE_DIR, file) +
-          chalk.red(' \u21D2 ') +
+          styleText('red', ' \u21D2 ') +
           path.relative(PACKAGE_DIR, destPath) +
           ' (copy)' +
           '\n',
@@ -95,9 +96,9 @@ function buildFile(file, silent) {
     }
     silent ||
       process.stdout.write(
-        chalk.green('  \u2022 ') +
+        styleText('green', '  \u2022 ') +
           path.relative(PACKAGE_DIR, file) +
-          chalk.green(' \u21D2 ') +
+          styleText('green', ' \u21D2 ') +
           path.relative(PACKAGE_DIR, destPath) +
           '\n',
       );
@@ -112,4 +113,4 @@ process.stdout.write(fixedWidth(`${path.basename(PACKAGE_DIR)}\n`));
 
 files.forEach(file => buildFile(file, !process.argv.includes('--verbose')));
 
-process.stdout.write(`[  ${chalk.green('OK')}  ]\n`);
+process.stdout.write(`[  ${styleText('green', 'OK')}  ]\n`);

--- a/packages/react-native/cli.js
+++ b/packages/react-native/cli.js
@@ -17,11 +17,11 @@ import type {IncomingMessage} from 'https';
 
 // $FlowFixMe[untyped-import]
 const {name, version: currentVersion} = require('./package.json');
-const chalk = require('chalk');
 const {spawn} = require('child_process');
 const {get} = require('https');
 const semver = require('semver');
 const {URL} = require('url');
+const {styleText} = require('util');
 
 const deprecated = () => {
   throw new Error(
@@ -99,7 +99,7 @@ function getLatestVersion(
 function warnWhenRunningInit() {
   if (isInitCommand) {
     console.warn(
-      `\nRunning: ${chalk.grey.bold('npx @react-native-community/cli init')}\n`,
+      `\nRunning: ${styleText(['grey', 'bold'], 'npx @react-native-community/cli init')}\n`,
     );
   }
 }
@@ -120,21 +120,21 @@ function warnWithDeprecationSchedule() {
     (CLI_DEPRECATION_DATE.getTime() - new Date().getTime()) / 86_400_000,
   );
 
-  const emphasis =
+  const emphasis = (text /*: string */) =>
     daysRemaining < 10
-      ? chalk.bgRed.white.bold
+      ? styleText(['bgRed', 'white', 'bold'], text)
       : daysRemaining < 30
-        ? chalk.red.bold
+        ? styleText(['red', 'bold'], text)
         : daysRemaining < 60
-          ? chalk.green.bold
-          : chalk.blueBright.bold;
+          ? styleText(['green', 'bold'], text)
+          : styleText(['blueBright', 'bold'], text);
 
   console.warn(`
-${chalk.yellow('⚠️')} The \`init\` command is deprecated.
-The behavior will be changed on ${chalk.white.bold(CLI_DEPRECATION_DATE.toLocaleDateString())} ${emphasis(`(${daysRemaining} day${daysRemaining > 1 ? 's' : ''})`)}.
+${styleText('yellow', '⚠️')} The \`init\` command is deprecated.
+The behavior will be changed on ${styleText(['white', 'bold'], CLI_DEPRECATION_DATE.toLocaleDateString())} ${emphasis(`(${daysRemaining} day${daysRemaining > 1 ? 's' : ''})`)}.
 
-- Switch to ${chalk.grey.bold('npx @react-native-community/cli init')} for the identical behavior.
-- Refer to the documentation for information about alternative tools: ${chalk.dim('https://reactnative.dev/docs/getting-started')}`);
+- Switch to ${styleText(['grey', 'bold'], 'npx @react-native-community/cli init')} for the identical behavior.
+- Refer to the documentation for information about alternative tools: ${styleText('dim', 'https://reactnative.dev/docs/getting-started')}`);
 }
 
 function warnWithDeprecated() {
@@ -144,19 +144,22 @@ function warnWithDeprecated() {
   console.warn(`
 🚨️ The \`init\` command is deprecated.
 
-- Switch to ${chalk.grey.bold('npx @react-native-community/cli init')} for the identical behavior.
-- Refer to the documentation for information about alternative tools: ${chalk.dim('https://reactnative.dev/docs/getting-started')}`);
+- Switch to ${styleText(['grey', 'bold'], 'npx @react-native-community/cli init')} for the identical behavior.
+- Refer to the documentation for information about alternative tools: ${styleText('dim', 'https://reactnative.dev/docs/getting-started')}`);
 }
 
 function warnWithExplicitDependency(version /*: string */ = '*') {
   console.warn(`
-${chalk.yellow('⚠')}️ ${chalk.dim('react-native')} depends on ${chalk.dim('@react-native-community/cli')} for cli commands. To fix update your ${chalk.dim('package.json')} to include:
+${styleText('yellow', '⚠')}️ ${styleText(['dim'], 'react-native')} depends on ${styleText('dim', '@react-native-community/cli')} for cli commands. To fix update your ${styleText(['dim'], 'package.json')} to include:
 
-${chalk.white.bold(`
+${styleText(
+  ['white', 'bold'],
+  `
   "devDependencies": {
     "@react-native-community/cli": "latest",
   }
-`)}
+`,
+)}
 
 `);
 }
@@ -182,11 +185,13 @@ async function main() {
       // TODO: T184416093 When cli is deprecated, remove semver from package.json
       if (semver.lt(currentVersion, latest)) {
         const msg = `
-  ${chalk.bold.yellow('WARNING:')} You should run ${chalk.white.bold(
+  ${styleText(['bold', 'yellow'], 'WARNING:')} You should run ${styleText(
+    ['white', 'bold'],
     'npx react-native@latest',
-  )} to ensure you're always using the most current version of the CLI. NPX has cached version (${chalk.bold.yellow(
+  )} to ensure you're always using the most current version of the CLI. NPX has cached version (${styleText(
+    ['bold', 'yellow'],
     currentVersion,
-  )}) != current release (${chalk.bold.green(latest)})
+  )}) != current release (${styleText(['bold', 'green'], latest)})
   `;
         console.warn(msg);
       }
@@ -214,7 +219,7 @@ async function main() {
       warnWithDeprecated();
       // We only exit if the user calls `init` and it's deprecated. All other cases should proxy to to @react-native-community/cli.
       // Be careful with this as it can break a lot of users.
-      console.warn(`${chalk.green('Exiting...')}`);
+      console.warn(`${styleText('green', 'Exiting...')}`);
       process.exit(1);
     } else if (
       currentVersion.startsWith('0.75') ||

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -171,7 +171,6 @@
     "babel-jest": "^29.7.0",
     "babel-plugin-syntax-hermes-parser": "0.28.1",
     "base64-js": "^1.5.1",
-    "chalk": "^4.0.0",
     "commander": "^12.0.0",
     "flow-enums-runtime": "^0.0.6",
     "glob": "^7.1.1",

--- a/packages/rn-tester/scripts/utils.js
+++ b/packages/rn-tester/scripts/utils.js
@@ -13,9 +13,9 @@ import type {Result} from 'execa';
 import type {ExecaPromise} from 'execa';
 import type {TaskResult, TaskSpec} from 'listr2';
 
-import chalk from 'chalk';
 import {Listr} from 'listr2';
 import {Observable} from 'rxjs';
+import {styleText} from 'util';
 
 export function trim(
   line: string,
@@ -57,7 +57,7 @@ export function observe(result: ExecaPromiseMetaized): TaskResult<{}, string> {
       error =>
         observer.error(
           new Error(
-            `${chalk.red.bold(error.shortMessage)}\n${
+            `${styleText(['red', 'bold'], error.shortMessage)}\n${
               error.stderr || error.stdout
             }`,
           ),

--- a/scripts/build-types/index.js
+++ b/scripts/build-types/index.js
@@ -12,9 +12,8 @@ require('../babel-register').registerForScript();
 
 const buildApiSnapshot = require('./BuildApiSnapshot');
 const buildGeneratedTypes = require('./buildGeneratedTypes');
-const chalk = require('chalk');
 const debug = require('debug');
-const {parseArgs} = require('util');
+const {parseArgs, styleText} = require('util');
 
 const config = {
   options: {
@@ -50,7 +49,10 @@ async function main() {
 
   console.log(
     '\n' +
-      chalk.bold.inverse('Building generated react-native package types') +
+      styleText(
+        ['bold', 'inverse'],
+        'Building generated react-native package types',
+      ) +
       '\n',
   );
 
@@ -59,7 +61,10 @@ async function main() {
   if (withSnapshot) {
     console.log(
       '\n' +
-        chalk.bold.inverse.yellow('EXPERIMENTAL - Building API snapshot') +
+        styleText(
+          ['bold', 'inverse', 'yellow'],
+          'EXPERIMENTAL - Building API snapshot',
+        ) +
         '\n',
     );
 

--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -18,7 +18,6 @@ const {
   getTypeScriptCompilerOptions,
 } = require('./config');
 const babel = require('@babel/core');
-const chalk = require('chalk');
 const translate = require('flow-api-translator');
 const {promises: fs} = require('fs');
 const glob = require('glob');
@@ -26,7 +25,7 @@ const micromatch = require('micromatch');
 const path = require('path');
 const prettier = require('prettier');
 const ts = require('typescript');
-const {parseArgs} = require('util');
+const {parseArgs, styleText} = require('util');
 
 const SRC_DIR = 'src';
 const BUILD_DIR = 'dist';
@@ -67,7 +66,9 @@ async function build() {
   }
 
   if (!validate) {
-    console.log('\n' + chalk.bold.inverse('Building packages') + '\n');
+    console.log(
+      '\n' + styleText(['bold', 'inverse'], 'Building packages') + '\n',
+    );
   }
 
   const packagesToBuild = packageNames.length
@@ -90,7 +91,7 @@ async function checkPackage(packageName /*: string */) /*: Promise<boolean> */ {
   const artifacts = await exportedBuildArtifacts(packageName);
   if (artifacts.length > 0) {
     console.log(
-      `${chalk.bgRed(packageName)}: has been built and the ${chalk.bold('build artifacts')} committed to the repository. This will break Flow checks.`,
+      `${styleText('bgRed', packageName)}: has been built and the ${styleText('bold', 'build artifacts')} committed to the repository. This will break Flow checks.`,
     );
     return false;
   }
@@ -113,7 +114,7 @@ async function buildPackage(packageName /*: string */) {
       );
 
     process.stdout.write(
-      `${packageName} ${chalk.dim('.').repeat(72 - packageName.length)} `,
+      `${packageName} ${styleText('dim', '.').repeat(72 - packageName.length)} `,
     );
 
     // Build regular files
@@ -138,9 +139,13 @@ async function buildPackage(packageName /*: string */) {
     // Rewrite package.json "exports" field (src -> dist)
     await rewritePackageExports(packageName);
 
-    process.stdout.write(chalk.reset.inverse.bold.green(' DONE '));
+    process.stdout.write(
+      styleText(['reset', 'inverse', 'bold', 'green'], ' DONE '),
+    );
   } catch (e) {
-    process.stdout.write(chalk.reset.inverse.bold.red(' FAIL ') + '\n');
+    process.stdout.write(
+      styleText(['reset', 'inverse', 'bold', 'red'], ' FAIL ') + '\n',
+    );
     throw e;
   } finally {
     process.stdout.write('\n');
@@ -159,7 +164,7 @@ async function buildFile(
   const logResult = ({copied, desc} /*: {copied: boolean, desc?: string} */) =>
     silent ||
     console.log(
-      chalk.dim('  - ') +
+      styleText('dim', '  - ') +
         path.relative(PACKAGES_DIR, file) +
         (copied ? ' -> ' + path.relative(PACKAGES_DIR, buildPath) : ' ') +
         (desc != null ? ' (' + desc + ')' : ''),
@@ -318,7 +323,7 @@ async function getEntryPoints(
 
       if (target.includes('*')) {
         console.warn(
-          `${chalk.yellow('Warning')}: Encountered subpath pattern ${subpath}` +
+          `${styleText('yellow', 'Warning')}: Encountered subpath pattern ${subpath}` +
             ` in package.json exports for ${packageName}. Matched entry points ` +
             'will not be validated.',
         );


### PR DESCRIPTION
Summary:
Replaces `chalk` with Node's `util.styleText` in `packages/`.

Changelog: [Internal]

Differential Revision: D76273412


