### PR TITLE
fix: remove redundant if checks in traceMark

### DIFF
--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.cpp
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.cpp
@@ -310,17 +310,16 @@ void PerformanceEntryReporter::traceMark(
     UserTimingDetailProvider&& detailProvider) const {
   auto& performanceTracer =
       jsinspector_modern::tracing::PerformanceTracer::getInstance();
-  if (ReactPerfettoLogger::isTracing() || performanceTracer.isTracing()) {
-    if (ReactPerfettoLogger::isTracing()) {
-      ReactPerfettoLogger::mark(entry.name, entry.startTime);
-    }
+  
+  if (ReactPerfettoLogger::isTracing()) {
+    ReactPerfettoLogger::mark(entry.name, entry.startTime);
+  }
 
-    if (performanceTracer.isTracing()) {
-      performanceTracer.reportMark(
-          entry.name,
-          entry.startTime,
-          detailProvider != nullptr ? detailProvider() : nullptr);
-    }
+  if (performanceTracer.isTracing()) {
+    performanceTracer.reportMark(
+        entry.name,
+        entry.startTime,
+        detailProvider != nullptr ? detailProvider() : nullptr);
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

There are some duplicated function calls in `PerformanceEntryReporter::reportMark()` . I know this is a micro optimization but I feel this way the code is cleaner.

This is called through `performance.mark` so there is potentially a tiny little performance improvement here?

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[INTERNAL] [FIXED] - Removed redundant checks in `PerformanceEntryReporter::reportMark()`

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

The existing testing infrastructure should cover these callsites i believe
