### PR TITLE
Fix keyboard navigation if snapToAlignment is set

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
@@ -281,10 +281,7 @@ jintArray FabricUIManagerBinding::getRelativeAncestorList(
   for (auto it = std::next(ancestorList.begin()); it != ancestorList.end();
        ++it) {
     auto& ancestor = *it;
-    if (ancestor.first.get().getTraits().check(
-            ShadowNodeTraits::Trait::FormsStackingContext)) {
-      ancestorTags.push_back(ancestor.first.get().getTag());
-    }
+    ancestorTags.push_back(ancestor.first.get().getTag());
   }
 
   jintArray result = env->NewIntArray(static_cast<jint>(ancestorTags.size()));


### PR DESCRIPTION
Summary:
There is an issue with keyboard navigation if some scroll view sets `snapToAlignment`. In this case, we are unable to find potential focus candidates clipping is enabled since this prop will make it so that certain views in the hierarchy under the scroll view form a native view without any traits being set. The fix we have in place relies on `FormsStackingContext` to be set so it will break in this case. To fix this, we just return the entire ancestor list, since native will know how to deal with the cases that are not actual views, and in general has the official knowledge of what can be in the hierarchy or not.

Changelog: [Internal]

Differential Revision: D77467933


