### PR TITLE
Restructure Fantom test for View to follow convention

### DIFF
--- a/packages/react-native/Libraries/Components/View/__tests__/View-itest.js
+++ b/packages/react-native/Libraries/Components/View/__tests__/View-itest.js
@@ -20,209 +20,217 @@ import {View} from 'react-native';
 import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 
 describe('<View>', () => {
-  describe('width and height style', () => {
-    it('handles correct percentage-based dimensions', () => {
-      const root = Fantom.createRoot();
+  describe('props', () => {
+    describe('style', () => {
+      describe('width and height style', () => {
+        it('handles correct percentage-based dimensions', () => {
+          const root = Fantom.createRoot();
 
-      Fantom.runTask(() => {
-        root.render(
-          <View style={{width: 100, height: 100}}>
-            <View style={{width: '20%', height: '50%'}} collapsable={false} />
-          </View>,
-        );
-      });
+          Fantom.runTask(() => {
+            root.render(
+              <View style={{width: 100, height: 100}}>
+                <View
+                  style={{width: '20%', height: '50%'}}
+                  collapsable={false}
+                />
+              </View>,
+            );
+          });
 
-      expect(
-        root.getRenderedOutput({includeLayoutMetrics: true}).toJSX(),
-      ).toEqual(
-        <rn-view
-          layoutMetrics-frame="{x:0,y:0,width:20,height:50}"
-          height="50.000000%"
-          layoutMetrics-borderWidth="{top:0,right:0,bottom:0,left:0}"
-          layoutMetrics-contentInsets="{top:0,right:0,bottom:0,left:0}"
-          layoutMetrics-displayType="Flex"
-          layoutMetrics-layoutDirection="LeftToRight"
-          layoutMetrics-overflowInset="{top:0,right:-0,bottom:-0,left:0}"
-          layoutMetrics-pointScaleFactor="3"
-          width="20.000000%"
-        />,
-      );
-    });
-
-    it('handles numeric values passed in as strings', () => {
-      const root = Fantom.createRoot();
-
-      Fantom.runTask(() => {
-        root.render(
-          <View style={{width: '5', height: '10'}} collapsable={false} />,
-        );
-      });
-
-      expect(
-        root.getRenderedOutput({includeLayoutMetrics: true}).toJSX(),
-      ).toEqual(
-        <rn-view
-          layoutMetrics-frame="{x:0,y:0,width:5,height:10}"
-          height="10.000000"
-          layoutMetrics-borderWidth="{top:0,right:0,bottom:0,left:0}"
-          layoutMetrics-contentInsets="{top:0,right:0,bottom:0,left:0}"
-          layoutMetrics-displayType="Flex"
-          layoutMetrics-layoutDirection="LeftToRight"
-          layoutMetrics-overflowInset="{top:0,right:-0,bottom:-0,left:0}"
-          layoutMetrics-pointScaleFactor="3"
-          width="5.000000"
-        />,
-      );
-    });
-
-    it('handles invalid values, falling back to default', () => {
-      const root = Fantom.createRoot();
-
-      Fantom.runTask(() => {
-        root.render(
-          <View style={{width: 100, height: 100}}>
-            <View
-              // 5pt is a valid CSS value but RN can't parse it.
-              style={{width: '5pt', height: 'error 50%'}}
-              collapsable={false}
-            />
-          </View>,
-        );
-      });
-
-      expect(
-        root.getRenderedOutput({includeLayoutMetrics: true}).toJSX(),
-      ).toEqual(
-        <rn-view
-          layoutMetrics-frame="{x:0,y:0,width:100,height:0}"
-          height="undefined"
-          layoutMetrics-borderWidth="{top:0,right:0,bottom:0,left:0}"
-          layoutMetrics-contentInsets="{top:0,right:0,bottom:0,left:0}"
-          layoutMetrics-displayType="Flex"
-          layoutMetrics-layoutDirection="LeftToRight"
-          layoutMetrics-overflowInset="{top:0,right:-0,bottom:-0,left:0}"
-          layoutMetrics-pointScaleFactor="3"
-          width="undefined"
-        />,
-      );
-    });
-  });
-
-  describe('margin style', () => {
-    it('handles correct percentage-based values', () => {
-      const root = Fantom.createRoot();
-
-      Fantom.runTask(() => {
-        root.render(
-          <View style={{width: 100, height: 200}}>
-            <View
-              style={{width: 5, height: 10, margin: '50%'}}
-              collapsable={false}
-            />
-          </View>,
-        );
-      });
-
-      expect(
-        root.getRenderedOutput({includeLayoutMetrics: true}).toJSX(),
-      ).toEqual(
-        <rn-view
-          layoutMetrics-frame="{x:50,y:50,width:5,height:10}"
-          height="10.000000"
-          layoutMetrics-borderWidth="{top:0,right:0,bottom:0,left:0}"
-          layoutMetrics-contentInsets="{top:0,right:0,bottom:0,left:0}"
-          layoutMetrics-displayType="Flex"
-          layoutMetrics-layoutDirection="LeftToRight"
-          layoutMetrics-overflowInset="{top:0,right:-0,bottom:-0,left:0}"
-          layoutMetrics-pointScaleFactor="3"
-          margin="50.000000%"
-          width="5.000000"
-        />,
-      );
-    });
-
-    it('handles numeric values passed in as strings', () => {
-      const root = Fantom.createRoot();
-
-      Fantom.runTask(() => {
-        root.render(
-          <View style={{width: 100, height: 200}}>
-            <View
-              style={{width: 5, height: 10, margin: '5'}}
-              collapsable={false}
-            />
-          </View>,
-        );
-      });
-
-      expect(
-        root.getRenderedOutput({includeLayoutMetrics: true}).toJSX(),
-      ).toEqual(
-        <rn-view
-          layoutMetrics-frame="{x:5,y:5,width:5,height:10}"
-          height="10.000000"
-          layoutMetrics-borderWidth="{top:0,right:0,bottom:0,left:0}"
-          layoutMetrics-contentInsets="{top:0,right:0,bottom:0,left:0}"
-          layoutMetrics-displayType="Flex"
-          layoutMetrics-layoutDirection="LeftToRight"
-          layoutMetrics-overflowInset="{top:0,right:-0,bottom:-0,left:0}"
-          layoutMetrics-pointScaleFactor="3"
-          margin="5.000000"
-          width="5.000000"
-        />,
-      );
-    });
-  });
-
-  describe('transform style', () => {
-    it('causes view to be unflattened', () => {
-      const root = Fantom.createRoot();
-
-      Fantom.runTask(() => {
-        root.render(<View style={{transform: [{translateX: 10}]}} />);
-      });
-
-      expect(root.getRenderedOutput({props: ['transform']}).toJSX()).toEqual(
-        <rn-view transform='[{"translateX": 10.000000}]' />,
-      );
-    });
-
-    [
-      [undefined, {x: -5, y: 0, width: 20, height: 10}],
-      ['50% 50%', {x: -5, y: 0, width: 20, height: 10}],
-      ['top left', {x: 0, y: 0, width: 20, height: 10}],
-      ['right bottom', {x: -10, y: 0, width: 20, height: 10}],
-    ].forEach(([transformOrigin, expectedBounds]) => {
-      it(`applies transformOrigin correctly for ${String(transformOrigin)}`, () => {
-        const root = Fantom.createRoot();
-
-        const viewRef = createRef<HostInstance>();
-        Fantom.runTask(() => {
-          root.render(
-            <View
-              ref={viewRef}
-              style={{
-                width: 10,
-                height: 10,
-                transform: [{scaleX: 2}],
-                transformOrigin,
-              }}
+          expect(
+            root.getRenderedOutput({includeLayoutMetrics: true}).toJSX(),
+          ).toEqual(
+            <rn-view
+              layoutMetrics-frame="{x:0,y:0,width:20,height:50}"
+              height="50.000000%"
+              layoutMetrics-borderWidth="{top:0,right:0,bottom:0,left:0}"
+              layoutMetrics-contentInsets="{top:0,right:0,bottom:0,left:0}"
+              layoutMetrics-displayType="Flex"
+              layoutMetrics-layoutDirection="LeftToRight"
+              layoutMetrics-overflowInset="{top:0,right:-0,bottom:-0,left:0}"
+              layoutMetrics-pointScaleFactor="3"
+              width="20.000000%"
             />,
           );
         });
 
-        const viewElement = ensureInstance(viewRef.current, ReactNativeElement);
+        it('handles numeric values passed in as strings', () => {
+          const root = Fantom.createRoot();
 
-        const viewBounds = viewElement.getBoundingClientRect();
-        expect(viewBounds.x).toBe(expectedBounds.x);
-        expect(viewBounds.y).toBe(expectedBounds.y);
-        expect(viewBounds.width).toBe(expectedBounds.width);
-        expect(viewBounds.height).toBe(expectedBounds.height);
+          Fantom.runTask(() => {
+            root.render(
+              <View style={{width: '5', height: '10'}} collapsable={false} />,
+            );
+          });
+
+          expect(
+            root.getRenderedOutput({includeLayoutMetrics: true}).toJSX(),
+          ).toEqual(
+            <rn-view
+              layoutMetrics-frame="{x:0,y:0,width:5,height:10}"
+              height="10.000000"
+              layoutMetrics-borderWidth="{top:0,right:0,bottom:0,left:0}"
+              layoutMetrics-contentInsets="{top:0,right:0,bottom:0,left:0}"
+              layoutMetrics-displayType="Flex"
+              layoutMetrics-layoutDirection="LeftToRight"
+              layoutMetrics-overflowInset="{top:0,right:-0,bottom:-0,left:0}"
+              layoutMetrics-pointScaleFactor="3"
+              width="5.000000"
+            />,
+          );
+        });
+
+        it('handles invalid values, falling back to default', () => {
+          const root = Fantom.createRoot();
+
+          Fantom.runTask(() => {
+            root.render(
+              <View style={{width: 100, height: 100}}>
+                <View
+                  // 5pt is a valid CSS value but RN can't parse it.
+                  style={{width: '5pt', height: 'error 50%'}}
+                  collapsable={false}
+                />
+              </View>,
+            );
+          });
+
+          expect(
+            root.getRenderedOutput({includeLayoutMetrics: true}).toJSX(),
+          ).toEqual(
+            <rn-view
+              layoutMetrics-frame="{x:0,y:0,width:100,height:0}"
+              height="undefined"
+              layoutMetrics-borderWidth="{top:0,right:0,bottom:0,left:0}"
+              layoutMetrics-contentInsets="{top:0,right:0,bottom:0,left:0}"
+              layoutMetrics-displayType="Flex"
+              layoutMetrics-layoutDirection="LeftToRight"
+              layoutMetrics-overflowInset="{top:0,right:-0,bottom:-0,left:0}"
+              layoutMetrics-pointScaleFactor="3"
+              width="undefined"
+            />,
+          );
+        });
+      });
+
+      describe('margin style', () => {
+        it('handles correct percentage-based values', () => {
+          const root = Fantom.createRoot();
+
+          Fantom.runTask(() => {
+            root.render(
+              <View style={{width: 100, height: 200}}>
+                <View
+                  style={{width: 5, height: 10, margin: '50%'}}
+                  collapsable={false}
+                />
+              </View>,
+            );
+          });
+
+          expect(
+            root.getRenderedOutput({includeLayoutMetrics: true}).toJSX(),
+          ).toEqual(
+            <rn-view
+              layoutMetrics-frame="{x:50,y:50,width:5,height:10}"
+              height="10.000000"
+              layoutMetrics-borderWidth="{top:0,right:0,bottom:0,left:0}"
+              layoutMetrics-contentInsets="{top:0,right:0,bottom:0,left:0}"
+              layoutMetrics-displayType="Flex"
+              layoutMetrics-layoutDirection="LeftToRight"
+              layoutMetrics-overflowInset="{top:0,right:-0,bottom:-0,left:0}"
+              layoutMetrics-pointScaleFactor="3"
+              margin="50.000000%"
+              width="5.000000"
+            />,
+          );
+        });
+
+        it('handles numeric values passed in as strings', () => {
+          const root = Fantom.createRoot();
+
+          Fantom.runTask(() => {
+            root.render(
+              <View style={{width: 100, height: 200}}>
+                <View
+                  style={{width: 5, height: 10, margin: '5'}}
+                  collapsable={false}
+                />
+              </View>,
+            );
+          });
+
+          expect(
+            root.getRenderedOutput({includeLayoutMetrics: true}).toJSX(),
+          ).toEqual(
+            <rn-view
+              layoutMetrics-frame="{x:5,y:5,width:5,height:10}"
+              height="10.000000"
+              layoutMetrics-borderWidth="{top:0,right:0,bottom:0,left:0}"
+              layoutMetrics-contentInsets="{top:0,right:0,bottom:0,left:0}"
+              layoutMetrics-displayType="Flex"
+              layoutMetrics-layoutDirection="LeftToRight"
+              layoutMetrics-overflowInset="{top:0,right:-0,bottom:-0,left:0}"
+              layoutMetrics-pointScaleFactor="3"
+              margin="5.000000"
+              width="5.000000"
+            />,
+          );
+        });
+      });
+
+      describe('transform style', () => {
+        it('causes view to be unflattened', () => {
+          const root = Fantom.createRoot();
+
+          Fantom.runTask(() => {
+            root.render(<View style={{transform: [{translateX: 10}]}} />);
+          });
+
+          expect(
+            root.getRenderedOutput({props: ['transform']}).toJSX(),
+          ).toEqual(<rn-view transform='[{"translateX": 10.000000}]' />);
+        });
+
+        [
+          [undefined, {x: -5, y: 0, width: 20, height: 10}],
+          ['50% 50%', {x: -5, y: 0, width: 20, height: 10}],
+          ['top left', {x: 0, y: 0, width: 20, height: 10}],
+          ['right bottom', {x: -10, y: 0, width: 20, height: 10}],
+        ].forEach(([transformOrigin, expectedBounds]) => {
+          it(`applies transformOrigin correctly for ${String(transformOrigin)}`, () => {
+            const root = Fantom.createRoot();
+
+            const viewRef = createRef<HostInstance>();
+            Fantom.runTask(() => {
+              root.render(
+                <View
+                  ref={viewRef}
+                  style={{
+                    width: 10,
+                    height: 10,
+                    transform: [{scaleX: 2}],
+                    transformOrigin,
+                  }}
+                />,
+              );
+            });
+
+            const viewElement = ensureInstance(
+              viewRef.current,
+              ReactNativeElement,
+            );
+
+            const viewBounds = viewElement.getBoundingClientRect();
+            expect(viewBounds.x).toBe(expectedBounds.x);
+            expect(viewBounds.y).toBe(expectedBounds.y);
+            expect(viewBounds.width).toBe(expectedBounds.width);
+            expect(viewBounds.height).toBe(expectedBounds.height);
+          });
+        });
       });
     });
-  });
 
-  describe('props', () => {
     describe('pointerEvents', () => {
       it('auto does not propagate to the mounting layer, it is the default', () => {
         const root = Fantom.createRoot();
@@ -285,6 +293,7 @@ describe('<View>', () => {
         ).toEqual(<rn-view pointerEvents="none" />);
       });
     });
+
     describe('accessibility', () => {
       describe('accessibilityActions', () => {
         it('is propagated to the mounting layer', () => {

--- a/packages/react-native/Libraries/Text/__tests__/Text-itest.js
+++ b/packages/react-native/Libraries/Text/__tests__/Text-itest.js
@@ -10,9 +10,15 @@
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
+import type {HostInstance} from 'react-native';
+
+import ensureInstance from '../../../src/private/__tests__/utilities/ensureInstance';
 import * as Fantom from '@react-native/fantom';
 import * as React from 'react';
+import {createRef} from 'react';
 import {Text} from 'react-native';
+import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
+import ReadOnlyText from 'react-native/src/private/webapis/dom/nodes/ReadOnlyText';
 
 describe('<Text>', () => {
   describe('props', () => {
@@ -58,6 +64,70 @@ describe('<Text>', () => {
           );
         });
       });
+    });
+  });
+
+  describe('ref', () => {
+    it('is a element node', () => {
+      const elementRef = createRef<HostInstance>();
+
+      const root = Fantom.createRoot();
+
+      Fantom.runTask(() => {
+        root.render(<Text ref={elementRef}>Some text</Text>);
+      });
+
+      const element = ensureInstance(elementRef.current, ReactNativeElement);
+      expect(element.tagName).toBe('RN:Paragraph');
+    });
+
+    it('has a single text child node when not nested', () => {
+      const elementRef = createRef<HostInstance>();
+
+      const root = Fantom.createRoot();
+
+      Fantom.runTask(() => {
+        root.render(<Text ref={elementRef}>Some text</Text>);
+      });
+
+      const element = ensureInstance(elementRef.current, ReactNativeElement);
+      expect(element.childNodes.length).toBe(1);
+
+      const textChild = ensureInstance(element.childNodes[0], ReadOnlyText);
+      expect(textChild.textContent).toBe('Some text');
+    });
+
+    it('has text and element child nodes when nested', () => {
+      const elementRef = createRef<HostInstance>();
+
+      const root = Fantom.createRoot();
+
+      Fantom.runTask(() => {
+        root.render(
+          <Text ref={elementRef}>
+            Some text <Text style={{fontWeight: 'bold'}}>also in bold</Text>
+          </Text>,
+        );
+      });
+
+      const element = ensureInstance(elementRef.current, ReactNativeElement);
+      expect(element.childNodes.length).toBe(2);
+
+      const firstChild = ensureInstance(element.childNodes[0], ReadOnlyText);
+      expect(firstChild.textContent).toBe('Some text ');
+
+      const secondChild = ensureInstance(
+        element.childNodes[1],
+        ReactNativeElement,
+      );
+      expect(secondChild.tagName).toBe('RN:Text');
+      expect(secondChild.childNodes.length).toBe(1);
+
+      const secondChildText = ensureInstance(
+        secondChild.childNodes[0],
+        ReadOnlyText,
+      );
+      expect(secondChildText.textContent).toBe('also in bold');
     });
   });
 });


### PR DESCRIPTION
Summary:
Changelog: [internal]

Just moving some tests that were defined under `<View>` that were related to styles, to under `<View> > props > style`.

Differential Revision: D79447450
