### PR TITLE
move fabric sync in C++ Animated to JS thread

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/AnimatedModule.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/AnimatedModule.cpp
@@ -284,7 +284,7 @@ void AnimatedModule::executeOperation(const Operation& operation) {
 
 void AnimatedModule::installJSIBindingsWithRuntime(jsi::Runtime& runtime) {
   if (nodesManagerProvider_) {
-    nodesManager_ = nodesManagerProvider_->getOrCreate(runtime);
+    nodesManager_ = nodesManagerProvider_->getOrCreate(runtime, jsInvoker_);
   }
 }
 

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/MergedValueDispatcher.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/MergedValueDispatcher.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "MergedValueDispatcher.h"
+#include <react/renderer/core/DynamicPropsUtilities.h>
+
+namespace facebook::react {
+
+MergedValueDispatcher::MergedValueDispatcher(
+    DispatchFunction dispatchFunction,
+    MergedValueFunction mergedValueFunction)
+    : dispatchFunction_(std::move(dispatchFunction)),
+      mergedValueFunction_(std::move(mergedValueFunction)) {}
+
+void MergedValueDispatcher::dispatch(
+    const std::unordered_map<Tag, folly::dynamic>& value) {
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (auto& [viewTag, props] : value) {
+      accumulatedValues_[viewTag] = mergeDynamicProps(
+          accumulatedValues_[viewTag], props, NullValueStrategy::Override);
+    }
+
+    if (hasPendingDispatch_) {
+      return;
+    }
+
+    hasPendingDispatch_ = true;
+  }
+
+  dispatchFunction_([this]() {
+    auto accumulatedValuesCopy = std::unordered_map<Tag, folly::dynamic>{};
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      std::swap(accumulatedValues_, accumulatedValuesCopy);
+      hasPendingDispatch_ = false;
+    }
+    mergedValueFunction_(std::move(accumulatedValuesCopy));
+  });
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/MergedValueDispatcher.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/MergedValueDispatcher.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/dynamic.h>
+#include <react/renderer/core/ReactPrimitives.h>
+#include <functional>
+#include <mutex>
+
+namespace facebook::react {
+
+/**
+ * A thread-safe dispatcher that ensures only the latest value is dispatched
+ * to avoid overloading the target thread. Multiple rapid calls are coalesced
+ * into a single dispatch operation merging the values.
+ */
+class MergedValueDispatcher {
+ public:
+  using DispatchFunction = std::function<void(std::function<void()>&&)>;
+  using MergedValueFunction =
+      std::function<void(std::unordered_map<Tag, folly::dynamic> tagToProps)>;
+
+  /**
+   * Creates a MergedValueDispatcher with the given dispatch function.
+   *
+   * @param dispatchFunction - function that dispatches to the target
+   * thread.
+   * @param latestValueFunction - function that will be called on the target
+   * thread with all values merged.
+   */
+  explicit MergedValueDispatcher(
+      DispatchFunction dispatchFunction,
+      MergedValueFunction mergedValueFunction);
+
+  /**
+   * Dispatches the given value. If a dispatch is already pending, this will
+   * merge with the pending value instead of creating a new dispatch.
+   *
+   * @param value - value to be dispatched.
+   */
+  void dispatch(const std::unordered_map<Tag, folly::dynamic>& value);
+
+ private:
+  DispatchFunction dispatchFunction_;
+  MergedValueFunction mergedValueFunction_;
+  std::mutex mutex_;
+  bool hasPendingDispatch_{false};
+  std::unordered_map<Tag, folly::dynamic> accumulatedValues_;
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManagerProvider.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManagerProvider.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <react/renderer/animated/MergedValueDispatcher.h>
 #include <react/renderer/uimanager/UIManagerNativeAnimatedDelegate.h>
 #include "NativeAnimatedNodesManager.h"
 
@@ -35,7 +36,8 @@ class NativeAnimatedNodesManagerProvider {
           nullptr);
 
   std::shared_ptr<NativeAnimatedNodesManager> getOrCreate(
-      jsi::Runtime& runtime);
+      jsi::Runtime& runtime,
+      std::shared_ptr<CallInvoker> jsInvoker);
 
   // Native Event Listeners
   void addEventEmitterListener(
@@ -55,6 +57,8 @@ class NativeAnimatedNodesManagerProvider {
 
   NativeAnimatedNodesManager::StartOnRenderCallback startOnRenderCallback_;
   NativeAnimatedNodesManager::StopOnRenderCallback stopOnRenderCallback_;
+
+  std::unique_ptr<MergedValueDispatcher> mergedValueDispatcher_;
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
changelog: [internal]

There is a race condition in `FabricUIManagerBinding::schedulerDidFinishTransaction`. Until it is addressed properly, let's do synchronisation Fabric commits through JavaScript thread.



It can have pretty serious consequences: a crash in better case and undefined behaviour in worse case. 


The race is between acquiring two mutexes:
1. One inside of `MountingCoordinator::pullTransaction`
2. Second one inside of `FabricMountingManager::executeMount`

The logic inside of `FabricUIManagerBinding::schedulerDidFinishTransaction` depends on the fact that whichever thread acquires mutex number 1, will acquire mutex number 2 without interruption. But that is not always the case as threads may be interrupted.

Differential Revision: D79080739


