### PR TITLE
Align APIs ReactSurfaceImpl.view with ReactSurfaceImpl.attachView()

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3112,7 +3112,8 @@ public final class com/facebook/react/runtime/ReactSurfaceImpl : com/facebook/re
 	public fun getContext ()Landroid/content/Context;
 	public fun getModuleName ()Ljava/lang/String;
 	public fun getSurfaceID ()I
-	public fun getView ()Landroid/view/ViewGroup;
+	public synthetic fun getView ()Landroid/view/ViewGroup;
+	public fun getView ()Lcom/facebook/react/runtime/ReactSurfaceView;
 	public fun isRunning ()Z
 	public fun prerender ()Lcom/facebook/react/interfaces/TaskInterface;
 	public fun start ()Lcom/facebook/react/interfaces/TaskInterface;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactSurfaceImpl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactSurfaceImpl.kt
@@ -11,7 +11,6 @@ import android.content.Context
 import android.os.Bundle
 import android.view.View
 import android.view.View.MeasureSpec
-import android.view.ViewGroup
 import androidx.annotation.UiThread
 import com.facebook.infer.annotation.ThreadSafe
 import com.facebook.react.ReactHost
@@ -116,7 +115,7 @@ internal constructor(
     reactHostRef.set(null)
   }
 
-  public override val view: ViewGroup?
+  public override val view: ReactSurfaceView?
     get() = surfaceViewRef.get()
 
   override fun prerender(): TaskInterface<Void> {


### PR DESCRIPTION
Summary:
This diff aligns the APIs ReactSurfaceImpl.view and ReactSurfaceImpl.attachView() to make sure they receive and return the same type

changelog: [Android][Changed] Changed return type of ReactSurfaceImpl.view to ReactSurfaceView to align with parameter recived by ReactSurfaceImpl.attachView()

Reviewed By: sammy-SC

Differential Revision: D80289764


