### PR TITLE
Fix deprecated C++ imports

### DIFF
--- a/packages/react-native-test-library/ios/RCTSampleNativeComponentViewManager.mm
+++ b/packages/react-native-test-library/ios/RCTSampleNativeComponentViewManager.mm
@@ -9,6 +9,8 @@
 #import <React/RCTUIManager.h>
 #import <React/RCTViewManager.h>
 
+#import <string>
+
 static UIColor *UIColorFromHexString(const std::string hexString)
 {
   unsigned rgbValue = 0;

--- a/packages/react-native/Libraries/Image/RCTImageURLLoaderWithAttribution.h
+++ b/packages/react-native/Libraries/Image/RCTImageURLLoaderWithAttribution.h
@@ -8,9 +8,10 @@
 #import <React/RCTImageLoaderLoggable.h>
 #import <React/RCTImageLoaderProtocol.h>
 #import <React/RCTImageURLLoader.h>
-
 // TODO (T61325135): Remove C++ checks
 #ifdef __cplusplus
+#import <string>
+
 namespace facebook::react {
 
 struct ImageURLLoaderAttribution {

--- a/packages/react-native/Libraries/Image/RCTImageUtils.mm
+++ b/packages/react-native/Libraries/Image/RCTImageUtils.mm
@@ -7,7 +7,7 @@
 
 #import <React/RCTImageUtils.h>
 
-#import <tgmath.h>
+#import <cmath>
 
 #import <ImageIO/ImageIO.h>
 #import <MobileCoreServices/UTCoreTypes.h>

--- a/packages/react-native/React/Base/RCTUtils.h
+++ b/packages/react-native/React/Base/RCTUtils.h
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#import <tgmath.h>
-
 #import <CoreGraphics/CoreGraphics.h>
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>


### PR DESCRIPTION
Summary:
Correcting some C++ imports that show up when build with Xcode 26:
- Missing `<string>` imports.
- `<tgmath.h>` is a deprecated C++ header file, which in this case can be substituted with `<cmath>`.

## Changelog: [Internal]

[iOS][Fixed] - Fix deprecated C++ imports

Reviewed By: zhenma

Differential Revision: D77192276


