### PR TITLE
Create runnable only when needed

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -935,14 +935,14 @@ public class FabricUIManager
     if (shouldSchedule) {
       Assertions.assertNotNull(mountItem, "MountItem is null");
       mMountItemDispatcher.addMountItem(mountItem);
-      Runnable runnable =
-          new GuardedRunnable(mReactApplicationContext) {
-            @Override
-            public void runGuarded() {
-              mMountItemDispatcher.tryDispatchMountItems();
-            }
-          };
       if (UiThreadUtil.isOnUiThread()) {
+        Runnable runnable =
+            new GuardedRunnable(mReactApplicationContext) {
+              @Override
+              public void runGuarded() {
+                mMountItemDispatcher.tryDispatchMountItems();
+              }
+            };
         runnable.run();
       }
     }


### PR DESCRIPTION
Summary:
In the FabricUIManager, the runnable created for scheduled mounts is only used if currently running on the UI thread.

With this diff the runnable only gets created when needed.

Changelog: [Internal]

Differential Revision: D79969412


