### PR TITLE
fix(android): make ReactSurfaceView inheritable

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactSurfaceView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactSurfaceView.kt
@@ -33,7 +33,7 @@ import kotlin.math.max
  * rendering a React component.
  */
 @OptIn(FrameworkAPI::class, UnstableReactNativeAPI::class)
-public class ReactSurfaceView(context: Context?, private val surface: ReactSurfaceImpl) :
+public open class ReactSurfaceView(context: Context?, private val surface: ReactSurfaceImpl) :
     ReactRootView(context) {
   private val jsTouchDispatcher: JSTouchDispatcher = JSTouchDispatcher(this)
   private var jsPointerDispatcher: JSPointerDispatcher? = null


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

We have a use case where we want to extend `ReactSurfaceView` (and pass it through our `ReactHost#createSurface`) .
The problem is that `ReactSurfaceView` isn't explicitly marked as `open`, and in kotlin all public classes become final by default. 

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

[ANDROID] [CHANGED] - Make `ReactSurfaceView` inheritable

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] [CHANGED] - Make `ReactSurfaceView` inheritable

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

CI tests + builds to pass
