### PR TITLE
Fix access to observers outside lock in ImageResponseObserverCoordinator

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponseObserverCoordinator.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponseObserverCoordinator.cpp
@@ -95,7 +95,7 @@ void ImageResponseObserverCoordinator::nativeImageResponseComplete(
   auto observers = observers_;
   mutex_.unlock();
 
-  for (auto observer : observers_) {
+  for (auto observer : observers) {
     observer->didReceiveImage(imageResponse);
   }
 }


### PR DESCRIPTION
Summary:
This is bypassing the mutex, and potentially not thread-safe.

Changelog: [Internal]

Differential Revision: D77541041


