### PR TITLE
Avoid copying strings when serializing TraceEvent / lock only on buffer operations

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -132,7 +132,13 @@ class PerformanceTracer {
   PerformanceTracer& operator=(const PerformanceTracer&) = delete;
   ~PerformanceTracer() = default;
 
-  folly::dynamic serializeTraceEvent(const TraceEvent& event) const;
+  /**
+   * Serialize a TraceEvent into a folly::dynamic object.
+   * \param event rvalue reference to the TraceEvent object.
+   * \return folly::dynamic object that represents a serialized into JSON Trace
+   * Event for CDP.
+   */
+  folly::dynamic serializeTraceEvent(TraceEvent&& event) const;
 
   uint64_t processId_;
 


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

Mainly, 2 changes:
1. `PerformanceTracer::serializeTraceEvent(const TraceEvent& event)` -> `PerformanceTracer::serializeTraceEvent(TraceEvent&& event)` for less copies, actually move strings from the `TraceEvent` into the serialized `folly:object`.
2. When collecting events from the buffer, only lock when accessing buffer, not when serializing.

Differential Revision: D77164969
