### PR TITLE
Create a debugOptimized buildType for Android

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactExtension.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactExtension.kt
@@ -100,10 +100,10 @@ abstract class ReactExtension @Inject constructor(val project: Project) {
    * Allows to specify the debuggable variants (by default just 'debug'). Variants in this list will
    * not be bundled (the bundle file will not be created and won't be copied over).
    *
-   * Default: ['debug']
+   * Default: ['debug', 'debugOptimized']
    */
   val debuggableVariants: ListProperty<String> =
-      objects.listProperty(String::class.java).convention(listOf("debug"))
+      objects.listProperty(String::class.java).convention(listOf("debug", "debugOptimized"))
 
   /** Hermes Config */
 

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -18,6 +18,7 @@ import com.facebook.react.tasks.GenerateEntryPointTask
 import com.facebook.react.tasks.GeneratePackageListTask
 import com.facebook.react.utils.AgpConfiguratorUtils.configureBuildConfigFieldsForApp
 import com.facebook.react.utils.AgpConfiguratorUtils.configureBuildConfigFieldsForLibraries
+import com.facebook.react.utils.AgpConfiguratorUtils.configureBuildTypesForApp
 import com.facebook.react.utils.AgpConfiguratorUtils.configureDevServerLocation
 import com.facebook.react.utils.AgpConfiguratorUtils.configureNamespaceForLibraries
 import com.facebook.react.utils.BackwardCompatUtils.configureBackwardCompatibilityReactMap
@@ -84,6 +85,7 @@ class ReactPlugin : Plugin<Project> {
       configureAutolinking(project, extension)
       configureCodegen(project, extension, rootExtension, isLibrary = false)
       configureResources(project, extension)
+      configureBuildTypesForApp(project)
     }
 
     // Library Only Configuration

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/AgpConfiguratorUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/AgpConfiguratorUtils.kt
@@ -19,6 +19,7 @@ import java.net.Inet4Address
 import java.net.NetworkInterface
 import javax.xml.parsers.DocumentBuilder
 import javax.xml.parsers.DocumentBuilderFactory
+import kotlin.plus
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.plugins.AppliedPlugin
@@ -26,6 +27,26 @@ import org.w3c.dom.Element
 
 @Suppress("UnstableApiUsage")
 internal object AgpConfiguratorUtils {
+
+  fun configureBuildTypesForApp(project: Project) {
+    val action =
+        Action<AppliedPlugin> {
+          project.extensions
+              .getByType(ApplicationAndroidComponentsExtension::class.java)
+              .finalizeDsl { ext ->
+                ext.buildTypes {
+                  val debug =
+                      getByName("debug").apply {
+                        manifestPlaceholders["usesCleartextTraffic"] = "true"
+                      }
+                  getByName("release").apply {
+                    manifestPlaceholders["usesCleartextTraffic"] = "false"
+                  }
+                }
+              }
+        }
+    project.pluginManager.withPlugin("com.android.application", action)
+  }
 
   fun configureBuildConfigFieldsForApp(project: Project, extension: ReactExtension) {
     val action =

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/AgpConfiguratorUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/AgpConfiguratorUtils.kt
@@ -42,6 +42,16 @@ internal object AgpConfiguratorUtils {
                   getByName("release").apply {
                     manifestPlaceholders["usesCleartextTraffic"] = "false"
                   }
+                  maybeCreate("debugOptimized").apply {
+                    manifestPlaceholders["usesCleartextTraffic"] = "true"
+                    initWith(debug)
+                    externalNativeBuild {
+                      cmake {
+                        arguments("-DCMAKE_BUILD_TYPE=Release")
+                        matchingFallbacks += listOf("release")
+                      }
+                    }
+                  }
                 }
               }
         }

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -599,13 +599,22 @@ android {
   publishing {
     multipleVariants {
       withSourcesJar()
-      includeBuildTypeValues("debug", "release")
+      includeBuildTypeValues("debug", "release", "debugOptimized")
     }
   }
 
   testOptions {
     unitTests { isIncludeAndroidResources = true }
     targetSdk = libs.versions.targetSdk.get().toInt()
+  }
+
+  buildTypes {
+    create("debugOptimized") {
+      initWith(getByName("debug"))
+      externalNativeBuild {
+        cmake { arguments("-DCMAKE_BUILD_TYPE=Release", "-DREACT_NATIVE_DEBUG_OPTIMIZED=True") }
+      }
+    }
   }
 }
 

--- a/packages/react-native/ReactAndroid/hermes-engine/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/hermes-engine/build.gradle.kts
@@ -306,6 +306,12 @@ android {
         }
       }
     }
+    buildTypes {
+      create("debugOptimized") {
+        initWith(getByName("debug"))
+        externalNativeBuild { cmake { arguments("-DCMAKE_BUILD_TYPE=Release") } }
+      }
+    }
   }
 
   sourceSets.getByName("main") {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/hermes/reactexecutor/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/hermes/reactexecutor/CMakeLists.txt
@@ -25,4 +25,6 @@ target_link_libraries(
         reactnative
 )
 target_compile_reactnative_options(hermes_executor PRIVATE)
-target_compile_options(hermes_executor PRIVATE $<$<CONFIG:Debug>:-DHERMES_ENABLE_DEBUGGER=1>)
+if(${CMAKE_BUILD_TYPE} MATCHES Debug OR REACT_NATIVE_DEBUG_OPTIMIZED)
+  target_compile_options(hermes_executor PRIVATE -DHERMES_ENABLE_DEBUGGER=1)
+endif()

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/hermes/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/hermes/jni/CMakeLists.txt
@@ -27,4 +27,6 @@ target_link_libraries(hermesinstancejni
 )
 
 target_compile_reactnative_options(hermesinstancejni PRIVATE)
-target_compile_options(hermesinstancejni PRIVATE $<$<CONFIG:Debug>:-DHERMES_ENABLE_DEBUGGER=1>)
+if(${CMAKE_BUILD_TYPE} MATCHES Debug OR REACT_NATIVE_DEBUG_OPTIMIZED)
+  target_compile_options(hermesinstancejni PRIVATE -DHERMES_ENABLE_DEBUGGER=1)
+endif ()

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/CMakeLists.txt
@@ -17,7 +17,9 @@ add_library(rninstance
 )
 
 target_compile_reactnative_options(rninstance PRIVATE)
-target_compile_options(rninstance PRIVATE $<$<CONFIG:Debug>:-DHERMES_ENABLE_DEBUGGER=1>)
+if(${CMAKE_BUILD_TYPE} MATCHES Debug OR REACT_NATIVE_DEBUG_OPTIMIZED)
+  target_compile_options(rninstance PRIVATE -DHERMES_ENABLE_DEBUGGER=1)
+endif ()
 
 target_merge_so(rninstance)
 target_include_directories(rninstance PUBLIC .)

--- a/packages/react-native/ReactCommon/hermes/executor/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/hermes/executor/CMakeLists.txt
@@ -26,7 +26,7 @@ target_link_libraries(hermes_executor_common
 )
 
 target_compile_reactnative_options(hermes_executor_common PRIVATE)
-if(${CMAKE_BUILD_TYPE} MATCHES Debug)
+if(${CMAKE_BUILD_TYPE} MATCHES Debug OR REACT_NATIVE_DEBUG_OPTIMIZED)
         target_compile_options(
                 hermes_executor_common
                 PRIVATE

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/CMakeLists.txt
@@ -17,7 +17,7 @@ add_library(hermes_inspector_modern
 
 target_compile_reactnative_options(hermes_inspector_modern PRIVATE)
 
-if(${CMAKE_BUILD_TYPE} MATCHES Debug)
+if(${CMAKE_BUILD_TYPE} MATCHES Debug OR REACT_NATIVE_DEBUG_OPTIMIZED)
         target_compile_options(
                 hermes_inspector_modern
                 PRIVATE

--- a/packages/react-native/ReactCommon/jsinspector-modern/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsinspector-modern/CMakeLists.txt
@@ -28,7 +28,9 @@ target_link_libraries(jsinspector
         reactperflogger
 )
 target_compile_reactnative_options(jsinspector PRIVATE)
-target_compile_options(jsinspector PRIVATE
-        $<$<CONFIG:Debug>:-DREACT_NATIVE_DEBUGGER_ENABLED=1>
-        $<$<CONFIG:Debug>:-DREACT_NATIVE_DEBUGGER_ENABLED_DEVONLY=1>
-)
+if(${CMAKE_BUILD_TYPE} MATCHES Debug OR REACT_NATIVE_DEBUG_OPTIMIZED)
+  target_compile_options(jsinspector PRIVATE
+          -DREACT_NATIVE_DEBUGGER_ENABLED=1
+          -DREACT_NATIVE_DEBUGGER_ENABLED_DEVONLY=1
+  )
+endif ()

--- a/packages/react-native/ReactCommon/react/debug/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/debug/CMakeLists.txt
@@ -21,6 +21,6 @@ endif()
 
 target_compile_reactnative_options(react_debug PRIVATE)
 target_compile_options(react_debug PRIVATE -Wpedantic)
-if(NOT ${CMAKE_BUILD_TYPE} MATCHES Debug)
+if(NOT ${CMAKE_BUILD_TYPE} MATCHES Debug AND NOT REACT_NATIVE_DEBUG_OPTIMIZED)
         target_compile_options(react_debug PUBLIC -DNDEBUG)
 endif()

--- a/packages/react-native/ReactCommon/react/runtime/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/runtime/CMakeLists.txt
@@ -16,7 +16,9 @@ add_library(bridgeless
         ${bridgeless_SRC}
 )
 target_compile_reactnative_options(bridgeless PRIVATE)
-target_compile_options(bridgeless PRIVATE $<$<CONFIG:Debug>:-DHERMES_ENABLE_DEBUGGER=1>)
+if(${CMAKE_BUILD_TYPE} MATCHES Debug OR REACT_NATIVE_DEBUG_OPTIMIZED)
+  target_compile_options(bridgeless PRIVATE -DHERMES_ENABLE_DEBUGGER=1)
+endif ()
 target_include_directories(bridgeless PUBLIC .)
 
 react_native_android_selector(fabricjni fabricjni "")

--- a/packages/react-native/ReactCommon/react/runtime/hermes/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/runtime/hermes/CMakeLists.txt
@@ -29,7 +29,7 @@ target_link_libraries(bridgelesshermes
 )
 
 target_compile_reactnative_options(bridgelesshermes PRIVATE)
-if(${CMAKE_BUILD_TYPE} MATCHES Debug)
+if(${CMAKE_BUILD_TYPE} MATCHES Debug OR REACT_NATIVE_DEBUG_OPTIMIZED)
         target_compile_options(
                 bridgelesshermes
                 PRIVATE

--- a/packages/rn-tester/android/app/src/debug/AndroidManifest.xml
+++ b/packages/rn-tester/android/app/src/debug/AndroidManifest.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
-
-    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
-
-    <application android:usesCleartextTraffic="true" tools:targetApi="28" tools:ignore="GoogleAppIndexingWarning" />
-</manifest>

--- a/packages/rn-tester/android/app/src/main/AndroidManifest.xml
+++ b/packages/rn-tester/android/app/src/main/AndroidManifest.xml
@@ -50,6 +50,7 @@
     </queries>
 
     <application
+        android:usesCleartextTraffic="${usesCleartextTraffic}"
         android:name=".RNTesterApplication"
         android:allowBackup="true"
         android:banner="@drawable/tv_banner"

--- a/private/helloworld/android/app/src/debug/AndroidManifest.xml
+++ b/private/helloworld/android/app/src/debug/AndroidManifest.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
-
-    <application
-        android:usesCleartextTraffic="true"
-        tools:targetApi="28"
-        tools:ignore="GoogleAppIndexingWarning"/>
-</manifest>

--- a/private/helloworld/android/app/src/main/AndroidManifest.xml
+++ b/private/helloworld/android/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
       android:icon="@mipmap/ic_launcher"
       android:roundIcon="@mipmap/ic_launcher_round"
       android:allowBackup="false"
+      android:usesCleartextTraffic="${usesCleartextTraffic}"
       android:theme="@style/AppTheme">
       <activity
         android:name=".MainActivity"


### PR DESCRIPTION
Summary:
This creates a `debugOptimized` build type for React Native Android, meaning that we can run C++ optimization on the debug build, while still having the debugger enabled. This is aimed at improving the developer experience for folks developing on low-end devices or emulators.

Users that intend to debug can still use the `debug` variant where the full debug symbols are shipped.

Changelog:

[ANDROID] [ADDED] - Create a debugOptimized buildType for Android

Differential Revision: D78425138
