### PR TITLE
Deprecate Legacy Architecture UIManagerModules class

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/CoreModulesPackage.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/CoreModulesPackage.kt
@@ -30,7 +30,6 @@ import com.facebook.react.modules.debug.DevSettingsModule
 import com.facebook.react.modules.debug.SourceCodeModule
 import com.facebook.react.modules.deviceinfo.DeviceInfoModule
 import com.facebook.react.modules.systeminfo.AndroidInfoModule
-import com.facebook.react.uimanager.UIManagerModule
 import com.facebook.react.uimanager.ViewManager
 import com.facebook.react.uimanager.ViewManagerResolver
 import com.facebook.systrace.Systrace
@@ -53,7 +52,7 @@ import com.facebook.systrace.Systrace
             HeadlessJsTaskSupportModule::class,
             SourceCodeModule::class,
             TimingModule::class,
-            UIManagerModule::class])
+            com.facebook.react.uimanager.UIManagerModule::class])
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
 @Suppress("DEPRECATION")
 internal class CoreModulesPackage(
@@ -103,7 +102,7 @@ internal class CoreModulesPackage(
             HeadlessJsTaskSupportModule::class.java,
             SourceCodeModule::class.java,
             TimingModule::class.java,
-            UIManagerModule::class.java,
+            com.facebook.react.uimanager.UIManagerModule::class.java,
         )
 
     val reactModuleInfoMap: MutableMap<String, ReactModuleInfo> = HashMap<String, ReactModuleInfo>()
@@ -140,7 +139,7 @@ internal class CoreModulesPackage(
       HeadlessJsTaskSupportModule.NAME -> HeadlessJsTaskSupportModule(reactContext)
       SourceCodeModule.NAME -> SourceCodeModule(reactContext)
       TimingModule.NAME -> TimingModule(reactContext, reactInstanceManager.devSupportManager)
-      UIManagerModule.NAME -> createUIManager(reactContext)
+      com.facebook.react.uimanager.UIManagerModule.NAME -> createUIManager(reactContext)
       DeviceInfoModule.NAME -> DeviceInfoModule(reactContext)
       else ->
           throw IllegalArgumentException(
@@ -148,7 +147,9 @@ internal class CoreModulesPackage(
     }
   }
 
-  private fun createUIManager(reactContext: ReactApplicationContext): UIManagerModule {
+  private fun createUIManager(
+      reactContext: ReactApplicationContext
+  ): com.facebook.react.uimanager.UIManagerModule {
     ReactMarker.logMarker(ReactMarkerConstants.CREATE_UI_MANAGER_MODULE_START)
     Systrace.beginSection(Systrace.TRACE_TAG_REACT, "createUIManagerModule")
 
@@ -165,9 +166,10 @@ internal class CoreModulesPackage(
               }
             }
 
-        return UIManagerModule(reactContext, resolver, minTimeLeftInFrameForNonBatchedOperationMs)
+        return com.facebook.react.uimanager.UIManagerModule(
+            reactContext, resolver, minTimeLeftInFrameForNonBatchedOperationMs)
       } else {
-        return UIManagerModule(
+        return com.facebook.react.uimanager.UIManagerModule(
             reactContext,
             reactInstanceManager.getOrCreateViewManagers(reactContext),
             minTimeLeftInFrameForNonBatchedOperationMs)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.kt
@@ -28,7 +28,6 @@ import com.facebook.react.modules.core.ReactChoreographer
 import com.facebook.react.uimanager.GuardedFrameCallback
 import com.facebook.react.uimanager.UIBlock
 import com.facebook.react.uimanager.UIManagerHelper
-import com.facebook.react.uimanager.UIManagerModule
 import com.facebook.react.uimanager.common.UIManagerType
 import com.facebook.react.uimanager.common.ViewUtil
 import java.util.ArrayList
@@ -74,9 +73,9 @@ import kotlin.concurrent.Volatile
  * that coordinates all the action: [NativeAnimatedNodesManager]. Since all the methods from
  * [NativeAnimatedNodesManager] need to be called from the UI thread, we we create a queue of
  * animated graph operations that is then enqueued to be executed in the UI Thread at the end of the
- * batch of JS->native calls (similarly to how it's handled in [UIManagerModule]). This isolates us
- * from the problems that may be caused by concurrent updates of animated graph while UI thread is
- * "executing" the animation loop.
+ * batch of JS->native calls (similarly to how it's handled in
+ * [com.facebook.react.uimanager.UIManagerModule]). This isolates us from the problems that may be
+ * caused by concurrent updates of animated graph while UI thread is "executing" the animation loop.
  */
 @OptIn(UnstableReactNativeAPI::class)
 @ReactModule(name = NativeAnimatedModuleSpec.NAME)
@@ -306,6 +305,7 @@ public class NativeAnimatedModule(reactContext: ReactApplicationContext) :
   }
 
   // For non-FabricUIManager only
+  @Suppress("DEPRECATION")
   @UiThread
   override fun willDispatchViewUpdates(uiManager: UIManager) {
     if (operations.isEmpty && preOperations.isEmpty) {
@@ -325,8 +325,8 @@ public class NativeAnimatedModule(reactContext: ReactApplicationContext) :
 
     val operationsUIBlock = UIBlock { operations.executeBatch(frameNo, nodesManager) }
 
-    assert(uiManager is UIManagerModule)
-    val uiManagerModule = uiManager as UIManagerModule
+    assert(uiManager is com.facebook.react.uimanager.UIManagerModule)
+    val uiManagerModule = uiManager as com.facebook.react.uimanager.UIManagerModule
     uiManagerModule.prependUIBlock(preOperationsUIBlock)
     uiManagerModule.addUIBlock(operationsUIBlock)
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/FpsDebugFrameCallback.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/debug/FpsDebugFrameCallback.kt
@@ -11,7 +11,6 @@ import android.view.Choreographer
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.common.build.ReactBuildConfig
-import com.facebook.react.uimanager.UIManagerModule
 
 /**
  * Each time a frame is drawn, records whether it should have expected any more callbacks since the
@@ -62,7 +61,8 @@ internal class FpsDebugFrameCallback(private val reactContext: ReactContext) :
     // removeBridgeIdleDebugListener for Bridgeless
     @Suppress("DEPRECATION")
     if (!ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE) {
-      val uiManagerModule = reactContext.getNativeModule(UIManagerModule::class.java)
+      val uiManagerModule =
+          reactContext.getNativeModule(com.facebook.react.uimanager.UIManagerModule::class.java)
       if (!reactContext.isBridgeless) {
         reactContext.catalystInstance.addBridgeIdleDebugListener(didJSUpdateUiDuringFrameDetector)
         isRunningOnFabric = false
@@ -83,7 +83,8 @@ internal class FpsDebugFrameCallback(private val reactContext: ReactContext) :
   fun stop() {
     @Suppress("DEPRECATION")
     if (!ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE) {
-      val uiManagerModule = reactContext.getNativeModule(UIManagerModule::class.java)
+      val uiManagerModule =
+          reactContext.getNativeModule(com.facebook.react.uimanager.UIManagerModule::class.java)
       if (!reactContext.isBridgeless) {
         reactContext.catalystInstance.removeBridgeIdleDebugListener(
             didJSUpdateUiDuringFrameDetector)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.kt
@@ -61,7 +61,6 @@ import com.facebook.react.runtime.internal.bolts.Task
 import com.facebook.react.runtime.internal.bolts.TaskCompletionSource
 import com.facebook.react.turbomodule.core.interfaces.CallInvokerHolder
 import com.facebook.react.uimanager.DisplayMetricsHolder
-import com.facebook.react.uimanager.UIManagerModule
 import com.facebook.react.uimanager.events.BlackHoleEventDispatcher
 import com.facebook.react.uimanager.events.EventDispatcher
 import com.facebook.react.views.imagehelper.ResourceDrawableIdHelper
@@ -523,9 +522,10 @@ public class ReactHostImpl(
   internal val nativeModules: Collection<NativeModule>
     get() = reactInstance?.nativeModules ?: listOf()
 
+  @Suppress("DEPRECATION")
   internal fun <T : NativeModule> getNativeModule(nativeModuleInterface: Class<T>): T? {
     if (!ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE &&
-        nativeModuleInterface == UIManagerModule::class.java) {
+        nativeModuleInterface == com.facebook.react.uimanager.UIManagerModule::class.java) {
       ReactSoftExceptionLogger.logSoftExceptionVerbose(
           TAG,
           ReactNoCrashSoftException(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LayoutDirectionUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LayoutDirectionUtil.kt
@@ -14,6 +14,9 @@ import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
 import com.facebook.yoga.YogaDirection
 
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
+@Deprecated(
+    message = "This class is part of Legacy Architecture and will be removed in a future release",
+    level = DeprecationLevel.WARNING)
 internal object LayoutDirectionUtil {
   init {
     LegacyArchitectureLogger.assertLegacyArchitecture(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeKind.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeKind.kt
@@ -14,6 +14,9 @@ import com.facebook.react.common.annotations.internal.LegacyArchitectureLogLevel
 //   - `kind == PARENT` checks whether the node can host children in the native tree.
 //   - `kind != NONE` checks whether the node appears in the native tree.
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
+@Deprecated(
+    message = "This class is part of Legacy Architecture and will be removed in a future release",
+    level = DeprecationLevel.WARNING)
 internal enum class NativeKind {
   // Node is in the native hierarchy and the HierarchyOptimizer should assume it can host children
   // (e.g. because it's a ViewGroup). Note that it's okay if the node doesn't support children. When

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
@@ -68,6 +68,8 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
+@Deprecated(
+    since = "This class is part of Legacy Architecture and will be removed in a future release")
 public class NativeViewHierarchyManager {
 
   static {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyOptimizer.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyOptimizer.java
@@ -49,6 +49,8 @@ import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger;
  * depending on where the views being added/removed are attached in the optimized hierarchy
  */
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
+@Deprecated(
+    since = "This class is part of Legacy Architecture and will be removed in a future release")
 public class NativeViewHierarchyOptimizer {
 
   static {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NoSuchNativeViewException.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NoSuchNativeViewException.kt
@@ -16,6 +16,9 @@ import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
  * associated with it.
  */
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
+@Deprecated(
+    message = "This class is part of Legacy Architecture and will be removed in a future release",
+    level = DeprecationLevel.WARNING)
 internal class NoSuchNativeViewException(detailMessage: String) :
     IllegalViewOperationException(detailMessage) {
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/OnLayoutEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/OnLayoutEvent.kt
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.facebook.react.uimanager
 
 import androidx.core.util.Pools.SynchronizedPool
@@ -20,6 +22,9 @@ import com.facebook.react.uimanager.events.Event
 
 /** Event used to notify JS component about changes of its position or dimensions. */
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.WARNING)
+@Deprecated(
+    message = "This class is part of Legacy Architecture and will be removed in a future release",
+    level = DeprecationLevel.WARNING)
 public class OnLayoutEvent private constructor() : Event<OnLayoutEvent>() {
   @VisibleForTesting internal var x: Int = 0
   @VisibleForTesting internal var y: Int = 0

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ShadowNodeRegistry.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ShadowNodeRegistry.kt
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.facebook.react.uimanager
 
 import android.util.SparseArray

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ShadowNodeRegistry.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ShadowNodeRegistry.kt
@@ -20,6 +20,9 @@ import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
  * UIManagerModule instance.
  */
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
+@Deprecated(
+    message = "This class is part of Legacy Architecture and will be removed in a future release",
+    level = DeprecationLevel.WARNING)
 internal class ShadowNodeRegistry {
   private val tagsToCSSNodes = SparseArray<ReactShadowNode<*>>()
   private val rootTags = SparseBooleanArray()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIBlock.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIBlock.kt
@@ -9,5 +9,7 @@ package com.facebook.react.uimanager
 
 /** A task to execute on the UI View for third party libraries. */
 public fun interface UIBlock {
-  public fun execute(nativeViewHierarchyManager: NativeViewHierarchyManager)
+  public fun execute(
+      @Suppress("DEPRECATION") nativeViewHierarchyManager: NativeViewHierarchyManager
+  )
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java
@@ -42,6 +42,8 @@ import java.util.Map;
  * hierarchy that is then mapped to a native view hierarchy.
  */
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
+@Deprecated(
+    since = "This class is part of Legacy Architecture and will be removed in a future release")
 public class UIImplementation {
   static {
     LegacyArchitectureLogger.assertLegacyArchitecture(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModule.java
@@ -89,6 +89,8 @@ import java.util.concurrent.CopyOnWriteArrayList;
  */
 @ReactModule(name = UIManagerModule.NAME)
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
+@Deprecated(
+    since = "This class is part of Legacy Architecture and will be removed in a future release")
 public class UIManagerModule extends ReactContextBaseJavaModule
     implements OnBatchCompleteListener, LifecycleEventListener, UIManager {
   static {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleListener.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleListener.kt
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.facebook.react.uimanager
 
 import com.facebook.react.common.annotations.internal.LegacyArchitecture

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIViewOperationQueue.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIViewOperationQueue.java
@@ -49,6 +49,8 @@ import java.util.Map;
  * for operations queue to save on allocations
  */
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
+@Deprecated(
+    since = "This class is part of Legacy Architecture and will be removed in a future release")
 public class UIViewOperationQueue {
 
   static {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewAtIndex.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewAtIndex.kt
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.facebook.react.uimanager
 
 import com.facebook.react.common.annotations.internal.LegacyArchitecture
@@ -17,6 +19,9 @@ import java.util.Objects
  * operation.
  */
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
+@Deprecated(
+    message = "This class is part of Legacy Architecture and will be removed in a future release",
+    level = DeprecationLevel.WARNING)
 internal class ViewAtIndex(
     @Suppress("NoHungarianNotation") @JvmField public val mTag: Int,
     @Suppress("NoHungarianNotation") @JvmField public val mIndex: Int

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/YogaNodePool.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/YogaNodePool.kt
@@ -15,6 +15,9 @@ import com.facebook.yoga.YogaNode
 
 /** Static holder for a recycling pool of YogaNodes. */
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
+@Deprecated(
+    message = "This class is part of Legacy Architecture and will be removed in a future release",
+    level = DeprecationLevel.WARNING)
 internal object YogaNodePool {
   init {
     LegacyArchitectureLogger.assertLegacyArchitecture(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/safeareaview/ReactSafeAreaView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/safeareaview/ReactSafeAreaView.kt
@@ -19,7 +19,6 @@ import com.facebook.react.common.build.ReactBuildConfig
 import com.facebook.react.uimanager.PixelUtil.pxToDp
 import com.facebook.react.uimanager.StateWrapper
 import com.facebook.react.uimanager.ThemedReactContext
-import com.facebook.react.uimanager.UIManagerModule
 
 internal class ReactSafeAreaView(val reactContext: ThemedReactContext) : ViewGroup(reactContext) {
   internal var stateWrapper: StateWrapper? = null
@@ -39,6 +38,7 @@ internal class ReactSafeAreaView(val reactContext: ThemedReactContext) : ViewGro
 
   override fun onLayout(p0: Boolean, p1: Int, p2: Int, p3: Int, p4: Int): Unit = Unit
 
+  @Suppress("DEPRECATION")
   @UiThread
   private fun updateState(insets: Insets) {
     val sw = stateWrapper
@@ -57,7 +57,7 @@ internal class ReactSafeAreaView(val reactContext: ThemedReactContext) : ViewGro
           object : GuardedRunnable(reactContext) {
             override fun runGuarded() {
               this@ReactSafeAreaView.reactContext.reactApplicationContext
-                  .getNativeModule(UIManagerModule::class.java)
+                  .getNativeModule(com.facebook.react.uimanager.UIManagerModule::class.java)
                   ?.updateInsetsPadding(id, insets.top, insets.left, insets.bottom, insets.right)
             }
           })

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.kt
@@ -63,7 +63,6 @@ import com.facebook.react.uimanager.PixelUtil.toDIPFromPixel
 import com.facebook.react.uimanager.ReactAccessibilityDelegate
 import com.facebook.react.uimanager.StateWrapper
 import com.facebook.react.uimanager.UIManagerHelper
-import com.facebook.react.uimanager.UIManagerModule
 import com.facebook.react.uimanager.common.UIManagerType
 import com.facebook.react.uimanager.common.ViewUtil.getUIManagerType
 import com.facebook.react.uimanager.events.EventDispatcher
@@ -850,7 +849,8 @@ public open class ReactEditText public constructor(context: Context) : AppCompat
       @Suppress("DEPRECATION")
       if (stateWrapper == null && !reactContext.isBridgeless) {
         val localData = ReactTextInputLocalData(this)
-        val uiManager = reactContext.getNativeModule(UIManagerModule::class.java)
+        val uiManager =
+            reactContext.getNativeModule(com.facebook.react.uimanager.UIManagerModule::class.java)
         uiManager?.setViewLocalData(id, localData)
       }
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.kt
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.facebook.react.views.textinput
 
 import android.annotation.SuppressLint

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/OnLayoutEventTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/OnLayoutEventTest.kt
@@ -31,6 +31,7 @@ class OnLayoutEventTest {
     val width = 100
     val height = 200
 
+    @Suppress("DEPRECATION")
     val event = OnLayoutEvent.obtain(surfaceId, viewTag, x, y, width, height)
 
     assertThat(event).isNotNull
@@ -43,14 +44,14 @@ class OnLayoutEventTest {
 
   @Test
   fun testGetEventName_shouldReturnCorrectEventName() {
-    val event = OnLayoutEvent.obtain(1, 1, 10, 20, 100, 200)
+    @Suppress("DEPRECATION") val event = OnLayoutEvent.obtain(1, 1, 10, 20, 100, 200)
 
     assertThat(event.getEventName()).isEqualTo("topLayout")
   }
 
   @Test
   fun testInit_shouldCorrectlyInitializeValues() {
-    val event = OnLayoutEvent.obtain(1, 1, 10, 20, 100, 200)
+    @Suppress("DEPRECATION") val event = OnLayoutEvent.obtain(1, 1, 10, 20, 100, 200)
 
     assertThat(event.surfaceId).isEqualTo(1)
     assertThat(event.viewTag).isEqualTo(1)


### PR DESCRIPTION
Summary:
Deprecate LegacyArchitecture UIManagerModules class

changelog: [Android][Changed] Deprecate LegacyArchitecture UIManagerModules class

Reviewed By: mlord93

Differential Revision: D79672294
