### PR TITLE
Migrate ClipboardModuleTest to use BridgelessReactContext

### DIFF
--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/ReactTestHelper.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/ReactTestHelper.kt
@@ -11,12 +11,18 @@
 
 package com.facebook.react.bridge
 
+import android.app.Application
 import com.facebook.react.bridge.queue.MessageQueueThreadSpec
 import com.facebook.react.bridge.queue.ReactQueueConfiguration
 import com.facebook.react.bridge.queue.ReactQueueConfigurationImpl
 import com.facebook.react.bridge.queue.ReactQueueConfigurationSpec
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
+import com.facebook.react.runtime.BridgelessReactContext
+import com.facebook.react.runtime.ReactHostImpl
+import com.facebook.react.runtime.internal.bolts.Task
 import com.facebook.react.uimanager.UIManagerModule
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.spy
 import org.mockito.kotlin.whenever
 import org.robolectric.RuntimeEnvironment
 
@@ -48,5 +54,21 @@ object ReactTestHelper {
         .thenReturn(mock<UIManagerModule>())
     whenever(reactInstance.isDestroyed).thenReturn(false)
     return reactInstance
+  }
+
+  @OptIn(UnstableReactNativeAPI::class)
+  fun createTestReactApplicationContext(application: Application): ReactApplicationContext {
+    val reactHost =
+        spy(
+            ReactHostImpl(
+                RuntimeEnvironment.getApplication(),
+                mock(),
+                mock(),
+                Task.Companion.IMMEDIATE_EXECUTOR,
+                Task.Companion.IMMEDIATE_EXECUTOR,
+                false /* allowPackagerServerAccess */,
+                false /* useDevSupport */,
+            ))
+    return BridgelessReactContext(application, reactHost)
   }
 }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/clipboard/ClipboardModuleTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/modules/clipboard/ClipboardModuleTest.kt
@@ -5,36 +5,45 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-@file:Suppress("DEPRECATION")
-
 package com.facebook.react.modules.clipboard
 
-import android.annotation.SuppressLint
 import android.content.ClipboardManager
 import android.content.Context
-import com.facebook.react.bridge.BridgeReactContext
+import com.facebook.react.bridge.ReactTestHelper.createTestReactApplicationContext
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsForTests
+import com.facebook.testutils.shadows.ShadowSoLoader
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
 
-@Suppress("DEPRECATION")
-@SuppressLint("ClipboardManager", "DeprecatedClass")
 @RunWith(RobolectricTestRunner::class)
+@Config(shadows = [ShadowSoLoader::class])
 class ClipboardModuleTest {
   private lateinit var clipboardModule: ClipboardModule
   private lateinit var clipboardManager: ClipboardManager
 
   @Before
   fun setUp() {
-    clipboardModule = ClipboardModule(BridgeReactContext(RuntimeEnvironment.getApplication()))
+    ReactNativeFeatureFlagsForTests.setUp()
+    clipboardModule =
+        ClipboardModule(createTestReactApplicationContext(RuntimeEnvironment.getApplication()))
     clipboardManager =
         RuntimeEnvironment.getApplication().getSystemService(Context.CLIPBOARD_SERVICE)
             as ClipboardManager
   }
 
+  @After
+  fun tearDown() {
+    ReactNativeFeatureFlags.dangerouslyReset()
+  }
+
+  @Suppress("DEPRECATION")
   @Test
   fun testSetString() {
     clipboardModule.setString(TEST_CONTENT)


### PR DESCRIPTION
## Summary:

This test was still using the old `BridgeReactContext`, I'm migrating it to `BridgelessReactContext`.

## Changelog:

[INTERNAL] - 

## Test Plan:

CI