### PR TITLE
Revert "Fix Dimensions window values on Android < 15 (#52481)"

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -621,7 +621,6 @@ dependencies {
   api(libs.androidx.autofill)
   api(libs.androidx.swiperefreshlayout)
   api(libs.androidx.tracing)
-  api(libs.androidx.window)
 
   api(libs.fbjni)
   api(libs.fresco)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -869,7 +869,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
     private int mDeviceRotation = 0;
 
     /* package */ CustomGlobalLayoutListener() {
-      DisplayMetricsHolder.initDisplayMetricsIfNotInitialized(getContext());
+      DisplayMetricsHolder.initDisplayMetricsIfNotInitialized(getContext().getApplicationContext());
       mVisibleViewArea = new Rect();
       mMinKeyboardHeightDetected = (int) PixelUtil.toPixelFromDIP(60);
     }
@@ -992,7 +992,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
         return;
       }
       mDeviceRotation = rotation;
-      DisplayMetricsHolder.initDisplayMetrics(getContext());
+      DisplayMetricsHolder.initDisplayMetrics(getContext().getApplicationContext());
       emitOrientationChanged(rotation);
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/DisplayMetricsHolder.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/DisplayMetricsHolder.kt
@@ -13,10 +13,8 @@ import android.util.DisplayMetrics
 import android.view.WindowManager
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
-import androidx.window.layout.WindowMetricsCalculator
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.WritableNativeMap
-import com.facebook.react.views.view.isEdgeToEdgeFeatureFlagOn
 
 /**
  * Holds an instance of the current DisplayMetrics so we don't have to thread it through all the
@@ -64,19 +62,9 @@ public object DisplayMetricsHolder {
   @JvmStatic
   public fun initDisplayMetrics(context: Context) {
     val displayMetrics = context.resources.displayMetrics
-    val windowDisplayMetrics = DisplayMetrics()
+    windowDisplayMetrics = displayMetrics
     val screenDisplayMetrics = DisplayMetrics()
-
-    windowDisplayMetrics.setTo(displayMetrics)
     screenDisplayMetrics.setTo(displayMetrics)
-
-    if (isEdgeToEdgeFeatureFlagOn) {
-      WindowMetricsCalculator.getOrCreate().computeCurrentWindowMetrics(context).let {
-        windowDisplayMetrics.widthPixels = it.bounds.width()
-        windowDisplayMetrics.heightPixels = it.bounds.height()
-      }
-    }
-
     val wm = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
     // Get the real display metrics if we are using API level 17 or higher.
     // The real metrics include system decor elements (e.g. soft menu bar).
@@ -84,8 +72,6 @@ public object DisplayMetricsHolder {
     // See:
     // http://developer.android.com/reference/android/view/Display.html#getRealMetrics(android.util.DisplayMetrics)
     @Suppress("DEPRECATION") wm.defaultDisplay.getRealMetrics(screenDisplayMetrics)
-
-    DisplayMetricsHolder.windowDisplayMetrics = windowDisplayMetrics
     DisplayMetricsHolder.screenDisplayMetrics = screenDisplayMetrics
   }
 

--- a/packages/react-native/gradle/libs.versions.toml
+++ b/packages/react-native/gradle/libs.versions.toml
@@ -16,7 +16,6 @@ androidx-swiperefreshlayout = "1.1.0"
 androidx-test = "1.5.0"
 androidx-test-junit = "1.2.1"
 androidx-tracing = "1.1.0"
-androidx-window = "1.4.0"
 assertj = "3.21.0"
 binary-compatibility-validator = "0.13.2"
 download = "5.4.0"
@@ -65,7 +64,6 @@ androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidx-
 androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidx-test" }
 androidx-tracing = { module = "androidx.tracing:tracing", version.ref = "androidx-tracing" }
 androidx-uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "uiautomator" }
-androidx-window = { module = "androidx.window:window", version.ref = "androidx-window" }
 
 fbjni = { module = "com.facebook.fbjni:fbjni", version.ref = "fbjni" }
 fresco = { module = "com.facebook.fresco:fresco", version.ref = "fresco" }


### PR DESCRIPTION
## Summary:

Commit 86994a6e22415dbb5c5348c3cede1f9942a894ea breaks Android for API level 24. Since it has landed last week, we had CI red. reverting this change while we found a valid fix forward.

## Changelog:
[Android][Changed] - Reverted fix `Dimensions` `window` values on Android < 15 when edge-to-edge is enabled

## Test Plan:
GHA is green.:
https://github.com/facebook/react-native/actions/runs/16414048087/job/46377878366?pr=52732
https://github.com/facebook/react-native/actions/runs/16414048087/job/46377878383?pr=52732