### PR TITLE
Record RuntimeSamplingProfile on TraceRecordingState

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
@@ -462,4 +462,17 @@ void HostAgent::setCurrentInstanceAgent(
   impl_->setCurrentInstanceAgent(std::move(instanceAgent));
 }
 
+#pragma mark - Tracing
+
+HostTracingAgent::HostTracingAgent(tracing::TraceRecordingState& state)
+    : tracing::TargetTracingAgent(state) {}
+
+void HostTracingAgent::setTracedInstance(InstanceTarget* instanceTarget) {
+  if (instanceTarget != nullptr) {
+    instanceTracingAgent_ = instanceTarget->createTracingAgent(state_);
+  } else {
+    instanceTracingAgent_ = nullptr;
+  }
+}
+
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
@@ -12,6 +12,7 @@
 #include <jsinspector-modern/InspectorInterfaces.h>
 #include <jsinspector-modern/InstanceAgent.h>
 #include <jsinspector-modern/cdp/CdpJson.h>
+#include <jsinspector-modern/tracing/TargetTracingAgent.h>
 
 namespace facebook::react::jsinspector_modern {
 
@@ -73,6 +74,27 @@ class HostAgent final {
   class Impl;
 
   std::unique_ptr<Impl> impl_;
+};
+
+#pragma mark - Tracing
+
+/**
+ * An Agent that handles Tracing events for a particular InstanceTarget.
+ *
+ * Lifetime of this agent is bound to the lifetime of the Tracing session -
+ * HostTargetTraceRecording.
+ */
+class HostTracingAgent : tracing::TargetTracingAgent {
+ public:
+  explicit HostTracingAgent(tracing::TraceRecordingState& state);
+
+  /**
+   * Registers the InstanceTarget with this tracing agent.
+   */
+  void setTracedInstance(InstanceTarget* instanceTarget);
+
+ private:
+  std::shared_ptr<InstanceTracingAgent> instanceTracingAgent_{nullptr};
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
@@ -34,8 +34,10 @@ namespace facebook::react::jsinspector_modern {
 
 class HostTargetSession;
 class HostAgent;
+class HostTracingAgent;
 class HostCommandSender;
 class HostTarget;
+class HostTargetTraceRecording;
 
 struct HostTargetMetadata {
   std::optional<std::string> appDisplayName;
@@ -237,6 +239,28 @@ class JSINSPECTOR_EXPORT HostTarget
    */
   void sendCommand(HostCommand command);
 
+  /**
+   * Creates a new HostTracingAgent.
+   * This Agent is not owned by the HostTarget. The Agent will be destroyed at
+   * the end of the tracing session.
+   *
+   * \param state A reference to the state of the active trace recording.
+   */
+  std::shared_ptr<HostTracingAgent> createTracingAgent(
+      tracing::TraceRecordingState& state);
+
+  /**
+   * Starts trace recording for this HostTarget.
+   *
+   * \return false if already tracing, true otherwise.
+   */
+  bool startTracing();
+
+  /**
+   * Stops previously started trace recording.
+   */
+  tracing::TraceRecordingState stopTracing();
+
  private:
   /**
    * Constructs a new HostTarget.
@@ -256,6 +280,14 @@ class JSINSPECTOR_EXPORT HostTarget
   std::shared_ptr<ExecutionContextManager> executionContextManager_;
   std::shared_ptr<InstanceTarget> currentInstance_{nullptr};
   std::unique_ptr<HostCommandSender> commandSender_;
+
+  /**
+   * Current pending trace recording, which encapsulates the configuration of
+   * the tracing session and the state.
+   *
+   * Should only be allocated when there is an active tracing session.
+   */
+  std::unique_ptr<HostTargetTraceRecording> traceRecording_{nullptr};
 
   inline HostTargetDelegate& getDelegate() {
     return delegate_;

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTraceRecording.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTraceRecording.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "HostTargetTraceRecording.h"
+#include "HostTarget.h"
+
+namespace facebook::react::jsinspector_modern {
+
+HostTargetTraceRecording::HostTargetTraceRecording(HostTarget& hostTarget)
+    : hostTarget_(hostTarget) {}
+
+void HostTargetTraceRecording::setTracedInstance(
+    InstanceTarget* instanceTarget) {
+  // If HostTracingAgent is allocated, it means that there is an active tracing
+  // recording session.
+  if (hostTracingAgent_ != nullptr) {
+    hostTracingAgent_->setTracedInstance(instanceTarget);
+  }
+}
+
+void HostTargetTraceRecording::start() {
+  assert(
+      hostTracingAgent_ == nullptr &&
+      "Tracing Agent for the HostTarget was already initialized.");
+
+  state_ = tracing::TraceRecordingState{};
+  hostTracingAgent_ = hostTarget_.createTracingAgent(*state_);
+}
+
+tracing::TraceRecordingState HostTargetTraceRecording::stop() {
+  assert(
+      hostTracingAgent_ != nullptr &&
+      "TracingAgent for the HostTarget has not been initialized.");
+  hostTracingAgent_.reset();
+
+  assert(
+      state_.has_value() &&
+      "The state for this tracing session has not been initialized.");
+  auto state = std::move(*state_);
+  state_.reset();
+
+  return state;
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTraceRecording.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTraceRecording.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "HostAgent.h"
+#include "HostTarget.h"
+#include "InstanceTarget.h"
+
+#include <jsinspector-modern/tracing/TraceRecordingState.h>
+
+#include <optional>
+
+namespace facebook::react::jsinspector_modern {
+
+/**
+ * A local representation of the Tracing "session".
+ *
+ * Owned by the HostTarget and should only be allocated during an active
+ * recording.
+ *
+ * Owns all allocated Tracing Agents. A single Target can have a single active
+ * Tracing Agent, but only as a std::weak_ptr.
+ */
+class HostTargetTraceRecording {
+ public:
+  explicit HostTargetTraceRecording(HostTarget& hostTarget);
+
+  /**
+   * Updates the current traced Instance for this recording.
+   */
+  void setTracedInstance(InstanceTarget* instanceTarget);
+
+  /**
+   * Starts the recording.
+   *
+   * Will allocate all Tracing Agents for all currently registered Targets.
+   */
+  void start();
+
+  /**
+   * Stops the recording and drops the recording state.
+   *
+   * Will deallocate all Tracing Agents.
+   */
+  tracing::TraceRecordingState stop();
+
+ private:
+  /**
+   * The Host for which this Trace Recording is going to happen.
+   */
+  HostTarget& hostTarget_;
+
+  /**
+   * The state of the current Trace Recording.
+   * Only allocated if the recording is enabled.
+   */
+  std::optional<tracing::TraceRecordingState> state_;
+
+  /**
+   * The TracingAgent of the targeted Host.
+   * Only allocated if the recording is enabled.
+   */
+  std::shared_ptr<HostTracingAgent> hostTracingAgent_;
+};
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTracing.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTracing.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "HostTarget.h"
+#include "HostTargetTraceRecording.h"
+
+namespace facebook::react::jsinspector_modern {
+
+std::shared_ptr<HostTracingAgent> HostTarget::createTracingAgent(
+    tracing::TraceRecordingState& state) {
+  auto agent = std::make_shared<HostTracingAgent>(state);
+  agent->setTracedInstance(currentInstance_.get());
+  return agent;
+}
+
+bool HostTarget::startTracing() {
+  if (traceRecording_ != nullptr) {
+    return false;
+  }
+
+  traceRecording_ = std::make_unique<HostTargetTraceRecording>(*this);
+  traceRecording_->setTracedInstance(currentInstance_.get());
+  traceRecording_->start();
+
+  return true;
+}
+
+tracing::TraceRecordingState HostTarget::stopTracing() {
+  assert(traceRecording_ != nullptr && "No tracing in progress");
+
+  auto state = traceRecording_->stop();
+  traceRecording_.reset();
+
+  return state;
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.cpp
@@ -176,4 +176,17 @@ tracing::InstanceTracingProfile InstanceAgent::collectTracingProfile() {
   };
 }
 
+#pragma mark - Tracing
+
+InstanceTracingAgent::InstanceTracingAgent(tracing::TraceRecordingState& state)
+    : tracing::TargetTracingAgent(state) {}
+
+void InstanceTracingAgent::setTracedRuntime(RuntimeTarget* runtimeTarget) {
+  if (runtimeTarget != nullptr) {
+    runtimeTracingAgent_ = runtimeTarget->createTracingAgent(state_);
+  } else {
+    runtimeTracingAgent_ = nullptr;
+  }
+}
+
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.h
@@ -15,6 +15,7 @@
 #include <jsinspector-modern/RuntimeAgent.h>
 #include <jsinspector-modern/cdp/CdpJson.h>
 #include <jsinspector-modern/tracing/InstanceTracingProfile.h>
+#include <jsinspector-modern/tracing/TargetTracingAgent.h>
 
 #include <functional>
 
@@ -85,6 +86,27 @@ class InstanceAgent final {
   InstanceTarget& target_;
   std::shared_ptr<RuntimeAgent> runtimeAgent_;
   SessionState& sessionState_;
+};
+
+#pragma mark - Tracing
+
+/**
+ * An Agent that handles Tracing events for a particular InstanceTarget.
+ *
+ * Lifetime of this agent is bound to the lifetime of the Tracing session -
+ * HostTargetTraceRecording and to the lifetime of the InstanceTarget.
+ */
+class InstanceTracingAgent : tracing::TargetTracingAgent {
+ public:
+  explicit InstanceTracingAgent(tracing::TraceRecordingState& state);
+
+  /**
+   * Registers the RuntimeTarget with this tracing agent.
+   */
+  void setTracedRuntime(RuntimeTarget* runtimeTarget);
+
+ private:
+  std::shared_ptr<RuntimeTracingAgent> runtimeTracingAgent_;
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.h
@@ -15,12 +15,15 @@
 
 #include <jsinspector-modern/InspectorInterfaces.h>
 #include <jsinspector-modern/RuntimeAgent.h>
+#include <jsinspector-modern/tracing/TraceRecordingState.h>
 
 #include <memory>
 
 namespace facebook::react::jsinspector_modern {
 
 class InstanceAgent;
+class InstanceTracingAgent;
+class HostTargetTraceRecording;
 
 /**
  * Receives events from an InstanceTarget. This is a shared interface that
@@ -69,6 +72,18 @@ class InstanceTarget : public EnableExecutorFromThis<InstanceTarget> {
       SessionState& sessionState);
 
   /**
+   * Creates a new InstanceTracingAgent.
+   * This Agent is not owned by the InstanceTarget. The Agent will be destroyed
+   * either before the InstanceTarget is destroyed, as part of the
+   * InstanceTarget unregistration in HostTarget, or at the end of the tracing
+   * session.
+   *
+   * \param state A reference to the state of the active trace recording.
+   */
+  std::shared_ptr<InstanceTracingAgent> createTracingAgent(
+      tracing::TraceRecordingState& state);
+
+  /**
    * Registers a JS runtime with this InstanceTarget. \returns a reference to
    * the created RuntimeTarget, which is owned by the \c InstanceTarget. All the
    * requirements of \c RuntimeTarget::create must be met.
@@ -103,6 +118,13 @@ class InstanceTarget : public EnableExecutorFromThis<InstanceTarget> {
   std::shared_ptr<RuntimeTarget> currentRuntime_{nullptr};
   WeakList<InstanceAgent> agents_;
   std::shared_ptr<ExecutionContextManager> executionContextManager_;
+
+  /**
+   * This TracingAgent is owned by the HostTracingAgent, both are bound to
+   * the lifetime of their corresponding targets and the lifetime of the tracing
+   * session - HostTargetTraceRecording.
+   */
+  std::weak_ptr<InstanceTracingAgent> tracingAgent_;
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.cpp
@@ -128,4 +128,9 @@ tracing::RuntimeSamplingProfile RuntimeAgent::collectSamplingProfile() {
   return targetController_.collectSamplingProfile();
 }
 
+#pragma mark - Tracing
+
+RuntimeTracingAgent::RuntimeTracingAgent(tracing::TraceRecordingState& state)
+    : tracing::TargetTracingAgent(state) {}
+
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.cpp
@@ -130,7 +130,18 @@ tracing::RuntimeSamplingProfile RuntimeAgent::collectSamplingProfile() {
 
 #pragma mark - Tracing
 
-RuntimeTracingAgent::RuntimeTracingAgent(tracing::TraceRecordingState& state)
-    : tracing::TargetTracingAgent(state) {}
+RuntimeTracingAgent::RuntimeTracingAgent(
+    tracing::TraceRecordingState& state,
+    RuntimeTargetController& targetController)
+    : tracing::TargetTracingAgent(state), targetController_(targetController) {
+  targetController_.enableSamplingProfiler();
+}
+
+RuntimeTracingAgent::~RuntimeTracingAgent() {
+  targetController_.disableSamplingProfiler();
+  auto profile = targetController_.collectSamplingProfile();
+
+  state_.runtimeSamplingProfiles.emplace_back(std::move(profile));
+}
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.h
@@ -118,7 +118,14 @@ class RuntimeAgent final {
  */
 class RuntimeTracingAgent : tracing::TargetTracingAgent {
  public:
-  explicit RuntimeTracingAgent(tracing::TraceRecordingState& state);
+  explicit RuntimeTracingAgent(
+      tracing::TraceRecordingState& state,
+      RuntimeTargetController& targetController);
+
+  ~RuntimeTracingAgent();
+
+ private:
+  RuntimeTargetController& targetController_;
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.h
@@ -13,6 +13,8 @@
 
 #include <jsinspector-modern/cdp/CdpJson.h>
 #include <jsinspector-modern/tracing/RuntimeSamplingProfile.h>
+#include <jsinspector-modern/tracing/TargetTracingAgent.h>
+#include <jsinspector-modern/tracing/TraceRecordingState.h>
 
 namespace facebook::react::jsinspector_modern {
 
@@ -104,6 +106,19 @@ class RuntimeAgent final {
   SessionState& sessionState_;
   const std::unique_ptr<RuntimeAgentDelegate> delegate_;
   const ExecutionContextDescription executionContextDescription_;
+};
+
+#pragma mark - Tracing
+
+/**
+ * An Agent that handles Tracing events for a particular RuntimeTarget.
+ *
+ * Lifetime of this agent is bound to the lifetime of the Tracing session -
+ * HostTargetTraceRecording and to the lifetime of the RuntimeTarget.
+ */
+class RuntimeTracingAgent : tracing::TargetTracingAgent {
+ public:
+  explicit RuntimeTracingAgent(tracing::TraceRecordingState& state);
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
@@ -79,7 +79,7 @@ std::shared_ptr<RuntimeAgent> RuntimeTarget::createAgent(
 
 std::shared_ptr<RuntimeTracingAgent> RuntimeTarget::createTracingAgent(
     tracing::TraceRecordingState& state) {
-  auto agent = std::make_shared<RuntimeTracingAgent>(state);
+  auto agent = std::make_shared<RuntimeTracingAgent>(state, controller_);
   tracingAgent_ = agent;
   return agent;
 }

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
@@ -77,12 +77,24 @@ std::shared_ptr<RuntimeAgent> RuntimeTarget::createAgent(
   return runtimeAgent;
 }
 
+std::shared_ptr<RuntimeTracingAgent> RuntimeTarget::createTracingAgent(
+    tracing::TraceRecordingState& state) {
+  auto agent = std::make_shared<RuntimeTracingAgent>(state);
+  tracingAgent_ = agent;
+  return agent;
+}
+
 RuntimeTarget::~RuntimeTarget() {
   // Agents are owned by the session, not by RuntimeTarget, but
   // they hold a RuntimeTarget& that we must guarantee is valid.
   assert(
       agents_.empty() &&
       "RuntimeAgent objects must be destroyed before their RuntimeTarget. Did you call InstanceTarget::unregisterRuntime()?");
+
+  // Tracing Agents are owned by the HostTargetTraceRecording.
+  assert(
+      tracingAgent_.expired() &&
+      "RuntimeTracingAgent must be destroyed before their InstanceTarget. Did you call InstanceTarget::unregisterRuntime()?");
 }
 
 void RuntimeTarget::installBindingHandler(const std::string& bindingName) {

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
@@ -17,6 +17,7 @@
 
 #include <ReactCommon/RuntimeExecutor.h>
 #include <jsinspector-modern/tracing/RuntimeSamplingProfile.h>
+#include <jsinspector-modern/tracing/TraceRecordingState.h>
 
 #include <memory>
 
@@ -35,6 +36,7 @@
 namespace facebook::react::jsinspector_modern {
 
 class RuntimeAgent;
+class RuntimeTracingAgent;
 class RuntimeAgentDelegate;
 class RuntimeTarget;
 struct SessionState;
@@ -203,6 +205,17 @@ class JSINSPECTOR_EXPORT RuntimeTarget
       SessionState& sessionState);
 
   /**
+   * Creates a new RuntimeTracingAgent.
+   * This Agent is not owned by the RuntimeTarget. The Agent will be destroyed
+   * either before the RuntimeTarget is destroyed, as part of the RuntimeTarget
+   * unregistration in InstanceTarget, or at the end of the tracing session.
+   *
+   * \param state A reference to the state of the active trace recording.
+   */
+  std::shared_ptr<RuntimeTracingAgent> createTracingAgent(
+      tracing::TraceRecordingState& state);
+
+  /**
    * Start sampling profiler for a particular JavaScript runtime.
    */
   void enableSamplingProfiler();
@@ -245,6 +258,13 @@ class JSINSPECTOR_EXPORT RuntimeTarget
   RuntimeExecutor jsExecutor_;
   WeakList<RuntimeAgent> agents_;
   RuntimeTargetController controller_{*this};
+
+  /**
+   * This TracingAgent is owned by the InstanceTracingAgent, both are bound to
+   * the lifetime of their corresponding targets and the lifetime of the tracing
+   * session - HostTargetTraceRecording.
+   */
+  std::weak_ptr<RuntimeTracingAgent> tracingAgent_;
 
   /**
    * Adds a function with the given name on the runtime's global object, that

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TargetTracingAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TargetTracingAgent.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "TraceRecordingState.h"
+
+namespace facebook::react::jsinspector_modern::tracing {
+
+/**
+ * An interface for a tracing agent of a target.
+ * Tracing Agents are only allocated during an active tracing session.
+ *
+ * Construction of a TracingAgent means that either the recording has just
+ * started or the target was just created during an active recording.
+ * Destruction of a TracingAgent means that either the recording has stopped or
+ * the target is about to be destroyed.
+ */
+class TargetTracingAgent {
+ public:
+  explicit TargetTracingAgent(TraceRecordingState& state) : state_(state) {
+    (void)state_;
+  }
+
+ protected:
+  TraceRecordingState& state_;
+};
+
+} // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceRecordingState.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceRecordingState.h
@@ -7,11 +7,15 @@
 
 #pragma once
 
+#include "RuntimeSamplingProfile.h"
+
+#include <vector>
+
 namespace facebook::react::jsinspector_modern::tracing {
 
-/**
- * Encapsulates the state of the Trace.
- */
-struct TraceRecordingState {};
+struct TraceRecordingState {
+  // All captured Runtime Sampling Profiles during this Trace Recording.
+  std::vector<RuntimeSamplingProfile> runtimeSamplingProfiles{};
+};
 
 } // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceRecordingState.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceRecordingState.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace facebook::react::jsinspector_modern::tracing {
+
+/**
+ * Encapsulates the state of the Trace.
+ */
+struct TraceRecordingState {};
+
+} // namespace facebook::react::jsinspector_modern::tracing


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

Now that we've defined all actors and relationship between Agents, we can start recording profiles and store them on a recording state.

Differential Revision: D79415396
