### PR TITLE
Check delegate for getModuleForClass and getModuleInstanceFromClass

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
@@ -146,6 +146,12 @@ using namespace facebook::react;
 #if RN_DISABLE_OSS_PLUGIN_HEADER
   return RCTTurboModulePluginClassProvider(name);
 #else
+  if ([_delegate respondsToSelector:@selector(getModuleClassFromName:)]) {
+    Class moduleClass = [_delegate getModuleClassFromName:name];
+    if (moduleClass != nil) {
+      return moduleClass;
+    }
+  }
   return RCTCoreModulesClassProvider(name);
 #endif
 }
@@ -176,7 +182,12 @@ using namespace facebook::react;
                 format:@"Delegate must provide a valid dependencyProvider"];
   }
 #endif
-
+  if ([_delegate respondsToSelector:@selector(getModuleInstanceFromClass:)]) {
+    id<RCTTurboModule> moduleInstance = [_delegate getModuleInstanceFromClass:moduleClass];
+    if (moduleInstance != nil) {
+      return moduleInstance;
+    }
+  }
   return RCTAppSetupDefaultModuleFromClass(moduleClass, self.delegate.dependencyProvider);
 }
 


### PR DESCRIPTION
Summary:
When restructuring the RCTReactNativeFactory, we forgot to add a couple of methods to check whether the delegate was implementing the RCTTurboModuleManager delegate methods.

This has been reported [here](https://github.com/react-native-community/discussions-and-proposals/issues/916)

This change fixes it.

## Changelog:
[iOS][Fixed] - Ask the delegate for `getModuleForClass` and `getModuleInstanceFromClass`

Differential Revision: D79998104


