### PR TITLE
Add inline toDynamic function for ImageSource

### DIFF
--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -532,7 +532,7 @@ folly::dynamic ImagePropNativeComponentViewProps::getDiffProps(
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
   if (thumbImage != oldProps->thumbImage) {
-    result[\\"thumbImage\\"] = thumbImage.toDynamic();
+    result[\\"thumbImage\\"] = toDynamic(thumbImage);
   }
   return result;
 }
@@ -740,7 +740,7 @@ folly::dynamic MultiNativePropNativeComponentViewProps::getDiffProps(
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
   if (thumbImage != oldProps->thumbImage) {
-    result[\\"thumbImage\\"] = thumbImage.toDynamic();
+    result[\\"thumbImage\\"] = toDynamic(thumbImage);
   }
     
   if (color != oldProps->color) {

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -532,7 +532,7 @@ folly::dynamic ImagePropNativeComponentViewProps::getDiffProps(
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
   if (thumbImage != oldProps->thumbImage) {
-    result[\\"thumbImage\\"] = thumbImage.toDynamic();
+    result[\\"thumbImage\\"] = toDynamic(thumbImage);
   }
   return result;
 }
@@ -740,7 +740,7 @@ folly::dynamic MultiNativePropNativeComponentViewProps::getDiffProps(
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
   if (thumbImage != oldProps->thumbImage) {
-    result[\\"thumbImage\\"] = thumbImage.toDynamic();
+    result[\\"thumbImage\\"] = toDynamic(thumbImage);
   }
     
   if (color != oldProps->color) {

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
@@ -105,7 +105,7 @@ function generatePropsDiffString(
             case 'ImageSourcePrimitive':
               return `
   if (${prop.name} != oldProps->${prop.name}) {
-    result["${prop.name}"] = ${prop.name}.toDynamic();
+    result["${prop.name}"] = toDynamic(${prop.name});
   }`;
             case 'ImageRequestPrimitive':
               // Shouldn't be used in props

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -852,7 +852,7 @@ folly::dynamic ImagePropNativeComponentProps::getDiffProps(
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
   if (thumbImage != oldProps->thumbImage) {
-    result[\\"thumbImage\\"] = thumbImage.toDynamic();
+    result[\\"thumbImage\\"] = toDynamic(thumbImage);
   }
   return result;
 }
@@ -1152,7 +1152,7 @@ folly::dynamic ImageColorPropNativeComponentProps::getDiffProps(
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
   if (thumbImage != oldProps->thumbImage) {
-    result[\\"thumbImage\\"] = thumbImage.toDynamic();
+    result[\\"thumbImage\\"] = toDynamic(thumbImage);
   }
     
   if (color != oldProps->color) {

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
@@ -201,17 +201,17 @@ folly::dynamic ImageProps::getDiffProps(const Props* prevProps) const {
   if (sources != oldProps->sources) {
     auto sourcesArray = folly::dynamic::array();
     for (const auto& source : sources) {
-      sourcesArray.push_back(source.toDynamic());
+      sourcesArray.push_back(toDynamic(source));
     }
     result["source"] = sourcesArray;
   }
 
   if (defaultSource != oldProps->defaultSource) {
-    result["defaultSource"] = defaultSource.toDynamic();
+    result["defaultSource"] = toDynamic(defaultSource);
   }
 
   if (loadingIndicatorSource != oldProps->loadingIndicatorSource) {
-    result["loadingIndicatorSource"] = loadingIndicatorSource.toDynamic();
+    result["loadingIndicatorSource"] = toDynamic(loadingIndicatorSource);
   }
 
   if (resizeMode != oldProps->resizeMode) {

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/primitives.h
@@ -92,6 +92,12 @@ class ImageSource {
 #endif
 };
 
+#ifdef RN_SERIALIZABLE_STATE
+inline folly::dynamic toDynamic(const ImageSource& imageSource) {
+  return imageSource.toDynamic();
+}
+#endif
+
 using ImageSources = std::vector<ImageSource>;
 
 enum class ImageResizeMode {


### PR DESCRIPTION
Summary:
For array props conversion following later in this stack, each type should have a toDynamic conversion available that can be called upon to convert all supported types to a `folly::dynamic` result.

This diff adds the toDynamic conversion function for `ImageSource`

 Changelog: [Internal]

Differential Revision: D77234063


