### PR TITLE
Introduce parameter to customize libraryGenerators used in the codegen

### DIFF
--- a/packages/react-native-codegen/src/generators/RNCodegen.js
+++ b/packages/react-native-codegen/src/generators/RNCodegen.js
@@ -73,6 +73,20 @@ const ALL_GENERATORS = {
   generateViewConfigJs: generateViewConfigJs.generate,
 };
 
+type FilesOutput = Map<string, string>;
+
+type GenerateFunction = (
+  libraryName: string,
+  schema: SchemaType,
+  packageName?: string,
+  assumeNonnull: boolean,
+  headerPrefix?: string,
+) => FilesOutput;
+
+type LibraryGeneratorsFunctions = $ReadOnly<{
+  [string]: Array<GenerateFunction>,
+}>;
+
 type LibraryOptions = $ReadOnly<{
   libraryName: string,
   schema: SchemaType,
@@ -113,7 +127,7 @@ type SchemasConfig = $ReadOnly<{
   test?: boolean,
 }>;
 
-const LIBRARY_GENERATORS = {
+const LIBRARY_GENERATORS: LibraryGeneratorsFunctions = {
   descriptors: [
     generateComponentDescriptorCpp.generate,
     generateComponentDescriptorH.generate,

--- a/packages/react-native-codegen/src/generators/RNCodegen.js
+++ b/packages/react-native-codegen/src/generators/RNCodegen.js
@@ -245,8 +245,6 @@ function checkOrWriteFiles(
 
 module.exports = {
   allGenerators: ALL_GENERATORS,
-  libraryGenerators: LIBRARY_GENERATORS,
-  schemaGenerators: SCHEMAS_GENERATORS,
 
   generate(
     {

--- a/packages/react-native-codegen/src/generators/RNCodegen.js
+++ b/packages/react-native-codegen/src/generators/RNCodegen.js
@@ -94,6 +94,7 @@ type LibraryOptions = $ReadOnly<{
   packageName?: string, // Some platforms have a notion of package, which should be configurable.
   assumeNonnull: boolean,
   useLocalIncludePaths?: boolean,
+  libraryGenerators?: LibraryGeneratorsFunctions,
 }>;
 
 type SchemasOptions = $ReadOnly<{
@@ -254,6 +255,7 @@ module.exports = {
       packageName,
       assumeNonnull,
       useLocalIncludePaths,
+      libraryGenerators = LIBRARY_GENERATORS,
     }: LibraryOptions,
     {generators, test}: LibraryConfig,
   ): boolean {
@@ -290,7 +292,7 @@ module.exports = {
     const generatedFiles: Array<CodeGenFile> = [];
 
     for (const name of generators) {
-      for (const generator of LIBRARY_GENERATORS[name]) {
+      for (const generator of libraryGenerators[name]) {
         generator(
           libraryName,
           schema,


### PR DESCRIPTION
Summary:
This diff introduces a new parameter to customize libraryGenerators used in the codegen, since I'm adding a default object, this diff shoulnd't change any behavior

changelog: [internal] internal

Reviewed By: christophpurrer

Differential Revision: D76472495
