### PR TITLE
Fixed UTF-8 encoding error during pod install when RCT_NEW_ARCH_ENABLED=1 by skipping binary Info.plist files in frameworks

### DIFF
--- a/packages/react-native/scripts/cocoapods/new_architecture.rb
+++ b/packages/react-native/scripts/cocoapods/new_architecture.rb
@@ -162,7 +162,7 @@ class NewArchitectureHelper
             .uniq{ |p| p.path }
             .map{ |p| p.path }
 
-        excluded_info_plist = ["/Pods", "Tests", "metainternal", ".bundle", "build/", "DerivedData/"]
+        excluded_info_plist = ["/Pods", "Tests", "metainternal", ".bundle", "build/", "DerivedData/", ".framework", ".xcframework"]
         projectPaths.each do |projectPath|
             projectFolderPath = File.dirname(projectPath)
             infoPlistFiles = `find #{projectFolderPath} -name "Info.plist"`
@@ -178,8 +178,31 @@ class NewArchitectureHelper
                 end
                 next if should_skip
 
+                # Skip binary plist files to avoid UTF-8 encoding errors
+                begin
+                    # Check if file is readable as UTF-8 text
+                    File.open(infoPlistFile, 'r:UTF-8') do |file|
+                        # Try to read first few bytes to detect binary format
+                        first_bytes = file.read(6)
+                        # Binary plist files start with 'bplist'
+                        if first_bytes && first_bytes.start_with?('bplist')
+                            next
+                        end
+                    end
+                rescue Encoding::InvalidByteSequenceError, Encoding::UndefinedConversionError
+                    # Skip files that can't be read as UTF-8
+                    next
+                end
+
                 # Read the file as a plist
-                info_plist = Xcodeproj::Plist.read_from_path(infoPlistFile)
+                begin
+                    info_plist = Xcodeproj::Plist.read_from_path(infoPlistFile)
+                rescue => e
+                    # Skip files that can't be parsed as plist
+                    Pod::UI.warn("Skipping Info.plist file that could not be parsed: #{infoPlistFile}")
+                    next
+                end
+
                 # Check if it contains the RCTNewArchEnabled key
                 if info_plist["RCTNewArchEnabled"] and info_plist["RCTNewArchEnabled"] == new_arch_enabled
                     next


### PR DESCRIPTION
## Summary

Fixes UTF-8 encoding errors during `pod install` when `RCT_NEW_ARCH_ENABLED=1` by preventing modification of binary Info.plist files in frameworks and xcframeworks.

## Problem

When React Native's New Architecture is enabled, the `NewArchitectureHelper.set_RCTNewArchEnabled_in_info_plist` method recursively searches for and attempts to modify all `Info.plist` files under the Xcode project root. This causes installation failures with the error:

```
[!] An error occurred while processing the post-install hook of the Podfile.
invalid byte sequence in UTF-8
```

**Root Cause:**
The method finds Info.plist files in locally bundled third-party `.framework` and `.xcframework` bundles, which are often in Apple Binary Plist format or encoded in non-UTF8 formats (UTF-16, GBK, etc.). These files should not be modified as they belong to precompiled frameworks.

## Solution

Added multiple layers of protection to skip problematic plist files:

1. **Extended exclusion list**: Added `.framework` and `.xcframework` to the excluded paths
2. **Binary plist detection**: Check for binary plist signature (`bplist`) before processing
3. **Encoding validation**: Catch UTF-8 encoding errors and skip unreadable files  
4. **Graceful error handling**: Wrap plist parsing in try-catch with warning messages

## Changes

- Enhanced `excluded_info_plist` array to include framework paths
- Added binary format detection before file processing
- Added encoding error handling with appropriate fallbacks
- Maintained existing functionality for legitimate app Info.plist files

The change is backward compatible and only affects the problematic file detection logic.
## Changelog:

[iOS] [Fixed] - Fixed UTF-8 encoding error during pod install when RCT_NEW_ARCH_ENABLED=1 by skipping binary Info.plist files in frameworks

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

This fix ensures `pod install` works correctly for projects with:
- Locally bundled frameworks containing binary Info.plist files
- Mixed encoding Info.plist files
- Edge cases where plist parsing fails
