### PR TITLE
Fix Dimensions window values on Android < 15 (#47554)

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -621,6 +621,7 @@ dependencies {
   api(libs.androidx.autofill)
   api(libs.androidx.swiperefreshlayout)
   api(libs.androidx.tracing)
+  api(libs.androidx.window)
 
   api(libs.fbjni)
   api(libs.fresco)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -865,7 +865,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
     private int mDeviceRotation = 0;
 
     /* package */ CustomGlobalLayoutListener() {
-      DisplayMetricsHolder.initDisplayMetricsIfNotInitialized(getContext().getApplicationContext());
+      DisplayMetricsHolder.initDisplayMetricsIfNotInitialized(getContext());
       mVisibleViewArea = new Rect();
       mMinKeyboardHeightDetected = (int) PixelUtil.toPixelFromDIP(60);
     }
@@ -988,7 +988,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
         return;
       }
       mDeviceRotation = rotation;
-      DisplayMetricsHolder.initDisplayMetrics(getContext().getApplicationContext());
+      DisplayMetricsHolder.initDisplayMetrics(getContext());
       emitOrientationChanged(rotation);
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/DisplayMetricsHolder.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/DisplayMetricsHolder.kt
@@ -13,8 +13,10 @@ import android.util.DisplayMetrics
 import android.view.WindowManager
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.window.layout.WindowMetricsCalculator
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.WritableNativeMap
+import com.facebook.react.views.view.isEdgeToEdgeFeatureFlagOn
 
 /**
  * Holds an instance of the current DisplayMetrics so we don't have to thread it through all the
@@ -62,9 +64,19 @@ public object DisplayMetricsHolder {
   @JvmStatic
   public fun initDisplayMetrics(context: Context) {
     val displayMetrics = context.resources.displayMetrics
-    windowDisplayMetrics = displayMetrics
+    val windowDisplayMetrics = DisplayMetrics()
     val screenDisplayMetrics = DisplayMetrics()
+
+    windowDisplayMetrics.setTo(displayMetrics)
     screenDisplayMetrics.setTo(displayMetrics)
+
+    if (isEdgeToEdgeFeatureFlagOn) {
+      WindowMetricsCalculator.getOrCreate().computeCurrentWindowMetrics(context).let {
+        windowDisplayMetrics.widthPixels = it.bounds.width()
+        windowDisplayMetrics.heightPixels = it.bounds.height()
+      }
+    }
+
     val wm = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
     // Get the real display metrics if we are using API level 17 or higher.
     // The real metrics include system decor elements (e.g. soft menu bar).
@@ -72,6 +84,8 @@ public object DisplayMetricsHolder {
     // See:
     // http://developer.android.com/reference/android/view/Display.html#getRealMetrics(android.util.DisplayMetrics)
     @Suppress("DEPRECATION") wm.defaultDisplay.getRealMetrics(screenDisplayMetrics)
+
+    DisplayMetricsHolder.windowDisplayMetrics = windowDisplayMetrics
     DisplayMetricsHolder.screenDisplayMetrics = screenDisplayMetrics
   }
 

--- a/packages/react-native/gradle/libs.versions.toml
+++ b/packages/react-native/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ androidx-swiperefreshlayout = "1.1.0"
 androidx-test = "1.5.0"
 androidx-test-junit = "1.2.1"
 androidx-tracing = "1.1.0"
+androidx-window = "1.4.0"
 assertj = "3.21.0"
 binary-compatibility-validator = "0.13.2"
 download = "5.4.0"
@@ -64,6 +65,7 @@ androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidx-
 androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidx-test" }
 androidx-tracing = { module = "androidx.tracing:tracing", version.ref = "androidx-tracing" }
 androidx-uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "uiautomator" }
+androidx-window = { module = "androidx.window:window", version.ref = "androidx-window" }
 
 fbjni = { module = "com.facebook.fbjni:fbjni", version.ref = "fbjni" }
 fresco = { module = "com.facebook.fresco:fresco", version.ref = "fresco" }


### PR DESCRIPTION
Summary:
This PR (initially created for edge-to-edge opt-in support, rebased multiple times) fixes the `Dimensions` API `window` values on Android < 15, when edge-to-edge is enabled.

Currently the window height doesn't include the status and navigation bar heights (but it does on Android >= 15):

<img width="300" alt="Screenshot 2025-06-27 at 16 23 02" src="https://github.com/user-attachments/assets/c7d11334-9298-4f7f-a75c-590df8cc2d8a" />

Using `WindowMetricsCalculator` from AndroidX:

<img width="300" alt="Screenshot 2025-06-27 at 16 34 01" src="https://github.com/user-attachments/assets/7a4e3dc7-a83b-421b-8f6d-fd1344f5fe81" />

Fixes https://github.com/facebook/react-native/issues/47080

## Changelog:

[Android] [Fixed] Fix `Dimensions` `window` values on Android < 15 when edge-to-edge is enabled


Test Plan:
Run the example app on an Android < 15 device.

Rollback Plan:

Differential Revision: D77906644

Pulled By: alanleedev


