### PR TITLE
Fix Type comparison (v2) in TurboModuleInteropUtils.kt (2/2)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleInteropUtils.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleInteropUtils.kt
@@ -233,8 +233,8 @@ internal object TurboModuleInteropUtils {
       i += 1
     }
 
-    if (returnClass == java.lang.Boolean::class.javaPrimitiveType ||
-        returnClass == java.lang.Boolean::class.java) {
+    if (returnClass == Boolean::class.javaPrimitiveType ||
+        returnClass == Boolean::class.javaObjectType) {
       return "BooleanKind"
     }
 


### PR DESCRIPTION
Summary:
Fix type checking that was left out from the last diff; D73224138

We should unify the type checking so remove uses of `java.lang.Boolean` and just use Kotlin version of `Boolean`.

Changelog:
[Internal]

Differential Revision: D76523674
