### PR TITLE
Enable experimental Flow 'match' syntax for react-native-github/packages/react-native/src/private/components/virtualview/

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -47,6 +47,8 @@ packages/react-native/flow/
 
 [options]
 enums=true
+experimental.pattern_matching=true
+experimental.pattern_matching.includes=<PROJECT_ROOT>/packages/react-native/src/private/components/virtualview/
 casting_syntax=both
 component_syntax=true
 

--- a/packages/react-native/src/private/components/virtualview/VirtualView.js
+++ b/packages/react-native/src/private/components/virtualview/VirtualView.js
@@ -83,26 +83,23 @@ function createVirtualView(initialState: State): VirtualViewComponent {
               thresholdRect: event.nativeEvent.thresholdRect,
             });
 
-      switch (mode) {
-        case VirtualViewMode.Visible: {
+      match (mode) {
+        VirtualViewMode.Visible => {
           setState(NotHidden);
           emitModeChange?.();
-          break;
         }
-        case VirtualViewMode.Prerender: {
+        VirtualViewMode.Prerender => {
           startTransition(() => {
             setState(NotHidden);
             emitModeChange?.();
           });
-          break;
         }
-        case VirtualViewMode.Hidden: {
+        VirtualViewMode.Hidden => {
           const {height} = event.nativeEvent.targetRect;
           startTransition(() => {
             setState(height as HiddenHeight);
             emitModeChange?.();
           });
-          break;
         }
       }
     };


### PR DESCRIPTION
Summary:
Enable experimental Flow 'match' syntax for `react-native-github/packages/react-native/src/private/components/virtualview/` and adopt in one case to see if there are any issues.

Changelog: [Internal]

Differential Revision: D77250963


