### PR TITLE
Fix accessibilityRespondsToUserInteraction not setting on first render

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.cpp
@@ -162,7 +162,7 @@ AccessibilityProps::AccessibilityProps(
                     rawProps,
                     "accessibilityRespondsToUserInteraction",
                     sourceProps.accessibilityRespondsToUserInteraction,
-                    {})),
+                    true)),
       onAccessibilityTap(
           ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.onAccessibilityTap

--- a/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.h
@@ -49,7 +49,10 @@ class AccessibilityProps {
   bool accessibilityViewIsModal{false};
   bool accessibilityElementsHidden{false};
   bool accessibilityIgnoresInvertColors{false};
-  bool accessibilityRespondsToUserInteraction{};
+  // This prop is enabled by default on iOS, we need to match this on
+  // C++ because if not, it will default to false before render which prevents
+  // the view from being updated with the correct value.
+  bool accessibilityRespondsToUserInteraction{true};
   bool onAccessibilityTap{};
   bool onAccessibilityMagicTap{};
   bool onAccessibilityEscape{};


### PR DESCRIPTION
Summary: "{}" defaults to false on C++ but the prop is not initialized which means that if accessibilityEnablesUserInteraction is set to false it will not be applied on first render. setting the default to true fixes that issue

Differential Revision: D76532158
