### PR TITLE
Update documentation for codegen options `interfaceOnly`

### DIFF
--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -104,6 +104,8 @@ export type ComponentShape = $ReadOnly<{
 }>;
 
 export type OptionsShape = $ReadOnly<{
+  // Use to generate only interfaces of components (C++ Props, C++ EventEmitters, JVM interfaces) and not their implementation.
+  // This is useful for components that have a custom implementation of ShadowNode, ComponentDescriptor, State.
   interfaceOnly?: boolean,
   // Use for components with no current paper rename in progress
   // Does not check for new name


### PR DESCRIPTION
Summary:
In this diff I'm updating the documentation for codegen options `interfaceOnly`

changelog: [internal] internal

Reviewed By: arushikesarwani94, cortinico

Differential Revision: D76293414


