### PR TITLE
ReactInstanceManager: Move clearReactRoot call to ensure proper cleanup

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -1404,14 +1404,14 @@ public class ReactInstanceManager {
             new RuntimeException(
                 "detachRootViewFromInstance called with ReactRootView with invalid id"));
       }
-
-      clearReactRoot(reactRoot);
     } else {
       reactContext
           .getCatalystInstance()
           .getJSModule(AppRegistry.class)
           .unmountApplicationComponentAtRootTag(reactRoot.getRootViewTag());
     }
+
+    clearReactRoot(reactRoot);
   }
 
   @ThreadConfined(UI)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

```
Trying to add a root view with an explicit id (11) already set. React Native uses the id field to track react tags and will overwrite this field. If that is fine, explicitly overwrite the id field to View.NO_ID before calling addRootView.
```

This issue affects Android only and is triggered by another library that calls `recreateReactContextInBackground`.
In my case, it occurred when performing an immediate reload under the old architecture using `react-native-code-push`.

The issue can be fixed by simply moving the `clearReactRoot` call inside `detachRootViewFromInstance` so that it also runs in the old-architecture code path.

## Changelog:

[ANDROID] [FIXED] - Ensure `clearReactRoot` runs for the old architecture as well, preventing leaked views and crashes when `recreateReactContextInBackground()` is called.

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Please refer to #50274.