### PR TITLE
Use `allVariants()` when publishing ReactAndroid

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -599,7 +599,7 @@ android {
   publishing {
     multipleVariants {
       withSourcesJar()
-      includeBuildTypeValues("debug", "release", "debugOptimized")
+      allVariants()
     }
   }
 


### PR DESCRIPTION
Summary:
This is really a nit. We don't need to list all the variants here,
we can instead use `allVariants()` which we also use for hermes-engine,
to publish every buildVariant from React Android.

Changelog:
[Internal] [Changed] -

Reviewed By: alanleedev

Differential Revision: D78561729


