### PR TITLE
Bump @types/react to 19.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@react-native/metro-babel-transformer": "0.80.0-main",
     "@react-native/metro-config": "0.80.0-main",
     "@tsconfig/node22": "22.0.2",
-    "@types/react": "^19.0.0",
+    "@types/react": "^19.1.0",
     "@typescript-eslint/parser": "^7.1.1",
     "ansi-styles": "^4.2.1",
     "babel-plugin-minify-dead-code-elimination": "^0.5.2",

--- a/packages/new-app-screen/package.json
+++ b/packages/new-app-screen/package.json
@@ -20,7 +20,7 @@
   ],
   "dependencies": {},
   "peerDependencies": {
-    "@types/react": "^19.0.0",
+    "@types/react": "^19.1.0",
     "react": "*",
     "react-native": "*"
   },

--- a/packages/react-native-popup-menu-android/package.json
+++ b/packages/react-native-popup-menu-android/package.json
@@ -24,7 +24,7 @@
     "@react-native/codegen": "0.80.0-main"
   },
   "peerDependencies": {
-    "@types/react": "^19.0.0",
+    "@types/react": "^19.1.0",
     "react": "*",
     "react-native": "*"
   },

--- a/packages/virtualized-lists/package.json
+++ b/packages/virtualized-lists/package.json
@@ -51,7 +51,7 @@
     "react-test-renderer": "19.1.0"
   },
   "peerDependencies": {
-    "@types/react": "^19.0.0",
+    "@types/react": "^19.1.0",
     "react": "*",
     "react-native": "*"
   },

--- a/scripts/releases/__tests__/__fixtures__/set-version/packages/react-native/template/package.json
+++ b/scripts/releases/__tests__/__fixtures__/set-version/packages/react-native/template/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "@monorepo/pkg-a": "0.0.1",
     "@monorepo/pkg-c": "0.0.0",
-    "@types/react": "^19.0.0",
+    "@types/react": "^19.1.0",
     "@types/react-test-renderer": "^19.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1020,7 +1020,20 @@
     "@babel/parser" "^7.26.9"
     "@babel/types" "^7.26.9"
 
-"@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3", "@babel/traverse@^7.25.3", "@babel/traverse@^7.25.9", "@babel/traverse@^7.26.5", "@babel/traverse@^7.26.8", "@babel/traverse@^7.26.9":
+"@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3":
+  version "7.26.9"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.26.9.tgz#4398f2394ba66d05d988b2ad13c219a2c857461a"
+  integrity sha512-ZYW7L+pL8ahU5fXmNbPF+iZFHCv5scFak7MZ9bwaRPLUhHh7QQEMjZUg0HevihoqCM5iSYHN61EyCoZvqC+bxg==
+  dependencies:
+    "@babel/code-frame" "^7.26.2"
+    "@babel/generator" "^7.26.9"
+    "@babel/parser" "^7.26.9"
+    "@babel/template" "^7.26.9"
+    "@babel/types" "^7.26.9"
+    debug "^4.3.1"
+    globals "^11.1.0"
+
+"@babel/traverse@^7.25.3", "@babel/traverse@^7.25.9", "@babel/traverse@^7.26.5", "@babel/traverse@^7.26.8", "@babel/traverse@^7.26.9":
   version "7.26.9"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.26.9.tgz#4398f2394ba66d05d988b2ad13c219a2c857461a"
   integrity sha512-ZYW7L+pL8ahU5fXmNbPF+iZFHCv5scFak7MZ9bwaRPLUhHh7QQEMjZUg0HevihoqCM5iSYHN61EyCoZvqC+bxg==
@@ -2107,10 +2120,10 @@
   dependencies:
     undici-types "~6.21.0"
 
-"@types/react@^19.0.0":
-  version "19.0.1"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.0.1.tgz#a000d5b78f473732a08cecbead0f3751e550b3df"
-  integrity sha512-YW6614BDhqbpR5KtUYzTA+zlA7nayzJRA9ljz9CQoxthR0sDisYZLuvSMsil36t4EH/uAt8T52Xb4sVw17G+SQ==
+"@types/react@^19.1.0":
+  version "19.1.8"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-19.1.8.tgz#ff8395f2afb764597265ced15f8dddb0720ae1c3"
+  integrity sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==
   dependencies:
     csstype "^3.0.2"
 


### PR DESCRIPTION
## Summary:

While testing I notice that `@types/react` was not updated in some peer depencies 

## Changelog:

[GENERAL] [CHANGED] - Bump @types/react to 19.1

## Test Plan:

CI should be green
