### PR TITLE
Isolate NativeDevSettings load

### DIFF
--- a/packages/react-native/Libraries/LogBox/Data/LogBoxData.js
+++ b/packages/react-native/Libraries/LogBox/Data/LogBoxData.js
@@ -20,7 +20,6 @@ import type {
 
 import DebuggerSessionObserver from '../../../src/private/devsupport/rndevtools/FuseboxSessionObserver';
 import parseErrorStack from '../../Core/Devtools/parseErrorStack';
-import NativeDevSettings from '../../NativeModules/specs/NativeDevSettings';
 import NativeLogBox from '../../NativeModules/specs/NativeLogBox';
 import LogBoxLog from './LogBoxLog';
 import {parseLogBoxException} from './parseLogBoxLog';
@@ -493,6 +492,10 @@ function showFuseboxWarningsMigrationMessageOnce() {
     return;
   }
   hasShownFuseboxWarningsMigrationMessage = true;
+
+  const NativeDevSettings =
+    require('../../NativeModules/specs/NativeDevSettings').default;
+
   appendNewLog(
     new LogBoxLog({
       level: 'warn',


### PR DESCRIPTION
Summary:
While adding an opt native/dev js mode to fantom, LogBox was trying to load NativeDevSettings when it didn't exist because of mode mismatch.

This is the only location it's happening, so this just moved the NativeDevSettings load into the one function that needs it, probably not the best solution because if this function gets called in this mode we will crash still, but it works for now.

Changelog: [Internal]

Differential Revision: D78952284


