### PR TITLE
Improve NativeDOM Turbo Module typing

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/dom/NativeDOM.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/dom/NativeDOM.h
@@ -21,6 +21,15 @@
 
 namespace facebook::react {
 
+using MeasureOnSuccessCallback =
+    SyncCallback<void(double, double, double, double, double, double)>;
+
+using MeasureInWindowOnSuccessCallback =
+    SyncCallback<void(double, double, double, double)>;
+
+using MeasureLayoutOnSuccessCallback =
+    SyncCallback<void(double, double, double, double)>;
+
 class NativeDOM : public NativeDOMCxxSpec<NativeDOM> {
  public:
   NativeDOM(std::shared_ptr<CallInvoker> jsInvoker);
@@ -117,19 +126,19 @@ class NativeDOM : public NativeDOMCxxSpec<NativeDOM> {
   void measure(
       jsi::Runtime& rt,
       std::shared_ptr<const ShadowNode> shadowNode,
-      jsi::Function callback);
+      const MeasureOnSuccessCallback& callback);
 
   void measureInWindow(
       jsi::Runtime& rt,
       std::shared_ptr<const ShadowNode> shadowNode,
-      jsi::Function callback);
+      const MeasureInWindowOnSuccessCallback& callback);
 
   void measureLayout(
       jsi::Runtime& rt,
       std::shared_ptr<const ShadowNode> shadowNode,
       std::shared_ptr<const ShadowNode> relativeToShadowNode,
       jsi::Function onFail,
-      jsi::Function onSuccess);
+      const MeasureLayoutOnSuccessCallback& onSuccess);
 
 #pragma mark - Legacy direct manipulation APIs (for `ReactNativeElement`).
 


### PR DESCRIPTION
Summary:
Changelog: [Internal]

- Use C++ private namespace instead of C static methods
- Strongly type C++ TM functions via AsyncCallback

Differential Revision: D77978354


