### PR TITLE
remove uses of ShadowNode::Shared from ShadowNode.cpp

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -330,14 +330,14 @@ void ShadowNode::setRuntimeShadowNodeReference(
 }
 
 void ShadowNode::updateRuntimeShadowNodeReference(
-    const Shared& destinationShadowNode) const {
+    const std::shared_ptr<const ShadowNode>& destinationShadowNode) const {
   if (auto reference = runtimeShadowNodeReference_.lock()) {
     reference->shadowNode = destinationShadowNode;
   }
 }
 
 void ShadowNode::transferRuntimeShadowNodeReference(
-    const Shared& destinationShadowNode) const {
+    const std::shared_ptr<const ShadowNode>& destinationShadowNode) const {
   destinationShadowNode->runtimeShadowNodeReference_ =
       runtimeShadowNodeReference_;
 
@@ -347,7 +347,7 @@ void ShadowNode::transferRuntimeShadowNodeReference(
 }
 
 void ShadowNode::transferRuntimeShadowNodeReference(
-    const Shared& destinationShadowNode,
+    const std::shared_ptr<const ShadowNode>& destinationShadowNode,
     const ShadowNodeFragment& fragment) const {
   if ((ReactNativeFeatureFlags::updateRuntimeShadowNodeReferencesOnCommit() ||
        useRuntimeShadowNodeReferenceUpdateOnThread) &&


### PR DESCRIPTION
Summary:
changelog: [internal]

In https://github.com/facebook/react-native/pull/52393 not all uses of ShadowNode::Shared were removed. Github CI fails if a deprecated API is used. Let's remove the last uses.

Differential Revision: D77790411


