### PR TITLE
Fix names of view manager methods arguments

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/debuggingoverlay/DebuggingOverlayManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/debuggingoverlay/DebuggingOverlayManager.kt
@@ -30,15 +30,12 @@ internal class DebuggingOverlayManager :
 
   override fun getDelegate(): ViewManagerDelegate<DebuggingOverlay> = delegate
 
-  override fun highlightTraceUpdates(
-      view: DebuggingOverlay,
-      providedTraceUpdates: ReadableArray
-  ): Unit {
+  override fun highlightTraceUpdates(view: DebuggingOverlay, updates: ReadableArray): Unit {
     val formattedTraceUpdates = mutableListOf<TraceUpdate>()
 
     var successfullyParsedPayload = true
-    for (i in 0 until providedTraceUpdates.size()) {
-      val traceUpdate = providedTraceUpdates.getMap(i) ?: continue
+    for (i in 0 until updates.size()) {
+      val traceUpdate = updates.getMap(i) ?: continue
       val serializedRectangle = traceUpdate.getMap("rectangle")
       if (serializedRectangle == null) {
         ReactSoftExceptionLogger.logSoftException(
@@ -82,12 +79,12 @@ internal class DebuggingOverlayManager :
     }
   }
 
-  override fun highlightElements(view: DebuggingOverlay, providedElements: ReadableArray): Unit {
+  override fun highlightElements(view: DebuggingOverlay, elements: ReadableArray): Unit {
     val elementsRectangles = mutableListOf<RectF>()
 
     var successfullyParsedPayload = true
-    for (i in 0 until providedElements.size()) {
-      val element = providedElements.getMap(i) ?: continue
+    for (i in 0 until elements.size()) {
+      val element = elements.getMap(i) ?: continue
       try {
         val left = element.getDouble("x").toFloat()
         val top = element.getDouble("y").toFloat()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/ReactDrawerLayoutManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/drawer/ReactDrawerLayoutManager.kt
@@ -108,20 +108,20 @@ public class ReactDrawerLayoutManager :
     view.setDrawerWidth(widthInPx)
   }
 
-  public override fun setDrawerWidth(view: ReactDrawerLayout, width: Float?) {
-    val widthInPx = width?.let { Math.round(it.dpToPx()) } ?: ReactDrawerLayout.DEFAULT_DRAWER_WIDTH
+  public override fun setDrawerWidth(view: ReactDrawerLayout, value: Float?) {
+    val widthInPx = value?.let { Math.round(it.dpToPx()) } ?: ReactDrawerLayout.DEFAULT_DRAWER_WIDTH
     view.setDrawerWidth(widthInPx)
   }
 
   @ReactProp(name = "drawerLockMode")
-  public override fun setDrawerLockMode(view: ReactDrawerLayout, drawerLockMode: String?) {
-    when (drawerLockMode) {
+  public override fun setDrawerLockMode(view: ReactDrawerLayout, value: String?) {
+    when (value) {
       null,
       "unlocked" -> view.setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED)
       "locked-closed" -> view.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED)
       "locked-open" -> view.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_OPEN)
       else -> {
-        FLog.w(ReactConstants.TAG, "Unknown drawerLockMode $drawerLockMode")
+        FLog.w(ReactConstants.TAG, "Unknown drawerLockMode $value")
         view.setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED)
       }
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostManager.kt
@@ -38,37 +38,34 @@ internal class ReactModalHostManager :
   }
 
   @ReactProp(name = "animationType")
-  override fun setAnimationType(view: ReactModalHostView, animationType: String?) {
-    if (animationType != null) {
-      view.animationType = animationType
+  override fun setAnimationType(view: ReactModalHostView, value: String?) {
+    if (value != null) {
+      view.animationType = value
     }
   }
 
   @ReactProp(name = "transparent")
-  override fun setTransparent(view: ReactModalHostView, transparent: Boolean) {
-    view.transparent = transparent
+  override fun setTransparent(view: ReactModalHostView, value: Boolean) {
+    view.transparent = value
   }
 
   @ReactProp(name = "statusBarTranslucent")
-  override fun setStatusBarTranslucent(view: ReactModalHostView, statusBarTranslucent: Boolean) {
-    view.statusBarTranslucent = statusBarTranslucent
+  override fun setStatusBarTranslucent(view: ReactModalHostView, value: Boolean) {
+    view.statusBarTranslucent = value
   }
 
   @ReactProp(name = "navigationBarTranslucent")
-  override fun setNavigationBarTranslucent(
-      view: ReactModalHostView,
-      navigationBarTranslucent: Boolean
-  ) {
-    view.navigationBarTranslucent = navigationBarTranslucent
+  override fun setNavigationBarTranslucent(view: ReactModalHostView, value: Boolean) {
+    view.navigationBarTranslucent = value
   }
 
   @ReactProp(name = "hardwareAccelerated")
-  override fun setHardwareAccelerated(view: ReactModalHostView, hardwareAccelerated: Boolean) {
-    view.hardwareAccelerated = hardwareAccelerated
+  override fun setHardwareAccelerated(view: ReactModalHostView, value: Boolean) {
+    view.hardwareAccelerated = value
   }
 
   @ReactProp(name = "visible")
-  override fun setVisible(view: ReactModalHostView, visible: Boolean) {
+  override fun setVisible(view: ReactModalHostView, value: Boolean) {
     // iOS only
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/progressbar/ReactProgressBarViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/progressbar/ReactProgressBarViewManager.kt
@@ -49,28 +49,28 @@ internal class ReactProgressBarViewManager :
   }
 
   @ReactProp(name = PROP_STYLE)
-  override fun setStyleAttr(view: ProgressBarContainerView, styleName: String?) {
-    view.setStyle(styleName)
+  override fun setStyleAttr(view: ProgressBarContainerView, value: String?) {
+    view.setStyle(value)
   }
 
   @ReactProp(name = ViewProps.COLOR, customType = "Color")
-  override fun setColor(view: ProgressBarContainerView, color: Int?) {
-    view.color = color
+  override fun setColor(view: ProgressBarContainerView, value: Int?) {
+    view.color = value
   }
 
   @ReactProp(name = PROP_INDETERMINATE)
-  override fun setIndeterminate(view: ProgressBarContainerView, indeterminate: Boolean) {
-    view.indeterminate = indeterminate
+  override fun setIndeterminate(view: ProgressBarContainerView, value: Boolean) {
+    view.indeterminate = value
   }
 
   @ReactProp(name = PROP_PROGRESS)
-  override fun setProgress(view: ProgressBarContainerView, progress: Double) {
-    view.progress = progress
+  override fun setProgress(view: ProgressBarContainerView, value: Double) {
+    view.progress = value
   }
 
   @ReactProp(name = PROP_ANIMATING)
-  override fun setAnimating(view: ProgressBarContainerView, animating: Boolean) {
-    view.animating = animating
+  override fun setAnimating(view: ProgressBarContainerView, value: Boolean) {
+    view.animating = value
   }
 
   override fun setTestID(view: ProgressBarContainerView, value: String?) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/SwipeRefreshLayoutManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/swiperefresh/SwipeRefreshLayoutManager.kt
@@ -42,19 +42,19 @@ internal open class SwipeRefreshLayoutManager :
   override fun getName(): String = REACT_CLASS
 
   @ReactProp(name = ViewProps.ENABLED, defaultBoolean = true)
-  override fun setEnabled(view: ReactSwipeRefreshLayout, enabled: Boolean) {
-    view.isEnabled = enabled
+  override fun setEnabled(view: ReactSwipeRefreshLayout, value: Boolean) {
+    view.isEnabled = value
   }
 
   @ReactProp(name = "colors", customType = "ColorArray")
-  override fun setColors(view: ReactSwipeRefreshLayout, colors: ReadableArray?) {
-    if (colors != null) {
-      val colorValues = IntArray(colors.size())
-      for (i in 0..<colors.size()) {
-        if (colors.getType(i) == ReadableType.Map) {
-          colorValues[i] = ColorPropConverter.getColor(colors.getMap(i), view.context, 0)
+  override fun setColors(view: ReactSwipeRefreshLayout, value: ReadableArray?) {
+    if (value != null) {
+      val colorValues = IntArray(value.size())
+      for (i in 0..<value.size()) {
+        if (value.getType(i) == ReadableType.Map) {
+          colorValues[i] = ColorPropConverter.getColor(value.getMap(i), view.context, 0)
         } else {
-          colorValues[i] = colors.getInt(i)
+          colorValues[i] = value.getInt(i)
         }
       }
       view.setColorSchemeColors(*colorValues)
@@ -64,8 +64,8 @@ internal open class SwipeRefreshLayoutManager :
   }
 
   @ReactProp(name = "progressBackgroundColor", customType = "Color")
-  override fun setProgressBackgroundColor(view: ReactSwipeRefreshLayout, color: Int?) {
-    view.setProgressBackgroundColorSchemeColor(color ?: Color.TRANSPARENT)
+  override fun setProgressBackgroundColor(view: ReactSwipeRefreshLayout, value: Int?) {
+    view.setProgressBackgroundColorSchemeColor(value ?: Color.TRANSPARENT)
   }
 
   // TODO(T46143833): Remove this method once the 'size' prop has been migrated to String in JS.
@@ -73,13 +73,13 @@ internal open class SwipeRefreshLayoutManager :
     view.setSize(value)
   }
 
-  override fun setSize(view: ReactSwipeRefreshLayout, size: String?) {
-    if (size == null || size.equals("default")) {
+  override fun setSize(view: ReactSwipeRefreshLayout, value: String?) {
+    if (value == null || value.equals("default")) {
       view.setSize(SwipeRefreshLayout.DEFAULT)
-    } else if (size.equals("large")) {
+    } else if (value.equals("large")) {
       view.setSize(SwipeRefreshLayout.LARGE)
     } else {
-      throw IllegalArgumentException("Size must be 'default' or 'large', received: $size")
+      throw IllegalArgumentException("Size must be 'default' or 'large', received: $value")
     }
   }
 
@@ -97,13 +97,13 @@ internal open class SwipeRefreshLayoutManager :
   }
 
   @ReactProp(name = "refreshing")
-  override fun setRefreshing(view: ReactSwipeRefreshLayout, refreshing: Boolean) {
-    view.isRefreshing = refreshing
+  override fun setRefreshing(view: ReactSwipeRefreshLayout, value: Boolean) {
+    view.isRefreshing = value
   }
 
   @ReactProp(name = "progressViewOffset", defaultFloat = 0f)
-  override fun setProgressViewOffset(view: ReactSwipeRefreshLayout, offset: Float) {
-    view.setProgressViewOffset(offset)
+  override fun setProgressViewOffset(view: ReactSwipeRefreshLayout, value: Float) {
+    view.setProgressViewOffset(value)
   }
 
   override fun setNativeRefreshing(view: ReactSwipeRefreshLayout, value: Boolean) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitchManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitchManager.kt
@@ -46,18 +46,18 @@ internal class ReactSwitchManager :
   }
 
   @ReactProp(name = "disabled", defaultBoolean = false)
-  override fun setDisabled(view: ReactSwitch, disabled: Boolean) {
-    view.isEnabled = !disabled
+  override fun setDisabled(view: ReactSwitch, value: Boolean) {
+    view.isEnabled = !value
   }
 
   @ReactProp(name = ViewProps.ENABLED, defaultBoolean = true)
-  override fun setEnabled(view: ReactSwitch, enabled: Boolean) {
-    view.isEnabled = enabled
+  override fun setEnabled(view: ReactSwitch, value: Boolean) {
+    view.isEnabled = value
   }
 
   @ReactProp(name = ViewProps.ON)
-  override fun setOn(view: ReactSwitch, on: Boolean) {
-    setValueInternal(view, on)
+  override fun setOn(view: ReactSwitch, value: Boolean) {
+    setValueInternal(view, value)
   }
 
   @ReactProp(name = "value")
@@ -66,28 +66,28 @@ internal class ReactSwitchManager :
   }
 
   @ReactProp(name = "thumbTintColor", customType = "Color")
-  override fun setThumbTintColor(view: ReactSwitch, color: Int?) {
-    setThumbColor(view, color)
+  override fun setThumbTintColor(view: ReactSwitch, value: Int?) {
+    setThumbColor(view, value)
   }
 
   @ReactProp(name = "thumbColor", customType = "Color")
-  override fun setThumbColor(view: ReactSwitch, color: Int?) {
-    view.setThumbColor(color)
+  override fun setThumbColor(view: ReactSwitch, value: Int?) {
+    view.setThumbColor(value)
   }
 
   @ReactProp(name = "trackColorForFalse", customType = "Color")
-  override fun setTrackColorForFalse(view: ReactSwitch, color: Int?) {
-    view.setTrackColorForFalse(color)
+  override fun setTrackColorForFalse(view: ReactSwitch, value: Int?) {
+    view.setTrackColorForFalse(value)
   }
 
   @ReactProp(name = "trackColorForTrue", customType = "Color")
-  override fun setTrackColorForTrue(view: ReactSwitch, color: Int?) {
-    view.setTrackColorForTrue(color)
+  override fun setTrackColorForTrue(view: ReactSwitch, value: Int?) {
+    view.setTrackColorForTrue(value)
   }
 
   @ReactProp(name = "trackTintColor", customType = "Color")
-  override fun setTrackTintColor(view: ReactSwitch, color: Int?) {
-    view.setTrackColor(color)
+  override fun setTrackTintColor(view: ReactSwitch, value: Int?) {
+    view.setTrackColor(value)
   }
 
   override fun setNativeValue(view: ReactSwitch, value: Boolean) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/unimplementedview/ReactUnimplementedViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/unimplementedview/ReactUnimplementedViewManager.kt
@@ -35,8 +35,8 @@ internal class ReactUnimplementedViewManager :
   override fun getName(): String = REACT_CLASS
 
   @ReactProp(name = "name")
-  override fun setName(view: ReactUnimplementedView, name: String?): Unit =
-      view.setName(name ?: "<null component name>")
+  override fun setName(view: ReactUnimplementedView, value: String?): Unit =
+      view.setName(value ?: "<null component name>")
 
   internal companion object {
     const val REACT_CLASS: String = "UnimplementedNativeView"


### PR DESCRIPTION
Summary:
This diff fixes the following warning:

```
The corresponding parameter in the supertype 'XYZViewManager' is named 'value'. This may cause problems when calling this function with named arguments.
```

changelog: [Android][Changed] Changed method arguments names for Core ViewManagers to match the names of ViewManagerInterfaces

Differential Revision: D78170316


