### PR TITLE
Mark prop diffing availability for codegen props

### DIFF
--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -737,6 +737,9 @@ folly::dynamic MixedPropNativeComponentViewProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (mixedProp != oldProps->mixedProp) {
+    result[\\"mixedProp\\"] = mixedProp;
+  }
   return result;
 }
 #endif

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -51,18 +51,57 @@ folly::dynamic ArrayPropsNativeComponentViewProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (names != oldProps->names) {
+    result[\\"names\\"] = toDynamic(names);
+  }
     
+  if (disableds != oldProps->disableds) {
+    result[\\"disableds\\"] = toDynamic(disableds);
+  }
     
+  if (progress != oldProps->progress) {
+    result[\\"progress\\"] = toDynamic(progress);
+  }
     
+  if (radii != oldProps->radii) {
+    result[\\"radii\\"] = toDynamic(radii);
+  }
     
+  if (colors != oldProps->colors) {
+    result[\\"colors\\"] = toDynamic(colors);
+  }
     
+  if (srcs != oldProps->srcs) {
+    result[\\"srcs\\"] = toDynamic(srcs);
+  }
     
+  if (points != oldProps->points) {
+    result[\\"points\\"] = toDynamic(points);
+  }
     
+  if (edgeInsets != oldProps->edgeInsets) {
+    result[\\"edgeInsets\\"] = toDynamic(edgeInsets);
+  }
     
+  if (dimensions != oldProps->dimensions) {
+    result[\\"dimensions\\"] = toDynamic(dimensions);
+  }
     
+  if (sizes != oldProps->sizes) {
+    result[\\"sizes\\"] = toDynamic(sizes);
+  }
     
+  if (object != oldProps->object) {
+    result[\\"object\\"] = toDynamic(object);
+  }
     
+  if (arrayOfObjects != oldProps->arrayOfObjects) {
+    result[\\"arrayOfObjects\\"] = toDynamic(arrayOfObjects);
+  }
     
+  if (arrayOfMixed != oldProps->arrayOfMixed) {
+    result[\\"arrayOfMixed\\"] = toDynamic(arrayOfMixed);
+  }
   return result;
 }
 #endif

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -40,6 +40,10 @@ ArrayPropsNativeComponentViewProps::ArrayPropsNativeComponentViewProps(
     arrayOfMixed(convertRawProp(context, rawProps, \\"arrayOfMixed\\", sourceProps.arrayOfMixed, {})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName ArrayPropsNativeComponentViewProps::getDiffPropsImplementationTarget() const {
+  return \\"ArrayPropsNativeComponentView\\";
+}
+
 folly::dynamic ArrayPropsNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = ArrayPropsNativeComponentViewProps();
@@ -138,6 +142,10 @@ BooleanPropNativeComponentViewProps::BooleanPropNativeComponentViewProps(
     disabledNullable(convertRawProp(context, rawProps, \\"disabledNullable\\", sourceProps.disabledNullable, {})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName BooleanPropNativeComponentViewProps::getDiffPropsImplementationTarget() const {
+  return \\"BooleanPropNativeComponentView\\";
+}
+
 folly::dynamic BooleanPropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = BooleanPropNativeComponentViewProps();
@@ -191,6 +199,10 @@ ColorPropNativeComponentViewProps::ColorPropNativeComponentViewProps(
     tintColor(convertRawProp(context, rawProps, \\"tintColor\\", sourceProps.tintColor, {})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName ColorPropNativeComponentViewProps::getDiffPropsImplementationTarget() const {
+  return \\"ColorPropNativeComponentView\\";
+}
+
 folly::dynamic ColorPropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = ColorPropNativeComponentViewProps();
@@ -241,6 +253,10 @@ DimensionPropNativeComponentViewProps::DimensionPropNativeComponentViewProps(
     marginBack(convertRawProp(context, rawProps, \\"marginBack\\", sourceProps.marginBack, {})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName DimensionPropNativeComponentViewProps::getDiffPropsImplementationTarget() const {
+  return \\"DimensionPropNativeComponentView\\";
+}
+
 folly::dynamic DimensionPropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = DimensionPropNativeComponentViewProps();
@@ -290,6 +306,10 @@ EdgeInsetsPropNativeComponentViewProps::EdgeInsetsPropNativeComponentViewProps(
      {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName EdgeInsetsPropNativeComponentViewProps::getDiffPropsImplementationTarget() const {
+  return \\"EdgeInsetsPropNativeComponentView\\";
+}
+
 folly::dynamic EdgeInsetsPropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = EdgeInsetsPropNativeComponentViewProps();
@@ -337,6 +357,10 @@ EnumPropNativeComponentViewProps::EnumPropNativeComponentViewProps(
     intervals(convertRawProp(context, rawProps, \\"intervals\\", sourceProps.intervals, {EnumPropNativeComponentViewIntervals::Intervals0})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName EnumPropNativeComponentViewProps::getDiffPropsImplementationTarget() const {
+  return \\"EnumPropNativeComponentView\\";
+}
+
 folly::dynamic EnumPropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = EnumPropNativeComponentViewProps();
@@ -390,6 +414,10 @@ EventNestedObjectPropsNativeComponentViewProps::EventNestedObjectPropsNativeComp
     disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {false})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName EventNestedObjectPropsNativeComponentViewProps::getDiffPropsImplementationTarget() const {
+  return \\"EventNestedObjectPropsNativeComponentView\\";
+}
+
 folly::dynamic EventNestedObjectPropsNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = EventNestedObjectPropsNativeComponentViewProps();
@@ -439,6 +467,10 @@ EventPropsNativeComponentViewProps::EventPropsNativeComponentViewProps(
     disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {false})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName EventPropsNativeComponentViewProps::getDiffPropsImplementationTarget() const {
+  return \\"EventPropsNativeComponentView\\";
+}
+
 folly::dynamic EventPropsNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = EventPropsNativeComponentViewProps();
@@ -494,6 +526,10 @@ FloatPropsNativeComponentViewProps::FloatPropsNativeComponentViewProps(
     blurRadiusNullable(convertRawProp(context, rawProps, \\"blurRadiusNullable\\", sourceProps.blurRadiusNullable, {})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName FloatPropsNativeComponentViewProps::getDiffPropsImplementationTarget() const {
+  return \\"FloatPropsNativeComponentView\\";
+}
+
 folly::dynamic FloatPropsNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = FloatPropsNativeComponentViewProps();
@@ -568,6 +604,10 @@ ImagePropNativeComponentViewProps::ImagePropNativeComponentViewProps(
     thumbImage(convertRawProp(context, rawProps, \\"thumbImage\\", sourceProps.thumbImage, {})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName ImagePropNativeComponentViewProps::getDiffPropsImplementationTarget() const {
+  return \\"ImagePropNativeComponentView\\";
+}
+
 folly::dynamic ImagePropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = ImagePropNativeComponentViewProps();
@@ -619,6 +659,10 @@ IntegerPropNativeComponentViewProps::IntegerPropNativeComponentViewProps(
     progress3(convertRawProp(context, rawProps, \\"progress3\\", sourceProps.progress3, {10})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName IntegerPropNativeComponentViewProps::getDiffPropsImplementationTarget() const {
+  return \\"IntegerPropNativeComponentView\\";
+}
+
 folly::dynamic IntegerPropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = IntegerPropNativeComponentViewProps();
@@ -676,6 +720,10 @@ InterfaceOnlyNativeComponentViewProps::InterfaceOnlyNativeComponentViewProps(
     title(convertRawProp(context, rawProps, \\"title\\", sourceProps.title, {\\"\\"})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName InterfaceOnlyNativeComponentViewProps::getDiffPropsImplementationTarget() const {
+  return \\"InterfaceOnlyNativeComponentView\\";
+}
+
 folly::dynamic InterfaceOnlyNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = InterfaceOnlyNativeComponentViewProps();
@@ -726,6 +774,10 @@ MixedPropNativeComponentViewProps::MixedPropNativeComponentViewProps(
     mixedProp(convertRawProp(context, rawProps, \\"mixedProp\\", sourceProps.mixedProp, {})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName MixedPropNativeComponentViewProps::getDiffPropsImplementationTarget() const {
+  return \\"MixedPropNativeComponentView\\";
+}
+
 folly::dynamic MixedPropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = MixedPropNativeComponentViewProps();
@@ -779,6 +831,10 @@ MultiNativePropNativeComponentViewProps::MultiNativePropNativeComponentViewProps
     point(convertRawProp(context, rawProps, \\"point\\", sourceProps.point, {})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName MultiNativePropNativeComponentViewProps::getDiffPropsImplementationTarget() const {
+  return \\"MultiNativePropNativeComponentView\\";
+}
+
 folly::dynamic MultiNativePropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = MultiNativePropNativeComponentViewProps();
@@ -840,6 +896,10 @@ NoPropsNoEventsNativeComponentViewProps::NoPropsNoEventsNativeComponentViewProps
      {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName NoPropsNoEventsNativeComponentViewProps::getDiffPropsImplementationTarget() const {
+  return \\"NoPropsNoEventsNativeComponentView\\";
+}
+
 folly::dynamic NoPropsNoEventsNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = NoPropsNoEventsNativeComponentViewProps();
@@ -889,6 +949,10 @@ ObjectPropsNativeComponentProps::ObjectPropsNativeComponentProps(
     objectPrimitiveRequiredProp(convertRawProp(context, rawProps, \\"objectPrimitiveRequiredProp\\", sourceProps.objectPrimitiveRequiredProp, {})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName ObjectPropsNativeComponentProps::getDiffPropsImplementationTarget() const {
+  return \\"ObjectPropsNativeComponent\\";
+}
+
 folly::dynamic ObjectPropsNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = ObjectPropsNativeComponentProps();
@@ -946,6 +1010,10 @@ PointPropNativeComponentViewProps::PointPropNativeComponentViewProps(
     startPoint(convertRawProp(context, rawProps, \\"startPoint\\", sourceProps.startPoint, {})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName PointPropNativeComponentViewProps::getDiffPropsImplementationTarget() const {
+  return \\"PointPropNativeComponentView\\";
+}
+
 folly::dynamic PointPropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = PointPropNativeComponentViewProps();
@@ -996,6 +1064,10 @@ StringPropNativeComponentViewProps::StringPropNativeComponentViewProps(
     defaultValue(convertRawProp(context, rawProps, \\"defaultValue\\", sourceProps.defaultValue, {})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName StringPropNativeComponentViewProps::getDiffPropsImplementationTarget() const {
+  return \\"StringPropNativeComponentView\\";
+}
+
 folly::dynamic StringPropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = StringPropNativeComponentViewProps();

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -858,8 +858,17 @@ folly::dynamic ObjectPropsNativeComponentProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (objectProp != oldProps->objectProp) {
+    result[\\"objectProp\\"] = toDynamic(objectProp);
+  }
     
+  if (objectArrayProp != oldProps->objectArrayProp) {
+    result[\\"objectArrayProp\\"] = toDynamic(objectArrayProp);
+  }
     
+  if (objectPrimitiveRequiredProp != oldProps->objectPrimitiveRequiredProp) {
+    result[\\"objectPrimitiveRequiredProp\\"] = toDynamic(objectPrimitiveRequiredProp);
+  }
   return result;
 }
 #endif

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -306,7 +306,13 @@ folly::dynamic EnumPropNativeComponentViewProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (alignment != oldProps->alignment) {
+    result[\\"alignment\\"] = toDynamic(alignment);
+  }
     
+  if (intervals != oldProps->intervals) {
+    result[\\"intervals\\"] = toDynamic(intervals);
+  }
   return result;
 }
 #endif

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -213,6 +213,9 @@ folly::dynamic DimensionPropNativeComponentViewProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (marginBack != oldProps->marginBack) {
+    result[\\"marginBack\\"] = toDynamic(marginBack);
+  }
   return result;
 }
 #endif

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
@@ -88,6 +88,16 @@ static inline std::string toString(const ArrayPropsNativeComponentViewSizesMaskW
 }
 struct ArrayPropsNativeComponentViewObjectStruct {
   std::string prop{};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ArrayPropsNativeComponentViewObjectStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    result[\\"prop\\"] = prop;
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentViewObjectStruct &result) {
@@ -103,6 +113,12 @@ static inline std::string toString(const ArrayPropsNativeComponentViewObjectStru
   return \\"[Object ArrayPropsNativeComponentViewObjectStruct]\\";
 }
 
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ArrayPropsNativeComponentViewObjectStruct &value) {
+  return value.toDynamic();
+}
+#endif
+
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, std::vector<ArrayPropsNativeComponentViewObjectStruct> &result) {
   auto items = (std::vector<RawValue>)value;
   for (const auto &item : items) {
@@ -116,6 +132,17 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 struct ArrayPropsNativeComponentViewArrayOfObjectsStruct {
   Float prop1{0.0};
   int prop2{0};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ArrayPropsNativeComponentViewArrayOfObjectsStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    result[\\"prop1\\"] = prop1;
+    result[\\"prop2\\"] = prop2;
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentViewArrayOfObjectsStruct &result) {
@@ -134,6 +161,12 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 static inline std::string toString(const ArrayPropsNativeComponentViewArrayOfObjectsStruct &value) {
   return \\"[Object ArrayPropsNativeComponentViewArrayOfObjectsStruct]\\";
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ArrayPropsNativeComponentViewArrayOfObjectsStruct &value) {
+  return value.toDynamic();
+}
+#endif
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, std::vector<ArrayPropsNativeComponentViewArrayOfObjectsStruct> &result) {
   auto items = (std::vector<RawValue>)value;
@@ -861,6 +894,21 @@ struct ObjectPropsNativeComponentObjectPropStruct {
   int intProp{0};
   ObjectPropsNativeComponentStringEnumProp stringEnumProp{ObjectPropsNativeComponentStringEnumProp::Small};
   ObjectPropsNativeComponentIntEnumProp intEnumProp{ObjectPropsNativeComponentIntEnumProp::IntEnumProp0};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ObjectPropsNativeComponentObjectPropStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    result[\\"stringProp\\"] = stringProp;
+    result[\\"booleanProp\\"] = booleanProp;
+    result[\\"floatProp\\"] = floatProp;
+    result[\\"intProp\\"] = intProp;
+    result[\\"stringEnumProp\\"] = ::facebook::react::toDynamic(stringEnumProp);
+    result[\\"intEnumProp\\"] = ::facebook::react::toDynamic(intEnumProp);
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsNativeComponentObjectPropStruct &result) {
@@ -896,8 +944,24 @@ static inline std::string toString(const ObjectPropsNativeComponentObjectPropStr
   return \\"[Object ObjectPropsNativeComponentObjectPropStruct]\\";
 }
 
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsNativeComponentObjectPropStruct &value) {
+  return value.toDynamic();
+}
+#endif
+
 struct ObjectPropsNativeComponentObjectArrayPropStruct {
   std::vector<std::string> array{};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ObjectPropsNativeComponentObjectArrayPropStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsNativeComponentObjectArrayPropStruct &result) {
@@ -913,10 +977,28 @@ static inline std::string toString(const ObjectPropsNativeComponentObjectArrayPr
   return \\"[Object ObjectPropsNativeComponentObjectArrayPropStruct]\\";
 }
 
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsNativeComponentObjectArrayPropStruct &value) {
+  return value.toDynamic();
+}
+#endif
+
 struct ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct {
   ImageSource image{};
   SharedColor color{};
   Point point{};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    result[\\"image\\"] = ::facebook::react::toDynamic(image);
+    result[\\"color\\"] = ::facebook::react::toDynamic(color);
+    result[\\"point\\"] = ::facebook::react::toDynamic(point);
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct &result) {
@@ -939,6 +1021,12 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 static inline std::string toString(const ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct &value) {
   return \\"[Object ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct]\\";
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct &value) {
+  return value.toDynamic();
+}
+#endif
 class ObjectPropsNativeComponentProps final : public ViewProps {
  public:
   ObjectPropsNativeComponentProps() = default;

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
@@ -16,6 +16,7 @@ Object {
 #include <cinttypes>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/core/propsConversions.h>
 #include <react/renderer/graphics/Color.h>
 #include <react/renderer/graphics/Point.h>
@@ -265,6 +266,7 @@ Object {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/graphicsConversions.h>
 #include <yoga/Yoga.h>
 
 namespace facebook::react {

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
@@ -958,7 +958,7 @@ struct ObjectPropsNativeComponentObjectArrayPropStruct {
 
   folly::dynamic toDynamic() const {
     folly::dynamic result = folly::dynamic::object();
-    
+    result[\\"array\\"] = ::facebook::react::toDynamic(array);
     return result;
   }
 #endif

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
@@ -199,6 +199,8 @@ class ArrayPropsNativeComponentViewProps final : public ViewProps {
   std::vector<folly::dynamic> arrayOfMixed{};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -237,6 +239,8 @@ class BooleanPropNativeComponentViewProps final : public ViewProps {
   bool disabledNullable{};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -275,6 +279,8 @@ class ColorPropNativeComponentViewProps final : public ViewProps {
   SharedColor tintColor{};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -314,6 +320,8 @@ class DimensionPropNativeComponentViewProps final : public ViewProps {
   YGValue marginBack{};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -351,6 +359,8 @@ class EdgeInsetsPropNativeComponentViewProps final : public ViewProps {
   
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -454,6 +464,8 @@ class EnumPropNativeComponentViewProps final : public ViewProps {
   EnumPropNativeComponentViewIntervals intervals{EnumPropNativeComponentViewIntervals::Intervals0};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -491,6 +503,8 @@ class EventNestedObjectPropsNativeComponentViewProps final : public ViewProps {
   bool disabled{false};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -528,6 +542,8 @@ class EventPropsNativeComponentViewProps final : public ViewProps {
   bool disabled{false};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -571,6 +587,8 @@ class FloatPropsNativeComponentViewProps final : public ViewProps {
   Float blurRadiusNullable{};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -609,6 +627,8 @@ class ImagePropNativeComponentViewProps final : public ViewProps {
   ImageSource thumbImage{};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -648,6 +668,8 @@ class IntegerPropNativeComponentViewProps final : public ViewProps {
   int progress3{10};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -685,6 +707,8 @@ class InterfaceOnlyNativeComponentViewProps final : public ViewProps {
   std::string title{\\"\\"};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -722,6 +746,8 @@ class MixedPropNativeComponentViewProps final : public ViewProps {
   folly::dynamic mixedProp{};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -765,6 +791,8 @@ class MultiNativePropNativeComponentViewProps final : public ViewProps {
   Point point{};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -802,6 +830,8 @@ class NoPropsNoEventsNativeComponentViewProps final : public ViewProps {
   
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -1039,6 +1069,8 @@ class ObjectPropsNativeComponentProps final : public ViewProps {
   ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct objectPrimitiveRequiredProp{};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -1077,6 +1109,8 @@ class PointPropNativeComponentViewProps final : public ViewProps {
   Point startPoint{};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -1115,6 +1149,8 @@ class StringPropNativeComponentViewProps final : public ViewProps {
   std::string defaultValue{};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
@@ -360,6 +360,12 @@ static inline std::string toString(const EnumPropNativeComponentViewAlignment &v
     case EnumPropNativeComponentViewAlignment::BottomRight: return \\"bottom-right\\";
   }
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const EnumPropNativeComponentViewAlignment &value) {
+  return toString(value);
+}
+#endif
 enum class EnumPropNativeComponentViewIntervals { Intervals0 = 0, Intervals15 = 15, Intervals30 = 30, Intervals60 = 60 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, EnumPropNativeComponentViewIntervals &result) {
@@ -390,6 +396,17 @@ static inline std::string toString(const EnumPropNativeComponentViewIntervals &v
     case EnumPropNativeComponentViewIntervals::Intervals60: return \\"60\\";
   }
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const EnumPropNativeComponentViewIntervals &value) {
+  switch (value) {
+    case EnumPropNativeComponentViewIntervals::Intervals0: return 0;
+    case EnumPropNativeComponentViewIntervals::Intervals15: return 15;
+    case EnumPropNativeComponentViewIntervals::Intervals30: return 30;
+    case EnumPropNativeComponentViewIntervals::Intervals60: return 60;
+  }
+}
+#endif
 
 class EnumPropNativeComponentViewProps final : public ViewProps {
  public:
@@ -798,6 +815,12 @@ static inline std::string toString(const ObjectPropsNativeComponentStringEnumPro
     case ObjectPropsNativeComponentStringEnumProp::Large: return \\"large\\";
   }
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsNativeComponentStringEnumProp &value) {
+  return toString(value);
+}
+#endif
 enum class ObjectPropsNativeComponentIntEnumProp { IntEnumProp0 = 0, IntEnumProp1 = 1 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsNativeComponentIntEnumProp &result) {
@@ -820,6 +843,15 @@ static inline std::string toString(const ObjectPropsNativeComponentIntEnumProp &
     case ObjectPropsNativeComponentIntEnumProp::IntEnumProp1: return \\"1\\";
   }
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsNativeComponentIntEnumProp &value) {
+  switch (value) {
+    case ObjectPropsNativeComponentIntEnumProp::IntEnumProp0: return 0;
+    case ObjectPropsNativeComponentIntEnumProp::IntEnumProp1: return 1;
+  }
+}
+#endif
 struct ObjectPropsNativeComponentObjectPropStruct {
   std::string stringProp{\\"\\"};
   bool booleanProp{false};

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -737,6 +737,9 @@ folly::dynamic MixedPropNativeComponentViewProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (mixedProp != oldProps->mixedProp) {
+    result[\\"mixedProp\\"] = mixedProp;
+  }
   return result;
 }
 #endif

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -51,18 +51,57 @@ folly::dynamic ArrayPropsNativeComponentViewProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (names != oldProps->names) {
+    result[\\"names\\"] = toDynamic(names);
+  }
     
+  if (disableds != oldProps->disableds) {
+    result[\\"disableds\\"] = toDynamic(disableds);
+  }
     
+  if (progress != oldProps->progress) {
+    result[\\"progress\\"] = toDynamic(progress);
+  }
     
+  if (radii != oldProps->radii) {
+    result[\\"radii\\"] = toDynamic(radii);
+  }
     
+  if (colors != oldProps->colors) {
+    result[\\"colors\\"] = toDynamic(colors);
+  }
     
+  if (srcs != oldProps->srcs) {
+    result[\\"srcs\\"] = toDynamic(srcs);
+  }
     
+  if (points != oldProps->points) {
+    result[\\"points\\"] = toDynamic(points);
+  }
     
+  if (edgeInsets != oldProps->edgeInsets) {
+    result[\\"edgeInsets\\"] = toDynamic(edgeInsets);
+  }
     
+  if (dimensions != oldProps->dimensions) {
+    result[\\"dimensions\\"] = toDynamic(dimensions);
+  }
     
+  if (sizes != oldProps->sizes) {
+    result[\\"sizes\\"] = toDynamic(sizes);
+  }
     
+  if (object != oldProps->object) {
+    result[\\"object\\"] = toDynamic(object);
+  }
     
+  if (arrayOfObjects != oldProps->arrayOfObjects) {
+    result[\\"arrayOfObjects\\"] = toDynamic(arrayOfObjects);
+  }
     
+  if (arrayOfMixed != oldProps->arrayOfMixed) {
+    result[\\"arrayOfMixed\\"] = toDynamic(arrayOfMixed);
+  }
   return result;
 }
 #endif

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -40,6 +40,10 @@ ArrayPropsNativeComponentViewProps::ArrayPropsNativeComponentViewProps(
     arrayOfMixed(convertRawProp(context, rawProps, \\"arrayOfMixed\\", sourceProps.arrayOfMixed, {})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName ArrayPropsNativeComponentViewProps::getDiffPropsImplementationTarget() const {
+  return \\"ArrayPropsNativeComponentView\\";
+}
+
 folly::dynamic ArrayPropsNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = ArrayPropsNativeComponentViewProps();
@@ -138,6 +142,10 @@ BooleanPropNativeComponentViewProps::BooleanPropNativeComponentViewProps(
     disabledNullable(convertRawProp(context, rawProps, \\"disabledNullable\\", sourceProps.disabledNullable, {})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName BooleanPropNativeComponentViewProps::getDiffPropsImplementationTarget() const {
+  return \\"BooleanPropNativeComponentView\\";
+}
+
 folly::dynamic BooleanPropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = BooleanPropNativeComponentViewProps();
@@ -191,6 +199,10 @@ ColorPropNativeComponentViewProps::ColorPropNativeComponentViewProps(
     tintColor(convertRawProp(context, rawProps, \\"tintColor\\", sourceProps.tintColor, {})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName ColorPropNativeComponentViewProps::getDiffPropsImplementationTarget() const {
+  return \\"ColorPropNativeComponentView\\";
+}
+
 folly::dynamic ColorPropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = ColorPropNativeComponentViewProps();
@@ -241,6 +253,10 @@ DimensionPropNativeComponentViewProps::DimensionPropNativeComponentViewProps(
     marginBack(convertRawProp(context, rawProps, \\"marginBack\\", sourceProps.marginBack, {})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName DimensionPropNativeComponentViewProps::getDiffPropsImplementationTarget() const {
+  return \\"DimensionPropNativeComponentView\\";
+}
+
 folly::dynamic DimensionPropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = DimensionPropNativeComponentViewProps();
@@ -290,6 +306,10 @@ EdgeInsetsPropNativeComponentViewProps::EdgeInsetsPropNativeComponentViewProps(
      {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName EdgeInsetsPropNativeComponentViewProps::getDiffPropsImplementationTarget() const {
+  return \\"EdgeInsetsPropNativeComponentView\\";
+}
+
 folly::dynamic EdgeInsetsPropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = EdgeInsetsPropNativeComponentViewProps();
@@ -337,6 +357,10 @@ EnumPropNativeComponentViewProps::EnumPropNativeComponentViewProps(
     intervals(convertRawProp(context, rawProps, \\"intervals\\", sourceProps.intervals, {EnumPropNativeComponentViewIntervals::Intervals0})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName EnumPropNativeComponentViewProps::getDiffPropsImplementationTarget() const {
+  return \\"EnumPropNativeComponentView\\";
+}
+
 folly::dynamic EnumPropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = EnumPropNativeComponentViewProps();
@@ -390,6 +414,10 @@ EventNestedObjectPropsNativeComponentViewProps::EventNestedObjectPropsNativeComp
     disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {false})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName EventNestedObjectPropsNativeComponentViewProps::getDiffPropsImplementationTarget() const {
+  return \\"EventNestedObjectPropsNativeComponentView\\";
+}
+
 folly::dynamic EventNestedObjectPropsNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = EventNestedObjectPropsNativeComponentViewProps();
@@ -439,6 +467,10 @@ EventPropsNativeComponentViewProps::EventPropsNativeComponentViewProps(
     disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {false})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName EventPropsNativeComponentViewProps::getDiffPropsImplementationTarget() const {
+  return \\"EventPropsNativeComponentView\\";
+}
+
 folly::dynamic EventPropsNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = EventPropsNativeComponentViewProps();
@@ -494,6 +526,10 @@ FloatPropsNativeComponentViewProps::FloatPropsNativeComponentViewProps(
     blurRadiusNullable(convertRawProp(context, rawProps, \\"blurRadiusNullable\\", sourceProps.blurRadiusNullable, {})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName FloatPropsNativeComponentViewProps::getDiffPropsImplementationTarget() const {
+  return \\"FloatPropsNativeComponentView\\";
+}
+
 folly::dynamic FloatPropsNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = FloatPropsNativeComponentViewProps();
@@ -568,6 +604,10 @@ ImagePropNativeComponentViewProps::ImagePropNativeComponentViewProps(
     thumbImage(convertRawProp(context, rawProps, \\"thumbImage\\", sourceProps.thumbImage, {})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName ImagePropNativeComponentViewProps::getDiffPropsImplementationTarget() const {
+  return \\"ImagePropNativeComponentView\\";
+}
+
 folly::dynamic ImagePropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = ImagePropNativeComponentViewProps();
@@ -619,6 +659,10 @@ IntegerPropNativeComponentViewProps::IntegerPropNativeComponentViewProps(
     progress3(convertRawProp(context, rawProps, \\"progress3\\", sourceProps.progress3, {10})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName IntegerPropNativeComponentViewProps::getDiffPropsImplementationTarget() const {
+  return \\"IntegerPropNativeComponentView\\";
+}
+
 folly::dynamic IntegerPropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = IntegerPropNativeComponentViewProps();
@@ -676,6 +720,10 @@ InterfaceOnlyNativeComponentViewProps::InterfaceOnlyNativeComponentViewProps(
     title(convertRawProp(context, rawProps, \\"title\\", sourceProps.title, {\\"\\"})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName InterfaceOnlyNativeComponentViewProps::getDiffPropsImplementationTarget() const {
+  return \\"InterfaceOnlyNativeComponentView\\";
+}
+
 folly::dynamic InterfaceOnlyNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = InterfaceOnlyNativeComponentViewProps();
@@ -726,6 +774,10 @@ MixedPropNativeComponentViewProps::MixedPropNativeComponentViewProps(
     mixedProp(convertRawProp(context, rawProps, \\"mixedProp\\", sourceProps.mixedProp, {})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName MixedPropNativeComponentViewProps::getDiffPropsImplementationTarget() const {
+  return \\"MixedPropNativeComponentView\\";
+}
+
 folly::dynamic MixedPropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = MixedPropNativeComponentViewProps();
@@ -779,6 +831,10 @@ MultiNativePropNativeComponentViewProps::MultiNativePropNativeComponentViewProps
     point(convertRawProp(context, rawProps, \\"point\\", sourceProps.point, {})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName MultiNativePropNativeComponentViewProps::getDiffPropsImplementationTarget() const {
+  return \\"MultiNativePropNativeComponentView\\";
+}
+
 folly::dynamic MultiNativePropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = MultiNativePropNativeComponentViewProps();
@@ -840,6 +896,10 @@ NoPropsNoEventsNativeComponentViewProps::NoPropsNoEventsNativeComponentViewProps
      {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName NoPropsNoEventsNativeComponentViewProps::getDiffPropsImplementationTarget() const {
+  return \\"NoPropsNoEventsNativeComponentView\\";
+}
+
 folly::dynamic NoPropsNoEventsNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = NoPropsNoEventsNativeComponentViewProps();
@@ -889,6 +949,10 @@ ObjectPropsNativeComponentProps::ObjectPropsNativeComponentProps(
     objectPrimitiveRequiredProp(convertRawProp(context, rawProps, \\"objectPrimitiveRequiredProp\\", sourceProps.objectPrimitiveRequiredProp, {})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName ObjectPropsNativeComponentProps::getDiffPropsImplementationTarget() const {
+  return \\"ObjectPropsNativeComponent\\";
+}
+
 folly::dynamic ObjectPropsNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = ObjectPropsNativeComponentProps();
@@ -946,6 +1010,10 @@ PointPropNativeComponentViewProps::PointPropNativeComponentViewProps(
     startPoint(convertRawProp(context, rawProps, \\"startPoint\\", sourceProps.startPoint, {})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName PointPropNativeComponentViewProps::getDiffPropsImplementationTarget() const {
+  return \\"PointPropNativeComponentView\\";
+}
+
 folly::dynamic PointPropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = PointPropNativeComponentViewProps();
@@ -996,6 +1064,10 @@ StringPropNativeComponentViewProps::StringPropNativeComponentViewProps(
     defaultValue(convertRawProp(context, rawProps, \\"defaultValue\\", sourceProps.defaultValue, {})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName StringPropNativeComponentViewProps::getDiffPropsImplementationTarget() const {
+  return \\"StringPropNativeComponentView\\";
+}
+
 folly::dynamic StringPropNativeComponentViewProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = StringPropNativeComponentViewProps();

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -858,8 +858,17 @@ folly::dynamic ObjectPropsNativeComponentProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (objectProp != oldProps->objectProp) {
+    result[\\"objectProp\\"] = toDynamic(objectProp);
+  }
     
+  if (objectArrayProp != oldProps->objectArrayProp) {
+    result[\\"objectArrayProp\\"] = toDynamic(objectArrayProp);
+  }
     
+  if (objectPrimitiveRequiredProp != oldProps->objectPrimitiveRequiredProp) {
+    result[\\"objectPrimitiveRequiredProp\\"] = toDynamic(objectPrimitiveRequiredProp);
+  }
   return result;
 }
 #endif

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -306,7 +306,13 @@ folly::dynamic EnumPropNativeComponentViewProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (alignment != oldProps->alignment) {
+    result[\\"alignment\\"] = toDynamic(alignment);
+  }
     
+  if (intervals != oldProps->intervals) {
+    result[\\"intervals\\"] = toDynamic(intervals);
+  }
   return result;
 }
 #endif

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -213,6 +213,9 @@ folly::dynamic DimensionPropNativeComponentViewProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (marginBack != oldProps->marginBack) {
+    result[\\"marginBack\\"] = toDynamic(marginBack);
+  }
   return result;
 }
 #endif

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
@@ -88,6 +88,16 @@ static inline std::string toString(const ArrayPropsNativeComponentViewSizesMaskW
 }
 struct ArrayPropsNativeComponentViewObjectStruct {
   std::string prop{};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ArrayPropsNativeComponentViewObjectStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    result[\\"prop\\"] = prop;
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentViewObjectStruct &result) {
@@ -103,6 +113,12 @@ static inline std::string toString(const ArrayPropsNativeComponentViewObjectStru
   return \\"[Object ArrayPropsNativeComponentViewObjectStruct]\\";
 }
 
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ArrayPropsNativeComponentViewObjectStruct &value) {
+  return value.toDynamic();
+}
+#endif
+
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, std::vector<ArrayPropsNativeComponentViewObjectStruct> &result) {
   auto items = (std::vector<RawValue>)value;
   for (const auto &item : items) {
@@ -116,6 +132,17 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 struct ArrayPropsNativeComponentViewArrayOfObjectsStruct {
   Float prop1{0.0};
   int prop2{0};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ArrayPropsNativeComponentViewArrayOfObjectsStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    result[\\"prop1\\"] = prop1;
+    result[\\"prop2\\"] = prop2;
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentViewArrayOfObjectsStruct &result) {
@@ -134,6 +161,12 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 static inline std::string toString(const ArrayPropsNativeComponentViewArrayOfObjectsStruct &value) {
   return \\"[Object ArrayPropsNativeComponentViewArrayOfObjectsStruct]\\";
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ArrayPropsNativeComponentViewArrayOfObjectsStruct &value) {
+  return value.toDynamic();
+}
+#endif
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, std::vector<ArrayPropsNativeComponentViewArrayOfObjectsStruct> &result) {
   auto items = (std::vector<RawValue>)value;
@@ -861,6 +894,21 @@ struct ObjectPropsNativeComponentObjectPropStruct {
   int intProp{0};
   ObjectPropsNativeComponentStringEnumProp stringEnumProp{ObjectPropsNativeComponentStringEnumProp::Small};
   ObjectPropsNativeComponentIntEnumProp intEnumProp{ObjectPropsNativeComponentIntEnumProp::IntEnumProp0};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ObjectPropsNativeComponentObjectPropStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    result[\\"stringProp\\"] = stringProp;
+    result[\\"booleanProp\\"] = booleanProp;
+    result[\\"floatProp\\"] = floatProp;
+    result[\\"intProp\\"] = intProp;
+    result[\\"stringEnumProp\\"] = ::facebook::react::toDynamic(stringEnumProp);
+    result[\\"intEnumProp\\"] = ::facebook::react::toDynamic(intEnumProp);
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsNativeComponentObjectPropStruct &result) {
@@ -896,8 +944,24 @@ static inline std::string toString(const ObjectPropsNativeComponentObjectPropStr
   return \\"[Object ObjectPropsNativeComponentObjectPropStruct]\\";
 }
 
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsNativeComponentObjectPropStruct &value) {
+  return value.toDynamic();
+}
+#endif
+
 struct ObjectPropsNativeComponentObjectArrayPropStruct {
   std::vector<std::string> array{};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ObjectPropsNativeComponentObjectArrayPropStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsNativeComponentObjectArrayPropStruct &result) {
@@ -913,10 +977,28 @@ static inline std::string toString(const ObjectPropsNativeComponentObjectArrayPr
   return \\"[Object ObjectPropsNativeComponentObjectArrayPropStruct]\\";
 }
 
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsNativeComponentObjectArrayPropStruct &value) {
+  return value.toDynamic();
+}
+#endif
+
 struct ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct {
   ImageSource image{};
   SharedColor color{};
   Point point{};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    result[\\"image\\"] = ::facebook::react::toDynamic(image);
+    result[\\"color\\"] = ::facebook::react::toDynamic(color);
+    result[\\"point\\"] = ::facebook::react::toDynamic(point);
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct &result) {
@@ -939,6 +1021,12 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 static inline std::string toString(const ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct &value) {
   return \\"[Object ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct]\\";
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct &value) {
+  return value.toDynamic();
+}
+#endif
 class ObjectPropsNativeComponentProps final : public ViewProps {
  public:
   ObjectPropsNativeComponentProps() = default;

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
@@ -16,6 +16,7 @@ Object {
 #include <cinttypes>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/core/propsConversions.h>
 #include <react/renderer/graphics/Color.h>
 #include <react/renderer/graphics/Point.h>
@@ -265,6 +266,7 @@ Object {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/graphicsConversions.h>
 #include <yoga/Yoga.h>
 
 namespace facebook::react {

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
@@ -958,7 +958,7 @@ struct ObjectPropsNativeComponentObjectArrayPropStruct {
 
   folly::dynamic toDynamic() const {
     folly::dynamic result = folly::dynamic::object();
-    
+    result[\\"array\\"] = ::facebook::react::toDynamic(array);
     return result;
   }
 #endif

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
@@ -199,6 +199,8 @@ class ArrayPropsNativeComponentViewProps final : public ViewProps {
   std::vector<folly::dynamic> arrayOfMixed{};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -237,6 +239,8 @@ class BooleanPropNativeComponentViewProps final : public ViewProps {
   bool disabledNullable{};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -275,6 +279,8 @@ class ColorPropNativeComponentViewProps final : public ViewProps {
   SharedColor tintColor{};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -314,6 +320,8 @@ class DimensionPropNativeComponentViewProps final : public ViewProps {
   YGValue marginBack{};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -351,6 +359,8 @@ class EdgeInsetsPropNativeComponentViewProps final : public ViewProps {
   
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -454,6 +464,8 @@ class EnumPropNativeComponentViewProps final : public ViewProps {
   EnumPropNativeComponentViewIntervals intervals{EnumPropNativeComponentViewIntervals::Intervals0};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -491,6 +503,8 @@ class EventNestedObjectPropsNativeComponentViewProps final : public ViewProps {
   bool disabled{false};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -528,6 +542,8 @@ class EventPropsNativeComponentViewProps final : public ViewProps {
   bool disabled{false};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -571,6 +587,8 @@ class FloatPropsNativeComponentViewProps final : public ViewProps {
   Float blurRadiusNullable{};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -609,6 +627,8 @@ class ImagePropNativeComponentViewProps final : public ViewProps {
   ImageSource thumbImage{};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -648,6 +668,8 @@ class IntegerPropNativeComponentViewProps final : public ViewProps {
   int progress3{10};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -685,6 +707,8 @@ class InterfaceOnlyNativeComponentViewProps final : public ViewProps {
   std::string title{\\"\\"};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -722,6 +746,8 @@ class MixedPropNativeComponentViewProps final : public ViewProps {
   folly::dynamic mixedProp{};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -765,6 +791,8 @@ class MultiNativePropNativeComponentViewProps final : public ViewProps {
   Point point{};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -802,6 +830,8 @@ class NoPropsNoEventsNativeComponentViewProps final : public ViewProps {
   
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -1039,6 +1069,8 @@ class ObjectPropsNativeComponentProps final : public ViewProps {
   ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct objectPrimitiveRequiredProp{};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -1077,6 +1109,8 @@ class PointPropNativeComponentViewProps final : public ViewProps {
   Point startPoint{};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -1115,6 +1149,8 @@ class StringPropNativeComponentViewProps final : public ViewProps {
   std::string defaultValue{};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
@@ -360,6 +360,12 @@ static inline std::string toString(const EnumPropNativeComponentViewAlignment &v
     case EnumPropNativeComponentViewAlignment::BottomRight: return \\"bottom-right\\";
   }
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const EnumPropNativeComponentViewAlignment &value) {
+  return toString(value);
+}
+#endif
 enum class EnumPropNativeComponentViewIntervals { Intervals0 = 0, Intervals15 = 15, Intervals30 = 30, Intervals60 = 60 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, EnumPropNativeComponentViewIntervals &result) {
@@ -390,6 +396,17 @@ static inline std::string toString(const EnumPropNativeComponentViewIntervals &v
     case EnumPropNativeComponentViewIntervals::Intervals60: return \\"60\\";
   }
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const EnumPropNativeComponentViewIntervals &value) {
+  switch (value) {
+    case EnumPropNativeComponentViewIntervals::Intervals0: return 0;
+    case EnumPropNativeComponentViewIntervals::Intervals15: return 15;
+    case EnumPropNativeComponentViewIntervals::Intervals30: return 30;
+    case EnumPropNativeComponentViewIntervals::Intervals60: return 60;
+  }
+}
+#endif
 
 class EnumPropNativeComponentViewProps final : public ViewProps {
  public:
@@ -798,6 +815,12 @@ static inline std::string toString(const ObjectPropsNativeComponentStringEnumPro
     case ObjectPropsNativeComponentStringEnumProp::Large: return \\"large\\";
   }
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsNativeComponentStringEnumProp &value) {
+  return toString(value);
+}
+#endif
 enum class ObjectPropsNativeComponentIntEnumProp { IntEnumProp0 = 0, IntEnumProp1 = 1 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsNativeComponentIntEnumProp &result) {
@@ -820,6 +843,15 @@ static inline std::string toString(const ObjectPropsNativeComponentIntEnumProp &
     case ObjectPropsNativeComponentIntEnumProp::IntEnumProp1: return \\"1\\";
   }
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsNativeComponentIntEnumProp &value) {
+  switch (value) {
+    case ObjectPropsNativeComponentIntEnumProp::IntEnumProp0: return 0;
+    case ObjectPropsNativeComponentIntEnumProp::IntEnumProp1: return 1;
+  }
+}
+#endif
 struct ObjectPropsNativeComponentObjectPropStruct {
   std::string stringProp{\\"\\"};
   bool booleanProp{false};

--- a/packages/react-native-codegen/src/generators/components/ComponentsGeneratorUtils.js
+++ b/packages/react-native-codegen/src/generators/components/ComponentsGeneratorUtils.js
@@ -245,6 +245,7 @@ function getLocalImports(
         return;
       case 'DimensionPrimitive':
         imports.add('#include <yoga/Yoga.h>');
+        imports.add('#include <react/renderer/core/graphicsConversions.h>');
         return;
       default:
         (name: empty);

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
@@ -132,8 +132,12 @@ function generatePropsDiffString(
               throw new Error('Received unknown ReservedPropTypeAnnotation');
           }
         case 'ArrayTypeAnnotation':
-        case 'ObjectTypeAnnotation':
           return '';
+        case 'ObjectTypeAnnotation':
+          return `
+  if (${prop.name} != oldProps->${prop.name}) {
+    result["${prop.name}"] = toDynamic(${prop.name});
+  }`;
         case 'StringEnumTypeAnnotation':
           return `
   if (${prop.name} != oldProps->${prop.name}) {

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
@@ -152,6 +152,10 @@ function generatePropsDiffString(
     result["${prop.name}"] = toDynamic(${prop.name});
   }`;
         case 'MixedTypeAnnotation':
+          return `
+  if (${prop.name} != oldProps->${prop.name}) {
+    result["${prop.name}"] = ${prop.name};
+  }`;
         default:
           // TODO: Implement diffProps for complex types
           return '';

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
@@ -165,6 +165,10 @@ function generatePropsDiffString(
 
   return `
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName ${className}::getDiffPropsImplementationTarget() const {
+  return "${componentName}";
+}
+
 folly::dynamic ${className}::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = ${className}();

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
@@ -132,7 +132,10 @@ function generatePropsDiffString(
               throw new Error('Received unknown ReservedPropTypeAnnotation');
           }
         case 'ArrayTypeAnnotation':
-          return '';
+          return `
+  if (${prop.name} != oldProps->${prop.name}) {
+    result["${prop.name}"] = toDynamic(${prop.name});
+  }`;
         case 'ObjectTypeAnnotation':
           return `
   if (${prop.name} != oldProps->${prop.name}) {

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
@@ -123,8 +123,10 @@ function generatePropsDiffString(
     result["${prop.name}"] = toDynamic(${prop.name});
   }`;
             case 'DimensionPrimitive':
-              // TODO: Implement diffProps for complex types
-              return '';
+              return `
+  if (${prop.name} != oldProps->${prop.name}) {
+    result["${prop.name}"] = toDynamic(${prop.name});
+  }`;
             default:
               (typeAnnotation.name: empty);
               throw new Error('Received unknown ReservedPropTypeAnnotation');

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
@@ -131,8 +131,17 @@ function generatePropsDiffString(
           }
         case 'ArrayTypeAnnotation':
         case 'ObjectTypeAnnotation':
+          return '';
         case 'StringEnumTypeAnnotation':
+          return `
+  if (${prop.name} != oldProps->${prop.name}) {
+    result["${prop.name}"] = toDynamic(${prop.name});
+  }`;
         case 'Int32EnumTypeAnnotation':
+          return `
+  if (${prop.name} != oldProps->${prop.name}) {
+    result["${prop.name}"] = toDynamic(${prop.name});
+  }`;
         case 'MixedTypeAnnotation':
         default:
           // TODO: Implement diffProps for complex types

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsH.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsH.js
@@ -85,6 +85,8 @@ class ${className} final${extendClasses} {
   ${props}
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsH.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsH.js
@@ -755,10 +755,8 @@ function generateStruct(
         case 'Int32TypeAnnotation':
         case 'DoubleTypeAnnotation':
         case 'FloatTypeAnnotation':
-          return `result["${name}"] = ${name};`;
         case 'MixedTypeAnnotation':
-          // MixedTypeAnnotation does not support prop diffing codegen
-          return '';
+          return `result["${name}"] = ${name};`;
         default:
           return `result["${name}"] = ::facebook::react::toDynamic(${name});`;
       }

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsH.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsH.js
@@ -756,8 +756,6 @@ function generateStruct(
         case 'DoubleTypeAnnotation':
         case 'FloatTypeAnnotation':
           return `result["${name}"] = ${name};`;
-        case 'ArrayTypeAnnotation':
-          return '';
         case 'MixedTypeAnnotation':
           // MixedTypeAnnotation does not support prop diffing codegen
           return '';

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -1268,6 +1268,9 @@ folly::dynamic ObjectPropsProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (objectProp != oldProps->objectProp) {
+    result[\\"objectProp\\"] = toDynamic(objectProp);
+  }
   return result;
 }
 #endif

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -40,6 +40,10 @@ ArrayPropsNativeComponentProps::ArrayPropsNativeComponentProps(
     arrayOfMixed(convertRawProp(context, rawProps, \\"arrayOfMixed\\", sourceProps.arrayOfMixed, {})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName ArrayPropsNativeComponentProps::getDiffPropsImplementationTarget() const {
+  return \\"ArrayPropsNativeComponent\\";
+}
+
 folly::dynamic ArrayPropsNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = ArrayPropsNativeComponentProps();
@@ -137,6 +141,10 @@ ArrayPropsNativeComponentProps::ArrayPropsNativeComponentProps(
     nativePrimitives(convertRawProp(context, rawProps, \\"nativePrimitives\\", sourceProps.nativePrimitives, {})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName ArrayPropsNativeComponentProps::getDiffPropsImplementationTarget() const {
+  return \\"ArrayPropsNativeComponent\\";
+}
+
 folly::dynamic ArrayPropsNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = ArrayPropsNativeComponentProps();
@@ -186,6 +194,10 @@ BooleanPropNativeComponentProps::BooleanPropNativeComponentProps(
     disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {false})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName BooleanPropNativeComponentProps::getDiffPropsImplementationTarget() const {
+  return \\"BooleanPropNativeComponent\\";
+}
+
 folly::dynamic BooleanPropNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = BooleanPropNativeComponentProps();
@@ -235,6 +247,10 @@ ColorPropNativeComponentProps::ColorPropNativeComponentProps(
     tintColor(convertRawProp(context, rawProps, \\"tintColor\\", sourceProps.tintColor, {})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName ColorPropNativeComponentProps::getDiffPropsImplementationTarget() const {
+  return \\"ColorPropNativeComponent\\";
+}
+
 folly::dynamic ColorPropNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = ColorPropNativeComponentProps();
@@ -284,6 +300,10 @@ CommandNativeComponentProps::CommandNativeComponentProps(
      {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName CommandNativeComponentProps::getDiffPropsImplementationTarget() const {
+  return \\"CommandNativeComponent\\";
+}
+
 folly::dynamic CommandNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = CommandNativeComponentProps();
@@ -330,6 +350,10 @@ CommandNativeComponentProps::CommandNativeComponentProps(
     accessibilityHint(convertRawProp(context, rawProps, \\"accessibilityHint\\", sourceProps.accessibilityHint, {\\"\\"})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName CommandNativeComponentProps::getDiffPropsImplementationTarget() const {
+  return \\"CommandNativeComponent\\";
+}
+
 folly::dynamic CommandNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = CommandNativeComponentProps();
@@ -380,6 +404,10 @@ DimensionPropNativeComponentProps::DimensionPropNativeComponentProps(
     marginBack(convertRawProp(context, rawProps, \\"marginBack\\", sourceProps.marginBack, {})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName DimensionPropNativeComponentProps::getDiffPropsImplementationTarget() const {
+  return \\"DimensionPropNativeComponent\\";
+}
+
 folly::dynamic DimensionPropNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = DimensionPropNativeComponentProps();
@@ -434,6 +462,10 @@ DoublePropNativeComponentProps::DoublePropNativeComponentProps(
     blurRadius6(convertRawProp(context, rawProps, \\"blurRadius6\\", sourceProps.blurRadius6, {0.0})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName DoublePropNativeComponentProps::getDiffPropsImplementationTarget() const {
+  return \\"DoublePropNativeComponent\\";
+}
+
 folly::dynamic DoublePropNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = DoublePropNativeComponentProps();
@@ -503,6 +535,10 @@ EventsNestedObjectNativeComponentProps::EventsNestedObjectNativeComponentProps(
     disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {false})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName EventsNestedObjectNativeComponentProps::getDiffPropsImplementationTarget() const {
+  return \\"EventsNestedObjectNativeComponent\\";
+}
+
 folly::dynamic EventsNestedObjectNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = EventsNestedObjectNativeComponentProps();
@@ -552,6 +588,10 @@ EventsNativeComponentProps::EventsNativeComponentProps(
     disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {false})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName EventsNativeComponentProps::getDiffPropsImplementationTarget() const {
+  return \\"EventsNativeComponent\\";
+}
+
 folly::dynamic EventsNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = EventsNativeComponentProps();
@@ -601,6 +641,10 @@ InterfaceOnlyComponentProps::InterfaceOnlyComponentProps(
      {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName InterfaceOnlyComponentProps::getDiffPropsImplementationTarget() const {
+  return \\"InterfaceOnlyComponent\\";
+}
+
 folly::dynamic InterfaceOnlyComponentProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = InterfaceOnlyComponentProps();
@@ -647,6 +691,10 @@ ExcludedAndroidComponentProps::ExcludedAndroidComponentProps(
      {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName ExcludedAndroidComponentProps::getDiffPropsImplementationTarget() const {
+  return \\"ExcludedAndroidComponent\\";
+}
+
 folly::dynamic ExcludedAndroidComponentProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = ExcludedAndroidComponentProps();
@@ -693,6 +741,10 @@ ExcludedAndroidIosComponentProps::ExcludedAndroidIosComponentProps(
      {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName ExcludedAndroidIosComponentProps::getDiffPropsImplementationTarget() const {
+  return \\"ExcludedAndroidIosComponent\\";
+}
+
 folly::dynamic ExcludedAndroidIosComponentProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = ExcludedAndroidIosComponentProps();
@@ -739,6 +791,10 @@ ExcludedIosComponentProps::ExcludedIosComponentProps(
      {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName ExcludedIosComponentProps::getDiffPropsImplementationTarget() const {
+  return \\"ExcludedIosComponent\\";
+}
+
 folly::dynamic ExcludedIosComponentProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = ExcludedIosComponentProps();
@@ -761,6 +817,10 @@ MultiFileIncludedNativeComponentProps::MultiFileIncludedNativeComponentProps(
     disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {true})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName MultiFileIncludedNativeComponentProps::getDiffPropsImplementationTarget() const {
+  return \\"MultiFileIncludedNativeComponent\\";
+}
+
 folly::dynamic MultiFileIncludedNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = MultiFileIncludedNativeComponentProps();
@@ -815,6 +875,10 @@ FloatPropNativeComponentProps::FloatPropNativeComponentProps(
     blurRadius6(convertRawProp(context, rawProps, \\"blurRadius6\\", sourceProps.blurRadius6, {0.0})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName FloatPropNativeComponentProps::getDiffPropsImplementationTarget() const {
+  return \\"FloatPropNativeComponent\\";
+}
+
 folly::dynamic FloatPropNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = FloatPropNativeComponentProps();
@@ -885,6 +949,10 @@ ImagePropNativeComponentProps::ImagePropNativeComponentProps(
     thumbImage(convertRawProp(context, rawProps, \\"thumbImage\\", sourceProps.thumbImage, {})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName ImagePropNativeComponentProps::getDiffPropsImplementationTarget() const {
+  return \\"ImagePropNativeComponent\\";
+}
+
 folly::dynamic ImagePropNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = ImagePropNativeComponentProps();
@@ -934,6 +1002,10 @@ InsetsPropNativeComponentProps::InsetsPropNativeComponentProps(
     contentInset(convertRawProp(context, rawProps, \\"contentInset\\", sourceProps.contentInset, {})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName InsetsPropNativeComponentProps::getDiffPropsImplementationTarget() const {
+  return \\"InsetsPropNativeComponent\\";
+}
+
 folly::dynamic InsetsPropNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = InsetsPropNativeComponentProps();
@@ -983,6 +1055,10 @@ Int32EnumPropsNativeComponentProps::Int32EnumPropsNativeComponentProps(
     maxInterval(convertRawProp(context, rawProps, \\"maxInterval\\", sourceProps.maxInterval, {Int32EnumPropsNativeComponentMaxInterval::MaxInterval0})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName Int32EnumPropsNativeComponentProps::getDiffPropsImplementationTarget() const {
+  return \\"Int32EnumPropsNativeComponent\\";
+}
+
 folly::dynamic Int32EnumPropsNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = Int32EnumPropsNativeComponentProps();
@@ -1034,6 +1110,10 @@ IntegerPropNativeComponentProps::IntegerPropNativeComponentProps(
     progress3(convertRawProp(context, rawProps, \\"progress3\\", sourceProps.progress3, {10})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName IntegerPropNativeComponentProps::getDiffPropsImplementationTarget() const {
+  return \\"IntegerPropNativeComponent\\";
+}
+
 folly::dynamic IntegerPropNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = IntegerPropNativeComponentProps();
@@ -1091,6 +1171,10 @@ InterfaceOnlyComponentProps::InterfaceOnlyComponentProps(
     accessibilityHint(convertRawProp(context, rawProps, \\"accessibilityHint\\", sourceProps.accessibilityHint, {\\"\\"})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName InterfaceOnlyComponentProps::getDiffPropsImplementationTarget() const {
+  return \\"InterfaceOnlyComponent\\";
+}
+
 folly::dynamic InterfaceOnlyComponentProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = InterfaceOnlyComponentProps();
@@ -1141,6 +1225,10 @@ MixedPropNativeComponentProps::MixedPropNativeComponentProps(
     mixedProp(convertRawProp(context, rawProps, \\"mixedProp\\", sourceProps.mixedProp, {})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName MixedPropNativeComponentProps::getDiffPropsImplementationTarget() const {
+  return \\"MixedPropNativeComponent\\";
+}
+
 folly::dynamic MixedPropNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = MixedPropNativeComponentProps();
@@ -1194,6 +1282,10 @@ ImageColorPropNativeComponentProps::ImageColorPropNativeComponentProps(
     point(convertRawProp(context, rawProps, \\"point\\", sourceProps.point, {})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName ImageColorPropNativeComponentProps::getDiffPropsImplementationTarget() const {
+  return \\"ImageColorPropNativeComponent\\";
+}
+
 folly::dynamic ImageColorPropNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = ImageColorPropNativeComponentProps();
@@ -1255,6 +1347,10 @@ NoPropsNoEventsComponentProps::NoPropsNoEventsComponentProps(
      {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName NoPropsNoEventsComponentProps::getDiffPropsImplementationTarget() const {
+  return \\"NoPropsNoEventsComponent\\";
+}
+
 folly::dynamic NoPropsNoEventsComponentProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = NoPropsNoEventsComponentProps();
@@ -1302,6 +1398,10 @@ ObjectPropsProps::ObjectPropsProps(
     objectProp(convertRawProp(context, rawProps, \\"objectProp\\", sourceProps.objectProp, {})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName ObjectPropsProps::getDiffPropsImplementationTarget() const {
+  return \\"ObjectProps\\";
+}
+
 folly::dynamic ObjectPropsProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = ObjectPropsProps();
@@ -1351,6 +1451,10 @@ PointPropNativeComponentProps::PointPropNativeComponentProps(
     startPoint(convertRawProp(context, rawProps, \\"startPoint\\", sourceProps.startPoint, {})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName PointPropNativeComponentProps::getDiffPropsImplementationTarget() const {
+  return \\"PointPropNativeComponent\\";
+}
+
 folly::dynamic PointPropNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = PointPropNativeComponentProps();
@@ -1400,6 +1504,10 @@ StringEnumPropsNativeComponentProps::StringEnumPropsNativeComponentProps(
     alignment(convertRawProp(context, rawProps, \\"alignment\\", sourceProps.alignment, {StringEnumPropsNativeComponentAlignment::Center})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName StringEnumPropsNativeComponentProps::getDiffPropsImplementationTarget() const {
+  return \\"StringEnumPropsNativeComponent\\";
+}
+
 folly::dynamic StringEnumPropsNativeComponentProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = StringEnumPropsNativeComponentProps();
@@ -1450,6 +1558,10 @@ StringPropComponentProps::StringPropComponentProps(
     accessibilityRole(convertRawProp(context, rawProps, \\"accessibilityRole\\", sourceProps.accessibilityRole, {})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName StringPropComponentProps::getDiffPropsImplementationTarget() const {
+  return \\"StringPropComponent\\";
+}
+
 folly::dynamic StringPropComponentProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = StringPropComponentProps();
@@ -1503,6 +1615,10 @@ MultiFile1NativeComponentProps::MultiFile1NativeComponentProps(
     disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {false})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName MultiFile1NativeComponentProps::getDiffPropsImplementationTarget() const {
+  return \\"MultiFile1NativeComponent\\";
+}
+
 folly::dynamic MultiFile1NativeComponentProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = MultiFile1NativeComponentProps();
@@ -1528,6 +1644,10 @@ MultiFile2NativeComponentProps::MultiFile2NativeComponentProps(
     disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {true})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName MultiFile2NativeComponentProps::getDiffPropsImplementationTarget() const {
+  return \\"MultiFile2NativeComponent\\";
+}
+
 folly::dynamic MultiFile2NativeComponentProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = MultiFile2NativeComponentProps();
@@ -1577,6 +1697,10 @@ MultiComponent1NativeComponentProps::MultiComponent1NativeComponentProps(
     disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {false})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName MultiComponent1NativeComponentProps::getDiffPropsImplementationTarget() const {
+  return \\"MultiComponent1NativeComponent\\";
+}
+
 folly::dynamic MultiComponent1NativeComponentProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = MultiComponent1NativeComponentProps();
@@ -1602,6 +1726,10 @@ MultiComponent2NativeComponentProps::MultiComponent2NativeComponentProps(
     disabled(convertRawProp(context, rawProps, \\"disabled\\", sourceProps.disabled, {true})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
+ComponentName MultiComponent2NativeComponentProps::getDiffPropsImplementationTarget() const {
+  return \\"MultiComponent2NativeComponent\\";
+}
+
 folly::dynamic MultiComponent2NativeComponentProps::getDiffProps(
     const Props* prevProps) const {
   static const auto defaultProps = MultiComponent2NativeComponentProps();

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -349,6 +349,9 @@ folly::dynamic DimensionPropNativeComponentProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (marginBack != oldProps->marginBack) {
+    result[\\"marginBack\\"] = toDynamic(marginBack);
+  }
   return result;
 }
 #endif

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -51,18 +51,57 @@ folly::dynamic ArrayPropsNativeComponentProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (names != oldProps->names) {
+    result[\\"names\\"] = toDynamic(names);
+  }
     
+  if (disableds != oldProps->disableds) {
+    result[\\"disableds\\"] = toDynamic(disableds);
+  }
     
+  if (progress != oldProps->progress) {
+    result[\\"progress\\"] = toDynamic(progress);
+  }
     
+  if (radii != oldProps->radii) {
+    result[\\"radii\\"] = toDynamic(radii);
+  }
     
+  if (colors != oldProps->colors) {
+    result[\\"colors\\"] = toDynamic(colors);
+  }
     
+  if (srcs != oldProps->srcs) {
+    result[\\"srcs\\"] = toDynamic(srcs);
+  }
     
+  if (points != oldProps->points) {
+    result[\\"points\\"] = toDynamic(points);
+  }
     
+  if (dimensions != oldProps->dimensions) {
+    result[\\"dimensions\\"] = toDynamic(dimensions);
+  }
     
+  if (sizes != oldProps->sizes) {
+    result[\\"sizes\\"] = toDynamic(sizes);
+  }
     
+  if (object != oldProps->object) {
+    result[\\"object\\"] = toDynamic(object);
+  }
     
+  if (array != oldProps->array) {
+    result[\\"array\\"] = toDynamic(array);
+  }
     
+  if (arrayOfArrayOfObject != oldProps->arrayOfArrayOfObject) {
+    result[\\"arrayOfArrayOfObject\\"] = toDynamic(arrayOfArrayOfObject);
+  }
     
+  if (arrayOfMixed != oldProps->arrayOfMixed) {
+    result[\\"arrayOfMixed\\"] = toDynamic(arrayOfMixed);
+  }
   return result;
 }
 #endif
@@ -109,6 +148,9 @@ folly::dynamic ArrayPropsNativeComponentProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (nativePrimitives != oldProps->nativePrimitives) {
+    result[\\"nativePrimitives\\"] = toDynamic(nativePrimitives);
+  }
   return result;
 }
 #endif

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -949,6 +949,9 @@ folly::dynamic Int32EnumPropsNativeComponentProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (maxInterval != oldProps->maxInterval) {
+    result[\\"maxInterval\\"] = toDynamic(maxInterval);
+  }
   return result;
 }
 #endif
@@ -1357,6 +1360,9 @@ folly::dynamic StringEnumPropsNativeComponentProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (alignment != oldProps->alignment) {
+    result[\\"alignment\\"] = toDynamic(alignment);
+  }
   return result;
 }
 #endif

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -1152,6 +1152,9 @@ folly::dynamic MixedPropNativeComponentProps::getDiffProps(
   }
   folly::dynamic result = HostPlatformViewProps::getDiffProps(prevProps);
   
+  if (mixedProp != oldProps->mixedProp) {
+    result[\\"mixedProp\\"] = mixedProp;
+  }
   return result;
 }
 #endif

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
@@ -16,6 +16,7 @@ Map {
 #include <cinttypes>
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/core/propsConversions.h>
 #include <react/renderer/graphics/Color.h>
 #include <react/renderer/graphics/Point.h>
@@ -469,6 +470,7 @@ Map {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/graphicsConversions.h>
 #include <yoga/Yoga.h>
 
 namespace facebook::react {

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
@@ -282,6 +282,8 @@ class ArrayPropsNativeComponentProps final : public ViewProps {
   std::vector<folly::dynamic> arrayOfMixed{};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -379,6 +381,8 @@ class ArrayPropsNativeComponentProps final : public ViewProps {
   std::vector<ArrayPropsNativeComponentNativePrimitivesStruct> nativePrimitives{};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -416,6 +420,8 @@ class BooleanPropNativeComponentProps final : public ViewProps {
   bool disabled{false};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -454,6 +460,8 @@ class ColorPropNativeComponentProps final : public ViewProps {
   SharedColor tintColor{};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -491,6 +499,8 @@ class CommandNativeComponentProps final : public ViewProps {
   
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -528,6 +538,8 @@ class CommandNativeComponentProps final : public ViewProps {
   std::string accessibilityHint{\\"\\"};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -567,6 +579,8 @@ class DimensionPropNativeComponentProps final : public ViewProps {
   YGValue marginBack{};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -609,6 +623,8 @@ class DoublePropNativeComponentProps final : public ViewProps {
   double blurRadius6{0.0};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -646,6 +662,8 @@ class EventsNestedObjectNativeComponentProps final : public ViewProps {
   bool disabled{false};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -683,6 +701,8 @@ class EventsNativeComponentProps final : public ViewProps {
   bool disabled{false};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -720,6 +740,8 @@ class InterfaceOnlyComponentProps final : public ViewProps {
   
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -757,6 +779,8 @@ class ExcludedAndroidComponentProps final : public ViewProps {
   
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -794,6 +818,8 @@ class ExcludedAndroidIosComponentProps final : public ViewProps {
   
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -831,6 +857,8 @@ class ExcludedIosComponentProps final : public ViewProps {
   
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -845,6 +873,8 @@ class MultiFileIncludedNativeComponentProps final : public ViewProps {
   bool disabled{true};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -887,6 +917,8 @@ class FloatPropNativeComponentProps final : public ViewProps {
   Float blurRadius6{0.0};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -925,6 +957,8 @@ class ImagePropNativeComponentProps final : public ViewProps {
   ImageSource thumbImage{};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -963,6 +997,8 @@ class InsetsPropNativeComponentProps final : public ViewProps {
   EdgeInsets contentInset{};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -1037,6 +1073,8 @@ class Int32EnumPropsNativeComponentProps final : public ViewProps {
   Int32EnumPropsNativeComponentMaxInterval maxInterval{Int32EnumPropsNativeComponentMaxInterval::MaxInterval0};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -1076,6 +1114,8 @@ class IntegerPropNativeComponentProps final : public ViewProps {
   int progress3{10};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -1113,6 +1153,8 @@ class InterfaceOnlyComponentProps final : public ViewProps {
   std::string accessibilityHint{\\"\\"};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -1150,6 +1192,8 @@ class MixedPropNativeComponentProps final : public ViewProps {
   folly::dynamic mixedProp{};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -1193,6 +1237,8 @@ class ImageColorPropNativeComponentProps final : public ViewProps {
   Point point{};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -1230,6 +1276,8 @@ class NoPropsNoEventsComponentProps final : public ViewProps {
   
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -1648,6 +1696,8 @@ class ObjectPropsProps final : public ViewProps {
   ObjectPropsObjectPropStruct objectProp{};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -1686,6 +1736,8 @@ class PointPropNativeComponentProps final : public ViewProps {
   Point startPoint{};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -1747,6 +1799,8 @@ class StringEnumPropsNativeComponentProps final : public ViewProps {
   StringEnumPropsNativeComponentAlignment alignment{StringEnumPropsNativeComponentAlignment::Center};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -1785,6 +1839,8 @@ class StringPropComponentProps final : public ViewProps {
   std::string accessibilityRole{};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -1822,6 +1878,8 @@ class MultiFile1NativeComponentProps final : public ViewProps {
   bool disabled{false};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -1836,6 +1894,8 @@ class MultiFile2NativeComponentProps final : public ViewProps {
   bool disabled{true};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -1873,6 +1933,8 @@ class MultiComponent1NativeComponentProps final : public ViewProps {
   bool disabled{false};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };
@@ -1887,6 +1949,8 @@ class MultiComponent2NativeComponentProps final : public ViewProps {
   bool disabled{true};
 
   #ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
 };

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
@@ -933,6 +933,16 @@ static inline std::string toString(const Int32EnumPropsNativeComponentMaxInterva
   }
 }
 
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const Int32EnumPropsNativeComponentMaxInterval &value) {
+  switch (value) {
+    case Int32EnumPropsNativeComponentMaxInterval::MaxInterval0: return 0;
+    case Int32EnumPropsNativeComponentMaxInterval::MaxInterval1: return 1;
+    case Int32EnumPropsNativeComponentMaxInterval::MaxInterval2: return 2;
+  }
+}
+#endif
+
 class Int32EnumPropsNativeComponentProps final : public ViewProps {
  public:
   Int32EnumPropsNativeComponentProps() = default;
@@ -1182,6 +1192,12 @@ static inline std::string toString(const ObjectPropsStringEnumProp &value) {
     case ObjectPropsStringEnumProp::Option1: return \\"option1\\";
   }
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsStringEnumProp &value) {
+  return toString(value);
+}
+#endif
 enum class ObjectPropsIntEnumProp { IntEnumProp0 = 0 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsIntEnumProp &result) {
@@ -1200,6 +1216,14 @@ static inline std::string toString(const ObjectPropsIntEnumProp &value) {
     case ObjectPropsIntEnumProp::IntEnumProp0: return \\"0\\";
   }
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsIntEnumProp &value) {
+  switch (value) {
+    case ObjectPropsIntEnumProp::IntEnumProp0: return 0;
+  }
+}
+#endif
 struct ObjectPropsObjectPropObjectArrayPropStruct {
   std::vector<std::string> array{};
 };
@@ -1495,6 +1519,12 @@ static inline std::string toString(const StringEnumPropsNativeComponentAlignment
     case StringEnumPropsNativeComponentAlignment::BottomRight: return \\"bottom-right\\";
   }
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const StringEnumPropsNativeComponentAlignment &value) {
+  return toString(value);
+}
+#endif
 
 class StringEnumPropsNativeComponentProps final : public ViewProps {
  public:

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
@@ -179,7 +179,7 @@ struct ArrayPropsNativeComponentArrayStruct {
 
   folly::dynamic toDynamic() const {
     folly::dynamic result = folly::dynamic::object();
-    
+    result[\\"object\\"] = ::facebook::react::toDynamic(object);
     return result;
   }
 #endif
@@ -325,9 +325,9 @@ struct ArrayPropsNativeComponentNativePrimitivesStruct {
 
   folly::dynamic toDynamic() const {
     folly::dynamic result = folly::dynamic::object();
-    
-    
-    
+    result[\\"colors\\"] = ::facebook::react::toDynamic(colors);
+    result[\\"srcs\\"] = ::facebook::react::toDynamic(srcs);
+    result[\\"points\\"] = ::facebook::react::toDynamic(points);
     return result;
   }
 #endif
@@ -1316,7 +1316,7 @@ struct ObjectPropsObjectPropObjectArrayPropStruct {
 
   folly::dynamic toDynamic() const {
     folly::dynamic result = folly::dynamic::object();
-    
+    result[\\"array\\"] = ::facebook::react::toDynamic(array);
     return result;
   }
 #endif
@@ -1503,7 +1503,7 @@ struct ObjectPropsObjectPropNestedArrayAsPropertyStruct {
 
   folly::dynamic toDynamic() const {
     folly::dynamic result = folly::dynamic::object();
-    
+    result[\\"arrayProp\\"] = ::facebook::react::toDynamic(arrayProp);
     return result;
   }
 #endif

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
@@ -87,6 +87,16 @@ static inline std::string toString(const ArrayPropsNativeComponentSizesMaskWrapp
 }
 struct ArrayPropsNativeComponentObjectStruct {
   std::string stringProp{\\"\\"};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ArrayPropsNativeComponentObjectStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    result[\\"stringProp\\"] = stringProp;
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentObjectStruct &result) {
@@ -102,6 +112,12 @@ static inline std::string toString(const ArrayPropsNativeComponentObjectStruct &
   return \\"[Object ArrayPropsNativeComponentObjectStruct]\\";
 }
 
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ArrayPropsNativeComponentObjectStruct &value) {
+  return value.toDynamic();
+}
+#endif
+
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, std::vector<ArrayPropsNativeComponentObjectStruct> &result) {
   auto items = (std::vector<RawValue>)value;
   for (const auto &item : items) {
@@ -114,6 +130,16 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 
 struct ArrayPropsNativeComponentArrayObjectStruct {
   std::string stringProp{\\"\\"};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ArrayPropsNativeComponentArrayObjectStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    result[\\"stringProp\\"] = stringProp;
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentArrayObjectStruct &result) {
@@ -129,6 +155,12 @@ static inline std::string toString(const ArrayPropsNativeComponentArrayObjectStr
   return \\"[Object ArrayPropsNativeComponentArrayObjectStruct]\\";
 }
 
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ArrayPropsNativeComponentArrayObjectStruct &value) {
+  return value.toDynamic();
+}
+#endif
+
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, std::vector<ArrayPropsNativeComponentArrayObjectStruct> &result) {
   auto items = (std::vector<RawValue>)value;
   for (const auto &item : items) {
@@ -141,6 +173,16 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 
 struct ArrayPropsNativeComponentArrayStruct {
   std::vector<ArrayPropsNativeComponentArrayObjectStruct> object{};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ArrayPropsNativeComponentArrayStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentArrayStruct &result) {
@@ -156,6 +198,12 @@ static inline std::string toString(const ArrayPropsNativeComponentArrayStruct &v
   return \\"[Object ArrayPropsNativeComponentArrayStruct]\\";
 }
 
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ArrayPropsNativeComponentArrayStruct &value) {
+  return value.toDynamic();
+}
+#endif
+
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, std::vector<ArrayPropsNativeComponentArrayStruct> &result) {
   auto items = (std::vector<RawValue>)value;
   for (const auto &item : items) {
@@ -168,6 +216,16 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 
 struct ArrayPropsNativeComponentArrayOfArrayOfObjectStruct {
   std::string stringProp{\\"\\"};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ArrayPropsNativeComponentArrayOfArrayOfObjectStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    result[\\"stringProp\\"] = stringProp;
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentArrayOfArrayOfObjectStruct &result) {
@@ -182,6 +240,12 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 static inline std::string toString(const ArrayPropsNativeComponentArrayOfArrayOfObjectStruct &value) {
   return \\"[Object ArrayPropsNativeComponentArrayOfArrayOfObjectStruct]\\";
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ArrayPropsNativeComponentArrayOfArrayOfObjectStruct &value) {
+  return value.toDynamic();
+}
+#endif
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, std::vector<std::vector<ArrayPropsNativeComponentArrayOfArrayOfObjectStruct>> &result) {
   auto items = (std::vector<std::vector<RawValue>>)value;
@@ -255,6 +319,18 @@ struct ArrayPropsNativeComponentNativePrimitivesStruct {
   std::vector<SharedColor> colors{};
   std::vector<ImageSource> srcs{};
   std::vector<Point> points{};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ArrayPropsNativeComponentNativePrimitivesStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    
+    
+    
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ArrayPropsNativeComponentNativePrimitivesStruct &result) {
@@ -277,6 +353,12 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 static inline std::string toString(const ArrayPropsNativeComponentNativePrimitivesStruct &value) {
   return \\"[Object ArrayPropsNativeComponentNativePrimitivesStruct]\\";
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ArrayPropsNativeComponentNativePrimitivesStruct &value) {
+  return value.toDynamic();
+}
+#endif
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, std::vector<ArrayPropsNativeComponentNativePrimitivesStruct> &result) {
   auto items = (std::vector<RawValue>)value;
@@ -1228,6 +1310,16 @@ static inline folly::dynamic toDynamic(const ObjectPropsIntEnumProp &value) {
 #endif
 struct ObjectPropsObjectPropObjectArrayPropStruct {
   std::vector<std::string> array{};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ObjectPropsObjectPropObjectArrayPropStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsObjectPropObjectArrayPropStruct &result) {
@@ -1243,10 +1335,28 @@ static inline std::string toString(const ObjectPropsObjectPropObjectArrayPropStr
   return \\"[Object ObjectPropsObjectPropObjectArrayPropStruct]\\";
 }
 
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsObjectPropObjectArrayPropStruct &value) {
+  return value.toDynamic();
+}
+#endif
+
 struct ObjectPropsObjectPropObjectPrimitiveRequiredPropStruct {
   ImageSource image{};
   SharedColor color{};
   Point point{};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ObjectPropsObjectPropObjectPrimitiveRequiredPropStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    result[\\"image\\"] = ::facebook::react::toDynamic(image);
+    result[\\"color\\"] = ::facebook::react::toDynamic(color);
+    result[\\"point\\"] = ::facebook::react::toDynamic(point);
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsObjectPropObjectPrimitiveRequiredPropStruct &result) {
@@ -1270,8 +1380,24 @@ static inline std::string toString(const ObjectPropsObjectPropObjectPrimitiveReq
   return \\"[Object ObjectPropsObjectPropObjectPrimitiveRequiredPropStruct]\\";
 }
 
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsObjectPropObjectPrimitiveRequiredPropStruct &value) {
+  return value.toDynamic();
+}
+#endif
+
 struct ObjectPropsObjectPropNestedPropANestedPropBStruct {
   std::string nestedPropC{\\"\\"};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ObjectPropsObjectPropNestedPropANestedPropBStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    result[\\"nestedPropC\\"] = nestedPropC;
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsObjectPropNestedPropANestedPropBStruct &result) {
@@ -1287,8 +1413,24 @@ static inline std::string toString(const ObjectPropsObjectPropNestedPropANestedP
   return \\"[Object ObjectPropsObjectPropNestedPropANestedPropBStruct]\\";
 }
 
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsObjectPropNestedPropANestedPropBStruct &value) {
+  return value.toDynamic();
+}
+#endif
+
 struct ObjectPropsObjectPropNestedPropAStruct {
   ObjectPropsObjectPropNestedPropANestedPropBStruct nestedPropB{};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ObjectPropsObjectPropNestedPropAStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    result[\\"nestedPropB\\"] = ::facebook::react::toDynamic(nestedPropB);
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsObjectPropNestedPropAStruct &result) {
@@ -1304,8 +1446,24 @@ static inline std::string toString(const ObjectPropsObjectPropNestedPropAStruct 
   return \\"[Object ObjectPropsObjectPropNestedPropAStruct]\\";
 }
 
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsObjectPropNestedPropAStruct &value) {
+  return value.toDynamic();
+}
+#endif
+
 struct ObjectPropsObjectPropNestedArrayAsPropertyArrayPropStruct {
   std::string stringProp{\\"\\"};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ObjectPropsObjectPropNestedArrayAsPropertyArrayPropStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    result[\\"stringProp\\"] = stringProp;
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsObjectPropNestedArrayAsPropertyArrayPropStruct &result) {
@@ -1321,6 +1479,12 @@ static inline std::string toString(const ObjectPropsObjectPropNestedArrayAsPrope
   return \\"[Object ObjectPropsObjectPropNestedArrayAsPropertyArrayPropStruct]\\";
 }
 
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsObjectPropNestedArrayAsPropertyArrayPropStruct &value) {
+  return value.toDynamic();
+}
+#endif
+
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, std::vector<ObjectPropsObjectPropNestedArrayAsPropertyArrayPropStruct> &result) {
   auto items = (std::vector<RawValue>)value;
   for (const auto &item : items) {
@@ -1333,6 +1497,16 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 
 struct ObjectPropsObjectPropNestedArrayAsPropertyStruct {
   std::vector<ObjectPropsObjectPropNestedArrayAsPropertyArrayPropStruct> arrayProp{};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ObjectPropsObjectPropNestedArrayAsPropertyStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsObjectPropNestedArrayAsPropertyStruct &result) {
@@ -1347,6 +1521,12 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 static inline std::string toString(const ObjectPropsObjectPropNestedArrayAsPropertyStruct &value) {
   return \\"[Object ObjectPropsObjectPropNestedArrayAsPropertyStruct]\\";
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsObjectPropNestedArrayAsPropertyStruct &value) {
+  return value.toDynamic();
+}
+#endif
 
 struct ObjectPropsObjectPropStruct {
   std::string stringProp{\\"\\"};
@@ -1363,6 +1543,29 @@ struct ObjectPropsObjectPropStruct {
   ObjectPropsObjectPropObjectPrimitiveRequiredPropStruct objectPrimitiveRequiredProp{};
   ObjectPropsObjectPropNestedPropAStruct nestedPropA{};
   ObjectPropsObjectPropNestedArrayAsPropertyStruct nestedArrayAsProperty{};
+
+#ifdef RN_SERIALIZABLE_STATE
+  bool operator==(const ObjectPropsObjectPropStruct&) const = default;
+
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    result[\\"stringProp\\"] = stringProp;
+    result[\\"booleanProp\\"] = booleanProp;
+    result[\\"floatProp\\"] = floatProp;
+    result[\\"intProp\\"] = intProp;
+    result[\\"stringUserDefaultProp\\"] = stringUserDefaultProp;
+    result[\\"booleanUserDefaultProp\\"] = booleanUserDefaultProp;
+    result[\\"floatUserDefaultProp\\"] = floatUserDefaultProp;
+    result[\\"intUserDefaultProp\\"] = intUserDefaultProp;
+    result[\\"stringEnumProp\\"] = ::facebook::react::toDynamic(stringEnumProp);
+    result[\\"intEnumProp\\"] = ::facebook::react::toDynamic(intEnumProp);
+    result[\\"objectArrayProp\\"] = ::facebook::react::toDynamic(objectArrayProp);
+    result[\\"objectPrimitiveRequiredProp\\"] = ::facebook::react::toDynamic(objectPrimitiveRequiredProp);
+    result[\\"nestedPropA\\"] = ::facebook::react::toDynamic(nestedPropA);
+    result[\\"nestedArrayAsProperty\\"] = ::facebook::react::toDynamic(nestedArrayAsProperty);
+    return result;
+  }
+#endif
 };
 
 static inline void fromRawValue(const PropsParserContext& context, const RawValue &value, ObjectPropsObjectPropStruct &result) {
@@ -1429,6 +1632,12 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 static inline std::string toString(const ObjectPropsObjectPropStruct &value) {
   return \\"[Object ObjectPropsObjectPropStruct]\\";
 }
+
+#ifdef RN_SERIALIZABLE_STATE
+static inline folly::dynamic toDynamic(const ObjectPropsObjectPropStruct &value) {
+  return value.toDynamic();
+}
+#endif
 class ObjectPropsProps final : public ViewProps {
  public:
   ObjectPropsProps() = default;

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
@@ -357,15 +357,6 @@ SharedDebugStringConvertibleList AndroidTextInputProps::getDebugProps() const {
 }
 #endif
 
-static folly::dynamic toDynamic(
-    const std::vector<std::string>& acceptDragAndDropTypes) {
-  folly::dynamic acceptDragAndDropTypesArray = folly::dynamic::array();
-  for (const auto& acceptDragAndDropType : acceptDragAndDropTypes) {
-    acceptDragAndDropTypesArray.push_back(acceptDragAndDropType);
-  }
-  return acceptDragAndDropTypesArray;
-}
-
 ComponentName AndroidTextInputProps::getDiffPropsImplementationTarget() const {
   return "TextInput";
 }

--- a/packages/react-native/ReactCommon/react/renderer/core/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/core/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(react_renderer_core
         react_renderer_mapbuffer
         react_renderer_runtimescheduler
         react_utils
-        runtimeexecutor)
+        runtimeexecutor
+        yoga)
 target_compile_reactnative_options(react_renderer_core PRIVATE)
 target_compile_options(react_renderer_core PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/core/graphicsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/graphicsConversions.h
@@ -24,6 +24,10 @@
 #include <react/renderer/graphics/RectangleEdges.h>
 #include <react/renderer/graphics/Size.h>
 
+#ifdef RN_SERIALIZABLE_STATE
+#include <yoga/Yoga.h>
+#endif
+
 namespace facebook::react {
 
 #pragma mark - Color
@@ -61,6 +65,27 @@ inline std::string toString(const SharedColor& value) {
 #pragma mark - Geometry
 
 #ifdef RN_SERIALIZABLE_STATE
+inline folly::dynamic toDynamic(const YGValue& dimension) {
+  switch (dimension.unit) {
+    case YGUnitUndefined:
+      return nullptr;
+    case YGUnitAuto:
+      return "auto";
+    case YGUnitMaxContent:
+      return "max-content";
+    case YGUnitFitContent:
+      return "fit-content";
+    case YGUnitStretch:
+      return "stretch";
+    case YGUnitPoint:
+      return dimension.value;
+    case YGUnitPercent:
+      return std::format("{}%", dimension.value);
+  }
+
+  return nullptr;
+}
+
 inline folly::dynamic toDynamic(const Point& point) {
   folly::dynamic pointResult = folly::dynamic::object();
   pointResult["x"] = point.x;

--- a/packages/react-native/ReactCommon/react/renderer/core/graphicsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/graphicsConversions.h
@@ -43,9 +43,6 @@ inline void fromRawValue(
 inline int toAndroidRepr(const SharedColor& color) {
   return *color;
 }
-inline folly::dynamic toDynamic(const SharedColor& color) {
-  return *color;
-}
 #endif
 
 inline std::string toString(const SharedColor& value) {

--- a/packages/react-native/ReactCommon/react/renderer/core/propsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/propsConversions.h
@@ -16,6 +16,43 @@
 
 namespace facebook::react {
 
+#ifdef RN_SERIALIZABLE_STATE
+
+inline folly::dynamic toDynamic(const std::vector<bool>& arrayValue) {
+  folly::dynamic resultArray = folly::dynamic::array();
+  for (auto value : arrayValue) {
+    resultArray.push_back(value);
+  }
+  return resultArray;
+}
+
+inline folly::dynamic toDynamic(const std::vector<std::string>& arrayValue) {
+  folly::dynamic resultArray = folly::dynamic::array();
+  for (auto& value : arrayValue) {
+    resultArray.push_back(value);
+  }
+  return resultArray;
+}
+
+inline folly::dynamic toDynamic(const std::vector<folly::dynamic>& arrayValue) {
+  folly::dynamic resultArray = folly::dynamic::array();
+  for (auto& value : arrayValue) {
+    resultArray.push_back(value);
+  }
+  return resultArray;
+}
+
+template <typename T>
+folly::dynamic toDynamic(const std::vector<T>& arrayValue) {
+  folly::dynamic resultArray = folly::dynamic::array();
+  for (const auto& value : arrayValue) {
+    resultArray.push_back(toDynamic(value));
+  }
+  return resultArray;
+}
+
+#endif
+
 /**
  * Use this only when a prop update has definitely been sent from JS;
  * essentially, cases where rawValue is virtually guaranteed to not be a

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Color.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Color.h
@@ -13,6 +13,10 @@
 #include <react/renderer/graphics/ColorComponents.h>
 #include <react/renderer/graphics/HostPlatformColor.h>
 
+#ifdef RN_SERIALIZABLE_STATE
+#include <folly/dynamic.h>
+#endif
+
 namespace facebook::react {
 
 /*
@@ -66,6 +70,12 @@ SharedColor colorFromRGBA(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
 SharedColor clearColor();
 SharedColor blackColor();
 SharedColor whiteColor();
+
+#ifdef RN_SERIALIZABLE_STATE
+inline folly::dynamic toDynamic(const SharedColor& sharedColor) {
+  return *sharedColor;
+}
+#endif
 
 } // namespace facebook::react
 


### PR DESCRIPTION
Summary:
This diff adds the required override to codegen props to make the `FabricMountingManager` aware of the availability of a prop diffing implementation for native components using codegen props.

Changelog: [Internal]

Differential Revision: D77234066
