### PR TITLE
Remove unnecessary collectEvents method from PerformanceTracer

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
@@ -101,36 +101,6 @@ void PerformanceTracer::collectEvents(
   }
 }
 
-folly::dynamic PerformanceTracer::collectEvents(uint16_t chunkSize) {
-  std::vector<TraceEvent> localBuffer;
-  {
-    std::lock_guard lock(mutex_);
-    buffer_.swap(localBuffer);
-  }
-
-  auto chunks = folly::dynamic::array();
-  if (localBuffer.empty()) {
-    return chunks;
-  }
-
-  auto chunk = folly::dynamic::array();
-  chunk.reserve(chunkSize);
-  for (auto&& event : localBuffer) {
-    chunk.push_back(TraceEventSerializer::serialize(std::move(event)));
-
-    if (chunk.size() == chunkSize) {
-      chunks.push_back(std::move(chunk));
-      chunk = folly::dynamic::array();
-      chunk.reserve(chunkSize);
-    }
-  }
-
-  if (!chunk.empty()) {
-    chunks.push_back(std::move(chunk));
-  }
-  return chunks;
-}
-
 std::vector<TraceEvent> PerformanceTracer::collectTraceEvents() {
   std::vector<TraceEvent> events;
   {

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -60,12 +60,6 @@ class PerformanceTracer {
       uint16_t chunkSize);
 
   /**
-   * Flush out buffered CDP Trace Events into a folly::dynamic collection of
-   * chunks, which can be sent over CDP later.
-   */
-  folly::dynamic collectEvents(uint16_t chunkSize);
-
-  /**
    * Transfers an ownership of all buffered TraceEvents, the local buffer state
    * is invalidated after this call.
    */


### PR DESCRIPTION
Summary:
Changelog: [internal]

This method is unused and we're no longer planning to use it.

Differential Revision: D79271691
