### PR TITLE
Flatten SampleCallStackFrame and use designated serializers

### DIFF
--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeSamplingProfileSerializer.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeSamplingProfileSerializer.cpp
@@ -34,20 +34,23 @@ inline bool shouldIgnoreHermesFrame(
 RuntimeSamplingProfile::SampleCallStackFrame convertNativeHermesFrame(
     const fhsp::ProfileSampleCallStackNativeFunctionFrame& frame) {
   return RuntimeSamplingProfile::SampleCallStackFrame{
-      RuntimeSamplingProfile::SampleCallStackFrame::Kind::NativeFunction,
-      FALLBACK_SCRIPT_ID, // JavaScript Runtime defines the implementation
-                          // for native function, no script ID to reference.
-      frame.getFunctionName(),
+      .kind =
+          RuntimeSamplingProfile::SampleCallStackFrame::Kind::NativeFunction,
+      .scriptId =
+          FALLBACK_SCRIPT_ID, // JavaScript Runtime defines the implementation
+                              // for native function, no script ID to reference.
+      .functionName = frame.getFunctionName(),
   };
 }
 
 RuntimeSamplingProfile::SampleCallStackFrame convertHostFunctionHermesFrame(
     const fhsp::ProfileSampleCallStackHostFunctionFrame& frame) {
   return RuntimeSamplingProfile::SampleCallStackFrame{
-      RuntimeSamplingProfile::SampleCallStackFrame::Kind::HostFunction,
-      FALLBACK_SCRIPT_ID, // JavaScript Runtime defines the implementation
-                          // for host function, no script ID to reference.
-      frame.getFunctionName(),
+      .kind = RuntimeSamplingProfile::SampleCallStackFrame::Kind::HostFunction,
+      .scriptId =
+          FALLBACK_SCRIPT_ID, // JavaScript Runtime defines the implementation
+                              // for host function, no script ID to reference.
+      .functionName = frame.getFunctionName(),
   };
 }
 
@@ -56,10 +59,11 @@ RuntimeSamplingProfile::SampleCallStackFrame convertSuspendHermesFrame(
   if (frame.getSuspendFrameKind() ==
       fhsp::ProfileSampleCallStackSuspendFrame::SuspendFrameKind::GC) {
     return RuntimeSamplingProfile::SampleCallStackFrame{
-        RuntimeSamplingProfile::SampleCallStackFrame::Kind::GarbageCollector,
-        FALLBACK_SCRIPT_ID, // GC frames are part of the VM, no script ID to
-                            // reference.
-        GARBAGE_COLLECTOR_FRAME_NAME,
+        .kind = RuntimeSamplingProfile::SampleCallStackFrame::Kind::
+            GarbageCollector,
+        .scriptId = FALLBACK_SCRIPT_ID, // GC frames are part of the VM, no
+                                        // script ID to reference.
+        .functionName = GARBAGE_COLLECTOR_FRAME_NAME,
     };
   }
 
@@ -71,18 +75,18 @@ RuntimeSamplingProfile::SampleCallStackFrame convertSuspendHermesFrame(
 RuntimeSamplingProfile::SampleCallStackFrame convertJSFunctionHermesFrame(
     const fhsp::ProfileSampleCallStackJSFunctionFrame& frame) {
   return RuntimeSamplingProfile::SampleCallStackFrame{
-      RuntimeSamplingProfile::SampleCallStackFrame::Kind::JSFunction,
-      frame.getScriptId(),
-      frame.getFunctionName(),
-      frame.hasScriptUrl()
+      .kind = RuntimeSamplingProfile::SampleCallStackFrame::Kind::JSFunction,
+      .scriptId = frame.getScriptId(),
+      .functionName = frame.getFunctionName(),
+      .scriptURL = frame.hasScriptUrl()
           ? std::optional<std::string_view>{frame.getScriptUrl()}
           : std::nullopt,
-      frame.hasFunctionLineNumber()
+      .lineNumber = frame.hasFunctionLineNumber()
           ? std::optional<uint32_t>{frame.getFunctionLineNumber() - 1}
           // Hermes VM keeps line numbers as 1-based. Convert
           // to 0-based.
           : std::nullopt,
-      frame.hasFunctionColumnNumber()
+      .columnNumber = frame.hasFunctionColumnNumber()
           ? std::optional<uint32_t>{frame.getFunctionColumnNumber() - 1}
           // Hermes VM keeps column numbers as 1-based. Convert to
           // 0-based.

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfile.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfile.h
@@ -30,6 +30,7 @@ struct RuntimeSamplingProfile {
  public:
   /// Represents a single frame inside the captured sample stack.
   struct SampleCallStackFrame {
+   public:
     /// Represents type of frame inside of recorded call stack.
     enum class Kind {
       JSFunction, /// JavaScript function frame.
@@ -39,76 +40,21 @@ struct RuntimeSamplingProfile {
       GarbageCollector, /// Garbage collection frame.
     };
 
-   public:
-    SampleCallStackFrame(
-        const Kind kind,
-        const uint32_t scriptId,
-        std::string_view functionName,
-        std::optional<std::string_view> url = std::nullopt,
-        const std::optional<uint32_t>& lineNumber = std::nullopt,
-        const std::optional<uint32_t>& columnNumber = std::nullopt)
-        : kind_(kind),
-          scriptId_(scriptId),
-          functionName_(std::move(functionName)),
-          url_(std::move(url)),
-          lineNumber_(lineNumber),
-          columnNumber_(columnNumber) {}
+    inline bool operator==(const SampleCallStackFrame& rhs) const noexcept =
+        default;
 
-    /// \return type of the call stack frame.
-    Kind getKind() const {
-      return kind_;
-    }
-
-    /// \return id of the corresponding script in the VM.
-    uint32_t getScriptId() const {
-      return scriptId_;
-    }
-
-    /// \return name of the function that represents call frame.
-    std::string_view getFunctionName() const {
-      return functionName_;
-    }
-
-    bool hasUrl() const {
-      return url_.has_value();
-    }
-
-    /// \return source url of the corresponding script in the VM.
-    std::string_view getUrl() const {
-      return url_.value();
-    }
-
-    bool hasLineNumber() const {
-      return lineNumber_.has_value();
-    }
-
-    /// \return 0-based line number of the corresponding call frame.
-    uint32_t getLineNumber() const {
-      return lineNumber_.value();
-    }
-
-    bool hasColumnNumber() const {
-      return columnNumber_.has_value();
-    }
-
-    /// \return 0-based column number of the corresponding call frame.
-    uint32_t getColumnNumber() const {
-      return columnNumber_.value();
-    }
-
-    inline bool operator==(const SampleCallStackFrame& rhs) const noexcept {
-      return kind_ == rhs.kind_ && scriptId_ == rhs.scriptId_ &&
-          functionName_ == rhs.functionName_ && url_ == rhs.url_ &&
-          lineNumber_ == rhs.lineNumber_ && columnNumber_ == rhs.columnNumber_;
-    }
-
-   private:
-    Kind kind_;
-    uint32_t scriptId_;
-    std::string_view functionName_;
-    std::optional<std::string_view> url_;
-    std::optional<uint32_t> lineNumber_;
-    std::optional<uint32_t> columnNumber_;
+    /// type of the call stack frame
+    Kind kind;
+    /// id of the corresponding script in the VM.
+    uint32_t scriptId;
+    /// name of the function that represents call frame.
+    std::string_view functionName;
+    /// source url of the corresponding script in the VM.
+    std::optional<std::string_view> scriptURL = std::nullopt;
+    /// 0-based line number of the corresponding call frame.
+    std::optional<uint32_t> lineNumber = std::nullopt;
+    /// 0-based column number of the corresponding call frame.
+    std::optional<uint32_t> columnNumber = std::nullopt;
   };
 
   /// A pair of a timestamp and a snapshot of the call stack at this point in


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

These doesn't have any custom internal logic, so can be flattened for simplicity.

Reviewed By: huntie

Differential Revision: D76986727


