### PR TITLE
Set final value via direct manipulation to fix animation glitches

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.cpp
@@ -756,6 +756,12 @@ bool NativeAnimatedNodesManager::commitProps() {
 
   if (fabricCommitCallback_ != nullptr) {
     if (!updateViewProps_.empty()) {
+      // Must call direct manipulation to set final values on components.
+      if (directManipulationCallback_ != nullptr) {
+        for (const auto& [viewTag, props] : updateViewProps_) {
+          directManipulationCallback_(viewTag, folly::dynamic(props));
+        }
+      }
       fabricCommitCallback_(updateViewProps_);
       updateViewProps_.clear();
     }


### PR DESCRIPTION
Summary:
changelog: [internal]

On iOS, once a prop on a view is controlled by animated, the control is never released to Fabric or React. That's why it is important to use direct manipulation to commit even final value.

Reviewed By: lenaic

Differential Revision: D76601913
