### PR TITLE
RN: Preserve Stack Traces in CLI Scripts

### DIFF
--- a/packages/helloworld/lib/cli.js
+++ b/packages/helloworld/lib/cli.js
@@ -54,13 +54,11 @@ export function observe(result: ExecaPromiseMetaized): TaskResult<{}, string> {
     result.stdout.on('error', error => observer.error(error.trim()));
     result.then(
       (_: Result) => observer.complete(),
-      error =>
+      cause =>
         observer.error(
-          new Error(
-            `${styleText(['red', 'bold'], error.shortMessage)}\n${
-              error.stderr || error.stdout
-            }`,
-          ),
+          new Error(`${styleText(['red', 'bold'], cause.shortMessage)}`, {
+            cause,
+          }),
         ),
     );
 

--- a/packages/rn-tester/scripts/utils.js
+++ b/packages/rn-tester/scripts/utils.js
@@ -54,13 +54,11 @@ export function observe(result: ExecaPromiseMetaized): TaskResult<{}, string> {
     result.stdout.on('error', error => observer.error(error.trim()));
     result.then(
       (_: Result) => observer.complete(),
-      error =>
+      cause =>
         observer.error(
-          new Error(
-            `${styleText(['red', 'bold'], error.shortMessage)}\n${
-              error.stderr || error.stdout
-            }`,
-          ),
+          new Error(`${styleText(['red', 'bold'], cause.shortMessage)}`, {
+            cause,
+          }),
         ),
     );
 


### PR DESCRIPTION
Summary:
Changes the error handling in `cli.js` scripts for `rn-tester` and `helloworld` so that the original error stack traces are preserved.

Changelog:
[Internal]

Reviewed By: huntie

Differential Revision: D76458284
