### PR TITLE
Fix multiple artifacts with the identical extension and classifier.

### DIFF
--- a/packages/react-native/ReactAndroid/external-artifacts/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/external-artifacts/build.gradle.kts
@@ -122,7 +122,7 @@ val reactCoreReleaseDSYMArtifact: PublishArtifact =
     artifacts.add("externalArtifacts", reactCoreReleaseDSYMArtifactFile) {
       type = "tgz"
       extension = "tar.gz"
-      classifier = "reactnative-dependencies-dSYM-release"
+      classifier = "reactnative-core-dSYM-release"
     }
 
 apply(from = "../publish.gradle")


### PR DESCRIPTION
Summary:
There is a copy and paste mistake, from dependencies to core, when uploading artefacts to maven.

This change fixes it.

## Changelog:
[Internal] -

Differential Revision: D76435336
