### PR TITLE
[LOCAL][0.77] Revert #46896 - Attempt to fix #50274

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -1409,14 +1409,14 @@ public class ReactInstanceManager {
             new RuntimeException(
                 "detachRootViewFromInstance called with ReactRootView with invalid id"));
       }
-
-      clearReactRoot(reactRoot);
     } else {
       reactContext
           .getCatalystInstance()
           .getJSModule(AppRegistry.class)
           .unmountApplicationComponentAtRootTag(reactRoot.getRootViewTag());
     }
+
+    clearReactRoot(reactRoot);
   }
 
   @ThreadConfined(UI)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
@@ -671,9 +671,6 @@ public class NativeViewHierarchyManager {
     View rootView = mTagsToViews.get(rootViewTag);
     dropView(rootView);
     mRootTags.delete(rootViewTag);
-    if (rootView != null) {
-      rootView.setId(View.NO_ID);
-    }
   }
 
   /**


### PR DESCRIPTION
## Summary:

Based on the proposed fix https://github.com/facebook/react-native/pull/52333, it seems the cause of the regression #50274 was likely #46896.

Since #50274 is a more significant bug than the one fixed by #46896, and both only affect legacy architecture [which is frozen](https://github.com/reactwg/react-native-new-architecture/discussions/290), we're going to roll back to the least-worst state.

## Changelog:

[ANDROID] [FIXED] - Fix Legacy Arch reload failures #50274

## Test Plan:

TBC in 0.77.3 release testing
