### PR TITLE
Rollout `preventShadowTreeCommitExhaustionWithLocking` in experimental

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Experimental_Android.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Experimental_Android.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c8b19934d19d6b4514a0395edecb1330>>
+ * @generated SignedSource<<93aab733661b558c1701b728c18b3d00>>
  */
 
 /**
@@ -23,5 +23,5 @@ public open class ReactNativeFeatureFlagsOverrides_RNOSS_Experimental_Android : 
   // We could use JNI to get the defaults from C++,
   // but that is more expensive than just duplicating the defaults here.
 
-
+  override fun preventShadowTreeCommitExhaustionWithLocking(): Boolean = true
 }

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSExperimental.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSExperimental.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<1de02178e1be302bb4b19501950b260a>>
+ * @generated SignedSource<<16c5fdf431579bbfd454a28c06f28c41>>
  */
 
 /**
@@ -27,7 +27,9 @@ class ReactNativeFeatureFlagsOverridesOSSExperimental : public ReactNativeFeatur
  public:
     ReactNativeFeatureFlagsOverridesOSSExperimental() = default;
 
-
+  bool preventShadowTreeCommitExhaustionWithLocking() override {
+    return true;
+  }
 };
 
 } // namespace facebook::react

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -545,7 +545,7 @@ const definitions: FeatureFlagDefinitions = {
         expectedReleaseValue: true,
         purpose: 'experimentation',
       },
-      ossReleaseStage: 'none',
+      ossReleaseStage: 'experimental',
     },
     releaseImageDataWhenConsumed: {
       defaultValue: false,


### PR DESCRIPTION
Summary:
We want to make user for folks in OSS to try
`preventShadowTreeCommitExhaustionWithLocking`. Therefore I'm updating the OSS
release channel for this flag to experimental.

Changelog:
[Internal] [Changed] - Rollout `preventShadowTreeCommitExhaustionWithLocking` in experimental

Differential Revision: D78558655


