### PR TITLE
RN: Default Hermes Parser to `reactRuntimeTarget: "19"`

### DIFF
--- a/packages/react-native-babel-preset/src/configs/main.js
+++ b/packages/react-native-babel-preset/src/configs/main.js
@@ -38,19 +38,6 @@ function isFirstParty(fileName) {
 // use `this.foo = bar` instead of `this.defineProperty('foo', ...)`
 const loose = true;
 
-const defaultPlugins = [
-  [require('babel-plugin-syntax-hermes-parser'), {parseLangTypes: 'flow'}],
-  [require('babel-plugin-transform-flow-enums')],
-  [require('@babel/plugin-transform-block-scoping')],
-  [require('@babel/plugin-transform-class-properties'), {loose}],
-  [require('@babel/plugin-transform-private-methods'), {loose}],
-  [require('@babel/plugin-transform-private-property-in-object'), {loose}],
-  [require('@babel/plugin-syntax-dynamic-import')],
-  [require('@babel/plugin-syntax-export-default-from')],
-  ...passthroughSyntaxPlugins,
-  [require('@babel/plugin-transform-unicode-regex')],
-];
-
 // For Static Hermes testing (experimental), the hermes-canary transformProfile
 // is used to enable regenerator (and some related lowering passes) because SH
 // requires more Babel lowering than Hermes temporarily.
@@ -234,7 +221,28 @@ const getPreset = (src, options) => {
         plugins: [require('@babel/plugin-transform-flow-strip-types')],
       },
       {
-        plugins: defaultPlugins,
+        plugins: [
+          [
+            require('babel-plugin-syntax-hermes-parser'),
+            {
+              parseLangTypes: 'flow',
+              reactRuntimeTarget: '19',
+              ...options.hermesParserOptions,
+            },
+          ],
+          [require('babel-plugin-transform-flow-enums')],
+          [require('@babel/plugin-transform-block-scoping')],
+          [require('@babel/plugin-transform-class-properties'), {loose}],
+          [require('@babel/plugin-transform-private-methods'), {loose}],
+          [
+            require('@babel/plugin-transform-private-property-in-object'),
+            {loose},
+          ],
+          [require('@babel/plugin-syntax-dynamic-import')],
+          [require('@babel/plugin-syntax-export-default-from')],
+          ...passthroughSyntaxPlugins,
+          [require('@babel/plugin-transform-unicode-regex')],
+        ],
       },
       {
         test: isTypeScriptSource,


### PR DESCRIPTION
Summary:
Changes `react-native/babel-preset` so that by default, `hermes-parser` is configured with `reactRuntimeTarget: "19"`. This changes the compiled output of Component Syntax to not use `forwardRef` when a `ref` prop is present.

Additionally, this adds a new preset option property, `hermesParserOptions`. This object allows users of `react-native/babel-preset` to supply overrides for any `hermes-parser` options.

Changelog:
[General][Changed] - Configures `react-native/babel-preset` to target React 19 by default, meaning Component Syntax will not compile to `forwardRef` calls when a `ref` prop is present.
[General][Added] - Added support to `react-native/babel-preset` for a `hermesParserOptions` option, that expects an object that enables overriding `hermes-parser` options.

Differential Revision: D78383269


