### PR TITLE
Add support for JS debugging in Fantom

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/http/IHttpClient.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/http/IHttpClient.cpp
@@ -10,4 +10,7 @@ namespace facebook::react {
 // NOLINTNEXTLINE(modernize-avoid-c-arrays)
 extern const char HttpClientFactoryKey[] = "HttpClientFactory";
 
+// NOLINTNEXTLINE(modernize-avoid-c-arrays)
+extern const char DevToolsHttpClientFactoryKey[] = "DevToolsHttpClientFactory";
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCxxPlatform/react/http/IHttpClient.h
+++ b/packages/react-native/ReactCxxPlatform/react/http/IHttpClient.h
@@ -82,6 +82,8 @@ struct IHttpClient {
 
 extern const char HttpClientFactoryKey[];
 
+extern const char DevToolsHttpClientFactoryKey[];
+
 using HttpClientFactory = std::function<std::unique_ptr<IHttpClient>()>;
 
 HttpClientFactory getHttpClientFactory();

--- a/packages/react-native/ReactCxxPlatform/react/http/IWebSocketClient.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/http/IWebSocketClient.cpp
@@ -10,4 +10,8 @@ namespace facebook::react {
 // NOLINTNEXTLINE(modernize-avoid-c-arrays)
 extern const char WebSocketClientFactoryKey[] = "WebSocketClientFactory";
 
+// NOLINTNEXTLINE(modernize-avoid-c-arrays)
+extern const char DevToolsWebSocketClientFactoryKey[] =
+    "DevToolsWebSocketClientFactory";
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCxxPlatform/react/http/IWebSocketClient.h
+++ b/packages/react-native/ReactCxxPlatform/react/http/IWebSocketClient.h
@@ -38,6 +38,8 @@ class IWebSocketClient {
 
 extern const char WebSocketClientFactoryKey[];
 
+extern const char DevToolsWebSocketClientFactoryKey[];
+
 using WebSocketClientFactory =
     std::function<std::unique_ptr<IWebSocketClient>()>;
 

--- a/packages/react-native/ReactCxxPlatform/react/runtime/ReactHost.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/runtime/ReactHost.cpp
@@ -136,6 +136,16 @@ void ReactHost::createReactInstance() {
       reactInstanceData_->contextContainer->at<WebSocketClientFactory>(
           WebSocketClientFactoryKey);
 
+  auto devToolsHttpClientFactory =
+      reactInstanceData_->contextContainer
+          ->find<HttpClientFactory>(DevToolsHttpClientFactoryKey)
+          .value_or(httpClientFactory);
+
+  auto devToolsWebSocketClientFactory =
+      reactInstanceData_->contextContainer
+          ->find<WebSocketClientFactory>(DevToolsWebSocketClientFactoryKey)
+          .value_or(webSocketClientFactory);
+
   // Create devServerHelper
   if (!devServerHelper_ &&
       (reactInstanceConfig_.enableInspector ||
@@ -145,7 +155,7 @@ void ReactHost::createReactInstance() {
         reactInstanceConfig_.deviceName,
         reactInstanceConfig_.devServerHost,
         reactInstanceConfig_.devServerPort,
-        httpClientFactory,
+        devToolsHttpClientFactory,
         [this](
             const std::string& moduleName,
             const std::string& methodName,
@@ -159,8 +169,8 @@ void ReactHost::createReactInstance() {
     inspector_ = std::make_shared<Inspector>(
         reactInstanceConfig_.appId,
         reactInstanceConfig_.deviceName,
-        webSocketClientFactory,
-        httpClientFactory);
+        devToolsWebSocketClientFactory,
+        devToolsHttpClientFactory);
     inspector_->ensureHostTarget(
         [this]() { reloadReactInstance(); },
         [weakDevUIDelegate =
@@ -179,7 +189,7 @@ void ReactHost::createReactInstance() {
 
   if (!packagerConnection_ && reactInstanceConfig_.enableDevMode) {
     packagerConnection_ = std::make_unique<PackagerConnection>(
-        webSocketClientFactory,
+        devToolsWebSocketClientFactory,
         devServerHelper_->getPackagerConnectionUrl(),
         [this]() { reloadReactInstance(); },
         []() {});

--- a/packages/react-native/ReactCxxPlatform/react/runtime/ReactHost.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/runtime/ReactHost.cpp
@@ -444,6 +444,12 @@ bool ReactHost::loadScript(
   return isLoaded;
 }
 
+void ReactHost::openDebugger() {
+  if (inspector_ != nullptr && devServerHelper_ != nullptr) {
+    devServerHelper_->openDebugger();
+  }
+}
+
 bool ReactHost::loadScriptFromDevServer() {
   try {
     auto bundleUrl = devServerHelper_->getBundleUrl();

--- a/packages/react-native/ReactCxxPlatform/react/runtime/ReactHost.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/runtime/ReactHost.cpp
@@ -240,6 +240,10 @@ void ReactHost::createReactInstance() {
   auto jsInvoker = std::make_shared<RuntimeSchedulerCallInvoker>(
       reactInstance_->getRuntimeScheduler());
 
+  if (inspector_ != nullptr) {
+    inspector_->connectDebugger(devServerHelper_->getInspectorUrl());
+  }
+
   auto liveReloadCallback = [this]() { reloadReactInstance(); };
   reactInstance_->initializeRuntime(
       {
@@ -451,9 +455,6 @@ bool ReactHost::loadScriptFromDevServer() {
     auto script = std::make_unique<JSBigStdString>(response);
     reactInstance_->loadScript(
         std::move(script), devServerHelper_->getBundleUrl());
-    if (inspector_ != nullptr) {
-      inspector_->connectDebugger(devServerHelper_->getInspectorUrl());
-    }
     devServerHelper_->setupHMRClient();
     return true;
   } catch (...) {

--- a/packages/react-native/ReactCxxPlatform/react/runtime/ReactHost.h
+++ b/packages/react-native/ReactCxxPlatform/react/runtime/ReactHost.h
@@ -63,6 +63,8 @@ class ReactHost {
       const std::string& bundlePath,
       const std::string& sourcePath) noexcept;
 
+  void openDebugger();
+
   void startSurface(
       SurfaceId surfaceId,
       const std::string& moduleName /* can be empty */,

--- a/packages/react-native/ReactCxxPlatform/react/runtime/ReactInstanceConfig.h
+++ b/packages/react-native/ReactCxxPlatform/react/runtime/ReactInstanceConfig.h
@@ -13,13 +13,15 @@
 namespace facebook::react {
 
 struct ReactInstanceConfig {
-#ifdef REACT_NATIVE_DEBUG
-  bool enableDebugging{true};
-#else
-  bool enableDebugging{false};
-#endif
   std::string appId;
   std::string deviceName;
+#ifdef REACT_NATIVE_DEBUG
+  bool enableDevMode{true};
+  bool enableInspector{true};
+#else
+  bool enableDevMode{false};
+  bool enableInspector{false};
+#endif
   std::string devServerHost{"localhost"};
   uint32_t devServerPort{8081};
 };

--- a/private/react-native-fantom/config/babel-plugins/inject-debugger-statements-in-tests.js
+++ b/private/react-native-fantom/config/babel-plugins/inject-debugger-statements-in-tests.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @noflow
+ * @format
+ */
+
+/**
+ * This transform injects a single `debugger;` statement at the top of every
+ * Fantom test, so we can automatically stop on them when debugging.
+ */
+module.exports = function ({types: t}) {
+  return {
+    name: 'inject-debugger-statements-in-tests',
+    visitor: {
+      Program(path, state) {
+        const filename = state.filename || '';
+        if (
+          (filename.endsWith('-itest.js') ||
+            filename.endsWith('-itest.fb.js')) &&
+          !filename.includes('/.out/')
+        ) {
+          // Check if the first statement is already a debugger statement
+          const first = path.node.body[0];
+          if (!first || first.type !== 'DebuggerStatement') {
+            path.unshiftContainer('body', t.debuggerStatement());
+          }
+        }
+      },
+    },
+  };
+};

--- a/private/react-native-fantom/config/metro-babel-transformer.flow.js
+++ b/private/react-native-fantom/config/metro-babel-transformer.flow.js
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {
+  BabelTransformer,
+  BabelTransformerArgs,
+} from 'metro-babel-transformer';
+
+import MetroBabelTransformer from '@react-native/metro-babel-transformer';
+import crypto from 'crypto';
+import fs from 'fs';
+
+const transform: BabelTransformer['transform'] = (
+  args: BabelTransformerArgs,
+) => {
+  const processedArgs = {
+    ...args,
+    plugins: [
+      ...(args.plugins ?? []),
+      // $FlowExpectedError[untyped-import]
+      require('./babel-plugins/inject-debugger-statements-in-tests'),
+    ],
+  };
+  return MetroBabelTransformer.transform(processedArgs);
+};
+
+module.exports = {
+  ...MetroBabelTransformer,
+  transform,
+  getCacheKey(): string {
+    const key = crypto.createHash('md5');
+    const cacheKeyParts = [
+      MetroBabelTransformer.getCacheKey?.() ?? '',
+      fs.readFileSync(__filename),
+      fs.readFileSync(
+        require.resolve('./babel-plugins/inject-debugger-statements-in-tests'),
+      ),
+    ];
+    cacheKeyParts.forEach(part => key.update(part));
+    return key.digest('hex');
+  },
+};

--- a/private/react-native-fantom/config/metro-babel-transformer.js
+++ b/private/react-native-fantom/config/metro-babel-transformer.js
@@ -11,4 +11,4 @@
 'use strict';
 
 require('../../../scripts/shared/babelRegister').registerForMonorepo();
-module.exports = require('@react-native/metro-babel-transformer');
+module.exports = require('./metro-babel-transformer.flow');

--- a/private/react-native-fantom/runner/EnvironmentOptions.js
+++ b/private/react-native-fantom/runner/EnvironmentOptions.js
@@ -16,6 +16,7 @@ const VALID_ENVIRONMENT_VARIABLES = [
   'FANTOM_FORCE_TEST_MODE',
   'FANTOM_LOG_COMMANDS',
   'FANTOM_PRINT_OUTPUT',
+  'FANTOM_DEBUG_JS',
   'FANTOM_PROFILE_JS',
   'FANTOM_ENABLE_JS_MEMORY_INSTRUMENTATION',
 ];
@@ -61,6 +62,8 @@ export const isCI: boolean =
 export const forceTestModeForBenchmarks: boolean = Boolean(
   process.env.FANTOM_FORCE_TEST_MODE,
 );
+
+export const debugJS: boolean = Boolean(process.env.FANTOM_DEBUG_JS);
 
 export const profileJS: boolean = Boolean(process.env.FANTOM_PROFILE_JS);
 

--- a/private/react-native-fantom/runner/global-setup/globalSetup.js
+++ b/private/react-native-fantom/runner/global-setup/globalSetup.js
@@ -11,6 +11,7 @@
 import {isOSS, validateEnvironmentVariables} from '../EnvironmentOptions';
 import build from './build';
 import Metro from 'metro';
+import {Server} from 'net';
 import path from 'path';
 
 export default async function globalSetup(
@@ -33,26 +34,38 @@ async function startMetroServer() {
     config: path.resolve(__dirname, '..', '..', 'config', 'metro.config.js'),
   });
 
+  if (process.env.__FANTOM_METRO_PORT__ == null) {
+    const availablePort = await findAvailablePort();
+    process.env.__FANTOM_METRO_PORT__ = String(availablePort);
+  }
+
   // We need to reuse the same port across runs because can only set environment
   // variables for workers in the first one.
   // $FlowExpectedError[cannot-write]
-  metroConfig.server.port =
-    process.env.__FANTOM_METRO_PORT__ != null
-      ? Number(process.env.__FANTOM_METRO_PORT__)
-      : // Any available port
-        0;
+  metroConfig.server.port = Number(process.env.__FANTOM_METRO_PORT__);
 
   const server = await Metro.runServer(metroConfig, {
     waitForBundler: true,
     watch: true,
   });
 
-  if (process.env.__FANTOM_METRO_PORT__ == null) {
-    process.env.__FANTOM_METRO_PORT__ = String(
-      server.httpServer.address().port,
-    );
-  }
-
   // $FlowExpectedError[prop-missing]
   globalThis.__METRO_SERVER__ = server;
+}
+
+async function findAvailablePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = new Server();
+    server.listen(0, 'localhost', undefined, () => {
+      const port = server.address().port;
+      server.close(error => {
+        if (error != null) {
+          reject(error);
+        } else {
+          resolve(port);
+        }
+      });
+    });
+    server.on('error', reject);
+  });
 }

--- a/private/react-native-fantom/runner/global-setup/globalSetup.js
+++ b/private/react-native-fantom/runner/global-setup/globalSetup.js
@@ -50,7 +50,7 @@ async function startMetroServer() {
   });
 
   // $FlowExpectedError[prop-missing]
-  globalThis.__METRO_SERVER__ = server;
+  globalThis.__FANTOM_METRO_SERVER__ = server;
 }
 
 async function findAvailablePort(): Promise<number> {

--- a/private/react-native-fantom/runner/global-setup/globalTeardown.js
+++ b/private/react-native-fantom/runner/global-setup/globalTeardown.js
@@ -12,11 +12,12 @@ import type {RunServerResult} from 'metro';
 
 type MetroServer = $NonMaybeType<RunServerResult?.['httpServer']>;
 
-declare var __METRO_SERVER__: ?RunServerResult;
+declare var __FANTOM_METRO_SERVER__: ?RunServerResult;
 
 function getMetroServer(): ?MetroServer {
-  return typeof __METRO_SERVER__ !== 'undefined' && __METRO_SERVER__ != null
-    ? __METRO_SERVER__.httpServer
+  return typeof __FANTOM_METRO_SERVER__ !== 'undefined' &&
+    __FANTOM_METRO_SERVER__ != null
+    ? __FANTOM_METRO_SERVER__.httpServer
     : null;
 }
 

--- a/private/react-native-fantom/runner/paths.js
+++ b/private/react-native-fantom/runner/paths.js
@@ -13,6 +13,8 @@ import type {FantomTestConfig} from './getFantomTestConfigs';
 import formatFantomConfig from './formatFantomConfig';
 import path from 'path';
 
+export const PROJECT_ROOT: string = path.resolve(__dirname, '..', '..', '..');
+
 export const OUTPUT_PATH: string = path.resolve(__dirname, '..', '.out');
 export const JS_BUILD_OUTPUT_PATH: string = path.join(OUTPUT_PATH, 'js-builds');
 export const NATIVE_BUILD_OUTPUT_PATH: string = path.join(

--- a/private/react-native-fantom/runner/runner.js
+++ b/private/react-native-fantom/runner/runner.js
@@ -364,6 +364,13 @@ module.exports = async function runTest(
       EnvironmentOptions.printCLIOutput ? 'info' : 'error',
     ];
 
+    if (EnvironmentOptions.debugJS) {
+      rnTesterCommandArgs.push(
+        '--inspectorPort',
+        nullthrows(process.env.__FANTOM_METRO_PORT__),
+      );
+    }
+
     const rnTesterCommandResult = EnvironmentOptions.isOSS
       ? runCommand(
           path.join(__dirname, '..', 'build', 'tester', 'fantom_tester'),

--- a/private/react-native-fantom/tester/src/AppSettings.cpp
+++ b/private/react-native-fantom/tester/src/AppSettings.cpp
@@ -16,6 +16,7 @@ static constexpr int DEFAULT_WINDOW_HEIGHT = 720;
 DEFINE_uint32(windowWidth, DEFAULT_WINDOW_WIDTH, "Application window width");
 DEFINE_uint32(windowHeight, DEFAULT_WINDOW_HEIGHT, "Application window height");
 DEFINE_string(bundlePath, "", "Default path to the application's bundle");
+DEFINE_uint32(inspectorPort, 0, "React Native inspector port");
 DEFINE_string(
     featureFlags,
     "",
@@ -30,6 +31,7 @@ namespace facebook::react {
 unsigned int AppSettings::windowWidth{DEFAULT_WINDOW_WIDTH};
 unsigned int AppSettings::windowHeight{DEFAULT_WINDOW_HEIGHT};
 std::string AppSettings::defaultBundlePath{};
+std::optional<uint32_t> AppSettings::inspectorPort{};
 std::optional<folly::dynamic> AppSettings::dynamicFeatureFlags;
 int AppSettings::minLogLevel{google::GLOG_INFO};
 
@@ -46,12 +48,19 @@ void AppSettings::init(int argc, char** argv) {
 void AppSettings::initInternal() {
   windowWidth = FLAGS_windowWidth;
   windowHeight = FLAGS_windowHeight;
+
   if (!FLAGS_featureFlags.empty()) {
     dynamicFeatureFlags = folly::parseJson(FLAGS_featureFlags);
   }
+
   if (!FLAGS_bundlePath.empty()) {
     defaultBundlePath = FLAGS_bundlePath;
   }
+
+  if (FLAGS_inspectorPort != 0) {
+    inspectorPort = FLAGS_inspectorPort;
+  }
+
   if (!FLAGS_minLogLevel.empty()) {
     if (FLAGS_minLogLevel == "info") {
       minLogLevel = google::GLOG_INFO;

--- a/private/react-native-fantom/tester/src/AppSettings.h
+++ b/private/react-native-fantom/tester/src/AppSettings.h
@@ -21,6 +21,8 @@ class AppSettings {
 
   static std::string defaultBundlePath;
 
+  static std::optional<unsigned int> inspectorPort;
+
   static std::optional<folly::dynamic> dynamicFeatureFlags;
 
   static void init(int argc, char* argv[]);

--- a/private/react-native-fantom/tester/src/TesterAppDelegate.cpp
+++ b/private/react-native-fantom/tester/src/TesterAppDelegate.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "TesterAppDelegate.h"
+
 #include "NativeFantom.h"
 #include "platform/TesterTurboModuleManagerDelegate.h"
 #include "stubs/StubClock.h"
@@ -77,9 +78,13 @@ TesterAppDelegate::TesterAppDelegate(
         queue_ = queue;
         return queue;
       }));
-  contextContainer->insert(HttpClientFactoryKey, getHttpClientFactory());
+  contextContainer->insert(HttpClientFactoryKey, getStubHttpClientFactory());
   contextContainer->insert(
-      WebSocketClientFactoryKey, getWebSocketClientFactory());
+      WebSocketClientFactoryKey, getStubWebSocketClientFactory());
+  contextContainer->insert(
+      DevToolsHttpClientFactoryKey, getHttpClientFactory());
+  contextContainer->insert(
+      DevToolsWebSocketClientFactoryKey, getWebSocketClientFactory());
 
   runLoopObserverManager_ = std::make_shared<RunLoopObserverManager>();
 
@@ -153,6 +158,10 @@ void TesterAppDelegate::loadScript(
                   .asFunction(*runtimePtr);
 
   func.call(*runtimePtr);
+}
+
+void TesterAppDelegate::openDebugger() const {
+  reactHost_->openDebugger();
 }
 
 void TesterAppDelegate::startSurface(

--- a/private/react-native-fantom/tester/src/TesterAppDelegate.h
+++ b/private/react-native-fantom/tester/src/TesterAppDelegate.h
@@ -38,6 +38,8 @@ class TesterAppDelegate {
 
   void loadScript(const std::string& bundlePath, const std::string& sourcePath);
 
+  void openDebugger() const;
+
   void startSurface(
       jsi::Runtime& runtime,
       float widthDp,

--- a/private/react-native-fantom/tester/src/platform/meta/HttpClient.cpp
+++ b/private/react-native-fantom/tester/src/platform/meta/HttpClient.cpp
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <react/http/HttpClient.h>

--- a/private/react-native-fantom/tester/src/platform/meta/WebSocketClient.cpp
+++ b/private/react-native-fantom/tester/src/platform/meta/WebSocketClient.cpp
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <react/http/WebSocketClient.h>

--- a/private/react-native-fantom/tester/src/platform/oss/HttpClient.cpp
+++ b/private/react-native-fantom/tester/src/platform/oss/HttpClient.cpp
@@ -5,13 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "StubHttpClient.h"
-#include <react/http/IHttpClient.h>
+#include "../../stubs/StubHttpClient.h"
 
 namespace facebook::react {
 
-HttpClientFactory getStubHttpClientFactory() {
-  return []() { return std::make_unique<StubHttpClient>(); };
+HttpClientFactory getHttpClientFactory() {
+  return getStubHttpClientFactory();
 }
 
 } // namespace facebook::react

--- a/private/react-native-fantom/tester/src/platform/oss/WebSocketClient.cpp
+++ b/private/react-native-fantom/tester/src/platform/oss/WebSocketClient.cpp
@@ -5,13 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include "StubHttpClient.h"
-#include <react/http/IHttpClient.h>
+#include "../../stubs/StubWebSocketClient.h"
 
 namespace facebook::react {
 
-HttpClientFactory getStubHttpClientFactory() {
-  return []() { return std::make_unique<StubHttpClient>(); };
+WebSocketClientFactory getWebSocketClientFactory() {
+  return getStubWebSocketClientFactory();
 }
 
 } // namespace facebook::react

--- a/private/react-native-fantom/tester/src/stubs/StubHttpClient.h
+++ b/private/react-native-fantom/tester/src/stubs/StubHttpClient.h
@@ -9,9 +9,9 @@
 
 #include <react/http/IHttpClient.h>
 
-namespace facebook::react::http {
+namespace facebook::react {
 
-class StubRequestToken : public IRequestToken {
+class StubRequestToken : public http::IRequestToken {
  public:
   StubRequestToken() = default;
   ~StubRequestToken() override = default;
@@ -33,15 +33,17 @@ class StubHttpClient : public IHttpClient {
   StubHttpClient& operator=(StubHttpClient&& other) = delete;
 
   std::unique_ptr<http::IRequestToken> sendRequest(
-      NetworkCallbacks&& /*callback*/,
+      http::NetworkCallbacks&& /*callback*/,
       const std::string& /*method*/,
       const std::string& /*url*/,
-      const Headers& /*headers*/ = {},
-      const Body& /*body*/ = {},
+      const http::Headers& /*headers*/ = {},
+      const http::Body& /*body*/ = {},
       uint32_t /*timeout*/ = 0,
       std::optional<std::string> /*loggingId*/ = std::nullopt) override {
-    return std::make_unique<http::StubRequestToken>();
+    return std::make_unique<StubRequestToken>();
   }
 };
 
-} // namespace facebook::react::http
+HttpClientFactory getStubHttpClientFactory();
+
+} // namespace facebook::react

--- a/private/react-native-fantom/tester/src/stubs/StubWebSocketClient.cpp
+++ b/private/react-native-fantom/tester/src/stubs/StubWebSocketClient.cpp
@@ -11,7 +11,7 @@
 
 namespace facebook::react {
 
-WebSocketClientFactory getWebSocketClientFactory() {
+WebSocketClientFactory getStubWebSocketClientFactory() {
   return []() { return std::make_unique<StubWebSocketClient>(); };
 }
 

--- a/private/react-native-fantom/tester/src/stubs/StubWebSocketClient.h
+++ b/private/react-native-fantom/tester/src/stubs/StubWebSocketClient.h
@@ -35,4 +35,6 @@ class StubWebSocketClient : public IWebSocketClient {
   void ping() override {}
 };
 
+WebSocketClientFactory getStubWebSocketClientFactory();
+
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
Changelog: [internal]

This adds a new environment variable to Fantom that allows debugging the JS code in tests.

Usage:

```
FANTOM_DEBUG_JS=1 yarn fantom <test>
```

**Does NOT work in OSS yet**. We need to include a third-party library to send HTTP and WebSocket requests and implement a wrapper on top of it.

Differential Revision: D79883372
