### PR TITLE
Fix the serialization of the alpha channel in the rgba() color string format

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/graphicsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/graphicsConversions.h
@@ -50,11 +50,11 @@ inline std::string toString(const SharedColor& value) {
   std::snprintf(
       buffer.data(),
       buffer.size(),
-      "rgba(%.0f, %.0f, %.0f, %.0f)",
+      "rgba(%.0f, %.0f, %.0f, %f)",
       components.red * 255.f,
       components.green * 255.f,
       components.blue * 255.f,
-      components.alpha * 255.f);
+      components.alpha);
   return buffer.data();
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/core/graphicsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/graphicsConversions.h
@@ -50,7 +50,7 @@ inline std::string toString(const SharedColor& value) {
   std::snprintf(
       buffer.data(),
       buffer.size(),
-      "rgba(%.0f, %.0f, %.0f, %f)",
+      "rgba(%.0f, %.0f, %.0f, %g)",
       components.red * 255.f,
       components.green * 255.f,
       components.blue * 255.f,

--- a/private/cxx-public-api/ReactNativeCPP.api
+++ b/private/cxx-public-api/ReactNativeCPP.api
@@ -28685,11 +28685,11 @@ inline std::string toString(const SharedColor& value) {
   std::snprintf(
       buffer.data(),
       buffer.size(),
-      "rgba(%.0f, %.0f, %.0f, %.0f)",
+      "rgba(%.0f, %.0f, %.0f, %f)",
       components.red * 255.f,
       components.green * 255.f,
       components.blue * 255.f,
-      components.alpha * 255.f);
+      components.alpha);
   return buffer.data();
 }
 inline void fromRawValue(

--- a/private/cxx-public-api/ReactNativeCPP.api
+++ b/private/cxx-public-api/ReactNativeCPP.api
@@ -28685,7 +28685,7 @@ inline std::string toString(const SharedColor& value) {
   std::snprintf(
       buffer.data(),
       buffer.size(),
-      "rgba(%.0f, %.0f, %.0f, %f)",
+      "rgba(%.0f, %.0f, %.0f, %g)",
       components.red * 255.f,
       components.green * 255.f,
       components.blue * 255.f,


### PR DESCRIPTION
## Summary:

The alpha channel in the `rgba()` color string format should be a value between [0, 1] instead of [0, 255], as stated in the [React Native Documentation](https://reactnative.dev/docs/colors#red-green-blue-rgb).

## Changelog:

[GENERAL] [FIXED] - Fix the serialization of the alpha channel in the `rgba()` color string format.

## Test Plan:

I didn't find any usage of that function in React Native, but it is part of the public API, and I just wanted to use it in Reanimated.
