### PR TITLE
Remove deprecated `isStartSamplingProfilerOnInit` from `DeveloperSettings`

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2738,7 +2738,6 @@ public abstract interface class com/facebook/react/modules/debug/interfaces/Deve
 	public abstract fun isHotModuleReplacementEnabled ()Z
 	public abstract fun isJSDevModeEnabled ()Z
 	public abstract fun isJSMinifyEnabled ()Z
-	public abstract fun isStartSamplingProfilerOnInit ()Z
 	public abstract fun setAnimationFpsDebugEnabled (Z)V
 	public abstract fun setDeviceDebugEnabled (Z)V
 	public abstract fun setElementInspectorEnabled (Z)V
@@ -2746,7 +2745,6 @@ public abstract interface class com/facebook/react/modules/debug/interfaces/Deve
 	public abstract fun setHotModuleReplacementEnabled (Z)V
 	public abstract fun setJSDevModeEnabled (Z)V
 	public abstract fun setJSMinifyEnabled (Z)V
-	public abstract fun setStartSamplingProfilerOnInit (Z)V
 }
 
 public final class com/facebook/react/modules/dialog/AlertFragment : androidx/fragment/app/DialogFragment, android/content/DialogInterface$OnClickListener {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevInternalSettings.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevInternalSettings.kt
@@ -75,10 +75,6 @@ internal class DevInternalSettings(applicationContext: Context, private val list
 
   override var isDeviceDebugEnabled: Boolean = ReactBuildConfig.DEBUG
 
-  @Deprecated(
-      "Legacy sampling profiler is no longer supported - This field will be removed in React Native 0.77")
-  override var isStartSamplingProfilerOnInit: Boolean = false
-
   // Not supported.
   override fun addMenuItem(title: String) = Unit
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/interfaces/DeveloperSettings.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/interfaces/DeveloperSettings.kt
@@ -32,11 +32,6 @@ public interface DeveloperSettings {
   /** Whether Nuclide JS debugging is enabled. */
   public var isDeviceDebugEnabled: Boolean
 
-  /** Whether Start Sampling Profiler on App Start is enabled. */
-  @Deprecated(
-      "Legacy sampling profiler is no longer supported - This field will be removed in React Native 0.77")
-  public var isStartSamplingProfilerOnInit: Boolean
-
   /** Whether HMR is enabled. */
   public var isHotModuleReplacementEnabled: Boolean
 


### PR DESCRIPTION
Summary:
This field has been deprecated since RN 0.77, we can safely remove it ahead of the branch cut.

Changelog:
[Android] [Removed] - Remove deprecated `isStartSamplingProfilerOnInit` from `DeveloperSettings`

Reviewed By: mdvacca, javache

Differential Revision: D77734913


