### PR TITLE
Do not override (xc)framework's Info.plist files with RCTNewArchEnabled

### DIFF
--- a/packages/react-native/scripts/cocoapods/new_architecture.rb
+++ b/packages/react-native/scripts/cocoapods/new_architecture.rb
@@ -161,7 +161,7 @@ class NewArchitectureHelper
             .uniq{ |p| p.path }
             .map{ |p| p.path }
 
-        excluded_info_plist = ["/Pods", "Tests", "metainternal", ".bundle", "build/", "DerivedData/"]
+        excluded_info_plist = ["/Pods", "Tests", "metainternal", ".bundle", "build/", "DerivedData/", ".xcframework", ".framework"]
         projectPaths.each do |projectPath|
             projectFolderPath = File.dirname(projectPath)
             infoPlistFiles = `find #{projectFolderPath} -name "Info.plist"`


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

`new_architecture.rb` script looks for `Info.plist` files in IOS directory, and adds RCTNewArchEnabled field to each one, except for those explicitly excluded. Framework files should remain unchanged, so I've extended the excluded_info_plist dict.

Modifying framework's Info.plist can break pod installation with errors like:

```
[!] An error occurred while processing the post-install hook of the Podfile.

invalid byte sequence in UTF-8
```

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [FIXED] Fix overriding (xc)framework Info.plist files with RCTNewArchEnabled field
## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Add any .framework or .xcframework to the iOS directory, install pods. If *.(xc)framework/Info.plist remains unchanged it works as intended.
