### PR TITLE
Support CDP response previews for chunked data

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobModule.kt
@@ -35,7 +35,6 @@ import java.util.HashMap
 import java.util.UUID
 import okhttp3.MediaType
 import okhttp3.RequestBody
-import okhttp3.ResponseBody
 import okio.ByteString
 
 @ReactModule(name = NativeBlobModuleSpec.NAME)
@@ -72,7 +71,7 @@ public class BlobModule(reactContext: ReactApplicationContext) :
           return !isRemote && responseType == "blob"
         }
 
-        override fun fetch(uri: Uri): WritableMap {
+        override fun fetch(uri: Uri): Pair<WritableMap, ByteArray> {
           val data = getBytesFromUri(uri)
 
           val blob = Arguments.createMap()
@@ -85,7 +84,7 @@ public class BlobModule(reactContext: ReactApplicationContext) :
           blob.putString("name", getNameFromUri(uri))
           blob.putDouble("lastModified", getLastModifiedFromUri(uri))
 
-          return blob
+          return blob to data
         }
       }
 
@@ -119,8 +118,7 @@ public class BlobModule(reactContext: ReactApplicationContext) :
           return responseType == "blob"
         }
 
-        override fun toResponseData(body: ResponseBody): WritableMap {
-          val data = body.bytes()
+        override fun toResponseData(data: ByteArray): WritableMap {
           val blob = Arguments.createMap()
           blob.putString("blobId", store(data))
           blob.putInt("offset", 0)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/InspectorNetworkReporter.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/InspectorNetworkReporter.kt
@@ -59,6 +59,13 @@ internal object InspectorNetworkReporter {
   )
 
   /**
+   * Report when additional chunks of the response body have been received.
+   *
+   * Corresponds to `Network.dataReceived` in CDP.
+   */
+  @JvmStatic external fun reportDataReceived(requestId: Int, dataLength: Int)
+
+  /**
    * Report when a network request is complete and we are no longer receiving response data.
    * - Corresponds to `Network.loadingFinished` in CDP.
    * - Corresponds to `PerformanceResourceTiming.responseEnd`.
@@ -71,4 +78,13 @@ internal object InspectorNetworkReporter {
    */
   @JvmStatic
   external fun maybeStoreResponseBody(requestId: Int, body: String, base64Encoded: Boolean)
+
+  /**
+   * Incrementally store a response body preview, when a string response is received in chunks.
+   * Buffered contents will be flushed to `NetworkReporter` with `reportResponseEnd`.
+   *
+   * As with `maybeStoreResponseBody`, calling this method is optional and a no-op if CDP debugging
+   * is disabled.
+   */
+  @JvmStatic external fun maybeStoreResponseBodyIncremental(requestId: Int, data: String)
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/InspectorNetworkReporter.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/InspectorNetworkReporter.kt
@@ -64,4 +64,11 @@ internal object InspectorNetworkReporter {
    * - Corresponds to `PerformanceResourceTiming.responseEnd`.
    */
   @JvmStatic external fun reportResponseEnd(requestId: Int, encodedDataLength: Long)
+
+  /**
+   * Store response body preview. This is an optional reporting method, and is a no-op if CDP
+   * debugging is disabled.
+   */
+  @JvmStatic
+  external fun maybeStoreResponseBody(requestId: Int, body: String, base64Encoded: Boolean)
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkEventUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkEventUtil.kt
@@ -10,6 +10,7 @@
 package com.facebook.react.modules.network
 
 import android.os.Bundle
+import android.util.Base64
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.WritableMap
@@ -92,7 +93,16 @@ internal object NetworkEventUtil {
   }
 
   @JvmStatic
-  fun onDataReceived(reactContext: ReactApplicationContext?, requestId: Int, data: String?) {
+  fun onDataReceived(
+      reactContext: ReactApplicationContext?,
+      requestId: Int,
+      data: String?,
+      responseType: String
+  ) {
+    if (ReactNativeFeatureFlags.enableNetworkEventReporting()) {
+      InspectorNetworkReporter.maybeStoreResponseBody(
+          requestId, data.orEmpty(), responseType == "base64")
+    }
     reactContext?.emitDeviceEvent(
         "didReceiveNetworkData",
         buildReadableArray {
@@ -102,7 +112,16 @@ internal object NetworkEventUtil {
   }
 
   @JvmStatic
-  fun onDataReceived(reactContext: ReactApplicationContext?, requestId: Int, data: WritableMap?) {
+  fun onDataReceived(
+      reactContext: ReactApplicationContext?,
+      requestId: Int,
+      data: WritableMap,
+      rawData: ByteArray
+  ) {
+    if (ReactNativeFeatureFlags.enableNetworkEventReporting()) {
+      InspectorNetworkReporter.maybeStoreResponseBody(
+          requestId, Base64.encodeToString(rawData, Base64.NO_WRAP), true)
+    }
     reactContext?.emitDeviceEvent(
         "didReceiveNetworkData",
         Arguments.createArray().apply {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkEventUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkEventUtil.kt
@@ -66,6 +66,10 @@ internal object NetworkEventUtil {
       progress: Long,
       total: Long
   ) {
+    if (ReactNativeFeatureFlags.enableNetworkEventReporting() && data != null) {
+      InspectorNetworkReporter.reportDataReceived(requestId, data.encodeToByteArray().size)
+      InspectorNetworkReporter.maybeStoreResponseBodyIncremental(requestId, data)
+    }
     reactContext?.emitDeviceEvent(
         "didReceiveNetworkIncrementalData",
         buildReadableArray {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/InspectorNetworkReporter.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/InspectorNetworkReporter.cpp
@@ -101,6 +101,23 @@ std::string limitRequestBodySize(std::string requestBody) {
       std::to_string(requestId), static_cast<std::int64_t>(encodedDataLength));
 }
 
+/* static */ void InspectorNetworkReporter::maybeStoreResponseBody(
+    jni::alias_ref<jclass> /*unused*/,
+    jint requestId,
+    jni::alias_ref<jstring> body,
+    jboolean base64Encoded) {
+#ifdef REACT_NATIVE_DEBUGGER_ENABLED
+  // Debug build: Process response body and report to NetworkReporter
+  auto& networkReporter = NetworkReporter::getInstance();
+  if (!networkReporter.isDebuggingEnabled()) {
+    return;
+  }
+
+  networkReporter.storeResponseBody(
+      std::to_string(requestId), body->toStdString(), base64Encoded != 0u);
+#endif
+}
+
 /* static */ void InspectorNetworkReporter::registerNatives() {
   javaClassLocal()->registerNatives({
       makeNativeMethod(
@@ -112,6 +129,9 @@ std::string limitRequestBodySize(std::string requestBody) {
       makeNativeMethod(
           "reportConnectionTiming",
           InspectorNetworkReporter::reportConnectionTiming),
+      makeNativeMethod(
+          "maybeStoreResponseBody",
+          InspectorNetworkReporter::maybeStoreResponseBody),
   });
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/InspectorNetworkReporter.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/InspectorNetworkReporter.h
@@ -44,6 +44,12 @@ class InspectorNetworkReporter
       jint requestId,
       jlong encodedDataLength);
 
+  static void maybeStoreResponseBody(
+      jni::alias_ref<jclass> /*unused*/,
+      jint requestId,
+      jni::alias_ref<jstring> body,
+      jboolean base64Encoded);
+
   static void registerNatives();
 
  private:

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/InspectorNetworkReporter.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/InspectorNetworkReporter.h
@@ -39,6 +39,11 @@ class InspectorNetworkReporter
       jni::alias_ref<jni::JMap<jstring, jstring>> responseHeaders,
       jlong encodedDataLength);
 
+  static void reportDataReceived(
+      jni::alias_ref<jclass> /*unused*/,
+      jint requestId,
+      jint dataLength);
+
   static void reportResponseEnd(
       jni::alias_ref<jclass> /*unused*/,
       jint requestId,
@@ -49,6 +54,11 @@ class InspectorNetworkReporter
       jint requestId,
       jni::alias_ref<jstring> body,
       jboolean base64Encoded);
+
+  static void maybeStoreResponseBodyIncremental(
+      jni::alias_ref<jclass> /*unused*/,
+      jint requestId,
+      jni::alias_ref<jstring> data);
 
   static void registerNatives();
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/network/NetworkEventUtilTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/network/NetworkEventUtilTest.kt
@@ -127,7 +127,7 @@ class NetworkEventUtilTest {
     val requestId = 1
     val data = "response data"
 
-    NetworkEventUtil.onDataReceived(reactContext, requestId, data)
+    NetworkEventUtil.onDataReceived(reactContext, requestId, data, "string")
 
     val eventNameCaptor = ArgumentCaptor.forClass(String::class.java)
     val eventArgumentsCaptor = ArgumentCaptor.forClass(WritableArray::class.java)
@@ -147,7 +147,7 @@ class NetworkEventUtilTest {
     val requestId = 1
     val data: WritableMap = Arguments.createMap().apply { putString("key", "value") }
 
-    NetworkEventUtil.onDataReceived(reactContext, requestId, data)
+    NetworkEventUtil.onDataReceived(reactContext, requestId, data, ByteArray(0))
 
     val eventNameCaptor = ArgumentCaptor.forClass(String::class.java)
     val eventArgumentsCaptor = ArgumentCaptor.forClass(WritableArray::class.java)
@@ -276,8 +276,8 @@ class NetworkEventUtilTest {
     NetworkEventUtil.onDataSend(null, 1, 100, 1000)
     NetworkEventUtil.onIncrementalDataReceived(null, 1, "data", 100, 1000)
     NetworkEventUtil.onDataReceivedProgress(null, 1, 100, 1000)
-    NetworkEventUtil.onDataReceived(null, 1, "data")
-    NetworkEventUtil.onDataReceived(null, 1, Arguments.createMap())
+    NetworkEventUtil.onDataReceived(null, 1, "data", "string")
+    NetworkEventUtil.onDataReceived(null, 1, Arguments.createMap(), ByteArray(0))
     NetworkEventUtil.onRequestError(null, 1, "error", null)
     NetworkEventUtil.onRequestSuccess(null, 1, 0)
     NetworkEventUtil.onResponseReceived(null, 1, url, response)

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/HttpUtils.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/HttpUtils.cpp
@@ -7,6 +7,8 @@
 
 #include "HttpUtils.h"
 
+#include <algorithm>
+
 namespace facebook::react::jsinspector_modern {
 
 std::string httpReasonPhrase(uint16_t status) {
@@ -147,8 +149,14 @@ std::string httpReasonPhrase(uint16_t status) {
 std::string mimeTypeFromHeaders(const Headers& headers) {
   std::string mimeType = "application/octet-stream";
 
-  if (headers.find("Content-Type") != headers.end()) {
-    mimeType = headers.at("Content-Type");
+  for (const auto& [name, value] : headers) {
+    std::string lowerName = name;
+    std::transform(
+        lowerName.begin(), lowerName.end(), lowerName.begin(), ::tolower);
+    if (lowerName == "content-type") {
+      mimeType = value;
+      break;
+    }
   }
 
   return mimeType;


### PR DESCRIPTION
Summary:
Continues integration of `NetworkReporter` (jsinspector-modern) on Android, to enable the Network panel in React Native DevTools.

NOTE: As with iOS, all changes are gated behind the `enableNetworkEventReporting` and `fuseboxNetworkInspectionEnabled` feature flags.

**This diff**

Updates the Android inputs to `NetworkReporter` to support incremental string data HTTP responses (`Transfer-Encoding: chunked`).

Implemented:

- Incremental response case for `Network.getResponseBody` (fetch response previews).
- `Network.dataReceived` (incremental response update event).

This means that incremental responses, such as Metro bundle requests, can be displayed as previews in React Native DevTools.

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D77927896


