### PR TITLE
Add Fantom test for layout props & fix an issue in c++ animated

### DIFF
--- a/packages/react-native/React/Fabric/RCTScheduler.mm
+++ b/packages/react-native/React/Fabric/RCTScheduler.mm
@@ -72,6 +72,12 @@ class SchedulerDelegateProxy : public SchedulerDelegate {
     [scheduler.delegate schedulerDidSynchronouslyUpdateViewOnUIThread:tag props:props];
   }
 
+  void schedulerDidUpdateShadowTree(const std::unordered_map<Tag, folly::dynamic> &tagToProps) override
+  {
+    // Does nothing.
+    // This delegate method is not currently used on iOS.
+  }
+
  private:
   void *scheduler_;
 };

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
@@ -722,6 +722,11 @@ void FabricUIManagerBinding::schedulerShouldSynchronouslyUpdateViewOnUIThread(
   }
 }
 
+void FabricUIManagerBinding::schedulerDidUpdateShadowTree(
+    const std::unordered_map<Tag, folly::dynamic>& /*tagToProps*/) {
+  // no-op
+}
+
 void FabricUIManagerBinding::onAnimationStarted() {
   auto mountingManager = getMountingManager("onAnimationStarted");
   if (!mountingManager) {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.h
@@ -126,6 +126,9 @@ class FabricUIManagerBinding : public jni::HybridClass<FabricUIManagerBinding>,
       Tag tag,
       const folly::dynamic& props) override;
 
+  void schedulerDidUpdateShadowTree(
+      const std::unordered_map<Tag, folly::dynamic>& tagToProps) override;
+
   void setPixelDensity(float pointScaleFactor);
 
   void driveCxxAnimations();

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -320,6 +320,13 @@ void Scheduler::uiManagerShouldSynchronouslyUpdateViewOnUIThread(
   }
 }
 
+void Scheduler::uiManagerDidUpdateShadowTree(
+    const std::unordered_map<Tag, folly::dynamic>& tagToProps) {
+  if (delegate_ != nullptr) {
+    delegate_->schedulerDidUpdateShadowTree(tagToProps);
+  }
+}
+
 void Scheduler::uiManagerShouldAddEventListener(
     std::shared_ptr<const EventListener> listener) {
   addEventListener(listener);

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
@@ -97,6 +97,8 @@ class Scheduler final : public UIManagerDelegate {
   void uiManagerShouldSynchronouslyUpdateViewOnUIThread(
       Tag tag,
       const folly::dynamic& props) override;
+  void uiManagerDidUpdateShadowTree(
+      const std::unordered_map<Tag, folly::dynamic>& tagToProps) override;
   void uiManagerShouldAddEventListener(
       std::shared_ptr<const EventListener> listener) final;
   void uiManagerShouldRemoveEventListener(

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerDelegate.h
@@ -68,6 +68,9 @@ class SchedulerDelegate {
       Tag tag,
       const folly::dynamic& props) = 0;
 
+  virtual void schedulerDidUpdateShadowTree(
+      const std::unordered_map<Tag, folly::dynamic>& tagToProps) = 0;
+
   virtual ~SchedulerDelegate() noexcept = default;
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerDelegate.h
@@ -67,6 +67,12 @@ class UIManagerDelegate {
       const folly::dynamic& props) = 0;
 
   /*
+   * Called after updateShadowTree is invoked.
+   */
+  virtual void uiManagerDidUpdateShadowTree(
+      const std::unordered_map<Tag, folly::dynamic>& tagToProps) = 0;
+
+  /*
    * Add event listener.
    */
   virtual void uiManagerShouldAddEventListener(

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerUpdateShadowTree.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerUpdateShadowTree.cpp
@@ -218,6 +218,10 @@ void UIManager::updateShadowTree(
       LOG(ERROR) << "Root ShadowNode has not been cloned";
     }
   });
+
+  if (delegate_ != nullptr) {
+    delegate_->uiManagerDidUpdateShadowTree(tagToProps);
+  }
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/PropsAnimatedNode.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/PropsAnimatedNode.h
@@ -43,7 +43,7 @@ class PropsAnimatedNode final : public AnimatedNode {
  private:
   std::mutex propsMutex_;
   folly::dynamic props_;
-  const bool layoutStyleUpdated_;
+  bool layoutStyleUpdated_{false};
 
   Tag connectedViewTag_{animated::undefinedAnimatedNodeIdentifier};
 };

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/StyleAnimatedNode.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/StyleAnimatedNode.cpp
@@ -11,12 +11,29 @@
 
 #include "StyleAnimatedNode.h"
 
+#include <react/renderer/animated/NativeAnimatedAllowlist.h>
 #include <react/renderer/animated/NativeAnimatedNodesManager.h>
 #include <react/renderer/animated/nodes/ColorAnimatedNode.h>
 #include <react/renderer/animated/nodes/TransformAnimatedNode.h>
 #include <react/renderer/animated/nodes/ValueAnimatedNode.h>
 
 namespace facebook::react {
+
+namespace {
+
+bool isLayoutPropsUpdated(const folly::dynamic& props) {
+  for (const auto& styleNodeProp : props.items()) {
+    if (getDirectManipulationAllowlist().count(
+            styleNodeProp.first.asString()) == 0u) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+} // namespace
+
 StyleAnimatedNode::StyleAnimatedNode(
     Tag tag,
     const folly::dynamic& config,
@@ -77,5 +94,8 @@ void StyleAnimatedNode::update() {
       }
     }
   }
+
+  layoutStyleUpdated_ = isLayoutPropsUpdated(props_);
 }
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/StyleAnimatedNode.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/StyleAnimatedNode.h
@@ -28,7 +28,12 @@ class StyleAnimatedNode final : public AnimatedNode {
     return props_;
   }
 
+  bool isLayoutStyleUpdated() const noexcept {
+    return layoutStyleUpdated_;
+  }
+
  private:
   folly::dynamic props_;
+  bool layoutStyleUpdated_;
 };
 } // namespace facebook::react

--- a/packages/react-native/ReactCxxPlatform/react/renderer/scheduler/SchedulerDelegateImpl.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/scheduler/SchedulerDelegateImpl.cpp
@@ -58,4 +58,9 @@ void SchedulerDelegateImpl::schedulerShouldSynchronouslyUpdateViewOnUIThread(
   mountingManager_->synchronouslyUpdateViewOnUIThread(tag, props);
 }
 
+void SchedulerDelegateImpl::schedulerDidUpdateShadowTree(
+    const std::unordered_map<Tag, folly::dynamic>& tagToProps) {
+  mountingManager_->onUpdateShadowTree(tagToProps);
+}
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCxxPlatform/react/renderer/scheduler/SchedulerDelegateImpl.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/scheduler/SchedulerDelegateImpl.h
@@ -56,6 +56,9 @@ class SchedulerDelegateImpl : public SchedulerDelegate {
       Tag tag,
       const folly::dynamic& props) override;
 
+  void schedulerDidUpdateShadowTree(
+      const std::unordered_map<Tag, folly::dynamic>& tagToProps) override;
+
   std::shared_ptr<IMountingManager> mountingManager_;
 };
 

--- a/packages/react-native/ReactCxxPlatform/react/renderer/uimanager/IMountingManager.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/uimanager/IMountingManager.h
@@ -54,6 +54,9 @@ class IMountingManager {
       Tag reactTag,
       const folly::dynamic& changedProps) {};
 
+  virtual void onUpdateShadowTree(
+      const std::unordered_map<Tag, folly::dynamic>& tagToProps) {};
+
   virtual void initializeAccessibilityManager() {};
 
   virtual void setAccessibilityFocusedView(Tag viewTag) {};

--- a/packages/react-native/src/private/testing/fantom/specs/NativeFantom.js
+++ b/packages/react-native/src/private/testing/fantom/specs/NativeFantom.js
@@ -97,6 +97,9 @@ interface Spec extends TurboModule {
   ) => $ReadOnly<{
     [string]: mixed,
   }>;
+  getFabricUpdateProps: (shadowNode: mixed /* ShadowNode */) => $ReadOnly<{
+    [string]: mixed,
+  }>;
   flushMessageQueue: () => void;
   flushEventQueue: () => void;
   produceFramesForDuration: (miliseconds: number) => void;

--- a/private/react-native-fantom/src/index.js
+++ b/private/react-native-fantom/src/index.js
@@ -226,6 +226,13 @@ export function unstable_getDirectManipulationProps(
   return NativeFantom.getDirectManipulationProps(shadowNode);
 }
 
+export function unstable_getFabricUpdateProps(node: ReadOnlyNode): $ReadOnly<{
+  [string]: mixed,
+}> {
+  const shadowNode = getNativeNodeReference(node);
+  return NativeFantom.getFabricUpdateProps(shadowNode);
+}
+
 /**
  * Simulates running a task on the UI thread and forces side effect to drain
  * the event queue, scheduling events to be dispatched to JavaScript.


### PR DESCRIPTION
Summary:
## Changelog:

[General] [Internal] - Add Fantom test for layout props

With this test it turns out `layoutStyleUpdated_` on PropsAnimatedNode actually can change after animation update, because its connected StyleAnimatedNodes might be changing. This bug was introduced since D74602321

Reviewed By: rshest

Differential Revision: D76753864
