### PR TITLE
Fix View Coopting View edge case on Android

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3659,6 +3659,7 @@ public class com/facebook/react/uimanager/ReactAccessibilityDelegate : androidx/
 	public static final field TOP_ACCESSIBILITY_ACTION_EVENT Ljava/lang/String;
 	public static final field sActionIdMap Ljava/util/HashMap;
 	public fun <init> (Landroid/view/View;ZI)V
+	public fun cleanUp ()V
 	public static fun createNodeInfoFromView (Landroid/view/View;)Landroidx/core/view/accessibility/AccessibilityNodeInfoCompat;
 	public fun getAccessibilityNodeProvider (Landroid/view/View;)Landroidx/core/view/accessibility/AccessibilityNodeProviderCompat;
 	protected fun getHostView ()Landroid/view/View;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -19,6 +19,7 @@ import android.view.accessibility.AccessibilityEvent;
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.view.AccessibilityDelegateCompat;
 import androidx.core.view.ViewCompat;
 import com.facebook.common.logging.FLog;
 import com.facebook.react.R;
@@ -185,6 +186,16 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
     @Nullable OnFocusChangeListener focusChangeListener = view.getOnFocusChangeListener();
     if (focusChangeListener instanceof BaseVMFocusChangeListener) {
       ((BaseVMFocusChangeListener) focusChangeListener).detach(view);
+    }
+
+    AccessibilityDelegateCompat axDelegate = ViewCompat.getAccessibilityDelegate(view);
+
+    if (axDelegate instanceof ReactAccessibilityDelegate) {
+      ((ReactAccessibilityDelegate) axDelegate).cleanUp();
+    }
+
+    if (view instanceof ViewGroup) {
+      ((ViewGroup) view).setOnHierarchyChangeListener(null);
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAxOrderHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAxOrderHelper.kt
@@ -10,7 +10,6 @@ package com.facebook.react.uimanager
 import android.graphics.Rect
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import com.facebook.react.R
 import com.facebook.react.bridge.ReadableArray
 
@@ -76,10 +75,6 @@ private object ReactAxOrderHelper {
         }
       }
 
-      if (!isIncluded && !isContained && parent != view && view !is TextView) {
-        view.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
-      }
-
       // Don't traverse the children of a nested accessibility order
       if (view is ViewGroup) {
         val axChildren: ArrayList<View> = getAxChildren(view)
@@ -99,6 +94,13 @@ private object ReactAxOrderHelper {
             traverseAndBuildAxOrder(parent, axChildren[i], null)
           }
         }
+      }
+
+      if (!isIncluded && !isContained && parent != view) {
+        if (view.getTag(R.id.original_focusability) == null) {
+          view.setTag(R.id.original_focusability, view.isFocusable)
+        }
+        view.isFocusable = false
       }
     }
 
@@ -158,5 +160,22 @@ private object ReactAxOrderHelper {
       host.addChildrenForAccessibility(axChildren)
     }
     return axChildren
+  }
+
+  @JvmStatic
+  public fun restoreSubtreeFocusability(view: View) {
+    val originalFocusability = view.getTag(R.id.original_focusability)
+    if (originalFocusability is Boolean) {
+      view.isFocusable = originalFocusability
+    }
+
+    if (view is ViewGroup) {
+      for (i in 0 until view.childCount) {
+        val child = view.getChildAt(i)
+        if (child != null) {
+          restoreSubtreeFocusability(child)
+        }
+      }
+    }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values/ids.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values/ids.xml
@@ -15,6 +15,9 @@
   <!-- tag is used to store the current state of the accessibility order tree-->
   <item type="id" name="accessibility_order_dirty"/>
 
+  <!-- tag is used to store the original focusability value of a view within the accessibility order tree if it was changed-->
+  <item type="id" name="original_focusability"/>
+
   <!-- tag is used to store the nativeID tag -->
   <item type="id" name="view_tag_instance_handle"/>
 


### PR DESCRIPTION
Summary:
Before, to disable views that were excluded from the order we were setting them to be not important for accessibility. This however breaks coopting behavior of parent views, because parent views will not announce content descriptions of children that are not important for accessibility.

Instead of disabling by setting `important for accessibility = no` now we just set `isFocusable = false` which disables focusing but still allows parent views to coopt

Changelog: [Internal]

Differential Revision: D76745057
