### PR TITLE
Fix incorrect locking in ShadowTree experiment

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
@@ -255,7 +255,7 @@ CommitStatus ShadowTree::commit(
 
     {
       std::unique_lock lock(commitMutex_);
-      return tryCommit(transaction, commitOptions);
+      return tryCommit(transaction, commitOptions, true);
     }
   } else {
     while (true) {
@@ -275,7 +275,8 @@ CommitStatus ShadowTree::commit(
 
 CommitStatus ShadowTree::tryCommit(
     const ShadowTreeCommitTransaction& transaction,
-    const CommitOptions& commitOptions) const {
+    const CommitOptions& commitOptions,
+    bool hasLocked) const {
   TraceSection s("ShadowTree::commit");
 
   auto telemetry = TransactionTelemetry{};
@@ -287,7 +288,10 @@ CommitStatus ShadowTree::tryCommit(
 
   {
     // Reading `currentRevision_` in shared manner.
-    std::shared_lock lock(commitMutex_);
+    std::shared_lock lock(commitMutex_, std::defer_lock);
+    if (!hasLocked) {
+      lock.lock();
+    }
     commitMode = commitMode_;
     oldRevision = currentRevision_;
   }
@@ -328,7 +332,10 @@ CommitStatus ShadowTree::tryCommit(
 
   {
     // Updating `currentRevision_` in unique manner if it hasn't changed.
-    std::unique_lock lock(commitMutex_);
+    std::unique_lock lock(commitMutex_, std::defer_lock);
+    if (!hasLocked) {
+      lock.lock();
+    }
 
     if (currentRevision_.number != oldRevision.number) {
       return CommitStatus::Failed;

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.h
@@ -111,7 +111,8 @@ class ShadowTree final {
    */
   CommitStatus tryCommit(
       const ShadowTreeCommitTransaction& transaction,
-      const CommitOptions& commitOptions) const;
+      const CommitOptions& commitOptions,
+      bool hasLocked = false) const;
 
   /*
    * Calls `tryCommit` in a loop until it finishes successfully.


### PR DESCRIPTION
Summary:
Changelog: [internal]

In the original change I made in D78418504 / https://github.com/facebook/react-native/pull/52645 I made a mistake and used a lock that would try to re-lock on itself without it being recursive (which would cause a deadlock). I didn't see that because when testing I didn't hit the case where we'd exhaust the options.

This propagates a flag to `tryCommit` to indicate we've already locked on the `commitMutex_` so we don't need to lock again in that case, fixing the issue.

Differential Revision: D78480136


