### PR TITLE
Update font scale on Android when recreating RootView

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -135,6 +135,10 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
   private void init() {
     setRootViewTag(ReactRootViewTagGenerator.getNextRootViewTag());
     setClipChildren(false);
+
+    if (ReactNativeFeatureFlags.enableFontScaleChangesUpdatingLayout()) {
+      DisplayMetricsHolder.initDisplayMetrics(getContext().getApplicationContext());
+    }
   }
 
   @Override


### PR DESCRIPTION
Summary:
Changelog: [ANDROID][FIXED] Update font scale when recreating `RootView`

At the moment `enableFontScaleChangesUpdatingLayout` flag only works when the activity is configured to handle font scale changes by itself (`configChanges="fontScale"` in the manifest).

When that configuration is missing, the OS handles the font scale changes by recreating the activity, but in this case the path responsible for updating internally kept font size isn't executed.

This diff updates the RootView, so that the display metrics are also updated when it's created. Alternative approach would be to do that on the Activity, but that assumes usage of `ReactActivity`.

Differential Revision: D78323174


