### PR TITLE
Gate RN_SERIALIZABLE_STATE behind ANDROID flag

### DIFF
--- a/packages/react-native/ReactCommon/cmake-utils/react-native-flags.cmake
+++ b/packages/react-native/ReactCommon/cmake-utils/react-native-flags.cmake
@@ -28,6 +28,8 @@ SET(reactnative_FLAGS
 
 function(target_compile_reactnative_options target_name scope)
   target_compile_options(${target_name} ${scope} ${reactnative_FLAGS})
-  target_compile_definitions(${target_name} ${scope} RN_SERIALIZABLE_STATE)
+  # TODO T228344694 improve this so that it works for all platforms
+  if(ANDROID)
+    target_compile_definitions(${target_name} ${scope} RN_SERIALIZABLE_STATE)
+  endif()
 endfunction()
-


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Gating RN_SERIALIZABLE_STATE behind ANDROID flag so we can build ReactCommon with cmake when targeting different platforms.
This will help build reac-native-fantom for OSS.

Differential Revision: D77034689


