### PR TITLE
Improve how throws from components are reported to the console

### DIFF
--- a/packages/react-native/Libraries/Core/ExceptionsManager.js
+++ b/packages/react-native/Libraries/Core/ExceptionsManager.js
@@ -105,7 +105,7 @@ function reportException(
     // we feed back into console.error, to make sure any methods that are
     // monkey patched on top of console.error are called when coming from
     // handleException
-    console.error(data.message);
+    console.error(e);
   }
 
   if (__DEV__) {


### PR DESCRIPTION
Summary:
Uncaught errors are currently raising a custom error to `console.error`:
* With somewhat unclear messaging.
* Only the **component stack** is reported.
* The top-most stack leads to the component where the throw occurred and not to the actual error being thrown.
* The actual error being thrown is never logged

After this change:
* We print the actual error thrown
* The *Owner stack* is attached

## Changelog:
[General][Breaking] Improve messaging and add error stack trace in console errors generated on throws from components.

----

This is a breaking change because someone might be monkey-patching console.errors, or just listens to them.

Differential Revision: D75080385
