### PR TITLE
Consume ReactNativeAttributePayloadFabric from ReactNativePrivateInterface (#33616)

### DIFF
--- a/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactNativeAttributePayload.js
+++ b/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactNativeAttributePayload.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-import type {PartialAttributeConfiguration as AttributeConfiguration} from '../../Renderer/shims/ReactNativeTypes';
+import type {AttributeConfiguration} from '../../Renderer/shims/ReactNativeTypes';
 
 import flattenStyle from '../../StyleSheet/flattenStyle';
 import deepDiffer from '../../Utilities/differ/deepDiffer';

--- a/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/ReactNativeAttributePayload-test.js
+++ b/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/ReactNativeAttributePayload-test.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-import type {PartialAttributeConfiguration as AttributeConfiguration} from '../../../Renderer/shims/ReactNativeTypes';
+import type {AttributeConfiguration} from '../../../Renderer/shims/ReactNativeTypes';
 
 const {create, diff} = require('../ReactNativeAttributePayload');
 

--- a/packages/react-native/Libraries/Renderer/shims/ReactNativeTypes.js
+++ b/packages/react-native/Libraries/Renderer/shims/ReactNativeTypes.js
@@ -7,7 +7,7 @@
  * @noformat
  * @nolint
  * @flow strict
- * @generated SignedSource<<4216c04f5a8c40a833b0146588fab5fa>>
+ * @generated SignedSource<<6166de7ecbfb5d83e56c11a3b6cde9ba>>
  */
 
 import type {
@@ -35,15 +35,6 @@ export type AttributeType<T, V> =
 export type AnyAttributeType = AttributeType<$FlowFixMe, $FlowFixMe>;
 
 export type AttributeConfiguration = $ReadOnly<{
-  [propName: string]: AnyAttributeType,
-  style: $ReadOnly<{
-    [propName: string]: AnyAttributeType,
-    ...
-  }>,
-  ...
-}>;
-
-export type PartialAttributeConfiguration = $ReadOnly<{
   [propName: string]: AnyAttributeType,
   style?: $ReadOnly<{
     [propName: string]: AnyAttributeType,
@@ -84,7 +75,7 @@ export type PartialViewConfig = $ReadOnly<{
   directEventTypes?: ViewConfig['directEventTypes'],
   supportsRawText?: boolean,
   uiViewClassName: string,
-  validAttributes?: PartialAttributeConfiguration,
+  validAttributes?: AttributeConfiguration,
 }>;
 
 type InspectorDataProps = $ReadOnly<{


### PR DESCRIPTION
Summary:
## Summary

ReactNativeAttributePayloadFabric was synced to react-native in
https://github.com/facebook/react-native/commit/0e42d33cbcfadcf5d787108da785d56a83d07a9f.
We should now consume these methods from the
ReactNativePrivateInterface.

Moving these methods to the React Native repo gives us more flexibility
to experiment with new techniques for bridging and diffing props
payloads.

I did have to leave some stub implementations for existing unit tests,
but moved all detailed tests to the React Native repo.

## How did you test this change?

* `yarn prettier`
* `yarn test ReactFabric-test`

DiffTrain build for [7a3ffef70339c10f8d65a27b88cd73bfbe13eb8a](https://github.com/facebook/react/commit/7a3ffef70339c10f8d65a27b88cd73bfbe13eb8a)

Reviewed By: rubennorte

Differential Revision: D77296286


