### PR TITLE
Add macros to remove old runtime

### DIFF
--- a/packages/react-native/React/Base/RCTBridge+Private.h
+++ b/packages/react-native/React/Base/RCTBridge+Private.h
@@ -16,11 +16,14 @@ RCT_EXTERN void RCTRegisterModule(Class);
 
 @interface RCTBridge ()
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
 // Private designated initializer
 - (instancetype)initWithDelegate:(id<RCTBridgeDelegate>)delegate
                        bundleURL:(NSURL *)bundleURL
                   moduleProvider:(RCTBridgeModuleListProvider)block
                    launchOptions:(NSDictionary *)launchOptions NS_DESIGNATED_INITIALIZER;
+
+#endif // RCT_FIT_RM_OLD_RUNTIME
 
 // Used for the profiler flow events between JS and native
 @property (nonatomic, assign) int64_t flowID;
@@ -146,6 +149,8 @@ RCT_EXTERN void RCTRegisterModule(Class);
 // TODO(cjhopman): this seems unsafe unless we require that it is only called on the main js queue.
 @property (nonatomic, readonly) void *runtime;
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
 - (instancetype)initWithParentBridge:(RCTBridge *)bridge NS_DESIGNATED_INITIALIZER;
+#endif // RCT_FIT_RM_OLD_RUNTIME
 
 @end

--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -265,6 +265,7 @@ void RCTUIManagerSetDispatchAccessibilityManagerInitOntoMain(BOOL enabled)
   kDispatchAccessibilityManagerInitOntoMain = enabled;
 }
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
 class RCTBridgeHostTargetDelegate : public facebook::react::jsinspector_modern::HostTargetDelegate {
  public:
   RCTBridgeHostTargetDelegate(RCTBridge *bridge)
@@ -675,3 +676,110 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
   return _inspectorTarget.get();
 }
 @end
+#else // RCT_FIT_RM_OLD_RUNTIME
+@implementation RCTBridge
+- (instancetype)initWithDelegate:(id<RCTBridgeDelegate>)delegate launchOptions:(NSDictionary *)launchOptions
+{
+  return self;
+}
+
+- (instancetype)initWithBundleURL:(NSURL *)bundleURL
+                   moduleProvider:(__strong RCTBridgeModuleListProvider)block
+                    launchOptions:(NSDictionary *)launchOptions
+{
+  return self;
+}
+
+- (void)enqueueJSCall:(NSString *)moduleDotMethod args:(NSArray *)args
+{
+}
+
+- (void)enqueueJSCall:(NSString *)module
+               method:(NSString *)method
+                 args:(NSArray *)args
+           completion:(__strong dispatch_block_t)completion
+{
+}
+
+- (void)registerSegmentWithId:(NSUInteger)segmentId path:(NSString *)path
+{
+}
+
+- (id)moduleForName:(NSString *)moduleName
+{
+  return nil;
+}
+
+- (id)moduleForName:(NSString *)moduleName lazilyLoadIfNecessary:(BOOL)lazilyLoad
+{
+  return nil;
+}
+
+- (id)moduleForClass:(Class)moduleClass
+{
+  return nil;
+}
+
+- (void)setRCTTurboModuleRegistry:(id<RCTTurboModuleRegistry>)turboModuleRegistry
+{
+}
+
+- (RCTBridgeModuleDecorator *)bridgeModuleDecorator
+{
+  return nil;
+}
+
+- (NSArray *)modulesConformingToProtocol:(Protocol *)protocol
+{
+  return @[];
+}
+
+- (BOOL)moduleIsInitialized:(Class)moduleClass
+{
+  return NO;
+}
+
+- (void)reload __attribute__((deprecated("Use RCTReloadCommand instead")))
+{
+}
+
+- (void)reloadWithReason:(NSString *)reason __attribute__((deprecated("Use RCTReloadCommand instead")))
+{
+}
+
+- (void)onFastRefresh
+{
+}
+
+- (void)requestReload __attribute__((deprecated("Use RCTReloadCommand instead")))
+{
+}
+
+- (BOOL)isBatchActive
+{
+  return NO;
+}
+
+- (void)setUp
+{
+}
+
+- (void)enqueueCallback:(NSNumber *)cbID args:(NSArray *)args
+{
+}
+
++ (void)setCurrentBridge:(RCTBridge *)bridge
+{
+}
+
+- (void)invalidate
+{
+}
+
++ (instancetype)currentBridge
+{
+  return nil;
+}
+
+@end
+#endif // RCT_FIT_RM_OLD_RUNTIME

--- a/packages/react-native/React/Base/RCTBridgeDelegate.h
+++ b/packages/react-native/React/Base/RCTBridgeDelegate.h
@@ -13,6 +13,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol RCTBridgeDelegate <NSObject>
+#ifndef RCT_FIT_RM_OLD_RUNTIME
 
 /**
  * The location of the JavaScript source file. When running from the packager
@@ -69,6 +70,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (NSDictionary<NSString *, Class> *)extraLazyModuleClassesForBridge:(RCTBridge *)bridge;
 
+#endif // RCT_FIT_RM_OLD_RUNTIME
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/react-native/React/Base/RCTBridgeModule.h
+++ b/packages/react-native/React/Base/RCTBridgeModule.h
@@ -354,7 +354,9 @@ RCT_EXTERN_C_END
  * A class that allows NativeModules and TurboModules to look up one another.
  */
 @interface RCTModuleRegistry : NSObject
+#ifndef RCT_FIT_RM_OLD_RUNTIME
 - (void)setBridge:(RCTBridge *)bridge;
+#endif // RCT_FIT_RM_OLD_RUNTIME
 - (void)setTurboModuleRegistry:(id<RCTTurboModuleRegistry>)turboModuleRegistry;
 
 - (id)moduleForName:(const char *)moduleName;
@@ -373,7 +375,9 @@ typedef void (^RCTViewRegistryUIBlock)(RCTViewRegistry *viewRegistry);
  * A class that allows NativeModules to query for views, given React Tags.
  */
 @interface RCTViewRegistry : NSObject
+#ifndef RCT_FIT_RM_OLD_RUNTIME
 - (void)setBridge:(RCTBridge *)bridge;
+#endif // RCT_FIT_RM_OLD_RUNTIME
 - (void)setBridgelessComponentViewProvider:(RCTBridgelessComponentViewProvider)bridgelessComponentViewProvider;
 
 - (UIView *)viewForReactTag:(NSNumber *)reactTag;
@@ -391,7 +395,9 @@ typedef void (^RCTBridgelessJSModuleMethodInvoker)(
  * as callable with React Native.
  */
 @interface RCTCallableJSModules : NSObject
+#ifndef RCT_FIT_RM_OLD_RUNTIME
 - (void)setBridge:(RCTBridge *)bridge;
+#endif // RCT_FIT_RM_OLD_RUNTIME
 - (void)setBridgelessJSModuleMethodInvoker:(RCTBridgelessJSModuleMethodInvoker)bridgelessJSModuleMethodInvoker;
 
 - (void)invokeModule:(NSString *)moduleName method:(NSString *)methodName withArgs:(NSArray *)args;

--- a/packages/react-native/React/Base/RCTBridgeProxy.mm
+++ b/packages/react-native/React/Base/RCTBridgeProxy.mm
@@ -308,6 +308,7 @@ using namespace facebook;
            cmd:_cmd];
 }
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
 - (void)registerModuleForFrameUpdates:(id<RCTBridgeModule>)module withModuleData:(RCTModuleData *)moduleData
 {
   [self logError:@"This method is not supported. Nooping" cmd:_cmd];
@@ -318,6 +319,7 @@ using namespace facebook;
   [self logError:@"This method is not supported. Returning nil." cmd:_cmd];
   return nil;
 }
+#endif // RCT_FIT_RM_OLD_RUNTIME
 
 - (void)registerAdditionalModuleClasses:(NSArray<Class> *)newModules
 {

--- a/packages/react-native/React/Base/RCTBundleManager.h
+++ b/packages/react-native/React/Base/RCTBundleManager.h
@@ -16,7 +16,9 @@ typedef void (^RCTBridgelessBundleURLSetter)(NSURL *bundleURL);
  * A class that allows NativeModules/TurboModules to read/write the bundleURL, with or without the bridge.
  */
 @interface RCTBundleManager : NSObject
+#ifndef RCT_FIT_RM_OLD_RUNTIME
 - (void)setBridge:(RCTBridge *)bridge;
+#endif // RCT_FIT_RM_OLD_RUNTIME
 - (void)setBridgelessBundleURLGetter:(RCTBridgelessBundleURLGetter)getter
                            andSetter:(RCTBridgelessBundleURLSetter)setter
                     andDefaultGetter:(RCTBridgelessBundleURLGetter)defaultGetter;

--- a/packages/react-native/React/Base/RCTBundleManager.m
+++ b/packages/react-native/React/Base/RCTBundleManager.m
@@ -11,16 +11,20 @@
 #import "RCTBridge.h"
 
 @implementation RCTBundleManager {
+#ifndef RCT_FIT_RM_OLD_RUNTIME
   __weak RCTBridge *_bridge;
+#endif // RCT_FIT_RM_OLD_RUNTIME
   RCTBridgelessBundleURLGetter _bridgelessBundleURLGetter;
   RCTBridgelessBundleURLSetter _bridgelessBundleURLSetter;
   RCTBridgelessBundleURLGetter _bridgelessBundleURLDefaultGetter;
 }
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
 - (void)setBridge:(RCTBridge *)bridge
 {
   _bridge = bridge;
 }
+#endif // RCT_FIT_RM_OLD_RUNTIME
 
 - (void)setBridgelessBundleURLGetter:(RCTBridgelessBundleURLGetter)getter
                            andSetter:(RCTBridgelessBundleURLSetter)setter
@@ -33,10 +37,12 @@
 
 - (void)setBundleURL:(NSURL *)bundleURL
 {
+#ifndef RCT_FIT_RM_OLD_RUNTIME
   if (_bridge) {
     _bridge.bundleURL = bundleURL;
     return;
   }
+#endif // RCT_FIT_RM_OLD_RUNTIME
 
   RCTAssert(
       _bridgelessBundleURLSetter != nil,
@@ -46,9 +52,11 @@
 
 - (NSURL *)bundleURL
 {
+#ifndef RCT_FIT_RM_OLD_RUNTIME
   if (_bridge) {
     return _bridge.bundleURL;
   }
+#endif // RCT_FIT_RM_OLD_RUNTIME
 
   RCTAssert(
       _bridgelessBundleURLGetter != nil,
@@ -59,11 +67,13 @@
 
 - (void)resetBundleURL
 {
+#ifndef RCT_FIT_RM_OLD_RUNTIME
   RCTBridge *strongBridge = _bridge;
   if (strongBridge) {
     strongBridge.bundleURL = [strongBridge.delegate sourceURLForBridge:strongBridge];
     return;
   }
+#endif // RCT_FIT_RM_OLD_RUNTIME
 
   RCTAssert(
       _bridgelessBundleURLDefaultGetter != nil,

--- a/packages/react-native/React/Base/RCTCallInvokerModule.h
+++ b/packages/react-native/React/Base/RCTCallInvokerModule.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#import <Foundation/Foundation.h>
+
 @class RCTCallInvoker;
 
 /**

--- a/packages/react-native/React/Base/RCTCallableJSModules.m
+++ b/packages/react-native/React/Base/RCTCallableJSModules.m
@@ -10,13 +10,17 @@
 
 @implementation RCTCallableJSModules {
   RCTBridgelessJSModuleMethodInvoker _bridgelessJSModuleMethodInvoker;
+#ifndef RCT_FIT_RM_OLD_RUNTIME
   __weak RCTBridge *_bridge;
+#endif // RCT_FIT_RM_OLD_RUNTIME
 }
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
 - (void)setBridge:(RCTBridge *)bridge
 {
   _bridge = bridge;
 }
+#endif // RCT_FIT_RM_OLD_RUNTIME
 
 - (void)setBridgelessJSModuleMethodInvoker:(RCTBridgelessJSModuleMethodInvoker)bridgelessJSModuleMethodInvoker
 {
@@ -33,11 +37,13 @@
             withArgs:(NSArray *)args
           onComplete:(dispatch_block_t)onComplete
 {
+#ifndef RCT_FIT_RM_OLD_RUNTIME
   RCTBridge *bridge = _bridge;
   if (bridge) {
     [bridge enqueueJSCall:moduleName method:methodName args:args completion:onComplete];
     return;
   }
+#endif // RCT_FIT_RM_OLD_RUNTIME
 
   if (_bridgelessJSModuleMethodInvoker) {
     _bridgelessJSModuleMethodInvoker(moduleName, methodName, args, onComplete);

--- a/packages/react-native/React/Base/RCTJavaScriptExecutor.h
+++ b/packages/react-native/React/Base/RCTJavaScriptExecutor.h
@@ -13,6 +13,7 @@
 typedef void (^RCTJavaScriptCompleteBlock)(NSError *error);
 typedef void (^RCTJavaScriptCallback)(id result, NSError *error);
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
 /**
  * Abstracts away a JavaScript execution context - we may be running code in a
  * web view (for debugging purposes), or may be running code in a `JSContext`.
@@ -78,3 +79,4 @@ typedef void (^RCTJavaScriptCallback)(id result, NSError *error);
 - (void)executeAsyncBlockOnJavaScriptQueue:(dispatch_block_t)block;
 
 @end
+#endif // RCT_FIT_RM_OLD_RUNTIME

--- a/packages/react-native/React/Base/RCTModuleData.mm
+++ b/packages/react-native/React/Base/RCTModuleData.mm
@@ -7,6 +7,8 @@
 
 #import "RCTModuleData.h"
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
 #import <objc/runtime.h>
 #import <atomic>
 #import <mutex>
@@ -485,3 +487,38 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init);
 }
 
 @end
+
+#else // RCT_FIT_RM_OLD_RUNTIME
+@implementation RCTModuleData
+
+- (instancetype)initWithModuleClass:(Class)moduleClass
+                             bridge:(RCTBridge *)bridge
+                     moduleRegistry:(RCTModuleRegistry *)moduleRegistry
+            viewRegistry_DEPRECATED:(RCTViewRegistry *)viewRegistry_DEPRECATED
+                      bundleManager:(RCTBundleManager *)bundleManager
+                  callableJSModules:(RCTCallableJSModules *)callableJSModules
+{
+  return self;
+}
+
+- (instancetype)initWithModuleInstance:(id<RCTBridgeModule>)instance
+                                bridge:(RCTBridge *)bridge
+                        moduleRegistry:(RCTModuleRegistry *)moduleRegistry
+               viewRegistry_DEPRECATED:(RCTViewRegistry *)viewRegistry_DEPRECATED
+                         bundleManager:(RCTBundleManager *)bundleManager
+                     callableJSModules:(RCTCallableJSModules *)callableJSModules
+{
+  return self;
+}
+
+- (void)gatherConstants
+{
+}
+
+- (void)invalidate
+{
+}
+
+@end
+
+#endif // RCT_FIT_RM_OLD_RUNTIME

--- a/packages/react-native/React/Base/RCTModuleMethod.mm
+++ b/packages/react-native/React/Base/RCTModuleMethod.mm
@@ -476,6 +476,7 @@ RCT_EXTERN_C_END
     [self processMethodSignature];
     RCT_PROFILE_END_EVENT(RCTProfileTagAlways, @"");
   }
+
   return _selector;
 }
 

--- a/packages/react-native/React/Base/RCTModuleRegistry.m
+++ b/packages/react-native/React/Base/RCTModuleRegistry.m
@@ -12,13 +12,17 @@
 
 @implementation RCTModuleRegistry {
   __weak id<RCTTurboModuleRegistry> _turboModuleRegistry;
+#ifndef RCT_FIT_RM_OLD_RUNTIME
   __weak RCTBridge *_bridge;
+#endif // RCT_FIT_RM_OLD_RUNTIME
 }
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
 - (void)setBridge:(RCTBridge *)bridge
 {
   _bridge = bridge;
 }
+#endif // RCT_FIT_RM_OLD_RUNTIME
 
 - (void)setTurboModuleRegistry:(id<RCTTurboModuleRegistry>)turboModuleRegistry
 {
@@ -34,10 +38,12 @@
 {
   id<RCTBridgeModule> module = nil;
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
   RCTBridge *bridge = _bridge;
   if (bridge) {
     module = [bridge moduleForName: [NSString stringWithUTF8String:moduleName] lazilyLoadIfNecessary:lazilyLoad];
   }
+#endif // RCT_FIT_RM_OLD_RUNTIME
 
   id<RCTTurboModuleRegistry> turboModuleRegistry = _turboModuleRegistry;
   if (module == nil && turboModuleRegistry && (lazilyLoad || [turboModuleRegistry moduleIsInitialized:moduleName])) {
@@ -49,11 +55,13 @@
 
 - (BOOL)moduleIsInitialized:(Class)moduleClass
 {
+#ifndef RCT_FIT_RM_OLD_RUNTIME
   RCTBridge *bridge = _bridge;
 
   if (bridge) {
     return [bridge moduleIsInitialized:moduleClass];
   }
+#endif // RCT_FIT_RM_OLD_RUNTIME
 
   id<RCTTurboModuleRegistry> turboModuleRegistry = _turboModuleRegistry;
   if (turboModuleRegistry) {

--- a/packages/react-native/React/Base/RCTRootContentView.h
+++ b/packages/react-native/React/Base/RCTRootContentView.h
@@ -7,6 +7,8 @@
 
 #import <UIKit/UIKit.h>
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
 #import <React/RCTInvalidating.h>
 #import <React/RCTRootView.h>
 #import <React/RCTView.h>
@@ -30,3 +32,5 @@
               sizeFlexibility:(RCTRootViewSizeFlexibility)sizeFlexibility NS_DESIGNATED_INITIALIZER;
 
 @end
+
+#endif // RCT_FIT_RM_OLD_RUNTIME

--- a/packages/react-native/React/Base/RCTRootContentView.m
+++ b/packages/react-native/React/Base/RCTRootContentView.m
@@ -7,6 +7,8 @@
 
 #import "RCTRootContentView.h"
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
 #import "RCTBridge.h"
 #import "RCTPerformanceLogger.h"
 #import "RCTRootView.h"
@@ -105,3 +107,5 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (nonnull NSCoder *)aDecoder)
 }
 
 @end
+
+#endif // RCT_FIT_RM_OLD_RUNTIME

--- a/packages/react-native/React/Base/RCTRootView.m
+++ b/packages/react-native/React/Base/RCTRootView.m
@@ -30,6 +30,8 @@
 
 NSString *const RCTContentDidAppearNotification = @"RCTContentDidAppearNotification";
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
 @implementation RCTRootView {
   RCTBridge *_bridge;
   NSString *_moduleName;
@@ -396,3 +398,33 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
 }
 
 @end
+
+#else // RCT_FIT_RM_OLD_RUNTIME
+
+@implementation RCTRootView
+- (nonnull instancetype)initWithFrame:(CGRect)frame
+                               bridge:(nonnull RCTBridge *)bridge
+                           moduleName:(nonnull NSString *)moduleName
+                    initialProperties:(nullable NSDictionary *)initialProperties
+{
+  return self;
+}
+
+- (nonnull instancetype)initWithBridge:(nonnull RCTBridge *)bridge
+                            moduleName:(nonnull NSString *)moduleName
+                     initialProperties:(nullable NSDictionary *)initialProperties
+{
+  return self;
+}
+
+- (nonnull instancetype)initWithBundleURL:(nonnull NSURL *)bundleURL
+                               moduleName:(nonnull NSString *)moduleName
+                        initialProperties:(nullable NSDictionary *)initialProperties
+                            launchOptions:(nullable NSDictionary *)launchOptions
+{
+  return self;
+}
+
+@end
+
+#endif // RCT_FIT_RM_OLD_RUNTIME

--- a/packages/react-native/React/Base/RCTRootViewInternal.h
+++ b/packages/react-native/React/Base/RCTRootViewInternal.h
@@ -7,6 +7,8 @@
 
 #import <React/RCTRootView.h>
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
 /**
  * The interface provides a set of functions that allow other internal framework
  * classes to change the RCTRootViews's internal state.
@@ -22,3 +24,5 @@
 - (void)contentViewInvalidated;
 
 @end
+
+#endif // RCT_FIT_RM_OLD_RUNTIME

--- a/packages/react-native/React/Base/RCTViewRegistry.m
+++ b/packages/react-native/React/Base/RCTViewRegistry.m
@@ -13,13 +13,17 @@
 
 @implementation RCTViewRegistry {
   RCTBridgelessComponentViewProvider _bridgelessComponentViewProvider;
+#ifndef RCT_FIT_RM_OLD_RUNTIME
   __weak RCTBridge *_bridge;
+#endif // RCT_FIT_RM_OLD_RUNTIME
 }
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
 - (void)setBridge:(RCTBridge *)bridge
 {
   _bridge = bridge;
 }
+#endif // RCT_FIT_RM_OLD_RUNTIME
 
 - (void)setBridgelessComponentViewProvider:(RCTBridgelessComponentViewProvider)bridgelessComponentViewProvider
 {
@@ -30,10 +34,12 @@
 {
   UIView *view = nil;
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
   RCTBridge *bridge = _bridge;
   if (bridge) {
     view = [bridge.uiManager viewForReactTag:reactTag];
   }
+#endif // RCT_FIT_RM_OLD_RUNTIME
 
   if (view == nil && _bridgelessComponentViewProvider) {
     view = _bridgelessComponentViewProvider(reactTag);
@@ -49,6 +55,7 @@
   }
 
   __weak __typeof(self) weakSelf = self;
+#ifndef RCT_FIT_RM_OLD_RUNTIME
   if (_bridge) {
     [_bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
       __typeof(self) strongSelf = weakSelf;
@@ -56,14 +63,16 @@
         block(strongSelf);
       }
     }];
-  } else {
-    RCTExecuteOnMainQueue(^{
-      __typeof(self) strongSelf = weakSelf;
-      if (strongSelf) {
-        block(strongSelf);
-      }
-    });
+    return;
   }
+#endif
+
+  RCTExecuteOnMainQueue(^{
+    __typeof(self) strongSelf = weakSelf;
+    if (strongSelf) {
+      block(strongSelf);
+    }
+  }); // RCT_FIT_RM_OLD_RUNTIME
 }
 
 @end

--- a/packages/react-native/React/Base/Surface/RCTSurface.mm
+++ b/packages/react-native/React/Base/Surface/RCTSurface.mm
@@ -27,6 +27,8 @@
 #import "RCTUIManagerObserverCoordinator.h"
 #import "RCTUIManagerUtils.h"
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
 @interface RCTSurface () <RCTSurfaceRootShadowViewDelegate, RCTUIManagerObserver>
 @end
 
@@ -604,3 +606,69 @@
 }
 
 @end
+
+#else // RCT_FIT_RM_OLD_RUNTIME
+@implementation RCTSurface
+@synthesize stage;
+@synthesize moduleName;
+@synthesize delegate;
+@synthesize rootViewTag;
+@synthesize properties;
+@synthesize rootTag;
+@synthesize intrinsicSize;
+
+- (nonnull instancetype)initWithBridge:(nonnull RCTBridge *)bridge
+                            moduleName:(nonnull NSString *)moduleName
+                     initialProperties:(nonnull NSDictionary *)initialProperties
+{
+  return self;
+}
+
+- (void)setSize:(CGSize)size
+{
+}
+
+- (BOOL)synchronouslyWaitForStage:(RCTSurfaceStage)stage timeout:(NSTimeInterval)timeout
+{
+  return NO;
+}
+
+- (void)mountReactComponentWithBridge:(nonnull RCTBridge *)bridge
+                           moduleName:(nonnull NSString *)moduleName
+                               params:(nonnull NSDictionary *)params
+{
+}
+
+- (void)unmountReactComponentWithBridge:(nonnull RCTBridge *)bridge rootViewTag:(nonnull NSNumber *)rootViewTag
+{
+}
+
+- (void)setMinimumSize:(CGSize)minimumSize maximumSize:(CGSize)maximumSize
+{
+}
+
+- (void)setMinimumSize:(CGSize)minimumSize maximumSize:(CGSize)maximumSize viewportOffset:(CGPoint)viewportOffset
+{
+}
+
+- (nonnull RCTSurfaceView *)view
+{
+  return nil;
+}
+
+- (CGSize)sizeThatFitsMinimumSize:(CGSize)minimumSize maximumSize:(CGSize)maximumSize
+{
+  return {};
+}
+
+- (void)start
+{
+}
+
+- (void)stop
+{
+}
+
+@end
+
+#endif // RCT_FIT_RM_OLD_RUNTIME

--- a/packages/react-native/React/Base/Surface/RCTSurfaceRootShadowView.m
+++ b/packages/react-native/React/Base/Surface/RCTSurfaceRootShadowView.m
@@ -7,6 +7,8 @@
 
 #import "RCTSurfaceRootShadowView.h"
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
 #import "RCTI18nUtil.h"
 #import "RCTShadowView+Layout.h"
 #import "RCTUIManagerUtils.h"
@@ -89,3 +91,18 @@
 }
 
 @end
+
+#else // RCT_FIT_RM_OLD_RUNTIME
+
+@implementation RCTSurfaceRootShadowView
+- (void)setMinimumSize:(CGSize)size maximumSize:(CGSize)maximumSize
+{
+}
+
+- (void)layoutWithAffectedShadowViews:(NSPointerArray *)affectedShadowViews
+{
+}
+
+@end
+
+#endif // RCT_FIT_RM_OLD_RUNTIME

--- a/packages/react-native/React/Base/Surface/RCTSurfaceView.mm
+++ b/packages/react-native/React/Base/Surface/RCTSurfaceView.mm
@@ -10,6 +10,7 @@
 
 #import "RCTDefines.h"
 #import "RCTSurface.h"
+#import "RCTSurfaceProtocol.h"
 #import "RCTSurfaceRootView.h"
 
 @implementation RCTSurfaceView {

--- a/packages/react-native/React/CoreModules/RCTLogBox.mm
+++ b/packages/react-native/React/CoreModules/RCTLogBox.mm
@@ -58,7 +58,9 @@ RCT_EXPORT_METHOD(show)
         strongSelf->_view = [[RCTLogBoxView alloc] initWithWindow:RCTKeyWindow()
                                                  surfacePresenter:strongSelf->_bridgelessSurfacePresenter];
         [strongSelf->_view show];
-      } else if (strongSelf->_bridge && strongSelf->_bridge.valid) {
+      }
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+      else if (strongSelf->_bridge && strongSelf->_bridge.valid) {
         if (strongSelf->_bridge.surfacePresenter) {
           strongSelf->_view = [[RCTLogBoxView alloc] initWithWindow:RCTKeyWindow()
                                                    surfacePresenter:strongSelf->_bridge.surfacePresenter];
@@ -67,6 +69,7 @@ RCT_EXPORT_METHOD(show)
         }
         [strongSelf->_view show];
       }
+#endif // RCT_FIT_RM_OLD_RUNTIME
     });
   }
 }

--- a/packages/react-native/React/CoreModules/RCTLogBoxView.h
+++ b/packages/react-native/React/CoreModules/RCTLogBoxView.h
@@ -16,7 +16,9 @@
 
 - (void)createRootViewController:(UIView *)view;
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
 - (instancetype)initWithWindow:(UIWindow *)window bridge:(RCTBridge *)bridge;
+#endif // RCT_FIT_RM_OLD_RUNTIME
 - (instancetype)initWithWindow:(UIWindow *)window surfacePresenter:(id<RCTSurfacePresenterStub>)surfacePresenter;
 
 - (void)show;

--- a/packages/react-native/React/CoreModules/RCTLogBoxView.mm
+++ b/packages/react-native/React/CoreModules/RCTLogBoxView.mm
@@ -12,7 +12,9 @@
 #import <React/RCTSurfaceHostingView.h>
 
 @implementation RCTLogBoxView {
+#ifndef RCT_FIT_RM_OLD_RUNTIME
   RCTSurface *_surface;
+#endif // RCT_FIT_RM_OLD_RUNTIME
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -33,6 +35,7 @@
   self.rootViewController = _rootViewController;
 }
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
 - (instancetype)initWithWindow:(UIWindow *)window bridge:(RCTBridge *)bridge
 {
   RCTErrorNewArchitectureValidation(RCTNotAllowedInFabricWithoutLegacy, @"RCTLogBoxView", nil);
@@ -52,6 +55,7 @@
 
   return self;
 }
+#endif // RCT_FIT_RM_OLD_RUNTIME
 
 - (instancetype)initWithWindow:(UIWindow *)window surfacePresenter:(id<RCTSurfacePresenterStub>)surfacePresenter
 {
@@ -70,7 +74,9 @@
 - (void)layoutSubviews
 {
   [super layoutSubviews];
+#ifndef RCT_FIT_RM_OLD_RUNTIME
   [_surface setSize:self.frame.size];
+#endif // RCT_FIT_RM_OLD_RUNTIME
 }
 
 - (void)dealloc

--- a/packages/react-native/React/CxxBridge/JSCExecutorFactory.h
+++ b/packages/react-native/React/CxxBridge/JSCExecutorFactory.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
 #include <jsireact/JSIExecutor.h>
 
 namespace facebook::react {
@@ -25,3 +27,5 @@ class JSCExecutorFactory : public JSExecutorFactory {
 };
 
 } // namespace facebook::react
+
+#endif // RCT_FIT_RM_OLD_RUNTIME

--- a/packages/react-native/React/CxxBridge/JSCExecutorFactory.mm
+++ b/packages/react-native/React/CxxBridge/JSCExecutorFactory.mm
@@ -7,6 +7,8 @@
 
 #include "JSCExecutorFactory.h"
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
 #import <jsc/JSCRuntime.h>
 
 #import <memory>
@@ -22,3 +24,5 @@ std::unique_ptr<JSExecutor> JSCExecutorFactory::createJSExecutor(
 }
 
 } // namespace facebook::react
+
+#endif // RCT_FIT_RM_OLD_RUNTIME

--- a/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
+++ b/packages/react-native/React/CxxBridge/RCTCxxBridge.mm
@@ -64,6 +64,8 @@
 #import <React/RCTDevLoadingViewProtocol.h>
 #endif
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
 static NSString *const RCTJSThreadName = @"com.facebook.react.JavaScript";
 
 typedef void (^RCTPendingCall)();
@@ -1587,3 +1589,8 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithBundleURL
 }
 
 @end
+
+#else // RCT_FIT_RM_OLD_RUNTIME
+@implementation RCTCxxBridge
+@end
+#endif // RCT_FIT_RM_OLD_RUNTIME

--- a/packages/react-native/React/CxxBridge/RCTJSIExecutorRuntimeInstaller.h
+++ b/packages/react-native/React/CxxBridge/RCTJSIExecutorRuntimeInstaller.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
 #include <jsireact/JSIExecutor.h>
 
 namespace facebook::react {
@@ -19,3 +21,5 @@ JSIExecutor::RuntimeInstaller RCTJSIExecutorRuntimeInstaller(
     JSIExecutor::RuntimeInstaller runtimeInstallerToWrap);
 
 } // namespace facebook::react
+
+#endif // RCT_FIT_RM_OLD_RUNTIME

--- a/packages/react-native/React/CxxBridge/RCTJSIExecutorRuntimeInstaller.mm
+++ b/packages/react-native/React/CxxBridge/RCTJSIExecutorRuntimeInstaller.mm
@@ -7,6 +7,8 @@
 
 #include "RCTJSIExecutorRuntimeInstaller.h"
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
 #import <React/RCTLog.h>
 #include <chrono>
 
@@ -28,3 +30,5 @@ JSIExecutor::RuntimeInstaller RCTJSIExecutorRuntimeInstaller(JSIExecutor::Runtim
 }
 
 } // namespace facebook::react
+
+#endif // RCT_FIT_RM_OLD_RUNTIME

--- a/packages/react-native/React/CxxBridge/RCTObjcExecutor.h
+++ b/packages/react-native/React/CxxBridge/RCTObjcExecutor.h
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
 #include <functional>
 #include <memory>
 
@@ -29,3 +31,5 @@ class RCTObjcExecutorFactory : public JSExecutorFactory {
 };
 
 } // namespace facebook::react
+
+#endif // RCT_FIT_RM_OLD_RUNTIME

--- a/packages/react-native/React/CxxBridge/RCTObjcExecutor.mm
+++ b/packages/react-native/React/CxxBridge/RCTObjcExecutor.mm
@@ -7,6 +7,8 @@
 
 #import "RCTObjcExecutor.h"
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
 #import <React/RCTCxxUtils.h>
 #import <React/RCTJavaScriptExecutor.h>
 #import <React/RCTLog.h>
@@ -144,3 +146,5 @@ std::unique_ptr<JSExecutor> RCTObjcExecutorFactory::createJSExecutor(
 }
 
 } // namespace facebook::react
+
+#endif // RCT_FIT_RM_OLD_RUNTIME

--- a/packages/react-native/React/CxxModule/DispatchMessageQueueThread.h
+++ b/packages/react-native/React/CxxModule/DispatchMessageQueueThread.h
@@ -10,6 +10,8 @@
 #include <React/RCTLog.h>
 #include <cxxreact/MessageQueueThread.h>
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
 namespace facebook::react {
 
 // RCTNativeModule arranges for native methods to be invoked on a queue which
@@ -43,3 +45,5 @@ class DispatchMessageQueueThread : public MessageQueueThread {
 };
 
 } // namespace facebook::react
+
+#endif // RCT_FIT_RM_OLD_RUNTIME

--- a/packages/react-native/React/CxxModule/RCTCxxUtils.h
+++ b/packages/react-native/React/CxxModule/RCTCxxUtils.h
@@ -18,8 +18,12 @@ namespace facebook::react {
 class Instance;
 class NativeModule;
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
 std::vector<std::unique_ptr<NativeModule>>
 createNativeModules(NSArray<RCTModuleData *> *modules, RCTBridge *bridge, const std::shared_ptr<Instance> &instance);
+
+#endif // RCT_FIT_RM_OLD_RUNTIME
 
 NSError *tryAndReturnError(const std::function<void()> &func);
 NSString *deriveSourceURL(NSURL *url);

--- a/packages/react-native/React/CxxModule/RCTCxxUtils.mm
+++ b/packages/react-native/React/CxxModule/RCTCxxUtils.mm
@@ -20,6 +20,8 @@ namespace facebook::react {
 
 using facebook::jsi::JSError;
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
 std::vector<std::unique_ptr<NativeModule>>
 createNativeModules(NSArray<RCTModuleData *> *modules, RCTBridge *bridge, const std::shared_ptr<Instance> &instance)
 {
@@ -37,6 +39,8 @@ createNativeModules(NSArray<RCTModuleData *> *modules, RCTBridge *bridge, const 
   }
   return nativeModules;
 }
+
+#endif // RCT_FIT_RM_OLD_RUNTIME
 
 static NSError *errorWithException(const std::exception &e)
 {

--- a/packages/react-native/React/CxxModule/RCTNativeModule.h
+++ b/packages/react-native/React/CxxModule/RCTNativeModule.h
@@ -8,6 +8,8 @@
 #import <React/RCTModuleData.h>
 #import <cxxreact/NativeModule.h>
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
 namespace facebook::react {
 
 class RCTNativeModule : public NativeModule {
@@ -30,3 +32,5 @@ class RCTNativeModule : public NativeModule {
 };
 
 } // namespace facebook::react
+
+#endif // RCT_FIT_RM_OLD_RUNTIME

--- a/packages/react-native/React/CxxModule/RCTNativeModule.mm
+++ b/packages/react-native/React/CxxModule/RCTNativeModule.mm
@@ -7,6 +7,8 @@
 
 #import "RCTNativeModule.h"
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
 #import <Foundation/Foundation.h>
 #import <React/RCTBridge.h>
 #import <React/RCTBridgeMethod.h>
@@ -235,3 +237,5 @@ static MethodCallResult invokeInner(
 }
 
 } // namespace facebook::react
+
+#endif // RCT_FIT_RM_OLD_RUNTIME

--- a/packages/react-native/ReactCommon/cxxreact/CxxNativeModule.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/CxxNativeModule.cpp
@@ -6,6 +6,9 @@
  */
 
 #include "CxxNativeModule.h"
+
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
 #include "Instance.h"
 
 #include <folly/json.h>
@@ -250,3 +253,5 @@ void CxxNativeModule::lazyInit() {
 }
 
 } // namespace facebook::react
+
+#endif // RCT_FIT_RM_OLD_RUNTIME

--- a/packages/react-native/ReactCommon/cxxreact/CxxNativeModule.h
+++ b/packages/react-native/ReactCommon/cxxreact/CxxNativeModule.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
 #include <cxxreact/CxxModule.h>
 #include <cxxreact/NativeModule.h>
 
@@ -66,3 +68,5 @@ class RN_EXPORT CxxNativeModule : public NativeModule {
 };
 
 } // namespace facebook::react
+
+#endif // RCT_FIT_RM_OLD_RUNTIME

--- a/packages/react-native/ReactCommon/cxxreact/Instance.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/Instance.cpp
@@ -7,6 +7,8 @@
 
 #include "Instance.h"
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
 #include "ErrorUtils.h"
 #include "JSBigString.h"
 #include "JSBundleType.h"
@@ -362,3 +364,5 @@ void Instance::JSCallInvoker::scheduleAsync(CallFunc&& work) noexcept {
 }
 
 } // namespace facebook::react
+
+#endif // RCT_FIT_RM_OLD_RUNTIME

--- a/packages/react-native/ReactCommon/cxxreact/Instance.h
+++ b/packages/react-native/ReactCommon/cxxreact/Instance.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
 #include <condition_variable>
 #include <list>
 #include <memory>
@@ -184,3 +186,5 @@ class RN_EXPORT Instance : private jsinspector_modern::InstanceTargetDelegate {
 };
 
 } // namespace facebook::react
+
+#endif // RCT_FIT_RM_OLD_RUNTIME

--- a/packages/react-native/ReactCommon/cxxreact/JSExecutor.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/JSExecutor.cpp
@@ -18,9 +18,11 @@ namespace facebook::react {
 std::string JSExecutor::getSyntheticBundlePath(
     uint32_t bundleId,
     const std::string& bundlePath) {
+#ifndef RCT_FIT_RM_OLD_RUNTIME
   if (bundleId == RAMBundleRegistry::MAIN_BUNDLE_ID) {
     return bundlePath;
   }
+#endif // RCT_FIT_RM_OLD_RUNTIME
 
   std::array<char, 32> buffer{};
   std::snprintf(buffer.data(), buffer.size(), "seg-%u.js", bundleId);

--- a/packages/react-native/ReactCommon/cxxreact/JSExecutor.h
+++ b/packages/react-native/ReactCommon/cxxreact/JSExecutor.h
@@ -70,11 +70,13 @@ class RN_EXPORT JSExecutor {
       std::unique_ptr<const JSBigString> script,
       std::string sourceURL) = 0;
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
   /**
    * Add an application "RAM" bundle registry
    */
   virtual void setBundleRegistry(
       std::unique_ptr<RAMBundleRegistry> bundleRegistry) = 0;
+#endif // RCT_FIT_RM_OLD_RUNTIME
 
   /**
    * Register a file path for an additional "RAM" bundle

--- a/packages/react-native/ReactCommon/cxxreact/JSIndexedRAMBundle.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/JSIndexedRAMBundle.cpp
@@ -7,6 +7,9 @@
 
 #include "JSIndexedRAMBundle.h"
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
+#include <glog/logging.h>
 #include <fstream>
 #include <sstream>
 
@@ -129,3 +132,5 @@ void JSIndexedRAMBundle::readBundle(
 }
 
 } // namespace facebook::react
+
+#endif // RCT_FIT_RM_OLD_RUNTIME

--- a/packages/react-native/ReactCommon/cxxreact/JSIndexedRAMBundle.h
+++ b/packages/react-native/ReactCommon/cxxreact/JSIndexedRAMBundle.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
 #include <functional>
 #include <istream>
 #include <memory>
@@ -71,3 +73,5 @@ class RN_EXPORT JSIndexedRAMBundle : public JSModulesUnbundle {
 };
 
 } // namespace facebook::react
+
+#endif // RCT_FIT_RM_OLD_RUNTIME

--- a/packages/react-native/ReactCommon/cxxreact/JSModulesUnbundle.h
+++ b/packages/react-native/ReactCommon/cxxreact/JSModulesUnbundle.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
 #include <cstdint>
 #include <stdexcept>
 #include <string>
@@ -42,3 +44,5 @@ class JSModulesUnbundle {
 };
 
 } // namespace facebook::react
+
+#endif // RCT_FIT_RM_OLD_RUNTIME

--- a/packages/react-native/ReactCommon/cxxreact/MethodCall.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/MethodCall.cpp
@@ -7,6 +7,8 @@
 
 #include "MethodCall.h"
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
 #include <folly/json.h>
 #include <stdexcept>
 
@@ -85,3 +87,5 @@ std::vector<MethodCall> parseMethodCalls(folly::dynamic&& jsonData) {
 }
 
 } // namespace facebook::react
+
+#endif // RCT_FIT_RM_OLD_RUNTIME

--- a/packages/react-native/ReactCommon/cxxreact/MethodCall.h
+++ b/packages/react-native/ReactCommon/cxxreact/MethodCall.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
 #include <map>
 #include <string>
 #include <vector>
@@ -32,3 +34,5 @@ struct MethodCall {
 std::vector<MethodCall> parseMethodCalls(folly::dynamic&& calls);
 
 } // namespace facebook::react
+
+#endif // RCT_FIT_RM_OLD_RUNTIME

--- a/packages/react-native/ReactCommon/cxxreact/ModuleRegistry.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/ModuleRegistry.cpp
@@ -7,6 +7,8 @@
 
 #include "ModuleRegistry.h"
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
 #include <glog/logging.h>
 #include <reactperflogger/BridgeNativeModulePerfLogger.h>
 
@@ -239,3 +241,5 @@ MethodCallResult ModuleRegistry::callSerializableNativeHook(
 }
 
 } // namespace facebook::react
+
+#endif // RCT_FIT_RM_OLD_RUNTIME

--- a/packages/react-native/ReactCommon/cxxreact/ModuleRegistry.h
+++ b/packages/react-native/ReactCommon/cxxreact/ModuleRegistry.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
 #include <memory>
 #include <unordered_set>
 #include <vector>
@@ -88,3 +90,5 @@ class RN_EXPORT ModuleRegistry {
 };
 
 } // namespace facebook::react
+
+#endif // RCT_FIT_RM_OLD_RUNTIME

--- a/packages/react-native/ReactCommon/cxxreact/NativeModule.h
+++ b/packages/react-native/ReactCommon/cxxreact/NativeModule.h
@@ -15,6 +15,7 @@
 
 namespace facebook::react {
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
 struct MethodDescriptor {
   std::string name;
   // type is one of js MessageQueue.MethodTypes
@@ -23,9 +24,11 @@ struct MethodDescriptor {
   MethodDescriptor(std::string n, std::string t)
       : name(std::move(n)), type(std::move(t)) {}
 };
+#endif // RCT_FIT_RM_OLD_RUNTIME
 
 using MethodCallResult = std::optional<folly::dynamic>;
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
 class NativeModule {
  public:
   virtual ~NativeModule() {}
@@ -39,5 +42,6 @@ class NativeModule {
       unsigned int reactMethodId,
       folly::dynamic&& args) = 0;
 };
+#endif // RCT_FIT_RM_OLD_RUNTIME
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/cxxreact/NativeToJsBridge.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/NativeToJsBridge.cpp
@@ -7,6 +7,8 @@
 
 #include "NativeToJsBridge.h"
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
 #include <ReactCommon/CallInvoker.h>
 #include <folly/json.h>
 #include <glog/logging.h>
@@ -345,3 +347,5 @@ NativeToJsBridge::getInspectorTargetDelegate() {
 }
 
 } // namespace facebook::react
+
+#endif // RCT_FIT_RM_OLD_RUNTIME

--- a/packages/react-native/ReactCommon/cxxreact/NativeToJsBridge.h
+++ b/packages/react-native/ReactCommon/cxxreact/NativeToJsBridge.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
 #include <atomic>
 #include <functional>
 #include <map>
@@ -135,3 +137,5 @@ class NativeToJsBridge {
 };
 
 } // namespace facebook::react
+
+#endif // RCT_FIT_RM_OLD_RUNTIME

--- a/packages/react-native/ReactCommon/cxxreact/RAMBundleRegistry.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/RAMBundleRegistry.cpp
@@ -7,6 +7,8 @@
 
 #include "RAMBundleRegistry.h"
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
 #include <folly/String.h>
 
 #include <memory>
@@ -78,3 +80,5 @@ JSModulesUnbundle* RAMBundleRegistry::getBundle(uint32_t bundleId) const {
 }
 
 } // namespace facebook::react
+
+#endif // RCT_FIT_RM_OLD_RUNTIME

--- a/packages/react-native/ReactCommon/cxxreact/RAMBundleRegistry.h
+++ b/packages/react-native/ReactCommon/cxxreact/RAMBundleRegistry.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -52,3 +54,5 @@ class RN_EXPORT RAMBundleRegistry {
 };
 
 } // namespace facebook::react
+
+#endif // RCT_FIT_RM_OLD_RUNTIME

--- a/packages/react-native/ReactCommon/jsiexecutor/jsireact/JSIExecutor.cpp
+++ b/packages/react-native/ReactCommon/jsiexecutor/jsireact/JSIExecutor.cpp
@@ -25,6 +25,8 @@ using namespace facebook::jsi;
 
 namespace facebook::react {
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
 class JSIExecutor::NativeModuleProxy : public jsi::HostObject {
  public:
   NativeModuleProxy(std::shared_ptr<JSINativeModules> nativeModules)
@@ -520,6 +522,55 @@ Value JSIExecutor::globalEvalWithSourceUrl(const Value* args, size_t count) {
   return runtime_->evaluateJavaScript(
       std::make_unique<StringBuffer>(std::move(code)), url);
 }
+
+#else // RCT_FIT_RM_OLD_RUNTIME
+
+JSIExecutor::JSIExecutor(
+    std::shared_ptr<jsi::Runtime> runtime,
+    std::shared_ptr<ExecutorDelegate> delegate,
+    const JSIScopedTimeoutInvoker& scopedTimeoutInvoker,
+    RuntimeInstaller runtimeInstaller) {}
+
+void JSIExecutor::initializeRuntime() {}
+
+void JSIExecutor::loadBundle(
+    std::unique_ptr<const JSBigString> script,
+    std::string sourceURL) {}
+
+void JSIExecutor::registerBundle(
+    uint32_t bundleId,
+    const std::string& bundlePath) {}
+
+void JSIExecutor::callFunction(
+    const std::string& moduleId,
+    const std::string& methodId,
+    const folly::dynamic& arguments) {}
+
+void JSIExecutor::invokeCallback(
+    const double callbackId,
+    const folly::dynamic& arguments) {}
+
+void JSIExecutor::setGlobalVariable(
+    std::string propName,
+    std::unique_ptr<const JSBigString> jsonValue) {}
+
+std::string JSIExecutor::getDescription() {
+  return "null";
+}
+
+void* JSIExecutor::getJavaScriptContext() {
+  return nullptr;
+}
+
+bool JSIExecutor::isInspectable() {
+  return false;
+}
+
+void JSIExecutor::handleMemoryPressure(int pressureLevel) {}
+
+void JSIExecutor::flush() {}
+
+#endif // RCT_FIT_RM_OLD_RUNTIME
 
 void bindNativeLogger(Runtime& runtime, Logger logger) {
   runtime.global().setProperty(

--- a/packages/react-native/ReactCommon/jsiexecutor/jsireact/JSIExecutor.h
+++ b/packages/react-native/ReactCommon/jsiexecutor/jsireact/JSIExecutor.h
@@ -80,7 +80,9 @@ class JSIExecutor : public JSExecutor {
   void loadBundle(
       std::unique_ptr<const JSBigString> script,
       std::string sourceURL) override;
+#ifndef RCT_FIT_RM_OLD_RUNTIME
   void setBundleRegistry(std::unique_ptr<RAMBundleRegistry>) override;
+#endif // RCT_FIT_RM_OLD_RUNTIME
   void registerBundle(uint32_t bundleId, const std::string& bundlePath)
       override;
   void callFunction(
@@ -109,6 +111,7 @@ class JSIExecutor : public JSExecutor {
   void flush() override;
 
  private:
+#ifndef RCT_FIT_RM_OLD_RUNTIME
   class NativeModuleProxy;
 
   void bindBridge();
@@ -129,6 +132,7 @@ class JSIExecutor : public JSExecutor {
   std::optional<jsi::Function> callFunctionReturnFlushedQueue_;
   std::optional<jsi::Function> invokeCallbackAndReturnFlushedQueue_;
   std::optional<jsi::Function> flushedQueue_;
+#endif // RCT_FIT_RM_OLD_RUNTIME
 };
 
 using Logger =

--- a/packages/react-native/ReactCommon/jsiexecutor/jsireact/JSINativeModules.cpp
+++ b/packages/react-native/ReactCommon/jsiexecutor/jsireact/JSINativeModules.cpp
@@ -6,6 +6,9 @@
  */
 
 #include "jsireact/JSINativeModules.h"
+
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
 #include <reactperflogger/BridgeNativeModulePerfLogger.h>
 
 #include <glog/logging.h>
@@ -107,3 +110,5 @@ std::optional<Object> JSINativeModules::createModule(
 }
 
 } // namespace facebook::react
+
+#endif // RCT_FIT_RM_OLD_RUNTIME

--- a/packages/react-native/ReactCommon/jsiexecutor/jsireact/JSINativeModules.h
+++ b/packages/react-native/ReactCommon/jsiexecutor/jsireact/JSINativeModules.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#ifndef RCT_FIT_RM_OLD_RUNTIME
+
 #include <memory>
 #include <string>
 
@@ -36,3 +38,5 @@ class JSINativeModules {
 };
 
 } // namespace facebook::react
+
+#endif // RCT_FIT_RM_OLD_RUNTIME

--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.h
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <ReactCommon/RuntimeExecutor.h>
+#include <cxxreact/JSBigString.h>
 #include <cxxreact/MessageQueueThread.h>
 #include <jserrorhandler/JsErrorHandler.h>
 #include <jsi/jsi.h>


### PR DESCRIPTION
Summary:
This diff adds macros around the legacy architecture core.

To compile out the legacy architecture, simply set: -DRCT_FIT_RM_OLD_RUNTIME=1.

* RCTBridge: interface kept around
* RCTRootView: interface kept around
* RCTSurface: interface kept around
* RCTModuleData: interface kept around (used by RCTProfile)
* RCTProfile: Kept around (doesn't work in bridgeless...)
* RCTCxxBridge: interface kept around
* c++ bridge: removed
* legacy components in core: kept around (for now)

## Details
I added comments to each of the #else, and #endif directives. That way, we can more easily codemod this code in the future.

Changelog: [Internal]

Reviewed By: mdvacca

Differential Revision: D72582307
