### PR TITLE
Fix Dimensions window values on Android < 15

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3360,7 +3360,6 @@ public final class com/facebook/react/uimanager/DisplayMetricsHolder {
 	public static final fun getScreenDisplayMetrics ()Landroid/util/DisplayMetrics;
 	public static final fun getWindowDisplayMetrics ()Landroid/util/DisplayMetrics;
 	public static final fun initDisplayMetrics (Landroid/content/Context;)V
-	public static final fun initDisplayMetricsIfNotInitialized (Landroid/content/Context;)V
 	public static final fun setScreenDisplayMetrics (Landroid/util/DisplayMetrics;)V
 	public static final fun setWindowDisplayMetrics (Landroid/util/DisplayMetrics;)V
 }

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3359,7 +3359,10 @@ public final class com/facebook/react/uimanager/DisplayMetricsHolder {
 	public static final fun getDisplayMetricsWritableMap (D)Lcom/facebook/react/bridge/WritableMap;
 	public static final fun getScreenDisplayMetrics ()Landroid/util/DisplayMetrics;
 	public static final fun getWindowDisplayMetrics ()Landroid/util/DisplayMetrics;
-	public static final fun initDisplayMetrics (Landroid/content/Context;)V
+	public static final fun initScreenDisplayMetrics (Landroid/content/Context;)V
+	public static final fun initWindowDisplayMetrics (Landroid/content/Context;)V
+	public static final fun initScreenDisplayMetricsIfNotInitialized (Landroid/content/Context;)V
+	public static final fun initWindowDisplayMetricsIfNotInitialized (Landroid/content/Context;)V
 	public static final fun setScreenDisplayMetrics (Landroid/util/DisplayMetrics;)V
 	public static final fun setWindowDisplayMetrics (Landroid/util/DisplayMetrics;)V
 }

--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -630,6 +630,7 @@ dependencies {
   api(libs.androidx.autofill)
   api(libs.androidx.swiperefreshlayout)
   api(libs.androidx.tracing)
+  api(libs.androidx.window)
 
   api(libs.fbjni)
   api(libs.fresco)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -259,7 +259,7 @@ public class ReactInstanceManager {
     FLog.d(TAG, "ReactInstanceManager.ctor()");
     initializeSoLoaderIfNecessary(applicationContext);
 
-    DisplayMetricsHolder.initDisplayMetricsIfNotInitialized(currentActivity);
+    DisplayMetricsHolder.initDisplayMetrics(applicationContext);
 
     // See {@code ReactInstanceManagerBuilder} for description of all flags here.
     mApplicationContext = applicationContext;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -259,7 +259,7 @@ public class ReactInstanceManager {
     FLog.d(TAG, "ReactInstanceManager.ctor()");
     initializeSoLoaderIfNecessary(applicationContext);
 
-    DisplayMetricsHolder.initDisplayMetricsIfNotInitialized(applicationContext);
+    DisplayMetricsHolder.initDisplayMetricsIfNotInitialized(currentActivity);
 
     // See {@code ReactInstanceManagerBuilder} for description of all flags here.
     mApplicationContext = applicationContext;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -259,7 +259,11 @@ public class ReactInstanceManager {
     FLog.d(TAG, "ReactInstanceManager.ctor()");
     initializeSoLoaderIfNecessary(applicationContext);
 
-    DisplayMetricsHolder.initDisplayMetrics(applicationContext);
+    DisplayMetricsHolder.initScreenDisplayMetricsIfNotInitialized(applicationContext);
+
+    if (currentActivity != null) {
+      DisplayMetricsHolder.initWindowDisplayMetricsIfNotInitialized(currentActivity);
+    }
 
     // See {@code ReactInstanceManagerBuilder} for description of all flags here.
     mApplicationContext = applicationContext;
@@ -924,6 +928,13 @@ public class ReactInstanceManager {
 
     ReactContext currentReactContext = getCurrentReactContext();
     if (currentReactContext != null) {
+      DisplayMetricsHolder.initScreenDisplayMetrics(currentReactContext);
+      Activity currentActivity = currentReactContext.getCurrentActivity();
+
+      if (currentActivity != null) {
+        DisplayMetricsHolder.initWindowDisplayMetrics(currentActivity);
+      }
+
       AppearanceModule appearanceModule =
           currentReactContext.getNativeModule(AppearanceModule.class);
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -137,7 +137,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
     setClipChildren(false);
 
     if (ReactNativeFeatureFlags.enableFontScaleChangesUpdatingLayout()) {
-      DisplayMetricsHolder.initDisplayMetrics(getContext().getApplicationContext());
+      DisplayMetricsHolder.initDisplayMetrics(getCurrentReactContext());
     }
   }
 
@@ -878,7 +878,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
     private int mDeviceRotation = 0;
 
     /* package */ CustomGlobalLayoutListener() {
-      DisplayMetricsHolder.initDisplayMetricsIfNotInitialized(getContext().getApplicationContext());
+      DisplayMetricsHolder.initDisplayMetricsIfNotInitialized(getCurrentReactContext());
       mVisibleViewArea = new Rect();
       mMinKeyboardHeightDetected = (int) PixelUtil.toPixelFromDIP(60);
     }
@@ -1001,7 +1001,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
         return;
       }
       mDeviceRotation = rotation;
-      DisplayMetricsHolder.initDisplayMetrics(getContext().getApplicationContext());
+      DisplayMetricsHolder.initDisplayMetrics(getCurrentReactContext());
       emitOrientationChanged(rotation);
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -136,9 +136,8 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
     setRootViewTag(ReactRootViewTagGenerator.getNextRootViewTag());
     setClipChildren(false);
 
-    if (ReactNativeFeatureFlags.enableFontScaleChangesUpdatingLayout()) {
-      DisplayMetricsHolder.initDisplayMetrics(getContext());
-    }
+    DisplayMetricsHolder.initScreenDisplayMetrics(getContext());
+    DisplayMetricsHolder.initWindowDisplayMetrics(getContext());
   }
 
   @Override
@@ -878,7 +877,8 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
     private int mDeviceRotation = 0;
 
     /* package */ CustomGlobalLayoutListener() {
-      DisplayMetricsHolder.initDisplayMetrics(getContext());
+      DisplayMetricsHolder.initScreenDisplayMetricsIfNotInitialized(getContext());
+      DisplayMetricsHolder.initWindowDisplayMetricsIfNotInitialized(getContext());
       mVisibleViewArea = new Rect();
       mMinKeyboardHeightDetected = (int) PixelUtil.toPixelFromDIP(60);
     }
@@ -1001,7 +1001,8 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
         return;
       }
       mDeviceRotation = rotation;
-      DisplayMetricsHolder.initDisplayMetrics(getContext());
+      DisplayMetricsHolder.initScreenDisplayMetrics(getContext());
+      DisplayMetricsHolder.initWindowDisplayMetrics(getContext());
       emitOrientationChanged(rotation);
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -137,7 +137,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
     setClipChildren(false);
 
     if (ReactNativeFeatureFlags.enableFontScaleChangesUpdatingLayout()) {
-      DisplayMetricsHolder.initDisplayMetrics(getCurrentReactContext());
+      DisplayMetricsHolder.initDisplayMetrics(getContext());
     }
   }
 
@@ -878,7 +878,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
     private int mDeviceRotation = 0;
 
     /* package */ CustomGlobalLayoutListener() {
-      DisplayMetricsHolder.initDisplayMetricsIfNotInitialized(getCurrentReactContext());
+      DisplayMetricsHolder.initDisplayMetrics(getContext());
       mVisibleViewArea = new Rect();
       mMinKeyboardHeightDetected = (int) PixelUtil.toPixelFromDIP(60);
     }
@@ -1001,7 +1001,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
         return;
       }
       mDeviceRotation = rotation;
-      DisplayMetricsHolder.initDisplayMetrics(getCurrentReactContext());
+      DisplayMetricsHolder.initDisplayMetrics(getContext());
       emitOrientationChanged(rotation);
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/deviceinfo/DeviceInfoModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/deviceinfo/DeviceInfoModule.kt
@@ -15,7 +15,7 @@ import com.facebook.react.bridge.ReactSoftExceptionLogger
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.DisplayMetricsHolder.getDisplayMetricsWritableMap
-import com.facebook.react.uimanager.DisplayMetricsHolder.initDisplayMetricsIfNotInitialized
+import com.facebook.react.uimanager.DisplayMetricsHolder.initDisplayMetrics
 import com.facebook.react.views.view.isEdgeToEdgeFeatureFlagOn
 
 /** Module that exposes Android Constants to JS. */
@@ -26,7 +26,7 @@ internal class DeviceInfoModule(reactContext: ReactApplicationContext) :
   private var previousDisplayMetrics: ReadableMap? = null
 
   init {
-    initDisplayMetricsIfNotInitialized(reactContext)
+    initDisplayMetrics(reactContext)
     reactContext.addLifecycleEventListener(this)
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/deviceinfo/DeviceInfoModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/deviceinfo/DeviceInfoModule.kt
@@ -15,7 +15,8 @@ import com.facebook.react.bridge.ReactSoftExceptionLogger
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.DisplayMetricsHolder.getDisplayMetricsWritableMap
-import com.facebook.react.uimanager.DisplayMetricsHolder.initDisplayMetrics
+import com.facebook.react.uimanager.DisplayMetricsHolder.initScreenDisplayMetricsIfNotInitialized
+import com.facebook.react.uimanager.DisplayMetricsHolder.initWindowDisplayMetricsIfNotInitialized
 import com.facebook.react.views.view.isEdgeToEdgeFeatureFlagOn
 
 /** Module that exposes Android Constants to JS. */
@@ -26,7 +27,8 @@ internal class DeviceInfoModule(reactContext: ReactApplicationContext) :
   private var previousDisplayMetrics: ReadableMap? = null
 
   init {
-    initDisplayMetrics(reactContext)
+    initScreenDisplayMetricsIfNotInitialized(reactContext)
+    reactContext.currentActivity?.let { initWindowDisplayMetricsIfNotInitialized(it) }
     reactContext.addLifecycleEventListener(this)
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.kt
@@ -625,9 +625,8 @@ public class ReactHostImpl(
   override fun onConfigurationChanged(context: Context) {
     val currentReactContext = this.currentReactContext
     if (currentReactContext != null) {
-      if (ReactNativeFeatureFlags.enableFontScaleChangesUpdatingLayout()) {
-        DisplayMetricsHolder.initDisplayMetrics(currentReactContext)
-      }
+      DisplayMetricsHolder.initScreenDisplayMetrics(currentReactContext)
+      currentReactContext.currentActivity?.let { DisplayMetricsHolder.initWindowDisplayMetrics(it) }
 
       val appearanceModule = currentReactContext.getNativeModule(AppearanceModule::class.java)
       appearanceModule?.onConfigurationChanged(context)
@@ -918,6 +917,7 @@ public class ReactHostImpl(
                 val instance =
                     ReactInstance(
                         reactContext,
+                        currentActivity,
                         reactHostDelegate,
                         componentFactory,
                         devSupportManager,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.kt
@@ -240,7 +240,7 @@ internal class ReactInstance(
         FabricUIManager(context, ViewManagerRegistry(viewManagerResolver), eventBeatManager)
 
     // Misc initialization that needs to be done before Fabric init
-    DisplayMetricsHolder.initDisplayMetricsIfNotInitialized(context)
+    DisplayMetricsHolder.initDisplayMetrics(context)
 
     val binding = FabricUIManagerBinding()
     binding.register(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.kt
@@ -7,6 +7,7 @@
 
 package com.facebook.react.runtime
 
+import android.app.Activity
 import android.content.res.AssetManager
 import android.view.View
 import com.facebook.common.logging.FLog
@@ -88,6 +89,7 @@ import kotlin.jvm.JvmStatic
 @UnstableReactNativeAPI
 internal class ReactInstance(
     private val context: BridgelessReactContext,
+    private val activity: Activity?,
     delegate: ReactHostDelegate,
     componentFactory: ComponentFactory,
     devSupportManager: DevSupportManager,
@@ -240,7 +242,8 @@ internal class ReactInstance(
         FabricUIManager(context, ViewManagerRegistry(viewManagerResolver), eventBeatManager)
 
     // Misc initialization that needs to be done before Fabric init
-    DisplayMetricsHolder.initDisplayMetrics(context)
+    DisplayMetricsHolder.initScreenDisplayMetricsIfNotInitialized(context)
+    activity?.let { DisplayMetricsHolder.initWindowDisplayMetricsIfNotInitialized(it) }
 
     val binding = FabricUIManagerBinding()
     binding.register(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/DisplayMetricsHolder.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/DisplayMetricsHolder.kt
@@ -16,6 +16,7 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.window.layout.WindowMetricsCalculator
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.WritableNativeMap
+import com.facebook.react.views.view.isEdgeToEdgeFeatureFlagOn
 
 /**
  * Holds an instance of the current DisplayMetrics so we don't have to thread it through all the
@@ -86,9 +87,11 @@ public object DisplayMetricsHolder {
     val displayMetrics = DisplayMetrics()
     displayMetrics.setTo(context.resources.displayMetrics)
 
-    WindowMetricsCalculator.getOrCreate().computeCurrentWindowMetrics(context).let {
-      displayMetrics.widthPixels = it.bounds.width()
-      displayMetrics.heightPixels = it.bounds.height()
+    if (isEdgeToEdgeFeatureFlagOn) {
+      WindowMetricsCalculator.getOrCreate().computeCurrentWindowMetrics(context).let {
+        displayMetrics.widthPixels = it.bounds.width()
+        displayMetrics.heightPixels = it.bounds.height()
+      }
     }
 
     windowDisplayMetrics = displayMetrics

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/DisplayMetricsHolder.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/DisplayMetricsHolder.kt
@@ -26,7 +26,7 @@ public object DisplayMetricsHolder {
   private const val SCREEN_INITIALIZATION_MISSING_MESSAGE =
       "DisplayMetricsHolder must be initialized with initScreenDisplayMetricsIfNotInitialized or initScreenDisplayMetrics"
   private const val WINDOW_INITIALIZATION_MISSING_MESSAGE =
-    "DisplayMetricsHolder must be initialized with initWindowDisplayMetricsIfNotInitialized or initWindowDisplayMetrics"
+      "DisplayMetricsHolder must be initialized with initWindowDisplayMetricsIfNotInitialized or initWindowDisplayMetrics"
 
   @JvmStatic private var windowDisplayMetrics: DisplayMetrics? = null
   @JvmStatic private var screenDisplayMetrics: DisplayMetrics? = null

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/DisplayMetricsHolder.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/DisplayMetricsHolder.kt
@@ -23,8 +23,10 @@ import com.facebook.react.views.view.isEdgeToEdgeFeatureFlagOn
  * classes that need it.
  */
 public object DisplayMetricsHolder {
-  private const val INITIALIZATION_MISSING_MESSAGE =
-      "DisplayMetricsHolder must be initialized with initScreenDisplayMetricsIfNotInitialized, initWindowDisplayMetricsIfNotInitialized, initScreenDisplayMetrics or initWindowDisplayMetrics"
+  private const val SCREEN_INITIALIZATION_MISSING_MESSAGE =
+      "DisplayMetricsHolder must be initialized with initScreenDisplayMetricsIfNotInitialized or initScreenDisplayMetrics"
+  private const val WINDOW_INITIALIZATION_MISSING_MESSAGE =
+    "DisplayMetricsHolder must be initialized with initWindowDisplayMetricsIfNotInitialized or initWindowDisplayMetrics"
 
   @JvmStatic private var windowDisplayMetrics: DisplayMetrics? = null
   @JvmStatic private var screenDisplayMetrics: DisplayMetrics? = null
@@ -32,7 +34,7 @@ public object DisplayMetricsHolder {
   /** The metrics of the window associated to the Context used to initialize ReactNative */
   @JvmStatic
   public fun getWindowDisplayMetrics(): DisplayMetrics {
-    checkNotNull(windowDisplayMetrics) { INITIALIZATION_MISSING_MESSAGE }
+    checkNotNull(windowDisplayMetrics) { WINDOW_INITIALIZATION_MISSING_MESSAGE }
     return windowDisplayMetrics as DisplayMetrics
   }
 
@@ -44,7 +46,7 @@ public object DisplayMetricsHolder {
   /** Screen metrics returns the metrics of the default screen on the device. */
   @JvmStatic
   public fun getScreenDisplayMetrics(): DisplayMetrics {
-    checkNotNull(screenDisplayMetrics) { INITIALIZATION_MISSING_MESSAGE }
+    checkNotNull(screenDisplayMetrics) { SCREEN_INITIALIZATION_MISSING_MESSAGE }
     return screenDisplayMetrics as DisplayMetrics
   }
 
@@ -99,8 +101,8 @@ public object DisplayMetricsHolder {
 
   @JvmStatic
   public fun getDisplayMetricsWritableMap(fontScale: Double): WritableMap {
-    checkNotNull(windowDisplayMetrics) { INITIALIZATION_MISSING_MESSAGE }
-    checkNotNull(screenDisplayMetrics) { INITIALIZATION_MISSING_MESSAGE }
+    checkNotNull(windowDisplayMetrics) { WINDOW_INITIALIZATION_MISSING_MESSAGE }
+    checkNotNull(screenDisplayMetrics) { SCREEN_INITIALIZATION_MISSING_MESSAGE }
 
     return WritableNativeMap().apply {
       putMap(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/DisplayMetricsHolder.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/DisplayMetricsHolder.kt
@@ -83,11 +83,19 @@ public object DisplayMetricsHolder {
     windowDisplayMetrics.setTo(displayMetrics)
     screenDisplayMetrics.setTo(displayMetrics)
 
-    if (isEdgeToEdgeFeatureFlagOn && isUiContext(context)) {
-      WindowMetricsCalculator.getOrCreate().computeCurrentWindowMetrics(context).let {
-        windowDisplayMetrics.widthPixels = it.bounds.width()
-        windowDisplayMetrics.heightPixels = it.bounds.height()
+    if (isEdgeToEdgeFeatureFlagOn) {
+      if (isUiContext(context)) {
+        WindowMetricsCalculator.getOrCreate().computeCurrentWindowMetrics(context).let {
+          windowDisplayMetrics.widthPixels = it.bounds.width()
+          windowDisplayMetrics.heightPixels = it.bounds.height()
+        }
+
+        DisplayMetricsHolder.windowDisplayMetrics = windowDisplayMetrics
+      } else if (DisplayMetricsHolder.windowDisplayMetrics == null) {
+        DisplayMetricsHolder.windowDisplayMetrics = windowDisplayMetrics
       }
+    } else {
+      DisplayMetricsHolder.windowDisplayMetrics = windowDisplayMetrics
     }
 
     val wm = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
@@ -98,7 +106,6 @@ public object DisplayMetricsHolder {
     // http://developer.android.com/reference/android/view/Display.html#getRealMetrics(android.util.DisplayMetrics)
     @Suppress("DEPRECATION") wm.defaultDisplay.getRealMetrics(screenDisplayMetrics)
 
-    DisplayMetricsHolder.windowDisplayMetrics = windowDisplayMetrics
     DisplayMetricsHolder.screenDisplayMetrics = screenDisplayMetrics
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/DisplayMetricsHolder.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/DisplayMetricsHolder.kt
@@ -9,12 +9,13 @@ package com.facebook.react.uimanager
 
 import android.app.Activity
 import android.content.Context
+import android.content.ContextWrapper
+import android.inputmethodservice.InputMethodService
 import android.util.DisplayMetrics
 import android.view.WindowManager
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.window.layout.WindowMetricsCalculator
-import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.WritableNativeMap
 import com.facebook.react.views.view.isEdgeToEdgeFeatureFlagOn
@@ -25,7 +26,7 @@ import com.facebook.react.views.view.isEdgeToEdgeFeatureFlagOn
  */
 public object DisplayMetricsHolder {
   private const val INITIALIZATION_MISSING_MESSAGE =
-      "DisplayMetricsHolder must be initialized with initDisplayMetricsIfNotInitialized or initDisplayMetrics"
+      "DisplayMetricsHolder must be initialized with initDisplayMetrics"
 
   @JvmStatic private var windowDisplayMetrics: DisplayMetrics? = null
   @JvmStatic private var screenDisplayMetrics: DisplayMetrics? = null
@@ -54,55 +55,51 @@ public object DisplayMetricsHolder {
     screenDisplayMetrics = displayMetrics
   }
 
-  @JvmStatic
-  public fun initDisplayMetricsIfNotInitialized(activity: Activity?) {
-    if (screenDisplayMetrics != null) {
-      return
-    }
-    initDisplayMetrics(activity)
-  }
+  private fun isUiContext(context: Context): Boolean {
+    var iterator = context
 
-  @JvmStatic
-  public fun initDisplayMetricsIfNotInitialized(reactContext: ReactContext?) {
-    if (screenDisplayMetrics != null) {
-      return
-    }
-    initDisplayMetrics(reactContext)
-  }
-
-  @JvmStatic
-  public fun initDisplayMetrics(activity: Activity?) {
-    activity?.let {
-      val displayMetrics = it.resources.displayMetrics
-      val windowDisplayMetrics = DisplayMetrics()
-      val screenDisplayMetrics = DisplayMetrics()
-
-      windowDisplayMetrics.setTo(displayMetrics)
-      screenDisplayMetrics.setTo(displayMetrics)
-
-      if (isEdgeToEdgeFeatureFlagOn) {
-        WindowMetricsCalculator.getOrCreate().computeCurrentWindowMetrics(it).let { windowMetrics ->
-          windowDisplayMetrics.widthPixels = windowMetrics.bounds.width()
-          windowDisplayMetrics.heightPixels = windowMetrics.bounds.height()
-        }
+    while (iterator is ContextWrapper) {
+      when (iterator) {
+        is Activity,
+        is InputMethodService -> return true
       }
 
-      val wm = activity.getSystemService(Context.WINDOW_SERVICE) as WindowManager
-      // Get the real display metrics if we are using API level 17 or higher.
-      // The real metrics include system decor elements (e.g. soft menu bar).
-      //
-      // See:
-      // http://developer.android.com/reference/android/view/Display.html#getRealMetrics(android.util.DisplayMetrics)
-      @Suppress("DEPRECATION") wm.defaultDisplay.getRealMetrics(screenDisplayMetrics)
+      if (iterator.baseContext == null) {
+        break
+      }
 
-      DisplayMetricsHolder.windowDisplayMetrics = windowDisplayMetrics
-      DisplayMetricsHolder.screenDisplayMetrics = screenDisplayMetrics
+      iterator = iterator.baseContext
     }
+
+    return false
   }
 
   @JvmStatic
-  public fun initDisplayMetrics(reactContext: ReactContext?) {
-    initDisplayMetrics(reactContext?.currentActivity)
+  public fun initDisplayMetrics(context: Context) {
+    val displayMetrics = context.resources.displayMetrics
+    val windowDisplayMetrics = DisplayMetrics()
+    val screenDisplayMetrics = DisplayMetrics()
+
+    windowDisplayMetrics.setTo(displayMetrics)
+    screenDisplayMetrics.setTo(displayMetrics)
+
+    if (isEdgeToEdgeFeatureFlagOn && isUiContext(context)) {
+      WindowMetricsCalculator.getOrCreate().computeCurrentWindowMetrics(context).let {
+        windowDisplayMetrics.widthPixels = it.bounds.width()
+        windowDisplayMetrics.heightPixels = it.bounds.height()
+      }
+    }
+
+    val wm = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+    // Get the real display metrics if we are using API level 17 or higher.
+    // The real metrics include system decor elements (e.g. soft menu bar).
+    //
+    // See:
+    // http://developer.android.com/reference/android/view/Display.html#getRealMetrics(android.util.DisplayMetrics)
+    @Suppress("DEPRECATION") wm.defaultDisplay.getRealMetrics(screenDisplayMetrics)
+
+    DisplayMetricsHolder.windowDisplayMetrics = windowDisplayMetrics
+    DisplayMetricsHolder.screenDisplayMetrics = screenDisplayMetrics
   }
 
   @JvmStatic

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
@@ -12,6 +12,7 @@ import static com.facebook.react.bridge.ReactMarkerConstants.CREATE_UI_MANAGER_M
 import static com.facebook.react.uimanager.common.UIManagerType.FABRIC;
 import static com.facebook.react.uimanager.common.UIManagerType.LEGACY;
 
+import android.app.Activity;
 import android.content.ComponentCallbacks2;
 import android.content.res.Configuration;
 import android.view.View;
@@ -126,7 +127,11 @@ public class UIManagerModule extends ReactContextBaseJavaModule
       ViewManagerResolver viewManagerResolver,
       int minTimeLeftInFrameForNonBatchedOperationMs) {
     super(reactContext);
-    DisplayMetricsHolder.initDisplayMetrics(reactContext);
+    DisplayMetricsHolder.initScreenDisplayMetricsIfNotInitialized(reactContext);
+    Activity currentActivity = reactContext.getCurrentActivity();
+    if (currentActivity != null) {
+      DisplayMetricsHolder.initWindowDisplayMetricsIfNotInitialized(currentActivity);
+    }
     mEventDispatcher = new EventDispatcherImpl(reactContext);
     mModuleConstants = createConstants(viewManagerResolver);
     mCustomDirectEvents = UIManagerModuleConstants.directEventTypeConstants;
@@ -146,7 +151,11 @@ public class UIManagerModule extends ReactContextBaseJavaModule
       List<ViewManager> viewManagersList,
       int minTimeLeftInFrameForNonBatchedOperationMs) {
     super(reactContext);
-    DisplayMetricsHolder.initDisplayMetrics(reactContext);
+    DisplayMetricsHolder.initScreenDisplayMetricsIfNotInitialized(reactContext);
+    Activity currentActivity = reactContext.getCurrentActivity();
+    if (currentActivity != null) {
+      DisplayMetricsHolder.initWindowDisplayMetricsIfNotInitialized(currentActivity);
+    }
     mEventDispatcher = new EventDispatcherImpl(reactContext);
     mCustomDirectEvents = MapBuilder.newHashMap();
     mModuleConstants = createConstants(viewManagersList, null, mCustomDirectEvents);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
@@ -126,7 +126,7 @@ public class UIManagerModule extends ReactContextBaseJavaModule
       ViewManagerResolver viewManagerResolver,
       int minTimeLeftInFrameForNonBatchedOperationMs) {
     super(reactContext);
-    DisplayMetricsHolder.initDisplayMetricsIfNotInitialized(reactContext);
+    DisplayMetricsHolder.initDisplayMetrics(reactContext);
     mEventDispatcher = new EventDispatcherImpl(reactContext);
     mModuleConstants = createConstants(viewManagerResolver);
     mCustomDirectEvents = UIManagerModuleConstants.directEventTypeConstants;
@@ -146,7 +146,7 @@ public class UIManagerModule extends ReactContextBaseJavaModule
       List<ViewManager> viewManagersList,
       int minTimeLeftInFrameForNonBatchedOperationMs) {
     super(reactContext);
-    DisplayMetricsHolder.initDisplayMetricsIfNotInitialized(reactContext);
+    DisplayMetricsHolder.initDisplayMetrics(reactContext);
     mEventDispatcher = new EventDispatcherImpl(reactContext);
     mCustomDirectEvents = MapBuilder.newHashMap();
     mModuleConstants = createConstants(viewManagersList, null, mCustomDirectEvents);

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.kt
@@ -71,7 +71,7 @@ class RootViewTest {
     reactContext = spy(BridgeReactContext(RuntimeEnvironment.getApplication()))
     reactContext.initializeWithInstance(catalystInstanceMock)
 
-    DisplayMetricsHolder.initDisplayMetricsIfNotInitialized(reactContext)
+    DisplayMetricsHolder.initDisplayMetrics(reactContext)
     val uiManagerModuleMock: UIManagerModule = mock()
     whenever(catalystInstanceMock.getNativeModule(UIManagerModule::class.java))
         .thenReturn(uiManagerModuleMock)

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.kt
@@ -71,7 +71,8 @@ class RootViewTest {
     reactContext = spy(BridgeReactContext(RuntimeEnvironment.getApplication()))
     reactContext.initializeWithInstance(catalystInstanceMock)
 
-    DisplayMetricsHolder.initDisplayMetrics(reactContext)
+    DisplayMetricsHolder.initScreenDisplayMetricsIfNotInitialized(reactContext)
+    DisplayMetricsHolder.initWindowDisplayMetricsIfNotInitialized(reactContext)
     val uiManagerModuleMock: UIManagerModule = mock()
     whenever(catalystInstanceMock.getNativeModule(UIManagerModule::class.java))
         .thenReturn(uiManagerModuleMock)

--- a/packages/react-native/gradle/libs.versions.toml
+++ b/packages/react-native/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ androidx-swiperefreshlayout = "1.1.0"
 androidx-test = "1.5.0"
 androidx-test-junit = "1.2.1"
 androidx-tracing = "1.1.0"
+androidx-window = "1.4.0"
 assertj = "3.21.0"
 binary-compatibility-validator = "0.13.2"
 download = "5.4.0"
@@ -64,6 +65,7 @@ androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidx-
 androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidx-test" }
 androidx-tracing = { module = "androidx.tracing:tracing", version.ref = "androidx-tracing" }
 androidx-uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "uiautomator" }
+androidx-window = { module = "androidx.window:window", version.ref = "androidx-window" }
 
 fbjni = { module = "com.facebook.fbjni:fbjni", version.ref = "fbjni" }
 fresco = { module = "com.facebook.fresco:fresco", version.ref = "fresco" }


### PR DESCRIPTION
## Summary:

This PR (initially created for edge-to-edge opt-in support, rebased multiple times) fixes the `Dimensions` API `window` values on Android < 15, when edge-to-edge is enabled.

Currently the window height doesn't include the status and navigation bar heights (but it does on Android >= 15):

<img width="300" alt="Screenshot 2025-06-27 at 16 23 02" src="https://github.com/user-attachments/assets/c7d11334-9298-4f7f-a75c-590df8cc2d8a" />

Using `WindowMetricsCalculator` from AndroidX:

<img width="300" alt="Screenshot 2025-06-27 at 16 34 01" src="https://github.com/user-attachments/assets/7a4e3dc7-a83b-421b-8f6d-fd1344f5fe81" />

Fixes https://github.com/facebook/react-native/issues/47080

## Changelog:

[Android] [Fixed] Fix `Dimensions` `window` values on Android < 15 when edge-to-edge is enabled

## Test Plan:

Run the example app on an Android < 15 device.
