### PR TITLE
Remove deprecated constructors for TextInput *Event classes

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactContentSizeChangedEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactContentSizeChangedEvent.kt
@@ -10,26 +10,16 @@ package com.facebook.react.views.textinput
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.buildReadableMap
-import com.facebook.react.uimanager.common.ViewUtil
 import com.facebook.react.uimanager.events.Event
 
 /** Event emitted by EditText native view when content size changes. */
-internal class ReactContentSizeChangedEvent(
+internal class ReactContentSizeChangedEvent
+constructor(
     surfaceId: Int,
     viewId: Int,
     private val contentWidth: Float,
     private val contentHeight: Float
 ) : Event<ReactTextChangedEvent>(surfaceId, viewId) {
-  @Deprecated(
-      "Use the constructor with surfaceId instead",
-      ReplaceWith(
-          "ReactContentSizeChangedEvent(surfaceId, viewId, contentSizeWidth, contentSizeHeight)"))
-  constructor(
-      viewId: Int,
-      contentSizeWidth: Float,
-      contentSizeHeight: Float
-  ) : this(ViewUtil.NO_SURFACE_ID, viewId, contentSizeWidth, contentSizeHeight)
-
   override fun getEventName(): String = EVENT_NAME
 
   override fun getEventData(): WritableMap {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextChangedEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextChangedEvent.kt
@@ -9,7 +9,6 @@ package com.facebook.react.views.textinput
 
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.WritableMap
-import com.facebook.react.uimanager.common.ViewUtil
 import com.facebook.react.uimanager.events.Event
 
 /** Event emitted by EditText native view when text changes. */
@@ -19,15 +18,6 @@ internal class ReactTextChangedEvent(
     private val text: String,
     private val eventCount: Int
 ) : Event<ReactTextChangedEvent>(surfaceId, viewId) {
-  @Deprecated(
-      "Use the constructor with surfaceId instead",
-      ReplaceWith("ReactTextChangedEvent(surfaceId, viewId, text, eventCount)"))
-  constructor(
-      viewId: Int,
-      text: String,
-      eventCount: Int
-  ) : this(ViewUtil.NO_SURFACE_ID, viewId, text, eventCount)
-
   override fun getEventName(): String = EVENT_NAME
 
   override fun getEventData(): WritableMap {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputEndEditingEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputEndEditingEvent.kt
@@ -9,7 +9,6 @@ package com.facebook.react.views.textinput
 
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.WritableMap
-import com.facebook.react.uimanager.common.ViewUtil
 import com.facebook.react.uimanager.events.Event
 
 /**
@@ -21,11 +20,6 @@ internal class ReactTextInputEndEditingEvent(
     viewId: Int,
     private val text: String
 ) : Event<ReactTextInputEndEditingEvent>(surfaceId, viewId) {
-  @Deprecated(
-      "Use the constructor with surfaceId instead",
-      ReplaceWith("ReactTextInputEndEditingEvent(surfaceId, viewId, text)"))
-  constructor(viewId: Int, text: String) : this(ViewUtil.NO_SURFACE_ID, viewId, text)
-
   override fun getEventName(): String = EVENT_NAME
 
   override fun canCoalesce(): Boolean = false

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputKeyPressEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputKeyPressEvent.kt
@@ -9,17 +9,11 @@ package com.facebook.react.views.textinput
 
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.WritableMap
-import com.facebook.react.uimanager.common.ViewUtil
 import com.facebook.react.uimanager.events.Event
 
 /** Event emitted by EditText native view when key pressed. */
 internal class ReactTextInputKeyPressEvent(surfaceId: Int, viewId: Int, private val key: String) :
     Event<ReactTextInputKeyPressEvent>(surfaceId, viewId) {
-  @Deprecated(
-      "Use the constructor with surfaceId instead",
-      ReplaceWith("ReactTextInputKeyPressEvent(surfaceId, viewId, key)"))
-  constructor(viewId: Int, key: String) : this(ViewUtil.NO_SURFACE_ID, viewId, key)
-
   override fun getEventName(): String = EVENT_NAME
 
   override fun getEventData(): WritableMap {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputSelectionEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputSelectionEvent.kt
@@ -10,7 +10,6 @@ package com.facebook.react.views.textinput
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.buildReadableMap
-import com.facebook.react.uimanager.common.ViewUtil
 import com.facebook.react.uimanager.events.Event
 
 /** Event emitted by EditText native view when the text selection changes. */
@@ -20,15 +19,6 @@ internal class ReactTextInputSelectionEvent(
     private val selectionStart: Int,
     private val selectionEnd: Int
 ) : Event<ReactTextInputSelectionEvent>(surfaceId, viewId) {
-  @Deprecated(
-      "Use the constructor with surfaceId instead",
-      ReplaceWith("ReactTextInputSelectionEvent(surfaceId, viewId, selectionStart, selectionEnd)"))
-  constructor(
-      viewId: Int,
-      selectionStart: Int,
-      selectionEnd: Int
-  ) : this(ViewUtil.NO_SURFACE_ID, viewId, selectionStart, selectionEnd)
-
   override fun getEventName(): String = EVENT_NAME
 
   override fun getEventData(): WritableMap {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputSubmitEditingEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputSubmitEditingEvent.kt
@@ -9,7 +9,6 @@ package com.facebook.react.views.textinput
 
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.WritableMap
-import com.facebook.react.uimanager.common.ViewUtil
 import com.facebook.react.uimanager.events.Event
 
 /** Event emitted by EditText native view when the user submits the text. */
@@ -18,11 +17,6 @@ internal class ReactTextInputSubmitEditingEvent(
     viewId: Int,
     private val text: String
 ) : Event<ReactTextInputSubmitEditingEvent>(surfaceId, viewId) {
-  @Deprecated(
-      "Use the constructor with surfaceId instead",
-      ReplaceWith("ReactTextInputSubmitEditingEvent(surfaceId, viewId, text)"))
-  constructor(viewId: Int, text: String) : this(ViewUtil.NO_SURFACE_ID, viewId, text)
-
   override fun getEventName(): String = EVENT_NAME
 
   override fun getEventData(): WritableMap {


### PR DESCRIPTION
Summary:
Those constructors are no longer necessary. They're deprecated + the class is internal so they're not breaking changes.
I'm just cleaning them up as they're not needed anymore.

Changelog:
[Internal] [Changed] - Remove deprecated constructors for TextInput *Event classes

Differential Revision: D78095748


