### PR TITLE
e2e test for Text.id/nativeID

### DIFF
--- a/packages/react-native/Libraries/Text/__tests__/Text-itest.js
+++ b/packages/react-native/Libraries/Text/__tests__/Text-itest.js
@@ -124,6 +124,47 @@ describe('<Text>', () => {
       });
     });
 
+    describe('id and nativeID', () => {
+      it(`has 'id' propagated correctly`, () => {
+        const root = Fantom.createRoot();
+
+        Fantom.runTask(() => {
+          root.render(<Text id="alpha">{TEST_TEXT}</Text>);
+        });
+
+        expect(root.getRenderedOutput({props: ['nativeID']}).toJSX()).toEqual(
+          <rn-paragraph nativeID={'alpha'}>{TEST_TEXT}</rn-paragraph>,
+        );
+      });
+
+      it(`has 'nativeID' propagated correctly`, () => {
+        const root = Fantom.createRoot();
+
+        Fantom.runTask(() => {
+          root.render(<Text nativeID="alpha">{TEST_TEXT}</Text>);
+        });
+
+        expect(root.getRenderedOutput({props: ['nativeID']}).toJSX()).toEqual(
+          <rn-paragraph nativeID={'alpha'}>{TEST_TEXT}</rn-paragraph>,
+        );
+      });
+      it(`has a precedence of 'id' over 'nativeID'`, () => {
+        const root = Fantom.createRoot();
+
+        Fantom.runTask(() => {
+          root.render(
+            <Text id="alpha" nativeID="gamma">
+              {TEST_TEXT}
+            </Text>,
+          );
+        });
+
+        expect(
+          root.getRenderedOutput({props: ['id', 'nativeID']}).toJSX(),
+        ).toEqual(<rn-paragraph nativeID={'alpha'}>{TEST_TEXT}</rn-paragraph>);
+      });
+    });
+
     describe('numberOfLines', () => {
       let originalConsoleError = null;
 

--- a/packages/react-native/Libraries/Text/__tests__/Text-itest.js
+++ b/packages/react-native/Libraries/Text/__tests__/Text-itest.js
@@ -183,6 +183,40 @@ describe('<Text>', () => {
       });
     });
 
+    describe('selectable', () => {
+      it(`can be set to "true"`, () => {
+        const root = Fantom.createRoot();
+
+        Fantom.runTask(() => {
+          root.render(<Text selectable={true}>{TEST_TEXT}</Text>);
+        });
+
+        expect(root.getRenderedOutput({props: ['selectable']}).toJSX()).toEqual(
+          <rn-paragraph selectable={'true'}>{TEST_TEXT}</rn-paragraph>,
+        );
+      });
+
+      it(`has 'false' as default`, () => {
+        const root = Fantom.createRoot();
+
+        Fantom.runTask(() => {
+          root.render(<Text>{TEST_TEXT}</Text>);
+        });
+
+        expect(root.getRenderedOutput({props: ['selectable']}).toJSX()).toEqual(
+          <rn-paragraph>{TEST_TEXT}</rn-paragraph>,
+        );
+
+        Fantom.runTask(() => {
+          root.render(<Text selectable={false}>{TEST_TEXT}</Text>);
+        });
+
+        expect(root.getRenderedOutput({props: ['selectable']}).toJSX()).toEqual(
+          <rn-paragraph>{TEST_TEXT}</rn-paragraph>,
+        );
+      });
+    });
+
     describe('style', () => {
       describe('writingDirection', () => {
         it('propagates to mounting layer', () => {

--- a/packages/react-native/Libraries/Text/__tests__/Text-itest.js
+++ b/packages/react-native/Libraries/Text/__tests__/Text-itest.js
@@ -124,6 +124,65 @@ describe('<Text>', () => {
       });
     });
 
+    describe('numberOfLines', () => {
+      let originalConsoleError = null;
+
+      afterEach(() => {
+        if (originalConsoleError != null) {
+          // $FlowExpectedError[cannot-write]
+          console.error = originalConsoleError;
+          originalConsoleError = null;
+        }
+      });
+
+      it(`doesn't allow negative numbers`, () => {
+        originalConsoleError = console.error;
+        // $FlowExpectedError[cannot-write]
+        console.error = jest.fn();
+
+        const root = Fantom.createRoot();
+
+        Fantom.runTask(() => {
+          root.render(<Text numberOfLines={-1}>{TEST_TEXT}</Text>);
+        });
+
+        expect(
+          // NB. "numberOfLines" is mapped to "maximumNumberOfLines" in C++
+          root.getRenderedOutput({props: ['maximumNumberOfLines']}).toJSX(),
+        ).toEqual(<rn-paragraph>{TEST_TEXT}</rn-paragraph>);
+      });
+
+      it(`has 0 as defult`, () => {
+        const root = Fantom.createRoot();
+
+        Fantom.runTask(() => {
+          root.render(<Text numberOfLines={0}>{TEST_TEXT}</Text>);
+        });
+
+        expect(
+          root.getRenderedOutput({props: ['maximumNumberOfLines']}).toJSX(),
+        ).toEqual(<rn-paragraph>{TEST_TEXT}</rn-paragraph>);
+      });
+
+      it(`propagates valid numbers correctly`, () => {
+        const root = Fantom.createRoot();
+
+        [3, 1000].forEach(val => {
+          Fantom.runTask(() => {
+            root.render(<Text numberOfLines={val}>{TEST_TEXT}</Text>);
+          });
+
+          expect(
+            root.getRenderedOutput({props: ['maximumNumberOfLines']}).toJSX(),
+          ).toEqual(
+            <rn-paragraph maximumNumberOfLines={val.toString()}>
+              {TEST_TEXT}
+            </rn-paragraph>,
+          );
+        });
+      });
+    });
+
     describe('style', () => {
       describe('writingDirection', () => {
         it('propagates to mounting layer', () => {

--- a/packages/react-native/Libraries/Text/__tests__/Text-itest.js
+++ b/packages/react-native/Libraries/Text/__tests__/Text-itest.js
@@ -46,6 +46,40 @@ describe('<Text>', () => {
       });
     });
 
+    describe('allowFontScaling', () => {
+      ([true, false] as const).forEach(propVal => {
+        it(`can be set to "${propVal.toString()}"`, () => {
+          const root = Fantom.createRoot();
+
+          Fantom.runTask(() => {
+            root.render(<Text allowFontScaling={propVal}>{TEST_TEXT}</Text>);
+          });
+
+          expect(
+            root.getRenderedOutput({props: ['allowFontScaling']}).toJSX(),
+          ).toEqual(
+            <rn-paragraph allowFontScaling={propVal.toString()}>
+              {TEST_TEXT}
+            </rn-paragraph>,
+          );
+        });
+      });
+
+      it(`has 'true' as default`, () => {
+        const root = Fantom.createRoot();
+
+        Fantom.runTask(() => {
+          root.render(<Text>{TEST_TEXT}</Text>);
+        });
+
+        expect(
+          root.getRenderedOutput({props: ['allowFontScaling']}).toJSX(),
+        ).toEqual(
+          <rn-paragraph allowFontScaling={'true'}>{TEST_TEXT}</rn-paragraph>,
+        );
+      });
+    });
+
     describe('ellipsizeMode', () => {
       it(`has 'tail' as default on JS side`, () => {
         const root = Fantom.createRoot();

--- a/packages/react-native/Libraries/Text/__tests__/Text-itest.js
+++ b/packages/react-native/Libraries/Text/__tests__/Text-itest.js
@@ -21,8 +21,75 @@ import {Text} from 'react-native';
 import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 import ReadOnlyText from 'react-native/src/private/webapis/dom/nodes/ReadOnlyText';
 
+const TEST_TEXT = 'the text';
+
 describe('<Text>', () => {
   describe('props', () => {
+    describe('empty props', () => {
+      it('renders an empty element when there are no props', () => {
+        const root = Fantom.createRoot();
+
+        Fantom.runTask(() => {
+          root.render(<Text>{TEST_TEXT}</Text>);
+        });
+
+        expect(root.getRenderedOutput().toJSX()).toEqual(
+          <rn-paragraph
+            allowFontScaling="true"
+            ellipsizeMode="tail"
+            fontSize="NaN"
+            fontSizeMultiplier="NaN"
+            foregroundColor="rgba(0, 0, 0, 0)">
+            {TEST_TEXT}
+          </rn-paragraph>,
+        );
+      });
+    });
+
+    describe('ellipsizeMode', () => {
+      it(`has 'tail' as default on JS side`, () => {
+        const root = Fantom.createRoot();
+
+        Fantom.runTask(() => {
+          root.render(<Text>{TEST_TEXT}</Text>);
+        });
+
+        expect(
+          root.getRenderedOutput({props: ['ellipsizeMode']}).toJSX(),
+        ).toEqual(
+          <rn-paragraph ellipsizeMode="tail">{TEST_TEXT}</rn-paragraph>,
+        );
+      });
+
+      it(`has 'clip' as default on C++ side`, () => {
+        const root = Fantom.createRoot();
+
+        Fantom.runTask(() => {
+          root.render(<Text ellipsizeMode="clip">{TEST_TEXT}</Text>);
+        });
+
+        expect(
+          root.getRenderedOutput({props: ['ellipsizeMode']}).toJSX(),
+        ).toEqual(<rn-paragraph>{TEST_TEXT}</rn-paragraph>);
+      });
+
+      (['head', 'middle', 'tail'] as const).forEach(propVal => {
+        it(`can be set to "${propVal}"`, () => {
+          const root = Fantom.createRoot();
+
+          Fantom.runTask(() => {
+            root.render(<Text ellipsizeMode={propVal}>{TEST_TEXT}</Text>);
+          });
+
+          expect(
+            root.getRenderedOutput({props: ['ellipsizeMode']}).toJSX(),
+          ).toEqual(
+            <rn-paragraph ellipsizeMode={propVal}>{TEST_TEXT}</rn-paragraph>,
+          );
+        });
+      });
+    });
+
     describe('style', () => {
       describe('writingDirection', () => {
         it('propagates to mounting layer', () => {


### PR DESCRIPTION
Summary:
# Changelog:
[Internal] - 

As in the title.

Differential Revision: D79887689


