### PR TITLE
Back out "Fix obfuscated scale type names"

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ScaleTypeStartInside.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ScaleTypeStartInside.kt
@@ -31,7 +31,9 @@ internal class ScaleTypeStartInside : AbstractScaleType() {
     outTransform.postTranslate(Math.round(dx).toFloat(), Math.round(dy).toFloat())
   }
 
-  override fun getDescription(): String = "start_inside"
+  override fun toString(): String {
+    return "start_inside"
+  }
 
   companion object {
     val INSTANCE: ScalingUtils.ScaleType = ScaleTypeStartInside()


### PR DESCRIPTION
Summary:
Original commit changeset: d4e84749324f

Original Phabricator Diff: D79354202

This is currently breaking React Native as this change was done in a breaking manner.

Differential Revision: D79446471
