### PR TITLE
fix: rename bottom stack frame (#33680)

### DIFF
--- a/packages/react-native/Libraries/LogBox/__tests__/LogBox-itest.js
+++ b/packages/react-native/Libraries/LogBox/__tests__/LogBox-itest.js
@@ -781,7 +781,7 @@ describe('LogBox', () => {
           '\n\nCheck the top-level render call using <TestComponent>. ' +
           'It was passed a child from TestComponent. ' +
           'See https://react.dev/link/warning-keys for more information.',
-        componentStackFrames: [],
+        componentStackFrames: ['<anonymous />', '<TestComponent />'],
         isDismissable: true,
       });
     });
@@ -818,7 +818,7 @@ describe('LogBox', () => {
         title: 'Console Error',
         message:
           'Invalid prop `invalid` supplied to `React.Fragment`. React.Fragment can only have `key` and `children` props.',
-        componentStackFrames: [],
+        componentStackFrames: ['<TestComponent />'],
         isDismissable: true,
       });
     });


### PR DESCRIPTION
Summary:
`react-stack-bottom-frame` -> `react_stack_bottom_frame`.

This survives `babel/plugin-transform-function-name`, but now frames
will be displayed as `at Object.react_stack_bottom_frame (...)` in V8.
Checks that were relying on exact function name match were updated to
use either `.indexOf()` or `.includes()`

For backwards compatibility, both React DevTools and Flight Client will
look for both options. I am not so sure about the latter and if React
version is locked.

DiffTrain build for [91d097b2c588a0977a7a10ed12512dc8a34e3a5b](https://github.com/facebook/react/commit/91d097b2c588a0977a7a10ed12512dc8a34e3a5b)

Reviewed By: jackpope

Differential Revision: D77601866


