### PR TITLE
Fix crash on ReactInstance due to null returned for getViewManagerNames

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -1079,6 +1079,10 @@ public class ReactInstanceManager {
             if (reactPackage instanceof ViewManagerOnDemandReactPackage) {
               Collection<String> names =
                   ((ViewManagerOnDemandReactPackage) reactPackage).getViewManagerNames(context);
+              // When converting this class to Kotlin, you need to retain this null check
+              // or wrap around a try/catch otherwise this will cause a crash for OSS libraries
+              // that are not migrated to Kotlin yet and are returning null for
+              // `getViewManagerNames`
               if (names != null) {
                 uniqueNames.addAll(names);
               }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.kt
@@ -67,6 +67,7 @@ import com.facebook.react.uimanager.ViewManager
 import com.facebook.react.uimanager.ViewManagerRegistry
 import com.facebook.react.uimanager.ViewManagerResolver
 import com.facebook.react.uimanager.events.EventDispatcher
+import com.facebook.react.util.RNLog
 import com.facebook.soloader.SoLoader
 import com.facebook.systrace.Systrace
 import com.facebook.systrace.SystraceMessage
@@ -542,7 +543,18 @@ internal class ReactInstance(
         for (reactPackage in reactPackages) {
           if (reactPackage is ViewManagerOnDemandReactPackage) {
             val names = reactPackage.getViewManagerNames(context)
-            uniqueNames.addAll(names)
+            // We need to null check here because some Java implementation of the
+            // `ViewManagerOnDemandReactPackage` interface could still return null even
+            // if the method is marked as returning a non-nullable collection in Kotlin.
+            // See https://github.com/facebook/react-native/issues/52014
+            @Suppress("SENSELESS_COMPARISON")
+            if (names == null) {
+              RNLog.w(
+                  context,
+                  "The ReactPackage called: `${reactPackage.javaClass.simpleName}` is returning null for getViewManagerNames(). This is violating the signature of the method. That method should be updated to return an empty collection.")
+            } else {
+              uniqueNames.addAll(names)
+            }
           }
         }
         return uniqueNames


### PR DESCRIPTION
Summary:
Fixes https://github.com/facebook/react-native/issues/52014

Some OSS library is still returning null for `getViewManagerNames` especially if they're
implementing the `ViewManagerOnDemandReactPackage` in Java.
I'm adding a try-catch here so that we prevent the NPE for those scenarios.

Changelog:
[Android] [Fixed] - Fix crash on ReactInstance due to null returned for getViewManagerNames

Differential Revision: D76723826
