### PR TITLE
Add react_nativemodule_fantomspecificmethods cmake

### DIFF
--- a/packages/react-native/ReactCommon/cmake-utils/react-native-flags.cmake
+++ b/packages/react-native/ReactCommon/cmake-utils/react-native-flags.cmake
@@ -28,6 +28,8 @@ SET(reactnative_FLAGS
 
 function(target_compile_reactnative_options target_name scope)
   target_compile_options(${target_name} ${scope} ${reactnative_FLAGS})
-  target_compile_definitions(${target_name} ${scope} RN_SERIALIZABLE_STATE)
+  # TODO T228344694 improve this so that it works for all platforms
+  if(ANDROID)
+    target_compile_definitions(${target_name} ${scope} RN_SERIALIZABLE_STATE)
+  endif()
 endfunction()
-

--- a/packages/react-native/ReactCommon/devtoolsruntimesettings/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/devtoolsruntimesettings/CMakeLists.txt
@@ -8,10 +8,10 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
-add_library(react_devtoolsruntimesettingscxx INTERFACE)
+file(GLOB devtoolsruntimesettings_SRCS *.cpp)
+add_library(devtoolsruntimesettings OBJECT ${devtoolsruntimesettings_SRCS})
 
-target_include_directories(react_devtoolsruntimesettingscxx INTERFACE .)
+target_include_directories(devtoolsruntimesettings PUBLIC .)
 
-target_link_libraries(react_devtoolsruntimesettingscxx jsi)
-target_compile_reactnative_options(react_devtoolsruntimesettingscxx PRIVATE)
-target_compile_options(react_devtoolsruntimesettingscxx PRIVATE -Wpedantic)
+target_link_libraries(devtoolsruntimesettings jsi react_codegen_rncore)
+target_compile_reactnative_options(devtoolsruntimesettings PRIVATE)

--- a/packages/react-native/ReactCommon/react/nativemodule/cputime/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/cputime/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+cmake_minimum_required(VERSION 3.13)
+set(CMAKE_VERBOSE_MAKEFILE on)
+
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
+
+file(GLOB react_nativemodule_cpu_SRC CONFIGURE_DEPENDS *.cpp)
+add_library(react_nativemodule_cpu OBJECT ${react_nativemodule_cpu_SRC})
+
+target_include_directories(react_nativemodule_cpu PUBLIC ${REACT_COMMON_DIR})
+
+target_link_libraries(react_nativemodule_cpu
+        react_codegen_rncore
+)
+target_compile_reactnative_options(react_nativemodule_cpu PRIVATE)
+target_compile_options(react_nativemodule_cpu PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/nativemodule/defaults/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/defaults/CMakeLists.txt
@@ -14,6 +14,8 @@ add_library(react_nativemodule_defaults OBJECT ${react_nativemodule_defaults_SRC
 target_include_directories(react_nativemodule_defaults PUBLIC ${REACT_COMMON_DIR})
 
 target_link_libraries(react_nativemodule_defaults
+        react_codegen_rncore
+        react_nativemodule_core
         react_nativemodule_dom
         react_nativemodule_devtoolsruntimesettings
         react_nativemodule_featureflags

--- a/packages/react-native/ReactCommon/react/nativemodule/devtoolsruntimesettings/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/devtoolsruntimesettings/CMakeLists.txt
@@ -14,7 +14,7 @@ add_library(react_nativemodule_devtoolsruntimesettings OBJECT ${react_nativemodu
 target_include_directories(react_nativemodule_devtoolsruntimesettings PUBLIC ${REACT_COMMON_DIR})
 
 target_link_libraries(react_nativemodule_devtoolsruntimesettings
-        react_devtoolsruntimesettingscxx
+        devtoolsruntimesettings
 )
 target_compile_reactnative_options(react_nativemodule_devtoolsruntimesettings PRIVATE)
 target_compile_options(react_nativemodule_devtoolsruntimesettings PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/nativemodule/devtoolsruntimesettings/DevToolsRuntimeSettingsModule.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/devtoolsruntimesettings/DevToolsRuntimeSettingsModule.cpp
@@ -6,7 +6,9 @@
  */
 
 #include "DevToolsRuntimeSettingsModule.h"
+#if RN_DISABLE_OSS_PLUGIN_HEADER
 #include "Plugins.h"
+#endif
 
 std::shared_ptr<facebook::react::TurboModule>
 ReactDevToolsRuntimeSettingsModuleProvider(

--- a/packages/react-native/ReactCommon/react/nativemodule/devtoolsruntimesettings/DevToolsRuntimeSettingsModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/devtoolsruntimesettings/DevToolsRuntimeSettingsModule.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include "devtoolsruntimesettingscxx/DevToolsRuntimeSettings.h"
+#include <devtoolsruntimesettings/DevToolsRuntimeSettings.h>
 
 namespace facebook::react {
 

--- a/packages/react-native/ReactCommon/react/nativemodule/fantomtestspecificmethods/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/fantomtestspecificmethods/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+cmake_minimum_required(VERSION 3.13)
+set(CMAKE_VERBOSE_MAKEFILE on)
+
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
+
+file(GLOB react_nativemodule_webperformance_SRC CONFIGURE_DEPENDS *.cpp internal/*.cpp)
+add_library(react_nativemodule_fantomspecificmethods OBJECT ${react_nativemodule_webperformance_SRC})
+
+target_include_directories(react_nativemodule_fantomspecificmethods PUBLIC ${REACT_COMMON_DIR})
+target_include_directories(react_nativemodule_fantomspecificmethods PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/internal)
+
+target_link_libraries(react_nativemodule_fantomspecificmethods
+        react_codegen_rncore
+        react_cxxreact
+        react_renderer_bridging
+        react_renderer_core
+        react_renderer_graphics
+        react_renderer_observers_intersection
+        react_renderer_runtimescheduler
+        react_renderer_uimanager
+        rrc_view
+)
+target_compile_reactnative_options(react_nativemodule_fantomspecificmethods PRIVATE)
+target_compile_options(react_nativemodule_fantomspecificmethods PRIVATE -Wpedantic -Wno-deprecated-declarations)

--- a/packages/react-native/ReactCommon/react/nativemodule/fantomtestspecificmethods/NativeFantomTestSpecificMethods.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/fantomtestspecificmethods/NativeFantomTestSpecificMethods.cpp
@@ -11,7 +11,9 @@
 
 #include "internal/FantomForcedCloneCommitHook.h"
 
+#if RN_DISABLE_OSS_PLUGIN_HEADER
 #include "Plugins.h"
+#endif
 
 std::shared_ptr<facebook::react::TurboModule>
 NativeFantomTestSpecificMethodsModuleProvider(


### PR DESCRIPTION
Summary:
Changelog: [Internal]
Add missing cmake target for react_nativemodule_fantomspecificmethods

Differential Revision: D77035521


