### PR TITLE
Move out enums VirtualViewMode and VirtualViewRenderState

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/VirtualView/RCTVirtualViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/VirtualView/RCTVirtualViewComponentView.mm
@@ -21,22 +21,12 @@
 #import <react/renderer/components/virtualview/VirtualViewComponentDescriptor.h>
 #import <react/renderer/components/virtualview/VirtualViewShadowNode.h>
 
+#import "../VirtualViewExperimental/RCTVirtualViewMode.h"
+#import "../VirtualViewExperimental/RCTVirtualViewRenderState.h"
 #import "RCTFabricComponentsPlugins.h"
 
 using namespace facebook;
 using namespace facebook::react;
-
-typedef NS_ENUM(NSInteger, RCTVirtualViewMode) {
-  RCTVirtualViewModeVisible = 0,
-  RCTVirtualViewModePrerender = 1,
-  RCTVirtualViewModeHidden = 2,
-};
-
-typedef NS_ENUM(NSInteger, RCTVirtualViewRenderState) {
-  RCTVirtualViewRenderStateUnknown = 0,
-  RCTVirtualViewRenderStateRendered = 1,
-  RCTVirtualViewRenderStateNone = 2,
-};
 
 /**
  * Checks whether one CGRect overlaps with another CGRect.
@@ -72,8 +62,8 @@ static BOOL CGRectOverlaps(CGRect rect1, CGRect rect2)
 
 @implementation RCTVirtualViewComponentView {
   RCTScrollViewComponentView *_lastParentScrollViewComponentView;
-  std::optional<enum RCTVirtualViewMode> _mode;
-  enum RCTVirtualViewRenderState _renderState;
+  std::optional<RCTVirtualViewMode> _mode;
+  RCTVirtualViewRenderState _renderState;
   std::optional<CGRect> _targetRect;
 }
 
@@ -234,7 +224,7 @@ static BOOL sIsAccessibilityUsed = NO;
     _targetRect = targetRect;
   }
 
-  enum RCTVirtualViewMode newMode;
+  RCTVirtualViewMode newMode;
   CGRect thresholdRect = CGRectMake(
       scrollView.contentOffset.x,
       scrollView.contentOffset.y,
@@ -278,7 +268,7 @@ static BOOL sIsAccessibilityUsed = NO;
            .height = thresholdRect.size.height},
   };
 
-  const std::optional<enum RCTVirtualViewMode> oldMode = _mode;
+  const std::optional<RCTVirtualViewMode> oldMode = _mode;
   _mode = newMode;
 
   switch (newMode) {

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/VirtualViewExperimental/RCTVirtualViewExperimentalComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/VirtualViewExperimental/RCTVirtualViewExperimentalComponentView.mm
@@ -22,21 +22,11 @@
 #import <react/renderer/components/virtualviewexperimental/VirtualViewExperimentalShadowNode.h>
 
 #import "RCTFabricComponentsPlugins.h"
+#import "RCTVirtualViewMode.h"
+#import "RCTVirtualViewRenderState.h"
 
 using namespace facebook;
 using namespace facebook::react;
-
-typedef NS_ENUM(NSInteger, RCTVirtualViewMode) {
-  RCTVirtualViewModeVisible = 0,
-  RCTVirtualViewModePrerender = 1,
-  RCTVirtualViewModeHidden = 2,
-};
-
-typedef NS_ENUM(NSInteger, RCTVirtualViewRenderState) {
-  RCTVirtualViewRenderStateUnknown = 0,
-  RCTVirtualViewRenderStateRendered = 1,
-  RCTVirtualViewRenderStateNone = 2,
-};
 
 /**
  * Checks whether one CGRect overlaps with another CGRect.
@@ -72,8 +62,8 @@ static BOOL CGRectOverlaps(CGRect rect1, CGRect rect2)
 
 @implementation RCTVirtualViewExperimentalComponentView {
   RCTScrollViewComponentView *_lastParentScrollViewComponentView;
-  std::optional<enum RCTVirtualViewMode> _mode;
-  enum RCTVirtualViewRenderState _renderState;
+  std::optional<RCTVirtualViewMode> _mode;
+  RCTVirtualViewRenderState _renderState;
   std::optional<CGRect> _targetRect;
 }
 
@@ -234,7 +224,7 @@ static BOOL sIsAccessibilityUsed = NO;
     _targetRect = targetRect;
   }
 
-  enum RCTVirtualViewMode newMode;
+  RCTVirtualViewMode newMode;
   CGRect thresholdRect = CGRectMake(
       scrollView.contentOffset.x,
       scrollView.contentOffset.y,
@@ -278,7 +268,7 @@ static BOOL sIsAccessibilityUsed = NO;
            .height = thresholdRect.size.height},
   };
 
-  const std::optional<enum RCTVirtualViewMode> oldMode = _mode;
+  const std::optional<RCTVirtualViewMode> oldMode = _mode;
   _mode = newMode;
 
   switch (newMode) {

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/VirtualViewExperimental/RCTVirtualViewMode.h
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/VirtualViewExperimental/RCTVirtualViewMode.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+#ifndef RCTVirtualViewMode_h
+#define RCTVirtualViewMode_h
+
+// Enum for virtual view modes
+using RCTVirtualViewMode = NS_ENUM(NSInteger){
+    RCTVirtualViewModeVisible = 0,
+    RCTVirtualViewModePrerender = 1,
+    RCTVirtualViewModeHidden = 2,
+};
+#endif /* RCTVirtualViewMode_h */

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/VirtualViewExperimental/RCTVirtualViewRenderState.h
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/VirtualViewExperimental/RCTVirtualViewRenderState.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+#ifndef RCTVirtualViewRenderState_h
+#define RCTVirtualViewRenderState_h
+
+using RCTVirtualViewRenderState = NS_ENUM(NSInteger){
+    RCTVirtualViewRenderStateUnknown = 0,
+    RCTVirtualViewRenderStateRendered = 1,
+    RCTVirtualViewRenderStateNone = 2,
+};
+#endif /* RCTVirtualViewRenderState_h */


### PR DESCRIPTION
Summary: Changelog: [Internal] - Move out VirtualViewMode and VirtualViewRenderState into separate files for experimental VirtualView

Reviewed By: mdvacca

Differential Revision: D78825700


