### PR TITLE
Make ui manager proxy not depend on ui manager logic

### DIFF
--- a/packages/react-native/React/Base/RCTBridgeProxy.mm
+++ b/packages/react-native/React/Base/RCTBridgeProxy.mm
@@ -445,7 +445,7 @@ using namespace facebook;
                cmd:_cmd];
   UIView *view = [_viewRegistry viewForReactTag:reactTag] ? [_viewRegistry viewForReactTag:reactTag]
                                                           : [_legacyViewRegistry objectForKey:reactTag];
-  return [RCTUIManager paperViewOrCurrentView:view];
+  return RCTPaperViewOrCurrentView(view);
 }
 
 - (void)addUIBlock:(RCTViewManagerUIBlock)block

--- a/packages/react-native/React/Modules/RCTUIManager.h
+++ b/packages/react-native/React/Modules/RCTUIManager.h
@@ -156,14 +156,6 @@ RCT_EXTERN NSString *const RCTUIManagerWillUpdateViewsDueToContentSizeMultiplier
 - (void)setNeedsLayout;
 
 /**
- * This method is used to extract the wrapped view
- * from a view that might be the Interop Layer view wrapper.
- * If the view passed as parameter is the Interop Layer wrapper, this method returns the wrapped view
- * Otherwise, it returns the view itself.
- */
-+ (UIView *)paperViewOrCurrentView:(UIView *)view;
-
-/**
  * Dedicated object for subscribing for UIManager events.
  * See `RCTUIManagerObserver` protocol for more details.
  */
@@ -211,6 +203,14 @@ RCT_EXTERN NSString *const RCTUIManagerWillUpdateViewsDueToContentSizeMultiplier
 @protocol RCTRendererInteropLayerAdapting
 - (UIView *)paperView;
 @end
+
+/**
+ * This method is used to extract the wrapped view
+ * from a view that might be the Interop Layer view wrapper.
+ * If the view passed as parameter is the Interop Layer wrapper, this method returns the wrapped view
+ * Otherwise, it returns the view itself.
+ */
+RCT_EXTERN UIView *RCTPaperViewOrCurrentView(UIView *view);
 
 RCT_EXTERN NSMutableDictionary<NSString *, id> *RCTModuleConstantsForDestructuredComponent(
     NSMutableDictionary<NSString *, NSDictionary *> *directEvents,

--- a/packages/react-native/React/Modules/RCTUIManager.mm
+++ b/packages/react-native/React/Modules/RCTUIManager.mm
@@ -473,7 +473,7 @@ static NSDictionary *deviceOrientationEventBody(UIDeviceOrientation orientation)
   if (!view) {
     view = _viewRegistry[reactTag];
   }
-  return [RCTUIManager paperViewOrCurrentView:view];
+  return RCTPaperViewOrCurrentView(view);
 }
 
 - (RCTShadowView *)shadowViewForReactTag:(NSNumber *)reactTag
@@ -1629,14 +1629,6 @@ static UIView *_jsResponder;
   return _jsResponder;
 }
 
-+ (UIView *)paperViewOrCurrentView:(UIView *)view
-{
-  if ([view respondsToSelector:@selector(paperView)]) {
-    return [view performSelector:@selector(paperView)];
-  }
-  return view;
-}
-
 - (void)removeViewFromRegistry:(NSNumber *)reactTag
 {
   [_viewRegistry removeObjectForKey:reactTag];
@@ -1737,11 +1729,6 @@ static UIView *_jsResponder;
   return nil;
 }
 
-+ (UIView *)paperViewOrCurrentView:(UIView *)view
-{
-  return nil;
-}
-
 + (NSString *)moduleName
 {
   return @"UIManager";
@@ -1763,6 +1750,14 @@ static UIView *_jsResponder;
 @end
 
 #endif // RCT_FIT_RM_OLD_RUNTIME
+
+UIView *RCTPaperViewOrCurrentView(UIView *view)
+{
+  if ([view respondsToSelector:@selector(paperView)]) {
+    return [view performSelector:@selector(paperView)];
+  }
+  return view;
+}
 
 @implementation RCTComposedViewRegistry {
   __weak RCTUIManager *_uiManager;
@@ -1798,11 +1793,11 @@ static UIView *_jsResponder;
   NSNumber *index = (NSNumber *)key;
   UIView *view = _registry[index];
   if (view) {
-    return [RCTUIManager paperViewOrCurrentView:view];
+    return RCTPaperViewOrCurrentView(view);
   }
   view = [_uiManager viewForReactTag:index];
   if (view) {
-    return [RCTUIManager paperViewOrCurrentView:view];
+    return RCTPaperViewOrCurrentView(view);
   }
   return NULL;
 }


### PR DESCRIPTION
Summary:
The ui manager proxy shouldn't depend on the legacy ui manager.

We plan to compile out the legacy ui manager soon. But, the ui manager proxy is supposed to linger around for longer.

Changelog: [internal]

Reviewed By: cipolleschi

Differential Revision: D78697148


