### PR TITLE
Support currentActivity after moving from Java to Kotlin

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContextBaseJavaModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContextBaseJavaModule.kt
@@ -30,7 +30,7 @@ public abstract class ReactContextBaseJavaModule : BaseJavaModule {
   protected fun getCurrentActivity(): Activity? {
     return reactApplicationContext.currentActivity
   }
-  
+
   @Deprecated(
       "Deprecated in 0.80.0. Use getReactApplicationContext().getCurrentActivity() instead.",
       ReplaceWith("reactApplicationContext.currentActivity"))

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContextBaseJavaModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContextBaseJavaModule.kt
@@ -24,12 +24,6 @@ public abstract class ReactContextBaseJavaModule : BaseJavaModule {
    * For example, never store the value returned by this method in a member variable. Instead, call
    * this method whenever you actually need the Activity and make sure to check for `null`.
    */
-  @Deprecated(
-      "Deprecated in 0.80.0. Use getReactApplicationContext().getCurrentActivity() instead.",
-      ReplaceWith("reactApplicationContext.currentActivity"))
-  protected fun getCurrentActivity(): Activity? {
-    return reactApplicationContext.currentActivity
-  }
 
   @Deprecated(
       "Deprecated in 0.80.0. Use getReactApplicationContext().getCurrentActivity() instead.",

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContextBaseJavaModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContextBaseJavaModule.kt
@@ -24,7 +24,6 @@ public abstract class ReactContextBaseJavaModule : BaseJavaModule {
    * For example, never store the value returned by this method in a member variable. Instead, call
    * this method whenever you actually need the Activity and make sure to check for `null`.
    */
-
   @Deprecated(
       "Deprecated in 0.80.0. Use getReactApplicationContext().getCurrentActivity() instead.",
       ReplaceWith("reactApplicationContext.currentActivity"))

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContextBaseJavaModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContextBaseJavaModule.kt
@@ -25,9 +25,15 @@ public abstract class ReactContextBaseJavaModule : BaseJavaModule {
    * this method whenever you actually need the Activity and make sure to check for `null`.
    */
   @Deprecated(
-      "Deprecated in 0.80.0. Use getReactApplicationContext.getCurrentActivity() instead.",
+      "Deprecated in 0.80.0. Use getReactApplicationContext().getCurrentActivity() instead.",
       ReplaceWith("reactApplicationContext.currentActivity"))
   protected fun getCurrentActivity(): Activity? {
     return reactApplicationContext.currentActivity
   }
+  
+  @Deprecated(
+      "Deprecated in 0.80.0. Use getReactApplicationContext().getCurrentActivity() instead.",
+      ReplaceWith("reactApplicationContext.currentActivity"))
+  protected val currentActivity: Activity?
+    get() = reactApplicationContext.currentActivity
 }


### PR DESCRIPTION
## Summary:

First of all thanks for moving this module from Java to Kotlin, hopefully we reach a state very soon to have everything in Kotlin and ditch Java completely.

Having said that, this change broke backward compatibility because some libraries are using kotlin and in kotlin when you call a Java getter you could do "variableName" instead of "getVariableName"

example here: https://github.com/segmentio/analytics-react-native/blob/master/packages/core/android/src/main/java/com/segmentanalyticsreactnative/AnalyticsReactNativeModule.kt

you can see how they do "currentActivity"

## Changelog:

[ANDROID] [FIXED] - Backward compatibility for currentActivity


## Test Plan:

run a new RN 81 project and add segment or any libraries that used to use "currentActivity"
with current changes Android build will fail
after applying my patch it will work.
