### PR TITLE
Deprecate Legacy Architecture classes belonging to com/facebook/react/uimanager

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LayoutDirectionUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LayoutDirectionUtil.kt
@@ -14,6 +14,9 @@ import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
 import com.facebook.yoga.YogaDirection
 
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
+@Deprecated(
+    message = "This class is part of Legacy Architecture and will be removed in a future release",
+    level = DeprecationLevel.WARNING)
 internal object LayoutDirectionUtil {
   init {
     LegacyArchitectureLogger.assertLegacyArchitecture(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeKind.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeKind.kt
@@ -14,6 +14,9 @@ import com.facebook.react.common.annotations.internal.LegacyArchitectureLogLevel
 //   - `kind == PARENT` checks whether the node can host children in the native tree.
 //   - `kind != NONE` checks whether the node appears in the native tree.
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
+@Deprecated(
+    message = "This class is part of Legacy Architecture and will be removed in a future release",
+    level = DeprecationLevel.WARNING)
 internal enum class NativeKind {
   // Node is in the native hierarchy and the HierarchyOptimizer should assume it can host children
   // (e.g. because it's a ViewGroup). Note that it's okay if the node doesn't support children. When

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
@@ -68,6 +68,8 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
+@Deprecated(
+    since = "This class is part of Legacy Architecture and will be removed in a future release")
 public class NativeViewHierarchyManager {
 
   static {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyOptimizer.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyOptimizer.java
@@ -49,6 +49,8 @@ import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger;
  * depending on where the views being added/removed are attached in the optimized hierarchy
  */
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
+@Deprecated(
+    since = "This class is part of Legacy Architecture and will be removed in a future release")
 public class NativeViewHierarchyOptimizer {
 
   static {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NoSuchNativeViewException.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NoSuchNativeViewException.kt
@@ -16,6 +16,9 @@ import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
  * associated with it.
  */
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
+@Deprecated(
+    message = "This class is part of Legacy Architecture and will be removed in a future release",
+    level = DeprecationLevel.WARNING)
 internal class NoSuchNativeViewException(detailMessage: String) :
     IllegalViewOperationException(detailMessage) {
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/OnLayoutEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/OnLayoutEvent.kt
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.facebook.react.uimanager
 
 import androidx.core.util.Pools.SynchronizedPool
@@ -20,6 +22,9 @@ import com.facebook.react.uimanager.events.Event
 
 /** Event used to notify JS component about changes of its position or dimensions. */
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.WARNING)
+@Deprecated(
+    message = "This class is part of Legacy Architecture and will be removed in a future release",
+    level = DeprecationLevel.WARNING)
 public class OnLayoutEvent private constructor() : Event<OnLayoutEvent>() {
   @VisibleForTesting internal var x: Int = 0
   @VisibleForTesting internal var y: Int = 0

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ShadowNodeRegistry.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ShadowNodeRegistry.kt
@@ -20,6 +20,9 @@ import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
  * UIManagerModule instance.
  */
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
+@Deprecated(
+    message = "This class is part of Legacy Architecture and will be removed in a future release",
+    level = DeprecationLevel.WARNING)
 internal class ShadowNodeRegistry {
   private val tagsToCSSNodes = SparseArray<ReactShadowNode<*>>()
   private val rootTags = SparseBooleanArray()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIBlock.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIBlock.kt
@@ -9,5 +9,7 @@ package com.facebook.react.uimanager
 
 /** A task to execute on the UI View for third party libraries. */
 public fun interface UIBlock {
-  public fun execute(nativeViewHierarchyManager: NativeViewHierarchyManager)
+  public fun execute(
+      @Suppress("DEPRECATION") nativeViewHierarchyManager: NativeViewHierarchyManager
+  )
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java
@@ -42,6 +42,8 @@ import java.util.Map;
  * hierarchy that is then mapped to a native view hierarchy.
  */
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
+@Deprecated(
+    since = "This class is part of Legacy Architecture and will be removed in a future release")
 public class UIImplementation {
   static {
     LegacyArchitectureLogger.assertLegacyArchitecture(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIViewOperationQueue.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIViewOperationQueue.java
@@ -49,6 +49,8 @@ import java.util.Map;
  * for operations queue to save on allocations
  */
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
+@Deprecated(
+    since = "This class is part of Legacy Architecture and will be removed in a future release")
 public class UIViewOperationQueue {
 
   static {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewAtIndex.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewAtIndex.kt
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.facebook.react.uimanager
 
 import com.facebook.react.common.annotations.internal.LegacyArchitecture
@@ -17,6 +19,9 @@ import java.util.Objects
  * operation.
  */
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
+@Deprecated(
+    message = "This class is part of Legacy Architecture and will be removed in a future release",
+    level = DeprecationLevel.WARNING)
 internal class ViewAtIndex(
     @Suppress("NoHungarianNotation") @JvmField public val mTag: Int,
     @Suppress("NoHungarianNotation") @JvmField public val mIndex: Int

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/YogaNodePool.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/YogaNodePool.kt
@@ -15,6 +15,9 @@ import com.facebook.yoga.YogaNode
 
 /** Static holder for a recycling pool of YogaNodes. */
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
+@Deprecated(
+    message = "This class is part of Legacy Architecture and will be removed in a future release",
+    level = DeprecationLevel.WARNING)
 internal object YogaNodePool {
   init {
     LegacyArchitectureLogger.assertLegacyArchitecture(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.kt
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.facebook.react.views.textinput
 
 import android.annotation.SuppressLint

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/OnLayoutEventTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/OnLayoutEventTest.kt
@@ -31,6 +31,7 @@ class OnLayoutEventTest {
     val width = 100
     val height = 200
 
+    @Suppress("DEPRECATION")
     val event = OnLayoutEvent.obtain(surfaceId, viewTag, x, y, width, height)
 
     assertThat(event).isNotNull
@@ -43,14 +44,14 @@ class OnLayoutEventTest {
 
   @Test
   fun testGetEventName_shouldReturnCorrectEventName() {
-    val event = OnLayoutEvent.obtain(1, 1, 10, 20, 100, 200)
+    @Suppress("DEPRECATION") val event = OnLayoutEvent.obtain(1, 1, 10, 20, 100, 200)
 
     assertThat(event.getEventName()).isEqualTo("topLayout")
   }
 
   @Test
   fun testInit_shouldCorrectlyInitializeValues() {
-    val event = OnLayoutEvent.obtain(1, 1, 10, 20, 100, 200)
+    @Suppress("DEPRECATION") val event = OnLayoutEvent.obtain(1, 1, 10, 20, 100, 200)
 
     assertThat(event.surfaceId).isEqualTo(1)
     assertThat(event.viewTag).isEqualTo(1)


### PR DESCRIPTION
Summary:
Deprecate large subset of Legacy Architecture classes belonging to com/facebook/react/uimanager

changelog: [Android][Changed] Deprecate LegacyArchitecture classes from com/facebook/react/uimanager

Reviewed By: mlord93

Differential Revision: D79672293


