### PR TITLE
Add JS implementation for PerformanceResourceTiming

### DIFF
--- a/packages/react-native/src/private/setup/setUpPerformanceObserver.js
+++ b/packages/react-native/src/private/setup/setUpPerformanceObserver.js
@@ -53,6 +53,13 @@ export default function setUpPerformanceObserver() {
   );
 
   polyfillGlobal(
+    'PerformanceResourceTiming',
+    () =>
+      require('../webapis/performance/ResourceTiming')
+        .PerformanceResourceTiming,
+  );
+
+  polyfillGlobal(
     'TaskAttributionTiming',
     () => require('../webapis/performance/LongTasks').TaskAttributionTiming,
   );

--- a/packages/react-native/src/private/webapis/performance/ResourceTiming.js
+++ b/packages/react-native/src/private/webapis/performance/ResourceTiming.js
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict
+ */
+
+// flowlint unsafe-getters-setters:off
+
+import type {
+  DOMHighResTimeStamp,
+  PerformanceEntryJSON,
+} from './PerformanceEntry';
+
+import {PerformanceEntry} from './PerformanceEntry';
+
+export type PerformanceResourceTimingJSON = {
+  ...PerformanceEntryJSON,
+  fetchStart: DOMHighResTimeStamp,
+  requestStart: DOMHighResTimeStamp,
+  connectStart: DOMHighResTimeStamp,
+  connectEnd: DOMHighResTimeStamp,
+  responseStart: DOMHighResTimeStamp,
+  responseEnd: DOMHighResTimeStamp,
+  responseStatus: ?number,
+  ...
+};
+
+export class PerformanceResourceTiming extends PerformanceEntry {
+  #fetchStart: DOMHighResTimeStamp;
+  #requestStart: DOMHighResTimeStamp;
+  #connectStart: DOMHighResTimeStamp;
+  #connectEnd: DOMHighResTimeStamp;
+  #responseStart: DOMHighResTimeStamp;
+  #responseEnd: DOMHighResTimeStamp;
+  #responseStatus: ?number;
+
+  constructor(init: {
+    name: string,
+    startTime: DOMHighResTimeStamp,
+    duration: DOMHighResTimeStamp,
+    fetchStart: DOMHighResTimeStamp,
+    requestStart: DOMHighResTimeStamp,
+    connectStart: DOMHighResTimeStamp,
+    connectEnd: DOMHighResTimeStamp,
+    responseStart: DOMHighResTimeStamp,
+    responseEnd: DOMHighResTimeStamp,
+    responseStatus?: number,
+  }) {
+    super({
+      name: init.name,
+      entryType: 'resource',
+      startTime: init.startTime,
+      duration: init.duration,
+    });
+    this.#fetchStart = init.fetchStart;
+    this.#requestStart = init.requestStart;
+    this.#connectStart = init.connectStart;
+    this.#connectEnd = init.connectEnd;
+    this.#responseStart = init.responseStart;
+    this.#responseEnd = init.responseEnd;
+    this.#responseStatus = init.responseStatus;
+  }
+
+  get fetchStart(): DOMHighResTimeStamp {
+    return this.#fetchStart;
+  }
+
+  get requestStart(): DOMHighResTimeStamp {
+    return this.#requestStart;
+  }
+
+  get connectStart(): DOMHighResTimeStamp {
+    return this.#connectStart;
+  }
+
+  get connectEnd(): DOMHighResTimeStamp {
+    return this.#connectEnd;
+  }
+
+  get responseStart(): DOMHighResTimeStamp {
+    return this.#responseStart;
+  }
+
+  get responseEnd(): DOMHighResTimeStamp {
+    return this.#responseEnd;
+  }
+
+  get responseStatus(): ?number {
+    return this.#responseStatus;
+  }
+
+  toJSON(): PerformanceResourceTimingJSON {
+    return {
+      ...super.toJSON(),
+      fetchStart: this.#fetchStart,
+      requestStart: this.#requestStart,
+      connectStart: this.#connectStart,
+      connectEnd: this.#connectEnd,
+      responseStart: this.#responseStart,
+      responseEnd: this.#responseEnd,
+      responseStatus: this.#responseStatus,
+    };
+  }
+}

--- a/packages/react-native/src/private/webapis/performance/internals/RawPerformanceEntry.js
+++ b/packages/react-native/src/private/webapis/performance/internals/RawPerformanceEntry.js
@@ -17,6 +17,7 @@ import type {
 import {PerformanceEventTiming} from '../EventTiming';
 import {PerformanceLongTaskTiming} from '../LongTasks';
 import {PerformanceEntry} from '../PerformanceEntry';
+import {PerformanceResourceTiming} from '../ResourceTiming';
 import {PerformanceMark, PerformanceMeasure} from '../UserTiming';
 
 export const RawPerformanceEntryTypeValues = {
@@ -30,38 +31,52 @@ export const RawPerformanceEntryTypeValues = {
 export function rawToPerformanceEntry(
   entry: RawPerformanceEntry,
 ): PerformanceEntry {
-  if (entry.entryType === RawPerformanceEntryTypeValues.EVENT) {
-    return new PerformanceEventTiming({
-      name: entry.name,
-      startTime: entry.startTime,
-      duration: entry.duration,
-      processingStart: entry.processingStart,
-      processingEnd: entry.processingEnd,
-      interactionId: entry.interactionId,
-    });
-  } else if (entry.entryType === RawPerformanceEntryTypeValues.LONGTASK) {
-    return new PerformanceLongTaskTiming({
-      name: entry.name,
-      entryType: rawToPerformanceEntryType(entry.entryType),
-      startTime: entry.startTime,
-      duration: entry.duration,
-    });
-  } else if (entry.entryType === RawPerformanceEntryTypeValues.MARK) {
-    return new PerformanceMark(entry.name, {
-      startTime: entry.startTime,
-    });
-  } else if (entry.entryType === RawPerformanceEntryTypeValues.MEASURE) {
-    return new PerformanceMeasure(entry.name, {
-      startTime: entry.startTime,
-      duration: entry.duration,
-    });
-  } else {
-    return new PerformanceEntry({
-      name: entry.name,
-      entryType: rawToPerformanceEntryType(entry.entryType),
-      startTime: entry.startTime,
-      duration: entry.duration,
-    });
+  switch (entry.entryType) {
+    case RawPerformanceEntryTypeValues.EVENT:
+      return new PerformanceEventTiming({
+        name: entry.name,
+        startTime: entry.startTime,
+        duration: entry.duration,
+        processingStart: entry.processingStart,
+        processingEnd: entry.processingEnd,
+        interactionId: entry.interactionId,
+      });
+    case RawPerformanceEntryTypeValues.LONGTASK:
+      return new PerformanceLongTaskTiming({
+        name: entry.name,
+        entryType: rawToPerformanceEntryType(entry.entryType),
+        startTime: entry.startTime,
+        duration: entry.duration,
+      });
+    case RawPerformanceEntryTypeValues.MARK:
+      return new PerformanceMark(entry.name, {
+        startTime: entry.startTime,
+      });
+    case RawPerformanceEntryTypeValues.MEASURE:
+      return new PerformanceMeasure(entry.name, {
+        startTime: entry.startTime,
+        duration: entry.duration,
+      });
+    case RawPerformanceEntryTypeValues.RESOURCE:
+      return new PerformanceResourceTiming({
+        name: entry.name,
+        startTime: entry.startTime,
+        duration: entry.duration,
+        fetchStart: entry.fetchStart ?? 0,
+        requestStart: entry.requestStart ?? 0,
+        connectStart: entry.connectStart ?? 0,
+        connectEnd: entry.connectEnd ?? 0,
+        responseStart: entry.responseStart ?? 0,
+        responseEnd: entry.responseEnd ?? 0,
+        responseStatus: entry.responseStatus,
+      });
+    default:
+      return new PerformanceEntry({
+        name: entry.name,
+        entryType: rawToPerformanceEntryType(entry.entryType),
+        startTime: entry.startTime,
+        duration: entry.duration,
+      });
   }
 }
 


### PR DESCRIPTION
Summary:
Adds and wires up a minimal implementation of `PerformanceResourceTiming` on the JS side. This materialises D74245441 in user space.

When all feature flags are enabled, network requests can now be observed from JS via `PerformanceObserver`.

<img width="1191" alt="image" src="https://github.com/user-attachments/assets/7afaab85-4d76-4402-a9ca-77f1f712e70d" />

Changelog: [Internal]

Reviewed By: rubennorte

Differential Revision: D75062713


