### PR TITLE
RN: Update Fantom Path in `EXCLUDED_FIRST_PARTY_PATHS`

### DIFF
--- a/packages/react-native-babel-preset/src/configs/main.js
+++ b/packages/react-native-babel-preset/src/configs/main.js
@@ -15,8 +15,9 @@ const lazyImports = require('./lazy-imports');
 
 const EXCLUDED_FIRST_PARTY_PATHS = [
   /[/\\]node_modules[/\\]/,
-  /[/\\]packages[/\\]react-native(?:-fantom)?[/\\]/,
+  /[/\\]packages[/\\]react-native[/\\]/,
   /[/\\]packages[/\\]virtualized-lists[/\\]/,
+  /[/\\]private[/\\]react-native-fantom[/\\]/,
 ];
 
 function isTypeScriptSource(fileName) {


### PR DESCRIPTION
Summary:
In {D76368959}, I moved `react-native-fantom` from `packages/` to `private/` and missed this reference.

Changelog:
[Internal]

Differential Revision: D76743071
