### PR TITLE
fix: add gunzip flag to replace hermes script

### DIFF
--- a/packages/react-native/sdks/hermes-engine/utils/replace_hermes_version.js
+++ b/packages/react-native/sdks/hermes-engine/utils/replace_hermes_version.js
@@ -62,7 +62,7 @@ function replaceHermesConfiguration(configuration, version, podsRoot) {
   fs.mkdirSync(finalLocation, {recursive: true});
 
   console.log('Extracting the tarball');
-  execSync(`tar -xf ${tarballURLPath} -C ${finalLocation}`);
+  execSync(`tar -xzf ${tarballURLPath} -C ${finalLocation}`);
 }
 
 function updateLastBuildConfiguration(configuration) {


### PR DESCRIPTION
## Summary:

It works without the -z flag on MacOS which is a surprise but it doesn't hurt to add it 😄 

## Changelog:

[iOS] [FIXED] - add gunzip flag to replace hermes script

## Test Plan:

- [ ] app builds with hermes engine
