### PR TITLE
Log task ID when scheduling and executing tasks in RuntimeScheduler

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/fantomtestspecificmethods/NativeFantomTestSpecificMethods.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/fantomtestspecificmethods/NativeFantomTestSpecificMethods.cpp
@@ -45,4 +45,8 @@ void NativeFantomTestSpecificMethods::registerForcedCloneCommitHook(
   uiManager.registerCommitHook(*fantomForcedCloneCommitHook_);
 }
 
+void NativeFantomTestSpecificMethods::takeFunctionAndNoop(
+    jsi::Runtime& runtime,
+    jsi::Function function) {}
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/fantomtestspecificmethods/NativeFantomTestSpecificMethods.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/fantomtestspecificmethods/NativeFantomTestSpecificMethods.h
@@ -22,6 +22,8 @@ class NativeFantomTestSpecificMethods
 
   void registerForcedCloneCommitHook(jsi::Runtime& runtime);
 
+  void takeFunctionAndNoop(jsi::Runtime& runtime, jsi::Function callback);
+
  private:
   std::shared_ptr<FantomForcedCloneCommitHook> fantomForcedCloneCommitHook_{};
 };

--- a/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserverManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/observers/intersection/IntersectionObserverManager.cpp
@@ -194,7 +194,10 @@ void IntersectionObserverManager::updateIntersectionObservations(
     return;
   }
 
-  TraceSection s("IntersectionObserverManager::updateIntersectionObservations");
+  TraceSection s(
+      "IntersectionObserverManager::updateIntersectionObservations",
+      "pendingObserverCount",
+      observersPendingInitialization_.size());
 
   std::unordered_map<SurfaceId, RootShadowNode::Shared> rootShadowNodeCache;
 
@@ -234,6 +237,7 @@ void IntersectionObserverManager::updateIntersectionObservations(
 void IntersectionObserverManager::shadowTreeDidMount(
     const RootShadowNode::Shared& rootShadowNode,
     HighResTimeStamp time) noexcept {
+  TraceSection s("IntersectionObserverManager::shadowTreeDidMount");
   updateIntersectionObservations(
       rootShadowNode->getSurfaceId(), rootShadowNode.get(), time);
 }
@@ -241,6 +245,7 @@ void IntersectionObserverManager::shadowTreeDidMount(
 void IntersectionObserverManager::shadowTreeDidUnmount(
     SurfaceId surfaceId,
     HighResTimeStamp time) noexcept {
+  TraceSection s("IntersectionObserverManager::shadowTreeDidUnmount");
   updateIntersectionObservations(surfaceId, nullptr, time);
 }
 
@@ -250,9 +255,6 @@ void IntersectionObserverManager::updateIntersectionObservations(
     SurfaceId surfaceId,
     const RootShadowNode* rootShadowNode,
     HighResTimeStamp time) {
-  TraceSection s(
-      "IntersectionObserverManager::updateIntersectionObservations(mount)");
-
   std::vector<IntersectionObserverEntry> entries;
 
   // Run intersection observations
@@ -263,6 +265,11 @@ void IntersectionObserverManager::updateIntersectionObservations(
     if (observersIt == observersBySurfaceId_.end()) {
       return;
     }
+
+    TraceSection s(
+        "IntersectionObserverManager::updateIntersectionObservations(mount)",
+        "observerCount",
+        observersIt->second.size());
 
     auto& observers = observersIt->second;
     for (auto& observer : observers) {

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
@@ -50,13 +50,6 @@ void RuntimeScheduler_Modern::scheduleWork(RawCallback&& callback) noexcept {
 std::shared_ptr<Task> RuntimeScheduler_Modern::scheduleTask(
     SchedulerPriority priority,
     jsi::Function&& callback) noexcept {
-  TraceSection s(
-      "RuntimeScheduler::scheduleTask",
-      "priority",
-      serialize(priority),
-      "callbackType",
-      "jsi::Function");
-
   auto expirationTime = now_() + timeoutForSchedulerPriority(priority);
   auto task =
       std::make_shared<Task>(priority, std::move(callback), expirationTime);
@@ -69,13 +62,6 @@ std::shared_ptr<Task> RuntimeScheduler_Modern::scheduleTask(
 std::shared_ptr<Task> RuntimeScheduler_Modern::scheduleTask(
     SchedulerPriority priority,
     RawCallback&& callback) noexcept {
-  TraceSection s(
-      "RuntimeScheduler::scheduleTask",
-      "priority",
-      serialize(priority),
-      "callbackType",
-      "RawCallback");
-
   auto expirationTime = now_() + timeoutForSchedulerPriority(priority);
   auto task =
       std::make_shared<Task>(priority, std::move(callback), expirationTime);
@@ -233,6 +219,13 @@ void RuntimeScheduler_Modern::setIntersectionObserverDelegate(
 #pragma mark - Private
 
 void RuntimeScheduler_Modern::scheduleTask(std::shared_ptr<Task> task) {
+  TraceSection s(
+      "RuntimeScheduler::scheduleTask",
+      "priority",
+      serialize(task->priority),
+      "id",
+      task->id);
+
   bool shouldScheduleEventLoop = false;
 
   {
@@ -384,6 +377,8 @@ void RuntimeScheduler_Modern::executeTask(
     bool didUserCallbackTimeout) const {
   TraceSection s(
       "RuntimeScheduler::executeTask",
+      "id",
+      task.id,
       "priority",
       serialize(task.priority),
       "didUserCallbackTimeout",

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/Task.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/Task.cpp
@@ -5,9 +5,19 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "RuntimeScheduler.h"
+#include "Task.h"
+#include <atomic>
 
 namespace facebook::react {
+
+namespace {
+
+inline uint64_t getNextId() noexcept {
+  static std::atomic<uint64_t> nextId = 1;
+  return nextId++;
+}
+
+} // namespace
 
 Task::Task(
     SchedulerPriority priority,
@@ -15,7 +25,8 @@ Task::Task(
     HighResTimeStamp expirationTime)
     : priority(priority),
       callback(std::move(callback)),
-      expirationTime(expirationTime) {}
+      expirationTime(expirationTime),
+      id(getNextId()) {}
 
 Task::Task(
     SchedulerPriority priority,
@@ -23,7 +34,8 @@ Task::Task(
     HighResTimeStamp expirationTime)
     : priority(priority),
       callback(std::move(callback)),
-      expirationTime(expirationTime) {}
+      expirationTime(expirationTime),
+      id(getNextId()) {}
 
 jsi::Value Task::execute(jsi::Runtime& runtime, bool didUserCallbackTimeout) {
   auto result = jsi::Value::undefined();

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/Task.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/Task.h
@@ -11,6 +11,7 @@
 #include <jsi/jsi.h>
 #include <react/timing/primitives.h>
 
+#include <cstdint>
 #include <optional>
 #include <variant>
 
@@ -41,6 +42,7 @@ struct Task final : public jsi::NativeState {
   SchedulerPriority priority;
   std::optional<std::variant<jsi::Function, RawCallback>> callback;
   HighResTimeStamp expirationTime;
+  uint64_t id;
 
   jsi::Value execute(jsi::Runtime& runtime, bool didUserCallbackTimeout);
 };

--- a/packages/react-native/src/private/renderer/runtimescheduler/__tests__/RuntimeScheduler-benchmark-itest.js
+++ b/packages/react-native/src/private/renderer/runtimescheduler/__tests__/RuntimeScheduler-benchmark-itest.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
+
+import NativeFantomTestSpecificMethods from '../../../testing/fantom/specs/NativeFantomTestSpecificMethods';
+import * as Fantom from '@react-native/fantom';
+
+const NUMBER_OF_TASKS_TO_SCHEDULE = 100;
+const noop = () => {};
+const takeFunctionAndNoop = NativeFantomTestSpecificMethods.takeFunctionAndNoop;
+
+Fantom.unstable_benchmark
+  .suite('RuntimeScheduler', {
+    minIterations: 100000,
+  })
+  .test(`call ${NUMBER_OF_TASKS_TO_SCHEDULE} noop JSI methods`, () => {
+    for (let i = 0; i < NUMBER_OF_TASKS_TO_SCHEDULE; i++) {
+      takeFunctionAndNoop(noop);
+    }
+  })
+  .test(
+    `schedule ${NUMBER_OF_TASKS_TO_SCHEDULE} tasks`,
+    () => {
+      for (let i = 0; i < NUMBER_OF_TASKS_TO_SCHEDULE; i++) {
+        Fantom.scheduleTask(noop);
+      }
+    },
+    {
+      afterEach: () => {
+        // Will flush the queue
+        Fantom.runWorkLoop();
+      },
+    },
+  )
+  .test(
+    `run ${NUMBER_OF_TASKS_TO_SCHEDULE} scheduled tasks`,
+    () => {
+      // Will flush the queue
+      Fantom.runWorkLoop();
+    },
+    {
+      beforeEach: () => {
+        for (let i = 0; i < NUMBER_OF_TASKS_TO_SCHEDULE; i++) {
+          Fantom.scheduleTask(noop);
+        }
+      },
+    },
+  )
+  .test(`schedule and run ${NUMBER_OF_TASKS_TO_SCHEDULE} tasks`, () => {
+    for (let i = 0; i < NUMBER_OF_TASKS_TO_SCHEDULE; i++) {
+      Fantom.runTask(noop);
+    }
+  });

--- a/packages/react-native/src/private/testing/fantom/specs/NativeFantomTestSpecificMethods.js
+++ b/packages/react-native/src/private/testing/fantom/specs/NativeFantomTestSpecificMethods.js
@@ -23,6 +23,7 @@ import * as TurboModuleRegistry from '../../../../../Libraries/TurboModule/Turbo
  */
 export interface Spec extends TurboModule {
   +registerForcedCloneCommitHook: () => void;
+  +takeFunctionAndNoop: (fn: () => void) => void;
 }
 
 export default (TurboModuleRegistry.getEnforcing<Spec>(

--- a/private/react-native-fantom/src/index.js
+++ b/private/react-native-fantom/src/index.js
@@ -27,8 +27,8 @@ import NativeFantom, {
 import {getNativeNodeReference} from 'react-native/src/private/webapis/dom/nodes/internals/NodeInternals';
 
 const nativeRuntimeScheduler = global.nativeRuntimeScheduler;
-const schedulerPriorityImmediate =
-  nativeRuntimeScheduler.unstable_ImmediatePriority;
+const {unstable_scheduleCallback, unstable_ImmediatePriority} =
+  nativeRuntimeScheduler;
 
 export type RootConfig = {
   viewportWidth?: number,
@@ -131,7 +131,7 @@ export type {Root};
 
 export {NativeEventCategory} from 'react-native/src/private/testing/fantom/specs/NativeFantom';
 
-const DEFAULT_TASK_PRIORITY = schedulerPriorityImmediate;
+const DEFAULT_TASK_PRIORITY = unstable_ImmediatePriority;
 
 /**
  * Schedules a task to run on the event loop.
@@ -154,7 +154,7 @@ const DEFAULT_TASK_PRIORITY = schedulerPriorityImmediate;
  * ```
  */
 export function scheduleTask(task: () => void | Promise<void>) {
-  nativeRuntimeScheduler.unstable_scheduleCallback(DEFAULT_TASK_PRIORITY, task);
+  unstable_scheduleCallback(DEFAULT_TASK_PRIORITY, task);
 }
 
 let flushingQueue = false;


### PR DESCRIPTION
Summary:
Changelog: [internal]

Some time ago we added logging for the timer ID in Systrace/Perfetto so we could see where timers were scheduled vs. executed.

This diff adds support for the same functionality for tasks in the runtime scheduler.

Differential Revision: D77039038


