### PR TITLE
Fix Switch layout with iOS26

### DIFF
--- a/packages/react-native/Libraries/Components/Switch/Switch.js
+++ b/packages/react-native/Libraries/Components/Switch/Switch.js
@@ -264,7 +264,7 @@ const Switch: component(
       disabled,
       onTintColor: trackColorForTrue,
       style: StyleSheet.compose(
-        {height: 31, width: 51},
+        {alignSelf: 'flex-start' as const},
         StyleSheet.compose(
           style,
           ios_backgroundColor == null

--- a/packages/react-native/src/private/specs_DEPRECATED/components/SwitchNativeComponent.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/components/SwitchNativeComponent.js
@@ -58,4 +58,5 @@ export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
 export default (codegenNativeComponent<SwitchNativeProps>('Switch', {
   paperComponentName: 'RCTSwitch',
   excludedPlatforms: ['android'],
+  interfaceOnly: true,
 }): ComponentType);


### PR DESCRIPTION
Summary:
Apple changed the sizes of the UISwitchComponent and now, if you build an iOs app using the <Switch> component, the layout of the app will be broken because of wrong layout measurements.
This has been reported also by [https://github.com/facebook/react-native/issues/52823](https://github.com/facebook/react-native/issues/52823).

The `<Switch>` component was using hardcoded values for its size.
This change fixes the problem by:
- Using codegen for interface only
- Implementing a custom Sadow Node to ask the platform for the Switch measurements
- Updating the JS layout to wrap the size around the native component.

## Changelog:

[iOS][Fixed] - Fix Switch layout to work with iOS26

Differential Revision: D80454350

## Test Plan


| iOS Version | Before | After |
| -- | -- | -- |
| < iOS 26 | <img src="https://github.com/user-attachments/assets/91d73ea3-30ba-4a5c-948e-ea5c63aa7c6d" /> |  <img src="https://github.com/user-attachments/assets/76061bc8-0f14-412a-a8fb-d1c3951772e6" />|
| >= iOS 26 |  <img src="https://github.com/user-attachments/assets/1abc477f-bc0a-4762-938e-98814fb2a054" />|  <img src="https://github.com/user-attachments/assets/77e562e1-b803-46ac-9cf6-102f062a1cd4" />|

