### PR TITLE
Correctly mark as deprecated the ReactActivityDelegate.getReactInstanceManager

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
@@ -117,6 +117,7 @@ public class ReactActivityDelegate {
    *     going away in the New Architecture. You should access {@link ReactHost} instead."
    * @noinspection deprecation
    */
+  @Deprecated
   public ReactInstanceManager getReactInstanceManager() {
     return Objects.requireNonNull(mReactDelegate).getReactInstanceManager();
   }


### PR DESCRIPTION
Summary:
This method is deprecated in the JavaDoc but not correctly annotated as Deprecated, let's fix it.

Changelog:
[Internal] [Changed] -

Differential Revision: D78092468


