### PR TITLE
Help Codegen to find library's package.json after failure of importing library's package.json due to missing of `./package.json` subpath (#53195)

### DIFF
--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/utils.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/utils.js
@@ -206,6 +206,26 @@ function findExternalLibraries(
     } catch (e) {
       // require.resolve fails if the dependency is a local node module.
       if (
+        // require.resolve fails if the `./package.json` subpath is not explicitly defined in the library's `exports` field in its package.json
+        'code' in e &&
+        e.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED'
+      ) {
+        // find the closest library's package.json with the search paths
+        // $FlowFixMe[prop-missing]
+        const paths /*: Array<string>*/ = require.main.paths;
+        for (const nodeModulesPath of paths) {
+          const packageJsonFilePath = path.join(
+            nodeModulesPath,
+            dependency,
+            'package.json',
+          );
+          if (fs.existsSync(packageJsonFilePath)) {
+            configFilePath = packageJsonFilePath;
+            break;
+          }
+        }
+      } else if (
+        // require.resolve fails if the dependency is a local node module.
         dependencies[dependency].startsWith('.') || // handles relative paths
         dependencies[dependency].startsWith('/') // handles absolute paths
       ) {


### PR DESCRIPTION
Summary:
This is fix for some React Native libraries can't be found by Codegen, and will make the libraries unusable in new architecture (Turbo Modules)

Internally in the Codegen script, it will try to import library's package.json file with the `require.resolve`, but for some React Native libraries will throw an error with `ERR_PACKAGE_PATH_NOT_EXPORTED` code due to using the `exports` field in their package.json file while not exposing the package.json file itself. As an example
```json
{
  "exports": {
    ".": {
      "import": {
        "types": "./lib/typescript/module/index.d.ts",
        "default": "./lib/module/index.js"
      },
      "require": {
        "types": "./lib/typescript/commonjs/index.d.ts",
        "default": "./lib/commonjs/index.js"
      }
    },
    "./package.json": "./package.json" <-- here some libraries missed this
  },
  "codegenConfig": {}
}
```

Personally feel weird that library author has to expose their package.json only for the sake of Codegen and i believe library author shouldn't, even the library consumer don't need it.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[GENERAL] [FIXED] - Help Codegen find library's package.json if some libraries using `exports` field in their package.json file and the `./package.json` subpath is not explicitly defined

bypass-github-export-checks


Test Plan:
`require.resolve('library/package.json')` [here](https://github.com/facebook/react-native/blob/main/packages/react-native/scripts/codegen/generate-artifacts-executor/utils.js#L203) will throw an error with `ERR_PACKAGE_PATH_NOT_EXPORTED` code by Node.js. So if it does, help Codegen retry to find closest library's package.json with [`require.main.paths`](https://nodejs.org/api/modules.html#requiremain) search paths

You can init new app React Native CLI app with my sample react native library here [`ping-react-native`](https://github.com/RakaDoank/ping-react-native) v1.2.2.
Due to missing of the `package.json` subpath, before this change, it's autolinked but unusable due to missing of the spec header file. After this change, it works normally.

Rollback Plan:

Reviewed By: cortinico

Differential Revision: D80080243

Pulled By: cipolleschi


