### PR TITLE
Deprecate the DefaultDevSupportManagerFactory.create() method used for Old Arch

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -229,6 +229,9 @@ public class ReactInstanceManager {
     return new ReactInstanceManagerBuilder();
   }
 
+  /**
+   * @noinspection deprecation
+   */
   /* package */ ReactInstanceManager(
       Context applicationContext,
       @Nullable Activity currentActivity,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DefaultDevSupportManagerFactory.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DefaultDevSupportManagerFactory.kt
@@ -25,6 +25,11 @@ import com.facebook.react.packagerconnection.RequestHandler
  */
 internal class DefaultDevSupportManagerFactory : DevSupportManagerFactory {
 
+  @Deprecated(
+      "Use the other create() method with useDevSupport parameter for New Architecture. This method will be removed in a future release.",
+      replaceWith =
+          ReplaceWith(
+              "create(applicationContext, reactInstanceManagerHelper, packagerPathForJSBundleName, enableOnCreate, redBoxHandler, devBundleDownloadListener, minNumShakes, customPackagerCommandHandlers, surfaceDelegateFactory, devLoadingViewManager, pausedInDebuggerOverlayManager)"))
   override fun create(
       applicationContext: Context,
       reactInstanceManagerHelper: ReactInstanceDevHelper,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerFactory.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerFactory.kt
@@ -22,6 +22,12 @@ public interface DevSupportManagerFactory {
    * Factory used by the Old Architecture flow to create a [DevSupportManager] and a
    * [BridgeDevSupportManager]
    */
+  @Deprecated(
+      message =
+          "Use the other create() method with useDevSupport parameter for New Architecture. This method will be removed in a future release.",
+      replaceWith =
+          ReplaceWith(
+              "create(applicationContext, reactInstanceManagerHelper, packagerPathForJSBundleName, enableOnCreate, redBoxHandler, devBundleDownloadListener, minNumShakes, customPackagerCommandHandlers, surfaceDelegateFactory, devLoadingViewManager, pausedInDebuggerOverlayManager)"))
   public fun create(
       applicationContext: Context,
       reactInstanceManagerHelper: ReactInstanceDevHelper,


### PR DESCRIPTION
Summary:
One of those 2 methods can be deprecated as it was used only for old architecture.
We'll be removing it at some point in the future.

Changelog:
[Android] [Deprecated] - DefaultDevSupportManagerFactory.create() method used for Old Arch

Differential Revision: D79806116


