### PR TITLE
disable subview clipping traversal when view culling is enabled

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -947,6 +947,10 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
 
 - (void)_remountChildrenIfNeeded
 {
+  if (ReactNativeFeatureFlags::enableViewCulling()) {
+    return;
+  }
+
   CGPoint contentOffset = _scrollView.contentOffset;
 
   if (std::abs(_contentOffsetWhenClipped.x - contentOffset.x) < kClippingLeeway &&
@@ -961,6 +965,10 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
 
 - (void)_remountChildren
 {
+  if (ReactNativeFeatureFlags::enableViewCulling()) {
+    return;
+  }
+
   [_scrollView updateClippedSubviewsWithClipRect:CGRectInset(_scrollView.bounds, -kClippingLeeway, -kClippingLeeway)
                                   relativeToView:_scrollView];
 }


### PR DESCRIPTION
Summary:
changelog: [internal]

disable subview clipping traversal when view culling is enabled.
Subview clipping is already disabled by preventing prop from being set to true: https://fburl.com/code/bynvtwfs but we found a crash where the traversal leads to memory corruption with view culling enabled.

Differential Revision: D79168116


