### PR TITLE
Make com.facebook.react.views.common.ContextUtils internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -5385,11 +5385,6 @@ public abstract interface class com/facebook/react/viewmanagers/UnimplementedNat
 	public abstract fun setName (Landroid/view/View;Ljava/lang/String;)V
 }
 
-public final class com/facebook/react/views/common/ContextUtils {
-	public static final field INSTANCE Lcom/facebook/react/views/common/ContextUtils;
-	public static final fun findContextOfType (Landroid/content/Context;Ljava/lang/Class;)Ljava/lang/Object;
-}
-
 public final class com/facebook/react/views/drawer/ReactDrawerLayout : androidx/drawerlayout/widget/DrawerLayout {
 	public fun <init> (Lcom/facebook/react/bridge/ReactContext;)V
 	public fun onInterceptTouchEvent (Landroid/view/MotionEvent;)Z

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/common/ContextUtils.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/common/ContextUtils.kt
@@ -13,7 +13,7 @@ import android.content.ContextWrapper
 /**
  * Class containing static methods involving manipulations of Contexts and their related subclasses.
  */
-public object ContextUtils {
+internal object ContextUtils {
 
   /**
    * Returns the nearest context in the chain (as defined by ContextWrapper.getBaseContext()) which
@@ -24,7 +24,7 @@ public object ContextUtils {
    * @return the first context which is an instance of the specified class, or null if none exists
    */
   @JvmStatic
-  public fun <T> findContextOfType(context: Context?, clazz: Class<out T>): T? {
+  fun <T> findContextOfType(context: Context?, clazz: Class<out T>): T? {
     var currentContext = context
     while (!clazz.isInstance(currentContext)) {
       if (currentContext is ContextWrapper) {


### PR DESCRIPTION
Summary:
This class is public while it should not. It's just internal utilities which we don't really want to expose to 3p users.

I've noticed only one unmaintained libraries (3 year old) that will be affected by this change: https://github.com/phanithken/react-native-pk-image-picker/blob/3c21d0e8e3a797d73806883041500fd546e427d6/android/src/main/java/com/pkimagepicker/PkImagePickerViewHost.kt#L63
So I'm marking this as not breaking.

Changelog:
[Android] [Changed] - Make com.facebook.react.views.common.ContextUtils internal

Reviewed By: alanleedev

Differential Revision: D76429746
