### PR TITLE
Add rncore stub headers for backwards-compat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,7 +139,6 @@ vendor/
 /packages/react-native/React/FBReactNativeSpec/
 /packages/react-native-codegen/lib
 /packages/react-native-codegen/tmp/
-/packages/react-native/ReactCommon/react/renderer/components/rncore/
 /packages/rn-tester/NativeModuleExample/ScreenshotManagerSpec*
 /**/RCTThirdPartyFabricComponentsProvider.*
 

--- a/packages/react-native/ReactCommon/React-FabricComponents.podspec
+++ b/packages/react-native/ReactCommon/React-FabricComponents.podspec
@@ -129,6 +129,12 @@ Pod::Spec.new do |s|
       sss.exclude_files        = "react/renderer/components/unimplementedview/tests"
       sss.header_dir           = "react/renderer/components/unimplementedview"
     end
+
+    # Legacy header paths for backwards compat
+    ss.subspec "rncore" do |sss|
+      sss.source_files         = "react/renderer/components/rncore/**/*.h"
+      sss.header_dir           = "react/renderer/components/rncore"
+    end
   end
 
   s.subspec "textlayoutmanager" do |ss|

--- a/packages/react-native/ReactCommon/react/renderer/components/rncore/ComponentDescriptors.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/rncore/ComponentDescriptors.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <react/renderer/components/FBReactNativeSpec/States.h>
+
+#warning \
+    "[DEPRECATION] `react/renderer/components/rncore/States.h` is deprecated and will be \
+    removed in the future. If this warning appears due to a library, please open an issue \
+    in that library, and ask for an update. Please, replace the `rncore` imports  with \
+    `FBReactNativeSpec` or remove them entirely.

--- a/packages/react-native/ReactCommon/react/renderer/components/rncore/EventEmitters.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/rncore/EventEmitters.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <react/renderer/components/FBReactNativeSpec/EventEmitters.h>
+
+#warning \
+    "[DEPRECATION] `react/renderer/components/rncore/EventEmitters.h` is deprecated \
+    and will be removed in the future. If this warning appears due to a library, \
+    please open an issue in that library, and ask for an update. Please, replace \
+    the `rncore` imports  with `FBReactNativeSpec` or remove them entirely.

--- a/packages/react-native/ReactCommon/react/renderer/components/rncore/Props.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/rncore/Props.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <react/renderer/components/FBReactNativeSpec/Props.h>
+
+#warning \
+    "[DEPRECATION] `react/renderer/components/rncore/Props.h` is deprecated and will \
+    be removed in the future. If this warning appears due to a library, please open \
+    an issue in that library, and ask for an update. Please, replace the `rncore` \
+    imports  with `FBReactNativeSpec` or remove them entirely.

--- a/packages/react-native/ReactCommon/react/renderer/components/rncore/ShadowNodes.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/rncore/ShadowNodes.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <react/renderer/components/FBReactNativeSpec/ShadowNodes.h>
+
+#warning \
+    "[DEPRECATION] `react/renderer/components/rncore/ShadowNodes.h` is deprecated and \
+    will be removed in the future. If this warning appears due to a library, please \
+    open an issue in that library, and ask for an update. Please, replace the `rncore` \
+    imports  with `FBReactNativeSpec` or remove them entirely.

--- a/packages/react-native/ReactCommon/react/renderer/components/rncore/States.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/rncore/States.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <react/renderer/components/FBReactNativeSpec/States.h>
+
+#warning \
+    "[DEPRECATION] `react/renderer/components/rncore/States.h` is deprecated and will be \
+    removed in the future. If this warning appears due to a library, please open an \
+    issue in that library, and ask for an update. Please, replace the `rncore` imports \
+    with `FBReactNativeSpec` or remove them entirely.


### PR DESCRIPTION
Summary:
These headers were removed in D55037569 but we may have some targets still depending on them. Add redirection headers with warnings to help users migrate without this being a breaking change.

Changelog: [Internal]

Differential Revision: D76810433
