### PR TITLE
refactor(react-native): fix condition

### DIFF
--- a/packages/react-native/src/private/webapis/performance/Performance.js
+++ b/packages/react-native/src/private/webapis/performance/Performance.js
@@ -245,7 +245,7 @@ export default class Performance {
     }
 
     resolvedMeasureName =
-      measureName === 'string' ? measureName : String(measureName);
+      typeof measureName === 'string' ? measureName : String(measureName);
 
     if (startMarkOrOptions != null) {
       switch (typeof startMarkOrOptions) {


### PR DESCRIPTION
## Summary:
Fixed a typo in Performance.js where `measureName === 'string'` should be `typeof measureName === 'string'` for proper type checking.

## Changelog:

[GENERAL] [FIXED] - Fix typo in Performance.js type checking condition

## Test Plan:

The change fixes a logical error where the condition was comparing the variable value to the string 'string' instead of checking its type. This ensures proper type checking for `measureName` parameter.
