### PR TITLE
chore: bump @react-native-community/cli* devDependencies to 20.0.0-alpha

### DIFF
--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -58,9 +58,9 @@
     }
   },
   "devDependencies": {
-    "@react-native-community/cli": "17.0.0",
-    "@react-native-community/cli-platform-android": "17.0.0",
-    "@react-native-community/cli-platform-ios": "17.0.0",
+    "@react-native-community/cli": "20.0.0-alpha.0",
+    "@react-native-community/cli-platform-android": "20.0.0-alpha.0",
+    "@react-native-community/cli-platform-ios": "20.0.0-alpha.0",
     "commander": "^12.0.0",
     "listr2": "^6.4.1",
     "rxjs": "npm:@react-native-community/rxjs@6.5.4-custom"


### PR DESCRIPTION
## Summary:

Upgrade `@react-native-community/cli` to version 20.

## Changelog:

[INTERNAL] [CHANGED] - Upgrade @react-native-community/cli to v20

## Test Plan:

n/a****