### PR TITLE
Add Value override for has/get/setProperty

### DIFF
--- a/packages/react-native/ReactCommon/jsi/jsi/decorator.h
+++ b/packages/react-native/ReactCommon/jsi/jsi/decorator.h
@@ -311,12 +311,18 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
   Value getProperty(const Object& o, const String& name) override {
     return plain_.getProperty(o, name);
   };
+  Value getProperty(const Object& o, const Value& name) override {
+    return plain_.getProperty(o, name);
+  }
   bool hasProperty(const Object& o, const PropNameID& name) override {
     return plain_.hasProperty(o, name);
   };
   bool hasProperty(const Object& o, const String& name) override {
     return plain_.hasProperty(o, name);
   };
+  bool hasProperty(const Object& o, const Value& name) override {
+    return plain_.hasProperty(o, name);
+  }
   void setPropertyValue(
       const Object& o,
       const PropNameID& name,
@@ -327,6 +333,10 @@ class RuntimeDecorator : public Base, private jsi::Instrumentation {
       override {
     plain_.setPropertyValue(o, name, value);
   };
+  void setPropertyValue(const Object& o, const Value& name, const Value& value)
+      override {
+    plain_.setPropertyValue(o, name, value);
+  }
 
   void deleteProperty(const Object& object, const PropNameID& name) override {
     plain_.deleteProperty(object, name);
@@ -843,6 +853,10 @@ class WithRuntimeDecorator : public RuntimeDecorator<Plain, Base> {
     Around around{with_};
     return RD::getProperty(o, name);
   };
+  Value getProperty(const Object& o, const Value& name) override {
+    Around around{with_};
+    return RD::getProperty(o, name);
+  }
   bool hasProperty(const Object& o, const PropNameID& name) override {
     Around around{with_};
     return RD::hasProperty(o, name);
@@ -851,6 +865,10 @@ class WithRuntimeDecorator : public RuntimeDecorator<Plain, Base> {
     Around around{with_};
     return RD::hasProperty(o, name);
   };
+  bool hasProperty(const Object& o, const Value& name) override {
+    Around around{with_};
+    return RD::hasProperty(o, name);
+  }
   void setPropertyValue(
       const Object& o,
       const PropNameID& name,
@@ -863,6 +881,11 @@ class WithRuntimeDecorator : public RuntimeDecorator<Plain, Base> {
     Around around{with_};
     RD::setPropertyValue(o, name, value);
   };
+  void setPropertyValue(const Object& o, const Value& name, const Value& value)
+      override {
+    Around around{with_};
+    RD::setPropertyValue(o, name, value);
+  }
 
   void deleteProperty(const Object& object, const PropNameID& name) override {
     Around around{with_};

--- a/packages/react-native/ReactCommon/jsi/jsi/jsi-inl.h
+++ b/packages/react-native/ReactCommon/jsi/jsi/jsi-inl.h
@@ -115,6 +115,10 @@ inline Value Object::getProperty(Runtime& runtime, const PropNameID& name)
   return runtime.getProperty(*this, name);
 }
 
+inline Value Object::getProperty(Runtime& runtime, const Value& name) const {
+  return runtime.getProperty(*this, name);
+}
+
 inline bool Object::hasProperty(Runtime& runtime, const char* name) const {
   return hasProperty(runtime, String::createFromAscii(runtime, name));
 }
@@ -125,6 +129,10 @@ inline bool Object::hasProperty(Runtime& runtime, const String& name) const {
 
 inline bool Object::hasProperty(Runtime& runtime, const PropNameID& name)
     const {
+  return runtime.hasProperty(*this, name);
+}
+
+inline bool Object::hasProperty(Runtime& runtime, const Value& name) const {
   return runtime.hasProperty(*this, name);
 }
 
@@ -144,6 +152,12 @@ void Object::setProperty(Runtime& runtime, const String& name, T&& value)
 template <typename T>
 void Object::setProperty(Runtime& runtime, const PropNameID& name, T&& value)
     const {
+  setPropertyValue(
+      runtime, name, detail::toValue(runtime, std::forward<T>(value)));
+}
+
+template <typename T>
+void Object::setProperty(Runtime& runtime, const Value& name, T&& value) const {
   setPropertyValue(
       runtime, name, detail::toValue(runtime, std::forward<T>(value)));
 }

--- a/packages/react-native/ReactCommon/jsi/jsi/jsi.cpp
+++ b/packages/react-native/ReactCommon/jsi/jsi/jsi.cpp
@@ -503,6 +503,33 @@ const void* Runtime::getRuntimeDataImpl(const UUID& uuid) {
   return nullptr;
 }
 
+Value Runtime::getProperty(const Object& object, const Value& name) {
+  auto getFn = global()
+                   .getPropertyAsObject(*this, "Reflect")
+                   .getPropertyAsFunction(*this, "get");
+  return getFn.call(*this, object, name);
+}
+
+bool Runtime::hasProperty(const Object& object, const Value& name) {
+  auto hasFn = global()
+                   .getPropertyAsObject(*this, "Reflect")
+                   .getPropertyAsFunction(*this, "has");
+  return hasFn.call(*this, object, name).getBool();
+}
+
+void Runtime::setPropertyValue(
+    const Object& object,
+    const Value& name,
+    const Value& value) {
+  auto setFn = global()
+                   .getPropertyAsObject(*this, "Reflect")
+                   .getPropertyAsFunction(*this, "set");
+  auto setResult = setFn.call(*this, object, name, value).getBool();
+  if (!setResult) {
+    throw JSError(*this, "Failed to set the property");
+  }
+}
+
 Pointer& Pointer::operator=(Pointer&& other) noexcept {
   if (ptr_) {
     ptr_->invalidate();

--- a/packages/react-native/ReactCommon/jsi/jsi/jsi.h
+++ b/packages/react-native/ReactCommon/jsi/jsi/jsi.h
@@ -477,14 +477,18 @@ class JSI_EXPORT Runtime : public ICast {
 
   virtual Value getProperty(const Object&, const PropNameID& name) = 0;
   virtual Value getProperty(const Object&, const String& name) = 0;
+  virtual Value getProperty(const Object&, const Value& name);
   virtual bool hasProperty(const Object&, const PropNameID& name) = 0;
   virtual bool hasProperty(const Object&, const String& name) = 0;
+  virtual bool hasProperty(const Object&, const Value& name);
   virtual void setPropertyValue(
       const Object&,
       const PropNameID& name,
       const Value& value) = 0;
   virtual void
   setPropertyValue(const Object&, const String& name, const Value& value) = 0;
+  virtual void
+  setPropertyValue(const Object&, const Value& name, const Value& value);
 
   virtual void deleteProperty(const Object&, const PropNameID& name);
   virtual void deleteProperty(const Object&, const String& name);
@@ -958,6 +962,12 @@ class JSI_EXPORT Object : public Pointer {
   /// undefined value.
   Value getProperty(Runtime& runtime, const PropNameID& name) const;
 
+  /// \return the Property of the object with the given JS Value name. If the
+  /// name isn't a property on the object, returns the undefined value.This
+  /// attempts to convert the JS Value to convert to a property key. If the
+  /// conversion fails, this method may throw.
+  Value getProperty(Runtime& runtime, const Value& name) const;
+
   /// \return true if and only if the object has a property with the
   /// given ascii name.
   bool hasProperty(Runtime& runtime, const char* name) const;
@@ -969,6 +979,11 @@ class JSI_EXPORT Object : public Pointer {
   /// \return true if and only if the object has a property with the
   /// given PropNameID name.
   bool hasProperty(Runtime& runtime, const PropNameID& name) const;
+
+  /// \return true if and only if the object has a property with the given
+  /// JS Value name. This attempts to convert the JS Value to convert to a
+  /// property key. If the conversion fails, this method may throw.
+  bool hasProperty(Runtime& runtime, const Value& name) const;
 
   /// Sets the property value from a Value or anything which can be
   /// used to make one: nullptr_t, bool, double, int, const char*,
@@ -987,6 +1002,14 @@ class JSI_EXPORT Object : public Pointer {
   /// String, or Object.
   template <typename T>
   void setProperty(Runtime& runtime, const PropNameID& name, T&& value) const;
+
+  /// Sets the property value from a Value or anything which can be
+  /// used to make one: nullptr_t, bool, double, int, const char*,
+  /// String, or Object. This takes a JS Value as the property name, and
+  /// attempts to convert to a property key. If the conversion fails, this
+  /// method may throw.
+  template <typename T>
+  void setProperty(Runtime& runtime, const Value& name, T&& value) const;
 
   /// Delete the property with the given ascii name. Throws if the deletion
   /// failed.
@@ -1142,6 +1165,11 @@ class JSI_EXPORT Object : public Pointer {
       Runtime& runtime,
       const PropNameID& name,
       const Value& value) const {
+    return runtime.setPropertyValue(*this, name, value);
+  }
+
+  void setPropertyValue(Runtime& runtime, const Value& name, const Value& value)
+      const {
     return runtime.setPropertyValue(*this, name, value);
   }
 


### PR DESCRIPTION
Summary:
For `get/has/setProperty`, we should also be able to take in a generic
JS Value as the property key. This change adds the Value overload for
these APIs.

The default implementation will use `Reflect.get`, `Object.hasOwn`, and
`Reflect.set`.

Reviewed By: lavenzg

Differential Revision: D79120823


