### PR TITLE
Make `ReactCxxErrorHandler` internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1140,11 +1140,6 @@ public abstract class com/facebook/react/bridge/ReactContextBaseJavaModule : com
 	protected final fun getCurrentActivity ()Landroid/app/Activity;
 }
 
-public final class com/facebook/react/bridge/ReactCxxErrorHandler {
-	public static final field INSTANCE Lcom/facebook/react/bridge/ReactCxxErrorHandler;
-	public static final fun setHandleErrorFunc (Ljava/lang/Object;Ljava/lang/reflect/Method;)V
-}
-
 public final class com/facebook/react/bridge/ReactMarker {
 	public static final field INSTANCE Lcom/facebook/react/bridge/ReactMarker;
 	public static final fun addFabricListener (Lcom/facebook/react/bridge/ReactMarker$FabricMarkerListener;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactCxxErrorHandler.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactCxxErrorHandler.kt
@@ -16,7 +16,7 @@ import java.lang.reflect.Method
 
 @DoNotStrip
 @LegacyArchitecture
-public object ReactCxxErrorHandler {
+internal object ReactCxxErrorHandler {
   init {
     LegacyArchitectureLogger.assertLegacyArchitecture(
         "ReactCxxErrorHandler", LegacyArchitectureLogLevel.WARNING)
@@ -27,7 +27,7 @@ public object ReactCxxErrorHandler {
 
   @DoNotStrip
   @JvmStatic
-  public fun setHandleErrorFunc(handlerObject: Any?, handleErrorFunc: Method?) {
+  fun setHandleErrorFunc(handlerObject: Any?, handleErrorFunc: Method?) {
     this.handlerObject = handlerObject
     this.handleErrorFunc = handleErrorFunc
   }


### PR DESCRIPTION
Summary:
This class is Legacy Arch and is not used in OSS. Let's make it internal.

Changelog:
[Internal] [Changed] -

Differential Revision: D79556615


