### PR TITLE
use trace section in C++ Animated instead of perfetto

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/CMakeLists.txt
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/CMakeLists.txt
@@ -26,7 +26,6 @@ target_link_libraries(react_cxx_platform_react_renderer_animated
       react_renderer_uimanager
       react_renderer_scheduler
       glog
-      react_cxx_platform_react_profiling
       folly_runtime
 )
 target_compile_reactnative_options(react_cxx_platform_react_renderer_animated PRIVATE)

--- a/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/animated/NativeAnimatedNodesManager.cpp
@@ -7,11 +7,11 @@
 
 #include "NativeAnimatedNodesManager.h"
 
+#include <cxxreact/TraceSection.h>
 #include <folly/json.h>
 #include <glog/logging.h>
 #include <react/debug/react_native_assert.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
-#include <react/profiling/perfetto.h>
 #include <react/renderer/animated/drivers/AnimationDriver.h>
 #include <react/renderer/animated/drivers/AnimationDriverUtils.h>
 #include <react/renderer/animated/drivers/DecayAnimationDriver.h>
@@ -828,8 +828,10 @@ void NativeAnimatedNodesManager::schedulePropsCommit(
 }
 
 void NativeAnimatedNodesManager::onRender() {
-  TRACE_EVENT("rncxx", "NativeAnimatedNodesManager::onRender");
-  TRACE_COUNTER("rncxx", "numActiveAnimations", activeAnimations_.size());
+  TraceSection s(
+      "NativeAnimatedNodesManager::onRender",
+      "numActiveAnimations",
+      activeAnimations_.size());
 
   isOnRenderThread_ = true;
 


### PR DESCRIPTION
Summary:
changelog: [internal]

remove dependency on perfetto and use TraceSection like we do elsewhere.

Differential Revision: D80087082


