### PR TITLE
Use host platform specific text props

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/text/BaseParagraphProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/BaseParagraphProps.cpp
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "ParagraphProps.h"
+#include "BaseParagraphProps.h"
 
 #include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/attributedstring/conversions.h>
@@ -17,9 +17,9 @@
 
 namespace facebook::react {
 
-ParagraphProps::ParagraphProps(
+BaseParagraphProps::BaseParagraphProps(
     const PropsParserContext& context,
-    const ParagraphProps& sourceProps,
+    const BaseParagraphProps& sourceProps,
     const RawProps& rawProps)
     : ViewProps(context, sourceProps, rawProps),
       BaseTextProps(context, sourceProps, rawProps),
@@ -57,7 +57,7 @@ ParagraphProps::ParagraphProps(
   textAttributes.backgroundColor = {};
 };
 
-void ParagraphProps::setProp(
+void BaseParagraphProps::setProp(
     const PropsParserContext& context,
     RawPropsPropNameHash hash,
     const char* propName,
@@ -68,7 +68,7 @@ void ParagraphProps::setProp(
   ViewProps::setProp(context, hash, propName, value);
   BaseTextProps::setProp(context, hash, propName, value);
 
-  static auto defaults = ParagraphProps{};
+  static auto defaults = BaseParagraphProps{};
 
   // ParagraphAttributes has its own switch statement - to keep all
   // of these fields together, and because there are some collisions between
@@ -150,99 +150,11 @@ void ParagraphProps::setProp(
 #pragma mark - DebugStringConvertible
 
 #if RN_DEBUG_STRING_CONVERTIBLE
-SharedDebugStringConvertibleList ParagraphProps::getDebugProps() const {
+SharedDebugStringConvertibleList BaseParagraphProps::getDebugProps() const {
   return ViewProps::getDebugProps() + BaseTextProps::getDebugProps() +
       paragraphAttributes.getDebugProps() +
       SharedDebugStringConvertibleList{
           debugStringConvertibleItem("selectable", isSelectable)};
 }
-#endif
-
-#ifdef RN_SERIALIZABLE_STATE
-
-ComponentName ParagraphProps::getDiffPropsImplementationTarget() const {
-  return "Paragraph";
-}
-
-folly::dynamic ParagraphProps::getDiffProps(const Props* prevProps) const {
-  static const auto defaultProps = ParagraphProps();
-
-  const ParagraphProps* oldProps = prevProps == nullptr
-      ? &defaultProps
-      : static_cast<const ParagraphProps*>(prevProps);
-
-  folly::dynamic result = ViewProps::getDiffProps(oldProps);
-
-  BaseTextProps::appendTextAttributesProps(result, oldProps);
-
-  if (paragraphAttributes.maximumNumberOfLines !=
-      oldProps->paragraphAttributes.maximumNumberOfLines) {
-    result["numberOfLines"] = paragraphAttributes.maximumNumberOfLines;
-  }
-
-  if (paragraphAttributes.ellipsizeMode !=
-      oldProps->paragraphAttributes.ellipsizeMode) {
-    result["ellipsizeMode"] = toString(paragraphAttributes.ellipsizeMode);
-  }
-
-  if (paragraphAttributes.textBreakStrategy !=
-      oldProps->paragraphAttributes.textBreakStrategy) {
-    result["textBreakStrategy"] =
-        toString(paragraphAttributes.textBreakStrategy);
-  }
-
-  if (paragraphAttributes.adjustsFontSizeToFit !=
-      oldProps->paragraphAttributes.adjustsFontSizeToFit) {
-    result["adjustsFontSizeToFit"] = paragraphAttributes.adjustsFontSizeToFit;
-  }
-
-  if (!floatEquality(
-          paragraphAttributes.minimumFontScale,
-          oldProps->paragraphAttributes.minimumFontScale)) {
-    result["minimumFontScale"] = paragraphAttributes.minimumFontScale;
-  }
-
-  if (!floatEquality(
-          paragraphAttributes.minimumFontSize,
-          oldProps->paragraphAttributes.minimumFontSize)) {
-    result["minimumFontSize"] = paragraphAttributes.minimumFontSize;
-  }
-
-  if (!floatEquality(
-          paragraphAttributes.maximumFontSize,
-          oldProps->paragraphAttributes.maximumFontSize)) {
-    result["maximumFontSize"] = paragraphAttributes.maximumFontSize;
-  }
-
-  if (paragraphAttributes.includeFontPadding !=
-      oldProps->paragraphAttributes.includeFontPadding) {
-    result["includeFontPadding"] = paragraphAttributes.includeFontPadding;
-  }
-
-  if (paragraphAttributes.android_hyphenationFrequency !=
-      oldProps->paragraphAttributes.android_hyphenationFrequency) {
-    result["android_hyphenationFrequency"] =
-        toString(paragraphAttributes.android_hyphenationFrequency);
-  }
-
-  if (paragraphAttributes.textAlignVertical !=
-      oldProps->paragraphAttributes.textAlignVertical) {
-    result["textAlignVertical"] =
-        paragraphAttributes.textAlignVertical.has_value()
-        ? toString(paragraphAttributes.textAlignVertical.value())
-        : nullptr;
-  }
-
-  if (isSelectable != oldProps->isSelectable) {
-    result["selectable"] = isSelectable;
-  }
-
-  if (onTextLayout != oldProps->onTextLayout) {
-    result["onTextLayout"] = onTextLayout;
-  }
-
-  return result;
-}
-
 #endif
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/BaseParagraphProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/BaseParagraphProps.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <limits>
+#include <memory>
+
+#include <react/renderer/attributedstring/ParagraphAttributes.h>
+#include <react/renderer/components/text/BaseTextProps.h>
+#include <react/renderer/components/view/ViewProps.h>
+#include <react/renderer/core/Props.h>
+#include <react/renderer/core/PropsParserContext.h>
+
+namespace facebook::react {
+
+/*
+ * Props of <Paragraph> component.
+ * Most of the props are directly stored in composed `ParagraphAttributes`
+ * object.
+ */
+class BaseParagraphProps : public ViewProps, public BaseTextProps {
+ public:
+  BaseParagraphProps() = default;
+  BaseParagraphProps(
+      const PropsParserContext& context,
+      const BaseParagraphProps& sourceProps,
+      const RawProps& rawProps);
+
+  void setProp(
+      const PropsParserContext& context,
+      RawPropsPropNameHash hash,
+      const char* propName,
+      const RawValue& value);
+
+#pragma mark - Props
+
+  /*
+   * Contains all prop values that affect visual representation of the
+   * paragraph.
+   */
+  ParagraphAttributes paragraphAttributes{};
+
+  /*
+   * Defines can the text be selected (and copied) or not.
+   */
+  bool isSelectable{};
+
+  bool onTextLayout{};
+
+#pragma mark - DebugStringConvertible
+
+#if RN_DEBUG_STRING_CONVERTIBLE
+  SharedDebugStringConvertibleList getDebugProps() const override;
+#endif
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/platform/android/react/renderer/components/text/HostPlatformParagraphProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/platform/android/react/renderer/components/text/HostPlatformParagraphProps.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "HostPlatformParagraphProps.h"
+
+#include <react/featureflags/ReactNativeFeatureFlags.h>
+#include <react/renderer/attributedstring/conversions.h>
+#include <react/renderer/attributedstring/primitives.h>
+#include <react/renderer/core/propsConversions.h>
+#include <react/renderer/debug/debugStringConvertibleUtils.h>
+
+#include <glog/logging.h>
+
+namespace facebook::react {
+
+HostPlatformParagraphProps::HostPlatformParagraphProps(
+    const PropsParserContext& context,
+    const HostPlatformParagraphProps& sourceProps,
+    const RawProps& rawProps)
+    : BaseParagraphProps(context, sourceProps, rawProps) {}
+
+void HostPlatformParagraphProps::setProp(
+    const PropsParserContext& context,
+    RawPropsPropNameHash hash,
+    const char* propName,
+    const RawValue& value) {
+  // All Props structs setProp methods must always, unconditionally,
+  // call all super::setProp methods, since multiple structs may
+  // reuse the same values.
+  BaseParagraphProps::setProp(context, hash, propName, value);
+}
+
+#pragma mark - DebugStringConvertible
+
+#if RN_DEBUG_STRING_CONVERTIBLE
+SharedDebugStringConvertibleList HostPlatformParagraphProps::getDebugProps()
+    const {
+  return BaseParagraphProps::getDebugProps();
+}
+#endif
+
+#ifdef RN_SERIALIZABLE_STATE
+
+ComponentName HostPlatformParagraphProps::getDiffPropsImplementationTarget()
+    const {
+  return "Paragraph";
+}
+
+folly::dynamic HostPlatformParagraphProps::getDiffProps(
+    const Props* prevProps) const {
+  static const auto defaultProps = HostPlatformParagraphProps();
+
+  const HostPlatformParagraphProps* oldProps = prevProps == nullptr
+      ? &defaultProps
+      : static_cast<const HostPlatformParagraphProps*>(prevProps);
+
+  folly::dynamic result = ViewProps::getDiffProps(oldProps);
+
+  BaseTextProps::appendTextAttributesProps(result, oldProps);
+
+  if (paragraphAttributes.maximumNumberOfLines !=
+      oldProps->paragraphAttributes.maximumNumberOfLines) {
+    result["numberOfLines"] = paragraphAttributes.maximumNumberOfLines;
+  }
+
+  if (paragraphAttributes.ellipsizeMode !=
+      oldProps->paragraphAttributes.ellipsizeMode) {
+    result["ellipsizeMode"] = toString(paragraphAttributes.ellipsizeMode);
+  }
+
+  if (paragraphAttributes.textBreakStrategy !=
+      oldProps->paragraphAttributes.textBreakStrategy) {
+    result["textBreakStrategy"] =
+        toString(paragraphAttributes.textBreakStrategy);
+  }
+
+  if (paragraphAttributes.adjustsFontSizeToFit !=
+      oldProps->paragraphAttributes.adjustsFontSizeToFit) {
+    result["adjustsFontSizeToFit"] = paragraphAttributes.adjustsFontSizeToFit;
+  }
+
+  if (!floatEquality(
+          paragraphAttributes.minimumFontScale,
+          oldProps->paragraphAttributes.minimumFontScale)) {
+    result["minimumFontScale"] = paragraphAttributes.minimumFontScale;
+  }
+
+  if (!floatEquality(
+          paragraphAttributes.minimumFontSize,
+          oldProps->paragraphAttributes.minimumFontSize)) {
+    result["minimumFontSize"] = paragraphAttributes.minimumFontSize;
+  }
+
+  if (!floatEquality(
+          paragraphAttributes.maximumFontSize,
+          oldProps->paragraphAttributes.maximumFontSize)) {
+    result["maximumFontSize"] = paragraphAttributes.maximumFontSize;
+  }
+
+  if (paragraphAttributes.includeFontPadding !=
+      oldProps->paragraphAttributes.includeFontPadding) {
+    result["includeFontPadding"] = paragraphAttributes.includeFontPadding;
+  }
+
+  if (paragraphAttributes.android_hyphenationFrequency !=
+      oldProps->paragraphAttributes.android_hyphenationFrequency) {
+    result["android_hyphenationFrequency"] =
+        toString(paragraphAttributes.android_hyphenationFrequency);
+  }
+
+  if (paragraphAttributes.textAlignVertical !=
+      oldProps->paragraphAttributes.textAlignVertical) {
+    result["textAlignVertical"] =
+        paragraphAttributes.textAlignVertical.has_value()
+        ? toString(paragraphAttributes.textAlignVertical.value())
+        : nullptr;
+  }
+
+  if (isSelectable != oldProps->isSelectable) {
+    result["selectable"] = isSelectable;
+  }
+
+  if (onTextLayout != oldProps->onTextLayout) {
+    result["onTextLayout"] = onTextLayout;
+  }
+
+  return result;
+}
+
+#endif
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/platform/android/react/renderer/components/text/HostPlatformParagraphProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/platform/android/react/renderer/components/text/HostPlatformParagraphProps.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <limits>
+#include <memory>
+
+#include <react/renderer/components/text/BaseParagraphProps.h>
+#include <react/renderer/core/Props.h>
+#include <react/renderer/core/PropsParserContext.h>
+
+namespace facebook::react {
+
+/*
+ * Props of <Paragraph> component.
+ * Most of the props are directly stored in composed `ParagraphAttributes`
+ * object.
+ */
+class HostPlatformParagraphProps : public BaseParagraphProps {
+ public:
+  HostPlatformParagraphProps() = default;
+  HostPlatformParagraphProps(
+      const PropsParserContext& context,
+      const HostPlatformParagraphProps& sourceProps,
+      const RawProps& rawProps);
+
+  void setProp(
+      const PropsParserContext& context,
+      RawPropsPropNameHash hash,
+      const char* propName,
+      const RawValue& value);
+
+#pragma mark - DebugStringConvertible
+
+#if RN_DEBUG_STRING_CONVERTIBLE
+  SharedDebugStringConvertibleList getDebugProps() const override;
+#endif
+
+#ifdef RN_SERIALIZABLE_STATE
+  ComponentName getDiffPropsImplementationTarget() const override;
+  folly::dynamic getDiffProps(const Props* prevProps) const override;
+#endif
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/platform/cxx/react/renderer/components/text/HostPlatformParagraphProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/platform/cxx/react/renderer/components/text/HostPlatformParagraphProps.h
@@ -7,14 +7,8 @@
 
 #pragma once
 
-#include <react/renderer/components/text/HostPlatformParagraphProps.h>
+#include <react/renderer/components/text/BaseParagraphProps.h>
 
 namespace facebook::react {
-
-/*
- * Props of <Paragraph> component.
- * Most of the props are directly stored in composed `ParagraphAttributes`
- * object.
- */
-using ParagraphProps = HostPlatformParagraphProps;
+using HostPlatformParagraphProps = BaseParagraphProps;
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
With Android having its own props for the Paragraph component, we need to create a Host Platform specific version for the `ParagraphProps` to hold those platform specific properties.

Changelog: [Internal]

Differential Revision: D78990838
