### PR TITLE
Improve codegen to add getDebugProps to components

### DIFF
--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -717,7 +717,7 @@ InterfaceOnlyNativeComponentViewProps::InterfaceOnlyNativeComponentViewProps(
     const InterfaceOnlyNativeComponentViewProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    title(convertRawProp(context, rawProps, \\"title\\", sourceProps.title, {\\"\\"})) {}
+    title(convertRawProp(context, rawProps, \\"title\\", sourceProps.title, {std::string{\\"\\"}})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
 ComponentName InterfaceOnlyNativeComponentViewProps::getDiffPropsImplementationTarget() const {
@@ -1060,7 +1060,7 @@ StringPropNativeComponentViewProps::StringPropNativeComponentViewProps(
     const StringPropNativeComponentViewProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    placeholder(convertRawProp(context, rawProps, \\"placeholder\\", sourceProps.placeholder, {\\"\\"})),
+    placeholder(convertRawProp(context, rawProps, \\"placeholder\\", sourceProps.placeholder, {std::string{\\"\\"}})),
     defaultValue(convertRawProp(context, rawProps, \\"defaultValue\\", sourceProps.defaultValue, {})) {}
     
 #ifdef RN_SERIALIZABLE_STATE

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
@@ -18,6 +18,7 @@ Object {
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/core/propsConversions.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/graphics/Color.h>
 #include <react/renderer/graphics/Point.h>
 #include <react/renderer/graphics/RectangleEdges.h>
@@ -89,6 +90,7 @@ static inline std::string toString(const ArrayPropsNativeComponentViewSizesMaskW
 struct ArrayPropsNativeComponentViewObjectStruct {
   std::string prop{};
 
+
 #ifdef RN_SERIALIZABLE_STATE
   bool operator==(const ArrayPropsNativeComponentViewObjectStruct&) const = default;
 
@@ -132,6 +134,7 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 struct ArrayPropsNativeComponentViewArrayOfObjectsStruct {
   Float prop1{0.0};
   int prop2{0};
+
 
 #ifdef RN_SERIALIZABLE_STATE
   bool operator==(const ArrayPropsNativeComponentViewArrayOfObjectsStruct&) const = default;
@@ -203,6 +206,8 @@ class ArrayPropsNativeComponentViewProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -225,6 +230,7 @@ Object {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -243,6 +249,8 @@ class BooleanPropNativeComponentViewProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -265,6 +273,7 @@ Object {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/graphics/Color.h>
 
 namespace facebook::react {
@@ -283,6 +292,8 @@ class ColorPropNativeComponentViewProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -306,6 +317,7 @@ Object {
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/graphicsConversions.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 #include <yoga/Yoga.h>
 
 namespace facebook::react {
@@ -324,6 +336,8 @@ class DimensionPropNativeComponentViewProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -346,6 +360,7 @@ Object {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -363,6 +378,8 @@ class EdgeInsetsPropNativeComponentViewProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -385,6 +402,7 @@ Object {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -468,6 +486,8 @@ class EnumPropNativeComponentViewProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -490,6 +510,7 @@ Object {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -507,6 +528,8 @@ class EventNestedObjectPropsNativeComponentViewProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -529,6 +552,7 @@ Object {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -546,6 +570,8 @@ class EventPropsNativeComponentViewProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -568,6 +594,7 @@ Object {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -591,6 +618,8 @@ class FloatPropsNativeComponentViewProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -613,6 +642,7 @@ Object {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/imagemanager/primitives.h>
 
 namespace facebook::react {
@@ -631,6 +661,8 @@ class ImagePropNativeComponentViewProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -653,6 +685,7 @@ Object {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -672,6 +705,8 @@ class IntegerPropNativeComponentViewProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -694,6 +729,7 @@ Object {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -704,13 +740,15 @@ class InterfaceOnlyNativeComponentViewProps final : public ViewProps {
 
 #pragma mark - Props
 
-  std::string title{\\"\\"};
+  std::string title{std::string{\\"\\"}};
 
   #ifdef RN_SERIALIZABLE_STATE
   ComponentName getDiffPropsImplementationTarget() const override;
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -733,6 +771,7 @@ Object {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -750,6 +789,8 @@ class MixedPropNativeComponentViewProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -772,6 +813,7 @@ Object {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/graphics/Color.h>
 #include <react/renderer/graphics/Point.h>
 #include <react/renderer/imagemanager/primitives.h>
@@ -795,6 +837,8 @@ class MultiNativePropNativeComponentViewProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -817,6 +861,7 @@ Object {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -834,6 +879,8 @@ class NoPropsNoEventsNativeComponentViewProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -858,6 +905,7 @@ Object {
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/propsConversions.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/graphics/Color.h>
 #include <react/renderer/graphics/Point.h>
 #include <react/renderer/imagemanager/primitives.h>
@@ -918,12 +966,13 @@ static inline folly::dynamic toDynamic(const ObjectPropsNativeComponentIntEnumPr
 }
 #endif
 struct ObjectPropsNativeComponentObjectPropStruct {
-  std::string stringProp{\\"\\"};
+  std::string stringProp{std::string{\\"\\"}};
   bool booleanProp{false};
   Float floatProp{0.0};
   int intProp{0};
   ObjectPropsNativeComponentStringEnumProp stringEnumProp{ObjectPropsNativeComponentStringEnumProp::Small};
   ObjectPropsNativeComponentIntEnumProp intEnumProp{ObjectPropsNativeComponentIntEnumProp::IntEnumProp0};
+
 
 #ifdef RN_SERIALIZABLE_STATE
   bool operator==(const ObjectPropsNativeComponentObjectPropStruct&) const = default;
@@ -983,6 +1032,7 @@ static inline folly::dynamic toDynamic(const ObjectPropsNativeComponentObjectPro
 struct ObjectPropsNativeComponentObjectArrayPropStruct {
   std::vector<std::string> array{};
 
+
 #ifdef RN_SERIALIZABLE_STATE
   bool operator==(const ObjectPropsNativeComponentObjectArrayPropStruct&) const = default;
 
@@ -1017,6 +1067,7 @@ struct ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct {
   ImageSource image{};
   SharedColor color{};
   Point point{};
+
 
 #ifdef RN_SERIALIZABLE_STATE
   bool operator==(const ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct&) const = default;
@@ -1073,6 +1124,8 @@ class ObjectPropsNativeComponentProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -1095,6 +1148,7 @@ Object {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/graphics/Point.h>
 
 namespace facebook::react {
@@ -1113,6 +1167,8 @@ class PointPropNativeComponentViewProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -1135,6 +1191,7 @@ Object {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -1145,7 +1202,7 @@ class StringPropNativeComponentViewProps final : public ViewProps {
 
 #pragma mark - Props
 
-  std::string placeholder{\\"\\"};
+  std::string placeholder{std::string{\\"\\"}};
   std::string defaultValue{};
 
   #ifdef RN_SERIALIZABLE_STATE
@@ -1153,6 +1210,8 @@ class StringPropNativeComponentViewProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -717,7 +717,7 @@ InterfaceOnlyNativeComponentViewProps::InterfaceOnlyNativeComponentViewProps(
     const InterfaceOnlyNativeComponentViewProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    title(convertRawProp(context, rawProps, \\"title\\", sourceProps.title, {\\"\\"})) {}
+    title(convertRawProp(context, rawProps, \\"title\\", sourceProps.title, {std::string{\\"\\"}})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
 ComponentName InterfaceOnlyNativeComponentViewProps::getDiffPropsImplementationTarget() const {
@@ -1060,7 +1060,7 @@ StringPropNativeComponentViewProps::StringPropNativeComponentViewProps(
     const StringPropNativeComponentViewProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    placeholder(convertRawProp(context, rawProps, \\"placeholder\\", sourceProps.placeholder, {\\"\\"})),
+    placeholder(convertRawProp(context, rawProps, \\"placeholder\\", sourceProps.placeholder, {std::string{\\"\\"}})),
     defaultValue(convertRawProp(context, rawProps, \\"defaultValue\\", sourceProps.defaultValue, {})) {}
     
 #ifdef RN_SERIALIZABLE_STATE

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
@@ -18,6 +18,7 @@ Object {
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/core/propsConversions.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/graphics/Color.h>
 #include <react/renderer/graphics/Point.h>
 #include <react/renderer/graphics/RectangleEdges.h>
@@ -89,6 +90,7 @@ static inline std::string toString(const ArrayPropsNativeComponentViewSizesMaskW
 struct ArrayPropsNativeComponentViewObjectStruct {
   std::string prop{};
 
+
 #ifdef RN_SERIALIZABLE_STATE
   bool operator==(const ArrayPropsNativeComponentViewObjectStruct&) const = default;
 
@@ -132,6 +134,7 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 struct ArrayPropsNativeComponentViewArrayOfObjectsStruct {
   Float prop1{0.0};
   int prop2{0};
+
 
 #ifdef RN_SERIALIZABLE_STATE
   bool operator==(const ArrayPropsNativeComponentViewArrayOfObjectsStruct&) const = default;
@@ -203,6 +206,8 @@ class ArrayPropsNativeComponentViewProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -225,6 +230,7 @@ Object {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -243,6 +249,8 @@ class BooleanPropNativeComponentViewProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -265,6 +273,7 @@ Object {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/graphics/Color.h>
 
 namespace facebook::react {
@@ -283,6 +292,8 @@ class ColorPropNativeComponentViewProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -306,6 +317,7 @@ Object {
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/graphicsConversions.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 #include <yoga/Yoga.h>
 
 namespace facebook::react {
@@ -324,6 +336,8 @@ class DimensionPropNativeComponentViewProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -346,6 +360,7 @@ Object {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -363,6 +378,8 @@ class EdgeInsetsPropNativeComponentViewProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -385,6 +402,7 @@ Object {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -468,6 +486,8 @@ class EnumPropNativeComponentViewProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -490,6 +510,7 @@ Object {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -507,6 +528,8 @@ class EventNestedObjectPropsNativeComponentViewProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -529,6 +552,7 @@ Object {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -546,6 +570,8 @@ class EventPropsNativeComponentViewProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -568,6 +594,7 @@ Object {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -591,6 +618,8 @@ class FloatPropsNativeComponentViewProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -613,6 +642,7 @@ Object {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/imagemanager/primitives.h>
 
 namespace facebook::react {
@@ -631,6 +661,8 @@ class ImagePropNativeComponentViewProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -653,6 +685,7 @@ Object {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -672,6 +705,8 @@ class IntegerPropNativeComponentViewProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -694,6 +729,7 @@ Object {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -704,13 +740,15 @@ class InterfaceOnlyNativeComponentViewProps final : public ViewProps {
 
 #pragma mark - Props
 
-  std::string title{\\"\\"};
+  std::string title{std::string{\\"\\"}};
 
   #ifdef RN_SERIALIZABLE_STATE
   ComponentName getDiffPropsImplementationTarget() const override;
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -733,6 +771,7 @@ Object {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -750,6 +789,8 @@ class MixedPropNativeComponentViewProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -772,6 +813,7 @@ Object {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/graphics/Color.h>
 #include <react/renderer/graphics/Point.h>
 #include <react/renderer/imagemanager/primitives.h>
@@ -795,6 +837,8 @@ class MultiNativePropNativeComponentViewProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -817,6 +861,7 @@ Object {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -834,6 +879,8 @@ class NoPropsNoEventsNativeComponentViewProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -858,6 +905,7 @@ Object {
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/propsConversions.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/graphics/Color.h>
 #include <react/renderer/graphics/Point.h>
 #include <react/renderer/imagemanager/primitives.h>
@@ -918,12 +966,13 @@ static inline folly::dynamic toDynamic(const ObjectPropsNativeComponentIntEnumPr
 }
 #endif
 struct ObjectPropsNativeComponentObjectPropStruct {
-  std::string stringProp{\\"\\"};
+  std::string stringProp{std::string{\\"\\"}};
   bool booleanProp{false};
   Float floatProp{0.0};
   int intProp{0};
   ObjectPropsNativeComponentStringEnumProp stringEnumProp{ObjectPropsNativeComponentStringEnumProp::Small};
   ObjectPropsNativeComponentIntEnumProp intEnumProp{ObjectPropsNativeComponentIntEnumProp::IntEnumProp0};
+
 
 #ifdef RN_SERIALIZABLE_STATE
   bool operator==(const ObjectPropsNativeComponentObjectPropStruct&) const = default;
@@ -983,6 +1032,7 @@ static inline folly::dynamic toDynamic(const ObjectPropsNativeComponentObjectPro
 struct ObjectPropsNativeComponentObjectArrayPropStruct {
   std::vector<std::string> array{};
 
+
 #ifdef RN_SERIALIZABLE_STATE
   bool operator==(const ObjectPropsNativeComponentObjectArrayPropStruct&) const = default;
 
@@ -1017,6 +1067,7 @@ struct ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct {
   ImageSource image{};
   SharedColor color{};
   Point point{};
+
 
 #ifdef RN_SERIALIZABLE_STATE
   bool operator==(const ObjectPropsNativeComponentObjectPrimitiveRequiredPropStruct&) const = default;
@@ -1073,6 +1124,8 @@ class ObjectPropsNativeComponentProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -1095,6 +1148,7 @@ Object {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/graphics/Point.h>
 
 namespace facebook::react {
@@ -1113,6 +1167,8 @@ class PointPropNativeComponentViewProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -1135,6 +1191,7 @@ Object {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -1145,7 +1202,7 @@ class StringPropNativeComponentViewProps final : public ViewProps {
 
 #pragma mark - Props
 
-  std::string placeholder{\\"\\"};
+  std::string placeholder{std::string{\\"\\"}};
   std::string defaultValue{};
 
   #ifdef RN_SERIALIZABLE_STATE
@@ -1153,6 +1210,8 @@ class StringPropNativeComponentViewProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react

--- a/packages/react-native-codegen/src/cli/generators/generate-all.js
+++ b/packages/react-native-codegen/src/cli/generators/generate-all.js
@@ -46,9 +46,17 @@ try {
 } catch (err) {
   throw new Error(`Can't parse schema to JSON. ${schemaPath}`);
 }
-
+const includeGetDebugPropsImplementation: boolean =
+  libraryName.includes('FBReactNativeSpec');
 RNCodegen.generate(
-  {libraryName, schema, outputDirectory, packageName, assumeNonnull},
+  {
+    libraryName,
+    schema,
+    outputDirectory,
+    packageName,
+    assumeNonnull,
+    includeGetDebugPropsImplementation,
+  },
   {
     generators: [
       'descriptors',

--- a/packages/react-native-codegen/src/generators/RNCodegen.js
+++ b/packages/react-native-codegen/src/generators/RNCodegen.js
@@ -81,6 +81,7 @@ export type GenerateFunction = (
   packageName?: string,
   assumeNonnull: boolean,
   headerPrefix?: string,
+  includeGetDebugPropsImplementation?: boolean,
 ) => FilesOutput;
 
 export type LibraryGeneratorsFunctions = $ReadOnly<{
@@ -94,6 +95,7 @@ export type LibraryOptions = $ReadOnly<{
   packageName?: string, // Some platforms have a notion of package, which should be configurable.
   assumeNonnull: boolean,
   useLocalIncludePaths?: boolean,
+  includeGetDebugPropsImplementation?: boolean,
   libraryGenerators?: LibraryGeneratorsFunctions,
 }>;
 
@@ -255,6 +257,7 @@ module.exports = {
       packageName,
       assumeNonnull,
       useLocalIncludePaths,
+      includeGetDebugPropsImplementation = false,
       libraryGenerators = LIBRARY_GENERATORS,
     }: LibraryOptions,
     {generators, test}: LibraryConfig,
@@ -299,6 +302,7 @@ module.exports = {
           packageName,
           assumeNonnull,
           headerPrefix,
+          includeGetDebugPropsImplementation,
         ).forEach((contents: string, fileName: string) => {
           generatedFiles.push({
             name: fileName,

--- a/packages/react-native-codegen/src/generators/components/CppHelpers.js
+++ b/packages/react-native-codegen/src/generators/components/CppHelpers.js
@@ -190,7 +190,7 @@ function convertDefaultTypeToString(
       if (typeAnnotation.default == null) {
         return '';
       }
-      return `"${typeAnnotation.default}"`;
+      return `std::string{"${typeAnnotation.default}"}`;
     case 'Int32TypeAnnotation':
       return String(typeAnnotation.default);
     case 'DoubleTypeAnnotation':

--- a/packages/react-native-codegen/src/generators/components/GenerateComponentDescriptorCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateComponentDescriptorCpp.js
@@ -61,6 +61,7 @@ module.exports = {
     packageName?: string,
     assumeNonnull: boolean = false,
     headerPrefix?: string,
+    includeGetDebugPropsImplementation?: boolean = false,
   ): FilesOutput {
     const fileName = 'ComponentDescriptors.cpp';
 

--- a/packages/react-native-codegen/src/generators/components/GenerateComponentDescriptorH.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateComponentDescriptorH.js
@@ -63,6 +63,7 @@ module.exports = {
     packageName?: string,
     assumeNonnull: boolean = false,
     headerPrefix?: string,
+    includeGetDebugPropsImplementation?: boolean = false,
   ): FilesOutput {
     const fileName = 'ComponentDescriptors.h';
 

--- a/packages/react-native-codegen/src/generators/components/GenerateComponentHObjCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateComponentHObjCpp.js
@@ -381,6 +381,7 @@ module.exports = {
     packageName?: string,
     assumeNonnull: boolean = false,
     headerPrefix?: string,
+    includeGetDebugPropsImplementation?: boolean = false,
   ): FilesOutput {
     const fileName = 'RCTComponentViewHelpers.h';
 

--- a/packages/react-native-codegen/src/generators/components/GenerateEventEmitterCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateEventEmitterCpp.js
@@ -413,6 +413,7 @@ module.exports = {
     packageName?: string,
     assumeNonnull: boolean = false,
     headerPrefix?: string,
+    includeGetDebugPropsImplementation?: boolean = false,
   ): FilesOutput {
     const moduleComponents: ComponentCollection = Object.keys(schema.modules)
       .map(moduleName => {

--- a/packages/react-native-codegen/src/generators/components/GenerateEventEmitterH.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateEventEmitterH.js
@@ -320,6 +320,7 @@ module.exports = {
     packageName?: string,
     assumeNonnull: boolean = false,
     headerPrefix?: string,
+    includeGetDebugPropsImplementation?: boolean = false,
   ): FilesOutput {
     const moduleComponents: ComponentCollection = Object.keys(schema.modules)
       .map(moduleName => {

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsCpp.js
@@ -77,6 +77,8 @@ function generatePropsDiffString(
   className: string,
   componentName: string,
   component: ComponentShape,
+  debugProps: string = '',
+  includeGetDebugPropsImplementation?: boolean = false,
 ) {
   const diffProps = component.props
     .map(prop => {
@@ -134,6 +136,12 @@ function generatePropsDiffString(
     })
     .join('\n' + '    ');
 
+  const getDebugPropsString = `#if RN_DEBUG_STRING_CONVERTIBLE
+SharedDebugStringConvertibleList ${className}::getDebugProps() const {
+  return ViewProps::getDebugProps()${debugProps && debugProps.length > 0 ? ` +\n\t\tSharedDebugStringConvertibleList{${debugProps}\n\t}` : ''};
+}
+#endif`;
+
   return `
 #ifdef RN_SERIALIZABLE_STATE
 ComponentName ${className}::getDiffPropsImplementationTarget() const {
@@ -153,8 +161,11 @@ folly::dynamic ${className}::getDiffProps(
   ${diffProps}
   return result;
 }
-#endif`;
+#endif
+${includeGetDebugPropsImplementation ? getDebugPropsString : ''}
+`;
 }
+
 function generatePropsString(componentName: string, component: ComponentShape) {
   return component.props
     .map(prop => {
@@ -168,6 +179,24 @@ function generatePropsString(componentName: string, component: ComponentShape) {
       return `${prop.name}(${convertRawProp})`;
     })
     .join(',\n' + '    ');
+}
+
+function generateDebugPropsString(
+  componentName: string,
+  component: ComponentShape,
+) {
+  return component.props
+    .map(prop => {
+      if (prop.typeAnnotation.type === 'ObjectTypeAnnotation') {
+        // Skip ObjectTypeAnnotation because there is no generic `toString`
+        // method for it. We would have to define an interface that the structs implement.
+        return '';
+      }
+
+      const defaultValue = convertDefaultTypeToString(componentName, prop);
+      return `\n\t\t\tdebugStringConvertibleItem("${prop.name}", ${prop.name}${defaultValue ? `, ${defaultValue}` : ''})`;
+    })
+    .join(',');
 }
 
 function getClassExtendString(component: ComponentShape): string {
@@ -202,12 +231,20 @@ module.exports = {
     packageName?: string,
     assumeNonnull: boolean = false,
     headerPrefix?: string,
+    includeGetDebugPropsImplementation?: boolean = false,
   ): FilesOutput {
     const fileName = 'Props.cpp';
     const allImports: Set<string> = new Set([
       '#include <react/renderer/core/propsConversions.h>',
       '#include <react/renderer/core/PropsParserContext.h>',
     ]);
+
+    if (includeGetDebugPropsImplementation) {
+      allImports.add('#include <react/renderer/core/graphicsConversions.h>');
+      allImports.add(
+        '#include <react/renderer/debug/debugStringConvertibleUtils.h>',
+      );
+    }
 
     const componentProps = Object.keys(schema.modules)
       .map(moduleName => {
@@ -229,10 +266,15 @@ module.exports = {
 
             const propsString = generatePropsString(componentName, component);
             const extendString = getClassExtendString(component);
+            const debugProps = includeGetDebugPropsImplementation
+              ? generateDebugPropsString(componentName, component)
+              : '';
             const diffPropsString = generatePropsDiffString(
               newName,
               componentName,
               component,
+              debugProps,
+              includeGetDebugPropsImplementation,
             );
 
             const imports = getImports(component.props);

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsJavaDelegate.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsJavaDelegate.js
@@ -299,6 +299,7 @@ module.exports = {
     packageName?: string,
     assumeNonnull: boolean = false,
     headerPrefix?: string,
+    includeGetDebugPropsImplementation?: boolean = false,
   ): FilesOutput {
     // TODO: This doesn't support custom package name yet.
     const normalizedPackageName = 'com.facebook.react.viewmanagers';

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsJavaInterface.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsJavaInterface.js
@@ -238,6 +238,7 @@ module.exports = {
     packageName?: string,
     assumeNonnull: boolean = false,
     headerPrefix?: string,
+    includeGetDebugPropsImplementation?: boolean = false,
   ): FilesOutput {
     // TODO: This doesn't support custom package name yet.
     const normalizedPackageName = 'com.facebook.react.viewmanagers';

--- a/packages/react-native-codegen/src/generators/components/GenerateShadowNodeCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateShadowNodeCpp.js
@@ -54,6 +54,7 @@ module.exports = {
     packageName?: string,
     assumeNonnull: boolean = false,
     headerPrefix?: string,
+    includeGetDebugPropsImplementation?: boolean = false,
   ): FilesOutput {
     const fileName = 'ShadowNodes.cpp';
 

--- a/packages/react-native-codegen/src/generators/components/GenerateShadowNodeH.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateShadowNodeH.js
@@ -74,6 +74,7 @@ module.exports = {
     packageName?: string,
     assumeNonnull: boolean = false,
     headerPrefix?: string,
+    includeGetDebugPropsImplementation?: boolean = false,
   ): FilesOutput {
     const fileName = 'ShadowNodes.h';
 

--- a/packages/react-native-codegen/src/generators/components/GenerateStateCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateStateCpp.js
@@ -50,6 +50,7 @@ module.exports = {
     packageName?: string,
     assumeNonnull: boolean = false,
     headerPrefix?: string,
+    includeGetDebugPropsImplementation?: boolean = false,
   ): FilesOutput {
     const fileName = 'States.cpp';
 

--- a/packages/react-native-codegen/src/generators/components/GenerateStateH.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateStateH.js
@@ -57,6 +57,7 @@ module.exports = {
     packageName?: string,
     assumeNonnull: boolean = false,
     headerPrefix?: string,
+    includeGetDebugPropsImplementation?: boolean = false,
   ): FilesOutput {
     const fileName = 'States.h';
 

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsCpp-test.js.snap
@@ -347,7 +347,7 @@ CommandNativeComponentProps::CommandNativeComponentProps(
     const CommandNativeComponentProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    accessibilityHint(convertRawProp(context, rawProps, \\"accessibilityHint\\", sourceProps.accessibilityHint, {\\"\\"})) {}
+    accessibilityHint(convertRawProp(context, rawProps, \\"accessibilityHint\\", sourceProps.accessibilityHint, {std::string{\\"\\"}})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
 ComponentName CommandNativeComponentProps::getDiffPropsImplementationTarget() const {
@@ -1168,7 +1168,7 @@ InterfaceOnlyComponentProps::InterfaceOnlyComponentProps(
     const InterfaceOnlyComponentProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    accessibilityHint(convertRawProp(context, rawProps, \\"accessibilityHint\\", sourceProps.accessibilityHint, {\\"\\"})) {}
+    accessibilityHint(convertRawProp(context, rawProps, \\"accessibilityHint\\", sourceProps.accessibilityHint, {std::string{\\"\\"}})) {}
     
 #ifdef RN_SERIALIZABLE_STATE
 ComponentName InterfaceOnlyComponentProps::getDiffPropsImplementationTarget() const {
@@ -1554,7 +1554,7 @@ StringPropComponentProps::StringPropComponentProps(
     const StringPropComponentProps &sourceProps,
     const RawProps &rawProps): ViewProps(context, sourceProps, rawProps),
 
-    accessibilityHint(convertRawProp(context, rawProps, \\"accessibilityHint\\", sourceProps.accessibilityHint, {\\"\\"})),
+    accessibilityHint(convertRawProp(context, rawProps, \\"accessibilityHint\\", sourceProps.accessibilityHint, {std::string{\\"\\"}})),
     accessibilityRole(convertRawProp(context, rawProps, \\"accessibilityRole\\", sourceProps.accessibilityRole, {})) {}
     
 #ifdef RN_SERIALIZABLE_STATE

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
@@ -18,6 +18,7 @@ Map {
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/graphicsConversions.h>
 #include <react/renderer/core/propsConversions.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/graphics/Color.h>
 #include <react/renderer/graphics/Point.h>
 #include <react/renderer/imagemanager/primitives.h>
@@ -86,7 +87,8 @@ static inline std::string toString(const ArrayPropsNativeComponentSizesMaskWrapp
     return result;
 }
 struct ArrayPropsNativeComponentObjectStruct {
-  std::string stringProp{\\"\\"};
+  std::string stringProp{std::string{\\"\\"}};
+
 
 #ifdef RN_SERIALIZABLE_STATE
   bool operator==(const ArrayPropsNativeComponentObjectStruct&) const = default;
@@ -129,7 +131,8 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 
 
 struct ArrayPropsNativeComponentArrayObjectStruct {
-  std::string stringProp{\\"\\"};
+  std::string stringProp{std::string{\\"\\"}};
+
 
 #ifdef RN_SERIALIZABLE_STATE
   bool operator==(const ArrayPropsNativeComponentArrayObjectStruct&) const = default;
@@ -174,6 +177,7 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 struct ArrayPropsNativeComponentArrayStruct {
   std::vector<ArrayPropsNativeComponentArrayObjectStruct> object{};
 
+
 #ifdef RN_SERIALIZABLE_STATE
   bool operator==(const ArrayPropsNativeComponentArrayStruct&) const = default;
 
@@ -215,7 +219,8 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 
 
 struct ArrayPropsNativeComponentArrayOfArrayOfObjectStruct {
-  std::string stringProp{\\"\\"};
+  std::string stringProp{std::string{\\"\\"}};
+
 
 #ifdef RN_SERIALIZABLE_STATE
   bool operator==(const ArrayPropsNativeComponentArrayOfArrayOfObjectStruct&) const = default;
@@ -286,6 +291,8 @@ class ArrayPropsNativeComponentProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -310,6 +317,7 @@ Map {
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/propsConversions.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/graphics/Color.h>
 #include <react/renderer/graphics/Point.h>
 #include <react/renderer/imagemanager/primitives.h>
@@ -321,6 +329,7 @@ struct ArrayPropsNativeComponentNativePrimitivesStruct {
   std::vector<SharedColor> colors{};
   std::vector<ImageSource> srcs{};
   std::vector<Point> points{};
+
 
 #ifdef RN_SERIALIZABLE_STATE
   bool operator==(const ArrayPropsNativeComponentNativePrimitivesStruct&) const = default;
@@ -385,6 +394,8 @@ class ArrayPropsNativeComponentProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -407,6 +418,7 @@ Map {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -424,6 +436,8 @@ class BooleanPropNativeComponentProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -446,6 +460,7 @@ Map {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/graphics/Color.h>
 
 namespace facebook::react {
@@ -464,6 +479,8 @@ class ColorPropNativeComponentProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -486,6 +503,7 @@ Map {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -503,6 +521,8 @@ class CommandNativeComponentProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -525,6 +545,7 @@ Map {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -535,13 +556,15 @@ class CommandNativeComponentProps final : public ViewProps {
 
 #pragma mark - Props
 
-  std::string accessibilityHint{\\"\\"};
+  std::string accessibilityHint{std::string{\\"\\"}};
 
   #ifdef RN_SERIALIZABLE_STATE
   ComponentName getDiffPropsImplementationTarget() const override;
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -565,6 +588,7 @@ Map {
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/graphicsConversions.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 #include <yoga/Yoga.h>
 
 namespace facebook::react {
@@ -583,6 +607,8 @@ class DimensionPropNativeComponentProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -605,6 +631,7 @@ Map {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -627,6 +654,8 @@ class DoublePropNativeComponentProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -649,6 +678,7 @@ Map {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -666,6 +696,8 @@ class EventsNestedObjectNativeComponentProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -688,6 +720,7 @@ Map {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -705,6 +738,8 @@ class EventsNativeComponentProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -727,6 +762,7 @@ Map {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -744,6 +780,8 @@ class InterfaceOnlyComponentProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -766,6 +804,7 @@ Map {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -783,6 +822,8 @@ class ExcludedAndroidComponentProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -805,6 +846,7 @@ Map {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -822,6 +864,8 @@ class ExcludedAndroidIosComponentProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -844,6 +888,7 @@ Map {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -861,6 +906,8 @@ class ExcludedIosComponentProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 class MultiFileIncludedNativeComponentProps final : public ViewProps {
@@ -877,6 +924,8 @@ class MultiFileIncludedNativeComponentProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -899,6 +948,7 @@ Map {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -921,6 +971,8 @@ class FloatPropNativeComponentProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -943,6 +995,7 @@ Map {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/imagemanager/primitives.h>
 
 namespace facebook::react {
@@ -961,6 +1014,8 @@ class ImagePropNativeComponentProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -983,6 +1038,7 @@ Map {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/graphics/RectangleEdges.h>
 
 namespace facebook::react {
@@ -1001,6 +1057,8 @@ class InsetsPropNativeComponentProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -1023,6 +1081,7 @@ Map {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -1077,6 +1136,8 @@ class Int32EnumPropsNativeComponentProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -1099,6 +1160,7 @@ Map {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -1118,6 +1180,8 @@ class IntegerPropNativeComponentProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -1140,6 +1204,7 @@ Map {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -1150,13 +1215,15 @@ class InterfaceOnlyComponentProps final : public ViewProps {
 
 #pragma mark - Props
 
-  std::string accessibilityHint{\\"\\"};
+  std::string accessibilityHint{std::string{\\"\\"}};
 
   #ifdef RN_SERIALIZABLE_STATE
   ComponentName getDiffPropsImplementationTarget() const override;
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -1179,6 +1246,7 @@ Map {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -1196,6 +1264,8 @@ class MixedPropNativeComponentProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -1218,6 +1288,7 @@ Map {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/graphics/Color.h>
 #include <react/renderer/graphics/Point.h>
 #include <react/renderer/imagemanager/primitives.h>
@@ -1241,6 +1312,8 @@ class ImageColorPropNativeComponentProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -1263,6 +1336,7 @@ Map {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -1280,6 +1354,8 @@ class NoPropsNoEventsComponentProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -1304,6 +1380,7 @@ Map {
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/propsConversions.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/graphics/Color.h>
 #include <react/renderer/graphics/Point.h>
 #include <react/renderer/imagemanager/primitives.h>
@@ -1359,6 +1436,7 @@ static inline folly::dynamic toDynamic(const ObjectPropsIntEnumProp &value) {
 struct ObjectPropsObjectPropObjectArrayPropStruct {
   std::vector<std::string> array{};
 
+
 #ifdef RN_SERIALIZABLE_STATE
   bool operator==(const ObjectPropsObjectPropObjectArrayPropStruct&) const = default;
 
@@ -1393,6 +1471,7 @@ struct ObjectPropsObjectPropObjectPrimitiveRequiredPropStruct {
   ImageSource image{};
   SharedColor color{};
   Point point{};
+
 
 #ifdef RN_SERIALIZABLE_STATE
   bool operator==(const ObjectPropsObjectPropObjectPrimitiveRequiredPropStruct&) const = default;
@@ -1435,7 +1514,8 @@ static inline folly::dynamic toDynamic(const ObjectPropsObjectPropObjectPrimitiv
 #endif
 
 struct ObjectPropsObjectPropNestedPropANestedPropBStruct {
-  std::string nestedPropC{\\"\\"};
+  std::string nestedPropC{std::string{\\"\\"}};
+
 
 #ifdef RN_SERIALIZABLE_STATE
   bool operator==(const ObjectPropsObjectPropNestedPropANestedPropBStruct&) const = default;
@@ -1470,6 +1550,7 @@ static inline folly::dynamic toDynamic(const ObjectPropsObjectPropNestedPropANes
 struct ObjectPropsObjectPropNestedPropAStruct {
   ObjectPropsObjectPropNestedPropANestedPropBStruct nestedPropB{};
 
+
 #ifdef RN_SERIALIZABLE_STATE
   bool operator==(const ObjectPropsObjectPropNestedPropAStruct&) const = default;
 
@@ -1501,7 +1582,8 @@ static inline folly::dynamic toDynamic(const ObjectPropsObjectPropNestedPropAStr
 #endif
 
 struct ObjectPropsObjectPropNestedArrayAsPropertyArrayPropStruct {
-  std::string stringProp{\\"\\"};
+  std::string stringProp{std::string{\\"\\"}};
+
 
 #ifdef RN_SERIALIZABLE_STATE
   bool operator==(const ObjectPropsObjectPropNestedArrayAsPropertyArrayPropStruct&) const = default;
@@ -1546,6 +1628,7 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 struct ObjectPropsObjectPropNestedArrayAsPropertyStruct {
   std::vector<ObjectPropsObjectPropNestedArrayAsPropertyArrayPropStruct> arrayProp{};
 
+
 #ifdef RN_SERIALIZABLE_STATE
   bool operator==(const ObjectPropsObjectPropNestedArrayAsPropertyStruct&) const = default;
 
@@ -1577,11 +1660,11 @@ static inline folly::dynamic toDynamic(const ObjectPropsObjectPropNestedArrayAsP
 #endif
 
 struct ObjectPropsObjectPropStruct {
-  std::string stringProp{\\"\\"};
+  std::string stringProp{std::string{\\"\\"}};
   bool booleanProp{false};
   Float floatProp{0.0};
   int intProp{0};
-  std::string stringUserDefaultProp{\\"user_default\\"};
+  std::string stringUserDefaultProp{std::string{\\"user_default\\"}};
   bool booleanUserDefaultProp{true};
   Float floatUserDefaultProp{3.14};
   int intUserDefaultProp{9999};
@@ -1591,6 +1674,7 @@ struct ObjectPropsObjectPropStruct {
   ObjectPropsObjectPropObjectPrimitiveRequiredPropStruct objectPrimitiveRequiredProp{};
   ObjectPropsObjectPropNestedPropAStruct nestedPropA{};
   ObjectPropsObjectPropNestedArrayAsPropertyStruct nestedArrayAsProperty{};
+
 
 #ifdef RN_SERIALIZABLE_STATE
   bool operator==(const ObjectPropsObjectPropStruct&) const = default;
@@ -1700,6 +1784,8 @@ class ObjectPropsProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -1722,6 +1808,7 @@ Map {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 #include <react/renderer/graphics/Point.h>
 
 namespace facebook::react {
@@ -1740,6 +1827,8 @@ class PointPropNativeComponentProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -1762,6 +1851,7 @@ Map {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -1803,6 +1893,8 @@ class StringEnumPropsNativeComponentProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -1825,6 +1917,7 @@ Map {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -1835,7 +1928,7 @@ class StringPropComponentProps final : public ViewProps {
 
 #pragma mark - Props
 
-  std::string accessibilityHint{\\"\\"};
+  std::string accessibilityHint{std::string{\\"\\"}};
   std::string accessibilityRole{};
 
   #ifdef RN_SERIALIZABLE_STATE
@@ -1843,6 +1936,8 @@ class StringPropComponentProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -1865,6 +1960,7 @@ Map {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -1882,6 +1978,8 @@ class MultiFile1NativeComponentProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 class MultiFile2NativeComponentProps final : public ViewProps {
@@ -1898,6 +1996,8 @@ class MultiFile2NativeComponentProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react
@@ -1920,6 +2020,7 @@ Map {
 
 #include <react/renderer/components/view/ViewProps.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/debug/DebugStringConvertible.h>
 
 namespace facebook::react {
 
@@ -1937,6 +2038,8 @@ class MultiComponent1NativeComponentProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 class MultiComponent2NativeComponentProps final : public ViewProps {
@@ -1953,6 +2056,8 @@ class MultiComponent2NativeComponentProps final : public ViewProps {
 
   folly::dynamic getDiffProps(const Props* prevProps) const override;
   #endif
+
+  
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/debug/DebugStringConvertible.h
+++ b/packages/react-native/ReactCommon/react/renderer/debug/DebugStringConvertible.h
@@ -101,6 +101,9 @@ inline std::string toString(const std::string& value) {
 inline std::string toString(const int& value) {
   return std::to_string(value);
 }
+inline std::string toString(const unsigned int& value) {
+  return std::to_string(value);
+}
 inline std::string toString(const bool& value) {
   return value ? "true" : "false";
 }
@@ -114,6 +117,19 @@ std::string toString(const std::optional<T>& value) {
     return "null";
   }
   return toString(value.value());
+}
+
+template <typename T>
+std::string toString(const std::vector<T>& value) {
+  std::string result = "[";
+  for (size_t i = 0; i < value.size(); i++) {
+    result += toString(value[i]);
+    if (i < value.size() - 1) {
+      result += ", ";
+    }
+  }
+  result += "]";
+  return result;
 }
 
 /*

--- a/packages/react-native/scripts/codegen/generate-specs-cli-executor.js
+++ b/packages/react-native/scripts/codegen/generate-specs-cli-executor.js
@@ -79,6 +79,8 @@ function generateSpecFromInMemorySchema(
 ) {
   validateLibraryType(libraryType);
   createOutputDirectoryIfNeeded(outputDirectory, libraryName);
+  const includeGetDebugPropsImplementation =
+    libraryName.includes('FBReactNativeSpec'); //only generate getDebugString for React Native Core Components
   utils.getCodegen().generate(
     {
       libraryName,
@@ -87,6 +89,7 @@ function generateSpecFromInMemorySchema(
       packageName,
       assumeNonnull: platform === 'ios',
       useLocalIncludePaths,
+      includeGetDebugPropsImplementation,
     },
     {
       generators: GENERATORS[libraryType][platform],


### PR DESCRIPTION
Summary:
Our Codegenerated components are not generating code for `getDebugProps`. This change modifies Codegen to add those functions for all the codegen components.

## Changelog:
[General][Added] - Added getDebugProps to codegen

Differential Revision: D79805145


