### PR TITLE
console.timeStamp: support warning color

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/ConsoleTimeStamp.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/ConsoleTimeStamp.h
@@ -21,6 +21,8 @@ namespace facebook::react::jsinspector_modern::tracing {
 using ConsoleTimeStampEntry = std::variant<HighResTimeStamp, std::string>;
 
 // https://developer.chrome.com/docs/devtools/performance/extension#devtools_object
+// Although warning is not listed in Chrome DevTools announcement, it is
+// actually supported.
 enum class ConsoleTimeStampColor {
   Primary,
   PrimaryLight,
@@ -31,6 +33,7 @@ enum class ConsoleTimeStampColor {
   Tertiary,
   TertiaryLight,
   TertiaryDark,
+  Warning,
   Error,
 };
 
@@ -54,6 +57,8 @@ inline std::string consoleTimeStampColorToString(ConsoleTimeStampColor color) {
       return "tertiary-light";
     case ConsoleTimeStampColor::TertiaryDark:
       return "tertiary-dark";
+    case ConsoleTimeStampColor::Warning:
+      return "warning";
     case ConsoleTimeStampColor::Error:
       return "error";
     default:
@@ -81,6 +86,8 @@ inline std::optional<ConsoleTimeStampColor> getConsoleTimeStampColorFromString(
     return ConsoleTimeStampColor::TertiaryLight;
   } else if (str == "tertiary-dark") {
     return ConsoleTimeStampColor::TertiaryDark;
+  } else if (str == "warning") {
+    return ConsoleTimeStampColor::Warning;
   } else if (str == "error") {
     return ConsoleTimeStampColor::Error;
   } else {


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

This is actually used in React for logging triggers, like Mount / Unmount / Reconnect / Disconnect.

Differential Revision: D78008351


