### PR TITLE
Remove unused Color/Transform #includes and use enum class for TransformOperationType

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/graphics/Color.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Color.h
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <functional>
-#include <limits>
 
 #include <react/renderer/graphics/ColorComponents.h>
 #include <react/renderer/graphics/HostPlatformColor.h>

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Transform.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Transform.h
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <array>
-#include <string>
 #include <vector>
 
 #include <react/renderer/debug/flags.h>
@@ -37,7 +36,7 @@ inline bool isZero(Float n) {
  * An "Arbitrary" operation means that the transform was seeded with some
  * arbitrary initial result.
  */
-enum class TransformOperationType {
+enum class TransformOperationType : uint8_t {
   Arbitrary,
   Identity,
   Perspective,


### PR DESCRIPTION
Summary:
Changelog: [Internal]

- The #includes are not used
- `enum class` is C++, (enum is C)

Differential Revision: D78135339


