### PR TITLE
[ios][prebuild] add release/debug switch script 

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
+++ b/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
@@ -84,4 +84,5 @@ Pod::Spec.new do |s|
 
   depend_on_js_engine(s)
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 end

--- a/packages/react-native/Libraries/Blob/React-RCTBlob.podspec
+++ b/packages/react-native/Libraries/Blob/React-RCTBlob.podspec
@@ -55,4 +55,5 @@ Pod::Spec.new do |s|
   end
 
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 end

--- a/packages/react-native/Libraries/Image/React-RCTImage.podspec
+++ b/packages/react-native/Libraries/Image/React-RCTImage.podspec
@@ -53,4 +53,5 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-NativeModulesApple")
 
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 end

--- a/packages/react-native/Libraries/NativeAnimation/React-RCTAnimation.podspec
+++ b/packages/react-native/Libraries/NativeAnimation/React-RCTAnimation.podspec
@@ -50,4 +50,5 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-featureflags")
 
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 end

--- a/packages/react-native/Libraries/Network/React-RCTNetwork.podspec
+++ b/packages/react-native/Libraries/Network/React-RCTNetwork.podspec
@@ -52,4 +52,5 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-NativeModulesApple", :additional_framework_paths => ["build/generated/ios"])
 
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 end

--- a/packages/react-native/Libraries/Settings/React-RCTSettings.podspec
+++ b/packages/react-native/Libraries/Settings/React-RCTSettings.podspec
@@ -49,4 +49,5 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-NativeModulesApple", :additional_framework_paths => ["build/generated/ios"])
 
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 end

--- a/packages/react-native/Libraries/Vibration/React-RCTVibration.podspec
+++ b/packages/react-native/Libraries/Vibration/React-RCTVibration.podspec
@@ -49,4 +49,5 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-NativeModulesApple")
 
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 end

--- a/packages/react-native/React-Core-prebuilt.podspec
+++ b/packages/react-native/React-Core-prebuilt.podspec
@@ -62,8 +62,7 @@ Pod::Spec.new do |s|
         CONFIG="Debug"
       fi
 
-      # TODO(T228219721): Add this for React Native Core as well
-      ##### "$NODE_BINARY" "$REACT_NATIVE_PATH/third-party-podspecs/replace_dependencies_version.js" -c "$CONFIG" -r "#{version}" -p "$PODS_ROOT"
+      "$NODE_BINARY" "$REACT_NATIVE_PATH/scripts/replace-rncore-version.js" -c "$CONFIG" -r "#{version}" -p "$PODS_ROOT"
       EOS
     }
 
@@ -73,7 +72,7 @@ Pod::Spec.new do |s|
       # always run the script without warning
       script_phase[:always_out_of_date] = "1"
     end
-    
+
     s.script_phase = script_phase
   end
 end

--- a/packages/react-native/React-Core.podspec
+++ b/packages/react-native/React-Core.podspec
@@ -83,10 +83,6 @@ Pod::Spec.new do |s|
     ss.exclude_files = exclude_files
     ss.private_header_files   = "React/Cxx*/*.h"
 
-    # Include prebuilt if we're not building from source
-    if !ReactNativeCoreUtils.build_rncore_from_source()
-      ss.dependency "React-Core-prebuilt", version
-    end
   end
 
   s.subspec "DevSupport" do |ss|
@@ -137,4 +133,5 @@ Pod::Spec.new do |s|
 
   depend_on_js_engine(s)
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 end

--- a/packages/react-native/React/CoreModules/React-CoreModules.podspec
+++ b/packages/react-native/React/CoreModules/React-CoreModules.podspec
@@ -63,4 +63,5 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-NativeModulesApple")
 
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 end

--- a/packages/react-native/React/React-RCTFBReactNativeSpec.podspec
+++ b/packages/react-native/React/React-RCTFBReactNativeSpec.podspec
@@ -61,6 +61,7 @@ Pod::Spec.new do |s|
 
   depend_on_js_engine(s)
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 
   s.subspec "components" do |ss|
     ss.source_files         = podspec_sources("FBReactNativeSpec/react/renderer/components/FBReactNativeSpec/**/*.{m,mm,cpp,h}", "FBReactNativeSpec/react/renderer/components/FBReactNativeSpec/**/*.{h}")

--- a/packages/react-native/React/React-RCTFabric.podspec
+++ b/packages/react-native/React/React-RCTFabric.podspec
@@ -97,6 +97,7 @@ Pod::Spec.new do |s|
 
   depend_on_js_engine(s)
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 
   s.test_spec 'Tests' do |test_spec|
     test_spec.source_files = podspec_sources("Tests/**/*.{mm}", "")

--- a/packages/react-native/React/Runtime/React-RCTRuntime.podspec
+++ b/packages/react-native/React/Runtime/React-RCTRuntime.podspec
@@ -68,4 +68,5 @@ Pod::Spec.new do |s|
 
   depend_on_js_engine(s)
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 end

--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
                             "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                             "DEFINES_MODULE" => "YES" }
 
-  if ENV['USE_FRAMEWORKS']
+  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
     s.header_mappings_dir     = './'
     s.module_name             = 'React_Fabric'
   end
@@ -56,6 +56,7 @@ Pod::Spec.new do |s|
 
   depend_on_js_engine(s)
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 
   s.subspec "animations" do |ss|
     ss.source_files         = podspec_sources("react/renderer/animations/**/*.{m,mm,cpp,h}", "react/renderer/animations/**/*.{h}")

--- a/packages/react-native/ReactCommon/React-FabricComponents.podspec
+++ b/packages/react-native/ReactCommon/React-FabricComponents.podspec
@@ -79,6 +79,7 @@ Pod::Spec.new do |s|
 
   depend_on_js_engine(s)
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 
   s.subspec "components" do |ss|
 

--- a/packages/react-native/ReactCommon/React-FabricImage.podspec
+++ b/packages/react-native/ReactCommon/React-FabricImage.podspec
@@ -78,4 +78,5 @@ Pod::Spec.new do |s|
 
   depend_on_js_engine(s)
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 end

--- a/packages/react-native/ReactCommon/React-Mapbuffer.podspec
+++ b/packages/react-native/ReactCommon/React-Mapbuffer.podspec
@@ -39,5 +39,5 @@ Pod::Spec.new do |s|
 
   add_dependency(s, "React-debug")
   add_rn_third_party_dependencies(s)
-
+  add_rncore_dependency(s)
 end

--- a/packages/react-native/ReactCommon/ReactCommon.podspec
+++ b/packages/react-native/ReactCommon/ReactCommon.podspec
@@ -32,11 +32,12 @@ Pod::Spec.new do |s|
                                "DEFINES_MODULE" => "YES",
                                "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                "GCC_WARN_PEDANTIC" => "YES" }
-  if ENV['USE_FRAMEWORKS']
+  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
     s.header_mappings_dir     = './'
   end
 
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 
   # TODO (T48588859): Restructure this target to align with dir structure: "react/nativemodule/..."
   # Note: Update this only when ready to minimize breaking changes.

--- a/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
+++ b/packages/react-native/ReactCommon/cxxreact/React-cxxreact.podspec
@@ -52,4 +52,5 @@ Pod::Spec.new do |s|
   end
 
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 end

--- a/packages/react-native/ReactCommon/hermes/React-hermes.podspec
+++ b/packages/react-native/ReactCommon/hermes/React-hermes.podspec
@@ -48,4 +48,5 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-runtimeexecutor", :additional_framework_paths => ["platform/ios"])
 
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 end

--- a/packages/react-native/ReactCommon/jserrorhandler/React-jserrorhandler.podspec
+++ b/packages/react-native/ReactCommon/jserrorhandler/React-jserrorhandler.podspec
@@ -33,7 +33,7 @@ Pod::Spec.new do |s|
     "USE_HEADERMAP" => "YES",
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard()
   }
-  if ENV['USE_FRAMEWORKS']
+  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
     s.header_mappings_dir     = '../'
     s.module_name             = 'React_jserrorhandler'
   end
@@ -49,5 +49,6 @@ Pod::Spec.new do |s|
   end
 
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 
 end

--- a/packages/react-native/ReactCommon/jsi/React-jsi.podspec
+++ b/packages/react-native/ReactCommon/jsi/React-jsi.podspec
@@ -46,4 +46,5 @@ Pod::Spec.new do |s|
   s.exclude_files = files_to_exclude
 
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 end

--- a/packages/react-native/ReactCommon/jsiexecutor/React-jsiexecutor.podspec
+++ b/packages/react-native/ReactCommon/jsiexecutor/React-jsiexecutor.podspec
@@ -41,4 +41,5 @@ Pod::Spec.new do |s|
   end
 
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 end

--- a/packages/react-native/ReactCommon/jsinspector-modern/React-jsinspector.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/React-jsinspector.podspec
@@ -60,4 +60,5 @@ Pod::Spec.new do |s|
   end
 
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 end

--- a/packages/react-native/ReactCommon/jsinspector-modern/cdp/React-jsinspectorcdp.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/cdp/React-jsinspectorcdp.podspec
@@ -41,10 +41,11 @@ Pod::Spec.new do |s|
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
     "DEFINES_MODULE" => "YES"}
 
-  if ENV['USE_FRAMEWORKS']
+  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
     s.module_name = module_name
     s.header_mappings_dir = "../.."
   end
 
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 end

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/React-jsinspectornetwork.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/React-jsinspectornetwork.podspec
@@ -41,7 +41,7 @@ Pod::Spec.new do |s|
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
     "DEFINES_MODULE" => "YES"}
 
-  if ENV['USE_FRAMEWORKS']
+  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
     s.module_name = module_name
     s.header_mappings_dir = "../.."
   end
@@ -52,4 +52,5 @@ Pod::Spec.new do |s|
   s.dependency "React-timing"
 
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 end

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/React-jsinspectortracing.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/React-jsinspectortracing.podspec
@@ -41,7 +41,7 @@ Pod::Spec.new do |s|
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
     "DEFINES_MODULE" => "YES"}
 
-  if ENV['USE_FRAMEWORKS']
+  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
     s.module_name = module_name
     s.header_mappings_dir = "../.."
   end
@@ -50,4 +50,5 @@ Pod::Spec.new do |s|
   s.dependency "React-timing"
 
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 end

--- a/packages/react-native/ReactCommon/jsitooling/React-jsitooling.podspec
+++ b/packages/react-native/ReactCommon/jsitooling/React-jsitooling.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   s.source_files           = podspec_sources("react/runtime/*.{cpp,h}", "react/runtime/*.h")
   s.header_dir             = "react/runtime"
 
-  if ENV['USE_FRAMEWORKS']
+  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
     s.module_name            = "JSITooling"
     s.header_mappings_dir  = "./"
   end
@@ -46,4 +46,5 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')
 
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 end

--- a/packages/react-native/ReactCommon/logger/React-logger.podspec
+++ b/packages/react-native/ReactCommon/logger/React-logger.podspec
@@ -30,4 +30,5 @@ Pod::Spec.new do |s|
   s.header_dir             = "logger"
 
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 end

--- a/packages/react-native/ReactCommon/react/debug/React-debug.podspec
+++ b/packages/react-native/ReactCommon/react/debug/React-debug.podspec
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                "DEFINES_MODULE" => "YES" }
 
-  if ENV['USE_FRAMEWORKS']
+  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
     s.module_name            = "React_debug"
     s.header_mappings_dir  = "../.."
   end

--- a/packages/react-native/ReactCommon/react/featureflags/React-featureflags.podspec
+++ b/packages/react-native/ReactCommon/react/featureflags/React-featureflags.podspec
@@ -37,10 +37,11 @@ Pod::Spec.new do |s|
                                "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),
                                "DEFINES_MODULE" => "YES" }
 
-  if ENV['USE_FRAMEWORKS']
+  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
     s.module_name            = "React_featureflags"
     s.header_mappings_dir  = "../.."
   end
 
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 end

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/React-NativeModulesApple.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/React-NativeModulesApple.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
                                 "USE_HEADERMAP" => "YES",
                                 "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                 "GCC_WARN_PEDANTIC" => "YES" }
-    if ENV['USE_FRAMEWORKS']
+    if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
         s.header_mappings_dir     = './'
     end
 
@@ -51,4 +51,5 @@ Pod::Spec.new do |s|
 
     depend_on_js_engine(s)
     add_rn_third_party_dependencies(s)
+    add_rncore_dependency(s)
 end

--- a/packages/react-native/ReactCommon/react/nativemodule/defaults/React-defaultsnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/defaults/React-defaultsnativemodule.podspec
@@ -47,6 +47,7 @@ Pod::Spec.new do |s|
   s.dependency "React-jsiexecutor"
   depend_on_js_engine(s)
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 
   s.dependency "React-domnativemodule"
   s.dependency "React-featureflagsnativemodule"

--- a/packages/react-native/ReactCommon/react/nativemodule/dom/React-domnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/dom/React-domnativemodule.podspec
@@ -50,6 +50,7 @@ Pod::Spec.new do |s|
 
   depend_on_js_engine(s)
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 
   s.dependency "Yoga"
   s.dependency "ReactCommon/turbomodule/core"

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/React-featureflagsnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/React-featureflagsnativemodule.podspec
@@ -48,6 +48,7 @@ Pod::Spec.new do |s|
 
   depend_on_js_engine(s)
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 
   s.dependency "ReactCommon/turbomodule/core"
   s.dependency "React-RCTFBReactNativeSpec"

--- a/packages/react-native/ReactCommon/react/nativemodule/idlecallbacks/React-idlecallbacksnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/idlecallbacks/React-idlecallbacksnativemodule.podspec
@@ -48,6 +48,7 @@ Pod::Spec.new do |s|
 
   depend_on_js_engine(s)
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 
   s.dependency "ReactCommon/turbomodule/core"
   s.dependency "React-runtimescheduler"

--- a/packages/react-native/ReactCommon/react/nativemodule/microtasks/React-microtasksnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/microtasks/React-microtasksnativemodule.podspec
@@ -48,6 +48,7 @@ Pod::Spec.new do |s|
 
   depend_on_js_engine(s)
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 
   s.dependency "ReactCommon/turbomodule/core"
   add_dependency(s, "React-RCTFBReactNativeSpec")

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon-Samples.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon-Samples.podspec
@@ -57,4 +57,5 @@ Pod::Spec.new do |s|
 
   depend_on_js_engine(s)
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 end

--- a/packages/react-native/ReactCommon/react/performance/timeline/React-performancetimeline.podspec
+++ b/packages/react-native/ReactCommon/react/performance/timeline/React-performancetimeline.podspec
@@ -38,7 +38,7 @@ Pod::Spec.new do |s|
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
     "HEADER_SEARCH_PATHS" => header_search_paths.join(' ')}
 
-  if ENV['USE_FRAMEWORKS']
+  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
     s.module_name            = "React_performancetimeline"
     s.header_mappings_dir  = "../../.."
   end
@@ -49,4 +49,5 @@ Pod::Spec.new do |s|
   s.dependency "React-perflogger"
 
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 end

--- a/packages/react-native/ReactCommon/react/renderer/css/React-renderercss.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/css/React-renderercss.podspec
@@ -18,7 +18,7 @@ end
 
 header_search_paths = []
 
-if ENV['USE_FRAMEWORKS']
+if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
   header_search_paths << "\"$(PODS_TARGET_SRCROOT)/../../..\"" # this is needed to allow the renderer/css access its own files
 end
 
@@ -40,7 +40,7 @@ Pod::Spec.new do |s|
     "DEFINES_MODULE" => "YES",
   }
 
-  if ENV['USE_FRAMEWORKS']
+  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
     s.module_name            = "React_renderercss"
     s.header_mappings_dir  = "../../.."
   end

--- a/packages/react-native/ReactCommon/react/renderer/debug/React-rendererdebug.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/debug/React-rendererdebug.podspec
@@ -40,11 +40,12 @@ Pod::Spec.new do |s|
     "DEFINES_MODULE" => "YES"
   }
 
-  if ENV['USE_FRAMEWORKS']
+  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
     s.module_name            = "React_rendererdebug"
     s.header_mappings_dir  = "../../.."
   end
 
   add_dependency(s, "React-debug")
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 end

--- a/packages/react-native/ReactCommon/react/renderer/graphics/React-graphics.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/React-graphics.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
   s.header_dir             = "react/renderer/graphics"
   s.framework = "UIKit"
 
-  if ENV['USE_FRAMEWORKS']
+  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
     s.module_name            = "React_graphics"
     s.header_mappings_dir  = "../../.."
     header_search_paths = header_search_paths + ["\"$(PODS_TARGET_SRCROOT)/platform/ios\""]
@@ -51,4 +51,5 @@ Pod::Spec.new do |s|
 
   depend_on_js_engine(s)
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 end

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/React-ImageManager.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/React-ImageManager.podspec
@@ -55,4 +55,5 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-rendererdebug")
 
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 end

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/React-runtimescheduler.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/React-runtimescheduler.podspec
@@ -38,7 +38,7 @@ Pod::Spec.new do |s|
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
     "HEADER_SEARCH_PATHS" => header_search_paths.join(' ')}
 
-  if ENV['USE_FRAMEWORKS']
+  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
     s.module_name            = "React_runtimescheduler"
     s.header_mappings_dir  = "../../.."
   end
@@ -58,4 +58,5 @@ Pod::Spec.new do |s|
 
   depend_on_js_engine(s)
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 end

--- a/packages/react-native/ReactCommon/react/runtime/React-RuntimeCore.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/React-RuntimeCore.podspec
@@ -33,7 +33,7 @@ Pod::Spec.new do |s|
                                 "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                 "GCC_WARN_PEDANTIC" => "YES" }
 
-  if ENV['USE_FRAMEWORKS']
+  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
     s.header_mappings_dir     = '../../'
     s.module_name             = 'React_RuntimeCore'
   end
@@ -52,6 +52,7 @@ Pod::Spec.new do |s|
 
   depend_on_js_engine(s)
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 
   s.dependency "React-jsinspector"
   add_dependency(s, "React-jsitooling", :framework_name => "JSITooling")

--- a/packages/react-native/ReactCommon/react/runtime/React-RuntimeHermes.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/React-RuntimeHermes.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
                                 "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                 "GCC_WARN_PEDANTIC" => "YES" }
 
-  if ENV['USE_FRAMEWORKS']
+  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
     s.header_mappings_dir     = '../../'
     s.module_name             = 'React_RuntimeHermes'
   end
@@ -52,4 +52,5 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-jsitooling", :framework_name => "JSITooling")
 
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 end

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/React-RuntimeApple.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/React-RuntimeApple.podspec
@@ -38,7 +38,7 @@ Pod::Spec.new do |s|
                                 "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                 "GCC_WARN_PEDANTIC" => "YES" }
 
-  if ENV['USE_FRAMEWORKS']
+  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
     s.header_mappings_dir     = './'
     s.module_name             = 'React_RuntimeApple'
   end
@@ -71,4 +71,5 @@ Pod::Spec.new do |s|
   end
 
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 end

--- a/packages/react-native/ReactCommon/react/utils/React-utils.podspec
+++ b/packages/react-native/ReactCommon/react/utils/React-utils.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
   s.header_dir             = "react/utils"
   s.exclude_files          = "tests"
 
-  if ENV['USE_FRAMEWORKS']
+  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
     s.module_name            = "React_utils"
     s.header_mappings_dir  = "../.."
     header_search_paths = header_search_paths + ["\"$(PODS_TARGET_SRCROOT)/platform/ios\""]
@@ -49,6 +49,7 @@ Pod::Spec.new do |s|
 
   depend_on_js_engine(s)
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 
   add_dependency(s, "React-debug")
 end

--- a/packages/react-native/ReactCommon/reactperflogger/React-perflogger.podspec
+++ b/packages/react-native/ReactCommon/reactperflogger/React-perflogger.podspec
@@ -38,4 +38,5 @@ Pod::Spec.new do |s|
   }
 
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 end

--- a/packages/react-native/ReactCommon/runtimeexecutor/React-runtimeexecutor.podspec
+++ b/packages/react-native/ReactCommon/runtimeexecutor/React-runtimeexecutor.podspec
@@ -33,7 +33,7 @@ Pod::Spec.new do |s|
   s.source_files           = podspec_sources(["ReactCommon/*.{m,mm,cpp,h}", "platform/ios/**/*.{m,mm,cpp,h}"], ["ReactCommon/*.h", "platform/ios/**/*.h"])
   s.header_dir             = "ReactCommon"
 
-  if ENV['USE_FRAMEWORKS']
+  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
     s.header_mappings_dir      = '.'
     header_search_paths = header_search_paths + ["\"$(PODS_TARGET_SRCROOT)/platform/ios\""]
   end
@@ -44,6 +44,7 @@ Pod::Spec.new do |s|
                                "DEFINES_MODULE" => "YES" }
 
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 
   s.dependency "React-jsi", version
   add_dependency(s, "React-featureflags")

--- a/packages/react-native/scripts/cocoapods/new_architecture.rb
+++ b/packages/react-native/scripts/cocoapods/new_architecture.rb
@@ -132,6 +132,7 @@ class NewArchitectureHelper
 
         depend_on_js_engine(spec)
         add_rn_third_party_dependencies(spec)
+        add_rncore_dependency(spec)
 
         spec.pod_target_xcconfig = current_config
     end

--- a/packages/react-native/scripts/cocoapods/rncore.rb
+++ b/packages/react-native/scripts/cocoapods/rncore.rb
@@ -9,6 +9,18 @@ require 'rexml/document'
 
 require_relative './utils.rb'
 
+### Adds ReactNativeCore-prebuilt as a dependency to the given podspec if we're not
+### building ReactNativeCore from source (then this function does nothing).
+def add_rncore_dependency(s)
+    if !ReactNativeCoreUtils.build_rncore_from_source()
+        current_pod_target_xcconfig = s.to_hash["pod_target_xcconfig"] || {}
+        current_pod_target_xcconfig = current_pod_target_xcconfig.to_h unless current_pod_target_xcconfig.is_a?(Hash)
+        s.dependency "React-Core-prebuilt"
+        current_pod_target_xcconfig["HEADER_SEARCH_PATHS"] ||= [] << "$(PODS_ROOT)/React-Core-prebuilt/React.xcframework/Headers"
+        s.pod_target_xcconfig = current_pod_target_xcconfig
+    end
+end
+
 ## - RCT_USE_PREBUILT_RNCORE: If set to 1, it will use the release tarball from Maven instead of building from source.
 ## - RCT_TESTONLY_RNCORE_TARBALL_PATH: **TEST ONLY** If set, it will use a local tarball of RNCore if it exists.
 ## - RCT_TESTONLY_RNCORE_VERSION: **TEST ONLY** If set, it will override the version of RNCore to be used.

--- a/packages/react-native/scripts/cocoapods/rncore.rb
+++ b/packages/react-native/scripts/cocoapods/rncore.rb
@@ -125,8 +125,8 @@ class ReactNativeCoreUtils
 
         url = stable_tarball_url(@@react_native_version, :debug)
         rncore_log("Using tarball from URL: #{url}")
-        download_stable_rndeps(@@react_native_path, @@react_native_version, :debug)
-        download_stable_rndeps(@@react_native_path, @@react_native_version, :release)
+        download_stable_rncore(@@react_native_path, @@react_native_version, :debug)
+        download_stable_rncore(@@react_native_path, @@react_native_version, :release)
         return {:http => url}
     end
 
@@ -157,9 +157,9 @@ class ReactNativeCoreUtils
         end
     end
 
-    def self.download_stable_rndeps(react_native_path, version, configuration)
+    def self.download_stable_rncore(react_native_path, version, configuration)
         tarball_url = stable_tarball_url(version, configuration)
-        download_rndeps_tarball(react_native_path, tarball_url, version, configuration)
+        download_rncore_tarball(react_native_path, tarball_url, version, configuration)
     end
 
     def self.podspec_source_download_prebuilt_nightly_tarball(version)
@@ -168,14 +168,14 @@ class ReactNativeCoreUtils
         return {:http => url}
     end
 
-    def self.download_rndeps_tarball(react_native_path, tarball_url, version, configuration)
+    def self.download_rncore_tarball(react_native_path, tarball_url, version, configuration)
         destination_path = configuration == nil ?
-            "#{artifacts_dir()}/reactnative-core-debug.tar.gz-#{version}.tar.gz" :
-            "#{artifacts_dir()}/reactnative-core-debug.tar.gz-#{version}-#{configuration}.tar.gz"
+            "#{artifacts_dir()}/reactnative-core-#{version}.tar.gz" :
+            "#{artifacts_dir()}/reactnative-core-#{version}-#{configuration}.tar.gz"
 
         unless File.exist?(destination_path)
           # Download to a temporary file first so we don't cache incomplete downloads.
-          tmp_file = "#{artifacts_dir()}/reactnative-core-debug.tar.gz.download"
+          tmp_file = "#{artifacts_dir()}/reactnative-core.download"
           `mkdir -p "#{artifacts_dir()}" && curl "#{tarball_url}" -Lo "#{tmp_file}" && mv "#{tmp_file}" "#{destination_path}"`
         end
 

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -255,18 +255,26 @@ class ReactNativePodsUtils
     end
 
     def self.create_header_search_path_for_frameworks(base_folder, pod_name, framework_name, additional_paths, include_base_path = true)
-        platforms = $RN_PLATFORMS != nil ? $RN_PLATFORMS : []
         search_paths = []
 
-        if platforms.empty?() || platforms.length() == 1
-            base_path = File.join("${#{base_folder}}", pod_name, "#{framework_name}.framework", "Headers")
-            self.add_search_path_to_result(search_paths, base_path, additional_paths, include_base_path)
-        else
-            platforms.each { |platform|
-                base_path = File.join("${#{base_folder}}", "#{pod_name}-#{platform}", "#{framework_name}.framework", "Headers")
+        # When building using the prebuilt rncore we can't use framework folders as search paths since these aren't created
+        if ReactNativeCoreUtils.build_rncore_from_source()
+            platforms = $RN_PLATFORMS != nil ? $RN_PLATFORMS : []
+
+            if platforms.empty?() || platforms.length() == 1
+                base_path = File.join("${#{base_folder}}", pod_name, "#{framework_name}.framework", "Headers")
                 self.add_search_path_to_result(search_paths, base_path, additional_paths, include_base_path)
-            }
+            else
+                platforms.each { |platform|
+                    base_path = File.join("${#{base_folder}}", "#{pod_name}-#{platform}", "#{framework_name}.framework", "Headers")
+                    self.add_search_path_to_result(search_paths, base_path, additional_paths, include_base_path)
+                }
+            end
+        else
+            base_path = File.join("${PODS_ROOT}", "#{pod_name}")
+            self.add_search_path_to_result(search_paths, base_path, additional_paths, include_base_path)
         end
+
         return search_paths
     end
 

--- a/packages/react-native/scripts/codegen/templates/ReactCodegen.podspec.template
+++ b/packages/react-native/scripts/codegen/templates/ReactCodegen.podspec.template
@@ -82,6 +82,7 @@ Pod::Spec.new do |s|
 
   depend_on_js_engine(s)
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 
   s.script_phases = {
     'name' => 'Generate Specs',

--- a/packages/react-native/scripts/ios-prebuild/headers.js
+++ b/packages/react-native/scripts/ios-prebuild/headers.js
@@ -49,7 +49,7 @@ function getHeaderFilesFromPodspecs(
         let arg2 = match[2]?.trim().replace(/['"]/g, '');
         if (!arg2) {
           // Skip
-          return;
+          continue;
         }
         // Check if arg2 is an array (e.g., ['a', 'b'])
         if (arg2.startsWith('[') && arg2.endsWith(']')) {

--- a/packages/react-native/scripts/replace-rncore-version.js
+++ b/packages/react-native/scripts/replace-rncore-version.js
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+const {execSync} = require('child_process');
+const fs = require('fs');
+const yargs = require('yargs');
+
+const LAST_BUILD_FILENAME = 'React-Core-prebuilt/.last_build_configuration';
+
+function validateBuildConfiguration(configuration /*: string */) {
+  if (!['Debug', 'Release'].includes(configuration)) {
+    throw new Error(`Invalid configuration ${configuration}`);
+  }
+}
+
+function validateVersion(version /*: ?string */) {
+  if (version == null || version === '') {
+    throw new Error('Version cannot be empty');
+  }
+}
+
+function shouldReplaceRnCoreConfiguration(configuration /*: string */) {
+  const fileExists = fs.existsSync(LAST_BUILD_FILENAME);
+
+  if (fileExists) {
+    console.log(`Found ${LAST_BUILD_FILENAME} file`);
+    const oldConfiguration = fs.readFileSync(LAST_BUILD_FILENAME).toString();
+    if (oldConfiguration === configuration) {
+      console.log(
+        'Same config of the previous build. No need to replace React-Core-prebuilt',
+      );
+      return false;
+    }
+  }
+
+  // Assumption: if there is no stored last build, we assume that it was build for debug.
+  if (!fileExists && configuration === 'Debug') {
+    console.log(
+      'No previous build detected, but Debug Configuration. No need to replace React-Core-prebuilt',
+    );
+    return false;
+  }
+
+  return true;
+}
+
+function replaceRNCoreConfiguration(
+  configuration /*: string */,
+  version /*: string */,
+  podsRoot /*: string */,
+) {
+  // Filename comes from rncore.rb
+  const tarballURLPath = `${podsRoot}/ReactNativeCore-artifacts/reactnative-core-${version.toLowerCase()}-${configuration.toLowerCase()}.tar.gz`;
+
+  const finalLocation = 'React-Core-prebuilt';
+  console.log('Preparing the final location', finalLocation);
+  fs.rmSync(finalLocation, {force: true, recursive: true});
+  fs.mkdirSync(finalLocation, {recursive: true});
+
+  console.log('Extracting the tarball', tarballURLPath);
+  execSync(`tar -xf ${tarballURLPath} -C ${finalLocation}`);
+}
+
+function updateLastBuildConfiguration(configuration /*: string */) {
+  console.log(`Updating ${LAST_BUILD_FILENAME} with ${configuration}`);
+  fs.writeFileSync(LAST_BUILD_FILENAME, configuration);
+}
+
+function main(
+  configuration /*: string */,
+  version /*: string */,
+  podsRoot /*: string */,
+) {
+  validateBuildConfiguration(configuration);
+  validateVersion(version);
+
+  if (!shouldReplaceRnCoreConfiguration(configuration)) {
+    return;
+  }
+
+  replaceRNCoreConfiguration(configuration, version, podsRoot);
+  updateLastBuildConfiguration(configuration);
+  console.log('Done replacing React Native prebuilt');
+}
+
+// This script is executed in the Pods folder, which is usually not synched to Github, so it should be ok
+const argv = yargs
+  .option('c', {
+    alias: 'configuration',
+    description:
+      'Configuration to use to download the right React-Core prebuilt version. Allowed values are "Debug" and "Release".',
+  })
+  .option('r', {
+    alias: 'reactNativeVersion',
+    description:
+      'The Version of React Native associated with the React-Core prebuilt tarball.',
+  })
+  .option('p', {
+    alias: 'podsRoot',
+    description: 'The path to the Pods root folder',
+  })
+  .usage('Usage: $0 -c Debug -r <version> -p <path/to/react-native>').argv;
+
+// $FlowFixMe[prop-missing]
+const configuration = argv.configuration;
+// $FlowFixMe[prop-missing]
+const version = argv.reactNativeVersion;
+// $FlowFixMe[prop-missing]
+const podsRoot = argv.podsRoot;
+
+main(configuration, version, podsRoot);

--- a/packages/rn-tester/RCTTest/React-RCTTest.podspec
+++ b/packages/rn-tester/RCTTest/React-RCTTest.podspec
@@ -41,4 +41,5 @@ Pod::Spec.new do |s|
   s.dependency "React-jsi", version
 
   add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
 end


### PR DESCRIPTION
## Summary:

Fixes #T228219721

This commit adds the debug/release switch script like we have for rn deps and hermes for react-core prebuilt:

- Added script: replace-rncore-version-js
- Inserted script into React-Core-prebuilt podspec
- Updated rncore.rb with correct filenames

## Changelog:

[IOS] [ADDED] - add release/debug switch script for React-Core-prebuilt

## Test Plan:

Run in RNTester and switch between release/debug