### PR TITLE
move some C++ Animated headers into internal folder

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/animated/internal/AnimatedMountingOverrideDelegate.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animated/internal/AnimatedMountingOverrideDelegate.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "AnimatedMountingOverrideDelegate.h"
+#include "../NativeAnimatedNodesManager.h"
+
+#include <react/renderer/componentregistry/ComponentDescriptorRegistry.h>
+#include <react/renderer/components/view/ViewProps.h>
+#include <react/renderer/core/DynamicPropsUtilities.h>
+#include <react/renderer/scheduler/Scheduler.h>
+#include <react/renderer/uimanager/UIManagerBinding.h>
+
+namespace facebook::react {
+
+AnimatedMountingOverrideDelegate::AnimatedMountingOverrideDelegate(
+    NativeAnimatedNodesManager& animatedManager,
+    const Scheduler& scheduler)
+    : MountingOverrideDelegate(),
+      animatedManager_(&animatedManager),
+      scheduler_(&scheduler){};
+
+bool AnimatedMountingOverrideDelegate::shouldOverridePullTransaction() const {
+  if (animatedManager_ != nullptr) {
+    return animatedManager_->hasManagedProps();
+  }
+  return false;
+}
+
+std::optional<MountingTransaction>
+AnimatedMountingOverrideDelegate::pullTransaction(
+    SurfaceId surfaceId,
+    MountingTransaction::Number transactionNumber,
+    const TransactionTelemetry& telemetry,
+    ShadowViewMutationList mutations) const {
+  std::unordered_map<Tag, folly::dynamic> animatedManagedProps;
+  for (const auto& mutation : mutations) {
+    if (mutation.type == ShadowViewMutation::Update) {
+      const auto tag = mutation.newChildShadowView.tag;
+      auto props = animatedManager_->managedProps(tag);
+      if (!props.isNull()) {
+        animatedManagedProps.insert({tag, std::move(props)});
+      }
+    } else if (mutation.type == ShadowViewMutation::Delete) {
+      animatedManager_->onManagedPropsRemoved(mutation.oldChildShadowView.tag);
+    }
+  }
+
+  if (animatedManagedProps.empty()) {
+    return MountingTransaction{
+        surfaceId, transactionNumber, std::move(mutations), telemetry};
+  }
+
+  ShadowViewMutation::List filteredMutations;
+  filteredMutations.reserve(mutations.size());
+  for (const auto& mutation : mutations) {
+    folly::dynamic modifiedProps = folly::dynamic::object();
+    if (mutation.type == ShadowViewMutation::Update) {
+      if (auto node =
+              animatedManagedProps.extract(mutation.newChildShadowView.tag)) {
+        modifiedProps = std::move(node.mapped());
+      }
+    }
+    if (modifiedProps.empty()) {
+      filteredMutations.push_back(mutation);
+    } else {
+      if (const auto* componentDescriptor =
+              scheduler_
+                  ->findComponentDescriptorByHandle_DO_NOT_USE_THIS_IS_BROKEN(
+                      mutation.newChildShadowView.componentHandle)) {
+        PropsParserContext propsParserContext{
+            mutation.newChildShadowView.surfaceId,
+            *scheduler_->getContextContainer()};
+        auto modifiedNewChildShadowView = mutation.newChildShadowView;
+        modifiedNewChildShadowView.props = componentDescriptor->cloneProps(
+            propsParserContext,
+            mutation.newChildShadowView.props,
+            RawProps(modifiedProps));
+#ifdef RN_SERIALIZABLE_STATE
+        // Until Props 2.0 is shipped, android uses rawProps.
+        // RawProps must be kept synced with C++ Animated as well
+        // as props object.
+        auto& castedProps =
+            const_cast<Props&>(*modifiedNewChildShadowView.props);
+        castedProps.rawProps = mergeDynamicProps(
+            mutation.newChildShadowView.props->rawProps,
+            modifiedProps,
+            NullValueStrategy::Override);
+#endif
+
+        filteredMutations.emplace_back(ShadowViewMutation::UpdateMutation(
+            mutation.oldChildShadowView,
+            std::move(modifiedNewChildShadowView),
+            mutation.parentTag));
+      }
+    }
+  }
+  return MountingTransaction{
+      surfaceId, transactionNumber, std::move(filteredMutations), telemetry};
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/animated/internal/AnimatedMountingOverrideDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/internal/AnimatedMountingOverrideDelegate.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/dynamic.h>
+#include <react/renderer/mounting/MountingOverrideDelegate.h>
+#include <react/renderer/mounting/MountingTransaction.h>
+#include <react/renderer/mounting/ShadowViewMutation.h>
+#include <functional>
+#include <optional>
+
+namespace facebook::react {
+
+class Scheduler;
+class NativeAnimatedNodesManager;
+
+class AnimatedMountingOverrideDelegate : public MountingOverrideDelegate {
+ public:
+  AnimatedMountingOverrideDelegate(
+      NativeAnimatedNodesManager& animatedManager,
+      const Scheduler& scheduler);
+
+  bool shouldOverridePullTransaction() const override;
+
+  std::optional<MountingTransaction> pullTransaction(
+      SurfaceId surfaceId,
+      MountingTransaction::Number transactionNumber,
+      const TransactionTelemetry& telemetry,
+      ShadowViewMutationList mutations) const override;
+
+ private:
+  mutable NativeAnimatedNodesManager* animatedManager_;
+
+  const Scheduler* scheduler_;
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/animated/internal/NativeAnimatedAllowlist.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/internal/NativeAnimatedAllowlist.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+#include <unordered_set>
+
+namespace facebook::react {
+
+inline static std::unordered_set<std::string> getDirectManipulationAllowlist() {
+  /**
+   * Direct manipulation eligible styles allowed by the NativeAnimated JS
+   * implementation. Keep in sync with
+   * packages/react-native/Libraries/Animated/NativeAnimatedAllowlist.js
+   */
+  static std::unordered_set<std::string> DIRECT_MANIPULATION_STYLES{
+      /* SUPPORTED_COLOR_STYLES */
+      "backgroundColor",
+      "borderBottomColor",
+      "borderColor",
+      "borderEndColor",
+      "borderLeftColor",
+      "borderRightColor",
+      "borderStartColor",
+      "borderTopColor",
+      "color",
+      "tintColor",
+
+      /* SUPPORTED STYLES */
+      "borderBottomEndRadius",
+      "borderBottomLeftRadius",
+      "borderBottomRightRadius",
+      "borderBottomStartRadius",
+      "borderEndEndRadius",
+      "borderEndStartRadius",
+      "borderRadius",
+      "borderTopEndRadius",
+      "borderTopLeftRadius",
+      "borderTopRightRadius",
+      "borderTopStartRadius",
+      "borderStartEndRadius",
+      "borderStartStartRadius",
+      "elevation",
+      "opacity",
+      "transform",
+      "zIndex",
+      /* ios styles */
+      "shadowOpacity",
+      "shadowRadius",
+      /* legacy android transform properties */
+      "scaleX",
+      "scaleY",
+      "translateX",
+      "translateY",
+  };
+  return DIRECT_MANIPULATION_STYLES;
+}
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/animated/internal/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/internal/primitives.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+#include <react/renderer/core/ReactPrimitives.h>
+
+namespace facebook::react::animated {
+// Indicates that the animated node identifier is not defined.
+// It is safe to use 0 because JavaScript starts assigning identifiers from 1.
+// https://github.com/facebook/react-native/blob/main/packages/react-native/src/private/animated/NativeAnimatedHelper.js#L35
+constexpr static Tag undefinedAnimatedNodeIdentifier = 0;
+} // namespace facebook::react::animated

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManagerProvider.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManagerProvider.cpp
@@ -9,8 +9,8 @@
 
 #include <glog/logging.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
-#include <react/renderer/animated/AnimatedMountingOverrideDelegate.h>
 #include <react/renderer/animated/MergedValueDispatcher.h>
+#include <react/renderer/animated/internal/AnimatedMountingOverrideDelegate.h>
 #include <react/renderer/uimanager/UIManagerBinding.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/InterpolationAnimatedNode.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/InterpolationAnimatedNode.cpp
@@ -13,7 +13,7 @@
 
 #include <react/renderer/animated/NativeAnimatedNodesManager.h>
 #include <react/renderer/animated/drivers/AnimationDriverUtils.h>
-#include <react/renderer/animated/primitives.h>
+#include <react/renderer/animated/internal/primitives.h>
 #include <react/renderer/graphics/HostPlatformColor.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/InterpolationAnimatedNode.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/InterpolationAnimatedNode.h
@@ -13,7 +13,7 @@
 
 #include "ValueAnimatedNode.h"
 
-#include <react/renderer/animated/primitives.h>
+#include <react/renderer/animated/internal/primitives.h>
 #include <react/renderer/graphics/Color.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/PropsAnimatedNode.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/PropsAnimatedNode.h
@@ -13,7 +13,7 @@
 
 #include "AnimatedNode.h"
 
-#include <react/renderer/animated/primitives.h>
+#include <react/renderer/animated/internal/primitives.h>
 #include <mutex>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/StyleAnimatedNode.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/nodes/StyleAnimatedNode.cpp
@@ -11,8 +11,8 @@
 
 #include "StyleAnimatedNode.h"
 
-#include <react/renderer/animated/NativeAnimatedAllowlist.h>
 #include <react/renderer/animated/NativeAnimatedNodesManager.h>
+#include <react/renderer/animated/internal/NativeAnimatedAllowlist.h>
 #include <react/renderer/animated/nodes/ColorAnimatedNode.h>
 #include <react/renderer/animated/nodes/TransformAnimatedNode.h>
 #include <react/renderer/animated/nodes/ValueAnimatedNode.h>

--- a/packages/react-native/ReactCxxPlatform/react/runtime/ReactHost.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/runtime/ReactHost.cpp
@@ -37,7 +37,6 @@
 #include <react/nativemodule/mutationobserver/NativeMutationObserver.h>
 #include <react/nativemodule/webperformance/NativePerformance.h>
 #include <react/renderer/animated/AnimatedModule.h>
-#include <react/renderer/animated/AnimatedMountingOverrideDelegate.h>
 #include <react/renderer/componentregistry/native/NativeComponentRegistryBinding.h>
 #include <react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.h>
 #include <react/renderer/scheduler/SchedulerDelegate.h>


### PR DESCRIPTION
Summary:
changelog: [internal]

move internal files only to internal folder in C++ Animated

Reviewed By: rshest

Differential Revision: D79436926
