### PR TITLE
Make it explicit to specify HttpClientFactoryKey and WebSocketClientFactoryKey values

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/http/IWebSocketClient.h
+++ b/packages/react-native/ReactCxxPlatform/react/http/IWebSocketClient.h
@@ -10,7 +10,6 @@
 #include <functional>
 #include <memory>
 #include <string>
-#include <utility>
 
 namespace facebook::react {
 

--- a/packages/react-native/ReactCxxPlatform/react/runtime/ReactHost.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/runtime/ReactHost.cpp
@@ -79,7 +79,7 @@ ReactHost::ReactHost(
     std::shared_ptr<SurfaceDelegate> logBoxSurfaceDelegate,
     std::shared_ptr<NativeAnimatedNodesManagerProvider>
         animatedNodesManagerProvider,
-    ReactInstance::BindingsInstallFunc bindingsInstallFunc) noexcept
+    ReactInstance::BindingsInstallFunc bindingsInstallFunc)
     : reactInstanceConfig_(std::move(reactInstanceConfig)) {
   auto componentRegistryFactory =
       mountingManager->getComponentRegistryFactory();
@@ -107,14 +107,12 @@ ReactHost::ReactHost(
   if (!reactInstanceData_->contextContainer
            ->find<HttpClientFactory>(HttpClientFactoryKey)
            .has_value()) {
-    reactInstanceData_->contextContainer->insert(
-        HttpClientFactoryKey, getHttpClientFactory());
+    throw std::runtime_error("No HttpClientFactory provided");
   }
   if (!reactInstanceData_->contextContainer
            ->find<WebSocketClientFactory>(WebSocketClientFactoryKey)
            .has_value()) {
-    reactInstanceData_->contextContainer->insert(
-        WebSocketClientFactoryKey, getWebSocketClientFactory());
+    throw std::runtime_error("No WebSocketClientFactory provided");
   }
   createReactInstance();
 }

--- a/packages/react-native/ReactCxxPlatform/react/runtime/ReactHost.h
+++ b/packages/react-native/ReactCxxPlatform/react/runtime/ReactHost.h
@@ -52,8 +52,7 @@ class ReactHost {
       std::shared_ptr<SurfaceDelegate> logBoxSurfaceDelegate = nullptr,
       std::shared_ptr<NativeAnimatedNodesManagerProvider>
           animatedNodesManagerProvider = nullptr,
-      ReactInstance::BindingsInstallFunc bindingsInstallFunc =
-          nullptr) noexcept;
+      ReactInstance::BindingsInstallFunc bindingsInstallFunc = nullptr);
   ReactHost(const ReactHost&) = delete;
   ReactHost& operator=(const ReactHost&) = delete;
   ReactHost(ReactHost&&) noexcept = delete;

--- a/private/react-native-fantom/tester/src/TesterAppDelegate.cpp
+++ b/private/react-native-fantom/tester/src/TesterAppDelegate.cpp
@@ -6,7 +6,12 @@
  */
 
 #include "TesterAppDelegate.h"
+#include "NativeFantom.h"
 #include "platform/TesterTurboModuleManagerDelegate.h"
+#include "stubs/StubClock.h"
+#include "stubs/StubHttpClient.h"
+#include "stubs/StubQueue.h"
+#include "stubs/StubWebSocketClient.h"
 
 #include <folly/dynamic.h>
 #include <folly/json.h>
@@ -25,10 +30,6 @@
 #include <react/utils/RunLoopObserverManager.h>
 #include <iostream>
 #include <vector>
-
-#include "NativeFantom.h"
-#include "stubs/StubClock.h"
-#include "stubs/StubQueue.h"
 
 namespace facebook::react {
 
@@ -75,6 +76,9 @@ TesterAppDelegate::TesterAppDelegate(
         queue_ = queue;
         return queue;
       }));
+  contextContainer->insert(HttpClientFactoryKey, getHttpClientFactory());
+  contextContainer->insert(
+      WebSocketClientFactoryKey, getWebSocketClientFactory());
 
   runLoopObserverManager_ = std::make_shared<RunLoopObserverManager>();
 


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Right now we rely on compile / link time magic to detect the implementation of
```
WebSocketClientFactory getWebSocketClientFactory();
HttpClientFactory getHttpClientFactory();
```
this actually works until it does not work anymore, see .e.g.:
```
ld.lld: error: undefined symbol: facebook::react::getHttpClientFactory()
>>> referenced by ReactHost.cpp:111 (xplat/js/react-native-github/packages/react-native/ReactCxxPlatform/react/runtime/ReactHost.cpp:111)
>>>               xplat/js/react-native-github/packages/react-native/ReactCxxPlatform/react/runtime/__runtimeAndroid__/__objects__/ReactHost.cpp.pic.o:(facebook::react::ReactHost::ReactHost(facebook::react::ReactInstanceConfig, std::__ndk1::shared_ptr<facebook::react::IMountingManager>, std::__ndk1::shared_ptr<facebook::react::RunLoopObserverManager>, std::__ndk1::shared_ptr<facebook::react::ContextContainer const>, std::__ndk1::function<void (facebook::jsi::Runtime&, facebook::react::JsErrorHandler::ProcessedError const&)>, std::__ndk1::function<void (std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&, unsigned int)>, std::__ndk1::shared_ptr<facebook::react::IDevUIDelegate>, std::__ndk1::vector<std::__ndk1::function<std::__ndk1::shared_ptr<facebook::react::TurboModule> (std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&, std::__ndk1::shared_ptr<facebook::react::CallInvoker> const&)>, std::__ndk1::allocator<std::__ndk1::function<std::__ndk1::shared_ptr<facebook::react::TurboModule> (std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&, std::__ndk1::shared_ptr<facebook::react::CallInvoker> const&)>>>, std::__ndk1::shared_ptr<facebook::react::SurfaceDelegate>, std::__ndk1::shared_ptr<facebook::react::NativeAnimatedNodesManagerProvider>, std::__ndk1::function<void (facebook::jsi::Runtime&)>))

ld.lld: error: undefined symbol: facebook::react::getWebSocketClientFactory()
>>> referenced by ReactHost.cpp:117 (xplat/js/react-native-github/packages/react-native/ReactCxxPlatform/react/runtime/ReactHost.cpp:117)
>>>               xplat/js/react-native-github/packages/react-native/ReactCxxPlatform/react/runtime/__runtimeAndroid__/__objects__/ReactHost.cpp.pic.o:(facebook::react::ReactHost::ReactHost(facebook::react::ReactInstanceConfig, std::__ndk1::shared_ptr<facebook::react::IMountingManager>, std::__ndk1::shared_ptr<facebook::react::RunLoopObserverManager>, std::__ndk1::shared_ptr<facebook::react::ContextContainer const>, std::__ndk1::function<void (facebook::jsi::Runtime&, facebook::react::JsErrorHandler::ProcessedError const&)>, std::__ndk1::function<void (std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&, unsigned int)>, std::__ndk1::shared_ptr<facebook::react::IDevUIDelegate>, std::__ndk1::vector<std::__ndk1::function<std::__ndk1::shared_ptr<facebook::react::TurboModule> (std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&, std::__ndk1::shared_ptr<facebook::react::CallInvoker> const&)>, std::__ndk1::allocator<std::__ndk1::function<std::__ndk1::shared_ptr<facebook::react::TurboModule> (std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char>> const&, std::__ndk1::shared_ptr<facebook::react::CallInvoker> const&)>>>, std::__ndk1::shared_ptr<facebook::react::SurfaceDelegate>, std::__ndk1::shared_ptr<facebook::react::NativeAnimatedNodesManagerProvider>, std::__ndk1::function<void (facebook::jsi::Runtime&)>))
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
The change here makes it explicit and mandatory to set the specific implementations of these interfaces

Differential Revision: D78529932


