### PR TITLE
Kotlin: clean up redundant visibility modifiers (2/2)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/ReactQueueConfigurationImpl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/ReactQueueConfigurationImpl.kt
@@ -36,9 +36,9 @@ private constructor(
     }
   }
 
-  public companion object {
+  companion object {
     @JvmStatic
-    public fun create(
+    fun create(
         spec: ReactQueueConfigurationSpec,
         exceptionHandler: QueueThreadExceptionHandler
     ): ReactQueueConfigurationImpl {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAxOrderHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAxOrderHelper.kt
@@ -30,7 +30,7 @@ private object ReactAxOrderHelper {
    * @return an array of views following the accessibility order
    */
   @JvmStatic
-  public fun processAxOrderTree(
+  fun processAxOrderTree(
       root: View,
       axOrderIds: MutableList<String?>,
       axOrderSet: MutableSet<String?>
@@ -123,7 +123,7 @@ private object ReactAxOrderHelper {
   }
 
   @JvmStatic
-  public fun getVirtualViewBounds(host: View, virtualView: View): Rect {
+  fun getVirtualViewBounds(host: View, virtualView: View): Rect {
     var currentView: View = virtualView
     val viewBoundsInParent =
         Rect(virtualView.left, virtualView.top, virtualView.right, virtualView.bottom)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ShadowNodeRegistry.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ShadowNodeRegistry.kt
@@ -92,7 +92,7 @@ internal class ShadowNodeRegistry {
   inner class SingleThreadAsserter {
     private var thread: Thread? = null
 
-    public fun assertNow() {
+    fun assertNow() {
       val currentThread = Thread.currentThread()
       if (thread == null) {
         thread = currentThread

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/TouchesHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/TouchesHelper.kt
@@ -86,7 +86,7 @@ internal object TouchesHelper {
    */
   @Suppress("DEPRECATION")
   @JvmStatic
-  public fun sendTouchesLegacy(rctEventEmitter: RCTEventEmitter, touchEvent: TouchEvent) {
+  fun sendTouchesLegacy(rctEventEmitter: RCTEventEmitter, touchEvent: TouchEvent) {
     val type = touchEvent.getTouchEventType()
 
     val pointers = getWritableArray(/* copyObjects */ false, createPointersArray(touchEvent))
@@ -122,7 +122,7 @@ internal object TouchesHelper {
    * @param event the touch event to extract data from
    */
   @JvmStatic
-  public fun sendTouchEvent(eventEmitter: RCTModernEventEmitter, event: TouchEvent) {
+  fun sendTouchEvent(eventEmitter: RCTModernEventEmitter, event: TouchEvent) {
     Systrace.beginSection(
         Systrace.TRACE_TAG_REACT,
         "TouchesHelper.sentTouchEventModern(" + event.getEventName() + ")")

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/events/DrawerClosedEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/events/DrawerClosedEvent.kt
@@ -21,7 +21,7 @@ internal class DrawerClosedEvent : Event<DrawerClosedEvent> {
 
   override fun getEventName(): String = EVENT_NAME
 
-  protected override fun getEventData(): WritableMap = Arguments.createMap()
+  override fun getEventData(): WritableMap = Arguments.createMap()
 
   companion object {
     const val EVENT_NAME: String = "topDrawerClose"

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/events/DrawerOpenedEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/events/DrawerOpenedEvent.kt
@@ -21,7 +21,7 @@ internal class DrawerOpenedEvent : Event<DrawerOpenedEvent> {
 
   override fun getEventName(): String = EVENT_NAME
 
-  protected override fun getEventData(): WritableMap = Arguments.createMap()
+  override fun getEventData(): WritableMap = Arguments.createMap()
 
   companion object {
     const val EVENT_NAME: String = "topDrawerOpen"

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/events/DrawerSlideEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/events/DrawerSlideEvent.kt
@@ -29,7 +29,7 @@ internal class DrawerSlideEvent : Event<DrawerSlideEvent> {
 
   override fun getEventName(): String = EVENT_NAME
 
-  protected override fun getEventData(): WritableMap {
+  override fun getEventData(): WritableMap {
     val eventData: WritableMap = Arguments.createMap()
     eventData.putDouble("offset", getOffset().toDouble())
     return eventData

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/events/DrawerStateChangedEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/events/DrawerStateChangedEvent.kt
@@ -29,7 +29,7 @@ internal class DrawerStateChangedEvent : Event<DrawerStateChangedEvent> {
 
   override fun getEventName(): String = EVENT_NAME
 
-  protected override fun getEventData(): WritableMap {
+  override fun getEventData(): WritableMap {
     val eventData: WritableMap = Arguments.createMap()
     eventData.putInt("drawerState", getDrawerState())
     return eventData

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostManager.kt
@@ -29,7 +29,7 @@ internal class ReactModalHostManager :
 
   override fun getName(): String = REACT_CLASS
 
-  protected override fun createViewInstance(reactContext: ThemedReactContext): ReactModalHostView =
+  override fun createViewInstance(reactContext: ThemedReactContext): ReactModalHostView =
       ReactModalHostView(reactContext)
 
   override fun onDropViewInstance(view: ReactModalHostView) {
@@ -93,7 +93,7 @@ internal class ReactModalHostManager :
     view.setDialogRootViewGroupTestId(value)
   }
 
-  protected override fun addEventEmitters(
+  override fun addEventEmitters(
       reactContext: ThemedReactContext,
       view: ReactModalHostView
   ) {
@@ -118,7 +118,7 @@ internal class ReactModalHostManager :
         put("topOrientationChange", mapOf("registrationName" to "onOrientationChange"))
       }
 
-  protected override fun onAfterUpdateTransaction(view: ReactModalHostView) {
+  override fun onAfterUpdateTransaction(view: ReactModalHostView) {
     super.onAfterUpdateTransaction(view)
     view.showOrUpdate()
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewAccessibilityDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewAccessibilityDelegate.kt
@@ -22,7 +22,7 @@ import com.facebook.react.uimanager.ReactAccessibilityDelegate
 import com.facebook.react.views.text.internal.span.ReactClickableSpan
 
 internal class ReactTextViewAccessibilityDelegate : ReactAccessibilityDelegate {
-  public constructor(
+  constructor(
       view: View,
       originalFocus: Boolean,
       originalImportantForAccessibility: Int
@@ -32,8 +32,8 @@ internal class ReactTextViewAccessibilityDelegate : ReactAccessibilityDelegate {
 
   private var accessibilityLinks: AccessibilityLinks? = null
 
-  public companion object {
-    public fun setDelegate(
+  companion object {
+    fun setDelegate(
         view: View,
         originalFocus: Boolean,
         originalImportantForAccessibility: Int
@@ -55,7 +55,7 @@ internal class ReactTextViewAccessibilityDelegate : ReactAccessibilityDelegate {
       }
     }
 
-    public fun resetDelegate(
+    fun resetDelegate(
         view: View,
         originalFocus: Boolean,
         originalImportantForAccessibility: Int
@@ -280,7 +280,7 @@ internal class ReactTextViewAccessibilityDelegate : ReactAccessibilityDelegate {
     return null
   }
 
-  public class AccessibilityLinks(text: Spanned) {
+  class AccessibilityLinks(text: Spanned) {
     private val links: List<AccessibleLink>
 
     init {
@@ -306,7 +306,7 @@ internal class ReactTextViewAccessibilityDelegate : ReactAccessibilityDelegate {
       links = accessibleLinks
     }
 
-    public fun getLinkById(id: Int): AccessibleLink? {
+    fun getLinkById(id: Int): AccessibleLink? {
       for (link in links) {
         if (link.id == id) {
           return link
@@ -316,7 +316,7 @@ internal class ReactTextViewAccessibilityDelegate : ReactAccessibilityDelegate {
       return null
     }
 
-    public fun getLinkBySpanPos(start: Int, end: Int): AccessibleLink? {
+    fun getLinkBySpanPos(start: Int, end: Int): AccessibleLink? {
       for (link in links) {
         if (link.start == start && link.end == end) {
           return link
@@ -326,15 +326,15 @@ internal class ReactTextViewAccessibilityDelegate : ReactAccessibilityDelegate {
       return null
     }
 
-    public fun size(): Int {
+    fun size(): Int {
       return links.size
     }
 
-    public class AccessibleLink {
-      public var description: String? = null
-      public var start: Int = 0
-      public var end: Int = 0
-      public var id: Int = 0
+    class AccessibleLink {
+      var description: String? = null
+      var start: Int = 0
+      var end: Int = 0
+      var id: Int = 0
     }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ViewGroupClickEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ViewGroupClickEvent.kt
@@ -19,7 +19,7 @@ internal class ViewGroupClickEvent(surfaceId: Int, viewId: Int) :
 
   override fun canCoalesce(): Boolean = false
 
-  protected override fun getEventData(): WritableMap = Arguments.createMap()
+  override fun getEventData(): WritableMap = Arguments.createMap()
 
   private companion object {
     private const val EVENT_NAME: String = "topClick"

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/systrace/Systrace.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/systrace/Systrace.kt
@@ -18,7 +18,7 @@ import kotlin.text.StringBuilder
 @Suppress("UNUSED_PARAMETER")
 internal object Systrace {
 
-  public const val TRACE_TAG_REACT: Long = 0L
+  const val TRACE_TAG_REACT: Long = 0L
 
   @JvmStatic fun registerListener(listener: TraceListener?): Unit = Unit
 


### PR DESCRIPTION
## Summary:

Follow up from #51960, this PR cleans up the remaining warnings for redundant visibility modifiers detected by static code analysis.

## Changelog:

[INTERNAL] - Kotlin: clean up redundant visibility modifiers (2/2)

## Test Plan:

```sh
yarn android
yarn test-android
```