### PR TITLE
Default initialize properties in custom structs

### DIFF
--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/modules/__snapshots__/GenerateModuleH-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/modules/__snapshots__/GenerateModuleH-test.js.snap
@@ -348,7 +348,8 @@ struct Bridging<NativeEnumTurboModuleStatusStrEnum> {
 
 template <typename P0>
 struct NativeEnumTurboModuleStateType {
-  P0 state;
+  P0 state{};
+
   bool operator==(const NativeEnumTurboModuleStateType &other) const {
     return state == other.state;
   }
@@ -389,11 +390,12 @@ struct NativeEnumTurboModuleStateTypeBridging {
 
 template <typename P0, typename P1, typename P2, typename P3, typename P4>
 struct NativeEnumTurboModuleStateTypeWithEnums {
-  P0 state;
-  P1 regular;
-  P2 str;
-  P3 num;
-  P4 lowerCase;
+  P0 state{};
+  P1 regular{};
+  P2 str{};
+  P3 num{};
+  P4 lowerCase{};
+
   bool operator==(const NativeEnumTurboModuleStateTypeWithEnums &other) const {
     return state == other.state && regular == other.regular && str == other.str && num == other.num && lowerCase == other.lowerCase;
   }
@@ -862,8 +864,9 @@ private:
 
 template <typename P0, typename P1>
 struct NativePartialAnnotationTurboModuleSomeObj {
-  P0 a;
-  P1 b;
+  P0 a{};
+  P1 b{};
+
   bool operator==(const NativePartialAnnotationTurboModuleSomeObj &other) const {
     return a == other.a && b == other.b;
   }
@@ -1055,7 +1058,8 @@ private:
 
 template <typename P0>
 struct NativeSampleTurboModuleAnimal {
-  P0 name;
+  P0 name{};
+
   bool operator==(const NativeSampleTurboModuleAnimal &other) const {
     return name == other.name;
   }
@@ -1257,7 +1261,8 @@ private:
 
 template <typename P0>
 struct NativeSampleTurboModuleArraysAnimal {
-  P0 name;
+  P0 name{};
+
   bool operator==(const NativeSampleTurboModuleArraysAnimal &other) const {
     return name == other.name;
   }
@@ -1459,7 +1464,8 @@ private:
 
 template <typename P0>
 struct NativeSampleTurboModuleNullableAnimal {
-  P0 name;
+  P0 name{};
+
   bool operator==(const NativeSampleTurboModuleNullableAnimal &other) const {
     return name == other.name;
   }
@@ -1661,7 +1667,8 @@ private:
 
 template <typename P0>
 struct NativeSampleTurboModuleNullableAndOptionalAnimal {
-  P0 name;
+  P0 name{};
+
   bool operator==(const NativeSampleTurboModuleNullableAndOptionalAnimal &other) const {
     return name == other.name;
   }
@@ -1865,7 +1872,8 @@ private:
 
 template <typename P0>
 struct NativeSampleTurboModuleOptionalAnimal {
-  P0 name;
+  P0 name{};
+
   bool operator==(const NativeSampleTurboModuleOptionalAnimal &other) const {
     return name == other.name;
   }
@@ -2478,7 +2486,8 @@ struct Bridging<NativeEnumTurboModuleStatusStrEnum> {
 
 template <typename P0>
 struct NativeEnumTurboModuleStateType {
-  P0 state;
+  P0 state{};
+
   bool operator==(const NativeEnumTurboModuleStateType &other) const {
     return state == other.state;
   }
@@ -2519,11 +2528,12 @@ struct NativeEnumTurboModuleStateTypeBridging {
 
 template <typename P0, typename P1, typename P2, typename P3, typename P4>
 struct NativeEnumTurboModuleStateTypeWithEnums {
-  P0 state;
-  P1 regular;
-  P2 str;
-  P3 num;
-  P4 lowerCase;
+  P0 state{};
+  P1 regular{};
+  P2 str{};
+  P3 num{};
+  P4 lowerCase{};
+
   bool operator==(const NativeEnumTurboModuleStateTypeWithEnums &other) const {
     return state == other.state && regular == other.regular && str == other.str && num == other.num && lowerCase == other.lowerCase;
   }
@@ -2992,8 +3002,9 @@ private:
 
 template <typename P0, typename P1>
 struct NativePartialAnnotationTurboModuleSomeObj {
-  P0 a;
-  P1 b;
+  P0 a{};
+  P1 b{};
+
   bool operator==(const NativePartialAnnotationTurboModuleSomeObj &other) const {
     return a == other.a && b == other.b;
   }
@@ -3185,7 +3196,8 @@ private:
 
 template <typename P0>
 struct NativeSampleTurboModuleAnimal {
-  P0 name;
+  P0 name{};
+
   bool operator==(const NativeSampleTurboModuleAnimal &other) const {
     return name == other.name;
   }
@@ -3387,7 +3399,8 @@ private:
 
 template <typename P0>
 struct NativeSampleTurboModuleArraysAnimal {
-  P0 name;
+  P0 name{};
+
   bool operator==(const NativeSampleTurboModuleArraysAnimal &other) const {
     return name == other.name;
   }
@@ -3589,7 +3602,8 @@ private:
 
 template <typename P0>
 struct NativeSampleTurboModuleNullableAnimal {
-  P0 name;
+  P0 name{};
+
   bool operator==(const NativeSampleTurboModuleNullableAnimal &other) const {
     return name == other.name;
   }
@@ -3791,7 +3805,8 @@ private:
 
 template <typename P0>
 struct NativeSampleTurboModuleNullableAndOptionalAnimal {
-  P0 name;
+  P0 name{};
+
   bool operator==(const NativeSampleTurboModuleNullableAndOptionalAnimal &other) const {
     return name == other.name;
   }
@@ -3995,7 +4010,8 @@ private:
 
 template <typename P0>
 struct NativeSampleTurboModuleOptionalAnimal {
-  P0 name;
+  P0 name{};
+
   bool operator==(const NativeSampleTurboModuleOptionalAnimal &other) const {
     return name == other.name;
   }

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
@@ -298,7 +298,7 @@ function createStructsString(
 
 template <${templateParameterWithTypename}>
 struct ${structName} {
-${templateMemberTypes.map(v => '  ' + v).join(';\n')};
+${templateMemberTypes.map(v => '  ' + v + '{};\n').join('')}
   bool operator==(const ${structName} &other) const {
     return ${value.properties
       .map(v => `${v.name} == other.${v.name}`)

--- a/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleH-test.js.snap
@@ -336,9 +336,10 @@ struct Bridging<NativeSampleTurboModuleEnumStr> {
 
 template <typename P0, typename P1, typename P2>
 struct NativeSampleTurboModuleConstantsStruct {
-  P0 const1;
-  P1 const2;
-  P2 const3;
+  P0 const1{};
+  P1 const2{};
+  P2 const3{};
+
   bool operator==(const NativeSampleTurboModuleConstantsStruct &other) const {
     return const1 == other.const1 && const2 == other.const2 && const3 == other.const3;
   }
@@ -392,9 +393,10 @@ struct NativeSampleTurboModuleConstantsStructBridging {
 
 template <typename P0>
 struct NativeSampleTurboModuleBinaryTreeNode {
-  std::unique_ptr<NativeSampleTurboModuleBinaryTreeNode<P0>> left;
-  P0 value;
-  std::unique_ptr<NativeSampleTurboModuleBinaryTreeNode<P0>> right;
+  std::unique_ptr<NativeSampleTurboModuleBinaryTreeNode<P0>> left{};
+  P0 value{};
+  std::unique_ptr<NativeSampleTurboModuleBinaryTreeNode<P0>> right{};
+
   bool operator==(const NativeSampleTurboModuleBinaryTreeNode &other) const {
     return left == other.left && value == other.value && right == other.right;
   }
@@ -451,8 +453,9 @@ struct NativeSampleTurboModuleBinaryTreeNodeBridging {
 
 template <typename P0>
 struct NativeSampleTurboModuleGraphNode {
-  P0 label;
-  std::optional<std::vector<NativeSampleTurboModuleGraphNode<P0>>> neighbors;
+  P0 label{};
+  std::optional<std::vector<NativeSampleTurboModuleGraphNode<P0>>> neighbors{};
+
   bool operator==(const NativeSampleTurboModuleGraphNode &other) const {
     return label == other.label && neighbors == other.neighbors;
   }
@@ -501,9 +504,10 @@ struct NativeSampleTurboModuleGraphNodeBridging {
 
 template <typename P0, typename P1, typename P2>
 struct NativeSampleTurboModuleObjectStruct {
-  P0 a;
-  P1 b;
-  P2 c;
+  P0 a{};
+  P1 b{};
+  P2 c{};
+
   bool operator==(const NativeSampleTurboModuleObjectStruct &other) const {
     return a == other.a && b == other.b && c == other.c;
   }
@@ -558,9 +562,10 @@ struct NativeSampleTurboModuleObjectStructBridging {
 
 template <typename P0, typename P1, typename P2>
 struct NativeSampleTurboModuleValueStruct {
-  P0 x;
-  P1 y;
-  P2 z;
+  P0 x{};
+  P1 y{};
+  P2 z{};
+
   bool operator==(const NativeSampleTurboModuleValueStruct &other) const {
     return x == other.x && y == other.y && z == other.z;
   }
@@ -613,10 +618,11 @@ struct NativeSampleTurboModuleValueStructBridging {
 
 template <typename P0, typename P1, typename P2>
 struct NativeSampleTurboModuleMenuItem {
-  P0 label;
-  P1 onPress;
-  P2 shortcut;
-  std::optional<std::vector<NativeSampleTurboModuleMenuItem<P0, P1, P2>>> items;
+  P0 label{};
+  P1 onPress{};
+  P2 shortcut{};
+  std::optional<std::vector<NativeSampleTurboModuleMenuItem<P0, P1, P2>>> items{};
+
   bool operator==(const NativeSampleTurboModuleMenuItem &other) const {
     return label == other.label && onPress == other.onPress && shortcut == other.shortcut && items == other.items;
   }
@@ -1059,9 +1065,10 @@ namespace facebook::react {
 
 template <typename P0, typename P1, typename P2>
 struct NativeSampleTurboModuleObjectStruct {
-  P0 a;
-  P1 b;
-  P2 c;
+  P0 a{};
+  P1 b{};
+  P2 c{};
+
   bool operator==(const NativeSampleTurboModuleObjectStruct &other) const {
     return a == other.a && b == other.b && c == other.c;
   }
@@ -1235,11 +1242,12 @@ namespace facebook::react {
 
 template <typename P0, typename P1, typename P2, typename P3, typename P4>
 struct AliasTurboModuleOptions {
-  P0 offset;
-  P1 size;
-  P2 displaySize;
-  P3 resizeMode;
-  P4 allowExternalStorage;
+  P0 offset{};
+  P1 size{};
+  P2 displaySize{};
+  P3 resizeMode{};
+  P4 allowExternalStorage{};
+
   bool operator==(const AliasTurboModuleOptions &other) const {
     return offset == other.offset && size == other.size && displaySize == other.displaySize && resizeMode == other.resizeMode && allowExternalStorage == other.allowExternalStorage;
   }
@@ -1395,12 +1403,13 @@ namespace facebook::react {
 
 template <typename P0, typename P1, typename P2, typename P3, typename P4, typename P5>
 struct NativeCameraRollManagerPhotoIdentifierImage {
-  P0 uri;
-  P1 playableDuration;
-  P2 width;
-  P3 height;
-  P4 isStored;
-  P5 filename;
+  P0 uri{};
+  P1 playableDuration{};
+  P2 width{};
+  P3 height{};
+  P4 isStored{};
+  P5 filename{};
+
   bool operator==(const NativeCameraRollManagerPhotoIdentifierImage &other) const {
     return uri == other.uri && playableDuration == other.playableDuration && width == other.width && height == other.height && isStored == other.isStored && filename == other.filename;
   }
@@ -1473,7 +1482,8 @@ struct NativeCameraRollManagerPhotoIdentifierImageBridging {
 
 template <typename P0>
 struct NativeCameraRollManagerPhotoIdentifier {
-  P0 node;
+  P0 node{};
+
   bool operator==(const NativeCameraRollManagerPhotoIdentifier &other) const {
     return node == other.node;
   }
@@ -1514,8 +1524,9 @@ struct NativeCameraRollManagerPhotoIdentifierBridging {
 
 template <typename P0, typename P1>
 struct NativeCameraRollManagerPhotoIdentifiersPage {
-  P0 edges;
-  P1 page_info;
+  P0 edges{};
+  P1 page_info{};
+
   bool operator==(const NativeCameraRollManagerPhotoIdentifiersPage &other) const {
     return edges == other.edges && page_info == other.page_info;
   }
@@ -1562,13 +1573,14 @@ struct NativeCameraRollManagerPhotoIdentifiersPageBridging {
 
 template <typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6>
 struct NativeCameraRollManagerGetPhotosParams {
-  P0 first;
-  P1 after;
-  P2 groupName;
-  P3 groupTypes;
-  P4 assetType;
-  P5 maxSize;
-  P6 mimeTypes;
+  P0 first{};
+  P1 after{};
+  P2 groupName{};
+  P3 groupTypes{};
+  P4 assetType{};
+  P5 maxSize{};
+  P6 mimeTypes{};
+
   bool operator==(const NativeCameraRollManagerGetPhotosParams &other) const {
     return first == other.first && after == other.after && groupName == other.groupName && groupTypes == other.groupTypes && assetType == other.assetType && maxSize == other.maxSize && mimeTypes == other.mimeTypes;
   }
@@ -1737,11 +1749,12 @@ private:
 
 template <typename P0, typename P1, typename P2, typename P3, typename P4>
 struct NativeExceptionsManagerStackFrame {
-  P0 column;
-  P1 file;
-  P2 lineNumber;
-  P3 methodName;
-  P4 collapse;
+  P0 column{};
+  P1 file{};
+  P2 lineNumber{};
+  P3 methodName{};
+  P4 collapse{};
+
   bool operator==(const NativeExceptionsManagerStackFrame &other) const {
     return column == other.column && file == other.file && lineNumber == other.lineNumber && methodName == other.methodName && collapse == other.collapse;
   }
@@ -1812,14 +1825,15 @@ struct NativeExceptionsManagerStackFrameBridging {
 
 template <typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6, typename P7>
 struct NativeExceptionsManagerExceptionData {
-  P0 message;
-  P1 originalMessage;
-  P2 name;
-  P3 componentStack;
-  P4 stack;
-  P5 id;
-  P6 isFatal;
-  P7 extraData;
+  P0 message{};
+  P1 originalMessage{};
+  P2 name{};
+  P3 componentStack{};
+  P4 stack{};
+  P5 id{};
+  P6 isFatal{};
+  P7 extraData{};
+
   bool operator==(const NativeExceptionsManagerExceptionData &other) const {
     return message == other.message && originalMessage == other.originalMessage && name == other.name && componentStack == other.componentStack && stack == other.stack && id == other.id && isFatal == other.isFatal && extraData == other.extraData;
   }


### PR DESCRIPTION
Summary:
If a native module spec declares a custom type:

https://www.internalfb.com/code/fbsource/[f6aeb413dbc3]/xplat/js/RKJSModules/Libraries/hsr/tm/code/editable_object/NativeEditableObjectModule.js?lines=151-154

The codegen will generate a c++ struct for that type, like so:

```
template <typename P0, typename P1>
struct NativeEditableObjectModuleChangedProperty {
  P0 propertyPath;
  P1 value;

  bool operator==(const NativeEditableObjectModuleChangedProperty &other) const {
    return propertyPath == other.propertyPath && value == other.value;
  }
};
```

## Problem
People can sometimes forget to default initialize this struct:
- **Report:** [post](https://fb.workplace.com/groups/rn.support/permalink/28506993098922601/)
- **Diff #1:** D74868762
- **Diff #2:** D77182083


In this scenario, all the members contain garbage data.

## Changes
This diff ensures that all the members are always default initialized, like so:

```
template <typename P0, typename P1>
struct NativeEditableObjectModuleChangedProperty {
  P0 propertyPath{};
  P1 value{};

  bool operator==(const NativeEditableObjectModuleChangedProperty &other) const {
    return propertyPath == other.propertyPath && value == other.value;
  }
};
```

This way, even if you forget to default initailize the struct, the members will still be default initialized.

## Concerns/Risks
This could cause compilation issues in some of our existing native modules. (if one of the member types doesn't have a default constructor).

Code could start behaving differently, now that all the members are default initialized. (my hunch is that the risk from this causing a problem is low).

Changelog: [General][Changed] c++ tm codegen: Default initialize properties in custom structs

Reviewed By: christophpurrer

Differential Revision: D77315742


