### PR TITLE
Add benchmarks for console.timeStamp

### DIFF
--- a/packages/react-native/src/private/webapis/performance/__tests__/Performance-benchmark-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/Performance-benchmark-itest.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @fantom_mode opt
  * @flow strict-local
  * @format
  */
@@ -23,7 +22,7 @@ const clearMarksAndMeasures = () => {
 };
 
 Fantom.unstable_benchmark
-  .suite('Performance API')
+  .suite('Performance API', {minIterations: 50000, minDuration: 0})
   .test(
     'mark (default)',
     () => {
@@ -135,4 +134,17 @@ Fantom.unstable_benchmark
       },
       afterEach: clearMarksAndMeasures,
     },
-  );
+  )
+  .test('console.timeStamp (defaults)', () => {
+    console.timeStamp('label');
+  })
+  .test('console.timeStamp (all options)', () => {
+    console.timeStamp(
+      'label',
+      100,
+      300,
+      'My track',
+      'My track group',
+      'primary',
+    );
+  });


### PR DESCRIPTION
Summary:
Changelog: [internal]

Just adding a benchmark for `console.timeStamp`, which in normal circumstances will just measure a no-op. We can force installing the inspector and simulate that we're profiling in Fantom to force `console.timeStamp` to go through the tracing paths for the benchmark.

Reviewed By: rshest

Differential Revision: D80272873


