### PR TITLE
Disable LongTasksAPI on Github CI

### DIFF
--- a/packages/react-native/src/private/webapis/performance/__tests__/LongTasksAPI-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/LongTasksAPI-itest.js
@@ -42,6 +42,16 @@ function ensurePerformanceLongTaskTiming(
 
 let observer: ?PerformanceObserver;
 
+const constants = Fantom.getConstants();
+const isGithubCI = constants.isOSS && constants.isRunningFromCI;
+
+// Skip the test on Github CI.
+// In that environment, execution speed is unreliable so some of the tasks
+// we schedule as part of the test run (even the task to report long tasks) are
+// also being reported as long, and we don't have a way to distinguish those
+// from the intentionally long tasks we're scheduling for testing.
+const describe = isGithubCI ? global.describe.skip : global.describe;
+
 describe('LongTasks API', () => {
   afterEach(() => {
     if (observer) {

--- a/private/react-native-fantom/runner/entrypoint-template.js
+++ b/private/react-native-fantom/runner/entrypoint-template.js
@@ -65,6 +65,7 @@ ${
 }
 
 setConstants({
+  isOSS: ${String(EnvironmentOptions.isOSS)},
   isRunningFromCI: ${String(EnvironmentOptions.isCI)},
   forceTestModeForBenchmarks: ${String(EnvironmentOptions.forceTestModeForBenchmarks)},
   fantomConfigSummary: '${formatFantomConfig(testConfig)}',

--- a/private/react-native-fantom/src/Constants.js
+++ b/private/react-native-fantom/src/Constants.js
@@ -9,12 +9,14 @@
  */
 
 type FantomConstants = $ReadOnly<{
+  isOSS: boolean,
   isRunningFromCI: boolean,
   forceTestModeForBenchmarks: boolean,
   fantomConfigSummary: string,
 }>;
 
 let constants: FantomConstants = {
+  isOSS: false,
   isRunningFromCI: false,
   forceTestModeForBenchmarks: false,
   fantomConfigSummary: '',


### PR DESCRIPTION
Summary:
Changelog: [internal]

This disables the test for LongTasks API on Github CI as the execution speed there is unreliable and makes the current tests flaky.

Differential Revision: D79510480


