### PR TITLE
Decouple ReactAndroidHWInputDeviceHelper from ReactRootView

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactAndroidHWInputDeviceHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactAndroidHWInputDeviceHelper.kt
@@ -9,11 +9,12 @@ package com.facebook.react
 
 import android.view.KeyEvent
 import android.view.View
+import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.WritableNativeMap
 
 /** Responsible for dispatching events specific for hardware inputs. */
-internal class ReactAndroidHWInputDeviceHelper(private val reactRootView: ReactRootView) {
+internal class ReactAndroidHWInputDeviceHelper() {
   /**
    * We keep a reference to the last focused view id so that we can send it as a target for key
    * events and be able to send a blur event when focus changes.
@@ -21,36 +22,41 @@ internal class ReactAndroidHWInputDeviceHelper(private val reactRootView: ReactR
   private var lastFocusedViewId = View.NO_ID
 
   /** Called from [ReactRootView]. This is the main place the key events are handled. */
-  fun handleKeyEvent(ev: KeyEvent) {
+  fun handleKeyEvent(ev: KeyEvent, context: ReactContext) {
     val eventKeyCode = ev.keyCode
     val eventKeyAction = ev.action
     if ((eventKeyAction == KeyEvent.ACTION_UP || eventKeyAction == KeyEvent.ACTION_DOWN) &&
         KEY_EVENTS_ACTIONS.containsKey(eventKeyCode)) {
-      dispatchEvent(KEY_EVENTS_ACTIONS[eventKeyCode], lastFocusedViewId, eventKeyAction)
+      dispatchEvent(context, KEY_EVENTS_ACTIONS[eventKeyCode], lastFocusedViewId, eventKeyAction)
     }
   }
 
   /** Called from [ReactRootView] when focused view changes. */
-  fun onFocusChanged(newFocusedView: View) {
+  fun onFocusChanged(newFocusedView: View, context: ReactContext) {
     if (lastFocusedViewId == newFocusedView.id) {
       return
     }
     if (lastFocusedViewId != View.NO_ID) {
-      dispatchEvent("blur", lastFocusedViewId)
+      dispatchEvent(context, "blur", lastFocusedViewId)
     }
     lastFocusedViewId = newFocusedView.id
-    dispatchEvent("focus", newFocusedView.id)
+    dispatchEvent(context, "focus", newFocusedView.id)
   }
 
   /** Called from [ReactRootView] when the whole view hierarchy looses focus. */
-  fun clearFocus() {
+  fun clearFocus(context: ReactContext) {
     if (lastFocusedViewId != View.NO_ID) {
-      dispatchEvent("blur", lastFocusedViewId)
+      dispatchEvent(context, "blur", lastFocusedViewId)
     }
     lastFocusedViewId = View.NO_ID
   }
 
-  private fun dispatchEvent(eventType: String?, targetViewId: Int, eventKeyAction: Int = -1) {
+  private fun dispatchEvent(
+      context: ReactContext,
+      eventType: String?,
+      targetViewId: Int,
+      eventKeyAction: Int = -1,
+  ) {
     val event: WritableMap =
         WritableNativeMap().apply {
           putString("eventType", eventType)
@@ -59,7 +65,7 @@ internal class ReactAndroidHWInputDeviceHelper(private val reactRootView: ReactR
             putInt("tag", targetViewId)
           }
         }
-    reactRootView.sendEvent("onHWKeyEvent", event)
+    context.emitDeviceEvent("onHWKeyEvent", event)
   }
 
   private companion object {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -106,7 +106,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
   private @Nullable JSTouchDispatcher mJSTouchDispatcher;
   private @Nullable JSPointerDispatcher mJSPointerDispatcher;
   private final ReactAndroidHWInputDeviceHelper mAndroidHWInputDeviceHelper =
-      new ReactAndroidHWInputDeviceHelper(this);
+      new ReactAndroidHWInputDeviceHelper();
   private boolean mWasMeasured = false;
   private int mWidthMeasureSpec = MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED);
   private int mHeightMeasureSpec = MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED);
@@ -328,7 +328,10 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
       FLog.w(TAG, "Unable to handle key event as the catalyst instance has not been attached");
       return super.dispatchKeyEvent(ev);
     }
-    mAndroidHWInputDeviceHelper.handleKeyEvent(ev);
+    ReactContext context = getCurrentReactContext();
+    if (context != null) {
+      mAndroidHWInputDeviceHelper.handleKeyEvent(ev, context);
+    }
     return super.dispatchKeyEvent(ev);
   }
 
@@ -341,7 +344,10 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
       super.onFocusChanged(gainFocus, direction, previouslyFocusedRect);
       return;
     }
-    mAndroidHWInputDeviceHelper.clearFocus();
+    ReactContext context = getCurrentReactContext();
+    if (context != null) {
+      mAndroidHWInputDeviceHelper.clearFocus(context);
+    }
     super.onFocusChanged(gainFocus, direction, previouslyFocusedRect);
   }
 
@@ -355,7 +361,10 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
       super.requestChildFocus(child, focused);
       return;
     }
-    mAndroidHWInputDeviceHelper.onFocusChanged(focused);
+    ReactContext context = getCurrentReactContext();
+    if (context != null) {
+      mAndroidHWInputDeviceHelper.onFocusChanged(focused, context);
+    }
     super.requestChildFocus(child, focused);
   }
 


### PR DESCRIPTION
Summary:
Right now these are tightly coupled for no reason. The device helper just asks the root view to send the event out, which it uses ReactContext for. We can just have that be passed in and accomplish the same task.

Changelog: [Internal]

Reviewed By: rozele

Differential Revision: D79007328


