### PR TITLE
IntersectionObserver: Clean up legacy observe/unobserve methods

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/NativeIntersectionObserver.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/NativeIntersectionObserver.cpp
@@ -49,21 +49,6 @@ NativeIntersectionObserver::NativeIntersectionObserver(
     std::shared_ptr<CallInvoker> jsInvoker)
     : NativeIntersectionObserverCxxSpec(std::move(jsInvoker)) {}
 
-void NativeIntersectionObserver::observe(
-    jsi::Runtime& runtime,
-    NativeIntersectionObserverObserveOptions options) {
-  observeV2(runtime, std::move(options));
-}
-
-void NativeIntersectionObserver::unobserve(
-    jsi::Runtime& runtime,
-    IntersectionObserverObserverId intersectionObserverId,
-    std::shared_ptr<const ShadowNode> targetShadowNode) {
-  auto token =
-      tokenFromShadowNodeFamily(runtime, targetShadowNode->getFamilyShared());
-  unobserveV2(runtime, intersectionObserverId, std::move(token));
-}
-
 jsi::Object NativeIntersectionObserver::observeV2(
     jsi::Runtime& runtime,
     NativeIntersectionObserverObserveOptions options) {

--- a/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/NativeIntersectionObserver.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/NativeIntersectionObserver.h
@@ -64,19 +64,6 @@ class NativeIntersectionObserver
  public:
   NativeIntersectionObserver(std::shared_ptr<CallInvoker> jsInvoker);
 
-  // TODO(T223605846): Remove legacy observe method
-  [[deprecated("Please use observeV2")]]
-  void observe(
-      jsi::Runtime& runtime,
-      NativeIntersectionObserverObserveOptions options);
-
-  // TODO(T223605846): Remove legacy unobserve method
-  [[deprecated("Please use unobserveV2")]]
-  void unobserve(
-      jsi::Runtime& runtime,
-      IntersectionObserverObserverId intersectionObserverId,
-      std::shared_ptr<const ShadowNode> targetShadowNode);
-
   jsi::Object observeV2(
       jsi::Runtime& runtime,
       NativeIntersectionObserverObserveOptions options);

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -856,16 +856,6 @@ const definitions: FeatureFlagDefinitions = {
       },
       ossReleaseStage: 'none',
     },
-    utilizeTokensInIntersectionObserver: {
-      defaultValue: true,
-      metadata: {
-        dateAdded: '2025-05-06',
-        description: 'Use tokens in IntersectionObserver vs ShadowNode.',
-        expectedReleaseValue: true,
-        purpose: 'experimentation',
-      },
-      ossReleaseStage: 'none',
-    },
   },
 };
 

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<d30fc4e36ad600353c9b9098fd71430a>>
+ * @generated SignedSource<<a9d5d55d54a442f6b546c867bd832df2>>
  * @flow strict
  * @noformat
  */
@@ -43,7 +43,6 @@ export type ReactNativeFeatureFlagsJsOnly = $ReadOnly<{
   shouldUseAnimatedObjectForTransform: Getter<boolean>,
   shouldUseRemoveClippedSubviewsAsDefaultOnIOS: Getter<boolean>,
   shouldUseSetNativePropsInFabric: Getter<boolean>,
-  utilizeTokensInIntersectionObserver: Getter<boolean>,
 }>;
 
 export type ReactNativeFeatureFlagsJsOnlyOverrides = OverridesFor<ReactNativeFeatureFlagsJsOnly>;
@@ -189,11 +188,6 @@ export const shouldUseRemoveClippedSubviewsAsDefaultOnIOS: Getter<boolean> = cre
  * Enables use of setNativeProps in JS driven animations.
  */
 export const shouldUseSetNativePropsInFabric: Getter<boolean> = createJavaScriptFlagGetter('shouldUseSetNativePropsInFabric', true);
-
-/**
- * Use tokens in IntersectionObserver vs ShadowNode.
- */
-export const utilizeTokensInIntersectionObserver: Getter<boolean> = createJavaScriptFlagGetter('utilizeTokensInIntersectionObserver', true);
 
 /**
  * Common flag for testing. Do NOT modify.

--- a/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-itest.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/__tests__/IntersectionObserver-itest.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @fantom_flags utilizeTokensInIntersectionObserver:*
  * @flow strict-local
  * @format
  */
@@ -20,7 +19,6 @@ import * as Fantom from '@react-native/fantom';
 import * as React from 'react';
 import {createRef, useState} from 'react';
 import {ScrollView, View} from 'react-native';
-import * as ReactNativeFeatureFlags from 'react-native/src/private/featureflags/ReactNativeFeatureFlags';
 import setUpIntersectionObserver from 'react-native/src/private/setup/setUpIntersectionObserver';
 import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 import DOMRectReadOnly from 'react-native/src/private/webapis/geometry/DOMRectReadOnly';
@@ -1494,44 +1492,42 @@ describe('IntersectionObserver', () => {
       });
     });
 
-    if (ReactNativeFeatureFlags.utilizeTokensInIntersectionObserver()) {
-      it('should not retain initial children of observed targets', () => {
-        const root = Fantom.createRoot();
-        observer = new IntersectionObserver(() => {});
+    it('should not retain initial children of observed targets', () => {
+      const root = Fantom.createRoot();
+      observer = new IntersectionObserver(() => {});
 
-        const [getReferenceCount, ref] = createShadowNodeReferenceCountingRef();
+      const [getReferenceCount, ref] = createShadowNodeReferenceCountingRef();
 
-        const observeRef: React.RefSetter<
-          React.ElementRef<typeof View>,
-        > = instance => {
-          const element = ensureReactNativeElement(instance);
-          observer.observe(element);
-          return () => {
-            observer.unobserve(element);
-          };
+      const observeRef: React.RefSetter<
+        React.ElementRef<typeof View>,
+      > = instance => {
+        const element = ensureReactNativeElement(instance);
+        observer.observe(element);
+        return () => {
+          observer.unobserve(element);
         };
+      };
 
-        function Observe({children}: $ReadOnly<{children?: React.Node}>) {
-          return <View ref={observeRef}>{children}</View>;
-        }
+      function Observe({children}: $ReadOnly<{children?: React.Node}>) {
+        return <View ref={observeRef}>{children}</View>;
+      }
 
-        Fantom.runTask(() => {
-          root.render(
-            <Observe>
-              <View ref={ref} />
-            </Observe>,
-          );
-        });
-
-        expect(getReferenceCount()).toBeGreaterThan(0);
-
-        Fantom.runTask(() => {
-          root.render(<Observe />);
-        });
-
-        expect(getReferenceCount()).toBe(0);
+      Fantom.runTask(() => {
+        root.render(
+          <Observe>
+            <View ref={ref} />
+          </Observe>,
+        );
       });
-    }
+
+      expect(getReferenceCount()).toBeGreaterThan(0);
+
+      Fantom.runTask(() => {
+        root.render(<Observe />);
+      });
+
+      expect(getReferenceCount()).toBe(0);
+    });
 
     it('should NOT report multiple entries when observing a target that exists and we modify it later in the same tick', () => {
       const root = Fantom.createRoot({

--- a/packages/react-native/src/private/webapis/intersectionobserver/specs/NativeIntersectionObserver.js
+++ b/packages/react-native/src/private/webapis/intersectionobserver/specs/NativeIntersectionObserver.js
@@ -34,10 +34,6 @@ export type NativeIntersectionObserverObserveOptions = {
 export opaque type NativeIntersectionObserverToken = mixed;
 
 export interface Spec extends TurboModule {
-  // TODO(T223605846): Remove legacy observe method
-  +observe: (options: NativeIntersectionObserverObserveOptions) => void;
-  // TODO(T223605846): Remove legacy unobserve method
-  +unobserve: (intersectionObserverId: number, targetShadowNode: mixed) => void;
   +observeV2?: (
     options: NativeIntersectionObserverObserveOptions,
   ) => NativeIntersectionObserverToken;


### PR DESCRIPTION
Summary:
In this diff, we migrated IntersectionObserver to tokens: D74262804.

So that we wouldn't have to store shadow nodes on the javascript side.

Storing shadow nodes lead to a memory leak in the past.

Changelog: [internal]

Reviewed By: rubennorte

Differential Revision: D78494075


