### PR TITLE
Rename global variable with Metro server for Fantom

### DIFF
--- a/private/react-native-fantom/runner/global-setup/globalSetup.js
+++ b/private/react-native-fantom/runner/global-setup/globalSetup.js
@@ -50,7 +50,7 @@ async function startMetroServer() {
   });
 
   // $FlowExpectedError[prop-missing]
-  globalThis.__METRO_SERVER__ = server;
+  globalThis.__FANTOM_METRO_SERVER__ = server;
 }
 
 async function findAvailablePort(): Promise<number> {

--- a/private/react-native-fantom/runner/global-setup/globalTeardown.js
+++ b/private/react-native-fantom/runner/global-setup/globalTeardown.js
@@ -12,11 +12,12 @@ import type {RunServerResult} from 'metro';
 
 type MetroServer = $NonMaybeType<RunServerResult?.['httpServer']>;
 
-declare var __METRO_SERVER__: ?RunServerResult;
+declare var __FANTOM_METRO_SERVER__: ?RunServerResult;
 
 function getMetroServer(): ?MetroServer {
-  return typeof __METRO_SERVER__ !== 'undefined' && __METRO_SERVER__ != null
-    ? __METRO_SERVER__.httpServer
+  return typeof __FANTOM_METRO_SERVER__ !== 'undefined' &&
+    __FANTOM_METRO_SERVER__ != null
+    ? __FANTOM_METRO_SERVER__.httpServer
     : null;
 }
 


### PR DESCRIPTION
Summary:
Changelog: [internal]

Just a minor refactor to follow the convention of prefixing Fantom-related globals and environment variables.

Differential Revision: D79804007


