### PR TITLE
Remove support for specifying track names for Perfetto and RNDT using the "Track:" prefix

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -78,7 +78,8 @@ class PerformanceTracer {
       const std::string_view& name,
       HighResTimeStamp start,
       HighResDuration duration,
-      const std::optional<DevToolsTrackEntryPayload>& trackMetadata);
+      const std::optional<DevToolsTrackEntryPayload>& trackMetadata =
+          std::nullopt);
 
   /**
    * Record a "TimeStamp" Trace Event - a labelled entry on Performance


### PR DESCRIPTION
Summary:
Changelog: [internal]

We're adding first-class support for custom tracks, so we can remove the legacy mechanism to specify tracks with the "Tracks:" prefix in the event names.

Reviewed By: sbuggay

Differential Revision: D78340910
