### PR TITLE
Fix AnimationDriverTests and align with android on rounding

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/drivers/AnimationDriver.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/drivers/AnimationDriver.cpp
@@ -69,7 +69,6 @@ void AnimationDriver::runAnimationStep(double renderingTime) {
     return;
   }
 
-  // ticks are 100 nanoseconds, divide by 10000 to get milliseconds.
   const auto frameTimeMs = renderingTime;
   auto restarting = false;
   if (startFrameTimeMs_ < 0) {

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/drivers/FrameAnimationDriver.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/drivers/FrameAnimationDriver.cpp
@@ -58,7 +58,7 @@ bool FrameAnimationDriver::update(double timeDeltaMs, bool /*restarting*/) {
     }
 
     const auto startIndex =
-        static_cast<size_t>(std::ceil(timeDeltaMs / SingleFrameIntervalMs));
+        static_cast<size_t>(std::round(timeDeltaMs / SingleFrameIntervalMs));
     assert(startIndex >= 0);
     const auto nextIndex = startIndex + 1;
 

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/tests/AnimationDriverTests.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/tests/AnimationDriverTests.cpp
@@ -40,21 +40,21 @@ TEST_F(AnimationDriverTests, framesAnimation) {
           "toValue", toValue),
       std::nullopt);
 
-  const auto startTimeInTick = 12345;
+  const double startTimeInTick = 12345;
 
   runAnimationFrame(startTimeInTick);
   EXPECT_EQ(round(nodesManager_->getValue(valueNodeTag).value()), 0);
 
-  runAnimationFrame(startTimeInTick + SingleFrameIntervalMs * 2.5 * TicksPerMs);
+  runAnimationFrame(startTimeInTick + SingleFrameIntervalMs * 2.5);
   EXPECT_EQ(round(nodesManager_->getValue(valueNodeTag).value()), 65);
 
-  runAnimationFrame(startTimeInTick + SingleFrameIntervalMs * 3 * TicksPerMs);
+  runAnimationFrame(startTimeInTick + SingleFrameIntervalMs * 3);
   EXPECT_EQ(round(nodesManager_->getValue(valueNodeTag).value()), 90);
 
-  runAnimationFrame(startTimeInTick + SingleFrameIntervalMs * 4 * TicksPerMs);
+  runAnimationFrame(startTimeInTick + SingleFrameIntervalMs * 4);
   EXPECT_EQ(round(nodesManager_->getValue(valueNodeTag).value()), toValue);
 
-  runAnimationFrame(startTimeInTick + SingleFrameIntervalMs * 10 * TicksPerMs);
+  runAnimationFrame(startTimeInTick + SingleFrameIntervalMs * 10);
   EXPECT_EQ(round(nodesManager_->getValue(valueNodeTag).value()), toValue);
 }
 

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/tests/AnimationTestsBase.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/tests/AnimationTestsBase.h
@@ -42,7 +42,7 @@ class AnimationTestsBase : public testing::Test {
   }
 
   void runAnimationFrame(double timestamp) {
-    nodesManager_->onAnimationFrame(static_cast<uint64_t>(timestamp));
+    nodesManager_->onAnimationFrame(timestamp);
   }
 
   std::shared_ptr<NativeAnimatedNodesManager> nodesManager_;


### PR DESCRIPTION
Summary:
changelog: [internal]

fix existing C++ Animated tests and align with Android on how to go from current time to applied frame.

On iOS [floor](https://fburl.com/code/7zy5e5ul) is used to decide which frame to apply. On Android, [round](https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/FrameBasedAnimationDriver.kt#L65) is used.

In D75813200 I chose to use `std::ceil` as I wanted to have a predictable behaviour in tests. This is not wrong but it is better to align at least with one of the existing implementations. Let's go with Android as it strikes the balance of what we want to see in tests (an animation that is running for 1000ms should finish after 1000ms, not 1000ms + one frame) and C++ Animated is closer to at least one of the existing implementations.

Differential Revision: D76337384


