### PR TITLE
Fix reporting of errors without stack traces

### DIFF
--- a/private/react-native-fantom/runner/runner.js
+++ b/private/react-native-fantom/runner/runner.js
@@ -59,7 +59,9 @@ function buildError(
   sourceMapPath: string,
 ): Error {
   const error = new Error(failureDetail.message);
-  error.stack = symbolicateStackTrace(sourceMapPath, failureDetail.stack);
+  if (failureDetail.stack != null) {
+    error.stack = symbolicateStackTrace(sourceMapPath, failureDetail.stack);
+  }
   if (failureDetail.cause != null) {
     error.cause = buildError(failureDetail.cause, sourceMapPath);
   }


### PR DESCRIPTION
Summary:
Changelog: [internal]

Fixes a bug in Fantom when throwing a value that's not an instance of `Error` in a test.

Reviewed By: javache

Differential Revision: D78332756


