### PR TITLE
Honor ignored frames in errors reported by Fantom

### DIFF
--- a/private/react-native-fantom/runtime/expect.js
+++ b/private/react-native-fantom/runtime/expect.js
@@ -24,6 +24,15 @@ class ErrorWithCustomBlame extends Error {
   #cachedProcessedStack: ?string;
   #customStack: ?string;
 
+  constructor(message?: string, options?: {cause?: mixed, ...}) {
+    super(message, options);
+
+    // The Error constructor forces an own `stack` property that shadows our
+    // getter, so deleting it restores that behavior.
+    // $FlowExpectedError[incompatible-type]
+    delete this.stack;
+  }
+
   blameToPreviousFrame(): this {
     this.#cachedProcessedStack = null;
     this.#ignoredFrameCount++;
@@ -34,6 +43,10 @@ class ErrorWithCustomBlame extends Error {
   get stack(): string {
     if (this.#cachedProcessedStack == null) {
       const originalStack = this.#customStack ?? super.stack;
+      // Calling `super.stack` forces an own `stack` property that shadows our
+      // getter, so deleting it restores that behavior.
+      // $FlowExpectedError[incompatible-type]
+      delete this.stack;
 
       const lines = originalStack.split('\n');
       const index = lines.findIndex(line =>


### PR DESCRIPTION
Summary:
Changelog: [internal]

Reported locations for errors in Fantom is wrong, because it seems it's not ignoring "infra" frames.

This was caused by the `stack` property in `ErrorWithCustomBlame` being set on the error objects and shadowing the getter that removes the necessary frames. This fixes that by forcing that property to be deleted.

Differential Revision: D78747119


