### PR TITLE
Fix all workflows to use node 22.14.0

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -4,7 +4,7 @@ inputs:
   node-version:
     description: 'The node.js version to use'
     required: false
-    default: '22'
+    default: '22.14.0'
 runs:
   using: "composite"
   steps:

--- a/.github/actions/yarn-install/action.yml
+++ b/.github/actions/yarn-install/action.yml
@@ -2,6 +2,8 @@ name: yarn-install
 runs:
   using: composite
   steps:
+    - name: Setup node.js
+      uses: ./.github/actions/setup-node
     - name: Install dependencies
       shell: bash
       run: |


### PR DESCRIPTION
Summary:
We hit this error when trying to release 0.81.0 (see [action run](https://github.com/facebook/react-native/actions/runs/16147471618/job/45570030039)):

> error react-native/metro-babel-transformer@0.81.0-main: The engine "node" is incompatible with this module. Expected version ">= 22.14.0". Got "20.19.2"

This should fix the issue.

Changelog: [Internal]

Reviewed By: motiz88, cortinico

Differential Revision: D77938906


