### PR TITLE
Add API to get image loader instance from rncxx IMountingManager interface

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/renderer/uimanager/IMountingManager.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/uimanager/IMountingManager.h
@@ -16,6 +16,7 @@ namespace facebook::react {
 
 class Scheduler;
 class UIManager;
+class IImageLoader;
 
 using SchedulerTask = std::function<void(Scheduler& scheduler)>;
 using SchedulerTaskExecutor = std::function<void(SchedulerTask&& task)>;
@@ -91,6 +92,10 @@ class IMountingManager {
       std::shared_ptr<EventEmitterListener> listener) noexcept {};
 
   virtual void setUIManager(std::weak_ptr<UIManager> uiManager) noexcept {};
+
+  virtual std::shared_ptr<IImageLoader> getImageLoader() noexcept {
+    return nullptr;
+  }
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
# Changelog:
[Internal] - 

Adds a helper method to the `IMountingManager` API in order to get the platform specific image loader implementation, if available.

Differential Revision: D77379053


