### PR TITLE
Delete ReactNativeNewArchitectureFeatureFlags.isNewArchitectureStrictModeEnabled()

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeNewArchitectureFeatureFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeNewArchitectureFeatureFlags.kt
@@ -24,10 +24,6 @@ import com.facebook.react.common.build.ReactBuildConfig
 public object ReactNativeNewArchitectureFeatureFlags {
 
   @JvmStatic
-  public fun isNewArchitectureStrictModeEnabled(): Boolean =
-      ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE
-
-  @JvmStatic
   public fun enableBridgelessArchitecture(): Boolean {
     if (ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE) {
       Assertions.assertCondition(


### PR DESCRIPTION
Summary:
ReactNativeNewArchitectureFeatureFlags.isNewArchitectureStrictModeEnabled() is unused, let's delete it

changelog: [internal] internal

Reviewed By: arushikesarwani94

Differential Revision: D78438409


