### PR TITLE
fix race condition in C++ Animated

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.h
@@ -225,6 +225,11 @@ class NativeAnimatedNodesManager {
   // React context required to commit props onto Component View
   DirectManipulationCallback directManipulationCallback_;
   FabricCommitCallback fabricCommitCallback_;
+
+  /*
+   * Tracks whether the render callback loop for animations is currently active.
+   */
+  std::atomic_bool isRenderCallbackStarted_{false};
   StartOnRenderCallback startOnRenderCallback_;
   StopOnRenderCallback stopOnRenderCallback_;
 


### PR DESCRIPTION
Summary:
changelog: [internal]


there is a race condition where `startRenderCallbackIfNeeded` may be called from JS thread and the main thread at the same time, leading to a crash. To address this, this diff adds uses a boolean to make sure `startOnRenderCallback_` is only called once and `stopOnRenderCallback_` is only called after start was called.

Reviewed By: javache

Differential Revision: D77871230


