### PR TITLE
Revert "[0.79] Close Sonatype repository during build_android (#52086)"

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -55,7 +55,7 @@ runs:
           TASKS="publishAllToMavenTempLocal publishAndroidToSonatype build"
         else
           # release: we want to build all archs (default)
-          TASKS="publishAllToMavenTempLocal publishAndroidToSonatype closeSonatypeStagingRepository build"
+          TASKS="publishAllToMavenTempLocal publishAndroidToSonatype build"
         fi
         ./gradlew $TASKS -PenableWarningsAsErrors=true
     - name: Save Android ccache

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -133,27 +133,6 @@ jobs:
           hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
 
-  build_android:
-    runs-on: 8-core-ubuntu
-    needs: [set_release_type]
-    container:
-      image: reactnativecommunity/react-native-android:latest
-      env:
-        TERM: "dumb"
-        GRADLE_OPTS: "-Dorg.gradle.daemon=false"
-        ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}
-        ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
-        ORG_GRADLE_PROJECT_SONATYPE_USERNAME: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_USERNAME }}
-        ORG_GRADLE_PROJECT_SONATYPE_PASSWORD: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_PASSWORD }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Build Android
-        uses: ./.github/actions/build-android
-        with:
-          release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
-          gradle-cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
-
   build_npm_package:
     runs-on: 8-core-ubuntu
     needs:
@@ -163,7 +142,6 @@ jobs:
         build_hermes_macos,
         build_hermesc_linux,
         build_hermesc_windows,
-        build_android,
         prebuild_apple_dependencies,
       ]
     container:

--- a/scripts/releases/utils/release-utils.js
+++ b/scripts/releases/utils/release-utils.js
@@ -68,7 +68,7 @@ function publishAndroidArtifactsToMaven(
     // -------- For stable releases, we also need to close and release the staging repository.
     if (
       exec(
-        './gradlew findSonatypeStagingRepository closeAndReleaseSonatypeStagingRepository',
+        './gradlew publishAndroidToSonatype closeAndReleaseSonatypeStagingRepository',
       ).code
     ) {
       echo(

--- a/scripts/releases/utils/release-utils.js
+++ b/scripts/releases/utils/release-utils.js
@@ -68,7 +68,7 @@ function publishAndroidArtifactsToMaven(
     // -------- For stable releases, we also need to close and release the staging repository.
     if (
       exec(
-        './gradlew findSonatypeStagingRepository releaseSonatypeStagingRepository',
+        './gradlew findSonatypeStagingRepository closeAndReleaseSonatypeStagingRepository',
       ).code
     ) {
       echo(


### PR DESCRIPTION
## Summary:

Taking a more drastic approach. It seems like `findSonatypeStagingRepository` doesn't work at all. Therefore I'm moving all the publish to happen inside `build_npm_package`.

See https://github.com/gradle-nexus/publish-plugin/issues/379

## Changelog:

[Internal] - 

## Test Plan:

CI