### PR TITLE
Migrate network profiling to console.timeStamp

### DIFF
--- a/packages/react-native/Libraries/Network/XMLHttpRequest.js
+++ b/packages/react-native/Libraries/Network/XMLHttpRequest.js
@@ -34,6 +34,9 @@ const RCTNetworking = require('./RCTNetworking').default;
 const base64 = require('base64-js');
 const invariant = require('invariant');
 
+const PERFORMANCE_TRACK_NAME = 'Network (JS-initiated only)';
+const PERFORMANCE_TRACK_GROUP = 'Chrome DevTools Temp Compat';
+
 declare var performance: Performance;
 
 const DEBUG_NETWORK_SEND_DELAY: false = false; // Set to a number of milliseconds when debugging
@@ -385,6 +388,9 @@ class XMLHttpRequest extends EventTarget {
     if (requestId !== this._requestId) {
       return;
     }
+
+    const start = XMLHttpRequest._profiling ? performance.now() : undefined;
+
     if (!this._response) {
       this._response = responseText;
     } else {
@@ -392,8 +398,13 @@ class XMLHttpRequest extends EventTarget {
     }
 
     if (XMLHttpRequest._profiling) {
-      performance.mark(
-        'Track:XMLHttpRequest:Incremental Data: ' + this._getMeasureURL(),
+      console.timeStamp(
+        'Incremental Data: ' + this._getMeasureURL(),
+        // $FlowFixMe[extra-arg] Add correct typing for `console.timeStamp`
+        start,
+        undefined,
+        PERFORMANCE_TRACK_NAME,
+        PERFORMANCE_TRACK_GROUP,
       );
     }
     XMLHttpRequest._interceptor &&
@@ -442,10 +453,14 @@ class XMLHttpRequest extends EventTarget {
       this.setReadyState(this.DONE);
       if (XMLHttpRequest._profiling && this._startTime != null) {
         const start = this._startTime;
-        performance.measure('Track:XMLHttpRequest:' + this._getMeasureURL(), {
+        console.timeStamp(
+          this._getMeasureURL(),
+          // $FlowFixMe[extra-arg] Add correct typing for `console.timeStamp`
           start,
-          end: performance.now(),
-        });
+          undefined,
+          PERFORMANCE_TRACK_NAME,
+          PERFORMANCE_TRACK_GROUP,
+        );
       }
       if (error) {
         XMLHttpRequest._interceptor &&

--- a/packages/react-native/Package.swift
+++ b/packages/react-native/Package.swift
@@ -166,7 +166,7 @@ let reactJsInspector = RNTarget(
   name: .reactJsInspector,
   path: "ReactCommon/jsinspector-modern",
   excludedPaths: ["tracing", "network", "tests"],
-  dependencies: [.reactNativeDependencies, .reactFeatureFlags, .jsi, .reactJsInspectorTracing, .reactJsInspectorNetwork, .reactRuntimeExecutor],
+  dependencies: [.reactNativeDependencies, .reactFeatureFlags, .jsi, .reactJsInspectorTracing, .reactJsInspectorNetwork, .reactRuntimeExecutor, .reactPerfLogger],
   defines: [
     CXXSetting.define("REACT_NATIVE_DEBUGGER_ENABLED", to: "1", .when(configuration: BuildConfiguration.debug)),
     CXXSetting.define("REACT_NATIVE_DEBUGGER_ENABLED_DEVONLY", to: "1", .when(configuration: BuildConfiguration.debug)),

--- a/packages/react-native/ReactCommon/jsinspector-modern/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsinspector-modern/CMakeLists.txt
@@ -25,6 +25,7 @@ target_link_libraries(jsinspector
         jsinspector_tracing
         react_featureflags
         runtimeexecutor
+        reactperflogger
 )
 target_compile_reactnative_options(jsinspector PRIVATE)
 target_compile_options(jsinspector PRIVATE

--- a/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfettoLogger.cpp
+++ b/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfettoLogger.cpp
@@ -22,10 +22,26 @@ const std::string PERFETTO_DEFAULT_TRACK_NAME = "# Web Performance";
 const std::string PERFETTO_TRACK_NAME_PREFIX = "# Web Performance: ";
 
 std::string toPerfettoTrackName(
-    const std::optional<std::string_view>& trackName) {
-  return trackName.has_value()
-      ? PERFETTO_TRACK_NAME_PREFIX + std::string(trackName.value())
-      : PERFETTO_DEFAULT_TRACK_NAME;
+    const std::optional<std::string_view>& trackName,
+    const std::optional<std::string_view>& trackGroup) {
+  std::string perfettoTrackName = PERFETTO_DEFAULT_TRACK_NAME;
+
+  if (trackName || trackGroup) {
+    perfettoTrackName += ": ";
+
+    if (trackGroup) {
+      perfettoTrackName += *trackGroup;
+      if (trackName) {
+        perfettoTrackName += " | ";
+      }
+    }
+
+    if (trackName) {
+      perfettoTrackName += *trackName;
+    }
+  }
+
+  return perfettoTrackName;
 }
 #elif defined(WITH_FBSYSTRACE)
 int64_t getDeltaNanos(HighResTimeStamp jsTime) {
@@ -50,10 +66,12 @@ int64_t getDeltaNanos(HighResTimeStamp jsTime) {
     const std::string_view& eventName,
     HighResTimeStamp startTime,
     HighResTimeStamp endTime,
-    const std::optional<std::string_view>& trackName) {
+    const std::optional<std::string_view>& trackName,
+    const std::optional<std::string_view>& trackGroup) {
 #if defined(WITH_PERFETTO)
   if (TRACE_EVENT_CATEGORY_ENABLED("react-native")) {
-    auto track = getPerfettoWebPerfTrackAsync(toPerfettoTrackName(trackName));
+    auto track = getPerfettoWebPerfTrackAsync(
+        toPerfettoTrackName(trackName, trackGroup));
     TRACE_EVENT_BEGIN(
         "react-native",
         perfetto::DynamicString(eventName.data(), eventName.size()),
@@ -75,13 +93,14 @@ int64_t getDeltaNanos(HighResTimeStamp jsTime) {
 /* static */ void ReactPerfettoLogger::mark(
     const std::string_view& eventName,
     HighResTimeStamp startTime,
-    const std::optional<std::string_view>& trackName) {
+    const std::optional<std::string_view>& trackName,
+    const std::optional<std::string_view>& trackGroup) {
 #if defined(WITH_PERFETTO)
   if (TRACE_EVENT_CATEGORY_ENABLED("react-native")) {
     TRACE_EVENT_INSTANT(
         "react-native",
         perfetto::DynamicString(eventName.data(), eventName.size()),
-        getPerfettoWebPerfTrackSync(toPerfettoTrackName(trackName)),
+        getPerfettoWebPerfTrackSync(toPerfettoTrackName(trackName, trackGroup)),
         highResTimeStampToPerfettoTraceTime(startTime));
   }
 #elif defined(WITH_FBSYSTRACE)

--- a/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfettoLogger.h
+++ b/packages/react-native/ReactCommon/reactperflogger/reactperflogger/ReactPerfettoLogger.h
@@ -11,7 +11,7 @@
 #include <reactperflogger/ReactPerfettoCategories.h>
 
 #include <optional>
-#include <string>
+#include <string_view>
 
 namespace facebook::react {
 
@@ -26,13 +26,15 @@ class ReactPerfettoLogger {
   static void mark(
       const std::string_view& eventName,
       HighResTimeStamp startTime,
-      const std::optional<std::string_view>& trackName);
+      const std::optional<std::string_view>& trackName = std::nullopt,
+      const std::optional<std::string_view>& trackGroup = std::nullopt);
 
   static void measure(
       const std::string_view& eventName,
       HighResTimeStamp startTime,
       HighResTimeStamp endTime,
-      const std::optional<std::string_view>& trackName);
+      const std::optional<std::string_view>& trackName = std::nullopt,
+      const std::optional<std::string_view>& trackGroup = std::nullopt);
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
Changelog: [internal]

This migrates the profiling logic for `XMLHttpRequest` from `performance.measure` to `console.timeStamp` with built-in support for tracks.

Reviewed By: hoxyq

Differential Revision: D78157407


