### PR TITLE
Properly setup headers for FBReactNativeSpec in prebuilds

### DIFF
--- a/.github/workflows/prebuild-ios-core.yml
+++ b/.github/workflows/prebuild-ios-core.yml
@@ -23,7 +23,7 @@ jobs:
         id: restore-ios-slice
         uses: actions/cache/restore@v4
         with:
-          key: v3-ios-core-${{ matrix.slice }}-${{ matrix.flavor }}-${{ hashFiles('packages/react-native/Package.swift', 'packages/react-native/scripts/ios-prebuild/setup.js', 'packages/react-native/React/**/*', 'packages/react-native/ReactCommon/**/*', 'packages/react-native/Libraries/**/*') }}
+          key: v3-ios-core-${{ matrix.slice }}-${{ matrix.flavor }}-${{ hashFiles('packages/react-native/Package.swift', 'packages/react-native/scripts/ios-prebuild/*.js', 'packages/react-native/scripts/ios-prebuild.js', 'packages/react-native/React/**/*', 'packages/react-native/ReactCommon/**/*', 'packages/react-native/Libraries/**/*') }}
           path: packages/react-native/
       - name: Setup node.js
         if: steps.restore-ios-slice.outputs.cache-hit != 'true'
@@ -117,7 +117,7 @@ jobs:
         uses: actions/cache/save@v4
         if: ${{ github.ref == 'refs/heads/main' }} # To avoid that the cache explode
         with:
-          key: v3-ios-core-${{ matrix.slice }}-${{ matrix.flavor }}-${{ hashFiles('packages/react-native/Package.swift', 'packages/react-native/scripts/ios-prebuild/setup.js', 'packages/react-native/React/**/*', 'packages/react-native/ReactCommon/**/*', 'packages/react-native/Libraries/**/*') }}
+          key: v3-ios-core-${{ matrix.slice }}-${{ matrix.flavor }}-${{ hashFiles('packages/react-native/Package.swift', 'packages/react-native/scripts/ios-prebuild/*.js', 'packages/react-native/scripts/ios-prebuild.js', 'packages/react-native/React/**/*', 'packages/react-native/ReactCommon/**/*', 'packages/react-native/Libraries/**/*') }}
           path: |
             packages/react-native/.build/output/spm/${{ matrix.flavor }}/Build/Products
             packages/react-native/.build/headers
@@ -140,7 +140,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: packages/react-native/.build/output/xcframeworks
-          key: v2-ios-core-xcframework-${{ matrix.flavor }}-${{ hashFiles('packages/react-native/Package.swift', 'packages/react-native/scripts/ios-prebuild/setup.js', 'packages/react-native/React/**/*', 'packages/react-native/ReactCommon/**/*', 'packages/react-native/Libraries/**/*') }}
+          key: v2-ios-core-xcframework-${{ matrix.flavor }}-${{ hashFiles('packages/react-native/Package.swift', 'packages/react-native/scripts/ios-prebuild/*.js', 'packages/react-native/scripts/ios-prebuild.js', 'packages/react-native/React/**/*', 'packages/react-native/ReactCommon/**/*', 'packages/react-native/Libraries/**/*') }}
       - name: Setup node.js
         if: steps.restore-ios-xcframework.outputs.cache-hit != 'true'
         uses: ./.github/actions/setup-node
@@ -209,4 +209,4 @@ jobs:
           path: |
             packages/react-native/.build/output/xcframeworks/ReactCore${{matrix.flavor}}.xcframework.tar.gz
             packages/react-native/.build/output/xcframeworks/ReactCore${{matrix.flavor}}.framework.dSYM.tar.gz
-          key: v2-ios-core-xcframework-${{ matrix.flavor }}-${{ hashFiles('packages/react-native/Package.swift', 'packages/react-native/scripts/ios-prebuild/setup.js', 'packages/react-native/React/**/*', 'packages/react-native/ReactCommon/**/*', 'packages/react-native/Libraries/**/*') }}
+          key: v2-ios-core-xcframework-${{ matrix.flavor }}-${{ hashFiles('packages/react-native/Package.swift', 'packages/react-native/scripts/ios-prebuild/*.js', 'packages/react-native/scripts/ios-prebuild.js', 'packages/react-native/React/**/*', 'packages/react-native/ReactCommon/**/*', 'packages/react-native/Libraries/**/*') }}

--- a/packages/react-native/Libraries/PushNotificationIOS/React-RCTPushNotification.podspec
+++ b/packages/react-native/Libraries/PushNotificationIOS/React-RCTPushNotification.podspec
@@ -18,7 +18,6 @@ end
 
 header_search_paths = [
   "\"${PODS_ROOT}/Headers/Public/ReactCodegen/react/renderer/components\"",
-  "\"${PODS_ROOT}/Headers/Public/React-RCTFBReactNativeSpec/FBReactNativeSpec\"",
 ]
 
 Pod::Spec.new do |s|
@@ -46,7 +45,7 @@ Pod::Spec.new do |s|
   s.dependency "React-Core/RCTPushNotificationHeaders"
   s.dependency "React-jsi"
 
-  add_dependency(s, "React-RCTFBReactNativeSpec", :additional_framework_paths => ['FBReactNativeSpec'])
+  add_dependency(s, "React-RCTFBReactNativeSpec")
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
   add_dependency(s, "React-NativeModulesApple")
 

--- a/packages/react-native/scripts/ios-prebuild/setup.js
+++ b/packages/react-native/scripts/ios-prebuild/setup.js
@@ -10,6 +10,9 @@
 
 /*:: import type {BuildFlavor} from './types'; */
 
+const {
+  generateFBReactNativeSpecIOS,
+} = require('../codegen/generate-artifacts-executor/generateFBReactNativeSpecIOS');
 const {prepareHermesArtifactsAsync} = require('./hermes');
 const {
   prepareReactNativeDependenciesArtifactsAsync,
@@ -25,6 +28,9 @@ async function setup(
   currentVersion /*: string */,
   buildType /*: BuildFlavor */,
 ) {
+  // First of all, let's run codegen to make sure that we have the FBreactNativeSpec files in the prebuilds
+  generateFBReactNativeSpecIOS('.');
+
   const prebuildLog = createLogger('prebuild');
   createFolderIfNotExists(buildFolder);
 

--- a/packages/react-native/scripts/ios-prebuild/xcframework.js
+++ b/packages/react-native/scripts/ios-prebuild/xcframework.js
@@ -10,6 +10,9 @@
 
 /*:: import type {BuildFlavor} from './types'; */
 
+const {
+  generateFBReactNativeSpecIOS,
+} = require('../codegen/generate-artifacts-executor/generateFBReactNativeSpecIOS');
 const headers = require('./headers');
 const utils = require('./utils');
 const childProcess = require('child_process');
@@ -49,6 +52,9 @@ function buildXCFrameworks(
   buildType /*: BuildFlavor */,
   identity /*: ?string */,
 ) {
+  // Let's run codegen for FBReactNativeSpec otherwise some headers will be missing
+  generateFBReactNativeSpecIOS('.');
+
   const outputPath = path.join(
     buildFolder,
     'output',
@@ -106,9 +112,15 @@ function buildXCFrameworks(
     if (headerFiles.length > 0) {
       // Get podspec name without directory and extension and make sure it is a valid identifier
       // by replacing any non-alphanumeric characters with an underscore.
-      const podSpecName = path
+      let podSpecName = path
         .basename(podspec, '.podspec')
         .replace(/[^a-zA-Z0-9_]/g, '_');
+
+      // Fix for FBReactNativeSpec. RN expect FBReactNative spec headers
+      // To be in a folder named FBReactNativeSpec.
+      if (podSpecName === 'React_RCTFBReactNativeSpec') {
+        podSpecName = 'FBReactNativeSpec';
+      }
 
       // Create a folder for the podspec in the output headers path
       const podSpecFolder = path.join(outputHeadersPath, podSpecName);


### PR DESCRIPTION
Summary:
This change reverts D78158734 which was a patch to make the dynamic frameworks work properly because we were not exporting the FBReactNativeSpec headers in prebuilds correctly.

This change fixes this, by exposritng those headers correctly.

## Changelog:
[Internal] -

Differential Revision: D78803425


