### PR TITLE
Align InteractionEntry payload to match Chrome

### DIFF
--- a/packages/react-native/Package.swift
+++ b/packages/react-native/Package.swift
@@ -13,7 +13,7 @@ import PackageDescription
  To build React Native, you need to follow these steps:
  1. inside the `react-native` root folder, run `yarn install`
  2. `cd packages/react-native`
- 3. `RN_DEP_VERSION=nightly HERMES_VERSION=nightly node scripts/prebuild-ios`
+ 3. `RN_DEP_VERSION=nightly HERMES_VERSION=nightly node scripts/ios-prebuild`
  4. `open Package.swift`
  5. Build in Xcode.
 
@@ -206,6 +206,14 @@ let reactHermes = RNTarget(
   defines: [
     CXXSetting.define("HERMES_ENABLE_DEBUGGER", to: "1", .when(configuration: BuildConfiguration.debug))
   ]
+)
+
+/// React-performancecdpmetrics.podspec
+let reactPerformanceCdpMetrics = RNTarget(
+  name: .reactPerformanceCdpMetrics,
+  path: "ReactCommon/react/performance/cdpmetrics",
+  excludedPaths: ["tests"],
+  dependencies: [.reactNativeDependencies, .reactCxxReact, .jsi, .reactPerformanceTimeline, .reactRuntimeExecutor]
 )
 
 /// React-performancetimeline.podspec
@@ -554,6 +562,7 @@ let targets = [
   reactNativeDependencies,
   hermesPrebuilt,
   reactJsiTooling,
+  reactPerformanceCdpMetrics,
   reactPerformanceTimeline,
   reactRuntimeScheduler,
   rctTypesafety,
@@ -724,6 +733,7 @@ extension String {
   static let hermesPrebuilt = "hermes-prebuilt"
 
   static let reactJsiTooling = "React-jsitooling"
+  static let reactPerformanceCdpMetrics = "React-performancecdpmetrics"
   static let reactPerformanceTimeline = "React-performancetimeline"
   static let reactRuntimeScheduler = "React-runtimescheduler"
   static let rctTypesafety = "RCTTypesafety"

--- a/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
@@ -81,6 +81,7 @@ add_react_common_subdir(hermes/inspector-modern)
 add_react_common_subdir(react/renderer/runtimescheduler)
 add_react_common_subdir(react/debug)
 add_react_common_subdir(react/featureflags)
+add_react_common_subdir(react/performance/cdpmetrics)
 add_react_common_subdir(react/performance/timeline)
 add_react_common_subdir(react/renderer/animations)
 add_react_common_subdir(react/renderer/attributedstring)
@@ -191,6 +192,7 @@ add_library(reactnative
           $<TARGET_OBJECTS:react_nativemodule_idlecallbacks>
           $<TARGET_OBJECTS:react_nativemodule_microtasks>
           $<TARGET_OBJECTS:react_newarchdefaults>
+          $<TARGET_OBJECTS:react_performance_cdpmetrics>
           $<TARGET_OBJECTS:react_performance_timeline>
           $<TARGET_OBJECTS:react_renderer_animations>
           $<TARGET_OBJECTS:react_renderer_attributedstring>
@@ -279,6 +281,7 @@ target_include_directories(reactnative
         $<TARGET_PROPERTY:react_nativemodule_idlecallbacks,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:react_nativemodule_microtasks,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:react_newarchdefaults,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:react_performance_cdpmetrics,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:react_performance_timeline,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:react_renderer_animations,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:react_renderer_attributedstring,INTERFACE_INCLUDE_DIRECTORIES>

--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -149,6 +149,7 @@ Pod::Spec.new do |s|
     ss.source_files         = podspec_sources("react/renderer/scheduler/**/*.{m,mm,cpp,h}", "react/renderer/scheduler/**/*.h")
     ss.header_dir           = "react/renderer/scheduler"
 
+    ss.dependency             "React-performancecdpmetrics"
     ss.dependency             "React-performancetimeline"
     ss.dependency             "React-Fabric/observers/events"
   end

--- a/packages/react-native/ReactCommon/react/performance/cdpmetrics/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/performance/cdpmetrics/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+cmake_minimum_required(VERSION 3.13)
+set(CMAKE_VERBOSE_MAKEFILE on)
+
+include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
+
+file(GLOB react_performance_cdpmetrics_SRC CONFIGURE_DEPENDS *.cpp)
+add_library(react_performance_cdpmetrics OBJECT ${react_performance_cdpmetrics_SRC})
+
+target_compile_reactnative_options(react_performance_cdpmetrics PRIVATE)
+target_compile_options(react_performance_cdpmetrics PRIVATE -Wpedantic)
+
+target_include_directories(react_performance_cdpmetrics PUBLIC ${REACT_COMMON_DIR})
+target_link_libraries(react_performance_cdpmetrics
+        folly_runtime
+        jsi
+        react_performancetimeline
+        react_timing
+        runtimeexecutor)

--- a/packages/react-native/ReactCommon/react/performance/cdpmetrics/CdpInteractionTypes.cpp
+++ b/packages/react-native/ReactCommon/react/performance/cdpmetrics/CdpInteractionTypes.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "CdpInteractionTypes.h"
+
+namespace facebook::react {
+
+const InteractionTypesMap& getInteractionTypes() {
+  static InteractionTypesMap INTERACTION_TYPES = {
+      {"auxclick", "pointer"},
+      {"click", "pointer"},
+      {"contextmenu", "pointer"},
+      {"dblclick", "pointer"},
+      {"mousedown", "pointer"},
+      {"mouseenter", "pointer"},
+      {"mouseleave", "pointer"},
+      {"mouseout", "pointer"},
+      {"mouseover", "pointer"},
+      {"mouseup", "pointer"},
+      {"pointerover", "pointer"},
+      {"pointerenter", "pointer"},
+      {"pointerdown", "pointer"},
+      {"pointerup", "pointer"},
+      {"pointercancel", "pointer"},
+      {"pointerout", "pointer"},
+      {"pointerleave", "pointer"},
+      {"gotpointercapture", "pointer"},
+      {"lostpointercapture", "pointer"},
+      {"touchstart", "touch"},
+      {"touchend", "touch"},
+      {"touchcancel", "touch"},
+      {"keydown", "keyboard"},
+      {"keypress", "keyboard"},
+      {"keyup", "keyboard"},
+      {"beforeinput", "keyboard"},
+      {"input", "keyboard"},
+      {"compositionstart", "composition"},
+      {"compositionupdate", "composition"},
+      {"compositionend", "composition"},
+      {"dragstart", "drag"},
+      {"dragend", "drag"},
+      {"dragenter", "drag"},
+      {"dragleave", "drag"},
+      {"dragover", "drag"},
+      {"drop", "drag"},
+  };
+  return INTERACTION_TYPES;
+}
+
+const std::string_view getInteractionTypeForEvent(std::string_view eventName) {
+  const auto& interactionTypes = getInteractionTypes();
+  auto it = interactionTypes.find(eventName);
+  if (it != interactionTypes.end()) {
+    return it->second;
+  }
+  return "unknown";
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/performance/cdpmetrics/CdpInteractionTypes.h
+++ b/packages/react-native/ReactCommon/react/performance/cdpmetrics/CdpInteractionTypes.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string_view>
+#include <unordered_map>
+
+namespace facebook::react {
+
+using InteractionTypesMap =
+    std::unordered_map<std::string_view, std::string_view>;
+
+const InteractionTypesMap& getInteractionTypes();
+
+const std::string_view getInteractionTypeForEvent(std::string_view eventName);
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/performance/cdpmetrics/CdpMetricsReporter.cpp
+++ b/packages/react-native/ReactCommon/react/performance/cdpmetrics/CdpMetricsReporter.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "CdpMetricsReporter.h"
+
+#include <folly/dynamic.h>
+#include <folly/json.h>
+#include <string_view>
+
+namespace facebook::react {
+
+namespace {
+
+constexpr std::string_view metricsReporterName =
+    "__chromium_devtools_metrics_reporter";
+
+} // namespace
+
+CdpMetricsReporter::CdpMetricsReporter(RuntimeExecutor runtimeExecutor)
+    : runtimeExecutor_(std::move(runtimeExecutor)) {}
+
+void CdpMetricsReporter::onEventTimingEntry(
+    const PerformanceEventTiming& entry) {
+  runtimeExecutor_([entry = std::move(entry)](jsi::Runtime& runtime) {
+    auto global = runtime.global();
+    if (!global.hasProperty(runtime, metricsReporterName.data())) {
+      return;
+    }
+
+    folly::dynamic jsonPayload = folly::dynamic::object;
+    jsonPayload["eventName"] = entry.name;
+    jsonPayload["durationMs"] =
+        static_cast<int>(entry.duration.toDOMHighResTimeStamp());
+    jsonPayload["startTime"] =
+        static_cast<int>(entry.startTime.toDOMHighResTimeStamp());
+    auto jsonString = folly::toJson(jsonPayload);
+    auto jsiString = jsi::String::createFromUtf8(runtime, jsonString);
+
+    auto metricsReporter =
+        global.getPropertyAsFunction(runtime, metricsReporterName.data());
+    metricsReporter.call(runtime, jsiString);
+  });
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/performance/cdpmetrics/CdpMetricsReporter.h
+++ b/packages/react-native/ReactCommon/react/performance/cdpmetrics/CdpMetricsReporter.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <ReactCommon/RuntimeExecutor.h>
+#include <jsi/jsi.h>
+#include <react/performance/timeline/PerformanceEntry.h>
+#include <react/performance/timeline/PerformanceEntryReporterListeners.h>
+#include <react/timing/primitives.h>
+
+namespace facebook::react {
+
+/**
+ * [Experimental] Reports CDP interaction events via the
+ * "__chromium_devtools_metrics_reporter" runtime binding.
+ *
+ * This populates the Interaction to Next Paint (INP) live metric in Chrome
+ * DevTools and the V2 Perf Monitor. Events are reported immediately and do
+ * not require an active CDP Tracing session.
+ */
+class CdpMetricsReporter : public PerformanceEntryReporterEventTimingListener {
+ public:
+  explicit CdpMetricsReporter(RuntimeExecutor runtimeExecutor);
+
+  void onEventTimingEntry(const PerformanceEventTiming& entry) override;
+
+ private:
+  const RuntimeExecutor runtimeExecutor_{};
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/performance/cdpmetrics/React-performancecdpmetrics.podspec
+++ b/packages/react-native/ReactCommon/react/performance/cdpmetrics/React-performancecdpmetrics.podspec
@@ -1,0 +1,53 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+require "json"
+
+package = JSON.parse(File.read(File.join(__dir__, "..", "..", "..", "..", "package.json")))
+version = package['version']
+
+source = { :git => 'https://github.com/facebook/react-native.git' }
+if version == '1000.0.0'
+  # This is an unpublished version, use the latest commit hash of the react-native repo, which we’re presumably in.
+  source[:commit] = `git rev-parse HEAD`.strip if system("git rev-parse --git-dir > /dev/null 2>&1")
+else
+  source[:tag] = "v#{version}"
+end
+
+header_search_paths = []
+
+if ENV['USE_FRAMEWORKS']
+  header_search_paths << "\"$(PODS_TARGET_SRCROOT)/../../..\"" # this is needed to allow the cdpmetrics access its own files
+end
+
+Pod::Spec.new do |s|
+  s.name                   = "React-performancecdpmetrics"
+  s.version                = version
+  s.summary                = "Module for reporting React Native performance live metrics to the debugger"
+  s.homepage               = "https://reactnative.dev/"
+  s.license                = package["license"]
+  s.author                 = "Meta Platforms, Inc. and its affiliates"
+  s.platforms              = min_supported_versions
+  s.source                 = source
+  s.source_files           = podspec_sources("**/*.{cpp,h}", "**/*.h")
+  s.header_dir             = "react/performance/cdpmetrics"
+  s.exclude_files          = "tests"
+  s.pod_target_xcconfig    = {
+    "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
+    "HEADER_SEARCH_PATHS" => header_search_paths.join(' ')}
+
+  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
+    s.module_name            = "React_performancecdpmetrics"
+    s.header_mappings_dir  = "../../.."
+  end
+
+  add_dependency(s, "React-runtimeexecutor", :additional_framework_paths => ["platform/ios"])
+  s.dependency "React-jsi"
+  s.dependency "React-performancetimeline"
+  s.dependency "React-timing"
+
+  add_rn_third_party_dependencies(s)
+  add_rncore_dependency(s)
+end

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporterListeners.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporterListeners.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "PerformanceEntry.h"
+
+#include <folly/dynamic.h>
+#include <react/timing/primitives.h>
+
+namespace facebook::react {
+
+class PerformanceEntryReporterEventTimingListener {
+ public:
+  virtual ~PerformanceEntryReporterEventTimingListener() = default;
+
+  virtual void onEventTimingEntry(const PerformanceEventTiming& entry) = 0;
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(react_renderer_scheduler
         jsi
         react_debug
         react_featureflags
+        react_performance_cdpmetrics
         react_performance_timeline
         react_renderer_componentregistry
         react_renderer_core

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.h
@@ -8,9 +8,9 @@
 #pragma once
 
 #include <memory>
-#include <mutex>
 
 #include <ReactCommon/RuntimeExecutor.h>
+#include <react/performance/cdpmetrics/CdpMetricsReporter.h>
 #include <react/performance/timeline/PerformanceEntryReporter.h>
 #include <react/renderer/componentregistry/ComponentDescriptorFactory.h>
 #include <react/renderer/core/ComponentDescriptor.h>
@@ -142,6 +142,7 @@ class Scheduler final : public UIManagerDelegate {
   std::shared_ptr<std::optional<const EventDispatcher>> eventDispatcher_;
 
   std::shared_ptr<PerformanceEntryReporter> performanceEntryReporter_;
+  std::optional<CdpMetricsReporter> cdpMetricsReporter_;
   std::shared_ptr<EventPerformanceLogger> eventPerformanceLogger_;
 
   /**

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -161,6 +161,7 @@ def use_react_native! (
   pod 'React-jsinspectortracing', :path => "#{prefix}/ReactCommon/jsinspector-modern/tracing"
 
   pod 'React-callinvoker', :path => "#{prefix}/ReactCommon/callinvoker"
+  pod 'React-performancecdpmetrics', :path => "#{prefix}/ReactCommon/react/performance/cdpmetrics"
   pod 'React-performancetimeline', :path => "#{prefix}/ReactCommon/react/performance/timeline"
   pod 'React-timing', :path => "#{prefix}/ReactCommon/react/timing"
   pod 'React-runtimeexecutor', :path => "#{prefix}/ReactCommon/runtimeexecutor"

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -16,7 +16,7 @@ PODS:
   - hermes-engine/inspector (1000.0.0)
   - hermes-engine/inspector_chrome (1000.0.0)
   - hermes-engine/Public (1000.0.0)
-  - MyNativeView (0.81.0-main):
+  - MyNativeView (0.82.0-main):
     - boost
     - DoubleConversion
     - fast_float
@@ -44,7 +44,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - NativeCxxModuleExample (0.81.0-main):
+  - NativeCxxModuleExample (0.82.0-main):
     - boost
     - DoubleConversion
     - fast_float
@@ -1085,6 +1085,7 @@ PODS:
     - React-jsi
     - React-jsiexecutor
     - React-logger
+    - React-performancecdpmetrics
     - React-performancetimeline
     - React-rendererdebug
     - React-runtimeexecutor
@@ -1867,6 +1868,19 @@ PODS:
     - RCT-Folly
     - RCT-Folly/Fabric
     - SocketRocket
+  - React-performancecdpmetrics (1000.0.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - React-jsi
+    - React-performancetimeline
+    - React-runtimeexecutor
+    - React-timing
+    - SocketRocket
   - React-performancetimeline (1000.0.0):
     - boost
     - DoubleConversion
@@ -2377,7 +2391,7 @@ PODS:
     - React-perflogger (= 1000.0.0)
     - React-utils (= 1000.0.0)
     - SocketRocket
-  - ScreenshotManager (0.81.0-main):
+  - ScreenshotManager (0.82.0-main):
     - boost
     - DoubleConversion
     - fast_float
@@ -2456,6 +2470,7 @@ DEPENDENCIES:
   - React-NativeModulesApple (from `../react-native/ReactCommon/react/nativemodule/core/platform/ios`)
   - React-oscompat (from `../react-native/ReactCommon/oscompat`)
   - React-perflogger (from `../react-native/ReactCommon/reactperflogger`)
+  - React-performancecdpmetrics (from `../react-native/ReactCommon/react/performance/cdpmetrics`)
   - React-performancetimeline (from `../react-native/ReactCommon/react/performance/timeline`)
   - React-RCTActionSheet (from `../react-native/Libraries/ActionSheetIOS`)
   - React-RCTAnimation (from `../react-native/Libraries/NativeAnimation`)
@@ -2587,6 +2602,8 @@ EXTERNAL SOURCES:
     :path: "../react-native/ReactCommon/oscompat"
   React-perflogger:
     :path: "../react-native/ReactCommon/reactperflogger"
+  React-performancecdpmetrics:
+    :path: "../react-native/ReactCommon/react/performance/cdpmetrics"
   React-performancetimeline:
     :path: "../react-native/ReactCommon/react/performance/timeline"
   React-RCTActionSheet:
@@ -2656,83 +2673,84 @@ SPEC CHECKSUMS:
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6
-  FBLazyVector: a67ac982f94e725e28eb5fdf00ae785a88fee122
+  FBLazyVector: d3c2dd739a63c1a124e775df075dc7c517a719cb
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
-  hermes-engine: 3350cd88070588a0c3ebf47ea6f81ba28c7aaf9f
-  MyNativeView: f9ac5b43a4d23e7d40f2e7c4337b40fc98f645cc
-  NativeCxxModuleExample: 9abb81d71be6898827e6c0bb65b1715f6f3b75a2
+  hermes-engine: 5a9adf9081befbac6b81bc0c81522430a7eb7da1
+  MyNativeView: 26b517931cc8bfc7b602c410572b323348185461
+  NativeCxxModuleExample: 6a9788a749d522f8b6cc55a56f4760a670e4e2eb
   OCMock: 589f2c84dacb1f5aaf6e4cec1f292551fe748e74
-  RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
+  RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: 3808e36294137f9ee5668f4df2e73dc079cd1dcf
-  RCTRequired: 2122b76857162ff9aa7e211de2575089ffe611d6
-  RCTTypeSafety: cda30ca2aadf5786d66ba137b5c06d2190e697e9
-  React: 662099b139948fd652fa9dc369f2a6aece1e18b2
-  React-callinvoker: 49a5a4449dbb4830fdac6341be9027ebf8ffc3bf
-  React-Core: 7e0f44e57d0dc4a814c1be194e8667ca6ee052b7
-  React-CoreModules: a82c6f0d605188a1261b020b4c43cd5c39a9e57f
-  React-cxxreact: bec05af5ce328afa9428fafa6d33730400e4b68c
-  React-debug: 40cbf9f72c96613c639f12f7fcc9a6cb8d54f588
-  React-defaultsnativemodule: 68c0affa6e5c4de5db8352aac0ff53eeace95035
-  React-domnativemodule: b9dc5b7141dbfb65e53039aa708f342c24ca2d30
-  React-Fabric: 15cced8cd4c50826215448b633362106dcfb98d4
-  React-FabricComponents: f6ef214976c812eb2bb59f8e9d10f4ada46ffe12
-  React-FabricImage: 32b54b2b17d61df7b22a0ff8b78b57de1245a588
-  React-featureflags: d2a5f1ee99706701567ad6ffacfefe54bf839813
-  React-featureflagsnativemodule: 722fa94f9d7ac24632df7d178b845c77ac794d36
-  React-graphics: aae15c16655f51e02f4ba211f108bb591d02f82a
-  React-hermes: afd04a013d8e73fcea46019a38724097d410c53c
-  React-idlecallbacksnativemodule: fdb1f69e1725303cd2fb302c6c104b117871dabc
-  React-ImageManager: c2119408bc90c98b037eb418855eac8484b79987
-  React-jserrorhandler: 710e7a368c42914e44a9065ad0f878286511c181
-  React-jsi: 6b6955a311c687ce2560fac466ed7ea6ae1ba851
-  React-jsiexecutor: a1837ded1bd224b94d57e36ee72bd26299cb0624
-  React-jsinspector: 99852440c65d84257ed9bb1a9f6a943ab3b2dc53
-  React-jsinspectorcdp: 51b7b9e98f69a5f43a200286e0f1809b8be2e7d6
-  React-jsinspectornetwork: 31c2d9f486c87f670ae8d76c5eee606995e9a994
-  React-jsinspectortracing: af188edab74f98d132a4170013a4073f13e02323
-  React-jsitooling: c16793498697b5bf00b2b5245529f5ad1bd7dc03
-  React-jsitracing: 1e5621e281f794777dd6933960b63b4001ff6688
-  React-logger: 6be7039c28299972c00f0b326591085037f2224b
-  React-Mapbuffer: c7da77a5d048ec7d7e1e050b3f946551241a768c
-  React-microtasksnativemodule: 394af907fa98cc28f993ed949975c6f4d3d53f5f
-  React-NativeModulesApple: 15bfbf94f0a1286ee7bf4fe0b0d3e8a04a9a3f26
-  React-oscompat: 496762720e2a4dd97786fa08f788e3f8763404ea
-  React-perflogger: 64a1b6eac6ff95474c02c3ee1734c8752a7a1da8
-  React-performancetimeline: 5bfcaa23bc90980d8cc4f0d4dd92e08fbdd10638
-  React-RCTActionSheet: fda681f38788c81040b6e0aebd7050580d5fd74d
-  React-RCTAnimation: 983a1257c6ca45998848a2129d1ea9ada70824a6
-  React-RCTAppDelegate: 15a4c95028249abb71d2769b9d5ec158ce81a9f8
-  React-RCTBlob: 8986952d547b4c81e2827f7dfa9d8457b36c673b
-  React-RCTFabric: 511cc7ff0f99c790330855d20ce7e7a7d28f548a
-  React-RCTFBReactNativeSpec: b4a3bfa2a45af3dcdba1cd13285a7b5c7da29b21
-  React-RCTImage: e4fa15c647802b7ed6c7e405d40db829e2146d02
-  React-RCTLinking: dc1cc3b29036a58f7c828d1ca0a6b24ea7801a97
-  React-RCTNetwork: dffe5f8de5ea63ba22baace02df4b84438e09986
-  React-RCTPushNotification: 4d8081e9d2c636469b7098e137ff39d141643a18
-  React-RCTRuntime: 0abb761a26d449eacfdd47f378ae365b830076c8
-  React-RCTSettings: 9ba77f0aebce1bf71582ee8845db723b264039f6
-  React-RCTTest: 09f99c5f8b2e5e00b9fa6b796ae81fd162843b2d
-  React-RCTText: 58b4e7484e6ce4903e5a9333c9fb744b84b16a05
-  React-RCTVibration: b65dc9f78e1c5d482599205e4a52ec33815c7a1c
-  React-rendererconsistency: 0d60f7275a5f39b37c3753d548e72186562c3a48
-  React-renderercss: 88f92ff8dc85711a2ff861f815876cf8e312fe49
-  React-rendererdebug: fa30da9cdff3556e43a29c5fd5468faee8615850
-  React-RuntimeApple: 415a26184ba8fc6cf372f39d351665b73f0ceeaf
-  React-RuntimeCore: a875f3c5479b1fc07ca3ae0c0797c623baf6516e
-  React-runtimeexecutor: 344502ff6d944ae095379ee587cea61720812751
-  React-RuntimeHermes: 8e0734f0dd51840d957bc2f5216ea84a599dad03
-  React-runtimescheduler: e3d95a3e38dd7c30b1faffdd808cf915fec0c991
-  React-timing: 1c3682ededd5ab4158b7f065404b9c493d1f97f9
-  React-utils: 99cab5ff9f585e8f6d57d97f35d2d38e1d51b4b7
-  ReactAppDependencyProvider: b3db1f6073cd2d5085705f812a6eef258aa9a9d7
-  ReactCodegen: 17ffed80c08ee934120f5962a19c8cdae62615f9
-  ReactCommon: 8135b5504e1ddab9348bb09a7e6c829eb1b21bc6
-  ReactCommon-Samples: 0fc23e4c63e23897cc41f2f6867f5358e7e60806
-  ScreenshotManager: 3b0059e34e3ac8ec152874e4ac9b7a304216ecca
+  RCTRequired: a00614e2da5344c2cda3d287050b6cee00e21dc6
+  RCTTypeSafety: 459a16418c6b413060d35434ba3e83f5b0bd2651
+  React: 170a01a19ba2525ab7f11243e2df6b19bf268093
+  React-callinvoker: f08f425e4043cd1998a158b6e39a6aed1fd1d718
+  React-Core: d35c5cf69898fd026e5cd93a0454b1d42e999d3e
+  React-CoreModules: 3ce1d43f6cc37f43759ec543ce1c0010080f1de1
+  React-cxxreact: 52ea845cf7eb1e0fb201ed36e2192de6522a1f60
+  React-debug: 195df38487d3f48a7af04deddeb4a5c6d4440416
+  React-defaultsnativemodule: 8afea5a4bd07addb523bf48489b8a684ea1bdff0
+  React-domnativemodule: 00a3d08568b4e573dcc21ecec829ed425ab10763
+  React-Fabric: e2ee903224e68c8fa24aa96e217bad36d7660f5a
+  React-FabricComponents: 82043c131381c8b1f6e91c559eb04cdf61decdb7
+  React-FabricImage: 264c9ce5241e43e25b94c8de55ac6c3c8a046472
+  React-featureflags: 595651ea13c63a9f77f06d9a1973b665b4a28b7e
+  React-featureflagsnativemodule: 06823479a2ee210cfa0e9c19447c2722a8d995f2
+  React-graphics: 1f99b9b5515eac389f0cf9c85b03abc366d6a933
+  React-hermes: f1034a4d5d8edaf78d47a4f21e9898c4bf6fe02f
+  React-idlecallbacksnativemodule: 4e65f183318b8a0fbabc481a4eafc0f0d62d1cbf
+  React-ImageManager: a6833445e17879933378b7c0ba45ee42115c14bc
+  React-jserrorhandler: bec134a192c50338193544404d45df24fb8a19ca
+  React-jsi: 4ad77650fb0ca4229569eb2532db7a87e3d12662
+  React-jsiexecutor: fa5b80bdbe1ceffc33a892da20fc07b4dfa4df7a
+  React-jsinspector: 10b5dc4eef2a3d05b80be2114ed676496c5bf59c
+  React-jsinspectorcdp: 5fb266e5f23d3a2819ba848e9d4d0b6b00f95934
+  React-jsinspectornetwork: 1655a81f3fe14789df41e063bd56dd130cc3562a
+  React-jsinspectortracing: 5b0be488e06958a572e1badfe8509929ae1cc83b
+  React-jsitooling: 9e563b89f94cf4baf872fe47105d60ae83f4ce4d
+  React-jsitracing: ce443686f52538d1033ce7db1e7d643e866262f0
+  React-logger: 116c3ae5a9906671d157aa00882a5ee75a5a7ebc
+  React-Mapbuffer: fc937cfa41140d7724c559c3d16c50dd725361c8
+  React-microtasksnativemodule: 09899c7389250279bdcc5384f0281bb069979855
+  React-NativeModulesApple: d05b718ccd8b68c184e76dbc1efb63385197595b
+  React-oscompat: 7133e0e945cda067ae36b22502df663d73002864
+  React-perflogger: ada3cdf3dfc8b7cd1fabe3c91b672e23981611ab
+  React-performancecdpmetrics: 89ea4585d30c7681ab1378afb3fd845cd0647860
+  React-performancetimeline: e7d5849d89ee39557dcd56dfb6e7b0d49003d925
+  React-RCTActionSheet: 1bf8cc8086ad1c15da3407dfb7bc9dd94dc7595d
+  React-RCTAnimation: 263593e66c89bf810604b1ace15dfa382a1ca2df
+  React-RCTAppDelegate: f66939ac7ce5da6eb839c3d84a7098e62498a791
+  React-RCTBlob: 7b76230c53fe87d305eeeb250b0aae031bb6cbae
+  React-RCTFabric: 2fd2ef899c7219fd39fd61c39750510f88a81434
+  React-RCTFBReactNativeSpec: bd9c8093cc3388fe55a8cce47e66712e326e967a
+  React-RCTImage: 3e28f3015bc7e8375298e01ebb2032aa05635c32
+  React-RCTLinking: 06742cfad41c506091403a414370743a4ed75af3
+  React-RCTNetwork: b4577eec0092c16d8996e415e4cac7a372d6d362
+  React-RCTPushNotification: ea11178d499696516e0ff9ae335edbe99b06f94b
+  React-RCTRuntime: 925039e78fc530e0421c308ccc607f214f3c7be1
+  React-RCTSettings: d3c2dd305ec81f7faf42762ec598d57f07fd43be
+  React-RCTTest: 2db46eda60bc2228cb67622a580e8e86b00088d9
+  React-RCTText: e416825b80c530647040ef91d23ffd35ccc87981
+  React-RCTVibration: 1837a27fc16eeffc9509779c3334fde54c012bcc
+  React-rendererconsistency: 777c894edc43dde01499189917ac54ee76ae6a6a
+  React-renderercss: a9cb6ba7f49a80dc4b4f7008bae1590d12f27049
+  React-rendererdebug: fea8bde927403a198742b2d940a5f1cd8230c0b4
+  React-RuntimeApple: 6a0c164a8855edb4987b90da2d4d8601302de72d
+  React-RuntimeCore: 6dec37113b759b76641bd028bfbbbec8cf923356
+  React-runtimeexecutor: f6ad01d321a3b99e772509b4d6f5c25b670103fa
+  React-RuntimeHermes: d4f661204d3061219a63951eb4efed4dcaf3f12f
+  React-runtimescheduler: ae44fe8b4170a9d59f62e8b7d7b060c179db739d
+  React-timing: 9d49179631e5e3c759e6e82d4c613c73da80a144
+  React-utils: 0944df8d553d66b27f486282c42a84a969fd2f6c
+  ReactAppDependencyProvider: 68f2d2cefd6c9b9f2865246be2bfe86ebd49238d
+  ReactCodegen: ff8d79aa6b195efceb75a7cd3cafa9f05d1cbfe0
+  ReactCommon: a53973ab35d399560ace331ec9e2b26db0592cec
+  ReactCommon-Samples: dcc128cbf51ac38d2578791750d0a046d1b8a5e9
+  ScreenshotManager: 370045f403c555760ae26d85a01dda89d257fa7b
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: d4ae2f851e524b23cb324409594f60bc3f091403
+  Yoga: 59290f2ce3fc5c34797a21244288cad99b357b63
 
 PODFILE CHECKSUM: 995beda3236c2c76801e7a4efc7fedcd390220e6
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/private/react-native-fantom/tester/CMakeLists.txt
+++ b/private/react-native-fantom/tester/CMakeLists.txt
@@ -73,6 +73,7 @@ add_react_common_subdir(react/nativemodule/intersectionobserver)
 add_react_common_subdir(react/nativemodule/microtasks)
 add_react_common_subdir(react/nativemodule/mutationobserver)
 add_react_common_subdir(react/nativemodule/webperformance)
+add_react_common_subdir(react/performance/cdpmetrics)
 add_react_common_subdir(react/performance/timeline)
 add_react_common_subdir(react/renderer/attributedstring)
 add_react_common_subdir(react/renderer/bridging)
@@ -187,6 +188,7 @@ target_link_libraries(fantom_tester
     react_nativemodule_microtasks
     react_nativemodule_mutationobserver
     react_nativemodule_webperformance
+    react_performance_cdpmetrics
     react_performance_timeline
     react_renderer_attributedstring
     react_renderer_componentregistry


### PR DESCRIPTION
Summary:
**Context**

Experimental V2 Performance Monitor prototype, beginning by bringing the [Interaction to Next Paint (INP)](https://web.dev/articles/inp) metric to React Native.

**This diff**

Completes populating a full `InteractionEntry` Live Event payload by implementing remaining fields sufficient to be rendered by Chrome DevTools.

Changelog: [Internal]

Differential Revision: D78904747
