### PR TITLE
Add codegen for ArrayType diffing

### DIFF
--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -51,18 +51,57 @@ folly::dynamic ArrayPropsNativeComponentViewProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (names != oldProps->names) {
+    result[\\"names\\"] = toDynamic(names);
+  }
     
+  if (disableds != oldProps->disableds) {
+    result[\\"disableds\\"] = toDynamic(disableds);
+  }
     
+  if (progress != oldProps->progress) {
+    result[\\"progress\\"] = toDynamic(progress);
+  }
     
+  if (radii != oldProps->radii) {
+    result[\\"radii\\"] = toDynamic(radii);
+  }
     
+  if (colors != oldProps->colors) {
+    result[\\"colors\\"] = toDynamic(colors);
+  }
     
+  if (srcs != oldProps->srcs) {
+    result[\\"srcs\\"] = toDynamic(srcs);
+  }
     
+  if (points != oldProps->points) {
+    result[\\"points\\"] = toDynamic(points);
+  }
     
+  if (edgeInsets != oldProps->edgeInsets) {
+    result[\\"edgeInsets\\"] = toDynamic(edgeInsets);
+  }
     
+  if (dimensions != oldProps->dimensions) {
+    result[\\"dimensions\\"] = toDynamic(dimensions);
+  }
     
+  if (sizes != oldProps->sizes) {
+    result[\\"sizes\\"] = toDynamic(sizes);
+  }
     
+  if (object != oldProps->object) {
+    result[\\"object\\"] = toDynamic(object);
+  }
     
+  if (arrayOfObjects != oldProps->arrayOfObjects) {
+    result[\\"arrayOfObjects\\"] = toDynamic(arrayOfObjects);
+  }
     
+  if (arrayOfMixed != oldProps->arrayOfMixed) {
+    result[\\"arrayOfMixed\\"] = toDynamic(arrayOfMixed);
+  }
   return result;
 }
 #endif

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -858,8 +858,17 @@ folly::dynamic ObjectPropsNativeComponentProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (objectProp != oldProps->objectProp) {
+    result[\\"objectProp\\"] = toDynamic(objectProp);
+  }
     
+  if (objectArrayProp != oldProps->objectArrayProp) {
+    result[\\"objectArrayProp\\"] = toDynamic(objectArrayProp);
+  }
     
+  if (objectPrimitiveRequiredProp != oldProps->objectPrimitiveRequiredProp) {
+    result[\\"objectPrimitiveRequiredProp\\"] = toDynamic(objectPrimitiveRequiredProp);
+  }
   return result;
 }
 #endif

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -306,7 +306,13 @@ folly::dynamic EnumPropNativeComponentViewProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (alignment != oldProps->alignment) {
+    result[\\"alignment\\"] = toDynamic(alignment);
+  }
     
+  if (intervals != oldProps->intervals) {
+    result[\\"intervals\\"] = toDynamic(intervals);
+  }
   return result;
 }
 #endif

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -213,6 +213,9 @@ folly::dynamic DimensionPropNativeComponentViewProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (marginBack != oldProps->marginBack) {
+    result[\\"marginBack\\"] = toDynamic(marginBack);
+  }
   return result;
 }
 #endif

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
@@ -88,6 +88,16 @@ static inline std::string toString(const ArrayPropsNativeComponentViewSizesMaskW
 }
 struct ArrayPropsNativeComponentViewObjectStruct {
   std::string prop{};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ArrayPropsNativeComponentViewObjectStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    result[\\"prop\\"] = prop;
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentViewObjectStruct &result) {
@@ -103,6 +113,12 @@ static inline std::string toString(const ArrayPropsNativeComponentViewObjectStru
   return \\"[Object ArrayPropsNativeComponentViewObjectStruct]\\";
 }
 
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ArrayPropsNativeComponentViewObjectStruct &value) {
+  return value.toDynamic();
+}
+#endif
+
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, std::vector<ArrayPropsNativeComponentViewObjectStruct> &result) {
   auto items = (std::vector<RawValue>)value;
   for (const auto &item : items) {
@@ -116,6 +132,17 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 struct ArrayPropsNativeComponentViewArrayOfObjectsStruct {
   Float prop1{0.0};
   int prop2{0};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ArrayPropsNativeComponentViewArrayOfObjectsStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    result[\\"prop1\\"] = prop1;
+    result[\\"prop2\\"] = prop2;
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentViewArrayOfObjectsStruct &result) {
@@ -134,6 +161,12 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 static inline std::string toString(const ArrayPropsNativeComponentViewArrayOfObjectsStruct &value) {
   return \\"[Object ArrayPropsNativeComponentViewArrayOfObjectsStruct]\\";
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ArrayPropsNativeComponentViewArrayOfObjectsStruct &value) {
+  return value.toDynamic();
+}
+#endif
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, std::vector<ArrayPropsNativeComponentViewArrayOfObjectsStruct> &result) {
   auto items = (std::vector<RawValue>)value;
@@ -861,6 +894,21 @@ struct ObjectPropsNativeComponentObjectPropStruct {
   int intProp{0};
   ObjectPropsNativeComponentStringEnumProp stringEnumProp{ObjectPropsNativeComponentStringEnumProp::Small};
   ObjectPropsNativeComponentIntEnumProp intEnumProp{ObjectPropsNativeComponentIntEnumProp::IntEnumProp0};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ObjectPropsNativeComponentObjectPropStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    result[\\"stringProp\\"] = stringProp;
+    result[\\"booleanProp\\"] = booleanProp;
+    result[\\"floatProp\\"] = floatProp;
+    result[\\"intProp\\"] = intProp;
+    result[\\"stringEnumProp\\"] = ::facebook::react::toDynamic(stringEnumProp);
+    result[\\"intEnumProp\\"] = ::facebook::react::toDynamic(intEnumProp);
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsNativeComponentObjectPropStruct &result) {
@@ -896,8 +944,24 @@ static inline std::string toString(const ObjectPropsNativeComponentObjectPropStr
   return \\"[Object ObjectPropsNativeComponentObjectPropStruct]\\";
 }
 
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsNativeComponentObjectPropStruct &value) {
+  return value.toDynamic();
+}
+#endif
+
 struct ObjectPropsNativeComponentObjectArrayPropStruct {
   std::vector<std::string> array{};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ObjectPropsNativeComponentObjectArrayPropStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsNativeComponentObjectArrayPropStruct &result) {
@@ -913,10 +977,28 @@ static inline std::string toString(const ObjectPropsNativeComponentObjectArrayPr
   return \\"[Object ObjectPropsNativeComponentObjectArrayPropStruct]\\";
 }
 
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsNativeComponentObjectArrayPropStruct &value) {
+  return value.toDynamic();
+}
+#endif
+
 struct ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct {
   ImageSource image{};
   SharedColor color{};
   Point point{};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    result[\\"image\\"] = ::facebook::react::toDynamic(image);
+    result[\\"color\\"] = ::facebook::react::toDynamic(color);
+    result[\\"point\\"] = ::facebook::react::toDynamic(point);
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct &result) {
@@ -939,6 +1021,12 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 static inline std::string toString(const ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct &value) {
   return \\"[Object ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct]\\";
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct &value) {
+  return value.toDynamic();
+}
+#endif
 class ObjectPropsNativeComponentProps final : public ViewProps {
  public:
   ObjectPropsNativeComponentProps() = default;

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
@@ -16,6 +16,7 @@ Object {
 #include <cinttypes>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/core/propsConversions.h>
 #include <react/renderer/graphics/Color.h>
 #include <react/renderer/graphics/Point.h>
@@ -265,6 +266,7 @@ Object {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/graphicsConversions.h>
 #include <yoga/Yoga.h>
 
 namespace facebook::react {

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
@@ -958,7 +958,7 @@ struct ObjectPropsNativeComponentObjectArrayPropStruct {
 
   folly::dynamic toDynamic() const {
     folly::dynamic result = folly::dynamic::object();
-    
+    result[\\"array\\"] = ::facebook::react::toDynamic(array);
     return result;
   }
 #endif

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
@@ -360,6 +360,12 @@ static inline std::string toString(const EnumPropNativeComponentViewAlignment &v
     case EnumPropNativeComponentViewAlignment::BottomRight: return \\"bottom-right\\";
   }
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const EnumPropNativeComponentViewAlignment &value) {
+  return toString(value);
+}
+#endif
 enum class EnumPropNativeComponentViewIntervals { Intervals0 = 0, Intervals15 = 15, Intervals30 = 30, Intervals60 = 60 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, EnumPropNativeComponentViewIntervals &result) {
@@ -390,6 +396,17 @@ static inline std::string toString(const EnumPropNativeComponentViewIntervals &v
     case EnumPropNativeComponentViewIntervals::Intervals60: return \\"60\\";
   }
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const EnumPropNativeComponentViewIntervals &value) {
+  switch (value) {
+    case EnumPropNativeComponentViewIntervals::Intervals0: return 0;
+    case EnumPropNativeComponentViewIntervals::Intervals15: return 15;
+    case EnumPropNativeComponentViewIntervals::Intervals30: return 30;
+    case EnumPropNativeComponentViewIntervals::Intervals60: return 60;
+  }
+}
+#endif
 
 class EnumPropNativeComponentViewProps final : public ViewProps {
  public:
@@ -798,6 +815,12 @@ static inline std::string toString(const ObjectPropsNativeComponentStringEnumPro
     case ObjectPropsNativeComponentStringEnumProp::Large: return \\"large\\";
   }
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsNativeComponentStringEnumProp &value) {
+  return toString(value);
+}
+#endif
 enum class ObjectPropsNativeComponentIntEnumProp { IntEnumProp0 = 0, IntEnumProp1 = 1 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsNativeComponentIntEnumProp &result) {
@@ -820,6 +843,15 @@ static inline std::string toString(const ObjectPropsNativeComponentIntEnumProp &
     case ObjectPropsNativeComponentIntEnumProp::IntEnumProp1: return \\"1\\";
   }
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsNativeComponentIntEnumProp &value) {
+  switch (value) {
+    case ObjectPropsNativeComponentIntEnumProp::IntEnumProp0: return 0;
+    case ObjectPropsNativeComponentIntEnumProp::IntEnumProp1: return 1;
+  }
+}
+#endif
 struct ObjectPropsNativeComponentObjectPropStruct {
   std::string stringProp{\\"\\"};
   bool booleanProp{false};

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -51,18 +51,57 @@ folly::dynamic ArrayPropsNativeComponentViewProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (names != oldProps->names) {
+    result[\\"names\\"] = toDynamic(names);
+  }
     
+  if (disableds != oldProps->disableds) {
+    result[\\"disableds\\"] = toDynamic(disableds);
+  }
     
+  if (progress != oldProps->progress) {
+    result[\\"progress\\"] = toDynamic(progress);
+  }
     
+  if (radii != oldProps->radii) {
+    result[\\"radii\\"] = toDynamic(radii);
+  }
     
+  if (colors != oldProps->colors) {
+    result[\\"colors\\"] = toDynamic(colors);
+  }
     
+  if (srcs != oldProps->srcs) {
+    result[\\"srcs\\"] = toDynamic(srcs);
+  }
     
+  if (points != oldProps->points) {
+    result[\\"points\\"] = toDynamic(points);
+  }
     
+  if (edgeInsets != oldProps->edgeInsets) {
+    result[\\"edgeInsets\\"] = toDynamic(edgeInsets);
+  }
     
+  if (dimensions != oldProps->dimensions) {
+    result[\\"dimensions\\"] = toDynamic(dimensions);
+  }
     
+  if (sizes != oldProps->sizes) {
+    result[\\"sizes\\"] = toDynamic(sizes);
+  }
     
+  if (object != oldProps->object) {
+    result[\\"object\\"] = toDynamic(object);
+  }
     
+  if (arrayOfObjects != oldProps->arrayOfObjects) {
+    result[\\"arrayOfObjects\\"] = toDynamic(arrayOfObjects);
+  }
     
+  if (arrayOfMixed != oldProps->arrayOfMixed) {
+    result[\\"arrayOfMixed\\"] = toDynamic(arrayOfMixed);
+  }
   return result;
 }
 #endif

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -858,8 +858,17 @@ folly::dynamic ObjectPropsNativeComponentProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (objectProp != oldProps->objectProp) {
+    result[\\"objectProp\\"] = toDynamic(objectProp);
+  }
     
+  if (objectArrayProp != oldProps->objectArrayProp) {
+    result[\\"objectArrayProp\\"] = toDynamic(objectArrayProp);
+  }
     
+  if (objectPrimitiveRequiredProp != oldProps->objectPrimitiveRequiredProp) {
+    result[\\"objectPrimitiveRequiredProp\\"] = toDynamic(objectPrimitiveRequiredProp);
+  }
   return result;
 }
 #endif

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -306,7 +306,13 @@ folly::dynamic EnumPropNativeComponentViewProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (alignment != oldProps->alignment) {
+    result[\\"alignment\\"] = toDynamic(alignment);
+  }
     
+  if (intervals != oldProps->intervals) {
+    result[\\"intervals\\"] = toDynamic(intervals);
+  }
   return result;
 }
 #endif

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -213,6 +213,9 @@ folly::dynamic DimensionPropNativeComponentViewProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (marginBack != oldProps->marginBack) {
+    result[\\"marginBack\\"] = toDynamic(marginBack);
+  }
   return result;
 }
 #endif

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
@@ -88,6 +88,16 @@ static inline std::string toString(const ArrayPropsNativeComponentViewSizesMaskW
 }
 struct ArrayPropsNativeComponentViewObjectStruct {
   std::string prop{};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ArrayPropsNativeComponentViewObjectStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    result[\\"prop\\"] = prop;
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentViewObjectStruct &result) {
@@ -103,6 +113,12 @@ static inline std::string toString(const ArrayPropsNativeComponentViewObjectStru
   return \\"[Object ArrayPropsNativeComponentViewObjectStruct]\\";
 }
 
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ArrayPropsNativeComponentViewObjectStruct &value) {
+  return value.toDynamic();
+}
+#endif
+
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, std::vector<ArrayPropsNativeComponentViewObjectStruct> &result) {
   auto items = (std::vector<RawValue>)value;
   for (const auto &item : items) {
@@ -116,6 +132,17 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 struct ArrayPropsNativeComponentViewArrayOfObjectsStruct {
   Float prop1{0.0};
   int prop2{0};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ArrayPropsNativeComponentViewArrayOfObjectsStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    result[\\"prop1\\"] = prop1;
+    result[\\"prop2\\"] = prop2;
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentViewArrayOfObjectsStruct &result) {
@@ -134,6 +161,12 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 static inline std::string toString(const ArrayPropsNativeComponentViewArrayOfObjectsStruct &value) {
   return \\"[Object ArrayPropsNativeComponentViewArrayOfObjectsStruct]\\";
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ArrayPropsNativeComponentViewArrayOfObjectsStruct &value) {
+  return value.toDynamic();
+}
+#endif
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, std::vector<ArrayPropsNativeComponentViewArrayOfObjectsStruct> &result) {
   auto items = (std::vector<RawValue>)value;
@@ -861,6 +894,21 @@ struct ObjectPropsNativeComponentObjectPropStruct {
   int intProp{0};
   ObjectPropsNativeComponentStringEnumProp stringEnumProp{ObjectPropsNativeComponentStringEnumProp::Small};
   ObjectPropsNativeComponentIntEnumProp intEnumProp{ObjectPropsNativeComponentIntEnumProp::IntEnumProp0};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ObjectPropsNativeComponentObjectPropStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    result[\\"stringProp\\"] = stringProp;
+    result[\\"booleanProp\\"] = booleanProp;
+    result[\\"floatProp\\"] = floatProp;
+    result[\\"intProp\\"] = intProp;
+    result[\\"stringEnumProp\\"] = ::facebook::react::toDynamic(stringEnumProp);
+    result[\\"intEnumProp\\"] = ::facebook::react::toDynamic(intEnumProp);
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsNativeComponentObjectPropStruct &result) {
@@ -896,8 +944,24 @@ static inline std::string toString(const ObjectPropsNativeComponentObjectPropStr
   return \\"[Object ObjectPropsNativeComponentObjectPropStruct]\\";
 }
 
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsNativeComponentObjectPropStruct &value) {
+  return value.toDynamic();
+}
+#endif
+
 struct ObjectPropsNativeComponentObjectArrayPropStruct {
   std::vector<std::string> array{};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ObjectPropsNativeComponentObjectArrayPropStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsNativeComponentObjectArrayPropStruct &result) {
@@ -913,10 +977,28 @@ static inline std::string toString(const ObjectPropsNativeComponentObjectArrayPr
   return \\"[Object ObjectPropsNativeComponentObjectArrayPropStruct]\\";
 }
 
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsNativeComponentObjectArrayPropStruct &value) {
+  return value.toDynamic();
+}
+#endif
+
 struct ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct {
   ImageSource image{};
   SharedColor color{};
   Point point{};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    result[\\"image\\"] = ::facebook::react::toDynamic(image);
+    result[\\"color\\"] = ::facebook::react::toDynamic(color);
+    result[\\"point\\"] = ::facebook::react::toDynamic(point);
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct &result) {
@@ -939,6 +1021,12 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 static inline std::string toString(const ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct &value) {
   return \\"[Object ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct]\\";
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct &value) {
+  return value.toDynamic();
+}
+#endif
 class ObjectPropsNativeComponentProps final : public ViewProps {
  public:
   ObjectPropsNativeComponentProps() = default;

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
@@ -16,6 +16,7 @@ Object {
 #include <cinttypes>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/core/propsConversions.h>
 #include <react/renderer/graphics/Color.h>
 #include <react/renderer/graphics/Point.h>
@@ -265,6 +266,7 @@ Object {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/graphicsConversions.h>
 #include <yoga/Yoga.h>
 
 namespace facebook::react {

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
@@ -958,7 +958,7 @@ struct ObjectPropsNativeComponentObjectArrayPropStruct {
 
   folly::dynamic toDynamic() const {
     folly::dynamic result = folly::dynamic::object();
-    
+    result[\\"array\\"] = ::facebook::react::toDynamic(array);
     return result;
   }
 #endif

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
@@ -360,6 +360,12 @@ static inline std::string toString(const EnumPropNativeComponentViewAlignment &v
     case EnumPropNativeComponentViewAlignment::BottomRight: return \\"bottom-right\\";
   }
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const EnumPropNativeComponentViewAlignment &value) {
+  return toString(value);
+}
+#endif
 enum class EnumPropNativeComponentViewIntervals { Intervals0 = 0, Intervals15 = 15, Intervals30 = 30, Intervals60 = 60 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, EnumPropNativeComponentViewIntervals &result) {
@@ -390,6 +396,17 @@ static inline std::string toString(const EnumPropNativeComponentViewIntervals &v
     case EnumPropNativeComponentViewIntervals::Intervals60: return \\"60\\";
   }
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const EnumPropNativeComponentViewIntervals &value) {
+  switch (value) {
+    case EnumPropNativeComponentViewIntervals::Intervals0: return 0;
+    case EnumPropNativeComponentViewIntervals::Intervals15: return 15;
+    case EnumPropNativeComponentViewIntervals::Intervals30: return 30;
+    case EnumPropNativeComponentViewIntervals::Intervals60: return 60;
+  }
+}
+#endif
 
 class EnumPropNativeComponentViewProps final : public ViewProps {
  public:
@@ -798,6 +815,12 @@ static inline std::string toString(const ObjectPropsNativeComponentStringEnumPro
     case ObjectPropsNativeComponentStringEnumProp::Large: return \\"large\\";
   }
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsNativeComponentStringEnumProp &value) {
+  return toString(value);
+}
+#endif
 enum class ObjectPropsNativeComponentIntEnumProp { IntEnumProp0 = 0, IntEnumProp1 = 1 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsNativeComponentIntEnumProp &result) {
@@ -820,6 +843,15 @@ static inline std::string toString(const ObjectPropsNativeComponentIntEnumProp &
     case ObjectPropsNativeComponentIntEnumProp::IntEnumProp1: return \\"1\\";
   }
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsNativeComponentIntEnumProp &value) {
+  switch (value) {
+    case ObjectPropsNativeComponentIntEnumProp::IntEnumProp0: return 0;
+    case ObjectPropsNativeComponentIntEnumProp::IntEnumProp1: return 1;
+  }
+}
+#endif
 struct ObjectPropsNativeComponentObjectPropStruct {
   std::string stringProp{\\"\\"};
   bool booleanProp{false};

--- a/packages/react-native-codegen/src/generators/components/ComponentsGeneratorUtils.js
+++ b/packages/react-native-codegen/src/generators/components/ComponentsGeneratorUtils.js
@@ -245,6 +245,7 @@ function getLocalImports(
         return;
       case 'DimensionPrimitive':
         imports.add('#include <yoga/Yoga.h>');
+        imports.add('#include <react/renderer/core/graphicsConversions.h>');
         return;
       default:
         (name: empty);

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
@@ -132,8 +132,12 @@ function generatePropsDiffString(
               throw new Error('Received unknown ReservedPropTypeAnnotation');
           }
         case 'ArrayTypeAnnotation':
-        case 'ObjectTypeAnnotation':
           return '';
+        case 'ObjectTypeAnnotation':
+          return `
+  if (${prop.name} != oldProps->${prop.name}) {
+    result["${prop.name}"] = toDynamic(${prop.name});
+  }`;
         case 'StringEnumTypeAnnotation':
           return `
   if (${prop.name} != oldProps->${prop.name}) {

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
@@ -132,7 +132,10 @@ function generatePropsDiffString(
               throw new Error('Received unknown ReservedPropTypeAnnotation');
           }
         case 'ArrayTypeAnnotation':
-          return '';
+          return `
+  if (${prop.name} != oldProps->${prop.name}) {
+    result["${prop.name}"] = toDynamic(${prop.name});
+  }`;
         case 'ObjectTypeAnnotation':
           return `
   if (${prop.name} != oldProps->${prop.name}) {

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
@@ -123,8 +123,10 @@ function generatePropsDiffString(
     result["${prop.name}"] = toDynamic(${prop.name});
   }`;
             case 'DimensionPrimitive':
-              // TODO: Implement diffProps for complex types
-              return '';
+              return `
+  if (${prop.name} != oldProps->${prop.name}) {
+    result["${prop.name}"] = toDynamic(${prop.name});
+  }`;
             default:
               (typeAnnotation.name: empty);
               throw new Error('Received unknown ReservedPropTypeAnnotation');

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
@@ -131,8 +131,17 @@ function generatePropsDiffString(
           }
         case 'ArrayTypeAnnotation':
         case 'ObjectTypeAnnotation':
+          return '';
         case 'StringEnumTypeAnnotation':
+          return `
+  if (${prop.name} != oldProps->${prop.name}) {
+    result["${prop.name}"] = toDynamic(${prop.name});
+  }`;
         case 'Int32EnumTypeAnnotation':
+          return `
+  if (${prop.name} != oldProps->${prop.name}) {
+    result["${prop.name}"] = toDynamic(${prop.name});
+  }`;
         case 'MixedTypeAnnotation':
         default:
           // TODO: Implement diffProps for complex types

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsH.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsH.js
@@ -756,8 +756,6 @@ function generateStruct(
         case 'DoubleTypeAnnotation':
         case 'FloatTypeAnnotation':
           return `result["${name}"] = ${name};`;
-        case 'ArrayTypeAnnotation':
-          return '';
         case 'MixedTypeAnnotation':
           // MixedTypeAnnotation does not support prop diffing codegen
           return '';

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -1268,6 +1268,9 @@ folly::dynamic ObjectPropsProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (objectProp != oldProps->objectProp) {
+    result[\\"objectProp\\"] = toDynamic(objectProp);
+  }
   return result;
 }
 #endif

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -349,6 +349,9 @@ folly::dynamic DimensionPropNativeComponentProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (marginBack != oldProps->marginBack) {
+    result[\\"marginBack\\"] = toDynamic(marginBack);
+  }
   return result;
 }
 #endif

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -51,18 +51,57 @@ folly::dynamic ArrayPropsNativeComponentProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (names != oldProps->names) {
+    result[\\"names\\"] = toDynamic(names);
+  }
     
+  if (disableds != oldProps->disableds) {
+    result[\\"disableds\\"] = toDynamic(disableds);
+  }
     
+  if (progress != oldProps->progress) {
+    result[\\"progress\\"] = toDynamic(progress);
+  }
     
+  if (radii != oldProps->radii) {
+    result[\\"radii\\"] = toDynamic(radii);
+  }
     
+  if (colors != oldProps->colors) {
+    result[\\"colors\\"] = toDynamic(colors);
+  }
     
+  if (srcs != oldProps->srcs) {
+    result[\\"srcs\\"] = toDynamic(srcs);
+  }
     
+  if (points != oldProps->points) {
+    result[\\"points\\"] = toDynamic(points);
+  }
     
+  if (dimensions != oldProps->dimensions) {
+    result[\\"dimensions\\"] = toDynamic(dimensions);
+  }
     
+  if (sizes != oldProps->sizes) {
+    result[\\"sizes\\"] = toDynamic(sizes);
+  }
     
+  if (object != oldProps->object) {
+    result[\\"object\\"] = toDynamic(object);
+  }
     
+  if (array != oldProps->array) {
+    result[\\"array\\"] = toDynamic(array);
+  }
     
+  if (arrayOfArrayOfObject != oldProps->arrayOfArrayOfObject) {
+    result[\\"arrayOfArrayOfObject\\"] = toDynamic(arrayOfArrayOfObject);
+  }
     
+  if (arrayOfMixed != oldProps->arrayOfMixed) {
+    result[\\"arrayOfMixed\\"] = toDynamic(arrayOfMixed);
+  }
   return result;
 }
 #endif
@@ -109,6 +148,9 @@ folly::dynamic ArrayPropsNativeComponentProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (nativePrimitives != oldProps->nativePrimitives) {
+    result[\\"nativePrimitives\\"] = toDynamic(nativePrimitives);
+  }
   return result;
 }
 #endif

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -949,6 +949,9 @@ folly::dynamic Int32EnumPropsNativeComponentProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (maxInterval != oldProps->maxInterval) {
+    result[\\"maxInterval\\"] = toDynamic(maxInterval);
+  }
   return result;
 }
 #endif
@@ -1357,6 +1360,9 @@ folly::dynamic StringEnumPropsNativeComponentProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (alignment != oldProps->alignment) {
+    result[\\"alignment\\"] = toDynamic(alignment);
+  }
   return result;
 }
 #endif

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
@@ -16,6 +16,7 @@ Map {
 #include <cinttypes>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/core/propsConversions.h>
 #include <react/renderer/graphics/Color.h>
 #include <react/renderer/graphics/Point.h>
@@ -469,6 +470,7 @@ Map {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/graphicsConversions.h>
 #include <yoga/Yoga.h>
 
 namespace facebook::react {

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
@@ -933,6 +933,16 @@ static inline std::string toString(const Int32EnumPropsNativeComponentMaxInterva
   }
 }
 
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const Int32EnumPropsNativeComponentMaxInterval &value) {
+  switch (value) {
+    case Int32EnumPropsNativeComponentMaxInterval::MaxInterval0: return 0;
+    case Int32EnumPropsNativeComponentMaxInterval::MaxInterval1: return 1;
+    case Int32EnumPropsNativeComponentMaxInterval::MaxInterval2: return 2;
+  }
+}
+#endif
+
 class Int32EnumPropsNativeComponentProps final : public ViewProps {
  public:
   Int32EnumPropsNativeComponentProps() = default;
@@ -1182,6 +1192,12 @@ static inline std::string toString(const ObjectPropsStringEnumProp &value) {
     case ObjectPropsStringEnumProp::Option1: return \\"option1\\";
   }
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsStringEnumProp &value) {
+  return toString(value);
+}
+#endif
 enum class ObjectPropsIntEnumProp { IntEnumProp0 = 0 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsIntEnumProp &result) {
@@ -1200,6 +1216,14 @@ static inline std::string toString(const ObjectPropsIntEnumProp &value) {
     case ObjectPropsIntEnumProp::IntEnumProp0: return \\"0\\";
   }
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsIntEnumProp &value) {
+  switch (value) {
+    case ObjectPropsIntEnumProp::IntEnumProp0: return 0;
+  }
+}
+#endif
 struct ObjectPropsObjectPropObjectArrayPropStruct {
   std::vector<std::string> array{};
 };
@@ -1495,6 +1519,12 @@ static inline std::string toString(const StringEnumPropsNativeComponentAlignment
     case StringEnumPropsNativeComponentAlignment::BottomRight: return \\"bottom-right\\";
   }
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const StringEnumPropsNativeComponentAlignment &value) {
+  return toString(value);
+}
+#endif
 
 class StringEnumPropsNativeComponentProps final : public ViewProps {
  public:

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
@@ -179,7 +179,7 @@ struct ArrayPropsNativeComponentArrayStruct {
 
   folly::dynamic toDynamic() const {
     folly::dynamic result = folly::dynamic::object();
-    
+    result[\\"object\\"] = ::facebook::react::toDynamic(object);
     return result;
   }
 #endif
@@ -325,9 +325,9 @@ struct ArrayPropsNativeComponentNativePrimitivesStruct {
 
   folly::dynamic toDynamic() const {
     folly::dynamic result = folly::dynamic::object();
-    
-    
-    
+    result[\\"colors\\"] = ::facebook::react::toDynamic(colors);
+    result[\\"srcs\\"] = ::facebook::react::toDynamic(srcs);
+    result[\\"points\\"] = ::facebook::react::toDynamic(points);
     return result;
   }
 #endif
@@ -1316,7 +1316,7 @@ struct ObjectPropsObjectPropObjectArrayPropStruct {
 
   folly::dynamic toDynamic() const {
     folly::dynamic result = folly::dynamic::object();
-    
+    result[\\"array\\"] = ::facebook::react::toDynamic(array);
     return result;
   }
 #endif
@@ -1503,7 +1503,7 @@ struct ObjectPropsObjectPropNestedArrayAsPropertyStruct {
 
   folly::dynamic toDynamic() const {
     folly::dynamic result = folly::dynamic::object();
-    
+    result[\\"arrayProp\\"] = ::facebook::react::toDynamic(arrayProp);
     return result;
   }
 #endif

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
@@ -87,6 +87,16 @@ static inline std::string toString(const ArrayPropsNativeComponentSizesMaskWrapp
 }
 struct ArrayPropsNativeComponentObjectStruct {
   std::string stringProp{\\"\\"};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ArrayPropsNativeComponentObjectStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    result[\\"stringProp\\"] = stringProp;
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentObjectStruct &result) {
@@ -102,6 +112,12 @@ static inline std::string toString(const ArrayPropsNativeComponentObjectStruct &
   return \\"[Object ArrayPropsNativeComponentObjectStruct]\\";
 }
 
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ArrayPropsNativeComponentObjectStruct &value) {
+  return value.toDynamic();
+}
+#endif
+
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, std::vector<ArrayPropsNativeComponentObjectStruct> &result) {
   auto items = (std::vector<RawValue>)value;
   for (const auto &item : items) {
@@ -114,6 +130,16 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 
 struct ArrayPropsNativeComponentArrayObjectStruct {
   std::string stringProp{\\"\\"};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ArrayPropsNativeComponentArrayObjectStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    result[\\"stringProp\\"] = stringProp;
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentArrayObjectStruct &result) {
@@ -129,6 +155,12 @@ static inline std::string toString(const ArrayPropsNativeComponentArrayObjectStr
   return \\"[Object ArrayPropsNativeComponentArrayObjectStruct]\\";
 }
 
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ArrayPropsNativeComponentArrayObjectStruct &value) {
+  return value.toDynamic();
+}
+#endif
+
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, std::vector<ArrayPropsNativeComponentArrayObjectStruct> &result) {
   auto items = (std::vector<RawValue>)value;
   for (const auto &item : items) {
@@ -141,6 +173,16 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 
 struct ArrayPropsNativeComponentArrayStruct {
   std::vector<ArrayPropsNativeComponentArrayObjectStruct> object{};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ArrayPropsNativeComponentArrayStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentArrayStruct &result) {
@@ -156,6 +198,12 @@ static inline std::string toString(const ArrayPropsNativeComponentArrayStruct &v
   return \\"[Object ArrayPropsNativeComponentArrayStruct]\\";
 }
 
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ArrayPropsNativeComponentArrayStruct &value) {
+  return value.toDynamic();
+}
+#endif
+
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, std::vector<ArrayPropsNativeComponentArrayStruct> &result) {
   auto items = (std::vector<RawValue>)value;
   for (const auto &item : items) {
@@ -168,6 +216,16 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 
 struct ArrayPropsNativeComponentArrayOfArrayOfObjectStruct {
   std::string stringProp{\\"\\"};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ArrayPropsNativeComponentArrayOfArrayOfObjectStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    result[\\"stringProp\\"] = stringProp;
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentArrayOfArrayOfObjectStruct &result) {
@@ -182,6 +240,12 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 static inline std::string toString(const ArrayPropsNativeComponentArrayOfArrayOfObjectStruct &value) {
   return \\"[Object ArrayPropsNativeComponentArrayOfArrayOfObjectStruct]\\";
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ArrayPropsNativeComponentArrayOfArrayOfObjectStruct &value) {
+  return value.toDynamic();
+}
+#endif
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, std::vector<std::vector<ArrayPropsNativeComponentArrayOfArrayOfObjectStruct>> &result) {
   auto items = (std::vector<std::vector<RawValue>>)value;
@@ -255,6 +319,18 @@ struct ArrayPropsNativeComponentNativePrimitivesStruct {
   std::vector<SharedColor> colors{};
   std::vector<ImageSource> srcs{};
   std::vector<Point> points{};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ArrayPropsNativeComponentNativePrimitivesStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    
+    
+    
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentNativePrimitivesStruct &result) {
@@ -277,6 +353,12 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 static inline std::string toString(const ArrayPropsNativeComponentNativePrimitivesStruct &value) {
   return \\"[Object ArrayPropsNativeComponentNativePrimitivesStruct]\\";
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ArrayPropsNativeComponentNativePrimitivesStruct &value) {
+  return value.toDynamic();
+}
+#endif
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, std::vector<ArrayPropsNativeComponentNativePrimitivesStruct> &result) {
   auto items = (std::vector<RawValue>)value;
@@ -1228,6 +1310,16 @@ static inline folly::dynamic toDynamic(const ObjectPropsIntEnumProp &value) {
 #endif
 struct ObjectPropsObjectPropObjectArrayPropStruct {
   std::vector<std::string> array{};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ObjectPropsObjectPropObjectArrayPropStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsObjectPropObjectArrayPropStruct &result) {
@@ -1243,10 +1335,28 @@ static inline std::string toString(const ObjectPropsObjectPropObjectArrayPropStr
   return \\"[Object ObjectPropsObjectPropObjectArrayPropStruct]\\";
 }
 
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsObjectPropObjectArrayPropStruct &value) {
+  return value.toDynamic();
+}
+#endif
+
 struct ObjectPropsObjectPropObjectPrimitiveRequiredPropStruct {
   ImageSource image{};
   SharedColor color{};
   Point point{};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ObjectPropsObjectPropObjectPrimitiveRequiredPropStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    result[\\"image\\"] = ::facebook::react::toDynamic(image);
+    result[\\"color\\"] = ::facebook::react::toDynamic(color);
+    result[\\"point\\"] = ::facebook::react::toDynamic(point);
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsObjectPropObjectPrimitiveRequiredPropStruct &result) {
@@ -1270,8 +1380,24 @@ static inline std::string toString(const ObjectPropsObjectPropObjectPrimitiveReq
   return \\"[Object ObjectPropsObjectPropObjectPrimitiveRequiredPropStruct]\\";
 }
 
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsObjectPropObjectPrimitiveRequiredPropStruct &value) {
+  return value.toDynamic();
+}
+#endif
+
 struct ObjectPropsObjectPropNestedPropANestedPropBStruct {
   std::string nestedPropC{\\"\\"};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ObjectPropsObjectPropNestedPropANestedPropBStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    result[\\"nestedPropC\\"] = nestedPropC;
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsObjectPropNestedPropANestedPropBStruct &result) {
@@ -1287,8 +1413,24 @@ static inline std::string toString(const ObjectPropsObjectPropNestedPropANestedP
   return \\"[Object ObjectPropsObjectPropNestedPropANestedPropBStruct]\\";
 }
 
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsObjectPropNestedPropANestedPropBStruct &value) {
+  return value.toDynamic();
+}
+#endif
+
 struct ObjectPropsObjectPropNestedPropAStruct {
   ObjectPropsObjectPropNestedPropANestedPropBStruct nestedPropB{};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ObjectPropsObjectPropNestedPropAStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    result[\\"nestedPropB\\"] = ::facebook::react::toDynamic(nestedPropB);
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsObjectPropNestedPropAStruct &result) {
@@ -1304,8 +1446,24 @@ static inline std::string toString(const ObjectPropsObjectPropNestedPropAStruct 
   return \\"[Object ObjectPropsObjectPropNestedPropAStruct]\\";
 }
 
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsObjectPropNestedPropAStruct &value) {
+  return value.toDynamic();
+}
+#endif
+
 struct ObjectPropsObjectPropNestedArrayAsPropertyArrayPropStruct {
   std::string stringProp{\\"\\"};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ObjectPropsObjectPropNestedArrayAsPropertyArrayPropStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    result[\\"stringProp\\"] = stringProp;
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsObjectPropNestedArrayAsPropertyArrayPropStruct &result) {
@@ -1321,6 +1479,12 @@ static inline std::string toString(const ObjectPropsObjectPropNestedArrayAsPrope
   return \\"[Object ObjectPropsObjectPropNestedArrayAsPropertyArrayPropStruct]\\";
 }
 
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsObjectPropNestedArrayAsPropertyArrayPropStruct &value) {
+  return value.toDynamic();
+}
+#endif
+
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, std::vector<ObjectPropsObjectPropNestedArrayAsPropertyArrayPropStruct> &result) {
   auto items = (std::vector<RawValue>)value;
   for (const auto &item : items) {
@@ -1333,6 +1497,16 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 
 struct ObjectPropsObjectPropNestedArrayAsPropertyStruct {
   std::vector<ObjectPropsObjectPropNestedArrayAsPropertyArrayPropStruct> arrayProp{};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ObjectPropsObjectPropNestedArrayAsPropertyStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsObjectPropNestedArrayAsPropertyStruct &result) {
@@ -1347,6 +1521,12 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 static inline std::string toString(const ObjectPropsObjectPropNestedArrayAsPropertyStruct &value) {
   return \\"[Object ObjectPropsObjectPropNestedArrayAsPropertyStruct]\\";
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsObjectPropNestedArrayAsPropertyStruct &value) {
+  return value.toDynamic();
+}
+#endif
 
 struct ObjectPropsObjectPropStruct {
   std::string stringProp{\\"\\"};
@@ -1363,6 +1543,29 @@ struct ObjectPropsObjectPropStruct {
   ObjectPropsObjectPropObjectPrimitiveRequiredPropStruct objectPrimitiveRequiredProp{};
   ObjectPropsObjectPropNestedPropAStruct nestedPropA{};
   ObjectPropsObjectPropNestedArrayAsPropertyStruct nestedArrayAsProperty{};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ObjectPropsObjectPropStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    result[\\"stringProp\\"] = stringProp;
+    result[\\"booleanProp\\"] = booleanProp;
+    result[\\"floatProp\\"] = floatProp;
+    result[\\"intProp\\"] = intProp;
+    result[\\"stringUserDefaultProp\\"] = stringUserDefaultProp;
+    result[\\"booleanUserDefaultProp\\"] = booleanUserDefaultProp;
+    result[\\"floatUserDefaultProp\\"] = floatUserDefaultProp;
+    result[\\"intUserDefaultProp\\"] = intUserDefaultProp;
+    result[\\"stringEnumProp\\"] = ::facebook::react::toDynamic(stringEnumProp);
+    result[\\"intEnumProp\\"] = ::facebook::react::toDynamic(intEnumProp);
+    result[\\"objectArrayProp\\"] = ::facebook::react::toDynamic(objectArrayProp);
+    result[\\"objectPrimitiveRequiredProp\\"] = ::facebook::react::toDynamic(objectPrimitiveRequiredProp);
+    result[\\"nestedPropA\\"] = ::facebook::react::toDynamic(nestedPropA);
+    result[\\"nestedArrayAsProperty\\"] = ::facebook::react::toDynamic(nestedArrayAsProperty);
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsObjectPropStruct &result) {
@@ -1429,6 +1632,12 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 static inline std::string toString(const ObjectPropsObjectPropStruct &value) {
   return \\"[Object ObjectPropsObjectPropStruct]\\";
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsObjectPropStruct &value) {
+  return value.toDynamic();
+}
+#endif
 class ObjectPropsProps final : public ViewProps {
  public:
   ObjectPropsProps() = default;

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
@@ -357,15 +357,6 @@ SharedDebugStringConvertibleList AndroidTextInputProps::getDebugProps() const {
 }
 #endif
 
-static folly::dynamic toDynamic(
-    const std::vector<std::string>& acceptDragAndDropTypes) {
-  folly::dynamic acceptDragAndDropTypesArray = folly::dynamic::array();
-  for (const auto& acceptDragAndDropType : acceptDragAndDropTypes) {
-    acceptDragAndDropTypesArray.push_back(acceptDragAndDropType);
-  }
-  return acceptDragAndDropTypesArray;
-}
-
 ComponentName AndroidTextInputProps::getDiffPropsImplementationTarget() const {
   return "TextInput";
 }

--- a/packages/react-native/ReactCommon/react/renderer/core/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/core/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(react_renderer_core
         react_renderer_mapbuffer
         react_renderer_runtimescheduler
         react_utils
-        runtimeexecutor)
+        runtimeexecutor
+        yoga)
 target_compile_reactnative_options(react_renderer_core PRIVATE)
 target_compile_options(react_renderer_core PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/core/graphicsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/graphicsConversions.h
@@ -24,6 +24,10 @@
 #include <react/renderer/graphics/RectangleEdges.h>
 #include <react/renderer/graphics/Size.h>
 
+#ifdef RN_SERIALIZABLE_STATE
+#include <yoga/Yoga.h>
+#endif
+
 namespace facebook::react {
 
 #pragma mark - Color
@@ -61,6 +65,27 @@ inline std::string toString(const SharedColor& value) {
 #pragma mark - Geometry
 
 #ifdef RN_SERIALIZABLE_STATE
+inline folly::dynamic toDynamic(const YGValue& dimension) {
+  switch (dimension.unit) {
+    case YGUnitUndefined:
+      return nullptr;
+    case YGUnitAuto:
+      return "auto";
+    case YGUnitMaxContent:
+      return "max-content";
+    case YGUnitFitContent:
+      return "fit-content";
+    case YGUnitStretch:
+      return "stretch";
+    case YGUnitPoint:
+      return dimension.value;
+    case YGUnitPercent:
+      return std::format("{}%", dimension.value);
+  }
+
+  return nullptr;
+}
+
 inline folly::dynamic toDynamic(const Point& point) {
   folly::dynamic pointResult = folly::dynamic::object();
   pointResult["x"] = point.x;

--- a/packages/react-native/ReactCommon/react/renderer/core/graphicsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/graphicsConversions.h
@@ -43,9 +43,6 @@ inline void fromRawValue(
 inline int toAndroidRepr(const SharedColor& color) {
   return *color;
 }
-inline folly::dynamic toDynamic(const SharedColor& color) {
-  return *color;
-}
 #endif
 
 inline std::string toString(const SharedColor& value) {

--- a/packages/react-native/ReactCommon/react/renderer/core/propsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/propsConversions.h
@@ -16,6 +16,43 @@
 
 namespace facebook::react {
 
+#ifdef RN_SERIALIZABLE_STATE
+
+inline folly::dynamic toDynamic(const std::vector<bool>& arrayValue) {
+  folly::dynamic resultArray = folly::dynamic::array();
+  for (auto value : arrayValue) {
+    resultArray.push_back(value);
+  }
+  return resultArray;
+}
+
+inline folly::dynamic toDynamic(const std::vector<std::string>& arrayValue) {
+  folly::dynamic resultArray = folly::dynamic::array();
+  for (auto& value : arrayValue) {
+    resultArray.push_back(value);
+  }
+  return resultArray;
+}
+
+inline folly::dynamic toDynamic(const std::vector<folly::dynamic>& arrayValue) {
+  folly::dynamic resultArray = folly::dynamic::array();
+  for (auto& value : arrayValue) {
+    resultArray.push_back(value);
+  }
+  return resultArray;
+}
+
+template <typename T>
+folly::dynamic toDynamic(const std::vector<T>& arrayValue) {
+  folly::dynamic resultArray = folly::dynamic::array();
+  for (const auto& value : arrayValue) {
+    resultArray.push_back(toDynamic(value));
+  }
+  return resultArray;
+}
+
+#endif
+
 /**
  * Use this only when a prop update has definitely been sent from JS;
  * essentially, cases where rawValue is virtually guaranteed to not be a

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Color.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Color.h
@@ -13,6 +13,10 @@
 #include <react/renderer/graphics/ColorComponents.h>
 #include <react/renderer/graphics/HostPlatformColor.h>
 
+#ifdef RN_SERIALIZABLE_STATE
+#include <folly/dynamic.h>
+#endif
+
 namespace facebook::react {
 
 /*
@@ -66,6 +70,12 @@ SharedColor colorFromRGBA(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
 SharedColor clearColor();
 SharedColor blackColor();
 SharedColor whiteColor();
+
+#ifdef RN_SERIALIZABLE_STATE
+inline folly::dynamic toDynamic(const SharedColor& sharedColor) {
+  return *sharedColor;
+}
+#endif
 
 } // namespace facebook::react
 


### PR DESCRIPTION
Summary:
The ArrayType props converts to std::vector. This prompted the need for `toDynamic(const T&)` conversion functions as this breaks to potential reliance on all type instances having a `toDynamic()` function available. This includes:
- array of arrays types
- array of objects types
- object with arrays

The ArrayType conversion uses the availability of the `toDynamic` conversion methods for all supported types to convert the values stored by the `std::vector` to `folly::dynamic` values to be stored on a `folly::dynamic::array`.

The diff removes unnecessary conversion methods implemented previously for the core components prop diffing. These are now handled by the generic `toDynamic(const std::vector<T>&)` conversion method.

Changelog: [Internal]

Differential Revision: D77234065
