### PR TITLE
Read the React Native version from the react-native's package.json

### DIFF
--- a/.github/workflows/prebuild-ios-core.yml
+++ b/.github/workflows/prebuild-ios-core.yml
@@ -83,7 +83,7 @@ jobs:
           # Move the XCFramework in the destination directory
           mv /tmp/third-party/packages/react-native/third-party/ReactNativeDependencies.xcframework packages/react-native/third-party/ReactNativeDependencies.xcframework
 
-          VERSION=$(jq -r '.version' package.json)
+          VERSION=$(jq -r '.version' packages/react-native/package.json)
           echo "$VERSION-${{matrix.flavor}}" > "packages/react-native/third-party/version.txt"
           cat "packages/react-native/third-party/version.txt"
           # Check destination directory

--- a/packages/react-native/scripts/ios-prebuild/utils.js
+++ b/packages/react-native/scripts/ios-prebuild/utils.js
@@ -65,13 +65,10 @@ async function computeNightlyTarballURL(
   artifactCoordinate /*: string */,
   artifactName /*: string */,
 ) /*: Promise<string> */ {
-  const urlLog = createLogger('NightlyURL');
   const xmlUrl = `https://central.sonatype.com/repository/maven-snapshots/com/facebook/react/${artifactCoordinate}/${version}-SNAPSHOT/maven-metadata.xml`;
 
-  urlLog(`Attempting to download maven-metadata.xml from: ${xmlUrl}...`);
   const response = await fetch(xmlUrl);
   if (!response.ok) {
-    urlLog(`Downloading maven-metadata.xml failed!`, 'error');
     return '';
   }
   const xmlText = await response.text();
@@ -79,7 +76,6 @@ async function computeNightlyTarballURL(
   // Extract the <snapshot> block
   const snapshotMatch = xmlText.match(/<snapshot>([\s\S]*?)<\/snapshot>/);
   if (!snapshotMatch) {
-    urlLog(`Could not find a <snapshot> tag that matches the regex!`, 'error');
     return '';
   }
   const snapshotContent = snapshotMatch[1];
@@ -87,10 +83,6 @@ async function computeNightlyTarballURL(
   // Extract <timestamp> from the snapshot block
   const timestampMatch = snapshotContent.match(/<timestamp>(.*?)<\/timestamp>/);
   if (!timestampMatch) {
-    urlLog(
-      `Could not find a <timestamp> tag inside <snapshot> that matches the regex!`,
-      'error',
-    );
     return '';
   }
   const timestamp = timestampMatch[1];
@@ -100,17 +92,12 @@ async function computeNightlyTarballURL(
     /<buildNumber>(.*?)<\/buildNumber>/,
   );
   if (!buildNumberMatch) {
-    urlLog(
-      `Could not find a <buildNumber> tag that matches the regex!`,
-      'error',
-    );
     return '';
   }
   const buildNumber = buildNumberMatch[1];
 
   const fullVersion = `${version}-${timestamp}-${buildNumber}`;
   const finalUrl = `https://central.sonatype.com/repository/maven-snapshots/com/facebook/react/${artifactCoordinate}/${version}-SNAPSHOT/${artifactCoordinate}-${fullVersion}-${artifactName}`;
-  urlLog(`Final artifact URL found: ${finalUrl}`);
   return finalUrl;
 }
 


### PR DESCRIPTION
Summary:
When building the CI Workflow to build React Native prebuilds, we were reading the react-native's version from the root package.json. This package.json is not updated by the release script, so the version is always 1000.
This makes the build process fail for stable releases.

With this change, we read the version from the right package.json file

## Changelog:
[Internal] - Read React Native version from the right package.json file

Differential Revision: D78007906


