### PR TITLE
fix: fix a typo in the react_native_pods.rb file

### DIFF
--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -377,7 +377,7 @@ end
 
 # This method can be used to set the fast_float config
 # that can be used to configure libraries.
-def set_fast_float_config(fmt_config)
+def set_fast_float_config(fast_float_config)
   Helpers::Constants.set_fast_float_config(fast_float_config)
 end
 


### PR DESCRIPTION
- Switches fmt_config to fast_float_config so it matches what is used in the method

## Summary:

When trying to use a forked version of the Pod it is not possible to set a new repo for Fast Float. This was caused by a typo in the method used to update the configuration of where to find the Pod.

## Changelog:

[IOS] [FIXED] - Fixed variable naming error in set_fast_float_config method in react_native_pods.rb

## Test Plan:

Add the line `set_fast_float_config({:git => 'some-git-repo'})` to an application's Podfile
