### PR TITLE
Add basic steps in CI (#49642)

### DIFF
--- a/.github/actions/run-fantom-tests/action.yml
+++ b/.github/actions/run-fantom-tests/action.yml
@@ -1,0 +1,83 @@
+name: Run Fantom Tests
+inputs:
+  release-type:
+    required: true
+    description: The type of release we are building. It could be nightly, release or dry-run
+  gradle-cache-encryption-key:
+    description: "The encryption key needed to store the Gradle Configuration cache"
+
+runs:
+  using: composite
+  steps:
+    - name: Install dependencies
+      shell: bash
+      run: |
+        sudo apt update
+        sudo apt install -y git cmake openssl libssl-dev clang
+    - name: Setup git safe folders
+      shell: bash
+      run: git config --global --add safe.directory '*'
+    - name: Setup node.js
+      uses: ./.github/actions/setup-node
+    - name: Install node dependencies
+      uses: ./.github/actions/yarn-install
+    - name: Setup gradle
+      uses: ./.github/actions/setup-gradle
+      with:
+        cache-read-only: "false"
+        cache-encryption-key: ${{ inputs.gradle-cache-encryption-key }}
+    - name: Restore Fantom ccache
+      uses: actions/cache/restore@v4
+      with:
+        path: /github/home/.cache/ccache
+        key: v2-ccache-fantom-${{ github.job }}-${{ github.ref }}-${{ hashFiles(
+            'packages/react-native/ReactAndroid/**/*.cpp',
+            'packages/react-native/ReactAndroid/**/*.h',
+            'packages/react-native/ReactAndroid/**/CMakeLists.txt',
+            'packages/react-native/ReactCommon/**/*.cpp',
+            'packages/react-native/ReactCommon/**/*.h',
+            'packages/react-native/ReactCommon/**/CMakeLists.txt',
+            'private/react-native-fantom/tester/**/*.cpp',
+            'private/react-native-fantom/tester/**/*.h',
+            'private/react-native-fantom/tester/**/CMakeLists.txt'
+          ) }}
+        restore-keys: |
+          v2-ccache-fantom-${{ github.job }}-${{ github.ref }}-
+          v2-ccache-fantom-${{ github.job }}-
+          v2-ccache-fantom-
+    - name: Show ccache stats
+      shell: bash
+      run: ccache -s -v
+    - name: Run Fantom Tests
+      shell: bash
+      run: yarn fantom
+      env:
+        CC: clang
+        CXX: clang++
+    - name: Save Fantom ccache
+      if: ${{ github.ref == 'refs/heads/main' || contains(github.ref, '-stable') }}
+      uses: actions/cache/save@v4
+      with:
+        path: /github/home/.cache/ccache
+        key: v2-ccache-fantom-${{ github.job }}-${{ github.ref }}-${{ hashFiles(
+            'packages/react-native/ReactAndroid/**/*.cpp',
+            'packages/react-native/ReactAndroid/**/*.h',
+            'packages/react-native/ReactAndroid/**/CMakeLists.txt',
+            'packages/react-native/ReactCommon/**/*.cpp',
+            'packages/react-native/ReactCommon/**/*.h',
+            'packages/react-native/ReactCommon/**/CMakeLists.txt',
+            'private/react-native-fantom/tester/**/*.cpp',
+            'private/react-native-fantom/tester/**/*.h',
+            'private/react-native-fantom/tester/**/CMakeLists.txt'
+          ) }}
+    - name: Show ccache stats
+      shell: bash
+      run: ccache -s -v
+    - name: Upload test results
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v4.3.4
+      with:
+        name: run-fantom-tests-results
+        compression-level: 1
+        path: |
+          private/react-native-fantom/build/reports

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -370,6 +370,25 @@ jobs:
           hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
 
+  run_fantom_tests:
+    runs-on: 8-core-ubuntu
+    needs: [set_release_type]
+    container:
+      image: reactnativecommunity/react-native-android:latest
+      env:
+        TERM: "dumb"
+        GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+        ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}
+        ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build and Test Fantom
+        uses: ./.github/actions/run-fantom-tests
+        with:
+          release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
+          gradle-cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
+
   build_hermesc_windows:
     runs-on: windows-2025
     needs: prepare_hermes_workspace

--- a/packages/react-native/ReactCommon/cxxreact/TraceSection.h
+++ b/packages/react-native/ReactCommon/cxxreact/TraceSection.h
@@ -54,8 +54,8 @@ struct TraceSection {
  public:
   template <typename... ConvertsToStringPiece>
   explicit TraceSection(
-      const __unused char* name,
-      __unused ConvertsToStringPiece&&... args) {
+      [[maybe_unused]] const char* name,
+      [[maybe_unused]] ConvertsToStringPiece&&... args) {
     TRACE_EVENT_BEGIN("react-native", perfetto::DynamicString{name}, args...);
   }
 
@@ -82,8 +82,8 @@ struct DummyTraceSection {
  public:
   template <typename... ConvertsToStringPiece>
   explicit DummyTraceSection(
-      const __unused char* name,
-      __unused ConvertsToStringPiece&&... args) {}
+      [[maybe_unused]] const char* name,
+      [[maybe_unused]] ConvertsToStringPiece&&... args) {}
 };
 using TraceSectionUnwrapped = DummyTraceSection;
 #endif

--- a/private/react-native-fantom/tester/CMakeLists.txt
+++ b/private/react-native-fantom/tester/CMakeLists.txt
@@ -5,6 +5,11 @@
 
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
+if(UNIX AND NOT APPLE)
+  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+  set(CMAKE_C_LINK_FLAGS "${CMAKE_C_LINK_FLAGS} -latomic")
+  set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -latomic")
+endif()
 
 project(fantom_tester)
 


### PR DESCRIPTION
Summary:

This diff prepares the RN CI to build and run Fantom Tests

## Changelog:
[Internal] - Fantom in RN CLI

Differential Revision: D70097944
