### PR TITLE
Add reproducer for Flow v0.275.0 syntax issue (#52850)

### DIFF
--- a/packages/rn-tester/js/examples/Playground/RNTesterPlayground.js
+++ b/packages/rn-tester/js/examples/Playground/RNTesterPlayground.js
@@ -4,35 +4,98 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow strict-local
  * @format
+ * @flow
  */
 
-import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
-
-import RNTesterText from '../../components/RNTesterText';
 import * as React from 'react';
-import {StyleSheet, View} from 'react-native';
 
-function Playground() {
+import {
+  Text,
+  View,
+  StyleSheet,
+  ActivityIndicator,
+  Button,
+  ScrollView,
+  SafeAreaView,
+} from 'react-native';
+
+/**
+ * Reproducer for Flow v0.275.0 syntax issue with Metro bundler
+ * 
+ * This file demonstrates that simply importing React Native components
+ * that use Flow component syntax causes Metro bundler to fail with:
+ * 
+ * Error: Unable to parse file .../Libraries/Components/ActivityIndicator/ActivityIndicator.js
+ * Unexpected token, expected ";" (63:28)
+ * 
+ * The issue occurs during bundling, not at runtime.
+ * 
+ * Affected components include:
+ * - ActivityIndicator
+ * - Button  
+ * - ScrollView
+ * - SafeAreaView
+ * - Pressable
+ * - Switch
+ * - StatusBar
+ * - And many more...
+ * 
+ * Root cause: Flow v0.233.0+ introduced component syntax that Metro's 
+ * Babel parser cannot parse.
+ * 
+ * Related issues:
+ * - https://github.com/facebook/react-native/issues/52850
+ * - https://github.com/facebook/metro/issues/1540
+ */
+
+export default function Playground(props: {}): React.Node {
   return (
     <View style={styles.container}>
-      <RNTesterText>
-        Edit "RNTesterPlayground.js" to change this file
-      </RNTesterText>
+      <Text style={styles.title}>
+        Flow v0.275.0 Syntax Issue Reproducer
+      </Text>
+      
+      <Text style={styles.text}>
+        If you see this, the issue has been fixed!
+      </Text>
+      
+      <Text style={styles.text}>
+        However, in React Native 0.79.5, Metro bundler fails before
+        this component can render due to Flow syntax parsing errors.
+      </Text>
+      
+      {/* These components use Flow component syntax that breaks Metro */}
+      <ActivityIndicator />
+      <Button title="Test Button" onPress={() => {}} />
+      
+      <ScrollView style={styles.scrollView}>
+        <Text>ScrollView also uses component syntax</Text>
+      </ScrollView>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
+    flex: 1,
+    padding: 20,
+    backgroundColor: '#f5f5f5',
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 20,
+    textAlign: 'center',
+  },
+  text: {
+    fontSize: 16,
+    marginBottom: 10,
+    textAlign: 'center',
+  },
+  scrollView: {
+    marginTop: 20,
+    backgroundColor: 'white',
     padding: 10,
   },
 });
-
-export default ({
-  title: 'Playground',
-  name: 'playground',
-  description: 'Test out new features and ideas.',
-  render: (): React.Node => <Playground />,
-}: RNTesterModuleExample);


### PR DESCRIPTION
## Summary

This PR adds a reproducer to RNTesterPlayground.js that demonstrates the Flow component syntax parsing issue with Metro bundler in React Native 0.79.5.

## Problem

React Native 0.79.5 uses Flow v0.275.0 with component syntax that Metro bundler cannot parse:

```
Error: Unable to parse file .../Libraries/Components/ActivityIndicator/ActivityIndicator.js
Unexpected token, expected ";" (63:28)

  61 | }>;
  62 |
> 63 | const ActivityIndicator: component(
     |                            ^
  64 |   ref?: React.RefSetter<HostComponent<empty>>,
```

## Reproducer

The updated RNTesterPlayground.js file demonstrates that simply importing React Native components (ActivityIndicator, Button, ScrollView, etc.) that use Flow component syntax causes Metro bundler to fail during the bundling phase.

### Affected components include:
- ActivityIndicator
- Button  
- ScrollView
- SafeAreaView
- Pressable
- Switch
- StatusBar
- And many more core components

## Root Cause

Flow v0.233.0+ introduced component syntax that Metro's Babel parser cannot parse. The issue occurs during bundling, not at runtime.

## Changelog

[Internal] [Added] - Add reproducer for Flow v0.275.0 syntax compatibility issue with Metro bundler

## Test Plan

1. Check out this branch
2. Run RNTester with `yarn start` in packages/rn-tester
3. Metro bundler will fail with the parsing error shown above, confirming the issue

The reproducer includes:
- Comments explaining the issue
- Imports of affected components  
- Links to related issues

## Related

- Issue: https://github.com/facebook/react-native/issues/52850
- Fix PR: https://github.com/facebook/react-native/pull/52853
- Metro issue: https://github.com/facebook/metro/issues/1540
- Metro PR: https://github.com/facebook/metro/pull/1541

## Note

This PR is only adding a reproducer to demonstrate the issue. The actual fix is provided in PR https://github.com/facebook/react-native/pull/52853.