### PR TITLE
Fix exhaustive switches

### DIFF
--- a/packages/react-native/Libraries/Image/RCTResizeMode.h
+++ b/packages/react-native/Libraries/Image/RCTResizeMode.h
@@ -21,19 +21,12 @@ static inline RCTResizeMode RCTResizeModeFromUIViewContentMode(UIViewContentMode
   switch (mode) {
     case UIViewContentModeScaleToFill:
       return RCTResizeModeStretch;
-      break;
     case UIViewContentModeScaleAspectFit:
       return RCTResizeModeContain;
-      break;
     case UIViewContentModeScaleAspectFill:
       return RCTResizeModeCover;
-      break;
-    case UIViewContentModeCenter:
-      return RCTResizeModeCenter;
-      break;
     case UIViewContentModeTopLeft:
       return RCTResizeModeNone;
-      break;
     case UIViewContentModeRedraw:
     case UIViewContentModeTop:
     case UIViewContentModeBottom:
@@ -43,6 +36,9 @@ static inline RCTResizeMode RCTResizeModeFromUIViewContentMode(UIViewContentMode
     case UIViewContentModeBottomLeft:
     case UIViewContentModeBottomRight:
       return RCTResizeModeRepeat;
+    case UIViewContentModeCenter:
+    default:
+      return RCTResizeModeCenter;
   }
 };
 

--- a/packages/react-native/React/Base/RCTBridgeMethod.h
+++ b/packages/react-native/React/Base/RCTBridgeMethod.h
@@ -18,12 +18,13 @@ typedef NS_ENUM(NSInteger, RCTFunctionType) {
 static inline const char *RCTFunctionDescriptorFromType(RCTFunctionType type)
 {
   switch (type) {
-    case RCTFunctionTypeNormal:
-      return "async";
     case RCTFunctionTypePromise:
       return "promise";
     case RCTFunctionTypeSync:
       return "sync";
+    case RCTFunctionTypeNormal:
+    default:
+      return "async";
   }
 };
 


### PR DESCRIPTION
Summary: Changelog: [General][Fixed] - Add `default:` case to avoid warnings/errors for targets that compile with `-Wswitch-enum` and `-Wswitch-default` enabled

Reviewed By: aary

Differential Revision: D77051150


