### PR TITLE
Unify test_ios_rntester_dynamic_frameworks with test_ios_rntester

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -141,26 +141,7 @@ jobs:
           ruby-version: "3.2.0"
           hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
-
-  test_ios_rntester_dynamic_frameworks:
-    runs-on: macos-14
-    needs:
-      [build_apple_slices_hermes, prepare_hermes_workspace, build_hermes_macos, prebuild_apple_dependencies]
-    env:
-      HERMES_WS_DIR: /tmp/hermes
-      HERMES_TARBALL_ARTIFACTS_DIR: /tmp/hermes/hermes-runtime-darwin
-    continue-on-error: true
-    strategy:
-      fail-fast: false
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Run it
-        uses: ./.github/actions/test-ios-rntester
-        with:
-          use-frameworks: DynamicFrameworks
-          hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
-          react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
+          flavor: Debug
 
   test_ios_rntester:
     runs-on: macos-14-large
@@ -174,14 +155,14 @@ jobs:
       fail-fast: false
       matrix:
         flavor: [Debug, Release]
+        frameworks: [StaticLibraries, DynamicFrameworks]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Run it
         uses: ./.github/actions/test-ios-rntester
         with:
-          run-unit-tests: "false"
-          use-frameworks: StaticLibraries
+          use-frameworks: ${{ matrix.frameworks }}
           hermes-version: ${{ needs.prepare_hermes_workspace.outputs.hermes-version }}
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
           flavor: ${{ matrix.flavor }}

--- a/packages/react-native/Libraries/PushNotificationIOS/React-RCTPushNotification.podspec
+++ b/packages/react-native/Libraries/PushNotificationIOS/React-RCTPushNotification.podspec
@@ -18,6 +18,7 @@ end
 
 header_search_paths = [
   "\"${PODS_ROOT}/Headers/Public/ReactCodegen/react/renderer/components\"",
+  "\"${PODS_ROOT}/Headers/Public/React-RCTFBReactNativeSpec/FBReactNativeSpec\"",
 ]
 
 Pod::Spec.new do |s|
@@ -45,7 +46,9 @@ Pod::Spec.new do |s|
   s.dependency "React-Core/RCTPushNotificationHeaders"
   s.dependency "React-jsi"
 
-  add_dependency(s, "React-RCTFBReactNativeSpec")
+  add_dependency(s, "React-RCTFBReactNativeSpec", :additional_framework_paths => ['FBReactNativeSpec'])
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
   add_dependency(s, "React-NativeModulesApple")
+
+  add_rncore_dependency(s)
 end


### PR DESCRIPTION
Summary:
The test_ios_rntester_dynamic_frameworks is identical to the test_ios_rntester but for the framework parameter.

This change unifies the two, using a matrix to test all the configurations:
- Debug / Static Libraries
- Release / Static Libraries
- Debug / Dynamic Frameworks
- Release / Dynamic Frameworks

## Changelog:
[Internal] -

Differential Revision: D78159366
