### PR TITLE
perf: Enable link-time-optimization for performance critical libraries

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
@@ -249,6 +249,9 @@ target_link_libraries(reactnative
             yogacore
 )
 
+# Enable aggressive compiler optimizations and link-time-optimizations
+target_compile_options(reactnative PRIVATE -O3 -flto)
+
 target_compile_reactnative_options(reactnative PRIVATE)
 
 target_include_directories(reactnative

--- a/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/first-party/yogajni/CMakeLists.txt
@@ -23,4 +23,4 @@ target_link_libraries(yoga
 )
 
 target_compile_reactnative_options(yoga PRIVATE)
-target_compile_options(yoga PRIVATE -fvisibility=hidden -O3)
+target_compile_options(yoga PRIVATE -fvisibility=hidden -O3 -flto)

--- a/packages/react-native/ReactCommon/jsi/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsi/CMakeLists.txt
@@ -23,4 +23,4 @@ target_link_libraries(jsi
         glog)
 
 target_compile_reactnative_options(jsi PRIVATE)
-target_compile_options(jsi PRIVATE -O3 -Wno-unused-lambda-capture)
+target_compile_options(jsi PRIVATE -O3 -flto -Wno-unused-lambda-capture)

--- a/packages/react-native/ReactCommon/jsiexecutor/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsiexecutor/CMakeLists.txt
@@ -23,4 +23,4 @@ target_link_libraries(jsireact
         jsi)
 
 target_compile_reactnative_options(jsireact PRIVATE)
-target_compile_options(jsireact PRIVATE -O3)
+target_compile_options(jsireact PRIVATE -O3 -flto)

--- a/packages/react-native/ReactCommon/yoga/cmake/project-defaults.cmake
+++ b/packages/react-native/ReactCommon/yoga/cmake/project-defaults.cmake
@@ -38,6 +38,8 @@ add_compile_options(
     $<$<COMPILE_LANGUAGE:CXX>:-frtti>
     # Use -O2 (prioritize speed)
     $<$<CONFIG:RELEASE>:-O2>
+    # Enable link-time-optimization if building in release
+    $<$<CONFIG:RELEASE>:-flto>
     # Enable separate sections per function/data item
     $<$<CONFIG:RELEASE>:-ffunction-sections>
     $<$<CONFIG:RELEASE>:-fdata-sections>)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Enables [Link Time Optimization](https://www.llvm.org/docs/LinkTimeOptimization.html) for performance critical libraries to optimize the native code across modules.

This might increase release build-time a tiny bit (not yet measured), but should improve runtime performance or startup performance a bit (60ms in the Discord app, not yet measured in other apps)

### Comparisons

#### Native Libraries Size

- Without `-flto` (current main): 19,4 MB for `rn-tester` apk (`assembleRelease`, arm64-v8a)
- With `-flto` (current PR): 19,4 MB for `rn-tester` apk (`assembleRelease`, arm64-v8a)

..so no difference.

#### Release apk build time

- Without `-flto` (current main): 8:40.24 
- With `-flto` (current PR): 10:19.57

...so 1min 20s increase in build time 😢 

#### Release apk performance

<table>
<tr>
<th>Without <code>-flto</code> (current main)</th>
<th>With <code>-flto</code> (current PR)</th>
</tr>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/3f841da0-4931-4fea-9c05-1b8163ff921a" width="100%" />
</td>
<td>
<img src="https://github.com/user-attachments/assets/3cba21ac-0be5-4c8d-bce5-264a45ac1113" width="100%" />
</td>
</tr>
</table>

I'm not sure how accurate the flashlight measurements are, but according to the average of 10 tests in this CI, enabling `-flto` makes the app start ~70ms (or ~10%) faster... 👀 

#### Release apk performance

- Without `-flto` (current main): ...
- With `-flto` (current PR): ...

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[GENERAL] [ADDED] - Enabled link-time-optimization to improve performance of some parts of the C++ codebase

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

1. Build once with, and once without `-flto` (release builds!)
2. Measure build time difference between clean builds
3. Measure startup time difference
4. Measure perceived performance when stress-testing something (maybe the Turbo Modules vs Nitro Modules benchmark got a bit tighter with this)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
