### PR TITLE
Polish the .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,12 +9,3 @@ end_of_line = lf
 insert_final_newline = true
 indent_style = space
 indent_size = 2
-
-[*.gradle]
-indent_size = 4
-
-[*.kts]
-indent_size = 4
-
-[BUCK]
-indent_size = 4


### PR DESCRIPTION
Summary: We should use indent size 2 everywhere. While we were using 4 for some old reasons. This is causing editing of .kts files and BUCK files inside OSS Android Studio quite painful.

Differential Revision: D78348532


