### PR TITLE
Breaking: Use named exports in `metro-babel-register`

### DIFF
--- a/packages/community-cli-plugin/src/commands/start/runServer.js
+++ b/packages/community-cli-plugin/src/commands/start/runServer.js
@@ -147,7 +147,7 @@ async function runServer(
   // $FlowIgnore[cannot-write] Assigning to readonly property
   metroConfig.reporter = reporter;
 
-  const serverInstance = await Metro.runServer(metroConfig, {
+  await Metro.runServer(metroConfig, {
     host: args.host,
     secure: args.https,
     secureCert: args.cert,
@@ -160,18 +160,6 @@ async function runServer(
   });
 
   reportEvent = eventsSocketEndpoint.reportEvent;
-
-  // In Node 8, the default keep-alive for an HTTP connection is 5 seconds. In
-  // early versions of Node 8, this was implemented in a buggy way which caused
-  // some HTTP responses (like those containing large JS bundles) to be
-  // terminated early.
-  //
-  // As a workaround, arbitrarily increase the keep-alive from 5 to 30 seconds,
-  // which should be enough to send even the largest of JS bundles.
-  //
-  // For more info: https://github.com/nodejs/node/issues/13391
-  //
-  serverInstance.keepAliveTimeout = 30000;
 
   await version.logIfUpdateAvailable(cliConfig, terminalReporter);
 }

--- a/scripts/shared/babelRegister.js
+++ b/scripts/shared/babelRegister.js
@@ -41,7 +41,15 @@ function registerForMonorepo() {
     // $FlowExpectedError[cannot-resolve-module] - Won't resolve in OSS
     require('@fb-tools/babel-register');
   } else {
-    require('metro-babel-register')([
+    // Temporarily allow the default export to be a function (Metro <= 0.82),
+    // or contain a `register` function (Metro >= 0.83). Remove shim once Metro
+    // is bumped in OSS.
+    const metroBabelRegister = require('metro-babel-register') /*:: as $FlowFixMe */;
+    const registerFunction =
+      typeof metroBabelRegister.register === 'function'
+        ? metroBabelRegister.register
+        : metroBabelRegister;
+    registerFunction([
       PACKAGES_DIR,
       PRIVATE_DIR,
       SCRIPTS_DIR,


### PR DESCRIPTION
Summary:
Currently, `metro-babel-register` has a function as its default export, to which we've tagged on various properties.

This tidies that up to a more idiomatic object of named exports, with `register` as a new one of them.

This also serves to make it more compatible with automatic TypeScript generation.

This is semver breaking, but `metro-babel-register` has very little usage outside Meta projects so isn't expected to be disruptive.

Changelog: [Internal]

Metro changelog:
```
 - **[Breaking]**: Move metro-babel-register's main function to a named export `register`
```

Differential Revision: D78157559


