### PR TITLE
Add tests for durationThreshold option for PerformanceObserver

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.cpp
@@ -464,4 +464,8 @@ void NativePerformance::setCurrentTimeStampForTesting(
   forcedCurrentTimeStamp_ = ts;
 }
 
+void NativePerformance::clearEventCountsForTesting(jsi::Runtime& /*rt*/) {
+  PerformanceEntryReporter::getInstance()->clearEventCounts();
+}
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.h
@@ -97,6 +97,17 @@ class NativePerformance : public NativePerformanceCxxSpec<NativePerformance> {
       std::optional<HighResTimeStamp> startTime);
 
   // https://w3c.github.io/user-timing/#measure-method
+  std::tuple<HighResTimeStamp, HighResDuration> measure(
+      jsi::Runtime& rt,
+      std::string name,
+      std::optional<HighResTimeStamp> startTime,
+      std::optional<HighResTimeStamp> endTime,
+      std::optional<HighResDuration> duration,
+      std::optional<std::string> startMark,
+      std::optional<std::string> endMark);
+
+  // https://w3c.github.io/user-timing/#measure-method
+  [[deprecated("This method is deprecated. Use the measure method instead.")]]
   std::tuple<HighResTimeStamp, HighResDuration> measureWithResult(
       jsi::Runtime& rt,
       std::string name,

--- a/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.h
@@ -184,6 +184,13 @@ class NativePerformance : public NativePerformanceCxxSpec<NativePerformance> {
   // tracking.
   std::unordered_map<std::string, double> getReactNativeStartupTiming(
       jsi::Runtime& rt);
+
+#pragma mark - Testing
+
+  void setCurrentTimeStampForTesting(jsi::Runtime& rt, HighResTimeStamp ts);
+
+ private:
+  std::optional<HighResTimeStamp> forcedCurrentTimeStamp_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.h
@@ -199,6 +199,7 @@ class NativePerformance : public NativePerformanceCxxSpec<NativePerformance> {
 #pragma mark - Testing
 
   void setCurrentTimeStampForTesting(jsi::Runtime& rt, HighResTimeStamp ts);
+  void clearEventCountsForTesting(jsi::Runtime& rt);
 
  private:
   std::optional<HighResTimeStamp> forcedCurrentTimeStamp_;

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.cpp
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.cpp
@@ -213,6 +213,10 @@ PerformanceMeasure PerformanceEntryReporter::reportMeasure(
   return entry;
 }
 
+void PerformanceEntryReporter::clearEventCounts() {
+  eventCounts_.clear();
+}
+
 std::optional<HighResTimeStamp> PerformanceEntryReporter::getMarkTime(
     const std::string& markName) const {
   std::shared_lock lock(buffersMutex_);

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.h
@@ -81,6 +81,8 @@ class PerformanceEntryReporter {
     return eventCounts_;
   }
 
+  void clearEventCounts();
+
   std::optional<HighResTimeStamp> getMarkTime(
       const std::string& markName) const;
 

--- a/packages/react-native/src/private/webapis/performance/Performance.js
+++ b/packages/react-native/src/private/webapis/performance/Performance.js
@@ -38,12 +38,17 @@ declare var global: {
 const getCurrentTimeStamp: () => DOMHighResTimeStamp =
   NativePerformance?.now ?? global.nativePerformanceNow ?? (() => Date.now());
 
-export type PerformanceMeasureOptions = {
-  detail?: DetailType,
-  start?: DOMHighResTimeStamp,
-  duration?: DOMHighResTimeStamp,
-  end?: DOMHighResTimeStamp,
-};
+export type PerformanceMeasureOptions =
+  | {
+      detail?: DetailType,
+      start?: DOMHighResTimeStamp | string,
+      duration?: DOMHighResTimeStamp,
+    }
+  | {
+      detail?: DetailType,
+      start?: DOMHighResTimeStamp | string,
+      end?: DOMHighResTimeStamp | string,
+    };
 
 const ENTRY_TYPES_AVAILABLE_FROM_TIMELINE: $ReadOnlyArray<PerformanceEntryType> =
   ['mark', 'measure'];

--- a/packages/react-native/src/private/webapis/performance/Performance.js
+++ b/packages/react-native/src/private/webapis/performance/Performance.js
@@ -116,11 +116,34 @@ export default class Performance {
     markName: string,
     markOptions?: PerformanceMarkOptions,
   ): PerformanceMark {
+    if (markName == null) {
+      throw new TypeError(
+        `Failed to execute 'mark' on 'Performance': 1 argument required, but only 0 present.`,
+      );
+    }
+
     let computedStartTime;
     if (NativePerformance?.markWithResult) {
+      let resolvedStartTime;
+
+      const startTime = markOptions?.startTime;
+      if (startTime !== undefined) {
+        resolvedStartTime = Number(startTime);
+        if (resolvedStartTime < 0) {
+          throw new TypeError(
+            `Failed to execute 'mark' on 'Performance': '${markName}' cannot have a negative start time.`,
+          );
+        } else if (!Number.isFinite(resolvedStartTime)) {
+          throw new TypeError(
+            `Failed to execute 'mark' on 'Performance': Failed to read the 'startTime' property from 'PerformanceMarkOptions': The provided double value is non-finite.`,
+          );
+        }
+      }
+
+      // $FlowExpectedError[not-a-function]
       computedStartTime = NativePerformance.markWithResult(
         markName,
-        markOptions?.startTime,
+        resolvedStartTime,
       );
     } else {
       warnNoNativePerformance();
@@ -147,66 +170,132 @@ export default class Performance {
     startMarkOrOptions?: string | PerformanceMeasureOptions,
     endMark?: string,
   ): PerformanceMeasure {
-    let options;
-    let startMarkName,
-      endMarkName = endMark,
-      duration,
-      startTime = 0,
-      endTime = 0;
+    let resolvedStartTime: number | void;
+    let resolvedStartMark: string | void;
+    let resolvedEndTime: number | void;
+    let resolvedEndMark: string | void;
+    let resolvedDuration: number | void;
+    let resolvedDetail: mixed;
 
-    if (typeof startMarkOrOptions === 'string') {
-      startMarkName = startMarkOrOptions;
-      options = {};
-    } else if (startMarkOrOptions !== undefined) {
-      options = startMarkOrOptions;
-      if (endMark !== undefined) {
-        throw new TypeError(
-          "Performance.measure: Can't have both options and endMark",
-        );
-      }
-      if (options.start === undefined && options.end === undefined) {
-        throw new TypeError(
-          'Performance.measure: Must have at least one of start/end specified in options',
-        );
-      }
-      if (
-        options.start !== undefined &&
-        options.end !== undefined &&
-        options.duration !== undefined
-      ) {
-        throw new TypeError(
-          "Performance.measure: Can't have both start/end and duration explicitly in options",
-        );
-      }
+    if (startMarkOrOptions != null) {
+      switch (typeof startMarkOrOptions) {
+        case 'object': {
+          if (endMark != null) {
+            throw new TypeError(
+              `Failed to execute 'measure' on 'Performance': If a non-empty PerformanceMeasureOptions object was passed, |end_mark| must not be passed.`,
+            );
+          }
 
-      if (typeof options.start === 'number') {
-        startTime = options.start;
-      } else {
-        startMarkName = options.start;
-      }
+          const start = startMarkOrOptions.start;
+          switch (typeof start) {
+            case 'number': {
+              resolvedStartTime = start;
+              break;
+            }
+            case 'string': {
+              resolvedStartMark = start;
+              break;
+            }
+            case 'undefined': {
+              break;
+            }
+            default: {
+              resolvedStartMark = String(start);
+            }
+          }
 
-      if (typeof options.end === 'number') {
-        endTime = options.end;
-      } else {
-        endMarkName = options.end;
-      }
+          const end = startMarkOrOptions.end;
+          switch (typeof end) {
+            case 'number': {
+              resolvedEndTime = end;
+              break;
+            }
+            case 'string': {
+              resolvedEndMark = end;
+              break;
+            }
+            case 'undefined': {
+              break;
+            }
+            default: {
+              resolvedEndMark = String(end);
+            }
+          }
 
-      duration = options.duration ?? duration;
+          const duration = startMarkOrOptions.duration;
+          switch (typeof duration) {
+            case 'number': {
+              resolvedDuration = duration;
+              break;
+            }
+            case 'undefined':
+              break;
+            default: {
+              resolvedDuration = Number(duration);
+              if (!Number.isFinite(resolvedDuration)) {
+                throw new TypeError(
+                  `Failed to execute 'measure' on 'Performance': Failed to read the 'duration' property from 'PerformanceMeasureOptions': The provided double value is non-finite.`,
+                );
+              }
+            }
+          }
+
+          if (
+            resolvedDuration != null &&
+            (resolvedEndMark != null || resolvedEndTime != null)
+          ) {
+            throw new TypeError(
+              `Failed to execute 'measure' on 'Performance': If a non-empty PerformanceMeasureOptions object was passed, it must not have all of its 'start', 'duration', and 'end' properties defined`,
+            );
+          }
+
+          resolvedDetail = startMarkOrOptions.detail;
+
+          break;
+        }
+        case 'string': {
+          resolvedStartMark = startMarkOrOptions;
+
+          if (endMark !== undefined) {
+            resolvedEndMark = String(endMark);
+          }
+          break;
+        }
+        default: {
+          resolvedStartMark = String(startMarkOrOptions);
+        }
+      }
     }
 
-    let computedStartTime = startTime;
-    let computedDuration = duration;
+    let computedStartTime = 0;
+    let computedDuration = 0;
 
-    if (NativePerformance?.measureWithResult) {
+    if (NativePerformance?.measure) {
+      try {
+        [computedStartTime, computedDuration] = NativePerformance.measure(
+          measureName,
+          resolvedStartTime,
+          resolvedEndTime,
+          resolvedDuration,
+          resolvedStartMark,
+          resolvedEndMark,
+        );
+      } catch (error) {
+        throw new DOMException(
+          "Failed to execute 'measure' on 'Performance': " + error.message,
+          'SyntaxError',
+        );
+      }
+    } else if (NativePerformance?.measureWithResult) {
       try {
         [computedStartTime, computedDuration] =
           NativePerformance.measureWithResult(
             measureName,
-            startTime,
-            endTime,
-            duration,
-            startMarkName,
-            endMarkName,
+            resolvedStartTime ?? 0,
+            resolvedEndTime ?? 0,
+            resolvedDuration,
+            resolvedStartMark,
+            resolvedEndMark,
           );
       } catch (error) {
         throw new DOMException(
@@ -221,7 +310,7 @@ export default class Performance {
     const measure = new PerformanceMeasure(measureName, {
       startTime: computedStartTime,
       duration: computedDuration ?? 0,
-      detail: options?.detail,
+      detail: resolvedDetail,
     });
 
     return measure;

--- a/packages/react-native/src/private/webapis/performance/PerformanceEntry.js
+++ b/packages/react-native/src/private/webapis/performance/PerformanceEntry.js
@@ -29,10 +29,14 @@ export type PerformanceEntryJSON = {
 };
 
 export class PerformanceEntry {
-  #name: string;
-  #entryType: PerformanceEntryType;
-  #startTime: DOMHighResTimeStamp;
-  #duration: DOMHighResTimeStamp;
+  // We don't use private fields because they're significantly slower to
+  // initialize on construction and to access.
+  // We also need these to be protected so they can be initialized in subclasses
+  // where we avoid calling `super()` for performance reasons.
+  __name: string;
+  __entryType: PerformanceEntryType;
+  __startTime: DOMHighResTimeStamp;
+  __duration: DOMHighResTimeStamp;
 
   constructor(init: {
     name: string,
@@ -40,34 +44,34 @@ export class PerformanceEntry {
     startTime: DOMHighResTimeStamp,
     duration: DOMHighResTimeStamp,
   }) {
-    this.#name = init.name;
-    this.#entryType = init.entryType;
-    this.#startTime = init.startTime;
-    this.#duration = init.duration;
+    this.__name = init.name;
+    this.__entryType = init.entryType;
+    this.__startTime = init.startTime;
+    this.__duration = init.duration;
   }
 
   get name(): string {
-    return this.#name;
+    return this.__name;
   }
 
   get entryType(): PerformanceEntryType {
-    return this.#entryType;
+    return this.__entryType;
   }
 
   get startTime(): DOMHighResTimeStamp {
-    return this.#startTime;
+    return this.__startTime;
   }
 
   get duration(): DOMHighResTimeStamp {
-    return this.#duration;
+    return this.__duration;
   }
 
   toJSON(): PerformanceEntryJSON {
     return {
-      name: this.#name,
-      entryType: this.#entryType,
-      startTime: this.#startTime,
-      duration: this.#duration,
+      name: this.__name,
+      entryType: this.__entryType,
+      startTime: this.__startTime,
+      duration: this.__duration,
     };
   }
 }

--- a/packages/react-native/src/private/webapis/performance/UserTiming.js
+++ b/packages/react-native/src/private/webapis/performance/UserTiming.js
@@ -29,9 +29,12 @@ export type PerformanceMeasureInit = {
   duration: DOMHighResTimeStamp,
 };
 
-export class PerformanceMark extends PerformanceEntry {
-  #detail: DetailType;
+class PerformanceMarkTemplate extends PerformanceEntry {
+  // We don't use private fields because they're significantly slower to
+  // initialize on construction and to access.
+  _detail: DetailType;
 
+  // This constructor isn't really used. See `PerformanceMark` below.
   constructor(markName: string, markOptions?: PerformanceMarkOptions) {
     super({
       name: markName,
@@ -41,18 +44,46 @@ export class PerformanceMark extends PerformanceEntry {
     });
 
     if (markOptions) {
-      this.#detail = markOptions.detail;
+      this._detail = markOptions.detail;
     }
   }
 
   get detail(): DetailType {
-    return this.#detail;
+    return this._detail;
   }
 }
 
-export class PerformanceMeasure extends PerformanceEntry {
-  #detail: DetailType;
+// This is the real value we're exporting where we define the class a function
+// so we don't need to call `super()` and we can avoid the performance penalty
+// of the current code transpiled with Babel.
+// We should remove this when we have built-in support for classes in the
+// runtime.
+export const PerformanceMark: typeof PerformanceMarkTemplate =
+  // $FlowExpectedError[incompatible-type]
+  function PerformanceMark(
+    this: PerformanceMarkTemplate,
+    markName: string,
+    markOptions?: PerformanceMarkOptions,
+  ) {
+    this.__name = markName;
+    this.__entryType = 'mark';
+    this.__startTime = markOptions?.startTime ?? performance.now();
+    this.__duration = 0;
 
+    if (markOptions) {
+      this._detail = markOptions.detail;
+    }
+  };
+
+// $FlowExpectedError[prop-missing]
+PerformanceMark.prototype = PerformanceMarkTemplate.prototype;
+
+class PerformanceMeasureTemplate extends PerformanceEntry {
+  // We don't use private fields because they're significantly slower to
+  // initialize on construction and to access.
+  _detail: DetailType;
+
+  // This constructor isn't really used. See `PerformanceMeasure` below.
   constructor(measureName: string, measureOptions: PerformanceMeasureInit) {
     super({
       name: measureName,
@@ -62,11 +93,32 @@ export class PerformanceMeasure extends PerformanceEntry {
     });
 
     if (measureOptions) {
-      this.#detail = measureOptions.detail;
+      this._detail = measureOptions.detail;
     }
   }
 
   get detail(): DetailType {
-    return this.#detail;
+    return this._detail;
   }
 }
+
+// We do the same here as we do for `PerformanceMark` for performance reasons.
+export const PerformanceMeasure: typeof PerformanceMeasureTemplate =
+  // $FlowExpectedError[incompatible-type]
+  function PerformanceMeasure(
+    this: PerformanceMeasureTemplate,
+    measureName: string,
+    measureOptions: PerformanceMeasureInit,
+  ) {
+    this.__name = measureName;
+    this.__entryType = 'measure';
+    this.__startTime = measureOptions.startTime;
+    this.__duration = measureOptions.duration;
+
+    if (measureOptions) {
+      this._detail = measureOptions.detail;
+    }
+  };
+
+// $FlowExpectedError[prop-missing]
+PerformanceMeasure.prototype = PerformanceMeasureTemplate.prototype;

--- a/packages/react-native/src/private/webapis/performance/__tests__/EventTimingAPI-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/EventTimingAPI-itest.js
@@ -10,8 +10,10 @@
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
+import type Performance from 'react-native/src/private/webapis/performance/Performance';
 import type {PerformanceObserverEntryList} from 'react-native/src/private/webapis/performance/PerformanceObserver';
 
+import NativePerformance from '../specs/NativePerformance';
 import * as Fantom from '@react-native/fantom';
 import nullthrows from 'nullthrows';
 import {useState} from 'react';
@@ -21,6 +23,8 @@ import {PerformanceEventTiming} from 'react-native/src/private/webapis/performan
 import {PerformanceObserver} from 'react-native/src/private/webapis/performance/PerformanceObserver';
 
 setUpPerformanceObserver();
+
+declare var performance: Performance;
 
 function sleep(ms: number) {
   const end = performance.now() + ms;
@@ -186,5 +190,62 @@ describe('Event Timing API', () => {
     // TODO: When Fantom provides structured data from mounting manager, add timestamp to operations and verify that the duration includes that.
 
     expect(entry.interactionId).toBeGreaterThanOrEqual(0);
+  });
+
+  it('reports number of dispatched events via performance.eventCounts', () => {
+    NativePerformance?.clearEventCountsForTesting?.();
+
+    const root = Fantom.createRoot();
+    Fantom.runTask(() => {
+      root.render(<View />);
+    });
+
+    const element = nullthrows(root.document.documentElement.firstElementChild);
+
+    expect(performance.eventCounts).not.toBeInstanceOf(Map);
+
+    // FIXME: this isn't spec compliant, as the map should be prepopulated with
+    // all the supported event names mapped to 0.
+    expect(performance.eventCounts.size).toBe(0);
+    expect([...performance.eventCounts.entries()]).toEqual([]);
+    const initialForEachCallback = jest.fn();
+    performance.eventCounts.forEach(initialForEachCallback);
+    expect(initialForEachCallback.mock.calls).toEqual([]);
+    expect([...performance.eventCounts.keys()]).toEqual([]);
+    expect([...performance.eventCounts.values()]).toEqual([]);
+
+    Fantom.dispatchNativeEvent(element, 'click');
+    Fantom.dispatchNativeEvent(element, 'click');
+    Fantom.dispatchNativeEvent(element, 'click');
+
+    Fantom.dispatchNativeEvent(element, 'pointerDown');
+    Fantom.dispatchNativeEvent(element, 'pointerUp');
+
+    expect(performance.eventCounts.size).toBe(3);
+    expect(performance.eventCounts.get('click')).toBe(3);
+    expect(performance.eventCounts.get('pointerdown')).toBe(1);
+    expect(performance.eventCounts.get('pointerup')).toBe(1);
+
+    expect([...performance.eventCounts.entries()]).toEqual([
+      ['pointerup', 1],
+      ['pointerdown', 1],
+      ['click', 3],
+    ]);
+
+    const forEachCallback = jest.fn();
+    performance.eventCounts.forEach(forEachCallback);
+    expect(forEachCallback.mock.calls).toEqual([
+      [1, 'pointerup', performance.eventCounts],
+      [1, 'pointerdown', performance.eventCounts],
+      [3, 'click', performance.eventCounts],
+    ]);
+
+    expect([...performance.eventCounts.keys()]).toEqual([
+      'pointerup',
+      'pointerdown',
+      'click',
+    ]);
+
+    expect([...performance.eventCounts.values()]).toEqual([1, 1, 3]);
   });
 });

--- a/packages/react-native/src/private/webapis/performance/__tests__/Performance-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/Performance-itest.js
@@ -8,32 +8,424 @@
  * @format
  */
 
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
+
 import type Performance from '../Performance';
 
-import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
+import ensureInstance from '../../../__tests__/utilities/ensureInstance';
+import DOMException from '../../errors/DOMException';
+import NativePerformance from '../specs/NativePerformance';
+import {PerformanceMark, PerformanceMeasure} from '../UserTiming';
+
+/* eslint-disable jest/no-disabled-tests */
 
 declare var performance: Performance;
 
+function getThrownError(fn: () => mixed): mixed {
+  try {
+    fn();
+  } catch (e) {
+    return e;
+  }
+  throw new Error('Expected function to throw');
+}
+
 describe('Performance', () => {
-  it('measure validates mark names presence in the buffer, if specified', () => {
-    expect(() => {
-      performance.measure('measure', 'start', 'end');
-    }).toThrow(
-      "Failed to execute 'measure' on 'Performance': The mark 'start' does not exist.",
-    ); // This should also check that Error is an instance of DOMException and is SyntaxError,
-    // but toThrow checked currently only supports string argument.
+  beforeEach(() => {
+    performance.clearMarks();
+    performance.clearMeasures();
+  });
 
-    performance.mark('start');
-    expect(() => {
-      performance.measure('measure', 'start', 'end');
-    }).toThrow(
-      "Failed to execute 'measure' on 'Performance': The mark 'end' does not exist.",
-    ); // This should also check that Error is an instance of DOMException and is SyntaxError,
-    // but toThrow checked currently only supports string argument.
+  describe('mark', () => {
+    it('works with default timestamp', () => {
+      NativePerformance?.setCurrentTimeStampForTesting?.(25);
 
-    performance.mark('end');
-    expect(() => {
-      performance.measure('measure', 'start', 'end');
-    }).not.toThrow();
+      const mark = performance.mark('mark-now');
+
+      expect(mark).toBeInstanceOf(PerformanceMark);
+      expect(mark.entryType).toBe('mark');
+      expect(mark.name).toBe('mark-now');
+      expect(mark.startTime).toBe(25);
+      expect(mark.duration).toBe(0);
+      expect(mark.detail).toBeUndefined();
+    });
+
+    it('works with custom timestamp', () => {
+      const mark = performance.mark('mark-custom', {startTime: 10});
+
+      expect(mark).toBeInstanceOf(PerformanceMark);
+      expect(mark.entryType).toBe('mark');
+      expect(mark.name).toBe('mark-custom');
+      expect(mark.startTime).toBe(10);
+      expect(mark.duration).toBe(0);
+      expect(mark.detail).toBeUndefined();
+    });
+
+    it('provides detail', () => {
+      const originalDetail = {foo: 'bar'};
+
+      const mark = performance.mark('some-mark', {
+        detail: originalDetail,
+      });
+
+      expect(mark.detail).toEqual(originalDetail);
+      // TODO structuredClone
+      // expect(mark.detail).not.toBe(originalDetail);
+    });
+
+    it.skip('throws if no name is provided', () => {
+      expect(() => {
+        // $FlowExpectedError[incompatible-call]
+        performance.mark();
+      }).toThrow(
+        `Failed to execute 'mark' on 'Performance': 1 argument required, but only 0 present.`,
+      );
+    });
+
+    it.skip('casts startTime to a number', () => {
+      const mark = performance.mark('some-mark', {
+        // $FlowExpectedError[incompatible-call]
+        startTime: '10',
+      });
+
+      expect(mark.startTime).toBe(10);
+
+      const mark2 = performance.mark('some-mark', {
+        // $FlowExpectedError[incompatible-call]
+        startTime: null,
+      });
+
+      expect(mark2.startTime).toBe(0);
+    });
+
+    it.skip('throws if startTime cannot be converted to a finite number', () => {
+      expect(() => {
+        performance.mark('some-mark', {startTime: NaN});
+      }).toThrow(
+        `Failed to execute 'mark' on 'Performance': Failed to read the 'startTime' property from 'PerformanceMarkOptions': The provided double value is non-finite.`,
+      );
+
+      expect(() => {
+        // $FlowExpectedError[incompatible-call]
+        performance.mark('some-mark', {startTime: {}});
+      }).toThrow(
+        `Failed to execute 'mark' on 'Performance': Failed to read the 'startTime' property from 'PerformanceMarkOptions': The provided double value is non-finite.`,
+      );
+    });
+
+    it.skip('throws if startTime is negative', () => {
+      expect(() => {
+        performance.mark('some-mark', {startTime: -1});
+      }).toThrow(
+        `Failed to execute 'mark' on 'Performance': 'some-mark' cannot have a negative start time.`,
+      );
+    });
+  });
+
+  describe('measure', () => {
+    describe('with measureOptions', () => {
+      it.skip('uses 0 as default start and now as default end', () => {
+        NativePerformance?.setCurrentTimeStampForTesting?.(25);
+
+        const measure = performance.measure('measure-with-defaults', {});
+
+        expect(measure).toBeInstanceOf(PerformanceMeasure);
+        expect(measure.entryType).toBe('measure');
+        expect(measure.name).toBe('measure-with-defaults');
+        expect(measure.startTime).toBe(0);
+        expect(measure.duration).toBe(25);
+        expect(measure.detail).toBeUndefined();
+      });
+
+      it.skip('works with a start timestamp', () => {
+        NativePerformance?.setCurrentTimeStampForTesting?.(25);
+
+        const measure = performance.measure('measure-with-start-timestamp', {
+          start: 10,
+        });
+
+        expect(measure).toBeInstanceOf(PerformanceMeasure);
+        expect(measure.entryType).toBe('measure');
+        expect(measure.name).toBe('measure-with-start-timestamp');
+        expect(measure.startTime).toBe(10);
+        expect(measure.duration).toBe(15);
+        expect(measure.detail).toBeUndefined();
+      });
+
+      it.skip('works with start mark', () => {
+        NativePerformance?.setCurrentTimeStampForTesting?.(25);
+
+        performance.mark('start-mark', {
+          startTime: 10,
+        });
+
+        // $FlowFixMe[incompatible-call]
+        const measure = performance.measure('measure-with-start-mark', {
+          start: 'start-mark',
+        });
+
+        expect(measure).toBeInstanceOf(PerformanceMeasure);
+        expect(measure.entryType).toBe('measure');
+        expect(measure.name).toBe('measure-with-start-mark');
+        expect(measure.startTime).toBe(10);
+        expect(measure.duration).toBe(15);
+        expect(measure.detail).toBeUndefined();
+      });
+
+      it.skip('works with end mark', () => {
+        NativePerformance?.setCurrentTimeStampForTesting?.(25);
+
+        performance.mark('end-mark', {
+          startTime: 50,
+        });
+
+        // $FlowFixMe[incompatible-call]
+        const measure = performance.measure('measure-with-end-mark', {
+          end: 'end-mark',
+        });
+
+        expect(measure).toBeInstanceOf(PerformanceMeasure);
+        expect(measure.entryType).toBe('measure');
+        expect(measure.name).toBe('measure-with-end-mark');
+        expect(measure.startTime).toBe(0);
+        expect(measure.duration).toBe(50);
+        expect(measure.detail).toBeUndefined();
+      });
+
+      it.skip('works with start mark and end mark', () => {
+        NativePerformance?.setCurrentTimeStampForTesting?.(25);
+
+        performance.mark('start-mark', {
+          startTime: 10,
+        });
+
+        performance.mark('end-mark', {
+          startTime: 50,
+        });
+
+        const measure = performance.measure(
+          'measure-with-start-mark-and-end-mark',
+          // $FlowFixMe[incompatible-call]
+          {
+            start: 'start-mark',
+            end: 'end-mark',
+          },
+        );
+
+        expect(measure).toBeInstanceOf(PerformanceMeasure);
+        expect(measure.entryType).toBe('measure');
+        expect(measure.name).toBe('measure-with-start-mark-and-end-mark');
+        expect(measure.startTime).toBe(10);
+        expect(measure.duration).toBe(40);
+        expect(measure.detail).toBeUndefined();
+      });
+
+      it('works with a start timestamp and an end timestamp', () => {
+        const measure = performance.measure(
+          'measure-with-start-timestamp-and-end-timestamp',
+          {
+            start: 10,
+            end: 25,
+          },
+        );
+
+        expect(measure).toBeInstanceOf(PerformanceMeasure);
+        expect(measure.entryType).toBe('measure');
+        expect(measure.name).toBe(
+          'measure-with-start-timestamp-and-end-timestamp',
+        );
+        expect(measure.startTime).toBe(10);
+        expect(measure.duration).toBe(15);
+        expect(measure.detail).toBeUndefined();
+      });
+
+      it.skip('works with a start timestamp and a duration', () => {
+        const measure = performance.measure(
+          'measure-with-start-timestamp-and-duration',
+          {
+            start: 10,
+            duration: 30,
+          },
+        );
+
+        expect(measure).toBeInstanceOf(PerformanceMeasure);
+        expect(measure.entryType).toBe('measure');
+        expect(measure.name).toBe('measure-with-start-timestamp-and-duration');
+        expect(measure.startTime).toBe(10);
+        expect(measure.duration).toBe(30);
+        expect(measure.detail).toBeUndefined();
+      });
+
+      it.skip('works with a start mark and a duration', () => {
+        performance.mark('start-mark', {
+          startTime: 10,
+        });
+
+        const measure = performance.measure(
+          'measure-with-start-mark-and-duration',
+          // $FlowFixMe[incompatible-call]
+          {
+            start: 'start-mark',
+            duration: 30,
+          },
+        );
+
+        expect(measure).toBeInstanceOf(PerformanceMeasure);
+        expect(measure.entryType).toBe('measure');
+        expect(measure.name).toBe('measure-with-start-mark-and-duration');
+        expect(measure.startTime).toBe(10);
+        expect(measure.duration).toBe(30);
+        expect(measure.detail).toBeUndefined();
+      });
+
+      it('throws if the specified mark does NOT exist', () => {
+        const missingStartMarkError = ensureInstance(
+          getThrownError(() => {
+            // $FlowFixMe[incompatible-call]
+            performance.measure('measure', {
+              start: 'start',
+              end: 'end',
+            });
+          }),
+          DOMException,
+        );
+
+        expect(missingStartMarkError.name).toBe('SyntaxError');
+        expect(missingStartMarkError.message).toBe(
+          "Failed to execute 'measure' on 'Performance': The mark 'start' does not exist.",
+        );
+
+        performance.mark('start');
+
+        const missingEndMarkError = ensureInstance(
+          getThrownError(() => {
+            // $FlowFixMe[incompatible-call]
+            performance.measure('measure', {
+              start: 'start',
+              end: 'end',
+            });
+          }),
+          DOMException,
+        );
+
+        expect(missingEndMarkError.message).toBe(
+          "Failed to execute 'measure' on 'Performance': The mark 'end' does not exist.",
+        );
+
+        performance.mark('end');
+        expect(() => {
+          // $FlowFixMe[incompatible-call]
+          performance.measure('measure', {
+            start: 'start',
+            end: 'end',
+          });
+        }).not.toThrow();
+      });
+    });
+
+    describe('with startMark / endMark', () => {
+      it.skip('uses 0 as default start and now as default end', () => {
+        NativePerformance?.setCurrentTimeStampForTesting?.(25);
+
+        const measure = performance.measure('measure-with-defaults', undefined);
+
+        expect(measure).toBeInstanceOf(PerformanceMeasure);
+        expect(measure.entryType).toBe('measure');
+        expect(measure.name).toBe('measure-with-defaults');
+        expect(measure.startTime).toBe(0);
+        expect(measure.duration).toBe(25);
+        expect(measure.detail).toBeUndefined();
+      });
+
+      it.skip('works with startMark', () => {
+        NativePerformance?.setCurrentTimeStampForTesting?.(25);
+
+        performance.mark('start-mark', {
+          startTime: 10,
+        });
+
+        const measure = performance.measure(
+          'measure-with-start-mark',
+          'start-mark',
+        );
+
+        expect(measure).toBeInstanceOf(PerformanceMeasure);
+        expect(measure.entryType).toBe('measure');
+        expect(measure.name).toBe('measure-with-start-mark');
+        expect(measure.startTime).toBe(10);
+        expect(measure.duration).toBe(15);
+        expect(measure.detail).toBeUndefined();
+      });
+
+      it.skip('works with startMark and endMark', () => {
+        NativePerformance?.setCurrentTimeStampForTesting?.(25);
+
+        performance.mark('start-mark', {
+          startTime: 10,
+        });
+
+        performance.mark('end-mark', {
+          startTime: 25,
+        });
+
+        const measure = performance.measure(
+          'measure-with-start-mark-and-end-mark',
+          'start-mark',
+        );
+
+        expect(measure).toBeInstanceOf(PerformanceMeasure);
+        expect(measure.entryType).toBe('measure');
+        expect(measure.name).toBe('measure-with-start-mark-and-end-mark');
+        expect(measure.startTime).toBe(10);
+        expect(measure.duration).toBe(15);
+        expect(measure.detail).toBeUndefined();
+      });
+
+      it('throws if the specified marks do NOT exist', () => {
+        const missingStartMarkError = ensureInstance(
+          getThrownError(() => {
+            performance.measure('measure', 'start', 'end');
+          }),
+          DOMException,
+        );
+
+        expect(missingStartMarkError.name).toBe('SyntaxError');
+        expect(missingStartMarkError.message).toBe(
+          "Failed to execute 'measure' on 'Performance': The mark 'start' does not exist.",
+        );
+
+        performance.mark('start');
+
+        const missingEndMarkError = ensureInstance(
+          getThrownError(() => {
+            performance.measure('measure', 'start', 'end');
+          }),
+          DOMException,
+        );
+
+        expect(missingEndMarkError.message).toBe(
+          "Failed to execute 'measure' on 'Performance': The mark 'end' does not exist.",
+        );
+
+        performance.mark('end');
+        expect(() => {
+          performance.measure('measure', 'start', 'end');
+        }).not.toThrow();
+      });
+    });
+
+    it('provides detail', () => {
+      const originalDetail = {foo: 'bar'};
+
+      const measure = performance.measure('measure-with-detail', {
+        start: 10,
+        end: 20,
+        detail: originalDetail,
+      });
+
+      expect(measure.detail).toEqual(originalDetail);
+      // TODO structuredClone
+      // expect(measure.detail).not.toBe(originalDetail);
+    });
   });
 });

--- a/packages/react-native/src/private/webapis/performance/__tests__/Performance-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/Performance-itest.js
@@ -159,7 +159,6 @@ describe('Performance', () => {
           startTime: 10,
         });
 
-        // $FlowFixMe[incompatible-call]
         const measure = performance.measure('measure-with-start-mark', {
           start: 'start-mark',
         });
@@ -179,7 +178,6 @@ describe('Performance', () => {
           startTime: 50,
         });
 
-        // $FlowFixMe[incompatible-call]
         const measure = performance.measure('measure-with-end-mark', {
           end: 'end-mark',
         });
@@ -205,7 +203,6 @@ describe('Performance', () => {
 
         const measure = performance.measure(
           'measure-with-start-mark-and-end-mark',
-          // $FlowFixMe[incompatible-call]
           {
             start: 'start-mark',
             end: 'end-mark',
@@ -263,7 +260,6 @@ describe('Performance', () => {
 
         const measure = performance.measure(
           'measure-with-start-mark-and-duration',
-          // $FlowFixMe[incompatible-call]
           {
             start: 'start-mark',
             duration: 30,
@@ -281,7 +277,6 @@ describe('Performance', () => {
       it('throws if the specified mark does NOT exist', () => {
         const missingStartMarkError = ensureInstance(
           getThrownError(() => {
-            // $FlowFixMe[incompatible-call]
             performance.measure('measure', {
               start: 'start',
               end: 'end',
@@ -299,7 +294,6 @@ describe('Performance', () => {
 
         const missingEndMarkError = ensureInstance(
           getThrownError(() => {
-            // $FlowFixMe[incompatible-call]
             performance.measure('measure', {
               start: 'start',
               end: 'end',
@@ -314,7 +308,6 @@ describe('Performance', () => {
 
         performance.mark('end');
         expect(() => {
-          // $FlowFixMe[incompatible-call]
           performance.measure('measure', {
             start: 'start',
             end: 'end',

--- a/packages/react-native/src/private/webapis/performance/__tests__/Performance-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/Performance-itest.js
@@ -17,8 +17,6 @@ import DOMException from '../../errors/DOMException';
 import NativePerformance from '../specs/NativePerformance';
 import {PerformanceMark, PerformanceMeasure} from '../UserTiming';
 
-/* eslint-disable jest/no-disabled-tests */
-
 declare var performance: Performance;
 
 function getThrownError(fn: () => mixed): mixed {
@@ -73,7 +71,7 @@ describe('Performance', () => {
       // expect(mark.detail).not.toBe(originalDetail);
     });
 
-    it.skip('throws if no name is provided', () => {
+    it('throws if no name is provided', () => {
       expect(() => {
         // $FlowExpectedError[incompatible-call]
         performance.mark();
@@ -82,7 +80,7 @@ describe('Performance', () => {
       );
     });
 
-    it.skip('casts startTime to a number', () => {
+    it('casts startTime to a number', () => {
       const mark = performance.mark('some-mark', {
         // $FlowExpectedError[incompatible-call]
         startTime: '10',
@@ -98,7 +96,7 @@ describe('Performance', () => {
       expect(mark2.startTime).toBe(0);
     });
 
-    it.skip('throws if startTime cannot be converted to a finite number', () => {
+    it('throws if startTime cannot be converted to a finite number', () => {
       expect(() => {
         performance.mark('some-mark', {startTime: NaN});
       }).toThrow(
@@ -113,7 +111,7 @@ describe('Performance', () => {
       );
     });
 
-    it.skip('throws if startTime is negative', () => {
+    it('throws if startTime is negative', () => {
       expect(() => {
         performance.mark('some-mark', {startTime: -1});
       }).toThrow(
@@ -124,7 +122,7 @@ describe('Performance', () => {
 
   describe('measure', () => {
     describe('with measureOptions', () => {
-      it.skip('uses 0 as default start and now as default end', () => {
+      it('uses 0 as default start and now as default end', () => {
         NativePerformance?.setCurrentTimeStampForTesting?.(25);
 
         const measure = performance.measure('measure-with-defaults', {});
@@ -137,7 +135,7 @@ describe('Performance', () => {
         expect(measure.detail).toBeUndefined();
       });
 
-      it.skip('works with a start timestamp', () => {
+      it('works with a start timestamp', () => {
         NativePerformance?.setCurrentTimeStampForTesting?.(25);
 
         const measure = performance.measure('measure-with-start-timestamp', {
@@ -152,7 +150,7 @@ describe('Performance', () => {
         expect(measure.detail).toBeUndefined();
       });
 
-      it.skip('works with start mark', () => {
+      it('works with start mark', () => {
         NativePerformance?.setCurrentTimeStampForTesting?.(25);
 
         performance.mark('start-mark', {
@@ -171,7 +169,7 @@ describe('Performance', () => {
         expect(measure.detail).toBeUndefined();
       });
 
-      it.skip('works with end mark', () => {
+      it('works with end mark', () => {
         NativePerformance?.setCurrentTimeStampForTesting?.(25);
 
         performance.mark('end-mark', {
@@ -190,7 +188,7 @@ describe('Performance', () => {
         expect(measure.detail).toBeUndefined();
       });
 
-      it.skip('works with start mark and end mark', () => {
+      it('works with start mark and end mark', () => {
         NativePerformance?.setCurrentTimeStampForTesting?.(25);
 
         performance.mark('start-mark', {
@@ -236,7 +234,7 @@ describe('Performance', () => {
         expect(measure.detail).toBeUndefined();
       });
 
-      it.skip('works with a start timestamp and a duration', () => {
+      it('works with a start timestamp and a duration', () => {
         const measure = performance.measure(
           'measure-with-start-timestamp-and-duration',
           {
@@ -253,7 +251,7 @@ describe('Performance', () => {
         expect(measure.detail).toBeUndefined();
       });
 
-      it.skip('works with a start mark and a duration', () => {
+      it('works with a start mark and a duration', () => {
         performance.mark('start-mark', {
           startTime: 10,
         });
@@ -317,10 +315,10 @@ describe('Performance', () => {
     });
 
     describe('with startMark / endMark', () => {
-      it.skip('uses 0 as default start and now as default end', () => {
+      it('uses 0 as default start and now as default end', () => {
         NativePerformance?.setCurrentTimeStampForTesting?.(25);
 
-        const measure = performance.measure('measure-with-defaults', undefined);
+        const measure = performance.measure('measure-with-defaults');
 
         expect(measure).toBeInstanceOf(PerformanceMeasure);
         expect(measure.entryType).toBe('measure');
@@ -330,7 +328,7 @@ describe('Performance', () => {
         expect(measure.detail).toBeUndefined();
       });
 
-      it.skip('works with startMark', () => {
+      it('works with startMark', () => {
         NativePerformance?.setCurrentTimeStampForTesting?.(25);
 
         performance.mark('start-mark', {
@@ -350,7 +348,7 @@ describe('Performance', () => {
         expect(measure.detail).toBeUndefined();
       });
 
-      it.skip('works with startMark and endMark', () => {
+      it('works with startMark and endMark', () => {
         NativePerformance?.setCurrentTimeStampForTesting?.(25);
 
         performance.mark('start-mark', {

--- a/packages/react-native/src/private/webapis/performance/__tests__/Performance-test.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/Performance-test.js
@@ -63,7 +63,7 @@ describe('Performance', () => {
         startTime: 10,
       },
       {
-        duration: -10,
+        duration: 15,
         entryType: 'measure',
         name: 'measure-now-with-start-mark',
         startTime: 10,

--- a/packages/react-native/src/private/webapis/performance/specs/NativePerformance.js
+++ b/packages/react-native/src/private/webapis/performance/specs/NativePerformance.js
@@ -96,6 +96,8 @@ export interface Spec extends TurboModule {
   ) => $ReadOnlyArray<RawPerformanceEntry>;
 
   +getSupportedPerformanceEntryTypes?: () => $ReadOnlyArray<RawPerformanceEntryType>;
+
+  +setCurrentTimeStampForTesting?: (timeStamp: number) => void;
 }
 
 export default (TurboModuleRegistry.get<Spec>('NativePerformanceCxx'): ?Spec);

--- a/packages/react-native/src/private/webapis/performance/specs/NativePerformance.js
+++ b/packages/react-native/src/private/webapis/performance/specs/NativePerformance.js
@@ -107,6 +107,7 @@ export interface Spec extends TurboModule {
   +getSupportedPerformanceEntryTypes?: () => $ReadOnlyArray<RawPerformanceEntryType>;
 
   +setCurrentTimeStampForTesting?: (timeStamp: number) => void;
+  +clearEventCountsForTesting?: () => void;
 }
 
 export default (TurboModuleRegistry.get<Spec>('NativePerformanceCxx'): ?Spec);

--- a/packages/react-native/src/private/webapis/performance/specs/NativePerformance.js
+++ b/packages/react-native/src/private/webapis/performance/specs/NativePerformance.js
@@ -58,6 +58,15 @@ export interface Spec extends TurboModule {
     name: string,
     startTime?: number,
   ) => NativePerformanceMarkResult;
+  +measure?: (
+    name: string,
+    startTime?: number,
+    endTime?: number,
+    duration?: number,
+    startMark?: string,
+    endMark?: string,
+  ) => NativePerformanceMeasureResult;
+  // DEPRECATED: Use measure instead.
   +measureWithResult?: (
     name: string,
     startTime: number,

--- a/packages/react-native/src/private/webapis/performance/specs/__mocks__/NativePerformanceMock.js
+++ b/packages/react-native/src/private/webapis/performance/specs/__mocks__/NativePerformanceMock.js
@@ -127,16 +127,17 @@ const NativePerformanceMock = {
     return computedStartTime;
   },
 
-  measureWithResult: (
+  measure: (
     name: string,
-    startTime: number,
-    endTime: number,
+    startTime?: number,
+    endTime?: number,
     duration?: number,
     startMark?: string,
     endMark?: string,
   ): NativePerformanceMeasureResult => {
-    const start = startMark != null ? marks.get(startMark) : startTime;
-    const end = endMark != null ? marks.get(endMark) : endTime;
+    const start = startMark != null ? marks.get(startMark) : startTime ?? 0;
+    const end =
+      endMark != null ? marks.get(endMark) : endTime ?? performance.now();
 
     if (start === undefined) {
       throw new Error('startMark does not exist');


### PR DESCRIPTION
Summary:
Changelog: [internal]

This adds tests for the `durationThreshold` option for `PerformanceObserver.prototype.observe`.

Differential Revision: D77860882


