### PR TITLE
Add initial UI for Perf Monitor V2 prototype

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1965,7 +1965,7 @@ public abstract interface class com/facebook/react/devsupport/DevServerHelper$Pa
 	public abstract fun onPackagerReloadCommand ()V
 }
 
-public abstract class com/facebook/react/devsupport/DevSupportManagerBase : com/facebook/react/devsupport/interfaces/DevSupportManager {
+public abstract class com/facebook/react/devsupport/DevSupportManagerBase : com/facebook/react/devsupport/interfaces/DevSupportManager, com/facebook/react/devsupport/interfaces/PerfMonitorV2Handler {
 	public static final field Companion Lcom/facebook/react/devsupport/DevSupportManagerBase$Companion;
 	public fun <init> (Landroid/content/Context;Lcom/facebook/react/devsupport/ReactInstanceDevHelper;Ljava/lang/String;ZLcom/facebook/react/devsupport/interfaces/RedBoxHandler;Lcom/facebook/react/devsupport/interfaces/DevBundleDownloadListener;ILjava/util/Map;Lcom/facebook/react/common/SurfaceDelegateFactory;Lcom/facebook/react/devsupport/interfaces/DevLoadingViewManager;Lcom/facebook/react/devsupport/interfaces/PausedInDebuggerOverlayManager;)V
 	public fun addCustomDevOption (Ljava/lang/String;Lcom/facebook/react/devsupport/interfaces/DevOptionHandler;)V
@@ -2023,6 +2023,7 @@ public abstract class com/facebook/react/devsupport/DevSupportManagerBase : com/
 	public fun startInspector ()V
 	public fun stopInspector ()V
 	public fun toggleElementInspector ()V
+	public fun unstable_updatePerfMonitor (Ljava/lang/String;I)V
 }
 
 public abstract interface class com/facebook/react/devsupport/DevSupportManagerBase$CallbackWithBundleLoader {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/PerfMonitorOverlayViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/PerfMonitorOverlayViewManager.kt
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.devsupport
+
+import android.app.Dialog
+import android.content.Context
+import android.graphics.Color
+import android.graphics.Typeface
+import android.graphics.drawable.ColorDrawable
+import android.graphics.drawable.GradientDrawable
+import android.view.Gravity
+import android.view.Window
+import android.view.WindowManager
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.core.util.Supplier
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import com.facebook.react.R
+import com.facebook.react.bridge.UiThreadUtil
+import com.facebook.react.devsupport.interfaces.PerfMonitorOverlayManager
+import com.facebook.react.uimanager.DisplayMetricsHolder
+import com.facebook.react.uimanager.PixelUtil
+import java.util.Locale
+
+internal class PerfMonitorOverlayViewManager(
+    private val contextSupplier: Supplier<Context?>,
+    private val onRequestAnalyzeTrace: () -> Unit
+) : PerfMonitorOverlayManager {
+  private var initialized: Boolean = false
+  private var enabled: Boolean = false
+  private var hasInteractionData: Boolean = false
+  private var interactionDialog: Dialog? = null
+  private var buttonDialog: Dialog? = null
+  private var interactionNameLabel: TextView? = null
+  private var durationLabel: TextView? = null
+
+  override fun enable() {
+    UiThreadUtil.runOnUiThread {
+      enabled = true
+      if (hasInteractionData) {
+        showOverlay()
+      }
+    }
+  }
+
+  override fun disable() {
+    UiThreadUtil.runOnUiThread {
+      enabled = false
+      hideOverlay()
+    }
+  }
+
+  override fun reset() {
+    UiThreadUtil.runOnUiThread {
+      hasInteractionData = false
+      hideOverlay()
+    }
+  }
+
+  override fun update(interactionName: String, durationMs: Int) {
+    UiThreadUtil.runOnUiThread {
+      ensureInitialized()
+      interactionNameLabel?.text = interactionName
+      durationLabel?.text = String.format(Locale.US, "%d ms", durationMs)
+      hasInteractionData = true
+      if (enabled) {
+        showOverlay()
+      }
+    }
+  }
+
+  private fun ensureInitialized() {
+    if (initialized) {
+      return
+    }
+    val context = contextSupplier.get() ?: return
+    DisplayMetricsHolder.initDisplayMetricsIfNotInitialized(context)
+    createDialog(context)
+    createButton(context)
+    initialized = true
+  }
+
+  private fun showOverlay() {
+    interactionDialog?.show()
+    buttonDialog?.show()
+  }
+
+  private fun hideOverlay() {
+    interactionDialog?.hide()
+    buttonDialog?.hide()
+  }
+
+  private fun createDialog(context: Context) {
+    val containerLayout = createInnerLayout(context)
+    interactionNameLabel =
+        TextView(context).apply {
+          textSize = TEXT_SIZE_PRIMARY
+          setTextColor(Color.WHITE)
+          typeface = TYPEFACE_BOLD
+        }
+    durationLabel =
+        TextView(context).apply {
+          textSize = TEXT_SIZE_PRIMARY
+          setTextColor(COLOR_TEXT_GREEN)
+          typeface = TYPEFACE_BOLD
+        }
+    containerLayout.addView(interactionNameLabel)
+    containerLayout.addView(durationLabel)
+
+    val dialog =
+        createAnchoredDialog(context, dpToPx(140f), dpToPx(16f)).apply {
+          setContentView(containerLayout)
+        }
+    dialog.window?.apply {
+      attributes =
+          attributes?.apply {
+            flags =
+                flags or
+                    WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE or
+                    WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
+          }
+    }
+
+    this.interactionDialog = dialog
+  }
+
+  private fun createButton(context: Context) {
+    val buttonInner = createInnerLayout(context)
+    buttonInner.addView(
+        TextView(context).apply {
+          text = "Analyze"
+          textSize = TEXT_SIZE_PRIMARY
+          setTextColor(Color.WHITE)
+          typeface = TYPEFACE_BOLD
+        })
+    buttonInner.addView(
+        TextView(context).apply {
+          text = "cmd + A"
+          textSize = TEXT_SIZE_ACCESSORY
+          setTextColor(Color.WHITE)
+          alpha = 0.7f
+          typeface = TYPEFACE_BOLD
+        })
+    val buttonView =
+        LinearLayout(context).apply {
+          orientation = LinearLayout.VERTICAL
+          setPadding(
+              dpToPx(8f).toInt(), dpToPx(16f).toInt(), dpToPx(16f).toInt(), dpToPx(8f).toInt())
+          addView(buttonInner)
+          setOnClickListener { onRequestAnalyzeTrace() }
+        }
+    val dialog =
+        createAnchoredDialog(context, dpToPx(0f), dpToPx(0f)).apply { setContentView(buttonView) }
+    dialog.window?.apply {
+      attributes =
+          attributes?.apply { flags = flags or WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE }
+    }
+
+    this.buttonDialog = dialog
+  }
+
+  private fun createAnchoredDialog(context: Context, offsetX: Float, offsetY: Float): Dialog {
+    val dialog =
+        Dialog(context, R.style.NoAnimationDialog).apply {
+          requestWindowFeature(Window.FEATURE_NO_TITLE)
+          window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+          window?.setDimAmount(0f)
+          setCancelable(false)
+        }
+    dialog.window?.apply {
+      attributes =
+          attributes?.apply {
+            width = WindowManager.LayoutParams.WRAP_CONTENT
+            height = WindowManager.LayoutParams.WRAP_CONTENT
+            gravity = Gravity.TOP or Gravity.END
+            x = offsetX.toInt()
+            y = offsetY.toInt()
+          }
+    }
+    dialog.window?.decorView?.let { decorView ->
+      ViewCompat.setOnApplyWindowInsetsListener(decorView) { view, windowInsets ->
+        val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+        val layoutParams = (view.layoutParams as WindowManager.LayoutParams)
+        layoutParams.y = insets.top + offsetY.toInt()
+        dialog.window?.attributes = layoutParams
+        WindowInsetsCompat.CONSUMED
+      }
+    }
+
+    return dialog
+  }
+
+  private fun createInnerLayout(context: Context): LinearLayout {
+    return LinearLayout(context).apply {
+      orientation = LinearLayout.HORIZONTAL
+      gravity = Gravity.CENTER_VERTICAL
+      val paddingHorizontal = dpToPx(14f).toInt()
+      val paddingVertical = dpToPx(8f).toInt()
+      setPadding(paddingHorizontal, paddingVertical, paddingHorizontal, paddingVertical)
+      layoutParams =
+          LinearLayout.LayoutParams(
+              LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT)
+      background =
+          GradientDrawable().apply {
+            shape = GradientDrawable.RECTANGLE
+            setColor(Color.BLACK)
+            cornerRadius = dpToPx(14.5f)
+            alpha = (0.8 * 255).toInt()
+            setStroke(dpToPx(1f).toInt(), COLOR_OVERLAY_BORDER)
+          }
+      showDividers = LinearLayout.SHOW_DIVIDER_MIDDLE
+      dividerDrawable =
+          object : ColorDrawable(Color.TRANSPARENT) {
+            override fun getIntrinsicWidth(): Int = dpToPx(8f).toInt()
+          }
+    }
+  }
+
+  private fun dpToPx(dp: Float): Float = PixelUtil.toPixelFromDIP(dp)
+
+  companion object {
+    private val COLOR_TEXT_GREEN = Color.parseColor("#4AEB2F")
+    private val COLOR_OVERLAY_BORDER = Color.parseColor("#6C6C6C")
+    private val TEXT_SIZE_PRIMARY = 13f
+    private val TEXT_SIZE_ACCESSORY = 9f
+    private val TYPEFACE_BOLD = Typeface.create("sans-serif", Typeface.BOLD)
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/PerfMonitorOverlayManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/PerfMonitorOverlayManager.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.devsupport.interfaces
+
+/** [Experimental] Interface to manage the V2 Perf Monitor overlay. */
+internal interface PerfMonitorOverlayManager {
+  /** Enable the Perf Monitor overlay. Will be shown when updates are received. */
+  public fun enable()
+
+  /** Disable the Perf Monitor overlay. Will remain hidden when updates are received. */
+  public fun disable()
+
+  /** Reset the Perf Monitor overlay, e.g. after a reload. */
+  public fun reset()
+
+  /** Update the state of the Perf Monitor overlay. */
+  public fun update(
+      interactionName: String,
+      durationMs: Int,
+  )
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/PerfMonitorV2Handler.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/PerfMonitorV2Handler.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.devsupport.interfaces
+
+/**
+ * [Experimental] Interface used by [com.facebook.react.devsupport.BridgeDevSupportManagerBase]
+ * implement the UI for the V2 Perf Monitor overlay.
+ */
+internal interface PerfMonitorV2Handler {
+
+  /** [Experimental] Update the V2 Perf Monitor overlay with the given data. */
+  // FIXME(T233950466): Refactor ReactHostImpl/DevSupport setup to avoid this public API addition
+  public fun unstable_updatePerfMonitor(
+      interactionName: String,
+      durationMs: Int,
+  )
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.kt
@@ -47,6 +47,7 @@ import com.facebook.react.devsupport.inspector.InspectorNetworkRequestListener
 import com.facebook.react.devsupport.interfaces.BundleLoadCallback
 import com.facebook.react.devsupport.interfaces.DevSupportManager
 import com.facebook.react.devsupport.interfaces.DevSupportManager.PausedInDebuggerOverlayCommandListener
+import com.facebook.react.devsupport.interfaces.PerfMonitorV2Handler
 import com.facebook.react.fabric.ComponentFactory
 import com.facebook.react.fabric.FabricUIManager
 import com.facebook.react.interfaces.TaskInterface
@@ -409,6 +410,13 @@ public class ReactHostImpl(
               reactHostInspectorTarget?.sendDebuggerResumeCommand()
             }
           })
+    }
+  }
+
+  @DoNotStrip
+  private fun unstable_updatePerfMonitor(interactionName: String, durationMs: Int) {
+    if (devSupportManager is PerfMonitorV2Handler) {
+      devSupportManager.unstable_updatePerfMonitor(interactionName, durationMs)
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.cpp
@@ -128,7 +128,12 @@ void JReactHostInspectorTarget::onSetPausedInDebuggerMessage(
 }
 
 void JReactHostInspectorTarget::unstable_onPerfMonitorUpdate(
-    const PerfMonitorUpdateRequest& /* unused */) {}
+    const PerfMonitorUpdateRequest& request) {
+  if (auto javaReactHostImplStrong = javaReactHostImpl_->get()) {
+    javaReactHostImplStrong->unstable_updatePerfMonitor(
+        request.interactionName, request.durationMs);
+  }
+}
 
 void JReactHostInspectorTarget::loadNetworkResource(
     const jsinspector_modern::LoadNetworkResourceRequest& params,

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.h
@@ -38,6 +38,15 @@ struct JReactHostImpl : public jni::JavaClass<JReactHostImpl> {
     method(self(), message ? jni::make_jstring(*message) : nullptr);
   }
 
+  void unstable_updatePerfMonitor(
+      const std::string& interactionName,
+      uint16_t durationMs) {
+    static auto method =
+        javaClassStatic()->getMethod<void(jni::local_ref<jni::JString>, jint)>(
+            "unstable_updatePerfMonitor");
+    method(self(), jni::make_jstring(interactionName), durationMs);
+  }
+
   jni::local_ref<jni::JMap<jstring, jstring>> getHostMetadata() const {
     static auto method =
         javaClassStatic()
@@ -83,9 +92,9 @@ class JReactHostInspectorTarget
   jsinspector_modern::HostTargetMetadata getMetadata() override;
   void onReload(const PageReloadRequest& request) override;
   void onSetPausedInDebuggerMessage(
-      const OverlaySetPausedInDebuggerMessageRequest&) override;
+      const OverlaySetPausedInDebuggerMessageRequest& request) override;
   void unstable_onPerfMonitorUpdate(
-      const PerfMonitorUpdateRequest& /* unused */) override;
+      const PerfMonitorUpdateRequest& request) override;
   void loadNetworkResource(
       const jsinspector_modern::LoadNetworkResourceRequest& params,
       jsinspector_modern::ScopedExecutor<


### PR DESCRIPTION
Summary:
Wires up the initial pass of the experimental V2 Perf Monitor UI.

Limitations:
- Does not yet clear last interaction.
- Only lightly tested.

Changelog: [Internal]

Differential Revision: D78904767


