### PR TITLE
Fix React-Fabric podspec to only use the sources for iOS

### DIFF
--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -120,8 +120,7 @@ Pod::Spec.new do |s|
     ss.subspec "view" do |sss|
       sss.dependency             "React-renderercss"
       sss.dependency             "Yoga"
-      sss.source_files         = podspec_sources("react/renderer/components/view/**/*.{m,mm,cpp,h}", "react/renderer/components/view/**/*.{h}")
-      sss.exclude_files        = "react/renderer/components/view/tests", "react/renderer/components/view/platform/android", "react/renderer/components/view/platform/windows"
+      sss.source_files         = podspec_sources(["react/renderer/components/view/*.{m,mm,cpp,h}", "react/renderer/components/view/platform/cxx/**/*.{m,mm,cpp,h}"], ["react/renderer/components/view/*.{h}", "react/renderer/components/view/platform/cxx/**/*.{h}"])
       sss.header_dir           = "react/renderer/components/view"
     end
 


### PR DESCRIPTION
Summary:
The current setup for several of our podspecs abuses the `**` globbing mechanism, forcing us to specify some excluded folders.
By excplicitly mention the folders that we want to use on iOS, we can avoid the usage of the `exclude_files` property.

This should make the setup more reliable and it will also avoid to leak to OSS the presence of some folders we only use internally like `platform/macos` and `platform/windows`

## Changelog:
[Internal] -

Differential Revision: D77381512


