### PR TITLE
Kotlin: accessor call can be replaced with property access syntax

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactFragment.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactFragment.kt
@@ -151,10 +151,10 @@ public open class ReactFragment : Fragment(), PermissionAwareActivity {
   }
 
   override fun checkPermission(permission: String, pid: Int, uid: Int): Int =
-      getActivity()?.checkPermission(permission, pid, uid) ?: 0
+      activity?.checkPermission(permission, pid, uid) ?: 0
 
   override fun checkSelfPermission(permission: String): Int =
-      getActivity()?.checkSelfPermission(permission) ?: 0
+      activity?.checkSelfPermission(permission) ?: 0
 
   @Suppress("DEPRECATION")
   override fun requestPermissions(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/RedBoxContentView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/RedBoxContentView.kt
@@ -221,7 +221,7 @@ internal class RedBoxContentView(
   }
 
   fun setExceptionDetails(title: String, stack: Array<StackFrame>) {
-    stackView.setAdapter(StackAdapter(title, stack))
+    stackView.adapter = StackAdapter(title, stack)
   }
 
   /** Show the report button, hide the report textview and the loading indicator. */

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/IntBufferBatchMountItem.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/mountitems/IntBufferBatchMountItem.kt
@@ -66,7 +66,7 @@ internal class IntBufferBatchMountItem(
           TAG, "Skipping batch of MountItems; no SurfaceMountingManager found for [%d].", surfaceId)
       return
     }
-    if (surfaceMountingManager.isStopped()) {
+    if (surfaceMountingManager.isStopped) {
       FLog.e(TAG, "Skipping batch of MountItems; was stopped [%d].", surfaceId)
       return
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.kt
@@ -264,7 +264,7 @@ internal class AccessibilityInfoModule(context: ReactApplicationContext) :
   }
 
   override fun initialize() {
-    getReactApplicationContext().addLifecycleEventListener(this)
+    reactApplicationContext.addLifecycleEventListener(this)
     updateAndSendTouchExplorationChangeEvent(
         accessibilityManager?.isTouchExplorationEnabled == true)
     updateAndSendAccessibilityServiceChangeEvent(accessibilityManager?.isEnabled == true)
@@ -273,7 +273,7 @@ internal class AccessibilityInfoModule(context: ReactApplicationContext) :
   }
 
   override fun invalidate() {
-    getReactApplicationContext().removeLifecycleEventListener(this)
+    reactApplicationContext.removeLifecycleEventListener(this)
     super.invalidate()
   }
 
@@ -287,7 +287,7 @@ internal class AccessibilityInfoModule(context: ReactApplicationContext) :
     val event = AccessibilityEvent.obtain(AccessibilityEvent.TYPE_ANNOUNCEMENT)
     event.text.add(message)
     event.className = AccessibilityInfoModule::class.java.name
-    event.packageName = getReactApplicationContext().getPackageName()
+    event.packageName = reactApplicationContext.packageName
     accessibilityManager.sendAccessibilityEvent(event)
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/blob/BlobModule.kt
@@ -132,8 +132,8 @@ public class BlobModule(reactContext: ReactApplicationContext) :
   }
 
   public override fun getTypedExportedConstants(): Map<String, Any> {
-    val resources = getReactApplicationContext().resources
-    val packageName = getReactApplicationContext().packageName
+    val resources = reactApplicationContext.resources
+    val packageName = reactApplicationContext.packageName
     val resourceId = resources.getIdentifier("blob_provider_authority", "string", packageName)
     if (resourceId == 0) {
       return mapOf()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/clipboard/ClipboardModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/clipboard/ClipboardModule.kt
@@ -20,8 +20,7 @@ import com.facebook.react.module.annotations.ReactModule
 internal class ClipboardModule(context: ReactApplicationContext) : NativeClipboardSpec(context) {
 
   private val clipboardService: ClipboardManager
-    get() =
-        getReactApplicationContext().getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    get() = reactApplicationContext.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
 
   override fun getString(promise: Promise) {
     try {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/DialogTitle.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/dialog/DialogTitle.kt
@@ -45,8 +45,8 @@ internal class DialogTitle : TextView {
       if (lineCount > 0) {
         val ellipsisCount = layout.getEllipsisCount(lineCount - 1)
         if (ellipsisCount > 0) {
-          setSingleLine(false)
-          setMaxLines(2)
+          isSingleLine = false
+          maxLines = 2
           super.onMeasure(widthMeasureSpec, heightMeasureSpec)
         }
       }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nUtil.kt
@@ -29,7 +29,7 @@ public class I18nUtil private constructor() {
    * set.
    */
   private fun applicationHasRtlSupport(context: Context): Boolean {
-    return (context.getApplicationInfo().flags and ApplicationInfo.FLAG_SUPPORTS_RTL) != 0
+    return (context.applicationInfo.flags and ApplicationInfo.FLAG_SUPPORTS_RTL) != 0
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/intent/IntentModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/intent/IntentModule.kt
@@ -141,7 +141,7 @@ public open class IntentModule(reactContext: ReactApplicationContext) :
       // We need Intent.FLAG_ACTIVITY_NEW_TASK since getReactApplicationContext() returns
       // the ApplicationContext instead of the Activity context.
       intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-      val packageManager = getReactApplicationContext().getPackageManager()
+      val packageManager = reactApplicationContext.packageManager
       val canOpen = packageManager != null && intent.resolveActivity(packageManager) != null
       promise.resolve(canOpen)
     } catch (e: Exception) {
@@ -159,9 +159,8 @@ public open class IntentModule(reactContext: ReactApplicationContext) :
   override fun openSettings(promise: Promise) {
     try {
       val intent = Intent()
-      val currentActivity: Activity =
-          checkNotNull(getReactApplicationContext().getCurrentActivity())
-      val selfPackageName = getReactApplicationContext().getPackageName()
+      val currentActivity: Activity = checkNotNull(reactApplicationContext.getCurrentActivity())
+      val selfPackageName = reactApplicationContext.packageName
 
       intent.setAction(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
       intent.addCategory(Intent.CATEGORY_DEFAULT)
@@ -196,7 +195,7 @@ public open class IntentModule(reactContext: ReactApplicationContext) :
 
     val intent = Intent(action)
 
-    val packageManager = getReactApplicationContext().getPackageManager()
+    val packageManager = reactApplicationContext.packageManager
     if (packageManager == null || intent.resolveActivity(packageManager) == null) {
       promise.reject(
           JSApplicationIllegalArgumentException("Could not launch Intent with action $action."))
@@ -241,10 +240,10 @@ public open class IntentModule(reactContext: ReactApplicationContext) :
   }
 
   private fun sendOSIntent(intent: Intent, useNewTaskFlag: Boolean) {
-    val currentActivity = getReactApplicationContext().getCurrentActivity()
+    val currentActivity = reactApplicationContext.getCurrentActivity()
 
-    val selfPackageName = getReactApplicationContext().getPackageName()
-    val packageManager = getReactApplicationContext().getPackageManager()
+    val selfPackageName = reactApplicationContext.packageName
+    val packageManager = reactApplicationContext.packageManager
     val componentName =
         if (packageManager == null) {
           intent.component
@@ -262,7 +261,7 @@ public open class IntentModule(reactContext: ReactApplicationContext) :
     if (currentActivity != null) {
       currentActivity.startActivity(intent)
     } else {
-      getReactApplicationContext().startActivity(intent)
+      reactApplicationContext.startActivity(intent)
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/permissions/PermissionsModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/permissions/PermissionsModule.kt
@@ -68,7 +68,7 @@ public class PermissionsModule(reactContext: ReactApplicationContext?) :
    * [Activity.checkSelfPermission].
    */
   public override fun requestPermission(permission: String, promise: Promise): Unit {
-    val context = getReactApplicationContext().getBaseContext()
+    val context = reactApplicationContext.baseContext
     if (context.checkSelfPermission(permission) == PackageManager.PERMISSION_GRANTED) {
       promise.resolve(GRANTED)
       return
@@ -106,7 +106,7 @@ public class PermissionsModule(reactContext: ReactApplicationContext?) :
     val grantedPermissions = WritableNativeMap()
     val permissionsToCheck = ArrayList<String>()
     var checkedPermissionsCount = 0
-    val context = getReactApplicationContext().getBaseContext()
+    val context = reactApplicationContext.baseContext
     for (i in 0 until permissions.size()) {
       val perm = permissions.getString(i) ?: continue
       if (context.checkSelfPermission(perm) == PackageManager.PERMISSION_GRANTED) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.kt
@@ -912,7 +912,7 @@ public class ReactHostImpl(
               { task ->
                 val bundleLoader = checkNotNull(task.getResult())
                 val reactContext = getOrCreateReactContext()
-                reactContext.setJSExceptionHandler(devSupportManager)
+                reactContext.jsExceptionHandler = devSupportManager
 
                 log(method, "Creating ReactInstance")
                 val instance =

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.kt
@@ -297,7 +297,7 @@ internal class ReactInstance(
               sourceURL: String,
               loadSynchronously: Boolean
           ) {
-            context.setSourceURL(sourceURL)
+            context.sourceURL = sourceURL
             loadJSBundleFromFile(fileName, sourceURL)
           }
 
@@ -310,12 +310,12 @@ internal class ReactInstance(
               assetURL: String,
               loadSynchronously: Boolean
           ) {
-            context.setSourceURL(assetURL)
+            context.sourceURL = assetURL
             loadJSBundleFromAssets(assetManager, assetURL)
           }
 
           override fun setSourceURLs(deviceURL: String, remoteURL: String) {
-            context.setSourceURL(deviceURL)
+            context.sourceURL = deviceURL
           }
         })
     Systrace.endSection(Systrace.TRACE_TAG_REACT)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactSurfaceImpl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactSurfaceImpl.kt
@@ -210,7 +210,7 @@ internal constructor(
 
     private fun getFontScale(context: Context): Float =
         if (ReactNativeFeatureFlags.enableFontScaleChangesUpdatingLayout())
-            context.getResources().getConfiguration().fontScale
+            context.resources.configuration.fontScale
         else 1f
 
     private fun doRTLSwap(context: Context): Boolean =

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerHelper.kt
@@ -225,8 +225,8 @@ public object UIManagerHelper {
         PixelUtil.toDIPFromPixel(ViewCompat.getPaddingStart(editText).toFloat())
     padding[PADDING_END_INDEX] =
         PixelUtil.toDIPFromPixel(ViewCompat.getPaddingEnd(editText).toFloat())
-    padding[PADDING_TOP_INDEX] = PixelUtil.toDIPFromPixel(editText.getPaddingTop().toFloat())
-    padding[PADDING_BOTTOM_INDEX] = PixelUtil.toDIPFromPixel(editText.getPaddingBottom().toFloat())
+    padding[PADDING_TOP_INDEX] = PixelUtil.toDIPFromPixel(editText.paddingTop.toFloat())
+    padding[PADDING_BOTTOM_INDEX] = PixelUtil.toDIPFromPixel(editText.paddingBottom.toFloat())
     return padding
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/FabricEventDispatcher.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/FabricEventDispatcher.kt
@@ -218,7 +218,7 @@ internal class FabricEventDispatcher(
       }
 
       // We should only hit this slow path when we receive events while the host activity is paused.
-      if (reactContext.isOnUiQueueThread()) {
+      if (reactContext.isOnUiQueueThread) {
         maybeDispatchBatchedEvents()
       } else {
         reactContext.runOnUiQueueThread { maybeDispatchBatchedEvents() }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.kt
@@ -335,13 +335,12 @@ constructor(private val fpsListener: FpsListener? = null) :
         // no-op
       }
     }
-    if (view.getFadingEdgeLengthStart() > 0 || view.getFadingEdgeLengthEnd() > 0) {
-      view.setHorizontalFadingEdgeEnabled(true)
+    if (view.fadingEdgeLengthStart > 0 || view.fadingEdgeLengthEnd > 0) {
+      view.isHorizontalFadingEdgeEnabled = true
       view.setFadingEdgeLength(
-          Math.round(
-              Math.max(view.getFadingEdgeLengthStart(), view.getFadingEdgeLengthEnd()).dpToPx()))
+          Math.round(Math.max(view.fadingEdgeLengthStart, view.fadingEdgeLengthEnd).dpToPx()))
     } else {
-      view.setHorizontalFadingEdgeEnabled(false)
+      view.isHorizontalFadingEdgeEnabled = false
       view.setFadingEdgeLength(0)
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
@@ -452,7 +452,7 @@ public object ReactScrollViewHelper {
     scroller.setFriction(1.0f - scrollState.decelerationRate)
 
     // predict where a fling would end up so we can scroll to the nearest snap offset
-    val width = scrollView.width - scrollView.getPaddingStart() - scrollView.getPaddingEnd()
+    val width = scrollView.width - scrollView.paddingStart - scrollView.paddingEnd
     val height = scrollView.height - scrollView.paddingBottom - scrollView.paddingTop
     val finalAnimatedPositionScroll = scrollState.finalAnimatedPositionScroll
     scroller.fling(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.kt
@@ -324,13 +324,12 @@ constructor(private val fpsListener: FpsListener? = null) :
         // no-op
       }
     }
-    if (view.getFadingEdgeLengthStart() > 0 || view.getFadingEdgeLengthEnd() > 0) {
-      view.setVerticalFadingEdgeEnabled(true)
+    if (view.fadingEdgeLengthStart > 0 || view.fadingEdgeLengthEnd > 0) {
+      view.isVerticalFadingEdgeEnabled = true
       view.setFadingEdgeLength(
-          Math.round(
-              Math.max(view.getFadingEdgeLengthStart(), view.getFadingEdgeLengthEnd()).dpToPx()))
+          Math.round(Math.max(view.fadingEdgeLengthStart, view.fadingEdgeLengthEnd).dpToPx()))
     } else {
-      view.setVerticalFadingEdgeEnabled(false)
+      view.isVerticalFadingEdgeEnabled = false
       view.setFadingEdgeLength(0)
     }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitch.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitch.kt
@@ -49,7 +49,7 @@ internal class ReactSwitch(context: Context) : SwitchCompat(context) {
     if (color == null) {
       drawable.clearColorFilter()
     } else {
-      drawable.setColorFilter(PorterDuffColorFilter(color, PorterDuff.Mode.MULTIPLY))
+      drawable.colorFilter = PorterDuffColorFilter(color, PorterDuff.Mode.MULTIPLY)
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextView.kt
@@ -110,8 +110,8 @@ internal class PreparedLayoutTextView(context: Context) : ViewGroup(context), Re
     val layout = preparedLayout?.layout
     if (layout != null) {
       if (selection != null) {
-        selectionPaint.setColor(
-            selectionColor ?: DefaultStyleValuesUtil.getDefaultTextColorHighlight(context))
+        selectionPaint.color =
+            selectionColor ?: DefaultStyleValuesUtil.getDefaultTextColorHighlight(context)
       }
 
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextViewManager.kt
@@ -180,7 +180,7 @@ internal class PreparedLayoutTextViewManager :
 
   @ReactProp(name = "disabled", defaultBoolean = false)
   fun setDisabled(view: PreparedLayoutTextView, disabled: Boolean): Unit {
-    view.setEnabled(!disabled)
+    view.isEnabled = !disabled
   }
 
   override fun setPadding(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.kt
@@ -62,7 +62,7 @@ public constructor(
 
   override fun updateViewAccessibility(view: ReactTextView) {
     ReactTextViewAccessibilityDelegate.setDelegate(
-        view, view.isFocusable(), view.getImportantForAccessibility())
+        view, view.isFocusable, view.importantForAccessibility)
   }
 
   public override fun createViewInstance(context: ThemedReactContext): ReactTextView =
@@ -85,7 +85,7 @@ public constructor(
       view.setTag(
           R.id.accessibility_links, if (accessibilityLinks.size() > 0) accessibilityLinks else null)
       ReactTextViewAccessibilityDelegate.resetDelegate(
-          view, view.isFocusable(), view.getImportantForAccessibility())
+          view, view.isFocusable, view.importantForAccessibility)
     }
   }
 
@@ -130,7 +130,7 @@ public constructor(
         state.getMapBuffer(TX_STATE_KEY_PARAGRAPH_ATTRIBUTES.toInt())
     val spanned: Spannable =
         TextLayoutManager.getOrCreateSpannableForText(
-            view.getContext(), attributedString, reactTextViewManagerCallback)
+            view.context, attributedString, reactTextViewManagerCallback)
     view.setSpanned(spanned)
 
     val minimumFontSize: Float =
@@ -141,7 +141,7 @@ public constructor(
         TextAttributeProps.getTextBreakStrategy(
             paragraphAttributes.getString(TextLayoutManager.PA_KEY_TEXT_BREAK_STRATEGY))
     val currentJustificationMode =
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) 0 else view.getJustificationMode()
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) 0 else view.justificationMode
 
     return ReactTextUpdate(
         spanned,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/frescosupport/FrescoBasedReactTextInlineImageShadowNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/frescosupport/FrescoBasedReactTextInlineImageShadowNode.kt
@@ -59,7 +59,7 @@ internal class FrescoBasedReactTextInlineImageShadowNode(
         // ignore malformed uri, then attempt to extract resource ID.
       }
       if (tempUri == null) {
-        tempUri = getResourceDrawableUri(getThemedContext(), source)
+        tempUri = getResourceDrawableUri(themedContext, source)
       }
     }
     if (tempUri != uri) {
@@ -109,7 +109,7 @@ internal class FrescoBasedReactTextInlineImageShadowNode(
   override fun isVirtual(): Boolean = true
 
   override fun buildInlineImageSpan(): TextInlineImageSpan {
-    val resources = getThemedContext().resources
+    val resources = themedContext.resources
     val finalWidth = Math.ceil(width.toDouble()).toInt()
     val finalHeight = Math.ceil(height.toDouble()).toInt()
     return FrescoBasedReactTextInlineImageSpan(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/unimplementedview/ReactUnimplementedView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/unimplementedview/ReactUnimplementedView.kt
@@ -20,7 +20,7 @@ internal class ReactUnimplementedView(context: Context) : LinearLayout(context) 
 
   init {
     textView.layoutParams = LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.MATCH_PARENT)
-    textView.setGravity(Gravity.CENTER)
+    textView.gravity = Gravity.CENTER
     textView.setTextColor(Color.WHITE)
     textView.text = ""
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
@@ -950,7 +950,7 @@ public open class ReactViewGroup public constructor(context: Context?) :
     if (axOrder != null) {
 
       val am: AccessibilityManager? =
-          this.getContext().getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager?
+          this.context.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager?
       if (accessibilityStateChangeListener == null && am != null) {
         val newAccessibilityStateChangeListener =
             AccessibilityManager.AccessibilityStateChangeListener { enabled ->

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.kt
@@ -206,7 +206,7 @@ class RootViewTest {
                   .build()
         }
     val rootViewSpy = spy(rootView)
-    whenever(rootViewSpy.getLayoutParams()).thenReturn(WindowManager.LayoutParams())
+    whenever(rootViewSpy.layoutParams).thenReturn(WindowManager.LayoutParams())
 
     rootViewSpy.startReactApplication(instanceManager, "")
     rootViewSpy.simulateCheckForKeyboardForTesting()

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropForShadowNodeSetterTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropForShadowNodeSetterTest.kt
@@ -73,7 +73,7 @@ class ReactPropForShadowNodeSetterTest {
     init {
       setViewClassName("ShadowViewUnderTest")
       val context = BridgeReactContext(RuntimeEnvironment.getApplication())
-      setThemedContext(ThemedReactContext(context, context, null, -1))
+      themedContext = ThemedReactContext(context, context, null, -1)
     }
 
     @ReactProp(name = "boolProp")

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterActivity.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterActivity.kt
@@ -68,7 +68,7 @@ internal class RNTesterActivity : ReactActivity() {
 
     // register insets listener to update margins on the ReactRootView to avoid overlap w/ system
     // bars
-    getReactDelegate()?.reactRootView?.let { rootView ->
+    reactDelegate?.reactRootView?.let { rootView ->
       val insetsType: Int =
           WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
 

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/component/MyNativeView.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/component/MyNativeView.kt
@@ -44,17 +44,17 @@ internal class MyNativeView(context: ThemedReactContext) : View(context) {
 
   fun addOverlays(overlayColors: ReadableArray) {
     val numOverlays = overlayColors.size()
-    val width = getMeasuredWidth() / numOverlays
+    val width = measuredWidth / numOverlays
     for (i in 0 until numOverlays) {
       val drawable = ColorDrawable(Color.parseColor(overlayColors.getString(i)))
       val leftOffset = width * i
-      drawable.setBounds(leftOffset, 0, leftOffset + width, getMeasuredHeight())
-      getOverlay().add(drawable)
+      drawable.setBounds(leftOffset, 0, leftOffset + width, measuredHeight)
+      overlay.add(drawable)
     }
   }
 
   fun removeOverlays() {
-    getOverlay().clear()
+    overlay.clear()
   }
 
   private fun emitNativeEvent(color: Int) {


### PR DESCRIPTION
## Summary:

Fixing a few warnings from static code analysis regarding the [accessor call can be replaced with property access](https://www.jetbrains.com/help/inspectopedia/UsePropertyAccessSyntax.html) rule

## Changelog:

[INTERNAL] - Kotlin: accessor call can be replaced with property access syntax

## Test Plan:

```sh
yarn test-android
yarn android
```