### PR TITLE
Validate max requestable IO.read size

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/HostTargetTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/HostTargetTest.cpp
@@ -1501,4 +1501,26 @@ TEST_F(HostTargetTest, NetworkLoadNetworkResource3xx) {
   });
 }
 
+TEST_F(HostTargetTest, IOReadSizeValidation) {
+  connect();
+
+  InSequence s;
+
+  EXPECT_CALL(fromPage(), onMessage(JsonEq(R"({
+                                            "id": 1,
+                                            "error": {
+                                              "message": "Invalid params: size cannot be greater than 10MB.",
+                                              "code": -32602
+                                            }
+                                          })")));
+  toPage_->sendMessage(R"({
+        "id": 1,
+        "method": "IO.read",
+        "params": {
+          "handle": "0",
+          "size": 134217728
+        }
+      })");
+}
+
 } // namespace facebook::react::jsinspector_modern


### PR DESCRIPTION
Summary:
Update `IO.read` CDP method handler to validate the received `size` parameter.

This now accepts a max value of 10MB — adding a layer of safety in front of our current Android implementation, which fails at around ~15MB due to OkHttp limits.

Changelog: [Internal]

Differential Revision: D79646155
