### PR TITLE
Record processId on TraceRecordingState

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
@@ -462,4 +462,37 @@ void HostAgent::setCurrentInstanceAgent(
   impl_->setCurrentInstanceAgent(std::move(instanceAgent));
 }
 
+#pragma mark - Tracing
+
+HostTracingAgent::HostTracingAgent(tracing::TraceRecordingState& state)
+    : tracing::TargetTracingAgent(state) {}
+
+void HostTracingAgent::setTracedInstance(InstanceTarget* instanceTarget) {
+  auto previousInstanceTracingAgent = std::move(instanceTracingAgent_);
+  if (previousInstanceTracingAgent != nullptr && state_.isRecording) {
+    previousInstanceTracingAgent->disable();
+  }
+
+  if (instanceTarget != nullptr) {
+    instanceTracingAgent_ = instanceTarget->createTracingAgent(state_);
+    if (state_.isRecording) {
+      instanceTracingAgent_->enable();
+    }
+  } else {
+    instanceTracingAgent_ = nullptr;
+  }
+}
+
+void HostTracingAgent::enable() {
+  if (instanceTracingAgent_ != nullptr) {
+    instanceTracingAgent_->enable();
+  }
+}
+
+void HostTracingAgent::disable() {
+  if (instanceTracingAgent_ != nullptr) {
+    instanceTracingAgent_->disable();
+  }
+}
+
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
@@ -12,6 +12,7 @@
 #include <jsinspector-modern/InspectorInterfaces.h>
 #include <jsinspector-modern/InstanceAgent.h>
 #include <jsinspector-modern/cdp/CdpJson.h>
+#include <jsinspector-modern/tracing/TargetTracingAgent.h>
 
 namespace facebook::react::jsinspector_modern {
 
@@ -73,6 +74,31 @@ class HostAgent final {
   class Impl;
 
   std::unique_ptr<Impl> impl_;
+};
+
+#pragma mark - Tracing
+
+/**
+ * An Agent that handles Tracing events for a particular InstanceTarget.
+ *
+ * Lifetime of this agent is bound to the lifetime of the Tracing session -
+ * HostTargetTraceRecording.
+ */
+class HostTracingAgent : tracing::TargetTracingAgent {
+ public:
+  explicit HostTracingAgent(tracing::TraceRecordingState& state);
+
+  /**
+   * Registers the InstanceTarget with this tracing agent.
+   */
+  void setTracedInstance(InstanceTarget* instanceTarget);
+
+  void enable() override;
+
+  void disable() override;
+
+ private:
+  std::shared_ptr<InstanceTracingAgent> instanceTracingAgent_{nullptr};
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
@@ -7,6 +7,7 @@
 
 #include "HostTarget.h"
 #include "HostAgent.h"
+#include "HostTargetTraceRecording.h"
 #include "InspectorInterfaces.h"
 #include "InspectorUtilities.h"
 #include "InstanceTarget.h"
@@ -191,6 +192,13 @@ InstanceTarget& HostTarget::registerInstance(InstanceTargetDelegate& delegate) {
       [currentInstance = &*currentInstance_](HostTargetSession& session) {
         session.setCurrentInstance(currentInstance);
       });
+
+  if (traceRecording_) {
+    // Registers the Instance for tracing, if a Trace is currently being
+    // recorded.
+    traceRecording_->setTracedInstance(currentInstance_.get());
+  }
+
   return *currentInstance_;
 }
 
@@ -200,6 +208,13 @@ void HostTarget::unregisterInstance(InstanceTarget& instance) {
       "Invalid unregistration");
   sessions_.forEach(
       [](HostTargetSession& session) { session.setCurrentInstance(nullptr); });
+
+  if (traceRecording_) {
+    // Unregisters the Instance for tracing, if a Trace is currently being
+    // recorded.
+    traceRecording_->setTracedInstance(nullptr);
+  }
+
   currentInstance_.reset();
 }
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
@@ -34,8 +34,10 @@ namespace facebook::react::jsinspector_modern {
 
 class HostTargetSession;
 class HostAgent;
+class HostTracingAgent;
 class HostCommandSender;
 class HostTarget;
+class HostTargetTraceRecording;
 
 struct HostTargetMetadata {
   std::optional<std::string> appDisplayName;
@@ -237,6 +239,28 @@ class JSINSPECTOR_EXPORT HostTarget
    */
   void sendCommand(HostCommand command);
 
+  /**
+   * Creates a new HostTracingAgent.
+   * This Agent is not owned by the HostTarget. The Agent will be destroyed at
+   * the end of the tracing session.
+   *
+   * \param state A reference to the state of the active trace recording.
+   */
+  std::shared_ptr<HostTracingAgent> createTracingAgent(
+      tracing::TraceRecordingState& state);
+
+  /**
+   * Starts trace recording for this HostTarget.
+   *
+   * \return false if already tracing, true otherwise.
+   */
+  bool startTracing();
+
+  /**
+   * Stops previously started trace recording.
+   */
+  tracing::TraceRecordingState stopTracing();
+
  private:
   /**
    * Constructs a new HostTarget.
@@ -256,6 +280,14 @@ class JSINSPECTOR_EXPORT HostTarget
   std::shared_ptr<ExecutionContextManager> executionContextManager_;
   std::shared_ptr<InstanceTarget> currentInstance_{nullptr};
   std::unique_ptr<HostCommandSender> commandSender_;
+
+  /**
+   * Current pending trace recording, which encapsulates the configuration of
+   * the tracing session and the state.
+   *
+   * Should only be allocated when there is an active tracing session.
+   */
+  std::unique_ptr<HostTargetTraceRecording> traceRecording_{nullptr};
 
   inline HostTargetDelegate& getDelegate() {
     return delegate_;

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTraceRecording.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTraceRecording.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "HostTargetTraceRecording.h"
+#include "HostTarget.h"
+
+namespace facebook::react::jsinspector_modern {
+
+HostTargetTraceRecording::HostTargetTraceRecording(HostTarget& hostTarget)
+    : hostTracingAgent_(hostTarget.createTracingAgent(state_)) {
+  (void)state_;
+}
+
+void HostTargetTraceRecording::setTracedInstance(
+    InstanceTarget* instanceTarget) {
+  hostTracingAgent_->setTracedInstance(instanceTarget);
+}
+
+void HostTargetTraceRecording::enable() {
+  if (state_.isRecording) {
+    return;
+  }
+
+  state_.isRecording = true;
+  hostTracingAgent_->enable();
+}
+
+void HostTargetTraceRecording::disable() {
+  if (!state_.isRecording) {
+    return;
+  }
+
+  state_.isRecording = false;
+  hostTracingAgent_->disable();
+}
+
+tracing::TraceRecordingState HostTargetTraceRecording::extractState() {
+  assert(!state_.isRecording && "Recording is still in progress");
+
+  auto previousState = std::move(state_);
+  state_ = tracing::TraceRecordingState{};
+
+  return previousState;
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTraceRecording.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTraceRecording.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "HostAgent.h"
+#include "HostTarget.h"
+#include "InstanceTarget.h"
+
+#include <jsinspector-modern/tracing/TraceRecordingState.h>
+
+namespace facebook::react::jsinspector_modern {
+
+class HostTargetTraceRecording {
+ public:
+  explicit HostTargetTraceRecording(HostTarget& hostTarget);
+
+  void setTracedInstance(InstanceTarget* instanceTarget);
+
+  void enable();
+
+  void disable();
+
+  tracing::TraceRecordingState extractState();
+
+ private:
+  tracing::TraceRecordingState state_;
+
+  std::shared_ptr<HostTracingAgent> hostTracingAgent_;
+};
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTracing.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTracing.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "HostTarget.h"
+#include "HostTargetTraceRecording.h"
+
+namespace facebook::react::jsinspector_modern {
+
+std::shared_ptr<HostTracingAgent> HostTarget::createTracingAgent(
+    tracing::TraceRecordingState& state) {
+  return std::make_shared<HostTracingAgent>(state);
+}
+
+bool HostTarget::startTracing() {
+  if (traceRecording_ != nullptr) {
+    return false;
+  }
+
+  traceRecording_ = std::make_unique<HostTargetTraceRecording>(*this);
+  traceRecording_->setTracedInstance(currentInstance_.get());
+  traceRecording_->enable();
+
+  return true;
+}
+
+tracing::TraceRecordingState HostTarget::stopTracing() {
+  assert(traceRecording_ != nullptr && "No tracing in progress");
+
+  traceRecording_->disable();
+  auto state = traceRecording_->extractState();
+  traceRecording_.reset();
+
+  return state;
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.cpp
@@ -9,6 +9,7 @@
 #include "RuntimeTarget.h"
 
 #include <jsinspector-modern/cdp/CdpJson.h>
+#include <jsinspector-modern/tracing/PerformanceTracer.h>
 
 #include <utility>
 
@@ -167,11 +168,11 @@ void InstanceAgent::stopTracing() {
   }
 }
 
-tracing::InstanceTracingProfile InstanceAgent::collectTracingProfile() {
+tracing::InstanceTracingProfileLegacy InstanceAgent::collectTracingProfile() {
   tracing::RuntimeSamplingProfile runtimeSamplingProfile =
       runtimeAgent_->collectSamplingProfile();
 
-  return tracing::InstanceTracingProfile{
+  return tracing::InstanceTracingProfileLegacy{
       .runtimeSamplingProfile = std::move(runtimeSamplingProfile),
   };
 }
@@ -201,11 +202,21 @@ void InstanceTracingAgent::enable() {
   if (runtimeTracingAgent_ != nullptr) {
     runtimeTracingAgent_->enable();
   }
+
+  tracing::PerformanceTracer::getInstance().startTracing();
 }
 
 void InstanceTracingAgent::disable() {
   if (runtimeTracingAgent_ != nullptr) {
     runtimeTracingAgent_->disable();
+  }
+
+  auto& performanceTracer = tracing::PerformanceTracer::getInstance();
+  auto performanceTraceEvents = performanceTracer.stopTracing();
+  if (performanceTraceEvents) {
+    state_.instanceTracingProfiles.emplace_back(tracing::InstanceTracingProfile{
+        .performanceTraceEvents = std::move(*performanceTraceEvents),
+    });
   }
 }
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.cpp
@@ -176,4 +176,37 @@ tracing::InstanceTracingProfile InstanceAgent::collectTracingProfile() {
   };
 }
 
+#pragma mark - Tracing
+
+InstanceTracingAgent::InstanceTracingAgent(tracing::TraceRecordingState& state)
+    : tracing::TargetTracingAgent(state) {}
+
+void InstanceTracingAgent::setTracedRuntime(RuntimeTarget* runtimeTarget) {
+  auto previousRuntimeTracingAgent = std::move(runtimeTracingAgent_);
+  if (previousRuntimeTracingAgent != nullptr && state_.isRecording) {
+    previousRuntimeTracingAgent->disable();
+  }
+
+  if (runtimeTarget != nullptr) {
+    runtimeTracingAgent_ = runtimeTarget->createTracingAgent(state_);
+    if (state_.isRecording) {
+      runtimeTracingAgent_->enable();
+    }
+  } else {
+    runtimeTracingAgent_ = nullptr;
+  }
+}
+
+void InstanceTracingAgent::enable() {
+  if (runtimeTracingAgent_ != nullptr) {
+    runtimeTracingAgent_->enable();
+  }
+}
+
+void InstanceTracingAgent::disable() {
+  if (runtimeTracingAgent_ != nullptr) {
+    runtimeTracingAgent_->disable();
+  }
+}
+
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.h
@@ -75,7 +75,7 @@ class InstanceAgent final {
   /**
    * Return recorded profile for the previous tracing session.
    */
-  tracing::InstanceTracingProfile collectTracingProfile();
+  tracing::InstanceTracingProfileLegacy collectTracingProfile();
 
  private:
   void maybeSendExecutionContextCreatedNotification();

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.h
@@ -15,6 +15,7 @@
 #include <jsinspector-modern/RuntimeAgent.h>
 #include <jsinspector-modern/cdp/CdpJson.h>
 #include <jsinspector-modern/tracing/InstanceTracingProfile.h>
+#include <jsinspector-modern/tracing/TargetTracingAgent.h>
 
 #include <functional>
 
@@ -85,6 +86,31 @@ class InstanceAgent final {
   InstanceTarget& target_;
   std::shared_ptr<RuntimeAgent> runtimeAgent_;
   SessionState& sessionState_;
+};
+
+#pragma mark - Tracing
+
+/**
+ * An Agent that handles Tracing events for a particular InstanceTarget.
+ *
+ * Lifetime of this agent is bound to the lifetime of the Tracing session -
+ * HostTargetTraceRecording and to the lifetime of the InstanceTarget.
+ */
+class InstanceTracingAgent : tracing::TargetTracingAgent {
+ public:
+  explicit InstanceTracingAgent(tracing::TraceRecordingState& state);
+
+  /**
+   * Registers the RuntimeTarget with this tracing agent.
+   */
+  void setTracedRuntime(RuntimeTarget* runtimeTarget);
+
+  void enable() override;
+
+  void disable() override;
+
+ private:
+  std::shared_ptr<RuntimeTracingAgent> runtimeTracingAgent_;
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.h
@@ -15,12 +15,15 @@
 
 #include <jsinspector-modern/InspectorInterfaces.h>
 #include <jsinspector-modern/RuntimeAgent.h>
+#include <jsinspector-modern/tracing/TraceRecordingState.h>
 
 #include <memory>
 
 namespace facebook::react::jsinspector_modern {
 
 class InstanceAgent;
+class InstanceTracingAgent;
+class HostTargetTraceRecording;
 
 /**
  * Receives events from an InstanceTarget. This is a shared interface that
@@ -69,6 +72,18 @@ class InstanceTarget : public EnableExecutorFromThis<InstanceTarget> {
       SessionState& sessionState);
 
   /**
+   * Creates a new InstanceTracingAgent.
+   * This Agent is not owned by the InstanceTarget. The Agent will be destroyed
+   * either before the InstanceTarget is destroyed, as part of the
+   * InstanceTarget unregistration in HostTarget, or at the end of the tracing
+   * session.
+   *
+   * \param state A reference to the state of the active trace recording.
+   */
+  std::shared_ptr<InstanceTracingAgent> createTracingAgent(
+      tracing::TraceRecordingState& state);
+
+  /**
    * Registers a JS runtime with this InstanceTarget. \returns a reference to
    * the created RuntimeTarget, which is owned by the \c InstanceTarget. All the
    * requirements of \c RuntimeTarget::create must be met.
@@ -103,6 +118,13 @@ class InstanceTarget : public EnableExecutorFromThis<InstanceTarget> {
   std::shared_ptr<RuntimeTarget> currentRuntime_{nullptr};
   WeakList<InstanceAgent> agents_;
   std::shared_ptr<ExecutionContextManager> executionContextManager_;
+
+  /**
+   * This TracingAgent is owned by the HostTracingAgent, both are bound to
+   * the lifetime of their corresponding targets and the lifetime of the tracing
+   * session - HostTargetTraceRecording.
+   */
+  std::weak_ptr<InstanceTracingAgent> tracingAgent_;
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.cpp
@@ -128,4 +128,13 @@ tracing::RuntimeSamplingProfile RuntimeAgent::collectSamplingProfile() {
   return targetController_.collectSamplingProfile();
 }
 
+#pragma mark - Tracing
+
+RuntimeTracingAgent::RuntimeTracingAgent(tracing::TraceRecordingState& state)
+    : tracing::TargetTracingAgent(state) {}
+
+void RuntimeTracingAgent::enable() {}
+
+void RuntimeTracingAgent::disable() {}
+
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.cpp
@@ -130,11 +130,20 @@ tracing::RuntimeSamplingProfile RuntimeAgent::collectSamplingProfile() {
 
 #pragma mark - Tracing
 
-RuntimeTracingAgent::RuntimeTracingAgent(tracing::TraceRecordingState& state)
-    : tracing::TargetTracingAgent(state) {}
+RuntimeTracingAgent::RuntimeTracingAgent(
+    tracing::TraceRecordingState& state,
+    RuntimeTargetController& targetController)
+    : tracing::TargetTracingAgent(state), targetController_(targetController) {}
 
-void RuntimeTracingAgent::enable() {}
+void RuntimeTracingAgent::enable() {
+  targetController_.enableSamplingProfiler();
+}
 
-void RuntimeTracingAgent::disable() {}
+void RuntimeTracingAgent::disable() {
+  targetController_.disableSamplingProfiler();
+  auto profile = targetController_.collectSamplingProfile();
+
+  state_.runtimeSamplingProfiles.emplace_back(std::move(profile));
+}
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.h
@@ -118,11 +118,16 @@ class RuntimeAgent final {
  */
 class RuntimeTracingAgent : tracing::TargetTracingAgent {
  public:
-  explicit RuntimeTracingAgent(tracing::TraceRecordingState& state);
+  explicit RuntimeTracingAgent(
+      tracing::TraceRecordingState& state,
+      RuntimeTargetController& targetController);
 
   void enable() override;
 
   void disable() override;
+
+ private:
+  RuntimeTargetController& targetController_;
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.h
@@ -13,6 +13,8 @@
 
 #include <jsinspector-modern/cdp/CdpJson.h>
 #include <jsinspector-modern/tracing/RuntimeSamplingProfile.h>
+#include <jsinspector-modern/tracing/TargetTracingAgent.h>
+#include <jsinspector-modern/tracing/TraceRecordingState.h>
 
 namespace facebook::react::jsinspector_modern {
 
@@ -104,6 +106,23 @@ class RuntimeAgent final {
   SessionState& sessionState_;
   const std::unique_ptr<RuntimeAgentDelegate> delegate_;
   const ExecutionContextDescription executionContextDescription_;
+};
+
+#pragma mark - Tracing
+
+/**
+ * An Agent that handles Tracing events for a particular RuntimeTarget.
+ *
+ * Lifetime of this agent is bound to the lifetime of the Tracing session -
+ * HostTargetTraceRecording and to the lifetime of the RuntimeTarget.
+ */
+class RuntimeTracingAgent : tracing::TargetTracingAgent {
+ public:
+  explicit RuntimeTracingAgent(tracing::TraceRecordingState& state);
+
+  void enable() override;
+
+  void disable() override;
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
@@ -79,7 +79,7 @@ std::shared_ptr<RuntimeAgent> RuntimeTarget::createAgent(
 
 std::shared_ptr<RuntimeTracingAgent> RuntimeTarget::createTracingAgent(
     tracing::TraceRecordingState& state) {
-  auto agent = std::make_shared<RuntimeTracingAgent>(state);
+  auto agent = std::make_shared<RuntimeTracingAgent>(state, controller_);
   tracingAgent_ = agent;
   return agent;
 }

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
@@ -77,12 +77,24 @@ std::shared_ptr<RuntimeAgent> RuntimeTarget::createAgent(
   return runtimeAgent;
 }
 
+std::shared_ptr<RuntimeTracingAgent> RuntimeTarget::createTracingAgent(
+    tracing::TraceRecordingState& state) {
+  auto agent = std::make_shared<RuntimeTracingAgent>(state);
+  tracingAgent_ = agent;
+  return agent;
+}
+
 RuntimeTarget::~RuntimeTarget() {
   // Agents are owned by the session, not by RuntimeTarget, but
   // they hold a RuntimeTarget& that we must guarantee is valid.
   assert(
       agents_.empty() &&
       "RuntimeAgent objects must be destroyed before their RuntimeTarget. Did you call InstanceTarget::unregisterRuntime()?");
+
+  // Tracing Agents are owned by the HostTargetTraceRecording.
+  assert(
+      tracingAgent_.expired() &&
+      "RuntimeTracingAgent must be destroyed before their InstanceTarget. Did you call InstanceTarget::unregisterRuntime()?");
 }
 
 void RuntimeTarget::installBindingHandler(const std::string& bindingName) {

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
@@ -17,6 +17,7 @@
 
 #include <ReactCommon/RuntimeExecutor.h>
 #include <jsinspector-modern/tracing/RuntimeSamplingProfile.h>
+#include <jsinspector-modern/tracing/TraceRecordingState.h>
 
 #include <memory>
 
@@ -35,6 +36,7 @@
 namespace facebook::react::jsinspector_modern {
 
 class RuntimeAgent;
+class RuntimeTracingAgent;
 class RuntimeAgentDelegate;
 class RuntimeTarget;
 struct SessionState;
@@ -203,6 +205,17 @@ class JSINSPECTOR_EXPORT RuntimeTarget
       SessionState& sessionState);
 
   /**
+   * Creates a new RuntimeTracingAgent.
+   * This Agent is not owned by the RuntimeTarget. The Agent will be destroyed
+   * either before the RuntimeTarget is destroyed, as part of the RuntimeTarget
+   * unregistration in InstanceTarget, or at the end of the tracing session.
+   *
+   * \param state A reference to the state of the active trace recording.
+   */
+  std::shared_ptr<RuntimeTracingAgent> createTracingAgent(
+      tracing::TraceRecordingState& state);
+
+  /**
    * Start sampling profiler for a particular JavaScript runtime.
    */
   void enableSamplingProfiler();
@@ -245,6 +258,13 @@ class JSINSPECTOR_EXPORT RuntimeTarget
   RuntimeExecutor jsExecutor_;
   WeakList<RuntimeAgent> agents_;
   RuntimeTargetController controller_{*this};
+
+  /**
+   * This TracingAgent is owned by the InstanceTracingAgent, both are bound to
+   * the lifetime of their corresponding targets and the lifetime of the tracing
+   * session - HostTargetTraceRecording.
+   */
+  std::weak_ptr<RuntimeTracingAgent> tracingAgent_;
 
   /**
    * Adds a function with the given name on the runtime's global object, that

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/InstanceTracingProfile.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/InstanceTracingProfile.h
@@ -8,12 +8,17 @@
 #pragma once
 
 #include "RuntimeSamplingProfile.h"
+#include "TraceEvent.h"
 
 namespace facebook::react::jsinspector_modern::tracing {
 
-struct InstanceTracingProfile {
+struct InstanceTracingProfileLegacy {
  public:
   RuntimeSamplingProfile runtimeSamplingProfile;
+};
+
+struct InstanceTracingProfile {
+  std::vector<TraceEvent> performanceTraceEvents;
 };
 
 } // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TargetTracingAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TargetTracingAgent.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "TraceRecordingState.h"
+
+namespace facebook::react::jsinspector_modern::tracing {
+
+class TargetTracingAgent {
+ public:
+  explicit TargetTracingAgent(TraceRecordingState& state) : state_(state) {
+    (void)state_;
+  }
+
+  virtual ~TargetTracingAgent() = default;
+
+  virtual void enable() = 0;
+
+  virtual void disable() = 0;
+
+ protected:
+  TraceRecordingState& state_;
+};
+
+} // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceRecordingState.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceRecordingState.h
@@ -10,12 +10,16 @@
 #include "InstanceTracingProfile.h"
 #include "RuntimeSamplingProfile.h"
 
+#include <oscompat/OSCompat.h>
+
 #include <vector>
 
 namespace facebook::react::jsinspector_modern::tracing {
 
 struct TraceRecordingState {
   bool isRecording = false;
+
+  ProcessId processId = oscompat::getCurrentProcessId();
 
   std::vector<RuntimeSamplingProfile> runtimeSamplingProfiles;
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceRecordingState.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceRecordingState.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include "InstanceTracingProfile.h"
 #include "RuntimeSamplingProfile.h"
 
 #include <vector>
@@ -17,6 +18,8 @@ struct TraceRecordingState {
   bool isRecording = false;
 
   std::vector<RuntimeSamplingProfile> runtimeSamplingProfiles;
+
+  std::vector<InstanceTracingProfile> instanceTracingProfiles;
 };
 
 } // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceRecordingState.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceRecordingState.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace facebook::react::jsinspector_modern::tracing {
+
+struct TraceRecordingState {
+  bool isRecording = false;
+};
+
+} // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceRecordingState.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceRecordingState.h
@@ -7,10 +7,16 @@
 
 #pragma once
 
+#include "RuntimeSamplingProfile.h"
+
+#include <vector>
+
 namespace facebook::react::jsinspector_modern::tracing {
 
 struct TraceRecordingState {
   bool isRecording = false;
+
+  std::vector<RuntimeSamplingProfile> runtimeSamplingProfiles;
 };
 
 } // namespace facebook::react::jsinspector_modern::tracing


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

We would need this to correctly serialize Runtime Sampling Profiles.

Differential Revision: D79433501
