### PR TITLE
Rename BridgeSoLoader -> ReactNativeJNISoLoader

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
@@ -50,7 +50,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 @LegacyArchitecture
 public class CatalystInstanceImpl implements CatalystInstance {
   static {
-    BridgeSoLoader.staticInit();
+    ReactNativeJNISoLoader.staticInit();
     LegacyArchitectureLogger.assertLegacyArchitecture(
         "CatalystInstanceImpl", LegacyArchitectureLogLevel.WARNING);
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CxxModuleWrapperBase.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CxxModuleWrapperBase.kt
@@ -50,7 +50,7 @@ protected constructor(
 
   private companion object {
     init {
-      BridgeSoLoader.staticInit()
+      ReactNativeJNISoLoader.staticInit()
       LegacyArchitectureLogger.assertLegacyArchitecture(
           "CxxModuleWrapperBase", LegacyArchitectureLogLevel.WARNING)
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/Inspector.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/Inspector.kt
@@ -49,7 +49,7 @@ private constructor(@Suppress("NoHungarianNotation") private val mHybridData: Hy
 
   public companion object {
     init {
-      BridgeSoLoader.staticInit()
+      ReactNativeJNISoLoader.staticInit()
     }
 
     @JvmStatic

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactInstanceManagerInspectorTarget.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactInstanceManagerInspectorTarget.kt
@@ -63,7 +63,7 @@ internal class ReactInstanceManagerInspectorTarget(delegate: TargetDelegate) : A
     init {
       LegacyArchitectureLogger.assertLegacyArchitecture(
           "ReactInstanceManagerInspectorTarget", LegacyArchitectureLogLevel.WARNING)
-      BridgeSoLoader.staticInit()
+      ReactNativeJNISoLoader.staticInit()
     }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactNativeJNISoLoader.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactNativeJNISoLoader.kt
@@ -7,15 +7,9 @@
 
 package com.facebook.react.bridge
 
-import com.facebook.react.common.annotations.internal.LegacyArchitecture
-import com.facebook.react.common.annotations.internal.LegacyArchitectureLogger
 import com.facebook.soloader.SoLoader
 
-@LegacyArchitecture
-internal object BridgeSoLoader {
-  init {
-    LegacyArchitectureLogger.assertLegacyArchitecture("BridgeSoLoader")
-  }
+internal object ReactNativeJNISoLoader {
 
   @JvmStatic
   @Synchronized


### PR DESCRIPTION
Summary:
In this diff I'm renaming BridgeSoLoader -> ReactNativeJNISoLoader and removing LegacyArchitecture becuase this class loads jni classes that are required in new architecture

changelog: [internal] internal

Reviewed By: RSNara

Differential Revision: D79827295
