### PR TITLE
@DoNotStrip ReactModalHostView to prevent instacrash on release

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
@@ -70,6 +70,7 @@ import com.facebook.yoga.annotations.DoNotStrip
  *    addition and removal of views to the DialogRootViewGroup.
  */
 @SuppressLint("ViewConstructor")
+@DoNotStrip
 public class ReactModalHostView(context: ThemedReactContext) :
     ViewGroup(context), LifecycleEventListener {
 


### PR DESCRIPTION
Summary:
RNTester is currently instacrashing on release due to use minifying the `ReactModalHostView`.
In that class there is a static method that is accessed by JNI so we should annotated this class
as `DoNotStrip` as otherwise we won't be able to access it.

Changelog:
[Internal] [Changed] -

Differential Revision: D77148010


