### PR TITLE
Deprecate MessageQueueThreadPerfStats

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1561,28 +1561,26 @@ public abstract interface class com/facebook/react/bridge/queue/MessageQueueThre
 	public abstract fun assertIsOnThread ()V
 	public abstract fun assertIsOnThread (Ljava/lang/String;)V
 	public abstract fun callOnQueue (Ljava/util/concurrent/Callable;)Ljava/util/concurrent/Future;
-	public abstract fun getPerfStats ()Lcom/facebook/react/bridge/queue/MessageQueueThreadPerfStats;
+	public fun getPerfStats ()Lcom/facebook/react/bridge/queue/MessageQueueThreadPerfStats;
 	public abstract fun isIdle ()Z
 	public abstract fun isOnThread ()Z
 	public abstract fun quitSynchronous ()V
-	public abstract fun resetPerfStats ()V
+	public fun resetPerfStats ()V
 	public abstract fun runOnQueue (Ljava/lang/Runnable;)Z
 }
 
 public final class com/facebook/react/bridge/queue/MessageQueueThreadImpl : com/facebook/react/bridge/queue/MessageQueueThread {
 	public static final field Companion Lcom/facebook/react/bridge/queue/MessageQueueThreadImpl$Companion;
-	public synthetic fun <init> (Ljava/lang/String;Landroid/os/Looper;Lcom/facebook/react/bridge/queue/QueueThreadExceptionHandler;Lcom/facebook/react/bridge/queue/MessageQueueThreadPerfStats;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Landroid/os/Looper;Lcom/facebook/react/bridge/queue/QueueThreadExceptionHandler;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun assertIsOnThread ()V
 	public fun assertIsOnThread (Ljava/lang/String;)V
 	public fun callOnQueue (Ljava/util/concurrent/Callable;)Ljava/util/concurrent/Future;
 	public static final fun create (Lcom/facebook/react/bridge/queue/MessageQueueThreadSpec;Lcom/facebook/react/bridge/queue/QueueThreadExceptionHandler;)Lcom/facebook/react/bridge/queue/MessageQueueThreadImpl;
 	public final fun getLooper ()Landroid/os/Looper;
 	public final fun getName ()Ljava/lang/String;
-	public fun getPerfStats ()Lcom/facebook/react/bridge/queue/MessageQueueThreadPerfStats;
 	public fun isIdle ()Z
 	public fun isOnThread ()Z
 	public fun quitSynchronous ()V
-	public fun resetPerfStats ()V
 	public fun runOnQueue (Ljava/lang/Runnable;)Z
 }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
@@ -108,14 +108,8 @@ public abstract class ReactContext extends ContextWrapper {
     mInteropModuleRegistry = new InteropModuleRegistry();
   }
 
-  public void resetPerfStats() {
-    if (mNativeModulesMessageQueueThread != null) {
-      mNativeModulesMessageQueueThread.resetPerfStats();
-    }
-    if (mJSMessageQueueThread != null) {
-      mJSMessageQueueThread.resetPerfStats();
-    }
-  }
+  @Deprecated(since = "MessageQueueThread perf stats are no longer collected")
+  public void resetPerfStats() {}
 
   public void setJSExceptionHandler(@Nullable JSExceptionHandler jSExceptionHandler) {
     mJSExceptionHandler = jSExceptionHandler;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/MessageQueueThread.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/MessageQueueThread.kt
@@ -55,13 +55,16 @@ public interface MessageQueueThread {
    * Returns the perf counters taken when the framework was started. This method is intended to be
    * used for instrumentation purposes.
    */
-  public fun getPerfStats(): MessageQueueThreadPerfStats?
+  @Deprecated("MessageQueueThread perf stats are no longer collected")
+  @Suppress("DEPRECATION")
+  public fun getPerfStats(): MessageQueueThreadPerfStats? = null
 
   /**
    * Resets the perf counters. This is useful if the RN threads are being re-used. This method is
    * intended to be used for instrumentation purposes.
    */
-  public fun resetPerfStats()
+  @Deprecated("MessageQueueThread perf stats are no longer collected")
+  public fun resetPerfStats(): Unit = Unit
 
   /**
    * Resets the perf counters. This is useful if the RN threads are being re-used. This method is

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/MessageQueueThreadPerfStats.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/MessageQueueThreadPerfStats.kt
@@ -8,6 +8,7 @@
 package com.facebook.react.bridge.queue
 
 /** This class holds perf counters' values at the beginning of an RN startup. */
+@Deprecated("MessageQueueThread perf stats are no longer collected")
 public class MessageQueueThreadPerfStats {
   @JvmField public var wallTime: Long = 0
   @JvmField public var cpuTime: Long = 0

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/MessageQueueThreadSpec.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/queue/MessageQueueThreadSpec.kt
@@ -26,6 +26,7 @@ private constructor(
     public const val DEFAULT_STACK_SIZE_BYTES: Long = 0
 
     @JvmStatic
+    @Deprecated("Use newBackgroundThreadSpec")
     public fun newUIBackgroundTreadSpec(name: String): MessageQueueThreadSpec =
         MessageQueueThreadSpec(ThreadType.NEW_BACKGROUND, name)
 


### PR DESCRIPTION
Summary:
These metrics are not actively consumed and are highly noisy.

Changelog: [Android][Removed] Deprecated MessageQueueThreadPerfStats API and replaced with stub.

Reviewed By: cortinico

Differential Revision: D77867087


