### PR TITLE
Add type-safe API for passing around benchmark results

### DIFF
--- a/private/react-native-fantom/runner/benchmarkUtils.js
+++ b/private/react-native-fantom/runner/benchmarkUtils.js
@@ -8,52 +8,36 @@
  * @format
  */
 
+import type {BenchmarkResult} from '../src/Benchmark';
+
 import {markdownTable} from './utils';
 
-type TestTaskTiming = {
-  name: string,
-  latency: {
-    mean: number,
-    min: number,
-    max: number,
-    p50: number,
-    p75: number,
-    p99: number,
-  },
-};
-
-export type BenchmarkTestArtifact = {
-  type: string,
-  timings: $ReadOnlyArray<TestTaskTiming>,
-};
-
 export const printBenchmarkResultsRanking = (
-  testResults: Array<{
+  benchmarkResults: Array<{
     title: string,
-    testArtifact: mixed,
+    result: BenchmarkResult,
   }>,
 ) => {
   const testTaskTimings: {[string]: {[string]: number}} = {};
   let numTestVariants = 0;
 
-  for (const testResult of testResults) {
-    // $FlowExpectedError[incompatible-cast]
-    const testArtifact = testResult?.testArtifact as ?BenchmarkTestArtifact;
+  for (const benchmarkResult of benchmarkResults) {
+    const result = benchmarkResult.result;
     if (
-      testArtifact == null ||
-      testArtifact.timings == null ||
-      testArtifact.type !== 'benchmark' ||
-      testResult.title == null
+      result == null ||
+      result.timings == null ||
+      benchmarkResult.title == null
     ) {
       continue;
     }
     numTestVariants++;
-    for (const taskTiming of testArtifact.timings) {
+    for (const taskTiming of result.timings) {
       const taskName = taskTiming.name;
       if (testTaskTimings[taskName] === undefined) {
         testTaskTimings[taskName] = {};
       }
-      testTaskTimings[taskName][testResult.title] = taskTiming.latency.p50;
+      testTaskTimings[taskName][benchmarkResult.title] =
+        taskTiming.latency?.p50 ?? taskTiming.latency.mean;
     }
   }
   if (numTestVariants <= 1 || Object.keys(testTaskTimings).length === 0) {

--- a/private/react-native-fantom/runtime/setup.js
+++ b/private/react-native-fantom/runtime/setup.js
@@ -8,6 +8,7 @@
  * @format
  */
 
+import type {BenchmarkResult} from '../src/Benchmark';
 import type {SnapshotConfig, TestSnapshotResults} from './snapshotContext';
 
 import {getConstants} from '../src/Constants';
@@ -26,7 +27,6 @@ export type TestCaseResult = {
   failureDetails: Array<FailureDetail>,
   numPassingAsserts: number,
   snapshotResults: TestSnapshotResults,
-  testArtifact?: mixed,
   // location: string,
 };
 
@@ -315,7 +315,6 @@ function runSpec(spec: Spec): TestCaseResult {
     failureDetails: [],
     numPassingAsserts: 0,
     snapshotResults: {},
-    testArtifact: null,
   };
 
   if (!shouldRunSuite(spec)) {
@@ -330,7 +329,7 @@ function runSpec(spec: Spec): TestCaseResult {
 
   try {
     invokeHooks(spec.parentContext, 'beforeEachHooks');
-    result.testArtifact = spec.implementation();
+    spec.implementation();
     invokeHooks(spec.parentContext, 'afterEachHooks');
 
     status = 'passed';
@@ -400,6 +399,13 @@ function reportTestSuiteResult(testSuiteResult: TestSuiteResult): void {
       ...testSuiteResult,
     }),
   );
+}
+
+export function reportBenchmarkResult(result: BenchmarkResult): void {
+  // Force the import of the native module to be lazy
+  const NativeFantom =
+    require('react-native/src/private/testing/fantom/specs/NativeFantom').default;
+  NativeFantom.reportTestSuiteResultsJSON(JSON.stringify(result));
 }
 
 function validateEmptyMessageQueue(): void {

--- a/private/react-native-fantom/src/Benchmark.js
+++ b/private/react-native-fantom/src/Benchmark.js
@@ -8,6 +8,7 @@
  * @format
  */
 
+import {reportBenchmarkResult} from '../runtime/setup';
 import {getConstants} from './index';
 import nullthrows from 'nullthrows';
 import NativeCPUTime from 'react-native/src/private/testing/fantom/specs/NativeCPUTime';
@@ -29,6 +30,23 @@ export type SuiteOptions = $ReadOnly<{
 }>;
 
 export type TestOptions = FnOptions;
+
+export type TestTaskTiming = {
+  name: string,
+  latency: {
+    mean: number,
+    min: number,
+    max: number,
+    p50?: number,
+    p75?: number,
+    p99?: number,
+  },
+};
+
+export type BenchmarkResult = {
+  type: string,
+  timings: $ReadOnlyArray<TestTaskTiming>,
+};
 
 type InternalTestOptions = $ReadOnly<{
   ...FnOptions,
@@ -176,7 +194,7 @@ export function suite(
         'Failing focused test to prevent it from being committed',
       );
     }
-    return createBenchmarkTestArtifact(bench, tasks);
+    reportBenchmarkResult(createBenchmarkResultsObject(bench, tasks));
   });
 
   const test = (
@@ -255,9 +273,12 @@ function printBenchmarkResults(bench: Bench) {
   console.log('');
 }
 
-function createBenchmarkTestArtifact(bench: Bench, tasks: Array<TestTask>) {
+function createBenchmarkResultsObject(
+  bench: Bench,
+  tasks: Array<TestTask>,
+): BenchmarkResult {
   return {
-    type: 'benchmark',
+    type: 'benchmark-result',
     timings: tasks.map((task, i) => {
       const result = bench.results[i];
       const {min, max, mean, p50, p75, p99} = result.latency;


### PR DESCRIPTION
Summary:
# Changelog:
[Internal] -

This refactors the way Fantom benchmark test results are passed to the top level, making it type safe and more maintainable.

Differential Revision: D79812707


