### PR TITLE
Change polling to try and download the pom manifest

### DIFF
--- a/.github/workflow-scripts/__tests__/verifyArtifactsAreOnMaven-test.js
+++ b/.github/workflow-scripts/__tests__/verifyArtifactsAreOnMaven-test.js
@@ -38,7 +38,7 @@ describe('#verifyArtifactsAreOnMaven', () => {
 
     expect(mockSleep).toHaveBeenCalledTimes(1);
     expect(mockFetch).toHaveBeenCalledWith(
-      'https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.78.1',
+      'https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.78.1/react-native-artifacts-0.78.1.pom',
     );
   });
 
@@ -55,7 +55,7 @@ describe('#verifyArtifactsAreOnMaven', () => {
 
     expect(mockSleep).toHaveBeenCalledTimes(1);
     expect(mockFetch).toHaveBeenCalledWith(
-      'https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.78.1',
+      'https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.78.1/react-native-artifacts-0.78.1.pom',
     );
   });
 
@@ -67,7 +67,7 @@ describe('#verifyArtifactsAreOnMaven', () => {
 
     expect(mockSleep).toHaveBeenCalledTimes(0);
     expect(mockFetch).toHaveBeenCalledWith(
-      'https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.78.1',
+      'https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.78.1/react-native-artifacts-0.78.1.pom',
     );
   });
 
@@ -81,7 +81,7 @@ describe('#verifyArtifactsAreOnMaven', () => {
     expect(mockSleep).toHaveBeenCalledTimes(90);
     expect(mockExit).toHaveBeenCalledWith(1);
     expect(mockFetch).toHaveBeenCalledWith(
-      'https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.78.1',
+      'https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.78.1/react-native-artifacts-0.78.1.pom',
     );
   });
 });

--- a/.github/workflow-scripts/verifyArtifactsAreOnMaven.js
+++ b/.github/workflow-scripts/verifyArtifactsAreOnMaven.js
@@ -13,13 +13,14 @@ const SLEEP_S = 60; // 1 minute
 const MAX_RETRIES = 90; // 90 attempts. Waiting between attempt: 1 min. Total time: 90 min.
 const ARTIFACT_URL =
   'https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/';
+const ARTIFACT_NAME = 'react-native-artifacts-';
 
 async function verifyArtifactsAreOnMaven(version, retries = MAX_RETRIES) {
   if (version.startsWith('v')) {
     version = version.substring(1);
   }
 
-  const artifactUrl = `${ARTIFACT_URL}${version}`;
+  const artifactUrl = `${ARTIFACT_URL}${version}/${ARTIFACT_NAME}${version}.pom`;
   for (let currentAttempt = 1; currentAttempt <= retries; currentAttempt++) {
     const response = await fetch(artifactUrl);
 

--- a/.github/workflows/bump-podfile-lock.yml
+++ b/.github/workflows/bump-podfile-lock.yml
@@ -18,6 +18,10 @@ jobs:
         run: |
           git config --local user.email "bot@reactnative.dev"
           git config --local user.name "React Native Bot"
+      - name: Setup xcode
+        uses: ./.github/actions/setup-xcode
+        with:
+          xcode-version: '16.2.0'
       - name: Extract branch name
         run: |
           TAG="${{ github.ref_name }}";

--- a/.github/workflows/prebuild-ios-core.yml
+++ b/.github/workflows/prebuild-ios-core.yml
@@ -83,7 +83,7 @@ jobs:
           # Move the XCFramework in the destination directory
           mv /tmp/third-party/packages/react-native/third-party/ReactNativeDependencies.xcframework packages/react-native/third-party/ReactNativeDependencies.xcframework
 
-          VERSION=$(jq -r '.version' package.json)
+          VERSION=$(jq -r '.version' packages/react-native/package.json)
           echo "$VERSION-${{matrix.flavor}}" > "packages/react-native/third-party/version.txt"
           cat "packages/react-native/third-party/version.txt"
           # Check destination directory

--- a/packages/react-native/scripts/ios-prebuild/utils.js
+++ b/packages/react-native/scripts/ios-prebuild/utils.js
@@ -65,13 +65,10 @@ async function computeNightlyTarballURL(
   artifactCoordinate /*: string */,
   artifactName /*: string */,
 ) /*: Promise<string> */ {
-  const urlLog = createLogger('NightlyURL');
   const xmlUrl = `https://central.sonatype.com/repository/maven-snapshots/com/facebook/react/${artifactCoordinate}/${version}-SNAPSHOT/maven-metadata.xml`;
 
-  urlLog(`Attempting to download maven-metadata.xml from: ${xmlUrl}...`);
   const response = await fetch(xmlUrl);
   if (!response.ok) {
-    urlLog(`Downloading maven-metadata.xml failed!`, 'error');
     return '';
   }
   const xmlText = await response.text();
@@ -79,7 +76,6 @@ async function computeNightlyTarballURL(
   // Extract the <snapshot> block
   const snapshotMatch = xmlText.match(/<snapshot>([\s\S]*?)<\/snapshot>/);
   if (!snapshotMatch) {
-    urlLog(`Could not find a <snapshot> tag that matches the regex!`, 'error');
     return '';
   }
   const snapshotContent = snapshotMatch[1];
@@ -87,10 +83,6 @@ async function computeNightlyTarballURL(
   // Extract <timestamp> from the snapshot block
   const timestampMatch = snapshotContent.match(/<timestamp>(.*?)<\/timestamp>/);
   if (!timestampMatch) {
-    urlLog(
-      `Could not find a <timestamp> tag inside <snapshot> that matches the regex!`,
-      'error',
-    );
     return '';
   }
   const timestamp = timestampMatch[1];
@@ -100,17 +92,12 @@ async function computeNightlyTarballURL(
     /<buildNumber>(.*?)<\/buildNumber>/,
   );
   if (!buildNumberMatch) {
-    urlLog(
-      `Could not find a <buildNumber> tag that matches the regex!`,
-      'error',
-    );
     return '';
   }
   const buildNumber = buildNumberMatch[1];
 
   const fullVersion = `${version}-${timestamp}-${buildNumber}`;
   const finalUrl = `https://central.sonatype.com/repository/maven-snapshots/com/facebook/react/${artifactCoordinate}/${version}-SNAPSHOT/${artifactCoordinate}-${fullVersion}-${artifactName}`;
-  urlLog(`Final artifact URL found: ${finalUrl}`);
   return finalUrl;
 }
 


### PR DESCRIPTION
Summary:
The way Maven works is that the artifacts are uploaded and available way before the browsing UI will allow us to browse them.

By trying to download the `.pom` file instead of checking for the browsing website to be visible, we can shave some minutes during the release

## Changelog:
[Internal] -

Differential Revision: D78008635


