### PR TITLE
Emit scroll end events when fling animator completes

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -37,8 +37,6 @@ import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.R;
-import com.facebook.react.animated.NativeAnimatedModule;
-import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.common.build.ReactBuildConfig;
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags;
@@ -1028,16 +1026,8 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
                 if (mSendMomentumEvents) {
                   ReactScrollViewHelper.emitScrollMomentumEndEvent(ReactHorizontalScrollView.this);
                 }
-
-                ReactContext context = (ReactContext) getContext();
-                if (context != null) {
-                  NativeAnimatedModule nativeAnimated =
-                      context.getNativeModule(NativeAnimatedModule.class);
-                  if (nativeAnimated != null) {
-                    nativeAnimated.userDrivenScrollEnded(ReactHorizontalScrollView.this.getId());
-                  }
-                }
-                disableFpsListener();
+                ReactScrollViewHelper.notifyUserDrivenScrollEnded_internal(
+                    ReactHorizontalScrollView.this);
               } else {
                 if (mPagingEnabled && !mSnappingToPage) {
                   // If we have pagingEnabled and we have not snapped to the page

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -37,8 +37,6 @@ import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.infer.annotation.Nullsafe;
 import com.facebook.react.R;
-import com.facebook.react.animated.NativeAnimatedModule;
-import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags;
@@ -805,14 +803,7 @@ public class ReactScrollView extends ScrollView
                 if (mSendMomentumEvents) {
                   ReactScrollViewHelper.emitScrollMomentumEndEvent(ReactScrollView.this);
                 }
-                ReactContext context = (ReactContext) getContext();
-                if (context != null) {
-                  NativeAnimatedModule nativeAnimated =
-                      context.getNativeModule(NativeAnimatedModule.class);
-                  if (nativeAnimated != null) {
-                    nativeAnimated.userDrivenScrollEnded(ReactScrollView.this.getId());
-                  }
-                }
+                ReactScrollViewHelper.notifyUserDrivenScrollEnded_internal(ReactScrollView.this);
                 disableFpsListener();
               } else {
                 if (mPagingEnabled && !mSnappingToPage) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
@@ -19,6 +19,7 @@ import androidx.annotation.RequiresApi
 import androidx.core.view.ViewCompat.FocusDirection
 import androidx.core.view.ViewCompat.FocusRealDirection
 import com.facebook.common.logging.FLog
+import com.facebook.react.animated.NativeAnimatedModule
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.WritableNativeMap
@@ -149,6 +150,19 @@ public object ReactScrollViewHelper {
               scrollView.height))
       if (scrollEventType == ScrollEventType.SCROLL) {
         scrollView.lastScrollDispatchTime = now
+      }
+    }
+  }
+
+  // TODO: Remove this once C++ animation driver is complete
+  @JvmStatic
+  @JvmName("notifyUserDrivenScrollEnded_internal")
+  internal fun notifyUserDrivenScrollEnded(scrollView: ViewGroup) {
+    val reactContext = scrollView.context as? ReactContext
+    if (reactContext != null) {
+      val nativeAnimated = reactContext.getNativeModule(NativeAnimatedModule::class.java)
+      if (nativeAnimated != null) {
+        nativeAnimated.userDrivenScrollEnded(scrollView.id)
       }
     }
   }
@@ -400,11 +414,13 @@ public object ReactScrollViewHelper {
 
               override fun onAnimationEnd(animator: Animator) {
                 scrollView.reactScrollViewScrollState.isFinished = true
+                notifyUserDrivenScrollEnded(scrollView)
                 updateFabricScrollState(scrollView)
               }
 
               override fun onAnimationCancel(animator: Animator) {
                 scrollView.reactScrollViewScrollState.isCanceled = true
+                notifyUserDrivenScrollEnded(scrollView)
               }
 
               override fun onAnimationRepeat(animator: Animator) = Unit


### PR DESCRIPTION
Summary:
Adds a call to `NativeAnimatedModule`'s `userDrivenScrollEnded` method whenever a scroll event completes a smooth scroll animation. This is necessary in cases where Animated events control any layout properties of children and we need to force the shadow tree to resync with the native tree. For example, if a scroll view's child transforms its scale based on the scrollX or scrollY properties and the user triggers a `scrollToOffset` or `scrollToIndex` call, we don't update the layout of that child until the next state change.

Changelog: [Android][Fixed] - Fixed an issue where shadow tree and native tree layouts mismatch at the end of a scroll event

Differential Revision: D79464176


