### PR TITLE
Remove LegacyArchitecture deprecation from ReactVirtualTextViewManager

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactVirtualTextViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactVirtualTextViewManager.kt
@@ -8,9 +8,6 @@
 package com.facebook.react.views.text
 
 import android.view.View
-import com.facebook.react.common.annotations.internal.LegacyArchitecture
-import com.facebook.react.common.annotations.internal.LegacyArchitectureLogLevel
-import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.BaseViewManager
 import com.facebook.react.uimanager.ThemedReactContext
@@ -20,7 +17,6 @@ import com.facebook.react.uimanager.ThemedReactContext
  * operation will throw an [IllegalStateException]
  */
 @ReactModule(name = ReactVirtualTextViewManager.REACT_CLASS)
-@LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
 internal class ReactVirtualTextViewManager : BaseViewManager<View, ReactVirtualTextShadowNode>() {
 
   override fun getName(): String = REACT_CLASS
@@ -38,10 +34,5 @@ internal class ReactVirtualTextViewManager : BaseViewManager<View, ReactVirtualT
 
   internal companion object {
     const val REACT_CLASS: String = "RCTVirtualText"
-
-    init {
-      LegacyArchitectureLogger.assertLegacyArchitecture(
-          "ReactVirtualTextViewManager", LegacyArchitectureLogLevel.ERROR)
-    }
   }
 }


### PR DESCRIPTION
Summary:
ReactVirtualTextViewManager is part of CommonReactPackage.

Enforcing the legacy architecture for this class is causing panel apps to fail to launch after D77654347

Apps that are failing: TV, Explore, Facebook

Differential Revision: D78363946


