### PR TITLE
RN: Return zero measure values in measure API when ReactRootView cannot be found in view hierarchy

### DIFF
--- a/packages/react-native/React/Modules/RCTUIManager.mm
+++ b/packages/react-native/React/Modules/RCTUIManager.mm
@@ -1381,6 +1381,14 @@ RCT_EXPORT_METHOD(measure : (nonnull NSNumber *)reactTag callback : (RCTResponse
       rootView = rootView.superview;
     }
 
+    // It is possible that the RootView can't be found because this view is no longer on the screen
+    // and has been removed by clipping (eg. by setting the `removeClippedSubview` prop to `true`)
+    if (![rootView isReactRootView]) {
+      RCTLogError(@"measure cannot find react root view for view with tag #%@", reactTag);
+      callback(@[ @(0), @(0), @(0), @(0), @(0), @(0) ]);
+      return;
+    }
+
     // By convention, all coordinates, whether they be touch coordinates, or
     // measurement coordinates are with respect to the root view.
     CGRect frame = view.frame;


### PR DESCRIPTION
## Summary:

This PR addresses a critical issue with the  `measure` API on iOS when used in conjunction with `removeClippedSubviews` in FlatList. The current implementation can lead to incorrect intersection measurements, particularly affecting components that rely on accurate view measurements for features like exposure tracking.

The root cause is that when `removeClippedSubviews` is enabled, views outside the visible area are removed from their superview. When measure is called on these views, it fails to properly traverse up to the `RCTRootView`, resulting in incorrect coordinate calculations. This leads to false positives in intersection detection, especially for components implementing exposure tracking functionality.

The fix follows [Android's more robust implementation](https://github.com/facebook/react-native/blob/e61daa831dd399e7f69d3c02c59ec6800e3f5342/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java#L711) by adding proper validation to ensure measurements are always relative to RCTRootView, and returning appropriate values when this cannot be achieved.

## Changelog:

[IOS] [FIXED] - Fixed incorrect measurements from measure API when used with removeClippedSubviews

## Test Plan:

1. Created a test case with a horizontal FlatList containing multiple items, each wrapped in an IntersectionObserverView
2. Verified that with removeClippedSubviews={true}:
3. Views outside the visible area return correct measurements (0,0,0,0) instead of false positives
4. Views inside the visible area maintain accurate measurements
5. Tested on both iOS simulator and physical devices

The testing video/representation is on the way.
