### PR TITLE
Fix downloading nightly prebuilds

### DIFF
--- a/packages/react-native/scripts/cocoapods/rncore.rb
+++ b/packages/react-native/scripts/cocoapods/rncore.rb
@@ -133,7 +133,7 @@ class ReactNativeCoreUtils
 
         response = Net::HTTP.get_response(URI(xml_url))
         if response.is_a?(Net::HTTPSuccess)
-          xml = REXML::Document.new(response)
+          xml = REXML::Document.new(response.body)
           timestamp = xml.elements['metadata/versioning/snapshot/timestamp'].text
           build_number = xml.elements['metadata/versioning/snapshot/buildNumber'].text
           full_version = "#{version}-#{timestamp}-#{build_number}"

--- a/packages/react-native/scripts/cocoapods/rndependencies.rb
+++ b/packages/react-native/scripts/cocoapods/rndependencies.rb
@@ -180,7 +180,7 @@ class ReactNativeDependenciesUtils
 
         response = Net::HTTP.get_response(URI(xml_url))
         if response.is_a?(Net::HTTPSuccess)
-          xml = REXML::Document.new(response)
+          xml = REXML::Document.new(response.body)
           timestamp = xml.elements['metadata/versioning/snapshot/timestamp'].text
           build_number = xml.elements['metadata/versioning/snapshot/buildNumber'].text
           full_version = "#{version}-#{timestamp}-#{build_number}"

--- a/packages/react-native/sdks/hermes-engine/hermes-utils.rb
+++ b/packages/react-native/sdks/hermes-engine/hermes-utils.rb
@@ -236,7 +236,7 @@ def nightly_tarball_url(version)
 
   response = Net::HTTP.get_response(URI(xml_url))
   if response.is_a?(Net::HTTPSuccess)
-    xml = REXML::Document.new(response)
+    xml = REXML::Document.new(response.body)
     timestamp = xml.elements['metadata/versioning/snapshot/timestamp'].text
     build_number = xml.elements['metadata/versioning/snapshot/buildNumber'].text
     full_version = "#{version}-#{timestamp}-#{build_number}"


### PR DESCRIPTION
Summary:
When working on [c1bf39bfdf](https://github.com/facebook/react-native/commit/c1bf39bfdfaa0381be3a20d0d89ce159e482afe1) I forgot to add a `.body` to extract the body from the response.

As a result, we can't install prebuilds in a nightly.

This change fixes this.

## Changelog:
[Internal] -

Differential Revision: D77241914


