### PR TITLE
expose HMRClient for use in Expo

### DIFF
--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -217,6 +217,13 @@ module.exports = {
   get findNodeHandle() {
     return require('./Libraries/ReactNative/RendererProxy').findNodeHandle;
   },
+  get HMRClient() {
+    if (__DEV__) {
+      return require('./Libraries/Utilities/HMRClient').default;
+    }
+    return require('./Libraries/Utilities/HMRClientProdShim').default;
+  },
+
   get I18nManager() {
     return require('./Libraries/ReactNative/I18nManager').default;
   },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

While upgrading Expo to the latest React Native, we're seeing a number of warnings from internal imports. We've been able to work around most of these https://github.com/expo/expo/pull/38587 https://github.com/expo/expo/pull/38588 https://github.com/expo/expo/pull/38495 but some are harder to work around.

<img width="1721" height="242" alt="Screenshot 2025-08-05 at 4 36 29 PM" src="https://github.com/user-attachments/assets/c2a2eadb-44c5-4329-9372-978bd1287b64" />

This PR exposes HMRClient module which we use for async bundle loading. While there is an new upstream version of `__loadBundleAsync`, it isn't enabled in production and doesn't give us the flexibility to send headers back to the server (which we use for React Server Components on native).

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[GENERAL] [ADDED] - Export HMRClient from react-native.

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
