### PR TITLE
fix: Android KeyboardAvoidingView bottom padding issue

### DIFF
--- a/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -26,6 +26,11 @@ import Keyboard from './Keyboard';
 import * as React from 'react';
 import {createRef} from 'react';
 
+// Android workaround: When the keyboard is dismissed, Android sometimes reports
+// small non-zero height values instead of 0. This threshold treats any height
+// less than this value as 0 to ensure proper layout collapse.
+const ANDROID_KEYBOARD_HIDE_THRESHOLD = 50;
+
 export type KeyboardAvoidingViewProps = $ReadOnly<{
   ...ViewProps,
 
@@ -164,7 +169,14 @@ class KeyboardAvoidingView extends React.Component<
       return;
     }
 
-    this._setBottom(height);
+    // Android workaround: When the keyboard is dismissed, Android sometimes
+    // reports small non-zero height values instead of 0. This causes unwanted
+    // bottom padding to remain visible. We treat any height less than the
+    // threshold as 0 to ensure proper layout collapse.
+    const adjustedHeight =
+      Platform.OS === 'android' && height < ANDROID_KEYBOARD_HIDE_THRESHOLD ? 0 : height;
+
+    this._setBottom(adjustedHeight);
 
     const enabled = this.props.enabled ?? true;
     if (enabled && duration && easing) {


### PR DESCRIPTION
## Summary

This PR fixes a bug on Android where `KeyboardAvoidingView` with `behavior="height"` leaves extra bottom padding after the keyboard is dismissed. This happens because the `keyboardDidChange` event sometimes reports a small, non-zero height during the hide animation instead of 0, causing unwanted padding to remain.

This change introduces a threshold in the `_onKeyboardChange` method. It treats any reported height below 50px as 0, but only on Android, ensuring the view returns to its original layout correctly when the keyboard is dismissed.

Fixes #52596

## Changelog:

[ANDROID] [FIXED] - Prevent KeyboardAvoidingView from leaving extra padding on hide

## Test Plan

I have manually tested this solution and confirmed that the issue is resolved.

### Manual Testing Scenarios

1.  **Android Device Testing**:
    *   Tested on a physical device (Android 13) and an emulator (Android 14).
    *   Verified that the keyboard opens and closes properly without leaving unwanted padding.
    *   Tested with `behavior` props: 'height', 'position', 'padding'. All work as expected.
    *   Confirmed the layout correctly returns to its original state after keyboard dismissal, including in combination with `SafeAreaView` and `useSafeAreaInsets`.
    *   Confirmed layout adjusts correctly after screen rotation with the keyboard open.

2.  **iOS Testing**:
    *   Verified on an iOS 16 Simulator that the behavior remains unchanged and no regressions were introduced.

### Test Environment
- **Android**: Physical device (Android 13), Emulator (Android 14)
- **iOS**: Simulator (iOS 16)
- **React Native version**: 0.79.2
