### PR TITLE
Expose unstable_TextAncestorContext API

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -55,7 +55,7 @@ import usePressability from '../../Pressability/usePressability';
 import flattenStyle from '../../StyleSheet/flattenStyle';
 import StyleSheet, {type TextStyleProp} from '../../StyleSheet/StyleSheet';
 import Text from '../../Text/Text';
-import TextAncestor from '../../Text/TextAncestor';
+import TextAncestorContext from '../../Text/TextAncestorContext';
 import Platform from '../../Utilities/Platform';
 import useMergeRefs from '../../Utilities/useMergeRefs';
 import TextInputState from './TextInputState';
@@ -775,9 +775,7 @@ function InternalTextInput(props: TextInputProps): React.Node {
       />
     );
   }
-  return (
-    <TextAncestor.Provider value={true}>{textInput}</TextAncestor.Provider>
-  );
+  return <TextAncestorContext value={true}>{textInput}</TextAncestorContext>;
 }
 
 const enterKeyHintToReturnTypeMap = {

--- a/packages/react-native/Libraries/Components/View/View.js
+++ b/packages/react-native/Libraries/Components/View/View.js
@@ -11,7 +11,7 @@
 import type {ViewProps} from './ViewPropTypes';
 
 import * as ReactNativeFeatureFlags from '../../../src/private/featureflags/ReactNativeFeatureFlags';
-import TextAncestor from '../../Text/TextAncestor';
+import TextAncestorContext from '../../Text/TextAncestorContext';
 import ViewNativeComponent from './ViewNativeComponent';
 import * as React from 'react';
 import {use} from 'react';
@@ -27,7 +27,7 @@ export default component View(
   ref?: React.RefSetter<React.ElementRef<typeof ViewNativeComponent>>,
   ...props: ViewProps
 ) {
-  const hasTextAncestor = use(TextAncestor);
+  const hasTextAncestor = use(TextAncestorContext);
 
   let actualView;
   if (ReactNativeFeatureFlags.reduceDefaultPropsInView()) {
@@ -207,7 +207,9 @@ export default component View(
   }
 
   if (hasTextAncestor) {
-    return <TextAncestor value={false}>{actualView}</TextAncestor>;
+    return (
+      <TextAncestorContext value={false}>{actualView}</TextAncestorContext>
+    );
   }
   return actualView;
 }

--- a/packages/react-native/Libraries/Image/Image.android.js
+++ b/packages/react-native/Libraries/Image/Image.android.js
@@ -16,7 +16,7 @@ import type {AbstractImageAndroid, ImageAndroid} from './ImageTypes.flow';
 
 import flattenStyle from '../StyleSheet/flattenStyle';
 import StyleSheet from '../StyleSheet/StyleSheet';
-import TextAncestor from '../Text/TextAncestor';
+import TextAncestorContext from '../Text/TextAncestorContext';
 import ImageAnalyticsTagContext from './ImageAnalyticsTagContext';
 import {
   unstable_getImageComponentDecorator,
@@ -222,7 +222,7 @@ let BaseImage: AbstractImageAndroid = ({
               }
             : nativeProps;
         return (
-          <TextAncestor.Consumer>
+          <TextAncestorContext.Consumer>
             {hasTextAncestor => {
               if (hasTextAncestor) {
                 return (
@@ -245,7 +245,7 @@ let BaseImage: AbstractImageAndroid = ({
                 />
               );
             }}
-          </TextAncestor.Consumer>
+          </TextAncestorContext.Consumer>
         );
       }}
     </ImageAnalyticsTagContext.Consumer>

--- a/packages/react-native/Libraries/Text/Text.d.ts
+++ b/packages/react-native/Libraries/Text/Text.d.ts
@@ -226,3 +226,5 @@ export interface TextProps
 declare class TextComponent extends React.Component<TextProps> {}
 declare const TextBase: Constructor<NativeMethods> & typeof TextComponent;
 export class Text extends TextBase {}
+
+export const unstable_TextAncestorContext: React.Context<boolean>;

--- a/packages/react-native/Libraries/Text/Text.js
+++ b/packages/react-native/Libraries/Text/Text.js
@@ -19,7 +19,7 @@ import usePressability from '../Pressability/usePressability';
 import flattenStyle from '../StyleSheet/flattenStyle';
 import processColor from '../StyleSheet/processColor';
 import Platform from '../Utilities/Platform';
-import TextAncestor from './TextAncestor';
+import TextAncestorContext from './TextAncestorContext';
 import {NativeText, NativeVirtualText} from './TextNativeComponent';
 import * as React from 'react';
 import {useContext, useMemo, useState} from 'react';
@@ -169,7 +169,7 @@ const TextImpl: component(
 
   const _nativeID = id ?? nativeID;
 
-  const hasTextAncestor = useContext(TextAncestor);
+  const hasTextAncestor = useContext(TextAncestorContext);
   if (hasTextAncestor) {
     if (isPressable) {
       return (
@@ -302,7 +302,7 @@ const TextImpl: component(
   }
 
   // If the children do not contain a JSX element it would not be possible to have a
-  // nested `Text` component so we can skip adding the `TextAncestor` context wrapper
+  // nested `Text` component so we can skip adding the `TextAncestorContext` context wrapper
   // which has a performance overhead. Since we do this for performance reasons we need
   // to keep the check simple to avoid regressing overall perf. For this reason the
   // `children.length` constant is set to `3`, this should be a reasonable tradeoff
@@ -322,9 +322,7 @@ const TextImpl: component(
     return nativeText;
   }
 
-  return (
-    <TextAncestor.Provider value={true}>{nativeText}</TextAncestor.Provider>
-  );
+  return <TextAncestorContext value={true}>{nativeText}</TextAncestorContext>;
 };
 
 TextImpl.displayName = 'Text';

--- a/packages/react-native/Libraries/Text/TextAncestor.js
+++ b/packages/react-native/Libraries/Text/TextAncestor.js
@@ -8,16 +8,9 @@
  * @format
  */
 
-'use strict';
+// Compatibility module for ReactStrictDOMTextAncestorContext.native.js.flow (react-strict-dom)
+// TODO(huntie): Delete after we've fixed this cross-repo reference
 
-import * as React from 'react';
-import {createContext} from 'react';
+import TextAncestorContext from './TextAncestorContext';
 
-/**
- * Whether the current element is the descendant of a <Text> element.
- */
-const TextAncestorContext: React.Context<boolean> = createContext(false);
-if (__DEV__) {
-  TextAncestorContext.displayName = 'TextAncestorContext';
-}
 export default TextAncestorContext;

--- a/packages/react-native/Libraries/Text/TextAncestorContext.js
+++ b/packages/react-native/Libraries/Text/TextAncestorContext.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ */
+
+'use strict';
+
+import * as React from 'react';
+import {createContext} from 'react';
+
+/**
+ * Whether the current element is the descendant of a <Text> element.
+ */
+const TextAncestorContext: React.Context<boolean> = createContext(false);
+if (__DEV__) {
+  TextAncestorContext.displayName = 'TextAncestorContext';
+}
+export default TextAncestorContext;

--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -112,6 +112,9 @@ module.exports = {
   get Text() {
     return require('./Libraries/Text/Text').default;
   },
+  get unstable_TextAncestorContext() {
+    return require('./Libraries/Text/TextAncestorContext').default;
+  },
   get TextInput() {
     return require('./Libraries/Components/TextInput/TextInput').default;
   },

--- a/packages/react-native/index.js.flow
+++ b/packages/react-native/index.js.flow
@@ -127,6 +127,7 @@ export {default as Switch} from './Libraries/Components/Switch/Switch';
 
 export type {TextProps} from './Libraries/Text/Text';
 export {default as Text} from './Libraries/Text/Text';
+export {default as unstable_TextAncestorContext} from './Libraries/Text/TextAncestorContext';
 
 export type {
   AutoCapitalize,


### PR DESCRIPTION
Summary:
Motivated by https://github.com/react-native-community/discussions-and-proposals/discussions/893#discussioncomment-13497461.

Also align naming for internal usages.

Also related to https://github.com/necolas/react-native-web/issues/2447.

Changelog:
[General][Added] - Expose `unstable_TextAncestorContext` API

Differential Revision: D77141176
