### PR TITLE
Specify missing default destructor and assignment operator declarations in ImageRequest

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageRequest.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageRequest.h
@@ -40,9 +40,20 @@ class ImageRequest final {
   ImageRequest(ImageRequest&& other) noexcept = default;
 
   /*
+   * Move assignment operator.
+   */
+  ImageRequest& operator=(ImageRequest&& other) noexcept = default;
+
+  /*
    * `ImageRequest` does not support copying by design.
    */
   ImageRequest(const ImageRequest& other) = delete;
+  ImageRequest& operator=(const ImageRequest& other) = delete;
+
+  /*
+   * Destructor
+   */
+  ~ImageRequest() = default;
 
   /*
    * Returns the Image Source associated with the request.


### PR DESCRIPTION
Summary:
# Changelog:
[Internal] -

Fixes a linter warning for the `ImageRequest` class declaration (AKA "C++ rule of 5").

Differential Revision: D76888523
