### PR TITLE
Improve typing of benchmark functions

### DIFF
--- a/flow-typed/npm/tinybench_v4.1.x.js
+++ b/flow-typed/npm/tinybench_v4.1.x.js
@@ -91,10 +91,15 @@ declare module 'tinybench' {
     beforeEach?: (this: Task) => void | Promise<void>,
   };
 
-  export interface FnReturnedObject {
-    overriddenDuration?: number;
-  }
+  // This is defined as an interface in tinybench but we define it as an object
+  // to catch problems like `overriddenDuration` being misspelled.
+  export type FnReturnedObject = {
+    overriddenDuration?: number,
+  };
 
+  // This type is defined as returning `unknown` instead of `void` in tinybench,
+  // but we type it this way to avoid mistakes (we can make breaking changes
+  // in our definition that they can't).
   export type Fn = () =>
     | Promise<void | FnReturnedObject>
     | void


### PR DESCRIPTION
Summary:
Changelog: [internal]

This changes the types for benchmark functions to improve safety:
1. It makes the return object be an object instead of an interface, to catch when `overriddenDuration` is misspelled.
2. It makes the function always synchronous, as asynchronous tests aren't supported in Fantom (even though they are in `tinybench`).

Differential Revision: D80404121


