### PR TITLE
Prevent users from opting-out of the New Architecture

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
@@ -31,7 +31,7 @@
 
 void RCTAppSetupPrepareApp(UIApplication *application, BOOL turboModuleEnabled)
 {
-  RCTEnableTurboModule(turboModuleEnabled);
+  RCTEnableTurboModule(YES);
 
 #if DEBUG
   // Disable idle timer in dev builds to avoid putting application in background and complicating
@@ -43,15 +43,12 @@ void RCTAppSetupPrepareApp(UIApplication *application, BOOL turboModuleEnabled)
 UIView *
 RCTAppSetupDefaultRootView(RCTBridge *bridge, NSString *moduleName, NSDictionary *initialProperties, BOOL fabricEnabled)
 {
-  if (fabricEnabled) {
-    id<RCTSurfaceProtocol> surface = [[RCTFabricSurface alloc] initWithBridge:bridge
-                                                                   moduleName:moduleName
-                                                            initialProperties:initialProperties];
-    UIView *rootView = [[RCTSurfaceHostingProxyRootView alloc] initWithSurface:surface];
-    [surface start];
-    return rootView;
-  }
-  return [[RCTRootView alloc] initWithBridge:bridge moduleName:moduleName initialProperties:initialProperties];
+  id<RCTSurfaceProtocol> surface = [[RCTFabricSurface alloc] initWithBridge:bridge
+                                                                 moduleName:moduleName
+                                                          initialProperties:initialProperties];
+  UIView *rootView = [[RCTSurfaceHostingProxyRootView alloc] initWithSurface:surface];
+  [surface start];
+  return rootView;
 }
 
 NSArray<NSString *> *RCTAppSetupUnstableModulesRequiringMainQueueSetup(id<RCTDependencyProvider> dependencyProvider)

--- a/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
@@ -57,8 +57,7 @@
                           moduleName:(NSString *)moduleName
                            initProps:(NSDictionary *)initProps
 {
-  BOOL enableFabric = self.fabricEnabled;
-  UIView *rootView = RCTAppSetupDefaultRootView(bridge, moduleName, initProps, enableFabric);
+  UIView *rootView = RCTAppSetupDefaultRootView(bridge, moduleName, initProps, YES);
 
   rootView.backgroundColor = [UIColor systemBackgroundColor];
 
@@ -107,22 +106,22 @@
 
 - (BOOL)newArchEnabled
 {
-  return RCTIsNewArchEnabled();
+  return YES;
 }
 
 - (BOOL)bridgelessEnabled
 {
-  return self.newArchEnabled;
+  return YES;
 }
 
 - (BOOL)fabricEnabled
 {
-  return self.newArchEnabled;
+  return YES;
 }
 
 - (BOOL)turboModuleEnabled
 {
-  return self.newArchEnabled;
+  return YES;
 }
 
 - (Class)getModuleClassFromName:(const char *)name

--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
@@ -52,17 +52,12 @@ using namespace facebook::react;
     self.delegate = delegate;
     [self _setUpFeatureFlags:releaseLevel];
 
-    auto newArchEnabled = [self newArchEnabled];
-    auto fabricEnabled = [self fabricEnabled];
-
     [RCTColorSpaceUtils applyDefaultColorSpace:[self defaultColorSpace]];
-    RCTEnableTurboModule([self turboModuleEnabled]);
+    RCTEnableTurboModule(YES);
 
     self.rootViewFactory = [self createRCTRootViewFactory];
 
-    if (newArchEnabled || fabricEnabled) {
-      [RCTComponentViewFactory currentComponentViewFactory].thirdPartyFabricComponentsProvider = self;
-    }
+    [RCTComponentViewFactory currentComponentViewFactory].thirdPartyFabricComponentsProvider = self;
   }
 
   return self;
@@ -126,37 +121,22 @@ using namespace facebook::react;
 
 - (BOOL)newArchEnabled
 {
-  if ([_delegate respondsToSelector:@selector(newArchEnabled)]) {
-    return _delegate.newArchEnabled;
-  }
-  return RCTIsNewArchEnabled();
+  return YES;
 }
 
 - (BOOL)fabricEnabled
 {
-  if ([_delegate respondsToSelector:@selector(fabricEnabled)]) {
-    return _delegate.fabricEnabled;
-  }
-
-  return [self newArchEnabled];
+  return YES;
 }
 
 - (BOOL)turboModuleEnabled
 {
-  if ([_delegate respondsToSelector:@selector(turboModuleEnabled)]) {
-    return _delegate.turboModuleEnabled;
-  }
-
-  return [self newArchEnabled];
+  return YES;
 }
 
 - (BOOL)bridgelessEnabled
 {
-  if ([_delegate respondsToSelector:@selector(bridgelessEnabled)]) {
-    return _delegate.bridgelessEnabled;
-  }
-
-  return [self newArchEnabled];
+  return YES;
 }
 
 #pragma mark - RCTTurboModuleManagerDelegate
@@ -250,9 +230,9 @@ using namespace facebook::react;
 
   RCTRootViewFactoryConfiguration *configuration =
       [[RCTRootViewFactoryConfiguration alloc] initWithBundleURLBlock:bundleUrlBlock
-                                                       newArchEnabled:self.fabricEnabled
-                                                   turboModuleEnabled:self.turboModuleEnabled
-                                                    bridgelessEnabled:self.bridgelessEnabled];
+                                                       newArchEnabled:YES
+                                                   turboModuleEnabled:YES
+                                                    bridgelessEnabled:YES];
 
   configuration.createRootViewWithBridge = ^UIView *(RCTBridge *bridge, NSString *moduleName, NSDictionary *initProps) {
     return [weakSelf.delegate createRootViewWithBridge:bridge moduleName:moduleName initProps:initProps];
@@ -334,9 +314,7 @@ using namespace facebook::react;
   dispatch_once(&setupFeatureFlagsToken, ^{
     switch (releaseLevel) {
       case Stable:
-        if ([self bridgelessEnabled]) {
-          ReactNativeFeatureFlags::override(std::make_unique<ReactNativeFeatureFlagsOverridesOSSStable>());
-        }
+        ReactNativeFeatureFlags::override(std::make_unique<ReactNativeFeatureFlagsOverridesOSSStable>());
         break;
       case Canary:
         ReactNativeFeatureFlags::override(std::make_unique<ReactNativeFeatureFlagsOverridesOSSCanary>());

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
@@ -73,9 +73,9 @@
 {
   if (self = [super init]) {
     _bundleURLBlock = bundleURLBlock;
-    _fabricEnabled = newArchEnabled;
-    _turboModuleEnabled = turboModuleEnabled;
-    _bridgelessEnabled = bridgelessEnabled;
+    _fabricEnabled = YES;
+    _turboModuleEnabled = YES;
+    _bridgelessEnabled = YES;
   }
   return self;
 }
@@ -135,17 +135,12 @@
 
 - (void)initializeReactHostWithLaunchOptions:(NSDictionary *)launchOptions
 {
-  if (_configuration.bridgelessEnabled) {
-    // Enable TurboModule interop by default in Bridgeless mode
-    RCTEnableTurboModuleInterop(YES);
-    RCTEnableTurboModuleInteropBridgeProxy(YES);
+  // Enable TurboModule interop by default in Bridgeless mode
+  RCTEnableTurboModuleInterop(YES);
+  RCTEnableTurboModuleInteropBridgeProxy(YES);
 
-    [self createReactHostIfNeeded:launchOptions];
-    return;
-  }
-
-  [self createBridgeIfNeeded:launchOptions];
-  [self createBridgeAdapterIfNeeded];
+  [self createReactHostIfNeeded:launchOptions];
+  return;
 }
 
 - (UIView *)viewWithModuleName:(NSString *)moduleName
@@ -154,29 +149,17 @@
 {
   [self initializeReactHostWithLaunchOptions:launchOptions];
 
-  if (_configuration.bridgelessEnabled) {
-    RCTFabricSurface *surface = [self.reactHost createSurfaceWithModuleName:moduleName initialProperties:initProps];
+  RCTFabricSurface *surface = [self.reactHost createSurfaceWithModuleName:moduleName
+                                                        initialProperties:initProps ? initProps : @{}];
 
-    RCTSurfaceHostingProxyRootView *surfaceHostingProxyRootView =
-        [[RCTSurfaceHostingProxyRootView alloc] initWithSurface:surface];
+  RCTSurfaceHostingProxyRootView *surfaceHostingProxyRootView =
+      [[RCTSurfaceHostingProxyRootView alloc] initWithSurface:surface];
 
-    surfaceHostingProxyRootView.backgroundColor = [UIColor systemBackgroundColor];
-    if (_configuration.customizeRootView != nil) {
-      _configuration.customizeRootView(surfaceHostingProxyRootView);
-    }
-    return surfaceHostingProxyRootView;
-  }
-
-  UIView *rootView;
-  if (_configuration.createRootViewWithBridge != nil) {
-    rootView = _configuration.createRootViewWithBridge(self.bridge, moduleName, initProps);
-  } else {
-    rootView = [self createRootViewWithBridge:self.bridge moduleName:moduleName initProps:initProps];
-  }
+  surfaceHostingProxyRootView.backgroundColor = [UIColor systemBackgroundColor];
   if (_configuration.customizeRootView != nil) {
-    _configuration.customizeRootView(rootView);
+    _configuration.customizeRootView(surfaceHostingProxyRootView);
   }
-  return rootView;
+  return surfaceHostingProxyRootView;
 }
 
 - (RCTBridge *)createBridgeWithDelegate:(id<RCTBridgeDelegate>)delegate launchOptions:(NSDictionary *)launchOptions
@@ -188,8 +171,7 @@
                           moduleName:(NSString *)moduleName
                            initProps:(NSDictionary *)initProps
 {
-  BOOL enableFabric = _configuration.fabricEnabled;
-  UIView *rootView = RCTAppSetupDefaultRootView(bridge, moduleName, initProps, enableFabric);
+  UIView *rootView = RCTAppSetupDefaultRootView(bridge, moduleName, initProps, YES);
   rootView.backgroundColor = [UIColor systemBackgroundColor];
   return rootView;
 }
@@ -198,19 +180,15 @@
 - (std::unique_ptr<facebook::react::JSExecutorFactory>)jsExecutorFactoryForBridge:(RCTBridge *)bridge
 {
   _runtimeScheduler = std::make_shared<facebook::react::RuntimeScheduler>(RCTRuntimeExecutorFromBridge(bridge));
-  if (RCTIsNewArchEnabled()) {
-    std::shared_ptr<facebook::react::CallInvoker> callInvoker =
-        std::make_shared<facebook::react::RuntimeSchedulerCallInvoker>(_runtimeScheduler);
-    RCTTurboModuleManager *turboModuleManager =
-        [[RCTTurboModuleManager alloc] initWithBridge:bridge
-                                             delegate:_turboModuleManagerDelegate
-                                            jsInvoker:callInvoker];
-    _contextContainer->erase("RuntimeScheduler");
-    _contextContainer->insert("RuntimeScheduler", _runtimeScheduler);
-    return RCTAppSetupDefaultJsExecutorFactory(bridge, turboModuleManager, _runtimeScheduler);
-  } else {
-    return RCTAppSetupJsExecutorFactoryForOldArch(bridge, _runtimeScheduler);
-  }
+
+  std::shared_ptr<facebook::react::CallInvoker> callInvoker =
+      std::make_shared<facebook::react::RuntimeSchedulerCallInvoker>(_runtimeScheduler);
+  RCTTurboModuleManager *turboModuleManager = [[RCTTurboModuleManager alloc] initWithBridge:bridge
+                                                                                   delegate:_turboModuleManagerDelegate
+                                                                                  jsInvoker:callInvoker];
+  _contextContainer->erase("RuntimeScheduler");
+  _contextContainer->insert("RuntimeScheduler", _runtimeScheduler);
+  return RCTAppSetupDefaultJsExecutorFactory(bridge, turboModuleManager, _runtimeScheduler);
 }
 
 - (void)createBridgeIfNeeded:(NSDictionary *)launchOptions
@@ -228,7 +206,7 @@
 
 - (void)createBridgeAdapterIfNeeded
 {
-  if (!self->_configuration.fabricEnabled || self.bridgeAdapter) {
+  if (self.bridgeAdapter != nullptr) {
     return;
   }
 

--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -141,8 +141,7 @@ NSMutableArray<NSString *> *getModulesLoadedWithOldArch(void)
 void RCTRegisterModule(Class);
 void RCTRegisterModule(Class moduleClass)
 {
-  if (RCTAreLegacyLogsEnabled() && RCTIsNewArchEnabled() &&
-      ![getCoreModuleClasses() containsObject:[moduleClass description]]) {
+  if (RCTAreLegacyLogsEnabled() && ![getCoreModuleClasses() containsObject:[moduleClass description]]) {
     addModuleLoadedWithOldArch([moduleClass description]);
   }
   static dispatch_once_t onceToken;
@@ -183,7 +182,7 @@ NSString *RCTBridgeModuleNameForClass(Class cls)
   return RCTDropReactPrefixes(name);
 }
 
-static BOOL turboModuleEnabled = NO;
+static const BOOL turboModuleEnabled = YES;
 BOOL RCTTurboModuleEnabled(void)
 {
 #if RCT_DEBUG
@@ -197,7 +196,7 @@ BOOL RCTTurboModuleEnabled(void)
 
 void RCTEnableTurboModule(BOOL enabled)
 {
-  turboModuleEnabled = enabled;
+  // The new Architecture is enabled by default and we are ignoring changes to the TurboModule system.
 }
 
 static BOOL turboModuleInteropEnabled = NO;

--- a/packages/react-native/React/Base/RCTUtils.mm
+++ b/packages/react-native/React/Base/RCTUtils.mm
@@ -43,8 +43,7 @@ UIDeviceOrientation RCTDeviceOrientation(void);
 // Whether the New Architecture is enabled or not
 BOOL RCTIsNewArchEnabled(void)
 {
-  NSNumber *rctNewArchEnabled = (NSNumber *)[[NSBundle mainBundle] objectForInfoDictionaryKey:@"RCTNewArchEnabled"];
-  return rctNewArchEnabled == nil || rctNewArchEnabled.boolValue;
+  return YES;
 }
 void RCTSetNewArchEnabled(BOOL enabled)
 {

--- a/packages/react-native/scripts/cocoapods/__tests__/new_architecture-test.rb
+++ b/packages/react-native/scripts/cocoapods/__tests__/new_architecture-test.rb
@@ -240,12 +240,6 @@ class NewArchitectureTests < Test::Unit::TestCase
         assert_true(is_enabled)
     end
 
-    def test_newArchEnabled_whenRCTNewArchEnabledIsSetTo0_returnFalse
-        ENV["RCT_NEW_ARCH_ENABLED"] = "0"
-        is_enabled = NewArchitectureHelper.new_arch_enabled
-        assert_false(is_enabled)
-    end
-
     def test_newArchEnabled_whenRCTNewArchEnabledIsNotSet_returnTrue
         ENV["RCT_NEW_ARCH_ENABLED"] = nil
         is_enabled = NewArchitectureHelper.new_arch_enabled

--- a/packages/react-native/scripts/cocoapods/codegen.rb
+++ b/packages/react-native/scripts/cocoapods/codegen.rb
@@ -9,7 +9,7 @@ require_relative './helpers.rb'
 def run_codegen!(
   app_path,
   config_file_dir,
-  new_arch_enabled: false,
+  new_arch_enabled: true,
   disable_codegen: false,
   react_native_path: "../node_modules/react-native",
   fabric_enabled: false,

--- a/packages/react-native/scripts/cocoapods/new_architecture.rb
+++ b/packages/react-native/scripts/cocoapods/new_architecture.rb
@@ -153,7 +153,7 @@ class NewArchitectureHelper
     end
 
     def self.new_arch_enabled
-        return ENV["RCT_NEW_ARCH_ENABLED"] == '0' ? false : true
+        return true
     end
 
     def self.set_RCTNewArchEnabled_in_info_plist(installer, new_arch_enabled)

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -56,7 +56,7 @@ end
 # Parameters
 # - path: path to react_native installation.
 # - fabric_enabled: whether fabric should be enabled or not.
-# - new_arch_enabled: whether the new architecture should be enabled or not.
+# - new_arch_enabled: [DEPRECATED] whether the new architecture should be enabled or not.
 # - :production [DEPRECATED] whether the dependencies must be installed to target a Debug or a Release build.
 # - hermes_enabled: whether Hermes should be enabled or not.
 # - app_path: path to the React Native app. Required by the New Architecture.
@@ -94,11 +94,11 @@ def use_react_native! (
   # Better to rely and enable this environment flag if the new architecture is turned on using flags.
   relative_path_from_current = Pod::Config.instance.installation_root.relative_path_from(Pathname.pwd)
   react_native_version = NewArchitectureHelper.extract_react_native_version(File.join(relative_path_from_current, path))
-  fabric_enabled = fabric_enabled || NewArchitectureHelper.new_arch_enabled
+  fabric_enabled = true
 
-  ENV['RCT_FABRIC_ENABLED'] = fabric_enabled ? "1" : "0"
+  ENV['RCT_FABRIC_ENABLED'] = "1"
   ENV['RCT_AGGREGATE_PRIVACY_FILES'] = privacy_file_aggregation_enabled ? "1" : "0"
-  ENV["RCT_NEW_ARCH_ENABLED"] = new_arch_enabled ? "1" : "0"
+  ENV["RCT_NEW_ARCH_ENABLED"] = "1"
 
   prefix = path
 
@@ -110,7 +110,7 @@ def use_react_native! (
   # Update ReactNativeCoreUtils so that we can easily switch between source and prebuilt
   ReactNativeCoreUtils.setup_rncore(prefix, react_native_version)
 
-  Pod::UI.puts "Configuring the target with the #{new_arch_enabled ? "New" : "Legacy"} Architecture\n"
+  Pod::UI.puts "Configuring the target with the New Architecture\n"
 
   # The Pods which should be included in all projects
   pod 'FBLazyVector', :path => "#{prefix}/Libraries/FBLazyVector"
@@ -270,10 +270,10 @@ end
 #
 # Parameters:
 # - spec: The spec that has to be configured with the New Architecture code
-# - new_arch_enabled: Whether the module should install dependencies for the new architecture
+# - new_arch_enabled: [DEPRECATED] Whether the module should install dependencies for the new architecture
 def install_modules_dependencies(spec, new_arch_enabled: NewArchitectureHelper.new_arch_enabled)
   folly_config = get_folly_config()
-  NewArchitectureHelper.install_modules_dependencies(spec, new_arch_enabled, folly_config[:version])
+  NewArchitectureHelper.install_modules_dependencies(spec, true, folly_config[:version])
 end
 
 # This function is used by podspecs that needs to use the prebuilt sources for React Native.

--- a/packages/rn-tester/RNTester/AppDelegate.mm
+++ b/packages/rn-tester/RNTester/AppDelegate.mm
@@ -137,7 +137,7 @@ static NSString *kBundlePath = @"js/RNTesterApp.ios";
 
 - (BOOL)bridgelessEnabled
 {
-  return [super bridgelessEnabled];
+  return YES;
 }
 
 #pragma mark - RCTComponentViewFactoryComponentProvider


### PR DESCRIPTION
Summary:
This change prevents users from opting out of the New Architecure.

The change is non breaking with respect to building an app: all the functions are still there, even if they are unreachable, in case users will still call them explicitly.
We hardcoded all the values to enable the New Architecture, so there is no way to disable it.

This is a behavioral breaking change, though.

## Changelog:
[iOS][Removed] - Removed the opt-out from the New Architecture.

Differential Revision: D79090048


