### PR TITLE
adding `scrollTo`, and imperative handle exports for ScrollView

### DIFF
--- a/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
+++ b/packages/react-native/Libraries/__tests__/__snapshots__/public-api-test.js.snap
@@ -9057,6 +9057,8 @@ export type {
 export { default as RefreshControl } from \\"./Libraries/Components/RefreshControl/RefreshControl\\";
 export { default as SafeAreaView } from \\"./Libraries/Components/SafeAreaView/SafeAreaView\\";
 export type {
+  ScrollViewImperativeMethods,
+  ScrollViewScrollToOptions,
   ScrollResponderType,
   ScrollViewProps,
   ScrollViewPropsAndroid,

--- a/packages/react-native/index.js.flow
+++ b/packages/react-native/index.js.flow
@@ -95,6 +95,8 @@ export {default as RefreshControl} from './Libraries/Components/RefreshControl/R
 export {default as SafeAreaView} from './Libraries/Components/SafeAreaView/SafeAreaView';
 
 export type {
+  ScrollViewImperativeMethods,
+  ScrollViewScrollToOptions,
   ScrollResponderType,
   ScrollViewProps,
   ScrollViewPropsAndroid,


### PR DESCRIPTION
Summary:
Changelog:
[General][Added] - Expose `ScrollViewImperativeMethods` and `ScrollViewScrollToOptions` types to public API

Reviewed By: huntie

Differential Revision: D76920770


