### PR TITLE
Fix bump-podfile-lock job by using Xcode 16.2

### DIFF
--- a/.github/workflows/bump-podfile-lock.yml
+++ b/.github/workflows/bump-podfile-lock.yml
@@ -18,6 +18,10 @@ jobs:
         run: |
           git config --local user.email "bot@reactnative.dev"
           git config --local user.name "React Native Bot"
+      - name: Setup xcode
+        uses: ./.github/actions/setup-xcode
+        with:
+          xcode-version: '16.2.0'
       - name: Extract branch name
         run: |
           TAG="${{ github.ref_name }}";

--- a/.github/workflows/prebuild-ios-core.yml
+++ b/.github/workflows/prebuild-ios-core.yml
@@ -83,7 +83,7 @@ jobs:
           # Move the XCFramework in the destination directory
           mv /tmp/third-party/packages/react-native/third-party/ReactNativeDependencies.xcframework packages/react-native/third-party/ReactNativeDependencies.xcframework
 
-          VERSION=$(jq -r '.version' package.json)
+          VERSION=$(jq -r '.version' packages/react-native/package.json)
           echo "$VERSION-${{matrix.flavor}}" > "packages/react-native/third-party/version.txt"
           cat "packages/react-native/third-party/version.txt"
           # Check destination directory

--- a/packages/react-native/scripts/ios-prebuild/utils.js
+++ b/packages/react-native/scripts/ios-prebuild/utils.js
@@ -65,13 +65,10 @@ async function computeNightlyTarballURL(
   artifactCoordinate /*: string */,
   artifactName /*: string */,
 ) /*: Promise<string> */ {
-  const urlLog = createLogger('NightlyURL');
   const xmlUrl = `https://central.sonatype.com/repository/maven-snapshots/com/facebook/react/${artifactCoordinate}/${version}-SNAPSHOT/maven-metadata.xml`;
 
-  urlLog(`Attempting to download maven-metadata.xml from: ${xmlUrl}...`);
   const response = await fetch(xmlUrl);
   if (!response.ok) {
-    urlLog(`Downloading maven-metadata.xml failed!`, 'error');
     return '';
   }
   const xmlText = await response.text();
@@ -79,7 +76,6 @@ async function computeNightlyTarballURL(
   // Extract the <snapshot> block
   const snapshotMatch = xmlText.match(/<snapshot>([\s\S]*?)<\/snapshot>/);
   if (!snapshotMatch) {
-    urlLog(`Could not find a <snapshot> tag that matches the regex!`, 'error');
     return '';
   }
   const snapshotContent = snapshotMatch[1];
@@ -87,10 +83,6 @@ async function computeNightlyTarballURL(
   // Extract <timestamp> from the snapshot block
   const timestampMatch = snapshotContent.match(/<timestamp>(.*?)<\/timestamp>/);
   if (!timestampMatch) {
-    urlLog(
-      `Could not find a <timestamp> tag inside <snapshot> that matches the regex!`,
-      'error',
-    );
     return '';
   }
   const timestamp = timestampMatch[1];
@@ -100,17 +92,12 @@ async function computeNightlyTarballURL(
     /<buildNumber>(.*?)<\/buildNumber>/,
   );
   if (!buildNumberMatch) {
-    urlLog(
-      `Could not find a <buildNumber> tag that matches the regex!`,
-      'error',
-    );
     return '';
   }
   const buildNumber = buildNumberMatch[1];
 
   const fullVersion = `${version}-${timestamp}-${buildNumber}`;
   const finalUrl = `https://central.sonatype.com/repository/maven-snapshots/com/facebook/react/${artifactCoordinate}/${version}-SNAPSHOT/${artifactCoordinate}-${fullVersion}-${artifactName}`;
-  urlLog(`Final artifact URL found: ${finalUrl}`);
   return finalUrl;
 }
 


### PR DESCRIPTION
Summary:
We bumped the requirement for cocoapods to use Xcode 16.1 or greater.
This job was not update and therefore it failed when releasing 0.81.0-rc.0.

This change should fix it and it should be cherry picked in the release branch too.
By default, the macos executor in github actions are using Xcode 15.2

## Changelog
[Internal] -

Reviewed By: fabriziocucci

Differential Revision: D78008316


