### PR TITLE
Fix possible invalid measurements when width or height is zero pixels

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
@@ -415,6 +415,12 @@ static void measureNodeWithoutChildren(
       Dimension::Height);
 }
 
+inline bool isFixedSize(float dim, SizingMode sizingMode) {
+  return yoga::isDefined(dim) &&
+      (sizingMode == SizingMode::StretchFit ||
+       (sizingMode == SizingMode::FitContent && dim <= 0.0));
+}
+
 static bool measureNodeWithFixedSize(
     yoga::Node* const node,
     const Direction direction,
@@ -424,12 +430,8 @@ static bool measureNodeWithFixedSize(
     const SizingMode heightSizingMode,
     const float ownerWidth,
     const float ownerHeight) {
-  if ((yoga::isDefined(availableWidth) &&
-       widthSizingMode == SizingMode::FitContent && availableWidth <= 0.0f) ||
-      (yoga::isDefined(availableHeight) &&
-       heightSizingMode == SizingMode::FitContent && availableHeight <= 0.0f) ||
-      (widthSizingMode == SizingMode::StretchFit &&
-       heightSizingMode == SizingMode::StretchFit)) {
+  if (isFixedSize(availableWidth, widthSizingMode) &&
+      isFixedSize(availableHeight, heightSizingMode)) {
     node->setLayoutMeasuredDimension(
         boundAxis(
             node,


### PR DESCRIPTION
Summary:
Yoga has a fast path when measuring a node, if it thinks it knows its dimensions ahead of time.

This path has some eroneous logic, to set both axis to owner size, if *either* will evaluate to zero, while having an `YGMeasureModeAtMost`/`FitContent` constraint. This means that if a node is given a zero width, and Yoga later measures with with `FitContent`, its height will become the maximum allowable height, even if it shouldn't be that large.

We can fix this, by only allowing if both axis are this fixed case, instead of just one.

This bug has existed for about a decade (going back to at least 🙂).

Changelog:
[General][Fixed] - Fix possible invalid measurements with width or height is zero pixels

Differential Revision: D76793705
