### PR TITLE
VirtualView: Simplify Window Focus Detection

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/VirtualViewContainer.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/VirtualViewContainer.kt
@@ -50,28 +50,32 @@ private fun rectsOverlap(rect1: Rect, rect2: Rect): Boolean {
 internal class VirtualViewContainerState {
 
   private val prerenderRatio: Double = ReactNativeFeatureFlags.virtualViewPrerenderRatio()
-  private val detectWindowFocus = ReactNativeFeatureFlags.enableVirtualViewWindowFocusDetection()
 
   private val virtualViews: MutableSet<VirtualView> = mutableSetOf()
   private val emptyRect: Rect = Rect()
   private val visibleRect: Rect = Rect()
   private val prerenderRect: Rect = Rect()
   private val onWindowFocusChangeListener =
-      ViewTreeObserver.OnWindowFocusChangeListener {
-        debugLog("onWindowFocusChanged")
-        updateModes()
+      if (ReactNativeFeatureFlags.enableVirtualViewWindowFocusDetection()) {
+        ViewTreeObserver.OnWindowFocusChangeListener {
+          debugLog("onWindowFocusChanged")
+          updateModes()
+        }
+      } else {
+        null
       }
+
   private val scrollView: ViewGroup
 
   constructor(scrollView: ViewGroup) {
     this.scrollView = scrollView
-    if (detectWindowFocus) {
+    if (onWindowFocusChangeListener != null) {
       scrollView.viewTreeObserver.addOnWindowFocusChangeListener(onWindowFocusChangeListener)
     }
   }
 
   public fun cleanup() {
-    if (detectWindowFocus) {
+    if (onWindowFocusChangeListener != null) {
       scrollView.viewTreeObserver.removeOnWindowFocusChangeListener(onWindowFocusChangeListener)
     }
   }
@@ -115,7 +119,7 @@ internal class VirtualViewContainerState {
         rect.isEmpty -> {}
         rectsOverlap(rect, visibleRect) -> {
           thresholdRect = visibleRect
-          if (detectWindowFocus) {
+          if (onWindowFocusChangeListener != null) {
             if (scrollView.hasWindowFocus()) {
               mode = VirtualViewMode.Visible
             } else {


### PR DESCRIPTION
Summary:
Refactors the window docus detection feature flag logic in `VirtualView` (Android) to eliminate one instance property and instead utilize the existence of the focus listener to determine whether window focus detection is enabled.

Changelog:
[Internal]

Reviewed By: mdvacca

Differential Revision: D79743782


