### PR TITLE
feat(ios): support condensed system font on fabric

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTFontUtils.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTFontUtils.mm
@@ -253,7 +253,7 @@ static UIFont *RCTDefaultFontWithFontProperties(RCTFontProperties fontProperties
 
   CGFloat effectiveFontSize = fontProperties.sizeMultiplier * fontProperties.size;
   NSString *cacheKey = [NSString
-      stringWithFormat:@"%.1f/%.2f/%ld", effectiveFontSize, fontProperties.weight, (long)fontProperties.style];
+      stringWithFormat:@"%@/%.1f/%.2f/%ld", fontProperties.family, effectiveFontSize, fontProperties.weight, (long)fontProperties.style];
   UIFont *font;
 
   {
@@ -267,11 +267,20 @@ static UIFont *RCTDefaultFontWithFontProperties(RCTFontProperties fontProperties
   if (!font) {
     font = [UIFont systemFontOfSize:effectiveFontSize weight:fontProperties.weight];
 
-    if (fontProperties.style == RCTFontStyleItalic) {
-      UIFontDescriptor *fontDescriptor = [font fontDescriptor];
-      UIFontDescriptorSymbolicTraits symbolicTraits = fontDescriptor.symbolicTraits;
+    BOOL isItalicFont = fontProperties.style == RCTFontStyleItalic;
+    BOOL isCondensedFont = [fontProperties.family isEqualToString:@"SystemCondensed"];
 
-      symbolicTraits |= UIFontDescriptorTraitItalic;
+    if (isItalicFont || isCondensedFont) {
+      UIFontDescriptor *fontDescriptor = [font fontDescriptor];
+      UIFontDescriptorSymbolicTraits symbolicTraits = fontDescriptor.symbolicTraits;  
+
+      if (isItalicFont) {
+        symbolicTraits |= UIFontDescriptorTraitItalic;
+      }
+
+      if (isCondensedFont) {
+        symbolicTraits |= UIFontDescriptorTraitCondensed;
+      }
 
       fontDescriptor = [fontDescriptor fontDescriptorWithSymbolicTraits:symbolicTraits];
       font = [UIFont fontWithDescriptor:fontDescriptor size:effectiveFontSize];
@@ -333,7 +342,7 @@ UIFont *RCTFontWithFontProperties(RCTFontProperties fontProperties)
         fontWeight = fontWeight ?: RCTGetFontWeight(font);
       } else {
         // Failback to system font.
-        font = [UIFont systemFontOfSize:effectiveFontSize weight:fontProperties.weight];
+        font = RCTDefaultFontWithFontProperties(fontProperties);
       }
     }
 


### PR DESCRIPTION
## Summary:

This PR adds support for using the condensed system font on iOS when passing "SystemCondensed" as fontFamily. This behavior existed in the old architecture but was never ported to the new one, see [RCTFont.mm](https://github.com/facebook/react-native/blob/main/packages/react-native/React/Views/RCTFont.mm#L434) as reference. Fixes #52258.

## Changelog:

[IOS] [ADDED] - Add support for condensed system font when using the new react native architecture.

## Test Plan:

Before:
<img width="275" src="https://github.com/user-attachments/assets/8744a5ae-252c-46db-b5f9-b803f3e1c671" />

After:
<img width="275" src="https://github.com/user-attachments/assets/69ec27a3-5c9a-46e3-a80a-0e02b76d8813" />