### PR TITLE
Fix missing SoLoader calls for inspector JNI modules

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactInstanceManagerInspectorTarget.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactInstanceManagerInspectorTarget.kt
@@ -13,11 +13,15 @@ import com.facebook.react.common.annotations.internal.LegacyArchitecture
 import com.facebook.react.common.annotations.internal.LegacyArchitectureLogLevel
 import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
 import com.facebook.react.devsupport.inspector.InspectorNetworkRequestListener
+import com.facebook.soloader.SoLoader
 import java.util.concurrent.Executor
 
 @DoNotStripAny
 @LegacyArchitecture
 internal class ReactInstanceManagerInspectorTarget(delegate: TargetDelegate) : AutoCloseable {
+  init {
+    SoLoader.loadLibrary("reactnativejni")
+  }
 
   @DoNotStripAny
   public interface TargetDelegate {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/inspector/InspectorNetworkRequestListener.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/inspector/InspectorNetworkRequestListener.kt
@@ -10,6 +10,7 @@ package com.facebook.react.devsupport.inspector
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
 import com.facebook.proguard.annotations.DoNotStripAny
+import com.facebook.soloader.SoLoader
 
 /**
  * JNI wrapper for `jsinspectormodern::NetworkRequestListener`. Handles the `ScopedExecutor`
@@ -19,6 +20,10 @@ import com.facebook.proguard.annotations.DoNotStripAny
 internal class InspectorNetworkRequestListener(
     @field:DoNotStrip private val mHybridData: HybridData
 ) {
+  init {
+    SoLoader.loadLibrary("reactnativejni")
+  }
+
   external fun onHeaders(httpStatusCode: Int, headers: Map<String?, String?>?)
 
   external fun onData(data: String?)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/InspectorNetworkReporter.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/InspectorNetworkReporter.kt
@@ -8,6 +8,7 @@
 package com.facebook.react.modules.network
 
 import com.facebook.proguard.annotations.DoNotStripAny
+import com.facebook.soloader.SoLoader
 
 /**
  * [Experimental] An interface for reporting network events to the modern debugger server and Web
@@ -19,6 +20,10 @@ import com.facebook.proguard.annotations.DoNotStripAny
  */
 @DoNotStripAny
 internal object InspectorNetworkReporter {
+  init {
+    SoLoader.loadLibrary("reactnativejni")
+  }
+
   @JvmStatic external fun isDebuggingEnabled(): Boolean
 
   /**


### PR DESCRIPTION
Summary:
Fixes a race condition that could create a runtime crash due to the `"reactnativejni"` native library not being loaded.

`SoLoader.loadLibrary` is now explicitly called for the remaining dependencies of `ReactAndroid/src/main/jni/react/jni/OnLoad.cpp`.

NOTE: ⚠️ There are other instances of this missing pattern across our codebase, which are not holistically addressed here.

Changelog: [Internal]

Differential Revision: D79568759
