### PR TITLE
[iOS][backgroundImage] - Use CAGradientLayer for radial gradient

### DIFF
--- a/packages/react-native/React/Fabric/Utils/RCTRadialGradient.mm
+++ b/packages/react-native/React/Fabric/Utils/RCTRadialGradient.mm
@@ -153,75 +153,41 @@ static RadiusVector GetRadialGradientRadius(
 
 + (CALayer *)gradientLayerWithSize:(CGSize)size gradient:(const RadialGradient &)gradient
 {
-  UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:size];
-  UIImage *gradientImage = [renderer imageWithActions:^(UIGraphicsImageRendererContext *_Nonnull rendererContext) {
-    CGContextRef context = rendererContext.CGContext;
+  CAGradientLayer *gradientLayer = [CAGradientLayer layer];
+  gradientLayer.type = kCAGradientLayerRadial;
+  CGPoint centerPoint = CGPointMake(size.width / 2.0, size.height / 2.0);
 
-    CGPoint centerPoint = CGPointMake(size.width / 2.0, size.height / 2.0);
+  if (gradient.position.top) {
+    centerPoint.y = gradient.position.top->resolve(size.height);
+  } else if (gradient.position.bottom) {
+    centerPoint.y = size.height - gradient.position.bottom->resolve(size.height);
+  }
+  
+  if (gradient.position.left) {
+    centerPoint.x = gradient.position.left->resolve(size.width);
+  } else if (gradient.position.right) {
+    centerPoint.x = size.width - gradient.position.right->resolve(size.width);
+  }
+  
+  bool isCircle = (gradient.shape == RadialGradientShape::Circle);
+  auto [radiusX, radiusY] =
+      GetRadialGradientRadius(isCircle, gradient.size, centerPoint.x, centerPoint.y, size.width, size.height);
+  const auto gradientLineLength = std::max(radiusX, radiusY);
+  const auto colorStops = [RCTGradientUtils getFixedColorStops:gradient.colorStops gradientLineLength: gradientLineLength];
+  gradientLayer.startPoint = CGPointMake(centerPoint.x / size.width, centerPoint.y / size.height);
+  // endpoint.x is horizontal length and endpoint.y is vertical length
+  gradientLayer.endPoint = CGPointMake(
+      gradientLayer.startPoint.x + radiusX / size.width, gradientLayer.startPoint.y + radiusY / size.height);
 
-    if (gradient.position.top) {
-      centerPoint.y = gradient.position.top->resolve(size.height);
-    } else if (gradient.position.bottom) {
-      centerPoint.y = size.height - gradient.position.bottom->resolve(size.height);
-    }
+  NSMutableArray<id> *colors = [NSMutableArray array];
+  NSMutableArray<NSNumber *> *locations = [NSMutableArray array];
+  for (const auto &colorStop : colorStops) {
+    [colors addObject:(id)RCTUIColorFromSharedColor(colorStop.color).CGColor];
+    [locations addObject:@(std::max(std::min(colorStop.position.value(), 1.0), 0.0))];
+  }
 
-    if (gradient.position.left) {
-      centerPoint.x = gradient.position.left->resolve(size.width);
-    } else if (gradient.position.right) {
-      centerPoint.x = size.width - gradient.position.right->resolve(size.width);
-    }
-
-    bool isCircle = (gradient.shape == RadialGradientShape::Circle);
-    auto [radiusX, radiusY] =
-        GetRadialGradientRadius(isCircle, gradient.size, centerPoint.x, centerPoint.y, size.width, size.height);
-
-    CGFloat scale = 1.0;
-    if (radiusX != radiusY && gradient.shape != RadialGradientShape::Circle) {
-      scale = radiusX / radiusY;
-      CGContextSaveGState(context);
-      // Scale the context to make the circular gradient appear elliptical
-      CGContextTranslateCTM(context, centerPoint.x, centerPoint.y);
-      CGContextScaleCTM(context, 1.0, 1.0 / scale);
-      CGContextTranslateCTM(context, -centerPoint.x, -centerPoint.y);
-      radiusX = std::max(radiusX, radiusY * scale);
-    }
-
-    const auto colorStops = [RCTGradientUtils getFixedColorStops:gradient.colorStops gradientLineLength:radiusX];
-
-    NSMutableArray *colors = [NSMutableArray array];
-    CGFloat locations[colorStops.size()];
-
-    for (size_t i = 0; i < colorStops.size(); ++i) {
-      const auto &colorStop = colorStops[i];
-      CGColorRef cgColor = RCTCreateCGColorRefFromSharedColor(colorStop.color);
-      [colors addObject:(__bridge id)cgColor];
-      locations[i] = std::max(std::min(colorStop.position.value(), 1.0), 0.0);
-    }
-
-    CGGradientRef cgGradient = CGGradientCreateWithColors(NULL, (__bridge CFArrayRef)colors, locations);
-
-    CGContextDrawRadialGradient(
-        context,
-        cgGradient,
-        centerPoint,
-        0,
-        centerPoint,
-        radiusX,
-        kCGGradientDrawsBeforeStartLocation | kCGGradientDrawsAfterEndLocation);
-
-    // Restore the context state if we scaled it
-    if (radiusX != radiusY && gradient.shape != RadialGradientShape::Circle) {
-      CGContextRestoreGState(context);
-    }
-
-    for (id color in colors) {
-      CGColorRelease((__bridge CGColorRef)color);
-    }
-    CGGradientRelease(cgGradient);
-  }];
-
-  CALayer *gradientLayer = [CALayer layer];
-  gradientLayer.contents = (__bridge id)gradientImage.CGImage;
+  gradientLayer.colors = colors;
+  gradientLayer.locations = locations;
 
   return gradientLayer;
 }

--- a/packages/rn-tester/js/examples/RadialGradient/RadialGradientExample.js
+++ b/packages/rn-tester/js/examples/RadialGradient/RadialGradientExample.js
@@ -254,4 +254,36 @@ exports.examples = [
       );
     },
   },
+  {
+    title: 'Radial gradient with non-square bounds',
+    name: 'radial-gradient-with-non-square-bounds',
+    render(): React.Node {
+      return (
+        <GradientBox
+          testID="radial-gradient-non-square-bounds"
+          style={{
+            experimental_backgroundImage: 'radial-gradient(red, blue)',
+            width: 200,
+            height: 100,
+          }}
+        />
+      );
+    },
+  },
+  {
+    title: 'Radial gradient with non-square bounds. height > width',
+    name: 'radial-gradient-with-non-square-bounds-height-gt-width',
+    render(): React.Node {
+      return (
+        <GradientBox
+          testID="radial-gradient-non-square-bounds"
+          style={{
+            experimental_backgroundImage: 'radial-gradient(red, blue)',
+            width: 100,
+            height: 300,
+          }}
+        />
+      );
+    },
+  },
 ];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

This PR replaces Core Graphics implementation with Core Animation for radial gradients. I found that `endPoints` for radial gradient type works differently than linear gradient type. The `endPoint.x` accounts for horizontal length and `endPoint.y` accounts for vertical. This makes it possible to draw ellipse gradients. So we don't need the core graphics API anymore.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[IOS] [CHANGED] - Optimised Radial Gradients.

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:



For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

Non breaking change. Test Radial gradient example from RNTester. Compare results with web, android and iOS. Each platform should render the gradients identically.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
