### PR TITLE
Expose `react_renderer_bridging` headers via prefab

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -112,6 +112,10 @@ val preparePrefab by
                       Pair(
                           "../ReactCommon/react/renderer/animations/",
                           "react/renderer/animations/"),
+                      // react_renderer_bridging
+                      Pair(
+                          "../ReactCommon/react/renderer/bridging/",
+                          "react/renderer/bridging/"),
                       // react_renderer_componentregistry
                       Pair(
                           "../ReactCommon/react/renderer/componentregistry/",

--- a/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
@@ -193,7 +193,6 @@ add_library(reactnative
           $<TARGET_OBJECTS:react_newarchdefaults>
           $<TARGET_OBJECTS:react_performance_timeline>
           $<TARGET_OBJECTS:react_renderer_animations>
-          $<TARGET_OBJECTS:react_renderer_bridging>
           $<TARGET_OBJECTS:react_renderer_attributedstring>
           $<TARGET_OBJECTS:react_renderer_componentregistry>
           $<TARGET_OBJECTS:react_renderer_consistency>
@@ -283,7 +282,6 @@ target_include_directories(reactnative
         $<TARGET_PROPERTY:react_performance_timeline,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:react_renderer_animations,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:react_renderer_attributedstring,INTERFACE_INCLUDE_DIRECTORIES>
-        $<TARGET_PROPERTY:react_renderer_bridging,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:react_renderer_componentregistry,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:react_renderer_componentregistry,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:react_renderer_consistency,INTERFACE_INCLUDE_DIRECTORIES>

--- a/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
@@ -193,6 +193,7 @@ add_library(reactnative
           $<TARGET_OBJECTS:react_newarchdefaults>
           $<TARGET_OBJECTS:react_performance_timeline>
           $<TARGET_OBJECTS:react_renderer_animations>
+          $<TARGET_OBJECTS:react_renderer_bridging>
           $<TARGET_OBJECTS:react_renderer_attributedstring>
           $<TARGET_OBJECTS:react_renderer_componentregistry>
           $<TARGET_OBJECTS:react_renderer_consistency>
@@ -282,6 +283,7 @@ target_include_directories(reactnative
         $<TARGET_PROPERTY:react_performance_timeline,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:react_renderer_animations,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:react_renderer_attributedstring,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:react_renderer_bridging,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:react_renderer_componentregistry,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:react_renderer_componentregistry,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:react_renderer_consistency,INTERFACE_INCLUDE_DIRECTORIES>


### PR DESCRIPTION
## Summary:

This PR fixes the following build error while trying to build `react-native@0.81.0-rc.0` app with `react-native-screens@4.10.0` installed using react-native prebuilds (AAR) due to a missing `react/renderer/bridging/bridging.h` file in `prefab/modules/` inside `react-android-0.81.0-rc.0-debug.aar`.

```
In file included from /Users/tomekzaw/RNOS/react-native-reanimated/node_modules/react-native-screens/android/src/main/cpp/NativeProxy.cpp:2:
  In file included from /Users/tomekzaw/.gradle/caches/8.14.1/transforms/75e7f8f7b5ef763e687a16737daf01b6/transformed/react-android-0.81.0-rc.0-debug/prefab/modules/reactnative/include/react/fabric/Binding.h:12:
  In file included from /Users/tomekzaw/.gradle/caches/8.14.1/transforms/75e7f8f7b5ef763e687a16737daf01b6/transformed/react-android-0.81.0-rc.0-debug/prefab/modules/reactnative/include/react/fabric/FabricUIManagerBinding.h:22:
  /Users/tomekzaw/.gradle/caches/8.14.1/transforms/75e7f8f7b5ef763e687a16737daf01b6/transformed/react-android-0.81.0-rc.0-debug/prefab/modules/reactnative/include/react/renderer/uimanager/primitives.h:14:10: fatal error: 'react/renderer/bridging/bridging.h' file not found
     14 | #include <react/renderer/bridging/bridging.h>
        |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  1 error generated.
  ninja: build stopped: subcommand failed.
```

## Changelog:

[ANDROID] [CHANGED] - Expose `react_renderer_bridging` headers via prefab 

## Test Plan:


