### PR TITLE
[iOS][backgroundImage] - Use CAGradientLayer for linear gradient

### DIFF
--- a/packages/react-native/React/Fabric/Utils/RCTGradientUtils.h
+++ b/packages/react-native/React/Fabric/Utils/RCTGradientUtils.h
@@ -16,6 +16,9 @@ NS_ASSUME_NONNULL_BEGIN
 + (std::vector<facebook::react::ProcessedColorStop>)getFixedColorStops:
                                                         (const std::vector<facebook::react::ColorStop> &)colorStops
                                                     gradientLineLength:(CGFloat)gradientLineLength;
++ (std::pair<CGPoint, CGPoint>)fixGradientPoints:(CGPoint)startPoint
+                                        endPoint:(CGPoint)endPoint
+                                          bounds:(CGSize)bounds;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/react-native/React/Fabric/Utils/RCTGradientUtils.h
+++ b/packages/react-native/React/Fabric/Utils/RCTGradientUtils.h
@@ -15,13 +15,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (std::vector<facebook::react::ProcessedColorStop>)getFixedColorStops:
                                                         (const std::vector<facebook::react::ColorStop> &)colorStops
-                                                    gradientLineLength:(CGFloat)gradientLineLength;
+                                                     gradientLineLength:(CGFloat)gradientLineLength;
 // CAGradientLayer linear gradient squishes the non-square gradient to square gradient.
 // This function fixes the "squished" effect.
 // See https://stackoverflow.com/a/43176174 for more information.
-+ (std::pair<CGPoint, CGPoint>)getPointsForCAGradientLayerLinearGradient:(CGPoint)startPoint
-                                        endPoint:(CGPoint)endPoint
-                                          bounds:(CGSize)bounds;
++ (std::pair<CGPoint, CGPoint>)pointsForCAGradientLayerLinearGradient:(CGPoint)startPoint
+                                                             endPoint:(CGPoint)endPoint
+                                                               bounds:(CGSize)bounds;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/react-native/React/Fabric/Utils/RCTGradientUtils.h
+++ b/packages/react-native/React/Fabric/Utils/RCTGradientUtils.h
@@ -16,7 +16,10 @@ NS_ASSUME_NONNULL_BEGIN
 + (std::vector<facebook::react::ProcessedColorStop>)getFixedColorStops:
                                                         (const std::vector<facebook::react::ColorStop> &)colorStops
                                                     gradientLineLength:(CGFloat)gradientLineLength;
-+ (std::pair<CGPoint, CGPoint>)fixGradientPoints:(CGPoint)startPoint
+// CAGradientLayer linear gradient squishes the non-square gradient to square gradient.
+// This function fixes the "squished" effect.
+// See https://stackoverflow.com/a/43176174 for more information.
++ (std::pair<CGPoint, CGPoint>)getPointsForCAGradientLayerLinearGradient:(CGPoint)startPoint
                                         endPoint:(CGPoint)endPoint
                                           bounds:(CGSize)bounds;
 @end

--- a/packages/react-native/React/Fabric/Utils/RCTGradientUtils.mm
+++ b/packages/react-native/React/Fabric/Utils/RCTGradientUtils.mm
@@ -339,9 +339,9 @@ gradientLineLength:(CGFloat)gradientLineLength
 // CAGradientLayer linear gradient squishes the non-square gradient to square gradient.
 // This function fixes the "squished" effect.
 // See https://stackoverflow.com/a/43176174 for more information.
-+ (std::pair<CGPoint, CGPoint>)getPointsForCAGradientLayerLinearGradient:(CGPoint)startPoint
-endPoint:(CGPoint)endPoint
-bounds:(CGSize)bounds
++ (std::pair<CGPoint, CGPoint>)pointsForCAGradientLayerLinearGradient:(CGPoint)startPoint
+                                                             endPoint:(CGPoint)endPoint
+                                                               bounds:(CGSize)bounds
 {
   if (floatEquality(startPoint.x, endPoint.x) ||
       floatEquality(startPoint.y, endPoint.y)) {

--- a/packages/react-native/React/Fabric/Utils/RCTGradientUtils.mm
+++ b/packages/react-native/React/Fabric/Utils/RCTGradientUtils.mm
@@ -46,7 +46,7 @@ struct LineSegment {
   CGFloat getSlope() const
   {
     CGFloat dx = p2.x - p1.x;
-    if (facebook::react::floatEquality(dx, 0.0f)) {
+    if (floatEquality(dx, 0.0f)) {
       return std::numeric_limits<CGFloat>::infinity();
     }
     return (p2.y - p1.y) / dx;
@@ -58,7 +58,7 @@ struct LineSegment {
     if (std::isinf(slope)) {
       return 0.0;
     }
-    if (facebook::react::floatEquality(slope, 0.0f)) {
+    if (floatEquality(slope, 0.0f)) {
       return -std::numeric_limits<CGFloat>::infinity();
     }
     return -1 / slope;
@@ -113,7 +113,7 @@ struct Line {
   {
     CGFloat n = other.m;
     CGFloat c = other.b;
-    if (facebook::react::floatEquality(m, n)) {
+    if (floatEquality(m, n)) {
       return std::nullopt;
     }
     CGFloat x = (c - b) / (m - n);
@@ -127,7 +127,7 @@ LineSegment::LineSegment(CGPoint p1, CGFloat m, CGFloat distance) : p1(p1)
   CGPoint measuringPoint = line.point(p1.x + 1);
   LineSegment measuringSegment(p1, measuringPoint);
   CGFloat measuringDeltaH = measuringSegment.getDistance();
-  CGFloat deltaX = !facebook::react::floatEquality(measuringDeltaH, 0.0f) ? distance / measuringDeltaH : 0.0f;
+  CGFloat deltaX = !floatEquality(measuringDeltaH, 0.0f) ? distance / measuringDeltaH : 0.0f;
   p2 = line.point(p1.x + deltaX);
 }
 
@@ -189,18 +189,18 @@ static std::vector<ProcessedColorStop> processColorTransitionHints(const std::ve
     SharedColor leftSharedColor = colorStops[x - 1].color;
     SharedColor rightSharedColor = colorStops[x + 1].color;
     
-    if (facebook::react::floatEquality(leftDist, rightDist)) {
+    if (floatEquality(leftDist, rightDist)) {
       colorStops.erase(colorStops.begin() + x);
       --indexOffset;
       continue;
     }
     
-    if (facebook::react::floatEquality(leftDist, .0f)) {
+    if (floatEquality(leftDist, .0f)) {
       colorStops[x].color = rightSharedColor;
       continue;
     }
     
-    if (facebook::react::floatEquality(rightDist, .0f)) {
+    if (floatEquality(rightDist, .0f)) {
       colorStops[x].color = leftSharedColor;
       continue;
     }
@@ -254,7 +254,7 @@ static std::vector<ProcessedColorStop> processColorTransitionHints(const std::ve
       auto green = (interpolatedColor >> 8) & 0xFF;
       auto blue = interpolatedColor & 0xFF;
       
-      newStop.color = facebook::react::colorFromRGBA(red, green, blue, alpha);
+      newStop.color = colorFromRGBA(red, green, blue, alpha);
     }
     
     // Replace the color hint with new color stops
@@ -339,12 +339,12 @@ gradientLineLength:(CGFloat)gradientLineLength
 // CAGradientLayer linear gradient squishes the non-square gradient to square gradient.
 // This function fixes the "squished" effect.
 // See https://stackoverflow.com/a/43176174 for more information.
-+ (std::pair<CGPoint, CGPoint>)fixGradientPoints:(CGPoint)startPoint
++ (std::pair<CGPoint, CGPoint>)getPointsForCAGradientLayerLinearGradient:(CGPoint)startPoint
 endPoint:(CGPoint)endPoint
 bounds:(CGSize)bounds
 {
-  if (facebook::react::floatEquality(startPoint.x, endPoint.x) ||
-      facebook::react::floatEquality(startPoint.y, endPoint.y)) {
+  if (floatEquality(startPoint.x, endPoint.x) ||
+      floatEquality(startPoint.y, endPoint.y)) {
     // Apple's implementation of horizontal and vertical gradients works just fine
     return {startPoint, endPoint};
   }

--- a/packages/react-native/React/Fabric/Utils/RCTLinearGradient.mm
+++ b/packages/react-native/React/Fabric/Utils/RCTLinearGradient.mm
@@ -51,7 +51,8 @@ using namespace facebook::react;
   CGPoint fixedStartPoint;
   CGPoint fixedEndPoint;
   
-  std::tie(fixedStartPoint, fixedEndPoint) = [RCTGradientUtils getPointsForCAGradientLayerLinearGradient: relativeStartPoint endPoint: relativeEndPoint bounds:size];
+  std::tie(fixedStartPoint, fixedEndPoint) =
+      [RCTGradientUtils pointsForCAGradientLayerLinearGradient:relativeStartPoint endPoint:relativeEndPoint bounds:size];
   
   gradientLayer.startPoint = fixedStartPoint;
   gradientLayer.endPoint = fixedEndPoint;

--- a/packages/react-native/React/Fabric/Utils/RCTLinearGradient.mm
+++ b/packages/react-native/React/Fabric/Utils/RCTLinearGradient.mm
@@ -43,7 +43,7 @@ using namespace facebook::react;
   CGFloat gradientLineLength = sqrt(dx * dx + dy * dy);
   const auto colorStops = [RCTGradientUtils getFixedColorStops:gradient.colorStops
                                             gradientLineLength:gradientLineLength];
-  NSMutableArray *colors = [NSMutableArray array];
+  NSMutableArray<id> *colors = [NSMutableArray array];
   NSMutableArray<NSNumber *> *locations = [NSMutableArray array];
   CGPoint relativeStartPoint = CGPointMake(startPoint.x / size.width, startPoint.y / size.height);
   CGPoint relativeEndPoint = CGPointMake(endPoint.x / size.width, endPoint.y / size.height);
@@ -51,24 +51,18 @@ using namespace facebook::react;
   CGPoint fixedStartPoint;
   CGPoint fixedEndPoint;
   
-  std::tie(fixedStartPoint, fixedEndPoint) = [RCTGradientUtils fixGradientPoints: relativeStartPoint endPoint: relativeEndPoint bounds:size];
+  std::tie(fixedStartPoint, fixedEndPoint) = [RCTGradientUtils getPointsForCAGradientLayerLinearGradient: relativeStartPoint endPoint: relativeEndPoint bounds:size];
   
   gradientLayer.startPoint = fixedStartPoint;
   gradientLayer.endPoint = fixedEndPoint;
-
-  for (size_t i = 0; i < colorStops.size(); ++i) {
-    const auto &colorStop = colorStops[i];
-    CGColorRef cgColor = RCTCreateCGColorRefFromSharedColor(colorStop.color);
-    [colors addObject:(__bridge id)cgColor];
-    [locations addObject: @(std::max(std::min(colorStop.position.value(), 1.0), 0.0))];
+  
+  for (const auto &colorStop : colorStops) {
+    [colors addObject:(id) RCTUIColorFromSharedColor(colorStop.color).CGColor];
+    [locations addObject:@(std::max(std::min(colorStop.position.value(), 1.0), 0.0))];
   }
   
   gradientLayer.colors = colors;
   gradientLayer.locations = locations;
-
-  for (id color in colors) {
-    CGColorRelease((__bridge CGColorRef)color);
-  }
   
   return gradientLayer;
 }

--- a/packages/rn-tester/js/examples/LinearGradient/LinearGradientExample.js
+++ b/packages/rn-tester/js/examples/LinearGradient/LinearGradientExample.js
@@ -261,4 +261,20 @@ exports.examples = [
       );
     },
   },
+  {
+    title: 'Non square multiple color stops',
+    render(): React.Node {
+      return (
+        <GradientBox
+          testID="linear-gradient-non-square-multiple-color-stops"
+          style={{
+            experimental_backgroundImage:
+              'linear-gradient(45deg, black 9%, red 20%, blue 30%, green 50%, black 90%, transparent)',
+            width: 100,
+            height: 200,
+          }}
+        />
+      );
+    },
+  },
 ];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:
This PR replaces Core Graphics implementation with Core Animation for linear gradients. I came across a great [solution](https://stackoverflow.com/questions/38821631/cagradientlayer-diagonal-gradient/43176174#43176174) that makes the `CAGradientLayer`'s start and end point behaviour CSS spec compliant. This will make gradients much more performant.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[IOS] [CHANGED] - Optimised Linear Gradients.
<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:
Non breaking change. Test Linear gradient example from RNTester. Compare results with web, android and iOS. Each platform should render the gradients identically. 
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

## Note:

I will be doing a PR to use `CAGradientLayer` for radial gradients as well. The next properties that I have locally working are `background-size`, `background-position` and `background-repeat`. These will be addressed in small PRs.