### PR TITLE
Kotlin: fix static code analysis weak warnings (1/n)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/MemoryPressureRouter.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/MemoryPressureRouter.kt
@@ -37,15 +37,15 @@ public class MemoryPressureRouter(context: Context) : ComponentCallbacks2 {
     listeners.remove(listener)
   }
 
-  override public fun onTrimMemory(level: Int) {
+  public override fun onTrimMemory(level: Int) {
     dispatchMemoryPressure(level)
   }
 
-  override public fun onConfigurationChanged(newConfig: Configuration): Unit = Unit
+  public override fun onConfigurationChanged(newConfig: Configuration): Unit = Unit
 
   @Deprecated(
       "onLowMemory is deprecated, use onTrimMemory instead.", ReplaceWith("onTrimMemory(level)"))
-  override public fun onLowMemory(): Unit = Unit
+  public override fun onLowMemory(): Unit = Unit
 
   private fun dispatchMemoryPressure(level: Int) {
     for (listener in listeners) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BaseActivityEventListener.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/BaseActivityEventListener.kt
@@ -18,12 +18,12 @@ public open class BaseActivityEventListener : ActivityEventListener {
       ReplaceWith("onActivityResult(activity, requestCode, resultCode, data)"))
   public open fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent): Unit = Unit
 
-  override public fun onActivityResult(
+  public override fun onActivityResult(
       activity: Activity,
       requestCode: Int,
       resultCode: Int,
       data: Intent?
   ): Unit = Unit
 
-  override public fun onNewIntent(intent: Intent): Unit = Unit
+  public override fun onNewIntent(intent: Intent): Unit = Unit
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/GuardedAsyncTask.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/GuardedAsyncTask.kt
@@ -25,7 +25,7 @@ protected constructor(private val exceptionHandler: JSExceptionHandler) :
   protected constructor(reactContext: ReactContext) : this(reactContext.exceptionHandler)
 
   @Deprecated("AsyncTask is deprecated.")
-  override protected final fun doInBackground(vararg params: Params): Void? {
+  protected final override fun doInBackground(vararg params: Params): Void? {
     try {
       doInBackgroundGuarded(*params)
     } catch (e: RuntimeException) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.kt
@@ -465,9 +465,7 @@ public abstract class DevSupportManagerBase(
     devOptionsDialog?.show()
 
     val reactContext = currentReactContext
-    if (reactContext != null) {
-      reactContext.getJSModule(RCTNativeAppEventEmitter::class.java).emit("RCTDevMenuShown", null)
-    }
+    reactContext?.getJSModule(RCTNativeAppEventEmitter::class.java)?.emit("RCTDevMenuShown", null)
   }
 
   override fun onNewReactContextCreated(reactContext: ReactContext) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.kt
@@ -181,10 +181,8 @@ internal class AccessibilityInfoModule(context: ReactApplicationContext) :
     val isReduceMotionEnabled = isReduceMotionEnabledValue
     if (reduceMotionEnabled != isReduceMotionEnabled) {
       reduceMotionEnabled = isReduceMotionEnabled
-      val reactApplicationContext = getReactApplicationContextIfActiveOrWarn()
-      if (reactApplicationContext != null) {
-        reactApplicationContext.emitDeviceEvent(REDUCE_MOTION_EVENT_NAME, reduceMotionEnabled)
-      }
+      getReactApplicationContextIfActiveOrWarn()
+          ?.emitDeviceEvent(REDUCE_MOTION_EVENT_NAME, reduceMotionEnabled)
     }
   }
 
@@ -192,10 +190,8 @@ internal class AccessibilityInfoModule(context: ReactApplicationContext) :
     val isInvertColorsEnabled = isInvertColorsEnabledValue
     if (invertColorsEnabled != isInvertColorsEnabled) {
       invertColorsEnabled = isInvertColorsEnabled
-      val reactApplicationContext = getReactApplicationContextIfActiveOrWarn()
-      if (reactApplicationContext != null) {
-        reactApplicationContext.emitDeviceEvent(INVERT_COLOR_EVENT_NAME, invertColorsEnabled)
-      }
+      getReactApplicationContextIfActiveOrWarn()
+          ?.emitDeviceEvent(INVERT_COLOR_EVENT_NAME, invertColorsEnabled)
     }
   }
 
@@ -203,13 +199,11 @@ internal class AccessibilityInfoModule(context: ReactApplicationContext) :
     val isHighTextContrastEnabled = isHighTextContrastEnabledValue
     if (highTextContrastEnabled != isHighTextContrastEnabled) {
       highTextContrastEnabled = isHighTextContrastEnabled
-      val reactApplicationContext = getReactApplicationContextIfActiveOrWarn()
-      if (reactApplicationContext != null) {
-        reactApplicationContext.emitDeviceEvent(
-            HIGH_TEXT_CONTRAST_EVENT_NAME,
-            highTextContrastEnabled,
-        )
-      }
+      getReactApplicationContextIfActiveOrWarn()
+          ?.emitDeviceEvent(
+              HIGH_TEXT_CONTRAST_EVENT_NAME,
+              highTextContrastEnabled,
+          )
     }
   }
 
@@ -239,10 +233,8 @@ internal class AccessibilityInfoModule(context: ReactApplicationContext) :
     val isGrayscaleModeEnabled = isGrayscaleEnabledValue
     if (grayscaleModeEnabled != isGrayscaleModeEnabled) {
       grayscaleModeEnabled = isGrayscaleModeEnabled
-      val reactApplicationContext = getReactApplicationContextIfActiveOrWarn()
-      if (reactApplicationContext != null) {
-        reactApplicationContext.emitDeviceEvent(GRAYSCALE_MODE_EVENT_NAME, grayscaleModeEnabled)
-      }
+      getReactApplicationContextIfActiveOrWarn()
+          ?.emitDeviceEvent(GRAYSCALE_MODE_EVENT_NAME, grayscaleModeEnabled)
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/SimpleSpringInterpolator.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/SimpleSpringInterpolator.kt
@@ -17,13 +17,9 @@ import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
 /** Simple spring interpolator */
 // TODO(7613736): Improve spring interpolator with friction and damping variable support
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
-internal class SimpleSpringInterpolator : Interpolator {
-  private val _springDamping: Float
-
-  @JvmOverloads
-  constructor(springDamping: Float = FACTOR) {
-    _springDamping = springDamping
-  }
+internal class SimpleSpringInterpolator @JvmOverloads constructor(springDamping: Float = FACTOR) :
+    Interpolator {
+  private val _springDamping: Float = springDamping
 
   override fun getInterpolation(input: Float): Float =
       // Using mSpringDamping in this equation is not really the exact mathematical springDamping,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewAccessibilityDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewAccessibilityDelegate.kt
@@ -21,16 +21,16 @@ import com.facebook.react.R
 import com.facebook.react.uimanager.ReactAccessibilityDelegate
 import com.facebook.react.views.text.internal.span.ReactClickableSpan
 
-internal class ReactTextViewAccessibilityDelegate : ReactAccessibilityDelegate {
-  public constructor(
-      view: View,
-      originalFocus: Boolean,
-      originalImportantForAccessibility: Int
-  ) : super(view, originalFocus, originalImportantForAccessibility) {
+internal class ReactTextViewAccessibilityDelegate(
+    view: View,
+    originalFocus: Boolean,
+    originalImportantForAccessibility: Int
+) : ReactAccessibilityDelegate(view, originalFocus, originalImportantForAccessibility) {
+  private var accessibilityLinks: AccessibilityLinks? = null
+
+  init {
     accessibilityLinks = hostView.getTag(R.id.accessibility_links) as AccessibilityLinks?
   }
-
-  private var accessibilityLinks: AccessibilityLinks? = null
 
   public companion object {
     public fun setDelegate(


### PR DESCRIPTION
## Summary:

Static code analysis reports several weak warnings, many of which seem to be leftovers after Kotlin migration. This PR addresses quite a few:

- [Convert to primary constructor](https://www.jetbrains.com/help/inspectopedia/ConvertSecondaryConstructorToPrimary.html)
- [If-Then foldable to '?.'﻿](https://www.jetbrains.com/help/inspectopedia/IfThenToSafeAccess.html)
- [Non-canonical modifier order](https://www.jetbrains.com/help/inspectopedia/SortModifiers.html)

## Changelog:

[INTERNAL] - Kotlin: fix static code analysis weak warnings (1/n)

## Test Plan:

```sh
yarn android
yarn test-android
```