### PR TITLE
Remove last use of Metro deep imports

### DIFF
--- a/packages/react-native/scripts/packager-reporter.js
+++ b/packages/react-native/scripts/packager-reporter.js
@@ -14,7 +14,7 @@ let reporter /*: $FlowFixMe */;
 
 const logPath = process.env.RCT_PACKAGER_LOG_PATH;
 if (logPath != null && logPath !== '') {
-  const JsonReporter = require('metro/src/lib/JsonReporter');
+  const {JsonReporter} = require('metro');
   const fs = require('fs');
   const path = require('path');
   // $FlowFixMe[missing-type-arg]
@@ -27,7 +27,7 @@ if (logPath != null && logPath !== '') {
     }
   };
 } else {
-  reporter = require('metro/src/lib/TerminalReporter');
+  reporter = require('metro').TerminalReporter;
 }
 
 module.exports = reporter;


### PR DESCRIPTION
Summary:
Remove the last use of a Metro deep import in preparation for making all deep imports semver-private.

Changelog: [Internal]

Reviewed By: huntie

Differential Revision: D77450110


