### PR TITLE
Add benchmark to compare rendering times for View and ViewNativeComponent

### DIFF
--- a/flow-typed/npm/tinybench_v4.1.x.js
+++ b/flow-typed/npm/tinybench_v4.1.x.js
@@ -91,7 +91,14 @@ declare module 'tinybench' {
     beforeEach?: (this: Task) => void | Promise<void>,
   };
 
-  export type Fn = () => Promise<mixed> | mixed;
+  export interface FnReturnedObject {
+    overriddenDuration?: number;
+  }
+
+  export type Fn = () =>
+    | Promise<void | FnReturnedObject>
+    | void
+    | FnReturnedObject;
 
   declare export class Bench extends EventTarget {
     concurrency: null | 'task' | 'bench';

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "signedsource": "^1.0.0",
     "supports-color": "^7.1.0",
     "temp-dir": "^2.0.0",
-    "tinybench": "^3.1.0",
+    "tinybench": "^4.1.0",
     "typescript": "5.8.3",
     "ws": "^6.2.3"
   },

--- a/packages/react-native/Libraries/Components/View/__tests__/View-vs-ViewNativeComponent-benchmark-itest.js
+++ b/packages/react-native/Libraries/Components/View/__tests__/View-vs-ViewNativeComponent-benchmark-itest.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
+
+import measureRenderTime from '../../../../src/private/__tests__/utilities/measureRenderTime';
+import ViewNativeComponent from '../ViewNativeComponent';
+import * as Fantom from '@react-native/fantom';
+import * as React from 'react';
+import {View} from 'react-native';
+
+let root;
+let testViews: React.MixedElement;
+
+const NUMBER_OF_VIEWS = 100;
+const NUMBER_OF_ITERATIONS = 1000;
+
+component Noop(children: React.Node, style?: mixed) {
+  return children;
+}
+
+Noop.displayName = 'Noop';
+
+Fantom.unstable_benchmark
+  .suite('View vs. ViewNativeComponent', {minIterations: NUMBER_OF_ITERATIONS})
+  .test.each(
+    [Noop, ViewNativeComponent, View],
+    Component =>
+      `render ${NUMBER_OF_VIEWS} views (${Component.displayName ?? Component.name ?? 'ViewNativeComponent'})`,
+    () => {
+      return {
+        overriddenDuration: measureRenderTime(root, testViews),
+      };
+    },
+    Component => ({
+      beforeAll: () => {
+        let views: React.Node = null;
+        for (let i = 0; i < NUMBER_OF_VIEWS; i++) {
+          views = (
+            <Component style={{width: i + 1, height: i + 1}}>{views}</Component>
+          );
+        }
+        // $FlowExpectedError[incompatible-type]
+        testViews = views;
+      },
+      beforeEach: () => {
+        root = Fantom.createRoot();
+      },
+      afterEach: () => {
+        root.destroy();
+      },
+    }),
+  );

--- a/packages/react-native/src/private/__tests__/utilities/measureRenderTime.js
+++ b/packages/react-native/src/private/__tests__/utilities/measureRenderTime.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+import * as Fantom from '@react-native/fantom';
+import nullthrows from 'nullthrows';
+
+const now = Fantom.unstable_benchmark.now;
+
+export default function measureRenderTime(
+  root: Fantom.Root,
+  elements: React.MixedElement,
+): number {
+  let startTime: ?number;
+  let endTime: ?number;
+
+  function RecordStart() {
+    startTime ??= now();
+    return null;
+  }
+
+  function RecordEnd() {
+    endTime = now();
+    return null;
+  }
+
+  Fantom.runTask(() => {
+    // React renders nodes using a depth-first algorithm.
+    root.render(
+      <>
+        <RecordStart />
+        {elements}
+        <RecordEnd />
+      </>,
+    );
+  });
+
+  return nullthrows(endTime) - nullthrows(startTime);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -9121,10 +9121,10 @@ through@^2.3.6:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
 
-tinybench@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-3.1.0.tgz#ec68451ff05233cf3de12c46f39f06011897109a"
-  integrity sha512-Km+oMh2xqNCxuyoUsqbRmHgFSd8sATh7v7xreP+kHN6x67w28Pawr83WmBxcaORvxkc0Ex6zgqK951yBnTFaaQ==
+tinybench@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-4.1.0.tgz#090118e51159eb105f3cc2ef5cf371f3f8adc7bf"
+  integrity sha512-8JZoQRJgWWEIIeAmpiNmMHIREmUY3oGX8GRmlmNapLr/qtgMe+K76vM2qabh85hNScnE2lqTVTajVETjuD9Ixg==
 
 tmp@^0.0.33:
   version "0.0.33"


### PR DESCRIPTION
Summary:
Changelog: [internal]

This adds a new benchmark that compares the rendering time (only rendering, not committing, mounting, effects, etc.) of `<View>` and `<ViewNativeComponent>`.

Baseline:

| (index) | Task name                                | Latency avg (ns)  | Latency med (ns)   | Throughput avg (ops/s) | Throughput med (ops/s) | Samples |
| ------- | ---------------------------------------- | ----------------- | ------------------ | ---------------------- | ---------------------- | ------- |
| 0       | 'render 100 views (View)'                | '2275288 ± 1.35%' | '2168988 ± 9875.0' | '450 ± 0.68%'          | '461 ± 2'              | 1000    |
| 1       | 'render 100 views (ViewNativeComponent)' | '1358222 ± 3.76%' | '1239564 ± 13381'  | '790 ± 0.72%'          | '807 ± 9'              | 1000    |

This shows that **`<View>` currently has an overhead of 75% in rendering time**.

I've also tested a modification of `View` such as:

```
component View(...props: ViewProps) {
  return {
    // This tag allows us to uniquely identify this as a React Element
    $$typeof: REACT_ELEMENT_TYPE,
    // Built-in properties that belong on the element
    type: ViewNativeComponent,
    key: undefined,
    // $FlowExpectedError[prop-missing]
    ref: props.ref,
    props,
  };
}
```

This makes `View` basically a no-op component, and the benchmark after this looks like:

| (index) | Task name                                | Latency avg (ns)  | Latency med (ns)  | Throughput avg (ops/s) | Throughput med (ops/s) | Samples |
| ------- | ---------------------------------------- | ----------------- | ----------------- | ---------------------- | ---------------------- | ------- |
| 0       | 'render 100 views (View)'                | '1743010 ± 2.25%' | '1630816 ± 10616' | '600 ± 0.74%'          | '613 ± 4'              | 1000    |
| 1       | 'render 100 views (ViewNativeComponent)' | '1370699 ± 4.04%' | '1242284 ± 14172' | '789 ± 0.74%'          | '805 ± 9'              | 1000    |

This shows that `View`, just for existing as a wrapper component, has an overhead of 31% in rendering time, which means that **the opportunities to reduce the overhead beyond what we already did are limited**.

Differential Revision: D80169514
