### PR TITLE
Unblock RNTester which is currently instacrashing.

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/JSRuntimeFactory.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/JSRuntimeFactory.kt
@@ -8,9 +8,14 @@
 package com.facebook.react.runtime
 
 import com.facebook.jni.HybridData
+import com.facebook.proguard.annotations.DoNotStrip
 import com.facebook.soloader.SoLoader
 
-public abstract class JSRuntimeFactory(private val mHybridData: HybridData) {
+public abstract class JSRuntimeFactory(
+    @Suppress("unused", "NoHungarianNotation", "NotAccessedPrivateField")
+    @DoNotStrip
+    private val mHybridData: HybridData
+) {
   private companion object {
     init {
       SoLoader.loadLibrary("rninstance")


### PR DESCRIPTION
Summary:
RNTester is currently crashing on release due to a stripped `mHybridData` field.

Changelog:
[Internal] [Changed] -

Differential Revision: D76808165
