### PR TITLE
Fix broken `LayoutableShadowNodeTest` after Modal fix.

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/tests/LayoutableShadowNodeTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/LayoutableShadowNodeTest.cpp
@@ -915,6 +915,10 @@ TEST(LayoutableShadowNodeTest, relativeLayoutMetricsOnClonedNode) {
  * │ └──────────────────────┘│
  * └─────────────────────────┘
  */
+// We're not running this on Android as ModalHostViewShadowNode
+// need to go through JNI to resolve the initial screen size
+// in order to position the modal.
+#ifndef ANDROID
 TEST(
     LayoutableShadowNodeTest,
     relativeLayoutMetricsOnNodesCrossingRootKindNode) {
@@ -951,6 +955,7 @@ TEST(
   EXPECT_EQ(relativeLayoutMetrics.frame.origin.x, 10);
   EXPECT_EQ(relativeLayoutMetrics.frame.origin.y, 10);
 }
+#endif
 
 TEST(LayoutableShadowNodeTest, includeViewportOffset) {
   auto builder = simpleComponentBuilder();


### PR DESCRIPTION
Summary:
After D73948178, Modals now need to access JNI to get the dimension of the
screen to properly position the modal on first rendering.

Before my change, the Modal was positioned in 0,0 (which is the default
behavior for CXX).
I'm suppressing this test for Android, as it will keep on running with the
previous behavior for CXX.

Changelog:
[Internal] [Changed] -

Differential Revision: D76979787


