### PR TITLE
Ship the new React-Core-prebuilt.podspec in the package.json

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -88,6 +88,7 @@
     "Libraries",
     "LICENSE",
     "React-Core.podspec",
+    "React-Core-prebuilt.podspec",
     "react-native.config.js",
     "React.podspec",
     "React",

--- a/packages/react-native/scripts/cocoapods/rncore.rb
+++ b/packages/react-native/scripts/cocoapods/rncore.rb
@@ -131,8 +131,8 @@ class ReactNativeCoreUtils
         artefact_name = "reactnative-core-debug.tar.gz"
         xml_url = "https://central.sonatype.com/repository/maven-snapshots/com/facebook/react/#{artefact_coordinate}/#{version}-SNAPSHOT/maven-metadata.xml"
 
-        response = Net::HTTP.get(URI(xml_url))
-        if response.kind_of? Net::HTTPSuccess
+        response = Net::HTTP.get_response(URI(xml_url))
+        if response.is_a?(Net::HTTPSuccess)
           xml = REXML::Document.new(response)
           timestamp = xml.elements['metadata/versioning/snapshot/timestamp'].text
           build_number = xml.elements['metadata/versioning/snapshot/buildNumber'].text

--- a/packages/react-native/scripts/cocoapods/rndependencies.rb
+++ b/packages/react-native/scripts/cocoapods/rndependencies.rb
@@ -178,9 +178,8 @@ class ReactNativeDependenciesUtils
         artifact_name = "reactnative-dependencies-debug.tar.gz"
         xml_url = "https://central.sonatype.com/repository/maven-snapshots/com/facebook/react/#{artifact_coordinate}/#{version}-SNAPSHOT/maven-metadata.xml"
 
-
-        response = Net::HTTP.get(URI(xml_url))
-        if response.kind_of? Net::HTTPSuccess
+        response = Net::HTTP.get_response(URI(xml_url))
+        if response.is_a?(Net::HTTPSuccess)
           xml = REXML::Document.new(response)
           timestamp = xml.elements['metadata/versioning/snapshot/timestamp'].text
           build_number = xml.elements['metadata/versioning/snapshot/buildNumber'].text

--- a/packages/react-native/sdks/hermes-engine/hermes-utils.rb
+++ b/packages/react-native/sdks/hermes-engine/hermes-utils.rb
@@ -234,8 +234,8 @@ def nightly_tarball_url(version)
   artifact_name = "hermes-ios-debug.tar.gz"
   xml_url = "https://central.sonatype.com/repository/maven-snapshots/com/facebook/react/#{artifact_coordinate}/#{version}-SNAPSHOT/maven-metadata.xml"
 
-  response = Net::HTTP.get(URI(xml_url))
-  if response.kind_of? Net::HTTPSuccess
+  response = Net::HTTP.get_response(URI(xml_url))
+  if response.is_a?(Net::HTTPSuccess)
     xml = REXML::Document.new(response)
     timestamp = xml.elements['metadata/versioning/snapshot/timestamp'].text
     build_number = xml.elements['metadata/versioning/snapshot/buildNumber'].text


### PR DESCRIPTION
Summary:
It is currently not possible to use prebuilds, because we are missing the `React-Core-prebuilt.podspec` from the npm package we publish.

This change should fix it.

## Changelog:
[iOS][Added] - Ship the `React-Core-prebuilt.podspec` in the package.json

Differential Revision: D77223271


