### PR TITLE
Make sure that build_npm_package waits for react-native-core prebuilds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -175,6 +175,7 @@ jobs:
         build_hermesc_windows,
         build_android,
         prebuild_apple_dependencies,
+        prebuild_react_native_core,
       ]
     container:
       image: reactnativecommunity/react-native-android:latest

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -172,6 +172,7 @@ jobs:
         build_hermesc_windows,
         build_android,
         prebuild_apple_dependencies,
+        prebuild_react_native_core,
       ]
     container:
       image: reactnativecommunity/react-native-android:latest

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -469,6 +469,7 @@ jobs:
         build_hermesc_windows,
         build_android,
         prebuild_apple_dependencies,
+        prebuild_react_native_core,
       ]
     container:
       image: reactnativecommunity/react-native-android:latest


### PR DESCRIPTION
Summary:
While working on landing the prebuild for React Native core in CI, I forgot to add a strong dependency between the build_npm_package job and the prebuild_react_native_core job in the workflow.

It was still technically working, because there are other jobs that are slower than building react_native_core that will delay built_npm_package for enough time, but this fix will make it more robust.

## Changelog:
[Internal] -

Differential Revision: D76423766
