### PR TITLE
Make functions async and add await to prepare for prettier v3 upgrade: 1/n

### DIFF
--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -187,7 +187,7 @@ async function buildFile(
   const prettierConfig = {parser: 'babel'};
 
   // Transform source file using Babel
-  const transformed = prettier.format(
+  const transformed = await prettier.format(
     (await babel.transformFileAsync(file, getBabelConfig(packageName))).code,
     /* $FlowFixMe[incompatible-call] Natural Inference rollout. See
      * https://fburl.com/workplace/6291gfvu */

--- a/scripts/js-api/build-types/buildApiSnapshot.js
+++ b/scripts/js-api/build-types/buildApiSnapshot.js
@@ -262,13 +262,13 @@ async function getProcessedSnapshotResult(
     postTransforms(options),
   );
 
-  return prettier
-    .format(transformedRollup, {
+  return (
+    await prettier.format(transformedRollup, {
       parser: 'typescript',
       semi: false,
       trailingComma: 'all',
     })
-    .trimEnd();
+  ).trimEnd();
 }
 
 async function generateConfigFiles(tempDirectory: string) {


### PR DESCRIPTION
Summary:
Prettier v3 has an async API. This diff adds in await ahead of the upgrade to prepare for the API change.

Changelog: [Internal]

Differential Revision: D78752354


