### PR TITLE
Unify ImageManager API

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageShadowNode.cpp
@@ -71,17 +71,10 @@ void ImageShadowNode::updateStateIfNeeded() {
     return;
   }
 
-  auto state = ImageState{
+  ImageState state{
       newImageSource,
       imageManager_->requestImage(
-          newImageSource,
-          getSurfaceId()
-#ifdef ANDROID
-              ,
-          newImageRequestParams,
-          getTag()
-#endif
-              ),
+          newImageSource, getSurfaceId(), newImageRequestParams, getTag()),
       newImageRequestParams};
   setStateData(std::move(state));
 }

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageManager.h
@@ -26,13 +26,9 @@ class ImageManager {
 
   virtual ImageRequest requestImage(
       const ImageSource& imageSource,
-      SurfaceId surfaceId) const;
-
-  virtual ImageRequest requestImage(
-      const ImageSource& imageSource,
       SurfaceId surfaceId,
-      const ImageRequestParams& imageRequestParams,
-      Tag tag) const;
+      const ImageRequestParams& imageRequestParams = {},
+      Tag tag = {}) const;
 
  private:
   void* self_{};

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/ImageManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/ImageManager.cpp
@@ -22,12 +22,6 @@ ImageManager::~ImageManager() {
 
 ImageRequest ImageManager::requestImage(
     const ImageSource& imageSource,
-    SurfaceId surfaceId) const {
-  return requestImage(imageSource, surfaceId, ImageRequestParams{}, {});
-}
-
-ImageRequest ImageManager::requestImage(
-    const ImageSource& imageSource,
     SurfaceId surfaceId,
     const ImageRequestParams& imageRequestParams,
     Tag tag) const {

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/cxx/react/renderer/imagemanager/ImageManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/cxx/react/renderer/imagemanager/ImageManager.cpp
@@ -22,12 +22,6 @@ ImageManager::~ImageManager() {
 
 ImageRequest ImageManager::requestImage(
     const ImageSource& imageSource,
-    SurfaceId surfaceId) const {
-  return requestImage(imageSource, surfaceId, ImageRequestParams{}, {});
-}
-
-ImageRequest ImageManager::requestImage(
-    const ImageSource& imageSource,
     SurfaceId /*surfaceId*/,
     const ImageRequestParams& /*imageRequestParams*/,
     Tag /*tag*/) const {

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/ImageManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/ImageManager.mm
@@ -34,11 +34,6 @@ ImageManager::~ImageManager()
   self_ = nullptr;
 }
 
-ImageRequest ImageManager::requestImage(const ImageSource &imageSource, SurfaceId surfaceId) const
-{
-  return requestImage(imageSource, surfaceId, ImageRequestParams{}, {});
-}
-
 ImageRequest ImageManager::requestImage(
     const ImageSource &imageSource,
     SurfaceId surfaceId,


### PR DESCRIPTION
Summary:
Changelog: [Internal]

The overloaded

```
  virtual ImageRequest requestImage(
      const ImageSource& imageSource,
      SurfaceId surfaceId) const;

  virtual ImageRequest requestImage(
      const ImageSource& imageSource,
      SurfaceId surfaceId,
      const ImageRequestParams& imageRequestParams,
      Tag tag) const;
```
can be expressed with default args in the header file
```
 virtual ImageRequest requestImage(
      const ImageSource& imageSource,
      SurfaceId surfaceId,
      const ImageRequestParams& imageRequestParams = {},
      Tag tag = {}) const;
```

Differential Revision: D78702755
