### PR TITLE
Fix nightly download of Hermes and react-native-dependencies

### DIFF
--- a/packages/react-native/scripts/cocoapods/rndependencies.rb
+++ b/packages/react-native/scripts/cocoapods/rndependencies.rb
@@ -142,8 +142,17 @@ class ReactNativeDependenciesUtils
     end
 
     def self.nightly_tarball_url(version)
-        params = "r=snapshots\&g=com.facebook.react\&a=react-native-artifacts\&c=reactnative-dependencies-debug\&e=tar.gz\&v=#{version}-SNAPSHOT"
-        return resolve_url_redirects("http://oss.sonatype.org/service/local/artifact/maven/redirect\?#{params}")
+        artefact_coordinate = "react-native-artifacts"
+        artefact_name = "reactnative-dependencies-debug.tar.gz"
+        xml_url = "https://central.sonatype.com/repository/maven-snapshots/com/facebook/react/#{artefact_coordinate}/#{version}-SNAPSHOT/maven-metadata.xml"
+
+        xml = REXML::Document.new(Net::HTTP.get(URI(xml_url)))
+        timestamp = xml.elements['metadata/versioning/snapshot/timestamp'].text
+        build_number = xml.elements['metadata/versioning/snapshot/buildNumber'].text
+        full_version = "#{version}-#{timestamp}-#{build_number}"
+
+        final_url = "https://central.sonatype.com/repository/maven-snapshots/com/facebook/react/#{artefact_coordinate}/#{version}-SNAPSHOT/#{artefact_coordinate}-#{full_version}-#{artefact_name}"
+        return final_url
     end
 
     def self.download_stable_rndeps(react_native_path, version, configuration)

--- a/packages/react-native/sdks/hermes-engine/hermes-utils.rb
+++ b/packages/react-native/sdks/hermes-engine/hermes-utils.rb
@@ -230,8 +230,17 @@ def download_hermes_tarball(react_native_path, tarball_url, version, configurati
 end
 
 def nightly_tarball_url(version)
-    params = "r=snapshots\&g=com.facebook.react\&a=react-native-artifacts\&c=hermes-ios-debug\&e=tar.gz\&v=#{version}-SNAPSHOT"
-    return resolve_url_redirects("http://oss.sonatype.org/service/local/artifact/maven/redirect\?#{params}")
+  artefact_coordinate = "react-native-artifacts"
+  artefact_name = "hermes-ios-debug.tar.gz"
+  xml_url = "https://central.sonatype.com/repository/maven-snapshots/com/facebook/react/#{artefact_coordinate}/#{version}-SNAPSHOT/maven-metadata.xml"
+
+  xml = REXML::Document.new(Net::HTTP.get(URI(xml_url)))
+  timestamp = xml.elements['metadata/versioning/snapshot/timestamp'].text
+  build_number = xml.elements['metadata/versioning/snapshot/buildNumber'].text
+  full_version = "#{version}-#{timestamp}-#{build_number}"
+
+  final_url = "https://central.sonatype.com/repository/maven-snapshots/com/facebook/react/#{artefact_coordinate}/#{version}-SNAPSHOT/#{artefact_coordinate}-#{full_version}-#{artefact_name}"
+  return final_url
 end
 
 def resolve_url_redirects(url)


### PR DESCRIPTION
Summary:
This change fixes the download of the artefacts for the nightlies of Hermes and React Native Dependencies after we changed the publishing logic for Maven

## Changelog:
[Internal] -

Reviewed By: cortinico

Differential Revision: D76723289
