### PR TITLE
[RN][iOS]Fix OSS CI

### DIFF
--- a/packages/react-native/ReactCommon/runtimeexecutor/React-runtimeexecutor.podspec
+++ b/packages/react-native/ReactCommon/runtimeexecutor/React-runtimeexecutor.podspec
@@ -43,8 +43,12 @@ Pod::Spec.new do |s|
                                "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),
                                "DEFINES_MODULE" => "YES" }
 
+  add_rn_third_party_dependencies(s)
+
   s.dependency "React-jsi", version
-  s.dependency "React-featureflags", version
+  add_dependency(s, "React-featureflags")
   add_dependency(s, "React-debug")
   add_dependency(s, "React-utils", :additional_framework_paths => ["react/utils/platform/ios"])
+
+
 end

--- a/packages/react-native/scripts/cocoapods/rndependencies.rb
+++ b/packages/react-native/scripts/cocoapods/rndependencies.rb
@@ -142,17 +142,23 @@ class ReactNativeDependenciesUtils
     end
 
     def self.nightly_tarball_url(version)
-        artefact_coordinate = "react-native-artifacts"
-        artefact_name = "reactnative-dependencies-debug.tar.gz"
-        xml_url = "https://central.sonatype.com/repository/maven-snapshots/com/facebook/react/#{artefact_coordinate}/#{version}-SNAPSHOT/maven-metadata.xml"
+        artifact_coordinate = "react-native-artifacts"
+        artifact_name = "reactnative-dependencies-debug.tar.gz"
+        xml_url = "https://central.sonatype.com/repository/maven-snapshots/com/facebook/react/#{artifact_coordinate}/#{version}-SNAPSHOT/maven-metadata.xml"
 
-        xml = REXML::Document.new(Net::HTTP.get(URI(xml_url)))
-        timestamp = xml.elements['metadata/versioning/snapshot/timestamp'].text
-        build_number = xml.elements['metadata/versioning/snapshot/buildNumber'].text
-        full_version = "#{version}-#{timestamp}-#{build_number}"
 
-        final_url = "https://central.sonatype.com/repository/maven-snapshots/com/facebook/react/#{artefact_coordinate}/#{version}-SNAPSHOT/#{artefact_coordinate}-#{full_version}-#{artefact_name}"
-        return final_url
+        response = Net::HTTP.get(URI(xml_url))
+        if response.kind_of? Net::HTTPSuccess
+          xml = REXML::Document.new(response)
+          timestamp = xml.elements['metadata/versioning/snapshot/timestamp'].text
+          build_number = xml.elements['metadata/versioning/snapshot/buildNumber'].text
+          full_version = "#{version}-#{timestamp}-#{build_number}"
+
+          final_url = "https://central.sonatype.com/repository/maven-snapshots/com/facebook/react/#{artifact_coordinate}/#{version}-SNAPSHOT/#{artifact_coordinate}-#{full_version}-#{artifact_name}"
+          return final_url
+        else
+          return ""
+        end
     end
 
     def self.download_stable_rndeps(react_native_path, version, configuration)

--- a/packages/react-native/sdks/hermes-engine/hermes-utils.rb
+++ b/packages/react-native/sdks/hermes-engine/hermes-utils.rb
@@ -230,17 +230,22 @@ def download_hermes_tarball(react_native_path, tarball_url, version, configurati
 end
 
 def nightly_tarball_url(version)
-  artefact_coordinate = "react-native-artifacts"
-  artefact_name = "hermes-ios-debug.tar.gz"
-  xml_url = "https://central.sonatype.com/repository/maven-snapshots/com/facebook/react/#{artefact_coordinate}/#{version}-SNAPSHOT/maven-metadata.xml"
+  artifact_coordinate = "react-native-artifacts"
+  artifact_name = "hermes-ios-debug.tar.gz"
+  xml_url = "https://central.sonatype.com/repository/maven-snapshots/com/facebook/react/#{artifact_coordinate}/#{version}-SNAPSHOT/maven-metadata.xml"
 
-  xml = REXML::Document.new(Net::HTTP.get(URI(xml_url)))
-  timestamp = xml.elements['metadata/versioning/snapshot/timestamp'].text
-  build_number = xml.elements['metadata/versioning/snapshot/buildNumber'].text
-  full_version = "#{version}-#{timestamp}-#{build_number}"
+  response = Net::HTTP.get(URI(xml_url))
+  if response.kind_of? Net::HTTPSuccess
+    xml = REXML::Document.new(response)
+    timestamp = xml.elements['metadata/versioning/snapshot/timestamp'].text
+    build_number = xml.elements['metadata/versioning/snapshot/buildNumber'].text
+    full_version = "#{version}-#{timestamp}-#{build_number}"
+    final_url = "https://central.sonatype.com/repository/maven-snapshots/com/facebook/react/#{artifact_coordinate}/#{version}-SNAPSHOT/#{artifact_coordinate}-#{full_version}-#{artifact_name}"
 
-  final_url = "https://central.sonatype.com/repository/maven-snapshots/com/facebook/react/#{artefact_coordinate}/#{version}-SNAPSHOT/#{artefact_coordinate}-#{full_version}-#{artefact_name}"
-  return final_url
+    return final_url
+  else
+    return ""
+  end
 end
 
 def resolve_url_redirects(url)


### PR DESCRIPTION
## Summary:
The OSS CI for iOS is broken because of a couple of commit that landed:
- Commit 05a61e816108774499bcf837d48d2c0c681d9559 : dynamic frameworks are broken
- Commit abc8fe1c92e5f8014d2c8b84f39daaed1fd6660e : pod donwload is broken

This change fixes both of them

## Changelog:
[Internal] - Fix OSS CI

## Test Plan:
Tested locally by building RNTester with Dynamic frameworks

```
USE_FRAMEWORKS=dynamic bundle exec pod install 
```

