### PR TITLE
Deprecate ReactPackageLogger

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/CoreModulesPackage.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/CoreModulesPackage.kt
@@ -55,6 +55,7 @@ import com.facebook.systrace.Systrace
             TimingModule::class,
             UIManagerModule::class])
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
+@Suppress("DEPRECATION")
 internal class CoreModulesPackage(
     private val reactInstanceManager: ReactInstanceManager,
     private val hardwareBackBtnHandler: DefaultHardwareBackBtnHandler,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageLogger.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageLogger.kt
@@ -11,6 +11,7 @@ import com.facebook.react.common.annotations.internal.LegacyArchitecture
 import com.facebook.react.common.annotations.internal.LegacyArchitectureLogLevel
 
 /** Interface for the bridge to call for TTI start and end markers. */
+@Deprecated("This class is deprecated and will be removed in the next major release.")
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
 internal interface ReactPackageLogger {
   fun startProcessPackage(): Unit


### PR DESCRIPTION
Summary:
ReactPackageLogger is not supported in the new architecture

changelog: [Android][Changed] ReactPackageLogger is not supported in the new architecture and being deprecated

Differential Revision: D78501563


