### PR TITLE
Enable Defines Module option for RCTImage pod

### DIFF
--- a/packages/react-native/Libraries/Image/React-RCTImage.podspec
+++ b/packages/react-native/Libraries/Image/React-RCTImage.podspec
@@ -38,7 +38,8 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig    = {
                                "USE_HEADERMAP" => "YES",
                                "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
-                               "HEADER_SEARCH_PATHS" => header_search_paths.join(' ')
+                               "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),
+                               "DEFINES_MODULE" => "YES"
                              }
   s.framework              = ["Accelerate", "UIKit", "QuartzCore", "ImageIO", "CoreGraphics"]
 


### PR DESCRIPTION
## Summary:

This is to enable consuming RCTImage pod in mixed ObjC/Swift codebase. W/o this option set I get following error when building the library:

```
Installing RNScreens 4.11.1
[!] The following Swift pods cannot yet be integrated as static libraries:

The Swift pod `RNScreens` depends upon `React-RCTImage`, which does not define modules. To opt into those targets generating module maps (which is necessary to import them from Swift when building as static libraries), you may set `use_modular_headers!` globally in your Podfile, or specify `:modular_headers => true` for particular dependencies.
```

I've noticed that there is also a precedent in the form of https://github.com/facebook/react-native/commit/c8fcac2765e0f79f0e7bb3a422a65698aec62536, which handled very simlar case but for `React-jsc` pod.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [FIXED] - Allow for consuming RCTImage in Swift codebase by enabling "Defines Module" option

## Test Plan:

RNTester should build & run correctly
