### PR TITLE
Create new environment variable to force running benchmarks in test mode

### DIFF
--- a/private/react-native-fantom/runner/EnvironmentOptions.js
+++ b/private/react-native-fantom/runner/EnvironmentOptions.js
@@ -17,3 +17,10 @@ export const enableCppDebugging: boolean = Boolean(
 );
 
 export const isOSS: boolean = Boolean(process.env.FANTOM_FORCE_OSS_BUILD);
+
+export const isCI: boolean =
+  Boolean(process.env.SANDCASTLE) || Boolean(process.env.GITHUB_ACTIONS);
+
+export const forceTestModeForBenchmarks: boolean = Boolean(
+  process.env.FANTOM_FORCE_TEST_MODE,
+);

--- a/private/react-native-fantom/runner/entrypoint-template.js
+++ b/private/react-native-fantom/runner/entrypoint-template.js
@@ -11,6 +11,7 @@
 import type {SnapshotConfig} from '../runtime/snapshotContext';
 import type {FantomTestConfig} from './getFantomTestConfigs';
 
+import * as EnvironmentOptions from './EnvironmentOptions';
 import formatFantomConfig from './formatFantomConfig';
 
 module.exports = function entrypointTemplate({
@@ -19,14 +20,12 @@ module.exports = function entrypointTemplate({
   featureFlagsModulePath,
   testConfig,
   snapshotConfig,
-  isRunningFromCI,
 }: {
   testPath: string,
   setupModulePath: string,
   featureFlagsModulePath: string,
   testConfig: FantomTestConfig,
   snapshotConfig: SnapshotConfig,
-  isRunningFromCI: boolean,
 }): string {
   return `/**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
@@ -66,7 +65,8 @@ ${
 }
 
 setConstants({
-  isRunningFromCI: ${String(isRunningFromCI)},
+  isRunningFromCI: ${String(EnvironmentOptions.isCI)},
+  forceTestModeForBenchmarks: ${String(EnvironmentOptions.forceTestModeForBenchmarks)},
   fantomConfigSummary: '${formatFantomConfig(testConfig)}',
 });
 

--- a/private/react-native-fantom/runner/runner.js
+++ b/private/react-native-fantom/runner/runner.js
@@ -32,7 +32,6 @@ import {
   getDebugInfoFromCommandResult,
   getHermesCompilerTarget,
   getShortHash,
-  isRunningFromCI,
   printConsoleLog,
   runBuck2,
   runBuck2Sync,
@@ -273,7 +272,6 @@ module.exports = async function runTest(
         updateSnapshot: snapshotState._updateSnapshot,
         data: getInitialSnapshotData(snapshotState),
       },
-      isRunningFromCI: isRunningFromCI(),
     });
 
     const entrypointPath = path.join(

--- a/private/react-native-fantom/runner/utils.js
+++ b/private/react-native-fantom/runner/utils.js
@@ -101,16 +101,6 @@ export type SyncCommandResult = {
   stderr: string,
 };
 
-function isEmpty(value: ?string): boolean {
-  return value == null || value === '';
-}
-
-export function isRunningFromCI(): boolean {
-  return (
-    !isEmpty(process.env.SANDCASTLE) || !isEmpty(process.env.GITHUB_ACTIONS)
-  );
-}
-
 function maybeLogCommand(command: string, args: Array<string>): void {
   if (EnvironmentOptions.logCommands) {
     console.log(`RUNNING \`${command} ${args.join(' ')}\``);

--- a/private/react-native-fantom/runtime/expect.js
+++ b/private/react-native-fantom/runtime/expect.js
@@ -24,6 +24,15 @@ class ErrorWithCustomBlame extends Error {
   #cachedProcessedStack: ?string;
   #customStack: ?string;
 
+  constructor(message?: string, options?: {cause?: mixed, ...}) {
+    super(message, options);
+
+    // The Error constructor forces an own `stack` property that shadows our
+    // getter, so deleting it restores that behavior.
+    // $FlowExpectedError[incompatible-type]
+    delete this.stack;
+  }
+
   blameToPreviousFrame(): this {
     this.#cachedProcessedStack = null;
     this.#ignoredFrameCount++;
@@ -34,6 +43,10 @@ class ErrorWithCustomBlame extends Error {
   get stack(): string {
     if (this.#cachedProcessedStack == null) {
       const originalStack = this.#customStack ?? super.stack;
+      // Calling `super.stack` forces an own `stack` property that shadows our
+      // getter, so deleting it restores that behavior.
+      // $FlowExpectedError[incompatible-type]
+      delete this.stack;
 
       const lines = originalStack.split('\n');
       const index = lines.findIndex(line =>

--- a/private/react-native-fantom/src/Benchmark.js
+++ b/private/react-native-fantom/src/Benchmark.js
@@ -61,7 +61,7 @@ export function suite(
       throw new Error('No benchmark tests defined');
     }
 
-    const {isRunningFromCI} = getConstants();
+    const {isRunningFromCI, forceTestModeForBenchmarks} = getConstants();
 
     // If we're running from CI and there's no verification function, there's
     // no point in running the benchmark.
@@ -69,6 +69,7 @@ export function suite(
     // logic in the benchmark doesn't break.
     const isTestOnly =
       suiteOptions.testOnly === true ||
+      forceTestModeForBenchmarks ||
       (isRunningFromCI && verifyFns.length === 0);
 
     const benchOptions: BenchOptions = isTestOnly

--- a/private/react-native-fantom/src/Constants.js
+++ b/private/react-native-fantom/src/Constants.js
@@ -10,11 +10,13 @@
 
 type FantomConstants = $ReadOnly<{
   isRunningFromCI: boolean,
+  forceTestModeForBenchmarks: boolean,
   fantomConfigSummary: string,
 }>;
 
 let constants: FantomConstants = {
   isRunningFromCI: false,
+  forceTestModeForBenchmarks: false,
   fantomConfigSummary: '',
 };
 


### PR DESCRIPTION
Summary:
Changelog: [internal]

This introduces a new environment variable for Fantom to disable benchmarks (`FANTOM_FORCE_TEST_MODE`), without having to run in CI mode.

Differential Revision: D78672864
