### PR TITLE
Remove methods for capturing Processes and Threads

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.cpp
@@ -157,7 +157,6 @@ void InstanceAgent::maybeSendPendingConsoleMessages() {
 
 void InstanceAgent::startTracing() {
   if (runtimeAgent_) {
-    runtimeAgent_->registerForTracing();
     runtimeAgent_->enableSamplingProfiler();
   }
 }

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.cpp
@@ -116,10 +116,6 @@ RuntimeAgent::~RuntimeAgent() {
   sessionState_.lastRuntimeAgentExportedState = getExportedState();
 }
 
-void RuntimeAgent::registerForTracing() {
-  targetController_.registerForTracing();
-}
-
 void RuntimeAgent::enableSamplingProfiler() {
   targetController_.enableSamplingProfiler();
 }

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.h
@@ -84,12 +84,6 @@ class RuntimeAgent final {
   ExportedState getExportedState();
 
   /**
-   * Registers the corresponding RuntimeTarget for Tracing: might enable some
-   * capabilities that will be later used in Tracing Profile.
-   */
-  void registerForTracing();
-
-  /**
    * Start sampling profiler for the corresponding RuntimeTarget.
    */
   void enableSamplingProfiler();

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
@@ -162,10 +162,6 @@ void RuntimeTargetController::notifyDebuggerSessionDestroyed() {
   target_.emitDebuggerSessionDestroyed();
 }
 
-void RuntimeTargetController::registerForTracing() {
-  target_.registerForTracing();
-}
-
 void RuntimeTargetController::enableSamplingProfiler() {
   target_.enableSamplingProfiler();
 }
@@ -177,12 +173,6 @@ void RuntimeTargetController::disableSamplingProfiler() {
 tracing::RuntimeSamplingProfile
 RuntimeTargetController::collectSamplingProfile() {
   return target_.collectSamplingProfile();
-}
-
-void RuntimeTarget::registerForTracing() {
-  jsExecutor_([](auto& /*runtime*/) {
-    tracing::PerformanceTracer::getInstance().reportJavaScriptThread();
-  });
 }
 
 void RuntimeTarget::enableSamplingProfiler() {

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
@@ -135,12 +135,6 @@ class RuntimeTargetController {
   void notifyDebuggerSessionDestroyed();
 
   /**
-   * Registers the corresponding RuntimeTarget for Tracing: might enable some
-   * capabilities that will be later used in Tracing Profile.
-   */
-  void registerForTracing();
-
-  /**
    * Start sampling profiler for the corresponding RuntimeTarget.
    */
   void enableSamplingProfiler();
@@ -207,12 +201,6 @@ class JSINSPECTOR_EXPORT RuntimeTarget
   std::shared_ptr<RuntimeAgent> createAgent(
       const FrontendChannel& channel,
       SessionState& sessionState);
-
-  /**
-   * Registers this Runtime for Tracing: might enable some
-   * capabilities that will be later used in Tracing Profile.
-   */
-  void registerForTracing();
 
   /**
    * Start sampling profiler for a particular JavaScript runtime.

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -104,22 +104,6 @@ class PerformanceTracer {
       std::optional<ConsoleTimeStampColor> color = std::nullopt);
 
   /**
-   * Record a corresponding Trace Event for OS-level process.
-   */
-  void reportProcess(uint64_t id, const std::string& name);
-
-  /**
-   * Record a corresponding Trace Event for OS-level thread.
-   */
-  void reportThread(uint64_t id, const std::string& name);
-
-  /**
-   * Should only be called from the JavaScript thread, will buffer metadata
-   * Trace Event.
-   */
-  void reportJavaScriptThread();
-
-  /**
    * Record an Event Loop tick, which will be represented as an Event Loop task
    * on a timeline view and grouped with JavaScript samples.
    */


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

We can't rely on RuntimeExecutor to actually tell us what JavaScript thread number is. Although this would work correct in most of the cases, this is not the solution we should go with.

Instead, we should fetch a map <id, name> of threads from the Host. This is what we will lazily call at the start of the Trace. I will add later on top of the stack.

Differential Revision: D78990872


