### PR TITLE
Disabling `updateRuntimeShadowNodeReferencesOnCommit` by default.

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
@@ -314,10 +314,6 @@ class RCTAppDelegateBridgelessFeatureFlags : public ReactNativeFeatureFlagsDefau
   {
     return true;
   }
-  bool updateRuntimeShadowNodeReferencesOnCommit() override
-  {
-    return true;
-  }
   bool useShadowNodeStateOnClone() override
   {
     return true;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android.kt
@@ -18,7 +18,5 @@ public class ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android(
 
   override fun useTurboModules(): Boolean = bridgelessEnabled || turboModulesEnabled
 
-  override fun updateRuntimeShadowNodeReferencesOnCommit(): Boolean = true
-
   override fun useShadowNodeStateOnClone(): Boolean = true
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Disabling `updateRuntimeShadowNodeReferencesOnCommit` by default on v0.79-stable

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Internal] - Disable updateRuntimeShadowNodeReferencesOnCommit for OSS

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
```
yarn test
```