### PR TITLE
Create aliases for ProcessId, ThreadId, RuntimeProfileId

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.cpp
@@ -157,7 +157,6 @@ void InstanceAgent::maybeSendPendingConsoleMessages() {
 
 void InstanceAgent::startTracing() {
   if (runtimeAgent_) {
-    runtimeAgent_->registerForTracing();
     runtimeAgent_->enableSamplingProfiler();
   }
 }

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.cpp
@@ -116,10 +116,6 @@ RuntimeAgent::~RuntimeAgent() {
   sessionState_.lastRuntimeAgentExportedState = getExportedState();
 }
 
-void RuntimeAgent::registerForTracing() {
-  targetController_.registerForTracing();
-}
-
 void RuntimeAgent::enableSamplingProfiler() {
   targetController_.enableSamplingProfiler();
 }

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.h
@@ -84,12 +84,6 @@ class RuntimeAgent final {
   ExportedState getExportedState();
 
   /**
-   * Registers the corresponding RuntimeTarget for Tracing: might enable some
-   * capabilities that will be later used in Tracing Profile.
-   */
-  void registerForTracing();
-
-  /**
    * Start sampling profiler for the corresponding RuntimeTarget.
    */
   void enableSamplingProfiler();

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
@@ -162,10 +162,6 @@ void RuntimeTargetController::notifyDebuggerSessionDestroyed() {
   target_.emitDebuggerSessionDestroyed();
 }
 
-void RuntimeTargetController::registerForTracing() {
-  target_.registerForTracing();
-}
-
 void RuntimeTargetController::enableSamplingProfiler() {
   target_.enableSamplingProfiler();
 }
@@ -177,12 +173,6 @@ void RuntimeTargetController::disableSamplingProfiler() {
 tracing::RuntimeSamplingProfile
 RuntimeTargetController::collectSamplingProfile() {
   return target_.collectSamplingProfile();
-}
-
-void RuntimeTarget::registerForTracing() {
-  jsExecutor_([](auto& /*runtime*/) {
-    tracing::PerformanceTracer::getInstance().reportJavaScriptThread();
-  });
 }
 
 void RuntimeTarget::enableSamplingProfiler() {

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
@@ -135,12 +135,6 @@ class RuntimeTargetController {
   void notifyDebuggerSessionDestroyed();
 
   /**
-   * Registers the corresponding RuntimeTarget for Tracing: might enable some
-   * capabilities that will be later used in Tracing Profile.
-   */
-  void registerForTracing();
-
-  /**
    * Start sampling profiler for the corresponding RuntimeTarget.
    */
   void enableSamplingProfiler();
@@ -207,12 +201,6 @@ class JSINSPECTOR_EXPORT RuntimeTarget
   std::shared_ptr<RuntimeAgent> createAgent(
       const FrontendChannel& channel,
       SessionState& sessionState);
-
-  /**
-   * Registers this Runtime for Tracing: might enable some
-   * capabilities that will be later used in Tracing Profile.
-   */
-  void registerForTracing();
 
   /**
    * Start sampling profiler for a particular JavaScript runtime.

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
@@ -306,8 +306,8 @@ void PerformanceTracer::reportEventLoopMicrotasks(
 }
 
 folly::dynamic PerformanceTracer::getSerializedRuntimeProfileTraceEvent(
-    uint64_t threadId,
-    uint16_t profileId,
+    ThreadId threadId,
+    RuntimeProfileId profileId,
     HighResTimeStamp profileTimestamp) {
   // CDT prioritizes event timestamp over startTime metadata field.
   // https://fburl.com/lo764pf4
@@ -328,8 +328,8 @@ folly::dynamic PerformanceTracer::getSerializedRuntimeProfileTraceEvent(
 }
 
 folly::dynamic PerformanceTracer::getSerializedRuntimeProfileChunkTraceEvent(
-    uint16_t profileId,
-    uint64_t threadId,
+    ThreadId threadId,
+    RuntimeProfileId profileId,
     HighResTimeStamp chunkTimestamp,
     tracing::TraceEventProfileChunk&& traceEventProfileChunk) {
   return TraceEventSerializer::serialize(TraceEvent{

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -104,22 +104,6 @@ class PerformanceTracer {
       std::optional<ConsoleTimeStampColor> color = std::nullopt);
 
   /**
-   * Record a corresponding Trace Event for OS-level process.
-   */
-  void reportProcess(uint64_t id, const std::string& name);
-
-  /**
-   * Record a corresponding Trace Event for OS-level thread.
-   */
-  void reportThread(uint64_t id, const std::string& name);
-
-  /**
-   * Should only be called from the JavaScript thread, will buffer metadata
-   * Trace Event.
-   */
-  void reportJavaScriptThread();
-
-  /**
    * Record an Event Loop tick, which will be represented as an Event Loop task
    * on a timeline view and grouped with JavaScript samples.
    */

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -120,8 +120,8 @@ class PerformanceTracer {
    * \return serialized Trace Event that represents a Profile for CDT.
    */
   folly::dynamic getSerializedRuntimeProfileTraceEvent(
-      uint64_t threadId,
-      uint16_t profileId,
+      ThreadId threadId,
+      RuntimeProfileId profileId,
       HighResTimeStamp profileTimestamp);
 
   /**
@@ -129,8 +129,8 @@ class PerformanceTracer {
    * \return serialized Trace Event that represents a Profile Chunk for CDT.
    */
   folly::dynamic getSerializedRuntimeProfileChunkTraceEvent(
-      uint16_t profileId,
-      uint64_t threadId,
+      ProcessId threadId,
+      RuntimeProfileId profileId,
       HighResTimeStamp chunkTimestamp,
       TraceEventProfileChunk&& traceEventProfileChunk);
 
@@ -140,7 +140,7 @@ class PerformanceTracer {
   PerformanceTracer& operator=(const PerformanceTracer&) = delete;
   ~PerformanceTracer() = default;
 
-  const uint64_t processId_;
+  const ProcessId processId_;
 
   /**
    * The flag is atomic in order to enable any thread to read it (via

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfile.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfile.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include "TraceEvent.h"
+
 #include <memory>
 #include <optional>
 #include <string>
@@ -62,7 +64,7 @@ struct RuntimeSamplingProfile {
    public:
     Sample(
         uint64_t timestamp,
-        uint64_t threadId,
+        ThreadId threadId,
         std::vector<SampleCallStackFrame> callStack)
         : timestamp(timestamp),
           threadId(threadId),
@@ -81,7 +83,7 @@ struct RuntimeSamplingProfile {
     /// When the call stack snapshot was taken (μs).
     uint64_t timestamp;
     /// Thread id where sample was recorded.
-    uint64_t threadId;
+    ThreadId threadId;
     /// Snapshot of the call stack. The first element of the vector is
     /// the lowest frame in the stack.
     std::vector<SampleCallStackFrame> callStack;

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.cpp
@@ -27,7 +27,7 @@ HighResTimeStamp getHighResTimeStampForSample(
 
 // Right now we only emit single Profile. We might revisit this decision in the
 // future, once we support multiple VMs being sampled at the same time.
-constexpr uint16_t PROFILE_ID = 1;
+constexpr RuntimeProfileId PROFILE_ID = 1;
 
 /// Fallback script ID for artificial call frames, such as (root), (idle) or
 /// (program). Required for emulating the payload in a format that is expected
@@ -96,8 +96,8 @@ class ProfileTreeRootNode : public ProfileTreeNode {
 } // namespace
 
 void RuntimeSamplingProfileTraceEventSerializer::sendProfileTraceEvent(
-    uint64_t threadId,
-    uint16_t profileId,
+    ThreadId threadId,
+    RuntimeProfileId profileId,
     HighResTimeStamp profileStartTimestamp) const {
   folly::dynamic serializedTraceEvent =
       performanceTracer_.getSerializedRuntimeProfileTraceEvent(
@@ -116,7 +116,7 @@ void RuntimeSamplingProfileTraceEventSerializer::chunkEmptySample(
 
 void RuntimeSamplingProfileTraceEventSerializer::bufferProfileChunkTraceEvent(
     ProfileChunk&& chunk,
-    uint16_t profileId) {
+    RuntimeProfileId profileId) {
   if (chunk.isEmpty()) {
     return;
   }
@@ -198,7 +198,7 @@ void RuntimeSamplingProfileTraceEventSerializer::serializeAndNotify(
     return;
   }
 
-  uint64_t firstChunkThreadId = samples.front().threadId;
+  ThreadId firstChunkThreadId = samples.front().threadId;
   HighResTimeStamp previousSampleTimestamp = tracingStartTime;
   HighResTimeStamp currentChunkTimestamp = tracingStartTime;
 
@@ -228,7 +228,7 @@ void RuntimeSamplingProfileTraceEventSerializer::serializeAndNotify(
   uint32_t idleNodeId = idleNode->getId();
 
   for (auto& sample : samples) {
-    uint64_t currentSampleThreadId = sample.threadId;
+    ThreadId currentSampleThreadId = sample.threadId;
     auto currentSampleTimestamp = getHighResTimeStampForSample(sample);
 
     // We should not attempt to merge samples from different threads.

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.h
@@ -37,7 +37,7 @@ class RuntimeSamplingProfileTraceEventSerializer {
   struct ProfileChunk {
     ProfileChunk(
         uint16_t chunkSize,
-        uint64_t chunkThreadId,
+        ThreadId chunkThreadId,
         HighResTimeStamp chunkTimestamp)
         : size(chunkSize), threadId(chunkThreadId), timestamp(chunkTimestamp) {
       samples.reserve(size);
@@ -56,7 +56,7 @@ class RuntimeSamplingProfileTraceEventSerializer {
     std::vector<uint32_t> samples;
     std::vector<HighResDuration> timeDeltas;
     uint16_t size;
-    uint64_t threadId;
+    ThreadId threadId;
     HighResTimeStamp timestamp;
   };
 
@@ -102,8 +102,8 @@ class RuntimeSamplingProfileTraceEventSerializer {
    * profile.
    */
   void sendProfileTraceEvent(
-      uint64_t threadId,
-      uint16_t profileId,
+      ThreadId threadId,
+      RuntimeProfileId profileId,
       HighResTimeStamp profileStartTimestamp) const;
 
   /**
@@ -123,7 +123,9 @@ class RuntimeSamplingProfileTraceEventSerializer {
    * \param chunk The chunk that will be buffered.
    * \param profileId The id of the Profile.
    */
-  void bufferProfileChunkTraceEvent(ProfileChunk&& chunk, uint16_t profileId);
+  void bufferProfileChunkTraceEvent(
+      ProfileChunk&& chunk,
+      RuntimeProfileId profileId);
 
   /**
    * Encapsulates logic for processing the call stack of the sample.

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEvent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEvent.h
@@ -13,6 +13,14 @@
 
 namespace facebook::react::jsinspector_modern::tracing {
 
+using ProcessId = uint64_t;
+using ThreadId = uint64_t;
+/**
+ * The ID for the JavaScript Sampling Profile. There can be multiple Profiles
+ * during a single session, in case RuntimeTarget is re-initialized.
+ */
+using RuntimeProfileId = uint16_t;
+
 /**
  * A trace event to send to the debugger frontend, as defined by the Trace Event
  * Format.
@@ -44,11 +52,11 @@ struct TraceEvent {
   /** The tracing clock timestamp of the event, in microseconds (µs). */
   HighResTimeStamp ts;
 
-  /** The process ID for the process that output this event. */
-  uint64_t pid;
+  /** The ID for the process that output this event. */
+  ProcessId pid;
 
-  /** The thread ID for the process that output this event. */
-  uint64_t tid;
+  /** The ID for the thread that output this event. */
+  ThreadId tid;
 
   /** Any arguments provided for the event. */
   folly::dynamic args = folly::dynamic::object();

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/tests/RuntimeSamplingProfileTraceEventSerializerTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/tests/RuntimeSamplingProfileTraceEventSerializerTest.cpp
@@ -49,7 +49,7 @@ class RuntimeSamplingProfileTraceEventSerializerTest : public ::testing::Test {
 
   RuntimeSamplingProfile::Sample createSample(
       uint64_t timestamp,
-      uint64_t threadId,
+      ThreadId threadId,
       std::vector<RuntimeSamplingProfile::SampleCallStackFrame> callStack) {
     return {timestamp, threadId, std::move(callStack)};
   }
@@ -108,7 +108,7 @@ TEST_F(
       createJSCallFrame("foo", 1, "test.js", 10, 5),
   };
 
-  uint64_t threadId = 1;
+  ThreadId threadId = 1;
   uint64_t timestamp1 = 1000000;
   uint64_t timestamp2 = 2000000;
   uint64_t timestamp3 = 3000000;
@@ -141,7 +141,7 @@ TEST_F(RuntimeSamplingProfileTraceEventSerializerTest, EmptySample) {
   // Create an empty sample (no call stack)
   std::vector<RuntimeSamplingProfile::SampleCallStackFrame> emptyCallStack;
 
-  uint64_t threadId = 1;
+  ThreadId threadId = 1;
   uint64_t timestamp = 1000000;
 
   auto samples = std::vector<RuntimeSamplingProfile::Sample>{};
@@ -179,8 +179,8 @@ TEST_F(
       createJSCallFrame("foo", 1, "test.js", 10, 5)};
 
   uint64_t timestamp = 1000000;
-  uint64_t threadId1 = 1;
-  uint64_t threadId2 = 2;
+  ThreadId threadId1 = 1;
+  ThreadId threadId2 = 2;
 
   auto samples = std::vector<RuntimeSamplingProfile::Sample>{};
   samples.emplace_back(createSample(timestamp, threadId1, callStack));
@@ -219,7 +219,7 @@ TEST_F(
       createJSCallFrame("foo", 1, "test.js", 10, 5)};
 
   uint64_t timestamp = 1000000;
-  uint64_t threadId = 1;
+  ThreadId threadId = 1;
 
   std::vector<RuntimeSamplingProfile::Sample> samples;
   samples.reserve(5);
@@ -260,7 +260,7 @@ TEST_F(RuntimeSamplingProfileTraceEventSerializerTest, ProfileChunkSizeLimit) {
       createJSCallFrame("foo", 1, "test.js", 10, 5)};
 
   uint64_t timestamp = 1000000;
-  uint64_t threadId = 1;
+  ThreadId threadId = 1;
 
   std::vector<RuntimeSamplingProfile::Sample> samples;
   samples.reserve(samplesCount);


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

Just an aliases for referencing these ids, instead of raw uint64_t.

Differential Revision: D78741191
