### PR TITLE
[0.79] Close Sonatype repository during build_android

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -55,7 +55,7 @@ runs:
           TASKS="publishAllToMavenTempLocal publishAndroidToSonatype build"
         else
           # release: we want to build all archs (default)
-          TASKS="publishAllToMavenTempLocal publishAndroidToSonatype build"
+          TASKS="publishAllToMavenTempLocal publishAndroidToSonatype closeSonatypeStagingRepository build"
         fi
         ./gradlew $TASKS -PenableWarningsAsErrors=true
     - name: Save Android ccache

--- a/scripts/releases/utils/release-utils.js
+++ b/scripts/releases/utils/release-utils.js
@@ -68,7 +68,7 @@ function publishAndroidArtifactsToMaven(
     // -------- For stable releases, we also need to close and release the staging repository.
     if (
       exec(
-        './gradlew findSonatypeStagingRepository closeAndReleaseSonatypeStagingRepository',
+        './gradlew findSonatypeStagingRepository releaseSonatypeStagingRepository',
       ).code
     ) {
       echo(


### PR DESCRIPTION
## Summary:

This attempts to fix the publishing of 0.79
I'm moving the publishing + closing of the staging repository to be inside the same workflow (`build_android`).
And I'm doing the publishing only in the last step `build_npm_package`.

See https://github.com/gradle-nexus/publish-plugin/issues/379

## Changelog:

[INTERNAL] -

## Test Plan:

I guess we Yolo here and if it fails the release won't be out.