### PR TITLE
Bump compileSdk to 36

### DIFF
--- a/packages/react-native/gradle/libs.versions.toml
+++ b/packages/react-native/gradle/libs.versions.toml
@@ -2,8 +2,8 @@
 # Android versions
 minSdk = "24"
 targetSdk = "35"
-compileSdk = "35"
-buildTools = "35.0.0"
+compileSdk = "36"
+buildTools = "36.0.0"
 ndkVersion = "27.1.12297006"
 # Dependencies versions
 agp = "8.10.1"

--- a/private/helloworld/android/build.gradle
+++ b/private/helloworld/android/build.gradle
@@ -7,9 +7,9 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "35.0.0"
+        buildToolsVersion = "36.0.0"
         minSdkVersion = 24
-        compileSdkVersion = 35
+        compileSdkVersion = 36
         targetSdkVersion = 35
         ndkVersion = "27.1.12297006"
         kotlinVersion = "2.1.20"


### PR DESCRIPTION
Summary:
This is to make sure we're using buildTools 36 (Android 16) to compile everything.

Changelog:
[Internal] [Changed] -

Differential Revision: D77014531


