### PR TITLE
Migrate helloworld to use `{usesCleartextTraffic}` manifest placeholder

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -18,6 +18,7 @@ import com.facebook.react.tasks.GenerateEntryPointTask
 import com.facebook.react.tasks.GeneratePackageListTask
 import com.facebook.react.utils.AgpConfiguratorUtils.configureBuildConfigFieldsForApp
 import com.facebook.react.utils.AgpConfiguratorUtils.configureBuildConfigFieldsForLibraries
+import com.facebook.react.utils.AgpConfiguratorUtils.configureBuildTypesForApp
 import com.facebook.react.utils.AgpConfiguratorUtils.configureDevServerLocation
 import com.facebook.react.utils.AgpConfiguratorUtils.configureNamespaceForLibraries
 import com.facebook.react.utils.BackwardCompatUtils.configureBackwardCompatibilityReactMap
@@ -84,6 +85,7 @@ class ReactPlugin : Plugin<Project> {
       configureAutolinking(project, extension)
       configureCodegen(project, extension, rootExtension, isLibrary = false)
       configureResources(project, extension)
+      configureBuildTypesForApp(project)
     }
 
     // Library Only Configuration

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/AgpConfiguratorUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/AgpConfiguratorUtils.kt
@@ -19,6 +19,7 @@ import java.net.Inet4Address
 import java.net.NetworkInterface
 import javax.xml.parsers.DocumentBuilder
 import javax.xml.parsers.DocumentBuilderFactory
+import kotlin.plus
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.plugins.AppliedPlugin
@@ -26,6 +27,26 @@ import org.w3c.dom.Element
 
 @Suppress("UnstableApiUsage")
 internal object AgpConfiguratorUtils {
+
+  fun configureBuildTypesForApp(project: Project) {
+    val action =
+        Action<AppliedPlugin> {
+          project.extensions
+              .getByType(ApplicationAndroidComponentsExtension::class.java)
+              .finalizeDsl { ext ->
+                ext.buildTypes {
+                  val debug =
+                      getByName("debug").apply {
+                        manifestPlaceholders["usesCleartextTraffic"] = "true"
+                      }
+                  getByName("release").apply {
+                    manifestPlaceholders["usesCleartextTraffic"] = "false"
+                  }
+                }
+              }
+        }
+    project.pluginManager.withPlugin("com.android.application", action)
+  }
 
   fun configureBuildConfigFieldsForApp(project: Project, extension: ReactExtension) {
     val action =

--- a/packages/rn-tester/android/app/src/debug/AndroidManifest.xml
+++ b/packages/rn-tester/android/app/src/debug/AndroidManifest.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
-
-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
-
-    <application android:usesCleartextTraffic="true" tools:targetApi="28" tools:ignore="GoogleAppIndexingWarning" />
-</manifest>

--- a/packages/rn-tester/android/app/src/main/AndroidManifest.xml
+++ b/packages/rn-tester/android/app/src/main/AndroidManifest.xml
@@ -50,6 +50,7 @@
     </queries>
 
     <application
+        android:usesCleartextTraffic="${usesCleartextTraffic}"
         android:name=".RNTesterApplication"
         android:allowBackup="true"
         android:banner="@drawable/tv_banner"

--- a/private/helloworld/android/app/src/debug/AndroidManifest.xml
+++ b/private/helloworld/android/app/src/debug/AndroidManifest.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
-
-    <application
-        android:usesCleartextTraffic="true"
-        tools:targetApi="28"
-        tools:ignore="GoogleAppIndexingWarning"/>
-</manifest>

--- a/private/helloworld/android/app/src/main/AndroidManifest.xml
+++ b/private/helloworld/android/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
       android:icon="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
+      android:usesCleartextTraffic="${usesCleartextTraffic}"
       android:theme="@style/AppTheme">
       <activity
         android:name=".MainActivity"


### PR DESCRIPTION
Summary:
This removes the need to specify 2 Manifests for apps and we can just use the `main` manifes to toggle if `usesCleartextTraffic` should be enabled or not.

This will have to be replicated in the template repository.

Changelog:
[Android] [Added] - Add support to specify a single Manifest rather than 2 (main/debug) by using the `usesCleartextTraffic` manifest placeholder which is autoconfigured by RNGP.

Differential Revision: D78425139
