### PR TITLE
Add test to verify that components like View and Text are not loaded as a side-effect of environment initialization

### DIFF
--- a/packages/react-native/Libraries/ReactNative/AppRegistryImpl.js
+++ b/packages/react-native/Libraries/ReactNative/AppRegistryImpl.js
@@ -26,8 +26,6 @@ import createPerformanceLogger from '../Utilities/createPerformanceLogger';
 import SceneTracker from '../Utilities/SceneTracker';
 import {coerceDisplayMode} from './DisplayMode';
 import HeadlessJsTaskError from './HeadlessJsTaskError';
-import NativeHeadlessJsTaskSupport from './NativeHeadlessJsTaskSupport';
-import renderApplication from './renderApplication';
 import {unmountComponentAtNodeAndRemoveContainer} from './RendererProxy';
 import invariant from 'invariant';
 
@@ -86,6 +84,7 @@ export function registerComponent(
 ): string {
   const scopedPerformanceLogger = createPerformanceLogger();
   runnables[appKey] = (appParameters, displayMode) => {
+    const renderApplication = require('./renderApplication').default;
     renderApplication(
       componentProviderInstrumentationHook(
         componentProvider,
@@ -258,6 +257,9 @@ export function startHeadlessTask(
   taskKey: string,
   data: any,
 ): void {
+  const NativeHeadlessJsTaskSupport =
+    require('./NativeHeadlessJsTaskSupport').default;
+
   const taskProvider = taskProviders.get(taskKey);
   if (!taskProvider) {
     console.warn(`No task registered for key ${taskKey}`);

--- a/packages/react-native/src/private/setup/__tests__/setUpDefaultReactNativeEnvironment-itest.js
+++ b/packages/react-native/src/private/setup/__tests__/setUpDefaultReactNativeEnvironment-itest.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import setUpDefaultReactNativeEnvironment from 'react-native/src/private/setup/setUpDefaultReactNativeEnvironment';
+
+describe('setUpReactNativeEnvironment', () => {
+  it('should not load components as a side effect', () => {
+    // We set up has not been done yet.
+    expect(globalThis.self).toBeUndefined();
+
+    setUpDefaultReactNativeEnvironment(false);
+
+    // The set up worked.
+    expect(globalThis.self).toBe(globalThis);
+
+    // Verify that `View` and `Text` are not loaded as a side-effect
+
+    // $FlowExpectedError[prop-missing]
+    const viewModuleId = require.resolveWeak(
+      'react-native/Libraries/Components/View/View',
+    );
+    // $FlowExpectedError[prop-missing]
+    const textModuleId = require.resolveWeak(
+      'react-native/Libraries/Text/Text',
+    );
+    // $FlowExpectedError[prop-missing]
+    const metroModules = require.getModules();
+    const viewModule = metroModules.get(viewModuleId);
+    const textModule = metroModules.get(textModuleId);
+    expect(viewModule).toBeInstanceOf(Object);
+    expect(textModule).toBeInstanceOf(Object);
+
+    expect(viewModule.isInitialized).toBe(false);
+    expect(textModule.isInitialized).toBe(false);
+
+    // But then we can detect when they're loaded (to verify the previous
+    // detection works).
+
+    require('react-native').View;
+
+    expect(viewModule.isInitialized).toBe(true);
+    expect(textModule.isInitialized).toBe(false);
+
+    require('react-native').Text;
+
+    expect(viewModule.isInitialized).toBe(true);
+    expect(textModule.isInitialized).toBe(true);
+  });
+});


### PR DESCRIPTION
Summary:
Changelog: [internal]

This adds a Fantom test to ensure that setting up the RN environment doesn't trigger the initialization for React components like View and Text, which should be lazy loaded when necessary.

Differential Revision: D79636160


