### PR TITLE
Wire through showView parameter

### DIFF
--- a/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
+++ b/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
@@ -57,7 +57,8 @@ export default function openDebuggerMiddleware({
       req.method === 'POST' ||
       (experiments.enableOpenDebuggerRedirect && req.method === 'GET')
     ) {
-      const paresedUrl = url.parse(req.url, true);
+      const parsedUrl = url.parse(req.url, true);
+
       const query: {
         /** @deprecated Will only match legacy Hermes targets */
         appId?: string,
@@ -66,8 +67,9 @@ export default function openDebuggerMiddleware({
         launchId?: string,
         telemetryInfo?: string,
         target?: string,
+        landingView?: string,
         ...
-      } = paresedUrl.query;
+      } = parsedUrl.query;
 
       const targets = inspectorProxy
         .getPageDescriptions({requestorRelativeBaseUrl: new URL(serverBaseUrl)})
@@ -150,6 +152,7 @@ export default function openDebuggerMiddleware({
                 telemetryInfo: query.telemetryInfo,
                 appId: target.appId,
                 useFuseboxEntryPoint,
+                landingView: query.landingView,
               },
             );
             if (

--- a/packages/dev-middleware/src/utils/getDevToolsFrontendUrl.js
+++ b/packages/dev-middleware/src/utils/getDevToolsFrontendUrl.js
@@ -24,6 +24,7 @@ export default function getDevToolsFrontendUrl(
     /** Whether to use the modern `rn_fusebox.html` entry point. */
     useFuseboxEntryPoint?: boolean,
     appId?: string,
+    landingView?: string,
   }>,
 ): string {
   const wsParam = getWsParam({
@@ -53,6 +54,9 @@ export default function getDevToolsFrontendUrl(
   }
   if (options?.telemetryInfo != null && options.telemetryInfo !== '') {
     searchParams.append('telemetryInfo', options.telemetryInfo);
+  }
+  if (options?.landingView != null && options.landingView !== '') {
+    searchParams.append('landingView', options.landingView);
   }
 
   return appUrl + '?' + searchParams.toString();

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1925,6 +1925,14 @@ public final class com/facebook/react/devsupport/BundleDownloader$BundleInfo$Com
 public final class com/facebook/react/devsupport/BundleDownloader$Companion {
 }
 
+public final class com/facebook/react/devsupport/ChromeDevToolsViewKeys : java/lang/Enum {
+	public static final field Performance Lcom/facebook/react/devsupport/ChromeDevToolsViewKeys;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/facebook/react/devsupport/ChromeDevToolsViewKeys;
+	public static fun values ()[Lcom/facebook/react/devsupport/ChromeDevToolsViewKeys;
+}
+
 public final class com/facebook/react/devsupport/DefaultDevLoadingViewImplementation : com/facebook/react/devsupport/interfaces/DevLoadingViewManager {
 	public static final field Companion Lcom/facebook/react/devsupport/DefaultDevLoadingViewImplementation$Companion;
 	public fun <init> (Lcom/facebook/react/devsupport/ReactInstanceDevHelper;)V
@@ -1952,7 +1960,7 @@ public class com/facebook/react/devsupport/DevServerHelper {
 	public fun getSourceUrl (Ljava/lang/String;)Ljava/lang/String;
 	public final fun getWebsocketProxyURL ()Ljava/lang/String;
 	public fun isPackagerRunning (Lcom/facebook/react/devsupport/interfaces/PackagerStatusCallback;)V
-	public final fun openDebugger (Lcom/facebook/react/bridge/ReactContext;Ljava/lang/String;)V
+	public final fun openDebugger (Lcom/facebook/react/bridge/ReactContext;Ljava/lang/String;Ljava/lang/String;)V
 	public final fun openInspectorConnection ()V
 	public final fun openPackagerConnection (Ljava/lang/String;Lcom/facebook/react/devsupport/DevServerHelper$PackagerCommandListener;)V
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.kt
@@ -351,17 +351,27 @@ public open class DevServerHelper(
   }
 
   /** Attempt to open the JS debugger on the host machine (on-device CDP debugging). */
-  public fun openDebugger(context: ReactContext?, errorMessage: String?) {
+  public fun openDebugger(context: ReactContext?, errorMessage: String?, landingView: String?) {
     // TODO(huntie): Requests to dev server should not assume 'http' URL scheme
-    val requestUrl =
+    val requestUrlBuilder = StringBuilder()
+
+    requestUrlBuilder.append(
         String.format(
             Locale.US,
             "http://%s/open-debugger?device=%s",
             packagerConnectionSettings.debugServerHost,
             Uri.encode(inspectorDeviceId),
-        )
+        ))
+
+    if (landingView != null) {
+      requestUrlBuilder.append("&landingView=" + Uri.encode(landingView))
+    }
+
     val request =
-        Request.Builder().url(requestUrl).method("POST", RequestBody.create(null, "")).build()
+        Request.Builder()
+            .url(requestUrlBuilder.toString())
+            .method("POST", RequestBody.create(null, ""))
+            .build()
 
     client
         .newCall(request)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.kt
@@ -76,6 +76,10 @@ import java.net.MalformedURLException
 import java.net.URL
 import java.util.Locale
 
+public enum class ChromeDevToolsViewKeys(public val value: String) {
+  Performance("timeline")
+}
+
 public abstract class DevSupportManagerBase(
     protected val applicationContext: Context,
     public val reactInstanceDevHelper: ReactInstanceDevHelper,
@@ -908,7 +912,7 @@ public abstract class DevSupportManagerBase(
     devServerHelper.openDebugger(
         currentReactContext,
         applicationContext.getString(R.string.catalyst_open_debugger_error),
-    )
+        ChromeDevToolsViewKeys.Performance.value)
   }
 
   override fun showPausedInDebuggerOverlay(


### PR DESCRIPTION
Summary:
Wires up a `showView` parameter to be passed to rn_fusebox.html that we can use to focus an arbitrary view on launch. Used from the new perf analyze scenario to open devtools on the performance panel.

Changelog: [Internal]

Differential Revision: D79329081
