### PR TITLE
fix: add missing `getNativeScrollRef` type for `ScrollView`

### DIFF
--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.d.ts
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.d.ts
@@ -10,6 +10,7 @@
 import type * as React from 'react';
 import {Constructor} from '../../../types/private/Utilities';
 import {Insets} from '../../../types/public/Insets';
+import {HostInstance} from '../../../types/public/ReactNativeTypes';
 import {ColorValue, StyleProp} from '../../StyleSheet/StyleSheet';
 import {ViewStyle} from '../../StyleSheet/StyleSheetTypes';
 import {
@@ -877,6 +878,12 @@ export class ScrollView extends ScrollViewBase {
 
   // Undocumented
   getInnerViewNode(): any;
+
+  /**
+   * Returns a reference to the underlying native scroll view, or null if the
+   * native instance is not mounted.
+   */
+  getNativeScrollRef: () => HostInstance | null;
 
   /**
    * @deprecated Use scrollTo instead


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

### The Problem

When trying to measure the location of a `View` within a `ScrollView` (ie. for scrolling to the view), the current recommended method is to use `measureLayout` on the nested view to determine its location inside the containing scroll view:

```tsx
const MyComponent = () => {
  const scrollViewRef = useRef<ScrollView>(null);
  const nestedViewRef = useRef<View>(null);

  const scrollToNestedView = () => {
    if (!scrollViewRef.current || !nestedViewRef.current) {
      return;
    }

    nestedViewRef.current.measureLayout(
      scrollViewRef.current.getInnerViewNode(),
      (x, y) => { scrollViewRef.current.scrollTo({ y, animated: true }); },
    );
  }

  return (
    <ScrollView ref={scrollViewRef}>
      <View ref={nestedViewRef}>
        { /* content */ }
      </View>
    </ScrollView>
  );
}
```

This is valid in the Typescript types layer. However, the only two methods on `ScrollView` to use in this scenario that are [available in the type definitions](https://github.com/facebook/react-native/blob/main/packages/react-native/Libraries/Components/ScrollView/ScrollView.d.ts#L830) are `getScrollableNode` and `getInnerViewNode` – both of these methods [return a `number`](https://github.com/facebook/react-native/blob/main/packages/react-native/Libraries/Components/ScrollView/ScrollView.js#L139-L140). The issue is that a `number` not a valid value to use with `measureLayout` because [its source returns early for that type](https://github.com/facebook/react-native/blob/main/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricHostComponent.js#L91-L102).

(Note, you can also use `findNodeHandle` with the scroll view ref, but this also returns a `number`.)

### The Solution

The long-term solution would be to update the types for both `measureLayout` and `ScrollView`. However, that would constitute a breaking change and require some fairly expansive updates. Instead, I am proposing an additive solution.

`ScrollView` has [a public method called `getNativeScrollRef`](https://github.com/facebook/react-native/blob/e69f0726cd2616fb112d2e4fabfeaafc8cada5d7/packages/react-native/Libraries/Components/ScrollView/ScrollView.js#L142) which returns the underlying `HostInstance`. This method correctly works in the runtime layer, but is not supported in the types layer. This PR exposes the public method in the type definition so that we can properly access the underlying instance without using `@ts-ignore`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:[GENERAL] [FIXED] - Expose `ScrollView.getNativeScrollRef` on the type definition to allow accessing the underlying `HostInstance`.

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

None needed. This is only a type update exposing existing functionality. 
