### PR TITLE
Use Jest naming for test regex in Fantom docs

### DIFF
--- a/private/react-native-fantom/__docs__/README.md
+++ b/private/react-native-fantom/__docs__/README.md
@@ -99,13 +99,13 @@ Run the test using the following command from the root of the React Native
 repository:
 
 ```shell
-yarn fantom [optional test pattern]
+yarn fantom <regexForTestFiles>
 ```
 
 Similar to Jest, you can also run Fantom in watch mode using `--watch`:
 
 ```shell
-yarn fantom --watch [optional test pattern]
+yarn fantom <regexForTestFiles> --watch
 ```
 
 ### Test configuration
@@ -195,7 +195,7 @@ With an output such as:
 To debug, run your fantom test with the flag `FANTOM_ENABLE_CPP_DEBUGGING`
 
 ```shell
-FANTOM_ENABLE_CPP_DEBUGGING=1 yarn fantom [optional test pattern]
+FANTOM_ENABLE_CPP_DEBUGGING=1 yarn fantom <regexForTestFiles>
 ```
 
 ### FAQ


### PR DESCRIPTION
Summary:
Changelog: [internal]

Tiny change to align with how Jest refers to this argument in its docs: https://jestjs.io/docs/cli#jest-regexfortestfiles

Differential Revision: D80090285


