### PR TITLE
Remove nullability from NativePerformance module methods

### DIFF
--- a/packages/react-native/src/private/webapis/performance/Performance.js
+++ b/packages/react-native/src/private/webapis/performance/Performance.js
@@ -29,10 +29,7 @@ import {
   performanceEntryTypeToRaw,
   rawToPerformanceEntry,
 } from './internals/RawPerformanceEntry';
-import {
-  getCurrentTimeStamp,
-  warnNoNativePerformance,
-} from './internals/Utilities';
+import {getCurrentTimeStamp} from './internals/Utilities';
 import MemoryInfo from './MemoryInfo';
 import ReactNativeStartupTiming from './ReactNativeStartupTiming';
 import MaybeNativePerformance from './specs/NativePerformance';
@@ -78,18 +75,16 @@ const MEASURE_OPTIONS_REUSABLE_OBJECT: {...PerformanceMeasureInit} = {
   detail: undefined,
 };
 
-const getMarkTimeForMeasure = cachedGetMarkTime
-  ? (markName: string): number => {
-      const markTime = cachedGetMarkTime(markName);
-      if (markTime == null) {
-        throw new DOMException(
-          `Failed to execute 'measure' on 'Performance': The mark '${markName}' does not exist.`,
-          'SyntaxError',
-        );
-      }
-      return markTime;
-    }
-  : undefined;
+const getMarkTimeForMeasure = (markName: string): number => {
+  const markTime = cachedGetMarkTime(markName);
+  if (markTime == null) {
+    throw new DOMException(
+      `Failed to execute 'measure' on 'Performance': The mark '${markName}' does not exist.`,
+      'SyntaxError',
+    );
+  }
+  return markTime;
+};
 
 /**
  * Partial implementation of the Performance interface for RN,
@@ -150,11 +145,6 @@ export default class Performance {
     // IMPORTANT: this method has been micro-optimized.
     // Please run the benchmarks in `Performance-benchmarks-itest` to ensure
     // changes do not regress performance.
-
-    if (cachedReportMark === undefined) {
-      warnNoNativePerformance();
-      return new PerformanceMark(markName, {startTime: 0});
-    }
 
     if (markName === undefined) {
       throw new TypeError(
@@ -224,14 +214,6 @@ export default class Performance {
     // IMPORTANT: this method has been micro-optimized.
     // Please run the benchmarks in `Performance-benchmarks-itest` to ensure
     // changes do not regress performance.
-
-    if (
-      getMarkTimeForMeasure === undefined ||
-      cachedReportMeasure === undefined
-    ) {
-      warnNoNativePerformance();
-      return new PerformanceMeasure(measureName, {startTime: 0, duration: 0});
-    }
 
     let resolvedMeasureName: string;
     let resolvedStartTime: number;

--- a/packages/react-native/src/private/webapis/performance/specs/NativePerformance.js
+++ b/packages/react-native/src/private/webapis/performance/specs/NativePerformance.js
@@ -54,14 +54,14 @@ export type PerformanceObserverInit = {
 
 export interface Spec extends TurboModule {
   +now: () => number;
-  +reportMark?: (name: string, startTime: number, entry: mixed) => void;
-  +reportMeasure?: (
+  +reportMark: (name: string, startTime: number, entry: mixed) => void;
+  +reportMeasure: (
     name: string,
     startTime: number,
     duration: number,
     entry: mixed,
   ) => void;
-  +getMarkTime?: (name: string) => ?number;
+  +getMarkTime: (name: string) => ?number;
   +clearMarks: (entryName?: string) => void;
   +clearMeasures: (entryName?: string) => void;
   +getEntries: () => $ReadOnlyArray<RawPerformanceEntry>;
@@ -93,7 +93,7 @@ export interface Spec extends TurboModule {
 
   +getSupportedPerformanceEntryTypes: () => $ReadOnlyArray<RawPerformanceEntryType>;
 
-  +clearEventCountsForTesting?: () => void;
+  +clearEventCountsForTesting: () => void;
 }
 
 export default (TurboModuleRegistry.get<Spec>('NativePerformanceCxx'): ?Spec);


### PR DESCRIPTION
Summary:
Changelog: [internal]

These methods have been defined for a month, so it's safe to make then non-nullable already.

Differential Revision: D80453413


