### PR TITLE
Improve CLI output for build-types

### DIFF
--- a/scripts/build-types/BuildApiSnapshot.js
+++ b/scripts/build-types/BuildApiSnapshot.js
@@ -12,6 +12,7 @@
 import type {PluginObj} from '@babel/core';
 
 const {PACKAGES_DIR, REACT_NATIVE_PACKAGE_DIR} = require('../consts');
+const {isGitRepo} = require('../scm-utils');
 const {API_EXTRACTOR_CONFIG_FILE, TYPES_OUTPUT_DIR} = require('./config');
 const apiSnapshotTemplate = require('./templates/ReactNativeApi.d.ts-template.js');
 const resolveCyclicImportsInDefinition = require('./transforms/resolveCyclicImportsInDefinition');
@@ -41,50 +42,79 @@ const postTransforms: $ReadOnlyArray<PluginObj<mixed>> = [
 ];
 
 async function buildAPISnapshot(validate: boolean) {
+  console.log(
+    styleText('yellow', '  >') + ' Creating temp dir for api-extractor',
+  );
   const tempDirectory = await createTempDir('react-native-js-api-snapshot');
   const packages = await findPackagesWithTypedef();
 
+  console.log(styleText('yellow', '  >') + ' Preparing codebase in temp dir');
   await preparePackagesInTempDir(tempDirectory, packages);
   await rewriteLocalImports(tempDirectory, packages);
 
+  console.log(styleText('yellow', '  >') + ' Running api-extractor');
   const extractorConfig = ExtractorConfig.loadFileAndPrepare(
     path.join(tempDirectory, API_EXTRACTOR_CONFIG_FILE),
   );
-
   const extractorResult = Extractor.invoke(extractorConfig, {
     localBuild: true,
     showVerboseMessages: true,
   });
 
-  if (extractorResult.succeeded) {
-    const apiSnapshot = apiSnapshotTemplate(
-      await getCleanedUpRollup(tempDirectory),
-    ) as string;
-
-    if (validate) {
-      const prevSnapshot = await fs.readFile(
-        path.join(REACT_NATIVE_PACKAGE_DIR, 'ReactNativeApi.d.ts'),
-        'utf-8',
-      );
-      const hasChanged = await validateSnapshots(prevSnapshot, apiSnapshot);
-      if (hasChanged) {
-        process.exitCode = 1;
-      }
-    } else {
-      await fs.writeFile(
-        path.join(REACT_NATIVE_PACKAGE_DIR, 'ReactNativeApi.d.ts'),
-        apiSnapshot,
-      );
-    }
-  } else {
-    process.exitCode = 1;
+  if (!extractorResult.succeeded) {
     console.error(
-      `API Extractor failed with ${extractorResult.errorCount} errors` +
-        ` and ${extractorResult.warningCount} warnings`,
+      '\n' +
+        styleText(['bold', 'inverse', 'red'], ' FAIL ') +
+        ' api-extractor encountered errors.\n',
     );
+    process.exitCode = 1;
+    return;
   }
 
+  console.log(styleText('yellow', '  >') + ' Applying additional transforms');
+  const apiSnapshot = apiSnapshotTemplate(
+    await getCleanedUpRollup(tempDirectory),
+  ) as string;
+
+  console.log(styleText('yellow', '  >') + ' Removing temp dir');
   await fs.rm(tempDirectory, {recursive: true});
+
+  const snapshotPath = path.join(
+    REACT_NATIVE_PACKAGE_DIR,
+    'ReactNativeApi.d.ts',
+  );
+
+  if (validate) {
+    console.log(
+      '\n' +
+        styleText(
+          ['bold', 'inverse'],
+          ' Validating API snapshot (--validate) ',
+        ) +
+        '\n',
+    );
+    console.log(
+      styleText('yellow', '  >') +
+        ' Diffing API with snapshot on disk\n' +
+        '    ' +
+        styleText('underline', snapshotPath) +
+        '\n',
+    );
+    const prevSnapshot = await fs.readFile(snapshotPath, 'utf-8');
+    const hasChanged = await validateSnapshots(prevSnapshot, apiSnapshot);
+    if (hasChanged) {
+      process.exitCode = 1;
+    }
+    return;
+  }
+
+  await fs.writeFile(snapshotPath, apiSnapshot);
+  console.log(
+    styleText('green', '  ✔') +
+      ' API snapshot written to ' +
+      styleText('underline', snapshotPath) +
+      '\n',
+  );
 }
 
 async function validateSnapshots(
@@ -104,9 +134,14 @@ async function validateSnapshots(
     };
 
     const diffResult = diff(prevSnapshot, newSnapshot, options);
+    const rerunCommand = isGitRepo() ? 'yarn build-types' : 'js1 build-js-api';
     console.error(
-      `\n${styleText(['inverse'], ' VALIDATE ')} ReactNativeApi.d.ts has changed. Please re-run \`yarn build-types\` and commit the updated snapshot.\n\n`,
-      diffResult,
+      `${styleText(['bold', 'inverse', 'red'], ' FAIL ')} ReactNativeApi.d.ts has changed. Please re-run '${rerunCommand}' and commit the updated snapshot.\n`,
+    );
+    console.error(diffResult);
+  } else {
+    console.log(
+      `${styleText(['bold', 'inverse', 'green'], ' PASS ')} API snapshot is up to date.\n`,
     );
   }
 
@@ -195,7 +230,7 @@ async function getCleanedUpRollup(tempDirectory: string) {
     tempDirectory,
     'react-native',
     'dist',
-    'api-rollup.d.ts',
+    'ReactNativeApi.d.ts',
   );
   const sourceRollup = await fs.readFile(rollupPath, 'utf-8');
 

--- a/scripts/build-types/buildGeneratedTypes.js
+++ b/scripts/build-types/buildGeneratedTypes.js
@@ -16,6 +16,7 @@ const translateSourceFile = require('./translateSourceFile');
 const {promises: fs} = require('fs');
 const micromatch = require('micromatch');
 const path = require('path');
+const {styleText} = require('util');
 
 /**
  * Build generated TypeScript types for react-native.
@@ -76,8 +77,29 @@ async function buildGeneratedTypes(): Promise<void> {
   ]);
 
   if (allErrors.length > 0) {
+    console.error(
+      '\n' +
+        styleText(['bold', 'inverse', 'red'], ' FAIL ') +
+        ' API translation encountered errors.\n',
+    );
     process.exitCode = 1;
+    return;
   }
+
+  const touchedPackages = new Set<string>(
+    Array.from(translatedFiles).map(
+      file =>
+        path.join(PACKAGES_DIR, getPackageName(file), TYPES_OUTPUT_DIR) + '/',
+    ),
+  );
+  for (const packagePath of touchedPackages) {
+    console.log(
+      styleText('green', '  ✔') +
+        ' Types built to ' +
+        styleText('underline', packagePath),
+    );
+  }
+  console.log('');
 }
 
 type DependencyEdges = Array<[string, string]>;

--- a/scripts/build-types/index.js
+++ b/scripts/build-types/index.js
@@ -38,9 +38,20 @@ async function main() {
   Build generated TypeScript types for react-native.
 
   Options:
+    --debug           Enable debug logging.
     --withSnapshot    [Experimental] Include API snapshot generation.
+    --validate        Validate if the current API snapshot on disk is up to
+                      date. Exits with an error if differences are detected.
     `);
     process.exitCode = 0;
+    return;
+  }
+
+  if (validate && !withSnapshot) {
+    console.error(
+      "build-types: '--validate' can only be used with '--withSnapshot'.",
+    );
+    process.exitCode = 2;
     return;
   }
 
@@ -52,23 +63,17 @@ async function main() {
     '\n' +
       styleText(
         ['bold', 'inverse'],
-        'Building generated react-native package types',
+        ' Building generated react-native package types ',
       ) +
       '\n',
   );
-
   await buildGeneratedTypes();
 
   if (withSnapshot) {
     console.log(
-      '\n' +
-        styleText(
-          ['bold', 'inverse', 'yellow'],
-          'EXPERIMENTAL - Building API snapshot',
-        ) +
+      styleText(['bold', 'inverse'], ' [Experimental] Building API snapshot ') +
         '\n',
     );
-
     await buildApiSnapshot(validate);
   }
 }

--- a/scripts/build-types/templates/api-extractor.json
+++ b/scripts/build-types/templates/api-extractor.json
@@ -22,7 +22,7 @@
     "dtsRollup": {
       "enabled": true,
       "untrimmedFilePath": "",
-      "alphaTrimmedFilePath": "<projectFolder>/dist/api-rollup.d.ts"
+      "alphaTrimmedFilePath": "<projectFolder>/dist/ReactNativeApi.d.ts"
     },
     "tsdocMetadata": {
       "enabled": false

--- a/scripts/scm-utils.js
+++ b/scripts/scm-utils.js
@@ -15,10 +15,10 @@ const path = require('path');
 const {cp, echo, exec, exit} = require('shelljs');
 
 /*::
-type Commit = string
+type Commit = string;
 */
 
-function isGitRepo() {
+function isGitRepo() /*: boolean */ {
   try {
     return (
       exec('git rev-parse --is-inside-work-tree', {
@@ -111,6 +111,7 @@ module.exports = {
   exitIfNotOnGit,
   getCurrentCommit,
   getBranchName,
+  isGitRepo,
   isTaggedLatest,
   revertFiles,
   saveFiles,


### PR DESCRIPTION
Summary:
Update `yarn build-types` with incremental progress output in the terminal. Minor refactoring.

<img width="959" alt="image" src="https://github.com/user-attachments/assets/0da41826-979c-485a-a7e1-865cb0466a5c" />

Changelog: [Internal]

Differential Revision: D77022957


