### PR TITLE
Long press back to open DevMenu

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.kt
@@ -247,7 +247,7 @@ public open class ReactDelegate {
   }
 
   public fun onKeyLongPress(keyCode: Int): Boolean {
-    if (keyCode == KeyEvent.KEYCODE_MEDIA_FAST_FORWARD) {
+    if (keyCode == KeyEvent.KEYCODE_MEDIA_FAST_FORWARD || keyCode == KeyEvent.KEYCODE_BACK) {
       if (ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture() &&
           reactHost != null) {
         val devSupportManager = reactHost?.devSupportManager


### PR DESCRIPTION
Summary:
In addition to the menu button and long pressing fast forward option, adds long pressing back as an option to open DevTools for devices like the Chromecast remote.

Changelog: [Internal]

{F1981060943}

Differential Revision: D79923779


