### PR TITLE
Add documentation for updating the issue triage oncall

### DIFF
--- a/.github/workflow-scripts/extractIssueOncalls.js
+++ b/.github/workflow-scripts/extractIssueOncalls.js
@@ -25,6 +25,31 @@ function extractUsersFromScheduleAndDate(schedule, userMap, date) {
   return [user1, user2];
 }
 
+/**
+ * You can invoke this script by doing:
+ * ```
+ * node .github/workflow-scripts/extractIssueOncalls.js $DATA
+ * ```
+ *
+ * the $DATA is stored in the github secrets as ONCALL_SCHEDULE variable.
+ * The format of the data is:
+ * ```
+ * {
+ *   \"userMap\": {
+ *     \"discord_handle1\": \"discord_id1\",
+ *     \"discord_handle2\": \"discord_id2\",
+ *    ...
+ *  },
+ *  \"schedule\": {
+ *    \"2025-07-29\": [\"discord_handle1\", \"discord_handle2\"],
+ *    \"2025-08-05\": [\"discord_handle3\", \"discord_handle4\"],
+ *   ...
+ * }
+ * ```
+ *
+ * When uploading the secret, make sure that the JSON strings are escaped!
+ * The script will fail otherwise, because GitHub will remove the `"` characters.
+ */
 function main() {
   const configuration = process.argv[2];
   const {userMap, schedule} = JSON.parse(configuration);

--- a/.github/workflows/monitor-new-issues.yml
+++ b/.github/workflows/monitor-new-issues.yml
@@ -27,10 +27,6 @@ jobs:
           ONCALL2=$(echo $ONCALLS | cut -d ' ' -f 2)
           echo "oncall1=$ONCALL1" >> $GITHUB_ENV
           echo "oncall2=$ONCALL2" >> $GITHUB_ENV
-      - name: Print oncalls
-        run: |
-          echo "oncall1: ${{ env.oncall1 }}"
-          echo "oncall2: ${{ env.oncall2 }}"
       - name: Monitor New Issues
         uses: react-native-community/repo-monitor@v1.0.1
         with:


### PR DESCRIPTION
Summary:
This Diff simply adds some docs on how the secret must be formatted, and removes a print that would expose the triager IDs is anyone would look at the logs (not a big deal given that the ids are public on Discord, though).

## Changelog:
[Internal] -

Reviewed By: cortinico

Differential Revision: D79556988
