### PR TITLE
Throw Exception if ReactApplication.reactNativeHost is not overriden

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -140,7 +140,7 @@ public class com/facebook/react/ReactActivityDelegate {
 
 public abstract interface class com/facebook/react/ReactApplication {
 	public fun getReactHost ()Lcom/facebook/react/ReactHost;
-	public abstract fun getReactNativeHost ()Lcom/facebook/react/ReactNativeHost;
+	public fun getReactNativeHost ()Lcom/facebook/react/ReactNativeHost;
 }
 
 public class com/facebook/react/ReactDelegate {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactApplication.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactApplication.kt
@@ -15,6 +15,9 @@ public interface ReactApplication {
       "You should not use ReactNativeHost directly in the New Architecture. Use ReactHost instead.",
       ReplaceWith("reactHost"))
   public val reactNativeHost: ReactNativeHost
+    get() {
+      throw RuntimeException("You should not use ReactNativeHost directly in the New Architecture")
+    }
 
   /**
    * Get the default [ReactHost] for this app. This method will be used by the new architecture of


### PR DESCRIPTION
Summary:
This diff throws an Exception if ReactApplication.reactNativeHost is not overriden. This field is deprecated and it will be deleted in the near future.
The goal of this diff is to be able to remove usages of reactNativeHost for classes that implement ReactApplication

changelog: [Android][Breaking] Throw Exception if ReactApplication.reactNativeHost is not overriden

Reviewed By: mlord93

Differential Revision: D79186336


