### PR TITLE
Exclude interfaceOnly components across all libraries for auto-generated registry

### DIFF
--- a/packages/react-native-codegen/src/cli/combine/combine-schemas-cli.js
+++ b/packages/react-native-codegen/src/cli/combine/combine-schemas-cli.js
@@ -94,20 +94,23 @@ for (const file of schemaFiles) {
               .includes(platform),
         );
 
-        if (isExcludedForPlatform) {
+        // Check for interfaceOnly components
+        const hasInterfaceOnly = Object.values(components).some(
+          component =>
+            component.interfaceOnly !== undefined && component.interfaceOnly,
+        );
+
+        if (
+          isExcludedForPlatform ||
+          hasInterfaceOnly ||
+          schema.libraryName === 'FBReactNativeSpec'
+        ) {
           continue;
         }
       }
 
-      if (
-        module.type === 'Component' &&
-        schema.libraryName === 'FBReactNativeSpec'
-      ) {
-        continue;
-      } else {
-        modules[specName] = module;
-        specNameToFile[specName] = file;
-      }
+      modules[specName] = module;
+      specNameToFile[specName] = file;
     }
   }
 }


### PR DESCRIPTION
Summary:
Changelog:
[Android][Fixed] - Exclude `interfaceOnly` components across all libraries for auto-generated registry

Differential Revision: D76700560
