### PR TITLE
Extract TraceEvent serialization logic

### DIFF
--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeSamplingProfileSerializer.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeSamplingProfileSerializer.cpp
@@ -34,20 +34,23 @@ inline bool shouldIgnoreHermesFrame(
 RuntimeSamplingProfile::SampleCallStackFrame convertNativeHermesFrame(
     const fhsp::ProfileSampleCallStackNativeFunctionFrame& frame) {
   return RuntimeSamplingProfile::SampleCallStackFrame{
-      RuntimeSamplingProfile::SampleCallStackFrame::Kind::NativeFunction,
-      FALLBACK_SCRIPT_ID, // JavaScript Runtime defines the implementation
-                          // for native function, no script ID to reference.
-      frame.getFunctionName(),
+      .kind =
+          RuntimeSamplingProfile::SampleCallStackFrame::Kind::NativeFunction,
+      .scriptId =
+          FALLBACK_SCRIPT_ID, // JavaScript Runtime defines the implementation
+                              // for native function, no script ID to reference.
+      .functionName = frame.getFunctionName(),
   };
 }
 
 RuntimeSamplingProfile::SampleCallStackFrame convertHostFunctionHermesFrame(
     const fhsp::ProfileSampleCallStackHostFunctionFrame& frame) {
   return RuntimeSamplingProfile::SampleCallStackFrame{
-      RuntimeSamplingProfile::SampleCallStackFrame::Kind::HostFunction,
-      FALLBACK_SCRIPT_ID, // JavaScript Runtime defines the implementation
-                          // for host function, no script ID to reference.
-      frame.getFunctionName(),
+      .kind = RuntimeSamplingProfile::SampleCallStackFrame::Kind::HostFunction,
+      .scriptId =
+          FALLBACK_SCRIPT_ID, // JavaScript Runtime defines the implementation
+                              // for host function, no script ID to reference.
+      .functionName = frame.getFunctionName(),
   };
 }
 
@@ -56,10 +59,11 @@ RuntimeSamplingProfile::SampleCallStackFrame convertSuspendHermesFrame(
   if (frame.getSuspendFrameKind() ==
       fhsp::ProfileSampleCallStackSuspendFrame::SuspendFrameKind::GC) {
     return RuntimeSamplingProfile::SampleCallStackFrame{
-        RuntimeSamplingProfile::SampleCallStackFrame::Kind::GarbageCollector,
-        FALLBACK_SCRIPT_ID, // GC frames are part of the VM, no script ID to
-                            // reference.
-        GARBAGE_COLLECTOR_FRAME_NAME,
+        .kind = RuntimeSamplingProfile::SampleCallStackFrame::Kind::
+            GarbageCollector,
+        .scriptId = FALLBACK_SCRIPT_ID, // GC frames are part of the VM, no
+                                        // script ID to reference.
+        .functionName = GARBAGE_COLLECTOR_FRAME_NAME,
     };
   }
 
@@ -71,18 +75,18 @@ RuntimeSamplingProfile::SampleCallStackFrame convertSuspendHermesFrame(
 RuntimeSamplingProfile::SampleCallStackFrame convertJSFunctionHermesFrame(
     const fhsp::ProfileSampleCallStackJSFunctionFrame& frame) {
   return RuntimeSamplingProfile::SampleCallStackFrame{
-      RuntimeSamplingProfile::SampleCallStackFrame::Kind::JSFunction,
-      frame.getScriptId(),
-      frame.getFunctionName(),
-      frame.hasScriptUrl()
+      .kind = RuntimeSamplingProfile::SampleCallStackFrame::Kind::JSFunction,
+      .scriptId = frame.getScriptId(),
+      .functionName = frame.getFunctionName(),
+      .scriptURL = frame.hasScriptUrl()
           ? std::optional<std::string_view>{frame.getScriptUrl()}
           : std::nullopt,
-      frame.hasFunctionLineNumber()
+      .lineNumber = frame.hasFunctionLineNumber()
           ? std::optional<uint32_t>{frame.getFunctionLineNumber() - 1}
           // Hermes VM keeps line numbers as 1-based. Convert
           // to 0-based.
           : std::nullopt,
-      frame.hasFunctionColumnNumber()
+      .columnNumber = frame.hasFunctionColumnNumber()
           ? std::optional<uint32_t>{frame.getFunctionColumnNumber() - 1}
           // Hermes VM keeps column numbers as 1-based. Convert to
           // 0-based.

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.cpp
@@ -172,7 +172,9 @@ tracing::InstanceTracingProfile InstanceAgent::collectTracingProfile() {
   tracing::RuntimeSamplingProfile runtimeSamplingProfile =
       runtimeAgent_->collectSamplingProfile();
 
-  return tracing::InstanceTracingProfile{std::move(runtimeSamplingProfile)};
+  return tracing::InstanceTracingProfile{
+      .runtimeSamplingProfile = std::move(runtimeSamplingProfile),
+  };
 }
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.cpp
@@ -115,7 +115,7 @@ bool TracingAgent::handleRequest(const cdp::PreparsedRequest& req) {
         dataCollectedCallback,
         PROFILE_TRACE_EVENT_CHUNK_SIZE);
     serializer.serializeAndNotify(
-        instanceAgent_->collectTracingProfile().getRuntimeSamplingProfile(),
+        instanceAgent_->collectTracingProfile().runtimeSamplingProfile,
         instanceTracingStartTimestamp_);
 
     frontendChannel_(cdp::jsonNotification(

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/InstanceTracingProfile.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/InstanceTracingProfile.h
@@ -13,15 +13,7 @@ namespace facebook::react::jsinspector_modern::tracing {
 
 struct InstanceTracingProfile {
  public:
-  explicit InstanceTracingProfile(RuntimeSamplingProfile runtimeSamplingProfile)
-      : runtimeSamplingProfile_(std::move(runtimeSamplingProfile)) {}
-
-  const RuntimeSamplingProfile& getRuntimeSamplingProfile() const {
-    return runtimeSamplingProfile_;
-  }
-
- private:
-  RuntimeSamplingProfile runtimeSamplingProfile_;
+  RuntimeSamplingProfile runtimeSamplingProfile;
 };
 
 } // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
@@ -83,8 +83,7 @@ bool PerformanceTracer::stopTracing() {
 }
 
 void PerformanceTracer::collectEvents(
-    const std::function<void(const folly::dynamic& eventsChunk)>&
-        resultCallback,
+    const std::function<void(folly::dynamic&& eventsChunk)>& resultCallback,
     uint16_t chunkSize) {
   std::vector<TraceEvent> localBuffer;
   {
@@ -102,12 +101,12 @@ void PerformanceTracer::collectEvents(
     serializedTraceEvents.push_back(serializeTraceEvent(std::move(event)));
 
     if (serializedTraceEvents.size() == chunkSize) {
-      resultCallback(serializedTraceEvents);
+      resultCallback(std::move(serializedTraceEvents));
       serializedTraceEvents = folly::dynamic::array();
     }
   }
   if (!serializedTraceEvents.empty()) {
-    resultCallback(serializedTraceEvents);
+    resultCallback(std::move(serializedTraceEvents));
   }
 }
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -56,8 +56,7 @@ class PerformanceTracer {
    * Flush out buffered CDP Trace Events using the given callback.
    */
   void collectEvents(
-      const std::function<void(const folly::dynamic& eventsChunk)>&
-          resultCallback,
+      const std::function<void(folly::dynamic&& eventsChunk)>& resultCallback,
       uint16_t chunkSize);
 
   /**

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -156,14 +156,6 @@ class PerformanceTracer {
   PerformanceTracer& operator=(const PerformanceTracer&) = delete;
   ~PerformanceTracer() = default;
 
-  /**
-   * Serialize a TraceEvent into a folly::dynamic object.
-   * \param event rvalue reference to the TraceEvent object.
-   * \return folly::dynamic object that represents a serialized into JSON Trace
-   * Event for CDP.
-   */
-  folly::dynamic serializeTraceEvent(TraceEvent&& event) const;
-
   const uint64_t processId_;
 
   /**

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfile.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfile.h
@@ -11,7 +11,6 @@
 #include <optional>
 #include <string>
 #include <string_view>
-#include <utility>
 #include <vector>
 
 namespace facebook::react::jsinspector_modern::tracing {
@@ -65,9 +64,9 @@ struct RuntimeSamplingProfile {
         uint64_t timestamp,
         uint64_t threadId,
         std::vector<SampleCallStackFrame> callStack)
-        : timestamp_(timestamp),
-          threadId_(threadId),
-          callStack_(std::move(callStack)) {}
+        : timestamp(timestamp),
+          threadId(threadId),
+          callStack(std::move(callStack)) {}
 
     // Movable.
     Sample& operator=(Sample&&) = default;
@@ -77,40 +76,24 @@ struct RuntimeSamplingProfile {
     Sample(const Sample&) = delete;
     Sample& operator=(const Sample&) = delete;
 
-    /// \return serialized unix timestamp in microseconds granularity. The
-    /// moment when this sample was recorded.
-    uint64_t getTimestamp() const {
-      return timestamp_;
-    }
+    ~Sample() = default;
 
-    /// \return thread id where sample was recorded.
-    uint64_t getThreadId() const {
-      return threadId_;
-    }
-
-    /// \return a snapshot of the call stack. The first element of the vector is
-    /// the lowest frame in the stack.
-    const std::vector<SampleCallStackFrame>& getCallStack() const {
-      return callStack_;
-    }
-
-   private:
     /// When the call stack snapshot was taken (μs).
-    uint64_t timestamp_;
+    uint64_t timestamp;
     /// Thread id where sample was recorded.
-    uint64_t threadId_;
+    uint64_t threadId;
     /// Snapshot of the call stack. The first element of the vector is
     /// the lowest frame in the stack.
-    std::vector<SampleCallStackFrame> callStack_;
+    std::vector<SampleCallStackFrame> callStack;
   };
 
   RuntimeSamplingProfile(
       std::string runtimeName,
       std::vector<Sample> samples,
       std::unique_ptr<RawRuntimeProfile> rawRuntimeProfile)
-      : runtimeName_(std::move(runtimeName)),
-        samples_(std::move(samples)),
-        rawRuntimeProfile_(std::move(rawRuntimeProfile)) {}
+      : runtimeName(std::move(runtimeName)),
+        samples(std::move(samples)),
+        rawRuntimeProfile(std::move(rawRuntimeProfile)) {}
 
   // Movable.
   RuntimeSamplingProfile& operator=(RuntimeSamplingProfile&&) = default;
@@ -120,26 +103,17 @@ struct RuntimeSamplingProfile {
   RuntimeSamplingProfile(const RuntimeSamplingProfile&) = delete;
   RuntimeSamplingProfile& operator=(const RuntimeSamplingProfile&) = delete;
 
-  /// \return name of the JavaScript runtime, where sampling occurred.
-  const std::string& getRuntimeName() const {
-    return runtimeName_;
-  }
+  ~RuntimeSamplingProfile() = default;
 
-  /// \return list of recorded samples, should be chronologically sorted.
-  const std::vector<Sample>& getSamples() const {
-    return samples_;
-  }
-
- private:
   /// Name of the runtime, where sampling occurred: Hermes, V8, etc.
-  std::string runtimeName_;
+  std::string runtimeName;
   /// List of recorded samples, should be chronologically sorted.
-  std::vector<Sample> samples_;
+  std::vector<Sample> samples;
   /// A unique pointer to the original raw runtime profile, collected from the
   /// runtime in RuntimeTargetDelegate. Keeping a pointer to the original
   /// profile allows it to remain alive as long as RuntimeSamplingProfile is
   /// alive, since it may be using the same std::string_view.
-  std::unique_ptr<RawRuntimeProfile> rawRuntimeProfile_;
+  std::unique_ptr<RawRuntimeProfile> rawRuntimeProfile;
 };
 
 } // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfile.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfile.h
@@ -30,6 +30,7 @@ struct RuntimeSamplingProfile {
  public:
   /// Represents a single frame inside the captured sample stack.
   struct SampleCallStackFrame {
+   public:
     /// Represents type of frame inside of recorded call stack.
     enum class Kind {
       JSFunction, /// JavaScript function frame.
@@ -39,76 +40,21 @@ struct RuntimeSamplingProfile {
       GarbageCollector, /// Garbage collection frame.
     };
 
-   public:
-    SampleCallStackFrame(
-        const Kind kind,
-        const uint32_t scriptId,
-        std::string_view functionName,
-        std::optional<std::string_view> url = std::nullopt,
-        const std::optional<uint32_t>& lineNumber = std::nullopt,
-        const std::optional<uint32_t>& columnNumber = std::nullopt)
-        : kind_(kind),
-          scriptId_(scriptId),
-          functionName_(std::move(functionName)),
-          url_(std::move(url)),
-          lineNumber_(lineNumber),
-          columnNumber_(columnNumber) {}
+    inline bool operator==(const SampleCallStackFrame& rhs) const noexcept =
+        default;
 
-    /// \return type of the call stack frame.
-    Kind getKind() const {
-      return kind_;
-    }
-
-    /// \return id of the corresponding script in the VM.
-    uint32_t getScriptId() const {
-      return scriptId_;
-    }
-
-    /// \return name of the function that represents call frame.
-    std::string_view getFunctionName() const {
-      return functionName_;
-    }
-
-    bool hasUrl() const {
-      return url_.has_value();
-    }
-
-    /// \return source url of the corresponding script in the VM.
-    std::string_view getUrl() const {
-      return url_.value();
-    }
-
-    bool hasLineNumber() const {
-      return lineNumber_.has_value();
-    }
-
-    /// \return 0-based line number of the corresponding call frame.
-    uint32_t getLineNumber() const {
-      return lineNumber_.value();
-    }
-
-    bool hasColumnNumber() const {
-      return columnNumber_.has_value();
-    }
-
-    /// \return 0-based column number of the corresponding call frame.
-    uint32_t getColumnNumber() const {
-      return columnNumber_.value();
-    }
-
-    inline bool operator==(const SampleCallStackFrame& rhs) const noexcept {
-      return kind_ == rhs.kind_ && scriptId_ == rhs.scriptId_ &&
-          functionName_ == rhs.functionName_ && url_ == rhs.url_ &&
-          lineNumber_ == rhs.lineNumber_ && columnNumber_ == rhs.columnNumber_;
-    }
-
-   private:
-    Kind kind_;
-    uint32_t scriptId_;
-    std::string_view functionName_;
-    std::optional<std::string_view> url_;
-    std::optional<uint32_t> lineNumber_;
-    std::optional<uint32_t> columnNumber_;
+    /// type of the call stack frame
+    Kind kind;
+    /// id of the corresponding script in the VM.
+    uint32_t scriptId;
+    /// name of the function that represents call frame.
+    std::string_view functionName;
+    /// source url of the corresponding script in the VM.
+    std::optional<std::string_view> scriptURL = std::nullopt;
+    /// 0-based line number of the corresponding call frame.
+    std::optional<uint32_t> lineNumber = std::nullopt;
+    /// 0-based column number of the corresponding call frame.
+    std::optional<uint32_t> columnNumber = std::nullopt;
   };
 
   /// A pair of a timestamp and a snapshot of the call stack at this point in

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.cpp
@@ -19,7 +19,7 @@ namespace {
 // update Hermes to return timestamps in chrono type.
 HighResTimeStamp getHighResTimeStampForSample(
     const RuntimeSamplingProfile::Sample& sample) {
-  auto microsecondsSinceSteadyClockEpoch = sample.getTimestamp();
+  auto microsecondsSinceSteadyClockEpoch = sample.timestamp;
   auto chronoTimePoint = std::chrono::steady_clock::time_point(
       std::chrono::microseconds(microsecondsSinceSteadyClockEpoch));
   return HighResTimeStamp::fromChronoSteadyClockTimePoint(chronoTimePoint);
@@ -191,13 +191,12 @@ void RuntimeSamplingProfileTraceEventSerializer::
 void RuntimeSamplingProfileTraceEventSerializer::serializeAndNotify(
     const RuntimeSamplingProfile& profile,
     HighResTimeStamp tracingStartTime) {
-  const std::vector<RuntimeSamplingProfile::Sample>& samples =
-      profile.getSamples();
+  const std::vector<RuntimeSamplingProfile::Sample>& samples = profile.samples;
   if (samples.empty()) {
     return;
   }
 
-  uint64_t firstChunkThreadId = samples.front().getThreadId();
+  uint64_t firstChunkThreadId = samples.front().threadId;
   HighResTimeStamp previousSampleTimestamp = tracingStartTime;
   HighResTimeStamp currentChunkTimestamp = tracingStartTime;
 
@@ -227,7 +226,7 @@ void RuntimeSamplingProfileTraceEventSerializer::serializeAndNotify(
   uint32_t idleNodeId = idleNode->getId();
 
   for (const auto& sample : samples) {
-    uint64_t currentSampleThreadId = sample.getThreadId();
+    uint64_t currentSampleThreadId = sample.threadId;
     auto currentSampleTimestamp = getHighResTimeStampForSample(sample);
 
     // We should not attempt to merge samples from different threads.
@@ -245,7 +244,7 @@ void RuntimeSamplingProfileTraceEventSerializer::serializeAndNotify(
     }
 
     processCallStack(
-        sample.getCallStack(),
+        sample.callStack,
         chunk,
         rootNode,
         idleNodeId,

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.h
@@ -72,7 +72,7 @@ class RuntimeSamplingProfileTraceEventSerializer {
    */
   RuntimeSamplingProfileTraceEventSerializer(
       PerformanceTracer& performanceTracer,
-      std::function<void(const folly::dynamic& traceEventsChunk)>
+      std::function<void(folly::dynamic&& traceEventsChunk)>
           notificationCallback,
       uint16_t traceEventChunkSize,
       uint16_t profileChunkSize = 10)
@@ -90,7 +90,7 @@ class RuntimeSamplingProfileTraceEventSerializer {
    * will be used as a starting reference point of JavaScript samples recording.
    */
   void serializeAndNotify(
-      const RuntimeSamplingProfile& profile,
+      RuntimeSamplingProfile&& profile,
       HighResTimeStamp tracingStartTime);
 
  private:
@@ -123,7 +123,7 @@ class RuntimeSamplingProfileTraceEventSerializer {
    * \param chunk The chunk that will be buffered.
    * \param profileId The id of the Profile.
    */
-  void bufferProfileChunkTraceEvent(ProfileChunk& chunk, uint16_t profileId);
+  void bufferProfileChunkTraceEvent(ProfileChunk&& chunk, uint16_t profileId);
 
   /**
    * Encapsulates logic for processing the call stack of the sample.
@@ -140,8 +140,7 @@ class RuntimeSamplingProfileTraceEventSerializer {
    * generating unique node ids.
    */
   void processCallStack(
-      const std::vector<RuntimeSamplingProfile::SampleCallStackFrame>&
-          callStack,
+      std::vector<RuntimeSamplingProfile::SampleCallStackFrame>&& callStack,
       ProfileChunk& chunk,
       ProfileTreeNode& rootNode,
       uint32_t idleNodeId,
@@ -154,10 +153,10 @@ class RuntimeSamplingProfileTraceEventSerializer {
   void sendBufferedTraceEventsAndClear();
 
   PerformanceTracer& performanceTracer_;
-  const std::function<void(const folly::dynamic& traceEventsChunk)>
+  const std::function<void(folly::dynamic&& traceEventsChunk)>
       notificationCallback_;
-  uint16_t traceEventChunkSize_;
-  uint16_t profileChunkSize_;
+  const uint16_t traceEventChunkSize_;
+  const uint16_t profileChunkSize_;
 
   folly::dynamic traceEventBuffer_;
 };

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEventSerializer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEventSerializer.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "TraceEventSerializer.h"
+#include "Timing.h"
+
+namespace facebook::react::jsinspector_modern::tracing {
+
+/* static */ folly::dynamic TraceEventSerializer::serialize(
+    TraceEvent&& event) {
+  folly::dynamic result = folly::dynamic::object;
+
+  if (event.id.has_value()) {
+    std::array<char, 16> buffer{};
+    snprintf(buffer.data(), buffer.size(), "0x%x", event.id.value());
+    result["id"] = buffer.data();
+  }
+  result["name"] = std::move(event.name);
+  result["cat"] = std::move(event.cat);
+  result["ph"] = std::string(1, event.ph);
+  result["ts"] = highResTimeStampToTracingClockTimeStamp(event.ts);
+  result["pid"] = event.pid;
+  result["tid"] = event.tid;
+  result["args"] = std::move(event.args);
+  if (event.dur.has_value()) {
+    result["dur"] = highResDurationToTracingClockDuration(event.dur.value());
+  }
+
+  return result;
+}
+
+} // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEventSerializer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEventSerializer.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "TraceEvent.h"
+
+#include <folly/dynamic.h>
+
+namespace facebook::react::jsinspector_modern::tracing {
+
+/**
+ * This class is only responsible for serializing a local TraceEvent
+ * representation into JSON, that should be ready to be dispatched over the
+ * protocol.
+ */
+class TraceEventSerializer {
+ public:
+  /**
+   * Serializes a TraceEvent to a folly::dynamic object.
+   *
+   * \param event rvalue reference to the TraceEvent object.
+   * \return A folly::dynamic object that represents a serialized into JSON
+   * Trace Event for CDP.
+   */
+  static folly::dynamic serialize(TraceEvent&& event);
+};
+
+} // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/tests/RuntimeSamplingProfileTraceEventSerializerTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/tests/RuntimeSamplingProfileTraceEventSerializerTest.cpp
@@ -18,9 +18,9 @@ class RuntimeSamplingProfileTraceEventSerializerTest : public ::testing::Test {
  protected:
   std::vector<folly::dynamic> notificationEvents_;
 
-  std::function<void(const folly::dynamic& traceEventsChunk)>
+  std::function<void(folly::dynamic&& traceEventsChunk)>
   createNotificationCallback() {
-    return [this](const folly::dynamic& traceEventsChunk) {
+    return [this](folly::dynamic&& traceEventsChunk) {
       notificationEvents_.push_back(traceEventsChunk);
     };
   }
@@ -74,7 +74,7 @@ TEST_F(RuntimeSamplingProfileTraceEventSerializerTest, EmptyProfile) {
   auto tracingStartTime = HighResTimeStamp::now();
 
   // Execute
-  serializer.serializeAndNotify(profile, tracingStartTime);
+  serializer.serializeAndNotify(std::move(profile), tracingStartTime);
 
   // Nothing should be reported if the profile is empty.
   EXPECT_TRUE(notificationEvents_.empty());
@@ -122,7 +122,7 @@ TEST_F(
   auto tracingStartTime = HighResTimeStamp::now();
 
   // Execute
-  serializer.serializeAndNotify(profile, tracingStartTime);
+  serializer.serializeAndNotify(std::move(profile), tracingStartTime);
 
   // Verify
   ASSERT_EQ(notificationEvents_.size(), 2);
@@ -155,7 +155,7 @@ TEST_F(RuntimeSamplingProfileTraceEventSerializerTest, EmptySample) {
   folly::dynamic chunkEvent = folly::dynamic::object;
 
   // Execute
-  serializer.serializeAndNotify(profile, tracingStartTime);
+  serializer.serializeAndNotify(std::move(profile), tracingStartTime);
 
   // Verify
   // [["Profile"], ["ProfileChunk"]]
@@ -192,7 +192,7 @@ TEST_F(
   auto tracingStartTime = HighResTimeStamp::now();
 
   // Execute
-  serializer.serializeAndNotify(profile, tracingStartTime);
+  serializer.serializeAndNotify(std::move(profile), tracingStartTime);
 
   // [["Profile"], ["ProfileChunk", "ProfileChunk", "ProfileChunk]]
   // Samples from different thread should never be grouped together in the same
@@ -231,7 +231,7 @@ TEST_F(
   auto tracingStartTime = HighResTimeStamp::now();
 
   // Execute
-  serializer.serializeAndNotify(profile, tracingStartTime);
+  serializer.serializeAndNotify(std::move(profile), tracingStartTime);
 
   // [["Profile"], ["ProfileChunk", "ProfileChunk"], ["ProfileChunk"]]
   ASSERT_EQ(notificationEvents_.size(), 3);
@@ -272,7 +272,7 @@ TEST_F(RuntimeSamplingProfileTraceEventSerializerTest, ProfileChunkSizeLimit) {
   auto tracingStartTime = HighResTimeStamp::now();
 
   // Execute
-  serializer.serializeAndNotify(profile, tracingStartTime);
+  serializer.serializeAndNotify(std::move(profile), tracingStartTime);
 
   // [["Profile"], ["ProfileChunk", "ProfileChunk", "ProfileChunk"]]
   ASSERT_EQ(notificationEvents_.size(), 2);


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

We are exctracting a logic for serialization of TraceEvent into a dedicated serializer class.

Conceptually:
- PerformanceTracer would be a local TraceEvent engine that is responsible for constructing and buffering TraceEvents.
- TraceEventSerializer will have a single responsibility: transforming from local structs to serialized json objects that are ready to be dispatched over CDP Tracing domain.

This would help avoid scenarios, where we are passing around `folly:dynamic` between internal subsystems: serialization should only happen right before emtting a CDP message.

Reviewed By: huntie

Differential Revision: D78738370


