### PR TITLE
Cache result when RenderOutput::render() is called

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/mounting/stubs/StubViewTree.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/stubs/StubViewTree.h
@@ -44,6 +44,10 @@ class StubViewTree {
    */
   std::vector<std::string> takeMountingLogs();
 
+  bool hasTag(Tag tag) const {
+    return registry_.find(tag) != registry_.end();
+  }
+
  private:
   Tag rootTag_{};
   std::unordered_map<Tag, StubView::Shared> registry_{};
@@ -53,10 +57,6 @@ class StubViewTree {
   friend bool operator!=(const StubViewTree& lhs, const StubViewTree& rhs);
 
   std::ostream& dumpTags(std::ostream& stream) const;
-
-  bool hasTag(Tag tag) const {
-    return registry_.find(tag) != registry_.end();
-  }
 
   std::string getNativeId(Tag tag);
   std::string getNativeId(const ShadowView& shadowView);

--- a/private/react-native-fantom/tester/src/NativeFantom.cpp
+++ b/private/react-native-fantom/tester/src/NativeFantom.cpp
@@ -89,7 +89,8 @@ std::string NativeFantom::getRenderedOutput(
       options.includeRoot, options.includeLayoutMetrics};
 
   auto viewTree = appDelegate_.mountingManager_->getViewTree(surfaceId);
-  return RenderOutput::render(viewTree, formatOptions);
+  return appDelegate_.mountingManager_->renderer()->render(
+      viewTree, formatOptions);
 }
 
 void NativeFantom::reportTestSuiteResultsJSON(

--- a/private/react-native-fantom/tester/src/TesterMountingManager.cpp
+++ b/private/react-native-fantom/tester/src/TesterMountingManager.cpp
@@ -11,6 +11,7 @@
 #include <glog/logging.h>
 #include <react/renderer/components/root/RootShadowNode.h>
 #include <react/renderer/core/DynamicPropsUtilities.h>
+#include <react/renderer/scheduler/Scheduler.h>
 
 namespace facebook::react {
 
@@ -18,7 +19,7 @@ using namespace std::string_literals;
 
 TesterMountingManager::TesterMountingManager(
     std::function<void(SurfaceId)>&& onAfterMount)
-    : onAfterMount_(onAfterMount) {
+    : onAfterMount_(onAfterMount), renderer_(std::make_unique<RenderOutput>()) {
   imageLoader_ = std::make_shared<FantomImageLoader>();
 }
 
@@ -28,8 +29,9 @@ void TesterMountingManager::executeMount(
   const auto& mutations = mountingTransaction.getMutations();
   LOG(INFO) << "executeMount: surfaceId = " << surfaceId;
 
-  if (viewTrees_.find(surfaceId) != viewTrees_.end()) {
-    viewTrees_[surfaceId].mutate(mutations);
+  if (auto it = viewTrees_.find(surfaceId); it != viewTrees_.end()) {
+    it->second.mutate(mutations);
+    renderer_->markMutated(surfaceId);
   } else {
     LOG(ERROR) << "Can't aplly mutations, missing view tree surfaceId = "
                << surfaceId;

--- a/private/react-native-fantom/tester/src/TesterMountingManager.h
+++ b/private/react-native-fantom/tester/src/TesterMountingManager.h
@@ -14,6 +14,8 @@
 #include <string>
 #include <unordered_map>
 
+#include "render/RenderOutput.h"
+
 namespace facebook::react {
 class IImageLoader;
 
@@ -56,11 +58,17 @@ class TesterMountingManager : public IMountingManager {
     return imageLoader_;
   }
 
+  std::unique_ptr<RenderOutput>& renderer() {
+    return renderer_;
+  }
+
  private:
   std::function<void(SurfaceId)> onAfterMount_;
   std::unordered_map<SurfaceId, StubViewTree> viewTrees_;
   std::unordered_map<Tag, folly::dynamic> viewDirectManipulationProps_;
   std::unordered_map<Tag, folly::dynamic> viewFabricUpdateProps_;
+
+  std::unique_ptr<RenderOutput> renderer_;
 };
 
 }; // namespace facebook::react

--- a/private/react-native-fantom/tester/src/render/RenderOutput.h
+++ b/private/react-native-fantom/tester/src/render/RenderOutput.h
@@ -15,22 +15,30 @@
 namespace facebook::react {
 class RenderOutput {
  public:
-  static std::string render(
+  std::string render(
       const StubViewTree& tree,
       const RenderFormatOptions& options);
 
+  void markMutated(SurfaceId surfaceId) {
+    treesMutated_.insert(surfaceId);
+  }
+
  private:
-  static folly::dynamic renderView(
+  folly::dynamic renderView(
       const StubView& view,
       const RenderFormatOptions& options);
 
 #if RN_DEBUG_STRING_CONVERTIBLE
-  static folly::dynamic renderProps(
-      const SharedDebugStringConvertibleList& propsList);
+  folly::dynamic renderProps(const SharedDebugStringConvertibleList& propsList);
 #endif
 
-  static folly::dynamic renderAttributedString(
+  folly::dynamic renderAttributedString(
       const Tag& selfTag,
       const AttributedString& string);
+
+  std::unordered_map<Tag, folly::dynamic> renderedViews_{};
+
+  // If true, the next call to render() will re-render the entire tree.
+  std::unordered_set<SurfaceId> treesMutated_{};
 };
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
## Changelog:

[Internal] [Changed] - Cache result when RenderOutput::render() is called

Rreviously, root.getRenderedOutput in fantom doesn't really reflect the result of direct manipulation from native animated (see the test case added here). This stack is enabling it.

* make RenderOutput an instance owned by TestMountingManager that can cache render result
  * why is this needed - native animation's direct manipulation should modify the render result (analog to directly manipulating host views on a platform) instead of props on a StubView
* here i also make sure that `RenderOutput::render()` will only re calculate the render result for a tree after StubViewTree::mutate is called

Differential Revision: D79737991


