### PR TITLE
Fix jumping talkback triggering scroll when reaching a view with accessibilityOrder

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3659,6 +3659,7 @@ public class com/facebook/react/uimanager/ReactAccessibilityDelegate : androidx/
 	public static final field TOP_ACCESSIBILITY_ACTION_EVENT Ljava/lang/String;
 	public static final field sActionIdMap Ljava/util/HashMap;
 	public fun <init> (Landroid/view/View;ZI)V
+	public fun cleanUp ()V
 	public static fun createNodeInfoFromView (Landroid/view/View;)Landroidx/core/view/accessibility/AccessibilityNodeInfoCompat;
 	public fun getAccessibilityNodeProvider (Landroid/view/View;)Landroidx/core/view/accessibility/AccessibilityNodeProviderCompat;
 	protected fun getHostView ()Landroid/view/View;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -19,6 +19,7 @@ import android.view.accessibility.AccessibilityEvent;
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.view.AccessibilityDelegateCompat;
 import androidx.core.view.ViewCompat;
 import com.facebook.common.logging.FLog;
 import com.facebook.react.R;
@@ -185,6 +186,16 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
     @Nullable OnFocusChangeListener focusChangeListener = view.getOnFocusChangeListener();
     if (focusChangeListener instanceof BaseVMFocusChangeListener) {
       ((BaseVMFocusChangeListener) focusChangeListener).detach(view);
+    }
+
+    AccessibilityDelegateCompat axDelegate = ViewCompat.getAccessibilityDelegate(view);
+
+    if (axDelegate instanceof ReactAccessibilityDelegate) {
+      ((ReactAccessibilityDelegate) axDelegate).cleanUp();
+    }
+
+    if (view instanceof ViewGroup) {
+      ((ViewGroup) view).setOnHierarchyChangeListener(null);
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.java
@@ -261,10 +261,13 @@ public class ReactAccessibilityDelegate extends ExploreByTouchHelper {
 
   @Override
   public void onInitializeAccessibilityNodeInfo(View host, AccessibilityNodeInfoCompat info) {
+    super.onInitializeAccessibilityNodeInfo(host, info);
     // If we set an accessibility order then all the focusing logic should go through our custom
     // virtual view tree hierarchy and ignore the default path
     ReadableArray axOrderIds = (ReadableArray) mView.getTag(R.id.accessibility_order);
     if (axOrderIds != null && axOrderIds.size() != 0) {
+      info.setContentDescription("");
+      info.setFocusable(false);
 
       AccessibilityManager am =
           (AccessibilityManager) host.getContext().getSystemService(Context.ACCESSIBILITY_SERVICE);
@@ -299,7 +302,6 @@ public class ReactAccessibilityDelegate extends ExploreByTouchHelper {
       return;
     }
 
-    super.onInitializeAccessibilityNodeInfo(host, info);
     populateAccessibilityNodeInfo(host, info);
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAxOrderHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAxOrderHelper.kt
@@ -10,7 +10,6 @@ package com.facebook.react.uimanager
 import android.graphics.Rect
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import com.facebook.react.R
 import com.facebook.react.bridge.ReadableArray
 
@@ -76,10 +75,6 @@ private object ReactAxOrderHelper {
         }
       }
 
-      if (!isIncluded && !isContained && parent != view && view !is TextView) {
-        view.importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
-      }
-
       // Don't traverse the children of a nested accessibility order
       if (view is ViewGroup) {
         val axChildren: ArrayList<View> = getAxChildren(view)
@@ -99,6 +94,13 @@ private object ReactAxOrderHelper {
             traverseAndBuildAxOrder(parent, axChildren[i], null)
           }
         }
+      }
+
+      if (!isIncluded && !isContained && parent != view) {
+        if (view.getTag(R.id.original_focusability) == null) {
+          view.setTag(R.id.original_focusability, view.isFocusable)
+        }
+        view.isFocusable = false
       }
     }
 
@@ -158,5 +160,22 @@ private object ReactAxOrderHelper {
       host.addChildrenForAccessibility(axChildren)
     }
     return axChildren
+  }
+
+  @JvmStatic
+  public fun restoreSubtreeFocusability(view: View) {
+    val originalFocusability = view.getTag(R.id.original_focusability)
+    if (originalFocusability is Boolean) {
+      view.isFocusable = originalFocusability
+    }
+
+    if (view is ViewGroup) {
+      for (i in 0 until view.childCount) {
+        val child = view.getChildAt(i)
+        if (child != null) {
+          restoreSubtreeFocusability(child)
+        }
+      }
+    }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values/ids.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/views/uimanager/values/ids.xml
@@ -15,6 +15,9 @@
   <!-- tag is used to store the current state of the accessibility order tree-->
   <item type="id" name="accessibility_order_dirty"/>
 
+  <!-- tag is used to store the original focusability value of a view within the accessibility order tree if it was changed-->
+  <item type="id" name="original_focusability"/>
+
   <!-- tag is used to store the nativeID tag -->
   <item type="id" name="view_tag_instance_handle"/>
 


### PR DESCRIPTION
Summary:
Not calling `super.onInitializeAccessibilityNodeInfo` on the host view with accessibilityOrder prevents setting proper dimensions for the node that backs the view which leads TalkBack to trigger scrolling when under a ScrollVIew.

We still need the host's node to not be accessible so we still set it to not be focusable and not have a content description since this should be handled by the virtual views

Reviewed By: joevilches

Differential Revision: D77180494


