### PR TITLE
Define isProfiling option when Fusebox is used in Production mode

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.kt
@@ -40,6 +40,7 @@ import com.facebook.react.bridge.queue.ReactQueueConfigurationImpl
 import com.facebook.react.bridge.queue.ReactQueueConfigurationSpec
 import com.facebook.react.common.annotations.FrameworkAPI
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
+import com.facebook.react.devsupport.InspectorFlags.getIsProfilingBuild
 import com.facebook.react.devsupport.StackTraceHelper
 import com.facebook.react.devsupport.interfaces.DevSupportManager
 import com.facebook.react.fabric.ComponentFactory
@@ -130,7 +131,10 @@ internal class ReactInstance(
             context, jsTimerExecutor, ReactChoreographer.getInstance(), devSupportManager)
 
     // Notify JS if profiling is enabled
-    val isProfiling = BuildConfig.ENABLE_PERFETTO || Systrace.isTracing(Systrace.TRACE_TAG_REACT)
+    val isProfiling =
+        BuildConfig.ENABLE_PERFETTO ||
+            Systrace.isTracing(Systrace.TRACE_TAG_REACT) ||
+            getIsProfilingBuild()
 
     mHybridData =
         initHybrid(

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -35,6 +35,7 @@
 #import <ReactCommon/RCTTurboModuleManager.h>
 #import <ReactCommon/RuntimeExecutor.h>
 #import <cxxreact/ReactMarker.h>
+#import <jsinspector-modern/InspectorFlags.h>
 #import <jsinspector-modern/ReactCdp.h>
 #import <jsireact/JSIExecutor.h>
 #import <react/featureflags/ReactNativeFeatureFlags.h>
@@ -406,8 +407,10 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
   // DisplayLink is used to call timer callbacks.
   _displayLink = [RCTDisplayLink new];
 
+  auto &inspectorFlags = jsinspector_modern::InspectorFlags::getInstance();
   ReactInstance::JSRuntimeFlags options = {
-      .isProfiling = false, .runtimeDiagnosticFlags = [RCTInstanceRuntimeDiagnosticFlags() UTF8String]};
+      .isProfiling = inspectorFlags.getIsProfilingBuild(),
+      .runtimeDiagnosticFlags = [RCTInstanceRuntimeDiagnosticFlags() UTF8String]};
   _reactInstance->initializeRuntime(options, [=](jsi::Runtime &runtime) {
     __strong __typeof(self) strongSelf = weakSelf;
     if (!strongSelf) {


### PR DESCRIPTION
Summary:
# Changelog [Internal]

We are gating `__RCTProfileIsProfiling` global definition under this `isProfiling` option - [1].

Differential Revision: D77315833


