### PR TITLE
Add the `ENTERPRISE_REPOSITORY` env var to let user consume artifacts from their personal maven mirror

### DIFF
--- a/packages/react-native/scripts/cocoapods/rncore.rb
+++ b/packages/react-native/scripts/cocoapods/rncore.rb
@@ -119,7 +119,12 @@ class ReactNativeCoreUtils
     end
 
     def self.stable_tarball_url(version, build_type)
-        maven_repo_url = "https://repo1.maven.org/maven2"
+        ## You can use the `ENTERPRISE_REPOSITORY` ariable to customise the base url from which artifacts will be downloaded.
+        ## The mirror's structure must be the same of the Maven repo the react-native core team publishes on Maven Central.
+        maven_repo_url =
+            ENV[ENTERPRISE_REPOSITORY] != nil && ENV[ENTERPRISE_REPOSITORY] != "" ?
+            ENV[ENTERPRISE_REPOSITORY] :
+            "https://repo1.maven.org/maven2"
         group = "com/facebook/react"
         # Sample url from Maven:
         # https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.81.0/react-native-artifacts-0.81.0-reactnative-core-debug.tar.gz

--- a/packages/react-native/scripts/cocoapods/rndependencies.rb
+++ b/packages/react-native/scripts/cocoapods/rndependencies.rb
@@ -166,7 +166,12 @@ class ReactNativeDependenciesUtils
     end
 
     def self.release_tarball_url(version, build_type)
-        maven_repo_url = "https://repo1.maven.org/maven2"
+        ## You can use the `ENTERPRISE_REPOSITORY` ariable to customise the base url from which artifacts will be downloaded.
+        ## The mirror's structure must be the same of the Maven repo the react-native core team publishes on Maven Central.
+        maven_repo_url =
+            ENV[ENTERPRISE_REPOSITORY] != nil && ENV[ENTERPRISE_REPOSITORY] != "" ?
+            ENV[ENTERPRISE_REPOSITORY] :
+            "https://repo1.maven.org/maven2"
         group = "com/facebook/react"
         # Sample url from Maven:
         # https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.79.0-rc.0/react-native-artifacts-0.79.0-rc.0-reactnative-dependencies-debug.tar.gz

--- a/packages/react-native/scripts/ios-prebuild/hermes.js
+++ b/packages/react-native/scripts/ios-prebuild/hermes.js
@@ -183,7 +183,10 @@ function getTarballUrl(
   version /*: string */,
   buildType /*: BuildFlavor */,
 ) /*: string */ {
-  const mavenRepoUrl = 'https://repo1.maven.org/maven2';
+  // You can use the `ENTERPRISE_REPOSITORY` ariable to customise the base url from which artifacts will be downloaded.
+  // The mirror's structure must be the same of the Maven repo the react-native core team publishes on Maven Central.
+  const mavenRepoUrl =
+    process.env.ENTERPRISE_REPOSITORY ?? 'https://repo1.maven.org/maven2';
   const namespace = 'com/facebook/react';
   return `${mavenRepoUrl}/${namespace}/react-native-artifacts/${version}/react-native-artifacts-${version}-hermes-ios-${buildType.toLowerCase()}.tar.gz`;
 }

--- a/packages/react-native/scripts/ios-prebuild/reactNativeDependencies.js
+++ b/packages/react-native/scripts/ios-prebuild/reactNativeDependencies.js
@@ -179,7 +179,10 @@ function getTarballUrl(
   version /*: string */,
   buildType /*: BuildFlavor */,
 ) /*: string */ {
-  const mavenRepoUrl = 'https://repo1.maven.org/maven2';
+  // You can use the `ENTERPRISE_REPOSITORY` ariable to customise the base url from which artifacts will be downloaded.
+  // The mirror's structure must be the same of the Maven repo the react-native core team publishes on Maven Central.
+  const mavenRepoUrl =
+    process.env.ENTERPRISE_REPOSITORY ?? 'https://repo1.maven.org/maven2';
   const namespace = 'com/facebook/react';
   return `${mavenRepoUrl}/${namespace}/react-native-artifacts/${version}/react-native-artifacts-${version}-reactnative-dependencies-${buildType.toLowerCase()}.tar.gz`;
 }

--- a/packages/react-native/sdks/hermes-engine/hermes-utils.rb
+++ b/packages/react-native/sdks/hermes-engine/hermes-utils.rb
@@ -204,7 +204,12 @@ def hermestag_file(react_native_path)
 end
 
 def release_tarball_url(version, build_type)
-    maven_repo_url = "https://repo1.maven.org/maven2"
+    ## You can use the `ENTERPRISE_REPOSITORY` ariable to customise the base url from which artifacts will be downloaded.
+    ## The mirror's structure must be the same of the Maven repo the react-native core team publishes on Maven Central.
+    maven_repo_url =
+        ENV[ENTERPRISE_REPOSITORY] != nil && ENV[ENTERPRISE_REPOSITORY] != "" ?
+        ENV[ENTERPRISE_REPOSITORY] :
+        "https://repo1.maven.org/maven2"
     namespace = "com/facebook/react"
     # Sample url from Maven:
     # https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.71.0/react-native-artifacts-0.71.0-hermes-ios-debug.tar.gz


### PR DESCRIPTION
Summary:
As per title, this change add the `ENTERPRISE_REPOSITORY` env variable so that users can use their owm maven mirror to consume artifacts rather than the official url.

This is helpful as:
- we can reduce the traffic toward maven central
- companies can speed up their builds by relying on local/closer replicas

## Changelog:
[iOS][Added] - Add the `ENTERPRISE_REPOSITORY` env variable to cocopaods infra

Differential Revision: D78011424


