### PR TITLE
Remove unnecessary feature flags from fantom tests

### DIFF
--- a/packages/react-native/src/private/renderer/consistency/__tests__/UIConsistency-itest.js
+++ b/packages/react-native/src/private/renderer/consistency/__tests__/UIConsistency-itest.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @fantom_flags enableAccessToHostTreeInFabric:true
  * @fantom_flags enableSynchronousStateUpdates:true
  * @flow strict-local
  * @format

--- a/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-benchmark-itest.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-benchmark-itest.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @fantom_flags enableAccessToHostTreeInFabric:true enableIntersectionObserverEventLoopIntegration:*
+ * @fantom_flags enableIntersectionObserverEventLoopIntegration:*
  * @flow strict-local
  * @format
  */


### PR DESCRIPTION
Summary:
Changelog: [internal]

`enableAccessToHostTreeInFabric` is enabled by default in tests, so doesn't need to be explicitly set.

Differential Revision: D76894319
