### PR TITLE
Fix path to react-native for Metro

### DIFF
--- a/private/helloworld/scripts/metro.js
+++ b/private/helloworld/scripts/metro.js
@@ -23,7 +23,7 @@ program
           android: {},
         },
         root: path.join(__dirname, '../'),
-        reactNativePath: path.join(__dirname, '../../react-native'),
+        reactNativePath: path.join(__dirname, '../../../packages/react-native'),
       },
       {
         experimentalDebugger: false,


### PR DESCRIPTION
Summary:
We moved the HelloWorld package from `packages`to `private` but we didn't update the path to React Native that is consumed by metro.

This change fixes this.

## Changelog:
[Internal] -

Reviewed By: huntie

Differential Revision: D78493478


