### PR TITLE
Add codegen for PointPrimitive prop type diffing

### DIFF
--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -532,7 +532,7 @@ folly::dynamic ImagePropNativeComponentViewProps::getDiffProps(
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
   if (thumbImage != oldProps->thumbImage) {
-    result[\\"thumbImage\\"] = thumbImage.toDynamic();
+    result[\\"thumbImage\\"] = toDynamic(thumbImage);
   }
   return result;
 }
@@ -740,7 +740,7 @@ folly::dynamic MultiNativePropNativeComponentViewProps::getDiffProps(
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
   if (thumbImage != oldProps->thumbImage) {
-    result[\\"thumbImage\\"] = thumbImage.toDynamic();
+    result[\\"thumbImage\\"] = toDynamic(thumbImage);
   }
     
   if (color != oldProps->color) {

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -752,10 +752,7 @@ folly::dynamic MultiNativePropNativeComponentViewProps::getDiffProps(
   }
     
   if (point != oldProps->point) {
-    folly::dynamic pointResult = folly::dynamic::object();
-    pointResult[\\"x\\"] = point.x;
-    pointResult[\\"y\\"] = point.y;
-    result[\\"point\\"] = pointResult;
+    result[\\"point\\"] = toDynamic(point);
   }
   return result;
 }
@@ -901,10 +898,7 @@ folly::dynamic PointPropNativeComponentViewProps::getDiffProps(
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
   if (startPoint != oldProps->startPoint) {
-    folly::dynamic pointResult = folly::dynamic::object();
-    pointResult[\\"x\\"] = startPoint.x;
-    pointResult[\\"y\\"] = startPoint.y;
-    result[\\"startPoint\\"] = pointResult;
+    result[\\"startPoint\\"] = toDynamic(startPoint);
   }
   return result;
 }

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -532,7 +532,7 @@ folly::dynamic ImagePropNativeComponentViewProps::getDiffProps(
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
   if (thumbImage != oldProps->thumbImage) {
-    result[\\"thumbImage\\"] = thumbImage.toDynamic();
+    result[\\"thumbImage\\"] = toDynamic(thumbImage);
   }
   return result;
 }
@@ -740,7 +740,7 @@ folly::dynamic MultiNativePropNativeComponentViewProps::getDiffProps(
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
   if (thumbImage != oldProps->thumbImage) {
-    result[\\"thumbImage\\"] = thumbImage.toDynamic();
+    result[\\"thumbImage\\"] = toDynamic(thumbImage);
   }
     
   if (color != oldProps->color) {

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -752,10 +752,7 @@ folly::dynamic MultiNativePropNativeComponentViewProps::getDiffProps(
   }
     
   if (point != oldProps->point) {
-    folly::dynamic pointResult = folly::dynamic::object();
-    pointResult[\\"x\\"] = point.x;
-    pointResult[\\"y\\"] = point.y;
-    result[\\"point\\"] = pointResult;
+    result[\\"point\\"] = toDynamic(point);
   }
   return result;
 }
@@ -901,10 +898,7 @@ folly::dynamic PointPropNativeComponentViewProps::getDiffProps(
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
   if (startPoint != oldProps->startPoint) {
-    folly::dynamic pointResult = folly::dynamic::object();
-    pointResult[\\"x\\"] = startPoint.x;
-    pointResult[\\"y\\"] = startPoint.y;
-    result[\\"startPoint\\"] = pointResult;
+    result[\\"startPoint\\"] = toDynamic(startPoint);
   }
   return result;
 }

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
@@ -115,10 +115,7 @@ function generatePropsDiffString(
             case 'PointPrimitive':
               return `
   if (${prop.name} != oldProps->${prop.name}) {
-    folly::dynamic pointResult = folly::dynamic::object();
-    pointResult["x"] = ${prop.name}.x;
-    pointResult["y"] = ${prop.name}.y;
-    result["${prop.name}"] = pointResult;
+    result["${prop.name}"] = toDynamic(${prop.name});
   }`;
             case 'EdgeInsetsPrimitive':
             case 'DimensionPrimitive':

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
@@ -105,7 +105,7 @@ function generatePropsDiffString(
             case 'ImageSourcePrimitive':
               return `
   if (${prop.name} != oldProps->${prop.name}) {
-    result["${prop.name}"] = ${prop.name}.toDynamic();
+    result["${prop.name}"] = toDynamic(${prop.name});
   }`;
             case 'ImageRequestPrimitive':
               // Shouldn't be used in props

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -852,7 +852,7 @@ folly::dynamic ImagePropNativeComponentProps::getDiffProps(
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
   if (thumbImage != oldProps->thumbImage) {
-    result[\\"thumbImage\\"] = thumbImage.toDynamic();
+    result[\\"thumbImage\\"] = toDynamic(thumbImage);
   }
   return result;
 }
@@ -1152,7 +1152,7 @@ folly::dynamic ImageColorPropNativeComponentProps::getDiffProps(
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
   if (thumbImage != oldProps->thumbImage) {
-    result[\\"thumbImage\\"] = thumbImage.toDynamic();
+    result[\\"thumbImage\\"] = toDynamic(thumbImage);
   }
     
   if (color != oldProps->color) {

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -1164,10 +1164,7 @@ folly::dynamic ImageColorPropNativeComponentProps::getDiffProps(
   }
     
   if (point != oldProps->point) {
-    folly::dynamic pointResult = folly::dynamic::object();
-    pointResult[\\"x\\"] = point.x;
-    pointResult[\\"y\\"] = point.y;
-    result[\\"point\\"] = pointResult;
+    result[\\"point\\"] = toDynamic(point);
   }
   return result;
 }
@@ -1309,10 +1306,7 @@ folly::dynamic PointPropNativeComponentProps::getDiffProps(
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
   if (startPoint != oldProps->startPoint) {
-    folly::dynamic pointResult = folly::dynamic::object();
-    pointResult[\\"x\\"] = startPoint.x;
-    pointResult[\\"y\\"] = startPoint.y;
-    result[\\"startPoint\\"] = pointResult;
+    result[\\"startPoint\\"] = toDynamic(startPoint);
   }
   return result;
 }

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
@@ -201,17 +201,17 @@ folly::dynamic ImageProps::getDiffProps(const Props* prevProps) const {
   if (sources != oldProps->sources) {
     auto sourcesArray = folly::dynamic::array();
     for (const auto& source : sources) {
-      sourcesArray.push_back(source.toDynamic());
+      sourcesArray.push_back(toDynamic(source));
     }
     result["source"] = sourcesArray;
   }
 
   if (defaultSource != oldProps->defaultSource) {
-    result["defaultSource"] = defaultSource.toDynamic();
+    result["defaultSource"] = toDynamic(defaultSource);
   }
 
   if (loadingIndicatorSource != oldProps->loadingIndicatorSource) {
-    result["loadingIndicatorSource"] = loadingIndicatorSource.toDynamic();
+    result["loadingIndicatorSource"] = toDynamic(loadingIndicatorSource);
   }
 
   if (resizeMode != oldProps->resizeMode) {

--- a/packages/react-native/ReactCommon/react/renderer/core/graphicsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/graphicsConversions.h
@@ -60,6 +60,15 @@ inline std::string toString(const SharedColor& value) {
 
 #pragma mark - Geometry
 
+#ifdef RN_SERIALIZABLE_STATE
+inline folly::dynamic toDynamic(const Point& point) {
+  folly::dynamic pointResult = folly::dynamic::object();
+  pointResult["x"] = point.x;
+  pointResult["y"] = point.y;
+  return pointResult;
+}
+#endif
+
 inline void fromRawValue(
     const PropsParserContext& context,
     const RawValue& value,

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/primitives.h
@@ -92,6 +92,12 @@ class ImageSource {
 #endif
 };
 
+#ifdef RN_SERIALIZABLE_STATE
+inline folly::dynamic toDynamic(const ImageSource& imageSource) {
+  return imageSource.toDynamic();
+}
+#endif
+
 using ImageSources = std::vector<ImageSource>;
 
 enum class ImageResizeMode {


### PR DESCRIPTION
Summary:
Add prop diffing codegen for `PointPrimitive` prop type by adding a `toDynamic` conversion for the struct and the prop diffing conditional result update.

The addition of the `toDynamic` function will allow for converting the type when used in array and object types.

Changelog: [Internal]

Differential Revision: D77234062


