### PR TITLE
Fix maxLength default value when null is passed

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputProps.cpp
@@ -6,22 +6,18 @@
  */
 
 #include "BaseTextInputProps.h"
-
-#include <react/renderer/core/propsConversions.h>
-
-#include <react/renderer/core/Props.h>
-#include <react/renderer/core/PropsMacros.h>
-
-#include <react/renderer/graphics/Color.h>
-
 #include <react/renderer/attributedstring/TextAttributes.h>
 #include <react/renderer/attributedstring/conversions.h>
 #include <react/renderer/components/image/conversions.h>
 #include <react/renderer/components/textinput/baseConversions.h>
+#include <react/renderer/core/Props.h>
+#include <react/renderer/core/PropsMacros.h>
 #include <react/renderer/core/PropsParserContext.h>
 #include <react/renderer/core/graphicsConversions.h>
+#include <react/renderer/core/propsConversions.h>
 #include <react/renderer/graphics/Color.h>
 #include <react/renderer/imagemanager/primitives.h>
+#include <limits>
 
 namespace facebook::react {
 
@@ -83,7 +79,7 @@ BaseTextInputProps::BaseTextInputProps(
           rawProps,
           "maxLength",
           sourceProps.maxLength,
-          {})),
+          {std::numeric_limits<int>::max()})),
       text(convertRawProp(context, rawProps, "text", sourceProps.text, {})),
       mostRecentEventCount(convertRawProp(
           context,


### PR DESCRIPTION
Summary:
In [c5956da8c0](https://github.com/facebook/react-native/commit/c5956da8c0b735d47761af51019ed25b49001c00) we landed a change of the default value of `maxLength`.

While doing that, we missed the case where the app is explicitly passing `null` for a value for `maxLength`. When this happens, the props parsing was initializing the `maxLength` to 0, making not possible to input any value.

This change fixes the issue by ensuring that the default value set when `null` is consistent with the default value when nothing is passed.

## Changelog:
[iOS][Fixed] - Fixed TextInput behavior when `maxLength={null}` is passed

Differential Revision: D80255637


