### PR TITLE
Correct the excludePlatforms logic

### DIFF
--- a/packages/react-native-codegen/src/cli/combine/combine-schemas-cli.js
+++ b/packages/react-native-codegen/src/cli/combine/combine-schemas-cli.js
@@ -85,6 +85,20 @@ for (const file of schemaFiles) {
         }
       }
 
+      if (module.type === 'Component') {
+        const components = module.components || {};
+        const isExcludedForPlatform = Object.values(components).some(
+          component =>
+            component.excludedPlatforms
+              ?.map(p => p.toLowerCase())
+              .includes(platform),
+        );
+
+        if (isExcludedForPlatform) {
+          continue;
+        }
+      }
+
       modules[specName] = module;
       specNameToFile[specName] = file;
     }


### PR DESCRIPTION
Summary:
Discovered an issue with how we are excluding platforms in processing codegen schema.

`excludedPlatforms` is a field on `OptionsShape` part of `ComponentShape` not Module

https://www.internalfb.com/code/fbsource/[153d78d4cd5d0fa652e5a0919bcdb26f32d0945e]/xplat/js/react-native-github/packages/react-native-codegen/src/CodegenSchema.js?lines=112

Hence for components modifying the script to iterate over component and for then exclude accordingly based on `platform`.

Differential Revision: D76158851


