### PR TITLE
publish `index.js.flow` instead of `index.flow.js`

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -81,7 +81,7 @@
     "gradle.properties",
     "gradle/libs.versions.toml",
     "index.js",
-    "index.flow.js",
+    "index.js.flow",
     "interface.js",
     "jest-preset.js",
     "jest",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:


I think in https://github.com/facebook/react-native/commit/50667eceb1be4771375d6a3cc2f4e42d4d8aad3a the file name was mixed up. Instead of `index.flow.js` it should be `index.js.flow` (see https://github.com/facebook/react-native/blob/main/packages/react-native/index.js.flow)

Should fix https://github.com/facebook/react-native/issues/51885


## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

[General][Added] Publish top-level Flow types for `react-native`

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

Steps to reproduce

1. Setup a react-native project with flow (or clone https://github.com/buschco/react-native-flow + `cd ReproducerApp && npm i`)
2. `import {Alert} from 'react-native'` -> `Alert` has type `any`
3. add `index.js.flow` File (https://github.com/facebook/react-native/blob/v0.79.3/packages/react-native/index.js.flow) to `node_modules/react-native/index.js.flow` -> `Alert` no longer `any`


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
