### PR TITLE
skip bytecode support for hermes

### DIFF
--- a/private/react-native-fantom/runner/runner.js
+++ b/private/react-native-fantom/runner/runner.js
@@ -8,7 +8,11 @@
  * @format
  */
 
-import type {FailureDetail, TestSuiteResult} from '../runtime/setup';
+import type {
+  FailureDetail,
+  TestCaseResult,
+  TestSuiteResult,
+} from '../runtime/setup';
 import type {TestSnapshotResults} from '../runtime/snapshotContext';
 import type {
   AsyncCommandResult,
@@ -218,25 +222,38 @@ module.exports = async function runTest(
 
   const testResultsByConfig = [];
 
+  const skippedTestResults = ({
+    ancestorTitles,
+    title,
+  }: {
+    ancestorTitles: string[],
+    title: string,
+  }) => [
+    {
+      ancestorTitles,
+      duration: 0,
+      failureDetails: [] as Array<Error>,
+      failureMessages: [] as Array<string>,
+      fullName: title,
+      numPassingAsserts: 0,
+      snapshotResults: {} as TestSnapshotResults,
+      status: 'pending' as TestCaseResult['status'],
+      testFilePath: testPath,
+      title,
+    },
+  ];
+
   for (const testConfig of testConfigs) {
     if (
       EnvironmentOptions.isOSS &&
       testConfig.mode === FantomTestConfigMode.Optimized
     ) {
-      testResultsByConfig.push([
-        {
+      testResultsByConfig.push(
+        skippedTestResults({
           ancestorTitles: ['"@fantom_mode opt" in docblock'],
-          duration: 0,
-          failureDetails: [] as Array<Error>,
-          failureMessages: [] as Array<string>,
-          fullName: 'Optimized mode is not yet supoprted in OSS',
-          numPassingAsserts: 0,
-          snapshotResults: {} as TestSnapshotResults,
-          status: 'pending' as 'passed' | 'failed' | 'pending',
-          testFilePath: testPath,
-          title: 'Optimized mode is not yet supoprted in OSS',
-        },
-      ]);
+          title: 'Optimized mode is not yet supported in OSS',
+        }),
+      );
       continue;
     }
 
@@ -244,22 +261,27 @@ module.exports = async function runTest(
       EnvironmentOptions.isOSS &&
       testConfig.hermesVariant !== HermesVariantEnum.Hermes
     ) {
-      testResultsByConfig.push([
-        {
+      testResultsByConfig.push(
+        skippedTestResults({
           ancestorTitles: [
             '"@fantom_hermes_variant static_hermes" in docblock (shermes 🧪)',
           ],
-          duration: 0,
-          failureDetails: [] as Array<Error>,
-          failureMessages: [] as Array<string>,
-          fullName: 'Static Hermes is not yet supoprted in OSS',
-          numPassingAsserts: 0,
-          snapshotResults: {} as TestSnapshotResults,
-          status: 'pending' as 'passed' | 'failed' | 'pending',
-          testFilePath: testPath,
-          title: 'Static Hermes is not yet supoprted in OSS',
-        },
-      ]);
+          title: 'Static Hermes is not yet supported in OSS',
+        }),
+      );
+      continue;
+    }
+
+    if (
+      EnvironmentOptions.isOSS &&
+      testConfig.mode !== FantomTestConfigMode.DevelopmentWithSource
+    ) {
+      testResultsByConfig.push(
+        skippedTestResults({
+          ancestorTitles: ['"@fantom_mode dev-bytecode" in docblock'],
+          title: 'Hermes bytecode is not yet supported in OSS',
+        }),
+      );
       continue;
     }
 


### PR DESCRIPTION
Summary:
Changelog: [Internal]
Currently tests that depend on hermes dev bytecode will fail because in OSS this case was not handled. We need to skip them for now before we integrate hermes compiler properly.

Differential Revision: D78750791


