### PR TITLE
Implement connectionTiming and dataReceived NetworkReporter methods

### DIFF
--- a/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.h
+++ b/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.h
@@ -32,6 +32,17 @@
          encodedDataLength:(int)encodedDataLength;
 
 /**
+ * Report timestamp for sending the network request, and (in a debug build)
+ * provide final headers to be reported via CDP.
+ *
+ * - Corresponds to `Network.requestWillBeSentExtraInfo` in CDP.
+ * - Corresponds to `PerformanceResourceTiming.domainLookupStart`,
+ *   `PerformanceResourceTiming.connectStart`. Defined as "immediately before
+ *   the browser starts to establish the connection to the server".
+ */
++ (void)reportConnectionTiming:(NSNumber *)requestId request:(NSURLRequest *)request;
+
+/**
  * Report when HTTP response headers have been received, corresponding to
  * when the first byte of the response is available.
  *
@@ -42,6 +53,13 @@
                    response:(NSURLResponse *)response
                  statusCode:(int)statusCode
                     headers:(NSDictionary<NSString *, NSString *> *)headers;
+
+/**
+ * Report when additional chunks of the response body have been received.
+ *
+ * Corresponds to `Network.dataReceived` in CDP.
+ */
++ (void)reportDataReceived:(NSNumber *)requestId data:(NSData *)data;
 
 /**
  * Report when a network request is complete and we are no longer receiving

--- a/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.h
+++ b/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.h
@@ -20,13 +20,41 @@
  */
 @interface RCTInspectorNetworkReporter : NSObject
 
+/**
+ * Report a network request that is about to be sent.
+ *
+ * - Corresponds to `Network.requestWillBeSent` in CDP.
+ * - Corresponds to `PerformanceResourceTiming.requestStart` (specifically,
+ *   marking when the native request was initiated).
+ */
 + (void)reportRequestStart:(NSNumber *)requestId
                    request:(NSURLRequest *)request
          encodedDataLength:(int)encodedDataLength;
+
+/**
+ * Report when HTTP response headers have been received, corresponding to
+ * when the first byte of the response is available.
+ *
+ * - Corresponds to `Network.responseReceived` in CDP.
+ * - Corresponds to `PerformanceResourceTiming.responseStart`.
+ */
 + (void)reportResponseStart:(NSNumber *)requestId
                    response:(NSURLResponse *)response
                  statusCode:(int)statusCode
                     headers:(NSDictionary<NSString *, NSString *> *)headers;
+
+/**
+ * Report when a network request is complete and we are no longer receiving
+ * response data.
+ *
+ * - Corresponds to `Network.loadingFinished` in CDP.
+ * - Corresponds to `PerformanceResourceTiming.responseEnd`.
+ */
 + (void)reportResponseEnd:(NSNumber *)requestId encodedDataLength:(int)encodedDataLength;
 
+/**
+ * Store response body preview. This is an optional reporting method, and is a
+ * no-op if CDP debugging is disabled.
+ */
++ (void)maybeStoreResponseBody:(NSNumber *)requestId data:(NSData *)data base64Encoded:(bool)base64Encoded;
 @end

--- a/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.h
+++ b/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.h
@@ -57,7 +57,7 @@
  *
  * - Corresponds to `Network.loadingFailed` in CDP.
  */
-+ (void)reportRequestFailed:(NSNumber *)requestId;
++ (void)reportRequestFailed:(NSNumber *)requestId cancelled:(BOOL)cancelled;
 
 /**
  * Store response body preview. This is an optional reporting method, and is a

--- a/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.h
+++ b/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.h
@@ -53,8 +53,26 @@
 + (void)reportResponseEnd:(NSNumber *)requestId encodedDataLength:(int)encodedDataLength;
 
 /**
+ * Report when a network request has failed.
+ *
+ * - Corresponds to `Network.loadingFailed` in CDP.
+ */
++ (void)reportRequestFailed:(NSNumber *)requestId;
+
+/**
  * Store response body preview. This is an optional reporting method, and is a
  * no-op if CDP debugging is disabled.
  */
 + (void)maybeStoreResponseBody:(NSNumber *)requestId data:(NSData *)data base64Encoded:(bool)base64Encoded;
+
+/**
+ * Incrementally store a response body preview, when a string response is
+ * received in chunks. Buffered contents will be flushed to `NetworkReporter`
+ * with `reportResponseEnd`.
+ *
+ * As with `maybeStoreResponseBody`, calling this method is optional and a
+ * no-op if CDP debugging is disabled.
+ */
++ (void)maybeStoreResponseBodyIncremental:(NSNumber *)requestId data:(NSString *)data;
+
 @end

--- a/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.mm
+++ b/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.mm
@@ -72,6 +72,18 @@ static const NSMutableDictionary<NSNumber *, NSMutableString *> *responseBuffers
       requestId.stringValue.UTF8String, requestInfo, encodedDataLength, std::nullopt);
 }
 
++ (void)reportConnectionTiming:(NSNumber *)requestId request:(NSURLRequest *)request
+{
+  Headers headersMap;
+
+#ifdef REACT_NATIVE_DEBUGGER_ENABLED
+  // Debug build: Process additional request info for CDP reporting
+  headersMap = convertNSDictionaryToHeaders(request.allHTTPHeaderFields);
+#endif
+
+  NetworkReporter::getInstance().reportConnectionTiming(requestId.stringValue.UTF8String, headersMap);
+}
+
 + (void)reportResponseStart:(NSNumber *)requestId
                    response:(NSURLResponse *)response
                  statusCode:(int)statusCode
@@ -88,6 +100,11 @@ static const NSMutableDictionary<NSNumber *, NSMutableString *> *responseBuffers
 
   NetworkReporter::getInstance().reportResponseStart(
       requestId.stringValue.UTF8String, responseInfo, response.expectedContentLength);
+}
+
++ (void)reportDataReceived:(NSNumber *)requestId data:(NSData *)data
+{
+  NetworkReporter::getInstance().reportDataReceived(requestId.stringValue.UTF8String, (int)data.length, std::nullopt);
 }
 
 + (void)reportResponseEnd:(NSNumber *)requestId encodedDataLength:(int)encodedDataLength

--- a/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.mm
+++ b/packages/react-native/Libraries/Network/RCTInspectorNetworkReporter.mm
@@ -109,9 +109,10 @@ static const NSMutableDictionary<NSNumber *, NSMutableString *> *responseBuffers
 #endif
 }
 
-// TODO(T218584924): Implement and report to NetworkReporter
-+ (void)reportRequestFailed:(NSNumber *)requestId
++ (void)reportRequestFailed:(NSNumber *)requestId cancelled:(bool)cancelled
 {
+  NetworkReporter::getInstance().reportRequestFailed(requestId.stringValue.UTF8String, cancelled);
+
 #ifdef REACT_NATIVE_DEBUGGER_ENABLED
   // Debug build: Clear buffer for request
   if (responseBuffers != nullptr) {

--- a/packages/react-native/Libraries/Network/RCTNetworkConversions.h
+++ b/packages/react-native/Libraries/Network/RCTNetworkConversions.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <UIKit/UIKit.h>
+
+#ifdef __cplusplus
+
+#import <string>
+
+NS_ASSUME_NONNULL_BEGIN
+
+inline std::string_view RCTStringViewFromNSString(NSString *string)
+{
+  return std::string_view{string.UTF8String, string.length};
+}
+
+NS_ASSUME_NONNULL_END
+
+#endif

--- a/packages/react-native/Libraries/Network/RCTNetworking.mm
+++ b/packages/react-native/Libraries/Network/RCTNetworking.mm
@@ -648,6 +648,7 @@ RCT_EXPORT_MODULE()
         ];
 
         if (facebook::react::ReactNativeFeatureFlags::enableNetworkEventReporting()) {
+          [RCTInspectorNetworkReporter reportDataReceived:task.requestID data:data];
           [RCTInspectorNetworkReporter maybeStoreResponseBodyIncremental:task.requestID data:responseString];
         }
         [weakSelf sendEventWithName:@"didReceiveNetworkIncrementalData" body:responseJSON];
@@ -701,6 +702,7 @@ RCT_EXPORT_MODULE()
       [RCTInspectorNetworkReporter reportRequestStart:task.requestID
                                               request:request
                                     encodedDataLength:task.response.expectedContentLength];
+      [RCTInspectorNetworkReporter reportConnectionTiming:task.requestID request:task.request];
     }
   }
 

--- a/packages/react-native/Libraries/Network/RCTNetworking.mm
+++ b/packages/react-native/Libraries/Network/RCTNetworking.mm
@@ -558,6 +558,20 @@ RCT_EXPORT_MODULE()
     }
   }
 
+  if (facebook::react::ReactNativeFeatureFlags::enableNetworkEventReporting()) {
+    id responseDataForPreview;
+    if ([responseType isEqualToString:@"blob"]) {
+      responseDataForPreview = data;
+    } else if ([responseData isKindOfClass:[NSString class]]) {
+      responseDataForPreview = responseData;
+    }
+    bool base64Encoded = [responseType isEqualToString:@"base64"] || [responseType isEqualToString:@"blob"];
+
+    [RCTInspectorNetworkReporter maybeStoreResponseBody:task.requestID
+                                                   data:responseDataForPreview
+                                          base64Encoded:base64Encoded];
+  }
+
   [self sendEventWithName:@"didReceiveNetworkData" body:@[ task.requestID, responseData ]];
 }
 

--- a/packages/react-native/Libraries/Network/RCTNetworking.mm
+++ b/packages/react-native/Libraries/Network/RCTNetworking.mm
@@ -437,8 +437,12 @@ RCT_EXPORT_MODULE()
     [task start];
 
     __weak RCTNetworkTask *weakTask = task;
+    NSNumber *requestId = [task.requestID copy];
     return ^{
       [weakTask cancel];
+      if (facebook::react::ReactNativeFeatureFlags::enableNetworkEventReporting()) {
+        [RCTInspectorNetworkReporter reportRequestFailed:requestId cancelled:YES];
+      }
       if (cancellationBlock) {
         cancellationBlock();
       }
@@ -672,7 +676,7 @@ RCT_EXPORT_MODULE()
 
     if (facebook::react::ReactNativeFeatureFlags::enableNetworkEventReporting()) {
       if (error != nullptr) {
-        [RCTInspectorNetworkReporter reportRequestFailed:task.requestID];
+        [RCTInspectorNetworkReporter reportRequestFailed:task.requestID cancelled:NO];
       } else {
         [RCTInspectorNetworkReporter reportResponseEnd:task.requestID encodedDataLength:data.length];
       }

--- a/packages/react-native/ReactCommon/jsinspector-modern/NetworkIOAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/NetworkIOAgent.cpp
@@ -14,6 +14,7 @@
 #include <jsinspector-modern/network/NetworkReporter.h>
 
 #include <sstream>
+#include <tuple>
 #include <utility>
 #include <variant>
 
@@ -290,8 +291,8 @@ bool NetworkIOAgent::handleRequest(
 
     // @cdp Network.getResponseBody support is experimental.
     if (req.method == "Network.getResponseBody") {
-      // TODO(T218468200)
-      return false;
+      handleGetResponseBody(req);
+      return true;
     }
   }
 
@@ -468,6 +469,57 @@ void NetworkIOAgent::handleIoClose(const cdp::PreparsedRequest& req) {
     streams_->erase(it->first);
     frontendChannel_(cdp::jsonResult(requestId));
   }
+}
+
+void NetworkIOAgent::handleGetResponseBody(const cdp::PreparsedRequest& req) {
+  long long requestId = req.id;
+  if (!req.params.isObject()) {
+    frontendChannel_(cdp::jsonError(
+        requestId,
+        cdp::ErrorCode::InvalidParams,
+        "Invalid params: not an object."));
+    return;
+  }
+  if ((req.params.count("requestId") == 0u) ||
+      !req.params.at("requestId").isString()) {
+    frontendChannel_(cdp::jsonError(
+        requestId,
+        cdp::ErrorCode::InvalidParams,
+        "Invalid params: requestId is missing or not a string."));
+    return;
+  }
+
+  auto& networkReporter = NetworkReporter::getInstance();
+
+  if (!networkReporter.isDebuggingEnabled()) {
+    frontendChannel_(cdp::jsonError(
+        requestId,
+        cdp::ErrorCode::InvalidRequest,
+        "Invalid request: The \"Network\" domain is not enabled."));
+    return;
+  }
+
+  auto storedResponse =
+      networkReporter.getResponseBody(req.params.at("requestId").asString());
+
+  if (!storedResponse) {
+    frontendChannel_(cdp::jsonError(
+        requestId,
+        cdp::ErrorCode::InternalError,
+        "Internal error: Could not retrieve response body for the given requestId."));
+    return;
+  }
+
+  std::string responseBody;
+  bool base64Encoded = false;
+  std::tie(responseBody, base64Encoded) = *storedResponse;
+
+  auto result = GetResponseBodyResult{
+      .body = responseBody,
+      .base64Encoded = base64Encoded,
+  };
+
+  frontendChannel_(cdp::jsonResult(requestId, result.toDynamic()));
 }
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/NetworkIOAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/NetworkIOAgent.h
@@ -88,6 +88,17 @@ struct IOReadResult {
   }
 };
 
+struct GetResponseBodyResult {
+  std::string body;
+  bool base64Encoded;
+  folly::dynamic toDynamic() const {
+    folly::dynamic params = folly::dynamic::object;
+    params["body"] = body;
+    params["base64Encoded"] = base64Encoded;
+    return params;
+  }
+};
+
 /**
  * Passed to `loadNetworkResource`, provides callbacks for processing incoming
  * data and other events.
@@ -259,6 +270,11 @@ class NetworkIOAgent {
    * Reports CDP ok if the stream is found, or a CDP error if not.
    */
   void handleIoClose(const cdp::PreparsedRequest& req);
+
+  /**
+   * Handle a Network.getResponseBody CDP request.
+   */
+  void handleGetResponseBody(const cdp::PreparsedRequest& req);
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/BoundedRequestBuffer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/BoundedRequestBuffer.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "BoundedRequestBuffer.h"
+
+namespace facebook::react::jsinspector_modern {
+
+bool BoundedRequestBuffer::put(
+    const std::string& requestId,
+    std::string_view data,
+    bool base64Encoded) noexcept {
+  if (data.size() > REQUEST_BUFFER_MAX_SIZE_BYTES) {
+    return false;
+  }
+
+  // Remove existing request with the same ID, if any
+  if (auto it = responses_.find(requestId); it != responses_.end()) {
+    currentSize_ -= it->second->data.size();
+    responses_.erase(it);
+    // Update order: remove requestId from deque
+    for (auto orderIt = order_.begin(); orderIt != order_.end(); ++orderIt) {
+      if (*orderIt == requestId) {
+        order_.erase(orderIt);
+        break;
+      }
+    }
+  }
+
+  // Evict oldest requests if necessary to make space
+  while (currentSize_ + data.size() > REQUEST_BUFFER_MAX_SIZE_BYTES &&
+         !order_.empty()) {
+    const auto& oldestId = order_.front();
+    auto it = responses_.find(oldestId);
+    if (it != responses_.end()) {
+      currentSize_ -= it->second->data.size();
+      responses_.erase(it);
+    }
+    order_.pop_front();
+  }
+
+  // If still no space, reject the new data (this should not be reached)
+  if (currentSize_ + data.size() > REQUEST_BUFFER_MAX_SIZE_BYTES) {
+    return false;
+  }
+
+  currentSize_ += data.size();
+  // `data` is copied at the point of insertion
+  responses_.emplace(
+      requestId,
+      std::make_shared<ResponseBody>(
+          ResponseBody{std::string(data), base64Encoded}));
+  order_.push_back(requestId);
+
+  return true;
+}
+
+std::shared_ptr<const BoundedRequestBuffer::ResponseBody>
+BoundedRequestBuffer::get(const std::string& requestId) const {
+  auto it = responses_.find(requestId);
+  if (it != responses_.end()) {
+    return it->second;
+  }
+
+  return nullptr;
+}
+
+void BoundedRequestBuffer::clear() {
+  responses_.clear();
+  order_.clear();
+  currentSize_ = 0;
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/BoundedRequestBuffer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/BoundedRequestBuffer.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <deque>
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+namespace facebook::react::jsinspector_modern {
+
+/**
+ * Maximum memory size (in bytes) to store buffered text and image request
+ * bodies.
+ */
+constexpr size_t REQUEST_BUFFER_MAX_SIZE_BYTES = 100 * 1024 * 1024; // 100MB
+
+/**
+ * A class to store network response previews keyed by requestId, with a fixed
+ * memory limit. Evicts oldest responses when memory is exceeded.
+ */
+class BoundedRequestBuffer {
+ public:
+  struct ResponseBody {
+    std::string data;
+    bool base64Encoded;
+  };
+
+  /**
+   * Store a response preview with the given requestId and data.
+   * If adding the data exceeds the memory limit, removes oldest requests until
+   * there is enough space or the buffer is empty.
+   * \param requestId Unique identifier for the request.
+   * \param data The request preview data (e.g. text or image body).
+   * \param base64Encoded True if the data is base64-encoded, false otherwise.
+   * \return True if the response body was stored, false otherwise.
+   */
+  bool put(
+      const std::string& requestId,
+      std::string_view data,
+      bool base64Encoded) noexcept;
+
+  /**
+   * Retrieve a response preview by requestId.
+   * \param requestId The unique identifier for the request.
+   * \return A shared pointer to the request data if found, otherwise nullptr.
+   */
+  std::shared_ptr<const ResponseBody> get(const std::string& requestId) const;
+
+  /**
+   * Remove all entries from the buffer.
+   */
+  void clear();
+
+ private:
+  std::unordered_map<std::string, std::shared_ptr<const ResponseBody>>
+      responses_;
+  std::deque<std::string> order_;
+  size_t currentSize_ = 0;
+};
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/CMakeLists.txt
@@ -23,6 +23,7 @@ target_include_directories(jsinspector_network PUBLIC ${REACT_COMMON_DIR})
 
 target_link_libraries(jsinspector_network
         folly_runtime
+        glog
         jsinspector_cdp
         react_performance_timeline
         react_timing)

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/CdpNetwork.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/CdpNetwork.cpp
@@ -94,6 +94,18 @@ folly::dynamic RequestWillBeSentParams::toDynamic() const {
   return params;
 }
 
+folly::dynamic RequestWillBeSentExtraInfoParams::toDynamic() const {
+  folly::dynamic params = folly::dynamic::object;
+
+  params["requestId"] = requestId;
+  params["associatedCookies"] = folly::dynamic::array;
+  params["headers"] = headersToDynamic(headers);
+  params["connectTiming"] =
+      folly::dynamic::object("requestTime", connectTiming.requestTime);
+
+  return params;
+}
+
 folly::dynamic ResponseReceivedParams::toDynamic() const {
   folly::dynamic params = folly::dynamic::object;
 
@@ -103,6 +115,17 @@ folly::dynamic ResponseReceivedParams::toDynamic() const {
   params["type"] = type;
   params["response"] = response.toDynamic();
   params["hasExtraInfo"] = hasExtraInfo;
+
+  return params;
+}
+
+folly::dynamic DataReceivedParams::toDynamic() const {
+  folly::dynamic params = folly::dynamic::object;
+
+  params["requestId"] = requestId;
+  params["timestamp"] = timestamp;
+  params["dataLength"] = dataLength;
+  params["encodedDataLength"] = encodedDataLength;
 
   return params;
 }

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/CdpNetwork.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/CdpNetwork.cpp
@@ -107,6 +107,18 @@ folly::dynamic ResponseReceivedParams::toDynamic() const {
   return params;
 }
 
+folly::dynamic LoadingFailedParams::toDynamic() const {
+  folly::dynamic params = folly::dynamic::object;
+
+  params["requestId"] = requestId;
+  params["timestamp"] = timestamp;
+  params["type"] = type;
+  params["errorText"] = errorText;
+  params["canceled"] = canceled;
+
+  return params;
+}
+
 folly::dynamic LoadingFinishedParams::toDynamic() const {
   folly::dynamic params = folly::dynamic::object;
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/CdpNetwork.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/CdpNetwork.h
@@ -90,6 +90,19 @@ struct ResponseReceivedParams {
 };
 
 /**
+ * https://chromedevtools.github.io/devtools-protocol/tot/Network/#event-loadingFailed
+ */
+struct LoadingFailedParams {
+  std::string requestId;
+  double timestamp;
+  std::string type;
+  std::string errorText;
+  bool canceled;
+
+  folly::dynamic toDynamic() const;
+};
+
+/**
  * https://chromedevtools.github.io/devtools-protocol/tot/Network/#event-loadingFinished
  */
 struct LoadingFinishedParams {

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/CdpNetwork.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/CdpNetwork.h
@@ -59,6 +59,13 @@ struct Response {
 };
 
 /**
+ * https://chromedevtools.github.io/devtools-protocol/tot/Network/#type-ConnectTiming
+ */
+struct ConnectTiming {
+  double requestTime;
+};
+
+/**
  * https://chromedevtools.github.io/devtools-protocol/tot/Network/#event-requestWillBeSent
  */
 struct RequestWillBeSentParams {
@@ -76,6 +83,17 @@ struct RequestWillBeSentParams {
 };
 
 /**
+ * https://chromedevtools.github.io/devtools-protocol/tot/Network/#event-requestWillBeSentExtraInfo
+ */
+struct RequestWillBeSentExtraInfoParams {
+  std::string requestId;
+  Headers headers;
+  ConnectTiming connectTiming;
+
+  folly::dynamic toDynamic() const;
+};
+
+/**
  * https://chromedevtools.github.io/devtools-protocol/tot/Network/#event-responseReceived
  */
 struct ResponseReceivedParams {
@@ -85,6 +103,18 @@ struct ResponseReceivedParams {
   std::string type;
   Response response;
   bool hasExtraInfo;
+
+  folly::dynamic toDynamic() const;
+};
+
+/**
+ * https://chromedevtools.github.io/devtools-protocol/tot/Network/#event-dataReceived
+ */
+struct DataReceivedParams {
+  std::string requestId;
+  double timestamp;
+  int dataLength;
+  int encodedDataLength;
 
   folly::dynamic toDynamic() const;
 };

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkReporter.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkReporter.h
@@ -114,13 +114,6 @@ class NetworkReporter {
   void reportConnectionTiming(const std::string& requestId);
 
   /**
-   * Report when a network request has failed.
-   *
-   * Corresponds to `Network.loadingFailed` in CDP.
-   */
-  void reportRequestFailed(const std::string& requestId) const;
-
-  /**
    * Report when HTTP response headers have been received, corresponding to
    * when the first byte of the response is available.
    *
@@ -151,6 +144,13 @@ class NetworkReporter {
    * https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-responseend
    */
   void reportResponseEnd(const std::string& requestId, int encodedDataLength);
+
+  /**
+   * Report when a network request has failed.
+   *
+   * Corresponds to `Network.loadingFailed` in CDP.
+   */
+  void reportRequestFailed(const std::string& requestId, bool cancelled) const;
 
   /**
    * Store the fetched response body for a text or image network response.
@@ -192,6 +192,9 @@ class NetworkReporter {
 
   std::unordered_map<std::string, ResourceTimingData> perfTimingsBuffer_{};
   std::mutex perfTimingsMutex_;
+
+  // Only populated when CDP debugging is enabled.
+  std::map<std::string, std::string> resourceTypeMap_{};
 
   // Only populated when CDP debugging is enabled.
   BoundedRequestBuffer requestBodyBuffer_{};

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkReporter.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkReporter.h
@@ -102,16 +102,19 @@ class NetworkReporter {
       const std::optional<ResponseInfo>& redirectResponse);
 
   /**
-   * Report detailed timing info, such as DNS lookup, when a request has
-   * started.
+   * Report timestamp for sending the network request, and (in a debug build)
+   * provide final headers to be reported via CDP.
    *
    * - Corresponds to `Network.requestWillBeSentExtraInfo` in CDP.
    * - Corresponds to `PerformanceResourceTiming.domainLookupStart`,
-   * `PerformanceResourceTiming.connectStart`.
+   *   `PerformanceResourceTiming.connectStart`. Defined as "immediately before
+   *   the browser starts to establish the connection to the server".
    *
    * https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-connectstart
    */
-  void reportConnectionTiming(const std::string& requestId);
+  void reportConnectionTiming(
+      const std::string& requestId,
+      const std::optional<Headers>& headers);
 
   /**
    * Report when HTTP response headers have been received, corresponding to
@@ -130,9 +133,13 @@ class NetworkReporter {
   /**
    * Report when additional chunks of the response body have been received.
    *
-   * Corresponds to `Network.dataReceived` in CDP.
+   * Corresponds to `Network.dataReceived` in CDP (used for progress bar
+   * rendering).
    */
-  void reportDataReceived(const std::string& requestId);
+  void reportDataReceived(
+      const std::string& requestId,
+      int dataLength,
+      const std::optional<int>& encodedDataLength);
 
   /**
    * Report when a network request is complete and we are no longer receiving


### PR DESCRIPTION
Summary:
Adds support for `Network.requestWillBeSentExtraInfo` and `Network.dataReceived` CDP events in jsinspector-modern and wires up for iOS.

In particular, `Network.requestWillBeSentExtraInfo` is necessary to populate request headers in the UI.

**End of base Network implementation for iOS**

After this diff, we are spec-complete on all CDP Network methods for our V1, on iOS.

Changelog: [Internal]

Differential Revision: D77489476


