### PR TITLE
Fix CMake dependency error

### DIFF
--- a/packages/react-native/ReactCommon/react/performance/cdpmetrics/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/performance/cdpmetrics/CMakeLists.txt
@@ -18,6 +18,6 @@ target_include_directories(react_performance_cdpmetrics PUBLIC ${REACT_COMMON_DI
 target_link_libraries(react_performance_cdpmetrics
         folly_runtime
         jsi
-        react_performancetimeline
+        react_performance_timeline
         react_timing
         runtimeexecutor)


### PR DESCRIPTION
Summary:
Follow-up to D78904748, where CI was broken on `main` for the `run_fantom_tests` job. It turns out this Android build uniquely included the new `react_performance_cdpmetrics` dependency, and this had an incorrect dep.

Changelog: [Internal]

Differential Revision: D79263124


