### PR TITLE
Prepare react-native for prettier v3: 2/n

### DIFF
--- a/packages/react-native-codegen/.prettierrc
+++ b/packages/react-native-codegen/.prettierrc
@@ -4,5 +4,6 @@
   "bracketSpacing": false,
   "requirePragma": true,
   "singleQuote": true,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "parser": "babel"
 }

--- a/private/helloworld/.prettierrc.js
+++ b/private/helloworld/.prettierrc.js
@@ -13,4 +13,20 @@ module.exports = {
   bracketSpacing: false,
   singleQuote: true,
   trailingComma: 'all',
+  plugins: [
+    // Using module.parent and createRequire hack to simulate prettier v2 plugin resolution behavior.
+    // The hack allows us to resolve the plugin from the install location of prettier.
+    (module.parent
+      ? require('module').createRequire(module.parent.id)
+      : require
+    ).resolve('prettier-plugin-hermes-parser'),
+  ],
+  overrides: [
+    {
+      files: ['*.js', '*.js.flow'],
+      options: {
+        parser: 'hermes',
+      },
+    },
+  ],
 };


### PR DESCRIPTION
Summary:
Prettier v3 no longer loads plugin implicitly. This diff first configures the hermes-parser plugin explicitly to prepare for v3 rollout. D78590158 missed this config.

Changelog: [Internal]

Reviewed By: christophpurrer

Differential Revision: D78673890


