### PR TITLE
Prevent exporting internal objects of codegen

### DIFF
--- a/packages/react-native-codegen/src/generators/RNCodegen.js
+++ b/packages/react-native-codegen/src/generators/RNCodegen.js
@@ -73,6 +73,20 @@ const ALL_GENERATORS = {
   generateViewConfigJs: generateViewConfigJs.generate,
 };
 
+type FilesOutput = Map<string, string>;
+
+type GenerateFunction = (
+  libraryName: string,
+  schema: SchemaType,
+  packageName?: string,
+  assumeNonnull: boolean,
+  headerPrefix?: string,
+) => FilesOutput;
+
+type LibraryGeneratorsFunctions = $ReadOnly<{
+  [string]: Array<GenerateFunction>,
+}>;
+
 type LibraryOptions = $ReadOnly<{
   libraryName: string,
   schema: SchemaType,
@@ -113,7 +127,7 @@ type SchemasConfig = $ReadOnly<{
   test?: boolean,
 }>;
 
-const LIBRARY_GENERATORS = {
+const LIBRARY_GENERATORS: LibraryGeneratorsFunctions = {
   descriptors: [
     generateComponentDescriptorCpp.generate,
     generateComponentDescriptorH.generate,

--- a/packages/react-native-codegen/src/generators/RNCodegen.js
+++ b/packages/react-native-codegen/src/generators/RNCodegen.js
@@ -245,8 +245,6 @@ function checkOrWriteFiles(
 
 module.exports = {
   allGenerators: ALL_GENERATORS,
-  libraryGenerators: LIBRARY_GENERATORS,
-  schemaGenerators: SCHEMAS_GENERATORS,
 
   generate(
     {


### PR DESCRIPTION
Summary:
In this diff I'm limiting visibility of internal objects of codegen, these objects are being exported but they are unused, let's avoid exporting them

changelog: [internal] internal

Reviewed By: christophpurrer

Differential Revision: D76470809
