### PR TITLE
fix: removed constexpr from now()

### DIFF
--- a/packages/react-native/ReactCommon/react/timing/primitives.h
+++ b/packages/react-native/ReactCommon/react/timing/primitives.h
@@ -196,7 +196,7 @@ class HighResTimeStamp {
   HighResTimeStamp() noexcept
       : chronoTimePoint_(std::chrono::steady_clock::now()) {}
 
-  static constexpr HighResTimeStamp now() noexcept {
+  static HighResTimeStamp now() noexcept {
     return HighResTimeStamp(std::chrono::steady_clock::now());
   }
 


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

This doesn't make sense, I've probably overlooked it while applying this to other methods.

Differential Revision: D79552990


