### PR TITLE
Move stripping unstable identifiers earlier in the API Snapshot pipeline

### DIFF
--- a/scripts/build-types/BuildApiSnapshot.js
+++ b/scripts/build-types/BuildApiSnapshot.js
@@ -32,10 +32,10 @@ const {styleText} = require('util');
 
 const inputFilesPostTransforms: $ReadOnlyArray<PluginObj<mixed>> = [
   require('./transforms/typescript/renameDefaultExportedIdentifiers'),
+  require('./transforms/typescript/stripUnstableApis'),
 ];
 
 const postTransforms: $ReadOnlyArray<PluginObj<mixed>> = [
-  require('./transforms/typescript/stripUnstableApis'),
   require('./transforms/typescript/sortProperties'),
   require('./transforms/typescript/sortUnions'),
   require('./transforms/typescript/removeUndefinedFromOptionalMembers'),

--- a/scripts/build-types/transforms/typescript/stripUnstableApis.js
+++ b/scripts/build-types/transforms/typescript/stripUnstableApis.js
@@ -70,6 +70,23 @@ const stripUnstableProperties: PluginObj<mixed> = {
         path.remove();
       }
     },
+    ExportNamedDeclaration(path) {
+      if (
+        path.node.declaration &&
+        isUnstableSymbol(path.node.declaration?.id?.name)
+      ) {
+        path.remove();
+      } else if (path.node.specifiers) {
+        path.node.specifiers = path.node.specifiers.filter(
+          specifier => !isUnstableSymbol(specifier.exported.name),
+        );
+      }
+    },
+    ExportDefaultDeclaration(path) {
+      if (isUnstableSymbol(path.node.declaration?.id?.name)) {
+        path.remove();
+      }
+    },
   },
 };
 


### PR DESCRIPTION
Summary: Changelog: [Internal]

Differential Revision: D77304456
