### PR TITLE
Make NetworkingModule handlers internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2887,16 +2887,10 @@ public final class com/facebook/react/modules/network/NetworkingModule : com/fac
 	public fun <init> (Lcom/facebook/react/bridge/ReactApplicationContext;Ljava/util/List;)V
 	public fun abortRequest (D)V
 	public fun addListener (Ljava/lang/String;)V
-	public final fun addRequestBodyHandler (Lcom/facebook/react/modules/network/NetworkingModule$RequestBodyHandler;)V
-	public final fun addResponseHandler (Lcom/facebook/react/modules/network/NetworkingModule$ResponseHandler;)V
-	public final fun addUriHandler (Lcom/facebook/react/modules/network/NetworkingModule$UriHandler;)V
 	public fun clearCookies (Lcom/facebook/react/bridge/Callback;)V
 	public fun initialize ()V
 	public fun invalidate ()V
 	public fun removeListeners (D)V
-	public final fun removeRequestBodyHandler (Lcom/facebook/react/modules/network/NetworkingModule$RequestBodyHandler;)V
-	public final fun removeResponseHandler (Lcom/facebook/react/modules/network/NetworkingModule$ResponseHandler;)V
-	public final fun removeUriHandler (Lcom/facebook/react/modules/network/NetworkingModule$UriHandler;)V
 	public fun sendRequest (Ljava/lang/String;Ljava/lang/String;DLcom/facebook/react/bridge/ReadableArray;Lcom/facebook/react/bridge/ReadableMap;Ljava/lang/String;ZDZ)V
 	public final fun sendRequestInternal (Ljava/lang/String;Ljava/lang/String;ILcom/facebook/react/bridge/ReadableArray;Lcom/facebook/react/bridge/ReadableMap;Ljava/lang/String;ZIZ)V
 	public static final fun setCustomClientBuilder (Lcom/facebook/react/modules/network/CustomClientBuilder;)V
@@ -2907,21 +2901,6 @@ public final class com/facebook/react/modules/network/NetworkingModule$Companion
 }
 
 public abstract interface class com/facebook/react/modules/network/NetworkingModule$CustomClientBuilder : com/facebook/react/modules/network/CustomClientBuilder {
-}
-
-public abstract interface class com/facebook/react/modules/network/NetworkingModule$RequestBodyHandler {
-	public abstract fun supports (Lcom/facebook/react/bridge/ReadableMap;)Z
-	public abstract fun toRequestBody (Lcom/facebook/react/bridge/ReadableMap;Ljava/lang/String;)Lokhttp3/RequestBody;
-}
-
-public abstract interface class com/facebook/react/modules/network/NetworkingModule$ResponseHandler {
-	public abstract fun supports (Ljava/lang/String;)Z
-	public abstract fun toResponseData (Lokhttp3/ResponseBody;)Lcom/facebook/react/bridge/WritableMap;
-}
-
-public abstract interface class com/facebook/react/modules/network/NetworkingModule$UriHandler {
-	public abstract fun fetch (Landroid/net/Uri;)Lcom/facebook/react/bridge/WritableMap;
-	public abstract fun supports (Landroid/net/Uri;Ljava/lang/String;)Z
 }
 
 public abstract interface class com/facebook/react/modules/network/OkHttpClientFactory {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.kt
@@ -57,7 +57,7 @@ public class NetworkingModule(
    * Allows to implement a custom fetching process for specific URIs. It is the handler's job to
    * fetch the URI and return the JS body payload.
    */
-  public interface UriHandler {
+  internal interface UriHandler {
     /** Returns if the handler should be used for an URI. */
     public fun supports(uri: Uri, responseType: String): Boolean
 
@@ -66,7 +66,7 @@ public class NetworkingModule(
   }
 
   /** Allows adding custom handling to build the [RequestBody] from the JS body payload. */
-  public interface RequestBodyHandler {
+  internal interface RequestBodyHandler {
     /** Returns if the handler should be used for a JS body payload. */
     public fun supports(map: ReadableMap): Boolean
 
@@ -75,7 +75,7 @@ public class NetworkingModule(
   }
 
   /** Allows adding custom handling to build the JS body payload from the [ResponseBody]. */
-  public interface ResponseHandler {
+  internal interface ResponseHandler {
     /** Returns if the handler should be used for a response type. */
     public fun supports(responseType: String): Boolean
 
@@ -180,27 +180,27 @@ public class NetworkingModule(
     uriHandlers.clear()
   }
 
-  public fun addUriHandler(handler: UriHandler): Unit {
+  internal fun addUriHandler(handler: UriHandler): Unit {
     uriHandlers.add(handler)
   }
 
-  public fun addRequestBodyHandler(handler: RequestBodyHandler): Unit {
+  internal fun addRequestBodyHandler(handler: RequestBodyHandler): Unit {
     requestBodyHandlers.add(handler)
   }
 
-  public fun addResponseHandler(handler: ResponseHandler): Unit {
+  internal fun addResponseHandler(handler: ResponseHandler): Unit {
     responseHandlers.add(handler)
   }
 
-  public fun removeUriHandler(handler: UriHandler): Unit {
+  internal fun removeUriHandler(handler: UriHandler): Unit {
     uriHandlers.remove(handler)
   }
 
-  public fun removeRequestBodyHandler(handler: RequestBodyHandler): Unit {
+  internal fun removeRequestBodyHandler(handler: RequestBodyHandler): Unit {
     requestBodyHandlers.remove(handler)
   }
 
-  public fun removeResponseHandler(handler: ResponseHandler): Unit {
+  internal fun removeResponseHandler(handler: ResponseHandler): Unit {
     responseHandlers.remove(handler)
   }
 


### PR DESCRIPTION
Summary:
Motivation: After some investigation, these make sense as private APIs, and we intend to modify `UriHandler` slightly in order to report blob response body payloads via CDP for Network debugging.

Changelog:
[Android][Removed] - Internalize `NetworkingModule`'s `UriHandler`, `RequestBodyHandler`, and `ResponseHandler` APIs

Reviewed By: cortinico

Differential Revision: D77799144


