### PR TITLE
Support CDP response previews

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobModule.kt
@@ -35,7 +35,6 @@ import java.util.HashMap
 import java.util.UUID
 import okhttp3.MediaType
 import okhttp3.RequestBody
-import okhttp3.ResponseBody
 import okio.ByteString
 
 @ReactModule(name = NativeBlobModuleSpec.NAME)
@@ -72,7 +71,7 @@ public class BlobModule(reactContext: ReactApplicationContext) :
           return !isRemote && responseType == "blob"
         }
 
-        override fun fetch(uri: Uri): WritableMap {
+        override fun fetch(uri: Uri): Pair<WritableMap, ByteArray> {
           val data = getBytesFromUri(uri)
 
           val blob = Arguments.createMap()
@@ -85,7 +84,7 @@ public class BlobModule(reactContext: ReactApplicationContext) :
           blob.putString("name", getNameFromUri(uri))
           blob.putDouble("lastModified", getLastModifiedFromUri(uri))
 
-          return blob
+          return Pair(blob, data)
         }
       }
 
@@ -119,8 +118,7 @@ public class BlobModule(reactContext: ReactApplicationContext) :
           return responseType == "blob"
         }
 
-        override fun toResponseData(body: ResponseBody): WritableMap {
-          val data = body.bytes()
+        override fun toResponseData(data: ByteArray): WritableMap {
           val blob = Arguments.createMap()
           blob.putString("blobId", store(data))
           blob.putInt("offset", 0)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/InspectorNetworkReporter.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/InspectorNetworkReporter.kt
@@ -64,4 +64,11 @@ internal object InspectorNetworkReporter {
    * - Corresponds to `PerformanceResourceTiming.responseEnd`.
    */
   @JvmStatic external fun reportResponseEnd(requestId: Int, encodedDataLength: Long)
+
+  /**
+   * Store response body preview. This is an optional reporting method, and is a no-op if CDP
+   * debugging is disabled.
+   */
+  @JvmStatic
+  external fun maybeStoreResponseBody(requestId: Int, body: String, base64Encoded: Boolean)
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/InspectorNetworkReporter.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/InspectorNetworkReporter.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.modules.network
+
+import com.facebook.proguard.annotations.DoNotStripAny
+
+/**
+ * [Experimental] An interface for reporting network events to the modern debugger server and Web
+ * Performance APIs.
+ *
+ * In a production (non dev or profiling) build, CDP reporting is disabled.
+ *
+ * This is a helper class wrapping `facebook::react::jsinspector_modern::NetworkReporter`.
+ */
+@DoNotStripAny
+internal object InspectorNetworkReporter {
+  /**
+   * Report a network request that is about to be sent.
+   * - Corresponds to `Network.requestWillBeSent` in CDP.
+   * - Corresponds to `PerformanceResourceTiming.requestStart` (specifically, marking when the
+   *   native request was initiated).
+   */
+  @JvmStatic
+  external fun reportRequestStart(
+      requestId: Int,
+      requestUrl: String,
+      requestMethod: String,
+      requestHeaders: Map<String, String>,
+      requestBody: String,
+      encodedDataLength: Long
+  )
+
+  /**
+   * Report detailed timing info, such as DNS lookup, when a request has started.
+   * - Corresponds to `Network.requestWillBeSentExtraInfo` in CDP.
+   * - Corresponds to `PerformanceResourceTiming.domainLookupStart`,
+   *   `PerformanceResourceTiming.connectStart`.
+   */
+  @JvmStatic external fun reportConnectionTiming(requestId: Int, headers: Map<String, String>)
+
+  /**
+   * Report when HTTP response headers have been received, corresponding to when the first byte of
+   * the response is available.
+   * - Corresponds to `Network.responseReceived` in CDP.
+   * - Corresponds to `PerformanceResourceTiming.responseStart`.
+   */
+  @JvmStatic
+  external fun reportResponseStart(
+      requestId: Int,
+      responseUrl: String,
+      responseStatus: Int,
+      responseHeaders: Map<String, String>,
+      expectedDataLength: Long
+  )
+
+  /**
+   * Report when a network request is complete and we are no longer receiving response data.
+   * - Corresponds to `Network.loadingFinished` in CDP.
+   * - Corresponds to `PerformanceResourceTiming.responseEnd`.
+   */
+  @JvmStatic external fun reportResponseEnd(requestId: Int, encodedDataLength: Long)
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkEventUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkEventUtil.kt
@@ -11,10 +11,32 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.buildReadableArray
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
 import java.net.SocketTimeoutException
+import okhttp3.Headers
+import okhttp3.Request
+import okhttp3.Response
 
-/** Util methods to send network responses to JS. */
-internal object ResponseUtil {
+/**
+ * Utility class for reporting network lifecycle events to JavaScript and InspectorNetworkReporter.
+ */
+internal object NetworkEventUtil {
+  @JvmStatic
+  fun onCreateRequest(requestId: Int, request: Request) {
+    if (ReactNativeFeatureFlags.enableNetworkEventReporting()) {
+      val headersMap = okHttpHeadersToMap(request.headers())
+      InspectorNetworkReporter.reportRequestStart(
+          requestId,
+          request.url().toString(),
+          request.method(),
+          headersMap,
+          request.body()?.toString() ?: "",
+          request.body()?.contentLength() ?: 0,
+      )
+      InspectorNetworkReporter.reportConnectionTiming(requestId, headersMap)
+    }
+  }
+
   @JvmStatic
   fun onDataSend(
       reactContext: ReactApplicationContext?,
@@ -104,7 +126,14 @@ internal object ResponseUtil {
   }
 
   @JvmStatic
-  fun onRequestSuccess(reactContext: ReactApplicationContext?, requestId: Int) {
+  fun onRequestSuccess(
+      reactContext: ReactApplicationContext?,
+      requestId: Int,
+      encodedDataLength: Long
+  ) {
+    if (ReactNativeFeatureFlags.enableNetworkEventReporting()) {
+      InspectorNetworkReporter.reportResponseEnd(requestId, encodedDataLength)
+    }
     reactContext?.emitDeviceEvent(
         "didCompleteNetworkResponse",
         buildReadableArray {
@@ -117,17 +146,72 @@ internal object ResponseUtil {
   fun onResponseReceived(
       reactContext: ReactApplicationContext?,
       requestId: Int,
-      statusCode: Int,
-      headers: WritableMap?,
-      url: String?
+      response: Response,
   ) {
+    val responseUrl = response.request().url().toString()
+    val headersMap = okHttpHeadersToMap(response.headers())
+
+    if (ReactNativeFeatureFlags.enableNetworkEventReporting()) {
+      InspectorNetworkReporter.reportResponseStart(
+          requestId,
+          responseUrl,
+          response.code(),
+          headersMap,
+          response.body()?.contentLength() ?: 0,
+      )
+    }
     reactContext?.emitDeviceEvent(
         "didReceiveNetworkResponse",
         Arguments.createArray().apply {
           pushInt(requestId)
-          pushInt(statusCode)
-          pushMap(headers)
-          pushString(url)
+          pushInt(response.code())
+          pushMap(Arguments.makeNativeMap(headersMap))
+
+          pushString(responseUrl)
         })
+  }
+
+  @Deprecated("Compatibility overload")
+  @JvmStatic
+  fun onResponseReceived(
+      reactContext: ReactApplicationContext?,
+      requestId: Int,
+      statusCode: Int,
+      headers: WritableMap?,
+      url: String?
+  ) {
+    val headersBuilder = Headers.Builder()
+    headers?.let { map ->
+      val iterator = map.keySetIterator()
+      while (iterator.hasNextKey()) {
+        val key = iterator.nextKey()
+        val value = map.getString(key)
+        if (value != null) {
+          headersBuilder.add(key, value)
+        }
+      }
+    }
+    onResponseReceived(
+        reactContext,
+        requestId,
+        Response.Builder()
+            .code(statusCode)
+            .request(Request.Builder().url(url.orEmpty()).build())
+            .headers(headersBuilder.build())
+            .build())
+  }
+
+  private fun okHttpHeadersToMap(headers: Headers): Map<String, String> {
+    val responseHeaders = mutableMapOf<String, String>()
+    for (i in 0 until headers.size()) {
+      val headerName = headers.name(i)
+      // multiple values for the same header
+      if (responseHeaders.containsKey(headerName)) {
+        responseHeaders[headerName] = responseHeaders[headerName] + ", " + headers.value(i)
+      } else {
+        responseHeaders[headerName] = headers.value(i)
+      }
+    }
+    return responseHeaders
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkEventUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkEventUtil.kt
@@ -7,6 +7,7 @@
 
 package com.facebook.react.modules.network
 
+import android.util.Base64
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.WritableMap
@@ -88,7 +89,16 @@ internal object NetworkEventUtil {
   }
 
   @JvmStatic
-  fun onDataReceived(reactContext: ReactApplicationContext?, requestId: Int, data: String?) {
+  fun onDataReceived(
+      reactContext: ReactApplicationContext?,
+      requestId: Int,
+      data: String?,
+      responseType: String
+  ) {
+    if (ReactNativeFeatureFlags.enableNetworkEventReporting()) {
+      InspectorNetworkReporter.maybeStoreResponseBody(
+          requestId, data.orEmpty(), responseType == "base64")
+    }
     reactContext?.emitDeviceEvent(
         "didReceiveNetworkData",
         buildReadableArray {
@@ -98,7 +108,16 @@ internal object NetworkEventUtil {
   }
 
   @JvmStatic
-  fun onDataReceived(reactContext: ReactApplicationContext?, requestId: Int, data: WritableMap?) {
+  fun onDataReceived(
+      reactContext: ReactApplicationContext?,
+      requestId: Int,
+      data: WritableMap,
+      rawData: ByteArray
+  ) {
+    if (ReactNativeFeatureFlags.enableNetworkEventReporting()) {
+      InspectorNetworkReporter.maybeStoreResponseBody(
+          requestId, Base64.encodeToString(rawData, Base64.NO_WRAP), true)
+    }
     reactContext?.emitDeviceEvent(
         "didReceiveNetworkData",
         Arguments.createArray().apply {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.kt
@@ -59,8 +59,10 @@ public class NetworkingModule(
     /** Returns if the handler should be used for an URI. */
     public fun supports(uri: Uri, responseType: String): Boolean
 
-    /** Fetch the URI and return the JS body payload. */
-    @Throws(IOException::class) public fun fetch(uri: Uri): WritableMap
+    /**
+     * Fetch the URI and return a tuple containing the JS body payload and the raw response body.
+     */
+    @Throws(IOException::class) public fun fetch(uri: Uri): Pair<WritableMap, ByteArray>
   }
 
   /** Allows adding custom handling to build the [RequestBody] from the JS body payload. */
@@ -78,7 +80,7 @@ public class NetworkingModule(
     public fun supports(responseType: String): Boolean
 
     /** Returns the JS body payload for the [ResponseBody]. */
-    @Throws(IOException::class) public fun toResponseData(body: ResponseBody): WritableMap
+    @Throws(IOException::class) public fun toResponseData(data: ByteArray): WritableMap
   }
 
   private val client: OkHttpClient
@@ -253,7 +255,7 @@ public class NetworkingModule(
       // Check if a handler is registered
       for (handler in uriHandlers) {
         if (handler.supports(uri, responseType)) {
-          val res = handler.fetch(uri)
+          val (res, rawBody) = handler.fetch(uri)
           val encodedDataLength = res.toString().toByteArray().size
           // fix: UriHandlers which are not using file:// scheme fail in whatwg-fetch at this line
           // https://github.com/JakeChampion/fetch/blob/main/fetch.js#L547
@@ -266,7 +268,7 @@ public class NetworkingModule(
                   .code(status)
                   .request(Request.Builder().url(url.orEmpty()).build())
                   .build())
-          NetworkEventUtil.onDataReceived(reactApplicationContext, requestId, res)
+          NetworkEventUtil.onDataReceived(reactApplicationContext, requestId, res, rawBody)
           NetworkEventUtil.onRequestSuccess(
               reactApplicationContext, requestId, encodedDataLength.toLong())
           return
@@ -542,8 +544,10 @@ public class NetworkingModule(
                   // Check if a handler is registered
                   for (responseHandler in responseHandlers) {
                     if (responseHandler.supports(responseType)) {
-                      val res = responseHandler.toResponseData(responseBody)
-                      NetworkEventUtil.onDataReceived(reactApplicationContext, requestId, res)
+                      val responseData = responseBody.bytes()
+                      val res = responseHandler.toResponseData(responseData)
+                      NetworkEventUtil.onDataReceived(
+                          reactApplicationContext, requestId, res, responseData)
                       NetworkEventUtil.onRequestSuccess(
                           reactApplicationContext, requestId, responseBody.contentLength())
                       return
@@ -581,7 +585,7 @@ public class NetworkingModule(
                     responseString = Base64.encodeToString(responseBody.bytes(), Base64.NO_WRAP)
                   }
                   NetworkEventUtil.onDataReceived(
-                      reactApplicationContext, requestId, responseString)
+                      reactApplicationContext, requestId, responseString, responseType)
                   NetworkEventUtil.onRequestSuccess(
                       reactApplicationContext, requestId, responseBody.contentLength())
                 } catch (e: IOException) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.kt
@@ -11,11 +11,9 @@
 package com.facebook.react.modules.network
 
 import android.net.Uri
-import android.os.Bundle
 import android.util.Base64
 import com.facebook.common.logging.FLog
 import com.facebook.fbreact.specs.NativeNetworkingAndroidSpec
-import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableArray
@@ -231,7 +229,7 @@ public class NetworkingModule(
     } catch (th: Throwable) {
       FLog.e(TAG, "Failed to send url request: $url", th)
 
-      ResponseUtil.onRequestError(
+      NetworkEventUtil.onRequestError(
           getReactApplicationContextIfActiveOrWarn(), requestId, th.message, th)
     }
   }
@@ -256,17 +254,26 @@ public class NetworkingModule(
       for (handler in uriHandlers) {
         if (handler.supports(uri, responseType)) {
           val res = handler.fetch(uri)
+          val encodedDataLength = res.toString().toByteArray().size
           // fix: UriHandlers which are not using file:// scheme fail in whatwg-fetch at this line
           // https://github.com/JakeChampion/fetch/blob/main/fetch.js#L547
-          ResponseUtil.onResponseReceived(
-              reactApplicationContext, requestId, 200, Arguments.createMap(), url)
-          ResponseUtil.onDataReceived(reactApplicationContext, requestId, res)
-          ResponseUtil.onRequestSuccess(reactApplicationContext, requestId)
+          val status = 200
+
+          NetworkEventUtil.onResponseReceived(
+              reactApplicationContext,
+              requestId,
+              Response.Builder()
+                  .code(status)
+                  .request(Request.Builder().url(url.orEmpty()).build())
+                  .build())
+          NetworkEventUtil.onDataReceived(reactApplicationContext, requestId, res)
+          NetworkEventUtil.onRequestSuccess(
+              reactApplicationContext, requestId, encodedDataLength.toLong())
           return
         }
       }
     } catch (e: IOException) {
-      ResponseUtil.onRequestError(reactApplicationContext, requestId, e.message, e)
+      NetworkEventUtil.onRequestError(reactApplicationContext, requestId, e.message, e)
       return
     }
 
@@ -274,7 +281,7 @@ public class NetworkingModule(
     try {
       requestBuilder = Request.Builder().url(url.orEmpty())
     } catch (e: Exception) {
-      ResponseUtil.onRequestError(reactApplicationContext, requestId, e.message, null)
+      NetworkEventUtil.onRequestError(reactApplicationContext, requestId, e.message, null)
       return
     }
 
@@ -313,7 +320,7 @@ public class NetworkingModule(
                       // JS below, so no need to do anything here.
                       return
                     }
-                    ResponseUtil.onDataReceivedProgress(
+                    NetworkEventUtil.onDataReceivedProgress(
                         reactApplicationContext, requestId, bytesWritten, contentLength)
                     last = now
                   }
@@ -333,7 +340,7 @@ public class NetworkingModule(
 
     val requestHeaders = extractHeaders(headers, data)
     if (requestHeaders == null) {
-      ResponseUtil.onRequestError(
+      NetworkEventUtil.onRequestError(
           reactApplicationContext, requestId, "Unrecognized headers format", null)
       return
     }
@@ -359,7 +366,7 @@ public class NetworkingModule(
       handler != null -> requestBody = handler.toRequestBody(data, contentType)
       data.hasKey(REQUEST_BODY_KEY_STRING) -> {
         if (contentType == null) {
-          ResponseUtil.onRequestError(
+          NetworkEventUtil.onRequestError(
               reactApplicationContext,
               requestId,
               "Payload is set but no content-type header specified",
@@ -374,7 +381,7 @@ public class NetworkingModule(
             requestBody = RequestBodyUtil.createGzip(contentMediaType, body)
           }
           if (requestBody == null) {
-            ResponseUtil.onRequestError(
+            NetworkEventUtil.onRequestError(
                 reactApplicationContext, requestId, "Failed to gzip request body", null)
             return
           }
@@ -389,7 +396,7 @@ public class NetworkingModule(
                 checkNotNull(contentMediaType.charset(StandardCharsets.UTF_8))
               }
           if (body == null) {
-            ResponseUtil.onRequestError(
+            NetworkEventUtil.onRequestError(
                 reactApplicationContext, requestId, "Received request but body was empty", null)
             return
           }
@@ -399,7 +406,7 @@ public class NetworkingModule(
       }
       data.hasKey(REQUEST_BODY_KEY_BASE64) -> {
         if (contentType == null) {
-          ResponseUtil.onRequestError(
+          NetworkEventUtil.onRequestError(
               reactApplicationContext,
               requestId,
               "Payload is set but no content-type header specified",
@@ -411,7 +418,7 @@ public class NetworkingModule(
 
         val contentMediaType = MediaType.parse(contentType)
         if (contentMediaType == null) {
-          ResponseUtil.onRequestError(
+          NetworkEventUtil.onRequestError(
               reactApplicationContext,
               requestId,
               "Invalid content type specified: $contentType",
@@ -420,7 +427,7 @@ public class NetworkingModule(
         }
         val base64DecodedString = ByteString.decodeBase64(base64String)
         if (base64DecodedString == null) {
-          ResponseUtil.onRequestError(
+          NetworkEventUtil.onRequestError(
               reactApplicationContext, requestId, "Request body base64 string was invalid", null)
           return
         }
@@ -429,7 +436,7 @@ public class NetworkingModule(
       }
       data.hasKey(REQUEST_BODY_KEY_URI) -> {
         if (contentType == null) {
-          ResponseUtil.onRequestError(
+          NetworkEventUtil.onRequestError(
               reactApplicationContext,
               requestId,
               "Payload is set but no content-type header specified",
@@ -438,13 +445,13 @@ public class NetworkingModule(
         }
         val uri = data.getString(REQUEST_BODY_KEY_URI)
         if (uri == null) {
-          ResponseUtil.onRequestError(
+          NetworkEventUtil.onRequestError(
               reactApplicationContext, requestId, "Request body URI field was set but null", null)
           return
         }
         val fileInputStream = RequestBodyUtil.getFileInputStream(getReactApplicationContext(), uri)
         if (fileInputStream == null) {
-          ResponseUtil.onRequestError(
+          NetworkEventUtil.onRequestError(
               reactApplicationContext, requestId, "Could not retrieve file for uri $uri", null)
           return
         }
@@ -456,7 +463,7 @@ public class NetworkingModule(
         }
         val parts = data.getArray(REQUEST_BODY_KEY_FORMDATA)
         if (parts == null) {
-          ResponseUtil.onRequestError(
+          NetworkEventUtil.onRequestError(
               reactApplicationContext, requestId, "Received request but form data was empty", null)
           return
         }
@@ -472,8 +479,11 @@ public class NetworkingModule(
     requestBuilder.method(method, wrapRequestBodyWithProgressEmitter(requestBody, requestId))
 
     addRequest(requestId)
+    val request = requestBuilder.build()
+    NetworkEventUtil.onCreateRequest(requestId, request)
+
     client
-        .newCall(requestBuilder.build())
+        .newCall(request)
         .enqueue(
             object : Callback {
               override fun onFailure(call: Call, e: IOException) {
@@ -483,7 +493,7 @@ public class NetworkingModule(
                 removeRequest(requestId)
                 val errorMessage =
                     e.message ?: ("Error while executing request: ${e.javaClass.simpleName}")
-                ResponseUtil.onRequestError(reactApplicationContext, requestId, errorMessage, e)
+                NetworkEventUtil.onRequestError(reactApplicationContext, requestId, errorMessage, e)
               }
 
               @Throws(IOException::class)
@@ -493,12 +503,7 @@ public class NetworkingModule(
                 }
                 removeRequest(requestId)
                 // Before we touch the body send headers to JS
-                ResponseUtil.onResponseReceived(
-                    reactApplicationContext,
-                    requestId,
-                    response.code(),
-                    translateHeaders(response.headers()),
-                    response.request().url().toString())
+                NetworkEventUtil.onResponseReceived(reactApplicationContext, requestId, response)
 
                 try {
                   // OkHttp implements something called transparent gzip, which mean that it will
@@ -517,7 +522,7 @@ public class NetworkingModule(
                   // https://github.com/square/okhttp/blob/5b37cda9e00626f43acf354df145fd452c3031f1/okhttp/src/main/java/okhttp3/internal/http/BridgeInterceptor.java#L76-L111
                   var responseBody: ResponseBody? = response.body()
                   if (responseBody == null) {
-                    ResponseUtil.onRequestError(
+                    NetworkEventUtil.onRequestError(
                         reactApplicationContext, requestId, "Response body is null", null)
                     return
                   }
@@ -538,8 +543,9 @@ public class NetworkingModule(
                   for (responseHandler in responseHandlers) {
                     if (responseHandler.supports(responseType)) {
                       val res = responseHandler.toResponseData(responseBody)
-                      ResponseUtil.onDataReceived(reactApplicationContext, requestId, res)
-                      ResponseUtil.onRequestSuccess(reactApplicationContext, requestId)
+                      NetworkEventUtil.onDataReceived(reactApplicationContext, requestId, res)
+                      NetworkEventUtil.onRequestSuccess(
+                          reactApplicationContext, requestId, responseBody.contentLength())
                       return
                     }
                   }
@@ -549,7 +555,8 @@ public class NetworkingModule(
                   // periodically send response data updates to JS.
                   if (useIncrementalUpdates && responseType == "text") {
                     readWithProgress(requestId, responseBody)
-                    ResponseUtil.onRequestSuccess(reactApplicationContext, requestId)
+                    NetworkEventUtil.onRequestSuccess(
+                        reactApplicationContext, requestId, responseBody.contentLength())
                     return
                   }
 
@@ -566,17 +573,19 @@ public class NetworkingModule(
                         // Javascript layer.
                         // Introduced to fix issue #7463.
                       } else {
-                        ResponseUtil.onRequestError(
+                        NetworkEventUtil.onRequestError(
                             reactApplicationContext, requestId, e.message, e)
                       }
                     }
                   } else if (responseType == "base64") {
                     responseString = Base64.encodeToString(responseBody.bytes(), Base64.NO_WRAP)
                   }
-                  ResponseUtil.onDataReceived(reactApplicationContext, requestId, responseString)
-                  ResponseUtil.onRequestSuccess(reactApplicationContext, requestId)
+                  NetworkEventUtil.onDataReceived(
+                      reactApplicationContext, requestId, responseString)
+                  NetworkEventUtil.onRequestSuccess(
+                      reactApplicationContext, requestId, responseBody.contentLength())
                 } catch (e: IOException) {
-                  ResponseUtil.onRequestError(reactApplicationContext, requestId, e.message, e)
+                  NetworkEventUtil.onRequestError(reactApplicationContext, requestId, e.message, e)
                 }
               }
             })
@@ -598,7 +607,7 @@ public class NetworkingModule(
           override fun onProgress(bytesWritten: Long, contentLength: Long, done: Boolean) {
             val now = System.nanoTime()
             if (done || shouldDispatch(now, last)) {
-              ResponseUtil.onDataSend(
+              NetworkEventUtil.onDataSend(
                   reactApplicationContext, requestId, bytesWritten, contentLength)
               last = now
             }
@@ -633,7 +642,7 @@ public class NetworkingModule(
       var read: Int
       val reactApplicationContext = getReactApplicationContextIfActiveOrWarn()
       while ((inputStream.read(buffer).also { read = it }) != -1) {
-        ResponseUtil.onIncrementalDataReceived(
+        NetworkEventUtil.onIncrementalDataReceived(
             reactApplicationContext,
             requestId,
             streamDecoder.decodeNext(buffer, read),
@@ -691,7 +700,8 @@ public class NetworkingModule(
     val multipartBuilder = MultipartBody.Builder()
     val mediaType = MediaType.parse(contentType)
     if (mediaType == null) {
-      ResponseUtil.onRequestError(reactApplicationContext, requestId, "Invalid media type.", null)
+      NetworkEventUtil.onRequestError(
+          reactApplicationContext, requestId, "Invalid media type.", null)
       return null
     }
     multipartBuilder.setType(mediaType)
@@ -699,7 +709,7 @@ public class NetworkingModule(
     for (i in 0 until body.size()) {
       val bodyPart = body.getMap(i)
       if (bodyPart == null) {
-        ResponseUtil.onRequestError(
+        NetworkEventUtil.onRequestError(
             reactApplicationContext, requestId, "Unrecognized FormData part.", null)
         return null
       }
@@ -708,7 +718,7 @@ public class NetworkingModule(
       val headersArray = bodyPart.getArray("headers")
       var headers = extractHeaders(headersArray, null)
       if (headers == null) {
-        ResponseUtil.onRequestError(
+        NetworkEventUtil.onRequestError(
             reactApplicationContext,
             requestId,
             "Missing or invalid header format for FormData part.",
@@ -732,7 +742,7 @@ public class NetworkingModule(
       } else if (bodyPart.hasKey(REQUEST_BODY_KEY_URI) &&
           bodyPart.getString(REQUEST_BODY_KEY_URI) != null) {
         if (partContentType == null) {
-          ResponseUtil.onRequestError(
+          NetworkEventUtil.onRequestError(
               reactApplicationContext,
               requestId,
               "Binary FormData part needs a content-type header.",
@@ -741,14 +751,14 @@ public class NetworkingModule(
         }
         val fileContentUriStr = bodyPart.getString(REQUEST_BODY_KEY_URI)
         if (fileContentUriStr == null) {
-          ResponseUtil.onRequestError(
+          NetworkEventUtil.onRequestError(
               reactApplicationContext, requestId, "Body must have a valid file uri", null)
           return null
         }
         val fileInputStream =
             RequestBodyUtil.getFileInputStream(getReactApplicationContext(), fileContentUriStr)
         if (fileInputStream == null) {
-          ResponseUtil.onRequestError(
+          NetworkEventUtil.onRequestError(
               reactApplicationContext,
               requestId,
               "Could not retrieve file for uri $fileContentUriStr",
@@ -757,7 +767,7 @@ public class NetworkingModule(
         }
         multipartBuilder.addPart(headers, RequestBodyUtil.create(partContentType, fileInputStream))
       } else {
-        ResponseUtil.onRequestError(
+        NetworkEventUtil.onRequestError(
             reactApplicationContext, requestId, "Unrecognized FormData part.", null)
       }
     }
@@ -827,20 +837,5 @@ public class NetworkingModule(
     }
 
     private fun shouldDispatch(now: Long, last: Long): Boolean = last + CHUNK_TIMEOUT_NS < now
-
-    private fun translateHeaders(headers: Headers): WritableMap {
-      val responseHeaders = Bundle()
-      for (i in 0..<headers.size()) {
-        val headerName = headers.name(i)
-        // multiple values for the same header
-        if (responseHeaders.containsKey(headerName)) {
-          responseHeaders.putString(
-              headerName, "${responseHeaders.getString(headerName)}, ${headers.value(i)}")
-        } else {
-          responseHeaders.putString(headerName, headers.value(i))
-        }
-      }
-      return Arguments.fromBundle(responseHeaders)
-    }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/CMakeLists.txt
@@ -80,8 +80,10 @@ target_link_libraries(reactnativejni
         fbjni
         folly_runtime
         glog_init
+        jsinspector_network
         logger
         react_cxxreact
+        react_featureflags
         react_renderer_runtimescheduler
         reactnativejni_common
         runtimeexecutor

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/InspectorNetworkReporter.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/InspectorNetworkReporter.cpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "InspectorNetworkReporter.h"
+
+#include <jsinspector-modern/network/NetworkReporter.h>
+
+#include <cstddef>
+#include <string>
+
+using namespace facebook::jni;
+using namespace facebook::react::jsinspector_modern;
+
+namespace facebook::react {
+
+namespace {
+
+Headers convertJavaMapToHeaders(
+    jni::alias_ref<jni::JMap<jstring, jstring>> headers) {
+  Headers responseHeaders;
+
+  for (auto it : *headers) {
+    auto key = it.first->toStdString();
+    auto value = it.second->toStdString();
+    responseHeaders[key] = value;
+  }
+
+  return responseHeaders;
+}
+
+std::string limitRequestBodySize(std::string requestBody) {
+  const size_t maxBodySize = 1024 * 1024; // 1MB
+  auto bodyLength = requestBody.size();
+  auto bytesToRead = std::min(bodyLength, maxBodySize);
+
+  requestBody.resize(bytesToRead);
+
+  if (bytesToRead < bodyLength) {
+    requestBody += "\n... [truncated, showing " + std::to_string(bytesToRead) +
+        " of " + std::to_string(bodyLength) + " bytes]";
+  }
+
+  return requestBody;
+}
+
+} // namespace
+
+/* static */ void InspectorNetworkReporter::reportRequestStart(
+    const jni::alias_ref<jclass> /*unused*/,
+    jint requestId,
+    jni::alias_ref<jstring> requestUrl,
+    jni::alias_ref<jstring> requestMethod,
+    jni::alias_ref<jni::JMap<jstring, jstring>> requestHeaders,
+    jni::alias_ref<jstring> requestBody,
+    jlong encodedDataLength) {
+  RequestInfo requestInfo;
+  requestInfo.url = requestUrl->toStdString();
+  requestInfo.httpMethod = requestMethod->toStdString();
+  requestInfo.headers = convertJavaMapToHeaders(requestHeaders);
+  requestInfo.httpBody = limitRequestBodySize(requestBody->toStdString());
+
+  NetworkReporter::getInstance().reportRequestStart(
+      std::to_string(requestId), requestInfo, encodedDataLength, std::nullopt);
+}
+
+/* static */ void InspectorNetworkReporter::reportConnectionTiming(
+    jni::alias_ref<jclass> /*unused*/,
+    jint requestId,
+    jni::alias_ref<jni::JMap<jstring, jstring>> headers) {
+  NetworkReporter::getInstance().reportConnectionTiming(
+      std::to_string(requestId), convertJavaMapToHeaders(headers));
+}
+
+/* static */ void InspectorNetworkReporter::reportResponseStart(
+    jni::alias_ref<jclass> /*unused*/,
+    jint requestId,
+    jni::alias_ref<jstring> responseUrl,
+    jint responseStatus,
+    jni::alias_ref<jni::JMap<jstring, jstring>> responseHeaders,
+    jlong encodedDataLength) {
+  ResponseInfo responseInfo;
+  responseInfo.url = responseUrl->toStdString();
+  responseInfo.statusCode = responseStatus;
+  responseInfo.headers = convertJavaMapToHeaders(responseHeaders);
+
+  NetworkReporter::getInstance().reportResponseStart(
+      std::to_string(requestId),
+      responseInfo,
+      static_cast<std::int64_t>(encodedDataLength));
+}
+
+/* static */ void InspectorNetworkReporter::reportResponseEnd(
+    jni::alias_ref<jclass> /*unused*/,
+    jint requestId,
+    jlong encodedDataLength) {
+  NetworkReporter::getInstance().reportResponseEnd(
+      std::to_string(requestId), static_cast<std::int64_t>(encodedDataLength));
+}
+
+void InspectorNetworkReporter::registerNatives() {
+  javaClassLocal()->registerNatives({
+      makeNativeMethod(
+          "reportRequestStart", InspectorNetworkReporter::reportRequestStart),
+      makeNativeMethod(
+          "reportResponseStart", InspectorNetworkReporter::reportResponseStart),
+      makeNativeMethod(
+          "reportResponseEnd", InspectorNetworkReporter::reportResponseEnd),
+      makeNativeMethod(
+          "reportConnectionTiming",
+          InspectorNetworkReporter::reportConnectionTiming),
+  });
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/InspectorNetworkReporter.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/InspectorNetworkReporter.cpp
@@ -101,6 +101,23 @@ std::string limitRequestBodySize(std::string requestBody) {
       std::to_string(requestId), static_cast<std::int64_t>(encodedDataLength));
 }
 
+/* static */ void InspectorNetworkReporter::maybeStoreResponseBody(
+    jni::alias_ref<jclass> /*unused*/,
+    jint requestId,
+    jni::alias_ref<jstring> body,
+    jboolean base64Encoded) {
+#ifdef REACT_NATIVE_DEBUGGER_ENABLED
+  // Debug build: Process response body and report to NetworkReporter
+  auto& networkReporter = NetworkReporter::getInstance();
+  if (!networkReporter.isDebuggingEnabled()) {
+    return;
+  }
+
+  networkReporter.storeResponseBody(
+      std::to_string(requestId), body->toStdString(), base64Encoded);
+#endif
+}
+
 void InspectorNetworkReporter::registerNatives() {
   javaClassLocal()->registerNatives({
       makeNativeMethod(
@@ -112,6 +129,9 @@ void InspectorNetworkReporter::registerNatives() {
       makeNativeMethod(
           "reportConnectionTiming",
           InspectorNetworkReporter::reportConnectionTiming),
+      makeNativeMethod(
+          "maybeStoreResponseBody",
+          InspectorNetworkReporter::maybeStoreResponseBody),
   });
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/InspectorNetworkReporter.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/InspectorNetworkReporter.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <fbjni/fbjni.h>
+
+namespace facebook::react {
+
+/**
+ * JNI wrapper for `facebook::react::jsinspector_modern::NetworkReporter`.
+ */
+class InspectorNetworkReporter
+    : public jni::HybridClass<InspectorNetworkReporter> {
+ public:
+  static constexpr auto kJavaDescriptor =
+      "Lcom/facebook/react/modules/network/InspectorNetworkReporter;";
+
+  static void reportRequestStart(
+      jni::alias_ref<jclass> /*unused*/,
+      jint requestId,
+      jni::alias_ref<jstring> requestUrl,
+      jni::alias_ref<jstring> requestMethod,
+      jni::alias_ref<jni::JMap<jstring, jstring>> requestHeaders,
+      jni::alias_ref<jstring> requestBody,
+      jlong encodedDataLength);
+
+  static void reportConnectionTiming(
+      jni::alias_ref<jclass> /*unused*/,
+      jint requestId,
+      jni::alias_ref<jni::JMap<jstring, jstring>> headers);
+
+  static void reportResponseStart(
+      jni::alias_ref<jclass> /*unused*/,
+      jint requestId,
+      jni::alias_ref<jstring> responseUrl,
+      jint responseStatus,
+      jni::alias_ref<jni::JMap<jstring, jstring>> responseHeaders,
+      jlong expectedDataLength);
+
+  static void reportResponseEnd(
+      jni::alias_ref<jclass> /*unused*/,
+      jint requestId,
+      jlong encodedDataLength);
+
+  static void registerNatives();
+
+ private:
+  InspectorNetworkReporter() = delete;
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/InspectorNetworkReporter.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/InspectorNetworkReporter.h
@@ -47,6 +47,12 @@ class InspectorNetworkReporter
       jint requestId,
       jlong encodedDataLength);
 
+  static void maybeStoreResponseBody(
+      jni::alias_ref<jclass> /*unused*/,
+      jint requestId,
+      jni::alias_ref<jstring> body,
+      jboolean base64Encoded);
+
   static void registerNatives();
 
  private:

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
@@ -5,8 +5,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <string>
-
 #include <glog/logging.h>
 
 #include <fb/glog_init.h>
@@ -14,6 +12,7 @@
 
 #include "CatalystInstanceImpl.h"
 #include "CxxModuleWrapperBase.h"
+#include "InspectorNetworkReporter.h"
 #include "InspectorNetworkRequestListener.h"
 #include "JInspector.h"
 #include "JavaScriptExecutorHolder.h"
@@ -46,6 +45,7 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
     JInspector::registerNatives();
     ReactInstanceManagerInspectorTarget::registerNatives();
     InspectorNetworkRequestListener::registerNatives();
+    InspectorNetworkReporter::registerNatives();
   });
 }
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/HttpUtils.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/HttpUtils.cpp
@@ -147,8 +147,11 @@ std::string httpReasonPhrase(uint16_t status) {
 std::string mimeTypeFromHeaders(const Headers& headers) {
   std::string mimeType = "application/octet-stream";
 
-  if (headers.find("Content-Type") != headers.end()) {
-    mimeType = headers.at("Content-Type");
+  for (const auto& header : headers) {
+    if (strcasecmp(header.first.c_str(), "Content-Type") == 0) {
+      mimeType = header.second;
+      break;
+    }
   }
 
   return mimeType;


### PR DESCRIPTION
Summary:
Continues integration of `NetworkReporter` (jsinspector-modern) on Android, to enable the Network panel in React Native DevTools.

NOTE: As with iOS, all changes are gated behind the `enableNetworkEventReporting` and `fuseboxNetworkInspectionEnabled` feature flags.

**This diff**

Integrates `Network.storeRequestBody` on Android (CDP: [`Network.getResponseBody`](https://chromedevtools.github.io/devtools-protocol/tot/Network/#method-getResponseBody) CDP event) to populate the "Preview" and "Response" tabs in the React Native DevTools Network panel.

This is integrated with `NetworkingModule.kt` to support synchronously received `text` or `blob` data types, with incremental response support added next in D77927896.

Changelog: [Internal]

Differential Revision: D77799617
