### PR TITLE
Do not die on collect-results after printing to Discord.

### DIFF
--- a/.github/workflow-scripts/collectNightlyOutcomes.js
+++ b/.github/workflow-scripts/collectNightlyOutcomes.js
@@ -118,7 +118,6 @@ async function collectResults(discordWebHook) {
     } else {
       console.log('Discord webhook not set');
     }
-    process.exit(1);
   }
 
   // Initialize Firebase client


### PR DESCRIPTION
Summary:
This will prevent the Firebase script from running at all. I'm removing it.

Changelog:
[Internal] [Changed] -

Differential Revision: D79801691


