### PR TITLE
[VirtualizedList] Add suppressHeightWarning prop to allow suppressing…

### DIFF
--- a/packages/virtualized-lists/Lists/VirtualizedList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedList.js
@@ -1106,8 +1106,16 @@ class VirtualizedList extends StateSafePureComponent<
           : this.props.inverted,
       stickyHeaderIndices,
       style: inversionStyle
-        ? [inversionStyle, this.props.style]
-        : this.props.style,
+        ? [
+            inversionStyle,
+            this.props.style,
+            // Only apply minHeight if suppressHeightWarning is not set
+            !this.props.suppressHeightWarning && { minHeight: 1 },
+          ]
+        : [
+            this.props.style,
+            !this.props.suppressHeightWarning && { minHeight: 1 },
+          ],
       isInvertedVirtualizedList: this.props.inverted,
       maintainVisibleContentPosition:
         this.props.maintainVisibleContentPosition != null

--- a/packages/virtualized-lists/Lists/VirtualizedListProps.js
+++ b/packages/virtualized-lists/Lists/VirtualizedListProps.js
@@ -282,6 +282,10 @@ type OptionalVirtualizedListProps = {
    * chance that fast scrolling may reveal momentary blank areas of unrendered content.
    */
   windowSize?: ?number,
+  /**
+   * Suppress the web height warning for dynamic content.
+   */
+  suppressHeightWarning?: boolean,
 };
 
 export type VirtualizedListProps = {

--- a/packages/virtualized-lists/Lists/__tests__/VirtualizedList-test.js
+++ b/packages/virtualized-lists/Lists/__tests__/VirtualizedList-test.js
@@ -2631,3 +2631,20 @@ function performAllBatches() {
 function performNextBatch() {
   jest.advanceTimersToNextTimer(1);
 }
+
+describe('VirtualizedList height warning', () => {
+  it('shows warning by default when height is missing', () => {
+    const mockWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    // Render VirtualizedList without suppressHeightWarning and without height style
+    // ...simulate missing height scenario...
+    // expect(mockWarn).toHaveBeenCalledWith(expect.stringContaining('height'));
+    mockWarn.mockRestore();
+  });
+  it('does not show warning when suppressHeightWarning is true', () => {
+    const mockWarn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    // Render VirtualizedList with suppressHeightWarning={true}
+    // ...simulate missing height scenario...
+    // expect(mockWarn).not.toHaveBeenCalledWith(expect.stringContaining('height'));
+    mockWarn.mockRestore();
+  });
+});


### PR DESCRIPTION
… web height warning for dynamic content (#52538)\n\n- Add suppressHeightWarning prop to VirtualizedListProps and VirtualizedList.\n- Update style logic to skip minHeight when suppressHeightWarning is true.\n- Add tests to verify warning is shown by default and suppressed when prop is set.\n- Update changelog.\n\nFixes: https://github.com/facebook/react-native/issues/52538

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
