### PR TITLE
Add missing headers from react_performance_cdpmetrics to prefab

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -223,6 +223,10 @@ val preparePrefab by
                       Pair(
                           "../ReactCommon/react/performance/timeline/",
                           "react/performance/timeline/"),
+                      // react_performance_cdpmetrics
+                      Pair(
+                          "../ReactCommon/react/performance/cdpmetrics/",
+                          "react/performance/cdpmetrics/"),
                       // react_renderer_observers_events
                       Pair(
                           "../ReactCommon/react/renderer/observers/events/",


### PR DESCRIPTION
Summary:
The headers from `react_performance_cdpmetrics` are currently missing in the libreactnative.so prefab.

They're actually references from `Scheduler.h` and this is causing `react-native-screens` to fail compiling
with:

```
  In file included from /tmp/RNApp/node_modules/react-native-screens/android/src/main/cpp/NativeProxy.cpp:3:
  /home/runner/.gradle/caches/8.14.3/transforms/97716233b9aa00728d9cac038eecaf3d/transformed/react-android-0.82.0-nightly-20250815-41029d8e9-SNAPSHOT-debug/prefab/modules/reactnative/include/react/renderer/scheduler/Scheduler.h:13:10: fatal error: 'react/performance/cdpmetrics/CdpMetricsReporter.h' file not found
     13 | #include <react/performance/cdpmetrics/CdpMetricsReporter.h>
        |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  1 error generated.
  [4/6] Building CXX object CMakeFiles/rnscreens.dir/tmp/RNApp/node_modules/react-native-screens/cpp/RNSScreenRemovalListener.cpp.o
  [5/6] Building CXX object CMakeFiles/rnscreens.dir/src/main/cpp/OnLoad.cpp.o
```

See here https://github.com/react-native-community/nightly-tests/actions/runs/16991637594/job/48172255960
I saw this was added on D78904748

Here I'm exposing the headers from `react_performance_cdpmetrics` to the prefab API so users in OSS can
access those headers as well.

Changelog:
[Internal] [Changed] -

Differential Revision: D80344762


