### PR TITLE
Reduce side-effects of AppRegistry

### DIFF
--- a/packages/react-native/Libraries/ReactNative/AppRegistryImpl.js
+++ b/packages/react-native/Libraries/ReactNative/AppRegistryImpl.js
@@ -26,8 +26,6 @@ import createPerformanceLogger from '../Utilities/createPerformanceLogger';
 import SceneTracker from '../Utilities/SceneTracker';
 import {coerceDisplayMode} from './DisplayMode';
 import HeadlessJsTaskError from './HeadlessJsTaskError';
-import NativeHeadlessJsTaskSupport from './NativeHeadlessJsTaskSupport';
-import renderApplication from './renderApplication';
 import {unmountComponentAtNodeAndRemoveContainer} from './RendererProxy';
 import invariant from 'invariant';
 
@@ -86,6 +84,7 @@ export function registerComponent(
 ): string {
   const scopedPerformanceLogger = createPerformanceLogger();
   runnables[appKey] = (appParameters, displayMode) => {
+    const renderApplication = require('./renderApplication').default;
     renderApplication(
       componentProviderInstrumentationHook(
         componentProvider,
@@ -258,6 +257,9 @@ export function startHeadlessTask(
   taskKey: string,
   data: any,
 ): void {
+  const NativeHeadlessJsTaskSupport =
+    require('./NativeHeadlessJsTaskSupport').default;
+
   const taskProvider = taskProviders.get(taskKey);
   if (!taskProvider) {
     console.warn(`No task registered for key ${taskKey}`);


### PR DESCRIPTION
Summary:
Changelog: [internal]

We eagerly require `AppRegistry` from environment initialization (`InitializeCore`) because it has some side-effects that are necessary for error reporting (see https://github.com/facebook/react-native/issues/34649 and https://github.com/facebook/react-native/pull/34650), but this change makes a lot of modules to be eagerly initialized.

This reduces that to avoid loading modules that not necessary for environment setup, which allows us to do things like setting up feature flags before modules like `View` and `Text` have been initialized.

Differential Revision: D79636159


