### PR TITLE
# Fixed Type Conversion Error in DynamicEventPayload

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/DynamicEventPayload.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/DynamicEventPayload.cpp
@@ -36,7 +36,7 @@ std::optional<double> DynamicEventPayload::extractValue(
   if (dynamic.type() == folly::dynamic::Type::DOUBLE) {
     return dynamic.asDouble();
   } else if (dynamic.type() == folly::dynamic::Type::INT64) {
-    return dynamic.asInt();
+    return static_cast<double>(dynamic.asInt());
   }
   return std::nullopt;
 }


### PR DESCRIPTION
## Summary:
Resolves https://github.com/microsoft/react-native-windows/issues/14797
We were facing a type conversion error in the DynamicEventPayload::extractValue() method. The function signature declares a return type of std::optional<double>, but when handling INT64 values, but when handling `INT64` values, the code was directly returning `dynamic.asInt()` without proper type conversion
We faced the issue while integrating https://github.com/microsoft/react-native-windows/pull/14791
## Changelog:
[General][Fixed]
## Test Plan:
 The fix involved wrapping the dynamic.asInt() call with static_cast<double>(), creating the corrected line: return static_cast<double>(dynamic.asInt())
 
Tested E2E in RNW