### PR TITLE
Remove recycled view from parent by default

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManager.java
@@ -9,10 +9,10 @@ package com.facebook.react.uimanager;
 
 import android.content.Context;
 import android.view.View;
+import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
-import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.bridge.BaseJavaModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
@@ -211,7 +211,16 @@ public abstract class ViewManager<T extends View, C extends ReactShadowNode>
     T view = null;
     @Nullable Stack<T> recyclableViews = getRecyclableViewStack(reactContext.getSurfaceId(), true);
     if (recyclableViews != null && !recyclableViews.empty()) {
-      view = recycleView(reactContext, recyclableViews.pop());
+      T recyclableView = recyclableViews.pop();
+
+      // When view recycling isn't enabled for all components, a recyclable view could still be
+      // attached to a non-recyclable view. This guarantees that recycled view have been removed
+      // from their parent.
+      if (ReactNativeFeatureFlags.enableViewRecycling() && recyclableView.getParent() != null) {
+        ((ViewGroup) recyclableView.getParent()).removeView(recyclableView);
+      }
+
+      view = recycleView(reactContext, recyclableView);
     } else {
       view = createViewInstance(reactContext);
     }
@@ -260,16 +269,6 @@ public abstract class ViewManager<T extends View, C extends ReactShadowNode>
     if (recyclableViews != null) {
       T recyclableView = prepareToRecycleView(themedReactContext, view);
       if (recyclableView != null) {
-        Assertions.assertCondition(
-            recyclableView.getParent() == null,
-            "Recycled view ["
-                + view.getId()
-                + "] should not be attached to a parent. View: "
-                + view
-                + " Parent: "
-                + recyclableView.getParent()
-                + " ThemedReactContext: "
-                + themedReactContext);
         recyclableViews.push(recyclableView);
       }
     }


### PR DESCRIPTION
Summary:
With view recyling enabled only on a subset of the components, a recyclabe view could still be attached to its parent if that parent is not recyclable. This diff removes any recycled view from its parent. This will allow the view to be attached to a new parent on mount.

This diff removes the assert checking for parents still set on views pushed on the recycle stack.

Changelog: [Internal]

Differential Revision: D78814943


