### PR TITLE
fix cmake empty spaces and naming

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/fantomtestspecificmethods/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/fantomtestspecificmethods/CMakeLists.txt
@@ -8,8 +8,8 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
-file(GLOB react_nativemodule_webperformance_SRC CONFIGURE_DEPENDS *.cpp internal/*.cpp)
-add_library(react_nativemodule_fantomspecificmethods OBJECT ${react_nativemodule_webperformance_SRC})
+file(GLOB react_nativemodule_fantomspecificmethods_SRC CONFIGURE_DEPENDS *.cpp internal/*.cpp)
+add_library(react_nativemodule_fantomspecificmethods OBJECT ${react_nativemodule_fantomspecificmethods_SRC})
 
 target_include_directories(react_nativemodule_fantomspecificmethods PUBLIC ${REACT_COMMON_DIR})
 target_include_directories(react_nativemodule_fantomspecificmethods PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/internal)

--- a/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/CMakeLists.txt
@@ -8,8 +8,8 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
-file(GLOB react_nativemodule_webperformance_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(react_nativemodule_intersectionobserver OBJECT ${react_nativemodule_webperformance_SRC})
+file(GLOB react_nativemodule_intersectionobserver_SRC CONFIGURE_DEPENDS *.cpp)
+add_library(react_nativemodule_intersectionobserver OBJECT ${react_nativemodule_intersectionobserver_SRC})
 
 target_include_directories(react_nativemodule_intersectionobserver PUBLIC ${REACT_COMMON_DIR})
 

--- a/packages/react-native/ReactCommon/react/nativemodule/mutationobserver/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/mutationobserver/CMakeLists.txt
@@ -5,14 +5,14 @@
 
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
-​​​
+
 include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
-​​​
-file(GLOB react_nativemodule_webperformance_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(react_nativemodule_mutationobserver OBJECT ${react_nativemodule_webperformance_SRC})
-​​​
+
+file(GLOB react_nativemodule_mutationobserver_SRC CONFIGURE_DEPENDS *.cpp)
+add_library(react_nativemodule_mutationobserver OBJECT ${react_nativemodule_mutationobserver_SRC})
+
 target_include_directories(react_nativemodule_mutationobserver PUBLIC ${REACT_COMMON_DIR})
-​​​
+
 target_link_libraries(react_nativemodule_mutationobserver
         react_codegen_rncore
         react_renderer_bridging

--- a/packages/react-native/ReactCommon/react/renderer/observers/intersection/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/observers/intersection/CMakeLists.txt
@@ -8,8 +8,8 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
-file(GLOB react_nativemodule_webperformance_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(react_renderer_observers_intersection OBJECT ${react_nativemodule_webperformance_SRC})
+file(GLOB react_renderer_observers_intersection_SRC CONFIGURE_DEPENDS *.cpp)
+add_library(react_renderer_observers_intersection OBJECT ${react_renderer_observers_intersection_SRC})
 
 target_include_directories(react_renderer_observers_intersection PUBLIC ${REACT_COMMON_DIR})
 

--- a/packages/react-native/ReactCommon/react/renderer/observers/mutation/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/observers/mutation/CMakeLists.txt
@@ -8,8 +8,8 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
-file(GLOB react_nativemodule_webperformance_SRC CONFIGURE_DEPENDS *.cpp)
-add_library(react_renderer_observers_mutation OBJECT ${react_nativemodule_webperformance_SRC})
+file(GLOB react_renderer_observers_mutation_SRC CONFIGURE_DEPENDS *.cpp)
+add_library(react_renderer_observers_mutation OBJECT ${react_renderer_observers_mutation_SRC})
 
 target_include_directories(react_renderer_observers_mutation PUBLIC ${REACT_COMMON_DIR})
 

--- a/packages/react-native/ReactCxxPlatform/react/coremodules/CMakeLists.txt
+++ b/packages/react-native/ReactCxxPlatform/react/coremodules/CMakeLists.txt
@@ -5,14 +5,14 @@
 
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
-​​​
+
 include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
-​​​
+
 file(GLOB react_cxx_platform_react_coremodules_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_cxx_platform_react_coremodules OBJECT ${react_cxx_platform_react_coremodules_SRC})
-​​​
+
 target_include_directories(react_cxx_platform_react_coremodules PUBLIC ${REACT_CXX_PLATFORM_DIR})
-​​​
+
 target_link_libraries(react_cxx_platform_react_coremodules
       folly_runtime
       jsi

--- a/packages/react-native/ReactCxxPlatform/react/renderer/scheduler/CMakeLists.txt
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/scheduler/CMakeLists.txt
@@ -5,14 +5,14 @@
 
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
-​​​
+
 include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
-​​​
+
 file(GLOB react_cxx_platform_react_renderer_scheduler_SRC CONFIGURE_DEPENDS *.cpp)
 add_library(react_cxx_platform_react_renderer_scheduler OBJECT ${react_cxx_platform_react_renderer_scheduler_SRC})
-​​​
+
 target_include_directories(react_cxx_platform_react_renderer_scheduler PUBLIC ${REACT_CXX_PLATFORM_DIR})
-​​​
+
 target_link_libraries(react_cxx_platform_react_renderer_scheduler
       react_renderer_mounting
       react_renderer_scheduler


### PR DESCRIPTION
Summary:
Changelog: [Internal]
Minor fixes to spacing in cmake files and naming inconsistency

Differential Revision: D77141854


