### PR TITLE
Mark ShadowNode::Shared as deprecated and replace all usages

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
@@ -200,7 +200,7 @@ jint FabricUIManagerBinding::findNextFocusableElement(
     jint parentTag,
     jint focusedTag,
     jint direction) {
-  ShadowNode::Shared nextNode;
+  std::shared_ptr<const ShadowNode> nextNode;
 
   std::optional<FocusDirection> focusDirection =
       FocusOrderingHelper::resolveFocusDirection(direction);
@@ -211,14 +211,14 @@ jint FabricUIManagerBinding::findNextFocusableElement(
 
   std::shared_ptr<UIManager> uimanager = getScheduler()->getUIManager();
 
-  ShadowNode::Shared parentShadowNode =
+  std::shared_ptr<const ShadowNode> parentShadowNode =
       uimanager->findShadowNodeByTag_DEPRECATED(parentTag);
 
   if (parentShadowNode == nullptr) {
     return -1;
   }
 
-  ShadowNode::Shared focusedShadowNode =
+  std::shared_ptr<const ShadowNode> focusedShadowNode =
       FocusOrderingHelper::findShadowNodeByTagRecursively(
           parentShadowNode, focusedTag);
 
@@ -260,9 +260,9 @@ jintArray FabricUIManagerBinding::getRelativeAncestorList(
 
   std::shared_ptr<UIManager> uimanager = getScheduler()->getUIManager();
 
-  ShadowNode::Shared childShadowNode =
+  std::shared_ptr<const ShadowNode> childShadowNode =
       uimanager->findShadowNodeByTag_DEPRECATED(childTag);
-  ShadowNode::Shared rootShadowNode =
+  std::shared_ptr<const ShadowNode> rootShadowNode =
       uimanager->findShadowNodeByTag_DEPRECATED(rootTag);
 
   if (childShadowNode == nullptr || rootShadowNode == nullptr) {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FocusOrderingHelper.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FocusOrderingHelper.cpp
@@ -192,14 +192,14 @@ bool isBetterCandidate(
 }
 
 void FocusOrderingHelper::traverseAndUpdateNextFocusableElement(
-    const ShadowNode::Shared& parentShadowNode,
-    const ShadowNode::Shared& focusedShadowNode,
-    const ShadowNode::Shared& currNode,
+    const std::shared_ptr<const ShadowNode>& parentShadowNode,
+    const std::shared_ptr<const ShadowNode>& focusedShadowNode,
+    const std::shared_ptr<const ShadowNode>& currNode,
     FocusDirection focusDirection,
     const UIManager& uimanager,
     Rect sourceRect,
     std::optional<Rect>& nextRect,
-    ShadowNode::Shared& nextNode) {
+    std::shared_ptr<const ShadowNode>& nextNode) {
   const auto* props =
       dynamic_cast<const ViewProps*>(currNode->getProps().get());
 
@@ -244,8 +244,9 @@ void FocusOrderingHelper::traverseAndUpdateNextFocusableElement(
   };
 };
 
-ShadowNode::Shared FocusOrderingHelper::findShadowNodeByTagRecursively(
-    const ShadowNode::Shared& parentShadowNode,
+std::shared_ptr<const ShadowNode>
+FocusOrderingHelper::findShadowNodeByTagRecursively(
+    const std::shared_ptr<const ShadowNode>& parentShadowNode,
     Tag tag) {
   if (parentShadowNode->getTag() == tag) {
     return parentShadowNode;

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FocusOrderingHelper.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FocusOrderingHelper.h
@@ -22,17 +22,17 @@ enum class FocusDirection {
 class FocusOrderingHelper {
  public:
   static void traverseAndUpdateNextFocusableElement(
-      const ShadowNode::Shared& parentShadowNode,
-      const ShadowNode::Shared& focusedShadowNode,
-      const ShadowNode::Shared& currNode,
+      const std::shared_ptr<const ShadowNode>& parentShadowNode,
+      const std::shared_ptr<const ShadowNode>& focusedShadowNode,
+      const std::shared_ptr<const ShadowNode>& currNode,
       FocusDirection focusDirection,
       const UIManager& uimanager,
       Rect sourceRect,
       std::optional<Rect>& nextRect,
-      ShadowNode::Shared& nextNode);
+      std::shared_ptr<const ShadowNode>& nextNode);
 
-  static ShadowNode::Shared findShadowNodeByTagRecursively(
-      const ShadowNode::Shared& parentShadowNode,
+  static std::shared_ptr<const ShadowNode> findShadowNodeByTagRecursively(
+      const std::shared_ptr<const ShadowNode>& parentShadowNode,
       Tag tag);
 
   static std::optional<FocusDirection> resolveFocusDirection(int direction);

--- a/packages/react-native/ReactCommon/react/nativemodule/dom/NativeDOM.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/dom/NativeDOM.cpp
@@ -24,10 +24,11 @@ std::shared_ptr<facebook::react::TurboModule> NativeDOMModuleProvider(
 namespace facebook::react {
 
 namespace {
-inline ShadowNode::Shared getShadowNode(
+inline std::shared_ptr<const ShadowNode> getShadowNode(
     facebook::jsi::Runtime& runtime,
     jsi::Value& shadowNodeValue) {
-  return Bridging<ShadowNode::Shared>::fromJs(runtime, shadowNodeValue);
+  return Bridging<std::shared_ptr<const ShadowNode>>::fromJs(
+      runtime, shadowNodeValue);
 }
 } // namespace
 
@@ -102,8 +103,8 @@ double NativeDOM::compareDocumentPosition(
     return dom::DOCUMENT_POSITION_DISCONNECTED;
   }
 
-  ShadowNode::Shared shadowNode;
-  ShadowNode::Shared otherShadowNode;
+  std::shared_ptr<const ShadowNode> shadowNode;
+  std::shared_ptr<const ShadowNode> otherShadowNode;
 
   // Check if document references are used
   if (nativeNodeReference.isNumber() || otherNativeNodeReference.isNumber()) {
@@ -221,7 +222,9 @@ std::tuple<
     /* rightWidth: */ int,
     /* bottomWidth: */ int,
     /* leftWidth: */ int>
-NativeDOM::getBorderWidth(jsi::Runtime& rt, ShadowNode::Shared shadowNode) {
+NativeDOM::getBorderWidth(
+    jsi::Runtime& rt,
+    std::shared_ptr<const ShadowNode> shadowNode) {
   auto currentRevision =
       getCurrentShadowTreeRevision(rt, shadowNode->getSurfaceId());
   if (currentRevision == nullptr) {
@@ -240,7 +243,7 @@ std::tuple<
     /* height: */ double>
 NativeDOM::getBoundingClientRect(
     jsi::Runtime& rt,
-    ShadowNode::Shared shadowNode,
+    std::shared_ptr<const ShadowNode> shadowNode,
     bool includeTransform) {
   auto currentRevision =
       getCurrentShadowTreeRevision(rt, shadowNode->getSurfaceId());
@@ -256,7 +259,7 @@ NativeDOM::getBoundingClientRect(
 
 std::tuple</* width: */ int, /* height: */ int> NativeDOM::getInnerSize(
     jsi::Runtime& rt,
-    ShadowNode::Shared shadowNode) {
+    std::shared_ptr<const ShadowNode> shadowNode) {
   auto currentRevision =
       getCurrentShadowTreeRevision(rt, shadowNode->getSurfaceId());
   if (currentRevision == nullptr) {
@@ -268,7 +271,9 @@ std::tuple</* width: */ int, /* height: */ int> NativeDOM::getInnerSize(
 }
 
 std::tuple</* scrollLeft: */ double, /* scrollTop: */ double>
-NativeDOM::getScrollPosition(jsi::Runtime& rt, ShadowNode::Shared shadowNode) {
+NativeDOM::getScrollPosition(
+    jsi::Runtime& rt,
+    std::shared_ptr<const ShadowNode> shadowNode) {
   auto currentRevision =
       getCurrentShadowTreeRevision(rt, shadowNode->getSurfaceId());
   if (currentRevision == nullptr) {
@@ -280,7 +285,9 @@ NativeDOM::getScrollPosition(jsi::Runtime& rt, ShadowNode::Shared shadowNode) {
 }
 
 std::tuple</* scrollWidth: */ int, /* scrollHeight */ int>
-NativeDOM::getScrollSize(jsi::Runtime& rt, ShadowNode::Shared shadowNode) {
+NativeDOM::getScrollSize(
+    jsi::Runtime& rt,
+    std::shared_ptr<const ShadowNode> shadowNode) {
   auto currentRevision =
       getCurrentShadowTreeRevision(rt, shadowNode->getSurfaceId());
   if (currentRevision == nullptr) {
@@ -293,13 +300,13 @@ NativeDOM::getScrollSize(jsi::Runtime& rt, ShadowNode::Shared shadowNode) {
 
 std::string NativeDOM::getTagName(
     jsi::Runtime& rt,
-    ShadowNode::Shared shadowNode) {
+    std::shared_ptr<const ShadowNode> shadowNode) {
   return dom::getTagName(*shadowNode);
 }
 
 std::string NativeDOM::getTextContent(
     jsi::Runtime& rt,
-    ShadowNode::Shared shadowNode) {
+    std::shared_ptr<const ShadowNode> shadowNode) {
   auto currentRevision =
       getCurrentShadowTreeRevision(rt, shadowNode->getSurfaceId());
   if (currentRevision == nullptr) {
@@ -311,7 +318,7 @@ std::string NativeDOM::getTextContent(
 
 bool NativeDOM::hasPointerCapture(
     jsi::Runtime& rt,
-    ShadowNode::Shared shadowNode,
+    std::shared_ptr<const ShadowNode> shadowNode,
     double pointerId) {
   bool isCapturing = getPointerEventsProcessorFromRuntime(rt).hasPointerCapture(
       static_cast<PointerIdentifier>(pointerId), shadowNode.get());
@@ -320,7 +327,7 @@ bool NativeDOM::hasPointerCapture(
 
 void NativeDOM::releasePointerCapture(
     jsi::Runtime& rt,
-    ShadowNode::Shared shadowNode,
+    std::shared_ptr<const ShadowNode> shadowNode,
     double pointerId) {
   getPointerEventsProcessorFromRuntime(rt).releasePointerCapture(
       static_cast<PointerIdentifier>(pointerId), shadowNode.get());
@@ -328,7 +335,7 @@ void NativeDOM::releasePointerCapture(
 
 void NativeDOM::setPointerCapture(
     jsi::Runtime& rt,
-    ShadowNode::Shared shadowNode,
+    std::shared_ptr<const ShadowNode> shadowNode,
     double pointerId) {
   getPointerEventsProcessorFromRuntime(rt).setPointerCapture(
       static_cast<PointerIdentifier>(pointerId), shadowNode);
@@ -340,7 +347,9 @@ std::tuple<
     /* offsetParent: */ jsi::Value,
     /* top: */ double,
     /* left: */ double>
-NativeDOM::getOffset(jsi::Runtime& rt, ShadowNode::Shared shadowNode) {
+NativeDOM::getOffset(
+    jsi::Runtime& rt,
+    std::shared_ptr<const ShadowNode> shadowNode) {
   auto currentRevision =
       getCurrentShadowTreeRevision(rt, shadowNode->getSurfaceId());
   if (currentRevision == nullptr) {
@@ -372,14 +381,14 @@ jsi::Value NativeDOM::linkRootNode(
       std::make_shared<InstanceHandle>(rt, instanceHandle, surfaceId);
   currentRevision->setInstanceHandle(instanceHandleWrapper);
 
-  return Bridging<ShadowNode::Shared>::toJs(rt, currentRevision);
+  return Bridging<std::shared_ptr<const ShadowNode>>::toJs(rt, currentRevision);
 }
 
 #pragma mark - Legacy layout APIs (for `ReactNativeElement`).
 
 void NativeDOM::measure(
     jsi::Runtime& rt,
-    ShadowNode::Shared shadowNode,
+    std::shared_ptr<const ShadowNode> shadowNode,
     jsi::Function callback) {
   auto currentRevision =
       getCurrentShadowTreeRevision(rt, shadowNode->getSurfaceId());
@@ -402,7 +411,7 @@ void NativeDOM::measure(
 
 void NativeDOM::measureInWindow(
     jsi::Runtime& rt,
-    ShadowNode::Shared shadowNode,
+    std::shared_ptr<const ShadowNode> shadowNode,
     jsi::Function callback) {
   auto currentRevision =
       getCurrentShadowTreeRevision(rt, shadowNode->getSurfaceId());
@@ -422,8 +431,8 @@ void NativeDOM::measureInWindow(
 
 void NativeDOM::measureLayout(
     jsi::Runtime& rt,
-    ShadowNode::Shared shadowNode,
-    ShadowNode::Shared relativeToShadowNode,
+    std::shared_ptr<const ShadowNode> shadowNode,
+    std::shared_ptr<const ShadowNode> relativeToShadowNode,
     jsi::Function onFail,
     jsi::Function onSuccess) {
   auto currentRevision =
@@ -455,7 +464,7 @@ void NativeDOM::measureLayout(
 
 void NativeDOM::setNativeProps(
     jsi::Runtime& rt,
-    ShadowNode::Shared shadowNode,
+    std::shared_ptr<const ShadowNode> shadowNode,
     jsi::Value updatePayload) {
   getUIManagerFromRuntime(rt).setNativeProps_DEPRECATED(
       shadowNode, RawProps(rt, updatePayload));

--- a/packages/react-native/ReactCommon/react/nativemodule/dom/NativeDOM.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/dom/NativeDOM.h
@@ -47,7 +47,9 @@ class NativeDOM : public NativeDOMCxxSpec<NativeDOM> {
       /* rightWidth: */ int,
       /* bottomWidth: */ int,
       /* leftWidth: */ int>
-  getBorderWidth(jsi::Runtime& rt, ShadowNode::Shared shadowNode);
+  getBorderWidth(
+      jsi::Runtime& rt,
+      std::shared_ptr<const ShadowNode> shadowNode);
 
   std::tuple<
       /* x: */ double,
@@ -56,37 +58,43 @@ class NativeDOM : public NativeDOMCxxSpec<NativeDOM> {
       /* height: */ double>
   getBoundingClientRect(
       jsi::Runtime& rt,
-      ShadowNode::Shared shadowNode,
+      std::shared_ptr<const ShadowNode> shadowNode,
       bool includeTransform);
 
   std::tuple</* width: */ int, /* height: */ int> getInnerSize(
       jsi::Runtime& rt,
-      ShadowNode::Shared shadowNode);
+      std::shared_ptr<const ShadowNode> shadowNode);
 
   std::tuple</* scrollLeft: */ double, /* scrollTop: */ double>
-  getScrollPosition(jsi::Runtime& rt, ShadowNode::Shared shadowNode);
+  getScrollPosition(
+      jsi::Runtime& rt,
+      std::shared_ptr<const ShadowNode> shadowNode);
 
   std::tuple</* scrollWidth: */ int, /* scrollHeight */ int> getScrollSize(
       jsi::Runtime& rt,
-      ShadowNode::Shared shadowNode);
+      std::shared_ptr<const ShadowNode> shadowNode);
 
-  std::string getTagName(jsi::Runtime& rt, ShadowNode::Shared shadowNode);
+  std::string getTagName(
+      jsi::Runtime& rt,
+      std::shared_ptr<const ShadowNode> shadowNode);
 
-  std::string getTextContent(jsi::Runtime& rt, ShadowNode::Shared shadowNode);
+  std::string getTextContent(
+      jsi::Runtime& rt,
+      std::shared_ptr<const ShadowNode> shadowNode);
 
   bool hasPointerCapture(
       jsi::Runtime& rt,
-      ShadowNode::Shared shadowNode,
+      std::shared_ptr<const ShadowNode> shadowNode,
       double pointerId);
 
   void releasePointerCapture(
       jsi::Runtime& rt,
-      ShadowNode::Shared shadowNode,
+      std::shared_ptr<const ShadowNode> shadowNode,
       double pointerId);
 
   void setPointerCapture(
       jsi::Runtime& rt,
-      ShadowNode::Shared shadowNode,
+      std::shared_ptr<const ShadowNode> shadowNode,
       double pointerId);
 
 #pragma mark - Methods from the `HTMLElement` interface (for `ReactNativeElement`).
@@ -95,7 +103,7 @@ class NativeDOM : public NativeDOMCxxSpec<NativeDOM> {
       /* offsetParent: */ jsi::Value,
       /* top: */ double,
       /* left: */ double>
-  getOffset(jsi::Runtime& rt, ShadowNode::Shared shadowNode);
+  getOffset(jsi::Runtime& rt, std::shared_ptr<const ShadowNode> shadowNode);
 
 #pragma mark - Special methods to handle the root node.
 
@@ -108,18 +116,18 @@ class NativeDOM : public NativeDOMCxxSpec<NativeDOM> {
 
   void measure(
       jsi::Runtime& rt,
-      ShadowNode::Shared shadowNode,
+      std::shared_ptr<const ShadowNode> shadowNode,
       jsi::Function callback);
 
   void measureInWindow(
       jsi::Runtime& rt,
-      ShadowNode::Shared shadowNode,
+      std::shared_ptr<const ShadowNode> shadowNode,
       jsi::Function callback);
 
   void measureLayout(
       jsi::Runtime& rt,
-      ShadowNode::Shared shadowNode,
-      ShadowNode::Shared relativeToShadowNode,
+      std::shared_ptr<const ShadowNode> shadowNode,
+      std::shared_ptr<const ShadowNode> relativeToShadowNode,
       jsi::Function onFail,
       jsi::Function onSuccess);
 
@@ -127,7 +135,7 @@ class NativeDOM : public NativeDOMCxxSpec<NativeDOM> {
 
   void setNativeProps(
       jsi::Runtime& rt,
-      ShadowNode::Shared shadowNode,
+      std::shared_ptr<const ShadowNode> shadowNode,
       jsi::Value updatePayload);
 };
 

--- a/packages/react-native/ReactCommon/react/nativemodule/fantomtestspecificmethods/internal/FantomForcedCloneCommitHook.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/fantomtestspecificmethods/internal/FantomForcedCloneCommitHook.cpp
@@ -13,7 +13,8 @@ namespace facebook::react {
 
 namespace {
 
-ShadowNode::Shared findAndClone(const ShadowNode::Shared& node) {
+std::shared_ptr<const ShadowNode> findAndClone(
+    const std::shared_ptr<const ShadowNode>& node) {
   if (node->getProps()->nativeId == "to-be-cloned-in-the-commit-hook") {
     return node->clone({});
   }
@@ -43,7 +44,7 @@ void FantomForcedCloneCommitHook::commitHookWasUnregistered(
 
 RootShadowNode::Unshared FantomForcedCloneCommitHook::shadowTreeWillCommit(
     const ShadowTree& /*shadowTree*/,
-    const RootShadowNode::Shared& /*oldRootShadowNode*/,
+    const std::shared_ptr<const RootShadowNode>& /*oldRootShadowNode*/,
     const RootShadowNode::Unshared& newRootShadowNode) noexcept {
   auto result = findAndClone(newRootShadowNode);
 

--- a/packages/react-native/ReactCommon/react/nativemodule/fantomtestspecificmethods/internal/FantomForcedCloneCommitHook.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/fantomtestspecificmethods/internal/FantomForcedCloneCommitHook.h
@@ -22,7 +22,7 @@ struct FantomForcedCloneCommitHook : public UIManagerCommitHook {
 
   RootShadowNode::Unshared shadowTreeWillCommit(
       const ShadowTree& shadowTree,
-      const RootShadowNode::Shared& oldRootShadowNode,
+      const std::shared_ptr<const RootShadowNode>& oldRootShadowNode,
       const RootShadowNode::Unshared& newRootShadowNode) noexcept override;
 };
 

--- a/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/NativeIntersectionObserver.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/NativeIntersectionObserver.cpp
@@ -58,7 +58,7 @@ void NativeIntersectionObserver::observe(
 void NativeIntersectionObserver::unobserve(
     jsi::Runtime& runtime,
     IntersectionObserverObserverId intersectionObserverId,
-    ShadowNode::Shared targetShadowNode) {
+    std::shared_ptr<const ShadowNode> targetShadowNode) {
   auto token =
       tokenFromShadowNodeFamily(runtime, targetShadowNode->getFamilyShared());
   unobserveV2(runtime, intersectionObserverId, std::move(token));

--- a/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/NativeIntersectionObserver.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/NativeIntersectionObserver.h
@@ -24,9 +24,9 @@ using NativeIntersectionObserverObserveOptions =
         // intersectionObserverId
         NativeIntersectionObserverIntersectionObserverId,
         // rootShadowNode
-        std::optional<ShadowNode::Shared>,
+        std::optional<std::shared_ptr<const ShadowNode>>,
         // targetShadowNode
-        ShadowNode::Shared,
+        std::shared_ptr<const ShadowNode>,
         // thresholds
         std::vector<Float>,
         // rootThresholds
@@ -75,7 +75,7 @@ class NativeIntersectionObserver
   void unobserve(
       jsi::Runtime& runtime,
       IntersectionObserverObserverId intersectionObserverId,
-      ShadowNode::Shared targetShadowNode);
+      std::shared_ptr<const ShadowNode> targetShadowNode);
 
   jsi::Object observeV2(
       jsi::Runtime& runtime,

--- a/packages/react-native/ReactCommon/react/nativemodule/mutationobserver/NativeMutationObserver.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/mutationobserver/NativeMutationObserver.cpp
@@ -98,7 +98,7 @@ jsi::Value NativeMutationObserver::getPublicInstanceFromShadowNode(
 
 std::vector<jsi::Value>
 NativeMutationObserver::getPublicInstancesFromShadowNodes(
-    const std::vector<ShadowNode::Shared>& shadowNodes) const {
+    const std::vector<std::shared_ptr<const ShadowNode>>& shadowNodes) const {
   std::vector<jsi::Value> publicInstances;
   publicInstances.reserve(shadowNodes.size());
 

--- a/packages/react-native/ReactCommon/react/nativemodule/mutationobserver/NativeMutationObserver.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/mutationobserver/NativeMutationObserver.h
@@ -20,7 +20,7 @@ using NativeMutationObserverObserveOptions =
         // mutationObserverId
         MutationObserverId,
         // targetShadowNode
-        ShadowNode::Shared,
+        std::shared_ptr<const ShadowNode>,
         // subtree
         bool>;
 
@@ -88,7 +88,7 @@ class NativeMutationObserver
   jsi::Value getPublicInstanceFromShadowNode(
       const ShadowNode& shadowNode) const;
   std::vector<jsi::Value> getPublicInstancesFromShadowNodes(
-      const std::vector<ShadowNode::Shared>& shadowNodes) const;
+      const std::vector<std::shared_ptr<const ShadowNode>>& shadowNodes) const;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/animations/tests/LayoutAnimationTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animations/tests/LayoutAnimationTest.cpp
@@ -84,7 +84,7 @@ static void testShadowNodeTreeLifeCycleLayoutAnimations(
         .count();
   });
 
-  auto allNodes = std::vector<ShadowNode::Shared>{};
+  auto allNodes = std::vector<std::shared_ptr<const ShadowNode>>{};
 
   for (int i = 0; i < repeats; i++) {
     allNodes.clear();

--- a/packages/react-native/ReactCommon/react/renderer/bridging/bridging.h
+++ b/packages/react-native/ReactCommon/react/renderer/bridging/bridging.h
@@ -14,8 +14,8 @@
 namespace facebook::react {
 
 template <>
-struct Bridging<ShadowNode::Shared> {
-  static ShadowNode::Shared fromJs(
+struct Bridging<std::shared_ptr<const ShadowNode>> {
+  static std::shared_ptr<const ShadowNode> fromJs(
       jsi::Runtime& rt,
       const jsi::Value& jsiValue) {
     auto object = jsiValue.asObject(rt);
@@ -40,7 +40,9 @@ struct Bridging<ShadowNode::Shared> {
     return shadowNodeWrapper->shadowNode;
   }
 
-  static jsi::Value toJs(jsi::Runtime& rt, const ShadowNode::Shared& value) {
+  static jsi::Value toJs(
+      jsi::Runtime& rt,
+      const std::shared_ptr<const ShadowNode>& value) {
     jsi::Object obj(rt);
     obj.setNativeState(rt, std::make_shared<ShadowNodeWrapper>(value));
     return obj;

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -224,7 +224,7 @@ void YogaLayoutableShadowNode::adoptYogaChild(size_t index) {
 }
 
 void YogaLayoutableShadowNode::appendChild(
-    const ShadowNode::Shared& childNode) {
+    const std::shared_ptr<const ShadowNode>& childNode) {
   ensureUnsealed();
   ensureConsistency();
 
@@ -260,7 +260,7 @@ void YogaLayoutableShadowNode::appendChild(
 
 void YogaLayoutableShadowNode::replaceChild(
     const ShadowNode& oldChild,
-    const ShadowNode::Shared& newChild,
+    const std::shared_ptr<const ShadowNode>& newChild,
     size_t suggestedIndex) {
   LayoutableShadowNode::replaceChild(oldChild, newChild, suggestedIndex);
 
@@ -304,8 +304,8 @@ void YogaLayoutableShadowNode::replaceChild(
     yogaNode_.replaceChild(&layoutableNewChild->yogaNode_, oldChildIndex);
     *oldChildIter = layoutableNewChild;
   } else {
-    // Layoutable child replaced with non layoutable child. Remove the previous
-    // child from the layoutable children list.
+    // Layoutable child replaced with non layoutable child. Remove the
+    // previous child from the layoutable children list.
     yogaNode_.removeChild(oldChildIndex);
     yogaLayoutableChildren_.erase(oldChildIter);
   }
@@ -380,7 +380,8 @@ void YogaLayoutableShadowNode::updateYogaProps() {
   auto& props = static_cast<const YogaStylableProps&>(*props_);
   auto styleResult = applyAliasedProps(props.yogaStyle, props);
 
-  // Resetting `dirty` flag only if `yogaStyle` portion of `Props` was changed.
+  // Resetting `dirty` flag only if `yogaStyle` portion of `Props` was
+  // changed.
   if (!YGNodeIsDirty(&yogaNode_) && (styleResult != yogaNode_.style())) {
     yogaNode_.setDirty(true);
   }
@@ -623,9 +624,9 @@ void YogaLayoutableShadowNode::layoutTree(
 
   // Yoga C++ API (and `YGNodeCalculateLayout` function particularly)
   // does not allow to specify sizing modes (see
-  // https://www.w3.org/TR/css-sizing-3/#auto-box-sizes) explicitly. Instead, it
-  // infers these from styles associated with the root node. To pass the actual
-  // layout constraints to Yoga we represent them as
+  // https://www.w3.org/TR/css-sizing-3/#auto-box-sizes) explicitly. Instead,
+  // it infers these from styles associated with the root node. To pass the
+  // actual layout constraints to Yoga we represent them as
   // `(min/max)(Height/Width)` style properties. Also, we pass `ownerWidth` &
   // `ownerHeight` to allow proper calculation of relative (e.g. specified in
   // percents) style values.
@@ -734,13 +735,13 @@ void YogaLayoutableShadowNode::layout(LayoutContext layoutContext) {
 
   if (YGNodeStyleGetOverflow(&yogaNode_) == YGOverflowVisible) {
     // Note that the parent node's overflow layout is NOT affected by its
-    // transform matrix. That transform matrix is applied on the parent node as
-    // well as all of its child nodes, which won't cause changes on the
-    // overflowInset values. A special note on the scale transform -- the scaled
-    // layout may look like it's causing overflowInset changes, but it's purely
-    // cosmetic and will be handled by pixel density conversion logic later when
-    // render the view. The actual overflowInset value is not changed as if the
-    // transform is not happening here.
+    // transform matrix. That transform matrix is applied on the parent node
+    // as well as all of its child nodes, which won't cause changes on the
+    // overflowInset values. A special note on the scale transform -- the
+    // scaled layout may look like it's causing overflowInset changes, but
+    // it's purely cosmetic and will be handled by pixel density conversion
+    // logic later when render the view. The actual overflowInset value is not
+    // changed as if the transform is not happening here.
     auto contentBounds = getContentBounds();
     layoutMetrics_.overflowInset =
         calculateOverflowInset(layoutMetrics_.frame, contentBounds);
@@ -765,8 +766,8 @@ Rect YogaLayoutableShadowNode::getContentBounds() const {
           ? viewChildNode->getConcreteProps().hitSlop
           : EdgeInsets{};
 
-      // The contentBounds should always union with existing child node layout +
-      // overflowInset. The transform may in a deferred animation and not
+      // The contentBounds should always union with existing child node layout
+      // + overflowInset. The transform may in a deferred animation and not
       // applied yet.
       contentBounds.unionInPlace(insetBy(
           layoutMetricsWithOverflowInset.frame,

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.h
@@ -49,10 +49,10 @@ class YogaLayoutableShadowNode : public LayoutableShadowNode {
    */
   void enableMeasurement();
 
-  void appendChild(const ShadowNode::Shared& child) override;
+  void appendChild(const std::shared_ptr<const ShadowNode>& child) override;
   void replaceChild(
       const ShadowNode& oldChild,
-      const ShadowNode::Shared& newChild,
+      const std::shared_ptr<const ShadowNode>& newChild,
       size_t suggestedIndex = SIZE_MAX) override;
 
   void updateYogaChildren();

--- a/packages/react-native/ReactCommon/react/renderer/core/ComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ComponentDescriptor.h
@@ -93,8 +93,8 @@ class ComponentDescriptor {
    * Appends (by mutating) a given `childShadowNode` to `parentShadowNode`.
    */
   virtual void appendChild(
-      const ShadowNode::Shared& parentShadowNode,
-      const ShadowNode::Shared& childShadowNode) const = 0;
+      const std::shared_ptr<const ShadowNode>& parentShadowNode,
+      const std::shared_ptr<const ShadowNode>& childShadowNode) const = 0;
 
   /*
    * Creates a new `Props` of a particular type with all values copied from

--- a/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ConcreteComponentDescriptor.h
@@ -88,8 +88,8 @@ class ConcreteComponentDescriptor : public ComponentDescriptor {
   }
 
   void appendChild(
-      const ShadowNode::Shared& parentShadowNode,
-      const ShadowNode::Shared& childShadowNode) const override {
+      const std::shared_ptr<const ShadowNode>& parentShadowNode,
+      const std::shared_ptr<const ShadowNode>& childShadowNode) const override {
     auto& concreteParentShadowNode =
         static_cast<const ShadowNodeT&>(*parentShadowNode);
     const_cast<ShadowNodeT&>(concreteParentShadowNode)

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.cpp
@@ -268,8 +268,8 @@ Float LayoutableShadowNode::baseline(
   return 0;
 }
 
-ShadowNode::Shared LayoutableShadowNode::findNodeAtPoint(
-    const ShadowNode::Shared& node,
+std::shared_ptr<const ShadowNode> LayoutableShadowNode::findNodeAtPoint(
+    const std::shared_ptr<const ShadowNode>& node,
     Point point) {
   auto layoutableShadowNode =
       dynamic_cast<const LayoutableShadowNode*>(node.get());

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.h
@@ -147,8 +147,8 @@ class LayoutableShadowNode : public ShadowNode {
    * Returns the ShadowNode that is rendered at the Point received as a
    * parameter.
    */
-  static ShadowNode::Shared findNodeAtPoint(
-      const ShadowNode::Shared& node,
+  static std::shared_ptr<const ShadowNode> findNodeAtPoint(
+      const std::shared_ptr<const ShadowNode>& node,
       Point point);
 
   /*

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -237,7 +237,7 @@ void ShadowNode::sealRecursive() const {
 
 #pragma mark - Mutating Methods
 
-void ShadowNode::appendChild(const ShadowNode::Shared& child) {
+void ShadowNode::appendChild(const std::shared_ptr<const ShadowNode>& child) {
   ensureUnsealed();
 
   cloneChildrenIfShared();
@@ -250,7 +250,7 @@ void ShadowNode::appendChild(const ShadowNode::Shared& child) {
 
 void ShadowNode::replaceChild(
     const ShadowNode& oldChild,
-    const ShadowNode::Shared& newChild,
+    const std::shared_ptr<const ShadowNode>& newChild,
     size_t suggestedIndex) {
   ensureUnsealed();
 

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
@@ -32,14 +32,16 @@ class ShadowNode : public Sealable,
                    public DebugStringConvertible,
                    public jsi::NativeState {
  public:
-  using Shared = std::shared_ptr<const ShadowNode>;
+  // TODO(T223558094): delete this in the next version.
+  using Shared [[deprecated("Use std::shared_ptr<const ShadowNode> instead")]] =
+      std::shared_ptr<const ShadowNode>;
   // TODO(T223558094): delete this in the next version.
   using Weak [[deprecated("Use std::weak_ptr<const ShadowNode> instead")]] =
       std::weak_ptr<const ShadowNode>;
   // TODO(T223558094): delete this in the next version.
   using Unshared [[deprecated("Use std::shared_ptr<ShadowNode> instead")]] =
       std::shared_ptr<ShadowNode>;
-  using ListOfShared = std::vector<Shared>;
+  using ListOfShared = std::vector<std::shared_ptr<const ShadowNode>>;
   using ListOfWeak = std::vector<std::weak_ptr<const ShadowNode>>;
   using SharedListOfShared = std::shared_ptr<const ListOfShared>;
   using UnsharedListOfShared = std::shared_ptr<ListOfShared>;
@@ -188,10 +190,10 @@ class ShadowNode : public Sealable,
 
 #pragma mark - Mutating Methods
 
-  virtual void appendChild(const Shared& child);
+  virtual void appendChild(const std::shared_ptr<const ShadowNode>& child);
   virtual void replaceChild(
       const ShadowNode& oldChild,
-      const Shared& newChild,
+      const std::shared_ptr<const ShadowNode>& newChild,
       size_t suggestedIndex = std::numeric_limits<size_t>::max());
 
   /*
@@ -218,13 +220,13 @@ class ShadowNode : public Sealable,
    * Update the runtime reference to point to the provided shadow node.
    */
   void updateRuntimeShadowNodeReference(
-      const Shared& destinationShadowNode) const;
+      const std::shared_ptr<const ShadowNode>& destinationShadowNode) const;
 
   /*
    * Transfer the runtime reference based on the fragment instructions.
    */
   void transferRuntimeShadowNodeReference(
-      const Shared& destinationShadowNode,
+      const std::shared_ptr<const ShadowNode>& destinationShadowNode,
       const ShadowNodeFragment& fragment) const;
 
 #pragma mark - DebugStringConvertible
@@ -272,7 +274,7 @@ class ShadowNode : public Sealable,
    * updating the reference to point to the new `ShadowNode` referencing it.
    */
   void transferRuntimeShadowNodeReference(
-      const Shared& destinationShadowNode) const;
+      const std::shared_ptr<const ShadowNode>& destinationShadowNode) const;
 
   /*
    * Pointer to a family object that this shadow node belongs to.
@@ -312,7 +314,7 @@ static_assert(
     "ShadowNode must have a virtual destructor");
 
 struct ShadowNodeWrapper : public jsi::NativeState {
-  explicit ShadowNodeWrapper(ShadowNode::Shared shadowNode)
+  explicit ShadowNodeWrapper(std::shared_ptr<const ShadowNode> shadowNode)
       : shadowNode(std::move(shadowNode)) {}
 
   // The below method needs to be implemented out-of-line in order for the class
@@ -320,7 +322,7 @@ struct ShadowNodeWrapper : public jsi::NativeState {
   // https://itanium-cxx-abi.github.io/cxx-abi/abi.html#vague-vtable)
   ~ShadowNodeWrapper() override;
 
-  ShadowNode::Shared shadowNode;
+  std::shared_ptr<const ShadowNode> shadowNode;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/ComponentDescriptorTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/ComponentDescriptorTest.cpp
@@ -36,7 +36,7 @@ TEST(ComponentDescriptorTest, createShadowNode) {
       /* .instanceHandle = */ nullptr,
   });
 
-  ShadowNode::Shared node = descriptor->createShadowNode(
+  std::shared_ptr<const ShadowNode> node = descriptor->createShadowNode(
       ShadowNodeFragment{
           /* .props = */ props,
       },
@@ -67,12 +67,13 @@ TEST(ComponentDescriptorTest, cloneShadowNode) {
       /* .surfaceId = */ 1,
       /* .instanceHandle = */ nullptr,
   });
-  ShadowNode::Shared node = descriptor->createShadowNode(
+  std::shared_ptr<const ShadowNode> node = descriptor->createShadowNode(
       ShadowNodeFragment{
           /* .props = */ props,
       },
       family);
-  ShadowNode::Shared cloned = descriptor->cloneShadowNode(*node, {});
+  std::shared_ptr<const ShadowNode> cloned =
+      descriptor->cloneShadowNode(*node, {});
 
   EXPECT_STREQ(cloned->getComponentName(), "Test");
   EXPECT_EQ(cloned->getTag(), 9);
@@ -101,7 +102,7 @@ TEST(ComponentDescriptorTest, appendChild) {
       /* .surfaceId = */ 1,
       /* .instanceHandle = */ nullptr,
   });
-  ShadowNode::Shared node1 = descriptor->createShadowNode(
+  std::shared_ptr<const ShadowNode> node1 = descriptor->createShadowNode(
       ShadowNodeFragment{
           /* .props = */ props,
       },
@@ -111,7 +112,7 @@ TEST(ComponentDescriptorTest, appendChild) {
       /* .surfaceId = */ 1,
       /* .instanceHandle = */ nullptr,
   });
-  ShadowNode::Shared node2 = descriptor->createShadowNode(
+  std::shared_ptr<const ShadowNode> node2 = descriptor->createShadowNode(
       ShadowNodeFragment{
           /* .props = */ props,
       },
@@ -121,7 +122,7 @@ TEST(ComponentDescriptorTest, appendChild) {
       /* .surfaceId = */ 1,
       /* .instanceHandle = */ nullptr,
   });
-  ShadowNode::Shared node3 = descriptor->createShadowNode(
+  std::shared_ptr<const ShadowNode> node3 = descriptor->createShadowNode(
       ShadowNodeFragment{
           /* .props = */ props,
       },

--- a/packages/react-native/ReactCommon/react/renderer/dom/DOM.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/dom/DOM.cpp
@@ -17,7 +17,7 @@ namespace facebook::react::dom {
 
 namespace {
 
-ShadowNode::Shared getShadowNodeInRevision(
+std::shared_ptr<const ShadowNode> getShadowNodeInRevision(
     const RootShadowNode::Shared& currentRevision,
     const ShadowNode& shadowNode) {
   // If the given shadow node is of the same family as the root shadow node,
@@ -36,7 +36,7 @@ ShadowNode::Shared getShadowNodeInRevision(
   return pair->first.get().getChildren().at(pair->second);
 }
 
-ShadowNode::Shared getParentShadowNodeInRevision(
+std::shared_ptr<const ShadowNode> getParentShadowNodeInRevision(
     const RootShadowNode::Shared& currentRevision,
     const ShadowNode& shadowNode) {
   // If the given shadow node is of the same family as the root shadow node,
@@ -61,7 +61,7 @@ ShadowNode::Shared getParentShadowNodeInRevision(
       parentOfParentPair.second);
 }
 
-ShadowNode::Shared getPositionedAncestorOfShadowNodeInRevision(
+std::shared_ptr<const ShadowNode> getPositionedAncestorOfShadowNodeInRevision(
     const RootShadowNode::Shared& currentRevision,
     const ShadowNode& shadowNode) {
   auto ancestors = shadowNode.getFamily().getAncestors(*currentRevision);
@@ -156,13 +156,13 @@ Rect getScrollableContentBounds(
 
 } // namespace
 
-ShadowNode::Shared getParentNode(
+std::shared_ptr<const ShadowNode> getParentNode(
     const RootShadowNode::Shared& currentRevision,
     const ShadowNode& shadowNode) {
   return getParentShadowNodeInRevision(currentRevision, shadowNode);
 }
 
-std::vector<ShadowNode::Shared> getChildNodes(
+std::vector<std::shared_ptr<const ShadowNode>> getChildNodes(
     const RootShadowNode::Shared& currentRevision,
     const ShadowNode& shadowNode) {
   auto shadowNodeInCurrentRevision =

--- a/packages/react-native/ReactCommon/react/renderer/dom/DOM.h
+++ b/packages/react-native/ReactCommon/react/renderer/dom/DOM.h
@@ -38,7 +38,7 @@ struct RNMeasureRect {
 };
 
 struct DOMOffset {
-  ShadowNode::Shared offsetParent = nullptr;
+  std::shared_ptr<const ShadowNode> offsetParent = nullptr;
   double top = 0;
   double left = 0;
 };
@@ -60,11 +60,11 @@ struct DOMBorderWidthRounded {
   int left = 0;
 };
 
-ShadowNode::Shared getParentNode(
+std::shared_ptr<const ShadowNode> getParentNode(
     const RootShadowNode::Shared& currentRevision,
     const ShadowNode& shadowNode);
 
-std::vector<ShadowNode::Shared> getChildNodes(
+std::vector<std::shared_ptr<const ShadowNode>> getChildNodes(
     const RootShadowNode::Shared& currentRevision,
     const ShadowNode& shadowNode);
 

--- a/packages/react-native/ReactCommon/react/renderer/element/Element.h
+++ b/packages/react-native/ReactCommon/react/renderer/element/Element.h
@@ -124,7 +124,8 @@ class Element final {
       std::function<void(const ConcreteUnsharedShadowNode& shadowNode)>
           callback) {
     fragment_.referenceCallback =
-        [callback = std::move(callback)](const ShadowNode::Shared& shadowNode) {
+        [callback = std::move(callback)](
+            const std::shared_ptr<const ShadowNode>& shadowNode) {
           callback(std::const_pointer_cast<ConcreteShadowNode>(
               std::static_pointer_cast<const ConcreteShadowNode>(shadowNode)));
         };
@@ -136,10 +137,11 @@ class Element final {
    * that is being constructed.
    */
   Element& reference(ConcreteUnsharedShadowNode& outShadowNode) {
-    fragment_.referenceCallback = [&](const ShadowNode::Shared& shadowNode) {
-      outShadowNode = std::const_pointer_cast<ConcreteShadowNode>(
-          std::static_pointer_cast<const ConcreteShadowNode>(shadowNode));
-    };
+    fragment_.referenceCallback =
+        [&](const std::shared_ptr<const ShadowNode>& shadowNode) {
+          outShadowNode = std::const_pointer_cast<ConcreteShadowNode>(
+              std::static_pointer_cast<const ConcreteShadowNode>(shadowNode));
+        };
     return *this;
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/mounting/tests/ShadowTreeLifeCycleTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/tests/ShadowTreeLifeCycleTest.cpp
@@ -46,7 +46,7 @@ static void testShadowNodeTreeLifeCycle(
 
   PropsParserContext parserContext{-1, *contextContainer};
 
-  auto allNodes = std::vector<ShadowNode::Shared>{};
+  auto allNodes = std::vector<std::shared_ptr<const ShadowNode>>{};
 
   for (int i = 0; i < repeats; i++) {
     allNodes.clear();
@@ -194,7 +194,7 @@ static void testShadowNodeTreeLifeCycleExtensiveFlatteningUnflattening(
 
   PropsParserContext parserContext{-1, *contextContainer};
 
-  auto allNodes = std::vector<ShadowNode::Shared>{};
+  auto allNodes = std::vector<std::shared_ptr<const ShadowNode>>{};
 
   for (int i = 0; i < repeats; i++) {
     allNodes.clear();

--- a/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserver.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserver.cpp
@@ -38,7 +38,7 @@ void MutationObserver::observe(
   list.push_back(targetShadowNodeFamily);
 }
 
-static ShadowNode::Shared getShadowNodeInTree(
+static std::shared_ptr<const ShadowNode> getShadowNodeInTree(
     const ShadowNodeFamily& shadowNodeFamily,
     const ShadowNode& newTree) {
   auto ancestors = shadowNodeFamily.getAncestors(newTree);
@@ -50,7 +50,7 @@ static ShadowNode::Shared getShadowNodeInTree(
   return pair->first.get().getChildren().at(pair->second);
 }
 
-static ShadowNode::Shared findNodeOfSameFamily(
+static std::shared_ptr<const ShadowNode> findNodeOfSameFamily(
     const ShadowNode::ListOfShared& list,
     const ShadowNode& node) {
   for (auto& current : list) {
@@ -129,8 +129,8 @@ void MutationObserver::recordMutationsInTarget(
 }
 
 void MutationObserver::recordMutationsInSubtrees(
-    const ShadowNode::Shared& oldNode,
-    const ShadowNode::Shared& newNode,
+    const std::shared_ptr<const ShadowNode>& oldNode,
+    const std::shared_ptr<const ShadowNode>& newNode,
     bool observeSubtree,
     std::vector<MutationRecord>& recordedMutations,
     SetOfShadowNodePointers& processedNodes) const {
@@ -146,8 +146,8 @@ void MutationObserver::recordMutationsInSubtrees(
   auto oldChildren = oldNode->getChildren();
   auto newChildren = newNode->getChildren();
 
-  std::vector<ShadowNode::Shared> addedNodes;
-  std::vector<ShadowNode::Shared> removedNodes;
+  std::vector<std::shared_ptr<const ShadowNode>> addedNodes;
+  std::vector<std::shared_ptr<const ShadowNode>> removedNodes;
 
   // Check for removed nodes (and equal nodes for further inspection)
   for (auto& oldChild : oldChildren) {

--- a/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserver.h
+++ b/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserver.h
@@ -17,9 +17,9 @@ using MutationObserverId = int32_t;
 
 struct MutationRecord {
   MutationObserverId mutationObserverId;
-  ShadowNode::Shared targetShadowNode;
-  std::vector<ShadowNode::Shared> addedShadowNodes;
-  std::vector<ShadowNode::Shared> removedShadowNodes;
+  std::shared_ptr<const ShadowNode> targetShadowNode;
+  std::vector<std::shared_ptr<const ShadowNode>> addedShadowNodes;
+  std::vector<std::shared_ptr<const ShadowNode>> removedShadowNodes;
 };
 
 class MutationObserver {
@@ -65,8 +65,8 @@ class MutationObserver {
       SetOfShadowNodePointers& processedNodes) const;
 
   void recordMutationsInSubtrees(
-      const ShadowNode::Shared& oldNode,
-      const ShadowNode::Shared& newNode,
+      const std::shared_ptr<const ShadowNode>& oldNode,
+      const std::shared_ptr<const ShadowNode>& newNode,
       bool observeSubtree,
       std::vector<MutationRecord>& recordedMutations,
       SetOfShadowNodePointers& processedNodes) const;

--- a/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserverManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserverManager.cpp
@@ -16,7 +16,7 @@ MutationObserverManager::MutationObserverManager() = default;
 
 void MutationObserverManager::observe(
     MutationObserverId mutationObserverId,
-    ShadowNode::Shared shadowNode,
+    std::shared_ptr<const ShadowNode> shadowNode,
     bool observeSubtree,
     const UIManager& uiManager) {
   TraceSection s("MutationObserverManager::observe");

--- a/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserverManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/observers/mutation/MutationObserverManager.h
@@ -22,7 +22,7 @@ class MutationObserverManager final : public UIManagerCommitHook {
 
   void observe(
       MutationObserverId mutationObserverId,
-      ShadowNode::Shared shadowNode,
+      std::shared_ptr<const ShadowNode> shadowNode,
       bool observeSubtree,
       const UIManager& uiManager);
 

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -270,7 +270,7 @@ void Scheduler::uiManagerDidCreateShadowNode(const ShadowNode& shadowNode) {
 }
 
 void Scheduler::uiManagerDidDispatchCommand(
-    const ShadowNode::Shared& shadowNode,
+    const std::shared_ptr<const ShadowNode>& shadowNode,
     const std::string& commandName,
     const folly::dynamic& args) {
   TraceSection s("Scheduler::uiManagerDispatchCommand");
@@ -289,7 +289,7 @@ void Scheduler::uiManagerDidDispatchCommand(
 }
 
 void Scheduler::uiManagerDidSendAccessibilityEvent(
-    const ShadowNode::Shared& shadowNode,
+    const std::shared_ptr<const ShadowNode>& shadowNode,
     const std::string& eventType) {
   TraceSection s("Scheduler::uiManagerDidSendAccessibilityEvent");
 
@@ -303,7 +303,7 @@ void Scheduler::uiManagerDidSendAccessibilityEvent(
  * Set JS responder for a view.
  */
 void Scheduler::uiManagerDidSetIsJSResponder(
-    const ShadowNode::Shared& shadowNode,
+    const std::shared_ptr<const ShadowNode>& shadowNode,
     bool isJSResponder,
     bool blockNativeResponder) {
   if (delegate_ != nullptr) {

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
@@ -84,14 +84,14 @@ class Scheduler final : public UIManagerDelegate {
       bool mountSynchronously) override;
   void uiManagerDidCreateShadowNode(const ShadowNode& shadowNode) override;
   void uiManagerDidDispatchCommand(
-      const ShadowNode::Shared& shadowNode,
+      const std::shared_ptr<const ShadowNode>& shadowNode,
       const std::string& commandName,
       const folly::dynamic& args) override;
   void uiManagerDidSendAccessibilityEvent(
-      const ShadowNode::Shared& shadowNode,
+      const std::shared_ptr<const ShadowNode>& shadowNode,
       const std::string& eventType) override;
   void uiManagerDidSetIsJSResponder(
-      const ShadowNode::Shared& shadowNode,
+      const std::shared_ptr<const ShadowNode>& shadowNode,
       bool isJSResponder,
       bool blockNativeResponder) override;
   void uiManagerShouldSynchronouslyUpdateViewOnUIThread(

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/PointerEventsProcessor.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/PointerEventsProcessor.cpp
@@ -12,7 +12,8 @@
 
 namespace facebook::react {
 
-ShadowNode::Shared PointerEventsProcessor::getShadowNodeFromEventTarget(
+std::shared_ptr<const ShadowNode>
+PointerEventsProcessor::getShadowNodeFromEventTarget(
     jsi::Runtime& runtime,
     const EventTarget* target) {
   if (target != nullptr) {
@@ -28,7 +29,8 @@ ShadowNode::Shared PointerEventsProcessor::getShadowNodeFromEventTarget(
           if (stateNodeObj.hasProperty(runtime, "node")) {
             auto node = stateNodeObj.getProperty(runtime, "node");
             if (node.isObject()) {
-              return Bridging<ShadowNode::Shared>::fromJs(runtime, node);
+              return Bridging<std::shared_ptr<const ShadowNode>>::fromJs(
+                  runtime, node);
             }
           }
         }
@@ -62,7 +64,7 @@ static bool isAnyViewInPathToRootListeningToEvents(
   }
 
   // Retrieve the node's root & a list of nodes between the target and the root
-  auto owningRootShadowNode = ShadowNode::Shared{};
+  auto owningRootShadowNode = std::shared_ptr<const ShadowNode>{};
   uiManager.getShadowTreeRegistry().visit(
       shadowNode.getSurfaceId(),
       [&owningRootShadowNode](const ShadowTree& shadowTree) {
@@ -114,7 +116,7 @@ static PointerEventTarget retargetPointerEvent(
   return result;
 }
 
-static ShadowNode::Shared getCaptureTargetOverride(
+static std::shared_ptr<const ShadowNode> getCaptureTargetOverride(
     PointerIdentifier pointerId,
     CaptureTargetOverrideRegistry& registry) {
   auto pendingPointerItr = registry.find(pointerId);
@@ -200,7 +202,7 @@ static bool shouldEmitPointerEvent(
 }
 
 void PointerEventsProcessor::interceptPointerEvent(
-    const ShadowNode::Shared& target,
+    const std::shared_ptr<const ShadowNode>& target,
     const std::string& type,
     ReactEventPriority priority,
     const PointerEvent& event,
@@ -210,7 +212,7 @@ void PointerEventsProcessor::interceptPointerEvent(
   processPendingPointerCapture(event, eventDispatcher, uiManager);
 
   PointerEvent pointerEvent(event);
-  ShadowNode::Shared targetNode = target;
+  std::shared_ptr<const ShadowNode> targetNode = target;
 
   // Retarget the event if it has a pointer capture override target
   auto overrideTarget = getCaptureTargetOverride(
@@ -284,7 +286,7 @@ void PointerEventsProcessor::interceptPointerEvent(
 
 void PointerEventsProcessor::setPointerCapture(
     PointerIdentifier pointerId,
-    const ShadowNode::Shared& shadowNode) {
+    const std::shared_ptr<const ShadowNode>& shadowNode) {
   if (auto activePointer = getActivePointer(pointerId)) {
     // As per the spec this method should silently fail if the pointer in
     // question does not have any active buttons
@@ -321,7 +323,7 @@ void PointerEventsProcessor::releasePointerCapture(
 bool PointerEventsProcessor::hasPointerCapture(
     PointerIdentifier pointerId,
     const ShadowNode* shadowNode) {
-  ShadowNode::Shared pendingTarget = getCaptureTargetOverride(
+  std::shared_ptr<const ShadowNode> pendingTarget = getCaptureTargetOverride(
       pointerId, pendingPointerCaptureTargetOverrides_);
   if (pendingTarget != nullptr) {
     return pendingTarget->getTag() == shadowNode->getTag();
@@ -422,7 +424,7 @@ void PointerEventsProcessor::processPendingPointerCapture(
 
 void PointerEventsProcessor::handleIncomingPointerEventOnNode(
     const PointerEvent& event,
-    const ShadowNode::Shared& targetNode,
+    const std::shared_ptr<const ShadowNode>& targetNode,
     const DispatchEvent& eventDispatcher,
     const UIManager& uiManager) {
   // Get the hover tracker from the previous event (default to null if the

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/PointerEventsProcessor.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/PointerEventsProcessor.h
@@ -18,7 +18,7 @@ namespace facebook::react {
 // Helper struct to package a PointerEvent and SharedEventTarget together
 struct PointerEventTarget {
   PointerEvent event;
-  ShadowNode::Shared target;
+  std::shared_ptr<const ShadowNode> target;
 };
 
 // Helper struct to contain an active pointer's event data along with additional
@@ -50,12 +50,12 @@ using PointerHoverTrackerRegistry =
 
 class PointerEventsProcessor final {
  public:
-  static ShadowNode::Shared getShadowNodeFromEventTarget(
+  static std::shared_ptr<const ShadowNode> getShadowNodeFromEventTarget(
       jsi::Runtime& runtime,
       const EventTarget* target);
 
   void interceptPointerEvent(
-      const ShadowNode::Shared& target,
+      const std::shared_ptr<const ShadowNode>& target,
       const std::string& type,
       ReactEventPriority priority,
       const PointerEvent& event,
@@ -64,7 +64,7 @@ class PointerEventsProcessor final {
 
   void setPointerCapture(
       PointerIdentifier pointerId,
-      const ShadowNode::Shared& shadowNode);
+      const std::shared_ptr<const ShadowNode>& shadowNode);
   void releasePointerCapture(
       PointerIdentifier pointerId,
       const ShadowNode* shadowNode);
@@ -101,7 +101,7 @@ class PointerEventsProcessor final {
    */
   void handleIncomingPointerEventOnNode(
       const PointerEvent& event,
-      const ShadowNode::Shared& targetNode,
+      const std::shared_ptr<const ShadowNode>& targetNode,
       const DispatchEvent& eventDispatcher,
       const UIManager& uiManager);
 

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/PointerHoverTracker.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/PointerHoverTracker.cpp
@@ -7,7 +7,6 @@
 
 #include "PointerHoverTracker.h"
 
-#include <ranges>
 #include <utility>
 
 namespace facebook::react {
@@ -15,13 +14,13 @@ namespace facebook::react {
 using EventPath = PointerHoverTracker::EventPath;
 
 PointerHoverTracker::PointerHoverTracker(
-    ShadowNode::Shared target,
+    std::shared_ptr<const ShadowNode> target,
     const UIManager& uiManager)
     : target_(std::move(target)) {
   if (target_ != nullptr) {
     // Retrieve the root shadow node at this current revision so that we can
     // leverage it to get the event path list at the moment the event occured
-    auto rootShadowNode = ShadowNode::Shared{};
+    auto rootShadowNode = std::shared_ptr<const ShadowNode>{};
     auto& shadowTreeRegistry = uiManager.getShadowTreeRegistry();
     shadowTreeRegistry.visit(
         target_->getSurfaceId(),

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/PointerHoverTracker.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/PointerHoverTracker.h
@@ -23,7 +23,9 @@ class PointerHoverTracker {
   using Unique = std::unique_ptr<PointerHoverTracker>;
   using EventPath = std::vector<std::reference_wrapper<const ShadowNode>>;
 
-  PointerHoverTracker(ShadowNode::Shared target, const UIManager& uiManager);
+  PointerHoverTracker(
+      std::shared_ptr<const ShadowNode> target,
+      const UIManager& uiManager);
 
   const ShadowNode* getTarget(const UIManager& uiManager) const;
   bool hasSameTarget(const PointerHoverTracker& other) const;
@@ -50,8 +52,8 @@ class PointerHoverTracker {
    */
   bool isOldTracker_ = false;
 
-  ShadowNode::Shared root_;
-  ShadowNode::Shared target_;
+  std::shared_ptr<const ShadowNode> root_;
+  std::shared_ptr<const ShadowNode> target_;
 
   /**
    * A thin wrapper around `UIManager::getNewestCloneOfShadowNode` that only

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
@@ -98,7 +98,7 @@ class UIManager final : public ShadowTreeDelegate {
   void registerMountHook(UIManagerMountHook& mountHook);
   void unregisterMountHook(UIManagerMountHook& mountHook);
 
-  ShadowNode::Shared getNewestCloneOfShadowNode(
+  std::shared_ptr<const ShadowNode> getNewestCloneOfShadowNode(
       const ShadowNode& shadowNode) const;
 
   ShadowTreeRevisionConsistencyManager*
@@ -148,8 +148,8 @@ class UIManager final : public ShadowTreeDelegate {
       RawProps rawProps) const;
 
   void appendChild(
-      const ShadowNode::Shared& parentShadowNode,
-      const ShadowNode::Shared& childShadowNode) const;
+      const std::shared_ptr<const ShadowNode>& parentShadowNode,
+      const std::shared_ptr<const ShadowNode>& childShadowNode) const;
 
   void completeSurface(
       SurfaceId surfaceId,
@@ -157,12 +157,12 @@ class UIManager final : public ShadowTreeDelegate {
       ShadowTree::CommitOptions commitOptions);
 
   void setIsJSResponder(
-      const ShadowNode::Shared& shadowNode,
+      const std::shared_ptr<const ShadowNode>& shadowNode,
       bool isJSResponder,
       bool blockNativeResponder) const;
 
-  ShadowNode::Shared findNodeAtPoint(
-      const ShadowNode::Shared& shadowNode,
+  std::shared_ptr<const ShadowNode> findNodeAtPoint(
+      const std::shared_ptr<const ShadowNode>& shadowNode,
       Point point) const;
 
   /*
@@ -182,16 +182,16 @@ class UIManager final : public ShadowTreeDelegate {
   void updateState(const StateUpdate& stateUpdate) const;
 
   void dispatchCommand(
-      const ShadowNode::Shared& shadowNode,
+      const std::shared_ptr<const ShadowNode>& shadowNode,
       const std::string& commandName,
       const folly::dynamic& args) const;
 
   void setNativeProps_DEPRECATED(
-      const ShadowNode::Shared& shadowNode,
+      const std::shared_ptr<const ShadowNode>& shadowNode,
       RawProps rawProps) const;
 
   void sendAccessibilityEvent(
-      const ShadowNode::Shared& shadowNode,
+      const std::shared_ptr<const ShadowNode>& shadowNode,
       const std::string& eventType);
 
   /*
@@ -200,7 +200,8 @@ class UIManager final : public ShadowTreeDelegate {
    * wasn't found. This is a temporary workaround that should not be used in
    * any core functionality.
    */
-  ShadowNode::Shared findShadowNodeByTag_DEPRECATED(Tag tag) const;
+  std::shared_ptr<const ShadowNode> findShadowNodeByTag_DEPRECATED(
+      Tag tag) const;
 
   const ShadowTreeRegistry& getShadowTreeRegistry() const;
 
@@ -235,9 +236,9 @@ class UIManager final : public ShadowTreeDelegate {
       const jsi::Value& successCallback,
       const jsi::Value& failureCallback) const;
 
-  ShadowNode::Shared getShadowNodeInSubtree(
+  std::shared_ptr<const ShadowNode> getShadowNodeInSubtree(
       const ShadowNode& shadowNode,
-      const ShadowNode::Shared& ancestorShadowNode) const;
+      const std::shared_ptr<const ShadowNode>& ancestorShadowNode) const;
 
   SharedComponentDescriptorRegistry componentDescriptorRegistry_;
   UIManagerDelegate* delegate_{};

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerBinding.cpp
@@ -249,7 +249,8 @@ jsi::Value UIManagerBinding::get(
           validateArgumentCount(runtime, methodName, paramCount, count);
 
           uiManager->setIsJSResponder(
-              Bridging<ShadowNode::Shared>::fromJs(runtime, arguments[0]),
+              Bridging<std::shared_ptr<const ShadowNode>>::fromJs(
+                  runtime, arguments[0]),
               arguments[1].getBool(),
               arguments[2].getBool());
 
@@ -270,8 +271,8 @@ jsi::Value UIManagerBinding::get(
             size_t count) {
           validateArgumentCount(runtime, methodName, paramCount, count);
 
-          auto node =
-              Bridging<ShadowNode::Shared>::fromJs(runtime, arguments[0]);
+          auto node = Bridging<std::shared_ptr<const ShadowNode>>::fromJs(
+              runtime, arguments[0]);
           auto locationX = (Float)arguments[1].getNumber();
           auto locationY = (Float)arguments[2].getNumber();
           auto onSuccessFunction =
@@ -316,7 +317,8 @@ jsi::Value UIManagerBinding::get(
           return valueFromShadowNode(
               runtime,
               uiManager->cloneNode(
-                  *Bridging<ShadowNode::Shared>::fromJs(runtime, arguments[0]),
+                  *Bridging<std::shared_ptr<const ShadowNode>>::fromJs(
+                      runtime, arguments[0]),
                   count > 1 ? shadowNodeListFromValue(runtime, arguments[1])
                             : ShadowNode::emptySharedShadowNodeSharedList(),
                   RawProps()),
@@ -341,7 +343,8 @@ jsi::Value UIManagerBinding::get(
           return valueFromShadowNode(
               runtime,
               uiManager->cloneNode(
-                  *Bridging<ShadowNode::Shared>::fromJs(runtime, arguments[0]),
+                  *Bridging<std::shared_ptr<const ShadowNode>>::fromJs(
+                      runtime, arguments[0]),
                   nullptr,
                   RawProps(runtime, arguments[1])),
               true);
@@ -368,7 +371,8 @@ jsi::Value UIManagerBinding::get(
           return valueFromShadowNode(
               runtime,
               uiManager->cloneNode(
-                  *Bridging<ShadowNode::Shared>::fromJs(runtime, arguments[0]),
+                  *Bridging<std::shared_ptr<const ShadowNode>>::fromJs(
+                      runtime, arguments[0]),
                   hasChildrenArg
                       ? shadowNodeListFromValue(runtime, arguments[1])
                       : ShadowNode::emptySharedShadowNodeSharedList(),
@@ -391,8 +395,10 @@ jsi::Value UIManagerBinding::get(
           validateArgumentCount(runtime, methodName, paramCount, count);
 
           uiManager->appendChild(
-              Bridging<ShadowNode::Shared>::fromJs(runtime, arguments[0]),
-              Bridging<ShadowNode::Shared>::fromJs(runtime, arguments[1]));
+              Bridging<std::shared_ptr<const ShadowNode>>::fromJs(
+                  runtime, arguments[0]),
+              Bridging<std::shared_ptr<const ShadowNode>>::fromJs(
+                  runtime, arguments[1]));
           return jsi::Value::undefined();
         });
   }
@@ -428,8 +434,8 @@ jsi::Value UIManagerBinding::get(
           validateArgumentCount(runtime, methodName, paramCount, count);
 
           auto shadowNodeList = shadowNodeListFromValue(runtime, arguments[0]);
-          auto shadowNode =
-              Bridging<ShadowNode::Shared>::fromJs(runtime, arguments[1]);
+          auto shadowNode = Bridging<std::shared_ptr<const ShadowNode>>::fromJs(
+              runtime, arguments[1]);
           shadowNodeList->push_back(shadowNode);
           return jsi::Value::undefined();
         });
@@ -499,8 +505,11 @@ jsi::Value UIManagerBinding::get(
           validateArgumentCount(runtime, methodName, paramCount, count);
 
           auto layoutMetrics = uiManager->getRelativeLayoutMetrics(
-              *Bridging<ShadowNode::Shared>::fromJs(runtime, arguments[0]),
-              Bridging<ShadowNode::Shared>::fromJs(runtime, arguments[1]).get(),
+              *Bridging<std::shared_ptr<const ShadowNode>>::fromJs(
+                  runtime, arguments[0]),
+              Bridging<std::shared_ptr<const ShadowNode>>::fromJs(
+                  runtime, arguments[1])
+                  .get(),
               {/* .includeTransform = */ false});
           auto frame = layoutMetrics.frame;
           auto result = jsi::Object(runtime);
@@ -527,7 +536,8 @@ jsi::Value UIManagerBinding::get(
 
           if (arguments[0].isObject()) {
             auto shadowNode =
-                Bridging<ShadowNode::Shared>::fromJs(runtime, arguments[0]);
+                Bridging<std::shared_ptr<const ShadowNode>>::fromJs(
+                    runtime, arguments[0]);
             uiManager->dispatchCommand(
                 shadowNode,
                 stringFromValue(runtime, arguments[1]),
@@ -551,7 +561,8 @@ jsi::Value UIManagerBinding::get(
           validateArgumentCount(runtime, methodName, paramCount, count);
 
           uiManager->setNativeProps_DEPRECATED(
-              Bridging<ShadowNode::Shared>::fromJs(runtime, arguments[0]),
+              Bridging<std::shared_ptr<const ShadowNode>>::fromJs(
+                  runtime, arguments[0]),
               RawProps(runtime, arguments[1]));
 
           return jsi::Value::undefined();
@@ -572,10 +583,11 @@ jsi::Value UIManagerBinding::get(
             size_t count) {
           validateArgumentCount(runtime, methodName, paramCount, count);
 
-          auto shadowNode =
-              Bridging<ShadowNode::Shared>::fromJs(runtime, arguments[0]);
+          auto shadowNode = Bridging<std::shared_ptr<const ShadowNode>>::fromJs(
+              runtime, arguments[0]);
           auto relativeToShadowNode =
-              Bridging<ShadowNode::Shared>::fromJs(runtime, arguments[1]);
+              Bridging<std::shared_ptr<const ShadowNode>>::fromJs(
+                  runtime, arguments[1]);
           auto onFailFunction =
               arguments[2].getObject(runtime).getFunction(runtime);
           auto onSuccessFunction =
@@ -622,8 +634,8 @@ jsi::Value UIManagerBinding::get(
             size_t count) {
           validateArgumentCount(runtime, methodName, paramCount, count);
 
-          auto shadowNode =
-              Bridging<ShadowNode::Shared>::fromJs(runtime, arguments[0]);
+          auto shadowNode = Bridging<std::shared_ptr<const ShadowNode>>::fromJs(
+              runtime, arguments[0]);
           auto callbackFunction =
               arguments[1].getObject(runtime).getFunction(runtime);
 
@@ -662,8 +674,8 @@ jsi::Value UIManagerBinding::get(
             size_t count) {
           validateArgumentCount(runtime, methodName, paramCount, count);
 
-          auto shadowNode =
-              Bridging<ShadowNode::Shared>::fromJs(runtime, arguments[0]);
+          auto shadowNode = Bridging<std::shared_ptr<const ShadowNode>>::fromJs(
+              runtime, arguments[0]);
           auto callbackFunction =
               arguments[1].getObject(runtime).getFunction(runtime);
 
@@ -701,7 +713,8 @@ jsi::Value UIManagerBinding::get(
           validateArgumentCount(runtime, methodName, paramCount, count);
 
           uiManager->sendAccessibilityEvent(
-              Bridging<ShadowNode::Shared>::fromJs(runtime, arguments[0]),
+              Bridging<std::shared_ptr<const ShadowNode>>::fromJs(
+                  runtime, arguments[0]),
               stringFromValue(runtime, arguments[1]));
 
           return jsi::Value::undefined();
@@ -801,8 +814,8 @@ jsi::Value UIManagerBinding::get(
             size_t count) -> jsi::Value {
           validateArgumentCount(runtime, methodName, paramCount, count);
 
-          auto shadowNode =
-              Bridging<ShadowNode::Shared>::fromJs(runtime, arguments[0]);
+          auto shadowNode = Bridging<std::shared_ptr<const ShadowNode>>::fromJs(
+              runtime, arguments[0]);
           bool includeTransform = arguments[1].getBool();
 
           auto currentRevision =
@@ -841,10 +854,11 @@ jsi::Value UIManagerBinding::get(
             size_t count) -> jsi::Value {
           validateArgumentCount(runtime, methodName, paramCount, count);
 
-          auto shadowNode =
-              Bridging<ShadowNode::Shared>::fromJs(runtime, arguments[0]);
+          auto shadowNode = Bridging<std::shared_ptr<const ShadowNode>>::fromJs(
+              runtime, arguments[0]);
           auto otherShadowNode =
-              Bridging<ShadowNode::Shared>::fromJs(runtime, arguments[1]);
+              Bridging<std::shared_ptr<const ShadowNode>>::fromJs(
+                  runtime, arguments[1]);
 
           auto currentRevision =
               uiManager->getShadowTreeRevisionProvider()->getCurrentRevision(

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerDelegate.h
@@ -38,7 +38,7 @@ class UIManagerDelegate {
    * Called when UIManager wants to dispatch a command to the mounting layer.
    */
   virtual void uiManagerDidDispatchCommand(
-      const ShadowNode::Shared& shadowNode,
+      const std::shared_ptr<const ShadowNode>& shadowNode,
       const std::string& commandName,
       const folly::dynamic& args) = 0;
 
@@ -48,14 +48,14 @@ class UIManagerDelegate {
    * platforms will necessarily implement the same set of events.
    */
   virtual void uiManagerDidSendAccessibilityEvent(
-      const ShadowNode::Shared& shadowNode,
+      const std::shared_ptr<const ShadowNode>& shadowNode,
       const std::string& eventType) = 0;
 
   /*
    * Set JS responder for a view.
    */
   virtual void uiManagerDidSetIsJSResponder(
-      const ShadowNode::Shared& shadowNode,
+      const std::shared_ptr<const ShadowNode>& shadowNode,
       bool isJSResponder,
       bool blockNativeResponder) = 0;
 

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/consistency/tests/LazyShadowTreeRevisionConsistencyManagerTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/consistency/tests/LazyShadowTreeRevisionConsistencyManagerTest.cpp
@@ -18,7 +18,7 @@ class FakeShadowTreeDelegate : public ShadowTreeDelegate {
  public:
   RootShadowNode::Unshared shadowTreeWillCommit(
       const ShadowTree& /*shadowTree*/,
-      const RootShadowNode::Shared& /*oldRootShadowNode*/,
+      const std::shared_ptr<const RootShadowNode>& /*oldRootShadowNode*/,
       const RootShadowNode::Unshared& newRootShadowNode,
       const ShadowTree::CommitOptions& /*commitOptions*/) const override {
     return newRootShadowNode;

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/primitives.h
@@ -33,7 +33,7 @@ struct ShadowNodeListWrapper : public jsi::NativeState {
 
 inline static jsi::Value valueFromShadowNode(
     jsi::Runtime& runtime,
-    ShadowNode::Shared shadowNode,
+    std::shared_ptr<const ShadowNode> shadowNode,
     bool assignRuntimeShadowNodeReference = false) {
   // Wrap the shadow node so that we can update JS references from native
   auto wrappedShadowNode =
@@ -64,8 +64,9 @@ inline static ShadowNode::UnsharedListOfShared shadowNodeListFromValue(
       shadowNodeArray->reserve(jsArrayLen);
 
       for (size_t i = 0; i < jsArrayLen; i++) {
-        shadowNodeArray->push_back(Bridging<ShadowNode::Shared>::fromJs(
-            runtime, jsArray.getValueAtIndex(runtime, i)));
+        shadowNodeArray->push_back(
+            Bridging<std::shared_ptr<const ShadowNode>>::fromJs(
+                runtime, jsArray.getValueAtIndex(runtime, i)));
       }
       return shadowNodeArray;
     } else {

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/tests/PointerEventsProcessorTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/tests/PointerEventsProcessorTest.cpp
@@ -198,7 +198,7 @@ class PointerEventsProcessorTest : public ::testing::Test {
   }
 
   EventLog dispatchPointerEvent(
-      const ShadowNode::Shared& target,
+      const std::shared_ptr<const ShadowNode>& target,
       std::string eventName,
       PointerEvent eventPayload) {
     EventLog eventLog;

--- a/packages/react-native/ReactCommon/react/test_utils/shadowTreeGeneration.h
+++ b/packages/react-native/ReactCommon/react/test_utils/shadowTreeGeneration.h
@@ -10,9 +10,7 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 #include <algorithm>
-#include <iostream>
 #include <memory>
-#include <random>
 
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/mounting/Differentiator.h>
@@ -29,13 +27,13 @@ static Tag generateReactTag() {
 
 class ShadowTreeEdge final {
  public:
-  ShadowNode::Shared shadowNode{nullptr};
-  ShadowNode::Shared parentShadowNode{nullptr};
+  std::shared_ptr<const ShadowNode> shadowNode{nullptr};
+  std::shared_ptr<const ShadowNode> parentShadowNode{nullptr};
   int index{0};
 };
 
 static bool traverseShadowTree(
-    const ShadowNode::Shared& parentShadowNode,
+    const std::shared_ptr<const ShadowNode>& parentShadowNode,
     const std::function<void(const ShadowTreeEdge& edge, bool& stop)>&
         callback) {
   auto index = int{0};
@@ -57,7 +55,8 @@ static bool traverseShadowTree(
   return false;
 }
 
-static int countShadowNodes(const ShadowNode::Shared& rootShadowNode) {
+static int countShadowNodes(
+    const std::shared_ptr<const ShadowNode>& rootShadowNode) {
   auto counter = int{0};
 
   traverseShadowTree(
@@ -68,7 +67,7 @@ static int countShadowNodes(const ShadowNode::Shared& rootShadowNode) {
 }
 
 static ShadowTreeEdge findShadowNodeWithIndex(
-    const ShadowNode::Shared& rootNode,
+    const std::shared_ptr<const ShadowNode>& rootNode,
     int index) {
   auto counter = int{0};
   auto result = ShadowTreeEdge{};
@@ -86,7 +85,7 @@ static ShadowTreeEdge findShadowNodeWithIndex(
 
 static ShadowTreeEdge findRandomShadowNode(
     const Entropy& entropy,
-    const ShadowNode::Shared& rootShadowNode) {
+    const std::shared_ptr<const ShadowNode>& rootShadowNode) {
   auto count = countShadowNodes(rootShadowNode);
   return findShadowNodeWithIndex(
       rootShadowNode,
@@ -284,7 +283,7 @@ static SharedViewProps generateDefaultProps(
       componentDescriptor.cloneProps(parserContext, nullptr, RawProps{}));
 }
 
-static inline ShadowNode::Shared generateShadowNodeTree(
+static inline std::shared_ptr<const ShadowNode> generateShadowNodeTree(
     const Entropy& entropy,
     const ComponentDescriptor& componentDescriptor,
     int size,
@@ -311,7 +310,7 @@ static inline ShadowNode::Shared generateShadowNodeTree(
   return componentDescriptor.createShadowNode(
       ShadowNodeFragment{
           generateDefaultProps(componentDescriptor),
-          std::make_shared<ShadowNode::ListOfShared>(children)},
+          std::make_shared<const ShadowNode::ListOfShared>(children)},
       family);
 }
 

--- a/private/react-native-fantom/tester/src/NativeFantom.cpp
+++ b/private/react-native-fantom/tester/src/NativeFantom.cpp
@@ -97,7 +97,7 @@ void NativeFantom::reportTestSuiteResultsJSON(
 
 jsi::Object NativeFantom::getDirectManipulationProps(
     jsi::Runtime& runtime,
-    const ShadowNode::Shared& shadowNode) {
+    const std::shared_ptr<const ShadowNode>& shadowNode) {
   auto props = appDelegate_.mountingManager_->getViewDirectManipulationProps(
       shadowNode->getTag());
   return facebook::jsi::valueFromDynamic(runtime, props).asObject(runtime);
@@ -105,7 +105,7 @@ jsi::Object NativeFantom::getDirectManipulationProps(
 
 jsi::Object NativeFantom::getFabricUpdateProps(
     jsi::Runtime& runtime,
-    const ShadowNode::Shared& shadowNode) {
+    const std::shared_ptr<const ShadowNode>& shadowNode) {
   auto props = appDelegate_.mountingManager_->getViewFabricUpdateProps(
       shadowNode->getTag());
   return facebook::jsi::valueFromDynamic(runtime, props).asObject(runtime);
@@ -113,7 +113,7 @@ jsi::Object NativeFantom::getFabricUpdateProps(
 
 void NativeFantom::enqueueNativeEvent(
     jsi::Runtime& /*runtime*/,
-    ShadowNode::Shared shadowNode,
+    std::shared_ptr<const ShadowNode> shadowNode,
     std::string type,
     const std::optional<folly::dynamic>& payload,
     std::optional<RawEvent::Category> category,
@@ -131,7 +131,7 @@ void NativeFantom::enqueueNativeEvent(
 
 void NativeFantom::enqueueScrollEvent(
     jsi::Runtime& /*runtime*/,
-    ShadowNode::Shared shadowNode,
+    std::shared_ptr<const ShadowNode> shadowNode,
     ScrollOptions options) {
   const auto* scrollViewShadowNode =
       dynamic_cast<const ScrollViewShadowNode*>(&*shadowNode);
@@ -174,7 +174,7 @@ void NativeFantom::enqueueScrollEvent(
 
 void NativeFantom::enqueueModalSizeUpdate(
     jsi::Runtime& /*runtime*/,
-    ShadowNode::Shared shadowNode,
+    std::shared_ptr<const ShadowNode> shadowNode,
     double width,
     double height) {
   const auto* modalHostViewShadowNode =
@@ -196,7 +196,7 @@ void NativeFantom::enqueueModalSizeUpdate(
 
 jsi::Function NativeFantom::createShadowNodeReferenceCounter(
     jsi::Runtime& runtime,
-    ShadowNode::Shared shadowNode) {
+    std::shared_ptr<const ShadowNode> shadowNode) {
   auto weakShadowNode = std::weak_ptr<const ShadowNode>(shadowNode);
 
   return jsi::Function::createFromHostFunction(
@@ -210,7 +210,7 @@ jsi::Function NativeFantom::createShadowNodeReferenceCounter(
 
 jsi::Function NativeFantom::createShadowNodeRevisionGetter(
     jsi::Runtime& runtime,
-    ShadowNode::Shared shadowNode) {
+    std::shared_ptr<const ShadowNode> shadowNode) {
 #if RN_DEBUG_STRING_CONVERTIBLE
   auto weakShadowNode = std::weak_ptr<const ShadowNode>(shadowNode);
 

--- a/private/react-native-fantom/tester/src/NativeFantom.h
+++ b/private/react-native-fantom/tester/src/NativeFantom.h
@@ -109,7 +109,7 @@ class NativeFantom : public NativeFantomCxxSpec<NativeFantom> {
 
   void enqueueNativeEvent(
       jsi::Runtime& runtime,
-      ShadowNode::Shared shadowNode,
+      std::shared_ptr<const ShadowNode> shadowNode,
       std::string type,
       const std::optional<folly::dynamic>& payload,
       std::optional<RawEvent::Category> category,
@@ -117,30 +117,30 @@ class NativeFantom : public NativeFantomCxxSpec<NativeFantom> {
 
   void enqueueScrollEvent(
       jsi::Runtime& runtime,
-      ShadowNode::Shared shadowNode,
+      std::shared_ptr<const ShadowNode> shadowNode,
       ScrollOptions options);
 
   jsi::Object getDirectManipulationProps(
       jsi::Runtime& runtime,
-      const ShadowNode::Shared& shadowNode);
+      const std::shared_ptr<const ShadowNode>& shadowNode);
 
   jsi::Object getFabricUpdateProps(
       jsi::Runtime& runtime,
-      const ShadowNode::Shared& shadowNode);
+      const std::shared_ptr<const ShadowNode>& shadowNode);
 
   void enqueueModalSizeUpdate(
       jsi::Runtime& runtime,
-      ShadowNode::Shared shadowNode,
+      std::shared_ptr<const ShadowNode> shadowNode,
       double width,
       double height);
 
   jsi::Function createShadowNodeReferenceCounter(
       jsi::Runtime& runtime,
-      ShadowNode::Shared shadowNode);
+      std::shared_ptr<const ShadowNode> shadowNode);
 
   jsi::Function createShadowNodeRevisionGetter(
       jsi::Runtime& runtime,
-      ShadowNode::Shared shadowNode);
+      std::shared_ptr<const ShadowNode> shadowNode);
 
   void saveJSMemoryHeapSnapshot(jsi::Runtime& runtime, std::string filePath);
 


### PR DESCRIPTION
Summary:
## Changelog:
[General][Deprecated] - ShadowNode::Shared is now deprecated. Use `std::shared_ptr<const ShadowNode>` instead.

- Mark ShadowNode::Shared as deprecated in ShadowNode.h
- Replace all uses of ShadowNode::Shared with std::shared_ptr<const ShadowNode>.

This continues the systematic effort to remove ShadowNode type aliases in favor of explicit standard library types for improved code clarity and maintainability.

Reviewed By: christophpurrer

Differential Revision: D77650696
