### PR TITLE
Fix antialiasing for Facsimile on Android < 10

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.kt
@@ -469,7 +469,7 @@ internal object TextLayoutManager {
       baseTextAttributes: TextAttributeProps,
       context: Context
   ): TextPaint {
-    val paint = TextPaint()
+    val paint = TextPaint(TextPaint.ANTI_ALIAS_FLAG)
     updateTextPaint(paint, baseTextAttributes, context)
     return paint
   }


### PR DESCRIPTION
Summary:
Noticed an E2E tests against old emulator version showed aliased Text against Facsimile. This is because non-scratch-paint path does not explicitly enable anti-aliasing (like TextView does), older versions of Android don't enable by default, and `updateTextPaint()` no longer sets, after call to `paint.reset()` was removed.

Changelog: [Internal]

Differential Revision: D76780749
