### PR TITLE
Kotlin: fix static code analysis weak warnings (3/n)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaOnlyArray.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaOnlyArray.kt
@@ -134,15 +134,14 @@ public class JavaOnlyArray : ReadableArray, WritableArray {
 
   override fun toString(): String = backingList.toString()
 
-  override fun equals(other: Any?): Boolean {
-    if (this === other) {
-      return true
-    } else if (other == null || javaClass != other.javaClass) {
-      return false
-    } else {
-      return backingList == (other as JavaOnlyArray).backingList
-    }
-  }
+  override fun equals(other: Any?): Boolean =
+      if (this === other) {
+        true
+      } else if (other == null || javaClass != other.javaClass) {
+        false
+      } else {
+        backingList == (other as JavaOnlyArray).backingList
+      }
 
   override fun hashCode(): Int = backingList.hashCode()
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableNativeMap.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableNativeMap.kt
@@ -79,10 +79,10 @@ public open class ReadableNativeMap protected constructor() : NativeMap(), Reada
 
   private inline fun <reified T> getNullableValue(name: String, type: Class<T>): T? {
     val res = getNullableValue(name)
-    if (res == null) {
-      return null
+    return if (res == null) {
+      null
     } else {
-      return checkInstance(name, res, type)
+      checkInstance(name, res, type)
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/LongStreamingStats.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/LongStreamingStats.kt
@@ -37,11 +37,12 @@ internal class LongStreamingStats {
     }
 
     len++
-    if (len == 1) {
-      average = n.toDouble()
-    } else {
-      average = (average / (len / (len - 1))) + (n / len)
-    }
+    average =
+        if (len == 1) {
+          n.toDouble()
+        } else {
+          (average / (len / (len - 1))) + (n / len)
+        }
 
     max = (if (n > max) n else max)
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.kt
@@ -121,14 +121,13 @@ internal class AccessibilityInfoModule(context: ReactApplicationContext) :
     }
 
   private val isInvertColorsEnabledValue: Boolean
-    get() {
-      try {
-        return Settings.Secure.getInt(
-            contentResolver, Settings.Secure.ACCESSIBILITY_DISPLAY_INVERSION_ENABLED) == 1
-      } catch (e: Settings.SettingNotFoundException) {
-        return false
-      }
-    }
+    get() =
+        try {
+          Settings.Secure.getInt(
+              contentResolver, Settings.Secure.ACCESSIBILITY_DISPLAY_INVERSION_ENABLED) == 1
+        } catch (e: Settings.SettingNotFoundException) {
+          false
+        }
 
   private val isGrayscaleEnabledValue: Boolean
     get() {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/intent/IntentModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/intent/IntentModule.kt
@@ -108,7 +108,7 @@ public open class IntentModule(reactContext: ReactApplicationContext) :
    * @param url the URL to open
    */
   override fun openURL(url: String?, promise: Promise) {
-    if (url == null || url.isEmpty()) {
+    if (url.isNullOrEmpty()) {
       promise.reject(JSApplicationIllegalArgumentException("Invalid URL: $url"))
       return
     }
@@ -131,7 +131,7 @@ public open class IntentModule(reactContext: ReactApplicationContext) :
    * @param promise a promise that is always resolved with a boolean argument
    */
   override fun canOpenURL(url: String?, promise: Promise) {
-    if (url == null || url.isEmpty()) {
+    if (url.isNullOrEmpty()) {
       promise.reject(JSApplicationIllegalArgumentException("Invalid URL: $url"))
       return
     }
@@ -189,7 +189,7 @@ public open class IntentModule(reactContext: ReactApplicationContext) :
    * @param extras An array of extras [{ String, String | Number | Boolean }]
    */
   override fun sendIntent(action: String?, extras: ReadableArray?, promise: Promise) {
-    if (action == null || action.isEmpty()) {
+    if (action.isNullOrEmpty()) {
       promise.reject(JSApplicationIllegalArgumentException("Invalid Action: $action."))
       return
     }
@@ -205,7 +205,7 @@ public open class IntentModule(reactContext: ReactApplicationContext) :
 
     try {
       if (extras != null) {
-        for (i in 0..<extras.size()) {
+        for (i in 0 ..< extras.size()) {
           val map = extras.getMap(i) ?: continue
           val name = map.getString("key")
           val type = map.getType(EXTRA_MAP_KEY_FOR_VALUE)
@@ -214,7 +214,6 @@ public open class IntentModule(reactContext: ReactApplicationContext) :
             ReadableType.String -> {
               intent.putExtra(name, map.getString(EXTRA_MAP_KEY_FOR_VALUE))
             }
-
             ReadableType.Number -> {
               // We cannot know from JS if is an Integer or Double
               // See: https://github.com/facebook/react-native/issues/4141
@@ -222,11 +221,9 @@ public open class IntentModule(reactContext: ReactApplicationContext) :
               val number = map.getDouble(EXTRA_MAP_KEY_FOR_VALUE)
               intent.putExtra(name, number)
             }
-
             ReadableType.Boolean -> {
               intent.putExtra(name, map.getBoolean(EXTRA_MAP_KEY_FOR_VALUE))
             }
-
             else -> {
               promise.reject(
                   JSApplicationIllegalArgumentException("Extra type for $name not supported."))

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/ProgressiveStringDecoder.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/ProgressiveStringDecoder.kt
@@ -62,14 +62,14 @@ internal class ProgressiveStringDecoder(charset: Charset) {
     }
 
     val hasRemainder = decoded && remainderLength > 0
-    if (hasRemainder) {
-      remainder =
+    remainder =
+        if (hasRemainder) {
           ByteArray(remainderLength).apply {
             System.arraycopy(decodeData, length - remainderLength, this, 0, remainderLength)
           }
-    } else {
-      remainder = null
-    }
+        } else {
+          null
+        }
 
     if (!decoded) {
       FLog.w(ReactConstants.TAG, "failed to decode string from byte array")

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/permissions/PermissionsModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/permissions/PermissionsModule.kt
@@ -80,7 +80,7 @@ public class PermissionsModule(reactContext: ReactApplicationContext?) :
           object : Callback {
             override operator fun invoke(vararg args: Any?) {
               val results = args[0] as IntArray
-              if (results.size > 0 && results[0] == PackageManager.PERMISSION_GRANTED) {
+              if (results.isNotEmpty() && results[0] == PackageManager.PERMISSION_GRANTED) {
                 promise.resolve(GRANTED)
               } else {
                 val callbackActivity = args[1] as PermissionAwareActivity

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/websocket/WebSocketModule.kt
@@ -131,7 +131,7 @@ public class WebSocketModule(context: ReactApplicationContext) :
           protocolsValue.append(",")
         }
       }
-      if (protocolsValue.length > 0) {
+      if (protocolsValue.isNotEmpty()) {
         protocolsValue.replace(protocolsValue.length - 1, protocolsValue.length, "")
         builder.addHeader("Sec-WebSocket-Protocol", protocolsValue.toString())
       }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/PointerEvents.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/PointerEvents.kt
@@ -29,13 +29,12 @@ public enum class PointerEvents {
   public companion object {
 
     @JvmStatic
-    public fun parsePointerEvents(pointerEventsStr: String?): PointerEvents {
-      if (pointerEventsStr == null) {
-        return AUTO
-      } else {
-        return PointerEvents.valueOf(pointerEventsStr.uppercase(Locale.US).replace("-", "_"))
-      }
-    }
+    public fun parsePointerEvents(pointerEventsStr: String?): PointerEvents =
+        if (pointerEventsStr == null) {
+          AUTO
+        } else {
+          PointerEvents.valueOf(pointerEventsStr.uppercase(Locale.US).replace("-", "_"))
+        }
 
     @JvmStatic
     public fun canBeTouchTarget(pointerEvents: PointerEvents): Boolean {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutUpdateAnimation.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/layoutanimation/LayoutUpdateAnimation.kt
@@ -32,16 +32,16 @@ internal class LayoutUpdateAnimation : AbstractLayoutAnimation() {
   ): Animation? {
     val animateLocation = view.x.toInt() != x || view.y.toInt() != y
     val animateSize = view.width != width || view.height != height
-    if (!animateLocation && !animateSize) {
-      return null
+    return if (!animateLocation && !animateSize) {
+      null
     } else if (animateLocation && !animateSize && USE_TRANSLATE_ANIMATION) {
       // Use GPU-accelerated animation, however we loose the ability to resume interrupted
       // animation where it was left off. We may be able to listen to animation interruption
       // and set the layout manually in this case, so that next animation kicks off smoothly.
-      return TranslateAnimation(view.x - x, 0f, view.y - y, 0f)
+      TranslateAnimation(view.x - x, 0f, view.y - y, 0f)
     } else {
       // Animation is sub-optimal for perf, but scale transformation can't be use in this case.
-      return PositionAndSizeAnimation(view, x, y, width, height)
+      PositionAndSizeAnimation(view, x, y, width, height)
     }
   }
 


### PR DESCRIPTION
## Summary:

Static code analysis reports several weak warnings, many of which seem to be leftovers after Kotlin migration. This PR addresses quite a few:

- [Return or assignment can be lifted out](https://www.jetbrains.com/help/inspectopedia/LiftReturnOrAssignment.html)
- [Verbose nullability and emptiness check](https://www.jetbrains.com/help/inspectopedia/VerboseNullabilityAndEmptiness.html)
- [Size check can be replaced with 'isNotEmpty()'](https://www.jetbrains.com/help/inspectopedia/ReplaceSizeCheckWithIsNotEmpty.html)

## Changelog:

[INTERNAL] - Kotlin: fix static code analysis weak warnings (3/n)

## Test Plan:

```sh
yarn android
yarn test-android
```