### PR TITLE
Deprecate ReactInstanceManager and ReactInstanceManagerBuilder

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -143,6 +143,8 @@ import java.util.Set;
  */
 @ThreadSafe
 @LegacyArchitecture
+@Deprecated(
+    since = "This class is part of Legacy Architecture and will be removed in a future release")
 public class ReactInstanceManager {
 
   static {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManagerBuilder.kt
@@ -40,6 +40,9 @@ import com.facebook.react.packagerconnection.RequestHandler
 
 /** Builder class for [ReactInstanceManager]. */
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
+@Deprecated(
+    message = "This class is part of Legacy Architecture and will be removed in a future release",
+    level = DeprecationLevel.WARNING)
 public class ReactInstanceManagerBuilder {
   private val packages: MutableList<ReactPackage> = mutableListOf()
   private var jsBundleAssetUrl: String? = null


### PR DESCRIPTION
Summary:
ReactInstanceManager and ReactInstanceManagerBuilder are legacy architecture classes that will be deleted in the future, in this diff we are deprecating them

changelog: [Android][Changed] Deprecate legacy architecture classes ReactInstanceManager and ReactInstanceManagerBuilder, these classes will be deleted in a future release

Reviewed By: mlord93

Differential Revision: D79677828


