### PR TITLE
Remove unused exception parameter from hermes/unittests/API/CDPAgentTest.cpp

### DIFF
--- a/packages/react-native/ReactCommon/cxxreact/CxxNativeModule.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/CxxNativeModule.cpp
@@ -200,7 +200,7 @@ void CxxNativeModule::invoke(
         "CxxMethodCallDispatch", "module", moduleName, "method", method.name);
     try {
       method.func(params, first, second);
-    } catch (const facebook::xplat::JsArgumentException& ex) {
+    } catch (const facebook::xplat::JsArgumentException&) {
       throw;
     } catch (std::exception& e) {
       LOG(ERROR) << "std::exception. Method call " << method.name.c_str()

--- a/packages/react-native/ReactCommon/cxxreact/tests/RecoverableErrorTest.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/tests/RecoverableErrorTest.cpp
@@ -31,7 +31,7 @@ TEST(RecoverableError, RunRethrowingAsRecoverableFallthroughTest) {
     RecoverableError::runRethrowingAsRecoverable<std::runtime_error>(
         []() { throw std::logic_error("catch me"); });
     FAIL() << "Unthrown exception";
-  } catch (const RecoverableError& err) {
+  } catch (const RecoverableError&) {
     FAIL() << "Recovered exception that should have fallen through";
   } catch (const std::exception& err) {
     ASSERT_STREQ(err.what(), "catch me");

--- a/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.cpp
@@ -119,7 +119,7 @@ PerformanceEntryReporter::UserTimingDetailProvider getDetailProviderFromEntry(
     try {
       auto detail = entry.asObject(rt).getProperty(rt, "detail");
       return jsi::dynamicFromValue(rt, detail);
-    } catch (jsi::JSIException& ex) {
+    } catch (jsi::JSIException&) {
       return nullptr;
     }
   };


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: dtolnay

Differential Revision: D79968851


