### PR TITLE
Add explicit Build Tools Version to RN Tester Android App Benchmark

### DIFF
--- a/packages/rn-tester/android/app/benchmark/build.gradle.kts
+++ b/packages/rn-tester/android/app/benchmark/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
 android {
   namespace = "com.example.benchmark"
   compileSdk = libs.versions.compileSdk.get().toInt()
+  buildToolsVersion = libs.versions.buildTools.get()
 
   defaultConfig {
     minSdk = libs.versions.minSdk.get().toInt()


### PR DESCRIPTION
## Summary:

After bumping to SDK version 36, the build process for Android was still pulling in SDK v35 unnecessarily. This PR fixes that issue. 

## Changelog:

[ANDROID] [FIXED] - Added explicit build tool version to RN Tester build.gradle to avoid automatic installation of Android SDK Build Tools.

## Test Plan:

Tested in fork pipeline to ensure it's working correctly. 

This is the logs from the pipeline before: 
![image](https://github.com/user-attachments/assets/9dc7f158-8dea-437e-836e-e5f500b3d5ff)

And this is after the fix: 
![image](https://github.com/user-attachments/assets/c6cc1c0a-5823-41cb-ba32-027b69d6eaa6)