### PR TITLE
Fix run-ci-javascript-tests script

### DIFF
--- a/scripts/run-ci-javascript-tests.js
+++ b/scripts/run-ci-javascript-tests.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @format
- * @noflow
+ * @flow strict-local
  */
 
 'use strict';
@@ -16,19 +16,32 @@
  * --maxWorkers [num] - how many workers, default 1
  * --jestBinary [path] - path to jest binary, defaults to local node modules
  * --yarnBinary [path] - path to yarn binary, defaults to yarn
+ * --flowBinary [path] - path to flow binary, defaults to running `yarn run flow-check`
  */
 
 const {execSync} = require('child_process');
-const argv = require('yargs').argv;
+// $FlowFixMe[unclear-type]
+const argv = require('yargs').argv /*:: as any as $ReadOnly<{
+  maxWorkers?: number,
+  jestBinary?: string,
+  flowBinary?: string,
+  yarnBinary?: string,
+}> */;
 
-const numberOfMaxWorkers = argv.maxWorkers || 1;
-let exitCode;
+const numberOfMaxWorkers = argv.maxWorkers ?? 1;
 
-const JEST_BINARY = argv.jestBinary || './node_modules/.bin/jest';
+const JEST_BINARY = argv.jestBinary ?? './node_modules/.bin/jest';
 const FLOW_BINARY = argv.flowBinary;
-const YARN_BINARY = argv.yarnBinary || 'yarn';
+const YARN_BINARY = argv.yarnBinary ?? 'yarn';
 
-function describe(message) {
+class ExecError extends Error {
+  constructor(cause /*: Error */) {
+    super(cause.message, {cause});
+    this.name = 'ExecError';
+  }
+}
+
+function describe(message /*: string */) {
   console.log(`\n\n>>>>> ${message}\n\n\n`);
 }
 
@@ -36,45 +49,21 @@ try {
   console.log('Executing JavaScript tests');
 
   describe('Test: feature flags codegen');
-  if (execSync(`${YARN_BINARY} run featureflags --verify-unchanged`).code) {
-    console.log('Failed to run featureflags check.');
-    exitCode = 1;
-    throw Error(exitCode);
-  }
-
+  execAndLog(`${YARN_BINARY} run featureflags --verify-unchanged`);
   describe('Test: eslint');
-  if (execSync(`${YARN_BINARY} run lint`).code) {
-    console.log('Failed to run eslint.');
-    exitCode = 1;
-    throw Error(exitCode);
-  }
-
+  execAndLog(`${YARN_BINARY} run lint`);
   describe('Test: No JS build artifacts');
-  if (execSync(`${YARN_BINARY} run build --validate`).code) {
-    console.log('Failed, there are build artifacts in this commit.');
-    exitCode = 1;
-    throw Error(exitCode);
-  }
+  execAndLog(`${YARN_BINARY} run build --validate`);
 
   describe('Test: Validate JS API snapshot');
-  if (execSync(`${YARN_BINARY} run build-types --validate`).code) {
-    echo(
-      'JS API snapshot validation failed. Please run `yarn build-types` to update the snapshot.',
-    );
-    exitCode = 1;
-    throw Error(exitCode);
-  }
+  execAndLog(`${YARN_BINARY} run build-types --validate`);
 
   describe('Test: Flow check');
   const flowCommand =
     FLOW_BINARY == null
       ? `${YARN_BINARY} run flow-check`
       : `${FLOW_BINARY} check`;
-  if (execSync(flowCommand).code) {
-    console.log('Failed to run flow.');
-    exitCode = 1;
-    throw Error(exitCode);
-  }
+  execAndLog(flowCommand);
 
   /*
    * Build @react-native/codegen and  @react-native/codegen-typescript-test
@@ -85,47 +74,38 @@ try {
    */
 
   describe('Test: Build @react-native/codegen');
-  if (
-    execSync(`${YARN_BINARY} --cwd ./packages/react-native-codegen run build`)
-      .code
-  ) {
-    console.log('Failed to build @react-native/codegen.');
-    exitCode = 1;
-    throw Error(exitCode);
-  }
+  execAndLog(`${YARN_BINARY} --cwd ./packages/react-native-codegen run build`);
   describe('Test: Build @react-native/codegen-typescript-test');
-  if (
-    execSync(
-      `${YARN_BINARY} --cwd ./private/react-native-codegen-typescript-test run build`,
-    ).code
-  ) {
-    console.log('Failed to build @react-native/codegen-typescript-test.');
-    exitCode = 1;
-    throw Error(exitCode);
-  }
+  execAndLog(
+    `${YARN_BINARY} --cwd ./private/react-native-codegen-typescript-test run build`,
+  );
 
   describe('Test: Jest');
-  if (
-    execSync(
-      `${JEST_BINARY} --maxWorkers=${numberOfMaxWorkers} --ci --reporters="default" --reporters="jest-junit"`,
-    ).code
-  ) {
-    console.log('Failed to run JavaScript tests.');
-    console.log('Most likely the code is broken.');
-    exitCode = 1;
-    throw Error(exitCode);
-  }
+  execAndLog(
+    `${JEST_BINARY} --maxWorkers=${numberOfMaxWorkers} --ci --reporters="default" --reporters="jest-junit"`,
+  );
 
   describe('Test: TypeScript tests');
-  if (execSync(`${YARN_BINARY} run test-typescript`).code) {
-    console.log('Failed to run TypeScript tests.');
-    exitCode = 1;
-    throw Error(exitCode);
+  execAndLog(`${YARN_BINARY} run test-typescript`);
+} catch (e) {
+  if (e instanceof ExecError) {
+    console.error(e.message);
+    process.exitCode = 1;
+  } else {
+    throw e;
   }
-
-  exitCode = 0;
 } finally {
-  // Do cleanup here
   console.log('Finished.');
 }
-process.exit(exitCode);
+
+function execAndLog(command /*: string */) {
+  console.log(`Executing: ${command}`);
+  try {
+    execSync(command, {
+      stdio: ['ignore', 'inherit', 'inherit'],
+      encoding: 'utf8',
+    });
+  } catch (e) {
+    throw new ExecError(e);
+  }
+}


### PR DESCRIPTION
Summary:
Changelog: [Internal]

D76512374 broke error reporting in `run-ci-javascript-tests.js`. This is partly because the file was untyped and we missed that the `.code` check on the result of `execSync` was always going to be falsy. Also, `execSync`'s default error handling mechanism is not human-friendly - it throws an `Error` with `Buffer`s for stdout and stderr (see [example](https://github.com/facebook/react-native/actions/runs/16003656383/job/45144825919?pr=52357&fbclid=IwY2xjawLRyfpleHRuA2FlbQIxMQBicmlkETFZSG1xeWhTWWczR1paS0lKAR4pF46Z-J2CbSk7YdHZJ-N3F9eQJ7hR4EowfLV6mUtzMLg8j-EWdZiGY1la6A_aem_1Zbvn6fD5NS9YO-B7QJssg)).

Here, I'm adding types, removing dead code and preserving stdout and stderr from all child processes in a human-readable format.

Differential Revision: D77648312


