### PR TITLE
Fix modal crash on create with initial props

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
@@ -256,8 +256,13 @@ public class ReactModalHostView(context: ThemedReactContext) :
     if (createNewDialog) {
       dismiss()
     } else {
-      updateProperties()
-      return
+      // With Props 2.0 the view creation could include initial props. This means the dialog might
+      // still have to be created before the properties can be set. We only update properties if the
+      // dialog was already initialized.
+      dialog?.let {
+        updateProperties()
+        return
+      }
     }
 
     // Reset the flag since we are going to create a new dialog


### PR DESCRIPTION
Summary:
The Modal view creation contains initial properties when using Props 2.0. This diff adds support for Modal view creations having initial properties by allowing the `updateProperties` fast path only if the dialog is already initialized.

Without the change, the fast path gets called before the dialog could be initialized which leads to throwing an exception when the dialog is being checked to see if it is initialized.

Changelog: [Internal]

Differential Revision: D78638902


