### PR TITLE
Refactor VirtualView target structure on Android

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/virtual/VirtualViewMode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/virtual/VirtualViewMode.kt
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.react.views.virtualview
+package com.facebook.react.views.virtual
 
 internal enum class VirtualViewMode(val value: Int) {
   Visible(0),

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/virtual/VirtualViewModeChangeEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/virtual/VirtualViewModeChangeEvent.kt
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.react.views.virtualview
+package com.facebook.react.views.virtual
 
 import android.graphics.Rect
 import androidx.annotation.VisibleForTesting

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/virtual/VirtualViewRenderState.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/virtual/VirtualViewRenderState.kt
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.react.views.virtualview
+package com.facebook.react.views.virtual
 
 /**
  * Represents the the render state of children in the most recent commit.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/virtual/view/ReactVirtualView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/virtual/view/ReactVirtualView.kt
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.react.views.virtualview
+package com.facebook.react.views.virtual.view
 
 import android.content.Context
 import android.graphics.Rect
@@ -24,6 +24,8 @@ import com.facebook.react.views.scroll.ReactScrollView
 import com.facebook.react.views.scroll.ReactScrollViewHelper
 import com.facebook.react.views.scroll.ScrollEventType
 import com.facebook.react.views.view.ReactViewGroup
+import com.facebook.react.views.virtual.VirtualViewMode
+import com.facebook.react.views.virtual.VirtualViewRenderState
 import com.facebook.systrace.Systrace
 
 internal class ReactVirtualView(context: Context) :

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/virtual/view/ReactVirtualViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/virtual/view/ReactVirtualViewManager.kt
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.react.views.virtualview
+package com.facebook.react.views.virtual.view
 
 import android.graphics.Rect
 import androidx.annotation.VisibleForTesting
@@ -19,6 +19,9 @@ import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.uimanager.events.EventDispatcher
 import com.facebook.react.viewmanagers.VirtualViewManagerDelegate
 import com.facebook.react.viewmanagers.VirtualViewManagerInterface
+import com.facebook.react.views.virtual.VirtualViewMode
+import com.facebook.react.views.virtual.VirtualViewModeChangeEvent
+import com.facebook.react.views.virtual.VirtualViewRenderState
 
 @ReactModule(name = ReactVirtualViewManager.REACT_CLASS)
 internal class ReactVirtualViewManager :

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/virtual/view/ReactVirtualViewTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/virtual/view/ReactVirtualViewTest.kt
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.react.views.virtualview
+package com.facebook.react.views.virtual.view
 
 import android.app.Activity
 import android.content.Context
@@ -19,6 +19,8 @@ import com.facebook.react.uimanager.DisplayMetricsHolder
 import com.facebook.react.uimanager.events.Event
 import com.facebook.react.uimanager.events.EventDispatcher
 import com.facebook.react.views.scroll.ReactScrollView
+import com.facebook.react.views.virtual.VirtualViewMode
+import com.facebook.react.views.virtual.VirtualViewModeChangeEvent
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test


### PR DESCRIPTION
Summary:
Changelog: [Internal] - Refactor package structure on Android to prepare for experimental VirtualView so that non-view related objects go under `virtual` and the native view goes under `view`.
This breaks dependency circles for experimental VirtualView in upcoming change.

Differential Revision: D77335426
