### PR TITLE
Add UiModeUtils.isDarkMode helper

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/appearance/AppearanceModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/appearance/AppearanceModule.kt
@@ -8,13 +8,13 @@
 package com.facebook.react.modules.appearance
 
 import android.content.Context
-import android.content.res.Configuration
 import androidx.appcompat.app.AppCompatDelegate
 import com.facebook.fbreact.specs.NativeAppearanceSpec
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.bridge.buildReadableMap
 import com.facebook.react.module.annotations.ReactModule
+import com.facebook.react.views.common.ContextUtils
 
 /** Module that exposes the user's preferred color scheme. */
 @ReactModule(name = NativeAppearanceSpec.NAME)
@@ -41,12 +41,9 @@ constructor(
       return overrideColorScheme.getScheme()
     }
 
-    val currentNightMode =
-        context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
-    return when (currentNightMode) {
-      Configuration.UI_MODE_NIGHT_NO -> "light"
-      Configuration.UI_MODE_NIGHT_YES -> "dark"
-      else -> "light"
+    return when (ContextUtils.isDarkMode(context)) {
+      true -> "dark"
+      false -> "light"
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/appearance/AppearanceModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/appearance/AppearanceModule.kt
@@ -14,7 +14,7 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.bridge.buildReadableMap
 import com.facebook.react.module.annotations.ReactModule
-import com.facebook.react.views.common.ContextUtils
+import com.facebook.react.views.common.UiModeUtils
 
 /** Module that exposes the user's preferred color scheme. */
 @ReactModule(name = NativeAppearanceSpec.NAME)
@@ -41,10 +41,7 @@ constructor(
       return overrideColorScheme.getScheme()
     }
 
-    return when (ContextUtils.isDarkMode(context)) {
-      true -> "dark"
-      false -> "light"
-    }
+    return if (UiModeUtils.isDarkMode(context)) "dark" else "light"
   }
 
   public override fun getColorScheme(): String {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/common/ContextUtils.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/common/ContextUtils.kt
@@ -17,17 +17,6 @@ import android.content.res.Configuration
 internal object ContextUtils {
 
   /**
-   * Determines whether the current UI mode is dark mode
-   *
-   * @param context The context to check the UI mode from
-   * @return true if the current UI mode is dark mode, false otherwise
-   */
-  @JvmStatic
-  public fun isDarkMode(context: Context): Boolean =
-    context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK ==
-      Configuration.UI_MODE_NIGHT_YES
-
-  /**
    * Returns the nearest context in the chain (as defined by ContextWrapper.getBaseContext()) which
    * is an instance of the specified type, or null if one could not be found
    *

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/common/ContextUtils.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/common/ContextUtils.kt
@@ -9,11 +9,23 @@ package com.facebook.react.views.common
 
 import android.content.Context
 import android.content.ContextWrapper
+import android.content.res.Configuration
 
 /**
  * Class containing static methods involving manipulations of Contexts and their related subclasses.
  */
 internal object ContextUtils {
+
+  /**
+   * Determines whether the current UI mode is dark mode
+   *
+   * @param context The context to check the UI mode from
+   * @return true if the current UI mode is dark mode, false otherwise
+   */
+  @JvmStatic
+  public fun isDarkMode(context: Context): Boolean =
+    context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK ==
+      Configuration.UI_MODE_NIGHT_YES
 
   /**
    * Returns the nearest context in the chain (as defined by ContextWrapper.getBaseContext()) which

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/common/UiModeUtils.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/common/UiModeUtils.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.views.common
+
+import android.content.Context
+import android.content.res.Configuration
+
+/**
+ * Utility object providing static methods for working with UI mode properties from Context.
+ */
+internal object UiModeUtils {
+
+  /**
+   * Determines whether the current UI mode is dark mode
+   *
+   * @param context The context to check the UI mode from
+   * @return true if the current UI mode is dark mode, false otherwise
+   */
+  @JvmStatic
+  fun isDarkMode(context: Context): Boolean =
+    context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK ==
+      Configuration.UI_MODE_NIGHT_YES
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/WindowUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/WindowUtil.kt
@@ -7,7 +7,6 @@
 
 package com.facebook.react.views.view
 
-import android.content.res.Configuration
 import android.graphics.Color
 import android.os.Build
 import android.view.Window
@@ -15,6 +14,7 @@ import android.view.WindowManager
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsControllerCompat
+import com.facebook.react.views.common.ContextUtils
 
 @Suppress("DEPRECATION")
 internal fun Window.setStatusBarTranslucency(isTranslucent: Boolean) {
@@ -71,9 +71,7 @@ internal fun Window.setSystemBarsTranslucency(isTranslucent: Boolean) {
   WindowCompat.setDecorFitsSystemWindows(this, !isTranslucent)
 
   if (isTranslucent) {
-    val isDarkMode =
-        context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK ==
-            Configuration.UI_MODE_NIGHT_YES
+    val isDarkMode = ContextUtils.isDarkMode(context)
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
       isStatusBarContrastEnforced = false

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/WindowUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/WindowUtil.kt
@@ -14,7 +14,7 @@ import android.view.WindowManager
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsControllerCompat
-import com.facebook.react.views.common.ContextUtils
+import com.facebook.react.views.common.UiModeUtils
 
 @Suppress("DEPRECATION")
 internal fun Window.setStatusBarTranslucency(isTranslucent: Boolean) {
@@ -71,7 +71,7 @@ internal fun Window.setSystemBarsTranslucency(isTranslucent: Boolean) {
   WindowCompat.setDecorFitsSystemWindows(this, !isTranslucent)
 
   if (isTranslucent) {
-    val isDarkMode = ContextUtils.isDarkMode(context)
+    val isDarkMode = UiModeUtils.isDarkMode(context)
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
       isStatusBarContrastEnforced = false


### PR DESCRIPTION
## Summary:

This PR is part of the [edge-to-edge core implementation effort](https://github.com/facebook/react-native/pull/47554). It adds a helper to `ContextUtils`, called `isDarkMode` in order to be reused accross the Android codebase.

## Changelog:

- [Internal] [Added] - Add `UiModeUtils.isDarkMode` helper

## Test Plan:

<img width="300" alt="Screenshot 2025-06-10 at 17 50 19" src="https://github.com/user-attachments/assets/48795406-e852-486a-bae8-54507ad769ee" />

<img width="300" alt="Screenshot 2025-06-10 at 17 50 42" src="https://github.com/user-attachments/assets/0dbdece9-04f7-487b-ace8-4786c8da381d" />