### PR TITLE
Add dev server host/port settings to ReactInstanceConfig

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/devsupport/DevServerHelper.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/devsupport/DevServerHelper.cpp
@@ -45,10 +45,14 @@ namespace facebook::react {
 DevServerHelper::DevServerHelper(
     std::string appId,
     std::string deviceName,
+    std::string devServerHost,
+    uint32_t devServerPort,
     const HttpClientFactory& httpClientFactory,
     JavaScriptModuleCallback javaScriptModuleCallback) noexcept
     : appId_(std::move(appId)),
       deviceName_(std::move(deviceName)),
+      devServerHost_(std::move(devServerHost)),
+      devServerPort_(devServerPort),
       httpClient_(httpClientFactory()),
       javaScriptModuleCallback_(std::move(javaScriptModuleCallback)) {
   deviceId_ = SHA256(fmt::format("{}-{}", deviceName_, appId_));
@@ -101,8 +105,8 @@ std::string DevServerHelper::getInspectorUrl() const {
 
   return fmt::format(
       "ws://{}:{}/inspector/device?name={}&app={}&device={}&profiling={}",
-      DEFAULT_DEV_SERVER_HOST,
-      DEFAULT_DEV_SERVER_PORT,
+      devServerHost_,
+      devServerPort_,
       urlEscape(deviceName_),
       appId_,
       deviceId_,
@@ -122,8 +126,8 @@ std::string DevServerHelper::getBundleUrl() const {
   bool runModule = !splitBundle;
   return fmt::format(
       "http://{}:{}/{}.bundle?platform={}&dev={}&lazy={}&minify={}&app={}&modulesOnly={}&runModule={}&inlineSourceMap=false&excludeSource=true&sourcePaths=url-server",
-      DEFAULT_DEV_SERVER_HOST,
-      DEFAULT_DEV_SERVER_PORT,
+      devServerHost_,
+      devServerPort_,
       sourcePath_,
       DEFAULT_PLATFORM,
       dev,
@@ -135,15 +139,14 @@ std::string DevServerHelper::getBundleUrl() const {
 };
 
 std::string DevServerHelper::getPackagerConnectionUrl() const {
-  return fmt::format(
-      "ws://{}:{}/message", DEFAULT_DEV_SERVER_HOST, DEFAULT_DEV_SERVER_PORT);
+  return fmt::format("ws://{}:{}/message", devServerHost_, devServerPort_);
 }
 
 void DevServerHelper::openDebugger() const {
   auto requestUrl = fmt::format(
       "http://{}:{}/open-debugger?device={}",
-      DEFAULT_DEV_SERVER_HOST,
-      DEFAULT_DEV_SERVER_PORT,
+      devServerHost_,
+      devServerPort_,
       deviceId_);
   httpClient_->sendRequest({}, "POST", requestUrl);
 }
@@ -152,8 +155,8 @@ void DevServerHelper::setupHMRClient() const {
   folly::dynamic params = folly::dynamic::array(
       DEFAULT_PLATFORM,
       sourcePath_,
-      DEFAULT_DEV_SERVER_HOST,
-      DEFAULT_DEV_SERVER_PORT,
+      devServerHost_,
+      devServerPort_,
       true /*enable*/);
   javaScriptModuleCallback_("HMRClient", "setup", std::move(params));
 }

--- a/packages/react-native/ReactCxxPlatform/react/devsupport/DevServerHelper.h
+++ b/packages/react-native/ReactCxxPlatform/react/devsupport/DevServerHelper.h
@@ -16,13 +16,6 @@
 
 namespace facebook::react {
 
-namespace {
-
-constexpr std::string_view DEFAULT_DEV_SERVER_HOST = "localhost";
-constexpr uint32_t DEFAULT_DEV_SERVER_PORT = 8081;
-
-} // namespace
-
 class DevServerHelper {
  public:
   enum class DownloadProgressStatus : short { STARTED, FAILED, FINISHED };
@@ -31,6 +24,8 @@ class DevServerHelper {
   DevServerHelper(
       std::string appId,
       std::string deviceName,
+      std::string devServerHost,
+      uint32_t devServerPort,
       const HttpClientFactory& httpClientFactory,
       JavaScriptModuleCallback javaScriptModuleCallback) noexcept;
   ~DevServerHelper() noexcept = default;
@@ -56,6 +51,8 @@ class DevServerHelper {
  private:
   std::string appId_;
   std::string deviceName_;
+  std::string devServerHost_;
+  uint32_t devServerPort_;
   std::unique_ptr<IHttpClient> httpClient_;
   JavaScriptModuleCallback javaScriptModuleCallback_;
   std::string deviceId_;

--- a/packages/react-native/ReactCxxPlatform/react/runtime/ReactHost.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/runtime/ReactHost.cpp
@@ -144,6 +144,8 @@ void ReactHost::createReactInstance() {
       devServerHelper_ = std::make_shared<DevServerHelper>(
           reactInstanceConfig_.appId,
           reactInstanceConfig_.deviceName,
+          reactInstanceConfig_.devServerHost,
+          reactInstanceConfig_.devServerPort,
           httpClientFactory,
           [this](
               const std::string& moduleName,

--- a/packages/react-native/ReactCxxPlatform/react/runtime/ReactInstanceConfig.h
+++ b/packages/react-native/ReactCxxPlatform/react/runtime/ReactInstanceConfig.h
@@ -20,6 +20,8 @@ struct ReactInstanceConfig {
 #endif
   std::string appId;
   std::string deviceName;
+  std::string devServerHost{"localhost"};
+  uint32_t devServerPort{8081};
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Adds a bare-bones API to set the dev server host and port at the time of creating a `ReactInstance` in the C++ platform.

Differential Revision: D77050457


