### PR TITLE
[ios-prebuild] Implemented support for prebuilt in cocoapods

### DIFF
--- a/packages/react-native/React-Core-prebuilt.podspec
+++ b/packages/react-native/React-Core-prebuilt.podspec
@@ -1,0 +1,122 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require "json"
+
+begin
+  react_native_path = File.dirname(Pod::Executable.execute_command('node', ['-p',
+    'require.resolve(
+    "react-native",
+    {paths: [process.argv[1]]},
+    )', __dir__]).strip
+  )
+rescue => e
+  # Fallback to the parent directory if the above command fails (e.g when building locally in OOT Platform)
+  react_native_path = File.join(__dir__, "..", "..")
+end
+
+# package.json
+package = JSON.parse(File.read(File.join(react_native_path, "package.json")))
+version = package['version']
+
+source = ReactNativeCoreUtils.resolve_podspec_source()
+
+header_search_paths = [
+  "${PODS_ROOT}/Headers/Private/React-Core-prebuilt",
+  "${PODS_ROOT}/Headers/Private/React-Core-prebuilt/RCTDeprecation",
+  "${PODS_ROOT}/Headers/Private/React-Core-prebuilt/ReactCommon/yoga",
+  "${PODS_ROOT}/Headers/Private/React-Core-prebuilt/ReactCommon",
+  "${PODS_ROOT}/Headers/Private/React-Core-prebuilt/Libraries/AppDelegate",
+  "${PODS_ROOT}/Headers/Private/React-Core-prebuilt/Libraries",
+
+  "$(REACT_NATIVE_PATH)/React/Base",
+  "$(REACT_NATIVE_PATH)/ReactCommon",
+  "$(REACT_NATIVE_PATH)/Libraries",
+  "$(REACT_NATIVE_PATH)/ReactApple",
+  "$(REACT_NATIVE_PATH)/ReactCxxPlatform",
+  "$(REACT_NATIVE_PATH)/ReactCommon/react/runtime/platform/ios",
+  "${REACT_NATIVE_PATH}/ReactCommon/jsi",
+  "$(REACT_NATIVE_PATH)/ReactCommon/jsiexecutor/",
+  "$(REACT_NATIVE_PATH)/ReactCommon/react/nativemodule/samples/platform/ios",
+  "$(REACT_NATIVE_PATH)/ReactCommon/react/nativemodule/samples",
+]
+
+Pod::Spec.new do |spec|
+  spec.name                 = 'React-Core-prebuilt'
+  spec.version              = version
+  spec.summary              = "Prebuilt core of React Native."
+  spec.homepage             = "https://reactnative.dev/"
+  spec.description          = 'Prebuilt React Native Core libraries and headers'
+  spec.homepage             = 'https://github.com/facebook/react-native'
+  spec.license              = package['license']
+  spec.authors              = 'meta'
+  spec.platforms            = min_supported_versions
+  spec.source               = source
+
+  spec.vendored_frameworks  = "React.xcframework"
+
+  spec.preserve_paths       = '**/*.*'
+  spec.header_mappings_dir  = 'React.xcframework/Headers'
+  spec.source_files         = 'React.xcframework/Headers/**/*.{h,hpp}'
+
+  spec.module_name          = 'React'
+  spec.module_map           = 'React.xcframework/Modules/module.modulemap'
+  spec.public_header_files  = 'React.xcframework/Headers/**/*.h'
+
+  # Setup the consuming project's search paths
+  spec.user_target_xcconfig = {
+    "HEADER_SEARCH_PATHS" => header_search_paths,
+    "SWIFT_INCLUDE_PATHS" => "${PODS_ROOT}/Headers/Private/React-Core-prebuilt",
+    'DEFINES_MODULE' => 'YES',
+    'CLANG_ENABLE_MODULES' => 'YES',
+  }
+
+  spec.pod_target_xcconfig  = {
+    'WARNING_CFLAGS' => '-Wno-comma -Wno-shorten-64-to-32',
+    "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
+    'DEFINES_MODULE' => 'YES',
+    'CLANG_ENABLE_MODULES' => 'YES',
+  }
+
+  # We need to make sure that the React.xcframework is copied correctly - in the downloaded tarball
+  # the root directory is the framework, but when using it we need to have it in a subdirectory
+  # called React.xcframework, so we need to move the contents of the tarball into that directory.
+  # This is done in the prepare_command.
+  spec.prepare_command = <<~'CMD'
+    CURRENT_PATH=$(pwd)
+    XCFRAMEWORK_PATH="${CURRENT_PATH}/React.xcframework"
+    mkdir -p "${XCFRAMEWORK_PATH}"
+    find "$CURRENT_PATH" -mindepth 1 -maxdepth 1 ! -name "$(basename "$XCFRAMEWORK_PATH")" -exec mv {} "$XCFRAMEWORK_PATH" \;
+  CMD
+
+  # If we are passing a local tarball, we don't want to switch between Debug and Release
+  if !ENV["RCT_USE_LOCAL_RN_CORE"]
+    script_phase = {
+      :name => "[RNDeps] Replace React Native Core for the right configuration, if needed",
+      :execution_position => :before_compile,
+      :script => <<-EOS
+      . "$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh"
+
+      CONFIG="Release"
+      if echo $GCC_PREPROCESSOR_DEFINITIONS | grep -q "DEBUG=1"; then
+        CONFIG="Debug"
+      fi
+
+      # TODO: Add this for React Native Core as well
+      ##### "$NODE_BINARY" "$REACT_NATIVE_PATH/third-party-podspecs/replace_dependencies_version.js" -c "$CONFIG" -r "#{version}" -p "$PODS_ROOT"
+      EOS
+    }
+
+
+    # :always_out_of_date is only available in CocoaPods 1.13.0 and later
+    if Gem::Version.new(Pod::VERSION) >= Gem::Version.new('1.13.0')
+      # always run the script without warning
+      script_phase[:always_out_of_date] = "1"
+    end
+
+    spec.script_phase = script_phase
+  end
+
+end

--- a/packages/react-native/scripts/cocoapods/rncore.rb
+++ b/packages/react-native/scripts/cocoapods/rncore.rb
@@ -1,0 +1,219 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require "json"
+require 'net/http'
+require 'rexml/document'
+
+require_relative './utils.rb'
+
+## - RCT_USE_PREBUILT_RNCORE: If set to 1, it will use the release tarball from Maven instead of building from source.
+## - RCT_USE_LOCAL_RNCORE: **TEST ONLY** If set, it will use a local tarball of RNCore if it exists.
+## - RCT_RNCORE_VERSION: **TEST ONLY** If set, it will override the version of RNCore to be used.
+
+class ReactNativeCoreUtils
+    @@build_from_source = true
+    @@react_native_path = ""
+    @@react_native_version = ""
+    @@use_nightly = false
+
+    ## Sets up wether ReactNative Core should be built from source or not.
+    ## If RCT_USE_PREBUILT_RNCORE is set to 1 and the artifacts exists on Maven, it will
+    ## not build from source. Otherwise, it will build from source.
+    def self.setup_rncore(react_native_path, react_native_version)
+        # We don't want setup to be called multiple times, so we check if the variables are already set.
+        if @@react_native_version == ""
+            rncore_log("Setting up ReactNativeCore...")
+            @@react_native_path = react_native_path
+            @@react_native_version = ENV["RCT_RNCORE_VERSION"] == nil ? react_native_version : ENV["RCT_RNCORE_VERSION"]
+
+            if @@react_native_version.include? 'nightly'
+                @@use_nightly = true
+                if ENV["RCT_RNCORE_VERSION"] == "nightly"
+                    @@react_native_version = ReactNativeDependenciesUtils.get_nightly_npm_version()
+                    rncore_log("Using nightly version from npm: #{@@react_native_version}")
+                else
+                    rncore_log("Using nightly build #{@@react_native_version}")
+                end
+            end
+
+            artifacts_exists = ENV["RCT_USE_PREBUILT_RNCORE"] == "1" && (@@use_nightly ? nightly_artifact_exists(@@react_native_version) : release_artifact_exists(@@react_native_version))
+            use_local_xcframework = ENV["RCT_USE_LOCAL_RNCORE"] && File.exist?(ENV["RCT_USE_LOCAL_RNCORE"])
+
+            if ENV["RCT_USE_LOCAL_RNCORE"]
+                if !File.exist?(ENV["RCT_USE_LOCAL_RNCORE"])
+                    abort("RCT_USE_LOCAL_RNCORE is set to #{ENV["RCT_USE_LOCAL_RNCORE"]} but the file does not exist!")
+                end
+            end
+
+            @@build_from_source = !use_local_xcframework && !artifacts_exists
+
+            if @@build_from_source && ENV["RCT_USE_LOCAL_RNCORE"] && !use_local_xcframework
+                rncore_log("No local xcframework found, reverting to building from source.")
+            end
+            if @@build_from_source && ENV["RCT_USE_PREBUILT_RNCORE"] && !artifacts_exists
+                rncore_log("No prebuilt artifacts found, reverting to building from source.")
+            end
+            rncore_log("Building from source: #{@@build_from_source}")
+            rncore_log("Source: #{self.resolve_podspec_source()}")
+        end
+    end
+
+    def self.build_rncore_from_source()
+        return @@build_from_source
+    end
+
+    def self.resolve_podspec_source()
+        if ENV["RCT_USE_LOCAL_RNCORE"]
+            if !File.exist?(ENV["RCT_USE_LOCAL_RNCORE"])
+                abort("RCT_USE_LOCAL_RNCORE is set to #{ENV["RCT_USE_LOCAL_RNCORE"]} but the file does not exist in the current directory (#{Dir.pwd}).")
+            end
+            rncore_log("Using local xcframework at #{ENV["RCT_USE_LOCAL_RNCORE"]}")
+            return {:http => "file://#{ENV["RCT_USE_LOCAL_RNCORE"]}" }
+        end
+
+        if ENV["RCT_USE_PREBUILT_RNCORE"] && ENV["RCT_USE_PREBUILT_RNCORE"] == "1"
+            if @@use_nightly
+                rncore_log("Using nightly tarball")
+                begin
+                    return self.podspec_source_download_prebuilt_nightly_tarball(@@react_native_version)
+                rescue => e
+                    rncore_log("Failed to download nightly tarball: #{e.message}", :error)
+                    return
+                end
+            end
+
+            begin
+                return self.podspec_source_download_prebuild_release_tarball()
+            rescue => e
+                rncore_log("Failed to download release tarball: #{e.message}", :error)
+                return
+            end
+        end
+
+    end
+
+    def self.podspec_source_download_prebuild_release_tarball()
+        # Warn if @@react_native_path is not set
+        if @@react_native_path == ""
+            rncore_log("react_native_path is not set", :error)
+            return
+        end
+
+        # Warn if @@react_native_version is not set
+        if @@react_native_version == ""
+            rncore_log("react_native_version is not set", :error)
+            return
+        end
+
+        if @@build_from_source
+            return
+        end
+
+        url = release_tarball_url(@@react_native_version, :debug)
+        rncore_log("Using tarball from URL: #{url}")
+        download_stable_rndeps(@@react_native_path, @@react_native_version, :debug)
+        download_stable_rndeps(@@react_native_path, @@react_native_version, :release)
+        return {:http => url}
+    end
+
+    def self.release_tarball_url(version, build_type)
+        maven_repo_url = "https://repo1.maven.org/maven2"
+        group = "com/facebook/react"
+        # Sample url from Maven:
+        return "#{maven_repo_url}/#{group}/react-native-artifacts/#{version}/react-native-artifacts-#{version}-reactnative-core-debug.tar.gz-#{build_type.to_s}.tar.gz"
+    end
+
+    def self.nightly_tarball_url(version)
+        artefact_coordinate = "react-native-artifacts"
+        artefact_name = "reactnative-core-debug.tar.gz"
+        xml_url = "https://central.sonatype.com/repository/maven-snapshots/com/facebook/react/#{artefact_coordinate}/#{version}-SNAPSHOT/maven-metadata.xml"
+
+        xml = REXML::Document.new(Net::HTTP.get(URI(xml_url)))
+        timestamp = xml.elements['metadata/versioning/snapshot/timestamp'].text
+        build_number = xml.elements['metadata/versioning/snapshot/buildNumber'].text
+        full_version = "#{version}-#{timestamp}-#{build_number}"
+
+        final_url = "https://central.sonatype.com/repository/maven-snapshots/com/facebook/react/#{artefact_coordinate}/#{version}-SNAPSHOT/#{artefact_coordinate}-#{full_version}-#{artefact_name}"
+        return final_url
+    end
+
+    def self.download_stable_rndeps(react_native_path, version, configuration)
+        tarball_url = release_tarball_url(version, configuration)
+        download_rndeps_tarball(react_native_path, tarball_url, version, configuration)
+    end
+
+    def self.podspec_source_download_prebuilt_nightly_tarball(version)
+        url = nightly_tarball_url(version)
+        rncore_log("Using nightly tarball from URL: #{url}")
+        return {:http => url}
+    end
+
+    def self.download_rndeps_tarball(react_native_path, tarball_url, version, configuration)
+        destination_path = configuration == nil ?
+            "#{artifacts_dir()}/reactnative-core-debug.tar.gz-#{version}.tar.gz" :
+            "#{artifacts_dir()}/reactnative-core-debug.tar.gz-#{version}-#{configuration}.tar.gz"
+
+        unless File.exist?(destination_path)
+          # Download to a temporary file first so we don't cache incomplete downloads.
+          tmp_file = "#{artifacts_dir()}/reactnative-core-debug.tar.gz.download"
+          `mkdir -p "#{artifacts_dir()}" && curl "#{tarball_url}" -Lo "#{tmp_file}" && mv "#{tmp_file}" "#{destination_path}"`
+        end
+
+        return destination_path
+    end
+
+    def self.release_artifact_exists(version)
+        return artifact_exists(release_tarball_url(version, :debug))
+    end
+
+    def self.nightly_artifact_exists(version)
+        return artifact_exists(nightly_tarball_url(version).gsub("\\", ""))
+    end
+
+    def self.artifacts_dir()
+        return File.join(Pod::Config.instance.project_pods_root, "ReactNativeCore-artifacts")
+    end
+
+    # This function checks that ReactNativeCore artifact exists on the maven repo
+    def self.artifact_exists(tarball_url)
+        # -L is used to follow redirects, useful for the nightlies
+        # I also needed to wrap the url in quotes to avoid escaping & and ?.
+        return (`curl -o /dev/null --silent -Iw '%{http_code}' -L "#{tarball_url}"` == "200")
+    end
+
+    def self.resolve_url_redirects(url)
+        return (`curl -Ls -o /dev/null -w %{url_effective} \"#{url}\"`)
+    end
+
+    def self.rncore_log(message, level = :info)
+        if !Object.const_defined?("Pod::UI")
+            return
+        end
+        log_message = '[ReactNativeCore] ' + message
+        case level
+        when :info
+            Pod::UI.puts log_message.green
+        when :error
+            Pod::UI.puts log_message.red
+        else
+            Pod::UI.puts log_message.yellow
+        end
+    end
+
+    def self.get_nightly_npm_version()
+        uri = URI('https://registry.npmjs.org/react-native/nightly')
+        response = Net::HTTP.get_response(uri)
+
+        unless response.is_a?(Net::HTTPSuccess)
+          raise "Couldn't get an answer from NPM: #{response.code} #{response.message}"
+        end
+
+        json = JSON.parse(response.body)
+        latest_nightly = json['version']
+        return latest_nightly
+    end
+
+end

--- a/packages/react-native/scripts/cocoapods/rndependencies.rb
+++ b/packages/react-native/scripts/cocoapods/rndependencies.rb
@@ -67,46 +67,76 @@ class ReactNativeDependenciesUtils
     end
 
     def self.resolve_podspec_source()
-        if ENV["RCT_USE_RN_DEP"] && ENV["RCT_USE_RN_DEP"] == "1"
-            if @@use_nightly
-                rndeps_log("Using nightly tarball")
-                return self.podspec_source_download_prebuilt_nightly_tarball(@@react_native_version)
+        if ENV["RCT_USE_LOCAL_RN_DEP"]
+            if !File.exist?(ENV["RCT_USE_LOCAL_RN_DEP"])
+                abort("RCT_USE_LOCAL_RN_DEP is set to #{ENV["RCT_USE_LOCAL_RN_DEP"]} but the file does not exist in the current directory (#{Dir.pwd}).")
             end
-
-            rndeps_log("Using release tarball")
-            return self.podspec_source_download_prebuild_release_tarball()
-        end
-
-        if ENV["RCT_USE_LOCAL_RN_DEP"] && File.exist?(ENV["RCT_USE_LOCAL_RN_DEP"])
             rndeps_log("Using local xcframework at #{ENV["RCT_USE_LOCAL_RN_DEP"]}")
             return {:http => "file://#{ENV["RCT_USE_LOCAL_RN_DEP"]}" }
         end
+
+        if ENV["RCT_USE_RN_DEP"] && ENV["RCT_USE_RN_DEP"] == "1"
+            if @@use_nightly
+                rndeps_log("Using nightly tarball")
+                begin
+                    return self.podspec_source_download_prebuilt_nightly_tarball(@@react_native_version)
+                rescue => e
+                    rndeps_log("Failed to download nightly tarball: #{e.message}", :error)
+                    return
+                end
+            end
+
+            rndeps_log("Using release tarball")
+            begin
+                return self.podspec_source_download_prebuild_release_tarball()
+            rescue => e
+                rndeps_log("Failed to download release tarball: #{e.message}", :error)
+                return
+            end
+        end
+
     end
 
     ## Sets up wether react-native-dependencies should be built from source or not.
     ## If RCT_USE_RN_DEP is set to 1 and the artifacts exists on Maven, it will
     ## not build from source. Otherwise, it will build from source.
     def self.setup_react_native_dependencies(react_native_path, react_native_version)
-        @@react_native_path = react_native_path
-        @@react_native_version = ENV["RCT_DEPS_VERSION"] == nil ? react_native_version : ENV["RCT_DEPS_VERSION"]
+        # We don't want setup to be called multiple times, so we check if the variables are already set.
+        if @@react_native_version == ""
+            rndeps_log("Setting up ReactNativeDependencies...")
+            @@react_native_path = react_native_path
+            @@react_native_version = ENV["RCT_DEPS_VERSION"] == nil ? react_native_version : ENV["RCT_DEPS_VERSION"]
 
-        if @@react_native_version.include? 'nightly'
-            rndeps_log("Using nightly build")
-            @@use_nightly = true
-        end
-
-        artifacts_exists = ENV["RCT_USE_RN_DEP"] == "1" && (@@use_nightly ? nightly_artifact_exists(@@react_native_version) : release_artifact_exists(@@react_native_version))
-        use_local_xcframework = ENV["RCT_USE_LOCAL_RN_DEP"] && File.exist?(ENV["RCT_USE_LOCAL_RN_DEP"])
-
-        if ENV["RCT_USE_LOCAL_RN_DEP"]
-            if !File.exist?(ENV["RCT_USE_LOCAL_RN_DEP"])
-                abort("RCT_USE_LOCAL_RN_DEP is set to #{ENV["RCT_USE_LOCAL_RN_DEP"]} but the file does not exist!")
+            if @@react_native_version.include? 'nightly'
+                @@use_nightly = true
+                if ENV["RCT_DEPS_VERSION"] == "nightly"
+                    @@react_native_version = ReactNativeDependenciesUtils.get_nightly_npm_version()
+                    rndeps_log("Using nightly version from npm: #{@@react_native_version}")
+                else
+                    rndeps_log("Using nightly build #{@@react_native_version}")
+                end
             end
+
+            artifacts_exists = ENV["RCT_USE_RN_DEP"] == "1" && (@@use_nightly ? nightly_artifact_exists(@@react_native_version) : release_artifact_exists(@@react_native_version))
+            use_local_xcframework = ENV["RCT_USE_LOCAL_RN_DEP"] && File.exist?(ENV["RCT_USE_LOCAL_RN_DEP"])
+
+            if ENV["RCT_USE_LOCAL_RN_DEP"]
+                if !File.exist?(ENV["RCT_USE_LOCAL_RN_DEP"])
+                    abort("RCT_USE_LOCAL_RN_DEP is set to #{ENV["RCT_USE_LOCAL_RN_DEP"]} but the file does not exist!")
+                end
+            end
+
+            @@build_from_source = !use_local_xcframework && !artifacts_exists
+
+            if @@build_from_source && ENV["RCT_USE_LOCAL_RNCORE"] && !use_local_xcframework
+                rndeps_log("No local xcframework found, reverting to building from source.")
+            end
+            if @@build_from_source && ENV["RCT_USE_PREBUILT_RNCORE"] && !artifacts_exists
+                rndeps_log("No prebuilt artifacts found, reverting to building from source.")
+            end
+            rndeps_log("Building from source: #{@@build_from_source}")
+            rndeps_log("Source: #{self.resolve_podspec_source()}")
         end
-
-        @@build_from_source = !use_local_xcframework && !artifacts_exists
-
-        rndeps_log("Building from source: #{@@build_from_source}")
     end
 
     def self.podspec_source_download_prebuild_release_tarball()
@@ -205,7 +235,7 @@ class ReactNativeDependenciesUtils
         return (`curl -o /dev/null --silent -Iw '%{http_code}' -L "#{tarball_url}"` == "200")
     end
 
-    def self.rndeps_log(message, level = :warning)
+    def self.rndeps_log(message, level = :info)
         if !Object.const_defined?("Pod::UI")
             return
         end
@@ -222,5 +252,18 @@ class ReactNativeDependenciesUtils
 
     def self.resolve_url_redirects(url)
         return (`curl -Ls -o /dev/null -w %{url_effective} \"#{url}\"`)
+    end
+
+    def self.get_nightly_npm_version()
+        uri = URI('https://registry.npmjs.org/react-native/nightly')
+        response = Net::HTTP.get_response(uri)
+
+        unless response.is_a?(Net::HTTPSuccess)
+          raise "Couldn't get an answer from NPM: #{response.code} #{response.message}"
+        end
+
+        json = JSON.parse(response.body)
+        latest_nightly = json['version']
+        return latest_nightly
     end
 end

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -19,6 +19,7 @@ require_relative './cocoapods/runtime.rb'
 require_relative './cocoapods/helpers.rb'
 require_relative './cocoapods/privacy_manifest_utils.rb'
 require_relative './cocoapods/spm.rb'
+require_relative './cocoapods/rncore.rb'
 # Importing to expose use_native_modules!
 require_relative './cocoapods/autolinking.rb'
 
@@ -105,102 +106,103 @@ def use_react_native! (
   # Update ReactNativeDependencies so that we can easily switch between source and prebuilt
   ReactNativeDependenciesUtils.setup_react_native_dependencies(prefix, react_native_version)
 
+  # Update ReactNativeCoreUtils so that we can easily switch between source and prebuilt
+  ReactNativeCoreUtils.setup_rncore(prefix, react_native_version)
+
   Pod::UI.puts "Configuring the target with the #{new_arch_enabled ? "New" : "Legacy"} Architecture\n"
 
-  # The Pods which should be included in all projects
-  pod 'FBLazyVector', :path => "#{prefix}/Libraries/FBLazyVector"
-  pod 'RCTRequired', :path => "#{prefix}/Libraries/Required"
-  pod 'RCTTypeSafety', :path => "#{prefix}/Libraries/TypeSafety", :modular_headers => true
-  pod 'React', :path => "#{prefix}/"
-  pod 'React-Core', :path => "#{prefix}/"
-  pod 'React-CoreModules', :path => "#{prefix}/React/CoreModules"
-  pod 'React-RCTRuntime', :path => "#{prefix}/React/Runtime"
-  pod 'React-RCTAppDelegate', :path => "#{prefix}/Libraries/AppDelegate"
-  pod 'React-RCTActionSheet', :path => "#{prefix}/Libraries/ActionSheetIOS"
-  pod 'React-RCTAnimation', :path => "#{prefix}/Libraries/NativeAnimation"
-  pod 'React-RCTBlob', :path => "#{prefix}/Libraries/Blob"
-  pod 'React-RCTImage', :path => "#{prefix}/Libraries/Image"
-  pod 'React-RCTLinking', :path => "#{prefix}/Libraries/LinkingIOS"
-  pod 'React-RCTNetwork', :path => "#{prefix}/Libraries/Network"
-  pod 'React-RCTSettings', :path => "#{prefix}/Libraries/Settings"
-  pod 'React-RCTText', :path => "#{prefix}/Libraries/Text"
-  pod 'React-RCTVibration', :path => "#{prefix}/Libraries/Vibration"
-  pod 'React-Core/RCTWebSocket', :path => "#{prefix}/"
-  pod 'React-cxxreact', :path => "#{prefix}/ReactCommon/cxxreact"
-  pod 'React-debug', :path => "#{prefix}/ReactCommon/react/debug"
-  pod 'React-utils', :path => "#{prefix}/ReactCommon/react/utils"
-  pod 'React-featureflags', :path => "#{prefix}/ReactCommon/react/featureflags"
-  pod 'React-featureflagsnativemodule', :path => "#{prefix}/ReactCommon/react/nativemodule/featureflags"
-  pod 'React-microtasksnativemodule', :path => "#{prefix}/ReactCommon/react/nativemodule/microtasks"
-  pod 'React-idlecallbacksnativemodule', :path => "#{prefix}/ReactCommon/react/nativemodule/idlecallbacks"
-  pod 'React-domnativemodule', :path => "#{prefix}/ReactCommon/react/nativemodule/dom"
-  pod 'React-defaultsnativemodule', :path => "#{prefix}/ReactCommon/react/nativemodule/defaults"
-  pod 'React-Mapbuffer', :path => "#{prefix}/ReactCommon"
-  pod 'React-jserrorhandler', :path => "#{prefix}/ReactCommon/jserrorhandler"
-  pod 'RCTDeprecation', :path => "#{prefix}/ReactApple/Libraries/RCTFoundation/RCTDeprecation"
-  pod 'React-RCTFBReactNativeSpec', :path => "#{prefix}/React"
-  pod 'React-jsi', :path => "#{prefix}/ReactCommon/jsi"
+  if ReactNativeCoreUtils.build_rncore_from_source()
+    # The Pods which should be included in all projects
+    pod 'FBLazyVector', :path => "#{prefix}/Libraries/FBLazyVector"
+    pod 'RCTRequired', :path => "#{prefix}/Libraries/Required"
+    pod 'RCTTypeSafety', :path => "#{prefix}/Libraries/TypeSafety", :modular_headers => true
+    pod 'React', :path => "#{prefix}/"
+    pod 'React-Core', :path => "#{prefix}/"
+    pod 'React-CoreModules', :path => "#{prefix}/React/CoreModules"
+    pod 'React-RCTRuntime', :path => "#{prefix}/React/Runtime"
+    pod 'React-RCTAppDelegate', :path => "#{prefix}/Libraries/AppDelegate"
+    pod 'React-RCTActionSheet', :path => "#{prefix}/Libraries/ActionSheetIOS"
+    pod 'React-RCTAnimation', :path => "#{prefix}/Libraries/NativeAnimation"
+    pod 'React-RCTBlob', :path => "#{prefix}/Libraries/Blob"
+    pod 'React-RCTImage', :path => "#{prefix}/Libraries/Image"
+    pod 'React-RCTLinking', :path => "#{prefix}/Libraries/LinkingIOS"
+    pod 'React-RCTNetwork', :path => "#{prefix}/Libraries/Network"
+    pod 'React-RCTSettings', :path => "#{prefix}/Libraries/Settings"
+    pod 'React-RCTText', :path => "#{prefix}/Libraries/Text"
+    pod 'React-RCTVibration', :path => "#{prefix}/Libraries/Vibration"
+    pod 'React-Core/RCTWebSocket', :path => "#{prefix}/"
+    pod 'React-cxxreact', :path => "#{prefix}/ReactCommon/cxxreact"
+    pod 'React-debug', :path => "#{prefix}/ReactCommon/react/debug"
+    pod 'React-utils', :path => "#{prefix}/ReactCommon/react/utils"
+    pod 'React-featureflags', :path => "#{prefix}/ReactCommon/react/featureflags"
+    pod 'React-featureflagsnativemodule', :path => "#{prefix}/ReactCommon/react/nativemodule/featureflags"
+    pod 'React-microtasksnativemodule', :path => "#{prefix}/ReactCommon/react/nativemodule/microtasks"
+    pod 'React-idlecallbacksnativemodule', :path => "#{prefix}/ReactCommon/react/nativemodule/idlecallbacks"
+    pod 'React-domnativemodule', :path => "#{prefix}/ReactCommon/react/nativemodule/dom"
+    pod 'React-defaultsnativemodule', :path => "#{prefix}/ReactCommon/react/nativemodule/defaults"
+    pod 'React-Mapbuffer', :path => "#{prefix}/ReactCommon"
+    pod 'React-jserrorhandler', :path => "#{prefix}/ReactCommon/jserrorhandler"
+    pod 'RCTDeprecation', :path => "#{prefix}/ReactApple/Libraries/RCTFoundation/RCTDeprecation"
+    pod 'React-RCTFBReactNativeSpec', :path => "#{prefix}/React"
+    pod 'React-jsi', :path => "#{prefix}/ReactCommon/jsi"
 
-  if hermes_enabled
-    setup_hermes!(:react_native_path => prefix)
-  end
+    if hermes_enabled
+      setup_hermes!(:react_native_path => prefix)
+    end
 
-  pod 'React-jsiexecutor', :path => "#{prefix}/ReactCommon/jsiexecutor"
-  pod 'React-jsinspector', :path => "#{prefix}/ReactCommon/jsinspector-modern"
-  pod 'React-jsitooling', :path => "#{prefix}/ReactCommon/jsitooling"
-  pod 'React-jsinspectorcdp', :path => "#{prefix}/ReactCommon/jsinspector-modern/cdp"
-  pod 'React-jsinspectornetwork', :path => "#{prefix}/ReactCommon/jsinspector-modern/network"
-  pod 'React-jsinspectortracing', :path => "#{prefix}/ReactCommon/jsinspector-modern/tracing"
+    pod 'React-jsiexecutor', :path => "#{prefix}/ReactCommon/jsiexecutor"
+    pod 'React-jsinspector', :path => "#{prefix}/ReactCommon/jsinspector-modern"
+    pod 'React-jsitooling', :path => "#{prefix}/ReactCommon/jsitooling"
+    pod 'React-jsinspectorcdp', :path => "#{prefix}/ReactCommon/jsinspector-modern/cdp"
+    pod 'React-jsinspectornetwork', :path => "#{prefix}/ReactCommon/jsinspector-modern/network"
+    pod 'React-jsinspectortracing', :path => "#{prefix}/ReactCommon/jsinspector-modern/tracing"
 
-  pod 'React-callinvoker', :path => "#{prefix}/ReactCommon/callinvoker"
-  pod 'React-performancetimeline', :path => "#{prefix}/ReactCommon/react/performance/timeline"
-  pod 'React-timing', :path => "#{prefix}/ReactCommon/react/timing"
-  pod 'React-runtimeexecutor', :path => "#{prefix}/ReactCommon/runtimeexecutor"
-  pod 'React-runtimescheduler', :path => "#{prefix}/ReactCommon/react/renderer/runtimescheduler"
-  pod 'React-renderercss', :path => "#{prefix}/ReactCommon/react/renderer/css"
-  pod 'React-rendererdebug', :path => "#{prefix}/ReactCommon/react/renderer/debug"
-  pod 'React-rendererconsistency', :path => "#{prefix}/ReactCommon/react/renderer/consistency"
-  pod 'React-perflogger', :path => "#{prefix}/ReactCommon/reactperflogger"
-  pod 'React-oscompat', :path => "#{prefix}/ReactCommon/oscompat"
-  pod 'React-logger', :path => "#{prefix}/ReactCommon/logger"
-  pod 'ReactCommon/turbomodule/core', :path => "#{prefix}/ReactCommon", :modular_headers => true
-  pod 'React-NativeModulesApple', :path => "#{prefix}/ReactCommon/react/nativemodule/core/platform/ios", :modular_headers => true
-  pod 'Yoga', :path => "#{prefix}/ReactCommon/yoga", :modular_headers => true
+    pod 'React-callinvoker', :path => "#{prefix}/ReactCommon/callinvoker"
+    pod 'React-performancetimeline', :path => "#{prefix}/ReactCommon/react/performance/timeline"
+    pod 'React-timing', :path => "#{prefix}/ReactCommon/react/timing"
+    pod 'React-runtimeexecutor', :path => "#{prefix}/ReactCommon/runtimeexecutor"
+    pod 'React-runtimescheduler', :path => "#{prefix}/ReactCommon/react/renderer/runtimescheduler"
+    pod 'React-renderercss', :path => "#{prefix}/ReactCommon/react/renderer/css"
+    pod 'React-rendererdebug', :path => "#{prefix}/ReactCommon/react/renderer/debug"
+    pod 'React-rendererconsistency', :path => "#{prefix}/ReactCommon/react/renderer/consistency"
+    pod 'React-perflogger', :path => "#{prefix}/ReactCommon/reactperflogger"
+    pod 'React-oscompat', :path => "#{prefix}/ReactCommon/oscompat"
+    pod 'React-logger', :path => "#{prefix}/ReactCommon/logger"
+    pod 'ReactCommon/turbomodule/core', :path => "#{prefix}/ReactCommon", :modular_headers => true
+    pod 'React-NativeModulesApple', :path => "#{prefix}/ReactCommon/react/nativemodule/core/platform/ios", :modular_headers => true
+    pod 'Yoga', :path => "#{prefix}/ReactCommon/yoga", :modular_headers => true
 
-  if ReactNativeDependenciesUtils.build_react_native_deps_from_source()
-    pod 'DoubleConversion', :podspec => "#{prefix}/third-party-podspecs/DoubleConversion.podspec"
-    pod 'glog', :podspec => "#{prefix}/third-party-podspecs/glog.podspec"
-    pod 'boost', :podspec => "#{prefix}/third-party-podspecs/boost.podspec"
-    pod 'fast_float', :podspec => "#{prefix}/third-party-podspecs/fast_float.podspec"
-    pod 'fmt', :podspec => "#{prefix}/third-party-podspecs/fmt.podspec", :modular_headers => true
-    pod 'RCT-Folly', :podspec => "#{prefix}/third-party-podspecs/RCT-Folly.podspec", :modular_headers => true
-    pod 'SocketRocket', "~> #{Helpers::Constants::socket_rocket_config[:version]}", :modular_headers => true
+    if ReactNativeDependenciesUtils.build_react_native_deps_from_source()
+      pod 'DoubleConversion', :podspec => "#{prefix}/third-party-podspecs/DoubleConversion.podspec"
+      pod 'glog', :podspec => "#{prefix}/third-party-podspecs/glog.podspec"
+      pod 'boost', :podspec => "#{prefix}/third-party-podspecs/boost.podspec"
+      pod 'fast_float', :podspec => "#{prefix}/third-party-podspecs/fast_float.podspec"
+      pod 'fmt', :podspec => "#{prefix}/third-party-podspecs/fmt.podspec", :modular_headers => true
+      pod 'RCT-Folly', :podspec => "#{prefix}/third-party-podspecs/RCT-Folly.podspec", :modular_headers => true
+      pod 'SocketRocket', "~> #{Helpers::Constants::socket_rocket_config[:version]}", :modular_headers => true
+    end
   else
+    # Install prebuilt React Native Core and React Native Dependencies
+    ReactNativeCoreUtils.rncore_log("Using React Native Core and React Native Dependencies prebuilt versions.")
+    pod 'React-Core-prebuilt', :podspec => "#{prefix}/React-Core-prebuilt.podspec", :modular_headers => true
     pod 'ReactNativeDependencies', :podspec => "#{prefix}/third-party-podspecs/ReactNativeDependencies.podspec", :modular_headers => true
+    pod 'hermes-engine', :podspec => "#{prefix}/sdks/hermes-engine/hermes-engine.podspec"
+
+    # Not needed, but run_codegen expects this to be set.
+    folly_config = get_folly_config()
+    run_codegen!(
+      app_path,
+      config_file_dir,
+      :new_arch_enabled => NewArchitectureHelper.new_arch_enabled,
+      :disable_codegen => ENV['DISABLE_CODEGEN'] == '1',
+      :react_native_path => prefix,
+      :fabric_enabled => fabric_enabled,
+      :hermes_enabled => hermes_enabled,
+      :codegen_output_dir => $CODEGEN_OUTPUT_DIR,
+      :package_json_file => File.join(__dir__, "..", "package.json"),
+      :folly_version => folly_config[:version]
+    )
   end
-
-  folly_config = get_folly_config()
-  run_codegen!(
-    app_path,
-    config_file_dir,
-    :new_arch_enabled => NewArchitectureHelper.new_arch_enabled,
-    :disable_codegen => ENV['DISABLE_CODEGEN'] == '1',
-    :react_native_path => prefix,
-    :fabric_enabled => fabric_enabled,
-    :hermes_enabled => hermes_enabled,
-    :codegen_output_dir => $CODEGEN_OUTPUT_DIR,
-    :package_json_file => File.join(__dir__, "..", "package.json"),
-    :folly_version => folly_config[:version]
-  )
-
-  pod 'ReactCodegen', :path => $CODEGEN_OUTPUT_DIR, :modular_headers => true
-  pod 'ReactAppDependencyProvider', :path => $CODEGEN_OUTPUT_DIR, :modular_headers => true
-
-  # Always need fabric to access the RCTSurfacePresenterBridgeAdapter which allow to enable the RuntimeScheduler
-  # If the New Arch is turned off, we will use the Old Renderer, though.
-  # RNTester always installed Fabric, this change is required to make the template work.
-  setup_fabric!(:react_native_path => prefix)
-  setup_bridgeless!(:react_native_path => prefix, :use_hermes => hermes_enabled)
 
   pods_to_update = LocalPodspecPatch.pods_to_update(:react_native_path => prefix)
   if !pods_to_update.empty?

--- a/packages/react-native/third-party-podspecs/ReactNativeDependencies.podspec
+++ b/packages/react-native/third-party-podspecs/ReactNativeDependencies.podspec
@@ -36,7 +36,7 @@ Pod::Spec.new do |spec|
     'WARNING_CFLAGS' => '-Wno-comma -Wno-shorten-64-to-32',
   }
 
-  spec.source             = source
+  spec.source               = source
   spec.preserve_paths       = '**/*.*'
   spec.vendored_frameworks  = 'framework/packages/react-native/ReactNativeDependencies.xcframework'
   spec.header_mappings_dir  = 'Headers'
@@ -49,6 +49,19 @@ Pod::Spec.new do |spec|
     mkdir -p Headers
     XCFRAMEWORK_PATH=$(find "$CURRENT_PATH" -type d -name "ReactNativeDependencies.xcframework")
     HEADERS_PATH=$(find "$XCFRAMEWORK_PATH" -type d -name "Headers" | head -n 1)
+
+    # Check if XCFRAMEWORK_PATH is empty
+    if [ -z "$XCFRAMEWORK_PATH" ]; then
+      echo "ERROR: XCFRAMEWORK_PATH is empty."
+      exit 0
+    fi
+
+    # Check if HEADERS_PATH is empty
+    if [ -z "$HEADERS_PATH" ]; then
+      echo "ERROR: HEADERS_PATH is empty."
+      exit 0
+    fi
+
     cp -R "$HEADERS_PATH/" Headers
     mkdir -p framework/packages/react-native
     cp -R "$XCFRAMEWORK_PATH/.." framework/packages/react-native/


### PR DESCRIPTION
## Summary:

This PR introduces the first working version of building React Native apps on iOS using prebuilt RNCore and cocoapods.

- Added React-Core-prebuilt.podspec for installing/consuming XCFrameworks
- Added logic in react_native_pods.rb for switching between build from source and using prebuilts
- Added rncore.rb - utilities for the ReactCore prebuilts
- Updated rndependencies with some extra error handling modelled after rncode.rb
- Added support for hard linking headers and modules in each inner framework in the XCFramework in xcframework.js

## Swift:
To enable support for the objective-c types from swift, the swift compiler uses a module map to gather exports from the framework (module.modulemap). This file basically points to an umbrella header file that exports the valid objective-c types (non c++) to Swift. In addition these files are read from the DerivedData and not the project source - so it is a bit hard to control everyting.

I was initially not able to use cocoapods own module definitions (module_name, module_file props) to use a custom module map. I finally found that these files are expected in the deriveddata (build folder) where only the active inner framework is copied - so then I had to hard link both module map and header files for each arch.

## Changelog:

[IOS] [ADDED] - Added support for using prebuilt RNCore with Cocoapods

## Test Plan:

Run with RN Tester. We need to remove all extra pods from RNTester pod file since none of them are yet compatible with prebuilt (they reference non-prebuilt pods)