### PR TITLE
make sure to only disable js sync & animate layout when disableFabricCommitInCXXAnimated==false

### DIFF
--- a/packages/react-native/Libraries/Animated/animations/Animation.js
+++ b/packages/react-native/Libraries/Animated/animations/Animation.js
@@ -150,12 +150,11 @@ export default class Animation {
           if (value != null) {
             animatedValue.__onAnimatedValueUpdateReceived(value, offset);
 
-            if (
-              !(
-                ReactNativeFeatureFlags.cxxNativeAnimatedEnabled() &&
-                ReactNativeFeatureFlags.cxxNativeAnimatedRemoveJsSync()
-              )
-            ) {
+            const isJsSyncRemoved =
+              ReactNativeFeatureFlags.cxxNativeAnimatedEnabled() &&
+              !ReactNativeFeatureFlags.disableFabricCommitInCXXAnimated() &&
+              ReactNativeFeatureFlags.cxxNativeAnimatedRemoveJsSync();
+            if (!isJsSyncRemoved) {
               if (this.__isLooping === true) {
                 return;
               }

--- a/packages/react-native/src/private/animated/createAnimatedPropsHook.js
+++ b/packages/react-native/src/private/animated/createAnimatedPropsHook.js
@@ -125,13 +125,11 @@ export default function createAnimatedPropsHook(
           if (node.__isNative) {
             // Check 2: this is an animation driven by native.
             // In native driven animations, this callback is only called once the animation completes.
-            if (
-              isFabricNode &&
-              !(
-                ReactNativeFeatureFlags.cxxNativeAnimatedEnabled() &&
-                ReactNativeFeatureFlags.cxxNativeAnimatedRemoveJsSync()
-              )
-            ) {
+            const shouldRemoveJsSync =
+              ReactNativeFeatureFlags.cxxNativeAnimatedEnabled() &&
+              !ReactNativeFeatureFlags.disableFabricCommitInCXXAnimated() &&
+              ReactNativeFeatureFlags.cxxNativeAnimatedRemoveJsSync();
+            if (isFabricNode && !shouldRemoveJsSync) {
               // Call `scheduleUpdate` to synchronise Fiber and Shadow tree.
               // Must not be called in Paper.
               scheduleUpdate();


### PR DESCRIPTION
Summary:
## Changelog:

[Internal] [Changed] - make sure to only disable js sync & animate layout when disableFabricCommitInCXXAnimated==false

Reviewed By: sammy-SC

Differential Revision: D80002015


