### PR TITLE
Propagate console.timeStamp entries to Perfetto

### DIFF
--- a/packages/react-native/Package.swift
+++ b/packages/react-native/Package.swift
@@ -166,7 +166,7 @@ let reactJsInspector = RNTarget(
   name: .reactJsInspector,
   path: "ReactCommon/jsinspector-modern",
   excludedPaths: ["tracing", "network", "tests"],
-  dependencies: [.reactNativeDependencies, .reactFeatureFlags, .jsi, .reactJsInspectorTracing, .reactJsInspectorNetwork, .reactRuntimeExecutor],
+  dependencies: [.reactNativeDependencies, .reactFeatureFlags, .jsi, .reactJsInspectorTracing, .reactJsInspectorNetwork, .reactRuntimeExecutor, .reactPerfLogger],
   defines: [
     CXXSetting.define("REACT_NATIVE_DEBUGGER_ENABLED", to: "1", .when(configuration: BuildConfiguration.debug)),
     CXXSetting.define("REACT_NATIVE_DEBUGGER_ENABLED_DEVONLY", to: "1", .when(configuration: BuildConfiguration.debug)),

--- a/packages/react-native/ReactCommon/jsinspector-modern/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsinspector-modern/CMakeLists.txt
@@ -25,6 +25,7 @@ target_link_libraries(jsinspector
         jsinspector_tracing
         react_featureflags
         runtimeexecutor
+        reactperflogger
 )
 target_compile_reactnative_options(jsinspector PRIVATE)
 target_compile_options(jsinspector PRIVATE

--- a/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfettoLogger.cpp
+++ b/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfettoLogger.cpp
@@ -22,10 +22,26 @@ const std::string PERFETTO_DEFAULT_TRACK_NAME = "# Web Performance";
 const std::string PERFETTO_TRACK_NAME_PREFIX = "# Web Performance: ";
 
 std::string toPerfettoTrackName(
-    const std::optional<std::string_view>& trackName) {
-  return trackName.has_value()
-      ? PERFETTO_TRACK_NAME_PREFIX + std::string(trackName.value())
-      : PERFETTO_DEFAULT_TRACK_NAME;
+    const std::optional<std::string_view>& trackName,
+    const std::optional<std::string_view>& trackGroup) {
+  std::string perfettoTrackName = PERFETTO_DEFAULT_TRACK_NAME;
+
+  if (trackName || trackGroup) {
+    perfettoTrackName += ": ";
+
+    if (trackGroup) {
+      perfettoTrackName += *trackGroup;
+      if (trackName) {
+        perfettoTrackName += " | ";
+      }
+    }
+
+    if (trackName) {
+      perfettoTrackName += *trackName;
+    }
+  }
+
+  return perfettoTrackName;
 }
 #elif defined(WITH_FBSYSTRACE)
 int64_t getDeltaNanos(HighResTimeStamp jsTime) {
@@ -50,10 +66,12 @@ int64_t getDeltaNanos(HighResTimeStamp jsTime) {
     const std::string_view& eventName,
     HighResTimeStamp startTime,
     HighResTimeStamp endTime,
-    const std::optional<std::string_view>& trackName) {
+    const std::optional<std::string_view>& trackName,
+    const std::optional<std::string_view>& trackGroup) {
 #if defined(WITH_PERFETTO)
   if (TRACE_EVENT_CATEGORY_ENABLED("react-native")) {
-    auto track = getPerfettoWebPerfTrackAsync(toPerfettoTrackName(trackName));
+    auto track = getPerfettoWebPerfTrackAsync(
+        toPerfettoTrackName(trackName, trackGroup));
     TRACE_EVENT_BEGIN(
         "react-native",
         perfetto::DynamicString(eventName.data(), eventName.size()),
@@ -75,13 +93,14 @@ int64_t getDeltaNanos(HighResTimeStamp jsTime) {
 /* static */ void ReactPerfettoLogger::mark(
     const std::string_view& eventName,
     HighResTimeStamp startTime,
-    const std::optional<std::string_view>& trackName) {
+    const std::optional<std::string_view>& trackName,
+    const std::optional<std::string_view>& trackGroup) {
 #if defined(WITH_PERFETTO)
   if (TRACE_EVENT_CATEGORY_ENABLED("react-native")) {
     TRACE_EVENT_INSTANT(
         "react-native",
         perfetto::DynamicString(eventName.data(), eventName.size()),
-        getPerfettoWebPerfTrackSync(toPerfettoTrackName(trackName)),
+        getPerfettoWebPerfTrackSync(toPerfettoTrackName(trackName, trackGroup)),
         highResTimeStampToPerfettoTraceTime(startTime));
   }
 #elif defined(WITH_FBSYSTRACE)

--- a/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfettoLogger.h
+++ b/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfettoLogger.h
@@ -11,7 +11,7 @@
 #include <reactperflogger/ReactPerfettoCategories.h>
 
 #include <optional>
-#include <string>
+#include <string_view>
 
 namespace facebook::react {
 
@@ -26,13 +26,15 @@ class ReactPerfettoLogger {
   static void mark(
       const std::string_view& eventName,
       HighResTimeStamp startTime,
-      const std::optional<std::string_view>& trackName);
+      const std::optional<std::string_view>& trackName = std::nullopt,
+      const std::optional<std::string_view>& trackGroup = std::nullopt);
 
   static void measure(
       const std::string_view& eventName,
       HighResTimeStamp startTime,
       HighResTimeStamp endTime,
-      const std::optional<std::string_view>& trackName);
+      const std::optional<std::string_view>& trackName = std::nullopt,
+      const std::optional<std::string_view>& trackGroup = std::nullopt);
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
Changelog: [internal]

This adds support to propagate performance entries logged to `console.timeStamp` to Perfetto, if enabled. It also modifies the Perfetto integration to support track groups, in addition to track names.

Differential Revision: D78092596


