### PR TITLE
Force every output to have a different filename in the same run

### DIFF
--- a/private/react-native-fantom/runner/runner.js
+++ b/private/react-native-fantom/runner/runner.js
@@ -35,7 +35,6 @@ import {
   getBuckOptionsForHermes,
   getDebugInfoFromCommandResult,
   getHermesCompilerTarget,
-  getShortHash,
   printConsoleLog,
   runBuck2,
   runBuck2Sync,
@@ -304,7 +303,7 @@ module.exports = async function runTest(
 
     const entrypointPath = path.join(
       BUILD_OUTPUT_PATH,
-      `${getShortHash(entrypointContents)}-${path.basename(testPath)}`,
+      `${Date.now()}-${path.basename(testPath)}`,
     );
     const testJSBundlePath = entrypointPath + '.bundle.js';
     const testBytecodeBundlePath = testJSBundlePath + '.hbc';

--- a/private/react-native-fantom/runner/utils.js
+++ b/private/react-native-fantom/runner/utils.js
@@ -10,7 +10,6 @@
 
 import * as EnvironmentOptions from './EnvironmentOptions';
 import {spawn, spawnSync} from 'child_process';
-import crypto from 'crypto';
 import fs from 'fs';
 import os from 'os';
 // $FlowExpectedError[untyped-import]
@@ -248,10 +247,6 @@ function processArgsForBuck(args: Array<string>): Array<string> {
   }
 
   return args;
-}
-
-export function getShortHash(contents: string): string {
-  return crypto.createHash('md5').update(contents).digest('hex').slice(0, 8);
 }
 
 export function symbolicateStackTrace(


### PR DESCRIPTION
Summary:
Changelog: [internal]

We're seeing some issues in stress runs for Fantom tests in optimized mode, failing when compiling the bytecode with Hermes. The specific error in the Hermes compiler isn't clear, but this started failing when we changed the folders for output. It's possible that it's due to race conditions in stress runs, where multiple workers are attempting to compile in the same locations.

This forces every output in every runner to be in a different file to prevent these possible collisions.

Differential Revision: D79084242


