### PR TITLE
Fix cmake build for devtoolsruntimesettings

### DIFF
--- a/packages/react-native/ReactCommon/cmake-utils/react-native-flags.cmake
+++ b/packages/react-native/ReactCommon/cmake-utils/react-native-flags.cmake
@@ -28,6 +28,8 @@ SET(reactnative_FLAGS
 
 function(target_compile_reactnative_options target_name scope)
   target_compile_options(${target_name} ${scope} ${reactnative_FLAGS})
-  target_compile_definitions(${target_name} ${scope} RN_SERIALIZABLE_STATE)
+  # TODO T228344694 improve this so that it works for all platforms
+  if(ANDROID)
+    target_compile_definitions(${target_name} ${scope} RN_SERIALIZABLE_STATE)
+  endif()
 endfunction()
-

--- a/packages/react-native/ReactCommon/devtoolsruntimesettings/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/devtoolsruntimesettings/CMakeLists.txt
@@ -8,10 +8,10 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
-add_library(react_devtoolsruntimesettingscxx INTERFACE)
+file(GLOB devtoolsruntimesettings_SRCS *.cpp)
+add_library(devtoolsruntimesettings OBJECT ${devtoolsruntimesettings_SRCS})
 
-target_include_directories(react_devtoolsruntimesettingscxx INTERFACE .)
+target_include_directories(devtoolsruntimesettings PUBLIC .)
 
-target_link_libraries(react_devtoolsruntimesettingscxx jsi)
-target_compile_reactnative_options(react_devtoolsruntimesettingscxx PRIVATE)
-target_compile_options(react_devtoolsruntimesettingscxx PRIVATE -Wpedantic)
+target_link_libraries(devtoolsruntimesettings jsi react_codegen_rncore)
+target_compile_reactnative_options(devtoolsruntimesettings PRIVATE)

--- a/packages/react-native/ReactCommon/react/nativemodule/devtoolsruntimesettings/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/devtoolsruntimesettings/CMakeLists.txt
@@ -14,7 +14,7 @@ add_library(react_nativemodule_devtoolsruntimesettings OBJECT ${react_nativemodu
 target_include_directories(react_nativemodule_devtoolsruntimesettings PUBLIC ${REACT_COMMON_DIR})
 
 target_link_libraries(react_nativemodule_devtoolsruntimesettings
-        react_devtoolsruntimesettingscxx
+        devtoolsruntimesettings
 )
 target_compile_reactnative_options(react_nativemodule_devtoolsruntimesettings PRIVATE)
 target_compile_options(react_nativemodule_devtoolsruntimesettings PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/nativemodule/devtoolsruntimesettings/DevToolsRuntimeSettingsModule.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/devtoolsruntimesettings/DevToolsRuntimeSettingsModule.cpp
@@ -6,7 +6,9 @@
  */
 
 #include "DevToolsRuntimeSettingsModule.h"
+#if RN_DISABLE_OSS_PLUGIN_HEADER
 #include "Plugins.h"
+#endif
 
 std::shared_ptr<facebook::react::TurboModule>
 ReactDevToolsRuntimeSettingsModuleProvider(

--- a/packages/react-native/ReactCommon/react/nativemodule/devtoolsruntimesettings/DevToolsRuntimeSettingsModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/devtoolsruntimesettings/DevToolsRuntimeSettingsModule.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include "devtoolsruntimesettingscxx/DevToolsRuntimeSettings.h"
+#include <devtoolsruntimesettings/DevToolsRuntimeSettings.h>
 
 namespace facebook::react {
 


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Fix devtoolsruntimesettings lib as it needs to be OBJECT library as it has source code included.

Differential Revision: D77035122


