### PR TITLE
fix crash where C++ Animated generates update for deleted view

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/AnimatedMountingOverrideDelegate.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/AnimatedMountingOverrideDelegate.h
@@ -17,11 +17,12 @@
 namespace facebook::react {
 
 class Scheduler;
+class NativeAnimatedNodesManager;
 
 class AnimatedMountingOverrideDelegate : public MountingOverrideDelegate {
  public:
   AnimatedMountingOverrideDelegate(
-      std::function<folly::dynamic(Tag)> getAnimatedManagedProps,
+      NativeAnimatedNodesManager& animatedManager,
       const Scheduler& scheduler);
 
   bool shouldOverridePullTransaction() const override;
@@ -33,7 +34,7 @@ class AnimatedMountingOverrideDelegate : public MountingOverrideDelegate {
       ShadowViewMutationList mutations) const override;
 
  private:
-  std::function<folly::dynamic(Tag)> getAnimatedManagedProps_;
+  mutable NativeAnimatedNodesManager* animatedManager_;
 
   const Scheduler* scheduler_;
 };

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.h
@@ -90,6 +90,8 @@ class NativeAnimatedNodesManager {
 
   void disconnectAnimatedNodeFromView(Tag propsNodeTag, Tag viewTag) noexcept;
 
+  void disconnectAnimationsForView(Tag viewTag) noexcept;
+
   void restoreDefaultValues(Tag tag) noexcept;
 
   void dropAnimatedNode(Tag tag) noexcept;
@@ -175,7 +177,7 @@ class NativeAnimatedNodesManager {
   void updateNodes(
       const std::set<int>& finishedAnimationValueNodes = {}) noexcept;
 
-  folly::dynamic managedProps(Tag tag) noexcept;
+  folly::dynamic managedProps(Tag tag) const noexcept;
 
   bool isOnRenderThread() const noexcept;
 
@@ -209,7 +211,7 @@ class NativeAnimatedNodesManager {
       eventDrivers_;
   std::unordered_set<Tag> updatedNodeTags_;
 
-  std::mutex connectedAnimatedNodesMutex_;
+  mutable std::mutex connectedAnimatedNodesMutex_;
 
   std::mutex uiTasksMutex_;
   std::vector<UiTask> operations_;

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManagerProvider.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManagerProvider.cpp
@@ -83,16 +83,7 @@ NativeAnimatedNodesManagerProvider::getOrCreate(jsi::Runtime& runtime) {
     auto* scheduler = (Scheduler*)uiManager->getDelegate();
     animatedMountingOverrideDelegate_ =
         std::make_shared<AnimatedMountingOverrideDelegate>(
-            [nativeAnimatedNodesManager =
-                 std::weak_ptr<NativeAnimatedNodesManager>(
-                     nativeAnimatedNodesManager_)](Tag tag) -> folly::dynamic {
-              if (auto nativeAnimatedNodesManagerStrong =
-                      nativeAnimatedNodesManager.lock()) {
-                return nativeAnimatedNodesManagerStrong->managedProps(tag);
-              }
-              return nullptr;
-            },
-            *scheduler);
+            *nativeAnimatedNodesManager_, *scheduler);
 
     // Register on existing surfaces
     uiManager->getShadowTreeRegistry().enumerate(

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/PropsAnimatedNode.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/PropsAnimatedNode.cpp
@@ -58,9 +58,6 @@ void PropsAnimatedNode::connectToView(Tag viewTag) {
 }
 
 void PropsAnimatedNode::disconnectFromView(Tag viewTag) {
-  react_native_assert(
-      connectedViewTag_ == viewTag &&
-      "Attempting to disconnect view that has not been connected with the given animated node.");
   connectedViewTag_ = animated::undefinedAnimatedNodeIdentifier;
 }
 


### PR DESCRIPTION
Summary:
changelog: [internal]

On Android, we can run into this problem where a deleted view is being animated. This occurs specifically when UI tick occurs after a view is deleted but before an animation for the view is disconnected. 


How come iOS doesn't crash?
It has a protection against this: https://fburl.com/code/pdoexj34

Reviewed By: zeyap

Differential Revision: D78815390


