### PR TITLE
[iOS] Fixes FlatList UIRefreshControl not working properly when redirect

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTPullToRefreshViewComponentView.mm
@@ -176,6 +176,14 @@ using namespace facebook::react;
   }
 }
 
+- (void)didMoveToWindow
+{
+  [super didMoveToWindow];
+  if (self.window) {
+    [self setNeedsLayout];
+  }
+}
+
 - (void)_attach
 {
   if (_scrollViewComponentView) {
@@ -212,7 +220,7 @@ using namespace facebook::react;
 
 - (void)beginRefreshingProgrammatically
 {
-  if (!_scrollViewComponentView) {
+  if (!_scrollViewComponentView || !_refreshControl.window) {
     return;
   }
 


### PR DESCRIPTION
## Summary:

Fxies #53263 .

## Changelog:

[IOS] [FIXED] - Fixes FlatList UIRefreshControl not working properly when redirect

## Test Plan:

Repro please see  #53263.
