### PR TITLE
Allow mocking HighResTimeStamp in debug builds

### DIFF
--- a/packages/react-native/ReactCommon/react/timing/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/timing/CMakeLists.txt
@@ -11,5 +11,7 @@ include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 add_library(react_timing INTERFACE)
 
 target_include_directories(react_timing INTERFACE ${REACT_COMMON_DIR})
+target_link_libraries(react_timing INTERFACE
+        react_debug)
 target_compile_reactnative_options(react_timing INTERFACE)
 target_compile_options(react_timing INTERFACE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/timing/React-timing.podspec
+++ b/packages/react-native/ReactCommon/react/timing/React-timing.podspec
@@ -41,4 +41,6 @@ Pod::Spec.new do |s|
     s.module_name            = "React_timing"
     s.header_mappings_dir  = "./"
   end
+
+  add_dependency(s, "React-debug")
 end

--- a/packages/react-native/ReactCommon/react/timing/primitives.h
+++ b/packages/react-native/ReactCommon/react/timing/primitives.h
@@ -7,7 +7,9 @@
 
 #pragma once
 
+#include <react/debug/flags.h>
 #include <chrono>
+#include <functional>
 
 namespace facebook::react {
 
@@ -227,6 +229,14 @@ class HighResTimeStamp {
     return HighResTimeStamp(chronoTimePoint);
   }
 
+#ifdef REACT_NATIVE_DEBUG
+  static void setTimeStampProviderForTesting(
+      std::function<std::chrono::steady_clock::time_point()>&&
+          timeStampProvider) {
+    getTimeStampProvider() = std::move(timeStampProvider);
+  }
+#endif
+
   // This method is provided for convenience, if you need to convert
   // HighResTimeStamp to some common epoch with time stamps from other sources.
   constexpr std::chrono::steady_clock::time_point toChronoSteadyClockTimePoint()
@@ -275,9 +285,24 @@ class HighResTimeStamp {
 
   std::chrono::steady_clock::time_point chronoTimePoint_;
 
+#ifdef REACT_NATIVE_DEBUG
+  static std::function<std::chrono::steady_clock::time_point()>&
+  getTimeStampProvider() {
+    static std::function<std::chrono::steady_clock::time_point()>
+        timeStampProvider = nullptr;
+    return timeStampProvider;
+  }
+
+  static std::chrono::steady_clock::time_point chronoNow() {
+    auto& timeStampProvider = getTimeStampProvider();
+    return timeStampProvider != nullptr ? timeStampProvider()
+                                        : std::chrono::steady_clock::now();
+  }
+#else
   inline static std::chrono::steady_clock::time_point chronoNow() {
     return std::chrono::steady_clock::now();
   }
+#endif
 };
 
 inline constexpr HighResDuration operator-(


### PR DESCRIPTION
Summary:
Changelog: [internal]

This adds a new feature to `HighResTimeStamp` to set a custom timestamp provider for "now" that can be useful for testing, only in debug builds to avoid potentially regressing performance.

Differential Revision: D79554725


