### PR TITLE
Fix loop iteration in Transform::Interpolate(...

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/graphics/Transform.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Transform.cpp
@@ -243,7 +243,7 @@ Transform::Translate(Float x, Float y, Float z) noexcept {
     if ((haveLHS &&
          lhs.operations[i].type == TransformOperationType::Arbitrary) ||
         (haveRHS &&
-         rhs.operations[i].type == TransformOperationType::Arbitrary)) {
+         rhs.operations[j].type == TransformOperationType::Arbitrary)) {
       return result;
     }
     if (haveLHS && lhs.operations[i].type == TransformOperationType::Identity) {


### PR DESCRIPTION
Summary:
Changelog: [Internal]

While this does not cause real crashes as the code is already gated via
```
bool haveRHS = j < rhs.operations.size();
```
it still represents a bug in the logic

Differential Revision: D78133364


