### PR TITLE
fix: crash when copying TurboModules between runtimes

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -58,7 +59,7 @@ class JSI_EXPORT TurboModule : public jsi::HostObject {
     // If we have a JS wrapper, cache the result of this lookup
     // We don't cache misses, to allow for methodMap_ to dynamically be
     // extended
-    if (jsRepresentation_ && !prop.isUndefined()) {
+    if (jsRepresentation_ && reinterpret_cast<std::uintptr_t>(&runtime) == representationRuntimeAddress_ && !prop.isUndefined()) {
       jsRepresentation_->lock(runtime).asObject(runtime).setProperty(runtime, propName, prop);
     }
     return prop;
@@ -138,6 +139,9 @@ class JSI_EXPORT TurboModule : public jsi::HostObject {
  private:
   friend class TurboModuleBinding;
   std::unique_ptr<jsi::WeakObject> jsRepresentation_;
+  /** This address is used only for identifying the runtime associated with the
+   * JS representation. Do not dereference or use for any other purpose. */
+  std::uintptr_t representationRuntimeAddress_;
 };
 
 /**

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.cpp
@@ -10,6 +10,7 @@
 #include <ReactCommon/TurboModuleWithJSIBindings.h>
 #include <cxxreact/TraceSection.h>
 #include <react/utils/jsi-utils.h>
+#include <cstdint>
 #include <stdexcept>
 #include <string>
 
@@ -177,6 +178,8 @@ jsi::Value TurboModuleBinding::getModule(
     jsi::Object jsRepresentation(runtime);
     weakJsRepresentation =
         std::make_unique<jsi::WeakObject>(runtime, jsRepresentation);
+    module->representationRuntimeAddress_ =
+        reinterpret_cast<std::uintptr_t>(&runtime);
 
     // Lazily populate the jsRepresentation, on property access.
     //


### PR DESCRIPTION
## Summary:

Since TurboModules got optimized for property lookups it became impossible to copy them between runtimes. These is because the C++ code tried to use `jsRepresentation` which was defined on another runtime. I added `representationRuntime` member to `TurboModule` class so the `jsRepresentation` would be used only if we are on the correct runtime. On other runtimes we should resolve to "slow" property lookup. The runtime can then make the same optimization on its own.

The code that works now:

```js
import { runOnUI } from 'react-native-worklets';
import { TurboModuleRegistry } from 'react-native';

const BlobModule = Object.getPrototypeOf(TurboModuleRegistry.getEnforcing('BlobModule'));

runOnUI(() => {
  BlobModule.getConstants();
})();
```

## Changelog:

[INTERNAL] [FIXED] - TurboModules don't try to use `jsRepresentation` for property lookups on wrong runtimes

## Test Plan:

Running TurboModule examples in RNTester didn't show any regressions and the code snippet above works now.
