### PR TITLE
Fix accessibilityOrder when referencing both a parent and its children

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -355,6 +355,9 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
                 @Override
                 public void onChildViewAdded(View parent, View child) {
                   view.setTag(R.id.accessibility_order_dirty, true);
+                  child.setTag(R.id.accessibility_order_parent, parent);
+                  ReactAccessibilityDelegate.setDelegate(
+                      child, child.isFocusable(), child.getImportantForAccessibility());
 
                   // We also want to listen to changes on the hierarchy of nested ViewGroups
                   if (child instanceof ViewGroup) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -19,6 +19,7 @@ import android.view.accessibility.AccessibilityEvent;
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.view.AccessibilityDelegateCompat;
 import androidx.core.view.ViewCompat;
 import com.facebook.common.logging.FLog;
 import com.facebook.react.R;
@@ -167,6 +168,20 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
     view.setForeground(null);
 
     return view;
+  }
+
+  @Override
+  public void onDropViewInstance(@NonNull T view) {
+    super.onDropViewInstance(view);
+    AccessibilityDelegateCompat axDelegate = ViewCompat.getAccessibilityDelegate(view);
+
+    if (axDelegate instanceof ReactAccessibilityDelegate) {
+      ((ReactAccessibilityDelegate) axDelegate).cleanUp();
+    }
+
+    if (view instanceof ViewGroup) {
+      ((ViewGroup) view).setOnHierarchyChangeListener(null);
+    }
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.java
@@ -117,6 +117,7 @@ public class ReactAccessibilityDelegate extends ExploreByTouchHelper {
     if (!ViewCompat.hasAccessibilityDelegate(view)
         && (view.getTag(R.id.accessibility_role) != null
             || view.getTag(R.id.accessibility_order) != null
+            || (view.getTag(R.id.accessibility_order_parent) != null && view.isFocusable())
             || view.getTag(R.id.accessibility_state) != null
             || view.getTag(R.id.accessibility_actions) != null
             || view.getTag(R.id.react_test_id) != null
@@ -538,7 +539,8 @@ public class ReactAccessibilityDelegate extends ExploreByTouchHelper {
 
   @Override
   public @Nullable AccessibilityNodeProviderCompat getAccessibilityNodeProvider(View host) {
-    if (mView.getTag(R.id.accessibility_order) != null) {
+    if ((mView.getTag(R.id.accessibility_order) != null)
+        || ((mView.getTag(R.id.accessibility_order_parent) != null) && mView.isFocusable())) {
       return super.getAccessibilityNodeProvider(host);
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAxOrderHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAxOrderHelper.kt
@@ -10,7 +10,6 @@ package com.facebook.react.uimanager
 import android.graphics.Rect
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import com.facebook.react.R
 import com.facebook.react.bridge.ReadableArray
 
@@ -76,10 +75,6 @@ private object ReactAxOrderHelper {
         }
       }
 
-      if (!isIncluded && !isContained && parent != view && view !is TextView) {
-        view.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
-      }
-
       // Don't traverse the children of a nested accessibility order
       if (view is ViewGroup) {
         val axChildren: ArrayList<View> = getAxChildren(view)
@@ -99,6 +94,13 @@ private object ReactAxOrderHelper {
             traverseAndBuildAxOrder(parent, axChildren[i], null)
           }
         }
+      }
+
+      if (!isIncluded && !isContained && parent != view) {
+        if (view.getTag(R.id.original_focusability) == null) {
+          view.setTag(R.id.original_focusability, view.isFocusable)
+        }
+        view.isFocusable = false
       }
     }
 
@@ -158,5 +160,22 @@ private object ReactAxOrderHelper {
       host.addChildrenForAccessibility(axChildren)
     }
     return axChildren
+  }
+
+  @JvmStatic
+  public fun restoreSubtreeFocusability(view: View) {
+    val originalFocusability = view.getTag(R.id.original_focusability)
+    if (originalFocusability is Boolean) {
+      view.isFocusable = originalFocusability
+    }
+
+    if (view is ViewGroup) {
+      for (i in 0 until view.childCount) {
+        val child = view.getChildAt(i)
+        if (child != null) {
+          restoreSubtreeFocusability(child)
+        }
+      }
+    }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAxOrderHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAxOrderHelper.kt
@@ -46,14 +46,8 @@ private object ReactAxOrderHelper {
 
       if (isIncluded && view.isFocusable) {
         axOrderViews[axOrderIds.indexOf(nativeId)].add(view)
-        if (parent != view) {
-          view.setTag(R.id.accessibility_order_parent, parent)
-        }
       } else if (isContained && view.isFocusable) {
         axOrderViews[axOrderIds.indexOf(containerId)].add(view)
-        if (parent != view) {
-          view.setTag(R.id.accessibility_order_parent, parent)
-        }
       }
 
       if (isNestedAxOrder) {

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values/ids.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values/ids.xml
@@ -15,6 +15,9 @@
   <!-- tag is used to store the current state of the accessibility order tree-->
   <item type="id" name="accessibility_order_dirty"/>
 
+  <!-- tag is used to store the original focusability value of a view within the accessibility order tree if it was changed-->
+  <item type="id" name="original_focusability"/>
+
   <!-- tag is used to store the nativeID tag -->
   <item type="id" name="view_tag_instance_handle"/>
 


### PR DESCRIPTION
Summary:
With the new implementation of accessibilityOrder we associate virtualView's nodes to the actual views they reperesent by calling `addChild(view)`

This however causes an issue, the view itself will populate its accessibility children which prevents them from following the axOrder if both the parent and children are mentioned in the order.

With this change we now set a delegate and a provider to every view within the view that sets an axOrder to prevent the default logic to set accessibilityChildren on views that are not considered "containers".

In the case that they are "containers" (not accessible yet mentioned in the order) We want to keep the default logic that assigns them accessibilityChildren.

Differential Revision: D76911074
