### PR TITLE
fix: add ImageSource type to TypeScript

### DIFF
--- a/packages/react-native/Libraries/Image/ImageSource.d.ts
+++ b/packages/react-native/Libraries/Image/ImageSource.d.ts
@@ -72,3 +72,8 @@ export interface ImageURISource {
 }
 
 export type ImageRequireSource = number;
+
+export type ImageSource =
+  | ImageRequireSource
+  | ImageURISource
+  | ReadonlyArray<ImageURISource>;


### PR DESCRIPTION
## Summary:

This PR adds ImageSource type to ImageSource.d.ts which is defined in Flow: 

https://github.com/facebook/react-native/blob/d6f29c8afd14b2cc835649db3c59ed2f0e685331/packages/react-native/Libraries/Image/ImageSource.js#L87-L90 

But not in the TypeScript file.

## Changelog:


[GENERAL] [FIXED] - add ImageSource type to TypeScript


## Test Plan:

CI Green
