### PR TITLE
Make IdleCallbackID opaque in NativeIdleCallbacks implementation

### DIFF
--- a/packages/react-native-codegen/src/parsers/consistency/__tests__/checkModuleSnaps-test.js
+++ b/packages/react-native-codegen/src/parsers/consistency/__tests__/checkModuleSnaps-test.js
@@ -18,7 +18,10 @@ const flowFixtures = require('../../flow/modules/__test_fixtures__/fixtures.js')
 const tsFixtures = require('../../typescript/modules/__test_fixtures__/fixtures.js');
 const {compareSnaps, compareTsArraySnaps} = require('../compareSnaps.js');
 
-const flowExtraCases = ['PROMISE_WITH_COMMONLY_USED_TYPES'];
+const flowExtraCases = [
+  'NATIVE_MODULE_WITH_OPAQUE_TYPES',
+  'PROMISE_WITH_COMMONLY_USED_TYPES',
+];
 const tsExtraCases = [
   'NATIVE_MODULE_WITH_ARRAY2_WITH_ALIAS',
   'NATIVE_MODULE_WITH_ARRAY2_WITH_UNION_AND_TOUPLE',

--- a/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
@@ -691,6 +691,37 @@ export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
 
 `;
 
+const NATIVE_MODULE_WITH_OPAQUE_TYPES = `
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+import type {TurboModule} from '../RCTExport';
+import * as TurboModuleRegistry from '../TurboModuleRegistry';
+
+export opaque type Task = mixed;
+export opaque type TimeoutID = number;
+
+export interface Spec extends TurboModule {
+  +createTask: (callback: () => void) => Task;
+  +cancelTask: (task: Task) => void;
+
+  +setTimeout: (callback: () => void) => TimeoutID;
+  +clearTimeout: (timeoutID: TimeoutID) => void;
+}
+
+export default TurboModuleRegistry.getEnforcing<Spec>('SampleTurboModule');
+
+`;
+
 const ANDROID_ONLY_NATIVE_MODULE = `
 /**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
@@ -976,6 +1007,7 @@ module.exports = {
   NATIVE_MODULE_WITH_UNION,
   NATIVE_MODULE_WITH_UNION_RETURN_TYPES,
   NATIVE_MODULE_WITH_EVENT_EMITTERS,
+  NATIVE_MODULE_WITH_OPAQUE_TYPES,
   EMPTY_NATIVE_MODULE,
   ANDROID_ONLY_NATIVE_MODULE,
   IOS_ONLY_NATIVE_MODULE,

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
@@ -2187,6 +2187,108 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_OBJECT_W
 }"
 `;
 
+exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_OPAQUE_TYPES 1`] = `
+"{
+  'modules': {
+    'NativeSampleTurboModule': {
+      'type': 'NativeModule',
+      'aliasMap': {},
+      'enumMap': {},
+      'spec': {
+        'eventEmitters': [],
+        'methods': [
+          {
+            'name': 'createTask',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'GenericObjectTypeAnnotation'
+              },
+              'params': [
+                {
+                  'name': 'callback',
+                  'optional': false,
+                  'typeAnnotation': {
+                    'type': 'FunctionTypeAnnotation',
+                    'returnTypeAnnotation': {
+                      'type': 'VoidTypeAnnotation'
+                    },
+                    'params': []
+                  }
+                }
+              ]
+            }
+          },
+          {
+            'name': 'cancelTask',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'VoidTypeAnnotation'
+              },
+              'params': [
+                {
+                  'name': 'task',
+                  'optional': false,
+                  'typeAnnotation': {
+                    'type': 'GenericObjectTypeAnnotation'
+                  }
+                }
+              ]
+            }
+          },
+          {
+            'name': 'setTimeout',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'NumberTypeAnnotation'
+              },
+              'params': [
+                {
+                  'name': 'callback',
+                  'optional': false,
+                  'typeAnnotation': {
+                    'type': 'FunctionTypeAnnotation',
+                    'returnTypeAnnotation': {
+                      'type': 'VoidTypeAnnotation'
+                    },
+                    'params': []
+                  }
+                }
+              ]
+            }
+          },
+          {
+            'name': 'clearTimeout',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'VoidTypeAnnotation'
+              },
+              'params': [
+                {
+                  'name': 'timeoutID',
+                  'optional': false,
+                  'typeAnnotation': {
+                    'type': 'NumberTypeAnnotation'
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      },
+      'moduleName': 'SampleTurboModule'
+    }
+  }
+}"
+`;
+
 exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_PARTIALS 1`] = `
 "{
   'modules': {

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -296,6 +296,7 @@ class FlowParser implements Parser {
         if (
           node.declaration != null &&
           (node.declaration.type === 'TypeAlias' ||
+            node.declaration.type === 'OpaqueType' ||
             node.declaration.type === 'InterfaceDeclaration')
         ) {
           types[node.declaration.id.name] = node.declaration;
@@ -309,6 +310,7 @@ class FlowParser implements Parser {
         types[node.declaration.id.name] = node.declaration;
       } else if (
         node.type === 'TypeAlias' ||
+        node.type === 'OpaqueType' ||
         node.type === 'InterfaceDeclaration' ||
         node.type === 'EnumDeclaration'
       ) {
@@ -543,6 +545,10 @@ class FlowParser implements Parser {
   }
 
   nextNodeForTypeAlias(typeAnnotation: $FlowFixMe): $FlowFixMe {
+    if (typeAnnotation.type === 'OpaqueType') {
+      return typeAnnotation.impltype;
+    }
+
     return typeAnnotation.right;
   }
 

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -1233,7 +1233,8 @@ function handleGenericTypeAnnotation(
   let node;
 
   switch (resolvedTypeAnnotation.type) {
-    case parser.typeAlias: {
+    case parser.typeAlias:
+    case 'OpaqueType': {
       typeResolutionStatus = getTypeResolutionStatus(
         'alias',
         typeAnnotation,

--- a/packages/react-native/src/private/webapis/idlecallbacks/specs/NativeIdleCallbacks.js
+++ b/packages/react-native/src/private/webapis/idlecallbacks/specs/NativeIdleCallbacks.js
@@ -12,6 +12,8 @@ import type {TurboModule} from '../../../../../Libraries/TurboModule/RCTExport';
 
 import * as TurboModuleRegistry from '../../../../../Libraries/TurboModule/TurboModuleRegistry';
 
+export opaque type IdleCallbackID = mixed;
+
 export type RequestIdleCallbackOptions = {
   timeout?: number,
 };
@@ -25,8 +27,8 @@ export interface Spec extends TurboModule {
   +requestIdleCallback: (
     callback: (idleDeadline: IdleDeadline) => mixed,
     options?: RequestIdleCallbackOptions,
-  ) => mixed;
-  +cancelIdleCallback: (handle: mixed) => void;
+  ) => IdleCallbackID;
+  +cancelIdleCallback: (handle: IdleCallbackID) => void;
 }
 
 export default (TurboModuleRegistry.getEnforcing<Spec>(

--- a/packages/react-native/src/private/webapis/intersectionobserver/specs/NativeIntersectionObserver.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/specs/NativeIntersectionObserver.js
@@ -31,7 +31,7 @@ export type NativeIntersectionObserverObserveOptions = {
   rootThresholds?: ?$ReadOnlyArray<number>,
 };
 
-export type NativeIntersectionObserverToken = mixed;
+export opaque type NativeIntersectionObserverToken = mixed;
 
 export interface Spec extends TurboModule {
   // TODO(T223605846): Remove legacy observe method


### PR DESCRIPTION
Summary:
Changelog: [internal]

This migrates NativeIdleCallbacks to use opaque types now that they're supported in the codegen

Reviewed By: yungsters

Differential Revision: D76744095
