### PR TITLE
Remove usage of SafeAreaView from RNTester

### DIFF
--- a/packages/rn-tester/js/components/RNTTitleBar.js
+++ b/packages/rn-tester/js/components/RNTTitleBar.js
@@ -11,7 +11,7 @@
 import RNTesterDocumentationURL from './RNTesterDocumentationURL';
 import {type RNTesterTheme} from './RNTesterTheme';
 import * as React from 'react';
-import {Platform, SafeAreaView, StyleSheet, Text, View} from 'react-native';
+import {Platform, StyleSheet, Text, View} from 'react-native';
 
 const HeaderIOS = ({
   children,
@@ -25,20 +25,16 @@ const HeaderIOS = ({
   theme: RNTesterTheme,
 }) => {
   return (
-    <SafeAreaView>
-      <View
-        style={[styles.header, {backgroundColor: theme.SystemBackgroundColor}]}>
-        <View style={styles.headerCenter}>
-          <Text style={{...styles.title, color: theme.LabelColor}}>
-            {title}
-          </Text>
-          {documentationURL && (
-            <RNTesterDocumentationURL documentationURL={documentationURL} />
-          )}
-        </View>
-        {children != null && <View>{children}</View>}
+    <View
+      style={[styles.header, {backgroundColor: theme.SystemBackgroundColor}]}>
+      <View style={styles.headerCenter}>
+        <Text style={{...styles.title, color: theme.LabelColor}}>{title}</Text>
+        {documentationURL && (
+          <RNTesterDocumentationURL documentationURL={documentationURL} />
+        )}
       </View>
-    </SafeAreaView>
+      {children != null && <View>{children}</View>}
+    </View>
   );
 };
 
@@ -54,17 +50,15 @@ const HeaderAndroid = ({
   theme: RNTesterTheme,
 }) => {
   return (
-    <SafeAreaView>
-      <View style={[styles.toolbar, {backgroundColor: theme.BackgroundColor}]}>
-        <View style={styles.toolbarCenter}>
-          <Text style={[styles.title, {color: theme.LabelColor}]}>{title}</Text>
-          {documentationURL && (
-            <RNTesterDocumentationURL documentationURL={documentationURL} />
-          )}
-        </View>
-        {children != null && <View>{children}</View>}
+    <View style={[styles.toolbar, {backgroundColor: theme.BackgroundColor}]}>
+      <View style={styles.toolbarCenter}>
+        <Text style={[styles.title, {color: theme.LabelColor}]}>{title}</Text>
+        {documentationURL && (
+          <RNTesterDocumentationURL documentationURL={documentationURL} />
+        )}
       </View>
-    </SafeAreaView>
+      {children != null && <View>{children}</View>}
+    </View>
   );
 };
 
@@ -104,6 +98,7 @@ const styles = StyleSheet.create({
   header: {
     height: 40,
     flexDirection: 'row',
+    marginTop: Platform.OS === 'ios' ? 50 : 0,
   },
   headerCenter: {
     flex: 1,

--- a/packages/rn-tester/js/components/RNTesterPage.js
+++ b/packages/rn-tester/js/components/RNTesterPage.js
@@ -13,7 +13,7 @@ import RNTesterTitle from './RNTesterTitle';
 import {useContext} from 'react';
 
 const React = require('react');
-const {SafeAreaView, ScrollView, StyleSheet, View} = require('react-native');
+const {Platform, ScrollView, StyleSheet, View} = require('react-native');
 
 type Props = $ReadOnly<{
   children?: React.Node,
@@ -25,10 +25,14 @@ function RNTesterPage({children, title, noScroll}: Props): React.Node {
   const theme = useContext(RNTesterThemeContext);
 
   return (
-    <SafeAreaView
+    <View
       style={[
         styles.background,
-        {backgroundColor: theme.SecondarySystemBackgroundColor},
+        {
+          backgroundColor: theme.SecondarySystemBackgroundColor,
+          marginTop: Platform.OS === 'ios' ? 50 : 20,
+          marginBottom: Platform.OS === 'ios' ? 20 : 10,
+        },
       ]}>
       {title && <RNTesterTitle title={title} />}
       {noScroll ? (
@@ -43,7 +47,7 @@ function RNTesterPage({children, title, noScroll}: Props): React.Node {
           {children}
         </ScrollView>
       )}
-    </SafeAreaView>
+    </View>
   );
 }
 


### PR DESCRIPTION
Summary:
This remove all the usages of SafeAreaView from RNTester.
The problem is that we introduced a warning that SafEAreaView is deprecated and, therefore, we had a warning in debug mode.

This was causing a yellow bubble to appear and the OSS E2E test started failing.

## Changelog:
[Internal] -

Differential Revision: D76978227


