### PR TITLE
Fewer calls to direct manipulation callback

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.cpp
@@ -743,6 +743,9 @@ void NativeAnimatedNodesManager::schedulePropsCommit(
       (layoutStyleUpdated || forceFabricCommit ||
        directManipulationCallback_ == nullptr)) {
     mergeObjects(updateViewProps_[viewTag], props);
+
+    // Must call direct manipulation to set final values on components.
+    mergeObjects(updateViewPropsDirect_[viewTag], props);
   } else if (directManipulationCallback_ != nullptr) {
     mergeObjects(updateViewPropsDirect_[viewTag], props);
   }
@@ -811,12 +814,6 @@ bool NativeAnimatedNodesManager::commitProps() {
 
   if (fabricCommitCallback_ != nullptr) {
     if (!updateViewProps_.empty()) {
-      // Must call direct manipulation to set final values on components.
-      if (directManipulationCallback_ != nullptr) {
-        for (const auto& [viewTag, props] : updateViewProps_) {
-          directManipulationCallback_(viewTag, folly::dynamic(props));
-        }
-      }
       fabricCommitCallback_(updateViewProps_);
       updateViewProps_.clear();
     }


### PR DESCRIPTION
Summary:
## Changelog:

[Internal] [Changed] - Fewer calls to direct manipulation callback

`NativeAnimatedNodesManager::onRender` is supposed to run each frame for c++ animation, from the callstack sample trace, the vast majority of time is spent on `updateNodes` (run update on all AnimatedNodes) and `commitProps` (where either Fabric ShadowTree commit or direct manipulation is called). Change in this PR is supposed to reduce time spent in `commitProps`

<img width="811" alt="Screenshot_2025-06-26_at_12 08 55 PM" src="https://github.com/user-attachments/assets/1794e783-9af0-4c69-94fe-17e1b585a4a3" />

Differential Revision: D77380842


