### PR TITLE
Fix deep react native imports eslint rule

### DIFF
--- a/packages/eslint-plugin-react-native/__tests__/no-deep-imports-test.js
+++ b/packages/eslint-plugin-react-native/__tests__/no-deep-imports-test.js
@@ -31,6 +31,8 @@ eslintTester.run('../no-deep-imports', rule, {
     "import Foo from 'react/native/Foo';",
     "import 'react-native/Libraries/Core/InitializeCore';",
     "require('react-native/Libraries/Core/InitializeCore');",
+    "import Foo from 'react-native/src/fb_internal/Foo'",
+    "require('react-native/src/fb_internal/Foo')",
   ],
   invalid: [
     {
@@ -99,6 +101,26 @@ eslintTester.run('../no-deep-imports', rule, {
         {
           messageId: 'deepImport',
           data: {importPath: 'react-native/Libraries/Foo'},
+        },
+      ],
+      output: null,
+    },
+    {
+      code: "import type {RootTag} from 'react-native/Libraries/Types/RootTagTypes';",
+      errors: [
+        {
+          messageId: 'deepImport',
+          data: {importPath: 'react-native/Libraries/Types/RootTagTypes'},
+        },
+      ],
+      output: "import type {RootTag} from 'react-native';",
+    },
+    {
+      code: "import type {ModalBaseProps, Foo} from 'react-native/Libraries/Modal/Modal';",
+      errors: [
+        {
+          messageId: 'deepImport',
+          data: {importPath: 'react-native/Libraries/Modal/Modal'},
         },
       ],
       output: null,

--- a/packages/eslint-plugin-react-native/no-deep-imports.js
+++ b/packages/eslint-plugin-react-native/no-deep-imports.js
@@ -31,7 +31,8 @@ module.exports = {
       ImportDeclaration(node) {
         if (
           !isDeepReactNativeImport(node.source) ||
-          isInitializeCoreImport(node.source)
+          isInitializeCoreImport(node.source) ||
+          isFbInternalImport(node.source)
         ) {
           return;
         }
@@ -40,25 +41,55 @@ module.exports = {
             'react-native/'.length,
           );
           const publicAPIDefaultComponent = publicAPIMapping[reactNativeSource];
-          if (publicAPIDefaultComponent) {
+          if (publicAPIDefaultComponent && publicAPIDefaultComponent.default) {
             context.report({
               ...getStandardReport(node.source),
               fix(fixer) {
                 return fixer.replaceText(
                   node,
-                  `import {${publicAPIDefaultComponent}} from 'react-native';`,
+                  `import {${publicAPIDefaultComponent.default}} from 'react-native';`,
                 );
               },
             });
           } else {
             context.report(getStandardReport(node.source));
           }
+        } else if (isTypeImport(node)) {
+          const reactNativeSource = node.source.value.slice(
+            'react-native/'.length,
+          );
+          const publicAPIDefaultComponent = publicAPIMapping[reactNativeSource];
+          if (publicAPIDefaultComponent && publicAPIDefaultComponent.types) {
+            const typeNames = [];
+            for (const specifier of node.specifiers) {
+              const importedName = specifier.imported.name;
+              if (!publicAPIDefaultComponent.types.includes(importedName)) {
+                context.report(getStandardReport(node.source));
+                return;
+              }
+              typeNames.push(importedName);
+            }
+
+            context.report({
+              ...getStandardReport(node.source),
+              fix(fixer) {
+                return fixer.replaceText(
+                  node,
+                  `import type {${typeNames.join(', ')}} from 'react-native';`,
+                );
+              },
+            });
+          }
         } else {
           context.report(getStandardReport(node.source));
         }
       },
       CallExpression(node) {
-        if (!isDeepRequire(node) || isInitializeCoreImport(node.arguments[0])) {
+        if (
+          !isDeepRequire(node) ||
+          isInitializeCoreImport(node.arguments[0]) ||
+          isFbInternalImport(node.arguments[0])
+        ) {
           return;
         }
 
@@ -71,13 +102,13 @@ module.exports = {
         ) {
           const reactNativeSource = importPath.slice('react-native/'.length);
           const publicAPIDefaultComponent = publicAPIMapping[reactNativeSource];
-          if (publicAPIDefaultComponent) {
+          if (publicAPIDefaultComponent && publicAPIDefaultComponent.default) {
             context.report({
               ...getStandardReport(node.arguments[0]),
               fix(fixer) {
                 return fixer.replaceText(
                   parent,
-                  `{${publicAPIDefaultComponent}} = require('react-native')`,
+                  `{${publicAPIDefaultComponent.default}} = require('react-native')`,
                 );
               },
             });
@@ -109,6 +140,10 @@ module.exports = {
       );
     }
 
+    function isTypeImport(node) {
+      return node.type === 'ImportDeclaration' && node.importKind === 'type';
+    }
+
     function isDeepRequire(node) {
       return (
         node.callee.type === 'Identifier' &&
@@ -136,6 +171,14 @@ module.exports = {
       }
 
       return source.value === 'react-native/Libraries/Core/InitializeCore';
+    }
+
+    function isFbInternalImport(source) {
+      if (source.type !== 'Literal' || typeof source.value !== 'string') {
+        return false;
+      }
+
+      return source.value.startsWith('react-native/src/fb_internal/');
     }
   },
 };

--- a/packages/eslint-plugin-react-native/utils.js
+++ b/packages/eslint-plugin-react-native/utils.js
@@ -17,92 +17,513 @@
  * If the path is not matched, the auto-fix won't be suggested.
  */
 const publicAPIMapping = {
-  'Libraries/Components/AccessibilityInfo/AccessibilityInfo':
-    'AccessibilityInfo',
-  'Libraries/Components/ActivityIndicator/ActivityIndicator':
-    'ActivityIndicator',
-  'Libraries/Components/Button': 'Button',
-  'Libraries/Components/DrawerAndroid/DrawerLayoutAndroid':
-    'DrawerLayoutAndroid',
-  'Libraries/Components/LayoutConformance/LayoutConformance':
-    'experimental_LayoutConformance',
-  'Libraries/Lists/FlatList': 'FlatList',
-  'Libraries/Image/Image': 'Image',
-  'Libraries/Image/ImageBackground': 'ImageBackground',
-  'Libraries/Components/TextInput/InputAccessoryView': 'InputAccessoryView',
-  'Libraries/Components/Keyboard/KeyboardAvoidingView': 'KeyboardAvoidingView',
-  'Libraries/Modal/Modal': 'Modal',
-  'Libraries/Components/Pressable/Pressable': 'Pressable',
-  'Libraries/Components/ProgressBarAndroid/ProgressBarAndroid':
-    'ProgressBarAndroid',
-  'Libraries/Components/RefreshControl/RefreshControl': 'RefreshControl',
-  'Libraries/Components/SafeAreaView/SafeAreaView': 'SafeAreaView',
-  'Libraries/Components/ScrollView/ScrollView': 'ScrollView',
-  'Libraries/Lists/SectionList': 'SectionList',
-  'Libraries/Components/StatusBar/StatusBar': 'StatusBar',
-  'Libraries/Components/Switch/Switch': 'Switch',
-  'Libraries/Text/Text': 'Text',
-  'Libraries/Components/TextInput/TextInput': 'TextInput',
-  'Libraries/Components/Touchable/Touchable': 'Touchable',
-  'Libraries/Components/Touchable/TouchableHighlight': 'TouchableHighlight',
-  'Libraries/Components/Touchable/TouchableNativeFeedback':
-    'TouchableNativeFeedback',
-  'Libraries/Components/Touchable/TouchableOpacity': 'TouchableOpacity',
-  'Libraries/Components/Touchable/TouchableWithoutFeedback':
-    'TouchableWithoutFeedback',
-  'Libraries/Components/View/View': 'View',
-  'Libraries/Lists/VirtualizedList': 'VirtualizedList',
-  'Libraries/Lists/VirtualizedSectionList': 'VirtualizedSectionList',
-  'Libraries/ActionSheetIOS/ActionSheetIOS': 'ActionSheetIOS',
-  'Libraries/Alert/Alert': 'Alert',
-  'Libraries/Animated/Animated': 'Animated',
-  'Libraries/Utilities/Appearance': 'Appearance',
-  'Libraries/ReactNative/AppRegistry': 'AppRegistry',
-  'Libraries/AppState/AppState': 'AppState',
-  'Libraries/Utilities/BackHandler': 'BackHandler',
-  'Libraries/Components/Clipboard/Clipboard': 'Clipboard',
-  'Libraries/Utilities/DeviceInfo': 'DeviceInfo',
-  'src/private/devsupport/devmenu/DevMenu': 'DevMenu',
-  'Libraries/Utilities/DevSettings': 'DevSettings',
-  'Libraries/Utilities/Dimensions': 'Dimensions',
-  'Libraries/Animated/Easing': 'Easing',
-  'Libraries/ReactNative/I18nManager': 'I18nManager',
-  'Libraries/Interaction/InteractionManager': 'InteractionManager',
-  'Libraries/Components/Keyboard/Keyboard': 'Keyboard',
-  'Libraries/LayoutAnimation/LayoutAnimation': 'LayoutAnimation',
-  'Libraries/Linking/Linking': 'Linking',
-  'Libraries/LogBox/LogBox': 'LogBox',
-  'Libraries/NativeModules/specs/NativeDialogManagerAndroid':
-    'NativeDialogManagerAndroid',
-  'Libraries/EventEmitter/NativeEventEmitter': 'NativeEventEmitter',
-  'Libraries/Network/RCTNetworking': 'Networking',
-  'Libraries/Interaction/PanResponder': 'PanResponder',
-  'Libraries/PermissionsAndroid/PermissionsAndroid': 'PermissionsAndroid',
-  'Libraries/Utilities/PixelRatio': 'PixelRatio',
-  'Libraries/PushNotificationIOS/PushNotificationIOS': 'PushNotificationIOS',
-  'Libraries/Settings/Settings': 'Settings',
-  'Libraries/Share/Share': 'Share',
-  'Libraries/StyleSheet/StyleSheet': 'StyleSheet',
-  'Libraries/Performance/Systrace': 'Systrace',
-  'Libraries/Components/ToastAndroid/ToastAndroid': 'ToastAndroid',
-  'Libraries/TurboModule/TurboModuleRegistry': 'TurboModuleRegistry',
-  'Libraries/ReactNative/UIManager': 'UIManager',
-  'Libraries/Animated/useAnimatedValue': 'useAnimatedValue',
-  'Libraries/Utilities/useColorScheme': 'useColorScheme',
-  'Libraries/Utilities/useWindowDimensions': 'useWindowDimensions',
-  'Libraries/UTFSequence': 'UTFSequence',
-  'Libraries/Vibration/Vibration': 'Vibration',
-  'Libraries/Utilities/codegenNativeComponent': 'codegenNativeComponent',
-  'Libraries/Utilities/codegenNativeCommands': 'codegenNativeCommands',
-  'Libraries/EventEmitter/RCTDeviceEventEmitter': 'DeviceEventEmitter',
-  'Libraries/StyleSheet/PlatformColorValueTypesIOS': 'DynamicColorIOS',
-  'Libraries/EventEmitter/RCTNativeAppEventEmitter': 'NativeAppEventEmitter',
-  'Libraries/BatchedBridge/NativeModules': 'NativeModules',
-  'Libraries/Utilities/Platform': 'Platform',
-  'Libraries/StyleSheet/PlatformColorValueTypes': 'PlatformColor',
-  'Libraries/StyleSheet/processColor': 'processColor',
-  'Libraries/ReactNative/requireNativeComponent': 'requireNativeComponent',
-  'Libraries/ReactNative/RootTag': 'RootTagContext',
+  'Libraries/Components/AccessibilityInfo/AccessibilityInfo': {
+    default: 'AccessibilityInfo',
+    types: null,
+  },
+  'Libraries/Components/ActivityIndicator/ActivityIndicator': {
+    default: 'ActivityIndicator',
+    types: ['ActivityIndicatorProps'],
+  },
+  'Libraries/Components/Button': {
+    default: 'Button',
+    types: ['ButtonProps'],
+  },
+  'Libraries/Components/DrawerAndroid/DrawerLayoutAndroid': {
+    default: 'DrawerLayoutAndroid',
+    types: ['DrawerLayoutAndroidProps', 'DrawerSlideEvent'],
+  },
+  'Libraries/Components/LayoutConformance/LayoutConformance': {
+    default: 'experimental_LayoutConformance',
+    types: ['LayoutConformanceProps'],
+  },
+  'Libraries/Lists/FlatList': {
+    default: 'FlatList',
+    types: ['FlatListProps'],
+  },
+  'Libraries/Image/Image': {
+    default: 'Image',
+    types: [
+      'ImageBackgroundProps',
+      'ImageErrorEvent',
+      'ImageLoadEvent',
+      'ImageProgressEventIOS',
+      'ImageProps',
+      'ImagePropsAndroid',
+      'ImagePropsBase',
+      'ImagePropsIOS',
+      'ImageResolvedAssetSource',
+      'ImageSize',
+      'ImageSourcePropType',
+    ],
+  },
+  'Libraries/Image/ImageSource': {
+    default: null,
+    types: ['ImageRequireSource', 'ImageSource', 'ImageURISource'],
+  },
+  'Libraries/Image/ImageBackground': {
+    default: 'ImageBackground',
+    types: null,
+  },
+  'Libraries/Components/TextInput/InputAccessoryView': {
+    default: 'InputAccessoryView',
+    types: ['InputAccessoryViewProps'],
+  },
+  'Libraries/Components/Keyboard/KeyboardAvoidingView': {
+    default: 'KeyboardAvoidingView',
+    types: ['KeyboardAvoidingViewProps'],
+  },
+  'Libraries/Modal/Modal': {
+    default: 'Modal',
+    types: [
+      'ModalBaseProps',
+      'ModalProps',
+      'ModalPropsAndroid',
+      'ModalPropsIOS',
+    ],
+  },
+  'Libraries/Components/Pressable/Pressable': {
+    default: 'Pressable',
+    types: [
+      'PressableAndroidRippleConfig',
+      'PressableProps',
+      'PressableStateCallbackType',
+    ],
+  },
+  'Libraries/Components/ProgressBarAndroid/ProgressBarAndroid': {
+    default: 'ProgressBarAndroid',
+    types: ['ProgressBarAndroidProps'],
+  },
+  'Libraries/Components/RefreshControl/RefreshControl': {
+    default: 'RefreshControl',
+    types: [
+      'RefreshControlProps',
+      'RefreshControlPropsAndroid',
+      'RefreshControlPropsIOS',
+    ],
+  },
+  'Libraries/Components/SafeAreaView/SafeAreaView': {
+    default: 'SafeAreaView',
+    types: null,
+  },
+  'Libraries/Components/ScrollView/ScrollView': {
+    default: 'ScrollView',
+    types: [
+      'ScrollResponderType',
+      'ScrollViewProps',
+      'ScrollViewPropsAndroid',
+      'ScrollViewPropsIOS',
+      'ScrollViewImperativeMethods',
+      'ScrollViewScrollToOptions',
+    ],
+  },
+  'Libraries/Lists/SectionList': {
+    default: 'SectionList',
+    types: [
+      'SectionListProps',
+      'SectionListRenderItem',
+      'SectionListRenderItemInfo',
+      'SectionListData',
+    ],
+  },
+  'Libraries/Components/StatusBar/StatusBar': {
+    default: 'StatusBar',
+    types: ['StatusBarAnimation', 'StatusBarProps', 'StatusBarStyle'],
+  },
+  'Libraries/Components/Switch/Switch': {
+    default: 'Switch',
+    types: ['SwitchChangeEvent', 'SwitchProps'],
+  },
+  'Libraries/Text/Text': {
+    default: 'Text',
+    types: ['TextProps'],
+  },
+  'Libraries/Components/TextInput/TextInput': {
+    default: 'TextInput',
+    types: [
+      'AutoCapitalize',
+      'EnterKeyHintTypeOptions',
+      'KeyboardTypeOptions',
+      'InputModeOptions',
+      'TextContentType',
+      'TextInputAndroidProps',
+      'TextInputIOSProps',
+      'TextInputProps',
+      'TextInputChangeEvent',
+      'TextInputContentSizeChangeEvent',
+      'TextInputEndEditingEvent',
+      'TextInputFocusEvent',
+      'TextInputKeyPressEvent',
+      'TextInputSelectionChangeEvent',
+      'TextInputSubmitEditingEvent',
+      'ReturnKeyTypeOptions',
+      'SubmitBehavior',
+    ],
+  },
+  'Libraries/Components/Touchable/Touchable': {
+    default: 'Touchable',
+    types: null,
+  },
+  'Libraries/Components/Touchable/TouchableHighlight': {
+    default: 'TouchableHighlight',
+    types: ['TouchableHighlightProps'],
+  },
+  'Libraries/Components/Touchable/TouchableNativeFeedback': {
+    default: 'TouchableNativeFeedback',
+    types: ['TouchableNativeFeedbackProps'],
+  },
+  'Libraries/Components/Touchable/TouchableOpacity': {
+    default: 'TouchableOpacity',
+    types: ['TouchableOpacityProps'],
+  },
+  'Libraries/Components/Touchable/TouchableWithoutFeedback': {
+    default: 'TouchableWithoutFeedback',
+    types: ['TouchableWithoutFeedbackProps'],
+  },
+  'Libraries/Components/View/View': {
+    default: 'View',
+    types: null,
+  },
+  'Libraries/Components/View/ViewAccessibility': {
+    default: null,
+    types: [
+      'AccessibilityActionEvent',
+      'AccessibilityProps',
+      'AccessibilityRole',
+      'AccessibilityState',
+      'AccessibilityValue',
+      'Role',
+    ],
+  },
+  'Libraries/Components/View/ViewPropTypes': {
+    default: null,
+    types: [
+      'GestureResponderHandlers',
+      'TVViewPropsIOS',
+      'ViewProps',
+      'ViewPropsAndroid',
+      'ViewPropsIOS',
+    ],
+  },
+  'Libraries/Lists/VirtualizedList': {
+    default: 'VirtualizedList',
+    types: [
+      'ListRenderItemInfo',
+      'ListRenderItem',
+      'Separators',
+      'VirtualizedListProps',
+    ],
+  },
+  'Libraries/Lists/VirtualizedSectionList': {
+    default: 'VirtualizedSectionList',
+    types: [
+      'ScrollToLocationParamsType',
+      'SectionBase',
+      'VirtualizedSectionListProps',
+    ],
+  },
+  'Libraries/ActionSheetIOS/ActionSheetIOS': {
+    default: 'ActionSheetIOS',
+    types: [
+      'ActionSheetIOSOptions',
+      'ShareActionSheetIOSOptions',
+      'ShareActionSheetError',
+    ],
+  },
+  'Libraries/Alert/Alert': {
+    default: 'Alert',
+    types: ['AlertType', 'AlertButtonStyle', 'AlertButton', 'AlertOptions'],
+  },
+  'Libraries/Animated/Animated': {
+    default: 'Animated',
+    types: null,
+  },
+  'Libraries/Utilities/Appearance': {
+    default: 'Appearance',
+    types: null,
+  },
+  'Libraries/ReactNative/AppRegistry': {
+    default: 'AppRegistry',
+    types: [
+      'TaskProvider',
+      'ComponentProvider',
+      'ComponentProviderInstrumentationHook',
+      'AppConfig',
+      'Runnable',
+      'Runnables',
+      'Registry',
+      'WrapperComponentProvider',
+      'RootViewStyleProvider',
+    ],
+  },
+  'Libraries/AppState/AppState': {
+    default: 'AppState',
+    types: ['AppStateStatus', 'AppStateEvent'],
+  },
+  'Libraries/Utilities/BackHandler': {
+    default: 'BackHandler',
+    types: ['BackPressEventName'],
+  },
+  'Libraries/Components/Clipboard/Clipboard': {
+    default: 'Clipboard',
+    types: null,
+  },
+  'Libraries/Utilities/DeviceInfo': {
+    default: 'DeviceInfo',
+    types: ['DeviceInfoConstants'],
+  },
+  'src/private/devsupport/devmenu/DevMenu': {
+    default: 'DevMenu',
+    types: null,
+  },
+  'Libraries/Utilities/DevSettings': {
+    default: 'DevSettings',
+    types: null,
+  },
+  'Libraries/Utilities/Dimensions': {
+    default: 'Dimensions',
+    types: [
+      'DimensionsPayload',
+      'DisplayMetrics',
+      'DisplayMetricsAndroid',
+      'ScaledSize',
+    ],
+  },
+  'Libraries/Animated/Easing': {
+    default: 'Easing',
+    types: ['EasingFunction'],
+  },
+  'Libraries/ReactNative/I18nManager': {
+    default: 'I18nManager',
+    types: null,
+  },
+  'Libraries/Interaction/InteractionManager': {
+    default: 'InteractionManager',
+    types: ['Handle', 'PromiseTask', 'SimpleTask'],
+  },
+  'Libraries/Components/Keyboard/Keyboard': {
+    default: 'Keyboard',
+    types: [
+      'AndroidKeyboardEvent',
+      'IOSKeyboardEvent',
+      'KeyboardEvent',
+      'KeyboardEventEasing',
+      'KeyboardEventName',
+      'KeyboardMetrics',
+    ],
+  },
+  'Libraries/LayoutAnimation/LayoutAnimation': {
+    default: 'LayoutAnimation',
+    types: [
+      'LayoutAnimationAnim',
+      'LayoutAnimationConfig',
+      'LayoutAnimationProperties',
+      'LayoutAnimationProperty',
+      'LayoutAnimationType',
+      'LayoutAnimationTypes',
+    ],
+  },
+  'Libraries/Linking/Linking': {
+    default: 'Linking',
+    types: null,
+  },
+  'Libraries/LogBox/LogBox': {
+    default: 'LogBox',
+    types: ['ExtendedExceptionData', 'IgnorePattern', 'LogData'],
+  },
+  'Libraries/NativeModules/specs/NativeDialogManagerAndroid': {
+    default: 'NativeDialogManagerAndroid',
+    types: null,
+  },
+  'Libraries/EventEmitter/NativeEventEmitter': {
+    default: 'NativeEventEmitter',
+    types: [
+      'EventSubscription',
+      'EmitterSubscription',
+      'NativeEventSubscription',
+    ],
+  },
+  'Libraries/Network/RCTNetworking': {
+    default: 'Networking',
+    types: null,
+  },
+  'Libraries/Interaction/PanResponder': {
+    default: 'PanResponder',
+    types: [
+      'PanResponderCallbacks',
+      'PanResponderGestureState',
+      'PanResponderInstance',
+    ],
+  },
+  'Libraries/PermissionsAndroid/PermissionsAndroid': {
+    default: 'PermissionsAndroid',
+    types: ['Permission', 'PermissionStatus', 'Rationale'],
+  },
+  'Libraries/Utilities/PixelRatio': {
+    default: 'PixelRatio',
+    types: null,
+  },
+  'Libraries/PushNotificationIOS/PushNotificationIOS': {
+    default: 'PushNotificationIOS',
+    types: ['PushNotificationEventName', 'PushNotificationPermissions'],
+  },
+  'Libraries/Settings/Settings': {
+    default: 'Settings',
+    types: null,
+  },
+  'Libraries/Share/Share': {
+    default: 'Share',
+    types: ['ShareAction', 'ShareContent', 'ShareOptions'],
+  },
+  'Libraries/StyleSheet/StyleSheet': {
+    default: 'StyleSheet',
+    types: [
+      'ColorValue',
+      'ImageStyle',
+      'FilterFunction',
+      'FontVariant',
+      'NativeColorValue',
+      'OpaqueColorValue',
+      'StyleProp',
+      'TextStyle',
+      'TransformsStyle',
+      'ViewStyle',
+    ],
+  },
+  'Libraries/StyleSheet/StyleSheetTypes': {
+    default: null,
+    types: [
+      'BoxShadowValue',
+      'CursorValue',
+      'DimensionValue',
+      'DropShadowValue',
+      'EdgeInsetsValue',
+      'PointValue',
+    ],
+  },
+  'Libraries/StyleSheet/Rect': {
+    default: null,
+    types: ['Insets'],
+  },
+  'Libraries/Performance/Systrace': {
+    default: 'Systrace',
+    types: null,
+  },
+  'Libraries/Components/ToastAndroid/ToastAndroid': {
+    default: 'ToastAndroid',
+    types: null,
+  },
+  'Libraries/TurboModule/TurboModuleRegistry': {
+    default: 'TurboModuleRegistry',
+    types: null,
+  },
+  'Libraries/TurboModule/RCTExport': {
+    default: null,
+    types: ['TurboModule'],
+  },
+  'Libraries/ReactNative/UIManager': {
+    default: 'UIManager',
+    types: null,
+  },
+  'Libraries/Animated/useAnimatedValue': {
+    default: 'useAnimatedValue',
+    types: null,
+  },
+  'Libraries/Utilities/useColorScheme': {
+    default: 'useColorScheme',
+    types: null,
+  },
+  'src/private/specs_DEPRECATED/modules/NativeAppearance': {
+    default: null,
+    types: ['ColorSchemeName'],
+  },
+  'Libraries/Utilities/useWindowDimensions': {
+    default: 'useWindowDimensions',
+    types: null,
+  },
+  'Libraries/UTFSequence': {
+    default: 'UTFSequence',
+    types: null,
+  },
+  'Libraries/Vibration/Vibration': {
+    default: 'Vibration',
+    types: null,
+  },
+  'Libraries/Utilities/codegenNativeComponent': {
+    default: 'codegenNativeComponent',
+    types: null,
+  },
+  'Libraries/Utilities/codegenNativeCommands': {
+    default: 'codegenNativeCommands',
+    types: null,
+  },
+  'Libraries/EventEmitter/RCTDeviceEventEmitter': {
+    default: 'DeviceEventEmitter',
+    types: null,
+  },
+  'Libraries/StyleSheet/PlatformColorValueTypesIOS': {
+    default: 'DynamicColorIOS',
+    types: ['DynamicColorIOSTuple'],
+  },
+  'Libraries/EventEmitter/RCTNativeAppEventEmitter': {
+    default: 'NativeAppEventEmitter',
+    types: null,
+  },
+  'Libraries/BatchedBridge/NativeModules': {
+    default: 'NativeModules',
+    types: null,
+  },
+  'Libraries/Utilities/Platform': {
+    default: 'Platform',
+    types: null,
+  },
+  './Libraries/Utilities/PlatformTypes': {
+    default: null,
+    types: ['PlatformOSType', 'PlatformSelectSpec'],
+  },
+  'Libraries/StyleSheet/PlatformColorValueTypes': {
+    default: 'PlatformColor',
+    types: null,
+  },
+  'Libraries/StyleSheet/processColor': {
+    default: 'processColor',
+    types: ['ProcessedColorValue'],
+  },
+  'Libraries/ReactNative/requireNativeComponent': {
+    default: 'requireNativeComponent',
+    types: null,
+  },
+  'Libraries/ReactNative/RootTag': {
+    default: 'RootTagContext',
+    types: ['RootTag'],
+  },
+  'Libraries/Types/RootTagTypes': {
+    default: null,
+    types: ['RootTag'],
+  },
+  'src/private/types/HostInstance': {
+    default: null,
+    types: [
+      'HostInstance',
+      'NativeMethods',
+      'NativeMethodsMixin',
+      'MeasureInWindowOnSuccessCallback',
+      'MeasureLayoutOnSuccessCallback',
+      'MeasureOnSuccessCallback',
+    ],
+  },
+  'src/private/types/HostComponent': {
+    default: null,
+    types: ['HostComponent'],
+  },
+  'Libraries/vendor/core/ErrorUtils': {
+    default: null,
+    types: ['ErrorUtils'],
+  },
+  'Libraries/ReactPrivate/ReactNativePrivateInterface': {
+    default: null,
+    types: ['PublicRootInstance', 'PublicTextInstance'],
+  },
 };
 
 module.exports = {


### PR DESCRIPTION
Summary:
Adds type imports autofix support and pass `fb_internal` paths in react native deep imports eslint rule. The rule fixes imports with all matched types with static API mapping to prevent splits.

Changelog:
[Internal]

Reviewed By: huntie

Differential Revision: D77445445


