### PR TITLE
Rename arguments of `onContentSizeChange` callback

### DIFF
--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.d.ts
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.d.ts
@@ -678,7 +678,7 @@ export interface ScrollViewProps
    * It's implemented using onLayout handler attached to the content container which this ScrollView renders.
    *
    */
-  onContentSizeChange?: ((w: number, h: number) => void) | undefined;
+  onContentSizeChange?: ((contentWidth: number, contentHeight: number) => void) | undefined;
 
   /**
    * Fires at most once per frame during scrolling.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
The argument names in the `onContentSizeChange` callback's type definition differ from the [documentation](https://reactnative.dev/docs/scrollview#oncontentsizechange). 

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[GENERAL] [FIXED] - Renamed argument names in the `onContentSizeChange` callback's type definition

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
The IDE reflects updated argument names. 
![Screenshot 2025-06-26 at 14 59 40](https://github.com/user-attachments/assets/1579998a-d9a8-4b98-a664-e5106ffb42f5)
