### PR TITLE
Remove LegacyArchitecture deprecation from JSONArguments

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JSONArguments.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JSONArguments.kt
@@ -7,21 +7,11 @@
 
 package com.facebook.react.bridge
 
-import com.facebook.react.common.annotations.internal.LegacyArchitecture
-import com.facebook.react.common.annotations.internal.LegacyArchitectureLogLevel
-import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject
 
-@LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
 public object JSONArguments {
-
-  init {
-    LegacyArchitectureLogger.assertLegacyArchitecture(
-        "JSONArguments", LegacyArchitectureLogLevel.ERROR)
-  }
-
   /**
    * Parse JSONObject to ReadableMap
    *


### PR DESCRIPTION
Summary:
JSONArguments is a set of utility methods that are not part of the legacy architecture, removing the annotation.

Changelog: [Internal]

Differential Revision: D78168536


