### PR TITLE
Fix broken Modal OSS E2E test due to `createNewDialog` setter

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
@@ -88,14 +88,14 @@ public class ReactModalHostView(context: ThemedReactContext) :
     get() = field || isEdgeToEdgeFeatureFlagOn
     set(value) {
       field = value
-      createNewDialog = !isEdgeToEdgeFeatureFlagOn
+      createNewDialog = createNewDialog || !isEdgeToEdgeFeatureFlagOn
     }
 
   public var navigationBarTranslucent: Boolean = false
     get() = field || isEdgeToEdgeFeatureFlagOn
     set(value) {
       field = value
-      createNewDialog = !isEdgeToEdgeFeatureFlagOn
+      createNewDialog = createNewDialog || !isEdgeToEdgeFeatureFlagOn
     }
 
   public var animationType: String? = null


### PR DESCRIPTION
Summary:
The setter for `createNewDialog` is now wrong (after D76834213).
If the `createNewDialog` has been set to `true` by any other field, we should respect it and not set it to true/false regardless
(only considering the `isEdgeToEdgeFeatureFlagOn`) property.

This fixes it.

Changelog:
[Internal] [Changed] -

Differential Revision: D77539533


