### PR TITLE
Back out "Remove ShadowNodeTraits::Trait::DirtyYogaNode"

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeTraits.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeTraits.h
@@ -82,6 +82,15 @@ class ShadowNodeTraits {
     // Must not be set directly. It is used by the view culling algorithm to
     // efficiently determine if a node is uncullable.
     Unstable_uncullableTrace = 1 << 13,
+
+    // Indicates that the `YogaLayoutableShadowNode` must set `isDirty` flag for
+    // Yoga node when a `ShadowNode` is being cloned. `ShadowNode`s that modify
+    // Yoga styles in the constructor (or later) *after* the `ShadowNode`
+    // is cloned must set this trait.
+    // Any Yoga node (not only Leaf ones) can have this trait.
+    // **Deprecated**: This trait is deprecated and will be removed in a future
+    // version of React Native.
+    DirtyYogaNode = 1 << 14,
   };
 
   /*


### PR DESCRIPTION
Summary:
This was a breaking change that is currently breaking `react-native-safe-area-context` so we can't ship it as it is, especially because all the apps in OSS will be affected by this.

Changelog:
[General] [Changed] - Revert breaking change due to the removal of `ShadowNodeTraits::Trait::DirtyYogaNode`

Original commit changeset: 869e81f0ae00

Original Phabricator Diff: D75324251

Rollback Plan:

Differential Revision: D78085848


