### PR TITLE
[ios][precompile] Use correct version of jsi.cpp

### DIFF
--- a/packages/react-native/Package.swift
+++ b/packages/react-native/Package.swift
@@ -84,7 +84,10 @@ let reactDebug = RNTarget(
 let jsi = RNTarget(
   name: .jsi,
   path: "ReactCommon/jsi",
-  excludedPaths: ["jsi/test", "CMakeLists.txt", "jsi/CMakeLists.txt"],
+  // JSI is a part of hermes-engine. Including them also in react-native will violate the One Definition Rule.
+  // Precompiled binaries are only supported with hermes - so we can safely exclude the jsi.cpp file.
+  // https://github.com/facebook/react-native/issues/53257
+  excludedPaths: ["jsi/test", "jsi/jsi.cpp", "CMakeLists.txt", "jsi/CMakeLists.txt"],
   dependencies: [.reactNativeDependencies]
 )
 


### PR DESCRIPTION
## Summary:

When building the xcframeworks on iOS we're including the file `jsi/jsi.cpp` in the Swift Package. This file is also included in Hermes and React Native should use the hermes version of these symbols. This is even described (but overlooked) in the React-jsi podspec file.

This causes the error seen in the bug addressed by this commit.

The fix is to exclude the `jsi/jsi.cpp` file from the jsi target in our swift package.

Fixes #53257 

## Changelog:

[IOS] [FIXED] - Fixed wrong jsi symbols in use when using React.xcframework

## Test Plan:

Tested using a precompiled xcframework in the reproduction repository. 