### PR TITLE
Remove reference to `react-native upgrade`

### DIFF
--- a/packages/react-native/Libraries/Renderer/README.md
+++ b/packages/react-native/Libraries/Renderer/README.md
@@ -19,4 +19,4 @@ as you will still be using the older renderer from the folder mentioned above. B
 
 For the sake of React 18, the first version of React Native compatible with React 18 is **0.69.0**. Users on React Native 0.68.0 and previous versions won't be able to use React 18.
 
-If you use the `react-native upgrade` command or the React Native Upgrade Helper, you'll bump to the correct React version once you upgrade React Native.
+If you use the [React Native Upgrade Helper](https://react-native-community.github.io/upgrade-helper/), you'll bump to the correct React version once you upgrade React Native.


### PR DESCRIPTION
This command doesn't exist anymore.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Remove reference to `react-native upgrade` as the command doesn't exist anymore.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[INTERNAL] [CHANGED] - Removed reference to removed `react native upgrade` in `Libraries/Renderer/README.md`

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

N/A