### PR TITLE
Move off of ReactScrollViewHelper.ScrollListener

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -377,6 +377,9 @@ public class ReactScrollView extends ScrollView
     }
 
     ReactScrollViewHelper.emitLayoutEvent(this);
+    if (mVirtualViewContainerState != null) {
+      mVirtualViewContainerState.updateState();
+    }
   }
 
   @Override
@@ -486,6 +489,9 @@ public class ReactScrollView extends ScrollView
             this,
             mOnScrollDispatchHelper.getXFlingVelocity(),
             mOnScrollDispatchHelper.getYFlingVelocity());
+        if (mVirtualViewContainerState != null) {
+          mVirtualViewContainerState.updateState();
+        }
       }
     } finally {
       Systrace.endSection(Systrace.TRACE_TAG_REACT);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/VirtualViewContainer.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/VirtualViewContainer.kt
@@ -46,18 +46,13 @@ private fun rectsOverlap(rect1: Rect, rect2: Rect): Boolean {
   return true
 }
 
-internal class VirtualViewContainerState(private val scrollView: ViewGroup) :
-    ReactScrollViewHelper.ScrollListener {
+internal class VirtualViewContainerState(private val scrollView: ViewGroup) {
 
   private val prerenderRatio: Double = ReactNativeFeatureFlags.virtualViewPrerenderRatio()
   private val virtualViews: MutableSet<VirtualView> = mutableSetOf()
   private val emptyRect: Rect = Rect()
   private val visibleRect: Rect = Rect()
   private val prerenderRect: Rect = Rect()
-
-  init {
-    ReactScrollViewHelper.addScrollListener(this)
-  }
 
   public fun onChange(virtualView: VirtualView) {
     if (virtualViews.add(virtualView)) {
@@ -75,29 +70,10 @@ internal class VirtualViewContainerState(private val scrollView: ViewGroup) :
     debugLog("remove", { "virtualViewID=${virtualView.virtualViewID}" })
   }
 
-  // ReactScrollViewHelper.ScrollListener.onLayout
-  // Emitted from ScrollView's onLayout
-  override fun onLayout(scrollView: ViewGroup?) {
-    // ReactScrollViewHelper is global
-    if (this.scrollView == scrollView) {
-      debugLog("ReactScrollViewHelper.onLayout")
-      updateModes()
-    }
-  }
-
-  // ReactScrollViewHelper.ScrollListener.onScroll
-  // Emitted from ScrollView's onLayout
-  override fun onScroll(
-      scrollView: ViewGroup?,
-      scrollEventType: ScrollEventType?,
-      xVelocity: Float,
-      yVelocity: Float
-  ) {
-    // ReactScrollViewHelper is global
-    if (this.scrollView == scrollView) {
-      debugLog("ReactScrollViewHelper.onScroll")
-      updateModes()
-    }
+  // Called on ScrollView onLayout or onScroll
+  public fun updateState() {
+    debugLog("VirtualViewContainer.updateState")
+    updateModes()
   }
 
   private fun updateModes(virtualView: VirtualView? = null) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/virtual/viewexperimental/ReactVirtualViewExperimental.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/virtual/viewexperimental/ReactVirtualViewExperimental.kt
@@ -34,6 +34,7 @@ public class ReactVirtualViewExperimental(context: Context) :
   override val containerRelativeRect: Rect = Rect()
   private var offsetX: Int = 0
   private var offsetY: Int = 0
+  private var hadLayout: Boolean = false
 
   internal val nativeId: String?
     get() = getTag(R.id.view_tag_native_id) as? String
@@ -45,14 +46,20 @@ public class ReactVirtualViewExperimental(context: Context) :
 
   @VisibleForTesting
   internal fun doAttachedToWindow() {
-    // Assuming that layout has been called before this
-    scrollView = getScrollView()?.also { scrollView?.virtualViewContainerState?.add(this) }
+    scrollView = getScrollView()
+    // onAttachedToWindow is usually called before layout but there are cases where it's called
+    // after. If called after, we need to report the updated layout to the VirtualViewContainer
+    if (hadLayout) {
+      updateParentOffset()
+      reportChangeToContainer()
+    }
   }
 
   /** From [View#onLayout] */
   // This is when the view itself has layout changes
   override fun onLayout(changed: Boolean, left: Int, top: Int, right: Int, bottom: Int) {
     super.onLayout(changed, left, top, right, bottom)
+    hadLayout = true
     if (changed) {
       containerRelativeRect.set(
           left + offsetX,
@@ -60,7 +67,7 @@ public class ReactVirtualViewExperimental(context: Context) :
           right + offsetX,
           bottom + offsetY,
       )
-      updateContainer()
+      reportChangeToContainer()
     }
   }
 
@@ -77,24 +84,8 @@ public class ReactVirtualViewExperimental(context: Context) :
       oldBottom: Int
   ) {
     if (oldLeft != left || oldTop != top) {
-      val virtualViewScrollView = scrollView ?: return
-      offsetX = 0
-      offsetY = 0
-      var parent: ViewParent? = parent
-      while (parent != null && parent != virtualViewScrollView) {
-        if (parent is View) {
-          offsetX += parent.left
-          offsetY += parent.top
-        }
-        parent = parent.parent
-      }
-      containerRelativeRect.set(
-          left + offsetX,
-          top + offsetY,
-          right + offsetX,
-          bottom + offsetY,
-      )
-      updateContainer()
+      updateParentOffset()
+      reportChangeToContainer()
     }
   }
 
@@ -109,6 +100,8 @@ public class ReactVirtualViewExperimental(context: Context) :
     scrollView = null
     mode = null
     modeChangeEmitter = null
+    hadLayout = false
+    containerRelativeRect.setEmpty()
   }
 
   override val virtualViewID: String
@@ -156,8 +149,28 @@ public class ReactVirtualViewExperimental(context: Context) :
     }
   }
 
-  private fun updateContainer() {
-    scrollView?.virtualViewContainerState?.update(this)
+  private fun updateParentOffset() {
+    val virtualViewScrollView = scrollView ?: return
+    offsetX = 0
+    offsetY = 0
+    var parent: ViewParent? = parent
+    while (parent != null && parent != virtualViewScrollView) {
+      if (parent is View) {
+        offsetX += parent.left
+        offsetY += parent.top
+      }
+      parent = parent.parent
+    }
+    containerRelativeRect.set(
+        left + offsetX,
+        top + offsetY,
+        right + offsetX,
+        bottom + offsetY,
+    )
+  }
+
+  private fun reportChangeToContainer() {
+    scrollView?.virtualViewContainerState?.onChange(this)
   }
 
   private fun getScrollView(): VirtualViewContainer? = traverseParentStack(true)


### PR DESCRIPTION
Summary: Changelog: [Internal] Stop using ReactScrollViewHelper.ScrollListener for layout, scroll events from ScrollView

Differential Revision: D78287689


