### PR TITLE
Add `fantom:oss` task script

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "test-typescript": "tsc -p packages/react-native/types/tsconfig.json",
     "test-generated-typescript": "tsc -p packages/react-native/types_generated/tsconfig.test.json",
     "test": "jest",
-    "fantom": "JS_DIR='..' yarn jest --config private/react-native-fantom/config/jest.config.js",
+    "fantom": "JS_DIR='..' FANTOM_LOG_COMMANDS=1 yarn jest --config private/react-native-fantom/config/jest.config.js",
+    "fantom:oss": "FANTOM_FORCE_OSS_BUILD=1 FANTOM_LOG_COMMANDS=1 yarn jest --config private/react-native-fantom/config/jest.config.js",
     "trigger-react-native-release": "node ./scripts/releases-local/trigger-react-native-release.js",
     "update-lock": "npx yarn-deduplicate"
   },

--- a/packages/react-native/Libraries/Components/View/__tests__/View-itest.js
+++ b/packages/react-native/Libraries/Components/View/__tests__/View-itest.js
@@ -170,16 +170,20 @@ describe('<View>', () => {
   });
 
   describe('transform style', () => {
-    it('causes view to be unflattened', () => {
+    it.only('causes view to be unflattened', () => {
       const root = Fantom.createRoot();
 
       Fantom.runTask(() => {
         root.render(<View style={{transform: [{translateX: 10}]}} />);
       });
 
-      expect(root.getRenderedOutput({props: ['transform']}).toJSX()).toEqual(
-        <rn-view transform='[{"translateX": 10.000000}]' />,
-      );
+      expect(root.takeMountingManagerLogs()).toEqual([
+        'Update {type: "RootView", nativeID: (root)}',
+      ]);
+
+      // expect(root.getRenderedOutput({props: ['transform']}).toJSX()).toEqual(
+      //   <rn-view transform='[{"translateX": 10.000000}]' />,
+      // );
     });
   });
 

--- a/private/react-native-fantom/runner/EnvironmentOptions.js
+++ b/private/react-native-fantom/runner/EnvironmentOptions.js
@@ -8,6 +8,9 @@
  * @format
  */
 
+import {existsSync} from 'fs';
+import path from 'path';
+
 export const printCLIOutput: boolean = Boolean(process.env.FANTOM_PRINT_OUTPUT);
 
 export const logCommands: boolean = Boolean(process.env.FANTOM_LOG_COMMANDS);
@@ -15,3 +18,13 @@ export const logCommands: boolean = Boolean(process.env.FANTOM_LOG_COMMANDS);
 export const enableCppDebugging: boolean = Boolean(
   process.env.FANTOM_ENABLE_CPP_DEBUGGING,
 );
+
+const testerHasBuckTarget = existsSync(
+  path.join(__dirname, '..', 'tester', 'BUCK'),
+);
+export const isOSS: boolean = Object.hasOwn(
+  process.env,
+  'FANTOM_FORCE_OSS_BUILD',
+)
+  ? Boolean(process.env.FANTOM_FORCE_OSS_BUILD)
+  : !testerHasBuckTarget;

--- a/private/react-native-fantom/runtime/expect.js
+++ b/private/react-native-fantom/runtime/expect.js
@@ -77,13 +77,14 @@ class Expect {
   }
 
   toEqual(expected: mixed): void {
+    console.log('toEqual', expected, this.#received);
     const pass = deepEqual(this.#received, expected, {strict: true});
     if (!this.#isExpectedResult(pass)) {
       throw new ErrorWithCustomBlame(
         `Expected${this.#maybeNotLabel()} to equal:\n${
           diff(expected, this.#received, {
             contextLines: 1,
-            expand: false,
+            expand: true,
             omitAnnotationLines: true,
           }) ?? 'Failed to compare outputs'
         }`,
@@ -108,7 +109,7 @@ class Expect {
         `Expected${this.#maybeNotLabel()} to strictly equal:\n${
           diff(expected, this.#received, {
             contextLines: 1,
-            expand: false,
+            expand: true,
             omitAnnotationLines: true,
           }) ?? 'Failed to compare outputs'
         }`,

--- a/private/react-native-fantom/src/getFantomRenderedOutput.js
+++ b/private/react-native-fantom/src/getFantomRenderedOutput.js
@@ -127,6 +127,7 @@ export default function getFantomRenderedOutput(
 function convertRawJsonToJSX(
   actualJSON: FantomJsonObject | $ReadOnlyArray<FantomJsonObject>,
 ): React.Node {
+  console.log({actualJSON});
   let actualJSX;
   if (actualJSON === null || typeof actualJSON === 'string') {
     actualJSX = actualJSON;


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Separate script to run oss only fantom test.

Looks like runtime scheduled tasks are not executed properly...

Diff for OSS vs FB bundles
```
$ diff -u /Users/asd/fbsource/xplat/js/react-native-github/private/react-native-fantom/build/js/run-1750792514597-H1qXmx/b75908e5-View-itest.js.bundle.js /Users/asd/fbsource/xplat/js/react-native-github/private/react-native-fantom/build/js/run-1750792534919-3lPll3/b75908e5-View-itest.js.bundle.js | pastry
```
{P1850320410}

Differential Revision: D77246823


