### PR TITLE
fix(ios): Correct gradient interpolation for when transitioning to transparent color

### DIFF
--- a/packages/react-native/React/Fabric/Utils/RCTGradientUtils.h
+++ b/packages/react-native/React/Fabric/Utils/RCTGradientUtils.h
@@ -23,6 +23,11 @@ NS_ASSUME_NONNULL_BEGIN
 + (std::pair<CGPoint, CGPoint>)pointsForCAGradientLayerLinearGradient:(CGPoint)startPoint
                                                              endPoint:(CGPoint)endPoint
                                                                bounds:(CGSize)bounds;
+
++ (void)getColors:(NSMutableArray<id> *)colors
+     andLocations:(NSMutableArray<NSNumber *> *)locations
+   fromColorStops:(const std::vector<facebook::react::ProcessedColorStop> &)colorStops;
+                                                               
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/react-native/React/Fabric/Utils/RCTLinearGradient.mm
+++ b/packages/react-native/React/Fabric/Utils/RCTLinearGradient.mm
@@ -58,11 +58,8 @@ using namespace facebook::react;
   gradientLayer.startPoint = fixedStartPoint;
   gradientLayer.endPoint = fixedEndPoint;
 
-  for (const auto &colorStop : colorStops) {
-    [colors addObject:(id)RCTUIColorFromSharedColor(colorStop.color).CGColor];
-    [locations addObject:@(std::max(std::min(colorStop.position.value(), 1.0), 0.0))];
-  }
-
+  [RCTGradientUtils getColors:colors andLocations:locations fromColorStops:colorStops];
+  
   gradientLayer.colors = colors;
   gradientLayer.locations = locations;
 

--- a/packages/react-native/React/Fabric/Utils/RCTRadialGradient.mm
+++ b/packages/react-native/React/Fabric/Utils/RCTRadialGradient.mm
@@ -182,10 +182,8 @@ static RadiusVector GetRadialGradientRadius(
 
   NSMutableArray<id> *colors = [NSMutableArray array];
   NSMutableArray<NSNumber *> *locations = [NSMutableArray array];
-  for (const auto &colorStop : colorStops) {
-    [colors addObject:(id)RCTUIColorFromSharedColor(colorStop.color).CGColor];
-    [locations addObject:@(std::max(std::min(colorStop.position.value(), 1.0), 0.0))];
-  }
+  
+  [RCTGradientUtils getColors:colors andLocations:locations fromColorStops:colorStops];
 
   gradientLayer.colors = colors;
   gradientLayer.locations = locations;

--- a/packages/rn-tester/js/examples/LinearGradient/LinearGradientExample.js
+++ b/packages/rn-tester/js/examples/LinearGradient/LinearGradientExample.js
@@ -290,4 +290,18 @@ exports.examples = [
       );
     },
   },
+  {
+    title: 'Gradient with transparent color transition',
+    name: 'transparent-color-transition',
+    render(): React.Node {
+      return (
+        <GradientBox
+          style={{
+            experimental_backgroundImage:
+              'linear-gradient(to right, red, transparent)',
+          }}
+        />
+      );
+    },
+  },
 ];


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:
This change fixes an issue on iOS where gradients that fade to a transparent color-stop appear dark or "muddy." The fix ensures that the color's hue is preserved during the transition, matching the behavior on Android and web.

### The Problem
When creating a gradient on iOS (e.g., linear-gradient(red, transparent)), the transparent keyword is treated as transparent black (rgba(0,0,0,0)). The `CAGradientLayer` on iOS then interpolates all color channels linearly, causing the red, green, and blue components of the start color to fade to 0. This transition through black results in an undesirable dark or "muddy" appearance in the middle of the gradient.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:
[IOS][FIXED] - Gradient interpolation for transparent colors
<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:
Checkout `LinearGradient` example in RNTester, checkout the newly added transparent color transition example, it should render same on android and iOS.


| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/c0bb54ad-ed0e-4a80-b37f-0458af0f1f77" width="300"> | <img src="https://github.com/user-attachments/assets/02da921a-bd0e-45c1-881c-cf6460d5ed43" width="300"> |
| `linear-gradient(to right, red, transparent)` transitions to black on iOS, creating a dark effect. | The gradient correctly fades the red color's alpha channel to zero |




<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
