### PR TITLE
Extend PerformanceEventTiming with taskEndTime

### DIFF
--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntry.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntry.h
@@ -46,6 +46,10 @@ struct PerformanceEventTiming : AbstractPerformanceEntry {
   static constexpr PerformanceEntryType entryType = PerformanceEntryType::EVENT;
   HighResTimeStamp processingStart;
   HighResTimeStamp processingEnd;
+  // Custom RN extension not exposed to JS for now.
+  // It's the same "taskEndTime" defined in the spec for the Event Loop:
+  // https://html.spec.whatwg.org/multipage/webappapis.html#event-loop-processing-model
+  HighResTimeStamp taskEndTime;
   PerformanceEntryInteractionId interactionId;
 };
 

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.cpp
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.cpp
@@ -247,6 +247,7 @@ void PerformanceEntryReporter::reportEvent(
     HighResDuration duration,
     HighResTimeStamp processingStart,
     HighResTimeStamp processingEnd,
+    HighResTimeStamp taskEndTime,
     uint32_t interactionId) {
   eventCounts_[name]++;
 
@@ -260,6 +261,7 @@ void PerformanceEntryReporter::reportEvent(
       {.name = name, .startTime = startTime, .duration = duration},
       processingStart,
       processingEnd,
+      taskEndTime,
       interactionId};
 
   {

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.h
@@ -105,6 +105,7 @@ class PerformanceEntryReporter {
       HighResDuration duration,
       HighResTimeStamp processingStart,
       HighResTimeStamp processingEnd,
+      HighResTimeStamp taskEndTime,
       uint32_t interactionId);
 
   void reportLongTask(HighResTimeStamp startTime, HighResDuration duration);

--- a/packages/react-native/ReactCommon/react/performance/timeline/tests/PerformanceObserverTest.cpp
+++ b/packages/react-native/ReactCommon/react/performance/timeline/tests/PerformanceObserverTest.cpp
@@ -96,6 +96,7 @@ TEST(PerformanceObserver, PerformanceObserverTestFilterMulti) {
       HighResDuration::fromMilliseconds(10),
       timeOrigin,
       timeOrigin,
+      timeOrigin,
       0);
   reporter->reportEvent(
       "test2",
@@ -103,11 +104,13 @@ TEST(PerformanceObserver, PerformanceObserverTestFilterMulti) {
       HighResDuration::fromMilliseconds(10),
       timeOrigin,
       timeOrigin,
+      timeOrigin,
       0);
   reporter->reportEvent(
       "test3",
       timeOrigin + HighResDuration::fromMilliseconds(10),
       HighResDuration::fromMilliseconds(10),
+      timeOrigin,
       timeOrigin,
       timeOrigin,
       0);
@@ -155,6 +158,7 @@ TEST(PerformanceObserver, PerformanceObserverTestFilterMultiCallbackNotCalled) {
       HighResDuration::fromMilliseconds(10),
       timeOrigin,
       timeOrigin,
+      timeOrigin,
       0);
   reporter->reportEvent(
       "test2",
@@ -162,11 +166,13 @@ TEST(PerformanceObserver, PerformanceObserverTestFilterMultiCallbackNotCalled) {
       HighResDuration::fromMilliseconds(10),
       timeOrigin,
       timeOrigin,
+      timeOrigin,
       0);
   reporter->reportEvent(
       "off3",
       timeOrigin + HighResDuration::fromMilliseconds(10),
       HighResDuration::fromMilliseconds(10),
+      timeOrigin,
       timeOrigin,
       timeOrigin,
       0);
@@ -230,6 +236,7 @@ TEST(PerformanceObserver, PerformanceObserverTestObserveDurationThreshold) {
       HighResDuration::fromMilliseconds(50),
       timeOrigin,
       timeOrigin,
+      timeOrigin,
       0);
   reporter->reportEvent(
       "test2",
@@ -237,11 +244,13 @@ TEST(PerformanceObserver, PerformanceObserverTestObserveDurationThreshold) {
       HighResDuration::fromMilliseconds(100),
       timeOrigin,
       timeOrigin,
+      timeOrigin,
       0);
   reporter->reportEvent(
       "off1",
       timeOrigin,
       HighResDuration::fromMilliseconds(40),
+      timeOrigin,
       timeOrigin,
       timeOrigin,
       0);
@@ -253,6 +262,7 @@ TEST(PerformanceObserver, PerformanceObserverTestObserveDurationThreshold) {
       HighResDuration::fromMilliseconds(60),
       timeOrigin,
       timeOrigin,
+      timeOrigin,
       0);
 
   const std::vector<PerformanceEntry> expected = {
@@ -262,6 +272,7 @@ TEST(PerformanceObserver, PerformanceObserverTestObserveDurationThreshold) {
            .duration = HighResDuration::fromMilliseconds(50)},
           timeOrigin,
           timeOrigin,
+          timeOrigin,
           0},
       PerformanceEventTiming{
           {.name = "test2",
@@ -269,11 +280,13 @@ TEST(PerformanceObserver, PerformanceObserverTestObserveDurationThreshold) {
            .duration = HighResDuration::fromMilliseconds(100)},
           timeOrigin,
           timeOrigin,
+          timeOrigin,
           0},
       PerformanceEventTiming{
           {.name = "test3",
            .startTime = timeOrigin,
            .duration = HighResDuration::fromMilliseconds(60)},
+          timeOrigin,
           timeOrigin,
           timeOrigin,
           0},
@@ -295,11 +308,13 @@ TEST(PerformanceObserver, PerformanceObserverTestObserveBuffered) {
       HighResDuration::fromMilliseconds(50),
       timeOrigin,
       timeOrigin,
+      timeOrigin,
       0);
   reporter->reportEvent(
       "test2",
       timeOrigin,
       HighResDuration::fromMilliseconds(100),
+      timeOrigin,
       timeOrigin,
       timeOrigin,
       0);
@@ -309,11 +324,13 @@ TEST(PerformanceObserver, PerformanceObserverTestObserveBuffered) {
       HighResDuration::fromMilliseconds(40),
       timeOrigin,
       timeOrigin,
+      timeOrigin,
       0);
   reporter->reportEvent(
       "test4",
       timeOrigin,
       HighResDuration::fromMilliseconds(100),
+      timeOrigin,
       timeOrigin,
       timeOrigin,
       0);
@@ -332,6 +349,7 @@ TEST(PerformanceObserver, PerformanceObserverTestObserveBuffered) {
            .duration = HighResDuration::fromMilliseconds(50)},
           timeOrigin,
           timeOrigin,
+          timeOrigin,
           0},
       PerformanceEventTiming{
           {.name = "test2",
@@ -339,11 +357,13 @@ TEST(PerformanceObserver, PerformanceObserverTestObserveBuffered) {
            .duration = HighResDuration::fromMilliseconds(100)},
           timeOrigin,
           timeOrigin,
+          timeOrigin,
           0},
       PerformanceEventTiming{
           {.name = "test4",
            .startTime = timeOrigin,
            .duration = HighResDuration::fromMilliseconds(100)},
+          timeOrigin,
           timeOrigin,
           timeOrigin,
           0},
@@ -378,11 +398,13 @@ TEST(PerformanceObserver, PerformanceObserverTestMultiple) {
       HighResDuration::fromMilliseconds(100),
       timeOrigin,
       timeOrigin,
+      timeOrigin,
       0);
   reporter->reportEvent(
       "event2",
       timeOrigin,
       HighResDuration::fromMilliseconds(40),
+      timeOrigin,
       timeOrigin,
       timeOrigin,
       0);
@@ -394,6 +416,7 @@ TEST(PerformanceObserver, PerformanceObserverTestMultiple) {
       HighResDuration::fromMilliseconds(60),
       timeOrigin,
       timeOrigin,
+      timeOrigin,
       0);
 
   const std::vector<PerformanceEntry> expected1 = {
@@ -403,11 +426,13 @@ TEST(PerformanceObserver, PerformanceObserverTestMultiple) {
            .duration = HighResDuration::fromMilliseconds(100)},
           timeOrigin,
           timeOrigin,
+          timeOrigin,
           0},
       PerformanceEventTiming{
           {.name = "event3",
            .startTime = timeOrigin,
            .duration = HighResDuration::fromMilliseconds(60)},
+          timeOrigin,
           timeOrigin,
           timeOrigin,
           0},
@@ -418,6 +443,7 @@ TEST(PerformanceObserver, PerformanceObserverTestMultiple) {
           {.name = "event1",
            .startTime = timeOrigin,
            .duration = HighResDuration::fromMilliseconds(100)},
+          timeOrigin,
           timeOrigin,
           timeOrigin,
           0},

--- a/packages/react-native/ReactCommon/react/renderer/observers/events/EventPerformanceLogger.h
+++ b/packages/react-native/ReactCommon/react/renderer/observers/events/EventPerformanceLogger.h
@@ -40,6 +40,7 @@ class EventPerformanceLogger : public EventLogger,
 #pragma mark - RuntimeSchedulerEventTimingDelegate
 
   void dispatchPendingEventTimingEntries(
+      HighResTimeStamp taskEndTime,
       const std::unordered_set<SurfaceId>&
           surfaceIdsWithPendingRenderingUpdates) override;
 
@@ -56,6 +57,7 @@ class EventPerformanceLogger : public EventLogger,
     HighResTimeStamp startTime;
     std::optional<HighResTimeStamp> processingStartTime;
     std::optional<HighResTimeStamp> processingEndTime;
+    std::optional<HighResTimeStamp> taskEndTime;
 
     bool isWaitingForMount{false};
 

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerEventTimingDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeSchedulerEventTimingDelegate.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <react/timing/primitives.h>
 #include <unordered_set>
 
 namespace facebook::react {
@@ -18,6 +19,7 @@ class RuntimeSchedulerEventTimingDelegate {
   virtual ~RuntimeSchedulerEventTimingDelegate() = default;
 
   virtual void dispatchPendingEventTimingEntries(
+      HighResTimeStamp taskEndTime,
       const std::unordered_set<SurfaceId>&
           surfaceIdsWithPendingRenderingUpdates) = 0;
 };

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.cpp
@@ -319,7 +319,7 @@ void RuntimeScheduler_Modern::runEventLoopTick(
   reportLongTasks(task, taskStartTime, taskEndTime);
 
   // "Update the rendering" step.
-  updateRendering();
+  updateRendering(taskEndTime);
 
   currentTask_ = nullptr;
 }
@@ -329,7 +329,7 @@ void RuntimeScheduler_Modern::runEventLoopTick(
  * event loop. See
  * https://html.spec.whatwg.org/multipage/webappapis.html#update-the-rendering.
  */
-void RuntimeScheduler_Modern::updateRendering() {
+void RuntimeScheduler_Modern::updateRendering(HighResTimeStamp taskEndTime) {
   TraceSection s("RuntimeScheduler::updateRendering");
 
   // This is the integration of the Event Timing API in the Event Loop.
@@ -337,7 +337,7 @@ void RuntimeScheduler_Modern::updateRendering() {
   const auto eventTimingDelegate = eventTimingDelegate_.load();
   if (eventTimingDelegate != nullptr) {
     eventTimingDelegate->dispatchPendingEventTimingEntries(
-        surfaceIdsWithPendingRenderingUpdates_);
+        taskEndTime, surfaceIdsWithPendingRenderingUpdates_);
   }
 
   // This is the integration of the Intersection Observer API in the Event Loop.

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.h
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/RuntimeScheduler_Modern.h
@@ -198,7 +198,7 @@ class RuntimeScheduler_Modern final : public RuntimeSchedulerBase {
       Task& task,
       bool didUserCallbackTimeout) const;
 
-  void updateRendering();
+  void updateRendering(HighResTimeStamp taskEndTime);
 
   bool performingMicrotaskCheckpoint_{false};
   void performMicrotaskCheckpoint(jsi::Runtime& runtime);


### PR DESCRIPTION
Summary:
Changelog: [internal]

This adds a new `taskEndTime` field in the internal C++ representation of `PerformanceEventTiming` so we can distinguish events that waited for mount (because they triggered changes) and events that didn't, so report INP correctly.

Differential Revision: D79894702


