### PR TITLE
Support namespaced references in snapshot type versioning

### DIFF
--- a/scripts/build-types/BuildApiSnapshot.js
+++ b/scripts/build-types/BuildApiSnapshot.js
@@ -41,6 +41,7 @@ const postTransforms: $ReadOnlyArray<PluginObj<mixed>> = [
   require('./transforms/typescript/sortUnions'),
   require('./transforms/typescript/removeUndefinedFromOptionalMembers'),
   require('./transforms/typescript/organizeDeclarations'),
+  require('./transforms/typescript/versionExportedApis'),
 ];
 
 async function buildAPISnapshot(validate: boolean) {
@@ -75,7 +76,7 @@ async function buildAPISnapshot(validate: boolean) {
 
   console.log(styleText('yellow', '  >') + ' Applying additional transforms');
   const apiSnapshot = apiSnapshotTemplate(
-    await getCleanedUpRollup(tempDirectory),
+    await getProcessedSnapshotResult(tempDirectory),
   ) as string;
 
   console.log(styleText('yellow', '  >') + ' Removing temp dir');
@@ -227,7 +228,9 @@ async function rewriteLocalImports(
   );
 }
 
-async function getCleanedUpRollup(tempDirectory: string) {
+async function getProcessedSnapshotResult(
+  tempDirectory: string,
+): Promise<string> {
   const rollupPath = path.join(
     tempDirectory,
     'react-native',
@@ -247,13 +250,13 @@ async function getCleanedUpRollup(tempDirectory: string) {
     postTransforms,
   );
 
-  const formattedRollup = prettier.format(transformedRollup, {
-    parser: 'typescript',
-    semi: false,
-    trailingComma: 'all',
-  });
-
-  return formattedRollup;
+  return prettier
+    .format(transformedRollup, {
+      parser: 'typescript',
+      semi: false,
+      trailingComma: 'all',
+    })
+    .trimEnd();
 }
 
 async function generateConfigFiles(tempDirectory: string) {

--- a/scripts/build-types/index.js
+++ b/scripts/build-types/index.js
@@ -18,6 +18,7 @@ const {parseArgs, styleText} = require('util');
 const config = {
   options: {
     debug: {type: 'boolean'},
+    'debug-version-annotations': {type: 'boolean'},
     help: {type: 'boolean'},
     withSnapshot: {type: 'boolean'},
     validate: {type: 'boolean'},
@@ -26,7 +27,13 @@ const config = {
 
 async function main() {
   const {
-    values: {debug: debugEnabled, help, withSnapshot, validate},
+    values: {
+      debug: debugEnabled,
+      'debug-version-annotations': debugVersionAnnotations,
+      help,
+      withSnapshot,
+      validate,
+    },
     /* $FlowFixMe[incompatible-call] Natural Inference rollout. See
      * https://fburl.com/workplace/6291gfvu */
   } = parseArgs(config);
@@ -39,6 +46,9 @@ async function main() {
 
   Options:
     --debug           Enable debug logging.
+    --debug-version-annotations
+                      Outputs debug info alongside versioned type hashes as
+                      part of the API snapshot contents.
     --withSnapshot    [Experimental] Include API snapshot generation.
     --validate        Validate if the current API snapshot on disk is up to
                       date. Exits with an error if differences are detected.
@@ -74,7 +84,7 @@ async function main() {
       styleText(['bold', 'inverse'], ' [Experimental] Building API snapshot ') +
         '\n',
     );
-    await buildApiSnapshot(validate);
+    await buildApiSnapshot({validate, debugVersionAnnotations});
   }
 }
 

--- a/scripts/build-types/transforms/typescript/versionExportedApis.js
+++ b/scripts/build-types/transforms/typescript/versionExportedApis.js
@@ -1,0 +1,270 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {PluginObj} from '@babel/core';
+
+const generate = require('@babel/generator').default;
+const t = require('@babel/types');
+const {createHash} = require('crypto');
+const debug = require('debug')('build-types:transforms:versionExportedApis');
+
+/**
+ * A visitor that annotates all exported types in the API snapshot with a
+ * version hash based on the shape of all input types.
+ *
+ * Any AST change to a given type or a dependency will trigger a rehash,
+ * indicating that the annotated type has changed in some way in a given
+ * commit.
+ *
+ * This transform is best-effort and we are okay with minor false positives.
+ * The approach also allows this implementation to be updated in future
+ * without causing structural changes elsewhere in the API snapshot.
+ */
+const visitor: PluginObj<mixed> = {
+  visitor: {
+    Program(path) {
+      const declarations = new Map<string, BabelNode>();
+      const dependencyGraph = new Map<string, Array<string>>();
+      const computedHashes = new Map<string, string>();
+
+      // Collect all type declarations and build dependency graph
+      for (const nodePath of path.get('body')) {
+        const node = nodePath.node;
+        const typeName = node.id?.name;
+        if (
+          (t.isTSDeclareFunction(node) ||
+            t.isTSTypeAliasDeclaration(node) ||
+            t.isTSInterfaceDeclaration(node) ||
+            t.isTSEnumDeclaration(node) ||
+            t.isClassDeclaration(node) ||
+            t.isTSModuleDeclaration(node)) &&
+          typeName != null
+        ) {
+          declarations.set(typeName, node);
+          dependencyGraph.set(
+            typeName,
+            Array.from(getTypeReferencesForNode(node)),
+          );
+        }
+      }
+
+      // Helper to recursively collect all dependencies for a type
+      const getAllDependencies = (
+        typeName: string,
+        visited: Set<string> = new Set(),
+        depth: number = 0,
+      ): Set<string> => {
+        if (visited.has(typeName)) {
+          return visited;
+        }
+
+        visited.add(typeName);
+        const directDeps = dependencyGraph.get(typeName) || [];
+
+        const indent = '  '.repeat(depth);
+
+        for (const dep of directDeps) {
+          if (declarations.has(dep) && !visited.has(dep)) {
+            debug(`${indent}- Found dependency: ${dep}`);
+            getAllDependencies(dep, visited, depth + 1);
+          } else if (!declarations.has(dep)) {
+            debug(`${indent}- External dependency: ${dep}`);
+          }
+        }
+
+        return visited;
+      };
+
+      // Helper to generate a stable hash for a type and all local dependencies
+      const generateTypeHash = (typeName: string): string => {
+        const cached = computedHashes.get(typeName);
+        if (cached != null) {
+          return cached;
+        }
+
+        debug(`\n[GENERATE HASH] Analyzing dependencies for ${typeName}`);
+        const allDeps = getAllDependencies(typeName);
+        allDeps.delete(typeName); // Remove self from dependencies
+
+        const sortedDeps = Array.from(allDeps).sort();
+        const hasher = createHash('sha256');
+
+        // Add the type's own code to the hash
+        const typeDecl = declarations.get(typeName);
+        if (typeDecl) {
+          const {code} = generate(typeDecl);
+          hasher.update(code);
+          debug(`\n[HASH INPUT] Type ${typeName}:\n${code}\n`);
+        }
+
+        // Add code for each dependency to the hash
+        for (const dep of sortedDeps) {
+          const depDecl = declarations.get(dep);
+          if (depDecl) {
+            const {code} = generate(depDecl);
+            hasher.update(code);
+            debug(`[HASH INPUT] Dependency ${dep} for ${typeName}:\n${code}\n`);
+          }
+        }
+
+        const hash = hasher.digest('hex').slice(0, 8);
+        debug(`[HASH RESULT] ${typeName}: ${hash}`);
+        computedHashes.set(typeName, hash);
+        return hash;
+      };
+
+      // Process export block and annotate with dependencies hash
+      for (const nodePath of path.get('body')) {
+        if (
+          t.isExportNamedDeclaration(nodePath.node) &&
+          !nodePath.node.declaration &&
+          nodePath.node.specifiers != null
+        ) {
+          const specifiers = nodePath.node.specifiers.map(specifier => {
+            // $FlowIgnore[incompatible-type] nodePath is refined above
+            // $FlowIgnore[incompatible-use]
+            const name: string = specifier.exported.name;
+            if (declarations.has(name)) {
+              const hash = generateTypeHash(name);
+              return t.addComment(specifier, 'trailing', ` ${hash}`, true);
+            }
+            return specifier;
+          });
+          // $FlowIgnore[prop-missing]
+          // $FlowIgnore[incompatible-type]
+          nodePath.node.specifiers = specifiers;
+        }
+      }
+    },
+  },
+};
+
+/**
+ * Collect all direct type references from a TypeScript AST node.
+ */
+function getTypeReferencesForNode(
+  node: BabelNode,
+  refs: Set<string> = new Set(),
+): Set<string> {
+  if (!node) {
+    return refs;
+  }
+
+  // Handle type references
+  if (t.isTSTypeReference(node) && node.typeName) {
+    refs.add(extractQualifiedName(node.typeName));
+  }
+
+  // Handle interface extends
+  if (t.isTSInterfaceDeclaration(node) && node.extends) {
+    for (const extend of node.extends) {
+      if (extend.expression) {
+        refs.add(extractQualifiedName(extend.expression));
+      }
+    }
+  }
+
+  // Handle class extends and implements
+  if (t.isClassDeclaration(node)) {
+    if (node.superClass && node.superClass.type === 'Identifier') {
+      refs.add(node.superClass.name);
+    }
+
+    if (node.implements) {
+      for (const impl of node.implements) {
+        if (impl.expression) {
+          refs.add(extractQualifiedName(impl.expression));
+        }
+      }
+    }
+  }
+
+  // Handle type parameters
+  if (node.typeParameters && node.typeParameters.params) {
+    for (const param of node.typeParameters.params) {
+      getTypeReferencesForNode(param, refs);
+      if (param.constraint) {
+        getTypeReferencesForNode(param.constraint, refs);
+      }
+      if (param.default) {
+        getTypeReferencesForNode(param.default, refs);
+      }
+    }
+  }
+
+  // Handle indexed access types (`T['key']`)
+  if (t.isTSIndexedAccessType(node)) {
+    getTypeReferencesForNode(node.objectType, refs);
+    getTypeReferencesForNode(node.indexType, refs);
+  }
+
+  // Handle conditional types (`T extends U ? X : Y`)
+  if (t.isTSConditionalType(node)) {
+    getTypeReferencesForNode(node.checkType, refs);
+    getTypeReferencesForNode(node.extendsType, refs);
+    getTypeReferencesForNode(node.trueType, refs);
+    getTypeReferencesForNode(node.falseType, refs);
+  }
+
+  // Handle mapped types (`{ [K in keyof T]: X }`)
+  if (t.isTSMappedType(node)) {
+    if (node.typeParameter && node.typeParameter.constraint) {
+      getTypeReferencesForNode(node.typeParameter.constraint, refs);
+    }
+    if (node.typeAnnotation) {
+      getTypeReferencesForNode(node.typeAnnotation, refs);
+    }
+  }
+
+  // Recursively traverse all properties
+  for (const key in node) {
+    // $FlowIgnore[invalid-computed-prop]
+    const value = node[key];
+    if (Array.isArray(value)) {
+      value.forEach(item => getTypeReferencesForNode(item, refs));
+    } else if (typeof value === 'object' && value !== null) {
+      getTypeReferencesForNode(value, refs);
+    }
+  }
+
+  return refs;
+}
+
+function extractQualifiedName(
+  node: BabelNodeIdentifier | BabelNodeTSQualifiedName,
+): string {
+  if (t.isIdentifier(node)) {
+    return node.name;
+  }
+
+  if (t.isTSQualifiedName(node)) {
+    let fullName = '';
+    let current = node;
+
+    while (t.isTSQualifiedName(current)) {
+      if (current.right && current.right.name) {
+        fullName = '.' + current.right.name + fullName;
+      }
+      // $FlowIgnore[prop-missing]
+      // $FlowIgnore[incompatible-type]
+      current = current.left;
+    }
+
+    if (t.isIdentifier(current) && current.name) {
+      return current.name + fullName;
+    }
+  }
+
+  throw new Error(
+    `Failed to parse type name from node of type: ${node.type}. Expected Identifier or TSQualifiedName.`,
+  );
+}
+
+module.exports = visitor;


### PR DESCRIPTION
Summary:
Correctness improvement to the `versionExportedApis` transform (D77303917). Now handles namespaced references (e.g. `Animated.Value`) by redirecting to the locally defined type name.

Changelog: [Internal]

Differential Revision: D77314293


