### PR TITLE
[ios][prebuild] resolve xcframework paths from conf switch script

### DIFF
--- a/packages/react-native/third-party-podspecs/replace_dependencies_version.js
+++ b/packages/react-native/third-party-podspecs/replace_dependencies_version.js
@@ -67,6 +67,25 @@ function replaceRNDepsConfiguration(
 
   console.log('Extracting the tarball', tarballURLPath);
   execSync(`tar -xf ${tarballURLPath} -C ${finalLocation}`);
+
+  // Now we need to remove the extra third-party folder as we do in the podspec's prepare-script
+  // We need to take the ReactNativeDependencies.xcframework folder and move it up one level
+  // from ${finalLocation}/packages/react-native/third-party/ to ${finalLocation}/packages/react-native/
+  console.log('Resolving ReactNativeDependencies.xcframework folder structure');
+  const thirdPartyPath = `${finalLocation}/packages/react-native/third-party`;
+  const sourcePath = `${thirdPartyPath}/ReactNativeDependencies.xcframework`;
+  const destinationPath = `${finalLocation}/packages/react-native/ReactNativeDependencies.xcframework`;
+  if (fs.existsSync(sourcePath)) {
+    fs.renameSync(sourcePath, destinationPath);
+  } else {
+    throw new Error(
+      `Expected ReactNativeDependencies.xcframework to be at ${sourcePath}, but it was not found.`,
+    );
+  }
+
+  if (fs.existsSync(thirdPartyPath)) {
+    fs.rmSync(thirdPartyPath, {force: true, recursive: true});
+  }
 }
 
 function updateLastBuildConfiguration(configuration /*: string */) {


### PR DESCRIPTION
## Summary:

When switching between debug/release we run a small script to make sure to copy the correct version of the RNDeps xcframework.

This script was missing a resolve function that fixed up some path issues that we do when installing in the podspec.

## Changelog:

[IOS] [FIXED] - Fixed issue with RNDeps release/debug switch failing

## Test Plan:

- Create new RN App
- Install pod with prebuilt deps
- Build (success)
- Switch to release
- Build (success)