### PR TITLE
Remove redundant methods to mock timers from PerformanceEntryReporter and NativePerformance

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.cpp
@@ -131,7 +131,7 @@ NativePerformance::NativePerformance(std::shared_ptr<CallInvoker> jsInvoker)
     : NativePerformanceCxxSpec(std::move(jsInvoker)) {}
 
 HighResTimeStamp NativePerformance::now(jsi::Runtime& /*rt*/) {
-  return forcedCurrentTimeStamp_.value_or(HighResTimeStamp::now());
+  return HighResTimeStamp::now();
 }
 
 void NativePerformance::reportMark(
@@ -394,12 +394,6 @@ NativePerformance::getSupportedPerformanceEntryTypes(jsi::Runtime& /*rt*/) {
 }
 
 #pragma mark - Testing
-
-void NativePerformance::setCurrentTimeStampForTesting(
-    jsi::Runtime& /*rt*/,
-    HighResTimeStamp ts) {
-  forcedCurrentTimeStamp_ = ts;
-}
 
 void NativePerformance::clearEventCountsForTesting(jsi::Runtime& /*rt*/) {
   PerformanceEntryReporter::getInstance()->clearEventCounts();

--- a/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.h
@@ -186,11 +186,7 @@ class NativePerformance : public NativePerformanceCxxSpec<NativePerformance> {
 
 #pragma mark - Testing
 
-  void setCurrentTimeStampForTesting(jsi::Runtime& rt, HighResTimeStamp ts);
   void clearEventCountsForTesting(jsi::Runtime& rt);
-
- private:
-  std::optional<HighResTimeStamp> forcedCurrentTimeStamp_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.cpp
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.cpp
@@ -89,9 +89,9 @@ PerformanceEntryReporter::PerformanceEntryReporter()
 }
 
 HighResTimeStamp PerformanceEntryReporter::getCurrentTimeStamp() const {
-  return timeStampProvider_ != nullptr ? timeStampProvider_()
-                                       : HighResTimeStamp::now();
+  return HighResTimeStamp::now();
 }
+
 void PerformanceEntryReporter::addEventTimingListener(
     PerformanceEntryReporterEventTimingListener* listener) {
   std::unique_lock lock(listenersMutex_);

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.h
@@ -70,10 +70,6 @@ class PerformanceEntryReporter {
 
   HighResTimeStamp getCurrentTimeStamp() const;
 
-  void setTimeStampProvider(std::function<HighResTimeStamp()> provider) {
-    timeStampProvider_ = std::move(provider);
-  }
-
   void addEventTimingListener(
       PerformanceEntryReporterEventTimingListener* listener);
   void removeEventTimingListener(
@@ -138,7 +134,6 @@ class PerformanceEntryReporter {
 
   std::unordered_map<std::string, uint32_t> eventCounts_;
 
-  std::function<HighResTimeStamp()> timeStampProvider_ = nullptr;
   mutable std::shared_mutex listenersMutex_;
   std::vector<PerformanceEntryReporterEventTimingListener*>
       eventTimingListeners_{};

--- a/packages/react-native/ReactCommon/react/timing/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/timing/CMakeLists.txt
@@ -11,5 +11,7 @@ include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 add_library(react_timing INTERFACE)
 
 target_include_directories(react_timing INTERFACE ${REACT_COMMON_DIR})
+target_link_libraries(react_timing INTERFACE
+        react_debug)
 target_compile_reactnative_options(react_timing INTERFACE)
 target_compile_options(react_timing INTERFACE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/timing/React-timing.podspec
+++ b/packages/react-native/ReactCommon/react/timing/React-timing.podspec
@@ -41,4 +41,6 @@ Pod::Spec.new do |s|
     s.module_name            = "React_timing"
     s.header_mappings_dir  = "./"
   end
+
+  add_dependency(s, "React-debug")
 end

--- a/packages/react-native/ReactCommon/react/timing/primitives.h
+++ b/packages/react-native/ReactCommon/react/timing/primitives.h
@@ -193,11 +193,10 @@ class HighResTimeStamp {
       const HighResDuration& rhs);
 
  public:
-  HighResTimeStamp() noexcept
-      : chronoTimePoint_(std::chrono::steady_clock::now()) {}
+  HighResTimeStamp() noexcept : chronoTimePoint_(chronoNow()) {}
 
   static HighResTimeStamp now() noexcept {
-    return HighResTimeStamp(std::chrono::steady_clock::now());
+    return HighResTimeStamp(chronoNow());
   }
 
   static constexpr HighResTimeStamp min() noexcept {
@@ -275,6 +274,10 @@ class HighResTimeStamp {
       : chronoTimePoint_(chronoTimePoint) {}
 
   std::chrono::steady_clock::time_point chronoTimePoint_;
+
+  inline static std::chrono::steady_clock::time_point chronoNow() {
+    return std::chrono::steady_clock::now();
+  }
 };
 
 inline constexpr HighResDuration operator-(

--- a/packages/react-native/ReactCommon/react/timing/primitives.h
+++ b/packages/react-native/ReactCommon/react/timing/primitives.h
@@ -7,7 +7,9 @@
 
 #pragma once
 
+#include <react/debug/flags.h>
 #include <chrono>
+#include <functional>
 
 namespace facebook::react {
 
@@ -227,6 +229,14 @@ class HighResTimeStamp {
     return HighResTimeStamp(chronoTimePoint);
   }
 
+#ifdef REACT_NATIVE_DEBUG
+  static void setTimeStampProviderForTesting(
+      std::function<std::chrono::steady_clock::time_point()>&&
+          timeStampProvider) {
+    getTimeStampProvider() = std::move(timeStampProvider);
+  }
+#endif
+
   // This method is provided for convenience, if you need to convert
   // HighResTimeStamp to some common epoch with time stamps from other sources.
   constexpr std::chrono::steady_clock::time_point toChronoSteadyClockTimePoint()
@@ -275,9 +285,24 @@ class HighResTimeStamp {
 
   std::chrono::steady_clock::time_point chronoTimePoint_;
 
+#ifdef REACT_NATIVE_DEBUG
+  static std::function<std::chrono::steady_clock::time_point()>&
+  getTimeStampProvider() {
+    static std::function<std::chrono::steady_clock::time_point()>
+        timeStampProvider = nullptr;
+    return timeStampProvider;
+  }
+
+  static std::chrono::steady_clock::time_point chronoNow() {
+    auto& timeStampProvider = getTimeStampProvider();
+    return timeStampProvider != nullptr ? timeStampProvider()
+                                        : std::chrono::steady_clock::now();
+  }
+#else
   inline static std::chrono::steady_clock::time_point chronoNow() {
     return std::chrono::steady_clock::now();
   }
+#endif
 };
 
 inline constexpr HighResDuration operator-(

--- a/packages/react-native/src/private/testing/fantom/specs/NativeFantom.js
+++ b/packages/react-native/src/private/testing/fantom/specs/NativeFantom.js
@@ -116,6 +116,7 @@ interface Spec extends TurboModule {
     shadowNode: mixed /* ShadowNode */,
   ): () => ?number;
   saveJSMemoryHeapSnapshot: (filePath: string) => void;
+  forceHighResTimeStamp: (timeStamp: ?number) => void;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>(

--- a/packages/react-native/src/private/webapis/performance/__tests__/UserTiming-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/UserTiming-itest.js
@@ -18,11 +18,8 @@ import type {
 
 import ensureInstance from '../../../__tests__/utilities/ensureInstance';
 import DOMException from '../../errors/DOMException';
-import MaybeNativePerformance from '../specs/NativePerformance';
 import {PerformanceMark, PerformanceMeasure} from '../UserTiming';
-import nullthrows from 'nullthrows';
-
-const NativePerformance = nullthrows(MaybeNativePerformance);
+import * as Fantom from '@react-native/fantom';
 
 declare var performance: Performance;
 
@@ -39,15 +36,23 @@ function toJSON(entries: PerformanceEntryList): Array<PerformanceEntryJSON> {
   return entries.map(entry => entry.toJSON());
 }
 
+let mockClock: Fantom.HighResTimeStampMock;
+
 describe('User Timing', () => {
   beforeEach(() => {
     performance.clearMarks();
     performance.clearMeasures();
+
+    mockClock = Fantom.installHighResTimeStampMock();
+  });
+
+  afterEach(() => {
+    mockClock.uninstall();
   });
 
   describe('mark', () => {
     it('works with default timestamp', () => {
-      NativePerformance.setCurrentTimeStampForTesting?.(25);
+      mockClock.setTime(25);
 
       const mark = performance.mark('mark-now');
 
@@ -147,7 +152,7 @@ describe('User Timing', () => {
   describe('measure', () => {
     describe('with measureOptions', () => {
       it('uses 0 as default start and now as default end', () => {
-        NativePerformance.setCurrentTimeStampForTesting?.(25);
+        mockClock.setTime(25);
 
         const measure = performance.measure('measure-with-defaults', {});
 
@@ -160,7 +165,7 @@ describe('User Timing', () => {
       });
 
       it('works with a start timestamp', () => {
-        NativePerformance.setCurrentTimeStampForTesting?.(25);
+        mockClock.setTime(25);
 
         const measure = performance.measure('measure-with-start-timestamp', {
           start: 10,
@@ -175,7 +180,7 @@ describe('User Timing', () => {
       });
 
       it('works with start mark', () => {
-        NativePerformance.setCurrentTimeStampForTesting?.(25);
+        mockClock.setTime(25);
 
         performance.mark('start-mark', {
           startTime: 10,
@@ -194,7 +199,7 @@ describe('User Timing', () => {
       });
 
       it('works with end mark', () => {
-        NativePerformance.setCurrentTimeStampForTesting?.(25);
+        mockClock.setTime(25);
 
         performance.mark('end-mark', {
           startTime: 50,
@@ -213,7 +218,7 @@ describe('User Timing', () => {
       });
 
       it('works with start mark and end mark', () => {
-        NativePerformance.setCurrentTimeStampForTesting?.(25);
+        mockClock.setTime(25);
 
         performance.mark('start-mark', {
           startTime: 10,
@@ -378,7 +383,7 @@ describe('User Timing', () => {
 
     describe('with startMark / endMark', () => {
       it('uses 0 as default start and now as default end', () => {
-        NativePerformance.setCurrentTimeStampForTesting?.(25);
+        mockClock.setTime(25);
 
         const measure = performance.measure('measure-with-defaults');
 
@@ -391,7 +396,7 @@ describe('User Timing', () => {
       });
 
       it('works with startMark', () => {
-        NativePerformance.setCurrentTimeStampForTesting?.(25);
+        mockClock.setTime(25);
 
         performance.mark('start-mark', {
           startTime: 10,
@@ -411,7 +416,7 @@ describe('User Timing', () => {
       });
 
       it('works with startMark and endMark', () => {
-        NativePerformance.setCurrentTimeStampForTesting?.(25);
+        mockClock.setTime(25);
 
         performance.mark('start-mark', {
           startTime: 10,

--- a/packages/react-native/src/private/webapis/performance/specs/NativePerformance.js
+++ b/packages/react-native/src/private/webapis/performance/specs/NativePerformance.js
@@ -93,7 +93,6 @@ export interface Spec extends TurboModule {
 
   +getSupportedPerformanceEntryTypes: () => $ReadOnlyArray<RawPerformanceEntryType>;
 
-  +setCurrentTimeStampForTesting?: (timeStamp: number) => void;
   +clearEventCountsForTesting?: () => void;
 }
 

--- a/private/react-native-fantom/src/HighResTimeStampMock.js
+++ b/private/react-native-fantom/src/HighResTimeStampMock.js
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import NativeFantom from 'react-native/src/private/testing/fantom/specs/NativeFantom';
+
+/**
+ * Represents a mocked clock for `HighResTimeStamp` values.
+ */
+export interface HighResTimeStampMock {
+  setTime(now: number): void;
+  advanceTimeBy(deltaMs: number): void;
+  uninstall(): void;
+}
+
+let activeMock: ?HighResTimeStampMock;
+
+/**
+ * Installs a mock clock for `HighResTimeStamp` values and returns an object
+ * that allows controlling the returned values.
+ *
+ * @example
+ * ```
+ * let mockClock;
+ *
+ * afterEach(() => {
+ *   mockClock.uninstall();
+ *   mockClock = null;
+ * });
+ *
+ * it('should do something when time passes', () => {
+ *   mockClock = Fantom.installHighResTimeStampMock();
+ *   mockClock.setTime(10);
+ *
+ *   doSomething();
+ *
+ *   mockClock.advanceTimeBy(100);
+ *
+ *   doSomethingElse();
+ *
+ *   expect(someSideEffectProduced).toBe(true);
+ * });
+ * ```
+ */
+export function installHighResTimeStampMock(): HighResTimeStampMock {
+  if (activeMock != null) {
+    throw new Error(
+      'Cannot install HighResTimeStamp mock because there is another mock installed already. Reuse the same mock or uninstall the previous one first.',
+    );
+  }
+
+  let mockedTimeStamp = 0;
+
+  const mock: HighResTimeStampMock = {
+    setTime: now => {
+      if (now < mockedTimeStamp) {
+        throw new Error('The mocked time cannot be decreased');
+      }
+      mockedTimeStamp = now;
+      NativeFantom.forceHighResTimeStamp(mockedTimeStamp);
+    },
+    advanceTimeBy: delta => {
+      if (delta < 0) {
+        throw new Error('The mocked time cannot be decreased');
+      }
+      mockedTimeStamp += delta;
+      mock.setTime(mockedTimeStamp);
+    },
+    uninstall: () => {
+      if (activeMock === mock) {
+        NativeFantom.forceHighResTimeStamp(undefined);
+        activeMock = null;
+      }
+    },
+  };
+
+  // Set default value
+  mock.setTime(mockedTimeStamp);
+
+  activeMock = mock;
+
+  return mock;
+}

--- a/private/react-native-fantom/src/__tests__/FantomHighResTimeStampMock-itest.js
+++ b/private/react-native-fantom/src/__tests__/FantomHighResTimeStampMock-itest.js
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @fantom_mode dev
+ * @flow strict-local
+ * @format
+ */
+
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
+
+import type {HighResTimeStampMock} from '../HighResTimeStampMock';
+
+import * as Fantom from '@react-native/fantom';
+
+const pendingMocks: Set<HighResTimeStampMock> = new Set();
+
+function installHighResTimeStampMock(): HighResTimeStampMock {
+  const mock = Fantom.installHighResTimeStampMock();
+  pendingMocks.add(mock);
+  return mock;
+}
+
+describe('Fantom HighResTimeStamp mocks', () => {
+  afterEach(() => {
+    for (const mock of pendingMocks) {
+      mock.uninstall();
+    }
+    pendingMocks.clear();
+  });
+
+  it('sets a default value', () => {
+    expect(performance.now()).toBeGreaterThan(0);
+
+    installHighResTimeStampMock();
+
+    expect(performance.now()).toBe(0);
+  });
+
+  it('sets custom values', () => {
+    const mock = installHighResTimeStampMock();
+
+    expect(performance.now()).toBe(0);
+
+    mock.setTime(50);
+
+    expect(performance.now()).toBe(50);
+
+    mock.setTime(70);
+
+    expect(performance.now()).toBe(70);
+
+    mock.advanceTimeBy(5);
+
+    expect(performance.now()).toBe(75);
+
+    mock.setTime(90);
+
+    expect(performance.now()).toBe(90);
+  });
+
+  it('throws an error when trying to set a time in the past', () => {
+    const mock = installHighResTimeStampMock();
+
+    expect(performance.now()).toBe(0);
+
+    mock.setTime(50);
+
+    expect(performance.now()).toBe(50);
+
+    expect(() => {
+      mock.setTime(40);
+    }).toThrow('The mocked time cannot be decreased');
+
+    expect(performance.now()).toBe(50);
+
+    expect(() => {
+      mock.advanceTimeBy(-1);
+    }).toThrow('The mocked time cannot be decreased');
+
+    expect(performance.now()).toBe(50);
+  });
+
+  it('allows uninstalling', () => {
+    expect(performance.now()).toBeGreaterThan(0);
+
+    const mock = installHighResTimeStampMock();
+
+    expect(performance.now()).toBe(0);
+
+    mock.uninstall();
+
+    expect(performance.now()).toBeGreaterThan(0);
+  });
+
+  it('does nothing when uninstalling multiple times', () => {
+    expect(performance.now()).toBeGreaterThan(0);
+
+    const mock = installHighResTimeStampMock();
+
+    expect(performance.now()).toBe(0);
+
+    mock.uninstall();
+    mock.uninstall();
+    mock.uninstall();
+
+    expect(performance.now()).toBeGreaterThan(0);
+  });
+
+  it('throws an error when installing multiple mocks at the same time', () => {
+    installHighResTimeStampMock();
+    expect(() => installHighResTimeStampMock()).toThrow(
+      'Cannot install HighResTimeStamp mock because there is another mock installed already. Reuse the same mock or uninstall the previous one first.',
+    );
+  });
+
+  it('does not uninstall other mocks', () => {
+    const initialMock = installHighResTimeStampMock();
+
+    expect(performance.now()).toBe(0);
+
+    initialMock.uninstall();
+
+    expect(performance.now()).toBeGreaterThan(0);
+
+    installHighResTimeStampMock();
+
+    expect(performance.now()).toBe(0);
+
+    initialMock.uninstall();
+
+    // Has no effect on the current mock
+    expect(performance.now()).toBe(0);
+  });
+});

--- a/private/react-native-fantom/src/__tests__/FantomHighResTimeStampMockOpt-itest.js
+++ b/private/react-native-fantom/src/__tests__/FantomHighResTimeStampMockOpt-itest.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @fantom_mode opt
+ * @flow strict-local
+ * @format
+ */
+
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
+
+import * as Fantom from '@react-native/fantom';
+
+describe('Fantom HighResTimeStamp mocks (optimized builds)', () => {
+  it('does not allow mocking the time in optimized builds', () => {
+    expect(() => Fantom.installHighResTimeStampMock()).toThrow(
+      'Mocking timers is not supported in optimized builds',
+    );
+  });
+});

--- a/private/react-native-fantom/src/index.js
+++ b/private/react-native-fantom/src/index.js
@@ -682,6 +682,8 @@ export function saveJSMemoryHeapSnapshot(filePath: string): void {
   NativeFantom.saveJSMemoryHeapSnapshot(filePath);
 }
 
+export * from './HighResTimeStampMock';
+
 function runLogBoxCheck() {
   if (isLogBoxCheckEnabled && LogBox.isInstalled()) {
     const message =

--- a/private/react-native-fantom/tester/src/NativeFantom.h
+++ b/private/react-native-fantom/tester/src/NativeFantom.h
@@ -146,6 +146,10 @@ class NativeFantom : public NativeFantomCxxSpec<NativeFantom> {
       jsi::Runtime& runtime,
       const std::string& filePath);
 
+  void forceHighResTimeStamp(
+      jsi::Runtime& runtime,
+      std::optional<HighResTimeStamp> now);
+
  private:
   TesterAppDelegate& appDelegate_;
   SurfaceId nextSurfaceId_ = 1;

--- a/scripts/cxx-api/ReactNativeCPP.api
+++ b/scripts/cxx-api/ReactNativeCPP.api
@@ -17307,7 +17307,6 @@ class NativePerformance : public NativePerformanceCxxSpec<NativePerformance> {
   std::unordered_map<std::string, double> getSimpleMemoryInfo(jsi::Runtime& rt);
   std::unordered_map<std::string, double> getReactNativeStartupTiming(
       jsi::Runtime& rt);
-  void setCurrentTimeStampForTesting(jsi::Runtime& rt, HighResTimeStamp ts);
   void clearEventCountsForTesting(jsi::Runtime& rt);
 };
 } // namespace facebook::react
@@ -17639,9 +17638,6 @@ class PerformanceEntryReporter {
       PerformanceEntryType entryType,
       const std::string& entryName);
   HighResTimeStamp getCurrentTimeStamp() const;
-  void setTimeStampProvider(std::function<HighResTimeStamp()> provider) {
-    timeStampProvider_ = std::move(provider);
-  }
   static std::vector<PerformanceEntryType> getSupportedEntryTypes();
   uint32_t getDroppedEntriesCount(PerformanceEntryType type) const noexcept;
   const std::unordered_map<std::string, uint32_t>& getEventCounts() const {


### PR DESCRIPTION
Summary:
Changelog: [internal]

Now that we have mocking at a more fundamental level (`HighResTimeStamp` API) we can replace other timing mocks with that one.

This does it for `PerformanceEntryReporter` and the `NativePerformance` module.

Differential Revision: D79557640
