### PR TITLE
Mark `NotThreadSafeBridgeIdleDebugListener` as LegacyArchitecture

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.kt
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.facebook.react
 
 import android.app.Activity

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstance.kt
@@ -78,13 +78,17 @@ public interface CatalystInstance : MemoryPressureListener, JSInstance, JSBundle
    * defined as there being some non-zero number of calls to JS that haven't resolved via a
    * onBatchCompleted call. The listener should be purely passive and not affect application logic.
    */
-  public fun addBridgeIdleDebugListener(listener: NotThreadSafeBridgeIdleDebugListener)
+  public fun addBridgeIdleDebugListener(
+      @Suppress("DEPRECATION") listener: NotThreadSafeBridgeIdleDebugListener
+  )
 
   /**
    * Removes a NotThreadSafeBridgeIdleDebugListener previously added with
    * [addBridgeIdleDebugListener]
    */
-  public fun removeBridgeIdleDebugListener(listener: NotThreadSafeBridgeIdleDebugListener)
+  public fun removeBridgeIdleDebugListener(
+      @Suppress("DEPRECATION") listener: NotThreadSafeBridgeIdleDebugListener
+  )
 
   /** This method registers the file path of an additional JS segment by its ID. */
   public fun registerSegment(segmentId: Int, path: String)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
@@ -528,6 +528,8 @@ public class CatalystInstanceImpl implements CatalystInstance {
    * whenever the bridge transitions from idle to busy and vice-versa, where the busy state is
    * defined as there being some non-zero number of calls to JS that haven't resolved via a
    * onBatchComplete call. The listener should be purely passive and not affect application logic.
+   *
+   * @noinspection deprecation
    */
   @Override
   public void addBridgeIdleDebugListener(NotThreadSafeBridgeIdleDebugListener listener) {
@@ -537,6 +539,8 @@ public class CatalystInstanceImpl implements CatalystInstance {
   /**
    * Removes a NotThreadSafeBridgeIdleDebugListener previously added with {@link
    * #addBridgeIdleDebugListener}
+   *
+   * @noinspection deprecation
    */
   @Override
   public void removeBridgeIdleDebugListener(NotThreadSafeBridgeIdleDebugListener listener) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NotThreadSafeBridgeIdleDebugListener.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/NotThreadSafeBridgeIdleDebugListener.kt
@@ -6,6 +6,10 @@
  */
 
 package com.facebook.react.bridge
+
+import com.facebook.react.common.annotations.internal.LegacyArchitecture
+import com.facebook.react.common.annotations.internal.LegacyArchitectureLogLevel
+
 /**
  * Interface for receiving notification for bridge idle/busy events. Should not affect application
  * logic and should only be used for debug/monitoring/testing purposes. Call
@@ -14,6 +18,8 @@ package com.facebook.react.bridge
  * NB: onTransitionToBridgeIdle and onTransitionToBridgeBusy may be called from different threads,
  * and those threads may not be the same thread on which the listener was originally registered.
  */
+@Deprecated("NotThreadSafeBridgeIdleDebugListener will be deleted in the new architecture.")
+@LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
 public interface NotThreadSafeBridgeIdleDebugListener {
   /**
    * Called once all pending JS calls have resolved via an onBatchComplete call in the bridge and


### PR DESCRIPTION
Summary:
This class should be marked as `LegacyArchitecture` while it was not.

Changelog:
[Internal] [Changed] -

Differential Revision: D79451041
