### PR TITLE
Mark `@react-native/metro-config` as optional peer to fix warning

### DIFF
--- a/packages/community-cli-plugin/package.json
+++ b/packages/community-cli-plugin/package.json
@@ -40,6 +40,9 @@
   "peerDependenciesMeta": {
     "@react-native-community/cli": {
       "optional": true
+    },
+    "@react-native/metro-config": {
+      "optional": true
     }
   },
   "engines": {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

The `@react-native/metro-config` peer was added in https://github.com/facebook/react-native/commit/fe2bcbf4ba7ce983fac0cd09727c165517b6337f / #51836 by @robhogan 

Side-note: It's pulled in via `@react-native/community-cli-plugin` which is a direct dependency of `react-native` for the `scripts/bundle.js` script. While, for expo, we'd love to find a way to make this an optional dependency (to avoid excessive deps that `expo` replaces otherwise), for now, it's a direct dependency.

The problem here is that this isn't optional, which means:
- with auto-installing peer dependencies it is directly fulfilled (while `@react-native-community/cli` is already marked as optional and skipped)
- with legacy/non-auto peer-dependencies it is flagged as missing, but in an Expo project it wouldn't make sense to install directly

This causes a **package manager regression in the form of either a peer dependency warning**, that shouldn't be fulfilled in an Expo project, or (in the best case scenario) pulls in dependencies [that a user does not need](https://npmgraph.js.org/?q=%40react-native%2Fmetro-config#zoom=w&select=exact%3A%40react-native%2Fmetro-config%400.81.0).

An error message is already in place to inform the user of this being missing when it's not installed, so marking it as optional seems appropriate.

## Changelog:

[INTERNAL] [FIXED] Mark added `@react-native/metro-config` peer dependency as optional

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

Warnings like the following won't occur in fresh Expo (54/preview/`@next`) projects
```
warning "workspace-aggregator-484d9ec3-587b-43cb-97de-4dcce3876578 > microfoam-mobile > react-native > @react-native/community-cli-plugin@0.81.0" has unmet peer dependency "@react-native/metro-config@*".
```
