### PR TITLE
Add annotations to fix future errors after fix for unsound array types

### DIFF
--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityAndroidExample.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityAndroidExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 import RNTesterBlock from '../../components/RNTesterBlock';
 import RNTesterPage from '../../components/RNTesterPage';
 import RNTesterText from '../../components/RNTesterText';
@@ -282,4 +284,4 @@ exports.examples = [
       return <AccessibilityAndroidExample />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
@@ -10,6 +10,7 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import type {EventSubscription, GestureResponderEvent} from 'react-native';
 
 import RNTesterBlock from '../../components/RNTesterBlock';
@@ -2250,4 +2251,4 @@ exports.examples = [
       return <LabelCooptingExample />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityIOSExample.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityIOSExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 const {RNTesterThemeContext} = require('../../components/RNTesterTheme');
 const React = require('react');
 const {Alert, Text, View} = require('react-native');
@@ -83,4 +85,4 @@ exports.examples = [
       return <AccessibilityIOSExample />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/ActionSheetIOS/ActionSheetIOSExample.js
+++ b/packages/rn-tester/js/examples/ActionSheetIOS/ActionSheetIOSExample.js
@@ -10,6 +10,7 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import type {HostInstance} from 'react-native';
 
 import {RNTesterThemeContext} from '../../components/RNTesterTheme';
@@ -573,4 +574,4 @@ exports.examples = [
       return <ShareScreenshotAnchorExample />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/AnimatedGratuitousApp/AnExApp.js
+++ b/packages/rn-tester/js/examples/AnimatedGratuitousApp/AnExApp.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 import AnExSet from './AnExSet';
 import React from 'react';
 import {
@@ -396,4 +398,4 @@ exports.examples = [
       return <AnExApp />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/Appearance/AppearanceExample.js
+++ b/packages/rn-tester/js/examples/Appearance/AppearanceExample.js
@@ -8,6 +8,7 @@
  * @format
  */
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import type {ColorSchemeName} from 'react-native';
 
 import RNTesterText from '../../components/RNTesterText';
@@ -245,4 +246,4 @@ exports.examples = [
       return <ToggleNativeAppearance />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/BoxShadow/BoxShadowExample.js
+++ b/packages/rn-tester/js/examples/BoxShadow/BoxShadowExample.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 import * as React from 'react';
 import {Image, StyleSheet, View} from 'react-native';
 
@@ -191,4 +193,4 @@ exports.examples = [
       );
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/Button/ButtonExample.js
+++ b/packages/rn-tester/js/examples/Button/ButtonExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 const {RNTesterThemeContext} = require('../../components/RNTesterTheme');
 const React = require('react');
 const {Alert, Button, StyleSheet, View} = require('react-native');
@@ -221,7 +223,7 @@ exports.examples = [
       );
     },
   },
-];
+] as Array<RNTesterModuleExample>;
 
 const styles = StyleSheet.create({
   container: {

--- a/packages/rn-tester/js/examples/ContentURLAndroid/ContentURLAndroid.js
+++ b/packages/rn-tester/js/examples/ContentURLAndroid/ContentURLAndroid.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 import RNTesterBlock from '../../components/RNTesterBlock';
 import RNTesterPage from '../../components/RNTesterPage';
 import RNTesterText from '../../components/RNTesterText';
@@ -116,4 +118,4 @@ exports.examples = [
       return <ContentURLAndroidExample />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/Crash/CrashExample.js
+++ b/packages/rn-tester/js/examples/Crash/CrashExample.js
@@ -8,6 +8,7 @@
  * @format
  */
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import type {Node} from 'react';
 
 import React from 'react';
@@ -37,4 +38,4 @@ exports.examples = [
       );
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/Cursor/CursorExample.js
+++ b/packages/rn-tester/js/examples/Cursor/CursorExample.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 import * as React from 'react';
 import {StyleSheet, Text, View} from 'react-native';
 
@@ -107,4 +109,4 @@ exports.examples = [
     description: 'Views with a cursor do not get flattened',
     render: CursorExampleViewFlattening,
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/DevSettings/DevSettingsExample.js
+++ b/packages/rn-tester/js/examples/DevSettings/DevSettingsExample.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 import * as React from 'react';
 import {Alert, Button, DevSettings} from 'react-native';
 
@@ -44,4 +46,4 @@ exports.examples = [
       );
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/Dimensions/DimensionsExample.js
+++ b/packages/rn-tester/js/examples/Dimensions/DimensionsExample.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 import RNTesterText from '../../components/RNTesterText';
 import React, {useEffect, useState} from 'react';
 import {Dimensions, useWindowDimensions} from 'react-native';
@@ -60,4 +62,4 @@ exports.examples = [
       return <DimensionsSubscription dim="screen" />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/DrawerLayoutAndroid/DrawerLayoutAndroidExample.js
+++ b/packages/rn-tester/js/examples/DrawerLayoutAndroid/DrawerLayoutAndroidExample.js
@@ -10,6 +10,7 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import type {Node} from 'react';
 
 import {RNTesterThemeContext} from '../../components/RNTesterTheme';
@@ -104,4 +105,4 @@ exports.examples = [
       return <Drawer />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/FabricInteropLayer/FabricInteropLayer.js
+++ b/packages/rn-tester/js/examples/FabricInteropLayer/FabricInteropLayer.js
@@ -9,6 +9,7 @@
  */
 
 'use strict';
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import type {ViewProps} from 'react-native';
 
 import React, {useState} from 'react';
@@ -155,4 +156,4 @@ exports.examples = [
       return <AddChildrenForInteropLayer testID="add-children" />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/FocusEventsExample/FocusEventsExample.android.js
+++ b/packages/rn-tester/js/examples/FocusEventsExample/FocusEventsExample.android.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 import RNTesterText from '../../components/RNTesterText';
 import {useState} from 'react';
 import {Alert, Pressable, StyleSheet, TextInput, View} from 'react-native';
@@ -184,5 +186,5 @@ export default {
         return <PressableExample />;
       },
     },
-  ],
+  ] as Array<RNTesterModuleExample>,
 };

--- a/packages/rn-tester/js/examples/InputAccessoryView/InputAccessoryViewExample.js
+++ b/packages/rn-tester/js/examples/InputAccessoryView/InputAccessoryViewExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 import {useTheme} from '../../components/RNTesterTheme';
 import {useState} from 'react';
 import {
@@ -111,4 +113,4 @@ exports.examples = [
       return <InputAccessoryViewExample />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/InvalidProps/InvalidPropsExample.js
+++ b/packages/rn-tester/js/examples/InvalidProps/InvalidPropsExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 import RNTesterText from '../../components/RNTesterText';
 import * as React from 'react';
 import {View} from 'react-native';
@@ -19,7 +21,7 @@ export const category = 'Other';
 export const description =
   'Examples of passing invalid prop values and how they fall back to expected defaults.';
 
-export const examples = [
+export const examples: Array<RNTesterModuleExample> = [
   {
     title: 'View flex',
     render(): React.Node {

--- a/packages/rn-tester/js/examples/JSResponderHandlerExample/JSResponderHandlerExample.js
+++ b/packages/rn-tester/js/examples/JSResponderHandlerExample/JSResponderHandlerExample.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 import RNTesterText from '../../components/RNTesterText';
 import React from 'react';
 import {PanResponder, ScrollView, StyleSheet, View} from 'react-native';
@@ -60,7 +62,7 @@ exports.examples = [
       );
     },
   },
-];
+] as Array<RNTesterModuleExample>;
 
 const styles = StyleSheet.create({
   container: {

--- a/packages/rn-tester/js/examples/KeyboardAvoidingView/KeyboardAvoidingViewExample.js
+++ b/packages/rn-tester/js/examples/KeyboardAvoidingView/KeyboardAvoidingViewExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 import React, {useState} from 'react';
 import {
   Alert,
@@ -276,4 +278,4 @@ exports.examples = [
       return <KeyboardAvoidingContentContainerStyle />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/Layout/LayoutAnimationExample.js
+++ b/packages/rn-tester/js/examples/Layout/LayoutAnimationExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 import RNTesterText from '../../components/RNTesterText';
 import React from 'react';
 import {
@@ -389,4 +391,4 @@ exports.examples = [
       return <LayoutUpdateExample />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/Layout/LayoutEventsExample.js
+++ b/packages/rn-tester/js/examples/Layout/LayoutEventsExample.js
@@ -10,6 +10,7 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import type {
   ViewLayout,
   ViewLayoutEvent,
@@ -163,4 +164,4 @@ exports.examples = [
       return <LayoutEventExample />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/Layout/LayoutExample.js
+++ b/packages/rn-tester/js/examples/Layout/LayoutExample.js
@@ -10,6 +10,7 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import type {ViewStyleProp} from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 import RNTesterBlock from '../../components/RNTesterBlock';
@@ -210,4 +211,4 @@ exports.examples = [
       return <LayoutExample />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/LinearGradient/LinearGradientExample.js
+++ b/packages/rn-tester/js/examples/LinearGradient/LinearGradientExample.js
@@ -10,6 +10,7 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import type {ViewStyleProp} from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 import RNTesterText from '../../components/RNTesterText';
@@ -305,4 +306,4 @@ exports.examples = [
       );
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/Linking/LinkingExample.js
+++ b/packages/rn-tester/js/examples/Linking/LinkingExample.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 import RNTesterBlock from '../../components/RNTesterBlock';
 import RNTesterText from '../../components/RNTesterText';
 import React from 'react';
@@ -168,4 +170,4 @@ exports.examples = [
       return <OpenSettingsExample />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/NativeAnimation/NativeAnimationsExample.js
+++ b/packages/rn-tester/js/examples/NativeAnimation/NativeAnimationsExample.js
@@ -10,6 +10,7 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import type AnimatedValue from 'react-native/Libraries/Animated/nodes/AnimatedValue';
 
 import RNTesterSettingSwitchRow from '../../components/RNTesterSettingSwitchRow';
@@ -657,4 +658,4 @@ exports.examples = [
       return <InternalSettings />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/NewAppScreen/NewAppScreenExample.js
+++ b/packages/rn-tester/js/examples/NewAppScreen/NewAppScreenExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 const {NewAppScreen} = require('@react-native/new-app-screen');
 const React = require('react');
 const {ScrollView} = require('react-native');
@@ -27,4 +29,4 @@ exports.examples = [
       );
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/NewArchitecture/NewArchitectureExample.js
+++ b/packages/rn-tester/js/examples/NewArchitecture/NewArchitectureExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 import MyNativeView from '../../../NativeComponentExample/js/MyNativeView';
 import * as React from 'react';
 
@@ -28,4 +30,4 @@ exports.examples = [
       );
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/OSSLibraryExample/OSSLibraryExample.js
+++ b/packages/rn-tester/js/examples/OSSLibraryExample/OSSLibraryExample.js
@@ -10,6 +10,7 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import type {NativeComponentType} from '@react-native/oss-library-example';
 
 import RNTesterText from '../../components/RNTesterText';
@@ -126,4 +127,4 @@ exports.examples = [
       );
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/OrientationChange/OrientationChangeExample.js
+++ b/packages/rn-tester/js/examples/OrientationChange/OrientationChangeExample.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 import RNTesterText from '../../components/RNTesterText';
 import React from 'react';
 import {useEffect, useState} from 'react';
@@ -57,4 +59,4 @@ exports.examples = [
       return <OrientationChangeExample />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/PanResponder/PanResponderExample.js
+++ b/packages/rn-tester/js/examples/PanResponder/PanResponderExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 import * as React from 'react';
 import {useMemo, useRef, useState} from 'react';
 import {PanResponder, StyleSheet, View} from 'react-native';
@@ -88,4 +90,4 @@ exports.examples = [
       return <PanResponderExample />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/PermissionsAndroid/PermissionsExample.js
+++ b/packages/rn-tester/js/examples/PermissionsAndroid/PermissionsExample.js
@@ -10,6 +10,7 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import type {Permission} from 'react-native';
 
 import RNTesterButton from '../../components/RNTesterButton';
@@ -158,4 +159,4 @@ exports.examples = [
       'Short example of how to use the runtime permissions API introduced in Android M.',
     render: (): React.Node => <PermissionsExample />,
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/PixelRatio/PixelRatioExample.js
+++ b/packages/rn-tester/js/examples/PixelRatio/PixelRatioExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 import RNTesterText from '../../components/RNTesterText';
 import {RNTesterThemeContext} from '../../components/RNTesterTheme';
 import * as React from 'react';
@@ -209,4 +211,4 @@ exports.examples = [
       return <RoundToNearestPixel />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/PlatformColor/PlatformColorExample.js
+++ b/packages/rn-tester/js/examples/PlatformColor/PlatformColorExample.js
@@ -8,6 +8,7 @@
  * @format
  */
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import type {ColorValue} from 'react-native';
 
 import RNTesterText from '../../components/RNTesterText';
@@ -357,4 +358,4 @@ exports.examples = [
       return <VariantColorsExample />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/PopupMenuAndroid/PopupMenuAndroidExample.js
+++ b/packages/rn-tester/js/examples/PopupMenuAndroid/PopupMenuAndroidExample.js
@@ -10,6 +10,7 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import type {PopupMenuAndroidInstance} from '@react-native/popup-menu-android';
 import type {Node} from 'react';
 
@@ -69,4 +70,4 @@ exports.examples = [
       return <PopupMenu />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/RCTRootView/RCTRootViewIOSExample.js
+++ b/packages/rn-tester/js/examples/RCTRootView/RCTRootViewIOSExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 const React = require('react');
 const {
   StyleSheet,
@@ -95,4 +97,4 @@ exports.examples = [
       return <RootViewSizeFlexibilityExample />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/RTL/RTLExample.js
+++ b/packages/rn-tester/js/examples/RTL/RTLExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 import RNTexterText from '../../components/RNTesterText';
 import React from 'react';
 import {
@@ -830,4 +832,4 @@ exports.examples = [
       return <BorderExample />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/RadialGradient/RadialGradientExample.js
+++ b/packages/rn-tester/js/examples/RadialGradient/RadialGradientExample.js
@@ -10,6 +10,7 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import type {ViewStyleProp} from 'react-native/Libraries/StyleSheet/StyleSheet';
 
 import RNTesterText from '../../components/RNTesterText';
@@ -286,4 +287,4 @@ exports.examples = [
       );
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/RefreshControl/RefreshControlExample.js
+++ b/packages/rn-tester/js/examples/RefreshControl/RefreshControlExample.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 import RNTesterText from '../../components/RNTesterText';
 import React from 'react';
 import {
@@ -154,4 +156,4 @@ exports.examples = [
       return <RefreshControlExample />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/SafeAreaView/SafeAreaViewExample.js
+++ b/packages/rn-tester/js/examples/SafeAreaView/SafeAreaViewExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 import RNTesterText from '../../components/RNTesterText';
 import React from 'react';
 import {useState} from 'react';
@@ -104,4 +106,4 @@ exports.examples = [
         'Use <SafeAreaView> instead.': string),
     render: (): React.Node => <IsIPhoneXExample />,
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/ScrollView/ScrollViewAnimatedExample.js
+++ b/packages/rn-tester/js/examples/ScrollView/ScrollViewAnimatedExample.js
@@ -10,6 +10,7 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import type AnimatedValue from 'react-native/Libraries/Animated/nodes/AnimatedValue';
 
 const React = require('react');
@@ -97,4 +98,4 @@ exports.examples = [
       return <ScrollViewAnimatedExample />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/ScrollView/ScrollViewIndicatorInsetsIOSExample.js
+++ b/packages/rn-tester/js/examples/ScrollView/ScrollViewIndicatorInsetsIOSExample.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 import * as React from 'react';
 import {useState} from 'react';
 import {
@@ -134,4 +136,4 @@ exports.examples = [
     title: '<ScrollView> automaticallyAdjustsScrollIndicatorInsets Example',
     render: (): React.Node => <ScrollViewIndicatorInsetsExample />,
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/ScrollView/ScrollViewKeyboardInsetsIOSExample.js
+++ b/packages/rn-tester/js/examples/ScrollView/ScrollViewKeyboardInsetsIOSExample.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 import * as React from 'react';
 import {useState} from 'react';
 import {
@@ -185,4 +187,4 @@ exports.examples = [
     title: '<ScrollView> automaticallyAdjustKeyboardInsets Example',
     render: (): React.Node => <ScrollViewKeyboardInsetsExample />,
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/ScrollView/ScrollViewSimpleExample.js
+++ b/packages/rn-tester/js/examples/ScrollView/ScrollViewSimpleExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 const React = require('react');
 const {
   ScrollView,
@@ -141,4 +143,4 @@ exports.examples = [
       return <ScrollViewSimpleExample />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/SectionList/SectionListIndex.js
+++ b/packages/rn-tester/js/examples/SectionList/SectionListIndex.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 import ContentInset from './SectionList-contentInset';
 import inverted from './SectionList-inverted';
 import onEndReached from './SectionList-onEndReached';
@@ -43,4 +45,4 @@ exports.examples = [
   onViewableItemsChanged_horizontal_waitForInteraction,
   onViewableItemsChanged_horizontal_offScreen_noWaitForInteraction,
   onViewableItemsChanged_offScreen_noWaitForInteraction,
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/Share/ShareExample.js
+++ b/packages/rn-tester/js/examples/Share/ShareExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 import RNTesterText from '../../components/RNTesterText';
 import React from 'react';
 import {useState} from 'react';
@@ -156,4 +158,4 @@ exports.examples = [
       return <SharedAction />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/Snapshot/SnapshotExample.js
+++ b/packages/rn-tester/js/examples/Snapshot/SnapshotExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 const ScreenshotManager = require('../../../NativeModuleExample/NativeScreenshotManager');
 const {RNTesterThemeContext} = require('../../components/RNTesterTheme');
 const React = require('react');
@@ -71,4 +73,4 @@ exports.examples = [
       return <ScreenshotExample />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/SwipeableCardExample/SwipeableCardExample.js
+++ b/packages/rn-tester/js/examples/SwipeableCardExample/SwipeableCardExample.js
@@ -8,6 +8,7 @@
  * @format
  */
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import type {ListRenderItemInfo} from 'react-native';
 
 import * as React from 'react';
@@ -39,7 +40,7 @@ module.exports = {
         return <SwipeableCardExample />;
       },
     },
-  ],
+  ] as Array<RNTesterModuleExample>,
 };
 
 function SwipeableCardExample() {

--- a/packages/rn-tester/js/examples/Switch/SwitchExample.js
+++ b/packages/rn-tester/js/examples/Switch/SwitchExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 import RNTesterText from '../../components/RNTesterText';
 import React from 'react';
 import {Platform, Switch, View} from 'react-native';
@@ -318,11 +320,9 @@ exports.examples = [
       return <ContainerBackgroundColorStyleExample />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;
 
 if (Platform.OS === 'ios') {
-  /* $FlowFixMe[incompatible-call] error found during natural inference roll-
-   * out. See https://fburl.com/workplace/tc9m3tcf */
   exports.examples.push({
     title: '[iOS Only] Custom background colors can be set',
     render(): React.MixedElement {

--- a/packages/rn-tester/js/examples/TextInput/TextInputKeyProp.js
+++ b/packages/rn-tester/js/examples/TextInput/TextInputKeyProp.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 import React, {useEffect, useState} from 'react';
 import {TextInput, View} from 'react-native';
 
@@ -48,4 +50,4 @@ exports.examples = [
       return <TextInputKeyProp />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/Timer/TimerExample.js
+++ b/packages/rn-tester/js/examples/Timer/TimerExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 import RNTesterButton from '../../components/RNTesterButton';
 import RNTesterText from '../../components/RNTesterText';
 import React from 'react';
@@ -376,4 +378,4 @@ exports.examples = [
       return <IntervalExample />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/ToastAndroid/ToastAndroidExample.js
+++ b/packages/rn-tester/js/examples/ToastAndroid/ToastAndroidExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 import RNTesterText from '../../components/RNTesterText';
 import React from 'react';
 import {Pressable, StyleSheet, ToastAndroid} from 'react-native';
@@ -166,4 +168,4 @@ exports.examples = [
       return <ToastWithYOffset />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/Transform/TransformExample.js
+++ b/packages/rn-tester/js/examples/Transform/TransformExample.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 import * as React from 'react';
 import {useEffect, useRef, useState} from 'react';
 import {Animated, Easing, StyleSheet, Text, View} from 'react-native';
@@ -412,4 +414,4 @@ exports.examples = [
       return <TranslatePercentage />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/TransparentHitTest/TransparentHitTestExample.js
+++ b/packages/rn-tester/js/examples/TransparentHitTest/TransparentHitTestExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 const React = require('react');
 const {Alert, Text, TouchableOpacity, View} = require('react-native');
 
@@ -48,4 +50,4 @@ exports.examples = [
       return <TransparentHitTestExample />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/TurboModule/LegacyModuleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/LegacyModuleExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 const {
   default: SampleLegacyModuleExample,
 } = require('./SampleLegacyModuleExample');
@@ -27,4 +29,4 @@ exports.examples = [
       return <SampleLegacyModuleExample />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/TurboModule/TurboCxxModuleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/TurboCxxModuleExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 const NativeCxxModuleExampleExample = require('./NativeCxxModuleExampleExample');
 const React = require('react');
 
@@ -24,4 +26,4 @@ exports.examples = [
       return <NativeCxxModuleExampleExample />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/TurboModule/TurboModuleExample.js
+++ b/packages/rn-tester/js/examples/TurboModule/TurboModuleExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 const SampleTurboModuleExample = require('./SampleTurboModuleExample');
 const React = require('react');
 
@@ -24,4 +26,4 @@ exports.examples = [
       return <SampleTurboModuleExample />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/Vibration/VibrationExample.js
+++ b/packages/rn-tester/js/examples/Vibration/VibrationExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 import RNTesterText from '../../components/RNTesterText';
 import React from 'react';
 import {
@@ -116,7 +118,7 @@ exports.examples = [
       );
     },
   },
-];
+] as Array<RNTesterModuleExample>;
 
 const styles = StyleSheet.create({
   wrapper: {

--- a/packages/rn-tester/js/examples/WebSocket/WebSocketExample.js
+++ b/packages/rn-tester/js/examples/WebSocket/WebSocketExample.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 import RNTesterText from '../../components/RNTesterText';
 import React from 'react';
 import {
@@ -380,4 +382,4 @@ exports.examples = [
       return <WebSocketExample />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/XHR/XHRExample.js
+++ b/packages/rn-tester/js/examples/XHR/XHRExample.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
 const XHRExampleAbortController = require('./XHRExampleAbortController');
 const XHRExampleBinaryUpload = require('./XHRExampleBinaryUpload');
 const XHRExampleDownload = require('./XHRExampleDownload');
@@ -60,4 +62,4 @@ exports.examples = [
       return <XHRExampleAbortController />;
     },
   },
-];
+] as Array<RNTesterModuleExample>;


### PR DESCRIPTION
Summary:
Unannotated array literals are unsound in Flow right now. This diff adds in annotations and makes a few things readonly, to reduce future errors.

Changelog: [Internal]

Reviewed By: marcoww6

Differential Revision: D78519638
