### PR TITLE
Bump AGP to 8.11.0

### DIFF
--- a/packages/gradle-plugin/gradle/libs.versions.toml
+++ b/packages/gradle-plugin/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.10.1"
+agp = "8.11.0"
 gson = "2.8.9"
 guava = "31.0.1-jre"
 javapoet = "1.13.0"

--- a/packages/react-native/gradle/libs.versions.toml
+++ b/packages/react-native/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ compileSdk = "36"
 buildTools = "36.0.0"
 ndkVersion = "27.1.12297006"
 # Dependencies versions
-agp = "8.10.1"
+agp = "8.11.0"
 androidx-annotation = "1.6.0"
 androidx-appcompat = "1.7.0"
 androidx-autofill = "1.1.0"


### PR DESCRIPTION
Summary:
Just keep the AGP version update.

Changelog:
[Android] [Changed] - Bump AGP to 8.11.0

Differential Revision: D77292284


