### PR TITLE
Improve filenames of JS sampling profiler traces

### DIFF
--- a/private/react-native-fantom/runner/paths.js
+++ b/private/react-native-fantom/runner/paths.js
@@ -8,6 +8,9 @@
  * @format
  */
 
+import type {FantomTestConfig} from './getFantomTestConfigs';
+
+import formatFantomConfig from './formatFantomConfig';
 import path from 'path';
 
 export const OUTPUT_PATH: string = path.resolve(__dirname, '..', '.out');
@@ -30,4 +33,25 @@ export function getTestBuildOutputPath(): string {
   }
 
   return path.join(JS_BUILD_OUTPUT_PATH, fantomRunID);
+}
+
+export function buildJSTracesOutputPath(
+  testPath: string,
+  testConfig: FantomTestConfig,
+  isMultiConfig: boolean,
+): string {
+  const fileNameParts = [path.basename(testPath)];
+
+  if (isMultiConfig) {
+    const configSummary = formatFantomConfig(testConfig, {style: 'short'});
+    if (configSummary !== '') {
+      fileNameParts.push(configSummary);
+    }
+  }
+
+  fileNameParts.push(new Date().toISOString());
+
+  const fileName = fileNameParts.join('-') + '.cpuprofile';
+
+  return path.join(JS_TRACES_OUTPUT_PATH, fileName);
 }

--- a/private/react-native-fantom/runner/runner.js
+++ b/private/react-native-fantom/runner/runner.js
@@ -15,7 +15,6 @@ import type {
 } from '../runtime/setup';
 import type {TestSnapshotResults} from '../runtime/snapshotContext';
 import type {BenchmarkTestArtifact} from './benchmarkUtils';
-import type {FantomTestConfig} from './getFantomTestConfigs';
 import type {
   AsyncCommandResult,
   ConsoleLogMessage,
@@ -30,7 +29,11 @@ import {run as runHermesCompiler} from './executables/hermesc';
 import {run as runFantomTester} from './executables/tester';
 import formatFantomConfig from './formatFantomConfig';
 import getFantomTestConfigs from './getFantomTestConfigs';
-import {JS_TRACES_OUTPUT_PATH, getTestBuildOutputPath} from './paths';
+import {
+  JS_TRACES_OUTPUT_PATH,
+  buildJSTracesOutputPath,
+  getTestBuildOutputPath,
+} from './paths';
 import {
   getInitialSnapshotData,
   updateSnapshotsAndGetJestSnapshotResult,
@@ -485,21 +488,4 @@ function containsError(testResult: TestSuiteResult): boolean {
         result.failureDetails.length > 0 || result.failureMessages.length > 0,
     )
   );
-}
-
-function buildJSTracesOutputPath(
-  testPath: string,
-  testConfig: FantomTestConfig,
-  isMultiConfig: boolean,
-): string {
-  let fileName;
-
-  if (isMultiConfig) {
-    const configSummary = formatFantomConfig(testConfig, {style: 'short'});
-    fileName = `${path.basename(testPath)}-${configSummary}-${Date.now()}.cpuprofile`;
-  } else {
-    fileName = `${path.basename(testPath)}-${Date.now()}.cpuprofile`;
-  }
-
-  return path.join(JS_TRACES_OUTPUT_PATH, fileName);
 }


### PR DESCRIPTION
Summary:
Changelog: [internal]

This changes the names of the JS traces from Fantom from using a unix timestamp in the file name to using the ISO date:

- From: `View-itest.js-1754406329686.cpuprofile`
- To: `View-itest.js-2025-08-05T15:05:29.686Z.cpuprofile`

Reviewed By: rshest

Differential Revision: D79646760


