### PR TITLE
Mark ReactHost functions noexcept

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/runtime/ReactHost.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/runtime/ReactHost.cpp
@@ -417,7 +417,7 @@ void ReactHost::reloadReactInstance() {
 
 bool ReactHost::loadScript(
     const std::string& bundlePath,
-    const std::string& sourcePath) {
+    const std::string& sourcePath) noexcept {
   bool isLoaded = false;
   if (devServerHelper_) {
     devServerHelper_->setSourcePath(sourcePath);
@@ -458,7 +458,7 @@ bool ReactHost::loadScriptFromDevServer() {
     }
     devServerHelper_->setupHMRClient();
     return true;
-  } catch (const std::exception& /*e*/) {
+  } catch (...) {
     devServerHelper_->setSourcePath("");
     LOG(WARNING)
         << "Unable to download JS bundle from Metro, falling back to prebuilt JS bundle. "
@@ -475,7 +475,7 @@ bool ReactHost::loadScriptFromBundlePath(const std::string& bundlePath) {
     reactInstance_->loadScript(std::move(script), bundlePath);
     LOG(INFO) << "Loaded JS bundle from bundle path: " << bundlePath;
     return true;
-  } catch (const std::exception& /*e*/) {
+  } catch (...) {
     LOG(WARNING) << "Unable to read bundle from bundle path" << bundlePath;
     return false;
   }
@@ -486,7 +486,7 @@ void ReactHost::startSurface(
     const std::string& moduleName,
     const folly::dynamic& initialProps,
     const LayoutConstraints& layoutConstraints,
-    const LayoutContext& layoutContext) {
+    const LayoutContext& layoutContext) noexcept {
   surfaceManager_->startSurface(
       surfaceId, moduleName, initialProps, layoutConstraints, layoutContext);
 }
@@ -494,16 +494,16 @@ void ReactHost::startSurface(
 void ReactHost::setSurfaceConstraints(
     SurfaceId surfaceId,
     const LayoutConstraints& layoutConstraints,
-    const LayoutContext& layoutContext) {
+    const LayoutContext& layoutContext) noexcept {
   surfaceManager_->constraintSurfaceLayout(
       surfaceId, layoutConstraints, layoutContext);
 }
 
-void ReactHost::stopSurface(SurfaceId surfaceId) {
+void ReactHost::stopSurface(SurfaceId surfaceId) noexcept {
   surfaceManager_->stopSurface(surfaceId);
 }
 
-void ReactHost::stopAllSurfaces() {
+void ReactHost::stopAllSurfaces() noexcept {
   surfaceManager_->stopAllSurfaces();
 }
 
@@ -522,7 +522,7 @@ void ReactHost::runOnScheduler(
 
 void ReactHost::runOnRuntimeScheduler(
     std::function<void(jsi::Runtime& runtime)>&& task,
-    SchedulerPriority priority) const {
+    SchedulerPriority priority) const noexcept {
   if (!isReloadingReactInstance_) {
     reactInstance_->getRuntimeScheduler()->scheduleTask(
         priority, std::move(task));

--- a/packages/react-native/ReactCxxPlatform/react/runtime/ReactHost.h
+++ b/packages/react-native/ReactCxxPlatform/react/runtime/ReactHost.h
@@ -60,23 +60,25 @@ class ReactHost {
   ReactHost& operator=(ReactHost&&) noexcept = delete;
   ~ReactHost() noexcept;
 
-  bool loadScript(const std::string& bundlePath, const std::string& sourcePath);
+  bool loadScript(
+      const std::string& bundlePath,
+      const std::string& sourcePath) noexcept;
 
   void startSurface(
       SurfaceId surfaceId,
       const std::string& moduleName /* can be empty */,
       const folly::dynamic& initialProps,
       const LayoutConstraints& layoutConstraints,
-      const LayoutContext& layoutContext = {});
+      const LayoutContext& layoutContext = {}) noexcept;
 
   void setSurfaceConstraints(
       SurfaceId surfaceId,
       const LayoutConstraints& layoutConstraints,
-      const LayoutContext& layoutContext);
+      const LayoutContext& layoutContext) noexcept;
 
-  void stopSurface(SurfaceId surfaceId);
+  void stopSurface(SurfaceId surfaceId) noexcept;
 
-  void stopAllSurfaces();
+  void stopAllSurfaces() noexcept;
 
   bool isSurfaceRunning(SurfaceId surfaceId) const noexcept;
 
@@ -86,7 +88,8 @@ class ReactHost {
 
   void runOnRuntimeScheduler(
       std::function<void(jsi::Runtime& runtime)>&& task,
-      SchedulerPriority priority = SchedulerPriority::NormalPriority) const;
+      SchedulerPriority priority =
+          SchedulerPriority::NormalPriority) const noexcept;
 
   void emitDeviceEvent(folly::dynamic&& args);
 


### PR DESCRIPTION
Summary:
Changelog: [Internal]

The main change here is to catch *all* exceptions in:
- loadScriptFromDevServer
- loadScriptFromBundlePath

so that we can make the `loadScript(...` method `noexcept`

Other methods which only call into `noexcept` methods have been marked with `noexcept` as well

Differential Revision: D78222989


