### PR TITLE
Clean up incorrect `@VisibleForTesting` annotation usages

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -74,7 +74,6 @@ import com.facebook.react.bridge.queue.ReactQueueConfigurationSpec;
 import com.facebook.react.common.LifecycleState;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.common.SurfaceDelegateFactory;
-import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.common.annotations.internal.LegacyArchitecture;
 import com.facebook.react.common.annotations.internal.LegacyArchitectureLogLevel;
 import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger;
@@ -1115,7 +1114,6 @@ public class ReactInstanceManager {
   /**
    * @return current ReactApplicationContext
    */
-  @VisibleForTesting
   public @Nullable ReactContext getCurrentReactContext() {
     synchronized (mReactContextLock) {
       return mCurrentReactContext;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BridgeReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BridgeReactContext.java
@@ -21,7 +21,6 @@ import com.facebook.react.common.ReactConstants;
 import com.facebook.react.common.annotations.DeprecatedInNewArchitecture;
 import com.facebook.react.common.annotations.FrameworkAPI;
 import com.facebook.react.common.annotations.UnstableReactNativeAPI;
-import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.common.annotations.internal.LegacyArchitecture;
 import com.facebook.react.common.annotations.internal.LegacyArchitectureLogLevel;
 import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger;
@@ -35,7 +34,6 @@ import java.util.Collection;
  * BridgeReactContext.
  */
 @DeprecatedInNewArchitecture
-@VisibleForTesting
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
 public class BridgeReactContext extends ReactApplicationContext {
   static {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstance.kt
@@ -9,7 +9,6 @@ package com.facebook.react.bridge
 
 import com.facebook.proguard.annotations.DoNotStrip
 import com.facebook.react.bridge.queue.ReactQueueConfiguration
-import com.facebook.react.common.annotations.VisibleForTesting
 import com.facebook.react.common.annotations.internal.LegacyArchitecture
 import com.facebook.react.internal.turbomodule.core.interfaces.TurboModuleRegistry
 import com.facebook.react.turbomodule.core.interfaces.CallInvokerHolder
@@ -53,7 +52,7 @@ public interface CatalystInstance : MemoryPressureListener, JSInstance, JSBundle
   public val isDestroyed: Boolean
 
   /** Initialize all the native modules */
-  @VisibleForTesting public fun initialize()
+  public fun initialize()
 
   public val reactQueueConfiguration: ReactQueueConfiguration
 
@@ -90,7 +89,7 @@ public interface CatalystInstance : MemoryPressureListener, JSInstance, JSBundle
   /** This method registers the file path of an additional JS segment by its ID. */
   public fun registerSegment(segmentId: Int, path: String)
 
-  @VisibleForTesting public fun setGlobalVariable(propName: String, jsonValue: String)
+  public fun setGlobalVariable(propName: String, jsonValue: String)
 
   /**
    * Do not use this anymore. Use [runtimeExecutor] instead. Get the C pointer (as a long) to the

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactSurfaceImpl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactSurfaceImpl.kt
@@ -188,7 +188,6 @@ internal constructor(
   internal val eventDispatcher: EventDispatcher?
     get() = reactHost?.eventDispatcher
 
-  @get:VisibleForTesting
   internal val isAttached: Boolean
     get() = reactHost != null
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CSSBackgroundDrawable.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CSSBackgroundDrawable.java
@@ -32,7 +32,6 @@ import androidx.core.graphics.ColorUtils;
 import androidx.core.util.Preconditions;
 import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.common.annotations.UnstableReactNativeAPI;
-import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.modules.i18nmanager.I18nUtil;
 import com.facebook.react.uimanager.FloatUtil;
 import com.facebook.react.uimanager.LengthPercentage;
@@ -346,7 +345,6 @@ public class CSSBackgroundDrawable extends Drawable {
     invalidateSelf();
   }
 
-  @VisibleForTesting
   public int getColor() {
     return mColor;
   }


### PR DESCRIPTION
## Summary:

Static code analysis reports 18 warnings for incorrect usages of the `@VisibleForTesting` annotation as some of the classes/functions/properties that are annotated are not used only in tests but also in other non-test files across the codebase. This PR cleans that up to fix those warnings.

## Changelog:

[INTERNAL] - Clean up incorrect @VisibleForTesting annotation usages

## Test Plan:

```sh
yarn test-android
yarn android
```