### PR TITLE
feat(HMRLogs): Add env variable to disable HMR refreshing logs

### DIFF
--- a/packages/react-native/Libraries/Utilities/HMRClient.js
+++ b/packages/react-native/Libraries/Utilities/HMRClient.js
@@ -21,6 +21,7 @@ const MetroHMRClient = require('metro-runtime/src/modules/HMRClient');
 const prettyFormat = require('pretty-format');
 
 const pendingEntryPoints = [];
+const refreshLogDisabled = Boolean(typeof process !== 'undefined' && process.env && process.env.DISABLE_HMR_LOGS);
 let hmrClient = null;
 let hmrUnavailableReason: string | null = null;
 let hmrOrigin: string | null = null;
@@ -79,7 +80,7 @@ const HMRClient: HMRClientNativeInterface = {
     // Since they'll get applied now, we'll show a banner.
     const hasUpdates = hmrClient.hasPendingUpdates();
 
-    if (hasUpdates) {
+    if (hasUpdates && !refreshLogDisabled) {
       DevLoadingView.showMessage('Refreshing...', 'refresh');
     }
     try {
@@ -214,7 +215,7 @@ Error: ${e.message}`;
       currentCompileErrorMessage = null;
       didConnect = true;
 
-      if (client.isEnabled() && !isInitialUpdate) {
+      if (client.isEnabled() && !isInitialUpdate && !refreshLogDisabled) {
         DevLoadingView.showMessage('Refreshing...', 'refresh');
       }
     });


### PR DESCRIPTION
## Summary:

Some development enviroments have files that change in src very frequently - this causes the blue refreshing bar to appear multiple times per second. 

Adding an environment variable to disable this help prevent this distraction

<img width="1052" height="388" alt="CleanShot 2025-07-11 at 11 49 44@2x" src="https://github.com/user-attachments/assets/1aa4948b-e128-4c14-8dff-d695eb07bdd5" />


## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[GENERAL] [ADDED] - Added environment variable `DISABLE_HMR_LOGS` to suppress the "Refreshing..." text.

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
