### PR TITLE
Add guards around nativeProps usage to prevent race conditions

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -136,6 +136,7 @@ ShadowNode::ShadowNode(
 std::shared_ptr<ShadowNode> ShadowNode::clone(
     const ShadowNodeFragment& fragment) const {
   const auto& family = *family_;
+  std::lock_guard<std::recursive_mutex> npGuard(family.nativePropsMutex);
   const auto& componentDescriptor = family.componentDescriptor_;
   if (family.nativeProps_DEPRECATED != nullptr) {
     auto propsParserContext = PropsParserContext{family_->getSurfaceId(), {}};

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -136,7 +136,7 @@ ShadowNode::ShadowNode(
 std::shared_ptr<ShadowNode> ShadowNode::clone(
     const ShadowNodeFragment& fragment) const {
   const auto& family = *family_;
-  std::lock_guard<std::recursive_mutex> npGuard(family.nativePropsMutex);
+  std::lock_guard<std::mutex> npGuard(family.nativePropsMutex);
   const auto& componentDescriptor = family.componentDescriptor_;
   if (family.nativeProps_DEPRECATED != nullptr) {
     auto propsParserContext = PropsParserContext{family_->getSurfaceId(), {}};

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFamily.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFamily.h
@@ -9,6 +9,7 @@
 
 #include <memory>
 #include <shared_mutex>
+#include <mutex>
 
 #include <react/renderer/core/EventEmitter.h>
 #include <react/renderer/core/InstanceHandle.h>
@@ -114,6 +115,7 @@ class ShadowNodeFamily final : public jsi::NativeState {
    * architecture and will be removed in the future.
    */
   mutable std::unique_ptr<folly::dynamic> nativeProps_DEPRECATED;
+  mutable std::recursive_mutex nativePropsMutex;
 
   /**
    * @return tag for the ShadowNodeFamily.

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFamily.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNodeFamily.h
@@ -115,7 +115,7 @@ class ShadowNodeFamily final : public jsi::NativeState {
    * architecture and will be removed in the future.
    */
   mutable std::unique_ptr<folly::dynamic> nativeProps_DEPRECATED;
-  mutable std::recursive_mutex nativePropsMutex;
+  mutable std::mutex nativePropsMutex;
 
   /**
    * @return tag for the ShadowNodeFamily.

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
@@ -121,6 +121,7 @@ std::shared_ptr<ShadowNode> UIManager::cloneNode(
   auto props = ShadowNodeFragment::propsPlaceholder();
 
   if (!rawProps.isEmpty()) {
+    std::lock_guard<std::recursive_mutex> npGuard(family.nativePropsMutex);
     if (family.nativeProps_DEPRECATED != nullptr) {
       // 1. update the nativeProps_DEPRECATED props.
       //
@@ -448,6 +449,7 @@ void UIManager::setNativeProps_DEPRECATED(
     const std::shared_ptr<const ShadowNode>& shadowNode,
     RawProps rawProps) const {
   auto& family = shadowNode->getFamily();
+  family.nativePropsMutex.lock();
   if (family.nativeProps_DEPRECATED) {
     // Values in `rawProps` patch (take precedence over)
     // `nativeProps_DEPRECATED`. For example, if both `nativeProps_DEPRECATED`
@@ -462,6 +464,7 @@ void UIManager::setNativeProps_DEPRECATED(
     family.nativeProps_DEPRECATED =
         std::make_unique<folly::dynamic>((folly::dynamic)rawProps);
   }
+  family.nativePropsMutex.unlock();
 
   shadowTreeRegistry_.visit(
       family.getSurfaceId(), [&](const ShadowTree& shadowTree) {

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
@@ -121,7 +121,7 @@ std::shared_ptr<ShadowNode> UIManager::cloneNode(
   auto props = ShadowNodeFragment::propsPlaceholder();
 
   if (!rawProps.isEmpty()) {
-    std::lock_guard<std::recursive_mutex> npGuard(family.nativePropsMutex);
+    std::lock_guard<std::mutex> npGuard(family.nativePropsMutex);
     if (family.nativeProps_DEPRECATED != nullptr) {
       // 1. update the nativeProps_DEPRECATED props.
       //


### PR DESCRIPTION
## Summary:

Some third-party libraries, like react-native-reanimated, can clone nodes in a different thread while react-native is calling `setNativeProps_DEPRECATED`. This results in a race condition, where a stale pointer to `nativeProps_DEPRECATED` can be accessed, resulting in a crash. This usually manifests as a `EXC_BAD_ACCESS` crash on iOS. On Android it seems more rare. We've added a lock around accesses to nativeProps_DEPRECATED, but alternative options of fixing this can be considered too.

For more information see https://github.com/software-mansion/react-native-reanimated/issues/7666

## Changelog:

[INTERNAL] [FIXED] - Fixed crashes caused by race conditions when third-party libraries clone the shadow dom from a different thread

## Test Plan:

Due to this being a race condition that only manifests in rare circumstances, it's very difficult to create a reliable reproduction case. The issue mentioned above contains ThreadSanitizer logs that demonstrate this issue. TSan no longer complains with this patch applied, and we've not seen any additional issues from it after deploying it in production over the past week.
