### PR TITLE
Comma separate co-opted accessibility labels

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -1215,7 +1215,7 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
         result = [NSMutableString string];
       }
       if (result.length > 0) {
-        [result appendString:@" "];
+        [result appendString:@", "];
       }
       [result appendString:label];
     }


### PR DESCRIPTION
Summary:
It is pretty jarring for semantically different labels to be read all at once, let's comma separate them - which VoiceOver will pause at. Android does this by default with its coopting implementation

Changelog: [Internal]

Differential Revision: D76921000
