### PR TITLE
Re-use assigned root tag if possible

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -365,7 +365,10 @@ public class FabricUIManager
       final SurfaceHandlerBinding surfaceHandler,
       final Context context,
       final @Nullable View rootView) {
-    final int rootTag = ReactRootViewTagGenerator.getNextRootViewTag();
+    final int rootTag =
+        rootView instanceof ReactRoot
+            ? ((ReactRoot) rootView).getRootViewTag()
+            : ReactRootViewTagGenerator.getNextRootViewTag();
 
     ThemedReactContext reactContext =
         new ThemedReactContext(


### PR DESCRIPTION
Summary:
ReactRootView already reliably assigns itself a fresh root tag from its constructor. Assuming this `FabricUIManager.startSurface` method is called with a valid `ReactRoot` instance, we can just re-use the existing tag without minting a new one. This makes some native initialization that depends on root tag assumptions easier to setup.

## Changelog

[Internal]

Differential Revision: D76370069


