### PR TITLE
[BugFix] [Windows] [error C4244]: 'return': conversion from 'int' to 'uint8_t', possible loss of data in CSSHexColor

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/css/CSSHexColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSHexColor.h
@@ -34,9 +34,9 @@ constexpr uint8_t hexToNumeric(std::string_view hex, HexColorType hexType) {
   }
 
   if (hexType == HexColorType::Short) {
-    return static_cast<uint8_t>(result * 16 + result); // Windows #14666
+    return static_cast<uint8_t>(result * 16 + result);
   } else {
-    return static_cast<uint8_t>(result); // Windows #14666
+    return static_cast<uint8_t>(result);
   }
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSHexColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSHexColor.h
@@ -34,9 +34,9 @@ constexpr uint8_t hexToNumeric(std::string_view hex, HexColorType hexType) {
   }
 
   if (hexType == HexColorType::Short) {
-    return result * 16 + result;
+    return static_cast<uint8_t>(result * 16 + result); // Windows #14666
   } else {
-    return result;
+    return static_cast<uint8_t>(result); // Windows #14666
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Resolves https://github.com/microsoft/react-native-windows/issues/14666 
We faced this issue while integrating [0.79.0-nightly-20250220-41b597c73](https://github.com/microsoft/react-native-windows/pull/14662/files#top)

This warning is treated as error and should be fixed here as well.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[GENERAL] [FIXED] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:
Fixed error:
##[error]node_modules\react-native\ReactCommon\react\renderer\css\CSSHexColor.h(39,12): Error C4244: 'return': conversion from 'int' to 'uint8_t', possible loss of data
2>D:\a_work\1\s\node_modules\react-native\ReactCommon\react\renderer\css\CSSHexColor.h(39,12): error C4244: 'return': conversion from 'int' to 'uint8_t', possible loss of data [D:\a_work\1\s\vnext\Microsoft.ReactNative\Microsoft.ReactNative.vcxproj]
(compiling source file '../../node_modules/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp')

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Tested E2E in RNW