### PR TITLE
Update RCTTextInputComponentView to recycle and properly clean the inputAccessoryView dependency.

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -377,6 +377,9 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
   _lastStringStateWasUpdatedWith = nil;
   _ignoreNextTextInputCall = NO;
   _didMoveToWindow = NO;
+  _backedTextInputView.inputAccessoryViewID = nil;
+  _backedTextInputView.inputAccessoryView = nil;
+  _hasInputAccessoryView = false;
   [_backedTextInputView resignFirstResponder];
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:
Update `RCTTextInputComponentView` to recycle and properly clean its `inputAccessoryView` dependency. Currently, `RCTTextInputComponentView` does not clean up this dependency during recycling, which can result in the `inputAccessoryView` being incorrectly applied to `TextInput` components that do not use an accessory view."

Related issue: https://github.com/facebook/react-native/issues/52824
Snack of the issue: https://snack.expo.dev/@arturkalach/privileged-blue-soda

https://github.com/user-attachments/assets/46a1f172-a75c-4e88-beee-059d4d2e1d0c


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:
[IOS][FIXED] Update recycling logic to clean up the `inputAccessoryView` dependency.
<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:
```
1. Render more than eight TextInput components on the screen, each with an AccessoryView.
2. Unmount the TextInput components using conditional rendering.
3. Open a Modal that contains a KeyboardAvoidingView and a TextInput.
4. Focus on the TextInput inside the Modal.
```


https://github.com/user-attachments/assets/8be1fdef-e8ab-4030-a2c5-e952c22ef743




<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
