### PR TITLE
docs: fix informal wording in Animated demo section

### DIFF
--- a/packages/rn-tester/js/examples/AnimatedGratuitousApp/AnExSlides.md
+++ b/packages/rn-tester/js/examples/AnimatedGratuitousApp/AnExSlides.md
@@ -42,7 +42,7 @@ ReactEurope 2015, Paris - Spencer Ahrens - Facebook
 
 <br /><br />
 
-## Gratuitous Animation Codez
+## Gratuitous Animation Code
 
 - Step 1: 2D tracking pan gesture
 - Step 2: Simple pop-out spring on select


### PR DESCRIPTION
## Summary:

This PR updates a heading in the React Native: Animated documentation.

The term **“Codez”** was used informally in the section titled **"Gratuitous Animation Codez"**. This slang-style wording has been replaced with the more appropriate and professional term **“Code”**.

This improves consistency, accessibility, and clarity throughout the documentation — especially for non-native English readers and newcomers to open source.

---

## Changelog:

**\[GENERAL]\[FIXED]** – Replaced informal term “Codez” with “Code” in Animated documentation title.

---

## Test Plan:

This is a documentation-only change.

* Manually reviewed the updated file to ensure:

  * The heading renders correctly.
  * No formatting or Markdown structure is broken.
  * No links, anchors, or references are affected.

No functional or UI behavior was changed.
