### PR TITLE
Fix sorting string literals in React Native API snapshot

### DIFF
--- a/scripts/build-types/transforms/__fixtures__/sortProperties.d.ts
+++ b/scripts/build-types/transforms/__fixtures__/sortProperties.d.ts
@@ -12,6 +12,8 @@ type A = {
   aMethod(): void;
   b: string,
   a: string,
+  "ba": string,
+  "ab": string,
 }
 
 interface B {

--- a/scripts/build-types/transforms/__tests__/__snapshots__/sortProperties-test.js.snap
+++ b/scripts/build-types/transforms/__tests__/__snapshots__/sortProperties-test.js.snap
@@ -10,7 +10,9 @@ exports[`sortProperties should divide type properties into methods, functions an
 
 type A = {
   a: string;
+  \\"ab\\": string;
   b: string;
+  \\"ba\\": string;
   aFn: () => void;
   bFn: () => void;
   aMethod(): void;

--- a/scripts/build-types/transforms/sortProperties.js
+++ b/scripts/build-types/transforms/sortProperties.js
@@ -48,12 +48,16 @@ function sortMembers<T>(members: T[]): T[] {
       ? a.key.id.name
       : t.isTSEnumMember(a)
         ? a.id.name
-        : a.key.name;
+        : t.isStringLiteral(a.key)
+          ? a.key.value
+          : a.key.name;
     const bName = t.isClassPrivateProperty(b)
       ? b.key.id.name
       : t.isTSEnumMember(b)
         ? b.id.name
-        : b.key.name;
+        : t.isStringLiteral(b.key)
+          ? b.key.value
+          : b.key.name;
 
     if (aName === undefined || bName === undefined) {
       return 0;


### PR DESCRIPTION
Summary:
String literals were not sorted in React Native API Snapshot. This diff fixes the issue by retrieving the value from the string literal.

Before:

```ts
type A = {
  a: string;
  b: string;
  \"ba\": string;
  \"ab\": string;
  aFn: () => void;
  bFn: () => void;
  aMethod(): void;
  bMethod(): void;
};
```

After:

```ts
type A = {
  a: string;
  \"ab\": string;
  b: string;
  \"ba\": string;
  aFn: () => void;
  bFn: () => void;
  aMethod(): void;
  bMethod(): void;
};
```

Changelog:
[Internal]

Differential Revision: D76329242


