### PR TITLE
Simplify PerformanceTracer API and move processing to TracingAgent

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.cpp
@@ -9,6 +9,7 @@
 
 #include <jsinspector-modern/tracing/PerformanceTracer.h>
 #include <jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.h>
+#include <jsinspector-modern/tracing/TraceEventSerializer.h>
 
 namespace facebook::react::jsinspector_modern {
 
@@ -28,6 +29,26 @@ const uint16_t TRACE_EVENT_CHUNK_SIZE = 1000;
  * than 16MB.
  */
 const uint16_t PROFILE_TRACE_EVENT_CHUNK_SIZE = 1;
+
+void serializeTraceEventsInChunks(
+    std::vector<tracing::TraceEvent>&& traceEvents,
+    uint16_t chunkSize,
+    const std::function<void(folly::dynamic&& eventsChunk)>& resultCallback) {
+  auto serializedTraceEvents = folly::dynamic::array();
+  for (auto&& traceEvent : traceEvents) {
+    // Emit trace events
+    serializedTraceEvents.push_back(
+        tracing::TraceEventSerializer::serialize(std::move(traceEvent)));
+
+    if (serializedTraceEvents.size() == chunkSize) {
+      resultCallback(std::move(serializedTraceEvents));
+      serializedTraceEvents = folly::dynamic::array();
+    }
+  }
+  if (!serializedTraceEvents.empty()) {
+    resultCallback(std::move(serializedTraceEvents));
+  }
+}
 
 } // namespace
 
@@ -89,8 +110,8 @@ bool TracingAgent::handleRequest(const cdp::PreparsedRequest& req) {
 
     tracing::PerformanceTracer& performanceTracer =
         tracing::PerformanceTracer::getInstance();
-    bool correctlyStopped = performanceTracer.stopTracing();
-    if (!correctlyStopped) {
+    auto collectedEvents = performanceTracer.stopTracing();
+    if (!collectedEvents) {
       frontendChannel_(cdp::jsonError(
           req.id,
           cdp::ErrorCode::InternalError,
@@ -107,8 +128,11 @@ bool TracingAgent::handleRequest(const cdp::PreparsedRequest& req) {
           "Tracing.dataCollected",
           folly::dynamic::object("value", std::move(eventsChunk))));
     };
-    performanceTracer.collectEvents(
-        dataCollectedCallback, TRACE_EVENT_CHUNK_SIZE);
+
+    serializeTraceEventsInChunks(
+        std::move(*collectedEvents),
+        TRACE_EVENT_CHUNK_SIZE,
+        dataCollectedCallback);
 
     auto tracingProfile = instanceAgent_->collectTracingProfile();
     tracing::IdGenerator profileIdGenerator;

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
@@ -101,36 +101,6 @@ void PerformanceTracer::collectEvents(
   }
 }
 
-folly::dynamic PerformanceTracer::collectEvents(uint16_t chunkSize) {
-  std::vector<TraceEvent> localBuffer;
-  {
-    std::lock_guard lock(mutex_);
-    buffer_.swap(localBuffer);
-  }
-
-  auto chunks = folly::dynamic::array();
-  if (localBuffer.empty()) {
-    return chunks;
-  }
-
-  auto chunk = folly::dynamic::array();
-  chunk.reserve(chunkSize);
-  for (auto&& event : localBuffer) {
-    chunk.push_back(TraceEventSerializer::serialize(std::move(event)));
-
-    if (chunk.size() == chunkSize) {
-      chunks.push_back(std::move(chunk));
-      chunk = folly::dynamic::array();
-      chunk.reserve(chunkSize);
-    }
-  }
-
-  if (!chunk.empty()) {
-    chunks.push_back(std::move(chunk));
-  }
-  return chunks;
-}
-
 std::vector<TraceEvent> PerformanceTracer::collectTraceEvents() {
   std::vector<TraceEvent> events;
   {

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -15,7 +15,6 @@
 
 #include <folly/dynamic.h>
 #include <atomic>
-#include <functional>
 #include <mutex>
 #include <optional>
 #include <vector>
@@ -34,14 +33,15 @@ class PerformanceTracer {
   static PerformanceTracer& getInstance();
 
   /**
-   * Mark trace session as started. Returns `false` if already tracing.
+   * Starts a tracing session. Returns `false` if already tracing.
    */
   bool startTracing();
 
   /**
-   * Mark trace session as stopped. Returns `false` if wasn't tracing.
+   * If there is a current tracing session, it stops tracing and returns all
+   * collected events. Otherwise, it returns empty.
    */
-  bool stopTracing();
+  std::optional<std::vector<TraceEvent>> stopTracing();
 
   /**
    * Returns whether the tracer is currently tracing. This can be useful to
@@ -51,19 +51,6 @@ class PerformanceTracer {
   inline bool isTracing() const {
     return tracingAtomic_;
   }
-
-  /**
-   * Flush out buffered CDP Trace Events using the given callback.
-   */
-  void collectEvents(
-      const std::function<void(folly::dynamic&& eventsChunk)>& resultCallback,
-      uint16_t chunkSize);
-
-  /**
-   * Transfers an ownership of all buffered TraceEvents, the local buffer state
-   * is invalidated after this call.
-   */
-  std::vector<TraceEvent> collectTraceEvents();
 
   /**
    * Record a `Performance.mark()` event - a labelled timestamp. If not

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -60,12 +60,6 @@ class PerformanceTracer {
       uint16_t chunkSize);
 
   /**
-   * Flush out buffered CDP Trace Events into a folly::dynamic collection of
-   * chunks, which can be sent over CDP later.
-   */
-  folly::dynamic collectEvents(uint16_t chunkSize);
-
-  /**
    * Transfers an ownership of all buffered TraceEvents, the local buffer state
    * is invalidated after this call.
    */


### PR DESCRIPTION
Summary:
Changelog: [internal]

Right now, the `PerformanceTracer` API has a method to stop the trace and a separate one to collect serialized events. This refactors the API to return the collected events when calling `stopTracing` instead.

The caller (in this case `TracingAgent`) is responsible for serializing and sending the events in chunks through CDP.

Differential Revision: D79271690
