### PR TITLE
Fix onTextLayout metrics not incorporating ReactTextViewManagerCallback

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -530,13 +530,18 @@ public class FabricUIManager
       ReadableMapBuffer paragraphAttributes,
       float width,
       float height) {
+    ViewManager textViewManager = mViewManagerRegistry.get(ReactTextViewManager.REACT_CLASS);
+
     return (NativeArray)
         TextLayoutManager.measureLines(
             mReactApplicationContext,
             attributedString,
             paragraphAttributes,
             PixelUtil.toPixelFromDIP(width),
-            PixelUtil.toPixelFromDIP(height));
+            PixelUtil.toPixelFromDIP(height),
+            textViewManager instanceof ReactTextViewManagerCallback
+                ? (ReactTextViewManagerCallback) textViewManager
+                : null);
   }
 
   public int getColor(int surfaceId, String[] resourcePaths) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.kt
@@ -1007,7 +1007,8 @@ internal object TextLayoutManager {
       attributedString: MapBuffer,
       paragraphAttributes: MapBuffer,
       width: Float,
-      height: Float
+      height: Float,
+      reactTextViewManagerCallback: ReactTextViewManagerCallback?
   ): WritableArray {
     val layout =
         createLayoutForMeasurement(
@@ -1018,7 +1019,7 @@ internal object TextLayoutManager {
             YogaMeasureMode.EXACTLY,
             height,
             YogaMeasureMode.EXACTLY,
-            null /* TODO T226571550: Fix measureLines with ReactTextViewManagerCallback */)
+            reactTextViewManagerCallback)
     return FontMetricsUtil.getFontMetrics(layout.text, layout, context)
   }
 


### PR DESCRIPTION
Summary:
The line metrics reported do not process the Spannable, meaning their layout results may disagree with those used for measurement and display.

Changelog:
[Android][Fixed] - Fix onTextLayout metrics not incorporating ReactTextViewManagerCallback

Reviewed By: lenaic

Differential Revision: D77261839


