### PR TITLE
Refactor HostAgent control flow

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/Utf8.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/Utf8.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <stdexcept>
 #include <vector>
 
 namespace facebook::react::jsinspector_modern {

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorPackagerConnectionTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorPackagerConnectionTest.cpp
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <folly/Format.h>
+#include <fmt/format.h>
 #include <folly/dynamic.h>
 #include <folly/executors/ManualExecutor.h>
 #include <folly/executors/QueuedImmediateExecutor.h>
@@ -16,7 +16,6 @@
 #include <jsinspector-modern/InspectorInterfaces.h>
 #include <jsinspector-modern/InspectorPackagerConnection.h>
 
-#include <format>
 #include <memory>
 
 #include "FollyDynamicMatchers.h"
@@ -282,7 +281,7 @@ TEST_F(InspectorPackagerConnectionTest, TestSendReceiveEvents) {
           .lazily_make_unique<std::unique_ptr<IRemoteConnection>>());
 
   // Connect to the page.
-  webSockets_[0]->getDelegate().didReceiveMessage(std::format(
+  webSockets_[0]->getDelegate().didReceiveMessage(fmt::format(
       R"({{
           "event": "connect",
           "payload": {{
@@ -322,7 +321,7 @@ TEST_F(InspectorPackagerConnectionTest, TestSendReceiveEvents) {
           AtJsonPtr("/params", ElementsAre("arg1", "arg2"))))))
       .RetiresOnSaturation();
 
-  webSockets_[0]->getDelegate().didReceiveMessage(std::format(
+  webSockets_[0]->getDelegate().didReceiveMessage(fmt::format(
       R"({{
           "event": "wrappedEvent",
           "payload": {{
@@ -374,7 +373,7 @@ TEST_F(InspectorPackagerConnectionTest, TestSendReceiveEventsToMultiplePages) {
 
   for (int i = 0; i < kNumPages; ++i) {
     // Connect to the i-th page.
-    webSockets_[0]->getDelegate().didReceiveMessage(std::format(
+    webSockets_[0]->getDelegate().didReceiveMessage(fmt::format(
         R"({{
         "event": "connect",
         "payload": {{
@@ -416,7 +415,7 @@ TEST_F(InspectorPackagerConnectionTest, TestSendReceiveEventsToMultiplePages) {
         *localConnections_[i],
         sendMessage(JsonParsed(AtJsonPtr("/method", Eq(method)))))
         .RetiresOnSaturation();
-    webSockets_[0]->getDelegate().didReceiveMessage(std::format(
+    webSockets_[0]->getDelegate().didReceiveMessage(fmt::format(
         R"({{
           "event": "wrappedEvent",
           "payload": {{
@@ -446,7 +445,7 @@ TEST_F(InspectorPackagerConnectionTest, TestSendEventToAllConnections) {
           .lazily_make_unique<std::unique_ptr<IRemoteConnection>>());
 
   // Connect to the page.
-  webSockets_[0]->getDelegate().didReceiveMessage(std::format(
+  webSockets_[0]->getDelegate().didReceiveMessage(fmt::format(
       R"({{
           "event": "connect",
           "payload": {{
@@ -487,7 +486,7 @@ TEST_F(InspectorPackagerConnectionTest, TestConnectThenDisconnect) {
           .lazily_make_unique<std::unique_ptr<IRemoteConnection>>());
 
   // Connect to the page.
-  webSockets_[0]->getDelegate().didReceiveMessage(std::format(
+  webSockets_[0]->getDelegate().didReceiveMessage(fmt::format(
       R"({{
           "event": "connect",
           "payload": {{
@@ -499,7 +498,7 @@ TEST_F(InspectorPackagerConnectionTest, TestConnectThenDisconnect) {
 
   // Disconnect from the page.
   EXPECT_CALL(*localConnections_[0], disconnect()).RetiresOnSaturation();
-  webSockets_[0]->getDelegate().didReceiveMessage(std::format(
+  webSockets_[0]->getDelegate().didReceiveMessage(fmt::format(
       R"({{
           "event": "disconnect",
           "payload": {{
@@ -522,7 +521,7 @@ TEST_F(InspectorPackagerConnectionTest, TestConnectThenCloseSocket) {
           .lazily_make_unique<std::unique_ptr<IRemoteConnection>>());
 
   // Connect to the page.
-  webSockets_[0]->getDelegate().didReceiveMessage(std::format(
+  webSockets_[0]->getDelegate().didReceiveMessage(fmt::format(
       R"({{
           "event": "connect",
           "payload": {{
@@ -550,7 +549,7 @@ TEST_F(InspectorPackagerConnectionTest, TestConnectThenSocketFailure) {
           .lazily_make_unique<std::unique_ptr<IRemoteConnection>>());
 
   // Connect to the page.
-  webSockets_[0]->getDelegate().didReceiveMessage(std::format(
+  webSockets_[0]->getDelegate().didReceiveMessage(fmt::format(
       R"({{
           "event": "connect",
           "payload": {{
@@ -580,7 +579,7 @@ TEST_F(
           .lazily_make_unique<std::unique_ptr<IRemoteConnection>>());
 
   // Connect to the page.
-  webSockets_[0]->getDelegate().didReceiveMessage(std::format(
+  webSockets_[0]->getDelegate().didReceiveMessage(fmt::format(
       R"({{
           "event": "connect",
           "payload": {{
@@ -626,7 +625,7 @@ TEST_F(
           .lazily_make_unique<std::unique_ptr<IRemoteConnection>>());
 
   // Connect to the page.
-  webSockets_[0]->getDelegate().didReceiveMessage(std::format(
+  webSockets_[0]->getDelegate().didReceiveMessage(fmt::format(
       R"({{
           "event": "connect",
           "payload": {{
@@ -638,7 +637,7 @@ TEST_F(
 
   // Try connecting to the same page again. This results in a disconnection.
   EXPECT_CALL(*localConnections_[0], disconnect()).RetiresOnSaturation();
-  webSockets_[0]->getDelegate().didReceiveMessage(std::format(
+  webSockets_[0]->getDelegate().didReceiveMessage(fmt::format(
       R"({{
           "event": "connect",
           "payload": {{
@@ -661,7 +660,7 @@ TEST_F(InspectorPackagerConnectionTest, TestMultipleDisconnect) {
           .lazily_make_unique<std::unique_ptr<IRemoteConnection>>());
 
   // Connect to the page.
-  webSockets_[0]->getDelegate().didReceiveMessage(std::format(
+  webSockets_[0]->getDelegate().didReceiveMessage(fmt::format(
       R"({{
           "event": "connect",
           "payload": {{
@@ -673,7 +672,7 @@ TEST_F(InspectorPackagerConnectionTest, TestMultipleDisconnect) {
 
   // Disconnect from the page.
   EXPECT_CALL(*localConnections_[0], disconnect()).RetiresOnSaturation();
-  webSockets_[0]->getDelegate().didReceiveMessage(std::format(
+  webSockets_[0]->getDelegate().didReceiveMessage(fmt::format(
       R"({{
           "event": "disconnect",
           "payload": {{
@@ -684,7 +683,7 @@ TEST_F(InspectorPackagerConnectionTest, TestMultipleDisconnect) {
   EXPECT_FALSE(localConnections_[0]);
 
   // Disconnect again. This is a noop.
-  webSockets_[0]->getDelegate().didReceiveMessage(std::format(
+  webSockets_[0]->getDelegate().didReceiveMessage(fmt::format(
       R"({{
           "event": "disconnect",
           "payload": {{
@@ -707,7 +706,7 @@ TEST_F(InspectorPackagerConnectionTest, TestDisconnectThenSendEvent) {
           .lazily_make_unique<std::unique_ptr<IRemoteConnection>>());
 
   // Connect to the page.
-  webSockets_[0]->getDelegate().didReceiveMessage(std::format(
+  webSockets_[0]->getDelegate().didReceiveMessage(fmt::format(
       R"({{
           "event": "connect",
           "payload": {{
@@ -719,7 +718,7 @@ TEST_F(InspectorPackagerConnectionTest, TestDisconnectThenSendEvent) {
 
   // Disconnect from the page.
   EXPECT_CALL(*localConnections_[0], disconnect()).RetiresOnSaturation();
-  webSockets_[0]->getDelegate().didReceiveMessage(std::format(
+  webSockets_[0]->getDelegate().didReceiveMessage(fmt::format(
       R"({{
           "event": "disconnect",
           "payload": {{
@@ -731,7 +730,7 @@ TEST_F(InspectorPackagerConnectionTest, TestDisconnectThenSendEvent) {
 
   // Send an event from the frontend (remote) to the backend (local). This
   // is a noop.
-  webSockets_[0]->getDelegate().didReceiveMessage(std::format(
+  webSockets_[0]->getDelegate().didReceiveMessage(fmt::format(
       R"({{
           "event": "wrappedEvent",
           "payload": {{
@@ -755,7 +754,7 @@ TEST_F(InspectorPackagerConnectionTest, TestSendEventToUnknownPage) {
 
   // Send an event from the frontend (remote) to the backend (local). This
   // is a noop (except for logging).
-  webSockets_[0]->getDelegate().didReceiveMessage(std::format(
+  webSockets_[0]->getDelegate().didReceiveMessage(fmt::format(
       R"({{
           "event": "wrappedEvent",
           "payload": {{
@@ -922,7 +921,7 @@ TEST_F(
           .lazily_make_unique<std::unique_ptr<IRemoteConnection>>());
 
   // Connect to the page.
-  retainedWebSocketDelegate->didReceiveMessage(std::format(
+  retainedWebSocketDelegate->didReceiveMessage(fmt::format(
       R"({{
           "event": "connect",
           "payload": {{
@@ -942,7 +941,7 @@ TEST_F(
           AtJsonPtr("/params", ElementsAre("arg1", "arg2"))))))
       .RetiresOnSaturation();
 
-  retainedWebSocketDelegate->didReceiveMessage(std::format(
+  retainedWebSocketDelegate->didReceiveMessage(fmt::format(
       R"({{
           "event": "wrappedEvent",
           "payload": {{
@@ -976,7 +975,7 @@ TEST_F(InspectorPackagerConnectionTest, TestDestroyConnectionOnPageRemoved) {
           .lazily_make_unique<std::unique_ptr<IRemoteConnection>>());
 
   // Connect to the page.
-  webSockets_[0]->getDelegate().didReceiveMessage(std::format(
+  webSockets_[0]->getDelegate().didReceiveMessage(fmt::format(
       R"({{
           "event": "connect",
           "payload": {{
@@ -1006,7 +1005,7 @@ TEST_F(
           .lazily_make_unique<std::unique_ptr<IRemoteConnection>>());
 
   // Connect to the page.
-  webSockets_[0]->getDelegate().didReceiveMessage(std::format(
+  webSockets_[0]->getDelegate().didReceiveMessage(fmt::format(
       R"({{
           "event": "connect",
           "payload": {{
@@ -1046,7 +1045,7 @@ TEST_F(
           .lazily_make_unique<std::unique_ptr<IRemoteConnection>>());
 
   // Connect to the page.
-  webSockets_[0]->getDelegate().didReceiveMessage(std::format(
+  webSockets_[0]->getDelegate().didReceiveMessage(fmt::format(
       R"({{
           "event": "connect",
           "payload": {{
@@ -1065,7 +1064,7 @@ TEST_F(
 
   // Disconnect from the page.
   EXPECT_CALL(*localConnections_[0], disconnect()).RetiresOnSaturation();
-  webSockets_[0]->getDelegate().didReceiveMessage(std::format(
+  webSockets_[0]->getDelegate().didReceiveMessage(fmt::format(
       R"({{
           "event": "disconnect",
           "payload": {{
@@ -1076,7 +1075,7 @@ TEST_F(
   EXPECT_FALSE(localConnections_[0]);
 
   // Connect to the same page again.
-  webSockets_[0]->getDelegate().didReceiveMessage(std::format(
+  webSockets_[0]->getDelegate().didReceiveMessage(fmt::format(
       R"({{
           "event": "connect",
           "payload": {{
@@ -1128,7 +1127,7 @@ TEST_F(
           .lazily_make_unique<std::unique_ptr<IRemoteConnection>>());
 
   // Connect to the page.
-  webSockets_[0]->getDelegate().didReceiveMessage(std::format(
+  webSockets_[0]->getDelegate().didReceiveMessage(fmt::format(
       R"({{
           "event": "connect",
           "payload": {{
@@ -1152,7 +1151,7 @@ TEST_F(
 
   // Disconnect from the page.
   EXPECT_CALL(*localConnections_[0], disconnect()).RetiresOnSaturation();
-  webSockets_[0]->getDelegate().didReceiveMessage(std::format(
+  webSockets_[0]->getDelegate().didReceiveMessage(fmt::format(
       R"({{
           "event": "disconnect",
           "payload": {{
@@ -1163,7 +1162,7 @@ TEST_F(
   EXPECT_FALSE(localConnections_[0]);
 
   // Connect to the same page again.
-  webSockets_[0]->getDelegate().didReceiveMessage(std::format(
+  webSockets_[0]->getDelegate().didReceiveMessage(fmt::format(
       R"({{
           "event": "connect",
           "payload": {{
@@ -1257,7 +1256,7 @@ TEST_F(InspectorPackagerConnectionTest, TestRejectedPageConnection) {
           AtJsonPtr("/payload/pageId", Eq(std::to_string(pageId)))))))
       .RetiresOnSaturation();
 
-  webSockets_[0]->getDelegate().didReceiveMessage(std::format(
+  webSockets_[0]->getDelegate().didReceiveMessage(fmt::format(
       R"({{
           "event": "connect",
           "payload": {{
@@ -1266,7 +1265,7 @@ TEST_F(InspectorPackagerConnectionTest, TestRejectedPageConnection) {
         }})",
       toJson(std::to_string(pageId))));
 
-  webSockets_[0]->getDelegate().didReceiveMessage(std::format(
+  webSockets_[0]->getDelegate().didReceiveMessage(fmt::format(
       R"({{
           "event": "wrappedEvent",
           "payload": {{
@@ -1292,7 +1291,7 @@ TEST_F(InspectorPackagerConnectionTest, TestRejectedPageConnection) {
           AtJsonPtr("/payload/pageId", Eq(std::to_string(pageId)))))))
       .RetiresOnSaturation();
 
-  webSockets_[0]->getDelegate().didReceiveMessage(std::format(
+  webSockets_[0]->getDelegate().didReceiveMessage(fmt::format(
       R"({{
           "event": "connect",
           "payload": {{
@@ -1301,7 +1300,7 @@ TEST_F(InspectorPackagerConnectionTest, TestRejectedPageConnection) {
         }})",
       toJson(std::to_string(pageId))));
 
-  webSockets_[0]->getDelegate().didReceiveMessage(std::format(
+  webSockets_[0]->getDelegate().didReceiveMessage(fmt::format(
       R"({{
           "event": "wrappedEvent",
           "payload": {{
@@ -1320,7 +1319,7 @@ TEST_F(InspectorPackagerConnectionTest, TestRejectedPageConnection) {
   // page.
   mockNextConnectionBehavior = Accept;
 
-  webSockets_[0]->getDelegate().didReceiveMessage(std::format(
+  webSockets_[0]->getDelegate().didReceiveMessage(fmt::format(
       R"({{
           "event": "connect",
           "payload": {{
@@ -1337,7 +1336,7 @@ TEST_F(InspectorPackagerConnectionTest, TestRejectedPageConnection) {
           AtJsonPtr("/params", ElementsAre("arg1", "arg2"))))))
       .RetiresOnSaturation();
 
-  webSockets_[0]->getDelegate().didReceiveMessage(std::format(
+  webSockets_[0]->getDelegate().didReceiveMessage(fmt::format(
       R"({{
           "event": "wrappedEvent",
           "payload": {{

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.cpp
@@ -5,10 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <folly/Format.h>
+#include <fmt/format.h>
 #include <folly/executors/ManualExecutor.h>
 #include <folly/executors/QueuedImmediateExecutor.h>
-#include <format>
 
 #include "JsiIntegrationTest.h"
 #include "engines/JsiIntegrationTestGenericEngineAdapter.h"
@@ -486,7 +485,7 @@ TYPED_TEST(JsiIntegrationHermesTest, EvaluateExpressionInExecutionContext) {
                                            }
                                          }
                                        })"));
-  this->toPage_->sendMessage(std::format(
+  this->toPage_->sendMessage(fmt::format(
       R"({{
         "id": 1,
         "method": "Runtime.evaluate",
@@ -508,7 +507,7 @@ TYPED_TEST(JsiIntegrationHermesTest, EvaluateExpressionInExecutionContext) {
   // Now the old execution context is stale.
   this->expectMessageFromPage(
       JsonParsed(AllOf(AtJsonPtr("/id", 3), AtJsonPtr("/error/code", -32600))));
-  this->toPage_->sendMessage(std::format(
+  this->toPage_->sendMessage(fmt::format(
       R"({{
         "id": 3,
         "method": "Runtime.evaluate",
@@ -731,7 +730,7 @@ TYPED_TEST(JsiIntegrationHermesTest, ReleaseRemoteObject) {
   // Ensure we can get the properties of the object.
   this->expectMessageFromPage(JsonParsed(
       AllOf(AtJsonPtr("/id", 2), AtJsonPtr("/result/result", SizeIs(Gt(0))))));
-  this->toPage_->sendMessage(std::format(
+  this->toPage_->sendMessage(fmt::format(
       R"({{
           "id": 2,
           "method": "Runtime.getProperties",
@@ -744,7 +743,7 @@ TYPED_TEST(JsiIntegrationHermesTest, ReleaseRemoteObject) {
                                          "id": 3,
                                          "result": {}
                                        })"));
-  this->toPage_->sendMessage(std::format(
+  this->toPage_->sendMessage(fmt::format(
       R"({{
           "id": 3,
           "method": "Runtime.releaseObject",
@@ -755,7 +754,7 @@ TYPED_TEST(JsiIntegrationHermesTest, ReleaseRemoteObject) {
   // Getting properties for a released object results in an error.
   this->expectMessageFromPage(
       JsonParsed(AllOf(AtJsonPtr("/id", 4), AtJsonPtr("/error/code", -32000))));
-  this->toPage_->sendMessage(std::format(
+  this->toPage_->sendMessage(fmt::format(
       R"({{
           "id": 4,
           "method": "Runtime.getProperties",
@@ -766,7 +765,7 @@ TYPED_TEST(JsiIntegrationHermesTest, ReleaseRemoteObject) {
   // Releasing an already released object is an error.
   this->expectMessageFromPage(
       JsonParsed(AllOf(AtJsonPtr("/id", 5), AtJsonPtr("/error/code", -32000))));
-  this->toPage_->sendMessage(std::format(
+  this->toPage_->sendMessage(fmt::format(
       R"({{
           "id": 5,
           "method": "Runtime.releaseObject",
@@ -797,7 +796,7 @@ TYPED_TEST(JsiIntegrationHermesTest, ReleaseRemoteObjectGroup) {
   // Ensure we can get the properties of the object.
   this->expectMessageFromPage(JsonParsed(
       AllOf(AtJsonPtr("/id", 2), AtJsonPtr("/result/result", SizeIs(Gt(0))))));
-  this->toPage_->sendMessage(std::format(
+  this->toPage_->sendMessage(fmt::format(
       R"({{
           "id": 2,
           "method": "Runtime.getProperties",
@@ -819,7 +818,7 @@ TYPED_TEST(JsiIntegrationHermesTest, ReleaseRemoteObjectGroup) {
   // Getting properties for a released object results in an error.
   this->expectMessageFromPage(
       JsonParsed(AllOf(AtJsonPtr("/id", 4), AtJsonPtr("/error/code", -32000))));
-  this->toPage_->sendMessage(std::format(
+  this->toPage_->sendMessage(fmt::format(
       R"({{
           "id": 4,
           "method": "Runtime.getProperties",

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/ReactInstanceIntegrationTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/ReactInstanceIntegrationTest.cpp
@@ -66,9 +66,8 @@ void ReactInstanceIntegrationTest::SetUp() {
     VoidExecutor inspectorExecutor = [this](auto callback) {
       immediateExecutor_.add(callback);
     };
-    MockHostTargetDelegate hostTargetDelegate;
     hostTargetIfModernCDP =
-        HostTarget::create(hostTargetDelegate, inspectorExecutor);
+        HostTarget::create(hostTargetDelegate_, inspectorExecutor);
   }
 
   instance = std::make_unique<react::ReactInstance>(

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/ReactInstanceIntegrationTest.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/ReactInstanceIntegrationTest.h
@@ -67,6 +67,7 @@ class ReactInstanceIntegrationTest
   UniquePtrFactory<MockRemoteConnection> mockRemoteConnections_;
   std::unique_ptr<ILocalConnection> clientToVM_;
   folly::QueuedImmediateExecutor immediateExecutor_;
+  MockHostTargetDelegate hostTargetDelegate_;
 };
 
 } // namespace facebook::react::jsinspector_modern


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Refactors `HostAgent::handleRequest` to make the control flow more explicit and the state (`isFinishedHandlingRequest`, `shouldSendOKResponse`) immutable.

Differential Revision: D78799898


