### PR TITLE
Remove mode from metro client-log data

### DIFF
--- a/packages/react-native/Libraries/Utilities/HMRClient.js
+++ b/packages/react-native/Libraries/Utilities/HMRClient.js
@@ -128,7 +128,6 @@ const HMRClient: HMRClientNativeInterface = {
         JSON.stringify({
           type: 'log',
           level,
-          mode: global.RN$Bridgeless === true ? 'NOBRIDGE' : 'BRIDGE',
           data: data.map(item =>
             typeof item === 'string'
               ? item


### PR DESCRIPTION
Summary:
Sending the mode is no longer needed as you can't opt out of legacy arch any longer, and was only used for printing a (NOBRIDGE) prefix.

Changelog: [Internal]

Reviewed By: shwanton

Differential Revision: D79762592


