### PR TITLE
Address lint warnings

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/ExecutionContext.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/ExecutionContext.h
@@ -9,7 +9,6 @@
 
 #include "UniqueMonostate.h"
 
-#include <cinttypes>
 #include <optional>
 #include <string>
 #include <unordered_set>
@@ -19,7 +18,7 @@ namespace facebook::react::jsinspector_modern {
 
 struct ExecutionContextDescription {
   int32_t id{};
-  std::string origin{""};
+  std::string origin;
   std::string name{"<anonymous>"};
   std::optional<std::string> uniqueId;
 };

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
@@ -36,8 +36,8 @@ namespace facebook::react::jsinspector_modern {
 class HostAgent::Impl final {
  public:
   explicit Impl(
-      HostAgent& hostAgent,
-      FrontendChannel frontendChannel,
+      HostAgent& /*hostAgent*/,
+      const FrontendChannel& frontendChannel,
       HostTargetController& targetController,
       HostTargetMetadata hostMetadata,
       SessionState& sessionState,
@@ -126,11 +126,11 @@ class HostAgent::Impl final {
     else if (req.method == "Page.reload") {
       targetController_.getDelegate().onReload({
           .ignoreCache =
-              req.params.isObject() && req.params.count("ignoreCache")
+              req.params.isObject() && (req.params.count("ignoreCache") != 0u)
               ? std::optional(req.params.at("ignoreCache").asBool())
               : std::nullopt,
           .scriptToEvaluateOnLoad = req.params.isObject() &&
-                  req.params.count("scriptToEvaluateOnLoad")
+                  (req.params.count("scriptToEvaluateOnLoad") != 0u)
               ? std::optional(
                     req.params.at("scriptToEvaluateOnLoad").asString())
               : std::nullopt,
@@ -139,7 +139,8 @@ class HostAgent::Impl final {
       shouldSendOKResponse = true;
       isFinishedHandlingRequest = true;
     } else if (req.method == "Overlay.setPausedInDebuggerMessage") {
-      auto message = req.params.isObject() && req.params.count("message")
+      auto message =
+          req.params.isObject() && (req.params.count("message") != 0u)
           ? std::optional(req.params.at("message").asString())
           : std::nullopt;
       if (!isPausedInDebuggerOverlayVisible_ && message.has_value()) {

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
@@ -45,13 +45,13 @@ class HostTargetSession {
             targetController,
             std::move(hostMetadata),
             state_,
-            executor) {}
+            std::move(executor)) {}
 
   /**
    * Called by CallbackLocalConnection to send a message to this Session's
    * Agent.
    */
-  void operator()(std::string message) {
+  void operator()(const std::string& message) {
     cdp::PreparsedRequest request;
     // Messages may be invalid JSON, or have unexpected types.
     try {
@@ -91,7 +91,7 @@ class HostTargetSession {
    * there's no current instance.
    */
   void setCurrentInstance(InstanceTarget* instance) {
-    if (instance) {
+    if (instance != nullptr) {
       hostAgent_.setCurrentInstanceAgent(
           instance->createAgent(frontendChannel_, state_));
     } else {
@@ -148,7 +148,7 @@ std::shared_ptr<HostTarget> HostTarget::create(
     HostTargetDelegate& delegate,
     VoidExecutor executor) {
   std::shared_ptr<HostTarget> hostTarget{new HostTarget(delegate)};
-  hostTarget->setExecutor(executor);
+  hostTarget->setExecutor(std::move(executor));
   return hostTarget;
 }
 
@@ -166,7 +166,7 @@ std::unique_ptr<ILocalConnection> HostTarget::connect(
   session->setCurrentInstance(currentInstance_.get());
   sessions_.insert(std::weak_ptr(session));
   return std::make_unique<CallbackLocalConnection>(
-      [session](std::string message) { (*session)(message); });
+      [session](const std::string& message) { (*session)(message); });
 }
 
 HostTarget::~HostTarget() {
@@ -228,10 +228,7 @@ void HostTargetController::incrementPauseOverlayCounter() {
 
 bool HostTargetController::decrementPauseOverlayCounter() {
   assert(pauseOverlayCounter_ > 0 && "Pause overlay counter underflow");
-  if (--pauseOverlayCounter_ == 0) {
-    return false;
-  }
-  return true;
+  return --pauseOverlayCounter_ != 0;
 }
 
 namespace {

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorInterfaces.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorInterfaces.h
@@ -39,7 +39,7 @@ struct InspectorTargetCapabilities {
   bool prefersFuseboxFrontend = false;
 };
 
-const folly::dynamic targetCapabilitiesToDynamic(
+folly::dynamic targetCapabilitiesToDynamic(
     const InspectorTargetCapabilities& capabilities);
 
 struct InspectorPageDescription {

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.cpp
@@ -16,7 +16,7 @@ InstanceAgent::InstanceAgent(
     FrontendChannel frontendChannel,
     InstanceTarget& target,
     SessionState& sessionState)
-    : frontendChannel_(frontendChannel),
+    : frontendChannel_(std::move(frontendChannel)),
       target_(target),
       sessionState_(sessionState) {
   (void)target_;
@@ -36,7 +36,7 @@ bool InstanceAgent::handleRequest(const cdp::PreparsedRequest& req) {
 
 void InstanceAgent::setCurrentRuntime(RuntimeTarget* runtimeTarget) {
   auto previousRuntimeAgent = std::move(runtimeAgent_);
-  if (runtimeTarget) {
+  if (runtimeTarget != nullptr) {
     runtimeAgent_ = runtimeTarget->createAgent(frontendChannel_, sessionState_);
   } else {
     runtimeAgent_.reset();

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.cpp
@@ -18,7 +18,7 @@ std::shared_ptr<InstanceTarget> InstanceTarget::create(
     VoidExecutor executor) {
   std::shared_ptr<InstanceTarget> instanceTarget{
       new InstanceTarget(executionContextManager, delegate)};
-  instanceTarget->setExecutor(executor);
+  instanceTarget->setExecutor(std::move(executor));
   return instanceTarget;
 }
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.h
@@ -16,9 +16,7 @@
 #include <jsinspector-modern/InspectorInterfaces.h>
 #include <jsinspector-modern/RuntimeAgent.h>
 
-#include <list>
 #include <memory>
-#include <optional>
 
 namespace facebook::react::jsinspector_modern {
 


### PR DESCRIPTION
Summary:
Quick pass over some of the main files in `jsinspector-modern` now that C++ lint warnings have become more prevalent / auto-fixable.

Changelog: [Internal]

Differential Revision: D78490415


