### PR TITLE
Add missing attempts++ in ShadowNode with MAX_COMMIT_ATTEMPTS_BEFORE_LOCKING

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
@@ -251,6 +251,7 @@ CommitStatus ShadowTree::commit(
       if (status != CommitStatus::Failed) {
         return status;
       }
+      attempts++;
     }
 
     {


### PR DESCRIPTION
Summary:
We should be incrementing the `attempts` variable as otherwise this loop with never stop.

Created from CodeHub with https://fburl.com/edit-in-codehub

Differential Revision: D78487202


