### PR TITLE
Rename setUpDefaultReactNativeEnvironment to scope it better

### DIFF
--- a/packages/react-native/src/private/setup/__tests__/setUpDefaultReactNativeEnvironment-ComponentSideEffects-itest.js
+++ b/packages/react-native/src/private/setup/__tests__/setUpDefaultReactNativeEnvironment-ComponentSideEffects-itest.js
@@ -10,7 +10,7 @@
 
 import setUpDefaultReactNativeEnvironment from 'react-native/src/private/setup/setUpDefaultReactNativeEnvironment';
 
-describe('setUpReactNativeEnvironment', () => {
+describe('setUpReactNativeEnvironment (components side-effects)', () => {
   it('should not load components as a side effect', () => {
     // We set up has not been done yet.
     expect(globalThis.self).toBeUndefined();

--- a/packages/react-native/src/private/setup/__tests__/setUpDefaultReactNativeEnvironment-FeatureFlags-itest.js
+++ b/packages/react-native/src/private/setup/__tests__/setUpDefaultReactNativeEnvironment-FeatureFlags-itest.js
@@ -12,7 +12,7 @@ import * as ReactNativeFeatureFlags from '../../featureflags/ReactNativeFeatureF
 import * as ReactNativeFeatureFlagsBase from '../../featureflags/ReactNativeFeatureFlagsBase';
 import setUpDefaultReactNativeEnvironment from 'react-native/src/private/setup/setUpDefaultReactNativeEnvironment';
 
-describe('setUpReactNativeEnvironment', () => {
+describe('setUpReactNativeEnvironment (feature flags side-effects)', () => {
   it('should not read any feature flags', () => {
     ReactNativeFeatureFlagsBase.dangerouslyResetForTesting();
 


### PR DESCRIPTION
Summary:
Changelog: [internal]

Test files that verify the behavior of the global setup can only have a single test, as we can't really reset it across tests. Because of that, I'm renaming the current one to make the behavior under test more explicit.

Differential Revision: D80177333
