### PR TITLE
RN: Always Flatten Animated Styles

### DIFF
--- a/packages/react-native/Libraries/Animated/__tests__/Animated-test.js
+++ b/packages/react-native/Libraries/Animated/__tests__/Animated-test.js
@@ -247,10 +247,6 @@ describe('Animated', () => {
     });
 
     it('renders animated and primitive style correctly', () => {
-      ReactNativeFeatureFlags.override({
-        alwaysFlattenAnimatedStyles: () => true,
-      });
-
       const anim = new Animated.Value(0);
       const staticProps = {
         style: [

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js
@@ -13,7 +13,6 @@ import type {AnimatedNodeConfig} from './AnimatedNode';
 import type {AnimatedStyleAllowlist} from './AnimatedStyle';
 
 import NativeAnimatedHelper from '../../../src/private/animated/NativeAnimatedHelper';
-import * as ReactNativeFeatureFlags from '../../../src/private/featureflags/ReactNativeFeatureFlags';
 import {findNodeHandle} from '../../ReactNative/RendererProxy';
 import flattenStyle from '../../StyleSheet/flattenStyle';
 import {AnimatedEvent} from '../AnimatedEvent';
@@ -58,9 +57,7 @@ function createAnimatedProps(
           // we propagate the flattened `style` object to the `props` object.
           const flatStyle = flattenStyle(value as $FlowFixMe);
           node = AnimatedStyle.from(flatStyle, allowlist?.style, value);
-          if (ReactNativeFeatureFlags.alwaysFlattenAnimatedStyles()) {
-            staticValue = flatStyle;
-          }
+          staticValue = flatStyle;
         }
       } else if (value instanceof AnimatedNode) {
         node = value;
@@ -164,9 +161,7 @@ export default class AnimatedProps extends AnimatedNode {
           maybeNode.__replaceAnimatedNodeWithValues(mutableStyle);
           props[key] = maybeNode.__getValueForStyle(mutableStyle);
         } else {
-          if (ReactNativeFeatureFlags.alwaysFlattenAnimatedStyles()) {
-            props[key] = flatStaticStyle;
-          }
+          props[key] = flatStaticStyle;
         }
       } else if (maybeNode instanceof AnimatedNode) {
         props[key] = maybeNode.__getValue();

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxInspectorSourceMapStatus-test.js.snap
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxInspectorSourceMapStatus-test.js.snap
@@ -35,18 +35,12 @@ exports[`LogBoxInspectorSourceMapStatus should render for failed 1`] = `
       }
     }
     style={
-      Array [
-        Object {
-          "height": 14,
-          "marginEnd": 4,
-          "tintColor": "rgba(255, 255, 255, 0.4)",
-          "width": 16,
-        },
-        Object {
-          "tintColor": "rgba(243, 83, 105, 1)",
-        },
-        null,
-      ]
+      Object {
+        "height": 14,
+        "marginEnd": 4,
+        "tintColor": "rgba(243, 83, 105, 1)",
+        "width": 16,
+      }
     }
   />
   <Text

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -641,17 +641,6 @@ const definitions: FeatureFlagDefinitions = {
 
   jsOnly: {
     ...testDefinitions.jsOnly,
-    alwaysFlattenAnimatedStyles: {
-      defaultValue: false,
-      metadata: {
-        dateAdded: '2025-06-02',
-        description:
-          'Changes `Animated` to always flatten style, fixing a bug with shadowed `AnimatedNode` instances.',
-        expectedReleaseValue: true,
-        purpose: 'experimentation',
-      },
-      ossReleaseStage: 'none',
-    },
     animatedShouldDebounceQueueFlush: {
       defaultValue: false,
       metadata: {

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<731dbe289a0c7cf5bec2c8033150ebb9>>
+ * @generated SignedSource<<ce8234b2a2b09cb0c756e1d587585372>>
  * @flow strict
  * @noformat
  */
@@ -29,7 +29,6 @@ import {
 
 export type ReactNativeFeatureFlagsJsOnly = $ReadOnly<{
   jsOnlyTestFlag: Getter<boolean>,
-  alwaysFlattenAnimatedStyles: Getter<boolean>,
   animatedShouldDebounceQueueFlush: Getter<boolean>,
   animatedShouldUseSingleOp: Getter<boolean>,
   avoidStateUpdateInAnimatedPropsMemo: Getter<boolean>,
@@ -112,11 +111,6 @@ export type ReactNativeFeatureFlags = $ReadOnly<{
  * JS-only flag for testing. Do NOT modify.
  */
 export const jsOnlyTestFlag: Getter<boolean> = createJavaScriptFlagGetter('jsOnlyTestFlag', false);
-
-/**
- * Changes `Animated` to always flatten style, fixing a bug with shadowed `AnimatedNode` instances.
- */
-export const alwaysFlattenAnimatedStyles: Getter<boolean> = createJavaScriptFlagGetter('alwaysFlattenAnimatedStyles', false);
 
 /**
  * Enables an experimental flush-queue debouncing in Animated.js.


### PR DESCRIPTION
Summary:
Ships the feature flag introduced in https://github.com/facebook/react-native/pull/51719 to fix crahes that result from shadowed animated style values.

Changelog:
[General][Changed] - Animated now always flattens `props.style`, which fixes an error that results from `props.style` objects in which `AnimatedNode` instances are shadowed (i.e. flattened to not exist in the resulting `props.style` object).

Differential Revision: D77314904


