### PR TITLE
Handle nullability of detail correctly in performance.mark and performance.measure

### DIFF
--- a/packages/react-native/src/private/webapis/performance/Performance.js
+++ b/packages/react-native/src/private/webapis/performance/Performance.js
@@ -25,31 +25,26 @@ import {
   performanceEntryTypeToRaw,
   rawToPerformanceEntry,
 } from './internals/RawPerformanceEntry';
-import {warnNoNativePerformance} from './internals/Utilities';
+import {
+  getCurrentTimeStamp,
+  warnNoNativePerformance,
+} from './internals/Utilities';
 import MemoryInfo from './MemoryInfo';
 import ReactNativeStartupTiming from './ReactNativeStartupTiming';
 import NativePerformance from './specs/NativePerformance';
 import {PerformanceMark, PerformanceMeasure} from './UserTiming';
 
-declare var global: {
-  // This value is defined directly via JSI, if available.
-  +nativePerformanceNow?: ?() => number,
-};
-
-const getCurrentTimeStamp: () => DOMHighResTimeStamp =
-  NativePerformance?.now ?? global.nativePerformanceNow ?? (() => Date.now());
-
 export type PerformanceMeasureOptions =
-  | {
+  | $ReadOnly<{
       detail?: DetailType,
       start?: DOMHighResTimeStamp | string,
       duration?: DOMHighResTimeStamp,
-    }
-  | {
+    }>
+  | $ReadOnly<{
       detail?: DetailType,
       start?: DOMHighResTimeStamp | string,
       end?: DOMHighResTimeStamp | string,
-    };
+    }>;
 
 const ENTRY_TYPES_AVAILABLE_FROM_TIMELINE: $ReadOnlyArray<PerformanceEntryType> =
   ['mark', 'measure'];
@@ -155,7 +150,7 @@ export default class Performance {
       );
     } else {
       warnNoNativePerformance();
-      computedStartTime = performance.now();
+      computedStartTime = getCurrentTimeStamp();
     }
 
     return new PerformanceMark(resolvedMarkName, {

--- a/packages/react-native/src/private/webapis/performance/Performance.js
+++ b/packages/react-native/src/private/webapis/performance/Performance.js
@@ -123,6 +123,8 @@ export default class Performance {
       );
     }
 
+    const resolvedMarkName = String(markName);
+
     let resolvedDetail;
     if (markOptions?.detail != null) {
       resolvedDetail = structuredClone(markOptions.detail);
@@ -137,7 +139,7 @@ export default class Performance {
         resolvedStartTime = Number(startTime);
         if (resolvedStartTime < 0) {
           throw new TypeError(
-            `Failed to execute 'mark' on 'Performance': '${markName}' cannot have a negative start time.`,
+            `Failed to execute 'mark' on 'Performance': '${resolvedMarkName}' cannot have a negative start time.`,
           );
         } else if (!Number.isFinite(resolvedStartTime)) {
           throw new TypeError(
@@ -148,7 +150,7 @@ export default class Performance {
 
       // $FlowExpectedError[not-a-function]
       computedStartTime = NativePerformance.markWithResult(
-        markName,
+        resolvedMarkName,
         resolvedStartTime,
       );
     } else {
@@ -156,7 +158,7 @@ export default class Performance {
       computedStartTime = performance.now();
     }
 
-    return new PerformanceMark(markName, {
+    return new PerformanceMark(resolvedMarkName, {
       startTime: computedStartTime,
       detail: resolvedDetail,
     });
@@ -176,6 +178,13 @@ export default class Performance {
     startMarkOrOptions?: string | PerformanceMeasureOptions,
     endMark?: string,
   ): PerformanceMeasure {
+    if (measureName == null) {
+      throw new TypeError(
+        `Failed to execute 'measure' on 'Performance': 1 argument required, but only 0 present.`,
+      );
+    }
+
+    let resolvedMeasureName = String(measureName);
     let resolvedStartTime: number | void;
     let resolvedStartMark: string | void;
     let resolvedEndTime: number | void;
@@ -282,7 +291,7 @@ export default class Performance {
     if (NativePerformance?.measure) {
       try {
         [computedStartTime, computedDuration] = NativePerformance.measure(
-          measureName,
+          resolvedMeasureName,
           resolvedStartTime,
           resolvedEndTime,
           resolvedDuration,
@@ -299,7 +308,7 @@ export default class Performance {
       try {
         [computedStartTime, computedDuration] =
           NativePerformance.measureWithResult(
-            measureName,
+            resolvedMeasureName,
             resolvedStartTime ?? 0,
             resolvedEndTime ?? 0,
             resolvedDuration,
@@ -316,7 +325,7 @@ export default class Performance {
       warnNoNativePerformance();
     }
 
-    const measure = new PerformanceMeasure(measureName, {
+    const measure = new PerformanceMeasure(resolvedMeasureName, {
       startTime: computedStartTime,
       duration: computedDuration ?? 0,
       detail: resolvedDetail,

--- a/packages/react-native/src/private/webapis/performance/UserTiming.js
+++ b/packages/react-native/src/private/webapis/performance/UserTiming.js
@@ -12,44 +12,45 @@
 
 import type {DOMHighResTimeStamp} from './PerformanceEntry';
 
+import {getCurrentTimeStamp} from './internals/Utilities';
 import {PerformanceEntry} from './PerformanceEntry';
 
 export type DetailType = mixed;
 
-export type PerformanceMarkOptions = {
+export type PerformanceMarkOptions = $ReadOnly<{
   detail?: DetailType,
   startTime?: DOMHighResTimeStamp,
-};
+}>;
 
 export type TimeStampOrName = DOMHighResTimeStamp | string;
 
-export type PerformanceMeasureInit = {
+export type PerformanceMeasureInit = $ReadOnly<{
   detail?: DetailType,
   startTime: DOMHighResTimeStamp,
   duration: DOMHighResTimeStamp,
-};
+}>;
 
 class PerformanceMarkTemplate extends PerformanceEntry {
   // We don't use private fields because they're significantly slower to
   // initialize on construction and to access.
-  _detail: DetailType;
+  __detail: DetailType;
 
   // This constructor isn't really used. See `PerformanceMark` below.
   constructor(markName: string, markOptions?: PerformanceMarkOptions) {
     super({
       name: markName,
       entryType: 'mark',
-      startTime: markOptions?.startTime ?? performance.now(),
+      startTime: markOptions?.startTime ?? getCurrentTimeStamp(),
       duration: 0,
     });
 
     if (markOptions) {
-      this._detail = markOptions.detail;
+      this.__detail = markOptions.detail;
     }
   }
 
   get detail(): DetailType {
-    return this._detail;
+    return this.__detail;
   }
 }
 
@@ -67,11 +68,11 @@ export const PerformanceMark: typeof PerformanceMarkTemplate =
   ) {
     this.__name = markName;
     this.__entryType = 'mark';
-    this.__startTime = markOptions?.startTime ?? performance.now();
+    this.__startTime = markOptions?.startTime ?? getCurrentTimeStamp();
     this.__duration = 0;
 
     if (markOptions) {
-      this._detail = markOptions.detail;
+      this.__detail = markOptions.detail;
     }
   };
 
@@ -81,7 +82,7 @@ PerformanceMark.prototype = PerformanceMarkTemplate.prototype;
 class PerformanceMeasureTemplate extends PerformanceEntry {
   // We don't use private fields because they're significantly slower to
   // initialize on construction and to access.
-  _detail: DetailType;
+  __detail: DetailType;
 
   // This constructor isn't really used. See `PerformanceMeasure` below.
   constructor(measureName: string, measureOptions: PerformanceMeasureInit) {
@@ -93,12 +94,12 @@ class PerformanceMeasureTemplate extends PerformanceEntry {
     });
 
     if (measureOptions) {
-      this._detail = measureOptions.detail;
+      this.__detail = measureOptions.detail;
     }
   }
 
   get detail(): DetailType {
-    return this._detail;
+    return this.__detail;
   }
 }
 
@@ -116,7 +117,7 @@ export const PerformanceMeasure: typeof PerformanceMeasureTemplate =
     this.__duration = measureOptions.duration;
 
     if (measureOptions) {
-      this._detail = measureOptions.detail;
+      this.__detail = measureOptions.detail;
     }
   };
 

--- a/packages/react-native/src/private/webapis/performance/UserTiming.js
+++ b/packages/react-native/src/private/webapis/performance/UserTiming.js
@@ -44,9 +44,7 @@ class PerformanceMarkTemplate extends PerformanceEntry {
       duration: 0,
     });
 
-    if (markOptions) {
-      this.__detail = markOptions.detail;
-    }
+    this.__detail = markOptions?.detail ?? null;
   }
 
   get detail(): DetailType {
@@ -71,9 +69,7 @@ export const PerformanceMark: typeof PerformanceMarkTemplate =
     this.__startTime = markOptions?.startTime ?? getCurrentTimeStamp();
     this.__duration = 0;
 
-    if (markOptions) {
-      this.__detail = markOptions.detail;
-    }
+    this.__detail = markOptions?.detail ?? null;
   };
 
 // $FlowExpectedError[prop-missing]
@@ -93,9 +89,7 @@ class PerformanceMeasureTemplate extends PerformanceEntry {
       duration: measureOptions.duration,
     });
 
-    if (measureOptions) {
-      this.__detail = measureOptions.detail;
-    }
+    this.__detail = measureOptions?.detail ?? null;
   }
 
   get detail(): DetailType {
@@ -116,9 +110,7 @@ export const PerformanceMeasure: typeof PerformanceMeasureTemplate =
     this.__startTime = measureOptions.startTime;
     this.__duration = measureOptions.duration;
 
-    if (measureOptions) {
-      this.__detail = measureOptions.detail;
-    }
+    this.__detail = measureOptions.detail ?? null;
   };
 
 // $FlowExpectedError[prop-missing]

--- a/packages/react-native/src/private/webapis/performance/__tests__/Performance-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/Performance-itest.js
@@ -53,7 +53,7 @@ describe('Performance', () => {
       expect(mark.name).toBe('mark-now');
       expect(mark.startTime).toBe(25);
       expect(mark.duration).toBe(0);
-      expect(mark.detail).toBeUndefined();
+      expect(mark.detail).toBe(null);
     });
 
     it('works with custom timestamp', () => {
@@ -64,7 +64,7 @@ describe('Performance', () => {
       expect(mark.name).toBe('mark-custom');
       expect(mark.startTime).toBe(10);
       expect(mark.duration).toBe(0);
-      expect(mark.detail).toBeUndefined();
+      expect(mark.detail).toBe(null);
     });
 
     it('provides detail', () => {
@@ -76,6 +76,13 @@ describe('Performance', () => {
 
       expect(mark.detail).toEqual(originalDetail);
       expect(mark.detail).not.toBe(originalDetail);
+    });
+
+    it('provides a null detail if it is not provided or is undefined', () => {
+      expect(performance.mark('mark-without-detail').detail).toBe(null);
+      expect(
+        performance.mark('mark-without-detail', {detail: undefined}).detail,
+      ).toBe(null);
     });
 
     it('throws if no name is provided', () => {
@@ -146,7 +153,7 @@ describe('Performance', () => {
         expect(measure.name).toBe('measure-with-defaults');
         expect(measure.startTime).toBe(0);
         expect(measure.duration).toBe(25);
-        expect(measure.detail).toBeUndefined();
+        expect(measure.detail).toBe(null);
       });
 
       it('works with a start timestamp', () => {
@@ -161,7 +168,7 @@ describe('Performance', () => {
         expect(measure.name).toBe('measure-with-start-timestamp');
         expect(measure.startTime).toBe(10);
         expect(measure.duration).toBe(15);
-        expect(measure.detail).toBeUndefined();
+        expect(measure.detail).toBe(null);
       });
 
       it('works with start mark', () => {
@@ -180,7 +187,7 @@ describe('Performance', () => {
         expect(measure.name).toBe('measure-with-start-mark');
         expect(measure.startTime).toBe(10);
         expect(measure.duration).toBe(15);
-        expect(measure.detail).toBeUndefined();
+        expect(measure.detail).toBe(null);
       });
 
       it('works with end mark', () => {
@@ -199,7 +206,7 @@ describe('Performance', () => {
         expect(measure.name).toBe('measure-with-end-mark');
         expect(measure.startTime).toBe(0);
         expect(measure.duration).toBe(50);
-        expect(measure.detail).toBeUndefined();
+        expect(measure.detail).toBe(null);
       });
 
       it('works with start mark and end mark', () => {
@@ -226,7 +233,7 @@ describe('Performance', () => {
         expect(measure.name).toBe('measure-with-start-mark-and-end-mark');
         expect(measure.startTime).toBe(10);
         expect(measure.duration).toBe(40);
-        expect(measure.detail).toBeUndefined();
+        expect(measure.detail).toBe(null);
       });
 
       it('works with a start timestamp and an end timestamp', () => {
@@ -245,7 +252,7 @@ describe('Performance', () => {
         );
         expect(measure.startTime).toBe(10);
         expect(measure.duration).toBe(15);
-        expect(measure.detail).toBeUndefined();
+        expect(measure.detail).toBe(null);
       });
 
       it('works with a start timestamp and a duration', () => {
@@ -262,7 +269,7 @@ describe('Performance', () => {
         expect(measure.name).toBe('measure-with-start-timestamp-and-duration');
         expect(measure.startTime).toBe(10);
         expect(measure.duration).toBe(30);
-        expect(measure.detail).toBeUndefined();
+        expect(measure.detail).toBe(null);
       });
 
       it('works with a start mark and a duration', () => {
@@ -283,7 +290,7 @@ describe('Performance', () => {
         expect(measure.name).toBe('measure-with-start-mark-and-duration');
         expect(measure.startTime).toBe(10);
         expect(measure.duration).toBe(30);
-        expect(measure.detail).toBeUndefined();
+        expect(measure.detail).toBe(null);
       });
 
       it('throws if the specified mark does NOT exist', () => {
@@ -339,7 +346,7 @@ describe('Performance', () => {
         expect(measure.name).toBe('measure-with-defaults');
         expect(measure.startTime).toBe(0);
         expect(measure.duration).toBe(25);
-        expect(measure.detail).toBeUndefined();
+        expect(measure.detail).toBe(null);
       });
 
       it('works with startMark', () => {
@@ -359,7 +366,7 @@ describe('Performance', () => {
         expect(measure.name).toBe('measure-with-start-mark');
         expect(measure.startTime).toBe(10);
         expect(measure.duration).toBe(15);
-        expect(measure.detail).toBeUndefined();
+        expect(measure.detail).toBe(null);
       });
 
       it('works with startMark and endMark', () => {
@@ -383,7 +390,7 @@ describe('Performance', () => {
         expect(measure.name).toBe('measure-with-start-mark-and-end-mark');
         expect(measure.startTime).toBe(10);
         expect(measure.duration).toBe(15);
-        expect(measure.detail).toBeUndefined();
+        expect(measure.detail).toBe(null);
       });
 
       it('throws if the specified marks do NOT exist', () => {
@@ -430,6 +437,14 @@ describe('Performance', () => {
 
       expect(measure.detail).toEqual(originalDetail);
       expect(measure.detail).not.toBe(originalDetail);
+    });
+
+    it('provides a null detail if it is not provided or is undefined', () => {
+      expect(performance.measure('measure-without-detail').detail).toBe(null);
+      expect(
+        performance.measure('measure-without-detail', {detail: undefined})
+          .detail,
+      ).toBe(null);
     });
 
     it('casts measure name to a string', () => {

--- a/packages/react-native/src/private/webapis/performance/__tests__/Performance-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/Performance-itest.js
@@ -87,6 +87,13 @@ describe('Performance', () => {
       );
     });
 
+    it('casts mark name to a string', () => {
+      // $FlowExpectedError[incompatible-call]
+      const mark = performance.mark(10);
+
+      expect(mark.name).toBe('10');
+    });
+
     it('casts startTime to a number', () => {
       const mark = performance.mark('some-mark', {
         // $FlowExpectedError[incompatible-call]
@@ -423,6 +430,22 @@ describe('Performance', () => {
 
       expect(measure.detail).toEqual(originalDetail);
       expect(measure.detail).not.toBe(originalDetail);
+    });
+
+    it('casts measure name to a string', () => {
+      // $FlowExpectedError[incompatible-call]
+      const measure = performance.measure(10);
+
+      expect(measure.name).toBe('10');
+    });
+
+    it('throws if no name is provided', () => {
+      expect(() => {
+        // $FlowExpectedError[incompatible-call]
+        performance.measure();
+      }).toThrow(
+        `Failed to execute 'measure' on 'Performance': 1 argument required, but only 0 present.`,
+      );
     });
   });
 

--- a/packages/react-native/src/private/webapis/performance/internals/Utilities.js
+++ b/packages/react-native/src/private/webapis/performance/internals/Utilities.js
@@ -9,6 +9,7 @@
  */
 
 import warnOnce from '../../../../../Libraries/Utilities/warnOnce';
+import NativePerformance from '../specs/NativePerformance';
 
 export function warnNoNativePerformance() {
   warnOnce(
@@ -16,3 +17,11 @@ export function warnNoNativePerformance() {
     'Missing native implementation of Performance',
   );
 }
+
+declare var global: {
+  // This value is defined directly via JSI, if available.
+  +nativePerformanceNow?: ?() => number,
+};
+
+export const getCurrentTimeStamp: () => DOMHighResTimeStamp =
+  NativePerformance?.now ?? global.nativePerformanceNow ?? (() => Date.now());


### PR DESCRIPTION
Summary:
Changelog: [internal]

`PerformanceEntry.detail` should be `null` if not defined, not undefined as it is currently. This fixes that.

Differential Revision: D78013568


