### PR TITLE
Reduce call to `folly::dynamic::object` insert and remove unnecessary AnimatedNode::update calls

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/PropsAnimatedNode.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/PropsAnimatedNode.cpp
@@ -123,11 +123,7 @@ void PropsAnimatedNode::update(bool forceFabricCommit) {
         case AnimatedNodeType::Style: {
           if (const auto& styleNode =
                   manager_->getAnimatedNode<StyleAnimatedNode>(nodeTag)) {
-            styleNode->update();
-            auto& styleNodeProps = styleNode->getProps();
-            for (const auto& styleNodeProp : styleNodeProps.items()) {
-              props_.insert(styleNodeProp.first.c_str(), styleNodeProp.second);
-            }
+            styleNode->collectViewUpdates(props_);
           }
         } break;
         case AnimatedNodeType::Props:

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/StyleAnimatedNode.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/StyleAnimatedNode.h
@@ -22,18 +22,13 @@ class StyleAnimatedNode final : public AnimatedNode {
       Tag tag,
       const folly::dynamic& config,
       NativeAnimatedNodesManager& manager);
-  void update() override;
-
-  const folly::dynamic& getProps() const noexcept {
-    return props_;
-  }
+  void collectViewUpdates(folly::dynamic& props);
 
   bool isLayoutStyleUpdated() const noexcept {
     return layoutStyleUpdated_;
   }
 
  private:
-  folly::dynamic props_;
   bool layoutStyleUpdated_;
 };
 } // namespace facebook::react

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/TransformAnimatedNode.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/TransformAnimatedNode.cpp
@@ -30,10 +30,9 @@ TransformAnimatedNode::TransformAnimatedNode(
     Tag tag,
     const folly::dynamic& config,
     NativeAnimatedNodesManager& manager)
-    : AnimatedNode(tag, config, manager, AnimatedNodeType::Transform),
-      props_(folly::dynamic::object()) {}
+    : AnimatedNode(tag, config, manager, AnimatedNodeType::Transform) {}
 
-void TransformAnimatedNode::update() {
+void TransformAnimatedNode::collectViewUpdates(folly::dynamic& props) {
   folly::dynamic transforms = folly::dynamic::array();
   auto transformsArray = getConfig()[sTransformsName];
   react_native_assert(transformsArray.type() == folly::dynamic::ARRAY);
@@ -53,11 +52,7 @@ void TransformAnimatedNode::update() {
       transforms.push_back(folly::dynamic::object(property, value.value()));
     }
   }
-  props_[sTransformPropName] = std::move(transforms);
-}
-
-const folly::dynamic& TransformAnimatedNode::getProps() {
-  return props_;
+  props[sTransformPropName] = std::move(transforms);
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/TransformAnimatedNode.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/TransformAnimatedNode.h
@@ -29,11 +29,6 @@ class TransformAnimatedNode final : public AnimatedNode {
       const folly::dynamic& config,
       NativeAnimatedNodesManager& manager);
 
-  void update() override;
-
-  const folly::dynamic& getProps();
-
- private:
-  folly::dynamic props_;
+  void collectViewUpdates(folly::dynamic& props);
 };
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
## Changelog:

[Internal] [Changed] - Reduce call to `folly::dynamic::object` insert and remove unnecessary AnimatedNode::update calls

Differential Revision: D77315659


