### PR TITLE
Improve type safety of constants passed from runner to runtime

### DIFF
--- a/private/react-native-fantom/runner/entrypoint-template.js
+++ b/private/react-native-fantom/runner/entrypoint-template.js
@@ -9,6 +9,7 @@
  */
 
 import type {SnapshotConfig} from '../runtime/snapshotContext';
+import type {FantomRuntimeConstants} from '../src/Constants';
 import type {FantomTestConfig} from './getFantomTestConfigs';
 
 import * as EnvironmentOptions from './EnvironmentOptions';
@@ -27,6 +28,13 @@ module.exports = function entrypointTemplate({
   testConfig: FantomTestConfig,
   snapshotConfig: SnapshotConfig,
 }): string {
+  const constants: FantomRuntimeConstants = {
+    isOSS: EnvironmentOptions.isOSS,
+    isRunningFromCI: EnvironmentOptions.isCI,
+    forceTestModeForBenchmarks: EnvironmentOptions.forceTestModeForBenchmarks,
+    fantomConfigSummary: formatFantomConfig(testConfig),
+  };
+
   return `/**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
@@ -64,12 +72,7 @@ ${
     : ''
 }
 
-setConstants({
-  isOSS: ${String(EnvironmentOptions.isOSS)},
-  isRunningFromCI: ${String(EnvironmentOptions.isCI)},
-  forceTestModeForBenchmarks: ${String(EnvironmentOptions.forceTestModeForBenchmarks)},
-  fantomConfigSummary: '${formatFantomConfig(testConfig)}',
-});
+setConstants(${JSON.stringify(constants)});
 
 registerTest(() => require('${testPath}'), ${JSON.stringify(snapshotConfig)});
 `;

--- a/private/react-native-fantom/src/Constants.js
+++ b/private/react-native-fantom/src/Constants.js
@@ -8,24 +8,24 @@
  * @format
  */
 
-type FantomConstants = $ReadOnly<{
+export type FantomRuntimeConstants = $ReadOnly<{
   isOSS: boolean,
   isRunningFromCI: boolean,
   forceTestModeForBenchmarks: boolean,
   fantomConfigSummary: string,
 }>;
 
-let constants: FantomConstants = {
+let constants: FantomRuntimeConstants = {
   isOSS: false,
   isRunningFromCI: false,
   forceTestModeForBenchmarks: false,
   fantomConfigSummary: '',
 };
 
-export function getConstants(): FantomConstants {
+export function getConstants(): FantomRuntimeConstants {
   return constants;
 }
 
-export function setConstants(newConstants: FantomConstants): void {
+export function setConstants(newConstants: FantomRuntimeConstants): void {
   constants = newConstants;
 }


### PR DESCRIPTION
Summary:
Changelog: [internal]

This is just a refactor to make sure that the constants we pass from the Fantom runner to its runtime are correct by using Flow to typecheck it.

Differential Revision: D79565574


