### PR TITLE
Add tests for Modal.navigationBarTranslucent prop

### DIFF
--- a/packages/react-native/Libraries/Modal/__tests__/Modal-itest.js
+++ b/packages/react-native/Libraries/Modal/__tests__/Modal-itest.js
@@ -154,6 +154,39 @@ describe('<Modal>', () => {
         );
       });
     });
+    describe('statusBarTranslucent', () => {
+      it('renders a Modal with statusBarTranslucent="true"', () => {
+        const root = Fantom.createRoot();
+
+        Fantom.runTask(() => {
+          root.render(<Modal statusBarTranslucent={true} />);
+        });
+
+        expect(
+          root.getRenderedOutput({props: ['statusBarTranslucent']}).toJSX(),
+        ).toEqual(
+          <rn-modalHostView statusBarTranslucent="true">
+            <rn-view />
+          </rn-modalHostView>,
+        );
+      });
+      it('renders a Modal with statusBarTranslucent="false"', () => {
+        const root = Fantom.createRoot();
+
+        Fantom.runTask(() => {
+          root.render(<Modal statusBarTranslucent={false} />);
+        });
+
+        expect(
+          root.getRenderedOutput({props: ['statusBarTranslucent']}).toJSX(),
+        ).toEqual(
+          <rn-modalHostView>
+            <rn-view />
+          </rn-modalHostView>,
+        );
+      });
+    });
+
     // ... more props
   });
   describe('ref', () => {

--- a/packages/react-native/Libraries/Modal/__tests__/Modal-itest.js
+++ b/packages/react-native/Libraries/Modal/__tests__/Modal-itest.js
@@ -77,6 +77,44 @@ describe('<Modal>', () => {
         });
       });
     });
+
+    describe('presentationStyle', () => {
+      it('renders a Modal with presentationStyle="fullScreen" by default', () => {
+        const root = Fantom.createRoot();
+
+        Fantom.runTask(() => {
+          root.render(<Modal presentationStyle="fullScreen" />);
+        });
+
+        expect(
+          root.getRenderedOutput({props: ['presentationStyle']}).toJSX(),
+        ).toEqual(
+          <rn-modalHostView>
+            <rn-view />
+          </rn-modalHostView>,
+        );
+      });
+
+      (['pageSheet', 'formSheet', 'overFullScreen'] as const).forEach(
+        presentationStyle => {
+          it(`renders a Modal with presentationStyle="${presentationStyle}"`, () => {
+            const root = Fantom.createRoot();
+
+            Fantom.runTask(() => {
+              root.render(<Modal presentationStyle={presentationStyle} />);
+            });
+
+            expect(
+              root.getRenderedOutput({props: ['presentationStyle']}).toJSX(),
+            ).toEqual(
+              <rn-modalHostView presentationStyle={presentationStyle}>
+                <rn-view />
+              </rn-modalHostView>,
+            );
+          });
+        },
+      );
+    });
     // ... more props
   });
   describe('ref', () => {

--- a/packages/react-native/Libraries/Modal/__tests__/Modal-itest.js
+++ b/packages/react-native/Libraries/Modal/__tests__/Modal-itest.js
@@ -186,7 +186,55 @@ describe('<Modal>', () => {
         );
       });
     });
+    describe('navigationBarTranslucent', () => {
+      it('renders a Modal with navigationBarTranslucent="true" and statusBarTranslucent="true"', () => {
+        const root = Fantom.createRoot();
 
+        Fantom.runTask(() => {
+          // navigationBarTranslucent=true with statusBarTranslucent=false is not supported
+          // and it emits a warning.
+          root.render(
+            <Modal
+              navigationBarTranslucent={true}
+              statusBarTranslucent={true}
+            />,
+          );
+        });
+
+        expect(
+          root
+            .getRenderedOutput({
+              props: ['navigationBarTranslucent', 'statusBarTranslucent'],
+            })
+            .toJSX(),
+        ).toEqual(
+          <rn-modalHostView
+            navigationBarTranslucent="true"
+            statusBarTranslucent="true">
+            <rn-view />
+          </rn-modalHostView>,
+        );
+      });
+      it('renders a Modal with navigationBarTranslucent="false"', () => {
+        const root = Fantom.createRoot();
+
+        Fantom.runTask(() => {
+          root.render(<Modal navigationBarTranslucent={false} />);
+        });
+
+        expect(
+          root
+            .getRenderedOutput({
+              props: ['navigationBarTranslucent', 'statusBarTranslucent'],
+            })
+            .toJSX(),
+        ).toEqual(
+          <rn-modalHostView>
+            <rn-view />
+          </rn-modalHostView>,
+        );
+      });
+    });
     // ... more props
   });
   describe('ref', () => {

--- a/packages/react-native/Libraries/Modal/__tests__/Modal-itest.js
+++ b/packages/react-native/Libraries/Modal/__tests__/Modal-itest.js
@@ -115,6 +115,45 @@ describe('<Modal>', () => {
         },
       );
     });
+    describe('transparent', () => {
+      it('renders a Modal with transparent="true"', () => {
+        const root = Fantom.createRoot();
+
+        Fantom.runTask(() => {
+          root.render(<Modal transparent={true} />);
+        });
+
+        expect(
+          root
+            .getRenderedOutput({props: ['transparent', 'presentationStyle']})
+            .toJSX(),
+        ).toEqual(
+          <rn-modalHostView
+            transparent="true"
+            presentationStyle="overFullScreen">
+            <rn-view />
+          </rn-modalHostView>,
+        );
+      });
+
+      it('renders a Modal with transparent="false"', () => {
+        const root = Fantom.createRoot();
+
+        Fantom.runTask(() => {
+          root.render(<Modal transparent={false} />);
+        });
+
+        expect(
+          root
+            .getRenderedOutput({props: ['transparent', 'presentationStyle']})
+            .toJSX(),
+        ).toEqual(
+          <rn-modalHostView>
+            <rn-view />
+          </rn-modalHostView>,
+        );
+      });
+    });
     // ... more props
   });
   describe('ref', () => {


### PR DESCRIPTION
Summary:
Add Fantom tests for Modal.navigationBarTranslucent prop

## Changelog:
[Internal] -

Differential Revision: D79881358


