### PR TITLE
Remove internal calls to BugReporting

### DIFF
--- a/packages/react-native/Libraries/ReactNative/AppRegistryImpl.js
+++ b/packages/react-native/Libraries/ReactNative/AppRegistryImpl.js
@@ -22,7 +22,6 @@ import type {
   WrapperComponentProvider,
 } from './AppRegistry.flow';
 
-import BugReporting from '../BugReporting/BugReporting';
 import createPerformanceLogger from '../Utilities/createPerformanceLogger';
 import SceneTracker from '../Utilities/SceneTracker';
 import {coerceDisplayMode} from './DisplayMode';
@@ -36,7 +35,6 @@ type TaskCanceller = () => void;
 type TaskCancelProvider = () => TaskCanceller;
 
 const runnables: Runnables = {};
-let runCount = 1;
 const sections: Runnables = {};
 const taskProviders: Map<string, TaskProvider> = new Map();
 const taskCancelProviders: Map<string, TaskCancelProvider> = new Map();
@@ -167,10 +165,6 @@ export function runApplication(
     const logParams = __DEV__ ? ` with ${JSON.stringify(appParameters)}` : '';
     const msg = `Running "${appKey}"${logParams}`;
     console.log(msg);
-    BugReporting.addSource(
-      'AppRegistry.runApplication' + runCount++,
-      () => msg,
-    );
   }
   invariant(
     runnables[appKey],
@@ -199,10 +193,6 @@ export function setSurfaceProps(
       '" with ' +
       JSON.stringify(appParameters);
     console.log(msg);
-    BugReporting.addSource(
-      'AppRegistry.setSurfaceProps' + runCount++,
-      () => msg,
-    );
   }
   invariant(
     runnables[appKey],


### PR DESCRIPTION
Summary:
Precursor to removing `BugReporting` from React Native's internals.

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D77014724
