### PR TITLE
refactor: make Targets traceable

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
@@ -186,6 +186,11 @@ InstanceTarget& HostTarget::registerInstance(InstanceTargetDelegate& delegate) {
   assert(!currentInstance_ && "Only one instance allowed");
   currentInstance_ = InstanceTarget::create(
       executionContextManager_, delegate, makeVoidExecutor(executorFromThis()));
+
+  if (isTracing_) {
+    startTracingInstanceTarget(currentInstance_.get());
+  }
+
   sessions_.forEach(
       [currentInstance = &*currentInstance_](HostTargetSession& session) {
         session.setCurrentInstance(currentInstance);
@@ -197,6 +202,11 @@ void HostTarget::unregisterInstance(InstanceTarget& instance) {
   assert(
       currentInstance_ && currentInstance_.get() == &instance &&
       "Invalid unregistration");
+
+  if (isTracing_) {
+    stopTracingInstanceTarget(&instance);
+  }
+
   sessions_.forEach(
       [](HostTargetSession& session) { session.setCurrentInstance(nullptr); });
   currentInstance_.reset();

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTracing.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTracing.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "HostTarget.h"
+
+namespace facebook::react::jsinspector_modern {
+
+void HostTargetController::startTracing() {
+  return target_.startTracing();
+}
+
+void HostTargetController::stopTracing() {
+  return target_.stopTracing();
+}
+
+tracing::HostTargetTracingProfile
+HostTargetController::collectTracingProfile() {
+  return target_.collectTracingProfile();
+}
+
+void HostTarget::startTracing() {
+  if (isTracing_) {
+    throw std::runtime_error(
+        "HostTarget already has a pending tracing session.");
+  }
+
+  isTracing_ = true;
+  /**
+   * In case if \c HostTarget::collectTracingProfile was never called.
+   */
+  storedInstanceTargetTracingProfiles_.clear();
+
+  if (currentInstance_) {
+    return startTracingInstanceTarget(currentInstance_.get());
+  }
+}
+
+void HostTarget::stopTracing() {
+  if (!isTracing_) {
+    throw std::runtime_error("HostTarget has no pending tracing session.");
+  }
+
+  isTracing_ = false;
+  if (currentInstance_) {
+    return stopTracingInstanceTarget(currentInstance_.get());
+  }
+}
+
+tracing::HostTargetTracingProfile HostTarget::collectTracingProfile() {
+  if (isTracing_) {
+    throw std::runtime_error(
+        "Attempted to collect HostTargetTracingProfile before stopping the tracing session.");
+  }
+
+  auto profiles = std::move(storedInstanceTargetTracingProfiles_);
+  storedInstanceTargetTracingProfiles_.clear();
+
+  return tracing::HostTargetTracingProfile{std::move(profiles)};
+}
+
+void HostTarget::startTracingInstanceTarget(InstanceTarget* instanceTarget) {
+  assert(
+      instanceTarget != nullptr &&
+      "Attempted to start tracing a null InstanceTarget");
+  return instanceTarget->startTracing();
+}
+
+void HostTarget::stopTracingInstanceTarget(InstanceTarget* instanceTarget) {
+  assert(
+      instanceTarget != nullptr &&
+      "Attempted to stop tracing a null InstanceTarget");
+
+  instanceTarget->stopTracing();
+  storedInstanceTargetTracingProfiles_.emplace_back(
+      instanceTarget->collectTracingProfile());
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.cpp
@@ -64,16 +64,25 @@ RuntimeTarget& InstanceTarget::registerRuntime(
       jsExecutor,
       makeVoidExecutor(executorFromThis()));
 
+  if (isTracing_) {
+    startTracingRuntimeTarget(currentRuntime_.get());
+  }
+
   agents_.forEach([currentRuntime = &*currentRuntime_](InstanceAgent& agent) {
     agent.setCurrentRuntime(currentRuntime);
   });
   return *currentRuntime_;
 }
 
-void InstanceTarget::unregisterRuntime(RuntimeTarget& Runtime) {
+void InstanceTarget::unregisterRuntime(RuntimeTarget& runtimeTarget) {
   assert(
-      currentRuntime_ && currentRuntime_.get() == &Runtime &&
+      currentRuntime_ && currentRuntime_.get() == &runtimeTarget &&
       "Invalid unregistration");
+
+  if (isTracing_) {
+    stopTracingRuntimeTarget(&runtimeTarget);
+  }
+
   agents_.forEach(
       [](InstanceAgent& agent) { agent.setCurrentRuntime(nullptr); });
   currentRuntime_.reset();

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceTargetTracing.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceTargetTracing.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "InstanceTarget.h"
+
+namespace facebook::react::jsinspector_modern {
+
+void InstanceTarget::startTracing() {
+  if (isTracing_) {
+    throw std::runtime_error(
+        "HostTarget already has a pending tracing session.");
+  }
+
+  isTracing_ = true;
+  /**
+   * In case if \c InstanceTarget::collectTracingProfile was never called.
+   */
+  storedRuntimeTargetSamplingProfiles_.clear();
+
+  if (currentRuntime_) {
+    return startTracingRuntimeTarget(currentRuntime_.get());
+  }
+}
+
+void InstanceTarget::stopTracing() {
+  if (!isTracing_) {
+    throw std::runtime_error("HostTarget has no pending tracing session.");
+  }
+
+  isTracing_ = false;
+  if (currentRuntime_) {
+    return stopTracingRuntimeTarget(currentRuntime_.get());
+  }
+}
+
+tracing::InstanceTargetTracingProfile InstanceTarget::collectTracingProfile() {
+  if (isTracing_) {
+    throw std::runtime_error(
+        "Attempted to collect InstanceTargetTracingProfile before stopping the tracing session.");
+  }
+
+  auto profiles = std::move(storedRuntimeTargetSamplingProfiles_);
+  storedRuntimeTargetSamplingProfiles_.clear();
+
+  return tracing::InstanceTargetTracingProfile{std::move(profiles)};
+}
+
+void InstanceTarget::startTracingRuntimeTarget(RuntimeTarget* runtimeTarget) {
+  assert(
+      runtimeTarget != nullptr &&
+      "Attempted to start tracing a null RuntimeTarget");
+
+  runtimeTarget->registerForTracing();
+  return runtimeTarget->enableSamplingProfiler();
+}
+
+void InstanceTarget::stopTracingRuntimeTarget(RuntimeTarget* runtimeTarget) {
+  assert(
+      runtimeTarget != nullptr &&
+      "Attempted to stop tracing a null RuntimeTarget");
+
+  runtimeTarget->disableSamplingProfiler();
+  storedRuntimeTargetSamplingProfiles_.emplace_back(
+      runtimeTarget->collectSamplingProfile());
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/HostTargetTracingProfile.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/HostTargetTracingProfile.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "InstanceTargetTracingProfile.h"
+
+#include <vector>
+
+namespace facebook::react::jsinspector_modern::tracing {
+
+/**
+ * A tracing profile for a single instance of an HostTarget.
+ *
+ * Captures Tracing Profiles for all InstanceTargets associated with the owning
+ * HostTarget during the tracing session.
+ */
+struct HostTargetTracingProfile {
+ public:
+  explicit HostTargetTracingProfile(
+      std::vector<InstanceTargetTracingProfile> instanceTargetTracingProfiles)
+      : instanceTargetTracingProfiles_(
+            std::move(instanceTargetTracingProfiles)) {}
+
+  const std::vector<InstanceTargetTracingProfile>&
+  getInstanceTargetTracingProfiles() const {
+    return instanceTargetTracingProfiles_;
+  }
+
+ private:
+  /**
+   * All captured InstanceTarget Tracing Profiles during the tracing session.
+   */
+  std::vector<InstanceTargetTracingProfile> instanceTargetTracingProfiles_;
+};
+
+} // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/InstanceTargetTracingProfile.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/InstanceTargetTracingProfile.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "RuntimeSamplingProfile.h"
+
+#include <vector>
+
+namespace facebook::react::jsinspector_modern::tracing {
+
+/**
+ * A tracing profile for a single instance of an InstanceTarget.
+ *
+ * Captures Sampling Profiles for all RuntimeTargets associated with the owning
+ * InstanceTarget during the tracing session.
+ */
+struct InstanceTargetTracingProfile {
+ public:
+  explicit InstanceTargetTracingProfile(
+      std::vector<RuntimeSamplingProfile> runtimeSamplingProfiles)
+      : runtimeSamplingProfiles_(std::move(runtimeSamplingProfiles)) {}
+
+  const std::vector<RuntimeSamplingProfile>& getRuntimeSamplingProfiles()
+      const {
+    return runtimeSamplingProfiles_;
+  }
+
+ private:
+  /**
+   * All captured Sampling Profiles during the tracing session.
+   */
+  std::vector<RuntimeSamplingProfile> runtimeSamplingProfiles_;
+};
+
+} // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -22,6 +22,16 @@
 
 namespace facebook::react::jsinspector_modern::tracing {
 
+namespace {
+
+/**
+ * Threshold for the size Trace Event chunk, that will be flushed out with
+ * Tracing.dataCollected event.
+ */
+const uint16_t TRACE_EVENT_CHUNK_SIZE = 1000;
+
+} // namespace
+
 // TODO: Review how this API is integrated into jsinspector_modern (singleton
 // design is copied from earlier FuseboxTracer prototype).
 
@@ -58,13 +68,13 @@ class PerformanceTracer {
   void collectEvents(
       const std::function<void(const folly::dynamic& eventsChunk)>&
           resultCallback,
-      uint16_t chunkSize);
+      uint16_t chunkSize = TRACE_EVENT_CHUNK_SIZE);
 
   /**
    * Flush out buffered CDP Trace Events into a folly::dynamic collection of
    * chunks, which can be sent over CDP later.
    */
-  folly::dynamic collectEvents(uint16_t chunkSize);
+  folly::dynamic collectEvents(uint16_t chunkSize = TRACE_EVENT_CHUNK_SIZE);
 
   /**
    * Record a `Performance.mark()` event - a labelled timestamp. If not


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

The current design for Tracing is flawed. Right now the logic is mostly scattered around CDP Agents, lifetime of which is tied to CDP session.

This diff introduces a new approach: Targets will expose an API to start / stop tracing.

This allows us to record Tracing Profiles even if there is no active CDP session.

Differential Revision: D78517818


