### PR TITLE
RNGP - Make sure the newArchEnabled is set to true for all the libs

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -29,7 +29,6 @@ import com.facebook.react.utils.JdkConfiguratorUtils.configureJavaToolChains
 import com.facebook.react.utils.JsonUtils
 import com.facebook.react.utils.NdkConfiguratorUtils.configureReactNativeNdk
 import com.facebook.react.utils.ProjectUtils.needsCodegenFromPackageJson
-import com.facebook.react.utils.PropertyUtils
 import com.facebook.react.utils.findPackageJsonFile
 import java.io.File
 import kotlin.system.exitProcess
@@ -43,7 +42,6 @@ import org.gradle.internal.jvm.Jvm
 class ReactPlugin : Plugin<Project> {
   override fun apply(project: Project) {
     checkJvmVersion(project)
-    checkLegacyArchProperty(project)
     val extension = project.extensions.create("react", ReactExtension::class.java, project)
 
     // We register a private extension on the rootProject so that project wide configs
@@ -113,30 +111,6 @@ class ReactPlugin : Plugin<Project> {
       """
               .trimIndent())
       exitProcess(1)
-    }
-  }
-
-  private fun checkLegacyArchProperty(project: Project) {
-    if ((project.hasProperty(PropertyUtils.NEW_ARCH_ENABLED) &&
-        !project.property(PropertyUtils.NEW_ARCH_ENABLED).toString().toBoolean()) ||
-        (project.hasProperty(PropertyUtils.SCOPED_NEW_ARCH_ENABLED) &&
-            !project.property(PropertyUtils.SCOPED_NEW_ARCH_ENABLED).toString().toBoolean())) {
-      project.logger.error(
-          """
-
-      ********************************************************************************
-
-      WARNING: Setting `newArchEnabled=false` in your `gradle.properties` file is not
-      supported anymore since React Native 0.82.
-      
-      You can remove the line from your `gradle.properties` file.
-      
-      The application will run with the New Architecture enabled by default.
-
-      ********************************************************************************
-
-      """
-              .trimIndent())
     }
   }
 

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactRootProjectPlugin.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactRootProjectPlugin.kt
@@ -7,8 +7,10 @@
 
 package com.facebook.react
 
+import com.facebook.react.utils.PropertyUtils
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.plugin.extraProperties
 
 /**
  * Gradle plugin applied to the `android/build.gradle` file.
@@ -18,13 +20,25 @@ import org.gradle.api.Project
  */
 class ReactRootProjectPlugin : Plugin<Project> {
   override fun apply(project: Project) {
-    project.subprojects {
+    checkLegacyArchProperty(project)
+    project.subprojects { subproject ->
       // As the :app project (i.e. ReactPlugin) configures both namespaces and JVM toolchains
       // for libraries, its evaluation must happen before the libraries' evaluation.
       // Eventually the configuration of namespace/JVM toolchain can be moved inside this plugin.
-      if (it.path != ":app") {
-        it.evaluationDependsOn(":app")
+      if (subproject.path != ":app") {
+        subproject.evaluationDependsOn(":app")
       }
+      // We set the New Architecture properties to true for all subprojects. So that
+      // libraries don't need to be modified and can keep on using the isNewArchEnabled()
+      // function to check if property is set.
+      if (subproject.hasProperty(PropertyUtils.SCOPED_NEW_ARCH_ENABLED)) {
+        subproject.setProperty(PropertyUtils.SCOPED_NEW_ARCH_ENABLED, "true")
+      }
+      if (subproject.hasProperty(PropertyUtils.NEW_ARCH_ENABLED)) {
+        subproject.setProperty(PropertyUtils.NEW_ARCH_ENABLED, "true")
+      }
+      subproject.extraProperties.set(PropertyUtils.NEW_ARCH_ENABLED, "true")
+      subproject.extraProperties.set(PropertyUtils.SCOPED_NEW_ARCH_ENABLED, "true")
     }
     // We need to make sure that `:app:preBuild` task depends on all other subprojects' preBuild
     // tasks. This is necessary in order to have all the codegen generated code before the CMake
@@ -41,6 +55,29 @@ class ReactRootProjectPlugin : Plugin<Project> {
         // Make :app:preBuild depend on all others
         appPreBuild.dependsOn(otherPreBuildTasks)
       }
+    }
+  }
+
+  private fun checkLegacyArchProperty(project: Project) {
+    if ((project.hasProperty(PropertyUtils.NEW_ARCH_ENABLED) &&
+        !project.property(PropertyUtils.NEW_ARCH_ENABLED).toString().toBoolean()) ||
+        (project.hasProperty(PropertyUtils.SCOPED_NEW_ARCH_ENABLED) &&
+            !project.property(PropertyUtils.SCOPED_NEW_ARCH_ENABLED).toString().toBoolean())) {
+      project.logger.error(
+          """
+      ********************************************************************************
+
+      WARNING: Setting `newArchEnabled=false` in your `gradle.properties` file is not
+      supported anymore since React Native 0.82.
+      
+      You can remove the line from your `gradle.properties` file.
+      
+      The application will run with the New Architecture enabled by default.
+
+      ********************************************************************************
+
+      """
+              .trimIndent())
     }
   }
 }


### PR DESCRIPTION
Summary:
Without this patch, library could break if the user removes the `newArchEnabled=`
property from the `gradle.properties` file.

With this patch instead we hardcode the property to true, so all the libraries can consume
it if they wish.

Changelog:
[Internal] [Changed] -

Differential Revision: D79805857


