### PR TITLE
Fix LogBox dealloc crashing Mac Catalyst

### DIFF
--- a/packages/react-native/React/CoreModules/RCTLogBoxView.mm
+++ b/packages/react-native/React/CoreModules/RCTLogBoxView.mm
@@ -81,7 +81,9 @@
 
 - (void)dealloc
 {
+#if !TARGET_OS_MACCATALYST // sharedApplication.delegate is not available on Mac Catalyst
   [RCTSharedApplication().delegate.window makeKeyWindow];
+#endif
 }
 
 - (void)show


### PR DESCRIPTION
Summary:
delegate.window is not supported in Mac Catalyst, causing a crash in various scenarios such as metro refresh.

Changelog: [Internal]

Differential Revision: D80189486


