### PR TITLE
Rollout `useNativeTransformHelperAndroid` and `useNativeEqualsInNativeReadableArrayAndroid` as experimental

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Experimental_Android.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Experimental_Android.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<93aab733661b558c1701b728c18b3d00>>
+ * @generated SignedSource<<14d71bf5be397fb0c139a47061ee4928>>
  */
 
 /**
@@ -24,4 +24,8 @@ public open class ReactNativeFeatureFlagsOverrides_RNOSS_Experimental_Android : 
   // but that is more expensive than just duplicating the defaults here.
 
   override fun preventShadowTreeCommitExhaustionWithLocking(): Boolean = true
+
+  override fun useNativeEqualsInNativeReadableArrayAndroid(): Boolean = true
+
+  override fun useNativeTransformHelperAndroid(): Boolean = true
 }

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSExperimental.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSExperimental.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<16c5fdf431579bbfd454a28c06f28c41>>
+ * @generated SignedSource<<83a7e70db7081b98df66692159636e60>>
  */
 
 /**
@@ -28,6 +28,14 @@ class ReactNativeFeatureFlagsOverridesOSSExperimental : public ReactNativeFeatur
     ReactNativeFeatureFlagsOverridesOSSExperimental() = default;
 
   bool preventShadowTreeCommitExhaustionWithLocking() override {
+    return true;
+  }
+
+  bool useNativeEqualsInNativeReadableArrayAndroid() override {
+    return true;
+  }
+
+  bool useNativeTransformHelperAndroid() override {
     return true;
   }
 };

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -640,7 +640,7 @@ const definitions: FeatureFlagDefinitions = {
         expectedReleaseValue: true,
         purpose: 'experimentation',
       },
-      ossReleaseStage: 'none',
+      ossReleaseStage: 'experimental',
     },
     useNativeTransformHelperAndroid: {
       defaultValue: false,
@@ -650,7 +650,7 @@ const definitions: FeatureFlagDefinitions = {
         expectedReleaseValue: true,
         purpose: 'experimentation',
       },
-      ossReleaseStage: 'none',
+      ossReleaseStage: 'experimental',
     },
     useNativeViewConfigsInBridgelessMode: {
       defaultValue: false,


### PR DESCRIPTION
Summary:
I'm adding those 2 feature flags as enabled for the experimental channel of React Native so that partners
can report back to us and let us know if there are significant regressions.

Changelog:
[Internal] [Changed] -

Reviewed By: rshest

Differential Revision: D78810737


