### PR TITLE
Tweak RNTester status bar on Android

### DIFF
--- a/packages/rn-tester/js/RNTesterAppShared.js
+++ b/packages/rn-tester/js/RNTesterAppShared.js
@@ -34,6 +34,7 @@ import {
   Button,
   Linking,
   Platform,
+  StatusBar,
   StyleSheet,
   View,
   useColorScheme,
@@ -275,6 +276,12 @@ const RNTesterApp = ({
 
   return (
     <RNTesterThemeContext.Provider value={theme}>
+      {Platform.OS === 'android' ? (
+        <StatusBar
+          barStyle="dark-content"
+          backgroundColor={theme.GroupedBackgroundColor}
+        />
+      ) : null}
       {!shouldHideChrome && (
         <RNTTitleBar
           title={title}


### PR DESCRIPTION
Summary:
Tiny fix where the system status bar elements were no longer visible under Android edge-to-edge.

Changelog: [Internal]

Differential Revision: D77653633


