### PR TITLE
(cherry-pick) Move RefreshControlMock into Jest preset files (#51530)

### DIFF
--- a/packages/react-native/jest/RefreshControlMock.js
+++ b/packages/react-native/jest/RefreshControlMock.js
@@ -10,9 +10,9 @@
 
 'use strict';
 
-import type {HostComponent} from '../../../../src/private/types/HostComponent';
+import type {HostComponent} from '../src/private/types/HostComponent';
 
-import requireNativeComponent from '../../../ReactNative/requireNativeComponent';
+import requireNativeComponent from '../Libraries/ReactNative/requireNativeComponent';
 import * as React from 'react';
 
 const RCTRefreshControl: HostComponent<{}> = requireNativeComponent<{}>(

--- a/packages/react-native/jest/setup.js
+++ b/packages/react-native/jest/setup.js
@@ -201,9 +201,7 @@ jest
   }))
   .mock('../Libraries/Components/RefreshControl/RefreshControl', () => ({
     __esModule: true,
-    default: jest.requireActual(
-      '../Libraries/Components/RefreshControl/__mocks__/RefreshControlMock',
-    ),
+    default: jest.requireActual('./RefreshControlMock').default,
   }))
   .mock('../Libraries/Components/ScrollView/ScrollView', () => {
     const baseComponent = mockComponent(


### PR DESCRIPTION
This is a cherry pick from: https://github.com/facebook/react-native/pull/51530

Summary:

Alternative to https://github.com/facebook/react-native/pull/50784.

`__mocks__` (and other underscored dirs) are correctly excluded from our npm package via `package.json#files`. But in this instance, this is a source file for the `jest/` directory (Jest preset within `react-native`), and should be included — fix by relocating.

Changelog:
[General][Fixed] - Fix missing RefreshControlMock source in Jest preset

Reviewed By: rshest

Differential Revision: D75215731

fbshipit-source-id: 1240344c4236288f31b16513f4df16766ad1e571

# Conflicts:
#	packages/react-native/jest/setup.js

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
