### PR TITLE
Update InspectorNetworkReporter to avoid overhead for CDP-only methods

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/InspectorNetworkReporter.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/InspectorNetworkReporter.kt
@@ -19,6 +19,8 @@ import com.facebook.proguard.annotations.DoNotStripAny
  */
 @DoNotStripAny
 internal object InspectorNetworkReporter {
+  @JvmStatic external fun isDebuggingEnabled(): Boolean
+
   /**
    * Report a network request that is about to be sent.
    * - Corresponds to `Network.requestWillBeSent` in CDP.
@@ -63,7 +65,15 @@ internal object InspectorNetworkReporter {
    *
    * Corresponds to `Network.dataReceived` in CDP.
    */
-  @JvmStatic external fun reportDataReceived(requestId: Int, dataLength: Int)
+  @JvmStatic
+  fun reportDataReceived(requestId: Int, data: String) {
+    // Guard call to CDP-only reporting method (avoid encodeToByteArray calculation)
+    if (isDebuggingEnabled()) {
+      reportDataReceivedImpl(requestId, data.encodeToByteArray().size)
+    }
+  }
+
+  @JvmStatic external fun reportDataReceivedImpl(requestId: Int, dataLength: Int)
 
   /**
    * Report when a network request is complete and we are no longer receiving response data.
@@ -77,7 +87,15 @@ internal object InspectorNetworkReporter {
    * debugging is disabled.
    */
   @JvmStatic
-  external fun maybeStoreResponseBody(requestId: Int, body: String, base64Encoded: Boolean)
+  fun maybeStoreResponseBody(requestId: Int, body: String, base64Encoded: Boolean) {
+    // Guard call to CDP-only reporting method (avoid sending string over JNI)
+    if (isDebuggingEnabled()) {
+      maybeStoreResponseBodyImpl(requestId, body, base64Encoded)
+    }
+  }
+
+  @JvmStatic
+  external fun maybeStoreResponseBodyImpl(requestId: Int, body: String, base64Encoded: Boolean)
 
   /**
    * Incrementally store a response body preview, when a string response is received in chunks.
@@ -86,5 +104,13 @@ internal object InspectorNetworkReporter {
    * As with `maybeStoreResponseBody`, calling this method is optional and a no-op if CDP debugging
    * is disabled.
    */
-  @JvmStatic external fun maybeStoreResponseBodyIncremental(requestId: Int, data: String)
+  @JvmStatic
+  fun maybeStoreResponseBodyIncremental(requestId: Int, data: String) {
+    // Guard call to CDP-only reporting method (avoid sending string over JNI)
+    if (isDebuggingEnabled()) {
+      maybeStoreResponseBodyIncrementalImpl(requestId, data)
+    }
+  }
+
+  @JvmStatic external fun maybeStoreResponseBodyIncrementalImpl(requestId: Int, data: String)
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkEventUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkEventUtil.kt
@@ -67,7 +67,7 @@ internal object NetworkEventUtil {
       total: Long
   ) {
     if (ReactNativeFeatureFlags.enableNetworkEventReporting() && data != null) {
-      InspectorNetworkReporter.reportDataReceived(requestId, data.encodeToByteArray().size)
+      InspectorNetworkReporter.reportDataReceived(requestId, data)
       InspectorNetworkReporter.maybeStoreResponseBodyIncremental(requestId, data)
     }
     reactContext?.emitDeviceEvent(

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/InspectorNetworkReporter.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/InspectorNetworkReporter.cpp
@@ -59,8 +59,13 @@ static std::unordered_map<int, std::string> responseBuffers;
 
 #endif
 
+/* static */ jboolean InspectorNetworkReporter::isDebuggingEnabled(
+    jni::alias_ref<jclass> /*unused*/) {
+  return NetworkReporter::getInstance().isDebuggingEnabled();
+}
+
 /* static */ void InspectorNetworkReporter::reportRequestStart(
-    const jni::alias_ref<jclass> /*unused*/,
+    jni::alias_ref<jclass> /*unused*/,
     jint requestId,
     jni::alias_ref<jstring> requestUrl,
     jni::alias_ref<jstring> requestMethod,
@@ -103,7 +108,7 @@ static std::unordered_map<int, std::string> responseBuffers;
       static_cast<std::int64_t>(encodedDataLength));
 }
 
-/* static */ void InspectorNetworkReporter::reportDataReceived(
+/* static */ void InspectorNetworkReporter::reportDataReceivedImpl(
     jni::alias_ref<jclass> /*unused*/,
     jint requestId,
     jint dataLength) {
@@ -129,7 +134,7 @@ static std::unordered_map<int, std::string> responseBuffers;
 #endif
 }
 
-/* static */ void InspectorNetworkReporter::maybeStoreResponseBody(
+/* static */ void InspectorNetworkReporter::maybeStoreResponseBodyImpl(
     jni::alias_ref<jclass> /*unused*/,
     jint requestId,
     jni::alias_ref<jstring> body,
@@ -146,7 +151,8 @@ static std::unordered_map<int, std::string> responseBuffers;
 #endif
 }
 
-/* static */ void InspectorNetworkReporter::maybeStoreResponseBodyIncremental(
+/* static */ void
+InspectorNetworkReporter::maybeStoreResponseBodyIncrementalImpl(
     jni::alias_ref<jclass> /*unused*/,
     jint requestId,
     jni::alias_ref<jstring> data) {
@@ -165,6 +171,8 @@ static std::unordered_map<int, std::string> responseBuffers;
 /* static */ void InspectorNetworkReporter::registerNatives() {
   javaClassLocal()->registerNatives({
       makeNativeMethod(
+          "isDebuggingEnabled", InspectorNetworkReporter::isDebuggingEnabled),
+      makeNativeMethod(
           "reportRequestStart", InspectorNetworkReporter::reportRequestStart),
       makeNativeMethod(
           "reportResponseStart", InspectorNetworkReporter::reportResponseStart),
@@ -172,15 +180,16 @@ static std::unordered_map<int, std::string> responseBuffers;
           "reportConnectionTiming",
           InspectorNetworkReporter::reportConnectionTiming),
       makeNativeMethod(
-          "reportDataReceived", InspectorNetworkReporter::reportDataReceived),
+          "reportDataReceivedImpl",
+          InspectorNetworkReporter::reportDataReceivedImpl),
       makeNativeMethod(
           "reportResponseEnd", InspectorNetworkReporter::reportResponseEnd),
       makeNativeMethod(
-          "maybeStoreResponseBody",
-          InspectorNetworkReporter::maybeStoreResponseBody),
+          "maybeStoreResponseBodyImpl",
+          InspectorNetworkReporter::maybeStoreResponseBodyImpl),
       makeNativeMethod(
-          "maybeStoreResponseBodyIncremental",
-          InspectorNetworkReporter::maybeStoreResponseBodyIncremental),
+          "maybeStoreResponseBodyIncrementalImpl",
+          InspectorNetworkReporter::maybeStoreResponseBodyIncrementalImpl),
   });
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/InspectorNetworkReporter.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/InspectorNetworkReporter.h
@@ -17,6 +17,8 @@ class InspectorNetworkReporter
   static constexpr auto kJavaDescriptor =
       "Lcom/facebook/react/modules/network/InspectorNetworkReporter;";
 
+  static jboolean isDebuggingEnabled(jni::alias_ref<jclass> /*unused*/);
+
   static void reportRequestStart(
       jni::alias_ref<jclass> /*unused*/,
       jint requestId,
@@ -39,7 +41,7 @@ class InspectorNetworkReporter
       jni::alias_ref<jni::JMap<jstring, jstring>> responseHeaders,
       jlong encodedDataLength);
 
-  static void reportDataReceived(
+  static void reportDataReceivedImpl(
       jni::alias_ref<jclass> /*unused*/,
       jint requestId,
       jint dataLength);
@@ -49,13 +51,13 @@ class InspectorNetworkReporter
       jint requestId,
       jlong encodedDataLength);
 
-  static void maybeStoreResponseBody(
+  static void maybeStoreResponseBodyImpl(
       jni::alias_ref<jclass> /*unused*/,
       jint requestId,
       jni::alias_ref<jstring> body,
       jboolean base64Encoded);
 
-  static void maybeStoreResponseBodyIncremental(
+  static void maybeStoreResponseBodyIncrementalImpl(
       jni::alias_ref<jclass> /*unused*/,
       jint requestId,
       jni::alias_ref<jstring> data);


### PR DESCRIPTION
Summary:
Following D77799617, D77927896, updates `InspectorNetworkReporter.kt` to check `isDebuggingEnabled` internally and avoid work/communication over the JNI layer — to minimise impact on the Android Network stack.

Changelog: [Internal]

Differential Revision: D78004462
