### PR TITLE
[prebuild][ios] added missing script in package.json

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -106,6 +106,7 @@
     "ReactCommon",
     "README.md",
     "rn-get-polyfills.js",
+    "scripts/replace-rncore-version.js",
     "scripts/bundle.js",
     "scripts/cocoapods",
     "scripts/codegen",


### PR DESCRIPTION
## Summary:

When switching between release/debug we're running a script to copy the correct xcframework. This script for the React-Core prebuilts was not part of the package.json file. 

This caused the build to fail after trying to switch from debug -> release.

## Changelog:
[IOS] [FIXED] - Fixed missing script for resolving prebuilt xcframework when switching between release/debug

## Test Plan:

- Create new RN App
- Install pod with prebuilt deps and core
- Build (success)
- Switch to release
- Build (success)