### PR TITLE
Update TurboModuleTestFixture to handle Promise types

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/core/tests/TurboModuleTestFixture.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/tests/TurboModuleTestFixture.h
@@ -10,7 +10,10 @@
 #include <ReactCommon/TestCallInvoker.h>
 #include <gtest/gtest.h>
 #include <hermes/hermes.h>
+#include <react/bridging/Bridging.h>
+#include <react/debug/react_native_assert.h>
 #include <memory>
+#include <optional>
 
 namespace facebook::react {
 
@@ -21,6 +24,75 @@ class TurboModuleTestFixture : public ::testing::Test {
       : runtime_(facebook::hermes::makeHermesRuntime()),
         jsInvoker_(std::make_shared<TestCallInvoker>(runtime_)),
         module_(std::make_shared<T>(jsInvoker_, std::forward<Args>(args)...)) {}
+
+  void SetUp() override {
+    auto setImmediateName =
+        jsi::PropNameID::forAscii(*runtime_, "setImmediate");
+    runtime_->global().setProperty(
+        *runtime_,
+        setImmediateName,
+        jsi::Function::createFromHostFunction(
+            *runtime_,
+            setImmediateName,
+            1,
+            [jsInvoker = jsInvoker_](
+                jsi::Runtime& rt,
+                [[maybe_unused]] const jsi::Value& thisVal,
+                const jsi::Value* args,
+                size_t count) {
+              react_native_assert(count >= 1);
+              jsInvoker->invokeAsync([cb = std::make_shared<jsi::Value>(
+                                          rt, args[0])](jsi::Runtime& rt) {
+                cb->asObject(rt).asFunction(rt).call(rt);
+              });
+              return jsi::Value::undefined();
+            }));
+  }
+
+  void TearDown() override {
+    module_ = nullptr;
+    jsInvoker_ = nullptr;
+    runtime_ = nullptr;
+  }
+
+  template <typename TPromise>
+  std::optional<TPromise> resolvePromise(
+      const AsyncPromise<TPromise>& asyncPromise) {
+    auto promise = asyncPromise.get(*runtime_);
+    std::optional<TPromise> result = std::nullopt;
+    promise.getPropertyAsFunction(*runtime_, "then")
+        .callWithThis(
+            *runtime_,
+            promise,
+            bridging::toJs(
+                *runtime_,
+                [&](TPromise value) { result = std::move(value); },
+                jsInvoker_));
+    jsInvoker_->flushQueue();
+    return result;
+  }
+
+  template <typename TPromise>
+  std::optional<std::string> handleError(
+      const AsyncPromise<TPromise>& asyncPromise) {
+    auto promise = asyncPromise.get(*runtime_);
+    std::optional<std::string> message;
+    promise.getPropertyAsFunction(*runtime_, "catch")
+        .callWithThis(
+            *runtime_,
+            promise,
+            bridging::toJs(
+                *runtime_,
+                [&](jsi::Object error) {
+                  message = bridging::fromJs<std::string>(
+                      *runtime_,
+                      error.getProperty(*runtime_, "message"),
+                      jsInvoker_);
+                },
+                jsInvoker_));
+    jsInvoker_->flushQueue();
+    return message;
+  }
 
  protected:
   std::shared_ptr<jsi::Runtime> runtime_{};

--- a/packages/rn-tester/NativeCxxModuleExample/tests/NativeCxxModuleExampleTests.cpp
+++ b/packages/rn-tester/NativeCxxModuleExample/tests/NativeCxxModuleExampleTests.cpp
@@ -154,6 +154,16 @@ TEST_F(NativeCxxModuleExampleTests, GetValueReturnsCorrectValues) {
   EXPECT_EQ(result.z.c, "seven");
 }
 
+TEST_F(NativeCxxModuleExampleTests, GetValueWithPromiseReturnsCorrectValues) {
+  auto promise1 = module_->getValueWithPromise(*runtime_, false);
+  auto result = resolvePromise(promise1);
+  EXPECT_EQ(result, "result!");
+
+  auto promise2 = module_->getValueWithPromise(*runtime_, true);
+  auto message = handleError(promise2);
+  EXPECT_EQ(message, "intentional promise rejection");
+}
+
 TEST_F(
     NativeCxxModuleExampleTests,
     GetWithWithOptionalArgsReturnsCorrectValues) {


### PR DESCRIPTION
Summary:
Changelog: [Internal]

This adds utility functions and sample test cases to verify AsyncPromises in GTests

Differential Revision: D78871865


