### PR TITLE
Make loadWithFeatureFlags correctly internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1868,7 +1868,6 @@ public final class com/facebook/react/defaults/DefaultNewArchitectureEntryPoint 
 	public static final fun load (ZZ)V
 	public static final fun load (ZZZ)V
 	public static synthetic fun load$default (ZZZILjava/lang/Object;)V
-	public static final fun loadWithFeatureFlags (Lcom/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider;)V
 	public final fun setReleaseLevel (Lcom/facebook/react/common/ReleaseLevel;)V
 }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
@@ -70,7 +70,7 @@ public object DefaultNewArchitectureEntryPoint {
   }
 
   @JvmStatic
-  public fun loadWithFeatureFlags(featureFlags: ReactNativeFeatureFlagsProvider) {
+  internal fun loadWithFeatureFlags(featureFlags: ReactNativeFeatureFlagsProvider) {
     ReactNativeFeatureFlags.override(featureFlags)
 
     privateFabricEnabled = featureFlags.enableFabricRenderer()


### PR DESCRIPTION
Summary:
This method was exposed as `public` but there is no need for us to expose it in OSS.
So I'm marking it as internal.

Changelog:
[Internal] [Changed] - Make loadWithFeatureFlags correctly internal

Differential Revision: D77734270


