### PR TITLE
Fix: Setting maxLength to 0 in TextInput still allows typing on iOS 

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -450,8 +450,8 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
     }
   }
 
-  if (props.maxLength) {
-    NSInteger allowedLength = props.maxLength - _backedTextInputView.attributedText.string.length + range.length;
+  if (props.maxLength.has_value()) {
+    NSInteger allowedLength = props.maxLength.value() - _backedTextInputView.attributedText.string.length + range.length;
 
     if (allowedLength > 0 && text.length > allowedLength) {
       // make sure unicode characters that are longer than 16 bits (such as emojis) are not cut off

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -23,6 +23,7 @@
 #import "RCTTextInputUtils.h"
 
 #import "RCTFabricComponentsPlugins.h"
+#import <limits>
 
 /** Native iOS text field bottom keyboard offset amount */
 static const CGFloat kSingleLineKeyboardBottomOffset = 15.0;
@@ -450,7 +451,7 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
     }
   }
 
-  if (props.maxLength) {
+  if (props.maxLength != std::numeric_limits<int>::max()) {
     NSInteger allowedLength = props.maxLength - _backedTextInputView.attributedText.string.length + range.length;
 
     if (allowedLength > 0 && text.length > allowedLength) {

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -451,7 +451,7 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
     }
   }
 
-  if (props.maxLength != std::numeric_limits<int>::max()) {
+  if (props.maxLength < std::numeric_limits<int>::max()) {
     NSInteger allowedLength = props.maxLength - _backedTextInputView.attributedText.string.length + range.length;
 
     if (allowedLength > 0 && text.length > allowedLength) {

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -450,8 +450,8 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
     }
   }
 
-  if (props.maxLength.has_value()) {
-    NSInteger allowedLength = props.maxLength.value() - _backedTextInputView.attributedText.string.length + range.length;
+  if (props.maxLength) {
+    NSInteger allowedLength = props.maxLength - _backedTextInputView.attributedText.string.length + range.length;
 
     if (allowedLength > 0 && text.length > allowedLength) {
       // make sure unicode characters that are longer than 16 bits (such as emojis) are not cut off

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.h
@@ -14,6 +14,7 @@
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/graphics/Color.h>
 #include <string>
+#include <optional>
 
 namespace facebook::react {
 
@@ -60,7 +61,7 @@ class BaseTextInputProps : public ViewProps, public BaseTextProps {
   // TODO: Rename to `tintColor` and make universal.
   SharedColor underlineColorAndroid{};
 
-  int maxLength{};
+  std::optional<int> maxLength{};
 
   /*
    * "Private" (only used by TextInput.js) props

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.h
@@ -14,7 +14,6 @@
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/graphics/Color.h>
 #include <string>
-#include <optional>
 
 namespace facebook::react {
 
@@ -61,7 +60,7 @@ class BaseTextInputProps : public ViewProps, public BaseTextProps {
   // TODO: Rename to `tintColor` and make universal.
   SharedColor underlineColorAndroid{};
 
-  std::optional<int> maxLength{};
+  int maxLength{};
 
   /*
    * "Private" (only used by TextInput.js) props

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.h
@@ -13,6 +13,7 @@
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/graphics/Color.h>
+#include <limits>
 #include <string>
 
 namespace facebook::react {
@@ -60,7 +61,7 @@ class BaseTextInputProps : public ViewProps, public BaseTextProps {
   // TODO: Rename to `tintColor` and make universal.
   SharedColor underlineColorAndroid{};
 
-  int maxLength{};
+  int maxLength=std::numeric_limits<int>::max();
 
   /*
    * "Private" (only used by TextInput.js) props

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
@@ -304,7 +304,7 @@ folly::dynamic AndroidTextInputProps::getDynamic() const {
   props["maxFontSizeMultiplier"] = maxFontSizeMultiplier;
   props["keyboardType"] = keyboardType;
   props["returnKeyType"] = returnKeyType;
-  props["maxLength"] = maxLength.has_value() ? maxLength.value() : folly::dynamic();
+  props["maxLength"] = maxLength;
   props["multiline"] = multiline;
   props["placeholder"] = placeholder;
   props["placeholderTextColor"] = toAndroidRepr(placeholderTextColor);
@@ -456,7 +456,7 @@ folly::dynamic AndroidTextInputProps::getDiffProps(
   }
 
   if (maxLength != oldProps->maxLength) {
-    result["maxLength"] = maxLength.has_value() ? maxLength.value() : folly::dynamic();
+    result["maxLength"] = maxLength;
   }
 
   if (text != oldProps->text) {

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputProps.cpp
@@ -304,7 +304,7 @@ folly::dynamic AndroidTextInputProps::getDynamic() const {
   props["maxFontSizeMultiplier"] = maxFontSizeMultiplier;
   props["keyboardType"] = keyboardType;
   props["returnKeyType"] = returnKeyType;
-  props["maxLength"] = maxLength;
+  props["maxLength"] = maxLength.has_value() ? maxLength.value() : folly::dynamic();
   props["multiline"] = multiline;
   props["placeholder"] = placeholder;
   props["placeholderTextColor"] = toAndroidRepr(placeholderTextColor);
@@ -456,7 +456,7 @@ folly::dynamic AndroidTextInputProps::getDiffProps(
   }
 
   if (maxLength != oldProps->maxLength) {
-    result["maxLength"] = maxLength;
+    result["maxLength"] = maxLength.has_value() ? maxLength.value() : folly::dynamic();
   }
 
   if (text != oldProps->text) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Trying to fix https://github.com/facebook/react-native/issues/52860
## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[IOS][FIXED] Setting maxLength to 0 in TextInput still allows typing on iOS
## Test Plan:

https://github.com/user-attachments/assets/56549e0f-6bbf-461e-815c-794abdee2018

Tested on Android too