### PR TITLE
Fix `ReactHostImpl.nativeModules` always returning an empty list

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.kt
@@ -521,7 +521,8 @@ public class ReactHostImpl(
   internal fun <T : NativeModule> hasNativeModule(nativeModuleInterface: Class<T>): Boolean =
       reactInstance?.hasNativeModule<T>(nativeModuleInterface) ?: false
 
-  internal val nativeModules: Collection<NativeModule> = reactInstance?.nativeModules ?: listOf()
+  internal val nativeModules: Collection<NativeModule>
+    get() = reactInstance?.nativeModules ?: listOf()
 
   internal fun <T : NativeModule> getNativeModule(nativeModuleInterface: Class<T>): T? {
     if (!ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE &&


### PR DESCRIPTION
## Summary:

During the Expo QA process, we discovered that `ReactContext.reactApplicationContext.nativeModules` always returns an empty list (https://github.com/expo/expo/blob/4e2bbb23edda74d0e24756fd1735b8763e38f7a7/packages/expo-modules-core/android/src/main/java/expo/modules/kotlin/ReactExtensions.kt#L12). This happens because, during object creation, the `reactInstance` is always null.


## Changelog:

[ANDROID] [FIXED] - Fix `ReactHostImpl.nativeModules` always returning an empty list

## Test Plan:

- RN tester compiles ✅ 