### PR TITLE
fix: unable to move cursor in absolutely positioned TextInput on Android when parent View has zIndex

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/TouchTargetHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/TouchTargetHelper.kt
@@ -160,6 +160,21 @@ public object TouchTargetHelper {
     return currentView
   }
 
+  @JvmStatic
+  public fun isInZeroSizedZIndexContainer(view: View, rootViewGroup: ViewGroup): Boolean {
+    var parent = view.parent
+    while (parent != null && parent != rootViewGroup) {
+      if (parent is ReactZIndexedViewGroup) {
+        val viewGroup = parent as ViewGroup
+        if (viewGroup.width <= 0 || viewGroup.height <= 0) {
+          return true
+        }
+      }
+      parent = parent.parent
+    }
+    return false
+  }
+
   private enum class TouchTargetReturnType {
     /** Allow returning the view passed in through the parameters. */
     SELF,
@@ -308,7 +323,7 @@ public object TouchTargetHelper {
    * Returns the touch target View of the event given, or null if neither the given View nor any of
    * its descendants are the touch target.
    */
-  private fun findTouchTargetViewWithPointerEvents(
+  public fun findTouchTargetViewWithPointerEvents(
       eventCoords: FloatArray,
       view: View,
       pathAccumulator: MutableList<ViewTarget>? = null


### PR DESCRIPTION
## Summary:

To fix https://github.com/facebook/react-native/issues/51469

I found in this scenario, a ghost container with no width and height is created. My touch events seem to be intercepted and never reach ReactEditText, the onTouchEvent in ReactEditText is not triggered at all.

This is a workaround approach, finds the targetView through touch coordinates and manually trigger onTouchEvent.
Not perfect, but currently solves my problem. I suspect this issue is related to the zIndex implementation on Android.


## Changelog:

[ANDROID] [FIXED] - Fix TextInput cursor positioning when absolutely positioned inside parent with zIndex

## Test Plan

Repro provided in https://github.com/facebook/react-native/issues/51469

