### PR TITLE
fix(hermes): Uncontrolled command line

### DIFF
--- a/packages/react-native/scripts/ios-prebuild/hermes.js
+++ b/packages/react-native/scripts/ios-prebuild/hermes.js
@@ -90,7 +90,7 @@ async function prepareHermesArtifactsAsync(
   }
 
   // Extract the tar.gz
-  execSync(`tar -xzf "${localPath}" -C "${artifactsPath}"`, {
+  execFileSync('tar', ['-xzf', localPath, '-C', artifactsPath], {
     stdio: 'inherit',
   });
 


### PR DESCRIPTION


fix the problem, we should avoid passing user-controlled values directly into a shell command string. Instead, we should use the `execFileSync` API, which accepts the command and its arguments as an array, thus avoiding shell interpretation and command injection risks. Specifically, replace the use of `execSync` with a call to `execFileSync('tar', ['-xzf', localPath, '-C', artifactsPath], { stdio: 'inherit' })`. This change should be made in the `prepareHermesArtifactsAsync` function, on line 93. No additional sanitization is needed if we use the argument array form, as the values will not be interpreted by the shell. The required import (`execFileSync`) is already available via `require('child_process')`, so no new imports are needed.

npm: [shell-quote](https://www.npmjs.com/package/shell-quote)