### PR TITLE
Fix support for `react.internal.useHermesNightly`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -124,7 +124,7 @@ if (project.findProperty("react.internal.useHermesNightly")?.toString()?.toBoole
     configurations.all {
       resolutionStrategy.dependencySubstitution {
         substitute(project(":packages:react-native:ReactAndroid:hermes-engine"))
-            .using(module("com.facebook.react:hermes-android:0.0.0-+"))
+            .using(module("com.facebook.react:hermes-android:0.+"))
             .because("Users opted to use hermes from nightly")
       }
     }


### PR DESCRIPTION
Summary:
Currently using `react.internal.useHermesNightly` is broken locally because we try to search for versions such as 0.0.0.+ while the nightlies version are of the form 0.81.0-...

This fixes it.

Changelog:
[Internal] [Changed] -

Reviewed By: NickGerleman

Differential Revision: D76901197


