### PR TITLE
Micro-optimise JavaScript part of Animated

### DIFF
--- a/packages/react-native/Libraries/Animated/animations/Animation.js
+++ b/packages/react-native/Libraries/Animated/animations/Animation.js
@@ -41,9 +41,9 @@ let startNativeAnimationNextId = 1;
 // Once an animation has been stopped or finished its course, it will
 // not be reused.
 export default class Animation {
-  #nativeID: ?number;
-  #onEnd: ?EndCallback;
-  #useNativeDriver: boolean;
+  _nativeID: ?number;
+  _onEnd: ?EndCallback;
+  _useNativeDriver: boolean;
 
   __active: boolean;
   __isInteraction: boolean;
@@ -52,10 +52,10 @@ export default class Animation {
   __debugID: ?string;
 
   constructor(config: AnimationConfig) {
-    this.#useNativeDriver = NativeAnimatedHelper.shouldUseNativeDriver(config);
+    this._useNativeDriver = NativeAnimatedHelper.shouldUseNativeDriver(config);
 
     this.__active = false;
-    this.__isInteraction = config.isInteraction ?? !this.#useNativeDriver;
+    this.__isInteraction = config.isInteraction ?? !this._useNativeDriver;
     this.__isLooping = config.isLooping;
     this.__iterations = config.iterations ?? 1;
     if (__DEV__) {
@@ -70,7 +70,7 @@ export default class Animation {
     previousAnimation: ?Animation,
     animatedValue: AnimatedValue,
   ): void {
-    if (!this.#useNativeDriver && animatedValue.__isNative === true) {
+    if (!this._useNativeDriver && animatedValue.__isNative === true) {
       throw new Error(
         'Attempting to run JS driven animation on animated node ' +
           'that has been moved to "native" earlier by starting an ' +
@@ -78,13 +78,13 @@ export default class Animation {
       );
     }
 
-    this.#onEnd = onEnd;
+    this._onEnd = onEnd;
     this.__active = true;
   }
 
   stop(): void {
-    if (this.#nativeID != null) {
-      const nativeID = this.#nativeID;
+    if (this._nativeID != null) {
+      const nativeID = this._nativeID;
       const identifier = `${nativeID}:stopAnimation`;
       try {
         // This is only required when singleOpBatching is used, as otherwise
@@ -123,7 +123,7 @@ export default class Animation {
   }
 
   __startAnimationIfNative(animatedValue: AnimatedValue): boolean {
-    if (!this.#useNativeDriver) {
+    if (!this._useNativeDriver) {
       return false;
     }
 
@@ -135,9 +135,9 @@ export default class Animation {
     try {
       const config = this.__getNativeAnimationConfig();
       animatedValue.__makeNative(config.platformConfig);
-      this.#nativeID = NativeAnimatedHelper.generateNewAnimationId();
+      this._nativeID = NativeAnimatedHelper.generateNewAnimationId();
       NativeAnimatedHelper.API.startAnimatingNode(
-        this.#nativeID,
+        this._nativeID,
         animatedValue.__getNativeTag(),
         config,
         result => {
@@ -185,9 +185,9 @@ export default class Animation {
    * callback will never be called more than once.
    */
   __notifyAnimationEnd(result: EndResult): void {
-    const callback = this.#onEnd;
+    const callback = this._onEnd;
     if (callback != null) {
-      this.#onEnd = null;
+      this._onEnd = null;
       callback(result);
     }
   }

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedNode.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedNode.js
@@ -28,7 +28,7 @@ let _assertNativeAnimatedModule: ?() => void = () => {
 };
 
 export default class AnimatedNode {
-  #listeners: Map<string, ValueListenerCallback>;
+  _listeners: Map<string, ValueListenerCallback>;
 
   _platformConfig: ?PlatformConfig = undefined;
 
@@ -38,7 +38,7 @@ export default class AnimatedNode {
       ...
     }>,
   ) {
-    this.#listeners = new Map();
+    this._listeners = new Map();
     if (__DEV__) {
       this.__debugID = config?.debugID;
     }
@@ -85,7 +85,7 @@ export default class AnimatedNode {
    */
   addListener(callback: (value: any) => mixed): string {
     const id = String(_uniqueId++);
-    this.#listeners.set(id, callback);
+    this._listeners.set(id, callback);
     return id;
   }
 
@@ -96,7 +96,7 @@ export default class AnimatedNode {
    * See https://reactnative.dev/docs/animatedvalue#removelistener
    */
   removeListener(id: string): void {
-    this.#listeners.delete(id);
+    this._listeners.delete(id);
   }
 
   /**
@@ -105,11 +105,11 @@ export default class AnimatedNode {
    * See https://reactnative.dev/docs/animatedvalue#removealllisteners
    */
   removeAllListeners(): void {
-    this.#listeners.clear();
+    this._listeners.clear();
   }
 
   hasListeners(): boolean {
-    return this.#listeners.size > 0;
+    return this._listeners.size > 0;
   }
 
   __onAnimatedValueUpdateReceived(value: number, offset: number): void {
@@ -118,7 +118,7 @@ export default class AnimatedNode {
 
   __callListeners(value: number): void {
     const event = {value};
-    this.#listeners.forEach(listener => {
+    this._listeners.forEach(listener => {
       listener(event);
     });
   }

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedObject.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedObject.js
@@ -82,7 +82,7 @@ function mapAnimatedNodes(value: any, fn: any => any, depth: number = 0): any {
 }
 
 export default class AnimatedObject extends AnimatedWithChildren {
-  #nodes: $ReadOnlyArray<AnimatedNode>;
+  _nodes: $ReadOnlyArray<AnimatedNode>;
   _value: mixed;
 
   /**
@@ -106,7 +106,7 @@ export default class AnimatedObject extends AnimatedWithChildren {
     config?: ?AnimatedNodeConfig,
   ) {
     super(config);
-    this.#nodes = nodes;
+    this._nodes = nodes;
     this._value = value;
   }
 
@@ -117,7 +117,7 @@ export default class AnimatedObject extends AnimatedWithChildren {
   }
 
   __getValueWithStaticObject(staticObject: mixed): any {
-    const nodes = this.#nodes;
+    const nodes = this._nodes;
     let index = 0;
     // NOTE: We can depend on `this._value` and `staticObject` sharing a
     // structure because of `useAnimatedPropsMemo`.
@@ -131,7 +131,7 @@ export default class AnimatedObject extends AnimatedWithChildren {
   }
 
   __attach(): void {
-    const nodes = this.#nodes;
+    const nodes = this._nodes;
     for (let ii = 0, length = nodes.length; ii < length; ii++) {
       const node = nodes[ii];
       node.__addChild(this);
@@ -140,7 +140,7 @@ export default class AnimatedObject extends AnimatedWithChildren {
   }
 
   __detach(): void {
-    const nodes = this.#nodes;
+    const nodes = this._nodes;
     for (let ii = 0, length = nodes.length; ii < length; ii++) {
       const node = nodes[ii];
       node.__removeChild(this);
@@ -149,7 +149,7 @@ export default class AnimatedObject extends AnimatedWithChildren {
   }
 
   __makeNative(platformConfig: ?PlatformConfig): void {
-    const nodes = this.#nodes;
+    const nodes = this._nodes;
     for (let ii = 0, length = nodes.length; ii < length; ii++) {
       const node = nodes[ii];
       node.__makeNative(platformConfig);

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js
@@ -92,11 +92,11 @@ function createAnimatedProps(
 }
 
 export default class AnimatedProps extends AnimatedNode {
-  #callback: () => void;
-  #nodeKeys: $ReadOnlyArray<string>;
-  #nodes: $ReadOnlyArray<AnimatedNode>;
-  #props: {[string]: mixed};
-  #target: ?TargetView = null;
+  _callback: () => void;
+  _nodeKeys: $ReadOnlyArray<string>;
+  _nodes: $ReadOnlyArray<AnimatedNode>;
+  _props: {[string]: mixed};
+  _target: ?TargetView = null;
 
   constructor(
     inputProps: {[string]: mixed},
@@ -106,19 +106,19 @@ export default class AnimatedProps extends AnimatedNode {
   ) {
     super(config);
     const [nodeKeys, nodes, props] = createAnimatedProps(inputProps, allowlist);
-    this.#nodeKeys = nodeKeys;
-    this.#nodes = nodes;
-    this.#props = props;
-    this.#callback = callback;
+    this._nodeKeys = nodeKeys;
+    this._nodes = nodes;
+    this._props = props;
+    this._callback = callback;
   }
 
   __getValue(): Object {
     const props: {[string]: mixed} = {};
 
-    const keys = Object.keys(this.#props);
+    const keys = Object.keys(this._props);
     for (let ii = 0, length = keys.length; ii < length; ii++) {
       const key = keys[ii];
-      const value = this.#props[key];
+      const value = this._props[key];
 
       if (value instanceof AnimatedNode) {
         props[key] = value.__getValue();
@@ -143,7 +143,7 @@ export default class AnimatedProps extends AnimatedNode {
     const keys = Object.keys(staticProps);
     for (let ii = 0, length = keys.length; ii < length; ii++) {
       const key = keys[ii];
-      const maybeNode = this.#props[key];
+      const maybeNode = this._props[key];
 
       if (key === 'style') {
         const staticStyle = staticProps.style;
@@ -176,10 +176,10 @@ export default class AnimatedProps extends AnimatedNode {
   __getNativeAnimatedEventTuples(): $ReadOnlyArray<[string, AnimatedEvent]> {
     const tuples = [];
 
-    const keys = Object.keys(this.#props);
+    const keys = Object.keys(this._props);
     for (let ii = 0, length = keys.length; ii < length; ii++) {
       const key = keys[ii];
-      const value = this.#props[key];
+      const value = this._props[key];
 
       if (value instanceof AnimatedEvent && value.__isNative) {
         tuples.push([key, value]);
@@ -192,8 +192,8 @@ export default class AnimatedProps extends AnimatedNode {
   __getAnimatedValue(): Object {
     const props: {[string]: mixed} = {};
 
-    const nodeKeys = this.#nodeKeys;
-    const nodes = this.#nodes;
+    const nodeKeys = this._nodeKeys;
+    const nodes = this._nodes;
     for (let ii = 0, length = nodes.length; ii < length; ii++) {
       const key = nodeKeys[ii];
       const node = nodes[ii];
@@ -204,7 +204,7 @@ export default class AnimatedProps extends AnimatedNode {
   }
 
   __attach(): void {
-    const nodes = this.#nodes;
+    const nodes = this._nodes;
     for (let ii = 0, length = nodes.length; ii < length; ii++) {
       const node = nodes[ii];
       node.__addChild(this);
@@ -213,12 +213,12 @@ export default class AnimatedProps extends AnimatedNode {
   }
 
   __detach(): void {
-    if (this.__isNative && this.#target != null) {
-      this.#disconnectAnimatedView(this.#target);
+    if (this.__isNative && this._target != null) {
+      this.#disconnectAnimatedView(this._target);
     }
-    this.#target = null;
+    this._target = null;
 
-    const nodes = this.#nodes;
+    const nodes = this._nodes;
     for (let ii = 0, length = nodes.length; ii < length; ii++) {
       const node = nodes[ii];
       node.__removeChild(this);
@@ -228,11 +228,11 @@ export default class AnimatedProps extends AnimatedNode {
   }
 
   update(): void {
-    this.#callback();
+    this._callback();
   }
 
   __makeNative(platformConfig: ?PlatformConfig): void {
-    const nodes = this.#nodes;
+    const nodes = this._nodes;
     for (let ii = 0, length = nodes.length; ii < length; ii++) {
       const node = nodes[ii];
       node.__makeNative(platformConfig);
@@ -246,19 +246,19 @@ export default class AnimatedProps extends AnimatedNode {
       // where it will be needed to traverse the graph of attached values.
       super.__setPlatformConfig(platformConfig);
 
-      if (this.#target != null) {
-        this.#connectAnimatedView(this.#target);
+      if (this._target != null) {
+        this.#connectAnimatedView(this._target);
       }
     }
   }
 
   setNativeView(instance: TargetViewInstance): void {
-    if (this.#target?.instance === instance) {
+    if (this._target?.instance === instance) {
       return;
     }
-    this.#target = {instance, connectedViewTag: null};
+    this._target = {instance, connectedViewTag: null};
     if (this.__isNative) {
-      this.#connectAnimatedView(this.#target);
+      this.#connectAnimatedView(this._target);
     }
   }
 
@@ -306,8 +306,8 @@ export default class AnimatedProps extends AnimatedNode {
     const platformConfig = this.__getPlatformConfig();
     const propsConfig: {[string]: number} = {};
 
-    const nodeKeys = this.#nodeKeys;
-    const nodes = this.#nodes;
+    const nodeKeys = this._nodeKeys;
+    const nodes = this._nodes;
     for (let ii = 0, length = nodes.length; ii < length; ii++) {
       const key = nodeKeys[ii];
       const node = nodes[ii];

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedStyle.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedStyle.js
@@ -82,10 +82,10 @@ function createAnimatedStyle(
 }
 
 export default class AnimatedStyle extends AnimatedWithChildren {
-  #originalStyleForWeb: ?mixed;
-  #nodeKeys: $ReadOnlyArray<string>;
-  #nodes: $ReadOnlyArray<AnimatedNode>;
-  #style: {[string]: mixed};
+  _originalStyleForWeb: ?mixed;
+  _nodeKeys: $ReadOnlyArray<string>;
+  _nodes: $ReadOnlyArray<AnimatedNode>;
+  _style: {[string]: mixed};
 
   /**
    * Creates an `AnimatedStyle` if `value` contains `AnimatedNode` instances.
@@ -118,9 +118,9 @@ export default class AnimatedStyle extends AnimatedWithChildren {
     config?: ?AnimatedNodeConfig,
   ) {
     super(config);
-    this.#nodeKeys = nodeKeys;
-    this.#nodes = nodes;
-    this.#style = style;
+    this._nodeKeys = nodeKeys;
+    this._nodes = nodes;
+    this._style = style;
 
     if ((Platform.OS as string) === 'web') {
       // $FlowIgnore[cannot-write] - Intentional shadowing.
@@ -134,10 +134,10 @@ export default class AnimatedStyle extends AnimatedWithChildren {
   __getValue(): FlatStyleForWeb<FlatStyle> | FlatStyle {
     const style: {[string]: mixed} = {};
 
-    const keys = Object.keys(this.#style);
+    const keys = Object.keys(this._style);
     for (let ii = 0, length = keys.length; ii < length; ii++) {
       const key = keys[ii];
-      const value = this.#style[key];
+      const value = this._style[key];
 
       if (value instanceof AnimatedNode) {
         style[key] = value.__getValue();
@@ -166,7 +166,7 @@ export default class AnimatedStyle extends AnimatedWithChildren {
     const keys = Object.keys(style);
     for (let ii = 0, length = keys.length; ii < length; ii++) {
       const key = keys[ii];
-      const maybeNode = this.#style[key];
+      const maybeNode = this._style[key];
 
       if (key === 'transform' && maybeNode instanceof AnimatedTransform) {
         style[key] = maybeNode.__getValueWithStaticTransforms(
@@ -185,8 +185,8 @@ export default class AnimatedStyle extends AnimatedWithChildren {
   __getAnimatedValue(): Object {
     const style: {[string]: mixed} = {};
 
-    const nodeKeys = this.#nodeKeys;
-    const nodes = this.#nodes;
+    const nodeKeys = this._nodeKeys;
+    const nodes = this._nodes;
     for (let ii = 0, length = nodes.length; ii < length; ii++) {
       const key = nodeKeys[ii];
       const node = nodes[ii];
@@ -197,7 +197,7 @@ export default class AnimatedStyle extends AnimatedWithChildren {
   }
 
   __attach(): void {
-    const nodes = this.#nodes;
+    const nodes = this._nodes;
     for (let ii = 0, length = nodes.length; ii < length; ii++) {
       const node = nodes[ii];
       node.__addChild(this);
@@ -206,7 +206,7 @@ export default class AnimatedStyle extends AnimatedWithChildren {
   }
 
   __detach(): void {
-    const nodes = this.#nodes;
+    const nodes = this._nodes;
     for (let ii = 0, length = nodes.length; ii < length; ii++) {
       const node = nodes[ii];
       node.__removeChild(this);
@@ -215,7 +215,7 @@ export default class AnimatedStyle extends AnimatedWithChildren {
   }
 
   __makeNative(platformConfig: ?PlatformConfig) {
-    const nodes = this.#nodes;
+    const nodes = this._nodes;
     for (let ii = 0, length = nodes.length; ii < length; ii++) {
       const node = nodes[ii];
       node.__makeNative(platformConfig);
@@ -227,8 +227,8 @@ export default class AnimatedStyle extends AnimatedWithChildren {
     const platformConfig = this.__getPlatformConfig();
     const styleConfig: {[string]: ?number} = {};
 
-    const nodeKeys = this.#nodeKeys;
-    const nodes = this.#nodes;
+    const nodeKeys = this._nodeKeys;
+    const nodes = this._nodes;
     for (let ii = 0, length = nodes.length; ii < length; ii++) {
       const key = nodeKeys[ii];
       const node = nodes[ii];

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedTransform.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedTransform.js
@@ -47,7 +47,7 @@ function flatAnimatedNodes(
 export default class AnimatedTransform extends AnimatedWithChildren {
   // NOTE: For potentially historical reasons, some operations only operate on
   // the first level of AnimatedNode instances. This optimizes that bevavior.
-  #nodes: $ReadOnlyArray<AnimatedNode>;
+  _nodes: $ReadOnlyArray<AnimatedNode>;
 
   _transforms: $ReadOnlyArray<Transform<>>;
 
@@ -74,12 +74,12 @@ export default class AnimatedTransform extends AnimatedWithChildren {
     config?: ?AnimatedNodeConfig,
   ) {
     super(config);
-    this.#nodes = nodes;
+    this._nodes = nodes;
     this._transforms = transforms;
   }
 
   __makeNative(platformConfig: ?PlatformConfig) {
-    const nodes = this.#nodes;
+    const nodes = this._nodes;
     for (let ii = 0, length = nodes.length; ii < length; ii++) {
       const node = nodes[ii];
       node.__makeNative(platformConfig);
@@ -112,7 +112,7 @@ export default class AnimatedTransform extends AnimatedWithChildren {
   }
 
   __attach(): void {
-    const nodes = this.#nodes;
+    const nodes = this._nodes;
     for (let ii = 0, length = nodes.length; ii < length; ii++) {
       const node = nodes[ii];
       node.__addChild(this);
@@ -121,7 +121,7 @@ export default class AnimatedTransform extends AnimatedWithChildren {
   }
 
   __detach(): void {
-    const nodes = this.#nodes;
+    const nodes = this._nodes;
     for (let ii = 0, length = nodes.length; ii < length; ii++) {
       const node = nodes[ii];
       node.__removeChild(this);

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedValue.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedValue.js
@@ -85,8 +85,8 @@ function _executeAsAnimatedBatch(id: string, operation: () => void) {
  * See https://reactnative.dev/docs/animatedvalue
  */
 export default class AnimatedValue extends AnimatedWithChildren {
-  #listenerCount: number;
-  #updateSubscription: ?EventSubscription;
+  _listenerCount: number;
+  _updateSubscription: ?EventSubscription;
 
   _value: number;
   _startingValue: number;
@@ -100,8 +100,8 @@ export default class AnimatedValue extends AnimatedWithChildren {
       throw new Error('AnimatedValue: Attempting to set value to undefined');
     }
 
-    this.#listenerCount = 0;
-    this.#updateSubscription = null;
+    this._listenerCount = 0;
+    this._updateSubscription = null;
 
     this._startingValue = this._value = value;
     this._offset = 0;
@@ -127,38 +127,38 @@ export default class AnimatedValue extends AnimatedWithChildren {
 
   __makeNative(platformConfig: ?PlatformConfig): void {
     super.__makeNative(platformConfig);
-    if (this.#listenerCount > 0) {
-      this.#ensureUpdateSubscriptionExists();
+    if (this._listenerCount > 0) {
+      this.__ensureUpdateSubscriptionExists();
     }
   }
 
   addListener(callback: (value: any) => mixed): string {
     const id = super.addListener(callback);
-    this.#listenerCount++;
+    this._listenerCount++;
     if (this.__isNative) {
-      this.#ensureUpdateSubscriptionExists();
+      this.__ensureUpdateSubscriptionExists();
     }
     return id;
   }
 
   removeListener(id: string): void {
     super.removeListener(id);
-    this.#listenerCount--;
-    if (this.__isNative && this.#listenerCount === 0) {
-      this.#updateSubscription?.remove();
+    this._listenerCount--;
+    if (this.__isNative && this._listenerCount === 0) {
+      this._updateSubscription?.remove();
     }
   }
 
   removeAllListeners(): void {
     super.removeAllListeners();
-    this.#listenerCount = 0;
+    this._listenerCount = 0;
     if (this.__isNative) {
-      this.#updateSubscription?.remove();
+      this._updateSubscription?.remove();
     }
   }
 
-  #ensureUpdateSubscriptionExists(): void {
-    if (this.#updateSubscription != null) {
+  __ensureUpdateSubscriptionExists(): void {
+    if (this._updateSubscription != null) {
       return;
     }
     const nativeTag = this.__getNativeTag();
@@ -173,13 +173,13 @@ export default class AnimatedValue extends AnimatedWithChildren {
         },
       );
 
-    this.#updateSubscription = {
+    this._updateSubscription = {
       remove: () => {
         // Only this function assigns to `this.#updateSubscription`.
-        if (this.#updateSubscription == null) {
+        if (this._updateSubscription == null) {
           return;
         }
-        this.#updateSubscription = null;
+        this._updateSubscription = null;
         subscription.remove();
         NativeAnimatedAPI.stopListeningToAnimatedNodeValue(nativeTag);
       },


### PR DESCRIPTION
Summary:
changelog: [internal]

Micro-optimise JavaScript part of Animated by avoiding JS syntax for private variable/method - #foo. Instead, use double underscores. Benchmarks indicate ~10% improvement.

# Before
### Animated (mode 🚀) ###

| (index) | Task name                                                                    | Latency average (ns)  | Latency median (ns)      | Throughput average (ops/s) | Throughput median (ops/s) | Samples |
| ------- | ---------------------------------------------------------------------------- | --------------------- | ------------------------ | -------------------------- | ------------------------- | ------- |
| 0       | 'render 1 views'                                                             | '84990.06 ± 1.49%'    | '80691.00'               | '12164 ± 0.14%'            | '12393'                   | 11767   |
| 1       | 'render 10 views'                                                            | '373372.50 ± 1.00%'   | '363786.00'              | '2727 ± 0.26%'             | '2749'                    | 2679    |
| 2       | 'render 100 views'                                                           | '3099588.37 ± 0.92%'  | '3017559.00'             | '324 ± 0.74%'              | '331'                     | 323     |
| 3       | 'render 1 animated views (without animations set up)'                        | '174636.87 ± 0.67%'   | '168783.00'              | '5808 ± 0.17%'             | '5925'                    | 5727    |
| 4       | 'render 10 animated views (without animations set up)'                       | '1054481.51 ± 0.61%'  | '1036686.00'             | '953 ± 0.37%'              | '965'                     | 949     |
| 5       | 'render 100 animated views (without animations set up)'                      | '9176283.60 ± 1.12%'  | '8932316.00'             | '109 ± 0.95%'              | '112'                     | 109     |
| 6       | 'render 1 animated views (with a single animation set up - JS driven)'       | '204383.77 ± 0.52%'   | '199109.00'              | '4943 ± 0.17%'             | '5022'                    | 4893    |
| 7       | 'render 10 animated views (with a single animation set up - JS driven)'      | '1315894.97 ± 0.36%'  | '1300562.00 ± 40.00'     | '762 ± 0.30%'              | '769'                     | 760     |
| 8       | 'render 100 animated views (with a single animation set up - JS driven)'     | '11924031.45 ± 1.36%' | '11753334.50 ± 30040.50' | '84 ± 1.18%'               | '85'                      | 84      |
| 9       | 'render 1 animated views (with a single animation set up - native driven)'   | '318103.70 ± 0.37%'   | '311657.50 ± 0.50'       | '3162 ± 0.20%'             | '3209'                    | 3144    |
| 10      | 'render 10 animated views (with a single animation set up - native driven)'  | '2230305.96 ± 0.51%'  | '2191890.00'             | '449 ± 0.41%'              | '456'                     | 449     |
| 11      | 'render 100 animated views (with a single animation set up - native driven)' | '21983695.16 ± 0.75%' | '21945687.00 ± 17186.00' | '46 ± 0.74%'               | '46'                      | 64      |

# After

### Animated (mode 🚀) ###

| (index) | Task name                                                                    | Latency average (ns)  | Latency median (ns)     | Throughput average (ops/s) | Throughput median (ops/s) | Samples |
| ------- | ---------------------------------------------------------------------------- | --------------------- | ----------------------- | -------------------------- | ------------------------- | ------- |
| 0       | 'render 1 views'                                                             | '82505.36 ± 1.31%'    | '79890.00'              | '12426 ± 0.07%'            | '12517'                   | 12121   |
| 1       | 'render 10 views'                                                            | '381812.58 ± 1.16%'   | '368513.00 ± 10.00'     | '2682 ± 0.31%'             | '2714'                    | 2620    |
| 2       | 'render 100 views'                                                           | '3125380.77 ± 0.94%'  | '3040818.50 ± 115.50'   | '322 ± 0.75%'              | '329'                     | 320     |
| 3       | 'render 1 animated views (without animations set up)'                        | '165247.80 ± 0.82%'   | '161202.00'             | '6146 ± 0.13%'             | '6203'                    | 6052    |
| 4       | 'render 10 animated views (without animations set up)'                       | '977894.08 ± 0.60%'   | '961353.00'             | '1028 ± 0.35%'             | '1040'                    | 1023    |
| 5       | 'render 100 animated views (without animations set up)'                      | '8508830.75 ± 1.26%'  | '8268995.50 ± 2889.50'  | '118 ± 1.01%'              | '121'                     | 118     |
| 6       | 'render 1 animated views (with a single animation set up - JS driven)'       | '186830.08 ± 0.56%'   | '182965.00'             | '5414 ± 0.15%'             | '5466'                    | 5353    |
| 7       | 'render 10 animated views (with a single animation set up - JS driven)'      | '1154908.67 ± 0.47%'  | '1137717.50 ± 19.50'    | '869 ± 0.33%'              | '879'                     | 866     |
| 8       | 'render 100 animated views (with a single animation set up - JS driven)'     | '10506163.45 ± 1.43%' | '10159563.00 ± 496.00'  | '96 ± 1.29%'               | '98'                      | 96      |
| 9       | 'render 1 animated views (with a single animation set up - native driven)'   | '293540.18 ± 0.43%'   | '287662.00'             | '3435 ± 0.21%'             | '3476'                    | 3407    |
| 10      | 'render 10 animated views (with a single animation set up - native driven)'  | '1997734.71 ± 0.47%'  | '1964489.00'            | '502 ± 0.38%'              | '509'                     | 501     |
| 11      | 'render 100 animated views (with a single animation set up - native driven)' | '19573376.03 ± 0.95%' | '19436706.00 ± 1467.00' | '51 ± 0.92%'               | '51'                      | 64      |

Rollback Plan:

Differential Revision: D79179369


