### PR TITLE
Publish, Close and Release the Maven repository during build_npm_package

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -140,27 +140,6 @@ jobs:
           hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
 
-  build_android:
-    runs-on: 8-core-ubuntu
-    needs: [set_release_type]
-    container:
-      image: reactnativecommunity/react-native-android:latest
-      env:
-        TERM: "dumb"
-        GRADLE_OPTS: "-Dorg.gradle.daemon=false"
-        ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}
-        ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
-        ORG_GRADLE_PROJECT_SONATYPE_USERNAME: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_USERNAME }}
-        ORG_GRADLE_PROJECT_SONATYPE_PASSWORD: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_PASSWORD }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Build Android
-        uses: ./.github/actions/build-android
-        with:
-          release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
-          gradle-cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
-
   build_npm_package:
     runs-on: 8-core-ubuntu
     needs:
@@ -170,7 +149,6 @@ jobs:
         build_hermes_macos,
         build_hermesc_linux,
         build_hermesc_windows,
-        build_android,
         prebuild_apple_dependencies,
         prebuild_react_native_core,
       ]

--- a/scripts/releases/utils/release-utils.js
+++ b/scripts/releases/utils/release-utils.js
@@ -67,7 +67,7 @@ function publishAndroidArtifactsToMaven(
     // -------- For stable releases, we also need to close and release the staging repository.
     if (
       exec(
-        './gradlew findSonatypeStagingRepository closeAndReleaseSonatypeStagingRepository',
+        './gradlew publishAndroidToSonatype closeAndReleaseSonatypeStagingRepository',
       ).code
     ) {
       echo(


### PR DESCRIPTION
Summary:
Due to us moving to central.sonatype.com for publishing, we cannot publish and release the Maven repository in 2 distinct invocations.
This consolidates all the publishing job to happen during build_npm_package

Changelog:
[Internal] [Changed] -

Reviewed By: fabriziocucci

Differential Revision: D76888543
