### PR TITLE
Implement Network.loadingFailed

### DIFF
--- a/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.h
+++ b/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.h
@@ -20,13 +20,41 @@
  */
 @interface RCTInspectorNetworkReporter : NSObject
 
+/**
+ * Report a network request that is about to be sent.
+ *
+ * - Corresponds to `Network.requestWillBeSent` in CDP.
+ * - Corresponds to `PerformanceResourceTiming.requestStart` (specifically,
+ *   marking when the native request was initiated).
+ */
 + (void)reportRequestStart:(NSNumber *)requestId
                    request:(NSURLRequest *)request
          encodedDataLength:(int)encodedDataLength;
+
+/**
+ * Report when HTTP response headers have been received, corresponding to
+ * when the first byte of the response is available.
+ *
+ * - Corresponds to `Network.responseReceived` in CDP.
+ * - Corresponds to `PerformanceResourceTiming.responseStart`.
+ */
 + (void)reportResponseStart:(NSNumber *)requestId
                    response:(NSURLResponse *)response
                  statusCode:(int)statusCode
                     headers:(NSDictionary<NSString *, NSString *> *)headers;
+
+/**
+ * Report when a network request is complete and we are no longer receiving
+ * response data.
+ *
+ * - Corresponds to `Network.loadingFinished` in CDP.
+ * - Corresponds to `PerformanceResourceTiming.responseEnd`.
+ */
 + (void)reportResponseEnd:(NSNumber *)requestId encodedDataLength:(int)encodedDataLength;
 
+/**
+ * Store response body preview. This is an optional reporting method, and is a
+ * no-op if CDP debugging is disabled.
+ */
++ (void)maybeStoreResponseBody:(NSNumber *)requestId data:(NSData *)data base64Encoded:(bool)base64Encoded;
 @end

--- a/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.h
+++ b/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.h
@@ -57,7 +57,7 @@
  *
  * - Corresponds to `Network.loadingFailed` in CDP.
  */
-+ (void)reportRequestFailed:(NSNumber *)requestId;
++ (void)reportRequestFailed:(NSNumber *)requestId cancelled:(BOOL)cancelled;
 
 /**
  * Store response body preview. This is an optional reporting method, and is a

--- a/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.h
+++ b/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.h
@@ -53,8 +53,26 @@
 + (void)reportResponseEnd:(NSNumber *)requestId encodedDataLength:(int)encodedDataLength;
 
 /**
+ * Report when a network request has failed.
+ *
+ * - Corresponds to `Network.loadingFailed` in CDP.
+ */
++ (void)reportRequestFailed:(NSNumber *)requestId;
+
+/**
  * Store response body preview. This is an optional reporting method, and is a
  * no-op if CDP debugging is disabled.
  */
 + (void)maybeStoreResponseBody:(NSNumber *)requestId data:(NSData *)data base64Encoded:(bool)base64Encoded;
+
+/**
+ * Incrementally store a response body preview, when a string response is
+ * received in chunks. Buffered contents will be flushed to `NetworkReporter`
+ * with `reportResponseEnd`.
+ *
+ * As with `maybeStoreResponseBody`, calling this method is optional and a
+ * no-op if CDP debugging is disabled.
+ */
++ (void)maybeStoreResponseBodyIncremental:(NSNumber *)requestId data:(NSString *)data;
+
 @end

--- a/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.mm
+++ b/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.mm
@@ -43,6 +43,13 @@ std::string convertRequestBodyToStringTruncated(NSURLRequest *request)
 } // namespace
 #endif
 
+#ifdef REACT_NATIVE_DEBUGGER_ENABLED
+
+// Dictionary to buffer incremental response bodies (CDP debugging active only)
+static NSMutableDictionary<NSNumber *, NSMutableString *> *responseBuffers = nil;
+
+#endif
+
 @implementation RCTInspectorNetworkReporter {
 }
 
@@ -84,6 +91,35 @@ std::string convertRequestBodyToStringTruncated(NSURLRequest *request)
 + (void)reportResponseEnd:(NSNumber *)requestId encodedDataLength:(int)encodedDataLength
 {
   NetworkReporter::getInstance().reportResponseEnd(requestId.stringValue.UTF8String, encodedDataLength);
+
+#ifdef REACT_NATIVE_DEBUGGER_ENABLED
+  // Debug build: Check for buffered response body and flush to NetworkReporter
+  auto &networkReporter = NetworkReporter::getInstance();
+  if (!networkReporter.isDebuggingEnabled()) {
+    return;
+  }
+
+  if (responseBuffers) {
+    NSMutableString *buffer = responseBuffers[requestId];
+    if (buffer) {
+      if (networkReporter.isDebuggingEnabled() && buffer.length > 0) {
+        networkReporter.storeResponseBody(requestId.stringValue.UTF8String, [buffer UTF8String], false);
+      }
+      [responseBuffers removeObjectForKey:requestId];
+    }
+  }
+#endif
+}
+
+// TODO(T218584924): Implement and report to NetworkReporter
++ (void)reportRequestFailed:(NSNumber *)requestId
+{
+#ifdef REACT_NATIVE_DEBUGGER_ENABLED
+  // Debug build: Clear buffer for request
+  if (responseBuffers) {
+    [responseBuffers removeObjectForKey:requestId];
+  }
+#endif
 }
 
 + (void)maybeStoreResponseBody:(NSNumber *)requestId data:(id)data base64Encoded:(bool)base64Encoded
@@ -111,4 +147,29 @@ std::string convertRequestBodyToStringTruncated(NSURLRequest *request)
   }
 #endif
 }
+
++ (void)maybeStoreResponseBodyIncremental:(NSNumber *)requestId data:(NSString *)data
+{
+#ifdef REACT_NATIVE_DEBUGGER_ENABLED
+  // Debug build: Buffer incremental response body contents
+  auto &networkReporter = NetworkReporter::getInstance();
+  if (!networkReporter.isDebuggingEnabled()) {
+    return;
+  }
+
+  if (!responseBuffers) {
+    responseBuffers = [NSMutableDictionary dictionary];
+  }
+
+  // Get or create buffer for this requestId
+  NSMutableString *buffer = responseBuffers[requestId];
+  if (!buffer) {
+    buffer = [NSMutableString string];
+    responseBuffers[requestId] = buffer;
+  }
+
+  [buffer appendString:data];
+#endif
+}
+
 @end

--- a/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.mm
+++ b/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.mm
@@ -7,6 +7,7 @@
 
 #import "RCTInspectorNetworkReporter.h"
 
+#import <React/RCTLog.h>
 #import <jsinspector-modern/network/NetworkReporter.h>
 
 using namespace facebook::react::jsinspector_modern;
@@ -85,4 +86,29 @@ std::string convertRequestBodyToStringTruncated(NSURLRequest *request)
   NetworkReporter::getInstance().reportResponseEnd(requestId.stringValue.UTF8String, encodedDataLength);
 }
 
++ (void)maybeStoreResponseBody:(NSNumber *)requestId data:(id)data base64Encoded:(bool)base64Encoded
+{
+#ifdef REACT_NATIVE_DEBUGGER_ENABLED
+  // Debug build: Process response body and report to NetworkReporter
+  auto &networkReporter = NetworkReporter::getInstance();
+  if (!networkReporter.isDebuggingEnabled()) {
+    return;
+  }
+
+  if ([data isKindOfClass:[NSData class]] && [(NSData *)data length] > 0) {
+    @try {
+      NSString *encodedString = [(NSData *)data base64EncodedStringWithOptions:0];
+      if (encodedString) {
+        networkReporter.storeResponseBody(requestId.stringValue.UTF8String, encodedString.UTF8String, base64Encoded);
+      } else {
+        RCTLogWarn(@"Failed to encode response data for request %@", requestId);
+      }
+    } @catch (NSException *exception) {
+      RCTLogWarn(@"Exception while encoding response data: %@", exception.reason);
+    }
+  } else if ([data isKindOfClass:[NSString class]] && [(NSString *)data length] > 0) {
+    networkReporter.storeResponseBody(requestId.stringValue.UTF8String, [(NSString *)data UTF8String], base64Encoded);
+  }
+#endif
+}
 @end

--- a/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.mm
+++ b/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.mm
@@ -111,9 +111,10 @@ static NSMutableDictionary<NSNumber *, NSMutableString *> *responseBuffers = nil
 #endif
 }
 
-// TODO(T218584924): Implement and report to NetworkReporter
-+ (void)reportRequestFailed:(NSNumber *)requestId
++ (void)reportRequestFailed:(NSNumber *)requestId cancelled:(bool)cancelled
 {
+  NetworkReporter::getInstance().reportRequestFailed(requestId.stringValue.UTF8String, cancelled);
+
 #ifdef REACT_NATIVE_DEBUGGER_ENABLED
   // Debug build: Clear buffer for request
   if (responseBuffers) {

--- a/packages/react-native/Libraries/Network/RCTNetworking.mm
+++ b/packages/react-native/Libraries/Network/RCTNetworking.mm
@@ -558,6 +558,20 @@ RCT_EXPORT_MODULE()
     }
   }
 
+  if (facebook::react::ReactNativeFeatureFlags::enableNetworkEventReporting()) {
+    id responseDataForPreview;
+    if ([responseType isEqualToString:@"blob"]) {
+      responseDataForPreview = data;
+    } else if ([responseData isKindOfClass:[NSString class]]) {
+      responseDataForPreview = responseData;
+    }
+    bool base64Encoded = [responseType isEqualToString:@"base64"] || [responseType isEqualToString:@"blob"];
+
+    [RCTInspectorNetworkReporter maybeStoreResponseBody:task.requestID
+                                                   data:responseDataForPreview
+                                          base64Encoded:base64Encoded];
+  }
+
   [self sendEventWithName:@"didReceiveNetworkData" body:@[ task.requestID, responseData ]];
 }
 

--- a/packages/react-native/Libraries/Network/RCTNetworking.mm
+++ b/packages/react-native/Libraries/Network/RCTNetworking.mm
@@ -627,9 +627,9 @@ RCT_EXPORT_MODULE()
       incrementalDataBlock = ^(NSData *data, int64_t progress, int64_t total) {
         NSUInteger initialCarryLength = incrementalDataCarry.length;
 
-        NSString *responseString = [RCTNetworking decodeTextData:data
-                                                    fromResponse:task.response
-                                                   withCarryData:incrementalDataCarry];
+        id responseString = [RCTNetworking decodeTextData:data
+                                             fromResponse:task.response
+                                            withCarryData:incrementalDataCarry];
         if (!responseString) {
           RCTLogWarn(@"Received data was not a string, or was not a recognised encoding.");
           return;
@@ -643,6 +643,9 @@ RCT_EXPORT_MODULE()
           @(total)
         ];
 
+        if (facebook::react::ReactNativeFeatureFlags::enableNetworkEventReporting()) {
+          [RCTInspectorNetworkReporter maybeStoreResponseBodyIncremental:task.requestID data:responseString];
+        }
         [weakSelf sendEventWithName:@"didReceiveNetworkIncrementalData" body:responseJSON];
       };
     } else {
@@ -668,7 +671,11 @@ RCT_EXPORT_MODULE()
         @[ task.requestID, RCTNullIfNil(error.localizedDescription), error.code == kCFURLErrorTimedOut ? @YES : @NO ];
 
     if (facebook::react::ReactNativeFeatureFlags::enableNetworkEventReporting()) {
-      [RCTInspectorNetworkReporter reportResponseEnd:task.requestID encodedDataLength:data.length];
+      if (error) {
+        [RCTInspectorNetworkReporter reportRequestFailed:task.requestID];
+      } else {
+        [RCTInspectorNetworkReporter reportResponseEnd:task.requestID encodedDataLength:data.length];
+      }
     }
     [strongSelf sendEventWithName:@"didCompleteNetworkResponse" body:responseJSON];
     [strongSelf->_tasksByRequestID removeObjectForKey:task.requestID];

--- a/packages/react-native/Libraries/Network/RCTNetworking.mm
+++ b/packages/react-native/Libraries/Network/RCTNetworking.mm
@@ -437,8 +437,12 @@ RCT_EXPORT_MODULE()
     [task start];
 
     __weak RCTNetworkTask *weakTask = task;
+    NSNumber *requestId = [task.requestID copy];
     return ^{
       [weakTask cancel];
+      if (facebook::react::ReactNativeFeatureFlags::enableNetworkEventReporting()) {
+        [RCTInspectorNetworkReporter reportRequestFailed:requestId cancelled:YES];
+      }
       if (cancellationBlock) {
         cancellationBlock();
       }
@@ -672,7 +676,7 @@ RCT_EXPORT_MODULE()
 
     if (facebook::react::ReactNativeFeatureFlags::enableNetworkEventReporting()) {
       if (error) {
-        [RCTInspectorNetworkReporter reportRequestFailed:task.requestID];
+        [RCTInspectorNetworkReporter reportRequestFailed:task.requestID cancelled:NO];
       } else {
         [RCTInspectorNetworkReporter reportResponseEnd:task.requestID encodedDataLength:data.length];
       }

--- a/packages/react-native/ReactCommon/jsinspector-modern/NetworkIOAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/NetworkIOAgent.cpp
@@ -14,6 +14,7 @@
 #include <jsinspector-modern/network/NetworkReporter.h>
 
 #include <sstream>
+#include <tuple>
 #include <utility>
 #include <variant>
 
@@ -290,8 +291,8 @@ bool NetworkIOAgent::handleRequest(
 
     // @cdp Network.getResponseBody support is experimental.
     if (req.method == "Network.getResponseBody") {
-      // TODO(T218468200)
-      return false;
+      handleGetResponseBody(req);
+      return true;
     }
   }
 
@@ -468,6 +469,55 @@ void NetworkIOAgent::handleIoClose(const cdp::PreparsedRequest& req) {
     streams_->erase(it->first);
     frontendChannel_(cdp::jsonResult(requestId));
   }
+}
+
+void NetworkIOAgent::handleGetResponseBody(const cdp::PreparsedRequest& req) {
+  long long requestId = req.id;
+  if (!req.params.isObject()) {
+    frontendChannel_(cdp::jsonError(
+        requestId,
+        cdp::ErrorCode::InvalidParams,
+        "Invalid params: not an object."));
+    return;
+  }
+  if ((req.params.count("requestId") == 0u) ||
+      !req.params.at("requestId").isString()) {
+    frontendChannel_(cdp::jsonError(
+        requestId,
+        cdp::ErrorCode::InvalidParams,
+        "Invalid params: requestId is missing or not a string."));
+    return;
+  }
+
+  auto& networkReporter = NetworkReporter::getInstance();
+
+  if (!networkReporter.isDebuggingEnabled()) {
+    frontendChannel_(cdp::jsonError(
+        requestId,
+        cdp::ErrorCode::InvalidRequest,
+        "Invalid request: The \"Network\" domain is not enabled."));
+    return;
+  }
+
+  try {
+    std::string responseBody;
+    bool base64Encoded;
+    std::tie(responseBody, base64Encoded) =
+        networkReporter.getResponseBody(req.params.at("requestId").asString());
+    auto result = GetResponseBodyResult{
+        .body = responseBody,
+        .base64Encoded = base64Encoded,
+    };
+
+    frontendChannel_(cdp::jsonResult(requestId, result.toDynamic()));
+  } catch (const std::exception& e) {
+    frontendChannel_(cdp::jsonError(
+        requestId,
+        cdp::ErrorCode::InternalError,
+        "Internal error: Could not retrieve response body for the given requestId."));
+  }
+
+  return;
 }
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/NetworkIOAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/NetworkIOAgent.h
@@ -88,6 +88,17 @@ struct IOReadResult {
   }
 };
 
+struct GetResponseBodyResult {
+  std::string body;
+  bool base64Encoded;
+  folly::dynamic toDynamic() const {
+    folly::dynamic params = folly::dynamic::object;
+    params["body"] = body;
+    params["base64Encoded"] = base64Encoded;
+    return params;
+  }
+};
+
 /**
  * Passed to `loadNetworkResource`, provides callbacks for processing incoming
  * data and other events.
@@ -259,6 +270,11 @@ class NetworkIOAgent {
    * Reports CDP ok if the stream is found, or a CDP error if not.
    */
   void handleIoClose(const cdp::PreparsedRequest& req);
+
+  /**
+   * Handle a Network.getResponseBody CDP request.
+   */
+  void handleGetResponseBody(const cdp::PreparsedRequest& req);
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/BoundedRequestBuffer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/BoundedRequestBuffer.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "BoundedRequestBuffer.h"
+
+#include <functional>
+#include <stdexcept>
+
+namespace facebook::react::jsinspector_modern {
+
+void BoundedRequestBuffer::put(
+    const std::string& requestId,
+    const std::string& data,
+    bool base64Encoded) {
+  if (data.empty()) {
+    throw std::invalid_argument("`data` cannot be empty");
+  }
+  if (data.size() > REQUEST_BUFFER_MAX_SIZE) {
+    throw std::runtime_error("Data size exceeds maximum buffer capacity");
+  }
+
+  // Remove existing request with the same ID, if any
+  if (auto it = responses_.find(requestId); it != responses_.end()) {
+    current_size_ -= it->second.data.size();
+    responses_.erase(it);
+    // Update order: remove requestId from deque
+    for (auto order_it = order_.begin(); order_it != order_.end(); ++order_it) {
+      if (*order_it == requestId) {
+        order_.erase(order_it);
+        break;
+      }
+    }
+  }
+
+  // Evict oldest requests if necessary to make space
+  while (current_size_ + data.size() > REQUEST_BUFFER_MAX_SIZE &&
+         !order_.empty()) {
+    const auto& oldest_id = order_.front();
+    if (auto it = responses_.find(oldest_id); it != responses_.end()) {
+      current_size_ -= it->second.data.size();
+      responses_.erase(it);
+    }
+    order_.pop_front();
+  }
+
+  // If still no space, reject the new data
+  if (current_size_ + data.size() > REQUEST_BUFFER_MAX_SIZE) {
+    throw std::runtime_error("Insufficient buffer capacity after eviction");
+  }
+
+  responses_.emplace(
+      requestId, BoundedRequestBuffer::ResponseBody{data, base64Encoded});
+  order_.push_back(requestId);
+  current_size_ += data.size();
+}
+
+std::optional<std::reference_wrapper<const BoundedRequestBuffer::ResponseBody>>
+BoundedRequestBuffer::get(const std::string& requestId) const {
+  if (auto it = responses_.find(requestId); it != responses_.end()) {
+    return std::make_optional(std::ref(it->second));
+  }
+
+  return std::nullopt;
+}
+
+bool BoundedRequestBuffer::remove(const std::string& requestId) {
+  if (auto it = responses_.find(requestId); it != responses_.end()) {
+    current_size_ -= it->second.data.size();
+    responses_.erase(it);
+
+    // Update order
+    for (auto order_it = order_.begin(); order_it != order_.end(); ++order_it) {
+      if (*order_it == requestId) {
+        order_.erase(order_it);
+        break;
+      }
+    }
+    return true;
+  }
+
+  return false;
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/BoundedRequestBuffer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/BoundedRequestBuffer.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <deque>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+namespace facebook::react::jsinspector_modern {
+
+/**
+ * Maximum memory size (in bytes) to store buffered text and image request
+ * bodies.
+ */
+constexpr size_t REQUEST_BUFFER_MAX_SIZE = 100 * 1024 * 1024; // 100MB
+
+/**
+ * A class to store network response previews keyed by requestId, with a fixed
+ * memory limit. Evicts oldest responses when memory is exceeded.
+ */
+class BoundedRequestBuffer {
+ public:
+  struct ResponseBody {
+    std::string data;
+    bool base64Encoded;
+  };
+
+  /**
+   * Store a response preview with the given requestId and data.
+   * If adding the data exceeds the memory limit, removes oldest requests until
+   * there is enough space or the buffer is empty.
+   * \param requestId Unique identifier for the request.
+   * \param data The request preview data (e.g., text or image body).
+   * \param base64Encoded True if the data is base64-encoded, false otherwise.
+   * \throws std::invalid_argument if requestId is empty or data is empty.
+   * \throws std::runtime_error if data is too large for the buffer.
+   */
+  void put(
+      const std::string& requestId,
+      const std::string& data,
+      bool base64Encoded);
+
+  /**
+   * Retrieve a response preview by requestId.
+   * \param requestId The unique identifier for the request.
+   * \return An optional containing a reference to the request data if found,
+   *         or an empty optional if not found.
+   */
+  std::optional<std::reference_wrapper<const ResponseBody>> get(
+      const std::string& requestId) const;
+
+  /**
+   * Remove a response preview by requestId.
+   * \param requestId The unique identifier for the request.
+   * \return True if the response was found and removed, false otherwise.
+   */
+  bool remove(const std::string& requestId);
+
+ private:
+  std::unordered_map<std::string, ResponseBody> responses_;
+  std::deque<std::string> order_;
+  size_t current_size_ = 0;
+};
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/CMakeLists.txt
@@ -23,6 +23,7 @@ target_include_directories(jsinspector_network PUBLIC ${REACT_COMMON_DIR})
 
 target_link_libraries(jsinspector_network
         folly_runtime
+        glog
         jsinspector_cdp
         react_performance_timeline
         react_timing)

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/CdpNetwork.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/CdpNetwork.cpp
@@ -107,6 +107,18 @@ folly::dynamic ResponseReceivedParams::toDynamic() const {
   return params;
 }
 
+folly::dynamic LoadingFailedParams::toDynamic() const {
+  folly::dynamic params = folly::dynamic::object;
+
+  params["requestId"] = requestId;
+  params["timestamp"] = timestamp;
+  params["type"] = type;
+  params["errorText"] = errorText;
+  params["canceled"] = canceled;
+
+  return params;
+}
+
 folly::dynamic LoadingFinishedParams::toDynamic() const {
   folly::dynamic params = folly::dynamic::object;
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/CdpNetwork.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/CdpNetwork.h
@@ -90,6 +90,19 @@ struct ResponseReceivedParams {
 };
 
 /**
+ * https://chromedevtools.github.io/devtools-protocol/tot/Network/#event-loadingFailed
+ */
+struct LoadingFailedParams {
+  std::string requestId;
+  double timestamp;
+  std::string type;
+  std::string errorText;
+  bool canceled;
+
+  folly::dynamic toDynamic() const;
+};
+
+/**
  * https://chromedevtools.github.io/devtools-protocol/tot/Network/#event-loadingFinished
  */
 struct LoadingFinishedParams {

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkReporter.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkReporter.cpp
@@ -12,7 +12,6 @@
 #endif
 
 #ifdef REACT_NATIVE_DEBUGGER_ENABLED
-#include <folly/dynamic.h>
 #include <jsinspector-modern/cdp/CdpJson.h>
 #endif
 #include <react/featureflags/ReactNativeFeatureFlags.h>
@@ -21,6 +20,7 @@
 #ifdef REACT_NATIVE_DEBUGGER_ENABLED
 #include <chrono>
 #endif
+#include <glog/logging.h>
 #include <stdexcept>
 
 namespace facebook::react::jsinspector_modern {
@@ -270,6 +270,32 @@ void NetworkReporter::reportResponseEnd(
   frontendChannel_(
       cdp::jsonNotification("Network.loadingFinished", params.toDynamic()));
 #endif
+}
+
+void NetworkReporter::storeResponseBody(
+    const std::string& requestId,
+    const std::string& body,
+    bool base64Encoded) {
+  try {
+    std::lock_guard<std::mutex> lock(requestBodyMutex_);
+    requestBodyBuffer_.put(requestId, body, base64Encoded);
+  } catch (const std::runtime_error& e) {
+    LOG(WARNING) << "Failed to store CDP response body for requestId: "
+                 << requestId;
+  }
+}
+
+std::tuple<std::string, bool> NetworkReporter::getResponseBody(
+    const std::string& requestId) {
+  std::lock_guard<std::mutex> lock(requestBodyMutex_);
+  auto responseBody = requestBodyBuffer_.get(requestId);
+
+  if (!responseBody.has_value()) {
+    throw std::runtime_error("No preview found");
+  }
+
+  return std::tuple(
+      responseBody->get().data, responseBody->get().base64Encoded);
 }
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkReporter.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkReporter.cpp
@@ -150,19 +150,6 @@ void NetworkReporter::reportConnectionTiming(const std::string& requestId) {
 #endif
 }
 
-void NetworkReporter::reportRequestFailed(
-    const std::string& /*requestId*/) const {
-#ifdef REACT_NATIVE_DEBUGGER_ENABLED
-  // Debug build: CDP event handling
-  if (!isDebuggingEnabledNoSync()) {
-    return;
-  }
-
-  // TODO(T218236855)
-  throw std::runtime_error("Not implemented");
-#endif
-}
-
 void NetworkReporter::reportResponseStart(
     const std::string& requestId,
     const ResponseInfo& responseInfo,
@@ -189,11 +176,14 @@ void NetworkReporter::reportResponseStart(
 
   auto response =
       cdp::network::Response::fromInputParams(responseInfo, encodedDataLength);
+  auto resourceType = cdp::network::resourceTypeFromMimeType(response.mimeType);
+  resourceTypeMap_.emplace(requestId, resourceType);
+
   auto params = cdp::network::ResponseReceivedParams{
       .requestId = requestId,
       .loaderId = "",
       .timestamp = getCurrentUnixTimestampSeconds(),
-      .type = cdp::network::resourceTypeFromMimeType(response.mimeType),
+      .type = resourceType,
       .response = response,
       .hasExtraInfo = false,
   };
@@ -269,6 +259,30 @@ void NetworkReporter::reportResponseEnd(
 
   frontendChannel_(
       cdp::jsonNotification("Network.loadingFinished", params.toDynamic()));
+#endif
+}
+
+void NetworkReporter::reportRequestFailed(
+    const std::string& requestId,
+    bool cancelled) const {
+#ifdef REACT_NATIVE_DEBUGGER_ENABLED
+  // Debug build: CDP event handling
+  if (!isDebuggingEnabledNoSync()) {
+    return;
+  }
+
+  auto params = cdp::network::LoadingFailedParams{
+      .requestId = requestId,
+      .timestamp = getCurrentUnixTimestampSeconds(),
+      .type = resourceTypeMap_.find(requestId) != resourceTypeMap_.end()
+          ? resourceTypeMap_.at(requestId)
+          : "Other",
+      .errorText = cancelled ? "net::ERR_ABORTED" : "net::ERR_FAILED",
+      .canceled = cancelled,
+  };
+
+  frontendChannel_(
+      cdp::jsonNotification("Network.loadingFailed", params.toDynamic()));
 #endif
 }
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkReporter.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkReporter.h
@@ -114,13 +114,6 @@ class NetworkReporter {
   void reportConnectionTiming(const std::string& requestId);
 
   /**
-   * Report when a network request has failed.
-   *
-   * Corresponds to `Network.loadingFailed` in CDP.
-   */
-  void reportRequestFailed(const std::string& requestId) const;
-
-  /**
    * Report when HTTP response headers have been received, corresponding to
    * when the first byte of the response is available.
    *
@@ -151,6 +144,13 @@ class NetworkReporter {
    * https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-responseend
    */
   void reportResponseEnd(const std::string& requestId, int encodedDataLength);
+
+  /**
+   * Report when a network request has failed.
+   *
+   * Corresponds to `Network.loadingFailed` in CDP.
+   */
+  void reportRequestFailed(const std::string& requestId, bool cancelled) const;
 
   /**
    * Store the fetched response body for a text or image network response.
@@ -191,6 +191,9 @@ class NetworkReporter {
 
   std::unordered_map<std::string, ResourceTimingData> perfTimingsBuffer_{};
   std::mutex perfTimingsMutex_;
+
+  // Only populated when CDP debugging is enabled.
+  std::map<std::string, std::string> resourceTypeMap_{};
 
   // Only populated when CDP debugging is enabled.
   BoundedRequestBuffer requestBodyBuffer_{};

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkReporter.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkReporter.h
@@ -7,14 +7,17 @@
 
 #pragma once
 
+#include "BoundedRequestBuffer.h"
 #include "NetworkTypes.h"
 
+#include <folly/dynamic.h>
 #include <react/timing/primitives.h>
 
 #include <atomic>
 #include <functional>
 #include <mutex>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 
 namespace facebook::react::jsinspector_modern {
@@ -75,6 +78,13 @@ class NetworkReporter {
    * Corresponds to `Network.disable` in CDP.
    */
   bool disableDebugging();
+
+  /**
+   * Returns whether network tracking over CDP is currently enabled.
+   */
+  inline bool isDebuggingEnabled() const {
+    return debuggingEnabled_.load(std::memory_order_acquire);
+  }
 
   /**
    * Report a network request that is about to be sent.
@@ -142,9 +152,30 @@ class NetworkReporter {
    */
   void reportResponseEnd(const std::string& requestId, int encodedDataLength);
 
- private:
-  FrontendChannel frontendChannel_;
+  /**
+   * Store the fetched response body for a text or image network response.
+   * These may be retrieved by CDP clients to to render a response preview via
+   * `Network.getReponseBody`.
+   *
+   * Reponse bodies are stored in a bounded buffer with a fixed maximum memory
+   * size, where oldest responses will be evicted if the buffer is exceeded.
+   *
+   * Should be called after checking \ref NetworkReporter::isDebuggingEnabled.
+   */
+  void storeResponseBody(
+      const std::string& requestId,
+      const std::string& body,
+      bool base64Encoded);
 
+  /**
+   * Retrieve a stored response body for a given request ID. Throws a
+   * std::exception if no entry is found in the buffer.
+   *
+   * \returns A tuple of [responseBody, base64Encoded].
+   */
+  std::tuple<std::string, bool> getResponseBody(const std::string& requestId);
+
+ private:
   NetworkReporter() = default;
   NetworkReporter(const NetworkReporter&) = delete;
   NetworkReporter& operator=(const NetworkReporter&) = delete;
@@ -156,8 +187,14 @@ class NetworkReporter {
     return debuggingEnabled_.load(std::memory_order_relaxed);
   }
 
+  FrontendChannel frontendChannel_;
+
   std::unordered_map<std::string, ResourceTimingData> perfTimingsBuffer_{};
   std::mutex perfTimingsMutex_;
+
+  // Only populated when CDP debugging is enabled.
+  BoundedRequestBuffer requestBodyBuffer_{};
+  std::mutex requestBodyMutex_;
 };
 
 } // namespace facebook::react::jsinspector_modern


### PR DESCRIPTION
Summary:
Adds support for `Network.loadingFailed` in jsinspector-modern and wires up for iOS.

Changelog: [Internal]

Differential Revision: D77489477


