### PR TITLE
Fix ktfmt symbolic links issues

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -157,4 +157,11 @@ allprojects {
           com.ncorti.ktfmt.gradle.tasks.KtfmtCheckTask::class,
           com.ncorti.ktfmt.gradle.tasks.KtfmtFormatTask::class)
       .forEach { tasks.withType(it) { exclude(excludePatterns) } }
+
+  // Disable the problematic ktfmt script tasks due to symbolic link issues in subprojects
+  afterEvaluate {
+    listOf("ktfmtCheckScripts", "ktfmtFormatScripts").forEach {
+      tasks.findByName(it)?.enabled = false
+    }
+  }
 }


### PR DESCRIPTION
## Summary:

There are symbolic link issues with ktfmt after building the rn-tester. Putting back this patch to address that issue.

## Changelog:

[INTERNAL] - Fix ktfmt symbolic links issues

## Test Plan:

1. Build the rn-tester:

```sh
yarn android
```

2. Unformat a file manually and then:

```sh
yarn lint-kotlin-check
yarn lint-kotlin
```