### PR TITLE
Fix data race in updateRendering

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
@@ -354,8 +354,9 @@ void RuntimeScheduler_Modern::updateRendering() {
 
   // This is the integration of the Event Timing API in the Event Loop.
   // See https://w3c.github.io/event-timing/#sec-modifications-HTML
-  if (eventTimingDelegate_ != nullptr) {
-    eventTimingDelegate_->dispatchPendingEventTimingEntries(
+  const auto eventTimingDelegate = eventTimingDelegate_.load();
+  if (eventTimingDelegate != nullptr) {
+    eventTimingDelegate->dispatchPendingEventTimingEntries(
         surfaceIdsWithPendingRenderingUpdates_);
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.h
@@ -228,11 +228,15 @@ class RuntimeScheduler_Modern final : public RuntimeSchedulerBase {
   std::queue<RuntimeSchedulerRenderingUpdate> pendingRenderingUpdates_;
   std::unordered_set<SurfaceId> surfaceIdsWithPendingRenderingUpdates_;
 
+  // TODO(T227212654) eventTimingDelegate_ is only set once during startup, so
+  // the real fix here would be to delay runEventLoop until
+  // setEventTimingDelegate.
   std::atomic<ShadowTreeRevisionConsistencyManager*>
       shadowTreeRevisionConsistencyManager_{nullptr};
+  std::atomic<RuntimeSchedulerEventTimingDelegate*> eventTimingDelegate_{
+      nullptr};
 
   PerformanceEntryReporter* performanceEntryReporter_{nullptr};
-  RuntimeSchedulerEventTimingDelegate* eventTimingDelegate_{nullptr};
   RuntimeSchedulerIntersectionObserverDelegate* intersectionObserverDelegate_{
       nullptr};
 


### PR DESCRIPTION
Summary: TSAN is showing a data race in RuntimeScheduler_Modern::updateRendering.

Reviewed By: javache

Differential Revision: D76415742
