### PR TITLE
[RN][Codegen] Backports fix: exclusion of selectively disabled libraries from codegen generation

### DIFF
--- a/packages/react-native/scripts/codegen/__tests__/generate-artifacts-executor-test.js
+++ b/packages/react-native/scripts/codegen/__tests__/generate-artifacts-executor-test.js
@@ -52,6 +52,7 @@ describe('extractLibrariesFromJSON', () => {
         jsSrcsDir: '.',
       },
       libraryPath: rootPath,
+      name: 'react-native',
     });
   });
 
@@ -71,6 +72,7 @@ describe('extractLibrariesFromJSON', () => {
         jsSrcsDir: '.',
       },
       libraryPath: myDependencyPath,
+      name: 'react-native',
     });
     expect(libraries[1]).toEqual({
       config: {
@@ -79,6 +81,7 @@ describe('extractLibrariesFromJSON', () => {
         jsSrcsDir: 'component/js',
       },
       libraryPath: myDependencyPath,
+      name: 'my-component',
     });
     expect(libraries[2]).toEqual({
       config: {
@@ -87,6 +90,7 @@ describe('extractLibrariesFromJSON', () => {
         jsSrcsDir: 'module/js',
       },
       libraryPath: myDependencyPath,
+      name: 'my-module',
     });
   });
 });

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor.js
@@ -198,6 +198,7 @@ function printDeprecationWarningIfNeeded(dependency) {
 function extractLibrariesFromConfigurationArray(configFile, dependencyPath) {
   return configFile.codegenConfig.libraries.map(config => {
     return {
+      name: config.name,
       config,
       libraryPath: dependencyPath,
     };
@@ -213,6 +214,7 @@ function extractLibrariesFromJSON(configFile, dependencyPath) {
     const config = configFile.codegenConfig;
     return [
       {
+        name: configFile.name,
         config,
         libraryPath: dependencyPath,
       },


### PR DESCRIPTION
## Summary:
Backport of #51838 to 0.79

## Changelog:
[IOS] [FIXED] - Skip codegen for selectively disabled libraries in react-native.config.js

## Test Plan:
1. Install a library that has the componentProvider field set in the codegen config (for example: react-native-safe-area-context and react-native-screens or see [reproducer](https://github.com/aattola/rn-codegen-exclude?rgh-link-date=2025-06-05T12%3A13%3A05Z))
1. Exclude library with react-native.config.js
1. install pods / run codegen
1. Check that codegen actually excluded the specified dependencies from: ios/build/generated/ios/RCTThirdPartyComponentsProvider.mm

