### PR TITLE
Avoid unnecessary copy of view props map in UIManager::updateShadowTree

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
@@ -207,8 +207,7 @@ class UIManager final : public ShadowTreeDelegate {
 
   void reportMount(SurfaceId surfaceId) const;
 
-  void updateShadowTree(
-      const std::unordered_map<Tag, folly::dynamic>& tagToProps);
+  void updateShadowTree(std::unordered_map<Tag, folly::dynamic>&& tagToProps);
 
 #pragma mark - Add & Remove event listener
 

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerUpdateShadowTree.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerUpdateShadowTree.cpp
@@ -86,10 +86,15 @@ void addAncestorsToUpdateList(
  * license).
  */
 void UIManager::updateShadowTree(
-    const std::unordered_map<Tag, folly::dynamic>& tagToProps) {
+    std::unordered_map<Tag, folly::dynamic>&& tagToProps) {
   const auto& contextContainer = *contextContainer_;
 
-  std::unordered_map<Tag, folly::dynamic> remainingTagToProps = tagToProps;
+  auto remainingTagToProps = std::move(tagToProps);
+
+  if (delegate_ != nullptr) {
+    delegate_->uiManagerDidUpdateShadowTree(remainingTagToProps);
+  }
+
   getShadowTreeRegistry().enumerate([&](const ShadowTree& shadowTree,
                                         bool& stop) {
     if (remainingTagToProps.empty()) {
@@ -219,10 +224,6 @@ void UIManager::updateShadowTree(
       LOG(ERROR) << "Root ShadowNode has not been cloned";
     }
   });
-
-  if (delegate_ != nullptr) {
-    delegate_->uiManagerDidUpdateShadowTree(tagToProps);
-  }
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/MergedValueDispatcher.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/MergedValueDispatcher.h
@@ -23,7 +23,7 @@ class MergedValueDispatcher {
  public:
   using DispatchFunction = std::function<void(std::function<void()>&&)>;
   using MergedValueFunction =
-      std::function<void(std::unordered_map<Tag, folly::dynamic> tagToProps)>;
+      std::function<void(std::unordered_map<Tag, folly::dynamic>&& tagToProps)>;
 
   /**
    * Creates a MergedValueDispatcher with the given dispatch function.

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManagerProvider.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManagerProvider.cpp
@@ -49,9 +49,8 @@ NativeAnimatedNodesManagerProvider::getOrCreate(
           [jsInvoker](std::function<void()>&& func) {
             jsInvoker->invokeAsync(std::move(func));
           },
-          [uiManager](
-              const std::unordered_map<Tag, folly::dynamic>& tagToProps) {
-            uiManager->updateShadowTree(tagToProps);
+          [uiManager](std::unordered_map<Tag, folly::dynamic>&& tagToProps) {
+            uiManager->updateShadowTree(std::move(tagToProps));
           });
 
       fabricCommitCallback =


### PR DESCRIPTION
Summary:
## Changelog:

[General] [Changed] - Avoid unnecessary copy of view props map in UIManager::updateShadowTree

Differential Revision: D79193215
