### PR TITLE
Scope HighContrastText to correct Settings namespace

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/accessibilityinfo/AccessibilityInfoModule.kt
@@ -244,7 +244,7 @@ internal class AccessibilityInfoModule(context: ReactApplicationContext) :
     val transitionUri = Settings.Global.getUriFor(Settings.Global.TRANSITION_ANIMATION_SCALE)
     contentResolver.registerContentObserver(transitionUri, false, animationScaleObserver)
     val highTextContrastUri =
-        Settings.Global.getUriFor(ACCESSIBILITY_HIGH_TEXT_CONTRAST_ENABLED_CONSTANT)
+        Settings.Secure.getUriFor(ACCESSIBILITY_HIGH_TEXT_CONTRAST_ENABLED_CONSTANT)
     contentResolver.registerContentObserver(highTextContrastUri, false, highTextContrastObserver)
     updateAndSendTouchExplorationChangeEvent(
         accessibilityManager?.isTouchExplorationEnabled == true)


### PR DESCRIPTION
Summary:
`ACCESSIBILITY_HIGH_TEXT_CONTRAST_ENABLED_CONSTANT` is a `Secure` setting, not a `Global` one:

See https://www.internalfb.com/code/fbsource/%5B0a73356db329%5D/fbandroid/java/com/facebook/fbreact/libraries/accessibilityinfosync/ReactAccessibilityInfoSync.kt?lines=316

Changelog: [Internal]

Differential Revision: D77977362


