### PR TITLE
Prepare Flow types for change in HostInstance

### DIFF
--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
@@ -1503,7 +1503,7 @@ class ScrollView extends React.Component<ScrollViewProps, ScrollViewState> {
         keyboardNeverPersistTaps &&
         this._keyboardIsDismissible() &&
         e.target != null &&
-        // $FlowFixMe[incompatible-type]
+        // $FlowFixMe Error supressed during the migration of HostInstance to ReactNativeElement
         !TextInputState.isTextInput(e.target)
       ) {
         return true;

--- a/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-test.js
+++ b/packages/react-native/Libraries/Components/TextInput/__tests__/TextInput-test.js
@@ -123,7 +123,7 @@ jest.unmock('../TextInput');
         throw new Error('Expected `textInputElement` to be non-null');
       }
 
-      // $FlowFixMe[prop-missing]
+      // $FlowFixMe
       textInputElement.currentProps = textInputElement.props;
       expect(textInputElement.isFocused()).toBe(false);
 

--- a/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricHostComponent.js
+++ b/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/ReactFabricHostComponent.js
@@ -58,10 +58,12 @@ export default class ReactFabricHostComponent implements NativeMethods {
   }
 
   blur() {
+    // $FlowFixMe[incompatible-call] - Error supressed during the migration of HostInstance to ReactNativeElement
     TextInputState.blurTextInput(this);
   }
 
   focus() {
+    // $FlowFixMe[incompatible-call] - Error supressed during the migration of HostInstance to ReactNativeElement
     TextInputState.focusTextInput(this);
   }
 

--- a/packages/react-native/jest/mockNativeComponent.js
+++ b/packages/react-native/jest/mockNativeComponent.js
@@ -47,5 +47,6 @@ export default function mockNativeComponent<TProps: {...}>(
     Component.displayName = viewName;
   }
 
+  // $FlowFixMe[incompatible-return] - Error supressed during the migration of HostInstance to ReactNativeElement
   return Component;
 }


### PR DESCRIPTION
Summary:
Changelog: [internal]

This prepares the codebase for an eventual migration of `HostInstance` to `ReactNativeElement`, so the actual migration doesn't need to adjust so much existing code.

Differential Revision: D80399739


