### PR TITLE
Added backwards compatible use of prebuild through cocoapods (#52223)

### DIFF
--- a/packages/react-native/Libraries/ActionSheetIOS/React-RCTActionSheet.podspec
+++ b/packages/react-native/Libraries/ActionSheetIOS/React-RCTActionSheet.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "*.{m}"
+  s.source_files           = podspec_sources("*.{m}", "")
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
   s.header_dir             = "RCTActionSheet"
 

--- a/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
+++ b/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
@@ -42,7 +42,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files            = "**/*.{c,h,m,mm,S,cpp}"
+  s.source_files           = podspec_sources("**/*.{c,h,m,mm,S,cpp}", "**/*.h")
 
   # This guard prevent to install the dependencies when we run `pod install` in the old architecture.
   s.compiler_flags = other_cflags

--- a/packages/react-native/Libraries/Blob/React-RCTBlob.podspec
+++ b/packages/react-native/Libraries/Blob/React-RCTBlob.podspec
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
   s.platforms              = min_supported_versions
   s.compiler_flags         = '-Wno-nullability-completeness'
   s.source                 = source
-  s.source_files           = "*.{h,m,mm}"
+  s.source_files           = podspec_sources("*.{h,m,mm}", "**/*.h")
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
   s.header_dir             = "RCTBlob"
   s.pod_target_xcconfig    = {

--- a/packages/react-native/Libraries/FBLazyVector/FBLazyVector.podspec
+++ b/packages/react-native/Libraries/FBLazyVector/FBLazyVector.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "**/*.{c,h,m,mm,cpp}"
+  s.source_files           = podspec_sources("**/*.{c,h,m,mm,cpp}", "**/*.h")
   s.header_dir             = "FBLazyVector"
 
 end

--- a/packages/react-native/Libraries/Image/React-RCTImage.podspec
+++ b/packages/react-native/Libraries/Image/React-RCTImage.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
   s.platforms              = min_supported_versions
   s.compiler_flags         = '-Wno-nullability-completeness'
   s.source                 = source
-  s.source_files           = "*.{m,mm}"
+  s.source_files           = podspec_sources("*.{m,mm}", "**/*.h")
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
   s.header_dir             = "RCTImage"
   s.pod_target_xcconfig    = {

--- a/packages/react-native/Libraries/LinkingIOS/React-RCTLinking.podspec
+++ b/packages/react-native/Libraries/LinkingIOS/React-RCTLinking.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   s.platforms              = min_supported_versions
   s.compiler_flags         = '-Wno-nullability-completeness'
   s.source                 = source
-  s.source_files           = "*.{m,mm}"
+  s.source_files           = podspec_sources("*.{m,mm}", "")
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
   s.header_dir             = "RCTLinking"
   s.pod_target_xcconfig    = {

--- a/packages/react-native/Libraries/NativeAnimation/React-RCTAnimation.podspec
+++ b/packages/react-native/Libraries/NativeAnimation/React-RCTAnimation.podspec
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
   s.platforms              = min_supported_versions
   s.compiler_flags         = '-Wno-nullability-completeness'
   s.source                 = source
-  s.source_files           = "**/*.{h,m,mm}"
+  s.source_files           = podspec_sources("**/*.{h,m,mm}", "**/*.h")
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
   s.header_dir             = "RCTAnimation"
   s.pod_target_xcconfig    = {

--- a/packages/react-native/Libraries/Network/React-RCTNetwork.podspec
+++ b/packages/react-native/Libraries/Network/React-RCTNetwork.podspec
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
   s.platforms              = min_supported_versions
   s.compiler_flags         = '-Wno-nullability-completeness'
   s.source                 = source
-  s.source_files           = "*.{m,mm}"
+  s.source_files           = podspec_sources("*.{m,mm}", "")
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
   s.header_dir             = "RCTNetwork"
   s.pod_target_xcconfig    = {

--- a/packages/react-native/Libraries/Required/RCTRequired.podspec
+++ b/packages/react-native/Libraries/Required/RCTRequired.podspec
@@ -25,6 +25,6 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "**/*.{c,h,m,mm,cpp}"
+  s.source_files           = podspec_sources("**/*.{c,h,m,mm,cpp}", "**/*.h")
   s.header_dir             = "RCTRequired"
 end

--- a/packages/react-native/Libraries/Settings/React-RCTSettings.podspec
+++ b/packages/react-native/Libraries/Settings/React-RCTSettings.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   s.platforms              = min_supported_versions
   s.compiler_flags         = '-Wno-nullability-completeness'
   s.source                 = source
-  s.source_files           = "*.{m,mm}"
+  s.source_files           = podspec_sources("*.{m,mm}", "**/*.h")
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
   s.header_dir             = "RCTSettings"
   s.pod_target_xcconfig    = {

--- a/packages/react-native/Libraries/Text/React-RCTText.podspec
+++ b/packages/react-native/Libraries/Text/React-RCTText.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "**/*.{h,m,mm}"
+  s.source_files           = podspec_sources("**/*.{h,m,mm}", "**/*.h")
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
   s.header_dir             = "RCTText"
   s.framework              = ["MobileCoreServices"]

--- a/packages/react-native/Libraries/TypeSafety/RCTTypeSafety.podspec
+++ b/packages/react-native/Libraries/TypeSafety/RCTTypeSafety.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "**/*.{c,h,m,mm,cpp}"
+  s.source_files           = podspec_sources("**/*.{c,h,m,mm,cpp}", "**/*.h")
   s.header_dir             = "RCTTypeSafety"
   s.pod_target_xcconfig    = {
                                "USE_HEADERMAP" => "YES",

--- a/packages/react-native/Libraries/Vibration/React-RCTVibration.podspec
+++ b/packages/react-native/Libraries/Vibration/React-RCTVibration.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   s.platforms              = min_supported_versions
   s.compiler_flags         = '-Wno-nullability-completeness'
   s.source                 = source
-  s.source_files           = "*.{m,mm}"
+  s.source_files           = podspec_sources("*.{m,mm}", "**/*.h")
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
   s.header_dir             = "RCTVibration"
   s.pod_target_xcconfig    = {

--- a/packages/react-native/Package.swift
+++ b/packages/react-native/Package.swift
@@ -495,6 +495,14 @@ let reactRCTNetwork = RNTarget(
   dependencies: [.yoga, .jsi, .reactTurboModuleCore]
 )
 
+/// React-RCTVibration.podspec
+let reactRCTVibration = RNTarget(
+  name: .reactRCTVibration,
+  path: "Libraries/Vibration",
+  linkedFrameworks: ["AudioToolbox"],
+  dependencies: [.yoga, .jsi, .reactTurboModuleCore]
+)
+
 /// React-RCTAppDelegate.podspec
 let reactAppDelegate = RNTarget(
   name: .reactAppDelegate,
@@ -560,6 +568,7 @@ let targets = [
   reactRCTText,
   reactRCTBlob,
   reactRCTNetwork,
+  reactRCTVibration,
   reactRCTLinking,
   reactCoreModules,
   reactTurboModuleBridging,
@@ -731,6 +740,7 @@ extension String {
   static let reactRCTText = "React-RCTText"
   static let reactRCTBlob = "React-RCTBlob"
   static let reactRCTNetwork = "React-RCTNetwork"
+  static let reactRCTVibration = "React-RCTVibration"
   static let reactRCTActionSheet = "React-RCTActionSheet" // Empty target
   static let reactRCTLinking = "React-RCTLinking"
   static let reactCoreModules = "React-CoreModules"

--- a/packages/react-native/React-Core-prebuilt.podspec
+++ b/packages/react-native/React-Core-prebuilt.podspec
@@ -4,76 +4,47 @@
 # LICENSE file in the root directory of this source tree.
 
 require "json"
-
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 version = package['version']
 
 source = ReactNativeCoreUtils.resolve_podspec_source()
+Pod::Spec.new do |s|
+  s.name                   = "React-Core-prebuilt"
+  s.version                = version
+  s.summary                = "The core of React Native prebuilt frameworks."
+  s.homepage               = "https://reactnative.dev/"
+  s.license                = package["license"]
+  s.author                 = "Meta Platforms, Inc. and its affiliates"
+  s.platforms              = min_supported_versions
+  s.source                 = source
+  s.vendored_frameworks    = "React.xcframework"
 
-header_search_paths = [
-  "${PODS_ROOT}/Headers/Private/React-Core-prebuilt",
-  "${PODS_ROOT}/Headers/Private/React-Core-prebuilt/RCTDeprecation",
-  "${PODS_ROOT}/Headers/Private/React-Core-prebuilt/ReactCommon/yoga",
-  "${PODS_ROOT}/Headers/Private/React-Core-prebuilt/ReactCommon",
-  "${PODS_ROOT}/Headers/Private/React-Core-prebuilt/Libraries/AppDelegate",
-  "${PODS_ROOT}/Headers/Private/React-Core-prebuilt/Libraries",
+  s.preserve_paths       = '**/*.*'
+  s.header_mappings_dir  = 'React.xcframework/Headers'
+  s.source_files         = 'React.xcframework/Headers/**/*.{h,hpp}'
 
-  "$(REACT_NATIVE_PATH)/React/Base",
-  "$(REACT_NATIVE_PATH)/ReactCommon",
-  "$(REACT_NATIVE_PATH)/Libraries",
-  "$(REACT_NATIVE_PATH)/ReactApple",
-  "$(REACT_NATIVE_PATH)/ReactCxxPlatform",
-  "$(REACT_NATIVE_PATH)/ReactCommon/react/runtime/platform/ios",
-  "${REACT_NATIVE_PATH}/ReactCommon/jsi",
-  "$(REACT_NATIVE_PATH)/ReactCommon/jsiexecutor/",
-  "$(REACT_NATIVE_PATH)/ReactCommon/react/nativemodule/samples/platform/ios",
-  "$(REACT_NATIVE_PATH)/ReactCommon/react/nativemodule/samples",
-]
+  s.module_name          = 'React'
+  s.module_map           = 'React.xcframework/Modules/module.modulemap'
+  s.public_header_files  = 'React.xcframework/Headers/**/*.h'
 
-Pod::Spec.new do |spec|
-  spec.name                 = 'React-Core-prebuilt'
-  spec.version              = version
-  spec.summary              = "Prebuilt core of React Native."
-  spec.homepage             = "https://reactnative.dev/"
-  spec.description          = 'Prebuilt React Native Core libraries and headers'
-  spec.homepage             = 'https://github.com/facebook/react-native'
-  spec.license              = package['license']
-  spec.authors              = 'meta'
-  spec.platforms            = min_supported_versions
-  spec.source               = source
-
-  spec.vendored_frameworks  = "React.xcframework"
-
-  spec.preserve_paths       = '**/*.*'
-  spec.header_mappings_dir  = 'React.xcframework/Headers'
-  spec.source_files         = 'React.xcframework/Headers/**/*.{h,hpp}'
-
-  spec.module_name          = 'React'
-  spec.module_map           = 'React.xcframework/Modules/module.modulemap'
-  spec.public_header_files  = 'React.xcframework/Headers/**/*.h'
-
-  # Setup the consuming project's search paths
-  spec.user_target_xcconfig = {
-    "HEADER_SEARCH_PATHS" => header_search_paths,
-    "SWIFT_INCLUDE_PATHS" => "${PODS_ROOT}/Headers/Private/React-Core-prebuilt",
-    'DEFINES_MODULE' => 'YES',
-    'CLANG_ENABLE_MODULES' => 'YES',
-  }
-
-  spec.pod_target_xcconfig  = {
-    'WARNING_CFLAGS' => '-Wno-comma -Wno-shorten-64-to-32',
-    "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
-    'DEFINES_MODULE' => 'YES',
-    'CLANG_ENABLE_MODULES' => 'YES',
-  }
+  add_rn_third_party_dependencies(s)
 
   # We need to make sure that the React.xcframework is copied correctly - in the downloaded tarball
   # the root directory is the framework, but when using it we need to have it in a subdirectory
   # called React.xcframework, so we need to move the contents of the tarball into that directory.
   # This is done in the prepare_command.
-  spec.prepare_command = <<~'CMD'
+  # We need to make sure that the headers are copied to the right place - local tar.gz has a different structure
+  # than the one from the maven repo
+  s.prepare_command = <<~'CMD'
     CURRENT_PATH=$(pwd)
     XCFRAMEWORK_PATH="${CURRENT_PATH}/React.xcframework"
+
+    # Check if XCFRAMEWORK_PATH is empty
+    if [ -z "$XCFRAMEWORK_PATH" ]; then
+      echo "ERROR: XCFRAMEWORK_PATH is empty."
+      exit 0
+    fi
+
     mkdir -p "${XCFRAMEWORK_PATH}"
     find "$CURRENT_PATH" -mindepth 1 -maxdepth 1 ! -name "$(basename "$XCFRAMEWORK_PATH")" -exec mv {} "$XCFRAMEWORK_PATH" \;
   CMD
@@ -102,8 +73,7 @@ Pod::Spec.new do |spec|
       # always run the script without warning
       script_phase[:always_out_of_date] = "1"
     end
-
-    spec.script_phase = script_phase
+    
+    s.script_phase = script_phase
   end
-
 end

--- a/packages/react-native/React-Core.podspec
+++ b/packages/react-native/React-Core.podspec
@@ -66,7 +66,7 @@ Pod::Spec.new do |s|
   s.default_subspec        = "Default"
 
   s.subspec "Default" do |ss|
-    ss.source_files           = "React/**/*.{c,h,m,mm,S,cpp}"
+    ss.source_files = podspec_sources("React/**/*.{c,h,m,mm,S,cpp}", "React/**/*.h")
     exclude_files = [
       "React/CoreModules/**/*",
       "React/DevSupport/**/*",
@@ -76,17 +76,24 @@ Pod::Spec.new do |s|
       "React/Inspector/**/*",
       "React/Runtime/**/*",
     ]
-    
+
     # The default is use hermes,  we don't have jsc installed
     exclude_files = exclude_files.append("React/CxxBridge/JSCExecutorFactory.{h,mm}")
 
     ss.exclude_files = exclude_files
     ss.private_header_files   = "React/Cxx*/*.h"
+
+    # Include prebuilt if we're not building from source
+    if !ReactNativeCoreUtils.build_rncore_from_source()
+      ss.dependency "React-Core-prebuilt", version
+    end
   end
 
   s.subspec "DevSupport" do |ss|
-    ss.source_files = "React/DevSupport/*.{h,mm,m}",
-                      "React/Inspector/*.{h,mm,m}"
+    ss.source_files = podspec_sources(["React/DevSupport/*.{h,mm,m}",
+                        "React/Inspector/*.{h,mm,m}"],
+                        ["React/DevSupport/*.h",
+                        "React/Inspector/*.h"])
 
     ss.dependency "React-Core/Default", version
     ss.dependency "React-Core/RCTWebSocket", version
@@ -94,7 +101,7 @@ Pod::Spec.new do |s|
   end
 
   s.subspec "RCTWebSocket" do |ss|
-    ss.source_files = "Libraries/WebSocket/*.{h,m}"
+    ss.source_files = podspec_sources("Libraries/WebSocket/*.{h,m}", "Libraries/WebSocket/*.h")
     ss.dependency "React-Core/Default", version
   end
 

--- a/packages/react-native/React/CoreModules/React-CoreModules.podspec
+++ b/packages/react-native/React/CoreModules/React-CoreModules.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
   s.compiler_flags         = '-Wno-nullability-completeness'
   s.source                 = source
 
-  s.source_files           = "**/*.{c,m,mm,cpp}"
+  s.source_files           = podspec_sources("**/*.{c,m,mm,cpp}", "**/*.h")
 
   s.ios.exclude_files      = "PlatformStubs/**/*"
   exclude_files            = ["RCTStatusBarManager.mm"]

--- a/packages/react-native/React/React-RCTFBReactNativeSpec.podspec
+++ b/packages/react-native/React/React-RCTFBReactNativeSpec.podspec
@@ -35,7 +35,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "FBReactNativeSpec/**/*.{c,h,m,mm,cpp}"
+  s.source_files           = podspec_sources("FBReactNativeSpec/**/*.{c,h,m,mm,cpp}", "FBReactNativeSpec/**/*.{h}")
   s.exclude_files          = "FBReactNativeSpec/react/renderer/components",
   s.compiler_flags         = new_arch_flags
   s.header_dir             = 'FBReactNativeSpec'
@@ -63,7 +63,7 @@ Pod::Spec.new do |s|
   add_rn_third_party_dependencies(s)
 
   s.subspec "components" do |ss|
-    ss.source_files         = "FBReactNativeSpec/react/renderer/components/FBReactNativeSpec/**/*.{m,mm,cpp,h}"
+    ss.source_files         = podspec_sources("FBReactNativeSpec/react/renderer/components/FBReactNativeSpec/**/*.{m,mm,cpp,h}", "FBReactNativeSpec/react/renderer/components/FBReactNativeSpec/**/*.{h}")
     ss.header_dir           = "react/renderer/components/FBReactNativeSpec"
 
     add_dependency(ss, "React-featureflags")

--- a/packages/react-native/React/React-RCTFabric.podspec
+++ b/packages/react-native/React/React-RCTFabric.podspec
@@ -42,7 +42,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "Fabric/**/*.{c,h,m,mm,S,cpp}"
+  s.source_files           = podspec_sources("Fabric/**/*.{c,h,m,mm,S,cpp}", "Fabric/**/*.{h}")
   s.exclude_files          = "**/tests/*",
                              "**/android/*",
   s.compiler_flags         = new_arch_flags
@@ -99,7 +99,7 @@ Pod::Spec.new do |s|
   add_rn_third_party_dependencies(s)
 
   s.test_spec 'Tests' do |test_spec|
-    test_spec.source_files = "Tests/**/*.{mm}"
+    test_spec.source_files = podspec_sources("Tests/**/*.{mm}", "")
     test_spec.framework = "XCTest"
   end
 end

--- a/packages/react-native/React/Runtime/React-RCTRuntime.podspec
+++ b/packages/react-native/React/Runtime/React-RCTRuntime.podspec
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "*.{h,mm}"
+  s.source_files           = podspec_sources("*.{h,mm}", "*.h")
   s.compiler_flags         = new_arch_flags
   s.header_dir             = header_dir
   s.module_name          = module_name

--- a/packages/react-native/ReactApple/Libraries/RCTFoundation/RCTDeprecation/RCTDeprecation.podspec
+++ b/packages/react-native/ReactApple/Libraries/RCTFoundation/RCTDeprecation/RCTDeprecation.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
     s.homepage               = "https://reactnative.dev/"
     s.source                 = { :git => 'https://github.com/facebook/react-native.git', :tag => 'v#{version}' }
     s.summary                = "Macros for marking APIs as deprecated"
-    s.source_files           = ["Exported/*.h", "RCTDeprecation.m"]
+    s.source_files           = podspec_sources(["Exported/*.h", "RCTDeprecation.m"], "Exported/*.h")
     s.pod_target_xcconfig    = {
       "DEFINES_MODULE" => "YES",
       "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard()

--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "dummyFile.cpp"
+  s.source_files           = podspec_sources("dummyFile.cpp", "")
   s.pod_target_xcconfig = { "USE_HEADERMAP" => "YES",
                             "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                             "DEFINES_MODULE" => "YES" }
@@ -58,19 +58,19 @@ Pod::Spec.new do |s|
   add_rn_third_party_dependencies(s)
 
   s.subspec "animations" do |ss|
-    ss.source_files         = "react/renderer/animations/**/*.{m,mm,cpp,h}"
+    ss.source_files         = podspec_sources("react/renderer/animations/**/*.{m,mm,cpp,h}", "react/renderer/animations/**/*.{h}")
     ss.exclude_files        = "react/renderer/animations/tests"
     ss.header_dir           = "react/renderer/animations"
   end
 
   s.subspec "attributedstring" do |ss|
-    ss.source_files         = "react/renderer/attributedstring/**/*.{m,mm,cpp,h}"
+    ss.source_files         = podspec_sources("react/renderer/attributedstring/**/*.{m,mm,cpp,h}", "react/renderer/attributedstring/**/*.{h}")
     ss.exclude_files        = "react/renderer/attributedstring/tests"
     ss.header_dir           = "react/renderer/attributedstring"
   end
 
   s.subspec "bridging" do |ss|
-    ss.source_files         = "react/renderer/bridging/**/*.{m,mm,cpp,h}"
+    ss.source_files         = podspec_sources("react/renderer/bridging/**/*.{m,mm,cpp,h}", "react/renderer/bridging/**/*.{h}")
     ss.exclude_files        = "react/renderer/bridging/tests"
     ss.header_dir           = "react/renderer/bridging"
   end
@@ -92,7 +92,7 @@ Pod::Spec.new do |s|
       ]
     end
 
-    ss.source_files         = "react/renderer/core/**/*.{m,mm,cpp,h}"
+    ss.source_files         = podspec_sources("react/renderer/core/**/*.{m,mm,cpp,h}", "react/renderer/core/**/*.{h}")
     ss.exclude_files        = "react/renderer/core/tests"
     ss.header_dir           = "react/renderer/core"
     ss.pod_target_xcconfig  = {
@@ -101,18 +101,18 @@ Pod::Spec.new do |s|
   end
 
   s.subspec "componentregistry" do |ss|
-    ss.source_files         = "react/renderer/componentregistry/*.{m,mm,cpp,h}"
+    ss.source_files         = podspec_sources("react/renderer/componentregistry/*.{m,mm,cpp,h}", "react/renderer/componentregistry/*.{h}")
     ss.header_dir           = "react/renderer/componentregistry"
   end
 
   s.subspec "componentregistrynative" do |ss|
-    ss.source_files         = "react/renderer/componentregistry/native/**/*.{m,mm,cpp,h}"
+    ss.source_files         = podspec_sources("react/renderer/componentregistry/native/**/*.{m,mm,cpp,h}", "react/renderer/componentregistry/native/**/*.{h}")
     ss.header_dir           = "react/renderer/componentregistry/native"
   end
 
   s.subspec "components" do |ss|
     ss.subspec "root" do |sss|
-      sss.source_files         = "react/renderer/components/root/**/*.{m,mm,cpp,h}"
+      sss.source_files         = podspec_sources("react/renderer/components/root/**/*.{m,mm,cpp,h}", "react/renderer/components/root/**/*.{h}")
       sss.exclude_files        = "react/renderer/components/root/tests"
       sss.header_dir           = "react/renderer/components/root"
     end
@@ -120,19 +120,19 @@ Pod::Spec.new do |s|
     ss.subspec "view" do |sss|
       sss.dependency             "React-renderercss"
       sss.dependency             "Yoga"
-      sss.source_files         = "react/renderer/components/view/**/*.{m,mm,cpp,h}"
+      sss.source_files         = podspec_sources("react/renderer/components/view/**/*.{m,mm,cpp,h}", "react/renderer/components/view/**/*.{h}")
       sss.exclude_files        = "react/renderer/components/view/tests", "react/renderer/components/view/platform/android", "react/renderer/components/view/platform/windows"
       sss.header_dir           = "react/renderer/components/view"
     end
 
     ss.subspec "scrollview" do |sss|
-      sss.source_files         = "react/renderer/components/scrollview/**/*.{m,mm,cpp,h}"
+      sss.source_files         = podspec_sources("react/renderer/components/scrollview/**/*.{m,mm,cpp,h}", "react/renderer/components/scrollview/**/*.{h}")
       sss.header_dir           = "react/renderer/components/scrollview"
       sss.exclude_files        = "react/renderer/components/scrollview/tests", "react/renderer/components/scrollview/platform/android"
     end
 
     ss.subspec "legacyviewmanagerinterop" do |sss|
-      sss.source_files         = "react/renderer/components/legacyviewmanagerinterop/**/*.{m,mm,cpp,h}"
+      sss.source_files         = podspec_sources("react/renderer/components/legacyviewmanagerinterop/**/*.{m,mm,cpp,h}", "react/renderer/components/legacyviewmanagerinterop/**/*.{h}")
       sss.exclude_files        = "react/renderer/components/legacyviewmanagerinterop/tests"
       sss.header_dir           = "react/renderer/components/legacyviewmanagerinterop"
     end
@@ -140,13 +140,13 @@ Pod::Spec.new do |s|
 
   s.subspec "dom" do |ss|
     ss.dependency             "React-graphics"
-    ss.source_files         = "react/renderer/dom/**/*.{m,mm,cpp,h}"
+    ss.source_files         = podspec_sources("react/renderer/dom/**/*.{m,mm,cpp,h}", "react/renderer/dom/**/*.{h}")
     ss.exclude_files        = "react/renderer/dom/tests"
     ss.header_dir           = "react/renderer/dom"
   end
 
   s.subspec "scheduler" do |ss|
-    ss.source_files         = "react/renderer/scheduler/**/*.{m,mm,cpp,h}"
+    ss.source_files         = podspec_sources("react/renderer/scheduler/**/*.{m,mm,cpp,h}", "react/renderer/scheduler/**/*.h")
     ss.header_dir           = "react/renderer/scheduler"
 
     ss.dependency             "React-performancetimeline"
@@ -154,55 +154,55 @@ Pod::Spec.new do |s|
   end
 
   s.subspec "imagemanager" do |ss|
-    ss.source_files         = "react/renderer/imagemanager/*.{m,mm,cpp,h}"
+    ss.source_files         = podspec_sources("react/renderer/imagemanager/*.{m,mm,cpp,h}", "react/renderer/imagemanager/*.h")
     ss.header_dir           = "react/renderer/imagemanager"
   end
 
   s.subspec "mounting" do |ss|
-    ss.source_files         = "react/renderer/mounting/**/*.{m,mm,cpp,h}"
+    ss.source_files         = podspec_sources("react/renderer/mounting/**/*.{m,mm,cpp,h}", "react/renderer/mounting/**/*.h")
     ss.exclude_files        = "react/renderer/mounting/tests"
     ss.header_dir           = "react/renderer/mounting"
   end
 
   s.subspec "observers" do |ss|
     ss.subspec "events" do |sss|
-      sss.source_files         = "react/renderer/observers/events/**/*.{m,mm,cpp,h}"
+      sss.source_files         = podspec_sources("react/renderer/observers/events/**/*.{m,mm,cpp,h}", "react/renderer/observers/events/**/*.h")
       sss.exclude_files        = "react/renderer/observers/events/tests"
       sss.header_dir           = "react/renderer/observers/events"
     end
   end
 
   s.subspec "templateprocessor" do |ss|
-    ss.source_files         = "react/renderer/templateprocessor/**/*.{m,mm,cpp,h}"
+    ss.source_files         = podspec_sources("react/renderer/templateprocessor/**/*.{m,mm,cpp,h}", "react/renderer/templateprocessor/**/*.h")
     ss.exclude_files        = "react/renderer/templateprocessor/tests"
     ss.header_dir           = "react/renderer/templateprocessor"
   end
 
   s.subspec "telemetry" do |ss|
-    ss.source_files         = "react/renderer/telemetry/**/*.{m,mm,cpp,h}"
+    ss.source_files         = podspec_sources("react/renderer/telemetry/**/*.{m,mm,cpp,h}", "react/renderer/telemetry/**/*.h")
     ss.exclude_files        = "react/renderer/telemetry/tests"
     ss.header_dir           = "react/renderer/telemetry"
 
   end
 
   s.subspec "consistency" do |ss|
-    ss.source_files         = "react/renderer/consistency/**/*.{m,mm,cpp,h}"
+    ss.source_files         = podspec_sources("react/renderer/consistency/**/*.{m,mm,cpp,h}", "react/renderer/consistency/**/*.h")
     ss.header_dir           = "react/renderer/consistency"
   end
 
   s.subspec "uimanager" do |ss|
     ss.subspec "consistency" do |sss|
-      sss.source_files         = "react/renderer/uimanager/consistency/*.{m,mm,cpp,h}"
+      sss.source_files         = podspec_sources("react/renderer/uimanager/consistency/*.{m,mm,cpp,h}", "react/renderer/uimanager/consistency/*.h")
       sss.header_dir           = "react/renderer/uimanager/consistency"
     end
 
     ss.dependency             "React-rendererconsistency"
-    ss.source_files         = "react/renderer/uimanager/*.{m,mm,cpp,h}"
+    ss.source_files         = podspec_sources("react/renderer/uimanager/*.{m,mm,cpp,h}", "react/renderer/uimanager/*.h")
     ss.header_dir           = "react/renderer/uimanager"
   end
 
   s.subspec "leakchecker" do |ss|
-    ss.source_files         = "react/renderer/leakchecker/**/*.{cpp,h}"
+    ss.source_files         = podspec_sources("react/renderer/leakchecker/**/*.{cpp,h}", "react/renderer/leakchecker/**/*.h")
     ss.exclude_files        = "react/renderer/leakchecker/tests"
     ss.header_dir           = "react/renderer/leakchecker"
     ss.pod_target_xcconfig  = { "GCC_WARN_PEDANTIC" => "YES" }

--- a/packages/react-native/ReactCommon/React-FabricComponents.podspec
+++ b/packages/react-native/ReactCommon/React-FabricComponents.podspec
@@ -43,7 +43,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "dummyFile.cpp"
+  s.source_files           = podspec_sources("dummyFile.cpp", "")
   s.pod_target_xcconfig = { "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                             "DEFINES_MODULE" => "YES",
                             "HEADER_SEARCH_PATHS" => header_search_path.join(" "),
@@ -83,49 +83,56 @@ Pod::Spec.new do |s|
   s.subspec "components" do |ss|
 
     ss.subspec "inputaccessory" do |sss|
-      sss.source_files         = "react/renderer/components/inputaccessory/**/*.{m,mm,cpp,h}"
+      sss.source_files         = podspec_sources("react/renderer/components/inputaccessory/**/*.{m,mm,cpp,h}", "react/renderer/components/inputaccessory/**/*.h")
       sss.exclude_files        = "react/renderer/components/inputaccessory/tests"
       sss.header_dir           = "react/renderer/components/inputaccessory"
     end
 
     ss.subspec "modal" do |sss|
-      sss.source_files         = "react/renderer/components/modal/*.{m,mm,cpp,h}"
+      sss.source_files         = podspec_sources("react/renderer/components/modal/*.{m,mm,cpp,h}", "react/renderer/components/modal/*.h")
       sss.exclude_files        = "react/renderer/components/modal/tests"
       sss.header_dir           = "react/renderer/components/modal"
     end
 
     ss.subspec "safeareaview" do |sss|
-      sss.source_files         = "react/renderer/components/safeareaview/**/*.{m,mm,cpp,h}"
+      sss.source_files         = podspec_sources("react/renderer/components/safeareaview/**/*.{m,mm,cpp,h}", "react/renderer/components/safeareaview/**/*.h")
+      # Exclude tests to avoid conflicts with the react-native-safe-area-context package
       sss.exclude_files        = "react/renderer/components/safeareaview/tests"
       sss.header_dir           = "react/renderer/components/safeareaview"
     end
 
     ss.subspec "scrollview" do |sss|
-      sss.source_files         = "react/renderer/components/scrollview/*.{m,mm,cpp,h}",
-                                 "react/renderer/components/scrollview/platform/cxx/**/*.{m,mm,cpp,h}"
+      sss.source_files         = podspec_sources(["react/renderer/components/scrollview/*.{m,mm,cpp,h}",
+                                  "react/renderer/components/scrollview/platform/cxx/**/*.{m,mm,cpp,h}"],
+                                  ["react/renderer/components/scrollview/*.h",
+                                  "react/renderer/components/scrollview/platform/cxx/**/*.h"])
       sss.exclude_files        = "react/renderer/components/scrollview/tests"
       sss.header_dir           = "react/renderer/components/scrollview"
     end
 
     ss.subspec "text" do |sss|
-      sss.source_files         = "react/renderer/components/text/*.{m,mm,cpp,h}",
-                                 "react/renderer/components/text/platform/cxx/**/*.{m,mm,cpp,h}"
+      sss.source_files         = podspec_sources(["react/renderer/components/text/*.{m,mm,cpp,h}",
+                                  "react/renderer/components/text/platform/cxx/**/*.{m,mm,cpp,h}"],
+                                  ["react/renderer/components/text/*.h",
+                                  "react/renderer/components/text/platform/cxx/**/*.h"])
       sss.header_dir           = "react/renderer/components/text"
     end
 
     ss.subspec "iostextinput" do |sss|
-      sss.source_files         = "react/renderer/components/textinput/*.{m,mm,cpp,h}",
-                                 "react/renderer/components/textinput/platform/ios/**/*.{m,mm,cpp,h}"
+      sss.source_files         = podspec_sources(["react/renderer/components/textinput/*.{m,mm,cpp,h}",
+                                  "react/renderer/components/textinput/platform/ios/**/*.{m,mm,cpp,h}"],
+                                  ["react/renderer/components/textinput/*.h",
+                                  "react/renderer/components/textinput/platform/ios/**/*.h"])
       sss.header_dir           = "react/renderer/components/iostextinput"
     end
 
     ss.subspec "textinput" do |sss|
-      sss.source_files         = "react/renderer/components/textinput/*.{m,mm,cpp,h}"
+      sss.source_files         = podspec_sources("react/renderer/components/textinput/*.{m,mm,cpp,h}", "react/renderer/components/textinput/**/*.h")
       sss.header_dir           = "react/renderer/components/textinput"
     end
 
     ss.subspec "unimplementedview" do |sss|
-      sss.source_files         = "react/renderer/components/unimplementedview/**/*.{m,mm,cpp,h}"
+      sss.source_files         = podspec_sources("react/renderer/components/unimplementedview/**/*.{m,mm,cpp,h}", "react/renderer/components/unimplementedview/**/*.h")
       sss.exclude_files        = "react/renderer/components/unimplementedview/tests"
       sss.header_dir           = "react/renderer/components/unimplementedview"
     end
@@ -138,15 +145,17 @@ Pod::Spec.new do |s|
 
     # Legacy header paths for backwards compat
     ss.subspec "rncore" do |sss|
-      sss.source_files         = "react/renderer/components/rncore/**/*.h"
+      sss.source_files         = podspec_sources("react/renderer/components/rncore/**/*.h", "react/renderer/components/rncore/**/*.h")
       sss.header_dir           = "react/renderer/components/rncore"
     end
   end
 
   s.subspec "textlayoutmanager" do |ss|
     ss.dependency             "React-Fabric"
-    ss.source_files         = "react/renderer/textlayoutmanager/platform/ios/**/*.{m,mm,cpp,h}",
-                              "react/renderer/textlayoutmanager/*.{m,mm,cpp,h}"
+    ss.source_files         = podspec_sources(["react/renderer/textlayoutmanager/platform/ios/**/*.{m,mm,cpp,h}",
+                                "react/renderer/textlayoutmanager/*.{m,mm,cpp,h}"],
+                                ["react/renderer/textlayoutmanager/platform/ios/**/*.h",
+                                "react/renderer/textlayoutmanager/*.{h}"])
     ss.exclude_files        = "react/renderer/textlayoutmanager/tests",
                               "react/renderer/textlayoutmanager/platform/android",
                               "react/renderer/textlayoutmanager/platform/cxx"

--- a/packages/react-native/ReactCommon/React-FabricImage.podspec
+++ b/packages/react-native/ReactCommon/React-FabricImage.podspec
@@ -42,7 +42,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files         = "react/renderer/components/image/**/*.{m,mm,cpp,h}"
+  s.source_files         = podspec_sources("react/renderer/components/image/**/*.{m,mm,cpp,h}", "react/renderer/components/image/**/*.h")
   s.exclude_files        = "react/renderer/components/image/tests"
   s.header_dir           = "react/renderer/components/image"
   s.pod_target_xcconfig = { "USE_HEADERMAP" => "YES",

--- a/packages/react-native/ReactCommon/React-Mapbuffer.podspec
+++ b/packages/react-native/ReactCommon/React-Mapbuffer.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "react/renderer/mapbuffer/*.{cpp,h}"
+  s.source_files           = podspec_sources("react/renderer/mapbuffer/*.{cpp,h}", "react/renderer/mapbuffer/*.h")
   s.exclude_files          = "react/renderer/mapbuffer/tests"
   s.public_header_files    = 'react/renderer/mapbuffer/*.h'
   s.header_dir             = "react/renderer/mapbuffer"

--- a/packages/react-native/ReactCommon/ReactCommon.podspec
+++ b/packages/react-native/ReactCommon/ReactCommon.podspec
@@ -52,7 +52,7 @@ Pod::Spec.new do |s|
 
     ss.subspec "bridging" do |sss|
       sss.dependency           "React-jsi", version
-      sss.source_files         = "react/bridging/**/*.{cpp,h}"
+      sss.source_files         = podspec_sources("react/bridging/**/*.{cpp,h}", "react/bridging/**/*.h")
       sss.exclude_files        = "react/bridging/tests"
       sss.header_dir           = "react/bridging"
       sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\"" }
@@ -62,7 +62,7 @@ Pod::Spec.new do |s|
     end
 
     ss.subspec "core" do |sss|
-      sss.source_files = "react/nativemodule/core/ReactCommon/**/*.{cpp,h}"
+      sss.source_files = podspec_sources("react/nativemodule/core/ReactCommon/**/*.{cpp,h}", "react/nativemodule/core/ReactCommon/**/*.h")
       sss.pod_target_xcconfig  = { "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/ReactCommon\" \"$(PODS_CONFIGURATION_BUILD_DIR)/React-debug/React_debug.framework/Headers\" \"$(PODS_CONFIGURATION_BUILD_DIR)/React-debug/React_featureflags.framework/Headers\" \"$(PODS_CONFIGURATION_BUILD_DIR)/React-utils/React_utils.framework/Headers\"" }
       sss.dependency "React-debug", version
       sss.dependency "React-featureflags", version

--- a/packages/react-native/ReactCommon/callinvoker/React-callinvoker.podspec
+++ b/packages/react-native/ReactCommon/callinvoker/React-callinvoker.podspec
@@ -25,6 +25,6 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "**/*.{cpp,h}"
+  s.source_files           = podspec_sources("**/*.{cpp,h}", "**/*.h")
   s.header_dir             = "ReactCommon"
 end

--- a/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
+++ b/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "*.{cpp,h}"
+  s.source_files           = podspec_sources("*.{cpp,h}", "*.h")
   s.exclude_files          = "SampleCxxModule.*"
   s.pod_target_xcconfig    = {
     "HEADER_SEARCH_PATHS" => "\"$(PODS_CONFIGURATION_BUILD_DIR)/React-debug/React_debug.framework/Headers\" \"${PODS_CONFIGURATION_BUILD_DIR}/React-runtimeexecutor/React_runtimeexecutor.framework/Headers\"",

--- a/packages/react-native/ReactCommon/hermes/React-hermes.podspec
+++ b/packages/react-native/ReactCommon/hermes/React-hermes.podspec
@@ -26,8 +26,10 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "executor/*.{cpp,h}",
-                             "inspector-modern/chrome/*.{cpp,h}",
+  s.source_files           = podspec_sources(["executor/*.{cpp,h}",
+                              "inspector-modern/chrome/*.{cpp,h}"],
+                              ["executor/*.h",
+                              "inspector-modern/chrome/*.h"])
   s.public_header_files    = "executor/HermesExecutorFactory.h"
   s.pod_target_xcconfig    = {
                                "HEADER_SEARCH_PATHS" => "\"${PODS_ROOT}/hermes-engine/destroot/include\" \"$(PODS_TARGET_SRCROOT)/..\"",

--- a/packages/react-native/ReactCommon/hermes/executor/React-jsitracing.podspec
+++ b/packages/react-native/ReactCommon/hermes/executor/React-jsitracing.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "JSITracing.{cpp,h}"
+  s.source_files           = podspec_sources("JSITracing.{cpp,h}", "JSITracing.h")
   s.header_dir             = "."
   s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"${PODS_TARGET_SRCROOT}/../..\"",
                                 "USE_HEADERMAP" => "YES",

--- a/packages/react-native/ReactCommon/jserrorhandler/React-jserrorhandler.podspec
+++ b/packages/react-native/ReactCommon/jserrorhandler/React-jserrorhandler.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   s.platforms              = min_supported_versions
   s.source                 = source
   s.header_dir             = "jserrorhandler"
-  s.source_files           = "JsErrorHandler.{cpp,h}", "StackTraceParser.{cpp,h}"
+  s.source_files           = podspec_sources(["JsErrorHandler.{cpp,h}", "StackTraceParser.{cpp,h}"], ["JsErrorHandler.h", "StackTraceParser.h"])
   s.pod_target_xcconfig = {
     "USE_HEADERMAP" => "YES",
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard()

--- a/packages/react-native/ReactCommon/jsi/React-jsi.podspec
+++ b/packages/react-native/ReactCommon/jsi/React-jsi.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
     "DEFINES_MODULE" => "YES"
   }
 
-  s.source_files  = "**/*.{cpp,h}"
+  s.source_files  = podspec_sources("**/*.{cpp,h}", "**/*.h")
   files_to_exclude = [
                       "jsi/jsilib-posix.cpp",
                       "jsi/jsilib-windows.cpp",

--- a/packages/react-native/ReactCommon/jsiexecutor/React-jsiexecutor.podspec
+++ b/packages/react-native/ReactCommon/jsiexecutor/React-jsiexecutor.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files         = "jsireact/*.{cpp,h}"
+  s.source_files           = podspec_sources("jsireact/*.{cpp,h}", "jsireact/*.h")
   s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard() }
   s.header_dir             = "jsireact"
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/React-jsinspector.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/React-jsinspector.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "*.{cpp,h}"
+  s.source_files           = podspec_sources("*.{cpp,h}", "*.h")
   s.header_dir             = header_dir
   s.pod_target_xcconfig    = {
     "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),

--- a/packages/react-native/ReactCommon/jsinspector-modern/cdp/React-jsinspectorcdp.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/cdp/React-jsinspectorcdp.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "*.{cpp,h}"
+  s.source_files           = podspec_sources("*.{cpp,h}", "*.h")
   s.header_dir             = header_dir
   s.pod_target_xcconfig    = {
     "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/React-jsinspectornetwork.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/React-jsinspectornetwork.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "*.{cpp,h}"
+  s.source_files           = podspec_sources("*.{cpp,h}", "*.h")
   s.header_dir             = header_dir
   s.pod_target_xcconfig    = {
     "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/React-jsinspectortracing.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/React-jsinspectortracing.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "*.{cpp,h}"
+  s.source_files           = podspec_sources("*.{cpp,h}", "*.h")
   s.header_dir             = header_dir
   s.pod_target_xcconfig    = {
     "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),

--- a/packages/react-native/ReactCommon/jsitooling/React-jsitooling.podspec
+++ b/packages/react-native/ReactCommon/jsitooling/React-jsitooling.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "react/runtime/*.{cpp,h}"
+  s.source_files           = podspec_sources("react/runtime/*.{cpp,h}", "react/runtime/*.h")
   s.header_dir             = "react/runtime"
 
   if ENV['USE_FRAMEWORKS']

--- a/packages/react-native/ReactCommon/logger/React-logger.podspec
+++ b/packages/react-native/ReactCommon/logger/React-logger.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "*.{cpp,h}"
+  s.source_files           = podspec_sources("*.{cpp,h}", "*.h")
   s.header_dir             = "logger"
 
   add_rn_third_party_dependencies(s)

--- a/packages/react-native/ReactCommon/oscompat/React-oscompat.podspec
+++ b/packages/react-native/ReactCommon/oscompat/React-oscompat.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "*.{cpp,h}"
+  s.source_files           = podspec_sources("*.{cpp,h}", "*.{h}")
   s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "" }
   s.header_dir             = "oscompat"
 end

--- a/packages/react-native/ReactCommon/react/debug/React-debug.podspec
+++ b/packages/react-native/ReactCommon/react/debug/React-debug.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "**/*.{cpp,h}"
+  s.source_files           = podspec_sources("**/*.{cpp,h}", "**/*.h")
   s.header_dir             = "react/debug"
   s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                "DEFINES_MODULE" => "YES" }

--- a/packages/react-native/ReactCommon/react/featureflags/React-featureflags.podspec
+++ b/packages/react-native/ReactCommon/react/featureflags/React-featureflags.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "*.{cpp,h}"
+  s.source_files           = podspec_sources("*.{cpp,h}", "*.h")
   s.header_dir             = "react/featureflags"
   s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/React-NativeModulesApple.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/React-NativeModulesApple.podspec
@@ -35,7 +35,7 @@ Pod::Spec.new do |s|
         s.header_mappings_dir     = './'
     end
 
-    s.source_files = "ReactCommon/**/*.{mm,cpp,h}"
+    s.source_files = podspec_sources("ReactCommon/**/*.{mm,cpp,h}", "ReactCommon/**/*.{h}")
 
     s.dependency "ReactCommon/turbomodule/core"
     s.dependency "ReactCommon/turbomodule/bridging"

--- a/packages/react-native/ReactCommon/react/nativemodule/defaults/React-defaultsnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/defaults/React-defaultsnativemodule.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "*.{cpp,h}"
+  s.source_files           = podspec_sources("*.{cpp,h}", "*.h")
   s.header_dir             = "react/nativemodule/defaults"
   s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),

--- a/packages/react-native/ReactCommon/react/nativemodule/dom/React-domnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/dom/React-domnativemodule.podspec
@@ -33,7 +33,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "*.{cpp,h}"
+  s.source_files           = podspec_sources("*.{cpp,h}", "*.h")
   s.header_dir             = "react/nativemodule/dom"
   s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/React-featureflagsnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/React-featureflagsnativemodule.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "*.{cpp,h}"
+  s.source_files           = podspec_sources("*.{cpp,h}", "*.h")
   s.header_dir             = "react/nativemodule/featureflags"
   s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),

--- a/packages/react-native/ReactCommon/react/nativemodule/idlecallbacks/React-idlecallbacksnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/idlecallbacks/React-idlecallbacksnativemodule.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "*.{cpp,h}"
+  s.source_files           = podspec_sources("*.{cpp,h}", "*.h")
   s.header_dir             = "react/nativemodule/idlecallbacks"
   s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),

--- a/packages/react-native/ReactCommon/react/nativemodule/microtasks/React-microtasksnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/microtasks/React-microtasksnativemodule.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "*.{cpp,h}"
+  s.source_files           = podspec_sources("*.{cpp,h}", "*.h")
   s.header_dir             = "react/nativemodule/microtasks"
   s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                "OTHER_CFLAGS" => "$(inherited)",

--- a/packages/react-native/ReactCommon/react/performance/timeline/React-performancetimeline.podspec
+++ b/packages/react-native/ReactCommon/react/performance/timeline/React-performancetimeline.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "**/*.{cpp,h}"
+  s.source_files           = podspec_sources("**/*.{cpp,h}", "**/*.h")
   s.header_dir             = "react/performance/timeline"
   s.exclude_files          = "tests"
   s.pod_target_xcconfig    = {

--- a/packages/react-native/ReactCommon/react/renderer/consistency/React-rendererconsistency.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/consistency/React-rendererconsistency.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "**/*.{cpp,h}"
+  s.source_files           = podspec_sources("**/*.{cpp,h}", "**/*.h")
   s.header_dir             = "react/renderer/consistency"
   s.exclude_files          = "tests"
   s.pod_target_xcconfig    = {

--- a/packages/react-native/ReactCommon/react/renderer/css/React-renderercss.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/css/React-renderercss.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "**/*.{cpp,h}"
+  s.source_files           = podspec_sources("**/*.{cpp,h}", "**/*.h")
   s.header_dir             = "react/renderer/css"
   s.exclude_files          = "tests"
   s.pod_target_xcconfig    = {

--- a/packages/react-native/ReactCommon/react/renderer/debug/React-rendererdebug.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/debug/React-rendererdebug.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "**/*.{cpp,h,mm}"
+  s.source_files           = podspec_sources("**/*.{cpp,h,mm}", "**/*.h")
   s.header_dir             = "react/renderer/debug"
   s.exclude_files          = "tests"
   s.pod_target_xcconfig    = {

--- a/packages/react-native/ReactCommon/react/renderer/graphics/React-graphics.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/React-graphics.podspec
@@ -17,7 +17,7 @@ else
 end
 
 Pod::Spec.new do |s|
-  source_files = "*.{m,mm,cpp,h}", "platform/ios/**/*.{m,mm,cpp,h}"
+  source_files = ["*.{m,mm,cpp,h}", "platform/ios/**/*.{m,mm,cpp,h}"]
   header_search_paths = [
     "\"$(PODS_TARGET_SRCROOT)/../../../\"",
   ]
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = source_files
+  s.source_files           = podspec_sources(source_files, ["*.h", "platform/ios/**/*.h"])
   s.header_dir             = "react/renderer/graphics"
   s.framework = "UIKit"
 

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/React-ImageManager.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/React-ImageManager.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = source_files
+  s.source_files           = podspec_sources(source_files, "**/*.h")
   s.header_dir             = "react/renderer/imagemanager"
 
   if ENV['USE_FRAMEWORKS']

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/React-runtimescheduler.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/React-runtimescheduler.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "**/*.{cpp,h}"
+  s.source_files           = podspec_sources("**/*.{cpp,h}", "**/*.h")
   s.header_dir             = "react/renderer/runtimescheduler"
   s.exclude_files          = "tests"
   s.pod_target_xcconfig    = {

--- a/packages/react-native/ReactCommon/react/runtime/React-RuntimeCore.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/React-RuntimeCore.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "*.{cpp,h}", "nativeviewconfig/*.{cpp,h}"
+  s.source_files           = podspec_sources(["*.{cpp,h}", "nativeviewconfig/*.{cpp,h}"], ["*.h", "nativeviewconfig/*.h"])
   s.exclude_files          = "iostests/*", "tests/**/*.{cpp,h}"
   s.header_dir             = "react/runtime"
   s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/Headers/Private/React-Core\" \"${PODS_TARGET_SRCROOT}/../..\"",

--- a/packages/react-native/ReactCommon/react/runtime/React-RuntimeHermes.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/React-RuntimeHermes.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "hermes/*.{cpp,h}"
+  s.source_files           = podspec_sources("hermes/*.{cpp,h}", "hermes/*.h")
   s.header_dir             = "react/runtime/hermes"
   s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => "\"${PODS_TARGET_SRCROOT}/../..\" \"${PODS_TARGET_SRCROOT}/../../hermes/executor\"",
                                 "USE_HEADERMAP" => "YES",

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/React-RuntimeApple.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/React-RuntimeApple.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "ReactCommon/*.{mm,h}"
+  s.source_files           = podspec_sources("ReactCommon/*.{mm,h}", "ReactCommon/*.{h}")
   s.header_dir             = "ReactCommon"
   s.pod_target_xcconfig    = { "HEADER_SEARCH_PATHS" => header_search_paths,
                                 "USE_HEADERMAP" => "YES",

--- a/packages/react-native/ReactCommon/react/timing/React-timing.podspec
+++ b/packages/react-native/ReactCommon/react/timing/React-timing.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "*.{cpp,h}"
+  s.source_files           = podspec_sources("*.{cpp,h}", "**/*.h")
   s.header_dir             = "react/timing"
   s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),

--- a/packages/react-native/ReactCommon/react/utils/React-utils.podspec
+++ b/packages/react-native/ReactCommon/react/utils/React-utils.podspec
@@ -17,7 +17,7 @@ else
 end
 
 Pod::Spec.new do |s|
-  source_files = "*.{m,mm,cpp,h}", "platform/ios/**/*.{m,mm,cpp,h}"
+  source_files = ["*.{m,mm,cpp,h}", "platform/ios/**/*.{m,mm,cpp,h}"]
   header_search_paths = [
     "\"$(PODS_TARGET_SRCROOT)/../../\"",
   ]
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = source_files
+  s.source_files           = podspec_sources(source_files, ["*.h", "platform/ios/**/*.h"])
   s.header_dir             = "react/utils"
   s.exclude_files          = "tests"
 

--- a/packages/react-native/ReactCommon/reactperflogger/React-perflogger.podspec
+++ b/packages/react-native/ReactCommon/reactperflogger/React-perflogger.podspec
@@ -29,7 +29,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "reactperflogger/*.{cpp,h}", "fusebox/*.{cpp,h}"
+  s.source_files           = podspec_sources(["reactperflogger/*.{cpp,h}", "fusebox/*.{cpp,h}"], ["reactperflogger/*.h", "fusebox/*.h"])
   s.header_dir             = "reactperflogger"
   s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard() }
   s.pod_target_xcconfig    = {

--- a/packages/react-native/ReactCommon/runtimeexecutor/React-runtimeexecutor.podspec
+++ b/packages/react-native/ReactCommon/runtimeexecutor/React-runtimeexecutor.podspec
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
   s.author                 = "Meta Platforms, Inc. and its affiliates"
   s.platforms              = min_supported_versions
   s.source                 = source
-  s.source_files           = "ReactCommon/*.{m,mm,cpp,h}", "platform/ios/**/*.{m,mm,cpp,h}"
+  s.source_files           = podspec_sources(["ReactCommon/*.{m,mm,cpp,h}", "platform/ios/**/*.{m,mm,cpp,h}"], ["ReactCommon/*.h", "platform/ios/**/*.h"])
   s.header_dir             = "ReactCommon"
 
   if ENV['USE_FRAMEWORKS']

--- a/packages/react-native/ReactCommon/yoga/Yoga.podspec
+++ b/packages/react-native/ReactCommon/yoga/Yoga.podspec
@@ -51,7 +51,7 @@ Pod::Spec.new do |spec|
   # E.g. when publishing this spec to a spec repo.
   source_files = 'yoga/**/*.{cpp,h}'
   source_files = File.join('ReactCommon/yoga', source_files) if ENV['INSTALL_YOGA_WITHOUT_PATH_OPTION']
-  spec.source_files = source_files
+  spec.source_files = podspec_sources(source_files, "yoga/**/*.h")
   spec.header_mappings_dir = 'yoga'
 
   public_header_files = 'yoga/*.h'

--- a/packages/react-native/scripts/codegen/__tests__/__snapshots__/generate-artifacts-executor-test.js.snap
+++ b/packages/react-native/scripts/codegen/__tests__/__snapshots__/generate-artifacts-executor-test.js.snap
@@ -415,51 +415,30 @@ boost_compiler_flags = Helpers::Constants.boost_config[:compiler_flags]
 header_search_paths = []
 framework_search_paths = []
 
-if ReactNativeCoreUtils.build_rncore_from_source()
+header_search_paths = [
+  \\"\\\\\\"$(PODS_ROOT)/ReactNativeDependencies\\\\\\"\\",
+  \\"\\\\\\"\${PODS_ROOT}/Headers/Public/ReactCodegen/react/renderer/components\\\\\\"\\",
+  \\"\\\\\\"$(PODS_ROOT)/Headers/Private/React-Fabric\\\\\\"\\",
+  \\"\\\\\\"$(PODS_ROOT)/Headers/Private/React-RCTFabric\\\\\\"\\",
+  \\"\\\\\\"$(PODS_ROOT)/Headers/Private/Yoga\\\\\\"\\",
+  \\"\\\\\\"$(PODS_TARGET_SRCROOT)\\\\\\"\\",
+]
 
-  header_search_paths = [
-    \\"\\\\\\"$(PODS_ROOT)/ReactNativeDependencies\\\\\\"\\",
-    \\"\\\\\\"\${PODS_ROOT}/Headers/Public/ReactCodegen/react/renderer/components\\\\\\"\\",
-    \\"\\\\\\"$(PODS_ROOT)/Headers/Private/React-Fabric\\\\\\"\\",
-    \\"\\\\\\"$(PODS_ROOT)/Headers/Private/React-RCTFabric\\\\\\"\\",
-    \\"\\\\\\"$(PODS_ROOT)/Headers/Private/Yoga\\\\\\"\\",
-    \\"\\\\\\"$(PODS_TARGET_SRCROOT)\\\\\\"\\",
-  ]
-
-  if use_frameworks
-    ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"React-Fabric\\", \\"React_Fabric\\", [\\"react/renderer/components/view/platform/cxx\\"])
-      .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"React-FabricImage\\", \\"React_FabricImage\\", []))
-      .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"React-graphics\\", \\"React_graphics\\", [\\"react/renderer/graphics/platform/ios\\"]))
-      .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"ReactCommon\\", \\"ReactCommon\\", [\\"react/nativemodule/core\\"]))
-      .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"React-NativeModulesApple\\", \\"React_NativeModulesApple\\", []))
-      .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"React-RCTFabric\\", \\"RCTFabric\\", []))
-      .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"React-debug\\", \\"React_debug\\", []))
-      .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"React-rendererdebug\\", \\"React_rendererdebug\\", []))
-      .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"React-utils\\", \\"React_utils\\", []))
-      .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"React-featureflags\\", \\"React_featureflags\\", []))
-      .each { |search_path|
-        header_search_paths << \\"\\\\\\"#{search_path}\\\\\\"\\"
-      }
-    end
-else
-  header_search_paths = [
-    \\"$(PODS_ROOT)/Headers/Public/React-Core-prebuilt/ReactCommon\\",
-		\\"$(PODS_ROOT)/ReactNativeDependencies\\",
-		\\"$(REACT_NATIVE_PATH)/Libraries\\",
-		\\"$(REACT_NATIVE_PATH)/Libraries/FBLazyVector\\",
-		\\"\${PODS_ROOT}/Headers/Public/React-Core-prebuilt\\",
-		\\"\${PODS_ROOT}/Headers/Public/React-Core-prebuilt/Libraries\\",
-		\\"\${PODS_ROOT}/Headers/Public/React-Core-prebuilt/Libraries/AppDelegate\\",
-		\\"\${PODS_ROOT}/Headers/Public/React-Core-prebuilt/RCTDeprecation\\",
-		\\"\${PODS_ROOT}/Headers/Public/React-Core-prebuilt/ReactCommon\\",
-		\\"\${PODS_ROOT}/Headers/Public/React-Core-prebuilt/ReactCommon/jsi\\",
-		\\"\${PODS_ROOT}/Headers/Public/React-Core-prebuilt/ReactCommon/yoga\\",
-		\\"\${PODS_ROOT}/Headers/Public/React-Core-prebuilt/react/nativemodule/core\\",
-		\\"\${PODS_ROOT}/Headers/Public/ReactCodegen/react/renderer/components\\",
-		\\"\${REACT_NATIVE_PATH}/ReactCommon/jsi\\",
-		\\"\${REACT_NATIVE_PATH}/ReactCommon/yoga\\",
-  ]
-end
+if use_frameworks
+  ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"React-Fabric\\", \\"React_Fabric\\", [\\"react/renderer/components/view/platform/cxx\\"])
+    .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"React-FabricImage\\", \\"React_FabricImage\\", []))
+    .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"React-graphics\\", \\"React_graphics\\", [\\"react/renderer/graphics/platform/ios\\"]))
+    .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"ReactCommon\\", \\"ReactCommon\\", [\\"react/nativemodule/core\\"]))
+    .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"React-NativeModulesApple\\", \\"React_NativeModulesApple\\", []))
+    .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"React-RCTFabric\\", \\"RCTFabric\\", []))
+    .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"React-debug\\", \\"React_debug\\", []))
+    .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"React-rendererdebug\\", \\"React_rendererdebug\\", []))
+    .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"React-utils\\", \\"React_utils\\", []))
+    .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"React-featureflags\\", \\"React_featureflags\\", []))
+    .each { |search_path|
+      header_search_paths << \\"\\\\\\"#{search_path}\\\\\\"\\"
+    }
+  end
 
 Pod::Spec.new do |s|
   s.name                = \\"ReactCodegen\\"
@@ -920,51 +899,30 @@ boost_compiler_flags = Helpers::Constants.boost_config[:compiler_flags]
 header_search_paths = []
 framework_search_paths = []
 
-if ReactNativeCoreUtils.build_rncore_from_source()
+header_search_paths = [
+  \\"\\\\\\"$(PODS_ROOT)/ReactNativeDependencies\\\\\\"\\",
+  \\"\\\\\\"\${PODS_ROOT}/Headers/Public/ReactCodegen/react/renderer/components\\\\\\"\\",
+  \\"\\\\\\"$(PODS_ROOT)/Headers/Private/React-Fabric\\\\\\"\\",
+  \\"\\\\\\"$(PODS_ROOT)/Headers/Private/React-RCTFabric\\\\\\"\\",
+  \\"\\\\\\"$(PODS_ROOT)/Headers/Private/Yoga\\\\\\"\\",
+  \\"\\\\\\"$(PODS_TARGET_SRCROOT)\\\\\\"\\",
+]
 
-  header_search_paths = [
-    \\"\\\\\\"$(PODS_ROOT)/ReactNativeDependencies\\\\\\"\\",
-    \\"\\\\\\"\${PODS_ROOT}/Headers/Public/ReactCodegen/react/renderer/components\\\\\\"\\",
-    \\"\\\\\\"$(PODS_ROOT)/Headers/Private/React-Fabric\\\\\\"\\",
-    \\"\\\\\\"$(PODS_ROOT)/Headers/Private/React-RCTFabric\\\\\\"\\",
-    \\"\\\\\\"$(PODS_ROOT)/Headers/Private/Yoga\\\\\\"\\",
-    \\"\\\\\\"$(PODS_TARGET_SRCROOT)\\\\\\"\\",
-  ]
-
-  if use_frameworks
-    ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"React-Fabric\\", \\"React_Fabric\\", [\\"react/renderer/components/view/platform/cxx\\"])
-      .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"React-FabricImage\\", \\"React_FabricImage\\", []))
-      .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"React-graphics\\", \\"React_graphics\\", [\\"react/renderer/graphics/platform/ios\\"]))
-      .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"ReactCommon\\", \\"ReactCommon\\", [\\"react/nativemodule/core\\"]))
-      .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"React-NativeModulesApple\\", \\"React_NativeModulesApple\\", []))
-      .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"React-RCTFabric\\", \\"RCTFabric\\", []))
-      .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"React-debug\\", \\"React_debug\\", []))
-      .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"React-rendererdebug\\", \\"React_rendererdebug\\", []))
-      .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"React-utils\\", \\"React_utils\\", []))
-      .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"React-featureflags\\", \\"React_featureflags\\", []))
-      .each { |search_path|
-        header_search_paths << \\"\\\\\\"#{search_path}\\\\\\"\\"
-      }
-    end
-else
-  header_search_paths = [
-    \\"$(PODS_ROOT)/Headers/Public/React-Core-prebuilt/ReactCommon\\",
-		\\"$(PODS_ROOT)/ReactNativeDependencies\\",
-		\\"$(REACT_NATIVE_PATH)/Libraries\\",
-		\\"$(REACT_NATIVE_PATH)/Libraries/FBLazyVector\\",
-		\\"\${PODS_ROOT}/Headers/Public/React-Core-prebuilt\\",
-		\\"\${PODS_ROOT}/Headers/Public/React-Core-prebuilt/Libraries\\",
-		\\"\${PODS_ROOT}/Headers/Public/React-Core-prebuilt/Libraries/AppDelegate\\",
-		\\"\${PODS_ROOT}/Headers/Public/React-Core-prebuilt/RCTDeprecation\\",
-		\\"\${PODS_ROOT}/Headers/Public/React-Core-prebuilt/ReactCommon\\",
-		\\"\${PODS_ROOT}/Headers/Public/React-Core-prebuilt/ReactCommon/jsi\\",
-		\\"\${PODS_ROOT}/Headers/Public/React-Core-prebuilt/ReactCommon/yoga\\",
-		\\"\${PODS_ROOT}/Headers/Public/React-Core-prebuilt/react/nativemodule/core\\",
-		\\"\${PODS_ROOT}/Headers/Public/ReactCodegen/react/renderer/components\\",
-		\\"\${REACT_NATIVE_PATH}/ReactCommon/jsi\\",
-		\\"\${REACT_NATIVE_PATH}/ReactCommon/yoga\\",
-  ]
-end
+if use_frameworks
+  ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"React-Fabric\\", \\"React_Fabric\\", [\\"react/renderer/components/view/platform/cxx\\"])
+    .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"React-FabricImage\\", \\"React_FabricImage\\", []))
+    .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"React-graphics\\", \\"React_graphics\\", [\\"react/renderer/graphics/platform/ios\\"]))
+    .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"ReactCommon\\", \\"ReactCommon\\", [\\"react/nativemodule/core\\"]))
+    .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"React-NativeModulesApple\\", \\"React_NativeModulesApple\\", []))
+    .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"React-RCTFabric\\", \\"RCTFabric\\", []))
+    .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"React-debug\\", \\"React_debug\\", []))
+    .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"React-rendererdebug\\", \\"React_rendererdebug\\", []))
+    .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"React-utils\\", \\"React_utils\\", []))
+    .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks(\\"PODS_CONFIGURATION_BUILD_DIR\\", \\"React-featureflags\\", \\"React_featureflags\\", []))
+    .each { |search_path|
+      header_search_paths << \\"\\\\\\"#{search_path}\\\\\\"\\"
+    }
+  end
 
 Pod::Spec.new do |s|
   s.name                = \\"ReactCodegen\\"

--- a/packages/react-native/scripts/codegen/templates/ReactCodegen.podspec.template
+++ b/packages/react-native/scripts/codegen/templates/ReactCodegen.podspec.template
@@ -19,51 +19,30 @@ boost_compiler_flags = Helpers::Constants.boost_config[:compiler_flags]
 header_search_paths = []
 framework_search_paths = []
 
-if ReactNativeCoreUtils.build_rncore_from_source()
+header_search_paths = [
+  "\"$(PODS_ROOT)/ReactNativeDependencies\"",
+  "\"${PODS_ROOT}/Headers/Public/ReactCodegen/react/renderer/components\"",
+  "\"$(PODS_ROOT)/Headers/Private/React-Fabric\"",
+  "\"$(PODS_ROOT)/Headers/Private/React-RCTFabric\"",
+  "\"$(PODS_ROOT)/Headers/Private/Yoga\"",
+  "\"$(PODS_TARGET_SRCROOT)\"",
+]
 
-  header_search_paths = [
-    "\"$(PODS_ROOT)/ReactNativeDependencies\"",
-    "\"${PODS_ROOT}/Headers/Public/ReactCodegen/react/renderer/components\"",
-    "\"$(PODS_ROOT)/Headers/Private/React-Fabric\"",
-    "\"$(PODS_ROOT)/Headers/Private/React-RCTFabric\"",
-    "\"$(PODS_ROOT)/Headers/Private/Yoga\"",
-    "\"$(PODS_TARGET_SRCROOT)\"",
-  ]
-
-  if use_frameworks
-    ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-Fabric", "React_Fabric", ["react/renderer/components/view/platform/cxx"])
-      .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-FabricImage", "React_FabricImage", []))
-      .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-graphics", "React_graphics", ["react/renderer/graphics/platform/ios"]))
-      .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "ReactCommon", "ReactCommon", ["react/nativemodule/core"]))
-      .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-NativeModulesApple", "React_NativeModulesApple", []))
-      .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-RCTFabric", "RCTFabric", []))
-      .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-debug", "React_debug", []))
-      .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-rendererdebug", "React_rendererdebug", []))
-      .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-utils", "React_utils", []))
-      .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-featureflags", "React_featureflags", []))
-      .each { |search_path|
-        header_search_paths << "\"#{search_path}\""
-      }
-    end
-else
-  header_search_paths = [
-    "$(PODS_ROOT)/Headers/Public/React-Core-prebuilt/ReactCommon",
-		"$(PODS_ROOT)/ReactNativeDependencies",
-		"$(REACT_NATIVE_PATH)/Libraries",
-		"$(REACT_NATIVE_PATH)/Libraries/FBLazyVector",
-		"${PODS_ROOT}/Headers/Public/React-Core-prebuilt",
-		"${PODS_ROOT}/Headers/Public/React-Core-prebuilt/Libraries",
-		"${PODS_ROOT}/Headers/Public/React-Core-prebuilt/Libraries/AppDelegate",
-		"${PODS_ROOT}/Headers/Public/React-Core-prebuilt/RCTDeprecation",
-		"${PODS_ROOT}/Headers/Public/React-Core-prebuilt/ReactCommon",
-		"${PODS_ROOT}/Headers/Public/React-Core-prebuilt/ReactCommon/jsi",
-		"${PODS_ROOT}/Headers/Public/React-Core-prebuilt/ReactCommon/yoga",
-		"${PODS_ROOT}/Headers/Public/React-Core-prebuilt/react/nativemodule/core",
-		"${PODS_ROOT}/Headers/Public/ReactCodegen/react/renderer/components",
-		"${REACT_NATIVE_PATH}/ReactCommon/jsi",
-		"${REACT_NATIVE_PATH}/ReactCommon/yoga",
-  ]
-end
+if use_frameworks
+  ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-Fabric", "React_Fabric", ["react/renderer/components/view/platform/cxx"])
+    .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-FabricImage", "React_FabricImage", []))
+    .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-graphics", "React_graphics", ["react/renderer/graphics/platform/ios"]))
+    .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "ReactCommon", "ReactCommon", ["react/nativemodule/core"]))
+    .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-NativeModulesApple", "React_NativeModulesApple", []))
+    .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-RCTFabric", "RCTFabric", []))
+    .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-debug", "React_debug", []))
+    .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-rendererdebug", "React_rendererdebug", []))
+    .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-utils", "React_utils", []))
+    .concat(ReactNativePodsUtils.create_header_search_path_for_frameworks("PODS_CONFIGURATION_BUILD_DIR", "React-featureflags", "React_featureflags", []))
+    .each { |search_path|
+      header_search_paths << "\"#{search_path}\""
+    }
+  end
 
 Pod::Spec.new do |s|
   s.name                = "ReactCodegen"

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -112,86 +112,87 @@ def use_react_native! (
 
   Pod::UI.puts "Configuring the target with the #{new_arch_enabled ? "New" : "Legacy"} Architecture\n"
 
-  if ReactNativeCoreUtils.build_rncore_from_source()
-    # The Pods which should be included in all projects
-    pod 'FBLazyVector', :path => "#{prefix}/Libraries/FBLazyVector"
-    pod 'RCTRequired', :path => "#{prefix}/Libraries/Required"
-    pod 'RCTTypeSafety', :path => "#{prefix}/Libraries/TypeSafety", :modular_headers => true
-    pod 'React', :path => "#{prefix}/"
-    pod 'React-Core', :path => "#{prefix}/"
-    pod 'React-CoreModules', :path => "#{prefix}/React/CoreModules"
-    pod 'React-RCTRuntime', :path => "#{prefix}/React/Runtime"
-    pod 'React-RCTAppDelegate', :path => "#{prefix}/Libraries/AppDelegate"
-    pod 'React-RCTActionSheet', :path => "#{prefix}/Libraries/ActionSheetIOS"
-    pod 'React-RCTAnimation', :path => "#{prefix}/Libraries/NativeAnimation"
-    pod 'React-RCTBlob', :path => "#{prefix}/Libraries/Blob"
-    pod 'React-RCTImage', :path => "#{prefix}/Libraries/Image"
-    pod 'React-RCTLinking', :path => "#{prefix}/Libraries/LinkingIOS"
-    pod 'React-RCTNetwork', :path => "#{prefix}/Libraries/Network"
-    pod 'React-RCTSettings', :path => "#{prefix}/Libraries/Settings"
-    pod 'React-RCTText', :path => "#{prefix}/Libraries/Text"
-    pod 'React-RCTVibration', :path => "#{prefix}/Libraries/Vibration"
-    pod 'React-Core/RCTWebSocket', :path => "#{prefix}/"
-    pod 'React-cxxreact', :path => "#{prefix}/ReactCommon/cxxreact"
-    pod 'React-debug', :path => "#{prefix}/ReactCommon/react/debug"
-    pod 'React-utils', :path => "#{prefix}/ReactCommon/react/utils"
-    pod 'React-featureflags', :path => "#{prefix}/ReactCommon/react/featureflags"
-    pod 'React-featureflagsnativemodule', :path => "#{prefix}/ReactCommon/react/nativemodule/featureflags"
-    pod 'React-microtasksnativemodule', :path => "#{prefix}/ReactCommon/react/nativemodule/microtasks"
-    pod 'React-idlecallbacksnativemodule', :path => "#{prefix}/ReactCommon/react/nativemodule/idlecallbacks"
-    pod 'React-domnativemodule', :path => "#{prefix}/ReactCommon/react/nativemodule/dom"
-    pod 'React-defaultsnativemodule', :path => "#{prefix}/ReactCommon/react/nativemodule/defaults"
-    pod 'React-Mapbuffer', :path => "#{prefix}/ReactCommon"
-    pod 'React-jserrorhandler', :path => "#{prefix}/ReactCommon/jserrorhandler"
-    pod 'RCTDeprecation', :path => "#{prefix}/ReactApple/Libraries/RCTFoundation/RCTDeprecation"
-    pod 'React-RCTFBReactNativeSpec', :path => "#{prefix}/React"
-    pod 'React-jsi', :path => "#{prefix}/ReactCommon/jsi"
+  # The Pods which should be included in all projects
+  pod 'FBLazyVector', :path => "#{prefix}/Libraries/FBLazyVector"
+  pod 'RCTRequired', :path => "#{prefix}/Libraries/Required"
+  pod 'RCTTypeSafety', :path => "#{prefix}/Libraries/TypeSafety", :modular_headers => true
+  pod 'React', :path => "#{prefix}/"
+  if !ReactNativeCoreUtils.build_rncore_from_source()
+    pod 'React-Core-prebuilt', :podspec => "#{prefix}/React-Core-prebuilt.podspec", :modular_headers => true
+  end
+  pod 'React-Core', :path => "#{prefix}/"
+  pod 'React-CoreModules', :path => "#{prefix}/React/CoreModules"
+  pod 'React-RCTRuntime', :path => "#{prefix}/React/Runtime"
+  pod 'React-RCTAppDelegate', :path => "#{prefix}/Libraries/AppDelegate"
+  pod 'React-RCTActionSheet', :path => "#{prefix}/Libraries/ActionSheetIOS"
+  pod 'React-RCTAnimation', :path => "#{prefix}/Libraries/NativeAnimation"
+  pod 'React-RCTBlob', :path => "#{prefix}/Libraries/Blob"
+  pod 'React-RCTImage', :path => "#{prefix}/Libraries/Image"
+  pod 'React-RCTLinking', :path => "#{prefix}/Libraries/LinkingIOS"
+  pod 'React-RCTNetwork', :path => "#{prefix}/Libraries/Network"
+  pod 'React-RCTSettings', :path => "#{prefix}/Libraries/Settings"
+  pod 'React-RCTText', :path => "#{prefix}/Libraries/Text"
+  pod 'React-RCTVibration', :path => "#{prefix}/Libraries/Vibration"
+  pod 'React-Core/RCTWebSocket', :path => "#{prefix}/"
+  pod 'React-cxxreact', :path => "#{prefix}/ReactCommon/cxxreact"
+  pod 'React-debug', :path => "#{prefix}/ReactCommon/react/debug"
+  pod 'React-utils', :path => "#{prefix}/ReactCommon/react/utils"
+  pod 'React-featureflags', :path => "#{prefix}/ReactCommon/react/featureflags"
+  pod 'React-featureflagsnativemodule', :path => "#{prefix}/ReactCommon/react/nativemodule/featureflags"
+  pod 'React-microtasksnativemodule', :path => "#{prefix}/ReactCommon/react/nativemodule/microtasks"
+  pod 'React-idlecallbacksnativemodule', :path => "#{prefix}/ReactCommon/react/nativemodule/idlecallbacks"
+  pod 'React-domnativemodule', :path => "#{prefix}/ReactCommon/react/nativemodule/dom"
+  pod 'React-defaultsnativemodule', :path => "#{prefix}/ReactCommon/react/nativemodule/defaults"
+  pod 'React-Mapbuffer', :path => "#{prefix}/ReactCommon"
+  pod 'React-jserrorhandler', :path => "#{prefix}/ReactCommon/jserrorhandler"
+  pod 'RCTDeprecation', :path => "#{prefix}/ReactApple/Libraries/RCTFoundation/RCTDeprecation"
+  pod 'React-RCTFBReactNativeSpec', :path => "#{prefix}/React"
+  pod 'React-jsi', :path => "#{prefix}/ReactCommon/jsi"
 
-    if hermes_enabled
-      setup_hermes!(:react_native_path => prefix)
-    end
+  if hermes_enabled
+    setup_hermes!(:react_native_path => prefix)
+  end
 
-    pod 'React-jsiexecutor', :path => "#{prefix}/ReactCommon/jsiexecutor"
-    pod 'React-jsinspector', :path => "#{prefix}/ReactCommon/jsinspector-modern"
-    pod 'React-jsitooling', :path => "#{prefix}/ReactCommon/jsitooling"
-    pod 'React-jsinspectorcdp', :path => "#{prefix}/ReactCommon/jsinspector-modern/cdp"
-    pod 'React-jsinspectornetwork', :path => "#{prefix}/ReactCommon/jsinspector-modern/network"
-    pod 'React-jsinspectortracing', :path => "#{prefix}/ReactCommon/jsinspector-modern/tracing"
+  pod 'React-jsiexecutor', :path => "#{prefix}/ReactCommon/jsiexecutor"
+  pod 'React-jsinspector', :path => "#{prefix}/ReactCommon/jsinspector-modern"
+  pod 'React-jsitooling', :path => "#{prefix}/ReactCommon/jsitooling"
+  pod 'React-jsinspectorcdp', :path => "#{prefix}/ReactCommon/jsinspector-modern/cdp"
+  pod 'React-jsinspectornetwork', :path => "#{prefix}/ReactCommon/jsinspector-modern/network"
+  pod 'React-jsinspectortracing', :path => "#{prefix}/ReactCommon/jsinspector-modern/tracing"
 
-    pod 'React-callinvoker', :path => "#{prefix}/ReactCommon/callinvoker"
-    pod 'React-performancetimeline', :path => "#{prefix}/ReactCommon/react/performance/timeline"
-    pod 'React-timing', :path => "#{prefix}/ReactCommon/react/timing"
-    pod 'React-runtimeexecutor', :path => "#{prefix}/ReactCommon/runtimeexecutor"
-    pod 'React-runtimescheduler', :path => "#{prefix}/ReactCommon/react/renderer/runtimescheduler"
-    pod 'React-renderercss', :path => "#{prefix}/ReactCommon/react/renderer/css"
-    pod 'React-rendererdebug', :path => "#{prefix}/ReactCommon/react/renderer/debug"
-    pod 'React-rendererconsistency', :path => "#{prefix}/ReactCommon/react/renderer/consistency"
-    pod 'React-perflogger', :path => "#{prefix}/ReactCommon/reactperflogger"
-    pod 'React-oscompat', :path => "#{prefix}/ReactCommon/oscompat"
-    pod 'React-logger', :path => "#{prefix}/ReactCommon/logger"
-    pod 'ReactCommon/turbomodule/core', :path => "#{prefix}/ReactCommon", :modular_headers => true
-    pod 'React-NativeModulesApple', :path => "#{prefix}/ReactCommon/react/nativemodule/core/platform/ios", :modular_headers => true
-    pod 'Yoga', :path => "#{prefix}/ReactCommon/yoga", :modular_headers => true
-    setup_fabric!(:react_native_path => prefix)
-    setup_bridgeless!(:react_native_path => prefix, :use_hermes => hermes_enabled)
+  pod 'React-callinvoker', :path => "#{prefix}/ReactCommon/callinvoker"
+  pod 'React-performancetimeline', :path => "#{prefix}/ReactCommon/react/performance/timeline"
+  pod 'React-timing', :path => "#{prefix}/ReactCommon/react/timing"
+  pod 'React-runtimeexecutor', :path => "#{prefix}/ReactCommon/runtimeexecutor"
+  pod 'React-runtimescheduler', :path => "#{prefix}/ReactCommon/react/renderer/runtimescheduler"
+  pod 'React-renderercss', :path => "#{prefix}/ReactCommon/react/renderer/css"
+  pod 'React-rendererdebug', :path => "#{prefix}/ReactCommon/react/renderer/debug"
+  pod 'React-rendererconsistency', :path => "#{prefix}/ReactCommon/react/renderer/consistency"
+  pod 'React-perflogger', :path => "#{prefix}/ReactCommon/reactperflogger"
+  pod 'React-oscompat', :path => "#{prefix}/ReactCommon/oscompat"
+  pod 'React-logger', :path => "#{prefix}/ReactCommon/logger"
+  pod 'ReactCommon/turbomodule/core', :path => "#{prefix}/ReactCommon", :modular_headers => true
+  pod 'React-NativeModulesApple', :path => "#{prefix}/ReactCommon/react/nativemodule/core/platform/ios", :modular_headers => true
+  pod 'Yoga', :path => "#{prefix}/ReactCommon/yoga", :modular_headers => true
+  setup_fabric!(:react_native_path => prefix)
+  setup_bridgeless!(:react_native_path => prefix, :use_hermes => hermes_enabled)
 
-    if ReactNativeDependenciesUtils.build_react_native_deps_from_source()
-      pod 'DoubleConversion', :podspec => "#{prefix}/third-party-podspecs/DoubleConversion.podspec"
-      pod 'glog', :podspec => "#{prefix}/third-party-podspecs/glog.podspec"
-      pod 'boost', :podspec => "#{prefix}/third-party-podspecs/boost.podspec"
-      pod 'fast_float', :podspec => "#{prefix}/third-party-podspecs/fast_float.podspec"
-      pod 'fmt', :podspec => "#{prefix}/third-party-podspecs/fmt.podspec", :modular_headers => true
-      pod 'RCT-Folly', :podspec => "#{prefix}/third-party-podspecs/RCT-Folly.podspec", :modular_headers => true
-      pod 'SocketRocket', "~> #{Helpers::Constants::socket_rocket_config[:version]}", :modular_headers => true
-    else
-      pod 'ReactNativeDependencies', :podspec => "#{prefix}/third-party-podspecs/ReactNativeDependencies.podspec", :modular_headers => true
-    end
+  if ReactNativeDependenciesUtils.build_react_native_deps_from_source()
+    pod 'DoubleConversion', :podspec => "#{prefix}/third-party-podspecs/DoubleConversion.podspec"
+    pod 'glog', :podspec => "#{prefix}/third-party-podspecs/glog.podspec"
+    pod 'boost', :podspec => "#{prefix}/third-party-podspecs/boost.podspec"
+    pod 'fast_float', :podspec => "#{prefix}/third-party-podspecs/fast_float.podspec"
+    pod 'fmt', :podspec => "#{prefix}/third-party-podspecs/fmt.podspec", :modular_headers => true
+    pod 'RCT-Folly', :podspec => "#{prefix}/third-party-podspecs/RCT-Folly.podspec", :modular_headers => true
+    pod 'SocketRocket', "~> #{Helpers::Constants::socket_rocket_config[:version]}", :modular_headers => true
   else
     # Install prebuilt React Native Core and React Native Dependencies
     ReactNativeCoreUtils.rncore_log("Using React Native Core and React Native Dependencies prebuilt versions.")
-    pod 'React-Core-prebuilt', :podspec => "#{prefix}/React-Core-prebuilt.podspec", :modular_headers => true
     pod 'ReactNativeDependencies', :podspec => "#{prefix}/third-party-podspecs/ReactNativeDependencies.podspec", :modular_headers => true
-    pod 'hermes-engine', :podspec => "#{prefix}/sdks/hermes-engine/hermes-engine.podspec"
+
+    if !ReactNativeCoreUtils.build_rncore_from_source()
+      pod 'React-Core-prebuilt', :podspec => "#{prefix}/React-Core-prebuilt.podspec", :modular_headers => true
+    end
   end
 
   pod 'ReactCodegen', :path => $CODEGEN_OUTPUT_DIR, :modular_headers => true
@@ -272,6 +273,22 @@ end
 def install_modules_dependencies(spec, new_arch_enabled: NewArchitectureHelper.new_arch_enabled)
   folly_config = get_folly_config()
   NewArchitectureHelper.install_modules_dependencies(spec, new_arch_enabled, folly_config[:version])
+end
+
+# This function is used by podspecs that needs to use the prebuilt sources for React Native.
+# It returns the sources to use for the podspec.
+#
+# Parameters:
+# - original_sources: The original sources of the podspec
+# - sources_for_prebuilds: The sources to use for prebuilt pods
+#
+# Returns: The sources to use for the podspec
+def podspec_sources(original_sources, sources_for_prebuilds)
+  if ReactNativeCoreUtils.build_rncore_from_source()
+    return original_sources
+  else
+    return sources_for_prebuilds
+  end
 end
 
 

--- a/packages/rn-tester/RCTTest/React-RCTTest.podspec
+++ b/packages/rn-tester/RCTTest/React-RCTTest.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.platforms              = min_supported_versions
   s.compiler_flags         = '-Wno-nullability-completeness'
   s.source                 = source
-  s.source_files           = "**/*.{h,m,mm}"
+  s.source_files           = podspec_sources("**/*.{h,m,mm}", "**/*.h")
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
   s.framework              = "XCTest"
   s.header_dir             = "RCTTest"


### PR DESCRIPTION
Summary:
Instead of declaring two different sets of Pods for prebuilt and build from source, this commit now keeps the pod structure the same for both modes so that consuming libraries can expect to have the same pods and header files available - without this, libraries would have to be updated to take advantage of the prebuilds.

This PR does:
- Added React-Core-prebuilt as a pod in React-Core if prebuilt is enabled
- Simplified react_native_pods to keep pods structure and add React-Core-prebuilt pod if prebuilts are enabled
- Added function for selecting source sets based on prebuilt/build from source

To be able to function both in prebuilt and in regular build from source mode, all podspecs are now using the switch function podspec_sources so that they only include header files if we are in prebuild mode.

Also added React-Core-prebuilt as dependency on React-Core if we are in prebuilt mode so that we install the React.XCFramework.

## Changelog:

[IOS] [FIXED] - Added backwards compatible use of prebuild through cocoapods


Test Plan:
Tested in RN-Tester both with and without prebuild.

Rollback Plan:

Differential Revision: D77296047

Pulled By: cipolleschi
