### PR TITLE
Deprecate Legacy Architecture class CallbackImpl

### DIFF
--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsJavaDelegate-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsJavaDelegate-test.js.snap
@@ -20,6 +20,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class ArrayPropsNativeComponentViewManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & ArrayPropsNativeComponentViewManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public ArrayPropsNativeComponentViewManagerDelegate(U viewManager) {
     super(viewManager);
@@ -94,6 +95,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class BooleanPropNativeComponentViewManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & BooleanPropNativeComponentViewManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public BooleanPropNativeComponentViewManagerDelegate(U viewManager) {
     super(viewManager);
@@ -136,6 +138,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class ColorPropNativeComponentViewManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & ColorPropNativeComponentViewManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public ColorPropNativeComponentViewManagerDelegate(U viewManager) {
     super(viewManager);
@@ -175,6 +178,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class DimensionPropNativeComponentViewManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & DimensionPropNativeComponentViewManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public DimensionPropNativeComponentViewManagerDelegate(U viewManager) {
     super(viewManager);
@@ -213,6 +217,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class EdgeInsetsPropNativeComponentViewManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & EdgeInsetsPropNativeComponentViewManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public EdgeInsetsPropNativeComponentViewManagerDelegate(U viewManager) {
     super(viewManager);
@@ -245,6 +250,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class EnumPropNativeComponentViewManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & EnumPropNativeComponentViewManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public EnumPropNativeComponentViewManagerDelegate(U viewManager) {
     super(viewManager);
@@ -286,6 +292,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class EventNestedObjectPropsNativeComponentViewManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & EventNestedObjectPropsNativeComponentViewManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public EventNestedObjectPropsNativeComponentViewManagerDelegate(U viewManager) {
     super(viewManager);
@@ -324,6 +331,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class EventPropsNativeComponentViewManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & EventPropsNativeComponentViewManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public EventPropsNativeComponentViewManagerDelegate(U viewManager) {
     super(viewManager);
@@ -362,6 +370,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class FloatPropsNativeComponentViewManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & FloatPropsNativeComponentViewManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public FloatPropsNativeComponentViewManagerDelegate(U viewManager) {
     super(viewManager);
@@ -419,6 +428,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class ImagePropNativeComponentViewManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & ImagePropNativeComponentViewManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public ImagePropNativeComponentViewManagerDelegate(U viewManager) {
     super(viewManager);
@@ -457,6 +467,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class IntegerPropNativeComponentViewManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & IntegerPropNativeComponentViewManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public IntegerPropNativeComponentViewManagerDelegate(U viewManager) {
     super(viewManager);
@@ -501,6 +512,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class InterfaceOnlyNativeComponentViewManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & InterfaceOnlyNativeComponentViewManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public InterfaceOnlyNativeComponentViewManagerDelegate(U viewManager) {
     super(viewManager);
@@ -540,6 +552,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class MixedPropNativeComponentViewManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & MixedPropNativeComponentViewManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public MixedPropNativeComponentViewManagerDelegate(U viewManager) {
     super(viewManager);
@@ -580,6 +593,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class MultiNativePropNativeComponentViewManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & MultiNativePropNativeComponentViewManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public MultiNativePropNativeComponentViewManagerDelegate(U viewManager) {
     super(viewManager);
@@ -627,6 +641,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class NoPropsNoEventsNativeComponentViewManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & NoPropsNoEventsNativeComponentViewManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public NoPropsNoEventsNativeComponentViewManagerDelegate(U viewManager) {
     super(viewManager);
@@ -660,6 +675,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class ObjectPropsNativeComponentManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & ObjectPropsNativeComponentManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public ObjectPropsNativeComponentManagerDelegate(U viewManager) {
     super(viewManager);
@@ -705,6 +721,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class PointPropNativeComponentViewManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & PointPropNativeComponentViewManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public PointPropNativeComponentViewManagerDelegate(U viewManager) {
     super(viewManager);
@@ -743,6 +760,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class StringPropNativeComponentViewManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & StringPropNativeComponentViewManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public StringPropNativeComponentViewManagerDelegate(U viewManager) {
     super(viewManager);

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsJavaDelegate-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsJavaDelegate-test.js.snap
@@ -20,6 +20,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class ArrayPropsNativeComponentViewManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & ArrayPropsNativeComponentViewManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public ArrayPropsNativeComponentViewManagerDelegate(U viewManager) {
     super(viewManager);
@@ -94,6 +95,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class BooleanPropNativeComponentViewManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & BooleanPropNativeComponentViewManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public BooleanPropNativeComponentViewManagerDelegate(U viewManager) {
     super(viewManager);
@@ -136,6 +138,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class ColorPropNativeComponentViewManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & ColorPropNativeComponentViewManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public ColorPropNativeComponentViewManagerDelegate(U viewManager) {
     super(viewManager);
@@ -175,6 +178,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class DimensionPropNativeComponentViewManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & DimensionPropNativeComponentViewManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public DimensionPropNativeComponentViewManagerDelegate(U viewManager) {
     super(viewManager);
@@ -213,6 +217,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class EdgeInsetsPropNativeComponentViewManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & EdgeInsetsPropNativeComponentViewManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public EdgeInsetsPropNativeComponentViewManagerDelegate(U viewManager) {
     super(viewManager);
@@ -245,6 +250,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class EnumPropNativeComponentViewManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & EnumPropNativeComponentViewManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public EnumPropNativeComponentViewManagerDelegate(U viewManager) {
     super(viewManager);
@@ -286,6 +292,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class EventNestedObjectPropsNativeComponentViewManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & EventNestedObjectPropsNativeComponentViewManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public EventNestedObjectPropsNativeComponentViewManagerDelegate(U viewManager) {
     super(viewManager);
@@ -324,6 +331,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class EventPropsNativeComponentViewManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & EventPropsNativeComponentViewManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public EventPropsNativeComponentViewManagerDelegate(U viewManager) {
     super(viewManager);
@@ -362,6 +370,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class FloatPropsNativeComponentViewManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & FloatPropsNativeComponentViewManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public FloatPropsNativeComponentViewManagerDelegate(U viewManager) {
     super(viewManager);
@@ -419,6 +428,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class ImagePropNativeComponentViewManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & ImagePropNativeComponentViewManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public ImagePropNativeComponentViewManagerDelegate(U viewManager) {
     super(viewManager);
@@ -457,6 +467,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class IntegerPropNativeComponentViewManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & IntegerPropNativeComponentViewManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public IntegerPropNativeComponentViewManagerDelegate(U viewManager) {
     super(viewManager);
@@ -501,6 +512,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class InterfaceOnlyNativeComponentViewManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & InterfaceOnlyNativeComponentViewManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public InterfaceOnlyNativeComponentViewManagerDelegate(U viewManager) {
     super(viewManager);
@@ -540,6 +552,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class MixedPropNativeComponentViewManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & MixedPropNativeComponentViewManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public MixedPropNativeComponentViewManagerDelegate(U viewManager) {
     super(viewManager);
@@ -580,6 +593,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class MultiNativePropNativeComponentViewManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & MultiNativePropNativeComponentViewManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public MultiNativePropNativeComponentViewManagerDelegate(U viewManager) {
     super(viewManager);
@@ -627,6 +641,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class NoPropsNoEventsNativeComponentViewManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & NoPropsNoEventsNativeComponentViewManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public NoPropsNoEventsNativeComponentViewManagerDelegate(U viewManager) {
     super(viewManager);
@@ -660,6 +675,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class ObjectPropsNativeComponentManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & ObjectPropsNativeComponentManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public ObjectPropsNativeComponentManagerDelegate(U viewManager) {
     super(viewManager);
@@ -705,6 +721,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class PointPropNativeComponentViewManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & PointPropNativeComponentViewManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public PointPropNativeComponentViewManagerDelegate(U viewManager) {
     super(viewManager);
@@ -743,6 +760,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class StringPropNativeComponentViewManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & StringPropNativeComponentViewManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public StringPropNativeComponentViewManagerDelegate(U viewManager) {
     super(viewManager);

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsJavaDelegate.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsJavaDelegate.js
@@ -55,6 +55,7 @@ package ${packageName};
 
 ${imports}
 
+@SuppressWarnings("deprecation")
 public class ${className}<T extends ${extendClasses}, U extends BaseViewManager<T, ? extends LayoutShadowNode> & ${interfaceClassName}<T>> extends BaseViewManagerDelegate<T, U> {
   public ${className}(U viewManager) {
     super(viewManager);

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsJavaDelegate-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsJavaDelegate-test.js.snap
@@ -20,6 +20,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class ArrayPropsNativeComponentManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & ArrayPropsNativeComponentManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public ArrayPropsNativeComponentManagerDelegate(U viewManager) {
     super(viewManager);
@@ -95,6 +96,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class ArrayPropsNativeComponentManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & ArrayPropsNativeComponentManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public ArrayPropsNativeComponentManagerDelegate(U viewManager) {
     super(viewManager);
@@ -133,6 +135,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class BooleanPropNativeComponentManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & BooleanPropNativeComponentManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public BooleanPropNativeComponentManagerDelegate(U viewManager) {
     super(viewManager);
@@ -172,6 +175,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class ColorPropNativeComponentManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & ColorPropNativeComponentManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public ColorPropNativeComponentManagerDelegate(U viewManager) {
     super(viewManager);
@@ -211,6 +215,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class CommandNativeComponentManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & CommandNativeComponentManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public CommandNativeComponentManagerDelegate(U viewManager) {
     super(viewManager);
@@ -256,6 +261,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class CommandNativeComponentManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & CommandNativeComponentManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public CommandNativeComponentManagerDelegate(U viewManager) {
     super(viewManager);
@@ -310,6 +316,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class DimensionPropNativeComponentManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & DimensionPropNativeComponentManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public DimensionPropNativeComponentManagerDelegate(U viewManager) {
     super(viewManager);
@@ -348,6 +355,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class DoublePropNativeComponentManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & DoublePropNativeComponentManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public DoublePropNativeComponentManagerDelegate(U viewManager) {
     super(viewManager);
@@ -401,6 +409,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class EventsNestedObjectNativeComponentManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & EventsNestedObjectNativeComponentManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public EventsNestedObjectNativeComponentManagerDelegate(U viewManager) {
     super(viewManager);
@@ -439,6 +448,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class EventsNativeComponentManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & EventsNativeComponentManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public EventsNativeComponentManagerDelegate(U viewManager) {
     super(viewManager);
@@ -477,6 +487,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class InterfaceOnlyComponentManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & InterfaceOnlyComponentManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public InterfaceOnlyComponentManagerDelegate(U viewManager) {
     super(viewManager);
@@ -513,6 +524,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class ExcludedIosComponentManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & ExcludedIosComponentManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public ExcludedIosComponentManagerDelegate(U viewManager) {
     super(viewManager);
@@ -540,6 +552,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class MultiFileIncludedNativeComponentManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & MultiFileIncludedNativeComponentManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public MultiFileIncludedNativeComponentManagerDelegate(U viewManager) {
     super(viewManager);
@@ -578,6 +591,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class FloatPropNativeComponentManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & FloatPropNativeComponentManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public FloatPropNativeComponentManagerDelegate(U viewManager) {
     super(viewManager);
@@ -632,6 +646,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class ImagePropNativeComponentManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & ImagePropNativeComponentManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public ImagePropNativeComponentManagerDelegate(U viewManager) {
     super(viewManager);
@@ -671,6 +686,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class InsetsPropNativeComponentManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & InsetsPropNativeComponentManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public InsetsPropNativeComponentManagerDelegate(U viewManager) {
     super(viewManager);
@@ -709,6 +725,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class Int32EnumPropsNativeComponentManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & Int32EnumPropsNativeComponentManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public Int32EnumPropsNativeComponentManagerDelegate(U viewManager) {
     super(viewManager);
@@ -747,6 +764,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class IntegerPropNativeComponentManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & IntegerPropNativeComponentManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public IntegerPropNativeComponentManagerDelegate(U viewManager) {
     super(viewManager);
@@ -791,6 +809,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class InterfaceOnlyComponentManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & InterfaceOnlyComponentManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public InterfaceOnlyComponentManagerDelegate(U viewManager) {
     super(viewManager);
@@ -830,6 +849,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class MixedPropNativeComponentManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & MixedPropNativeComponentManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public MixedPropNativeComponentManagerDelegate(U viewManager) {
     super(viewManager);
@@ -870,6 +890,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class ImageColorPropNativeComponentManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & ImageColorPropNativeComponentManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public ImageColorPropNativeComponentManagerDelegate(U viewManager) {
     super(viewManager);
@@ -917,6 +938,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class NoPropsNoEventsComponentManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & NoPropsNoEventsComponentManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public NoPropsNoEventsComponentManagerDelegate(U viewManager) {
     super(viewManager);
@@ -950,6 +972,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class ObjectPropsManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & ObjectPropsManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public ObjectPropsManagerDelegate(U viewManager) {
     super(viewManager);
@@ -989,6 +1012,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class PointPropNativeComponentManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & PointPropNativeComponentManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public PointPropNativeComponentManagerDelegate(U viewManager) {
     super(viewManager);
@@ -1027,6 +1051,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class StringEnumPropsNativeComponentManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & StringEnumPropsNativeComponentManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public StringEnumPropsNativeComponentManagerDelegate(U viewManager) {
     super(viewManager);
@@ -1065,6 +1090,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class StringPropComponentManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & StringPropComponentManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public StringPropComponentManagerDelegate(U viewManager) {
     super(viewManager);
@@ -1106,6 +1132,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class MultiFile1NativeComponentManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & MultiFile1NativeComponentManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public MultiFile1NativeComponentManagerDelegate(U viewManager) {
     super(viewManager);
@@ -1139,6 +1166,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class MultiFile2NativeComponentManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & MultiFile2NativeComponentManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public MultiFile2NativeComponentManagerDelegate(U viewManager) {
     super(viewManager);
@@ -1177,6 +1205,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class MultiComponent1NativeComponentManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & MultiComponent1NativeComponentManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public MultiComponent1NativeComponentManagerDelegate(U viewManager) {
     super(viewManager);
@@ -1210,6 +1239,7 @@ import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings(\\"deprecation\\")
 public class MultiComponent2NativeComponentManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & MultiComponent2NativeComponentManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public MultiComponent2NativeComponentManagerDelegate(U viewManager) {
     super(viewManager);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CallbackImpl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CallbackImpl.kt
@@ -13,6 +13,9 @@ import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
 
 /** Implementation of javascript callback function that uses Bridge to schedule method execution. */
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
+@Deprecated(
+    message = "This class is part of Legacy Architecture and will be removed in a future release",
+    level = DeprecationLevel.WARNING)
 internal class CallbackImpl(private val jsInstance: JSInstance, private val callbackId: Int) :
     Callback {
   private var invoked = false

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaMethodWrapper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaMethodWrapper.kt
@@ -17,6 +17,9 @@ import com.facebook.systrace.SystraceMessage
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
 
+@Deprecated(
+    message = "This class is part of Legacy Architecture and will be removed in a future release",
+    level = DeprecationLevel.WARNING)
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
 internal class JavaMethodWrapper(
     private val moduleWrapper: JavaModuleWrapper,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaMethodWrapper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaMethodWrapper.kt
@@ -324,7 +324,7 @@ internal class JavaMethodWrapper(
                 null
               } else {
                 val id = jsArguments.getDouble(atIndex).toInt()
-                CallbackImpl(jsInstance, id)
+                @Suppress("DEPRECATION") CallbackImpl(jsInstance, id)
               }
         }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaModuleWrapper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaModuleWrapper.kt
@@ -74,6 +74,7 @@ internal class JavaModuleWrapper(
       targetMethod.getAnnotation(ReactMethod::class.java)?.let { annotation ->
         val methodName = targetMethod.name
         val md = MethodDescriptor()
+        @Suppress("DEPRECATION")
         val method = JavaMethodWrapper(this, targetMethod, annotation.isBlockingSynchronousMethod)
         md.name = methodName
         md.type = method.type

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManagerDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManagerDelegate.kt
@@ -20,7 +20,7 @@ import com.facebook.yoga.YogaConstants
  * every view should support, such as rotation, background color, etc.
  */
 public abstract class BaseViewManagerDelegate<
-    T : View, U : BaseViewManager<T, out LayoutShadowNode>>(
+    T : View, @Suppress("DEPRECATION") U : BaseViewManager<T, out LayoutShadowNode>>(
     @Suppress("NoHungarianNotation") @JvmField protected val mViewManager: U
 ) : ViewManagerDelegate<T> {
   @Suppress("ACCIDENTAL_OVERRIDE", "DEPRECATION")

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LayoutShadowNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LayoutShadowNode.java
@@ -38,6 +38,8 @@ import com.facebook.yoga.YogaWrap;
  * explored, namely using the VirtualText class in JS and setting the correct set of validAttributes
  */
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
+@Deprecated(
+    since = "This class is part of Legacy Architecture and will be removed in a future release")
 public class LayoutShadowNode extends ReactShadowNodeImpl {
   static {
     LegacyArchitectureLogger.assertLegacyArchitecture(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactShadowNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactShadowNode.java
@@ -46,6 +46,8 @@ import com.facebook.yoga.YogaWrap;
  * NativeViewHierarchyOptimizer} for more information.
  */
 @LegacyArchitecture
+@Deprecated(
+    since = "This class is part of Legacy Architecture and will be removed in a future release")
 public interface ReactShadowNode<T extends ReactShadowNode> {
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactShadowNodeImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactShadowNodeImpl.java
@@ -60,6 +60,8 @@ import java.util.Arrays;
  */
 @ReactPropertyHolder
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
+@Deprecated(
+    since = "This class is part of Legacy Architecture and will be removed in a future release")
 public class ReactShadowNodeImpl implements ReactShadowNode<ReactShadowNodeImpl> {
 
   private static final YogaConfig sYogaConfig;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/SimpleViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/SimpleViewManager.kt
@@ -17,6 +17,7 @@ import android.view.View
  *
  * @param <T> the view handled by this manager
  */
+@Suppress("DEPRECATION")
 public abstract class SimpleViewManager<T : View> : BaseViewManager<T, LayoutShadowNode>() {
 
   public override fun createShadowNodeInstance(): LayoutShadowNode {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupManager.kt
@@ -13,6 +13,7 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.UiThreadUtil
 import java.util.WeakHashMap
 
+@Suppress("DEPRECATION")
 public abstract class ViewGroupManager<T : ViewGroup>
 @JvmOverloads
 constructor(reactContext: ReactApplicationContext? = null) :

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagerPropertyUpdater.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewManagerPropertyUpdater.kt
@@ -13,6 +13,7 @@ import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.uimanager.ViewManagersPropertyCache.PropSetter
 import java.util.HashMap
 
+@Suppress("DEPRECATION")
 public object ViewManagerPropertyUpdater {
   public fun interface Settable {
     public fun getProperties(props: MutableMap<String, String>)
@@ -24,7 +25,7 @@ public object ViewManagerPropertyUpdater {
   }
 
   @Suppress("FINITE_BOUNDS_VIOLATION_IN_JAVA")
-  public interface ShadowNodeSetter<in T : ReactShadowNode<*>> : Settable {
+  public interface ShadowNodeSetter<@Suppress("DEPRECATION") in T : ReactShadowNode<*>> : Settable {
     public fun setProperty(node: T, name: String, value: Any?)
   }
 
@@ -71,7 +72,10 @@ public object ViewManagerPropertyUpdater {
 
   @JvmStatic
   @Deprecated("Use ViewManager#updateProperties to update a view's properties")
-  public fun <T : ReactShadowNode<T>> updateProps(node: T, props: ReactStylesDiffMap) {
+  public fun <@Suppress("DEPRECATION") T : ReactShadowNode<T>> updateProps(
+      node: T,
+      props: ReactStylesDiffMap
+  ) {
     val setter = findNodeSetter(node.javaClass)
     val iterator = props.backingMap.entryIterator
     while (iterator.hasNext()) {
@@ -108,7 +112,7 @@ public object ViewManagerPropertyUpdater {
     return setter as ViewManagerSetter<ViewManager<V, *>, V>
   }
 
-  private fun <T : ReactShadowNode<T>> findNodeSetter(
+  private fun <@Suppress("DEPRECATION") T : ReactShadowNode<T>> findNodeSetter(
       nodeClass: Class<out T>
   ): ShadowNodeSetter<T> {
     var setter = SHADOW_NODE_SETTER_MAP[nodeClass]

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/progressbar/ProgressBarShadowNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/progressbar/ProgressBarShadowNode.kt
@@ -14,7 +14,6 @@ import com.facebook.react.common.annotations.LegacyArchitectureShadowNodeWithCxx
 import com.facebook.react.common.annotations.internal.LegacyArchitecture
 import com.facebook.react.common.annotations.internal.LegacyArchitectureLogLevel
 import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
-import com.facebook.react.uimanager.LayoutShadowNode
 import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.yoga.YogaMeasureFunction
 import com.facebook.yoga.YogaMeasureMode
@@ -25,9 +24,11 @@ import com.facebook.yoga.YogaNode
  * Node responsible for holding the style of the ProgressBar, see under [ ] for possible styles.
  * ReactProgressBarViewManager manages how this style is applied to the ProgressBar.
  */
+@Suppress("DEPRECATION")
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
 @LegacyArchitectureShadowNodeWithCxxImpl
-internal class ProgressBarShadowNode : LayoutShadowNode(), YogaMeasureFunction {
+internal class ProgressBarShadowNode :
+    com.facebook.react.uimanager.LayoutShadowNode(), YogaMeasureFunction {
   private val height: SparseIntArray = SparseIntArray()
   private val width: SparseIntArray = SparseIntArray()
   private val measured: MutableSet<Int> = HashSet()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/safeareaview/ReactSafeAreaViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/safeareaview/ReactSafeAreaViewManager.kt
@@ -8,7 +8,6 @@
 package com.facebook.react.views.safeareaview
 
 import com.facebook.react.module.annotations.ReactModule
-import com.facebook.react.uimanager.LayoutShadowNode
 import com.facebook.react.uimanager.ReactStylesDiffMap
 import com.facebook.react.uimanager.StateWrapper
 import com.facebook.react.uimanager.ThemedReactContext
@@ -31,9 +30,13 @@ internal class ReactSafeAreaViewManager :
 
   override fun getName(): String = REACT_CLASS
 
-  override fun createShadowNodeInstance(): LayoutShadowNode = LayoutShadowNode()
+  @Suppress("DEPRECATION")
+  override fun createShadowNodeInstance(): com.facebook.react.uimanager.LayoutShadowNode =
+      com.facebook.react.uimanager.LayoutShadowNode()
 
-  override fun getShadowNodeClass(): Class<out LayoutShadowNode> = LayoutShadowNode::class.java
+  @Suppress("DEPRECATION")
+  override fun getShadowNodeClass(): Class<out com.facebook.react.uimanager.LayoutShadowNode> =
+      com.facebook.react.uimanager.LayoutShadowNode::class.java
 
   override fun updateState(
       view: ReactSafeAreaView,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitchShadowNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/switchview/ReactSwitchShadowNode.kt
@@ -12,15 +12,16 @@ import com.facebook.react.common.annotations.LegacyArchitectureShadowNodeWithCxx
 import com.facebook.react.common.annotations.internal.LegacyArchitecture
 import com.facebook.react.common.annotations.internal.LegacyArchitectureLogLevel
 import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
-import com.facebook.react.uimanager.LayoutShadowNode
 import com.facebook.yoga.YogaMeasureFunction
 import com.facebook.yoga.YogaMeasureMode
 import com.facebook.yoga.YogaMeasureOutput
 import com.facebook.yoga.YogaNode
 
+@Suppress("DEPRECATION")
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
 @LegacyArchitectureShadowNodeWithCxxImpl
-internal class ReactSwitchShadowNode : LayoutShadowNode(), YogaMeasureFunction {
+internal class ReactSwitchShadowNode :
+    com.facebook.react.uimanager.LayoutShadowNode(), YogaMeasureFunction {
   private var width = 0
   private var height = 0
   private var measured = false

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextViewManager.kt
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.facebook.react.views.text
 
 import android.text.Spannable

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.kt
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.facebook.react.views.text
 
 import android.graphics.Color

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactRawTextShadowNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactRawTextShadowNode.kt
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.facebook.react.views.text
 
 import com.facebook.react.common.annotations.internal.LegacyArchitecture

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/ReactTextInlineImageShadowNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/ReactTextInlineImageShadowNode.kt
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.facebook.react.views.text.internal
 
 import com.facebook.react.uimanager.LayoutShadowNode

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.kt
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.facebook.react.views.textinput
 
 import android.annotation.SuppressLint

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropAnnotationSetterSpecTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropAnnotationSetterSpecTest.kt
@@ -16,8 +16,9 @@ import org.junit.Before
 import org.junit.Test
 
 /** Test that verifies that spec of methods annotated with @ReactProp is correct */
-@Suppress("UNUSED_PARAMETER")
+@Suppress("UNUSED_PARAMETER", "DEPRECATED")
 class ReactPropAnnotationSetterSpecTest {
+  @Suppress("DEPRECATION")
   private abstract inner class BaseViewManager : ViewManager<View, ReactShadowNode<*>>() {
     override fun getName(): String = "IgnoredName"
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropAnnotationSetterTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropAnnotationSetterTest.kt
@@ -52,7 +52,7 @@ class ReactPropAnnotationSetterTest {
     fun onBoxedIntGroupPropSetterCalled(index: Int, value: Int?)
   }
 
-  @Suppress("UNUSED_PARAMETER")
+  @Suppress("UNUSED_PARAMETER", "DEPRECATION")
   private inner class ViewManagerUnderTest(
       val viewManagerUpdatesReceiver: ViewManagerUpdatesReceiver
   ) : ViewManager<View, ReactShadowNode<*>>() {

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropForShadowNodeSpecTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropForShadowNodeSpecTest.kt
@@ -31,6 +31,7 @@ import org.robolectric.annotation.Config
  * Test that verifies that spec of methods annotated with @ReactProp in {@link ReactShadowNode} is
  * correct
  */
+@Suppress("DEPRECATION")
 @RunWith(RobolectricTestRunner::class)
 @Config(shadows = [ShadowSoLoader::class])
 class ReactPropForShadowNodeSpecTest {


### PR DESCRIPTION
Summary:
Deprecate Legacy Architecture class CallbackImpl

changelog: [Android][Changed] Deprecate Legacy Architecture class CallbackImpl

Reviewed By: mlord93

Differential Revision: D79672292
