### PR TITLE
Use `by lazy(LazyThreadSafetyMode.NONE)` for RNTester

### DIFF
--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.kt
@@ -41,81 +41,82 @@ internal class RNTesterApplication : Application(), ReactApplication {
   @Deprecated(
       "You should not use ReactNativeHost directly in the New Architecture. Use ReactHost instead.",
       replaceWith = ReplaceWith("reactHost"))
-  override val reactNativeHost: ReactNativeHost by lazy {
-    object : DefaultReactNativeHost(this) {
-      public override fun getJSMainModuleName(): String = BuildConfig.JS_MAIN_MODULE_NAME
+  override val reactNativeHost: ReactNativeHost by
+      lazy(LazyThreadSafetyMode.NONE) {
+        object : DefaultReactNativeHost(this) {
+          public override fun getJSMainModuleName(): String = BuildConfig.JS_MAIN_MODULE_NAME
 
-      public override fun getBundleAssetName(): String = BuildConfig.BUNDLE_ASSET_NAME
+          public override fun getBundleAssetName(): String = BuildConfig.BUNDLE_ASSET_NAME
 
-      override fun getUseDeveloperSupport(): Boolean = BuildConfig.DEBUG
+          override fun getUseDeveloperSupport(): Boolean = BuildConfig.DEBUG
 
-      public override fun getPackages(): List<ReactPackage> {
-        return listOf(
-            MainReactPackage(),
-            PopupMenuPackage(),
-            object : BaseReactPackage() {
-              override fun getModule(
-                  name: String,
-                  reactContext: ReactApplicationContext
-              ): NativeModule? =
-                  when {
-                    SampleTurboModule.NAME == name -> SampleTurboModule(reactContext)
-                    SampleLegacyModule.NAME == name -> SampleLegacyModule(reactContext)
-                    else -> null
-                  }
+          public override fun getPackages(): List<ReactPackage> {
+            return listOf(
+                MainReactPackage(),
+                PopupMenuPackage(),
+                object : BaseReactPackage() {
+                  override fun getModule(
+                      name: String,
+                      reactContext: ReactApplicationContext
+                  ): NativeModule? =
+                      when {
+                        SampleTurboModule.NAME == name -> SampleTurboModule(reactContext)
+                        SampleLegacyModule.NAME == name -> SampleLegacyModule(reactContext)
+                        else -> null
+                      }
 
-              // Note: Specialized annotation processor for @ReactModule isn't configured in OSS
-              // yet. For now, hardcode this information, though it's not necessary for most
-              // modules.
-              override fun getReactModuleInfoProvider(): ReactModuleInfoProvider =
-                  ReactModuleInfoProvider {
-                    mapOf(
-                        SampleTurboModule.NAME to
-                            ReactModuleInfo(
-                                SampleTurboModule.NAME,
-                                "SampleTurboModule",
-                                canOverrideExistingModule = false,
-                                needsEagerInit = false,
-                                isCxxModule = false,
-                                isTurboModule = true),
-                        SampleLegacyModule.NAME to
-                            ReactModuleInfo(
-                                SampleLegacyModule.NAME,
-                                "SampleLegacyModule",
-                                canOverrideExistingModule = false,
-                                needsEagerInit = false,
-                                isCxxModule = false,
-                                isTurboModule = false))
-                  }
-            },
-            object : ReactPackage, ViewManagerOnDemandReactPackage {
-              override fun getViewManagerNames(reactContext: ReactApplicationContext) =
-                  listOf("RNTMyNativeView", "RNTMyLegacyNativeView", "RNTReportFullyDrawnView")
+                  // Note: Specialized annotation processor for @ReactModule isn't configured in OSS
+                  // yet. For now, hardcode this information, though it's not necessary for most
+                  // modules.
+                  override fun getReactModuleInfoProvider(): ReactModuleInfoProvider =
+                      ReactModuleInfoProvider {
+                        mapOf(
+                            SampleTurboModule.NAME to
+                                ReactModuleInfo(
+                                    SampleTurboModule.NAME,
+                                    "SampleTurboModule",
+                                    canOverrideExistingModule = false,
+                                    needsEagerInit = false,
+                                    isCxxModule = false,
+                                    isTurboModule = true),
+                            SampleLegacyModule.NAME to
+                                ReactModuleInfo(
+                                    SampleLegacyModule.NAME,
+                                    "SampleLegacyModule",
+                                    canOverrideExistingModule = false,
+                                    needsEagerInit = false,
+                                    isCxxModule = false,
+                                    isTurboModule = false))
+                      }
+                },
+                object : ReactPackage, ViewManagerOnDemandReactPackage {
+                  override fun getViewManagerNames(reactContext: ReactApplicationContext) =
+                      listOf("RNTMyNativeView", "RNTMyLegacyNativeView", "RNTReportFullyDrawnView")
 
-              override fun createViewManagers(
-                  reactContext: ReactApplicationContext
-              ): List<ViewManager<*, *>> =
-                  listOf(
-                      MyNativeViewManager(),
-                      MyLegacyViewManager(reactContext),
-                      ReportFullyDrawnViewManager())
+                  override fun createViewManagers(
+                      reactContext: ReactApplicationContext
+                  ): List<ViewManager<*, *>> =
+                      listOf(
+                          MyNativeViewManager(),
+                          MyLegacyViewManager(reactContext),
+                          ReportFullyDrawnViewManager())
 
-              override fun createViewManager(
-                  reactContext: ReactApplicationContext,
-                  viewManagerName: String
-              ): ViewManager<*, out ReactShadowNode<*>>? =
-                  when (viewManagerName) {
-                    "RNTMyNativeView" -> MyNativeViewManager()
-                    "RNTMyLegacyNativeView" -> MyLegacyViewManager(reactContext)
-                    "RNTReportFullyDrawnView" -> ReportFullyDrawnViewManager()
-                    else -> null
-                  }
-            })
+                  override fun createViewManager(
+                      reactContext: ReactApplicationContext,
+                      viewManagerName: String
+                  ): ViewManager<*, out ReactShadowNode<*>>? =
+                      when (viewManagerName) {
+                        "RNTMyNativeView" -> MyNativeViewManager()
+                        "RNTMyLegacyNativeView" -> MyLegacyViewManager(reactContext)
+                        "RNTReportFullyDrawnView" -> ReportFullyDrawnViewManager()
+                        else -> null
+                      }
+                })
+          }
+
+          override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
+        }
       }
-
-      override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
-    }
-  }
 
   override val reactHost: ReactHost
     get() = DefaultReactHost.getDefaultReactHost(applicationContext, reactNativeHost)


### PR DESCRIPTION
Summary:
RNTester was using just a plain `by lazy{}` which gets flagged by our internal linter over and over.
This fixes it.

Changelog:
[Internal] [Changed] -

Differential Revision: D79094496


