### PR TITLE
return object with string keys from getDirectManipulationProps

### DIFF
--- a/packages/react-native/Libraries/Animated/__tests__/Animated-itest.js
+++ b/packages/react-native/Libraries/Animated/__tests__/Animated-itest.js
@@ -185,7 +185,6 @@ test('animated opacity', () => {
   });
 
   Fantom.unstable_produceFramesForDuration(30);
-  // $FlowFixMe[incompatible-use]
   expect(Fantom.unstable_getDirectManipulationProps(viewElement).opacity).toBe(
     0,
   );

--- a/packages/react-native/src/private/testing/fantom/specs/NativeFantom.js
+++ b/packages/react-native/src/private/testing/fantom/specs/NativeFantom.js
@@ -90,7 +90,11 @@ interface Spec extends TurboModule {
     width: number,
   ) => void;
   takeMountingManagerLogs: (surfaceId: number) => Array<string>;
-  getDirectManipulationProps: (shadowNode: mixed /* ShadowNode */) => mixed;
+  getDirectManipulationProps: (
+    shadowNode: mixed /* ShadowNode */,
+  ) => $ReadOnly<{
+    [string]: mixed,
+  }>;
   flushMessageQueue: () => void;
   flushEventQueue: () => void;
   produceFramesForDuration: (miliseconds: number) => void;

--- a/private/react-native-fantom/src/index.js
+++ b/private/react-native-fantom/src/index.js
@@ -226,7 +226,11 @@ export function unstable_produceFramesForDuration(milliseconds: number) {
  *
  * Note: This API is marked as unstable and may change in future versions.
  */
-export function unstable_getDirectManipulationProps(node: ReadOnlyNode): mixed {
+export function unstable_getDirectManipulationProps(
+  node: ReadOnlyNode,
+): $ReadOnly<{
+  [string]: mixed,
+}> {
   const shadowNode = getNativeNodeReference(node);
   return NativeFantom.getDirectManipulationProps(shadowNode);
 }


### PR DESCRIPTION
Summary:
changelog: [internal]

make API getDirectManipulationProps slightly nicer by returning `[string]: mixed` instead of mixed.

Reviewed By: rubennorte

Differential Revision: D76763893
