### PR TITLE
Refactor Fantom runner to decouple compilation from execution to speed up test execution

### DIFF
--- a/private/react-native-fantom/runner/executables/hermesc.js
+++ b/private/react-native-fantom/runner/executables/hermesc.js
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {HermesVariant, SyncCommandResult} from '../utils';
+
+import {isCI} from '../EnvironmentOptions';
+import {
+  getBuckModesForPlatform,
+  getBuckOptionsForHermes,
+  getDebugInfoFromCommandResult,
+  getHermesCompilerTarget,
+  runBuck2Sync,
+  runCommandSync,
+} from '../utils';
+import {getNativeBuildOutputPath} from './utils';
+import fs from 'fs';
+import path from 'path';
+
+type TesterOptions = $ReadOnly<{
+  isOptimizedMode: boolean,
+  hermesVariant: HermesVariant,
+}>;
+
+function getHermesCompilerPath({
+  isOptimizedMode,
+  hermesVariant,
+}: TesterOptions): string {
+  return path.join(
+    getNativeBuildOutputPath(),
+    `hermesc-${(hermesVariant as string).toLowerCase()}-${isOptimizedMode ? 'opt' : 'dev'}`,
+  );
+}
+
+export function build(options: TesterOptions): void {
+  const destPath = getHermesCompilerPath(options);
+  if (fs.existsSync(destPath)) {
+    return;
+  }
+
+  const tmpPath = destPath + '-' + Date.now();
+
+  try {
+    const result = runBuck2Sync([
+      'build',
+      ...getBuckModesForPlatform(options.isOptimizedMode),
+      ...getBuckOptionsForHermes(options.hermesVariant),
+      getHermesCompilerTarget(options.hermesVariant),
+      '--out',
+      tmpPath,
+    ]);
+
+    if (result.status !== 0) {
+      throw new Error(getDebugInfoFromCommandResult(result));
+    }
+
+    if (fs.existsSync(destPath)) {
+      // Another test might have compiled the binary after our initial check.
+      return;
+    }
+
+    fs.renameSync(tmpPath, destPath);
+  } finally {
+    try {
+      fs.unlinkSync(tmpPath);
+    } catch {}
+  }
+}
+
+export function run(
+  args: $ReadOnlyArray<string>,
+  options: TesterOptions,
+): SyncCommandResult {
+  if (!isCI) {
+    build(options);
+  }
+
+  return runCommandSync(getHermesCompilerPath(options), args);
+}

--- a/private/react-native-fantom/runner/executables/tester.js
+++ b/private/react-native-fantom/runner/executables/tester.js
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {AsyncCommandResult, HermesVariant} from '../utils';
+
+import {debugCpp, isCI} from '../EnvironmentOptions';
+import {
+  getBuckModesForPlatform,
+  getBuckOptionsForHermes,
+  getDebugInfoFromCommandResult,
+  runBuck2,
+  runBuck2Sync,
+  runCommand,
+} from '../utils';
+import {getNativeBuildOutputPath} from './utils';
+import fs from 'fs';
+import path from 'path';
+
+const FANTOM_TESTER_BUCK_TARGET =
+  'fbsource//xplat/js/react-native-github/private/react-native-fantom/tester:tester';
+
+type TesterOptions = $ReadOnly<{
+  isOptimizedMode: boolean,
+  hermesVariant: HermesVariant,
+}>;
+
+function getFantomTesterPath({
+  isOptimizedMode,
+  hermesVariant,
+}: TesterOptions): string {
+  return path.join(
+    getNativeBuildOutputPath(),
+    `fantom-tester-${(hermesVariant as string).toLowerCase()}-${isOptimizedMode ? 'opt' : 'dev'}`,
+  );
+}
+
+export function build(options: TesterOptions): void {
+  const destPath = getFantomTesterPath(options);
+  if (fs.existsSync(destPath)) {
+    return;
+  }
+
+  const tmpPath = destPath + '-' + Date.now();
+
+  try {
+    const result = runBuck2Sync([
+      'build',
+      ...getBuckModesForPlatform(options.isOptimizedMode),
+      ...getBuckOptionsForHermes(options.hermesVariant),
+      FANTOM_TESTER_BUCK_TARGET,
+      '--out',
+      tmpPath,
+    ]);
+
+    if (result.status !== 0) {
+      throw new Error(getDebugInfoFromCommandResult(result));
+    }
+
+    if (fs.existsSync(destPath)) {
+      // Another test might have compiled the binary after our initial check.
+      return;
+    }
+
+    fs.renameSync(tmpPath, destPath);
+  } finally {
+    try {
+      fs.unlinkSync(tmpPath);
+    } catch {}
+  }
+}
+
+export function run(
+  args: $ReadOnlyArray<string>,
+  options: TesterOptions,
+): AsyncCommandResult {
+  if (isCI && debugCpp) {
+    throw new Error('Cannot run Fantom with C++ debugging on CI');
+  }
+
+  if (!isCI && !debugCpp) {
+    build(options);
+  }
+
+  if (debugCpp) {
+    return runBuck2(
+      [
+        'run',
+        ...getBuckModesForPlatform(options.isOptimizedMode),
+        ...getBuckOptionsForHermes(options.hermesVariant),
+        FANTOM_TESTER_BUCK_TARGET,
+        '--',
+        ...args,
+      ],
+      {
+        withFDB: true,
+      },
+    );
+  }
+
+  return runCommand(getFantomTesterPath(options), args);
+}

--- a/private/react-native-fantom/runner/executables/utils.js
+++ b/private/react-native-fantom/runner/executables/utils.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import path from 'path';
+
+const BUILD_OUTPUT_ROOT = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  'build',
+  'native',
+);
+
+export function getNativeBuildOutputPath(): string {
+  return BUILD_OUTPUT_ROOT;
+}

--- a/private/react-native-fantom/runner/utils.js
+++ b/private/react-native-fantom/runner/utils.js
@@ -96,7 +96,7 @@ export type SyncCommandResult = {
   stderr: string,
 };
 
-function maybeLogCommand(command: string, args: Array<string>): void {
+function maybeLogCommand(command: string, args: $ReadOnlyArray<string>): void {
   if (EnvironmentOptions.logCommands) {
     console.log(`RUNNING \`${command} ${args.join(' ')}\``);
   }
@@ -104,17 +104,22 @@ function maybeLogCommand(command: string, args: Array<string>): void {
 
 export function runCommand(
   command: string,
-  args: Array<string>,
+  args: $ReadOnlyArray<string>,
 ): AsyncCommandResult {
   maybeLogCommand(command, args);
 
-  const childProcess = spawn(command, args, {
-    encoding: 'utf8',
-    env: {
-      ...process.env,
-      PATH: `/usr/local/bin:${process.env.PATH ?? ''}`,
+  const childProcess = spawn(
+    command,
+    // spawn is typed with Array instead of with $ReadOnlyArray
+    [...args],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PATH: `/usr/local/bin:${process.env.PATH ?? ''}`,
+      },
     },
-  });
+  );
 
   const result: AsyncCommandResult = {
     childProcess,
@@ -143,11 +148,11 @@ export function runCommand(
 
 export function runCommandSync(
   command: string,
-  args: Array<string>,
+  args: $ReadOnlyArray<string>,
 ): SyncCommandResult {
   maybeLogCommand(command, args);
 
-  const result = spawnSync(command, args, {
+  const result = spawnSync(command, [...args], {
     encoding: 'utf8',
     env: {
       ...process.env,


### PR DESCRIPTION
Summary:
Changelog: [internal]

This is a change to how Fantom tests run in Meta infra via Buck.

Differential Revision: D78672863
