### PR TITLE
Kotlin: fix static code analysis weak warnings (4/n)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.kt
@@ -494,7 +494,7 @@ public class NativeAnimatedModule(reactContext: ReactApplicationContext?) :
   override fun createAnimatedNode(tagDouble: Double, config: ReadableMap) {
     val tag = tagDouble.toInt()
     if (ANIMATED_MODULE_DEBUG) {
-      FLog.d(NAME, "queue createAnimatedNode: ${tag} config: ${config.toHashMap().toString()}")
+      FLog.d(NAME, "queue createAnimatedNode: $tag config: ${config.toHashMap().toString()}")
     }
 
     addOperation(
@@ -503,7 +503,7 @@ public class NativeAnimatedModule(reactContext: ReactApplicationContext?) :
             if (ANIMATED_MODULE_DEBUG) {
               FLog.d(
                   NAME,
-                  ("execute createAnimatedNode: ${tag} config: ${config.toHashMap().toString()}"))
+                  ("execute createAnimatedNode: $tag config: ${config.toHashMap().toString()}"))
             }
             animatedNodesManager.createAnimatedNode(tag, config)
           }
@@ -514,7 +514,7 @@ public class NativeAnimatedModule(reactContext: ReactApplicationContext?) :
     val tag = tagDouble.toInt()
     if (ANIMATED_MODULE_DEBUG) {
       FLog.d(
-          NAME, "queue updateAnimatedNodeConfig: ${tag} config: ${config.toHashMap().toString()}")
+          NAME, "queue updateAnimatedNodeConfig: $tag config: ${config.toHashMap().toString()}")
     }
 
     addOperation(
@@ -523,7 +523,7 @@ public class NativeAnimatedModule(reactContext: ReactApplicationContext?) :
             if (ANIMATED_MODULE_DEBUG) {
               FLog.d(
                   NAME,
-                  ("execute updateAnimatedNodeConfig: ${tag} config: ${config.toHashMap().toString()}"))
+                  ("execute updateAnimatedNodeConfig: $tag config: ${config.toHashMap().toString()}"))
             }
             animatedNodesManager.updateAnimatedNodeConfig(tag, config)
           }
@@ -714,7 +714,7 @@ public class NativeAnimatedModule(reactContext: ReactApplicationContext?) :
             if (ANIMATED_MODULE_DEBUG) {
               FLog.d(
                   NAME,
-                  ("execute connectAnimatedNodes: parent: ${parentNodeTag} child: ${childNodeTag}"))
+                  ("execute connectAnimatedNodes: parent: $parentNodeTag child: $childNodeTag"))
             }
             animatedNodesManager.connectAnimatedNodes(parentNodeTag, childNodeTag)
           }
@@ -734,7 +734,7 @@ public class NativeAnimatedModule(reactContext: ReactApplicationContext?) :
             if (ANIMATED_MODULE_DEBUG) {
               FLog.d(
                   NAME,
-                  ("execute disconnectAnimatedNodes: parent: ${parentNodeTag} child: ${childNodeTag}"))
+                  ("execute disconnectAnimatedNodes: parent: $parentNodeTag child: $childNodeTag"))
             }
             animatedNodesManager.disconnectAnimatedNodes(parentNodeTag, childNodeTag)
           }
@@ -747,7 +747,7 @@ public class NativeAnimatedModule(reactContext: ReactApplicationContext?) :
     if (ANIMATED_MODULE_DEBUG) {
       FLog.d(
           NAME,
-          ("queue connectAnimatedNodeToView: animatedNodeTag: ${animatedNodeTag} viewTag: ${viewTag}"))
+          ("queue connectAnimatedNodeToView: animatedNodeTag: $animatedNodeTag viewTag: $viewTag"))
     }
 
     initializeLifecycleEventListenersForViewTag(viewTag)
@@ -758,7 +758,7 @@ public class NativeAnimatedModule(reactContext: ReactApplicationContext?) :
             if (ANIMATED_MODULE_DEBUG) {
               FLog.d(
                   NAME,
-                  ("execute connectAnimatedNodeToView: animatedNodeTag: ${animatedNodeTag} viewTag: ${viewTag}"))
+                  ("execute connectAnimatedNodeToView: animatedNodeTag: $animatedNodeTag viewTag: $viewTag"))
             }
             animatedNodesManager.connectAnimatedNodeToView(animatedNodeTag, viewTag)
           }
@@ -783,7 +783,7 @@ public class NativeAnimatedModule(reactContext: ReactApplicationContext?) :
             if (ANIMATED_MODULE_DEBUG) {
               FLog.d(
                   NAME,
-                  ("execute disconnectAnimatedNodeFromView: ${animatedNodeTag} viewTag: ${viewTag}"))
+                  ("execute disconnectAnimatedNodeFromView: $animatedNodeTag viewTag: $viewTag"))
             }
             animatedNodesManager.disconnectAnimatedNodeFromView(animatedNodeTag, viewTag)
           }
@@ -816,7 +816,7 @@ public class NativeAnimatedModule(reactContext: ReactApplicationContext?) :
     if (ANIMATED_MODULE_DEBUG) {
       FLog.d(
           NAME,
-          ("queue addAnimatedEventToView: ${viewTag} eventName: ${eventName} eventMapping: ${eventMapping.toHashMap().toString()}"))
+          ("queue addAnimatedEventToView: $viewTag eventName: $eventName eventMapping: ${eventMapping.toHashMap().toString()}"))
     }
 
     initializeLifecycleEventListenersForViewTag(viewTag)
@@ -827,7 +827,7 @@ public class NativeAnimatedModule(reactContext: ReactApplicationContext?) :
             if (ANIMATED_MODULE_DEBUG) {
               FLog.d(
                   NAME,
-                  ("execute addAnimatedEventToView: ${viewTag} eventName: ${eventName} eventMapping: ${eventMapping.toHashMap().toString()}"))
+                  ("execute addAnimatedEventToView: $viewTag eventName: $eventName eventMapping: ${eventMapping.toHashMap().toString()}"))
             }
             animatedNodesManager.addAnimatedEventToView(viewTag, eventName, eventMapping)
           }
@@ -844,7 +844,7 @@ public class NativeAnimatedModule(reactContext: ReactApplicationContext?) :
     if (ANIMATED_MODULE_DEBUG) {
       FLog.d(
           NAME,
-          ("queue removeAnimatedEventFromView: viewTag: ${viewTag} eventName: ${eventName} animatedValueTag: ${animatedValueTag}"))
+          ("queue removeAnimatedEventFromView: viewTag: $viewTag eventName: $eventName animatedValueTag: $animatedValueTag"))
     }
 
     decrementInFlightAnimationsForViewTag(viewTag)
@@ -855,7 +855,7 @@ public class NativeAnimatedModule(reactContext: ReactApplicationContext?) :
             if (ANIMATED_MODULE_DEBUG) {
               FLog.d(
                   NAME,
-                  ("execute removeAnimatedEventFromView: viewTag: ${viewTag} eventName: ${eventName} animatedValueTag: ${animatedValueTag}"))
+                  ("execute removeAnimatedEventFromView: viewTag: $viewTag eventName: $eventName animatedValueTag: $animatedValueTag"))
             }
             animatedNodesManager.removeAnimatedEventFromView(viewTag, eventName, animatedValueTag)
           }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.kt
@@ -494,7 +494,7 @@ public class NativeAnimatedModule(reactContext: ReactApplicationContext?) :
   override fun createAnimatedNode(tagDouble: Double, config: ReadableMap) {
     val tag = tagDouble.toInt()
     if (ANIMATED_MODULE_DEBUG) {
-      FLog.d(NAME, "queue createAnimatedNode: $tag config: ${config.toHashMap().toString()}")
+      FLog.d(NAME, "queue createAnimatedNode: $tag config: ${config.toHashMap()}")
     }
 
     addOperation(
@@ -503,7 +503,7 @@ public class NativeAnimatedModule(reactContext: ReactApplicationContext?) :
             if (ANIMATED_MODULE_DEBUG) {
               FLog.d(
                   NAME,
-                  ("execute createAnimatedNode: $tag config: ${config.toHashMap().toString()}"))
+                  ("execute createAnimatedNode: $tag config: ${config.toHashMap()}"))
             }
             animatedNodesManager.createAnimatedNode(tag, config)
           }
@@ -514,7 +514,7 @@ public class NativeAnimatedModule(reactContext: ReactApplicationContext?) :
     val tag = tagDouble.toInt()
     if (ANIMATED_MODULE_DEBUG) {
       FLog.d(
-          NAME, "queue updateAnimatedNodeConfig: $tag config: ${config.toHashMap().toString()}")
+          NAME, "queue updateAnimatedNodeConfig: $tag config: ${config.toHashMap()}")
     }
 
     addOperation(
@@ -523,7 +523,7 @@ public class NativeAnimatedModule(reactContext: ReactApplicationContext?) :
             if (ANIMATED_MODULE_DEBUG) {
               FLog.d(
                   NAME,
-                  ("execute updateAnimatedNodeConfig: $tag config: ${config.toHashMap().toString()}"))
+                  ("execute updateAnimatedNodeConfig: $tag config: ${config.toHashMap()}"))
             }
             animatedNodesManager.updateAnimatedNodeConfig(tag, config)
           }
@@ -816,7 +816,7 @@ public class NativeAnimatedModule(reactContext: ReactApplicationContext?) :
     if (ANIMATED_MODULE_DEBUG) {
       FLog.d(
           NAME,
-          ("queue addAnimatedEventToView: $viewTag eventName: $eventName eventMapping: ${eventMapping.toHashMap().toString()}"))
+          ("queue addAnimatedEventToView: $viewTag eventName: $eventName eventMapping: ${eventMapping.toHashMap()}"))
     }
 
     initializeLifecycleEventListenersForViewTag(viewTag)
@@ -827,7 +827,7 @@ public class NativeAnimatedModule(reactContext: ReactApplicationContext?) :
             if (ANIMATED_MODULE_DEBUG) {
               FLog.d(
                   NAME,
-                  ("execute addAnimatedEventToView: $viewTag eventName: $eventName eventMapping: ${eventMapping.toHashMap().toString()}"))
+                  ("execute addAnimatedEventToView: $viewTag eventName: $eventName eventMapping: ${eventMapping.toHashMap()}"))
             }
             animatedNodesManager.addAnimatedEventToView(viewTag, eventName, eventMapping)
           }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedNodesManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedNodesManager.kt
@@ -381,7 +381,7 @@ public class NativeAnimatedNodesManager(
           ("connectAnimatedNodeToView: Animated node connected to view [${viewTag}] should be of type ${PropsAnimatedNode::class.java.name}"))
     }
     checkNotNull(reactApplicationContext) {
-      ("connectAnimatedNodeToView: Animated node could not be connected, no ReactApplicationContext: ${viewTag}")
+      ("connectAnimatedNodeToView: Animated node could not be connected, no ReactApplicationContext: $viewTag")
     }
 
     val uiManager = UIManagerHelper.getUIManagerForReactTag(reactApplicationContext, viewTag)
@@ -389,7 +389,7 @@ public class NativeAnimatedNodesManager(
       ReactSoftExceptionLogger.logSoftException(
           TAG,
           ReactNoCrashSoftException(
-              ("connectAnimatedNodeToView: Animated node could not be connected to UIManager - uiManager disappeared for tag: ${viewTag}")))
+              ("connectAnimatedNodeToView: Animated node could not be connected to UIManager - uiManager disappeared for tag: $viewTag")))
       return
     }
 
@@ -751,7 +751,7 @@ public class NativeAnimatedNodesManager(
       val reason = if (cyclesDetected > 0) ("cycles ($cyclesDetected)") else "disconnected regions"
       val ex =
           IllegalStateException(
-              ("Looks like animated nodes graph has ${reason}, there are ${activeNodesCount} but toposort visited only ${updatedNodesCount}"))
+              ("Looks like animated nodes graph has ${reason}, there are $activeNodesCount but toposort visited only $updatedNodesCount"))
       if (eventListenerInitializedForFabric && cyclesDetected == 0) {
         // TODO T71377544: investigate these SoftExceptions and see if we can remove entirely
         // or fix the root cause

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/PackagerStatusCheck.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/PackagerStatusCheck.kt
@@ -76,7 +76,7 @@ internal class PackagerStatusCheck {
                 if (PACKAGER_OK_STATUS != bodyString) {
                   FLog.e(
                       ReactConstants.TAG,
-                      "Got unexpected response from packager when requesting status: ${bodyString}")
+                      "Got unexpected response from packager when requesting status: $bodyString")
                   callback.onPackagerStatusFetched(false)
                   return
                 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/BoxShadow.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/style/BoxShadow.kt
@@ -38,7 +38,7 @@ public data class BoxShadow(
             when (val type = boxShadow.getType("color")) {
               ReadableType.Number -> boxShadow.getInt("color")
               ReadableType.Map -> ColorPropConverter.getColor(boxShadow.getMap("color"), context)
-              else -> throw JSApplicationCausedNativeException("Unsupported color type ${type}")
+              else -> throw JSApplicationCausedNativeException("Unsupported color type $type")
             }
           } else null
       val blurRadius =


### PR DESCRIPTION
## Summary:

Static code analysis reports several weak warnings, many of which seem to be leftovers after Kotlin migration. This PR addresses quite a few:

- [Redundant curly braces in string template](https://www.jetbrains.com/help/inspectopedia/RemoveCurlyBracesFromTemplate.html)
- [Redundant call to toString() in string template](https://www.jetbrains.com/help/inspectopedia/RemoveToStringInStringTemplate.html)

## Changelog:

[INTERNAL] - Kotlin: fix static code analysis weak warnings (4/n)

## Test Plan:

```sh
yarn android
yarn test-android
```