### PR TITLE
fix cp command in ReactNativeDependencies.podspec

### DIFF
--- a/packages/react-native/third-party-podspecs/ReactNativeDependencies.podspec
+++ b/packages/react-native/third-party-podspecs/ReactNativeDependencies.podspec
@@ -64,7 +64,7 @@ Pod::Spec.new do |spec|
 
     cp -R "$HEADERS_PATH/" Headers
     mkdir -p framework/packages/react-native
-    cp -R "$XCFRAMEWORK_PATH/.." framework/packages/react-native/
+    cp -R "$XCFRAMEWORK_PATH/../." framework/packages/react-native/
     find "$XCFRAMEWORK_PATH/.." -type f -exec rm {} +
     find "$CURRENT_PATH" -type d -empty -delete
   CMD


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

When running `RCT_USE_PREBUILT_RNCORE=1 RCT_USE_RN_DEP=1 pod install` I'm getting an error: `cp: framework/packages/react-native/..: File exists`

This is not seen consistently by everyone but I've seen in reported one more time at Expo. Could be related to running MacOS 26.

Somehow, apparently, the `..` is being treated as a literal directory name and cp is trying to create a directory named `..` inside `framework/packages/react-native/` which is not what we want.



---
What also seemed to work(around) was to change `mkdir -p framework/packages/react-native` to `mkdir -p framework/packages/` and then `cp` can create the `framework/packages/react-native/..` folder. But this is definitely more confusing.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
