### PR TITLE
Deprecate the DefaultNewArchitectureEntryPoint.load(Boolean, Boolean, Boolean)

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1867,6 +1867,8 @@ public final class com/facebook/react/defaults/DefaultNewArchitectureEntryPoint 
 	public static final fun load (Z)V
 	public static final fun load (ZZ)V
 	public static final fun load (ZZZ)V
+	public static synthetic fun load$default (ZILjava/lang/Object;)V
+	public static synthetic fun load$default (ZZILjava/lang/Object;)V
 	public static synthetic fun load$default (ZZZILjava/lang/Object;)V
 	public final fun setReleaseLevel (Lcom/facebook/react/common/ReleaseLevel;)V
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
@@ -33,8 +33,47 @@ public object DefaultNewArchitectureEntryPoint {
 
   public var releaseLevel: ReleaseLevel = ReleaseLevel.STABLE
 
+  /**
+   * Loads the React Native New Architecture entry point with the default configuration.
+   *
+   * This will load the app with TurboModules, Fabric and Bridgeless by default.
+   */
   @JvmStatic
-  @JvmOverloads
+  public fun load() {
+    load(turboModulesEnabled = true, fabricEnabled = true, bridgelessEnabled = true)
+  }
+
+  @JvmStatic
+  @Deprecated(
+      message =
+          "Loading the entry point with different flags for Fabric, TurboModule and Bridgeless is deprecated." +
+              "Please use load() instead when loading the New Architecture.",
+      replaceWith = ReplaceWith("load()"))
+  public fun load(
+      turboModulesEnabled: Boolean = true,
+  ) {
+    load(turboModulesEnabled, fabricEnabled = true, bridgelessEnabled = true)
+  }
+
+  @JvmStatic
+  @Deprecated(
+      message =
+          "Loading the entry point with different flags for Fabric, TurboModule and Bridgeless is deprecated." +
+              "Please use load() instead when loading the New Architecture.",
+      replaceWith = ReplaceWith("load()"))
+  public fun load(
+      turboModulesEnabled: Boolean = true,
+      fabricEnabled: Boolean = true,
+  ) {
+    load(turboModulesEnabled, fabricEnabled, bridgelessEnabled = true)
+  }
+
+  @JvmStatic
+  @Deprecated(
+      message =
+          "Loading the entry point with different flags for Fabric, TurboModule and Bridgeless is deprecated." +
+              "Please use load() instead when loading the New Architecture.",
+      replaceWith = ReplaceWith("load()"))
   public fun load(
       turboModulesEnabled: Boolean = true,
       fabricEnabled: Boolean = true,


### PR DESCRIPTION
Summary:
Users should not be passing true/false values for the 3 params in the `load()` method. The app template already uses the no param overload.
I'm deprecating it so it can go in 0.81.

Changelog:
[Android] [Changed] - Deprecate the DefaultNewArchitectureEntryPoint.load(Boolean, Boolean, Boolean)

Reviewed By: rubennorte

Differential Revision: D77739268
