### PR TITLE
Remove focus change listener and restore original when dropping view instance

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3315,6 +3315,7 @@ public abstract class com/facebook/react/uimanager/BaseViewManager : com/faceboo
 	public fun getExportedCustomBubblingEventTypeConstants ()Ljava/util/Map;
 	public fun getExportedCustomDirectEventTypeConstants ()Ljava/util/Map;
 	protected fun onAfterUpdateTransaction (Landroid/view/View;)V
+	public fun onDropViewInstance (Landroid/view/View;)V
 	public fun onLayoutChange (Landroid/view/View;IIIIIIII)V
 	protected fun prepareToRecycleView (Lcom/facebook/react/uimanager/ThemedReactContext;Landroid/view/View;)Landroid/view/View;
 	public fun setAccessibilityActions (Landroid/view/View;Lcom/facebook/react/bridge/ReadableArray;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -173,30 +173,19 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
   protected void addEventEmitters(@NonNull ThemedReactContext reactContext, @NonNull T view) {
     super.addEventEmitters(reactContext, view);
 
-    @Nullable OnFocusChangeListener originalFocusChangeListener = view.getOnFocusChangeListener();
-    view.setOnFocusChangeListener(
-        (v, hasFocus) -> {
-          if (originalFocusChangeListener != null) {
-            originalFocusChangeListener.onFocusChange(v, hasFocus);
-          }
-          int surfaceId = UIManagerHelper.getSurfaceId(v.getContext());
-          if (surfaceId == View.NO_ID) {
-            return;
-          }
-          if (view.getContext() instanceof ThemedReactContext) {
-            ThemedReactContext themedReactContext = (ThemedReactContext) v.getContext();
-            @Nullable
-            EventDispatcher eventDispatcher =
-                UIManagerHelper.getEventDispatcherForReactTag(themedReactContext, view.getId());
-            if (eventDispatcher != null) {
-              if (hasFocus) {
-                eventDispatcher.dispatchEvent(new FocusEvent(surfaceId, view.getId()));
-              } else {
-                eventDispatcher.dispatchEvent(new BlurEvent(surfaceId, view.getId()));
-              }
-            }
-          }
-        });
+    BaseVMFocusChangeListener focusChangeListener =
+        new BaseVMFocusChangeListener(view.getOnFocusChangeListener());
+    focusChangeListener.attach(view);
+  }
+
+  @Override
+  public void onDropViewInstance(@NonNull T view) {
+    super.onDropViewInstance(view);
+
+    @Nullable OnFocusChangeListener focusChangeListener = view.getOnFocusChangeListener();
+    if (focusChangeListener instanceof BaseVMFocusChangeListener) {
+      ((BaseVMFocusChangeListener) focusChangeListener).detach(view);
+    }
   }
 
   // Currently, layout listener is only attached when transform or transformOrigin is set.
@@ -1052,4 +1041,49 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
   }
 
   // Please add new props to BaseViewManagerDelegate as well!
+
+  /**
+   * A helper class to keep track of the original focus change listener if one is set. This is
+   * especially helpful for views that are recycled so we can retain and restore the original
+   * listener upon recycling (onDropViewInstance).
+   */
+  private class BaseVMFocusChangeListener<V extends View> implements OnFocusChangeListener {
+    private @Nullable OnFocusChangeListener mOriginalFocusChangeListener;
+
+    public BaseVMFocusChangeListener(@Nullable OnFocusChangeListener originalFocusChangeListener) {
+      mOriginalFocusChangeListener = originalFocusChangeListener;
+    }
+
+    public void attach(T view) {
+      view.setOnFocusChangeListener(this);
+    }
+
+    public void detach(T view) {
+      view.setOnFocusChangeListener(mOriginalFocusChangeListener);
+    }
+
+    @Override
+    public void onFocusChange(View view, boolean hasFocus) {
+      if (mOriginalFocusChangeListener != null) {
+        mOriginalFocusChangeListener.onFocusChange(view, hasFocus);
+      }
+      int surfaceId = UIManagerHelper.getSurfaceId(view.getContext());
+      if (surfaceId == View.NO_ID) {
+        return;
+      }
+      if (view.getContext() instanceof ThemedReactContext) {
+        ThemedReactContext themedReactContext = (ThemedReactContext) view.getContext();
+        @Nullable
+        EventDispatcher eventDispatcher =
+            UIManagerHelper.getEventDispatcherForReactTag(themedReactContext, view.getId());
+        if (eventDispatcher != null) {
+          if (hasFocus) {
+            eventDispatcher.dispatchEvent(new FocusEvent(surfaceId, view.getId()));
+          } else {
+            eventDispatcher.dispatchEvent(new BlurEvent(surfaceId, view.getId()));
+          }
+        }
+      }
+    }
+  }
 }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/BaseViewManagerTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/BaseViewManagerTest.kt
@@ -93,4 +93,21 @@ class BaseViewManagerTest {
     view.onFocusChangeListener.onFocusChange(view, true)
     verify(originalFocusListener, times(1)).onFocusChange(view, true)
   }
+
+  @Test
+  fun testDroppingViewInstanceRestoresFocusChangeListener() {
+    val originalFocusListener = mock<OnFocusChangeListener>()
+    view.onFocusChangeListener = originalFocusListener
+    viewManager.addEventEmitters(themedReactContext, view)
+    Assertions.assertThat(view.onFocusChangeListener).isNotEqualTo(originalFocusListener)
+
+    view.onFocusChangeListener.onFocusChange(view, true)
+    verify(originalFocusListener, times(1)).onFocusChange(view, true)
+    Assertions.assertThat(originalFocusListener).isNotEqualTo(view.onFocusChangeListener)
+
+    viewManager.onDropViewInstance(view)
+    view.onFocusChangeListener.onFocusChange(view, true)
+    verify(originalFocusListener, times(2)).onFocusChange(view, true)
+    Assertions.assertThat(originalFocusListener).isEqualTo(view.onFocusChangeListener)
+  }
 }


### PR DESCRIPTION
Summary:
This change updates the `BaseViewManager` implementation to drop and restore the original focus listener when a view instance has its `onDropViewInstance` method called. This is necessary to support view recycling, since the `addEventEmitters` method is called each time a recycled view is popped out of the stack. This would result in N+1 `onFocus`/`onBlur` calls for each time the view is recycled.

Changelog: [Android][Fixed] - Remove focus change listener when dropping/recycling view instances

Differential Revision: D76852137
