### PR TITLE
Fix memory leak in TestCallInvoker

### DIFF
--- a/packages/react-native/ReactCommon/callinvoker/ReactCommon/tests/TestCallInvoker.h
+++ b/packages/react-native/ReactCommon/callinvoker/ReactCommon/tests/TestCallInvoker.h
@@ -10,13 +10,12 @@
 #include <ReactCommon/CallInvoker.h>
 #include <jsi/jsi.h>
 #include <list>
-#include <memory>
 
 namespace facebook::react {
 
 class TestCallInvoker : public CallInvoker {
  public:
-  explicit TestCallInvoker(std::shared_ptr<facebook::jsi::Runtime> runtime)
+  explicit TestCallInvoker(facebook::jsi::Runtime& runtime)
       : runtime_(runtime) {}
 
   void invokeAsync(CallFunc&& func) noexcept override {
@@ -24,14 +23,14 @@ class TestCallInvoker : public CallInvoker {
   }
 
   void invokeSync(CallFunc&& func) override {
-    func(*runtime_);
+    func(runtime_);
   }
 
   void flushQueue() {
     while (!queue_.empty()) {
-      queue_.front()(*runtime_);
+      queue_.front()(runtime_);
       queue_.pop_front();
-      runtime_->drainMicrotasks(); // Run microtasks every cycle.
+      runtime_.drainMicrotasks(); // Run microtasks every cycle.
     }
   }
 
@@ -40,8 +39,8 @@ class TestCallInvoker : public CallInvoker {
   }
 
  private:
+  facebook::jsi::Runtime& runtime_;
   std::list<CallFunc> queue_{};
-  std::shared_ptr<facebook::jsi::Runtime> runtime_{};
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/bridging/tests/BridgingTest.h
+++ b/packages/react-native/ReactCommon/react/bridging/tests/BridgingTest.h
@@ -31,7 +31,7 @@ class BridgingTest : public ::testing::Test {
                 .withMicrotaskQueue(true)
                 .build())),
         rt(*runtime),
-        invoker(std::make_shared<TestCallInvoker>(runtime)) {}
+        invoker(std::make_shared<TestCallInvoker>(*runtime)) {}
 
   ~BridgingTest() override {
     LongLivedObjectCollection::get(rt).clear();

--- a/packages/react-native/ReactCommon/react/nativemodule/core/tests/TurboModuleTestFixture.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/tests/TurboModuleTestFixture.h
@@ -27,7 +27,7 @@ class TurboModuleTestFixture : public ::testing::Test {
  public:
   explicit TurboModuleTestFixture(Args... args)
       : runtime_(hermes::makeHermesRuntime()),
-        jsInvoker_(std::make_shared<TestCallInvoker>(runtime_)),
+        jsInvoker_(std::make_shared<TestCallInvoker>(*runtime_)),
         module_(std::make_shared<T>(jsInvoker_, std::forward<Args>(args)...)) {}
 
   void SetUp() override {

--- a/packages/react-native/ReactCxxPlatform/react/io/tests/NetworkingModuleTests.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/io/tests/NetworkingModuleTests.cpp
@@ -25,7 +25,7 @@ class NetworkingModuleTests : public testing::Test {
  protected:
   void SetUp() override {
     rt_ = facebook::hermes::makeHermesRuntime();
-    jsInvoker_ = std::make_shared<TestCallInvoker>(rt_);
+    jsInvoker_ = std::make_shared<TestCallInvoker>(*rt_);
   }
 
   static void verifyFormData(

--- a/packages/rn-tester/NativeCxxModuleExample/tests/NativeCxxModuleExampleTests.cpp
+++ b/packages/rn-tester/NativeCxxModuleExample/tests/NativeCxxModuleExampleTests.cpp
@@ -6,7 +6,6 @@
  */
 
 #include <NativeCxxModuleExample/NativeCxxModuleExample.h>
-#include <ReactCommon/TestCallInvoker.h>
 #include <ReactCommon/TurboModuleTestFixture.h>
 #include <gtest/gtest.h>
 #include <list>


### PR DESCRIPTION
Summary:
Changelog: [General][Fixed] Fix memory leak in TestCallInvoker

This fixes leaks in TestCallInvoker holding onto the jsi::Runtime

Differential Revision: D80295420


