### PR TITLE
Clarify the deprecation message for react-native-safe-area-context

### DIFF
--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -86,14 +86,14 @@ module.exports = {
   /**
    * @deprecated SafeAreaView has been deprecated and will be removed in a future release.
    * Please use 'react-native-safe-area-context' instead.
-   * See https://github.com/th3rdwave/react-native-safe-area-context
+   * See https://github.com/AppAndFlow/react-native-safe-area-context
    */
   get SafeAreaView() {
     warnOnce(
       'safe-area-view-deprecated',
       'SafeAreaView has been deprecated and will be removed in a future release. ' +
         "Please use 'react-native-safe-area-context' instead. " +
-        'See https://github.com/th3rdwave/react-native-safe-area-context',
+        'See https://github.com/AppAndFlow/react-native-safe-area-context',
     );
     return require('./Libraries/Components/SafeAreaView/SafeAreaView').default;
   },


### PR DESCRIPTION
Summary:
The correct url for react-native-safe-area-context is:
https://github.com/AppAndFlow/react-native-safe-area-context
the former would still work through a redirect but let's be explicit here.

Changelog:
[Internal] [Changed] -

Reviewed By: huntie

Differential Revision: D78272667


