### PR TITLE
Add Text benchmark clause for elements without props

### DIFF
--- a/packages/react-native/Libraries/Text/__tests__/Text-benchmark-itest.js
+++ b/packages/react-native/Libraries/Text/__tests__/Text-benchmark-itest.js
@@ -17,33 +17,60 @@ import {Text} from 'react-native';
 let root;
 let testElements: React.MixedElement;
 
-Fantom.unstable_benchmark.suite('Text').test.each(
-  [100, 1000],
-  n => `render ${n.toString()} text component instances`,
-  () => {
-    Fantom.runTask(() => root.render(testElements));
-  },
-  n => ({
-    beforeAll: () => {
-      testElements = (
-        <>
-          {[...Array(n).keys()].map(i => (
-            <Text
-              id={String(i)}
-              nativeID={String(i)}
-              style={{
-                width: i + 1,
-                height: i + 1,
-              }}>{`Text instance ${i}`}</Text>
-          ))}
-        </>
-      );
+Fantom.unstable_benchmark
+  .suite('Text')
+  .test.each(
+    [100, 1000],
+    n =>
+      `render ${n.toString()} text component instances with no explicit props`,
+    () => {
+      Fantom.runTask(() => root.render(testElements));
     },
-    beforeEach: () => {
-      root = Fantom.createRoot();
+    n => ({
+      beforeAll: () => {
+        testElements = (
+          <>
+            {[...Array(n).keys()].map(i => (
+              <Text />
+            ))}
+          </>
+        );
+      },
+      beforeEach: () => {
+        root = Fantom.createRoot();
+      },
+      afterEach: () => {
+        root.destroy();
+      },
+    }),
+  )
+  .test.each(
+    [100, 1000],
+    n => `render ${n.toString()} text component instances`,
+    () => {
+      Fantom.runTask(() => root.render(testElements));
     },
-    afterEach: () => {
-      root.destroy();
-    },
-  }),
-);
+    n => ({
+      beforeAll: () => {
+        testElements = (
+          <>
+            {[...Array(n).keys()].map(i => (
+              <Text
+                id={String(i)}
+                nativeID={String(i)}
+                style={{
+                  width: i + 1,
+                  height: i + 1,
+                }}>{`Text instance ${i}`}</Text>
+            ))}
+          </>
+        );
+      },
+      beforeEach: () => {
+        root = Fantom.createRoot();
+      },
+      afterEach: () => {
+        root.destroy();
+      },
+    }),
+  );


### PR DESCRIPTION
Summary:
# Changelog:
[Internal] -

Adds another test clause to the Text benchmark test, to test the case when the component doesn't have any props altogether, which can be useful to establish a baseline.

Differential Revision: D79352849
