### PR TITLE
[RN][iOS]Use prebuilds for nightlies

### DIFF
--- a/.github/actions/test-library-on-nightly/action.yml
+++ b/.github/actions/test-library-on-nightly/action.yml
@@ -31,7 +31,7 @@ runs:
       run: |
         cd /tmp/RNApp/ios
         bundle install
-        bundle exec pod install
+        RCT_USE_RN_DEP=1 RCT_USE_PREBUILT_RNCORE=1 bundle exec pod install
         xcodebuild build \
           -workspace RNApp.xcworkspace \
           -scheme RNApp \


### PR DESCRIPTION
## Summary:
Use prebuilds for nightly checks. This should save a lot of time in CI.
An example job which used to take 18 min took less than 4 min.

## Changelog:
[Internal] -

## Test Plan:
GHA
Sample job, 3' 23'': https://github.com/facebook/react-native/actions/runs/16447578916/job/46483698898?pr=52762
(Same job last night, 18' 27'': https://github.com/facebook/react-native/actions/runs/16434647827/job/46442342235)
