### PR TITLE
Add a method for transfering an ownership of captured TraceEvents

### DIFF
--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeSamplingProfileSerializer.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeSamplingProfileSerializer.cpp
@@ -5,9 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <variant>
-
 #include "HermesRuntimeSamplingProfileSerializer.h"
+
+#include <oscompat/OSCompat.h>
+
+#include <variant>
 
 namespace facebook::react::jsinspector_modern::tracing {
 
@@ -163,6 +165,10 @@ HermesRuntimeSamplingProfileSerializer::serializeToTracingSamplingProfile(
 
   return RuntimeSamplingProfile{
       "Hermes",
+      // Hermes' Profile should be the source of truth for this,
+      // but it is safe to reuse the process ID here, since everything runs in
+      // the same process.
+      oscompat::getCurrentProcessId(),
       std::move(reconciledSamples),
       std::make_unique<RawHermesRuntimeProfile>(std::move(hermesProfile))};
 }

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.cpp
@@ -157,7 +157,6 @@ void InstanceAgent::maybeSendPendingConsoleMessages() {
 
 void InstanceAgent::startTracing() {
   if (runtimeAgent_) {
-    runtimeAgent_->registerForTracing();
     runtimeAgent_->enableSamplingProfiler();
   }
 }

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.cpp
@@ -116,10 +116,6 @@ RuntimeAgent::~RuntimeAgent() {
   sessionState_.lastRuntimeAgentExportedState = getExportedState();
 }
 
-void RuntimeAgent::registerForTracing() {
-  targetController_.registerForTracing();
-}
-
 void RuntimeAgent::enableSamplingProfiler() {
   targetController_.enableSamplingProfiler();
 }

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.h
@@ -84,12 +84,6 @@ class RuntimeAgent final {
   ExportedState getExportedState();
 
   /**
-   * Registers the corresponding RuntimeTarget for Tracing: might enable some
-   * capabilities that will be later used in Tracing Profile.
-   */
-  void registerForTracing();
-
-  /**
    * Start sampling profiler for the corresponding RuntimeTarget.
    */
   void enableSamplingProfiler();

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
@@ -162,10 +162,6 @@ void RuntimeTargetController::notifyDebuggerSessionDestroyed() {
   target_.emitDebuggerSessionDestroyed();
 }
 
-void RuntimeTargetController::registerForTracing() {
-  target_.registerForTracing();
-}
-
 void RuntimeTargetController::enableSamplingProfiler() {
   target_.enableSamplingProfiler();
 }
@@ -177,12 +173,6 @@ void RuntimeTargetController::disableSamplingProfiler() {
 tracing::RuntimeSamplingProfile
 RuntimeTargetController::collectSamplingProfile() {
   return target_.collectSamplingProfile();
-}
-
-void RuntimeTarget::registerForTracing() {
-  jsExecutor_([](auto& /*runtime*/) {
-    tracing::PerformanceTracer::getInstance().reportJavaScriptThread();
-  });
 }
 
 void RuntimeTarget::enableSamplingProfiler() {

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
@@ -135,12 +135,6 @@ class RuntimeTargetController {
   void notifyDebuggerSessionDestroyed();
 
   /**
-   * Registers the corresponding RuntimeTarget for Tracing: might enable some
-   * capabilities that will be later used in Tracing Profile.
-   */
-  void registerForTracing();
-
-  /**
    * Start sampling profiler for the corresponding RuntimeTarget.
    */
   void enableSamplingProfiler();
@@ -207,12 +201,6 @@ class JSINSPECTOR_EXPORT RuntimeTarget
   std::shared_ptr<RuntimeAgent> createAgent(
       const FrontendChannel& channel,
       SessionState& sessionState);
-
-  /**
-   * Registers this Runtime for Tracing: might enable some
-   * capabilities that will be later used in Tracing Profile.
-   */
-  void registerForTracing();
 
   /**
    * Start sampling profiler for a particular JavaScript runtime.

--- a/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.cpp
@@ -111,9 +111,7 @@ bool TracingAgent::handleRequest(const cdp::PreparsedRequest& req) {
         dataCollectedCallback, TRACE_EVENT_CHUNK_SIZE);
 
     tracing::RuntimeSamplingProfileTraceEventSerializer serializer(
-        performanceTracer,
-        dataCollectedCallback,
-        PROFILE_TRACE_EVENT_CHUNK_SIZE);
+        dataCollectedCallback, PROFILE_TRACE_EVENT_CHUNK_SIZE);
     auto tracingProfile = instanceAgent_->collectTracingProfile();
     serializer.serializeAndNotify(
         std::move(tracingProfile.runtimeSamplingProfile),

--- a/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.cpp
@@ -110,12 +110,14 @@ bool TracingAgent::handleRequest(const cdp::PreparsedRequest& req) {
     performanceTracer.collectEvents(
         dataCollectedCallback, TRACE_EVENT_CHUNK_SIZE);
 
-    tracing::RuntimeSamplingProfileTraceEventSerializer serializer(
-        dataCollectedCallback, PROFILE_TRACE_EVENT_CHUNK_SIZE);
     auto tracingProfile = instanceAgent_->collectTracingProfile();
-    serializer.serializeAndNotify(
+    tracing::IdGenerator profileIdGenerator;
+    tracing::RuntimeSamplingProfileTraceEventSerializer::serializeAndDispatch(
         std::move(tracingProfile.runtimeSamplingProfile),
-        instanceTracingStartTimestamp_);
+        profileIdGenerator,
+        instanceTracingStartTimestamp_,
+        dataCollectedCallback,
+        PROFILE_TRACE_EVENT_CHUNK_SIZE);
 
     frontendChannel_(cdp::jsonNotification(
         "Tracing.tracingComplete",

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
@@ -305,46 +305,49 @@ void PerformanceTracer::reportEventLoopMicrotasks(
   });
 }
 
-folly::dynamic PerformanceTracer::getSerializedRuntimeProfileTraceEvent(
-    ThreadId threadId,
+/* static */ TraceEvent PerformanceTracer::constructRuntimeProfileTraceEvent(
     RuntimeProfileId profileId,
+    ProcessId processId,
+    ThreadId threadId,
     HighResTimeStamp profileTimestamp) {
   // CDT prioritizes event timestamp over startTime metadata field.
   // https://fburl.com/lo764pf4
-  return TraceEventSerializer::serialize(TraceEvent{
+  return TraceEvent{
       .id = profileId,
       .name = "Profile",
       .cat = "disabled-by-default-v8.cpu_profiler",
       .ph = 'P',
       .ts = profileTimestamp,
-      .pid = processId_,
+      .pid = processId,
       .tid = threadId,
       .args = folly::dynamic::object(
           "data",
           folly::dynamic::object(
               "startTime",
               highResTimeStampToTracingClockTimeStamp(profileTimestamp))),
-  });
+  };
 }
 
-folly::dynamic PerformanceTracer::getSerializedRuntimeProfileChunkTraceEvent(
-    ThreadId threadId,
+/* static */ TraceEvent
+PerformanceTracer::constructRuntimeProfileChunkTraceEvent(
     RuntimeProfileId profileId,
+    ProcessId processId,
+    ProcessId threadId,
     HighResTimeStamp chunkTimestamp,
-    tracing::TraceEventProfileChunk&& traceEventProfileChunk) {
-  return TraceEventSerializer::serialize(TraceEvent{
+    TraceEventProfileChunk&& traceEventProfileChunk) {
+  return TraceEvent{
       .id = profileId,
       .name = "ProfileChunk",
       .cat = "disabled-by-default-v8.cpu_profiler",
       .ph = 'P',
       .ts = chunkTimestamp,
-      .pid = processId_,
+      .pid = processId,
       .tid = threadId,
       .args = folly::dynamic::object(
           "data",
           TraceEventSerializer::serializeProfileChunk(
               std::move(traceEventProfileChunk))),
-  });
+  };
 }
 
 } // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
@@ -131,6 +131,15 @@ folly::dynamic PerformanceTracer::collectEvents(uint16_t chunkSize) {
   return chunks;
 }
 
+std::vector<TraceEvent> PerformanceTracer::collectTraceEvents() {
+  std::vector<TraceEvent> events;
+  {
+    std::lock_guard lock(mutex_);
+    buffer_.swap(events);
+  }
+  return events;
+}
+
 void PerformanceTracer::reportMark(
     const std::string_view& name,
     HighResTimeStamp start,

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
@@ -306,8 +306,8 @@ void PerformanceTracer::reportEventLoopMicrotasks(
 }
 
 folly::dynamic PerformanceTracer::getSerializedRuntimeProfileTraceEvent(
-    uint64_t threadId,
-    uint16_t profileId,
+    ThreadId threadId,
+    RuntimeProfileId profileId,
     HighResTimeStamp profileTimestamp) {
   // CDT prioritizes event timestamp over startTime metadata field.
   // https://fburl.com/lo764pf4
@@ -328,8 +328,8 @@ folly::dynamic PerformanceTracer::getSerializedRuntimeProfileTraceEvent(
 }
 
 folly::dynamic PerformanceTracer::getSerializedRuntimeProfileChunkTraceEvent(
-    uint16_t profileId,
-    uint64_t threadId,
+    ThreadId threadId,
+    RuntimeProfileId profileId,
     HighResTimeStamp chunkTimestamp,
     tracing::TraceEventProfileChunk&& traceEventProfileChunk) {
   return TraceEventSerializer::serialize(TraceEvent{

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -116,21 +116,25 @@ class PerformanceTracer {
   void reportEventLoopMicrotasks(HighResTimeStamp start, HighResTimeStamp end);
 
   /**
-   * Create and serialize Profile Trace Event.
-   * \return serialized Trace Event that represents a Profile for CDT.
+   * Creates "Profile" Trace Event.
+   *
+   * Can be serialized to JSON with TraceEventSerializer::serialize.
    */
-  folly::dynamic getSerializedRuntimeProfileTraceEvent(
-      ThreadId threadId,
+  static TraceEvent constructRuntimeProfileTraceEvent(
       RuntimeProfileId profileId,
+      ProcessId processId,
+      ThreadId threadId,
       HighResTimeStamp profileTimestamp);
 
   /**
-   * Create and serialize ProfileChunk Trace Event.
-   * \return serialized Trace Event that represents a Profile Chunk for CDT.
+   * Creates "ProfileChunk" Trace Event.
+   *
+   * Can be serialized to JSON with TraceEventSerializer::serialize.
    */
-  folly::dynamic getSerializedRuntimeProfileChunkTraceEvent(
-      ProcessId threadId,
+  static TraceEvent constructRuntimeProfileChunkTraceEvent(
       RuntimeProfileId profileId,
+      ProcessId processId,
+      ProcessId threadId,
       HighResTimeStamp chunkTimestamp,
       TraceEventProfileChunk&& traceEventProfileChunk);
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -104,22 +104,6 @@ class PerformanceTracer {
       std::optional<ConsoleTimeStampColor> color = std::nullopt);
 
   /**
-   * Record a corresponding Trace Event for OS-level process.
-   */
-  void reportProcess(uint64_t id, const std::string& name);
-
-  /**
-   * Record a corresponding Trace Event for OS-level thread.
-   */
-  void reportThread(uint64_t id, const std::string& name);
-
-  /**
-   * Should only be called from the JavaScript thread, will buffer metadata
-   * Trace Event.
-   */
-  void reportJavaScriptThread();
-
-  /**
    * Record an Event Loop tick, which will be represented as an Event Loop task
    * on a timeline view and grouped with JavaScript samples.
    */

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -66,6 +66,12 @@ class PerformanceTracer {
   folly::dynamic collectEvents(uint16_t chunkSize);
 
   /**
+   * Transfers an ownership of all buffered TraceEvents, the local buffer state
+   * is invalidated after this call.
+   */
+  std::vector<TraceEvent> collectTraceEvents();
+
+  /**
    * Record a `Performance.mark()` event - a labelled timestamp. If not
    * currently tracing, this is a no-op.
    *

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -120,8 +120,8 @@ class PerformanceTracer {
    * \return serialized Trace Event that represents a Profile for CDT.
    */
   folly::dynamic getSerializedRuntimeProfileTraceEvent(
-      uint64_t threadId,
-      uint16_t profileId,
+      ThreadId threadId,
+      RuntimeProfileId profileId,
       HighResTimeStamp profileTimestamp);
 
   /**
@@ -129,8 +129,8 @@ class PerformanceTracer {
    * \return serialized Trace Event that represents a Profile Chunk for CDT.
    */
   folly::dynamic getSerializedRuntimeProfileChunkTraceEvent(
-      uint16_t profileId,
-      uint64_t threadId,
+      ProcessId threadId,
+      RuntimeProfileId profileId,
       HighResTimeStamp chunkTimestamp,
       TraceEventProfileChunk&& traceEventProfileChunk);
 
@@ -140,7 +140,7 @@ class PerformanceTracer {
   PerformanceTracer& operator=(const PerformanceTracer&) = delete;
   ~PerformanceTracer() = default;
 
-  const uint64_t processId_;
+  const ProcessId processId_;
 
   /**
    * The flag is atomic in order to enable any thread to read it (via

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfile.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfile.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include "TraceEvent.h"
+
 #include <memory>
 #include <optional>
 #include <string>
@@ -62,7 +64,7 @@ struct RuntimeSamplingProfile {
    public:
     Sample(
         uint64_t timestamp,
-        uint64_t threadId,
+        ThreadId threadId,
         std::vector<SampleCallStackFrame> callStack)
         : timestamp(timestamp),
           threadId(threadId),
@@ -81,7 +83,7 @@ struct RuntimeSamplingProfile {
     /// When the call stack snapshot was taken (μs).
     uint64_t timestamp;
     /// Thread id where sample was recorded.
-    uint64_t threadId;
+    ThreadId threadId;
     /// Snapshot of the call stack. The first element of the vector is
     /// the lowest frame in the stack.
     std::vector<SampleCallStackFrame> callStack;

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfile.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfile.h
@@ -91,9 +91,11 @@ struct RuntimeSamplingProfile {
 
   RuntimeSamplingProfile(
       std::string runtimeName,
+      ProcessId processId,
       std::vector<Sample> samples,
       std::unique_ptr<RawRuntimeProfile> rawRuntimeProfile)
       : runtimeName(std::move(runtimeName)),
+        processId(processId),
         samples(std::move(samples)),
         rawRuntimeProfile(std::move(rawRuntimeProfile)) {}
 
@@ -109,6 +111,8 @@ struct RuntimeSamplingProfile {
 
   /// Name of the runtime, where sampling occurred: Hermes, V8, etc.
   std::string runtimeName;
+  /// The ID of the OS-level process where the sampling occurred.
+  ProcessId processId;
   /// List of recorded samples, should be chronologically sorted.
   std::vector<Sample> samples;
   /// A unique pointer to the original raw runtime profile, collected from the

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.cpp
@@ -27,10 +27,6 @@ HighResTimeStamp getHighResTimeStampForSample(
   return HighResTimeStamp::fromChronoSteadyClockTimePoint(chronoTimePoint);
 }
 
-// Right now we only emit single Profile. We might revisit this decision in the
-// future, once we support multiple VMs being sampled at the same time.
-constexpr RuntimeProfileId PROFILE_ID = 1;
-
 /// Fallback script ID for artificial call frames, such as (root), (idle) or
 /// (program). Required for emulating the payload in a format that is expected
 /// by Chrome DevTools.
@@ -62,7 +58,7 @@ TraceEventProfileChunk::CPUProfile::Node convertToTraceEventProfileNode(
 
   return TraceEventProfileChunk::CPUProfile::Node{
       .id = node.getId(),
-      .callFrame = traceEventCallFrame,
+      .callFrame = std::move(traceEventCallFrame),
       .parentId = node.hasParent() ? std::optional<uint32_t>(node.getParentId())
                                    : std::nullopt,
   };
@@ -95,22 +91,55 @@ class ProfileTreeRootNode : public ProfileTreeNode {
             createArtificialCallFrame(ROOT_FRAME_NAME)) {}
 };
 
-} // namespace
+struct ProfileChunk {
+  ProfileChunk(
+      uint16_t chunkSize,
+      ProcessId chunkProcessId,
+      ThreadId chunkThreadId,
+      HighResTimeStamp chunkTimestamp)
+      : size(chunkSize),
+        processId(chunkProcessId),
+        threadId(chunkThreadId),
+        timestamp(chunkTimestamp) {
+    samples.reserve(size);
+    timeDeltas.reserve(size);
+  }
 
-void RuntimeSamplingProfileTraceEventSerializer::sendProfileTraceEvent(
+  inline bool isFull() const {
+    return samples.size() == size;
+  }
+
+  inline bool isEmpty() const {
+    return samples.empty();
+  }
+
+  std::vector<ProfileTreeNode> nodes;
+  std::vector<uint32_t> samples;
+  std::vector<HighResDuration> timeDeltas;
+  uint16_t size;
+  ProcessId processId;
+  ThreadId threadId;
+  HighResTimeStamp timestamp;
+};
+
+// Construct and send "Profile" Trace Event with dispatchCallback.
+void sendProfileTraceEvent(
     ProcessId processId,
     ThreadId threadId,
     RuntimeProfileId profileId,
-    HighResTimeStamp profileStartTimestamp) const {
+    HighResTimeStamp profileStartTimestamp,
+    const std::function<void(folly::dynamic&& traceEventsChunk)>&
+        dispatchCallback) {
   auto traceEvent = PerformanceTracer::constructRuntimeProfileTraceEvent(
       profileId, processId, threadId, profileStartTimestamp);
   folly::dynamic serializedTraceEvent =
       TraceEventSerializer::serialize(std::move(traceEvent));
 
-  notificationCallback_(folly::dynamic::array(std::move(serializedTraceEvent)));
+  dispatchCallback(folly::dynamic::array(std::move(serializedTraceEvent)));
 }
 
-void RuntimeSamplingProfileTraceEventSerializer::chunkEmptySample(
+// Add an empty sample to the chunk.
+void chunkEmptySample(
     ProfileChunk& chunk,
     uint32_t idleNodeId,
     HighResDuration samplesTimeDelta) {
@@ -118,13 +147,12 @@ void RuntimeSamplingProfileTraceEventSerializer::chunkEmptySample(
   chunk.timeDeltas.push_back(samplesTimeDelta);
 }
 
-void RuntimeSamplingProfileTraceEventSerializer::bufferProfileChunkTraceEvent(
+// Take the current local ProfileChunk, serialize it as "ProfileChunk" Trace
+// Event and buffer it.
+void bufferProfileChunkTraceEvent(
     ProfileChunk&& chunk,
-    RuntimeProfileId profileId) {
-  if (chunk.isEmpty()) {
-    return;
-  }
-
+    RuntimeProfileId profileId,
+    folly::dynamic& traceEventBuffer) {
   std::vector<TraceEventProfileChunk::CPUProfile::Node> traceEventNodes;
   traceEventNodes.reserve(chunk.nodes.size());
   for (const auto& node : chunk.nodes) {
@@ -146,16 +174,17 @@ void RuntimeSamplingProfileTraceEventSerializer::bufferProfileChunkTraceEvent(
   auto serializedTraceEvent =
       TraceEventSerializer::serialize(std::move(traceEvent));
 
-  traceEventBuffer_.push_back(std::move(serializedTraceEvent));
+  traceEventBuffer.push_back(std::move(serializedTraceEvent));
 }
 
-void RuntimeSamplingProfileTraceEventSerializer::processCallStack(
+// Process a call stack of a single sample and add it to the chunk.
+void processCallStack(
     std::vector<RuntimeSamplingProfile::SampleCallStackFrame>&& callStack,
     ProfileChunk& chunk,
     ProfileTreeNode& rootNode,
     uint32_t idleNodeId,
     HighResDuration samplesTimeDelta,
-    NodeIdGenerator& nodeIdGenerator) {
+    IdGenerator& nodeIdGenerator) {
   if (callStack.empty()) {
     chunkEmptySample(chunk, idleNodeId, samplesTimeDelta);
     return;
@@ -190,39 +219,71 @@ void RuntimeSamplingProfileTraceEventSerializer::processCallStack(
   chunk.timeDeltas.push_back(samplesTimeDelta);
 }
 
-void RuntimeSamplingProfileTraceEventSerializer::
-    sendBufferedTraceEventsAndClear() {
-  notificationCallback_(std::move(traceEventBuffer_));
-
-  traceEventBuffer_ = folly::dynamic::array();
-  traceEventBuffer_.reserve(traceEventChunkSize_);
+// Send buffered Trace Events and reset the buffer.
+void sendBufferedTraceEvents(
+    folly::dynamic&& traceEventBuffer,
+    const std::function<void(folly::dynamic&& traceEventsChunk)>&
+        dispatchCallback) {
+  dispatchCallback(std::move(traceEventBuffer));
 }
 
-void RuntimeSamplingProfileTraceEventSerializer::serializeAndNotify(
+} // namespace
+
+/* static */ void
+RuntimeSamplingProfileTraceEventSerializer::serializeAndDispatch(
+    std::vector<RuntimeSamplingProfile>&& profiles,
+    IdGenerator& profileIdGenerator,
+    HighResTimeStamp tracingStartTime,
+    const std::function<void(folly::dynamic&& traceEventsChunk)>&
+        dispatchCallback,
+    uint16_t traceEventChunkSize,
+    uint16_t profileChunkSize) {
+  for (auto&& profile : profiles) {
+    serializeAndDispatch(
+        std::move(profile),
+        profileIdGenerator,
+        tracingStartTime,
+        dispatchCallback,
+        traceEventChunkSize,
+        profileChunkSize);
+  }
+}
+
+/* static */ void
+RuntimeSamplingProfileTraceEventSerializer::serializeAndDispatch(
     RuntimeSamplingProfile&& profile,
-    HighResTimeStamp tracingStartTime) {
+    IdGenerator& profileIdGenerator,
+    HighResTimeStamp tracingStartTime,
+    const std::function<void(folly::dynamic&& traceEventsChunk)>&
+        dispatchCallback,
+    uint16_t traceEventChunkSize,
+    uint16_t profileChunkSize) {
   auto samples = std::move(profile.samples);
   if (samples.empty()) {
     return;
   }
 
-  ThreadId firstChunkThreadId = samples.front().threadId;
+  auto traceEventBuffer = folly::dynamic::array();
+  traceEventBuffer.reserve(traceEventChunkSize);
+
+  ThreadId threadId = samples.front().threadId;
   HighResTimeStamp previousSampleTimestamp = tracingStartTime;
   HighResTimeStamp currentChunkTimestamp = tracingStartTime;
+  auto profileId = profileIdGenerator.getNext();
 
   sendProfileTraceEvent(
-      profile.processId, firstChunkThreadId, PROFILE_ID, tracingStartTime);
+      profile.processId,
+      threadId,
+      profileId,
+      tracingStartTime,
+      dispatchCallback);
 
   // There could be any number of new nodes in this chunk. Empty if all nodes
   // are already emitted in previous chunks.
   ProfileChunk chunk{
-      profileChunkSize_,
-      profile.processId,
-      firstChunkThreadId,
-      currentChunkTimestamp};
+      profileChunkSize, profile.processId, threadId, currentChunkTimestamp};
 
-  NodeIdGenerator nodeIdGenerator{};
-
+  IdGenerator nodeIdGenerator{};
   ProfileTreeRootNode rootNode(nodeIdGenerator.getNext());
   chunk.nodes.push_back(rootNode);
 
@@ -248,16 +309,20 @@ void RuntimeSamplingProfileTraceEventSerializer::serializeAndNotify(
     // We should group samples by thread id once we support executing JavaScript
     // on different threads.
     if (currentSampleThreadId != chunk.threadId || chunk.isFull()) {
-      bufferProfileChunkTraceEvent(std::move(chunk), PROFILE_ID);
+      bufferProfileChunkTraceEvent(
+          std::move(chunk), profileId, traceEventBuffer);
       chunk = ProfileChunk{
-          profileChunkSize_,
+          profileChunkSize,
           profile.processId,
           currentSampleThreadId,
           currentChunkTimestamp};
     }
 
-    if (traceEventBuffer_.size() == traceEventChunkSize_) {
-      sendBufferedTraceEventsAndClear();
+    if (traceEventBuffer.size() == traceEventChunkSize) {
+      sendBufferedTraceEvents(std::move(traceEventBuffer), dispatchCallback);
+
+      traceEventBuffer = folly::dynamic::array();
+      traceEventBuffer.reserve(traceEventChunkSize);
     }
 
     processCallStack(
@@ -272,11 +337,11 @@ void RuntimeSamplingProfileTraceEventSerializer::serializeAndNotify(
   }
 
   if (!chunk.isEmpty()) {
-    bufferProfileChunkTraceEvent(std::move(chunk), PROFILE_ID);
+    bufferProfileChunkTraceEvent(std::move(chunk), profileId, traceEventBuffer);
   }
 
-  if (!traceEventBuffer_.empty()) {
-    sendBufferedTraceEventsAndClear();
+  if (!traceEventBuffer.empty()) {
+    sendBufferedTraceEvents(std::move(traceEventBuffer), dispatchCallback);
   }
 }
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.cpp
@@ -27,7 +27,7 @@ HighResTimeStamp getHighResTimeStampForSample(
 
 // Right now we only emit single Profile. We might revisit this decision in the
 // future, once we support multiple VMs being sampled at the same time.
-constexpr uint16_t PROFILE_ID = 1;
+constexpr RuntimeProfileId PROFILE_ID = 1;
 
 /// Fallback script ID for artificial call frames, such as (root), (idle) or
 /// (program). Required for emulating the payload in a format that is expected
@@ -96,8 +96,8 @@ class ProfileTreeRootNode : public ProfileTreeNode {
 } // namespace
 
 void RuntimeSamplingProfileTraceEventSerializer::sendProfileTraceEvent(
-    uint64_t threadId,
-    uint16_t profileId,
+    ThreadId threadId,
+    RuntimeProfileId profileId,
     HighResTimeStamp profileStartTimestamp) const {
   folly::dynamic serializedTraceEvent =
       performanceTracer_.getSerializedRuntimeProfileTraceEvent(
@@ -116,7 +116,7 @@ void RuntimeSamplingProfileTraceEventSerializer::chunkEmptySample(
 
 void RuntimeSamplingProfileTraceEventSerializer::bufferProfileChunkTraceEvent(
     ProfileChunk&& chunk,
-    uint16_t profileId) {
+    RuntimeProfileId profileId) {
   if (chunk.isEmpty()) {
     return;
   }
@@ -198,7 +198,7 @@ void RuntimeSamplingProfileTraceEventSerializer::serializeAndNotify(
     return;
   }
 
-  uint64_t firstChunkThreadId = samples.front().threadId;
+  ThreadId firstChunkThreadId = samples.front().threadId;
   HighResTimeStamp previousSampleTimestamp = tracingStartTime;
   HighResTimeStamp currentChunkTimestamp = tracingStartTime;
 
@@ -228,7 +228,7 @@ void RuntimeSamplingProfileTraceEventSerializer::serializeAndNotify(
   uint32_t idleNodeId = idleNode->getId();
 
   for (auto& sample : samples) {
-    uint64_t currentSampleThreadId = sample.threadId;
+    ThreadId currentSampleThreadId = sample.threadId;
     auto currentSampleTimestamp = getHighResTimeStampForSample(sample);
 
     // We should not attempt to merge samples from different threads.

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.h
@@ -7,16 +7,13 @@
 
 #pragma once
 
-#include "ProfileTreeNode.h"
 #include "RuntimeSamplingProfile.h"
 
 #include <react/timing/primitives.h>
 
 namespace facebook::react::jsinspector_modern::tracing {
 
-namespace {
-
-struct NodeIdGenerator {
+struct IdGenerator {
  public:
   uint32_t getNext() {
     return ++counter_;
@@ -26,144 +23,42 @@ struct NodeIdGenerator {
   uint32_t counter_ = 0;
 };
 
-} // namespace
-
 /**
  * Serializes RuntimeSamplingProfile into collection of specific Trace Events,
  * which represent Profile information on a timeline.
  */
 class RuntimeSamplingProfileTraceEventSerializer {
-  struct ProfileChunk {
-    ProfileChunk(
-        uint16_t chunkSize,
-        ProcessId chunkProcessId,
-        ThreadId chunkThreadId,
-        HighResTimeStamp chunkTimestamp)
-        : size(chunkSize),
-          processId(chunkProcessId),
-          threadId(chunkThreadId),
-          timestamp(chunkTimestamp) {
-      samples.reserve(size);
-      timeDeltas.reserve(size);
-    }
-
-    bool isFull() const {
-      return samples.size() == size;
-    }
-
-    bool isEmpty() const {
-      return samples.empty();
-    }
-
-    std::vector<ProfileTreeNode> nodes;
-    std::vector<uint32_t> samples;
-    std::vector<HighResDuration> timeDeltas;
-    uint16_t size;
-    ProcessId processId;
-    ThreadId threadId;
-    HighResTimeStamp timestamp;
-  };
-
  public:
   /**
-   * \param notificationCallback A reference to a callback, which is called
-   * when a chunk of trace events is ready to be sent.
-   * \param traceEventChunkSize The maximum number of ProfileChunk trace
-   * events that can be sent in a single CDP Tracing.dataCollected message.
+   * \param profile What we will be serializing.
+   * \param profileIdGenerator A reference to an IdGenerator, which will be
+   * used for generating unique ids for ProfileChunks.
+   * \param tracingStartTime A timestamp of when tracing started, will be used
+   * as a starting reference point of JavaScript samples recording.
+   * \param dispatchCallback A reference to a callback, which is called when a
+   * chunk of trace events is ready to be sent.
+   * \param traceEventChunkSize The maximum number of ProfileChunk trace events
+   * that can be sent in a single CDP Tracing.dataCollected message.
    * \param profileChunkSize The maximum number of ProfileChunk trace events
    * that can be sent in a single ProfileChunk trace event.
    */
-  RuntimeSamplingProfileTraceEventSerializer(
-      std::function<void(folly::dynamic&& traceEventsChunk)>
-          notificationCallback,
-      uint16_t traceEventChunkSize,
-      uint16_t profileChunkSize = 10)
-      : notificationCallback_(std::move(notificationCallback)),
-        traceEventChunkSize_(traceEventChunkSize),
-        profileChunkSize_(profileChunkSize) {
-    traceEventBuffer_ = folly::dynamic::array();
-    traceEventBuffer_.reserve(traceEventChunkSize);
-  }
-
-  /**
-   * \param profile What we will be serializing.
-   * \param tracingStartTime A timestamp of when tracing of an Instance started,
-   * will be used as a starting reference point of JavaScript samples recording.
-   */
-  void serializeAndNotify(
+  static void serializeAndDispatch(
       RuntimeSamplingProfile&& profile,
-      HighResTimeStamp tracingStartTime);
+      IdGenerator& profileIdGenerator,
+      HighResTimeStamp tracingStartTime,
+      const std::function<void(folly::dynamic&& traceEventsChunk)>&
+          dispatchCallback,
+      uint16_t traceEventChunkSize,
+      uint16_t profileChunkSize = 10);
 
- private:
-  /**
-   * Sends a single "Profile" Trace Event via notificationCallback_.
-
-   * \param processId The id of the process, where the Profile was collected.
-   * \param threadId The id of the thread, where the Profile was collected.
-   * \param profileId The id of the Profile.
-   * \param profileStartUnixTimestamp The Unix timestamp of the start of the
-   * profile.
-   */
-  void sendProfileTraceEvent(
-      ProcessId processId,
-      ThreadId threadId,
-      RuntimeProfileId profileId,
-      HighResTimeStamp profileStartTimestamp) const;
-
-  /**
-   * Encapsulates logic for processing the empty sample, when the VM was idling.
-   * \param chunk The profile chunk, which will record this sample.
-   * \param idleNodeId The id of the (idle) node.
-   * \param samplesTimeDelta Delta between the current sample and the
-   * previous one.
-   */
-  void chunkEmptySample(
-      ProfileChunk& chunk,
-      uint32_t idleNodeId,
-      HighResDuration samplesTimeDelta);
-
-  /**
-   * Records ProfileChunk as a "ProfileChunk" Trace Event in traceEventBuffer_.
-   * \param chunk The chunk that will be buffered.
-   * \param profileId The id of the Profile.
-   */
-  void bufferProfileChunkTraceEvent(
-      ProfileChunk&& chunk,
-      RuntimeProfileId profileId);
-
-  /**
-   * Encapsulates logic for processing the call stack of the sample.
-   * \param callStack The call stack that will be processed.
-   * \param chunk The profile chunk, which will buffer the sample with the
-   * provided call stack.
-   * \param rootNode The (root) node. Will be the parent node of the
-   * corresponding profile tree branch.
-   * \param idleNodeId Id of the (idle) node. Will be the only node that is used
-   * for the corresponding profile tree branch, in case of an empty call stack.
-   * \param samplesTimeDelta Delta between the current sample and the previous
-   * one.
-   * \param nodeIdGenerator NodeIdGenerator instance that will be used for
-   * generating unique node ids.
-   */
-  void processCallStack(
-      std::vector<RuntimeSamplingProfile::SampleCallStackFrame>&& callStack,
-      ProfileChunk& chunk,
-      ProfileTreeNode& rootNode,
-      uint32_t idleNodeId,
-      HighResDuration samplesTimeDelta,
-      NodeIdGenerator& nodeIdGenerator);
-
-  /**
-   * Sends buffered Trace Events via notificationCallback_ and then clears it.
-   */
-  void sendBufferedTraceEventsAndClear();
-
-  const std::function<void(folly::dynamic&& traceEventsChunk)>
-      notificationCallback_;
-  const uint16_t traceEventChunkSize_;
-  const uint16_t profileChunkSize_;
-
-  folly::dynamic traceEventBuffer_;
+  static void serializeAndDispatch(
+      std::vector<RuntimeSamplingProfile>&& profiles,
+      IdGenerator& profileIdGenerator,
+      HighResTimeStamp tracingStartTime,
+      const std::function<void(folly::dynamic&& traceEventsChunk)>&
+          dispatchCallback,
+      uint16_t traceEventChunkSize,
+      uint16_t profileChunkSize = 10);
 };
 
 } // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.h
@@ -37,7 +37,7 @@ class RuntimeSamplingProfileTraceEventSerializer {
   struct ProfileChunk {
     ProfileChunk(
         uint16_t chunkSize,
-        uint64_t chunkThreadId,
+        ThreadId chunkThreadId,
         HighResTimeStamp chunkTimestamp)
         : size(chunkSize), threadId(chunkThreadId), timestamp(chunkTimestamp) {
       samples.reserve(size);
@@ -56,7 +56,7 @@ class RuntimeSamplingProfileTraceEventSerializer {
     std::vector<uint32_t> samples;
     std::vector<HighResDuration> timeDeltas;
     uint16_t size;
-    uint64_t threadId;
+    ThreadId threadId;
     HighResTimeStamp timestamp;
   };
 
@@ -102,8 +102,8 @@ class RuntimeSamplingProfileTraceEventSerializer {
    * profile.
    */
   void sendProfileTraceEvent(
-      uint64_t threadId,
-      uint16_t profileId,
+      ThreadId threadId,
+      RuntimeProfileId profileId,
       HighResTimeStamp profileStartTimestamp) const;
 
   /**
@@ -123,7 +123,9 @@ class RuntimeSamplingProfileTraceEventSerializer {
    * \param chunk The chunk that will be buffered.
    * \param profileId The id of the Profile.
    */
-  void bufferProfileChunkTraceEvent(ProfileChunk&& chunk, uint16_t profileId);
+  void bufferProfileChunkTraceEvent(
+      ProfileChunk&& chunk,
+      RuntimeProfileId profileId);
 
   /**
    * Encapsulates logic for processing the call stack of the sample.

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEvent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEvent.h
@@ -13,6 +13,14 @@
 
 namespace facebook::react::jsinspector_modern::tracing {
 
+using ProcessId = uint64_t;
+using ThreadId = uint64_t;
+/**
+ * The ID for the JavaScript Sampling Profile. There can be multiple Profiles
+ * during a single session, in case RuntimeTarget is re-initialized.
+ */
+using RuntimeProfileId = uint16_t;
+
 /**
  * A trace event to send to the debugger frontend, as defined by the Trace Event
  * Format.
@@ -44,11 +52,11 @@ struct TraceEvent {
   /** The tracing clock timestamp of the event, in microseconds (µs). */
   HighResTimeStamp ts;
 
-  /** The process ID for the process that output this event. */
-  uint64_t pid;
+  /** The ID for the process that output this event. */
+  ProcessId pid;
 
-  /** The thread ID for the process that output this event. */
-  uint64_t tid;
+  /** The ID for the thread that output this event. */
+  ThreadId tid;
 
   /** Any arguments provided for the event. */
   folly::dynamic args = folly::dynamic::object();

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/tests/RuntimeSamplingProfileTraceEventSerializerTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/tests/RuntimeSamplingProfileTraceEventSerializerTest.cpp
@@ -55,12 +55,12 @@ class RuntimeSamplingProfileTraceEventSerializerTest : public ::testing::Test {
   }
 
   RuntimeSamplingProfile createEmptyProfile() {
-    return {"TestRuntime", {}, {}};
+    return {"TestRuntime", 1, {}, {}};
   }
 
   RuntimeSamplingProfile createProfileWithSamples(
       std::vector<RuntimeSamplingProfile::Sample> samples) {
-    return {"TestRuntime", std::move(samples), {}};
+    return {"TestRuntime", 1, std::move(samples), {}};
   }
 };
 
@@ -68,7 +68,7 @@ TEST_F(RuntimeSamplingProfileTraceEventSerializerTest, EmptyProfile) {
   // Setup
   auto notificationCallback = createNotificationCallback();
   RuntimeSamplingProfileTraceEventSerializer serializer(
-      PerformanceTracer::getInstance(), notificationCallback, 10);
+      notificationCallback, 10);
 
   auto profile = createEmptyProfile();
   auto tracingStartTime = HighResTimeStamp::now();
@@ -86,7 +86,7 @@ TEST_F(
   // Setup
   auto notificationCallback = createNotificationCallback();
   RuntimeSamplingProfileTraceEventSerializer serializer(
-      PerformanceTracer::getInstance(), notificationCallback, 10);
+      notificationCallback, 10);
 
   // [     foo     ]
   // [     bar     ]
@@ -136,7 +136,7 @@ TEST_F(RuntimeSamplingProfileTraceEventSerializerTest, EmptySample) {
   // Setup
   auto notificationCallback = createNotificationCallback();
   RuntimeSamplingProfileTraceEventSerializer serializer(
-      PerformanceTracer::getInstance(), notificationCallback, 10);
+      notificationCallback, 10);
 
   // Create an empty sample (no call stack)
   std::vector<RuntimeSamplingProfile::SampleCallStackFrame> emptyCallStack;
@@ -172,7 +172,7 @@ TEST_F(
   // Setup
   auto notificationCallback = createNotificationCallback();
   RuntimeSamplingProfileTraceEventSerializer serializer(
-      PerformanceTracer::getInstance(), notificationCallback, 10);
+      notificationCallback, 10);
 
   // Create samples with different thread IDs
   std::vector<RuntimeSamplingProfile::SampleCallStackFrame> callStack = {
@@ -209,10 +209,7 @@ TEST_F(
   uint16_t traceEventChunkSize = 2;
   uint16_t profileChunkSize = 2;
   RuntimeSamplingProfileTraceEventSerializer serializer(
-      PerformanceTracer::getInstance(),
-      notificationCallback,
-      traceEventChunkSize,
-      profileChunkSize);
+      notificationCallback, traceEventChunkSize, profileChunkSize);
 
   // Create multiple samples
   std::vector<RuntimeSamplingProfile::SampleCallStackFrame> callStack = {
@@ -250,10 +247,7 @@ TEST_F(RuntimeSamplingProfileTraceEventSerializerTest, ProfileChunkSizeLimit) {
   uint16_t profileChunkSize = 2;
   double samplesCount = 5;
   RuntimeSamplingProfileTraceEventSerializer serializer(
-      PerformanceTracer::getInstance(),
-      notificationCallback,
-      traceEventChunkSize,
-      profileChunkSize);
+      notificationCallback, traceEventChunkSize, profileChunkSize);
 
   // Create multiple samples
   std::vector<RuntimeSamplingProfile::SampleCallStackFrame> callStack = {

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/tests/RuntimeSamplingProfileTraceEventSerializerTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/tests/RuntimeSamplingProfileTraceEventSerializerTest.cpp
@@ -49,7 +49,7 @@ class RuntimeSamplingProfileTraceEventSerializerTest : public ::testing::Test {
 
   RuntimeSamplingProfile::Sample createSample(
       uint64_t timestamp,
-      uint64_t threadId,
+      ThreadId threadId,
       std::vector<RuntimeSamplingProfile::SampleCallStackFrame> callStack) {
     return {timestamp, threadId, std::move(callStack)};
   }
@@ -108,7 +108,7 @@ TEST_F(
       createJSCallFrame("foo", 1, "test.js", 10, 5),
   };
 
-  uint64_t threadId = 1;
+  ThreadId threadId = 1;
   uint64_t timestamp1 = 1000000;
   uint64_t timestamp2 = 2000000;
   uint64_t timestamp3 = 3000000;
@@ -141,7 +141,7 @@ TEST_F(RuntimeSamplingProfileTraceEventSerializerTest, EmptySample) {
   // Create an empty sample (no call stack)
   std::vector<RuntimeSamplingProfile::SampleCallStackFrame> emptyCallStack;
 
-  uint64_t threadId = 1;
+  ThreadId threadId = 1;
   uint64_t timestamp = 1000000;
 
   auto samples = std::vector<RuntimeSamplingProfile::Sample>{};
@@ -179,8 +179,8 @@ TEST_F(
       createJSCallFrame("foo", 1, "test.js", 10, 5)};
 
   uint64_t timestamp = 1000000;
-  uint64_t threadId1 = 1;
-  uint64_t threadId2 = 2;
+  ThreadId threadId1 = 1;
+  ThreadId threadId2 = 2;
 
   auto samples = std::vector<RuntimeSamplingProfile::Sample>{};
   samples.emplace_back(createSample(timestamp, threadId1, callStack));
@@ -219,7 +219,7 @@ TEST_F(
       createJSCallFrame("foo", 1, "test.js", 10, 5)};
 
   uint64_t timestamp = 1000000;
-  uint64_t threadId = 1;
+  ThreadId threadId = 1;
 
   std::vector<RuntimeSamplingProfile::Sample> samples;
   samples.reserve(5);
@@ -260,7 +260,7 @@ TEST_F(RuntimeSamplingProfileTraceEventSerializerTest, ProfileChunkSizeLimit) {
       createJSCallFrame("foo", 1, "test.js", 10, 5)};
 
   uint64_t timestamp = 1000000;
-  uint64_t threadId = 1;
+  ThreadId threadId = 1;
 
   std::vector<RuntimeSamplingProfile::Sample> samples;
   samples.reserve(samplesCount);


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

This is required for storing these Trace Events somewhere outside of PerformanceTracer, in case these events will be dispatched later.

Reviewed By: rubennorte

Differential Revision: D78741192


