### PR TITLE
Pin Node.js version in GitHub Actions to 24.4.1

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -592,7 +592,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["24", "22", "20.19.4"]
+        node-version: ["24.4.1", "22", "20.19.4"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Summary:
Quick fix to restore CI on `main`. `actions/setup-node` is now pulling Node.js `24.5.0`, which introduces a bug affecting `packages/dev-middleware/src/__tests__/` Jest tests.

Changelog: [Internal]

Differential Revision: D79551277
