### PR TITLE
Initialize props for RCTPullToRefreshViewComponentView

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
@@ -40,6 +40,7 @@ using namespace facebook::react;
     // attaching and detaching of a pull-to-refresh view to a scroll view.
     // The pull-to-refresh view is not a subview of this view.
     self.hidden = YES;
+    _props = PullToRefreshViewShadowNode::defaultSharedProps();
     _recycled = NO;
     [self _initializeUIRefreshControl];
   }


### PR DESCRIPTION
Summary:
The RCTPullToRefreshViewComponentView props are not initialized when the component view is created. this could lead to undefined behaviors and crashes.

This change fixes it.

## Changelog:
[iOS][Fixed] - Properly initialize the RCTPullToRefreshViewComponentView

Reviewed By: sammy-SC

Differential Revision: D80093141


