### PR TITLE
upgrade[react-devtools]: 6.1.5

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -184,7 +184,7 @@
     "nullthrows": "^1.1.1",
     "pretty-format": "^29.7.0",
     "promise": "^8.3.0",
-    "react-devtools-core": "^6.1.4",
+    "react-devtools-core": "^6.1.5",
     "react-refresh": "^0.14.0",
     "regenerator-runtime": "^0.13.2",
     "scheduler": "0.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8111,10 +8111,10 @@ raw-body@2.5.2:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-react-devtools-core@^6.1.4:
-  version "6.1.4"
-  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-6.1.4.tgz#3c4836831b72cb198ea24b3b6e3eece6ba491667"
-  integrity sha512-1mrUI6BQ/jEB1DEC8l5JsmrhQPAXs/zc5b7tgoYfRZ9IrHw4hc9v95RWOFJAGar5f2ujoI53HztN7X1BcZ7UgQ==
+react-devtools-core@^6.1.5:
+  version "6.1.5"
+  resolved "https://registry.yarnpkg.com/react-devtools-core/-/react-devtools-core-6.1.5.tgz#c5eca79209dab853a03b2158c034c5166975feee"
+  integrity sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==
   dependencies:
     shell-quote "^1.6.1"
     ws "^7"


### PR DESCRIPTION
Summary:
# Changelog:
[General] [Changed] - Bumped React DevTools to 6.1.5

Differential Revision: D77799615
