### PR TITLE
keep track of last direct manipulation props

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/AnimatedMountingOverrideDelegate.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/AnimatedMountingOverrideDelegate.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "AnimatedMountingOverrideDelegate.h"
+#include "NativeAnimatedNodesManager.h"
 
 #include <react/renderer/componentregistry/ComponentDescriptorRegistry.h>
 #include <react/renderer/components/view/ViewProps.h>
@@ -16,14 +17,17 @@
 namespace facebook::react {
 
 AnimatedMountingOverrideDelegate::AnimatedMountingOverrideDelegate(
-    std::function<folly::dynamic(Tag)> getAnimatedManagedProps,
+    NativeAnimatedNodesManager& animatedManager,
     const Scheduler& scheduler)
     : MountingOverrideDelegate(),
-      getAnimatedManagedProps_(std::move(getAnimatedManagedProps)),
+      animatedManager_(&animatedManager),
       scheduler_(&scheduler){};
 
 bool AnimatedMountingOverrideDelegate::shouldOverridePullTransaction() const {
-  return getAnimatedManagedProps_ != nullptr;
+  if (animatedManager_ != nullptr) {
+    return animatedManager_->hasManagedProps();
+  }
+  return false;
 }
 
 std::optional<MountingTransaction>
@@ -32,19 +36,16 @@ AnimatedMountingOverrideDelegate::pullTransaction(
     MountingTransaction::Number transactionNumber,
     const TransactionTelemetry& telemetry,
     ShadowViewMutationList mutations) const {
-  if (!getAnimatedManagedProps_) {
-    return MountingTransaction{
-        surfaceId, transactionNumber, std::move(mutations), telemetry};
-  }
-
   std::unordered_map<Tag, folly::dynamic> animatedManagedProps;
   for (const auto& mutation : mutations) {
     if (mutation.type == ShadowViewMutation::Update) {
       const auto tag = mutation.newChildShadowView.tag;
-      auto props = getAnimatedManagedProps_(tag);
+      auto props = animatedManager_->managedProps(tag);
       if (!props.isNull()) {
         animatedManagedProps.insert({tag, std::move(props)});
       }
+    } else if (mutation.type == ShadowViewMutation::Delete) {
+      animatedManager_->onManagedPropsRemoved(mutation.oldChildShadowView.tag);
     }
   }
 

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/AnimatedMountingOverrideDelegate.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/AnimatedMountingOverrideDelegate.h
@@ -17,11 +17,12 @@
 namespace facebook::react {
 
 class Scheduler;
+class NativeAnimatedNodesManager;
 
 class AnimatedMountingOverrideDelegate : public MountingOverrideDelegate {
  public:
   AnimatedMountingOverrideDelegate(
-      std::function<folly::dynamic(Tag)> getAnimatedManagedProps,
+      NativeAnimatedNodesManager& animatedManager,
       const Scheduler& scheduler);
 
   bool shouldOverridePullTransaction() const override;
@@ -33,7 +34,7 @@ class AnimatedMountingOverrideDelegate : public MountingOverrideDelegate {
       ShadowViewMutationList mutations) const override;
 
  private:
-  std::function<folly::dynamic(Tag)> getAnimatedManagedProps_;
+  mutable NativeAnimatedNodesManager* animatedManager_;
 
   const Scheduler* scheduler_;
 };

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManagerProvider.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManagerProvider.cpp
@@ -88,16 +88,7 @@ NativeAnimatedNodesManagerProvider::getOrCreate(jsi::Runtime& runtime) {
     auto* scheduler = (Scheduler*)uiManager->getDelegate();
     animatedMountingOverrideDelegate_ =
         std::make_shared<AnimatedMountingOverrideDelegate>(
-            [nativeAnimatedNodesManager =
-                 std::weak_ptr<NativeAnimatedNodesManager>(
-                     nativeAnimatedNodesManager_)](Tag tag) -> folly::dynamic {
-              if (auto nativeAnimatedNodesManagerStrong =
-                      nativeAnimatedNodesManager.lock()) {
-                return nativeAnimatedNodesManagerStrong->managedProps(tag);
-              }
-              return nullptr;
-            },
-            *scheduler);
+            *nativeAnimatedNodesManager_, *scheduler);
 
     // Register on existing surfaces
     uiManager->getShadowTreeRegistry().enumerate(


### PR DESCRIPTION
Summary:
## Changelog:

[Internal] [Fixed] - keep track of last direct manipulation props

* so that at next time there's a ShadowTree commit (regardless of which thread), they're merged into the update mutation
* the props will stay until the view is disconnected from props node via Animated API or the view is removed/deleted. This should be expected behavior, because in RN we expect that once Animated changes a prop, subsequent react commits should not change the value.

Reviewed By: sammy-SC

Differential Revision: D78702843


