### PR TITLE
Add ISerialization interface

### DIFF
--- a/packages/react-native/ReactCommon/jsi/jsi/jsi.cpp
+++ b/packages/react-native/ReactCommon/jsi/jsi/jsi.cpp
@@ -284,6 +284,8 @@ HostObject::~HostObject() {}
 
 NativeState::~NativeState() {}
 
+Serialized::~Serialized() {}
+
 Runtime::~Runtime() {}
 
 ICast* Runtime::castInterface(const UUID& /*interfaceUUID*/) {

--- a/packages/react-native/ReactCommon/jsi/jsi/jsi.h
+++ b/packages/react-native/ReactCommon/jsi/jsi/jsi.h
@@ -252,6 +252,43 @@ class JSI_EXPORT NativeState {
   virtual ~NativeState();
 };
 
+/// Opaque class that is used to store serialized object from a runtime. The
+/// lifetime of this object is orthogonal to the original runtime object, and
+/// may outlive the original object.
+class JSI_EXPORT Serialized {
+ public:
+  virtual ~Serialized();
+};
+
+/// Provides a set of APIs that allows copying objects between different
+/// runtime instances. The runtimes instances must be of the same type. As an
+/// example, a serialized object from Hermes runtime may only be deserialized by
+/// another Hermes runtime.
+class JSI_EXPORT ISerialization : public ICast {
+ public:
+  static constexpr jsi::UUID uuid{
+      0xd40fe0ec,
+      0xa47c,
+      0x42c9,
+      0x8c09,
+      0x661aeab832d8};
+
+  /// Serializes the given jsi::Value using the structured clone algorithm. It
+  /// returns an opaque Serialized object that can be deserialized multiple
+  /// times. The lifetime of the Serialized object is not tied to the lifetime
+  /// of the original object.
+  virtual std::shared_ptr<Serialized> serialize(jsi::Value& value) = 0;
+
+  /// Given a Serialized object, deserialize it using the structured clone
+  /// algorithm into a JS value in the current runtime. Returns the resulting JS
+  /// value.
+  virtual jsi::Value deserialize(
+      const std::shared_ptr<Serialized>& serialized) = 0;
+
+ protected:
+  ~ISerialization() = default;
+};
+
 /// Represents a JS runtime.  Movable, but not copyable.  Note that
 /// this object may not be thread-aware, but cannot be used safely from
 /// multiple threads at once.  The application is responsible for


### PR DESCRIPTION
Summary:
Add a new optional interface `ISerialization` to JSI. This interface
contains two APIs to copy objects from one runtime to another runtime.

Two methods are introduced in this interface:

`serialize` will take in some JS value (represented by `jsi::Value`) and
serialize the object into an opaque `Serialize` object. The lifetime of
the serialized object is independent from the original object.

`deserialize` will take in the serialized object and deserialize it into
the runtime, returning the created JS object.

Note that objects can only be copied into another runtime instance of
the same type. For example, a serialized object produced by the Hermes
runtime can only be deserialized by another Hermes runtime.

Differential Revision: D76547681


