### PR TITLE
Remove optionality for stable methods of the NativePerformance module

### DIFF
--- a/packages/react-native/src/private/webapis/performance/EventTiming.js
+++ b/packages/react-native/src/private/webapis/performance/EventTiming.js
@@ -86,14 +86,14 @@ function getCachedEventCounts(): Map<string, number> {
     return cachedEventCounts;
   }
 
-  if (!NativePerformance || !NativePerformance?.getEventCounts) {
+  if (!NativePerformance) {
     warnNoNativePerformance();
     cachedEventCounts = new Map();
     return cachedEventCounts;
   }
 
   const eventCounts = new Map<string, number>(
-    NativePerformance.getEventCounts?.() ?? [],
+    NativePerformance.getEventCounts() ?? [],
   );
   cachedEventCounts = eventCounts;
 

--- a/packages/react-native/src/private/webapis/performance/Performance.js
+++ b/packages/react-native/src/private/webapis/performance/Performance.js
@@ -98,53 +98,56 @@ export default class Performance {
 
   // Get the current JS memory information.
   get memory(): MemoryInfo {
-    if (NativePerformance?.getSimpleMemoryInfo) {
-      // JSI API implementations may have different variants of names for the JS
-      // heap information we need here. We will parse the result based on our
-      // guess of the implementation for now.
-      const memoryInfo = NativePerformance.getSimpleMemoryInfo();
-      if (memoryInfo.hasOwnProperty('hermes_heapSize')) {
-        // We got memory information from Hermes
-        const {
-          hermes_heapSize: totalJSHeapSize,
-          hermes_allocatedBytes: usedJSHeapSize,
-        } = memoryInfo;
-
-        return new MemoryInfo({
-          jsHeapSizeLimit: null, // We don't know the heap size limit from Hermes.
-          totalJSHeapSize,
-          usedJSHeapSize,
-        });
-      } else {
-        // JSC and V8 has no native implementations for memory information in JSI::Instrumentation
-        return new MemoryInfo();
-      }
+    if (!NativePerformance) {
+      warnNoNativePerformance();
+      return new MemoryInfo();
     }
 
-    return new MemoryInfo();
+    // JSI API implementations may have different variants of names for the JS
+    // heap information we need here. We will parse the result based on our
+    // guess of the implementation for now.
+    const memoryInfo = NativePerformance.getSimpleMemoryInfo();
+    if (memoryInfo.hasOwnProperty('hermes_heapSize')) {
+      // We got memory information from Hermes
+      const {
+        hermes_heapSize: totalJSHeapSize,
+        hermes_allocatedBytes: usedJSHeapSize,
+      } = memoryInfo;
+
+      return new MemoryInfo({
+        jsHeapSizeLimit: null, // We don't know the heap size limit from Hermes.
+        totalJSHeapSize,
+        usedJSHeapSize,
+      });
+    } else {
+      // JSC and V8 has no native implementations for memory information in JSI::Instrumentation
+      return new MemoryInfo();
+    }
   }
 
   // Startup metrics is not used in web, but only in React Native.
   get rnStartupTiming(): ReactNativeStartupTiming {
-    if (NativePerformance?.getReactNativeStartupTiming) {
-      const {
-        startTime,
-        endTime,
-        initializeRuntimeStart,
-        initializeRuntimeEnd,
-        executeJavaScriptBundleEntryPointStart,
-        executeJavaScriptBundleEntryPointEnd,
-      } = NativePerformance.getReactNativeStartupTiming();
-      return new ReactNativeStartupTiming({
-        startTime,
-        endTime,
-        initializeRuntimeStart,
-        initializeRuntimeEnd,
-        executeJavaScriptBundleEntryPointStart,
-        executeJavaScriptBundleEntryPointEnd,
-      });
+    if (!NativePerformance) {
+      warnNoNativePerformance();
+      return new ReactNativeStartupTiming();
     }
-    return new ReactNativeStartupTiming();
+
+    const {
+      startTime,
+      endTime,
+      initializeRuntimeStart,
+      initializeRuntimeEnd,
+      executeJavaScriptBundleEntryPointStart,
+      executeJavaScriptBundleEntryPointEnd,
+    } = NativePerformance.getReactNativeStartupTiming();
+    return new ReactNativeStartupTiming({
+      startTime,
+      endTime,
+      initializeRuntimeStart,
+      initializeRuntimeEnd,
+      executeJavaScriptBundleEntryPointStart,
+      executeJavaScriptBundleEntryPointEnd,
+    });
   }
 
   mark(
@@ -434,10 +437,11 @@ export default class Performance {
    * https://www.w3.org/TR/performance-timeline/#extensions-to-the-performance-interface
    */
   getEntries(): PerformanceEntryList {
-    if (!NativePerformance?.getEntries) {
+    if (!NativePerformance) {
       warnNoNativePerformance();
       return [];
     }
+
     return NativePerformance.getEntries().map(rawToPerformanceEntry);
   }
 
@@ -450,7 +454,7 @@ export default class Performance {
       return [];
     }
 
-    if (!NativePerformance?.getEntriesByType) {
+    if (!NativePerformance) {
       warnNoNativePerformance();
       return [];
     }
@@ -472,7 +476,7 @@ export default class Performance {
       return [];
     }
 
-    if (!NativePerformance?.getEntriesByName) {
+    if (!NativePerformance) {
       warnNoNativePerformance();
       return [];
     }

--- a/packages/react-native/src/private/webapis/performance/specs/NativePerformance.js
+++ b/packages/react-native/src/private/webapis/performance/specs/NativePerformance.js
@@ -53,7 +53,7 @@ export type PerformanceObserverInit = {
 };
 
 export interface Spec extends TurboModule {
-  +now?: () => number;
+  +now: () => number;
   +reportMark?: (name: string, startTime: number, entry: mixed) => void;
   +reportMeasure?: (
     name: string,
@@ -62,36 +62,36 @@ export interface Spec extends TurboModule {
     entry: mixed,
   ) => void;
   +getMarkTime?: (name: string) => ?number;
-  +clearMarks?: (entryName?: string) => void;
-  +clearMeasures?: (entryName?: string) => void;
-  +getEntries?: () => $ReadOnlyArray<RawPerformanceEntry>;
-  +getEntriesByName?: (
+  +clearMarks: (entryName?: string) => void;
+  +clearMeasures: (entryName?: string) => void;
+  +getEntries: () => $ReadOnlyArray<RawPerformanceEntry>;
+  +getEntriesByName: (
     entryName: string,
     entryType?: ?RawPerformanceEntryType,
   ) => $ReadOnlyArray<RawPerformanceEntry>;
-  +getEntriesByType?: (
+  +getEntriesByType: (
     entryType: RawPerformanceEntryType,
   ) => $ReadOnlyArray<RawPerformanceEntry>;
-  +getEventCounts?: () => $ReadOnlyArray<[string, number]>;
+  +getEventCounts: () => $ReadOnlyArray<[string, number]>;
   +getSimpleMemoryInfo: () => NativeMemoryInfo;
   +getReactNativeStartupTiming: () => ReactNativeStartupTiming;
 
-  +createObserver?: (
+  +createObserver: (
     callback: NativeBatchedObserverCallback,
   ) => OpaqueNativeObserverHandle;
-  +getDroppedEntriesCount?: (observer: OpaqueNativeObserverHandle) => number;
+  +getDroppedEntriesCount: (observer: OpaqueNativeObserverHandle) => number;
 
-  +observe?: (
+  +observe: (
     observer: OpaqueNativeObserverHandle,
     options: PerformanceObserverInit,
   ) => void;
-  +disconnect?: (observer: OpaqueNativeObserverHandle) => void;
-  +takeRecords?: (
+  +disconnect: (observer: OpaqueNativeObserverHandle) => void;
+  +takeRecords: (
     observer: OpaqueNativeObserverHandle,
     sort: boolean,
   ) => $ReadOnlyArray<RawPerformanceEntry>;
 
-  +getSupportedPerformanceEntryTypes?: () => $ReadOnlyArray<RawPerformanceEntryType>;
+  +getSupportedPerformanceEntryTypes: () => $ReadOnlyArray<RawPerformanceEntryType>;
 
   +setCurrentTimeStampForTesting?: (timeStamp: number) => void;
   +clearEventCountsForTesting?: () => void;


### PR DESCRIPTION
Summary:
Changelog: [internal]

These methods have been available for months so no need to consider backwards compatibility with older binaries.

Reviewed By: huntie

Differential Revision: D78412932


