### PR TITLE
Also test node 20.19.4 in the test_js matrix

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -592,8 +592,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["24", "22"]
-        # node-version: ["24", "22", "20.19.4"]
+        node-version: ["24", "22", "20.19.4"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Summary:
Now that Metro is bumped to also support node >= 20.19.4
we should be able to run test_js on `main` against 20.19.4

Changelog:
[Internal] [Changed] -

Differential Revision: D79087608


