### PR TITLE
Run E2E tests on each PR

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -4,9 +4,6 @@ inputs:
   release-type:
     required: true
     description: The type of release we are building. It could be nightly, release or dry-run
-  run-e2e-tests:
-    default: 'false'
-    description: If we need to build to run E2E tests. If yes, we need to build also x86.
   gradle-cache-encryption-key:
     description: "The encryption key needed to store the Gradle Configuration cache"
 runs:
@@ -43,11 +40,7 @@ runs:
       run: |
         if [[ "${{ inputs.release-type }}" == "dry-run" ]]; then
           # dry-run: we only build ARM64 to save time/resources. For release/nightlies the default is to build all archs.
-          if [[ "${{ inputs.run-e2e-tests }}" == 'true' ]]; then
-            export ORG_GRADLE_PROJECT_reactNativeArchitectures="arm64-v8a,x86" # x86 is required for E2E testing
-          else
-            export ORG_GRADLE_PROJECT_reactNativeArchitectures="arm64-v8a"
-          fi
+          export ORG_GRADLE_PROJECT_reactNativeArchitectures="arm64-v8a,x86" # x86 is required for E2E testing
           TASKS="publishAllToMavenTempLocal build"
         elif [[ "${{ inputs.release-type }}" == "nightly" ]]; then
           # nightly: we set isSnapshot to true so artifacts are sent to the right repository on Maven Central.

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -2,11 +2,6 @@ name: Test All
 
 on:
   workflow_dispatch:
-    inputs:
-      run-e2e-tests:
-        description: Whether to run E2E tests or not
-        type: boolean
-        default: false
   pull_request:
   push:
     branches:
@@ -168,7 +163,6 @@ jobs:
           flavor: ${{ matrix.flavor }}
 
   test_e2e_ios_rntester:
-    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
     runs-on: macos-14-large
     needs:
       [test_ios_rntester]
@@ -202,7 +196,6 @@ jobs:
           flavor: ${{ matrix.flavor }}
 
   test_e2e_ios_templateapp:
-    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
     runs-on: macos-14-large
     needs: [build_npm_package, prebuild_apple_dependencies]
     env:
@@ -295,7 +288,6 @@ jobs:
           working-directory: /tmp/RNTestProject
 
   test_e2e_android_templateapp:
-    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
     runs-on: 4-core-ubuntu
     needs: build_npm_package
     strategy:
@@ -414,11 +406,9 @@ jobs:
         uses: ./.github/actions/build-android
         with:
           release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
-          run-e2e-tests: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
           gradle-cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
 
   test_e2e_android_rntester:
-    if: ${{ github.ref == 'refs/heads/main' || contains(github.ref,  'stable') || inputs.run-e2e-tests }}
     runs-on: 4-core-ubuntu
     needs: [build_android]
     strategy:
@@ -616,7 +606,7 @@ jobs:
   rerun-failed-jobs:
     runs-on: ubuntu-latest
     needs: [test_e2e_ios_rntester, test_e2e_android_rntester, test_e2e_ios_templateapp, test_e2e_android_templateapp]
-    if: always()
+    if: ${{ github.ref == 'refs/heads/main' && always() }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Summary:
This Diff enables E2E tests to run on every PR.
We estimated that, now that we removed JSC and the legacy arch, the cost of running E2E tests on each PR should not be that high.

## Changelog:
[Internal] - Run E2E tests on each PR

Differential Revision: D77148473


