### PR TITLE
Back out "(Redo PR #51264) Remove native animation fabric sync in JS and infinite animation loop workaround"

### DIFF
--- a/packages/react-native/Libraries/Animated/animations/Animation.js
+++ b/packages/react-native/Libraries/Animated/animations/Animation.js
@@ -13,7 +13,6 @@ import type AnimatedNode from '../nodes/AnimatedNode';
 import type AnimatedValue from '../nodes/AnimatedValue';
 
 import NativeAnimatedHelper from '../../../src/private/animated/NativeAnimatedHelper';
-import * as ReactNativeFeatureFlags from '../../../src/private/featureflags/ReactNativeFeatureFlags';
 import AnimatedProps from '../nodes/AnimatedProps';
 
 export type EndResult = {
@@ -150,10 +149,8 @@ export default class Animation {
           if (value != null) {
             animatedValue.__onAnimatedValueUpdateReceived(value, offset);
 
-            if (!ReactNativeFeatureFlags.cxxNativeAnimatedEnabled()) {
-              if (this.__isLooping === true) {
-                return;
-              }
+            if (this.__isLooping === true) {
+              return;
             }
 
             // Once the JS side node is synced with the updated values, trigger an

--- a/packages/react-native/src/private/animated/createAnimatedPropsHook.js
+++ b/packages/react-native/src/private/animated/createAnimatedPropsHook.js
@@ -132,10 +132,7 @@ export default function createAnimatedPropsHook(
           if (node.__isNative) {
             // Check 2: this is an animation driven by native.
             // In native driven animations, this callback is only called once the animation completes.
-            if (
-              isFabricNode &&
-              !ReactNativeFeatureFlags.cxxNativeAnimatedEnabled()
-            ) {
+            if (isFabricNode) {
               // Call `scheduleUpdate` to synchronise Fiber and Shadow tree.
               // Must not be called in Paper.
               scheduleUpdate();


### PR DESCRIPTION
Summary:
Reverting for the same reason as D75108344.

Original commit changeset: 966e2b187f43

Original Phabricator Diff: D75789100

Reviewed By: zijunl

Differential Revision: D76352826


