### PR TITLE
fix: turn off build IDs for reproducibility

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
@@ -29,9 +29,6 @@ if(CCACHE_FOUND)
   set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
 endif(CCACHE_FOUND)
 
-# Make sure every shared lib includes a .note.gnu.build-id header
-add_link_options(-Wl,--build-id)
-
 function(add_react_android_subdir relative_path)
   add_subdirectory(${REACT_ANDROID_DIR}/${relative_path} ReactAndroid/${relative_path})
 endfunction()


### PR DESCRIPTION
## Summary:

these cause issues for apps that want to be "reproducible" (i.e. the same code leads to the same output, which can be helpful for detemining if there's been any tampering or similar). see also https://gitlab.com/IzzyOnDroid/repo/-/wikis/Reproducible-Builds/RB-Hints-for-Developers#no-funny-build-time-generated-ids

I'm not exactly sure why this was set. it seems to have been introduced in https://github.com/facebook/react-native/commit/e3830ddffd9260fe071e0c9f9df40b379d54cf26 without any (public) explanation as to why it was needed?

## Changelog:

[ANDROID] [FIXED] - Turned off build IDs for native libraries, fixing issues with reproducibility

## Test Plan:

I've successfully used similar patches in my own app for a while.