### PR TITLE
Make accessors inside HeadlessJsTaskService open again

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -31,8 +31,8 @@ public abstract class com/facebook/react/HeadlessJsTaskService : android/app/Ser
 	public fun <init> ()V
 	public static final fun acquireWakeLockNow (Landroid/content/Context;)V
 	protected final fun getReactContext ()Lcom/facebook/react/bridge/ReactContext;
-	protected final fun getReactHost ()Lcom/facebook/react/ReactHost;
-	protected final fun getReactNativeHost ()Lcom/facebook/react/ReactNativeHost;
+	protected fun getReactHost ()Lcom/facebook/react/ReactHost;
+	protected fun getReactNativeHost ()Lcom/facebook/react/ReactNativeHost;
 	protected fun getTaskConfig (Landroid/content/Intent;)Lcom/facebook/react/jstasks/HeadlessJsTaskConfig;
 	public fun onBind (Landroid/content/Intent;)Landroid/os/IBinder;
 	public fun onDestroy ()V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/HeadlessJsTaskService.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/HeadlessJsTaskService.kt
@@ -113,7 +113,7 @@ public abstract class HeadlessJsTaskService : Service(), HeadlessJsTaskEventList
    * somewhere.
    */
   @Suppress("DEPRECATION")
-  protected val reactNativeHost: ReactNativeHost
+  protected open val reactNativeHost: ReactNativeHost
     get() = (application as ReactApplication).reactNativeHost
 
   /**
@@ -121,7 +121,7 @@ public abstract class HeadlessJsTaskService : Service(), HeadlessJsTaskEventList
    * [ReactApplication] and calls [ReactApplication.reactHost]. This method assumes it is called in
    * new architecture and returns null if not.
    */
-  protected val reactHost: ReactHost?
+  protected open val reactHost: ReactHost?
     get() = (application as ReactApplication).reactHost
 
   protected val reactContext: ReactContext?


### PR DESCRIPTION
Summary:
The documentation for those methods mention that users should override them to
provide their own implementation.

However those vals are not `open` so users cannot really override them.
This fixes it.

See more context on https://github.com/facebook/react-native/pull/48800#issuecomment-3082665024

So this was practically a breaking change, that I'm attempting to mitigate.

Changelog:
[Android] [Fixed] - Make accessors inside HeadlessJsTaskService open again

Differential Revision: D78479162


