### PR TITLE
Clean up unnecessary test setup for Android tests

### DIFF
--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.kt
@@ -18,11 +18,10 @@ import android.view.WindowManager
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.BridgeReactContext
 import com.facebook.react.bridge.CatalystInstance
-import com.facebook.react.bridge.JavaOnlyArray
 import com.facebook.react.bridge.JavaOnlyMap
 import com.facebook.react.bridge.ReactTestHelper
 import com.facebook.react.bridge.WritableArray
-import com.facebook.react.bridge.WritableMap
+import com.facebook.testutils.shadows.ShadowArguments
 import com.facebook.react.common.SystemClock
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsForTests
 import com.facebook.react.uimanager.DisplayMetricsHolder
@@ -32,12 +31,9 @@ import com.facebook.react.uimanager.events.RCTEventEmitter
 import com.facebook.react.uimanager.events.TouchEvent
 import java.util.Date
 import org.assertj.core.api.Assertions.*
-import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.MockedStatic
-import org.mockito.Mockito.mockStatic
 import org.mockito.kotlin.KArgumentCaptor
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
@@ -52,15 +48,15 @@ import org.mockito.kotlin.whenever
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
 
+@Config(shadows = [ShadowArguments::class])
 @RunWith(RobolectricTestRunner::class)
 class RootViewTest {
 
   private lateinit var reactContext: BridgeReactContext
   private lateinit var catalystInstanceMock: CatalystInstance
 
-  private lateinit var arguments: MockedStatic<Arguments>
-  private lateinit var systemClock: MockedStatic<SystemClock>
 
   private lateinit var downEventCaptor: KArgumentCaptor<TouchEvent>
   private lateinit var downActionTouchesArgCaptor: KArgumentCaptor<WritableArray>
@@ -71,14 +67,6 @@ class RootViewTest {
   @Before
   fun setUp() {
     ReactNativeFeatureFlagsForTests.setUp()
-
-    arguments = mockStatic(Arguments::class.java)
-    arguments.`when`<WritableArray> { Arguments.createArray() }.thenAnswer { JavaOnlyArray() }
-    arguments.`when`<WritableMap> { Arguments.createMap() }.thenAnswer { JavaOnlyMap() }
-
-    val ts = SystemClock.uptimeMillis()
-    systemClock = mockStatic(SystemClock::class.java)
-    systemClock.`when`<Long> { SystemClock.uptimeMillis() }.thenReturn(ts)
 
     catalystInstanceMock = ReactTestHelper.createMockCatalystInstance()
     reactContext = spy(BridgeReactContext(RuntimeEnvironment.getApplication()))
@@ -94,12 +82,6 @@ class RootViewTest {
 
     upEventCaptor = argumentCaptor()
     upActionTouchesArgCaptor = argumentCaptor()
-  }
-
-  @After
-  fun tearDown() {
-    systemClock.close()
-    arguments.close()
   }
 
   @Test

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/animated/NativeAnimatedNodeTraversalTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/animated/NativeAnimatedNodeTraversalTest.kt
@@ -17,8 +17,6 @@ import com.facebook.react.bridge.JavaOnlyArray
 import com.facebook.react.bridge.JavaOnlyMap
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableMap
-import com.facebook.react.bridge.WritableArray
-import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.UIManagerModule
 import com.facebook.react.uimanager.events.Event
 import com.facebook.react.uimanager.events.EventDispatcher
@@ -26,7 +24,6 @@ import com.facebook.react.uimanager.events.RCTEventEmitter
 import kotlin.collections.Map
 import kotlin.math.abs
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -34,8 +31,6 @@ import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.eq
-import org.mockito.MockedStatic
-import org.mockito.Mockito.mockStatic
 import org.mockito.kotlin.atMost
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.reset
@@ -44,8 +39,11 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import com.facebook.testutils.shadows.ShadowArguments
 
 /** Tests the animated nodes graph traversal algorithm from {@link NativeAnimatedNodesManager}. */
+@Config(shadows = [ShadowArguments::class])
 @RunWith(RobolectricTestRunner::class)
 class NativeAnimatedNodeTraversalTest {
 
@@ -55,7 +53,6 @@ class NativeAnimatedNodeTraversalTest {
   private lateinit var uiManagerMock: UIManagerModule
   private lateinit var eventDispatcherMock: EventDispatcher
   private lateinit var nativeAnimatedNodesManager: NativeAnimatedNodesManager
-  private lateinit var arguments: MockedStatic<Arguments>
 
   private fun nextFrameTime(): Long {
     frameTimeNanos += FRAME_LEN_NANOS
@@ -64,10 +61,6 @@ class NativeAnimatedNodeTraversalTest {
 
   @Before
   fun setUp() {
-    arguments = mockStatic(Arguments::class.java)
-    arguments.`when`<WritableArray> { Arguments.createArray() }.thenAnswer { JavaOnlyArray() }
-    arguments.`when`<WritableMap> { Arguments.createMap() }.thenAnswer { JavaOnlyMap() }
-
     frameTimeNanos = INITIAL_FRAME_TIME_NANOS
 
     reactApplicationContextMock = mock<ReactApplicationContext>()
@@ -111,11 +104,6 @@ class NativeAnimatedNodeTraversalTest {
       "on${arg.substring(3)}"
     }
     nativeAnimatedNodesManager = NativeAnimatedNodesManager(reactApplicationContextMock)
-  }
-
-  @After
-  fun tearDown() {
-    arguments.close()
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/fabric/events/TouchEventDispatchTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/fabric/events/TouchEventDispatchTest.kt
@@ -11,7 +11,6 @@ import android.util.DisplayMetrics
 import android.view.MotionEvent
 import android.view.MotionEvent.PointerCoords
 import android.view.MotionEvent.PointerProperties
-import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.JavaOnlyArray
 import com.facebook.react.bridge.JavaOnlyMap
 import com.facebook.react.bridge.ReactTestHelper
@@ -41,9 +40,10 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import com.facebook.testutils.shadows.ShadowArguments
 
 @RunWith(RobolectricTestRunner::class)
-@Config(shadows = [ShadowSoLoader::class])
+@Config(shadows = [ShadowSoLoader::class, ShadowArguments::class])
 class TouchEventDispatchTest {
   private val touchEventCoalescingKeyHelper = TouchEventCoalescingKeyHelper()
 
@@ -460,16 +460,12 @@ class TouchEventDispatchTest {
 
   private lateinit var eventDispatcher: EventDispatcher
   private lateinit var eventEmitter: FabricEventEmitter
-  private lateinit var arguments: MockedStatic<Arguments>
   private var reactChoreographerOriginal: ReactChoreographer? = null
 
   @Before
   fun setUp() {
     ReactNativeFeatureFlagsForTests.setUp()
 
-    arguments = mockStatic(Arguments::class.java)
-    arguments.`when`<WritableArray> { Arguments.createArray() }.thenAnswer { JavaOnlyArray() }
-    arguments.`when`<WritableMap> { Arguments.createMap() }.thenAnswer { JavaOnlyMap() }
     val metrics = DisplayMetrics()
     metrics.xdpi = 1f
     metrics.ydpi = 1f
@@ -488,7 +484,6 @@ class TouchEventDispatchTest {
 
   @After
   fun tearDown() {
-    arguments.close()
     ReactChoreographer.overrideInstanceForTest(reactChoreographerOriginal)
   }
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/appstate/AppStateModuleTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/appstate/AppStateModuleTest.kt
@@ -9,47 +9,37 @@ package com.facebook.react.modules.appstate
 
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Callback
-import com.facebook.react.bridge.JavaOnlyArray
-import com.facebook.react.bridge.JavaOnlyMap
 import com.facebook.react.bridge.ReactApplicationContext
-import com.facebook.react.bridge.WritableArray
 import com.facebook.react.bridge.WritableMap
+import com.facebook.testutils.shadows.ShadowArguments
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.mockito.ArgumentCaptor
-import org.mockito.MockedStatic
-import org.mockito.Mockito.mockStatic
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.junit.runner.RunWith
 
+@Config(shadows = [ShadowArguments::class])
+@RunWith(RobolectricTestRunner::class)
 class AppStateModuleTest {
   private lateinit var appStateModule: AppStateModule
   private lateinit var reactContext: ReactApplicationContext
-  private lateinit var arguments: MockedStatic<Arguments>
 
   @Before
   fun setUp() {
     reactContext = mock()
     appStateModule = AppStateModule(reactContext)
 
-    arguments = mockStatic(Arguments::class.java)
-    arguments.`when`<WritableArray>(Arguments::createArray).thenAnswer { JavaOnlyArray() }
-    arguments.`when`<WritableMap>(Arguments::createMap).thenAnswer { JavaOnlyMap() }
-
     // we check whether we have an active react instance before emitting an event,
     // therefore for the tests we need this returning `true`.
     whenever(reactContext.hasActiveReactInstance()).thenReturn(true)
-  }
-
-  @After
-  fun tearDown() {
-    arguments.close()
   }
 
   @Test

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/blob/BlobModuleTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/blob/BlobModuleTest.kt
@@ -8,7 +8,6 @@
 package com.facebook.react.modules.blob
 
 import android.net.Uri
-import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.JavaOnlyArray
 import com.facebook.react.bridge.JavaOnlyMap
 import com.facebook.react.bridge.ReactTestHelper
@@ -21,8 +20,6 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.MockedStatic
-import org.mockito.Mockito.mockStatic
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
@@ -32,13 +29,9 @@ class BlobModuleTest {
   private lateinit var bytes: ByteArray
   private lateinit var blobId: String
   private lateinit var blobModule: BlobModule
-  private lateinit var arguments: MockedStatic<Arguments>
 
   @Before
   fun prepareModules() {
-    arguments = mockStatic(Arguments::class.java)
-    arguments.`when`<WritableMap> { Arguments.createMap() }.thenAnswer { JavaOnlyMap() }
-
     bytes = ByteArray(120)
     Random.Default.nextBytes(bytes)
 
@@ -49,7 +42,6 @@ class BlobModuleTest {
   @After
   fun cleanUp() {
     blobModule.remove(blobId)
-    arguments.close()
   }
 
   @Test

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/network/NetworkingModuleTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/network/NetworkingModuleTest.kt
@@ -46,15 +46,17 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.kotlin.withSettings
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import com.facebook.testutils.shadows.ShadowArguments
 
 /** Tests [NetworkingModule] */
+@Config(shadows = [ShadowArguments::class])
 @RunWith(RobolectricTestRunner::class)
 class NetworkingModuleTest {
 
   private lateinit var networkingModule: NetworkingModule
   private lateinit var httpClient: OkHttpClient
   private lateinit var context: ReactApplicationContext
-  private lateinit var arguments: MockedStatic<Arguments>
   private lateinit var okHttpCallUtil: MockedStatic<OkHttpCallUtil>
   private lateinit var requestBodyUtil: MockedStatic<RequestBodyUtil>
   private lateinit var requestArgumentCaptor: KArgumentCaptor<Request>
@@ -74,10 +76,6 @@ class NetworkingModuleTest {
 
     networkingModule = NetworkingModule(context, "", httpClient, null)
 
-    arguments = mockStatic(Arguments::class.java)
-    arguments.`when`<WritableArray> { Arguments.createArray() }.thenAnswer { JavaOnlyArray() }
-    arguments.`when`<WritableMap> { Arguments.createMap() }.thenAnswer { JavaOnlyMap() }
-
     okHttpCallUtil = mockStatic(OkHttpCallUtil::class.java)
     requestArgumentCaptor = argumentCaptor()
   }
@@ -92,7 +90,6 @@ class NetworkingModuleTest {
 
   @After
   fun tearDown() {
-    arguments.close()
     okHttpCallUtil.close()
   }
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/network/ResponseUtilTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/network/ResponseUtilTest.kt
@@ -8,40 +8,31 @@
 package com.facebook.react.modules.network
 
 import com.facebook.react.bridge.Arguments
-import com.facebook.react.bridge.JavaOnlyArray
-import com.facebook.react.bridge.JavaOnlyMap
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.WritableArray
 import com.facebook.react.bridge.WritableMap
 import java.net.SocketTimeoutException
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.ArgumentCaptor
-import org.mockito.MockedStatic
-import org.mockito.Mockito.mockStatic
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import com.facebook.testutils.shadows.ShadowArguments
 
+@Config(shadows = [ShadowArguments::class])
+@RunWith(RobolectricTestRunner::class)
 class ResponseUtilTest {
   private lateinit var reactContext: ReactApplicationContext
-  private lateinit var arguments: MockedStatic<Arguments>
 
   @Before
   fun setUp() {
     reactContext = mock()
-
-    arguments = mockStatic(Arguments::class.java)
-    arguments.`when`<WritableArray>(Arguments::createArray).thenAnswer { JavaOnlyArray() }
-    arguments.`when`<WritableMap>(Arguments::createMap).thenAnswer { JavaOnlyMap() }
-  }
-
-  @After
-  fun tearDown() {
-    arguments.close()
   }
 
   @Test

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/timing/TimingModuleTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/timing/TimingModuleTest.kt
@@ -14,12 +14,10 @@ package com.facebook.react.modules.timing
 import android.content.Context
 import android.os.Looper
 import android.view.Choreographer.FrameCallback
-import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.BridgeReactContext
 import com.facebook.react.bridge.CatalystInstance
 import com.facebook.react.bridge.JavaOnlyArray
 import com.facebook.react.bridge.JavaOnlyMap
-import com.facebook.react.bridge.WritableArray
 import com.facebook.react.common.SystemClock
 import com.facebook.react.devsupport.interfaces.DevSupportManager
 import com.facebook.react.jstasks.HeadlessJsTaskConfig
@@ -49,6 +47,8 @@ import org.mockito.kotlin.whenever
 import org.mockito.stubbing.Answer
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import com.facebook.testutils.shadows.ShadowArguments
 
 object MockCompat {
   // Same as Mockito's 'eq()', but works for non-nullable types
@@ -63,6 +63,7 @@ object MockCompat {
   @Suppress("UNCHECKED_CAST") fun <T> uninitialized(): T = null as T
 }
 
+@Config(shadows = [ShadowArguments::class])
 @RunWith(RobolectricTestRunner::class)
 class TimingModuleTest {
   companion object {
@@ -75,7 +76,6 @@ class TimingModuleTest {
   private lateinit var postFrameCallbackHandler: PostFrameCallbackHandler
   private lateinit var idlePostFrameCallbackHandler: PostFrameCallbackHandler
   private lateinit var jsTimersMock: JSTimers
-  private lateinit var arguments: MockedStatic<Arguments>
   private lateinit var systemClock: MockedStatic<SystemClock>
   private lateinit var reactChoreographerMock: ReactChoreographer
 
@@ -84,9 +84,6 @@ class TimingModuleTest {
 
   @Before
   fun prepareModules() {
-    arguments = mockStatic(Arguments::class.java)
-    arguments.`when`<WritableArray> { Arguments.createArray() }.thenAnswer { JavaOnlyArray() }
-
     systemClock = mockStatic(SystemClock::class.java)
     systemClock
         .`when`<Long> { SystemClock.uptimeMillis() }
@@ -147,7 +144,6 @@ class TimingModuleTest {
   @After
   fun tearDown() {
     systemClock.close()
-    arguments.close()
     ReactChoreographer.overrideInstanceForTest(reactChoreographerOriginal)
   }
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/BaseViewManagerTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/BaseViewManagerTest.kt
@@ -9,33 +9,29 @@ package com.facebook.react.uimanager
 
 import android.view.View.OnFocusChangeListener
 import com.facebook.react.R
-import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.BridgeReactContext
-import com.facebook.react.bridge.JavaOnlyArray
 import com.facebook.react.bridge.JavaOnlyMap
-import com.facebook.react.bridge.WritableArray
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsForTests
+import com.facebook.testutils.shadows.ShadowArguments
 import com.facebook.react.views.view.ReactViewGroup
 import com.facebook.react.views.view.ReactViewManager
 import java.util.Locale
 import org.assertj.core.api.Assertions
-import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.MockedStatic
-import org.mockito.Mockito
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
 
+@Config(shadows = [ShadowArguments::class])
 @RunWith(RobolectricTestRunner::class)
 class BaseViewManagerTest {
   private lateinit var viewManager: BaseViewManager<ReactViewGroup, *>
   private lateinit var view: ReactViewGroup
-  private lateinit var arguments: MockedStatic<Arguments>
   private lateinit var themedReactContext: ThemedReactContext
 
   @Before
@@ -45,13 +41,6 @@ class BaseViewManagerTest {
     val context = BridgeReactContext(RuntimeEnvironment.getApplication())
     themedReactContext = ThemedReactContext(context, context, null, -1)
     view = ReactViewGroup(themedReactContext)
-    arguments = Mockito.mockStatic(Arguments::class.java)
-    arguments.`when`<WritableArray> { Arguments.createMap() }.thenAnswer { JavaOnlyArray() }
-  }
-
-  @After
-  fun tearDown() {
-    arguments.close()
   }
 
   @Test

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/OnLayoutEventTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/OnLayoutEventTest.kt
@@ -7,32 +7,19 @@
 
 package com.facebook.react.uimanager
 
-import com.facebook.react.common.SystemClock
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsForTests
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.MockedStatic
-import org.mockito.Mockito.mockStatic
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class OnLayoutEventTest {
-  private lateinit var systemClock: MockedStatic<SystemClock>
 
   @Before
   fun setup() {
     ReactNativeFeatureFlagsForTests.setUp()
-    val ts = SystemClock.uptimeMillis()
-    systemClock = mockStatic(SystemClock::class.java)
-    systemClock.`when`<Long> { SystemClock.uptimeMillis() }.thenReturn(ts)
-  }
-
-  @After
-  fun tearDown() {
-    systemClock.close()
   }
 
   @Test

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/image/ReactImagePropertyTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/image/ReactImagePropertyTest.kt
@@ -32,6 +32,7 @@ import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.util.RNLog
 import com.facebook.react.views.imagehelper.ImageSource
 import com.facebook.soloader.SoLoader
+import com.facebook.testutils.shadows.ShadowArguments
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
@@ -47,26 +48,24 @@ import org.mockito.kotlin.reset
 import org.mockito.kotlin.verify
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
 
 /**
  * Verify that [com.facebook.drawee.drawable.ScalingUtils] properties are being applied correctly by
  * [ReactImageManager].
  */
+@Config(shadows = [ShadowArguments::class])
 @RunWith(RobolectricTestRunner::class)
 class ReactImagePropertyTest {
 
   private lateinit var context: BridgeReactContext
   private lateinit var catalystInstanceMock: CatalystInstance
   private lateinit var themeContext: ThemedReactContext
-  private lateinit var arguments: MockedStatic<Arguments>
   private lateinit var rnLog: MockedStatic<RNLog>
   private lateinit var flogMock: MockedStatic<FLog>
 
   @Before
   fun setup() {
-    arguments = mockStatic(Arguments::class.java)
-    arguments.`when`<WritableArray> { Arguments.createArray() }.thenAnswer { JavaOnlyArray() }
-    arguments.`when`<WritableMap> { Arguments.createMap() }.thenAnswer { JavaOnlyMap() }
 
     rnLog = mockStatic(RNLog::class.java)
     rnLog.`when`<Boolean> { RNLog.w(any(), anyString()) }.thenAnswer {}
@@ -87,7 +86,6 @@ class ReactImagePropertyTest {
   @After
   fun teardown() {
     DisplayMetricsHolder.setWindowDisplayMetrics(null)
-    arguments.close()
     rnLog.close()
     flogMock.close()
   }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/shadows/ShadowArguments.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/shadows/ShadowArguments.kt
@@ -18,18 +18,15 @@ import org.robolectric.annotation.Implements
 import org.robolectric.shadow.api.Shadow
 
 @Implements(Arguments::class)
-class ShadowArguments {
+object ShadowArguments {
+  @JvmStatic @Implementation fun createArray(): WritableArray = JavaOnlyArray()
 
-  companion object {
-    @JvmStatic @Implementation fun createArray(): WritableArray = JavaOnlyArray()
+  @JvmStatic @Implementation fun createMap(): WritableMap = JavaOnlyMap()
 
-    @JvmStatic @Implementation fun createMap(): WritableMap = JavaOnlyMap()
-
-    @JvmStatic
-    @Implementation
-    fun fromJavaArgs(args: Array<Any?>): WritableNativeArray =
-        WritableNativeArray().apply {
-          (Shadow.extract(this) as ShadowNativeArray).backingArray = JavaOnlyArray.of(*args)
-        }
-  }
+  @JvmStatic
+  @Implementation
+  fun fromJavaArgs(args: Array<Any?>): WritableNativeArray =
+      WritableNativeArray().apply {
+        (Shadow.extract(this) as ShadowNativeArray).backingArray = JavaOnlyArray.of(*args)
+      }
 }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/shadows/ShadowNativeArray.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/testutils/shadows/ShadowNativeArray.kt
@@ -19,20 +19,6 @@ import org.robolectric.shadow.api.Shadow
 open class ShadowNativeArray {
   var backingArray: JavaOnlyArray = JavaOnlyArray()
 
-  @Deprecated(
-      "Use ShadowReadableNativeArray",
-      ReplaceWith(
-          "ShadowReadableNativeArray", "com.facebook.testutils.shadows.ShadowReadableNativeArray"))
-  @Implements(ReadableNativeArray::class)
-  class Readable : ShadowNativeArray()
-
-  @Deprecated(
-      "Use ShadowWritableNativeArray",
-      ReplaceWith(
-          "ShadowWritableNativeArray", "com.facebook.testutils.shadows.ShadowWritableNativeArray"))
-  @Implements(WritableNativeArray::class)
-  class Writable : ShadowNativeArray()
-
   companion object {
     fun getContents(array: NativeArray): List<Any?> =
         (Shadow.extract(array) as ShadowNativeArray).backingArray.toArrayList()


### PR DESCRIPTION
## Summary:

This came out of #52457 as I had to fix some tests and realised there is a lot of setup that could be shadow and other things that are not needed at all.

## Changelog:

[INTERNAL] - Clean up unnecessary test setup for Android tests


## Test Plan:

```sh
yarn test-android
```