### PR TITLE
fix: fix maintainVisibleContentPosition on iOS when _firstVisibleView is removed

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -109,6 +109,7 @@ RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrollView, NSInt
   __weak UIView *_contentView;
 
   CGRect _prevFirstVisibleFrame;
+  NSInteger _firstVisibleViewTag;
   __weak UIView *_firstVisibleView;
 
   CGFloat _endDraggingSensitivityMultiplier;
@@ -677,6 +678,7 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
   self.frame = oldFrame;
   _contentView = nil;
   _prevFirstVisibleFrame = CGRectZero;
+  _firstVisibleViewTag = 0;
   _firstVisibleView = nil;
 }
 
@@ -1036,6 +1038,7 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
     }
     if (hasNewView || ii == _contentView.subviews.count - 1) {
       _prevFirstVisibleFrame = subview.frame;
+      _firstVisibleViewTag = subview.tag;
       _firstVisibleView = subview;
       break;
     }
@@ -1047,6 +1050,12 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
   const auto &props = static_cast<const ScrollViewProps &>(*_props);
   if (!props.maintainVisibleContentPosition) {
     return;
+  }
+
+  if(_firstVisibleView && _firstVisibleView.tag != _firstVisibleViewTag) {
+    _prevFirstVisibleFrame = CGRectZero;
+    _firstVisibleViewTag = 0;
+    _firstVisibleView = nil;
   }
 
   std::optional<int> autoscrollThreshold = props.maintainVisibleContentPosition.value().autoscrollToTopThreshold;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Addresses #52757 

On Fabric, when the `maintainVisibleContentPosition` is passed with `minIndexForVisible` and that index is deleted, the `_firstVisibleView` will point to the wrong view because of Fabric's view recycling. 

The behaviour observed in #52757 is that when `minIndexForVisible` is 0 and that item is removed, the list jumps to the end and then scrolls back all the way to the top because of `autoscrollToTopThreshold ` since item 0 is deleted and added to the recycled view pool and the newly to render item(all the way at the bottom) dequeues that same view resulting in `_firstVisibleView` which was pointing to the item of index 0 now points at item of index ~203.

This was not happening in old arch(Paper) because old arch doesnt recycle views.

My fix is to validate whether `_firstVisibleView` is the same view we stored in `_prepareForMaintainVisibleScrollPosition` and to do that I thought of storing the view's tag as the id. If the tag changed then we do not need to adjust the scrolling depending on that view since that view pointer is pointing to a different view and I reset the identifiers related to it.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[IOS] [FIXED] - Fix maintainVisibleContentPosition on iOS when item with index equal to minIndexForVisible is removed

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[IOS] [FIXED] - Fix maintainVisibleContentPosition on iOS when item with index equal to minIndexForVisible is removed

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
I am open to the maintainers' suggestion on what is the best way to test this.

But here is a recording from the repro of #52757 with a patch including the changes in this pr implemented in [this branch](https://github.com/itsramiel/FlatlistScroll/tree/patch-fix).

## Screen Recordings

| **Without Patch** | **With Patch** |
| ---------- | --------- |
| <video src="https://github.com/user-attachments/assets/fe17a6e9-107e-4e45-8236-f4da00e430e2"></video> | <video src="https://github.com/user-attachments/assets/eec107ff-522c-46c1-88cb-c8fb30218391"></video> |


