### PR TITLE
Back out "Fix incorrect locking in ShadowTree experiment"

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.h
@@ -111,8 +111,7 @@ class ShadowTree final {
    */
   CommitStatus tryCommit(
       const ShadowTreeCommitTransaction& transaction,
-      const CommitOptions& commitOptions,
-      bool hasLocked = false) const;
+      const CommitOptions& commitOptions) const;
 
   /*
    * Calls `tryCommit` in a loop until it finishes successfully.


### PR DESCRIPTION
Summary:
Changelog: [internal]

Reverting to make the fix easier to pick. Will land again on top.

Original commit changeset: c18e967488de

Original Phabricator Diff: D78480136

Differential Revision: D78497510


