### PR TITLE
Kotlin: fix static code analysis weak warnings (2/n) 

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/ShakeDetector.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/ShakeDetector.kt
@@ -12,6 +12,7 @@ import android.hardware.SensorEvent
 import android.hardware.SensorEventListener
 import android.hardware.SensorManager
 import java.util.concurrent.TimeUnit
+import kotlin.math.abs
 
 /** Listens for the user shaking their phone. Allocation-less once it starts listening. */
 public class ShakeDetector
@@ -63,7 +64,7 @@ constructor(private val shakeListener: ShakeListener, private val minNumShakes: 
    * @return true if the magnitude of the force exceeds the minimum required amount of force. false
    *   otherwise.
    */
-  private fun atLeastRequiredForce(a: Float): Boolean = Math.abs(a) > REQUIRED_FORCE
+  private fun atLeastRequiredForce(a: Float): Boolean = abs(a) > REQUIRED_FORCE
 
   /**
    * Save data about last shake

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactSurfaceView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactSurfaceView.kt
@@ -26,6 +26,7 @@ import com.facebook.react.uimanager.JSTouchDispatcher
 import com.facebook.react.uimanager.common.UIManagerType
 import com.facebook.systrace.Systrace
 import java.util.Objects
+import kotlin.math.max
 
 /**
  * A view created by [com.facebook.react.interfaces.fabric.ReactSurface] that's responsible for
@@ -55,7 +56,7 @@ public class ReactSurfaceView(context: Context?, private val surface: ReactSurfa
       for (i in 0 until childCount) {
         val child = getChildAt(i)
         val childSize = (child.left + child.measuredWidth + child.paddingLeft + child.paddingRight)
-        width = Math.max(width, childSize)
+        width = max(width, childSize)
       }
     } else {
       width = MeasureSpec.getSize(widthMeasureSpec)
@@ -65,7 +66,7 @@ public class ReactSurfaceView(context: Context?, private val surface: ReactSurfa
       for (i in 0 until childCount) {
         val child = getChildAt(i)
         val childSize = (child.top + child.measuredHeight + child.paddingTop + child.paddingBottom)
-        height = Math.max(height, childSize)
+        height = max(height, childSize)
       }
     } else {
       height = MeasureSpec.getSize(heightMeasureSpec)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/MatrixMathHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/MatrixMathHelper.kt
@@ -8,6 +8,12 @@
 package com.facebook.react.uimanager
 
 import com.facebook.infer.annotation.Assertions
+import kotlin.math.abs
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.math.sqrt
+import kotlin.math.tan
 
 /**
  * Provides helper methods for converting transform operations into a matrix and then into a list of
@@ -19,7 +25,7 @@ public object MatrixMathHelper {
   private fun isZero(d: Double): Boolean {
     return if (java.lang.Double.isNaN(d)) {
       false
-    } else Math.abs(d) < EPSILON
+    } else abs(d) < EPSILON
   }
 
   @JvmStatic
@@ -181,12 +187,11 @@ public object MatrixMathHelper {
     // Now, get the rotations out
     // Based on: http://nghiaho.com/?page_id=846
     val conv = 180 / Math.PI
-    rotationDegrees[0] = roundTo3Places(-Math.atan2(row[2][1], row[2][2]) * conv)
+    rotationDegrees[0] = roundTo3Places(-atan2(row[2][1], row[2][2]) * conv)
     rotationDegrees[1] =
         roundTo3Places(
-            -Math.atan2(-row[2][0], Math.sqrt(row[2][1] * row[2][1] + row[2][2] * row[2][2])) *
-                conv)
-    rotationDegrees[2] = roundTo3Places(-Math.atan2(row[1][0], row[0][0]) * conv)
+            -atan2(-row[2][0], sqrt(row[2][1] * row[2][1] + row[2][2] * row[2][2])) * conv)
+    rotationDegrees[2] = roundTo3Places(-atan2(row[1][0], row[0][0]) * conv)
   }
 
   @JvmStatic
@@ -322,7 +327,7 @@ public object MatrixMathHelper {
   /** From: https://code.google.com/p/webgl-mjs/source/browse/mjs.js */
   @JvmStatic
   public fun v3Length(a: DoubleArray): Double {
-    return Math.sqrt(a[0] * a[0] + a[1] * a[1] + a[2] * a[2])
+    return sqrt(a[0] * a[0] + a[1] * a[1] + a[2] * a[2])
   }
 
   /** Based on: https://code.google.com/p/webgl-mjs/source/browse/mjs.js */
@@ -437,37 +442,37 @@ public object MatrixMathHelper {
 
   @JvmStatic
   public fun applySkewX(m: DoubleArray, radians: Double) {
-    m[4] = Math.tan(radians)
+    m[4] = tan(radians)
   }
 
   @JvmStatic
   public fun applySkewY(m: DoubleArray, radians: Double) {
-    m[1] = Math.tan(radians)
+    m[1] = tan(radians)
   }
 
   @JvmStatic
   public fun applyRotateX(m: DoubleArray, radians: Double) {
-    m[5] = Math.cos(radians)
-    m[6] = Math.sin(radians)
-    m[9] = -Math.sin(radians)
-    m[10] = Math.cos(radians)
+    m[5] = cos(radians)
+    m[6] = sin(radians)
+    m[9] = -sin(radians)
+    m[10] = cos(radians)
   }
 
   @JvmStatic
   public fun applyRotateY(m: DoubleArray, radians: Double) {
-    m[0] = Math.cos(radians)
-    m[2] = -Math.sin(radians)
-    m[8] = Math.sin(radians)
-    m[10] = Math.cos(radians)
+    m[0] = cos(radians)
+    m[2] = -sin(radians)
+    m[8] = sin(radians)
+    m[10] = cos(radians)
   }
 
   // http://www.w3.org/TR/css3-transforms/#recomposing-to-a-2d-matrix
   @JvmStatic
   public fun applyRotateZ(m: DoubleArray, radians: Double) {
-    m[0] = Math.cos(radians)
-    m[1] = Math.sin(radians)
-    m[4] = -Math.sin(radians)
-    m[5] = Math.cos(radians)
+    m[0] = cos(radians)
+    m[1] = sin(radians)
+    m[4] = -sin(radians)
+    m[5] = cos(radians)
   }
 
   public open class MatrixDecompositionContext {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewProps.kt
@@ -10,7 +10,6 @@ package com.facebook.react.uimanager
 import android.graphics.Color
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.ReadableType
-import java.util.Arrays
 
 /** Keys for props that need to be shared across multiple classes. */
 public object ViewProps {
@@ -206,7 +205,7 @@ public object ViewProps {
           Spacing.RIGHT)
   private val LAYOUT_ONLY_PROPS: HashSet<String> =
       HashSet(
-          Arrays.asList(
+          listOf(
               ALIGN_SELF,
               ALIGN_ITEMS,
               COLLAPSABLE,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/SimpleSpringInterpolator.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/SimpleSpringInterpolator.kt
@@ -13,6 +13,8 @@ import com.facebook.react.bridge.ReadableType
 import com.facebook.react.common.annotations.internal.LegacyArchitecture
 import com.facebook.react.common.annotations.internal.LegacyArchitectureLogLevel
 import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
+import kotlin.math.pow
+import kotlin.math.sin
 
 /** Simple spring interpolator */
 // TODO(7613736): Improve spring interpolator with friction and damping variable support
@@ -27,8 +29,8 @@ internal class SimpleSpringInterpolator @JvmOverloads constructor(springDamping:
       // We need to replace this equation with the right Factor that accounts for damping and
       // friction
       (1 +
-              Math.pow(2.0, (-10 * input).toDouble()) *
-                  Math.sin((input - _springDamping / 4) * Math.PI * 2 / _springDamping))
+              2.0.pow((-10 * input).toDouble()) *
+                  sin((input - _springDamping / 4) * Math.PI * 2 / _springDamping))
           .toFloat()
 
   companion object {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/imagehelper/ImageSource.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/imagehelper/ImageSource.kt
@@ -44,7 +44,7 @@ constructor(
     }
 
     val that = other as ImageSource
-    return java.lang.Double.compare(that.size, size) == 0 &&
+    return that.size.compareTo(size) == 0 &&
         isResource == that.isResource &&
         uri == that.uri &&
         source == that.source &&

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/imagehelper/MultiSourceHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/imagehelper/MultiSourceHelper.kt
@@ -9,6 +9,7 @@ package com.facebook.react.views.imagehelper
 
 import com.facebook.imagepipeline.core.ImagePipelineFactory
 import com.facebook.react.modules.fresco.ImageCacheControl
+import kotlin.math.abs
 
 /** Helper class for dealing with multisource images. */
 internal object MultiSourceHelper {
@@ -54,7 +55,7 @@ internal object MultiSourceHelper {
     var bestPrecision = Double.MAX_VALUE
     var bestCachePrecision = Double.MAX_VALUE
     for (source in sources) {
-      val precision = Math.abs(1.0 - source.size / viewArea)
+      val precision = abs(1.0 - source.size / viewArea)
       if (precision < bestPrecision) {
         bestPrecision = precision
         best = source

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
@@ -32,6 +32,8 @@ import com.facebook.react.uimanager.common.UIManagerType
 import com.facebook.react.uimanager.common.ViewUtil
 import java.lang.ref.WeakReference
 import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.math.abs
+import kotlin.math.max
 
 /** Helper class that deals with emitting Scroll Events. */
 public object ReactScrollViewHelper {
@@ -115,7 +117,8 @@ public object ReactScrollViewHelper {
     // We limit the delta to 17ms so that small throttles intended to enable 60fps updates will not
     // inadvertently filter out any scroll events.
     if (scrollEventType == ScrollEventType.SCROLL &&
-        scrollView.scrollEventThrottle >= Math.max(17, now - scrollView.lastScrollDispatchTime)) {
+        scrollView.scrollEventThrottle >= max(17, now - scrollView.lastScrollDispatchTime)
+    ) {
       // Scroll events are throttled.
       return
     }
@@ -284,7 +287,7 @@ public object ReactScrollViewHelper {
       velocity: Int
   ): Int where T : HasFlingAnimator?, T : HasScrollState?, T : ViewGroup {
     val scrollState = scrollView.reactScrollViewScrollState
-    val velocityDirectionMask = if (velocity != 0) velocity / Math.abs(velocity) else 0
+    val velocityDirectionMask = if (velocity != 0) velocity / abs(velocity) else 0
     val isMovingTowardsAnimatedValue =
         velocityDirectionMask * (postAnimationValue - currentValue) > 0
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/ReactSwipeRefreshLayout.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/ReactSwipeRefreshLayout.kt
@@ -14,6 +14,7 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.uimanager.events.NativeGestureUtil
+import kotlin.math.abs
 
 /** Basic extension of [SwipeRefreshLayout] with ReactNative-specific functionality. */
 public class ReactSwipeRefreshLayout(reactContext: ReactContext) :
@@ -115,7 +116,7 @@ public class ReactSwipeRefreshLayout(reactContext: ReactContext) :
       }
       MotionEvent.ACTION_MOVE -> {
         val eventX = ev.x
-        val xDiff = Math.abs(eventX - prevTouchX)
+        val xDiff = abs(eventX - prevTouchX)
 
         if (intercepted || xDiff > touchSlop) {
           intercepted = true


### PR DESCRIPTION
## Summary:

Static code analysis reports several weak warnings, many of which seem to be leftovers after Kotlin migration. This PR addresses:

- [Kotlin Java methods should be replaced with Kotlin analog](https://www.jetbrains.com/help/inspectopedia/ReplaceJavaStaticMethodWithKotlinAnalog.html)

## Changelog:

[INTERNAL] - Kotlin: fix static code analysis weak warnings (2/n)

## Test Plan:

```sh
yarn android
yarn test-android
```
