### PR TITLE
Add a mechanism for emitting stashed trace recording

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
@@ -311,8 +311,6 @@ class HostAgent::Impl final {
   }
 
   void setCurrentInstanceAgent(std::shared_ptr<InstanceAgent> instanceAgent) {
-    tracingAgent_.setCurrentInstanceAgent(instanceAgent);
-
     auto previousInstanceAgent = std::move(instanceAgent_);
     instanceAgent_ = std::move(instanceAgent);
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
@@ -462,4 +462,17 @@ void HostAgent::setCurrentInstanceAgent(
   impl_->setCurrentInstanceAgent(std::move(instanceAgent));
 }
 
+#pragma mark - Tracing
+
+HostTracingAgent::HostTracingAgent(tracing::TraceRecordingState& state)
+    : tracing::TargetTracingAgent(state) {}
+
+void HostTracingAgent::setTracedInstance(InstanceTarget* instanceTarget) {
+  if (instanceTarget != nullptr) {
+    instanceTracingAgent_ = instanceTarget->createTracingAgent(state_);
+  } else {
+    instanceTracingAgent_ = nullptr;
+  }
+}
+
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
@@ -47,7 +47,8 @@ class HostAgent::Impl final {
         hostMetadata_(std::move(hostMetadata)),
         sessionState_(sessionState),
         networkIOAgent_(NetworkIOAgent(frontendChannel, std::move(executor))),
-        tracingAgent_(TracingAgent(frontendChannel, sessionState)) {}
+        tracingAgent_(
+            TracingAgent(frontendChannel, sessionState, targetController)) {}
 
   ~Impl() {
     if (isPausedInDebuggerOverlayVisible_) {

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
@@ -41,14 +41,18 @@ class HostAgent::Impl final {
       HostTargetController& targetController,
       HostTargetMetadata hostMetadata,
       SessionState& sessionState,
-      VoidExecutor executor)
+      VoidExecutor executor,
+      std::optional<tracing::TraceRecordingState> maybeTraceToDisplay)
       : frontendChannel_(frontendChannel),
         targetController_(targetController),
         hostMetadata_(std::move(hostMetadata)),
         sessionState_(sessionState),
         networkIOAgent_(NetworkIOAgent(frontendChannel, std::move(executor))),
-        tracingAgent_(
-            TracingAgent(frontendChannel, sessionState, targetController)) {}
+        tracingAgent_(TracingAgent(
+            frontendChannel,
+            sessionState,
+            targetController,
+            std::move(maybeTraceToDisplay))) {}
 
   ~Impl() {
     if (isPausedInDebuggerOverlayVisible_) {
@@ -428,7 +432,8 @@ class HostAgent::Impl final {
       HostTargetController& targetController,
       HostTargetMetadata hostMetadata,
       SessionState& sessionState,
-      VoidExecutor executor) {}
+      VoidExecutor executor,
+      std::optional<tracing::TraceRecordingState> maybeTraceToDisplay) {}
 
   void handleRequest(const cdp::PreparsedRequest& req) {}
   void setCurrentInstanceAgent(std::shared_ptr<InstanceAgent> agent) {}
@@ -441,14 +446,16 @@ HostAgent::HostAgent(
     HostTargetController& targetController,
     HostTargetMetadata hostMetadata,
     SessionState& sessionState,
-    VoidExecutor executor)
+    VoidExecutor executor,
+    std::optional<tracing::TraceRecordingState> maybeTraceToDisplay)
     : impl_(std::make_unique<Impl>(
           *this,
           frontendChannel,
           targetController,
           std::move(hostMetadata),
           sessionState,
-          std::move(executor))) {}
+          std::move(executor),
+          std::move(maybeTraceToDisplay))) {}
 
 HostAgent::~HostAgent() = default;
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
@@ -12,6 +12,7 @@
 #include <jsinspector-modern/InspectorInterfaces.h>
 #include <jsinspector-modern/InstanceAgent.h>
 #include <jsinspector-modern/cdp/CdpJson.h>
+#include <jsinspector-modern/tracing/TargetTracingAgent.h>
 
 namespace facebook::react::jsinspector_modern {
 
@@ -73,6 +74,27 @@ class HostAgent final {
   class Impl;
 
   std::unique_ptr<Impl> impl_;
+};
+
+#pragma mark - Tracing
+
+/**
+ * An Agent that handles Tracing events for a particular InstanceTarget.
+ *
+ * Lifetime of this agent is bound to the lifetime of the Tracing session -
+ * HostTargetTraceRecording.
+ */
+class HostTracingAgent : tracing::TargetTracingAgent {
+ public:
+  explicit HostTracingAgent(tracing::TraceRecordingState& state);
+
+  /**
+   * Registers the InstanceTarget with this tracing agent.
+   */
+  void setTracedInstance(InstanceTarget* instanceTarget);
+
+ private:
+  std::shared_ptr<InstanceTracingAgent> instanceTracingAgent_{nullptr};
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
@@ -36,13 +36,16 @@ class HostAgent final {
    * \param hostMetadata Metadata about the host that created this agent.
    * \param sessionState The state of the session that created this agent.
    * \param executor A void executor to be used by async-aware handlers.
+   * \param maybeTraceToDisplay If set, this is the trace that Host has
+   * requested to display in the Frontend.
    */
   HostAgent(
       const FrontendChannel& frontendChannel,
       HostTargetController& targetController,
       HostTargetMetadata hostMetadata,
       SessionState& sessionState,
-      VoidExecutor executor);
+      VoidExecutor executor,
+      std::optional<tracing::TraceRecordingState> maybeTraceToDisplay);
 
   HostAgent(const HostAgent&) = delete;
   HostAgent(HostAgent&&) = delete;

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
@@ -34,7 +34,8 @@ class HostTargetSession {
       std::unique_ptr<IRemoteConnection> remote,
       HostTargetController& targetController,
       HostTargetMetadata hostMetadata,
-      VoidExecutor executor)
+      VoidExecutor executor,
+      std::optional<tracing::TraceRecordingState> maybeTraceToDisplay)
       : remote_(std::make_shared<RAIIRemoteConnection>(std::move(remote))),
         frontendChannel_(
             [remoteWeak = std::weak_ptr(remote_)](std::string_view message) {
@@ -47,7 +48,8 @@ class HostTargetSession {
             targetController,
             std::move(hostMetadata),
             state_,
-            std::move(executor)) {}
+            std::move(executor),
+            std::move(maybeTraceToDisplay)) {}
 
   /**
    * Called by CallbackLocalConnection to send a message to this Session's
@@ -164,7 +166,8 @@ std::unique_ptr<ILocalConnection> HostTarget::connect(
       std::move(connectionToFrontend),
       controller_,
       delegate_.getMetadata(),
-      makeVoidExecutor(executorFromThis()));
+      makeVoidExecutor(executorFromThis()),
+      delegate_.getStashedTraceRecordingStateForDisplaying());
   session->setCurrentInstance(currentInstance_.get());
   sessions_.insert(std::weak_ptr(session));
   return std::make_unique<CallbackLocalConnection>(

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
@@ -18,6 +18,8 @@
 #include <optional>
 #include <string>
 
+#include <jsinspector-modern/tracing/TracingMode.h>
+
 #ifndef JSINSPECTOR_EXPORT
 #ifdef _MSC_VER
 #ifdef CREATE_SHARED_LIBRARY
@@ -171,9 +173,10 @@ class HostTargetController final {
   /**
    * Starts trace recording for this HostTarget.
    *
+   * \param mode In which mode to start the trace recording.
    * \return false if already tracing, true otherwise.
    */
-  bool startTracing();
+  bool startTracing(tracing::Mode mode);
 
   /**
    * Stops previously started trace recording.
@@ -264,9 +267,10 @@ class JSINSPECTOR_EXPORT HostTarget
   /**
    * Starts trace recording for this HostTarget.
    *
+   * \param mode In which mode to start the trace recording.
    * \return false if already tracing, true otherwise.
    */
-  bool startTracing();
+  bool startTracing(tracing::Mode mode);
 
   /**
    * Stops previously started trace recording.

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
@@ -168,6 +168,18 @@ class HostTargetController final {
    */
   bool decrementPauseOverlayCounter();
 
+  /**
+   * Starts trace recording for this HostTarget.
+   *
+   * \return false if already tracing, true otherwise.
+   */
+  bool startTracing();
+
+  /**
+   * Stops previously started trace recording.
+   */
+  tracing::TraceRecordingState stopTracing();
+
  private:
   HostTarget& target_;
   size_t pauseOverlayCounter_{0};

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
@@ -34,8 +34,10 @@ namespace facebook::react::jsinspector_modern {
 
 class HostTargetSession;
 class HostAgent;
+class HostTracingAgent;
 class HostCommandSender;
 class HostTarget;
+class HostTargetTraceRecording;
 
 struct HostTargetMetadata {
   std::optional<std::string> appDisplayName;
@@ -237,6 +239,28 @@ class JSINSPECTOR_EXPORT HostTarget
    */
   void sendCommand(HostCommand command);
 
+  /**
+   * Creates a new HostTracingAgent.
+   * This Agent is not owned by the HostTarget. The Agent will be destroyed at
+   * the end of the tracing session.
+   *
+   * \param state A reference to the state of the active trace recording.
+   */
+  std::shared_ptr<HostTracingAgent> createTracingAgent(
+      tracing::TraceRecordingState& state);
+
+  /**
+   * Starts trace recording for this HostTarget.
+   *
+   * \return false if already tracing, true otherwise.
+   */
+  bool startTracing();
+
+  /**
+   * Stops previously started trace recording.
+   */
+  tracing::TraceRecordingState stopTracing();
+
  private:
   /**
    * Constructs a new HostTarget.
@@ -256,6 +280,14 @@ class JSINSPECTOR_EXPORT HostTarget
   std::shared_ptr<ExecutionContextManager> executionContextManager_;
   std::shared_ptr<InstanceTarget> currentInstance_{nullptr};
   std::unique_ptr<HostCommandSender> commandSender_;
+
+  /**
+   * Current pending trace recording, which encapsulates the configuration of
+   * the tracing session and the state.
+   *
+   * Should only be allocated when there is an active tracing session.
+   */
+  std::unique_ptr<HostTargetTraceRecording> traceRecording_{nullptr};
 
   inline HostTargetDelegate& getDelegate() {
     return delegate_;

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
@@ -137,6 +137,19 @@ class HostTargetDelegate : public LoadNetworkResourceDelegate {
     throw NotImplementedException(
         "LoadNetworkResourceDelegate.loadNetworkResource is not implemented by this host target delegate.");
   }
+
+  /**
+   * Will be called at the CDP session initialization to get the trace recording
+   * that could have been stashed by the Host from the previous background
+   * session.
+   *
+   * \return the trace recording state if there is one that needs to be
+   * displayed, otherwise std::nullopt.
+   */
+  virtual std::optional<tracing::TraceRecordingState>
+  getStashedTraceRecordingStateForDisplaying() {
+    return std::nullopt;
+  }
 };
 
 /**

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTraceRecording.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTraceRecording.cpp
@@ -10,8 +10,10 @@
 
 namespace facebook::react::jsinspector_modern {
 
-HostTargetTraceRecording::HostTargetTraceRecording(HostTarget& hostTarget)
-    : hostTarget_(hostTarget) {}
+HostTargetTraceRecording::HostTargetTraceRecording(
+    tracing::Mode tracingMode,
+    HostTarget& hostTarget)
+    : tracingMode_(tracingMode), hostTarget_(hostTarget) {}
 
 void HostTargetTraceRecording::setTracedInstance(
     InstanceTarget* instanceTarget) {

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTraceRecording.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTraceRecording.cpp
@@ -29,7 +29,10 @@ void HostTargetTraceRecording::start() {
       hostTracingAgent_ == nullptr &&
       "Tracing Agent for the HostTarget was already initialized.");
 
-  state_ = tracing::TraceRecordingState{.startTime = HighResTimeStamp::now()};
+  state_ = tracing::TraceRecordingState{
+      .mode = tracingMode_,
+      .startTime = HighResTimeStamp::now(),
+  };
   hostTracingAgent_ = hostTarget_.createTracingAgent(*state_);
 }
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTraceRecording.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTraceRecording.cpp
@@ -27,7 +27,7 @@ void HostTargetTraceRecording::start() {
       hostTracingAgent_ == nullptr &&
       "Tracing Agent for the HostTarget was already initialized.");
 
-  state_ = tracing::TraceRecordingState{};
+  state_ = tracing::TraceRecordingState{.startTime = HighResTimeStamp::now()};
   hostTracingAgent_ = hostTarget_.createTracingAgent(*state_);
 }
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTraceRecording.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTraceRecording.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "HostTargetTraceRecording.h"
+#include "HostTarget.h"
+
+namespace facebook::react::jsinspector_modern {
+
+HostTargetTraceRecording::HostTargetTraceRecording(HostTarget& hostTarget)
+    : hostTarget_(hostTarget) {}
+
+void HostTargetTraceRecording::setTracedInstance(
+    InstanceTarget* instanceTarget) {
+  // If HostTracingAgent is allocated, it means that there is an active tracing
+  // recording session.
+  if (hostTracingAgent_ != nullptr) {
+    hostTracingAgent_->setTracedInstance(instanceTarget);
+  }
+}
+
+void HostTargetTraceRecording::start() {
+  assert(
+      hostTracingAgent_ == nullptr &&
+      "Tracing Agent for the HostTarget was already initialized.");
+
+  state_ = tracing::TraceRecordingState{};
+  hostTracingAgent_ = hostTarget_.createTracingAgent(*state_);
+}
+
+tracing::TraceRecordingState HostTargetTraceRecording::stop() {
+  assert(
+      hostTracingAgent_ != nullptr &&
+      "TracingAgent for the HostTarget has not been initialized.");
+  hostTracingAgent_.reset();
+
+  assert(
+      state_.has_value() &&
+      "The state for this tracing session has not been initialized.");
+  auto state = std::move(*state_);
+  state_.reset();
+
+  return state;
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTraceRecording.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTraceRecording.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "HostAgent.h"
+#include "HostTarget.h"
+#include "InstanceTarget.h"
+
+#include <jsinspector-modern/tracing/TraceRecordingState.h>
+
+#include <optional>
+
+namespace facebook::react::jsinspector_modern {
+
+/**
+ * A local representation of the Tracing "session".
+ *
+ * Owned by the HostTarget and should only be allocated during an active
+ * recording.
+ *
+ * Owns all allocated Tracing Agents. A single Target can have a single active
+ * Tracing Agent, but only as a std::weak_ptr.
+ */
+class HostTargetTraceRecording {
+ public:
+  explicit HostTargetTraceRecording(HostTarget& hostTarget);
+
+  /**
+   * Updates the current traced Instance for this recording.
+   */
+  void setTracedInstance(InstanceTarget* instanceTarget);
+
+  /**
+   * Starts the recording.
+   *
+   * Will allocate all Tracing Agents for all currently registered Targets.
+   */
+  void start();
+
+  /**
+   * Stops the recording and drops the recording state.
+   *
+   * Will deallocate all Tracing Agents.
+   */
+  tracing::TraceRecordingState stop();
+
+ private:
+  /**
+   * The Host for which this Trace Recording is going to happen.
+   */
+  HostTarget& hostTarget_;
+
+  /**
+   * The state of the current Trace Recording.
+   * Only allocated if the recording is enabled.
+   */
+  std::optional<tracing::TraceRecordingState> state_;
+
+  /**
+   * The TracingAgent of the targeted Host.
+   * Only allocated if the recording is enabled.
+   */
+  std::shared_ptr<HostTracingAgent> hostTracingAgent_;
+};
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTraceRecording.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTraceRecording.h
@@ -28,7 +28,17 @@ namespace facebook::react::jsinspector_modern {
  */
 class HostTargetTraceRecording {
  public:
-  explicit HostTargetTraceRecording(HostTarget& hostTarget);
+  explicit HostTargetTraceRecording(
+      tracing::Mode tracingMode,
+      HostTarget& hostTarget);
+
+  inline bool isBackgroundInitiated() const {
+    return tracingMode_ == tracing::Mode::Background;
+  }
+
+  inline bool isUserInitiated() const {
+    return tracingMode_ == tracing::Mode::CDP;
+  }
 
   /**
    * Updates the current traced Instance for this recording.
@@ -50,6 +60,11 @@ class HostTargetTraceRecording {
   tracing::TraceRecordingState stop();
 
  private:
+  /**
+   * The mode in which this trace recording was initialized.
+   */
+  tracing::Mode tracingMode_;
+
   /**
    * The Host for which this Trace Recording is going to happen.
    */

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTracing.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTracing.cpp
@@ -10,6 +10,14 @@
 
 namespace facebook::react::jsinspector_modern {
 
+bool HostTargetController::startTracing() {
+  return target_.startTracing();
+}
+
+tracing::TraceRecordingState HostTargetController::stopTracing() {
+  return target_.stopTracing();
+}
+
 std::shared_ptr<HostTracingAgent> HostTarget::createTracingAgent(
     tracing::TraceRecordingState& state) {
   auto agent = std::make_shared<HostTracingAgent>(state);

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTracing.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTracing.cpp
@@ -10,8 +10,8 @@
 
 namespace facebook::react::jsinspector_modern {
 
-bool HostTargetController::startTracing() {
-  return target_.startTracing();
+bool HostTargetController::startTracing(tracing::Mode tracingMode) {
+  return target_.startTracing(tracingMode);
 }
 
 tracing::TraceRecordingState HostTargetController::stopTracing() {
@@ -25,12 +25,13 @@ std::shared_ptr<HostTracingAgent> HostTarget::createTracingAgent(
   return agent;
 }
 
-bool HostTarget::startTracing() {
+bool HostTarget::startTracing(tracing::Mode tracingMode) {
   if (traceRecording_ != nullptr) {
     return false;
   }
 
-  traceRecording_ = std::make_unique<HostTargetTraceRecording>(*this);
+  traceRecording_ =
+      std::make_unique<HostTargetTraceRecording>(tracingMode, *this);
   traceRecording_->setTracedInstance(currentInstance_.get());
   traceRecording_->start();
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTracing.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTracing.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "HostTarget.h"
+#include "HostTargetTraceRecording.h"
+
+namespace facebook::react::jsinspector_modern {
+
+std::shared_ptr<HostTracingAgent> HostTarget::createTracingAgent(
+    tracing::TraceRecordingState& state) {
+  auto agent = std::make_shared<HostTracingAgent>(state);
+  agent->setTracedInstance(currentInstance_.get());
+  return agent;
+}
+
+bool HostTarget::startTracing() {
+  if (traceRecording_ != nullptr) {
+    return false;
+  }
+
+  traceRecording_ = std::make_unique<HostTargetTraceRecording>(*this);
+  traceRecording_->setTracedInstance(currentInstance_.get());
+  traceRecording_->start();
+
+  return true;
+}
+
+tracing::TraceRecordingState HostTarget::stopTracing() {
+  assert(traceRecording_ != nullptr && "No tracing in progress");
+
+  auto state = traceRecording_->stop();
+  traceRecording_.reset();
+
+  return state;
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTracing.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTracing.cpp
@@ -27,7 +27,12 @@ std::shared_ptr<HostTracingAgent> HostTarget::createTracingAgent(
 
 bool HostTarget::startTracing(tracing::Mode tracingMode) {
   if (traceRecording_ != nullptr) {
-    return false;
+    if (traceRecording_->isBackgroundInitiated() &&
+        tracingMode == tracing::Mode::CDP) {
+      traceRecording_.reset();
+    } else {
+      return false;
+    }
   }
 
   traceRecording_ =

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.cpp
@@ -15,6 +15,15 @@
 
 namespace facebook::react::jsinspector_modern {
 
+namespace {
+
+// The size of the timeline for the trace recording that happened in the
+// background.
+constexpr HighResDuration kBackgroundTracePerformanceTracerWindowSize =
+    HighResDuration::fromMilliseconds(20000);
+
+} // namespace
+
 InstanceAgent::InstanceAgent(
     FrontendChannel frontendChannel,
     InstanceTarget& target,
@@ -160,7 +169,12 @@ void InstanceAgent::maybeSendPendingConsoleMessages() {
 
 InstanceTracingAgent::InstanceTracingAgent(tracing::TraceRecordingState& state)
     : tracing::TargetTracingAgent(state) {
-  tracing::PerformanceTracer::getInstance().startTracing();
+  auto& performanceTracer = tracing::PerformanceTracer::getInstance();
+  if (state.mode == tracing::Mode::Background) {
+    performanceTracer.startTracing(kBackgroundTracePerformanceTracerWindowSize);
+  } else {
+    performanceTracer.startTracing();
+  }
 }
 
 InstanceTracingAgent::~InstanceTracingAgent() {

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.cpp
@@ -176,4 +176,17 @@ tracing::InstanceTracingProfile InstanceAgent::collectTracingProfile() {
   };
 }
 
+#pragma mark - Tracing
+
+InstanceTracingAgent::InstanceTracingAgent(tracing::TraceRecordingState& state)
+    : tracing::TargetTracingAgent(state) {}
+
+void InstanceTracingAgent::setTracedRuntime(RuntimeTarget* runtimeTarget) {
+  if (runtimeTarget != nullptr) {
+    runtimeTracingAgent_ = runtimeTarget->createTracingAgent(state_);
+  } else {
+    runtimeTracingAgent_ = nullptr;
+  }
+}
+
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.cpp
@@ -156,27 +156,6 @@ void InstanceAgent::maybeSendPendingConsoleMessages() {
   }
 }
 
-void InstanceAgent::startTracing() {
-  if (runtimeAgent_) {
-    runtimeAgent_->enableSamplingProfiler();
-  }
-}
-
-void InstanceAgent::stopTracing() {
-  if (runtimeAgent_) {
-    runtimeAgent_->disableSamplingProfiler();
-  }
-}
-
-tracing::InstanceTracingProfileLegacy InstanceAgent::collectTracingProfile() {
-  tracing::RuntimeSamplingProfile runtimeSamplingProfile =
-      runtimeAgent_->collectSamplingProfile();
-
-  return tracing::InstanceTracingProfileLegacy{
-      .runtimeSamplingProfile = std::move(runtimeSamplingProfile),
-  };
-}
-
 #pragma mark - Tracing
 
 InstanceTracingAgent::InstanceTracingAgent(tracing::TraceRecordingState& state)

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.h
@@ -15,6 +15,7 @@
 #include <jsinspector-modern/RuntimeAgent.h>
 #include <jsinspector-modern/cdp/CdpJson.h>
 #include <jsinspector-modern/tracing/InstanceTracingProfile.h>
+#include <jsinspector-modern/tracing/TargetTracingAgent.h>
 
 #include <functional>
 
@@ -85,6 +86,27 @@ class InstanceAgent final {
   InstanceTarget& target_;
   std::shared_ptr<RuntimeAgent> runtimeAgent_;
   SessionState& sessionState_;
+};
+
+#pragma mark - Tracing
+
+/**
+ * An Agent that handles Tracing events for a particular InstanceTarget.
+ *
+ * Lifetime of this agent is bound to the lifetime of the Tracing session -
+ * HostTargetTraceRecording and to the lifetime of the InstanceTarget.
+ */
+class InstanceTracingAgent : tracing::TargetTracingAgent {
+ public:
+  explicit InstanceTracingAgent(tracing::TraceRecordingState& state);
+
+  /**
+   * Registers the RuntimeTarget with this tracing agent.
+   */
+  void setTracedRuntime(RuntimeTarget* runtimeTarget);
+
+ private:
+  std::shared_ptr<RuntimeTracingAgent> runtimeTracingAgent_;
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.h
@@ -60,23 +60,6 @@ class InstanceAgent final {
    */
   void sendConsoleMessage(SimpleConsoleMessage message);
 
-  /**
-   * Notify Instance about started Tracing session. Should be initiated by
-   * TracingAgent on Tracing.start CDP method.
-   */
-  void startTracing();
-
-  /**
-   * Notify Instance about stopped Tracing session. Should be initiated by
-   * TracingAgent on Tracing.end CDP method.
-   */
-  void stopTracing();
-
-  /**
-   * Return recorded profile for the previous tracing session.
-   */
-  tracing::InstanceTracingProfileLegacy collectTracingProfile();
-
  private:
   void maybeSendExecutionContextCreatedNotification();
   void sendConsoleMessageImmediately(SimpleConsoleMessage message);

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceAgent.h
@@ -75,7 +75,7 @@ class InstanceAgent final {
   /**
    * Return recorded profile for the previous tracing session.
    */
-  tracing::InstanceTracingProfile collectTracingProfile();
+  tracing::InstanceTracingProfileLegacy collectTracingProfile();
 
  private:
   void maybeSendExecutionContextCreatedNotification();
@@ -99,6 +99,8 @@ class InstanceAgent final {
 class InstanceTracingAgent : tracing::TargetTracingAgent {
  public:
   explicit InstanceTracingAgent(tracing::TraceRecordingState& state);
+
+  ~InstanceTracingAgent();
 
   /**
    * Registers the RuntimeTarget with this tracing agent.

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.h
@@ -15,12 +15,15 @@
 
 #include <jsinspector-modern/InspectorInterfaces.h>
 #include <jsinspector-modern/RuntimeAgent.h>
+#include <jsinspector-modern/tracing/TraceRecordingState.h>
 
 #include <memory>
 
 namespace facebook::react::jsinspector_modern {
 
 class InstanceAgent;
+class InstanceTracingAgent;
+class HostTargetTraceRecording;
 
 /**
  * Receives events from an InstanceTarget. This is a shared interface that
@@ -69,6 +72,18 @@ class InstanceTarget : public EnableExecutorFromThis<InstanceTarget> {
       SessionState& sessionState);
 
   /**
+   * Creates a new InstanceTracingAgent.
+   * This Agent is not owned by the InstanceTarget. The Agent will be destroyed
+   * either before the InstanceTarget is destroyed, as part of the
+   * InstanceTarget unregistration in HostTarget, or at the end of the tracing
+   * session.
+   *
+   * \param state A reference to the state of the active trace recording.
+   */
+  std::shared_ptr<InstanceTracingAgent> createTracingAgent(
+      tracing::TraceRecordingState& state);
+
+  /**
    * Registers a JS runtime with this InstanceTarget. \returns a reference to
    * the created RuntimeTarget, which is owned by the \c InstanceTarget. All the
    * requirements of \c RuntimeTarget::create must be met.
@@ -103,6 +118,13 @@ class InstanceTarget : public EnableExecutorFromThis<InstanceTarget> {
   std::shared_ptr<RuntimeTarget> currentRuntime_{nullptr};
   WeakList<InstanceAgent> agents_;
   std::shared_ptr<ExecutionContextManager> executionContextManager_;
+
+  /**
+   * This TracingAgent is owned by the HostTracingAgent, both are bound to
+   * the lifetime of their corresponding targets and the lifetime of the tracing
+   * session - HostTargetTraceRecording.
+   */
+  std::weak_ptr<InstanceTracingAgent> tracingAgent_;
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.cpp
@@ -134,14 +134,18 @@ RuntimeTracingAgent::RuntimeTracingAgent(
     tracing::TraceRecordingState& state,
     RuntimeTargetController& targetController)
     : tracing::TargetTracingAgent(state), targetController_(targetController) {
-  targetController_.enableSamplingProfiler();
+  if (state.mode == tracing::Mode::CDP) {
+    targetController_.enableSamplingProfiler();
+  }
 }
 
 RuntimeTracingAgent::~RuntimeTracingAgent() {
-  targetController_.disableSamplingProfiler();
-  auto profile = targetController_.collectSamplingProfile();
+  if (state_.mode == tracing::Mode::CDP) {
+    targetController_.disableSamplingProfiler();
+    auto profile = targetController_.collectSamplingProfile();
 
-  state_.runtimeSamplingProfiles.emplace_back(std::move(profile));
+    state_.runtimeSamplingProfiles.emplace_back(std::move(profile));
+  }
 }
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.cpp
@@ -128,4 +128,9 @@ tracing::RuntimeSamplingProfile RuntimeAgent::collectSamplingProfile() {
   return targetController_.collectSamplingProfile();
 }
 
+#pragma mark - Tracing
+
+RuntimeTracingAgent::RuntimeTracingAgent(tracing::TraceRecordingState& state)
+    : tracing::TargetTracingAgent(state) {}
+
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.cpp
@@ -130,7 +130,18 @@ tracing::RuntimeSamplingProfile RuntimeAgent::collectSamplingProfile() {
 
 #pragma mark - Tracing
 
-RuntimeTracingAgent::RuntimeTracingAgent(tracing::TraceRecordingState& state)
-    : tracing::TargetTracingAgent(state) {}
+RuntimeTracingAgent::RuntimeTracingAgent(
+    tracing::TraceRecordingState& state,
+    RuntimeTargetController& targetController)
+    : tracing::TargetTracingAgent(state), targetController_(targetController) {
+  targetController_.enableSamplingProfiler();
+}
+
+RuntimeTracingAgent::~RuntimeTracingAgent() {
+  targetController_.disableSamplingProfiler();
+  auto profile = targetController_.collectSamplingProfile();
+
+  state_.runtimeSamplingProfiles.emplace_back(std::move(profile));
+}
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.h
@@ -118,7 +118,14 @@ class RuntimeAgent final {
  */
 class RuntimeTracingAgent : tracing::TargetTracingAgent {
  public:
-  explicit RuntimeTracingAgent(tracing::TraceRecordingState& state);
+  explicit RuntimeTracingAgent(
+      tracing::TraceRecordingState& state,
+      RuntimeTargetController& targetController);
+
+  ~RuntimeTracingAgent();
+
+ private:
+  RuntimeTargetController& targetController_;
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.h
@@ -13,6 +13,8 @@
 
 #include <jsinspector-modern/cdp/CdpJson.h>
 #include <jsinspector-modern/tracing/RuntimeSamplingProfile.h>
+#include <jsinspector-modern/tracing/TargetTracingAgent.h>
+#include <jsinspector-modern/tracing/TraceRecordingState.h>
 
 namespace facebook::react::jsinspector_modern {
 
@@ -104,6 +106,19 @@ class RuntimeAgent final {
   SessionState& sessionState_;
   const std::unique_ptr<RuntimeAgentDelegate> delegate_;
   const ExecutionContextDescription executionContextDescription_;
+};
+
+#pragma mark - Tracing
+
+/**
+ * An Agent that handles Tracing events for a particular RuntimeTarget.
+ *
+ * Lifetime of this agent is bound to the lifetime of the Tracing session -
+ * HostTargetTraceRecording and to the lifetime of the RuntimeTarget.
+ */
+class RuntimeTracingAgent : tracing::TargetTracingAgent {
+ public:
+  explicit RuntimeTracingAgent(tracing::TraceRecordingState& state);
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
@@ -79,7 +79,7 @@ std::shared_ptr<RuntimeAgent> RuntimeTarget::createAgent(
 
 std::shared_ptr<RuntimeTracingAgent> RuntimeTarget::createTracingAgent(
     tracing::TraceRecordingState& state) {
-  auto agent = std::make_shared<RuntimeTracingAgent>(state);
+  auto agent = std::make_shared<RuntimeTracingAgent>(state, controller_);
   tracingAgent_ = agent;
   return agent;
 }

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.cpp
@@ -77,12 +77,24 @@ std::shared_ptr<RuntimeAgent> RuntimeTarget::createAgent(
   return runtimeAgent;
 }
 
+std::shared_ptr<RuntimeTracingAgent> RuntimeTarget::createTracingAgent(
+    tracing::TraceRecordingState& state) {
+  auto agent = std::make_shared<RuntimeTracingAgent>(state);
+  tracingAgent_ = agent;
+  return agent;
+}
+
 RuntimeTarget::~RuntimeTarget() {
   // Agents are owned by the session, not by RuntimeTarget, but
   // they hold a RuntimeTarget& that we must guarantee is valid.
   assert(
       agents_.empty() &&
       "RuntimeAgent objects must be destroyed before their RuntimeTarget. Did you call InstanceTarget::unregisterRuntime()?");
+
+  // Tracing Agents are owned by the HostTargetTraceRecording.
+  assert(
+      tracingAgent_.expired() &&
+      "RuntimeTracingAgent must be destroyed before their InstanceTarget. Did you call InstanceTarget::unregisterRuntime()?");
 }
 
 void RuntimeTarget::installBindingHandler(const std::string& bindingName) {

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
@@ -17,6 +17,7 @@
 
 #include <ReactCommon/RuntimeExecutor.h>
 #include <jsinspector-modern/tracing/RuntimeSamplingProfile.h>
+#include <jsinspector-modern/tracing/TraceRecordingState.h>
 
 #include <memory>
 
@@ -35,6 +36,7 @@
 namespace facebook::react::jsinspector_modern {
 
 class RuntimeAgent;
+class RuntimeTracingAgent;
 class RuntimeAgentDelegate;
 class RuntimeTarget;
 struct SessionState;
@@ -203,6 +205,17 @@ class JSINSPECTOR_EXPORT RuntimeTarget
       SessionState& sessionState);
 
   /**
+   * Creates a new RuntimeTracingAgent.
+   * This Agent is not owned by the RuntimeTarget. The Agent will be destroyed
+   * either before the RuntimeTarget is destroyed, as part of the RuntimeTarget
+   * unregistration in InstanceTarget, or at the end of the tracing session.
+   *
+   * \param state A reference to the state of the active trace recording.
+   */
+  std::shared_ptr<RuntimeTracingAgent> createTracingAgent(
+      tracing::TraceRecordingState& state);
+
+  /**
    * Start sampling profiler for a particular JavaScript runtime.
    */
   void enableSamplingProfiler();
@@ -245,6 +258,13 @@ class JSINSPECTOR_EXPORT RuntimeTarget
   RuntimeExecutor jsExecutor_;
   WeakList<RuntimeAgent> agents_;
   RuntimeTargetController controller_{*this};
+
+  /**
+   * This TracingAgent is owned by the InstanceTracingAgent, both are bound to
+   * the lifetime of their corresponding targets and the lifetime of the tracing
+   * session - HostTargetTraceRecording.
+   */
+  std::weak_ptr<RuntimeTracingAgent> tracingAgent_;
 
   /**
    * Adds a function with the given name on the runtime's global object, that

--- a/packages/react-native/ReactCommon/jsinspector-modern/SessionState.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/SessionState.h
@@ -26,6 +26,12 @@ struct SessionState {
   bool isRuntimeDomainEnabled{false};
 
   /**
+   * Whether the Trace Recording was initialized via CDP Tracing.start method
+   * and not finished yet with Tracing.stop.
+   */
+  bool hasPendingTraceRecording{false};
+
+  /**
    * A map from binding names (registered during this session using @cdp
    * Runtime.addBinding) to execution context selectors.
    *

--- a/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.cpp
@@ -95,9 +95,4 @@ bool TracingAgent::handleRequest(const cdp::PreparsedRequest& req) {
   return false;
 }
 
-void TracingAgent::setCurrentInstanceAgent(
-    std::shared_ptr<InstanceAgent> instanceAgent) {
-  instanceAgent_ = std::move(instanceAgent);
-}
-
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.cpp
@@ -10,6 +10,7 @@
 #include <jsinspector-modern/tracing/PerformanceTracer.h>
 #include <jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.h>
 #include <jsinspector-modern/tracing/TraceEventSerializer.h>
+#include <jsinspector-modern/tracing/TraceRecordingStateSerializer.h>
 
 namespace facebook::react::jsinspector_modern {
 
@@ -24,39 +25,22 @@ const uint16_t TRACE_EVENT_CHUNK_SIZE = 1000;
 /**
  * The maximum number of ProfileChunk trace events
  * that will be sent in a single CDP Tracing.dataCollected message.
- * TODO(T219394401): Increase the size once we manage the queue on OkHTTP side
+ * TODO(T219394401): Increase the size once we manage the queue on OkHTTP
+ side
  * properly and avoid WebSocket disconnections when sending a message larger
  * than 16MB.
  */
 const uint16_t PROFILE_TRACE_EVENT_CHUNK_SIZE = 1;
 
-void serializeTraceEventsInChunks(
-    std::vector<tracing::TraceEvent>&& traceEvents,
-    uint16_t chunkSize,
-    const std::function<void(folly::dynamic&& eventsChunk)>& resultCallback) {
-  auto serializedTraceEvents = folly::dynamic::array();
-  for (auto&& traceEvent : traceEvents) {
-    // Emit trace events
-    serializedTraceEvents.push_back(
-        tracing::TraceEventSerializer::serialize(std::move(traceEvent)));
-
-    if (serializedTraceEvents.size() == chunkSize) {
-      resultCallback(std::move(serializedTraceEvents));
-      serializedTraceEvents = folly::dynamic::array();
-    }
-  }
-  if (!serializedTraceEvents.empty()) {
-    resultCallback(std::move(serializedTraceEvents));
-  }
-}
-
 } // namespace
 
 TracingAgent::TracingAgent(
     FrontendChannel frontendChannel,
-    const SessionState& sessionState)
+    const SessionState& sessionState,
+    HostTargetController& hostTargetController)
     : frontendChannel_(std::move(frontendChannel)),
-      sessionState_(sessionState) {}
+      sessionState_(sessionState),
+      hostTargetController_(hostTargetController) {}
 
 bool TracingAgent::handleRequest(const cdp::PreparsedRequest& req) {
   if (req.method == "Tracing.start") {
@@ -69,56 +53,23 @@ bool TracingAgent::handleRequest(const cdp::PreparsedRequest& req) {
 
       return true;
     }
-    if (!instanceAgent_) {
+
+    bool didNotHaveAlreadyRunningRecording =
+        hostTargetController_.startTracing();
+    if (!didNotHaveAlreadyRunningRecording) {
       frontendChannel_(cdp::jsonError(
           req.id,
-          cdp::ErrorCode::InternalError,
-          "Couldn't find instance available for Tracing"));
+          cdp::ErrorCode::InvalidRequest,
+          "Tracing has already been started"));
 
       return true;
     }
-
-    bool correctlyStartedPerformanceTracer =
-        tracing::PerformanceTracer::getInstance().startTracing();
-
-    if (!correctlyStartedPerformanceTracer) {
-      frontendChannel_(cdp::jsonError(
-          req.id,
-          cdp::ErrorCode::InternalError,
-          "Tracing session already started"));
-
-      return true;
-    }
-
-    instanceAgent_->startTracing();
-    instanceTracingStartTimestamp_ = HighResTimeStamp::now();
     frontendChannel_(cdp::jsonResult(req.id));
 
     return true;
   } else if (req.method == "Tracing.end") {
     // @cdp Tracing.end support is experimental.
-    if (!instanceAgent_) {
-      frontendChannel_(cdp::jsonError(
-          req.id,
-          cdp::ErrorCode::InternalError,
-          "Couldn't find instance available for Tracing"));
-
-      return true;
-    }
-
-    instanceAgent_->stopTracing();
-
-    tracing::PerformanceTracer& performanceTracer =
-        tracing::PerformanceTracer::getInstance();
-    auto collectedEvents = performanceTracer.stopTracing();
-    if (!collectedEvents) {
-      frontendChannel_(cdp::jsonError(
-          req.id,
-          cdp::ErrorCode::InternalError,
-          "Tracing session not started"));
-
-      return true;
-    }
+    auto state = hostTargetController_.stopTracing();
 
     // Send response to Tracing.end request.
     frontendChannel_(cdp::jsonResult(req.id));
@@ -128,19 +79,10 @@ bool TracingAgent::handleRequest(const cdp::PreparsedRequest& req) {
           "Tracing.dataCollected",
           folly::dynamic::object("value", std::move(eventsChunk))));
     };
-
-    serializeTraceEventsInChunks(
-        std::move(*collectedEvents),
-        TRACE_EVENT_CHUNK_SIZE,
-        dataCollectedCallback);
-
-    auto tracingProfile = instanceAgent_->collectTracingProfile();
-    tracing::IdGenerator profileIdGenerator;
-    tracing::RuntimeSamplingProfileTraceEventSerializer::serializeAndDispatch(
-        std::move(tracingProfile.runtimeSamplingProfile),
-        profileIdGenerator,
-        instanceTracingStartTimestamp_,
+    tracing::TraceRecordingStateSerializer::dispatchAsDataCollectedChunks(
+        std::move(state),
         dataCollectedCallback,
+        TRACE_EVENT_CHUNK_SIZE,
         PROFILE_TRACE_EVENT_CHUNK_SIZE);
 
     frontendChannel_(cdp::jsonNotification(

--- a/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.cpp
@@ -11,6 +11,7 @@
 #include <jsinspector-modern/tracing/RuntimeSamplingProfileTraceEventSerializer.h>
 #include <jsinspector-modern/tracing/TraceEventSerializer.h>
 #include <jsinspector-modern/tracing/TraceRecordingStateSerializer.h>
+#include <jsinspector-modern/tracing/TracingMode.h>
 
 namespace facebook::react::jsinspector_modern {
 
@@ -63,7 +64,7 @@ bool TracingAgent::handleRequest(const cdp::PreparsedRequest& req) {
     }
 
     bool didNotHaveAlreadyRunningRecording =
-        hostTargetController_.startTracing();
+        hostTargetController_.startTracing(tracing::Mode::CDP);
     if (!didNotHaveAlreadyRunningRecording) {
       frontendChannel_(cdp::jsonError(
           req.id,

--- a/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.cpp
@@ -38,10 +38,15 @@ const uint16_t PROFILE_TRACE_EVENT_CHUNK_SIZE = 1;
 TracingAgent::TracingAgent(
     FrontendChannel frontendChannel,
     SessionState& sessionState,
-    HostTargetController& hostTargetController)
+    HostTargetController& hostTargetController,
+    std::optional<tracing::TraceRecordingState> maybeTraceToDisplay)
     : frontendChannel_(std::move(frontendChannel)),
       sessionState_(sessionState),
-      hostTargetController_(hostTargetController) {}
+      hostTargetController_(hostTargetController) {
+  if (maybeTraceToDisplay.has_value()) {
+    emitTraceRecording(std::move(maybeTraceToDisplay.value()));
+  }
+}
 
 TracingAgent::~TracingAgent() {
   // Agents are owned by the session. If the agent is destroyed, it means that
@@ -86,25 +91,29 @@ bool TracingAgent::handleRequest(const cdp::PreparsedRequest& req) {
     // Send response to Tracing.end request.
     frontendChannel_(cdp::jsonResult(req.id));
 
-    auto dataCollectedCallback = [this](folly::dynamic&& eventsChunk) {
-      frontendChannel_(cdp::jsonNotification(
-          "Tracing.dataCollected",
-          folly::dynamic::object("value", std::move(eventsChunk))));
-    };
-    tracing::TraceRecordingStateSerializer::dispatchAsDataCollectedChunks(
-        std::move(state),
-        dataCollectedCallback,
-        TRACE_EVENT_CHUNK_SIZE,
-        PROFILE_TRACE_EVENT_CHUNK_SIZE);
-
-    frontendChannel_(cdp::jsonNotification(
-        "Tracing.tracingComplete",
-        folly::dynamic::object("dataLossOccurred", false)));
-
+    emitTraceRecording(std::move(state));
     return true;
   }
 
   return false;
+}
+
+void TracingAgent::emitTraceRecording(
+    tracing::TraceRecordingState state) const {
+  auto dataCollectedCallback = [this](folly::dynamic&& eventsChunk) {
+    frontendChannel_(cdp::jsonNotification(
+        "Tracing.dataCollected",
+        folly::dynamic::object("value", std::move(eventsChunk))));
+  };
+  tracing::TraceRecordingStateSerializer::dispatchAsDataCollectedChunks(
+      std::move(state),
+      dataCollectedCallback,
+      TRACE_EVENT_CHUNK_SIZE,
+      PROFILE_TRACE_EVENT_CHUNK_SIZE);
+
+  frontendChannel_(cdp::jsonNotification(
+      "Tracing.tracingComplete",
+      folly::dynamic::object("dataLossOccurred", false)));
 }
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include "HostTarget.h"
 #include "InspectorInterfaces.h"
 #include "InstanceAgent.h"
 
@@ -27,7 +28,8 @@ class TracingAgent {
    */
   TracingAgent(
       FrontendChannel frontendChannel,
-      const SessionState& sessionState);
+      const SessionState& sessionState,
+      HostTargetController& hostTargetController);
 
   /**
    * Handle a CDP request. The response will be sent over the provided
@@ -63,6 +65,8 @@ class TracingAgent {
   HighResTimeStamp instanceTracingStartTimestamp_;
 
   const SessionState& sessionState_;
+
+  HostTargetController& hostTargetController_;
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.h
@@ -9,7 +9,6 @@
 
 #include "HostTarget.h"
 #include "InspectorInterfaces.h"
-#include "InstanceAgent.h"
 
 #include <jsinspector-modern/cdp/CdpJson.h>
 #include <jsinspector-modern/tracing/Timing.h>
@@ -38,31 +37,11 @@ class TracingAgent {
    */
   bool handleRequest(const cdp::PreparsedRequest& req);
 
-  /**
-   * Replace the current InstanceAgent with the given one.
-   * \param agent The new InstanceAgent. May be null to signify that there is
-   * currently no active instance.
-   */
-  void setCurrentInstanceAgent(std::shared_ptr<InstanceAgent> agent);
-
  private:
   /**
    * A channel used to send responses and events to the frontend.
    */
   FrontendChannel frontendChannel_;
-
-  /**
-   * Current InstanceAgent. May be null to signify that there is
-   * currently no active instance.
-   */
-  std::shared_ptr<InstanceAgent> instanceAgent_;
-
-  /**
-   * Timestamp of when we started tracing of an Instance, will be used as a
-   * a start of JavaScript samples recording and as a time origin for the events
-   * in this trace.
-   */
-  HighResTimeStamp instanceTracingStartTimestamp_;
 
   const SessionState& sessionState_;
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.h
@@ -27,8 +27,10 @@ class TracingAgent {
    */
   TracingAgent(
       FrontendChannel frontendChannel,
-      const SessionState& sessionState,
+      SessionState& sessionState,
       HostTargetController& hostTargetController);
+
+  ~TracingAgent();
 
   /**
    * Handle a CDP request. The response will be sent over the provided
@@ -43,7 +45,7 @@ class TracingAgent {
    */
   FrontendChannel frontendChannel_;
 
-  const SessionState& sessionState_;
+  SessionState& sessionState_;
 
   HostTargetController& hostTargetController_;
 };

--- a/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.h
@@ -24,11 +24,18 @@ class TracingAgent {
   /**
    * \param frontendChannel A channel used to send responses to the
    * frontend.
+   * \param sessionState The state of the session that created this agent.
+   * \param hostTargetController An interface to the HostTarget that this agent
+   * is attached to. The caller is responsible for ensuring that the
+   * HostTargetDelegate and underlying HostTarget both outlive the agent.
+   * \param maybeTraceToDisplay If set, this is the trace that Host has
+   * requested to display in the Frontend.
    */
   TracingAgent(
       FrontendChannel frontendChannel,
       SessionState& sessionState,
-      HostTargetController& hostTargetController);
+      HostTargetController& hostTargetController,
+      std::optional<tracing::TraceRecordingState> maybeTraceToDisplay);
 
   ~TracingAgent();
 
@@ -48,6 +55,12 @@ class TracingAgent {
   SessionState& sessionState_;
 
   HostTargetController& hostTargetController_;
+
+  /**
+   * Emits the captured Trace Recording state in a series of
+   * Tracing.dataCollected events, followed by a Tracing.tracingComplete event.
+   */
+  void emitTraceRecording(tracing::TraceRecordingState state) const;
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/InstanceTracingProfile.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/InstanceTracingProfile.h
@@ -7,15 +7,9 @@
 
 #pragma once
 
-#include "RuntimeSamplingProfile.h"
 #include "TraceEvent.h"
 
 namespace facebook::react::jsinspector_modern::tracing {
-
-struct InstanceTracingProfileLegacy {
- public:
-  RuntimeSamplingProfile runtimeSamplingProfile;
-};
 
 struct InstanceTracingProfile {
   std::vector<TraceEvent> performanceTraceEvents;

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/InstanceTracingProfile.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/InstanceTracingProfile.h
@@ -8,12 +8,17 @@
 #pragma once
 
 #include "RuntimeSamplingProfile.h"
+#include "TraceEvent.h"
 
 namespace facebook::react::jsinspector_modern::tracing {
 
-struct InstanceTracingProfile {
+struct InstanceTracingProfileLegacy {
  public:
   RuntimeSamplingProfile runtimeSamplingProfile;
+};
+
+struct InstanceTracingProfile {
+  std::vector<TraceEvent> performanceTraceEvents;
 };
 
 } // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
@@ -77,7 +77,6 @@ std::optional<std::vector<TraceEvent>> PerformanceTracer::stopTracing() {
 
     tracingAtomic_ = false;
     performanceMeasureCount_ = 0;
-    currentTraceMaxDuration_ = std::nullopt;
 
     events = collectEventsAndClearBuffers(currentTraceEndTime);
   }
@@ -114,6 +113,7 @@ std::optional<std::vector<TraceEvent>> PerformanceTracer::stopTracing() {
       .tid = oscompat::getCurrentThreadId(),
   });
 
+  currentTraceMaxDuration_ = std::nullopt;
   return events;
 }
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TargetTracingAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TargetTracingAgent.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "TraceRecordingState.h"
+
+namespace facebook::react::jsinspector_modern::tracing {
+
+/**
+ * An interface for a tracing agent of a target.
+ * Tracing Agents are only allocated during an active tracing session.
+ *
+ * Construction of a TracingAgent means that either the recording has just
+ * started or the target was just created during an active recording.
+ * Destruction of a TracingAgent means that either the recording has stopped or
+ * the target is about to be destroyed.
+ */
+class TargetTracingAgent {
+ public:
+  explicit TargetTracingAgent(TraceRecordingState& state) : state_(state) {
+    (void)state_;
+  }
+
+ protected:
+  TraceRecordingState& state_;
+};
+
+} // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceRecordingSerializer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceRecordingSerializer.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "RuntimeSamplingProfileTraceEventSerializer.h"
+#include "TraceEventSerializer.h"
+#include "TraceRecordingStateSerializer.h"
+
+namespace facebook::react::jsinspector_modern::tracing {
+
+namespace {
+
+folly::dynamic generateNewChunk(uint16_t chunkSize) {
+  folly::dynamic chunk = folly::dynamic::array();
+  chunk.reserve(chunkSize);
+
+  return chunk;
+}
+
+} // namespace
+
+/* static */ void TraceRecordingStateSerializer::dispatchAsDataCollectedChunks(
+    TraceRecordingState&& recording,
+    const std::function<void(folly::dynamic&&)>& chunkCallback,
+    uint16_t performanceTraceEventsChunkSize,
+    uint16_t profileTraceEventsChunkSize) {
+  auto instancesProfiles = std::move(recording.instanceTracingProfiles);
+  IdGenerator profileIdGenerator;
+
+  for (auto& instanceProfile : instancesProfiles) {
+    dispatchPerformanceTraceEvents(
+        std::move(instanceProfile.performanceTraceEvents),
+        chunkCallback,
+        performanceTraceEventsChunkSize);
+  }
+
+  RuntimeSamplingProfileTraceEventSerializer::serializeAndDispatch(
+      std::move(recording.runtimeSamplingProfiles),
+      profileIdGenerator,
+      recording.startTime,
+      chunkCallback,
+      profileTraceEventsChunkSize);
+}
+
+/* static */ void TraceRecordingStateSerializer::dispatchPerformanceTraceEvents(
+    std::vector<TraceEvent>&& events,
+    const std::function<void(folly::dynamic&&)>& chunkCallback,
+    uint16_t chunkSize) {
+  folly::dynamic chunk = generateNewChunk(chunkSize);
+
+  for (auto& event : events) {
+    if (chunk.size() == chunkSize) {
+      chunkCallback(std::move(chunk));
+      chunk = generateNewChunk(chunkSize);
+    }
+
+    chunk.push_back(TraceEventSerializer::serialize(std::move(event)));
+  }
+
+  if (!chunk.empty()) {
+    chunkCallback(std::move(chunk));
+  }
+}
+
+} // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceRecordingState.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceRecordingState.h
@@ -7,11 +7,15 @@
 
 #pragma once
 
+#include "RuntimeSamplingProfile.h"
+
+#include <vector>
+
 namespace facebook::react::jsinspector_modern::tracing {
 
-/**
- * Encapsulates the state of the Trace.
- */
-struct TraceRecordingState {};
+struct TraceRecordingState {
+  // All captured Runtime Sampling Profiles during this Trace Recording.
+  std::vector<RuntimeSamplingProfile> runtimeSamplingProfiles{};
+};
 
 } // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceRecordingState.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceRecordingState.h
@@ -9,6 +9,7 @@
 
 #include "InstanceTracingProfile.h"
 #include "RuntimeSamplingProfile.h"
+#include "TracingMode.h"
 
 #include <oscompat/OSCompat.h>
 #include <react/timing/primitives.h>
@@ -18,6 +19,9 @@
 namespace facebook::react::jsinspector_modern::tracing {
 
 struct TraceRecordingState {
+  // The mode of this Trace Recording.
+  tracing::Mode mode;
+
   // The ID of the OS-level process that this Trace Recording is associated
   // with.
   ProcessId processId = oscompat::getCurrentProcessId();

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceRecordingState.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceRecordingState.h
@@ -10,11 +10,17 @@
 #include "InstanceTracingProfile.h"
 #include "RuntimeSamplingProfile.h"
 
+#include <oscompat/OSCompat.h>
+
 #include <vector>
 
 namespace facebook::react::jsinspector_modern::tracing {
 
 struct TraceRecordingState {
+  // The ID of the OS-level process that this Trace Recording is associated
+  // with.
+  ProcessId processId = oscompat::getCurrentProcessId();
+
   // All captured Runtime Sampling Profiles during this Trace Recording.
   std::vector<RuntimeSamplingProfile> runtimeSamplingProfiles{};
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceRecordingState.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceRecordingState.h
@@ -11,6 +11,7 @@
 #include "RuntimeSamplingProfile.h"
 
 #include <oscompat/OSCompat.h>
+#include <react/timing/primitives.h>
 
 #include <vector>
 
@@ -20,6 +21,9 @@ struct TraceRecordingState {
   // The ID of the OS-level process that this Trace Recording is associated
   // with.
   ProcessId processId = oscompat::getCurrentProcessId();
+
+  // The timestamp at which this Trace Recording started.
+  HighResTimeStamp startTime;
 
   // All captured Runtime Sampling Profiles during this Trace Recording.
   std::vector<RuntimeSamplingProfile> runtimeSamplingProfiles{};

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceRecordingState.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceRecordingState.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include "InstanceTracingProfile.h"
 #include "RuntimeSamplingProfile.h"
 
 #include <vector>
@@ -16,6 +17,9 @@ namespace facebook::react::jsinspector_modern::tracing {
 struct TraceRecordingState {
   // All captured Runtime Sampling Profiles during this Trace Recording.
   std::vector<RuntimeSamplingProfile> runtimeSamplingProfiles{};
+
+  // All captures Instance Tracing Profiles during this Trace Recording.
+  std::vector<InstanceTracingProfile> instanceTracingProfiles{};
 };
 
 } // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceRecordingState.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceRecordingState.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace facebook::react::jsinspector_modern::tracing {
+
+/**
+ * Encapsulates the state of the Trace.
+ */
+struct TraceRecordingState {};
+
+} // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceRecordingStateSerializer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceRecordingStateSerializer.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "TraceEvent.h"
+#include "TraceRecordingState.h"
+
+#include <folly/dynamic.h>
+#include <vector>
+
+namespace facebook::react::jsinspector_modern::tracing {
+
+/**
+ * A serializer for TraceRecordingState that can be used for tranforming the
+ * recording into sequence of serialized Trace Events.
+ */
+class TraceRecordingStateSerializer {
+ public:
+  /**
+   * Transforms the recording into a sequence of serialized Trace Events, which
+   * is split in chunks of sizes \p performanceTraceEventsChunkSize or
+   * \p profileTraceEventsChunkSize, depending on type, and sent with \p
+   * chunkCallback.
+   */
+  static void dispatchAsDataCollectedChunks(
+      TraceRecordingState&& recording,
+      const std::function<void(folly::dynamic&& chunk)>& chunkCallback,
+      uint16_t performanceTraceEventsChunkSize,
+      uint16_t profileTraceEventsChunkSize);
+
+  static void dispatchPerformanceTraceEvents(
+      std::vector<TraceEvent>&& events,
+      const std::function<void(folly::dynamic&& chunk)>& chunkCallback,
+      uint16_t chunkSize);
+};
+
+} // namespace facebook::react::jsinspector_modern::tracing

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TracingMode.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TracingMode.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace facebook::react::jsinspector_modern::tracing {
+
+enum class Mode {
+  CDP, // Initiated by the user via Chrome DevTools Frontend.
+  Background, // Initiated by the host, doesn't require active CDP session.
+};
+
+}


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

When CDP session is created via `HostTarget::connect`, it will ask `HostTargetDelegate` is there is a previously recorded trace that Host wants to display in the Frontend.

`TracingAgent` will serialize and send the recording at the initialization time in constructor.

Differential Revision: D79672597
