### PR TITLE
Remove possibility to newArchEnabled=false in 0.82

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -28,8 +28,8 @@ import com.facebook.react.utils.DependencyUtils.readVersionAndGroupStrings
 import com.facebook.react.utils.JdkConfiguratorUtils.configureJavaToolChains
 import com.facebook.react.utils.JsonUtils
 import com.facebook.react.utils.NdkConfiguratorUtils.configureReactNativeNdk
-import com.facebook.react.utils.ProjectUtils.isNewArchEnabled
 import com.facebook.react.utils.ProjectUtils.needsCodegenFromPackageJson
+import com.facebook.react.utils.PropertyUtils
 import com.facebook.react.utils.findPackageJsonFile
 import java.io.File
 import kotlin.system.exitProcess
@@ -43,6 +43,7 @@ import org.gradle.internal.jvm.Jvm
 class ReactPlugin : Plugin<Project> {
   override fun apply(project: Project) {
     checkJvmVersion(project)
+    checkLegacyArchProperty(project)
     val extension = project.extensions.create("react", ReactExtension::class.java, project)
 
     // We register a private extension on the rootProject so that project wide configs
@@ -112,6 +113,30 @@ class ReactPlugin : Plugin<Project> {
       """
               .trimIndent())
       exitProcess(1)
+    }
+  }
+
+  private fun checkLegacyArchProperty(project: Project) {
+    if ((project.hasProperty(PropertyUtils.NEW_ARCH_ENABLED) &&
+        !project.property(PropertyUtils.NEW_ARCH_ENABLED).toString().toBoolean()) ||
+        (project.hasProperty(PropertyUtils.SCOPED_NEW_ARCH_ENABLED) &&
+            !project.property(PropertyUtils.SCOPED_NEW_ARCH_ENABLED).toString().toBoolean())) {
+      project.logger.error(
+          """
+
+      ********************************************************************************
+
+      WARNING: Setting `newArchEnabled=false` in your `gradle.properties` file is not
+      supported anymore since React Native 0.82.
+      
+      You can remove the line from your `gradle.properties` file.
+      
+      The application will run with the New Architecture enabled by default.
+
+      ********************************************************************************
+
+      """
+              .trimIndent())
     }
   }
 
@@ -271,19 +296,17 @@ class ReactPlugin : Plugin<Project> {
               task.generatedOutputDirectory.set(generatedAutolinkingJavaDir)
             }
 
-    if (project.isNewArchEnabled(extension)) {
-      // For New Arch, we also need to generate code for C++ Autolinking
-      val generateAutolinkingNewArchitectureFilesTask =
-          project.tasks.register(
-              "generateAutolinkingNewArchitectureFiles",
-              GenerateAutolinkingNewArchitecturesFileTask::class.java) { task ->
-                task.autolinkInputFile.set(rootGeneratedAutolinkingFile)
-                task.generatedOutputDirectory.set(generatedAutolinkingJniDir)
-              }
-      project.tasks
-          .named("preBuild", Task::class.java)
-          .dependsOn(generateAutolinkingNewArchitectureFilesTask)
-    }
+    // We also need to generate code for C++ Autolinking
+    val generateAutolinkingNewArchitectureFilesTask =
+        project.tasks.register(
+            "generateAutolinkingNewArchitectureFiles",
+            GenerateAutolinkingNewArchitecturesFileTask::class.java) { task ->
+              task.autolinkInputFile.set(rootGeneratedAutolinkingFile)
+              task.generatedOutputDirectory.set(generatedAutolinkingJniDir)
+            }
+    project.tasks
+        .named("preBuild", Task::class.java)
+        .dependsOn(generateAutolinkingNewArchitectureFilesTask)
 
     // We let generateAutolinkingPackageList and generateEntryPoint depend on the preBuild task so
     // it's executed before

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/AgpConfiguratorUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/AgpConfiguratorUtils.kt
@@ -13,7 +13,6 @@ import com.android.build.gradle.LibraryExtension
 import com.facebook.react.ReactExtension
 import com.facebook.react.utils.ProjectUtils.isEdgeToEdgeEnabled
 import com.facebook.react.utils.ProjectUtils.isHermesEnabled
-import com.facebook.react.utils.ProjectUtils.isNewArchEnabled
 import java.io.File
 import java.net.Inet4Address
 import java.net.NetworkInterface
@@ -65,10 +64,7 @@ internal object AgpConfiguratorUtils {
               .getByType(ApplicationAndroidComponentsExtension::class.java)
               .finalizeDsl { ext ->
                 ext.buildFeatures.buildConfig = true
-                ext.defaultConfig.buildConfigField(
-                    "boolean",
-                    "IS_NEW_ARCHITECTURE_ENABLED",
-                    project.isNewArchEnabled(extension).toString())
+                ext.defaultConfig.buildConfigField("boolean", "IS_NEW_ARCHITECTURE_ENABLED", "true")
                 ext.defaultConfig.buildConfigField(
                     "boolean", "IS_HERMES_ENABLED", project.isHermesEnabled.toString())
                 ext.defaultConfig.buildConfigField(

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/ProjectUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/ProjectUtils.kt
@@ -13,11 +13,9 @@ import com.facebook.react.utils.KotlinStdlibCompatUtils.lowercaseCompat
 import com.facebook.react.utils.KotlinStdlibCompatUtils.toBooleanStrictOrNullCompat
 import com.facebook.react.utils.PropertyUtils.EDGE_TO_EDGE_ENABLED
 import com.facebook.react.utils.PropertyUtils.HERMES_ENABLED
-import com.facebook.react.utils.PropertyUtils.NEW_ARCH_ENABLED
 import com.facebook.react.utils.PropertyUtils.REACT_NATIVE_ARCHITECTURES
 import com.facebook.react.utils.PropertyUtils.SCOPED_EDGE_TO_EDGE_ENABLED
 import com.facebook.react.utils.PropertyUtils.SCOPED_HERMES_ENABLED
-import com.facebook.react.utils.PropertyUtils.SCOPED_NEW_ARCH_ENABLED
 import com.facebook.react.utils.PropertyUtils.SCOPED_REACT_NATIVE_ARCHITECTURES
 import com.facebook.react.utils.PropertyUtils.SCOPED_USE_THIRD_PARTY_JSC
 import com.facebook.react.utils.PropertyUtils.USE_THIRD_PARTY_JSC
@@ -28,12 +26,7 @@ internal object ProjectUtils {
 
   const val HERMES_FALLBACK = true
 
-  internal fun Project.isNewArchEnabled(extension: ReactExtension): Boolean {
-    return (project.hasProperty(NEW_ARCH_ENABLED) &&
-        project.property(NEW_ARCH_ENABLED).toString().toBoolean()) ||
-        (project.hasProperty(SCOPED_NEW_ARCH_ENABLED) &&
-            project.property(SCOPED_NEW_ARCH_ENABLED).toString().toBoolean())
-  }
+  internal fun Project.isNewArchEnabled(): Boolean = true
 
   internal val Project.isHermesEnabled: Boolean
     get() =

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/ProjectUtilsTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/ProjectUtilsTest.kt
@@ -27,70 +27,8 @@ class ProjectUtilsTest {
   @get:Rule val tempFolder = TemporaryFolder()
 
   @Test
-  fun isNewArchEnabled_returnsFalseByDefault() {
-    val project = createProject()
-    val extension = TestReactExtension(project)
-    assertThat(createProject().isNewArchEnabled(extension)).isFalse()
-  }
-
-  @Test
-  fun isNewArchEnabled_withDisabled_returnsFalse() {
-    val project = createProject()
-    project.extensions.extraProperties.set("newArchEnabled", "false")
-    val extension = TestReactExtension(project)
-    assertThat(project.isNewArchEnabled(extension)).isFalse()
-  }
-
-  @Test
-  fun isNewArchEnabled_withEnabled_returnsTrue() {
-    val project = createProject()
-    project.extensions.extraProperties.set("newArchEnabled", "true")
-    val extension = TestReactExtension(project)
-    assertThat(project.isNewArchEnabled(extension)).isTrue()
-  }
-
-  @Test
-  fun isNewArchEnabled_withInvalid_returnsFalse() {
-    val project = createProject()
-    project.extensions.extraProperties.set("newArchEnabled", "¯\\_(ツ)_/¯")
-    val extension = TestReactExtension(project)
-    assertThat(project.isNewArchEnabled(extension)).isFalse()
-  }
-
-  @Test
-  fun isNewArchEnabled_withRNVersion0_returnFalse() {
-    val project = createProject()
-    val extension = TestReactExtension(project)
-    File(tempFolder.root, "package.json").apply {
-      writeText(
-          // language=json
-          """
-      {
-        "version": "0.73.0"
-      }
-      """
-              .trimIndent())
-    }
-    extension.reactNativeDir.set(tempFolder.root)
-    assertThat(project.isNewArchEnabled(extension)).isFalse()
-  }
-
-  @Test
-  fun isNewArchEnabled_withRNVersion1000_returnFalse() {
-    val project = createProject()
-    val extension = TestReactExtension(project)
-    File(tempFolder.root, "package.json").apply {
-      writeText(
-          // language=json
-          """
-      {
-        "version": "1000.0.0"
-      }
-      """
-              .trimIndent())
-    }
-    extension.reactNativeDir.set(tempFolder.root)
-    assertThat(project.isNewArchEnabled(extension)).isFalse()
+  fun isNewArchEnabled_alwaysReturnsTrue() {
+    assertThat(createProject().isNewArchEnabled()).isTrue()
   }
 
   @Test

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactNativeHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactNativeHost.kt
@@ -42,7 +42,8 @@ protected constructor(
       if (isNewArchEnabled) {
         DefaultTurboModuleManagerDelegate.Builder()
       } else {
-        null
+        error(
+            "Overriding isNewArchEnabled to false is not supported anymore since React Native 0.82. Please check your MainApplication.kt file, and remove the override for `isNewArchEnabled`.")
       }
 
   override fun getUIManagerProvider(): UIManagerProvider? =
@@ -69,7 +70,8 @@ protected constructor(
               .createUIManager(reactApplicationContext)
         }
       } else {
-        null
+        error(
+            "Overriding isNewArchEnabled to false is not supported anymore since React Native 0.82. Please check your MainApplication.kt file, and remove the override for `isNewArchEnabled`.")
       }
 
   override fun clear() {
@@ -86,7 +88,7 @@ protected constructor(
    * If false, the app will not attempt to load the New Architecture modules.
    */
   protected open val isNewArchEnabled: Boolean
-    get() = false
+    get() = true
 
   /**
    * Returns whether the user wants to use Hermes.

--- a/private/helloworld/android/app/src/main/java/com/helloworld/MainApplication.kt
+++ b/private/helloworld/android/app/src/main/java/com/helloworld/MainApplication.kt
@@ -30,8 +30,6 @@ class MainApplication : Application(), ReactApplication {
         override fun getJSMainModuleName(): String = "index"
 
         override fun getUseDeveloperSupport(): Boolean = BuildConfig.DEBUG
-
-        override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
       }
 
   override val reactHost: ReactHost


### PR DESCRIPTION
Summary:
It's now time to say goodbye to the Legacy Architecture :')

This change hardcodes the `newArchEnabled` property to true, and warns the users
if they're attempting to set it to false.

Changelog:
[Android] [Breaking] - Remove possibility to newArchEnabled=false in 0.82

Differential Revision: D78560296


