### PR TITLE
Add method for collecting all events in a single container

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
@@ -111,6 +111,36 @@ void PerformanceTracer::collectEvents(
   }
 }
 
+folly::dynamic PerformanceTracer::collectEvents(uint16_t chunkSize) {
+  std::vector<TraceEvent> localBuffer;
+  {
+    std::lock_guard lock(mutex_);
+    buffer_.swap(localBuffer);
+  }
+
+  auto chunks = folly::dynamic::array();
+  if (localBuffer.empty()) {
+    return chunks;
+  }
+
+  auto chunk = folly::dynamic::array();
+  chunk.reserve(chunkSize);
+  for (auto&& event : localBuffer) {
+    chunk.push_back(serializeTraceEvent(std::move(event)));
+
+    if (chunk.size() == chunkSize) {
+      chunks.push_back(std::move(chunk));
+      chunk = folly::dynamic::array();
+      chunk.reserve(chunkSize);
+    }
+  }
+
+  if (!chunk.empty()) {
+    chunks.push_back(std::move(chunk));
+  }
+  return chunks;
+}
+
 void PerformanceTracer::reportMark(
     const std::string_view& name,
     HighResTimeStamp start,

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -61,6 +61,12 @@ class PerformanceTracer {
       uint16_t chunkSize);
 
   /**
+   * Flush out buffered CDP Trace Events into a folly::dynamic collection of
+   * chunks, which can be sent over CDP later.
+   */
+  folly::dynamic collectEvents(uint16_t chunkSize);
+
+  /**
    * Record a `Performance.mark()` event - a labelled timestamp. If not
    * currently tracing, this is a no-op.
    *


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

We are going to need it at the top of the stack, once we will capture the Trace Events as part of the Tracing Profile for the whole Host.

This is also would be used for always-on tracing.

Differential Revision: D78660071


