### PR TITLE
Remove EventPipeConclusion and RuntimeScheduler::callExpiredTasks

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/EventPipe.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventPipe.h
@@ -25,6 +25,4 @@ using EventPipe = std::function<void(
     ReactEventPriority priority,
     const EventPayload& payload)>;
 
-using EventPipeConclusion = std::function<void(jsi::Runtime& runtime)>;
-
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/EventQueueProcessor.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventQueueProcessor.cpp
@@ -17,11 +17,9 @@ namespace facebook::react {
 
 EventQueueProcessor::EventQueueProcessor(
     EventPipe eventPipe,
-    EventPipeConclusion eventPipeConclusion,
     StatePipe statePipe,
     std::weak_ptr<EventLogger> eventLogger)
     : eventPipe_(std::move(eventPipe)),
-      eventPipeConclusion_(std::move(eventPipeConclusion)),
       statePipe_(std::move(statePipe)),
       eventLogger_(std::move(eventLogger)) {}
 
@@ -106,9 +104,6 @@ void EventQueueProcessor::flushEvents(
       hasContinuousEventStarted_ = true;
     }
   }
-
-  // We only run the "Conclusion" once per event group when batched.
-  eventPipeConclusion_(runtime);
 
   // No need to lock `EventEmitter::DispatchMutex()` here.
   // The mutex protects from a situation when the `instanceHandle` can be

--- a/packages/react-native/ReactCommon/react/renderer/core/EventQueueProcessor.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventQueueProcessor.h
@@ -21,7 +21,6 @@ class EventQueueProcessor {
  public:
   EventQueueProcessor(
       EventPipe eventPipe,
-      EventPipeConclusion eventPipeConclusion,
       StatePipe statePipe,
       std::weak_ptr<EventLogger> eventLogger);
 
@@ -30,7 +29,6 @@ class EventQueueProcessor {
 
  private:
   const EventPipe eventPipe_;
-  const EventPipeConclusion eventPipeConclusion_;
   const StatePipe statePipe_;
   const std::weak_ptr<EventLogger> eventLogger_;
 

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/EventQueueProcessorTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/EventQueueProcessorTest.cpp
@@ -47,12 +47,11 @@ class EventQueueProcessorTest : public testing::Test {
       eventPriorities_.push_back(priority);
     };
 
-    auto dummyEventPipeConclusion = [](jsi::Runtime& runtime) {};
     auto dummyStatePipe = [](const StateUpdate& stateUpdate) {};
     auto mockEventLogger = std::make_shared<MockEventLogger>();
 
     eventProcessor_ = std::make_unique<EventQueueProcessor>(
-        eventPipe, dummyEventPipeConclusion, dummyStatePipe, mockEventLogger);
+        eventPipe, dummyStatePipe, mockEventLogger);
   }
 
   std::unique_ptr<facebook::hermes::HermesRuntime> runtime_;

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.cpp
@@ -97,10 +97,6 @@ void RuntimeScheduler::executeNowOnTheSameThread(RawCallback&& callback) {
   return runtimeSchedulerImpl_->executeNowOnTheSameThread(std::move(callback));
 }
 
-void RuntimeScheduler::callExpiredTasks(jsi::Runtime& runtime) {
-  return runtimeSchedulerImpl_->callExpiredTasks(runtime);
-}
-
 void RuntimeScheduler::scheduleRenderingUpdate(
     SurfaceId surfaceId,
     RuntimeSchedulerRenderingUpdate&& renderingUpdate) {

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler.h
@@ -51,7 +51,6 @@ class RuntimeSchedulerBase {
   virtual bool getShouldYield() noexcept = 0;
   virtual SchedulerPriority getCurrentPriorityLevel() const noexcept = 0;
   virtual HighResTimeStamp now() const noexcept = 0;
-  virtual void callExpiredTasks(jsi::Runtime& runtime) = 0;
   virtual void scheduleRenderingUpdate(
       SurfaceId surfaceId,
       RuntimeSchedulerRenderingUpdate&& renderingUpdate) = 0;
@@ -152,16 +151,6 @@ class RuntimeScheduler final : RuntimeSchedulerBase {
    * Thread synchronization must be enforced externally.
    */
   HighResTimeStamp now() const noexcept override;
-
-  /*
-   * Expired task is a task that should have been already executed. Designed to
-   * be called in the event pipeline after an event is dispatched to React.
-   * React may schedule events with immediate priority which need to be handled
-   * before the next event is sent to React.
-   *
-   * Thread synchronization must be enforced externally.
-   */
-  void callExpiredTasks(jsi::Runtime& runtime) override;
 
   void scheduleRenderingUpdate(
       SurfaceId surfaceId,

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.cpp
@@ -153,32 +153,6 @@ void RuntimeScheduler_Legacy::executeNowOnTheSameThread(
   scheduleWorkLoopIfNecessary();
 }
 
-void RuntimeScheduler_Legacy::callExpiredTasks(jsi::Runtime& runtime) {
-  TraceSection s("RuntimeScheduler::callExpiredTasks");
-
-  auto previousPriority = currentPriority_;
-  try {
-    while (!taskQueue_.empty()) {
-      auto topPriorityTask = taskQueue_.top();
-      auto now = now_();
-      auto didUserCallbackTimeout = topPriorityTask->expirationTime <= now;
-
-      if (!didUserCallbackTimeout) {
-        break;
-      }
-
-      executeTask(runtime, topPriorityTask, didUserCallbackTimeout);
-    }
-  } catch (jsi::JSError& error) {
-    onTaskError_(runtime, error);
-  } catch (std::exception& ex) {
-    jsi::JSError error(runtime, std::string("Non-js exception: ") + ex.what());
-    onTaskError_(runtime, error);
-  }
-
-  currentPriority_ = previousPriority;
-}
-
 void RuntimeScheduler_Legacy::scheduleRenderingUpdate(
     SurfaceId /*surfaceId*/,
     RuntimeSchedulerRenderingUpdate&& renderingUpdate) {

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Legacy.h
@@ -110,16 +110,6 @@ class RuntimeScheduler_Legacy final : public RuntimeSchedulerBase {
    */
   HighResTimeStamp now() const noexcept override;
 
-  /*
-   * Expired task is a task that should have been already executed. Designed to
-   * be called in the event pipeline after an event is dispatched to React.
-   * React may schedule events with immediate priority which need to be handled
-   * before the next event is sent to React.
-   *
-   * Thread synchronization must be enforced externally.
-   */
-  void callExpiredTasks(jsi::Runtime& runtime) override;
-
   void scheduleRenderingUpdate(
       SurfaceId surfaceId,
       RuntimeSchedulerRenderingUpdate&& renderingUpdate) override;

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
@@ -180,10 +180,6 @@ void RuntimeScheduler_Modern::executeNowOnTheSameThread(
   }
 }
 
-void RuntimeScheduler_Modern::callExpiredTasks(jsi::Runtime& runtime) {
-  // No-op in the event loop implementation.
-}
-
 void RuntimeScheduler_Modern::scheduleRenderingUpdate(
     SurfaceId surfaceId,
     RuntimeSchedulerRenderingUpdate&& renderingUpdate) {

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.h
@@ -119,18 +119,6 @@ class RuntimeScheduler_Modern final : public RuntimeSchedulerBase {
    */
   HighResTimeStamp now() const noexcept override;
 
-  /*
-   * Expired task is a task that should have been already executed. Designed to
-   * be called in the event pipeline after an event is dispatched to React.
-   * React may schedule events with immediate priority which need to be handled
-   * before the next event is sent to React.
-   *
-   * Thread synchronization must be enforced externally.
-   *
-   * TODO remove when we add support for microtasks
-   */
-  void callExpiredTasks(jsi::Runtime& runtime) override;
-
   /**
    * Schedules a function that notifies or applies UI changes in the host
    * platform, to be executed during the "Update the rendering" step of the

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -75,11 +75,6 @@ Scheduler::Scheduler(
         runtime);
   };
 
-  auto eventPipeConclusion = [runtimeScheduler =
-                                  runtimeScheduler_](jsi::Runtime& runtime) {
-    runtimeScheduler->callExpiredTasks(runtime);
-  };
-
   auto statePipe = [uiManager](const StateUpdate& stateUpdate) {
     uiManager->updateState(stateUpdate);
   };
@@ -89,8 +84,7 @@ Scheduler::Scheduler(
   // Creating an `EventDispatcher` instance inside the already allocated
   // container (inside the optional).
   eventDispatcher_->emplace(
-      EventQueueProcessor(
-          eventPipe, eventPipeConclusion, statePipe, eventPerformanceLogger_),
+      EventQueueProcessor(eventPipe, statePipe, eventPerformanceLogger_),
       std::move(eventBeat),
       statePipe,
       eventPerformanceLogger_);

--- a/private/cxx-public-api/ReactNativeCPP.api
+++ b/private/cxx-public-api/ReactNativeCPP.api
@@ -27676,7 +27676,6 @@ using EventPipe = std::function<void(
     const std::string& type,
     ReactEventPriority priority,
     const EventPayload& payload)>;
-using EventPipeConclusion = std::function<void(jsi::Runtime& runtime)>;
 } // namespace facebook::react
 
 /// @src {packages/react-native/ReactCommon/react/renderer/core/EventQueue.h}:
@@ -27710,7 +27709,6 @@ class EventQueueProcessor {
  public:
   EventQueueProcessor(
       EventPipe eventPipe,
-      EventPipeConclusion eventPipeConclusion,
       StatePipe statePipe,
       std::weak_ptr<EventLogger> eventLogger);
   void flushEvents(jsi::Runtime& runtime, std::vector<RawEvent>&& events) const;
@@ -35944,7 +35942,6 @@ class RuntimeSchedulerBase {
   virtual bool getShouldYield() noexcept = 0;
   virtual SchedulerPriority getCurrentPriorityLevel() const noexcept = 0;
   virtual HighResTimeStamp now() const noexcept = 0;
-  virtual void callExpiredTasks(jsi::Runtime& runtime) = 0;
   virtual void scheduleRenderingUpdate(
       SurfaceId surfaceId,
       RuntimeSchedulerRenderingUpdate&& renderingUpdate) = 0;
@@ -35988,7 +35985,6 @@ class RuntimeScheduler final : RuntimeSchedulerBase {
   bool getShouldYield() noexcept override;
   SchedulerPriority getCurrentPriorityLevel() const noexcept override;
   HighResTimeStamp now() const noexcept override;
-  void callExpiredTasks(jsi::Runtime& runtime) override;
   void scheduleRenderingUpdate(
       SurfaceId surfaceId,
       RuntimeSchedulerRenderingUpdate&& renderingUpdate) override;
@@ -36087,7 +36083,6 @@ class RuntimeScheduler_Legacy final : public RuntimeSchedulerBase {
   bool getShouldYield() noexcept override;
   SchedulerPriority getCurrentPriorityLevel() const noexcept override;
   HighResTimeStamp now() const noexcept override;
-  void callExpiredTasks(jsi::Runtime& runtime) override;
   void scheduleRenderingUpdate(
       SurfaceId surfaceId,
       RuntimeSchedulerRenderingUpdate&& renderingUpdate) override;
@@ -36151,7 +36146,6 @@ class RuntimeScheduler_Modern final : public RuntimeSchedulerBase {
   bool getShouldYield() noexcept override;
   SchedulerPriority getCurrentPriorityLevel() const noexcept override;
   HighResTimeStamp now() const noexcept override;
-  void callExpiredTasks(jsi::Runtime& runtime) override;
   void scheduleRenderingUpdate(
       SurfaceId surfaceId,
       RuntimeSchedulerRenderingUpdate&& renderingUpdate) override;


### PR DESCRIPTION
Summary:
Changelog: [internal]

Before the event loop, we had some functionality in the event system to run "expired" tasks after dispatching batched events, providing a functionality similar to microtasks in the Event Loop. After the migration to the Event Loop, we no longer need this mechanism in the new architecture, so we can clean up the related code.

This diff does that.

IMPORTANT: this assumes there's nothing using `Scheduler` that's not on bridgeless, which we need to validate.

Differential Revision: D77155461
