### PR TITLE
Introduce react_native_android_dep

### DIFF
--- a/packages/react-native/ReactCommon/cmake-utils/internal/react-native-platform-selector.cmake
+++ b/packages/react-native/ReactCommon/cmake-utils/internal/react-native-platform-selector.cmake
@@ -1,0 +1,24 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+cmake_minimum_required(VERSION 3.13)
+set(CMAKE_VERBOSE_MAKEFILE on)
+
+# This function can be used to define a dependency for Android, with optional
+# fallback for cross platform.
+#
+# Usage:
+# react_native_android_selector(jsijni jsijni jsi)
+# react_native_android_selector(fabricjni fabricjni "")
+# target_link_librarues(target_name ${jsijni} ${fabricjni})
+
+function(react_native_android_selector output_var name fallback)
+  if(ANDROID)
+    set(${output_var} ${name})
+  else()
+    set(${output_var} ${fallback})
+  endif()
+  set(${output_var} ${${output_var}} PARENT_SCOPE)
+endfunction()

--- a/packages/react-native/ReactCommon/hermes/executor/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/hermes/executor/CMakeLists.txt
@@ -6,6 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
+include(${REACT_COMMON_DIR}/cmake-utils/internal/react-native-platform-selector.cmake)
 include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB_RECURSE hermes_executor_SRC CONFIGURE_DEPENDS *.cpp)
@@ -15,11 +16,13 @@ add_library(
         ${hermes_executor_SRC}
 )
 target_include_directories(hermes_executor_common PUBLIC .)
+react_native_android_selector(reactnative reactnative "")
 target_link_libraries(hermes_executor_common
         hermes-engine::libhermes
         hermes_inspector_modern
         jsi
-        reactnative
+        jsireact
+        ${reactnative}
 )
 
 target_compile_reactnative_options(hermes_executor_common PRIVATE)

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/CMakeLists.txt
@@ -6,6 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
+include(${REACT_COMMON_DIR}/cmake-utils/internal/react-native-platform-selector.cmake)
 include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB hermesinspectormodern_SRC CONFIGURE_DEPENDS chrome/*.cpp)
@@ -25,7 +26,9 @@ if(${CMAKE_BUILD_TYPE} MATCHES Debug)
 endif()
 
 target_include_directories(hermes_inspector_modern PUBLIC ${REACT_COMMON_DIR})
+react_native_android_selector(reactnative reactnative "")
 target_link_libraries(hermes_inspector_modern
         hermes-engine::libhermes
         jsi
-        reactnative)
+        jsinspector
+        ${reactnative})

--- a/packages/react-native/ReactCommon/jserrorhandler/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jserrorhandler/CMakeLists.txt
@@ -15,10 +15,12 @@ add_library(
         ${js_error_handler_SRC}
 )
 target_include_directories(jserrorhandler PUBLIC .)
+react_native_android_selector(marbufferjni marbufferjni "")
 target_link_libraries(jserrorhandler
         jsi
+        callinvoker
         folly_runtime
-        mapbufferjni
+        ${mapbufferjni}
         react_featureflags
 )
 target_compile_reactnative_options(jserrorhandler PRIVATE)

--- a/packages/react-native/ReactCommon/react/nativemodule/core/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/CMakeLists.txt
@@ -8,21 +8,25 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
+react_native_android_selector(platform_SRC platform/android/ReactCommon/*.cpp "")
 file(GLOB react_nativemodule_core_SRC CONFIGURE_DEPENDS
         ReactCommon/*.cpp
-        platform/android/ReactCommon/*.cpp)
+        ${platform_SRC})
 add_library(react_nativemodule_core
         OBJECT
         ${react_nativemodule_core_SRC})
 
+react_native_android_selector(platform_DIR ${CMAKE_CURRENT_SOURCE_DIR}/platform/android/ "")
 target_include_directories(react_nativemodule_core
         PUBLIC
           ${CMAKE_CURRENT_SOURCE_DIR}
-          ${CMAKE_CURRENT_SOURCE_DIR}/platform/android/
+          ${platform_DIR}
         )
 
+react_native_android_selector(fbjni fbjni "")
+react_native_android_selector(reactnativejni reactnativejni "")
 target_link_libraries(react_nativemodule_core
-        fbjni
+        ${fbjni}
         folly_runtime
         glog
         jsi
@@ -31,6 +35,6 @@ target_link_libraries(react_nativemodule_core
         react_utils
         react_featureflags
         reactperflogger
-        reactnativejni)
+        ${reactnativejni})
 target_compile_reactnative_options(react_nativemodule_core PRIVATE)
 target_compile_options(react_nativemodule_core PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/components/modal/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/modal/CMakeLists.txt
@@ -6,11 +6,15 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
+include(${REACT_COMMON_DIR}/cmake-utils/internal/react-native-platform-selector.cmake)
 include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
+react_native_android_selector(platform_SRC
+        platform/android/*.cpp
+        platform/cxx/*.cpp)
 file(GLOB rrc_modal_SRC CONFIGURE_DEPENDS
         *.cpp
-        platform/android/*.cpp)
+        ${platform_SRC})
 
 add_library(rrc_modal STATIC ${rrc_modal_SRC})
 

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/CMakeLists.txt
@@ -6,15 +6,25 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
+include(${REACT_COMMON_DIR}/cmake-utils/internal/react-native-platform-selector.cmake)
 include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
-file(GLOB rrc_scrollview_SRC CONFIGURE_DEPENDS *.cpp platform/android/react/renderer/components/scrollview/*.cpp)
+react_native_android_selector(platform_SRC
+        platform/android/react/renderer/components/scrollview/*.cpp
+        platform/cxx/react/renderer/components/scrollview/*.cpp
+)
+file(GLOB rrc_scrollview_SRC CONFIGURE_DEPENDS *.cpp ${platform_SRC})
 add_library(rrc_scrollview STATIC ${rrc_scrollview_SRC})
 
-target_include_directories(rrc_scrollview PUBLIC ${REACT_COMMON_DIR} . ${CMAKE_CURRENT_SOURCE_DIR}/platform/android/)
+react_native_android_selector(platform_DIR
+        ${CMAKE_CURRENT_SOURCE_DIR}/platform/android/
+        ${CMAKE_CURRENT_SOURCE_DIR}/platform/cxx/)
+target_include_directories(rrc_scrollview PUBLIC ${REACT_COMMON_DIR} . ${platform_DIR})
 
-target_include_directories(rrc_scrollview PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/platform/android/react/renderer/components/scrollview/)
+react_native_android_selector(platform_DIR_PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/platform/android/react/renderer/components/scrollview/
+        ${CMAKE_CURRENT_SOURCE_DIR}/platform/cxx/react/renderer/components/scrollview/)
+target_include_directories(rrc_scrollview PRIVATE ${platform_DIR_PRIVATE})
 
 target_link_libraries(rrc_scrollview
         glog

--- a/packages/react-native/ReactCommon/react/renderer/components/text/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/CMakeLists.txt
@@ -6,20 +6,29 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
+include(${REACT_COMMON_DIR}/cmake-utils/internal/react-native-platform-selector.cmake)
 include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
-file(GLOB rrc_text_SRC CONFIGURE_DEPENDS
-        *.cpp
-        platform/android/react/renderer/components/text/*.cpp)
+react_native_android_selector(platform_SRC
+        platform/android/react/renderer/components/text/*.cpp
+        platform/cxx/react/renderer/components/text/*.cpp
+)
+file(GLOB rrc_text_SRC CONFIGURE_DEPENDS *.cpp ${platform_SRC})
 
 add_library(rrc_text OBJECT ${rrc_text_SRC})
 
+react_native_android_selector(platform_DIR
+        ${CMAKE_CURRENT_SOURCE_DIR}/platform/android/
+        ${CMAKE_CURRENT_SOURCE_DIR}/platform/cxx/)
 target_include_directories(rrc_text PUBLIC
         ${REACT_COMMON_DIR}
-        ${CMAKE_CURRENT_SOURCE_DIR}/platform/android/)
+        ${platform_DIR})
 
+react_native_android_selector(platform_DIR_PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/platform/android/react/renderer/components/text/
+        ${CMAKE_CURRENT_SOURCE_DIR}/platform/cxx/react/renderer/components/text/)
 target_include_directories(rrc_text PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/platform/android/react/renderer/components/text/)
+        ${platform_DIR_PRIVATE})
 
 target_link_libraries(rrc_text
         glog

--- a/packages/react-native/ReactCommon/react/renderer/components/view/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/CMakeLists.txt
@@ -6,19 +6,23 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
+include(${REACT_COMMON_DIR}/cmake-utils/internal/react-native-platform-selector.cmake)
 include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
+react_native_android_selector(platform_SRC
+        platform/android/react/renderer/components/view/*.cpp
+        platform/cxx/react/renderer/components/view/*.cpp
+)
 file(GLOB rrc_view_SRC CONFIGURE_DEPENDS
         *.cpp
-        platform/android/react/renderer/components/view/*.cpp)
+        ${platform_SRC})
 
 add_library(rrc_view OBJECT ${rrc_view_SRC})
 
-target_include_directories(rrc_view
-        PUBLIC
-          ${REACT_COMMON_DIR}
-          ${CMAKE_CURRENT_SOURCE_DIR}/platform/android/
-)
+react_native_android_selector(platform_DIR
+        ${CMAKE_CURRENT_SOURCE_DIR}/platform/android/
+        ${CMAKE_CURRENT_SOURCE_DIR}/platform/cxx/)
+target_include_directories(rrc_view PUBLIC ${REACT_COMMON_DIR} ${platform_DIR})
 
 target_link_libraries(rrc_view
         folly_runtime

--- a/packages/react-native/ReactCommon/react/renderer/graphics/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/CMakeLists.txt
@@ -6,20 +6,28 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
+include(${REACT_COMMON_DIR}/cmake-utils/internal/react-native-platform-selector.cmake)
 include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
-file(GLOB react_renderer_graphics_SRC CONFIGURE_DEPENDS *.cpp)
+react_native_android_selector(platform_SRC
+        platform/android/react/renderer/graphics/*.cpp
+        platform/cxx/react/renderer/graphics/*.cpp)
+file(GLOB react_renderer_graphics_SRC CONFIGURE_DEPENDS *.cpp ${platform_SRC})
 add_library(react_renderer_graphics OBJECT ${react_renderer_graphics_SRC})
 
+react_native_android_selector(platform_DIR
+        ${CMAKE_CURRENT_SOURCE_DIR}/platform/android/
+        ${CMAKE_CURRENT_SOURCE_DIR}/platform/cxx/)
 target_include_directories(react_renderer_graphics
         PUBLIC
           ${REACT_COMMON_DIR}
-          ${CMAKE_CURRENT_SOURCE_DIR}/platform/android/
+          ${platform_DIR}
         )
 
+react_native_android_selector(fbjni fbjni "")
 target_link_libraries(react_renderer_graphics
         glog
-        fbjni
+        ${fbjni}
         folly_runtime
         react_debug
         react_utils

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/CMakeLists.txt
@@ -6,33 +6,42 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
+include(${REACT_COMMON_DIR}/cmake-utils/internal/react-native-platform-selector.cmake)
 include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
+react_native_android_selector(platform_SRC
+        platform/android/react/renderer/imagemanager/*.cpp
+        platform/cxx/react/renderer/imagemanager/*.cpp)
 file(GLOB react_renderer_imagemanager_SRC CONFIGURE_DEPENDS
         *.cpp
-        platform/android/react/renderer/imagemanager/*.cpp)
+        ${platform_SRC})
 
 add_library(react_renderer_imagemanager
         OBJECT
         ${react_renderer_imagemanager_SRC})
 
+react_native_android_selector(platform_DIR
+        ${CMAKE_CURRENT_SOURCE_DIR}/platform/android/
+        ${CMAKE_CURRENT_SOURCE_DIR}/platform/cxx/)
 target_include_directories(react_renderer_imagemanager
         PUBLIC
           ${REACT_COMMON_DIR}
-          ${CMAKE_CURRENT_SOURCE_DIR}/platform/android/
+          ${platform_DIR}
         PRIVATE
           ${CMAKE_CURRENT_SOURCE_DIR}
         )
 
+react_native_android_selector(mapbufferjni mapbufferjni "")
+react_native_android_selector(reactnativejni reactnativejni "")
 target_link_libraries(react_renderer_imagemanager
         folly_runtime
-        mapbufferjni
+        ${mapbufferjni}
         react_debug
         react_renderer_core
         react_renderer_debug
         react_renderer_graphics
         react_renderer_mounting
-        reactnativejni
+        ${reactnativejni}
         yoga)
 target_compile_reactnative_options(react_renderer_imagemanager PRIVATE)
 target_compile_options(react_renderer_imagemanager PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/CMakeLists.txt
@@ -6,28 +6,38 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
+include(${REACT_COMMON_DIR}/cmake-utils/internal/react-native-platform-selector.cmake)
 include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
+react_native_android_selector(platform_SRC
+        platform/android/react/renderer/textlayoutmanager/*.cpp
+        platform/cxx/react/renderer/textlayoutmanager/*.cpp)
 file(GLOB react_renderer_textlayourmanager_SRC CONFIGURE_DEPENDS
         *.cpp
-        platform/android/react/renderer/textlayoutmanager/*.cpp)
+        ${platform_SRC})
 
 add_library(react_renderer_textlayoutmanager
         OBJECT
         ${react_renderer_textlayourmanager_SRC})
 
+react_native_android_selector(platform_DIR
+        ${CMAKE_CURRENT_SOURCE_DIR}/platform/android/
+        ${CMAKE_CURRENT_SOURCE_DIR}/platform/cxx/)
 target_include_directories(react_renderer_textlayoutmanager
         PUBLIC
           .
           ${REACT_COMMON_DIR}
-          ${CMAKE_CURRENT_SOURCE_DIR}/platform/android/
+          ${platform_DIR}
 )
 
+react_native_android_selector(fbjni fbjni "")
+react_native_android_selector(mapbufferjni mapbufferjni "")
+react_native_android_selector(reactnativejni reactnativejni "")
 target_link_libraries(react_renderer_textlayoutmanager
         glog
-        fbjni
+        ${fbjni}
         folly_runtime
-        mapbufferjni
+        ${mapbufferjni}
         react_debug
         react_renderer_attributedstring
         react_renderer_componentregistry
@@ -38,7 +48,7 @@ target_link_libraries(react_renderer_textlayoutmanager
         react_renderer_mounting
         react_renderer_telemetry
         react_utils
-        reactnativejni
+        ${reactnativejni}
         yoga
 )
 target_compile_reactnative_options(react_renderer_textlayoutmanager PRIVATE)

--- a/packages/react-native/ReactCommon/react/runtime/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/runtime/CMakeLists.txt
@@ -6,6 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
+include(${REACT_COMMON_DIR}/cmake-utils/internal/react-native-platform-selector.cmake)
 include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB bridgeless_SRC "*.cpp")
@@ -18,12 +19,16 @@ target_compile_reactnative_options(bridgeless PRIVATE)
 target_compile_options(bridgeless PRIVATE $<$<CONFIG:Debug>:-DHERMES_ENABLE_DEBUGGER=1>)
 target_include_directories(bridgeless PUBLIC .)
 
+react_native_android_selector(fabricjni fabricjni "")
+react_native_android_selector(react_featureflagsjni react_featureflagsjni react_featureflags)
+react_native_android_selector(turbomodulejsijni turbomodulejsijni "")
+
 target_link_libraries(
         bridgeless
         jserrorhandler
-        fabricjni
-        react_featureflagsjni
-        turbomodulejsijni
+        ${fabricjni}
+        ${react_featureflagsjni}
+        ${turbomodulejsijni}
         jsi
         jsitooling
         jsireact

--- a/packages/react-native/ReactCommon/react/runtime/hermes/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/runtime/hermes/CMakeLists.txt
@@ -6,6 +6,7 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
+include(${REACT_COMMON_DIR}/cmake-utils/internal/react-native-platform-selector.cmake)
 include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
 file(GLOB_RECURSE bridgeless_hermes_SRC CONFIGURE_DEPENDS *.cpp)
@@ -16,13 +17,15 @@ add_library(
 )
 target_include_directories(bridgelesshermes PUBLIC .)
 
+react_native_android_selector(reactnative reactnative "")
 target_link_libraries(bridgelesshermes
         hermes-engine::libhermes
         hermes_executor_common
         hermes_inspector_modern
         jsi
+        jsitooling
         jsinspector
-        reactnative
+        ${reactnative}
 )
 
 target_compile_reactnative_options(bridgelesshermes PRIVATE)

--- a/packages/react-native/ReactCommon/react/utils/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/utils/CMakeLists.txt
@@ -8,13 +8,23 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
-file(GLOB react_utils_SRC CONFIGURE_DEPENDS *.cpp platform/android/react/utils/*.cpp)
+react_native_android_selector(platform_SRC
+        platform/android/react/utils/*.cpp
+        cxx/android/react/utils/*.cpp)
+
+file(GLOB react_utils_SRC CONFIGURE_DEPENDS
+        *.cpp
+        ${platform_SRC})
 add_library(react_utils OBJECT ${react_utils_SRC})
 
+react_native_android_selector(platform_DIR
+        ${CMAKE_CURRENT_SOURCE_DIR}/platform/android/
+        ${CMAKE_CURRENT_SOURCE_DIR}/platform/cxx/
+)
 target_include_directories(react_utils
         PUBLIC
           ${REACT_COMMON_DIR}
-          ${CMAKE_CURRENT_SOURCE_DIR}/platform/android/
+          ${platform_DIR}
 )
 
 target_link_libraries(react_utils


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Introducing a way to include sources and deps via function that react_native_android_dep.

This will help with Fantom OSS build.

Differential Revision: D77146189


