### PR TITLE
Bring back SharedImageManager = std::shared_ptr<ImageManager> alias to allow gradual API migration

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageManager.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/imagemanager/ImageRequest.h>
 #include <react/renderer/imagemanager/ImageRequestParams.h>
@@ -14,6 +16,12 @@
 #include <react/utils/ContextContainer.h>
 
 namespace facebook::react {
+
+class ImageManager;
+
+using SharedImageManager
+    [[deprecated("Use std::shared_ptr<ImageManager> instead.")]] =
+        std::shared_ptr<ImageManager>;
 
 /*
  * Cross platform facade for image management (e.g. iOS-specific


### PR DESCRIPTION
Summary:
This brings back the type erased in  https://github.com/facebook/react-native/pull/52747 to fix build breaks in consuming libraries as: `react-native-svg`

https://github.com/facebook/react-native/actions/runs/16560124464/job/46828273956?fbclid=IwY2xjawL0f1dleHRuA2FlbQIxMQBicmlkETFXVnFJUkhXMDNkSlJhY1c1AR6vMc_wUFxgfUN-JsCFMzl4L2V2JaSfX37gKIoUu8U9WGGmb0JBG1LNl0Ogjg_aem_aM4XSISUjhqE7S8_QA2KfA

Changelog: [General][Fixed] Bring back SharedImageManager = std::shared_ptr<ImageManager> alias

Differential Revision: D79097253


