### PR TITLE
Updated targetSdk to 36

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/AndroidManifest.xml
+++ b/packages/react-native/ReactAndroid/src/main/AndroidManifest.xml
@@ -9,7 +9,7 @@
    as the min SDK to lint the file.-->
   <uses-sdk
       android:minSdkVersion="24"
-      android:targetSdkVersion="35"
+      android:targetSdkVersion="36"
       />
 
 </manifest>

--- a/packages/react-native/gradle/libs.versions.toml
+++ b/packages/react-native/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Android versions
 minSdk = "24"
-targetSdk = "35"
+targetSdk = "36"
 compileSdk = "36"
 buildTools = "36.0.0"
 ndkVersion = "27.1.12297006"


### PR DESCRIPTION
## Summary:

We need to upgrade the targetSdk to 36, which requires ensuring compatibility with the latest Android APIs and addressing any deprecations or behavior changes introduced in this version.

## Changelog:

[Android] [Changed] - Updated targetSdk to 36 in Android.

## Test Plan:

- Verified that the app builds and runs successfully with targetSdkVersion 36.

- Ran the full suite of unit and instrumentation tests: all tests passed.

- Manually tested key user flows (login, navigation, data sync) on devices running Android 14 (API 34) and emulator with API 36

- Confirmed that there are no runtime crashes or warnings related to `targetSDK` upgrade.

Behavioral guide for migration: https://developer.android.com/about/versions/16/behavior-changes-16