### PR TITLE
Add codegen for DimensionType diffing

### DIFF
--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -306,7 +306,13 @@ folly::dynamic EnumPropNativeComponentViewProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (alignment != oldProps->alignment) {
+    result[\\"alignment\\"] = toDynamic(alignment);
+  }
     
+  if (intervals != oldProps->intervals) {
+    result[\\"intervals\\"] = toDynamic(intervals);
+  }
   return result;
 }
 #endif

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -213,6 +213,9 @@ folly::dynamic DimensionPropNativeComponentViewProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (marginBack != oldProps->marginBack) {
+    result[\\"marginBack\\"] = toDynamic(marginBack);
+  }
   return result;
 }
 #endif

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
@@ -16,6 +16,7 @@ Object {
 #include <cinttypes>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/core/propsConversions.h>
 #include <react/renderer/graphics/Color.h>
 #include <react/renderer/graphics/Point.h>
@@ -265,6 +266,7 @@ Object {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/graphicsConversions.h>
 #include <yoga/Yoga.h>
 
 namespace facebook::react {

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
@@ -360,6 +360,12 @@ static inline std::string toString(const EnumPropNativeComponentViewAlignment &v
     case EnumPropNativeComponentViewAlignment::BottomRight: return \\"bottom-right\\";
   }
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const EnumPropNativeComponentViewAlignment &value) {
+  return toString(value);
+}
+#endif
 enum class EnumPropNativeComponentViewIntervals { Intervals0 = 0, Intervals15 = 15, Intervals30 = 30, Intervals60 = 60 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, EnumPropNativeComponentViewIntervals &result) {
@@ -390,6 +396,17 @@ static inline std::string toString(const EnumPropNativeComponentViewIntervals &v
     case EnumPropNativeComponentViewIntervals::Intervals60: return \\"60\\";
   }
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const EnumPropNativeComponentViewIntervals &value) {
+  switch (value) {
+    case EnumPropNativeComponentViewIntervals::Intervals0: return 0;
+    case EnumPropNativeComponentViewIntervals::Intervals15: return 15;
+    case EnumPropNativeComponentViewIntervals::Intervals30: return 30;
+    case EnumPropNativeComponentViewIntervals::Intervals60: return 60;
+  }
+}
+#endif
 
 class EnumPropNativeComponentViewProps final : public ViewProps {
  public:
@@ -798,6 +815,12 @@ static inline std::string toString(const ObjectPropsNativeComponentStringEnumPro
     case ObjectPropsNativeComponentStringEnumProp::Large: return \\"large\\";
   }
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsNativeComponentStringEnumProp &value) {
+  return toString(value);
+}
+#endif
 enum class ObjectPropsNativeComponentIntEnumProp { IntEnumProp0 = 0, IntEnumProp1 = 1 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsNativeComponentIntEnumProp &result) {
@@ -820,6 +843,15 @@ static inline std::string toString(const ObjectPropsNativeComponentIntEnumProp &
     case ObjectPropsNativeComponentIntEnumProp::IntEnumProp1: return \\"1\\";
   }
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsNativeComponentIntEnumProp &value) {
+  switch (value) {
+    case ObjectPropsNativeComponentIntEnumProp::IntEnumProp0: return 0;
+    case ObjectPropsNativeComponentIntEnumProp::IntEnumProp1: return 1;
+  }
+}
+#endif
 struct ObjectPropsNativeComponentObjectPropStruct {
   std::string stringProp{\\"\\"};
   bool booleanProp{false};

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -306,7 +306,13 @@ folly::dynamic EnumPropNativeComponentViewProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (alignment != oldProps->alignment) {
+    result[\\"alignment\\"] = toDynamic(alignment);
+  }
     
+  if (intervals != oldProps->intervals) {
+    result[\\"intervals\\"] = toDynamic(intervals);
+  }
   return result;
 }
 #endif

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -213,6 +213,9 @@ folly::dynamic DimensionPropNativeComponentViewProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (marginBack != oldProps->marginBack) {
+    result[\\"marginBack\\"] = toDynamic(marginBack);
+  }
   return result;
 }
 #endif

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
@@ -16,6 +16,7 @@ Object {
 #include <cinttypes>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/core/propsConversions.h>
 #include <react/renderer/graphics/Color.h>
 #include <react/renderer/graphics/Point.h>
@@ -265,6 +266,7 @@ Object {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/graphicsConversions.h>
 #include <yoga/Yoga.h>
 
 namespace facebook::react {

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
@@ -360,6 +360,12 @@ static inline std::string toString(const EnumPropNativeComponentViewAlignment &v
     case EnumPropNativeComponentViewAlignment::BottomRight: return \\"bottom-right\\";
   }
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const EnumPropNativeComponentViewAlignment &value) {
+  return toString(value);
+}
+#endif
 enum class EnumPropNativeComponentViewIntervals { Intervals0 = 0, Intervals15 = 15, Intervals30 = 30, Intervals60 = 60 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, EnumPropNativeComponentViewIntervals &result) {
@@ -390,6 +396,17 @@ static inline std::string toString(const EnumPropNativeComponentViewIntervals &v
     case EnumPropNativeComponentViewIntervals::Intervals60: return \\"60\\";
   }
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const EnumPropNativeComponentViewIntervals &value) {
+  switch (value) {
+    case EnumPropNativeComponentViewIntervals::Intervals0: return 0;
+    case EnumPropNativeComponentViewIntervals::Intervals15: return 15;
+    case EnumPropNativeComponentViewIntervals::Intervals30: return 30;
+    case EnumPropNativeComponentViewIntervals::Intervals60: return 60;
+  }
+}
+#endif
 
 class EnumPropNativeComponentViewProps final : public ViewProps {
  public:
@@ -798,6 +815,12 @@ static inline std::string toString(const ObjectPropsNativeComponentStringEnumPro
     case ObjectPropsNativeComponentStringEnumProp::Large: return \\"large\\";
   }
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsNativeComponentStringEnumProp &value) {
+  return toString(value);
+}
+#endif
 enum class ObjectPropsNativeComponentIntEnumProp { IntEnumProp0 = 0, IntEnumProp1 = 1 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsNativeComponentIntEnumProp &result) {
@@ -820,6 +843,15 @@ static inline std::string toString(const ObjectPropsNativeComponentIntEnumProp &
     case ObjectPropsNativeComponentIntEnumProp::IntEnumProp1: return \\"1\\";
   }
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsNativeComponentIntEnumProp &value) {
+  switch (value) {
+    case ObjectPropsNativeComponentIntEnumProp::IntEnumProp0: return 0;
+    case ObjectPropsNativeComponentIntEnumProp::IntEnumProp1: return 1;
+  }
+}
+#endif
 struct ObjectPropsNativeComponentObjectPropStruct {
   std::string stringProp{\\"\\"};
   bool booleanProp{false};

--- a/packages/react-native-codegen/src/generators/components/ComponentsGeneratorUtils.js
+++ b/packages/react-native-codegen/src/generators/components/ComponentsGeneratorUtils.js
@@ -245,6 +245,7 @@ function getLocalImports(
         return;
       case 'DimensionPrimitive':
         imports.add('#include <yoga/Yoga.h>');
+        imports.add('#include <react/renderer/core/graphicsConversions.h>');
         return;
       default:
         (name: empty);

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
@@ -123,8 +123,10 @@ function generatePropsDiffString(
     result["${prop.name}"] = toDynamic(${prop.name});
   }`;
             case 'DimensionPrimitive':
-              // TODO: Implement diffProps for complex types
-              return '';
+              return `
+  if (${prop.name} != oldProps->${prop.name}) {
+    result["${prop.name}"] = toDynamic(${prop.name});
+  }`;
             default:
               (typeAnnotation.name: empty);
               throw new Error('Received unknown ReservedPropTypeAnnotation');

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
@@ -131,8 +131,17 @@ function generatePropsDiffString(
           }
         case 'ArrayTypeAnnotation':
         case 'ObjectTypeAnnotation':
+          return '';
         case 'StringEnumTypeAnnotation':
+          return `
+  if (${prop.name} != oldProps->${prop.name}) {
+    result["${prop.name}"] = toDynamic(${prop.name});
+  }`;
         case 'Int32EnumTypeAnnotation':
+          return `
+  if (${prop.name} != oldProps->${prop.name}) {
+    result["${prop.name}"] = toDynamic(${prop.name});
+  }`;
         case 'MixedTypeAnnotation':
         default:
           // TODO: Implement diffProps for complex types

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -349,6 +349,9 @@ folly::dynamic DimensionPropNativeComponentProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (marginBack != oldProps->marginBack) {
+    result[\\"marginBack\\"] = toDynamic(marginBack);
+  }
   return result;
 }
 #endif

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -949,6 +949,9 @@ folly::dynamic Int32EnumPropsNativeComponentProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (maxInterval != oldProps->maxInterval) {
+    result[\\"maxInterval\\"] = toDynamic(maxInterval);
+  }
   return result;
 }
 #endif
@@ -1357,6 +1360,9 @@ folly::dynamic StringEnumPropsNativeComponentProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (alignment != oldProps->alignment) {
+    result[\\"alignment\\"] = toDynamic(alignment);
+  }
   return result;
 }
 #endif

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
@@ -16,6 +16,7 @@ Map {
 #include <cinttypes>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/core/propsConversions.h>
 #include <react/renderer/graphics/Color.h>
 #include <react/renderer/graphics/Point.h>
@@ -469,6 +470,7 @@ Map {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/graphicsConversions.h>
 #include <yoga/Yoga.h>
 
 namespace facebook::react {

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
@@ -933,6 +933,16 @@ static inline std::string toString(const Int32EnumPropsNativeComponentMaxInterva
   }
 }
 
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const Int32EnumPropsNativeComponentMaxInterval &value) {
+  switch (value) {
+    case Int32EnumPropsNativeComponentMaxInterval::MaxInterval0: return 0;
+    case Int32EnumPropsNativeComponentMaxInterval::MaxInterval1: return 1;
+    case Int32EnumPropsNativeComponentMaxInterval::MaxInterval2: return 2;
+  }
+}
+#endif
+
 class Int32EnumPropsNativeComponentProps final : public ViewProps {
  public:
   Int32EnumPropsNativeComponentProps() = default;
@@ -1182,6 +1192,12 @@ static inline std::string toString(const ObjectPropsStringEnumProp &value) {
     case ObjectPropsStringEnumProp::Option1: return \\"option1\\";
   }
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsStringEnumProp &value) {
+  return toString(value);
+}
+#endif
 enum class ObjectPropsIntEnumProp { IntEnumProp0 = 0 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsIntEnumProp &result) {
@@ -1200,6 +1216,14 @@ static inline std::string toString(const ObjectPropsIntEnumProp &value) {
     case ObjectPropsIntEnumProp::IntEnumProp0: return \\"0\\";
   }
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsIntEnumProp &value) {
+  switch (value) {
+    case ObjectPropsIntEnumProp::IntEnumProp0: return 0;
+  }
+}
+#endif
 struct ObjectPropsObjectPropObjectArrayPropStruct {
   std::vector<std::string> array{};
 };
@@ -1495,6 +1519,12 @@ static inline std::string toString(const StringEnumPropsNativeComponentAlignment
     case StringEnumPropsNativeComponentAlignment::BottomRight: return \\"bottom-right\\";
   }
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const StringEnumPropsNativeComponentAlignment &value) {
+  return toString(value);
+}
+#endif
 
 class StringEnumPropsNativeComponentProps final : public ViewProps {
  public:

--- a/packages/react-native/ReactCommon/react/renderer/core/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/core/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(react_renderer_core
         react_renderer_mapbuffer
         react_renderer_runtimescheduler
         react_utils
-        runtimeexecutor)
+        runtimeexecutor
+        yoga)
 target_compile_reactnative_options(react_renderer_core PRIVATE)
 target_compile_options(react_renderer_core PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/core/graphicsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/graphicsConversions.h
@@ -24,6 +24,10 @@
 #include <react/renderer/graphics/RectangleEdges.h>
 #include <react/renderer/graphics/Size.h>
 
+#ifdef RN_SERIALIZABLE_STATE
+#include <yoga/Yoga.h>
+#endif
+
 namespace facebook::react {
 
 #pragma mark - Color
@@ -61,6 +65,27 @@ inline std::string toString(const SharedColor& value) {
 #pragma mark - Geometry
 
 #ifdef RN_SERIALIZABLE_STATE
+inline folly::dynamic toDynamic(const YGValue& dimension) {
+  switch (dimension.unit) {
+    case YGUnitUndefined:
+      return nullptr;
+    case YGUnitAuto:
+      return "auto";
+    case YGUnitMaxContent:
+      return "max-content";
+    case YGUnitFitContent:
+      return "fit-content";
+    case YGUnitStretch:
+      return "stretch";
+    case YGUnitPoint:
+      return dimension.value;
+    case YGUnitPercent:
+      return std::format("{}%", dimension.value);
+  }
+
+  return nullptr;
+}
+
 inline folly::dynamic toDynamic(const Point& point) {
   folly::dynamic pointResult = folly::dynamic::object();
   pointResult["x"] = point.x;


### PR DESCRIPTION
Summary:
Codegen supports `DimensionType` props which represents a YGValue. This diff adds a conversion to `folly::dynamic` supporting all the existing value types `YGValue` can represent.

This completes codegen support for all allowed `ReservedPropTypeAnnotation` prop types.

Changelog: [Internal]

Differential Revision: D77234061
