### PR TITLE
Do not define default transformOrigin

### DIFF
--- a/packages/react-native/Libraries/Components/View/__tests__/View-itest.js
+++ b/packages/react-native/Libraries/Components/View/__tests__/View-itest.js
@@ -10,9 +10,14 @@
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
+import type {HostInstance} from 'react-native';
+
+import ensureInstance from '../../../../src/private/__tests__/utilities/ensureInstance';
 import * as Fantom from '@react-native/fantom';
 import * as React from 'react';
+import {createRef} from 'react';
 import {View} from 'react-native';
+import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 
 describe('<View>', () => {
   describe('width and height style', () => {
@@ -180,6 +185,40 @@ describe('<View>', () => {
       expect(root.getRenderedOutput({props: ['transform']}).toJSX()).toEqual(
         <rn-view transform='[{"translateX": 10.000000}]' />,
       );
+    });
+
+    [
+      [undefined, {x: -5, y: 0, width: 20, height: 10}],
+      ['50% 50%', {x: -5, y: 0, width: 20, height: 10}],
+      ['top left', {x: 0, y: 0, width: 20, height: 10}],
+      ['right bottom', {x: -10, y: 0, width: 20, height: 10}],
+    ].forEach(([transformOrigin, expectedBounds]) => {
+      it(`applies transformOrigin correctly for ${String(transformOrigin)}`, () => {
+        const root = Fantom.createRoot();
+
+        const viewRef = createRef<HostInstance>();
+        Fantom.runTask(() => {
+          root.render(
+            <View
+              ref={viewRef}
+              style={{
+                width: 10,
+                height: 10,
+                transform: [{scaleX: 2}],
+                transformOrigin,
+              }}
+            />,
+          );
+        });
+
+        const viewElement = ensureInstance(viewRef.current, ReactNativeElement);
+
+        const viewBounds = viewElement.getBoundingClientRect();
+        expect(viewBounds.x).toBe(expectedBounds.x);
+        expect(viewBounds.y).toBe(expectedBounds.y);
+        expect(viewBounds.width).toBe(expectedBounds.width);
+        expect(viewBounds.height).toBe(expectedBounds.height);
+      });
     });
   });
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.h
@@ -84,14 +84,7 @@ class BaseViewProps : public YogaStylableProps, public AccessibilityProps {
 
   // Transform
   Transform transform{};
-  TransformOrigin transformOrigin{
-      {
-          ValueUnit{50.0f, UnitType::Percent},
-          ValueUnit{50.0f, UnitType::Percent},
-      },
-      0.0f,
-
-  };
+  TransformOrigin transformOrigin{};
   BackfaceVisibility backfaceVisibility{};
   bool shouldRasterize{};
   std::optional<int> zIndex{};

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Transform.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Transform.h
@@ -55,7 +55,9 @@ struct TransformOperation {
 };
 
 struct TransformOrigin {
-  std::array<ValueUnit, 2> xy;
+  std::array<ValueUnit, 2> xy = {
+      ValueUnit(0.0f, UnitType::Undefined),
+      ValueUnit(0.0f, UnitType::Undefined)};
   float z = 0.0f;
 
   bool operator==(const TransformOrigin& other) const {


### PR DESCRIPTION
Summary:
Defining this as {50%, 50%} mean we do unnecessary work as part of every transform. Instead set it to undefined, which means we'll ignore it when determining the final transform.

Changelog: [Internal]

Differential Revision: D78298587


