### PR TITLE
Optimize DOM APIs

### DIFF
--- a/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/ReactFabricPublicInstance-itest.js
+++ b/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/ReactFabricPublicInstance-itest.js
@@ -14,7 +14,6 @@ import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 import type {HostInstance} from 'react-native';
 
 import ReactNativeElement from '../../../../src/private/webapis/dom/nodes/ReactNativeElement';
-import {getRawNativeDOMForTests} from '../../../../src/private/webapis/dom/nodes/specs/NativeDOM';
 import TextInputState from '../../../Components/TextInput/TextInputState';
 import View from '../../../Components/View/View';
 import ReactFabricHostComponent from '../ReactFabricHostComponent';
@@ -349,58 +348,5 @@ describe('ReactFabricPublicInstance', () => {
           .toJSX(),
       ).toEqual(<rn-view testID={'second test id'} />);
     });
-
-    // TODO: delete when NativeDOM.setNativeProps is NOT nullable.
-    // This logic is to ensure compatibility with old app versions without the native module method.
-    if (ReactNativeFeatureFlags.enableAccessToHostTreeInFabric()) {
-      let RawNativeDOM;
-      let originalSetNativeProps;
-
-      beforeAll(() => {
-        RawNativeDOM = nullthrows(getRawNativeDOMForTests());
-        originalSetNativeProps = RawNativeDOM.setNativeProps;
-      });
-
-      beforeEach(() => {
-        // $FlowExpectedError[cannot-write]
-        RawNativeDOM.setNativeProps = originalSetNativeProps;
-      });
-
-      it('should propagate changes to the host component (when NativeDOM.setNativeProps is not available)', () => {
-        // $FlowExpectedError[cannot-write]
-        RawNativeDOM.setNativeProps = null;
-
-        expect(RawNativeDOM.setNativeProps).toBeNull();
-
-        const root = Fantom.createRoot();
-        const nodeRef = createRef<HostInstance>();
-
-        Fantom.runTask(() => {
-          root.render(<View ref={nodeRef} testID="first test id" />);
-        });
-
-        expect(
-          root
-            .getRenderedOutput({
-              props: ['testID'],
-            })
-            .toJSX(),
-        ).toEqual(<rn-view testID={'first test id'} />);
-
-        const element = nullthrows(nodeRef.current);
-
-        Fantom.runTask(() => {
-          element.setNativeProps({testID: 'second test id'});
-        });
-
-        expect(
-          root
-            .getRenderedOutput({
-              props: ['testID'],
-            })
-            .toJSX(),
-        ).toEqual(<rn-view testID={'second test id'} />);
-      });
-    }
   });
 });

--- a/packages/react-native/Libraries/ReactNative/RendererImplementation.js
+++ b/packages/react-native/Libraries/ReactNative/RendererImplementation.js
@@ -22,6 +22,9 @@ import {
 import {type RootTag} from './RootTag';
 import * as React from 'react';
 
+let cachedFabricRender;
+let cachedPaperRender;
+
 export function renderElement({
   element,
   rootTag,
@@ -34,50 +37,70 @@ export function renderElement({
   useConcurrentRoot: boolean,
 }): void {
   if (useFabric) {
-    require('../Renderer/shims/ReactFabric').default.render(
-      element,
-      rootTag,
-      null,
-      useConcurrentRoot,
-      {
-        onCaughtError,
-        onUncaughtError,
-        onRecoverableError,
-      },
-    );
+    if (cachedFabricRender == null) {
+      cachedFabricRender = require('../Renderer/shims/ReactFabric').default
+        .render;
+    }
+
+    cachedFabricRender(element, rootTag, null, useConcurrentRoot, {
+      onCaughtError,
+      onUncaughtError,
+      onRecoverableError,
+    });
   } else {
-    require('../Renderer/shims/ReactNative').default.render(
-      element,
-      rootTag,
-      undefined,
-      {
-        onCaughtError,
-        onUncaughtError,
-        onRecoverableError,
-      },
-    );
+    if (cachedPaperRender == null) {
+      cachedPaperRender = require('../Renderer/shims/ReactNative').default
+        .render;
+    }
+
+    cachedPaperRender(element, rootTag, undefined, {
+      onCaughtError,
+      onUncaughtError,
+      onRecoverableError,
+    });
   }
 }
+
+let cachedFindHostInstance_DEPRECATED: ?<TElementType: React.ElementType>(
+  componentOrHandle: ?(React.ElementRef<TElementType> | number),
+) => ?HostInstance;
 
 export function findHostInstance_DEPRECATED<TElementType: React.ElementType>(
   // $FlowFixMe[incompatible-type]
   componentOrHandle: ?(React.ElementRef<TElementType> | number),
 ): ?HostInstance {
-  return require('../Renderer/shims/ReactNative').default.findHostInstance_DEPRECATED(
+  if (cachedFindHostInstance_DEPRECATED == null) {
+    cachedFindHostInstance_DEPRECATED = require('../Renderer/shims/ReactNative')
+      .default.findHostInstance_DEPRECATED;
+  }
+
+  return cachedFindHostInstance_DEPRECATED(
     // $FlowFixMe[incompatible-type]
     componentOrHandle,
   );
 }
 
+let cachedFindNodeHandle: ?<TElementType: React.ElementType>(
+  componentOrHandle: ?(React.ElementRef<TElementType> | number),
+) => ?number;
+
 export function findNodeHandle<TElementType: React.ElementType>(
   // $FlowFixMe[incompatible-type]
   componentOrHandle: ?(React.ElementRef<TElementType> | number),
 ): ?number {
-  return require('../Renderer/shims/ReactNative').default.findNodeHandle(
+  if (cachedFindNodeHandle == null) {
+    cachedFindNodeHandle = require('../Renderer/shims/ReactNative').default
+      .findNodeHandle;
+  }
+
+  return cachedFindNodeHandle(
     // $FlowFixMe[incompatible-type]
     componentOrHandle,
   );
 }
+
+let cachedFabricDispatchCommand;
+let cachedPaperDispatchCommand;
 
 export function dispatchCommand(
   handle: HostInstance,
@@ -87,29 +110,37 @@ export function dispatchCommand(
   if (global.RN$Bridgeless === true) {
     // Note: this function has the same implementation in the legacy and new renderer.
     // However, evaluating the old renderer comes with some side effects.
-    return require('../Renderer/shims/ReactFabric').default.dispatchCommand(
-      handle,
-      command,
-      args,
-    );
+    if (cachedFabricDispatchCommand == null) {
+      cachedFabricDispatchCommand = require('../Renderer/shims/ReactFabric')
+        .default.dispatchCommand;
+    }
+
+    return cachedFabricDispatchCommand(handle, command, args);
   } else {
-    return require('../Renderer/shims/ReactNative').default.dispatchCommand(
-      handle,
-      command,
-      args,
-    );
+    if (cachedPaperDispatchCommand == null) {
+      cachedPaperDispatchCommand = require('../Renderer/shims/ReactNative')
+        .default.dispatchCommand;
+    }
+
+    return cachedPaperDispatchCommand(handle, command, args);
   }
 }
+
+let cachedSendAccessibilityEvent;
 
 export function sendAccessibilityEvent(
   handle: HostInstance,
   eventType: string,
 ): void {
-  return require('../Renderer/shims/ReactNative').default.sendAccessibilityEvent(
-    handle,
-    eventType,
-  );
+  if (cachedSendAccessibilityEvent == null) {
+    cachedSendAccessibilityEvent = require('../Renderer/shims/ReactNative')
+      .default.sendAccessibilityEvent;
+  }
+
+  return cachedSendAccessibilityEvent(handle, eventType);
 }
+
+let cachedUnmountComponentAtNodeAndRemoveContainer;
 
 /**
  * This method is used by AppRegistry to unmount a root when using the old
@@ -118,59 +149,90 @@ export function sendAccessibilityEvent(
 export function unmountComponentAtNodeAndRemoveContainer(rootTag: RootTag) {
   // $FlowExpectedError[incompatible-type] rootTag is an opaque type so we can't really cast it as is.
   const rootTagAsNumber: number = rootTag;
-  require('../Renderer/shims/ReactNative').default.unmountComponentAtNodeAndRemoveContainer(
-    rootTagAsNumber,
-  );
+  if (cachedUnmountComponentAtNodeAndRemoveContainer == null) {
+    cachedUnmountComponentAtNodeAndRemoveContainer =
+      require('../Renderer/shims/ReactNative').default
+        .unmountComponentAtNodeAndRemoveContainer;
+  }
+
+  cachedUnmountComponentAtNodeAndRemoveContainer(rootTagAsNumber);
 }
+
+let cachedUnstableBatchedUpdates: ?<T>(fn: (T) => void, bookkeeping: T) => void;
 
 export function unstable_batchedUpdates<T>(
   fn: T => void,
   bookkeeping: T,
 ): void {
+  if (cachedUnstableBatchedUpdates == null) {
+    cachedUnstableBatchedUpdates = require('../Renderer/shims/ReactNative')
+      .default.unstable_batchedUpdates;
+  }
+
   // This doesn't actually do anything when batching updates for a Fabric root.
-  return require('../Renderer/shims/ReactNative').default.unstable_batchedUpdates(
-    fn,
-    bookkeeping,
-  );
+  return cachedUnstableBatchedUpdates(fn, bookkeeping);
 }
 
 export function isProfilingRenderer(): boolean {
   return Boolean(__DEV__);
 }
 
+let cachedIsChildPublicInstance;
+
 export function isChildPublicInstance(
   parentInstance: HostInstance,
   childInstance: HostInstance,
 ): boolean {
-  return require('../Renderer/shims/ReactNative').default.isChildPublicInstance(
-    parentInstance,
-    childInstance,
-  );
+  if (cachedIsChildPublicInstance == null) {
+    cachedIsChildPublicInstance = require('../Renderer/shims/ReactNative')
+      .default.isChildPublicInstance;
+  }
+
+  return cachedIsChildPublicInstance(parentInstance, childInstance);
 }
+
+let cachedGetNodeFromInternalInstanceHandle;
 
 export function getNodeFromInternalInstanceHandle(
   internalInstanceHandle: InternalInstanceHandle,
 ): ?Node {
+  if (cachedGetNodeFromInternalInstanceHandle == null) {
+    cachedGetNodeFromInternalInstanceHandle =
+      require('../Renderer/shims/ReactFabric').default
+        .getNodeFromInternalInstanceHandle;
+  }
+
   // This is only available in Fabric
-  return require('../Renderer/shims/ReactFabric').default.getNodeFromInternalInstanceHandle(
-    internalInstanceHandle,
-  );
+  return cachedGetNodeFromInternalInstanceHandle(internalInstanceHandle);
 }
+
+let cachedGetPublicInstanceFromInternalInstanceHandle;
 
 export function getPublicInstanceFromInternalInstanceHandle(
   internalInstanceHandle: InternalInstanceHandle,
 ): mixed /*PublicInstance | PublicTextInstance | null*/ {
   // This is only available in Fabric
-  return require('../Renderer/shims/ReactFabric').default.getPublicInstanceFromInternalInstanceHandle(
+  if (cachedGetPublicInstanceFromInternalInstanceHandle == null) {
+    cachedGetPublicInstanceFromInternalInstanceHandle =
+      require('../Renderer/shims/ReactFabric').default
+        .getPublicInstanceFromInternalInstanceHandle;
+  }
+  return cachedGetPublicInstanceFromInternalInstanceHandle(
     internalInstanceHandle,
   );
 }
+
+let cachedGetPublicInstanceFromRootTag;
 
 export function getPublicInstanceFromRootTag(
   rootTag: number,
 ): mixed /*PublicRootInstance | null*/ {
   // This is only available in Fabric
-  return require('../Renderer/shims/ReactFabric').default.getPublicInstanceFromRootTag(
-    rootTag,
-  );
+  if (cachedGetPublicInstanceFromRootTag == null) {
+    cachedGetPublicInstanceFromRootTag =
+      require('../Renderer/shims/ReactFabric').default
+        .getPublicInstanceFromRootTag;
+  }
+
+  return cachedGetPublicInstanceFromRootTag(rootTag);
 }

--- a/packages/react-native/src/private/webapis/dom/nodes/ReadOnlyElement.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/ReadOnlyElement.js
@@ -221,8 +221,10 @@ export default class ReadOnlyElement extends ReadOnlyNode {
 
 function getChildElements(node: ReadOnlyNode): $ReadOnlyArray<ReadOnlyElement> {
   // $FlowFixMe[incompatible-type]
-  return getChildNodes(node).filter(
-    childNode => childNode instanceof ReadOnlyElement,
+  return getChildNodes(
+    node,
+    (childNode: ReadOnlyNode) =>
+      childNode.nodeType === ReadOnlyNode.ELEMENT_NODE,
   );
 }
 

--- a/packages/react-native/src/private/webapis/dom/nodes/internals/NodeInternals.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/internals/NodeInternals.js
@@ -37,14 +37,30 @@ export type InstanceHandle =
   | ReactNativeDocumentElementInstanceHandle // root element managed by React Native
   | ReactNativeDocumentInstanceHandle; // document node managed by React Native
 
-let RendererProxy;
-function getRendererProxy() {
-  if (RendererProxy == null) {
+let cachedGetNodeFromInternalInstanceHandle;
+function getNodeFromInternalInstanceHandle(
+  instanceHandle: InternalInstanceHandle,
+) {
+  if (cachedGetNodeFromInternalInstanceHandle == null) {
     // Lazy import Fabric here to avoid DOM Node APIs classes from having side-effects.
     // With a static import we can't use these classes for Paper-only variants.
-    RendererProxy = require('../../../../../../Libraries/ReactNative/RendererProxy');
+    cachedGetNodeFromInternalInstanceHandle =
+      require('../../../../../../Libraries/ReactNative/RendererProxy').getNodeFromInternalInstanceHandle;
   }
-  return RendererProxy;
+  return cachedGetNodeFromInternalInstanceHandle(instanceHandle);
+}
+
+let cachedGetPublicInstanceFromInternalInstanceHandle;
+function getPublicInstanceFromInternalInstanceHandle(
+  instanceHandle: InternalInstanceHandle,
+) {
+  if (cachedGetPublicInstanceFromInternalInstanceHandle == null) {
+    // Lazy import Fabric here to avoid DOM Node APIs classes from having side-effects.
+    // With a static import we can't use these classes for Paper-only variants.
+    cachedGetPublicInstanceFromInternalInstanceHandle =
+      require('../../../../../../Libraries/ReactNative/RendererProxy').getPublicInstanceFromInternalInstanceHandle;
+  }
+  return cachedGetPublicInstanceFromInternalInstanceHandle(instanceHandle);
 }
 
 const INSTANCE_HANDLE_KEY = Symbol('internalInstanceHandle');
@@ -81,6 +97,15 @@ export function setOwnerDocument(
 export function getPublicInstanceFromInstanceHandle(
   instanceHandle: InstanceHandle,
 ): ?ReadOnlyNode {
+  const mixedPublicInstance =
+    // $FlowExpectedError[incompatible-type]
+    getPublicInstanceFromInternalInstanceHandle(instanceHandle);
+
+  if (mixedPublicInstance != null) {
+    // $FlowExpectedError[incompatible-type] React defines public instances as "mixed" because it can't access the definition from React Native.
+    return mixedPublicInstance;
+  }
+
   if (isReactNativeDocumentInstanceHandle(instanceHandle)) {
     return getPublicInstanceFromReactNativeDocumentInstanceHandle(
       instanceHandle,
@@ -92,20 +117,21 @@ export function getPublicInstanceFromInstanceHandle(
       instanceHandle,
     );
   }
-
-  const mixedPublicInstance =
-    getRendererProxy().getPublicInstanceFromInternalInstanceHandle(
-      instanceHandle,
-    );
-
-  // $FlowExpectedError[incompatible-type] React defines public instances as "mixed" because it can't access the definition from React Native.
-  return mixedPublicInstance;
 }
 
 export function getNativeNodeReference(
   node: ReadOnlyNode,
 ): ?NativeNodeReference {
   const instanceHandle = getInstanceHandle(node);
+
+  // Try React nodes first
+  const nativeReference =
+    // $FlowExpectedError[incompatible-type]
+    getNodeFromInternalInstanceHandle(instanceHandle);
+  if (nativeReference != null) {
+    // $FlowExpectedError[incompatible-type]
+    return nativeReference;
+  }
 
   if (isReactNativeDocumentInstanceHandle(instanceHandle)) {
     return getNativeNodeReferenceFromReactNativeDocumentInstanceHandle(
@@ -118,9 +144,6 @@ export function getNativeNodeReference(
       instanceHandle,
     );
   }
-
-  // $FlowExpectedError[incompatible-type]
-  return getRendererProxy().getNodeFromInternalInstanceHandle(instanceHandle);
 }
 
 export function getNativeElementReference(
@@ -136,7 +159,7 @@ export function getNativeElementReference(
   }
 
   // $FlowExpectedError[incompatible-type]
-  return getRendererProxy().getNodeFromInternalInstanceHandle(instanceHandle);
+  return getNodeFromInternalInstanceHandle(instanceHandle);
 }
 
 export function getNativeTextReference(
@@ -146,5 +169,5 @@ export function getNativeTextReference(
   const instanceHandle = getInstanceHandle(node) as InternalInstanceHandle;
 
   // $FlowExpectedError[incompatible-type]
-  return getRendererProxy().getNodeFromInternalInstanceHandle(instanceHandle);
+  return getNodeFromInternalInstanceHandle(instanceHandle);
 }

--- a/packages/react-native/src/private/webapis/dom/nodes/specs/NativeDOM.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/specs/NativeDOM.js
@@ -13,7 +13,6 @@ import type {Node as ShadowNode} from '../../../../../../Libraries/Renderer/shim
 import type {TurboModule} from '../../../../../../Libraries/TurboModule/RCTExport';
 import type {InstanceHandle} from '../internals/NodeInternals';
 
-import {getFabricUIManager} from '../../../../../../Libraries/ReactNative/FabricUIManager';
 import * as TurboModuleRegistry from '../../../../../../Libraries/TurboModule/TurboModuleRegistry';
 import nullthrows from 'nullthrows';
 
@@ -165,7 +164,7 @@ export interface Spec extends TurboModule {
    * Legacy direct manipulation APIs (for `ReactNativeElement`).
    */
 
-  +setNativeProps?: (
+  +setNativeProps: (
     nativeElementReference: mixed,
     updatePayload: mixed,
   ) => void;
@@ -623,16 +622,10 @@ const NativeDOM: RefinedSpec = {
    * Legacy direct manipulation APIs
    */
   setNativeProps(nativeNodeReference, updatePayload) {
-    // TODO: remove when RawNativeDOM.setNativeProps is NOT nullable.
-    if (RawNativeDOM?.setNativeProps == null) {
-      nullthrows(getFabricUIManager()).setNativeProps(
-        nativeNodeReference,
-        updatePayload,
-      );
-      return;
-    }
-
-    return RawNativeDOM.setNativeProps(nativeNodeReference, updatePayload);
+    return nullthrows(RawNativeDOM).setNativeProps(
+      nativeNodeReference,
+      updatePayload,
+    );
   },
 };
 

--- a/packages/react-native/src/private/webapis/dom/nodes/specs/NativeDOM.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/specs/NativeDOM.js
@@ -14,7 +14,6 @@ import type {TurboModule} from '../../../../../../Libraries/TurboModule/RCTExpor
 import type {InstanceHandle} from '../internals/NodeInternals';
 
 import * as TurboModuleRegistry from '../../../../../../Libraries/TurboModule/TurboModuleRegistry';
-import nullthrows from 'nullthrows';
 
 export opaque type NativeElementReference = ShadowNode;
 export opaque type NativeTextReference = ShadowNode;
@@ -168,12 +167,6 @@ export interface Spec extends TurboModule {
     nativeElementReference: mixed,
     updatePayload: mixed,
   ) => void;
-}
-
-const RawNativeDOM = (TurboModuleRegistry.get<Spec>('NativeDOMCxx'): ?Spec);
-
-export function getRawNativeDOMForTests(): ?Spec {
-  return RawNativeDOM;
 }
 
 // This is the actual interface of this module, but the native module codegen
@@ -445,188 +438,14 @@ export interface RefinedSpec {
   ) => void;
 }
 
-const NativeDOM: RefinedSpec = {
-  /*
-   * Methods from the `Node` interface (for `ReadOnlyNode`).
-   */
-
-  compareDocumentPosition(nativeNodeReference, otherNativeNodeReference) {
-    return nullthrows(RawNativeDOM).compareDocumentPosition(
-      nativeNodeReference,
-      otherNativeNodeReference,
-    );
-  },
-
-  getChildNodes(nativeNodeReference) {
-    // $FlowExpectedError[incompatible-type]
-    return (nullthrows(RawNativeDOM).getChildNodes(
-      nativeNodeReference,
-    ): $ReadOnlyArray<InstanceHandle>);
-  },
-
-  getElementById(rootTag, id) {
-    // $FlowExpectedError[incompatible-type]
-    return (nullthrows(RawNativeDOM?.getElementById)(
-      rootTag,
-      id,
-    ): ?InstanceHandle);
-  },
-
-  getParentNode(nativeNodeReference) {
-    // $FlowExpectedError[incompatible-type]
-    return (nullthrows(RawNativeDOM).getParentNode(
-      nativeNodeReference,
-    ): ?InstanceHandle);
-  },
-
-  isConnected(nativeNodeReference) {
-    return nullthrows(RawNativeDOM).isConnected(nativeNodeReference);
-  },
-
-  /*
-   * Methods from the `Element` interface (for `ReactNativeElement`).
-   */
-
-  getBorderWidth(nativeNodeReference) {
-    // $FlowExpectedError[incompatible-type]
-    return (nullthrows(RawNativeDOM).getBorderWidth(
-      nativeNodeReference,
-    ): $ReadOnly<
-      [
-        /* topWidth: */ number,
-        /* rightWidth: */ number,
-        /* bottomWidth: */ number,
-        /* leftWidth: */ number,
-      ],
-    >);
-  },
-
-  getBoundingClientRect(nativeNodeReference, includeTransform: boolean) {
-    // $FlowExpectedError[incompatible-type]
-    return (nullthrows(RawNativeDOM).getBoundingClientRect(
-      nativeNodeReference,
-      includeTransform,
-    ): $ReadOnly<
-      [
-        /* x: */ number,
-        /* y: */ number,
-        /* width: */ number,
-        /* height: */ number,
-      ],
-    >);
-  },
-
-  getInnerSize(nativeNodeReference) {
-    // $FlowExpectedError[incompatible-type]
-    return (nullthrows(RawNativeDOM).getInnerSize(
-      nativeNodeReference,
-    ): $ReadOnly<[/* width: */ number, /* height: */ number]>);
-  },
-
-  getScrollPosition(nativeNodeReference) {
-    // $FlowExpectedError[incompatible-type]
-    return (nullthrows(RawNativeDOM).getScrollPosition(
-      nativeNodeReference,
-    ): $ReadOnly<[/* scrollLeft: */ number, /* scrollTop: */ number]>);
-  },
-
-  getScrollSize(nativeNodeReference) {
-    // $FlowExpectedError[incompatible-type]
-    return (nullthrows(RawNativeDOM).getScrollSize(
-      nativeNodeReference,
-    ): $ReadOnly<[/* scrollWidth: */ number, /* scrollHeight: */ number]>);
-  },
-
-  getTagName(nativeNodeReference) {
-    return nullthrows(RawNativeDOM).getTagName(nativeNodeReference);
-  },
-
-  getTextContent(nativeNodeReference) {
-    return nullthrows(RawNativeDOM).getTextContent(nativeNodeReference);
-  },
-
-  hasPointerCapture(nativeNodeReference, pointerId) {
-    return nullthrows(RawNativeDOM).hasPointerCapture(
-      nativeNodeReference,
-      pointerId,
-    );
-  },
-
-  releasePointerCapture(nativeNodeReference, pointerId) {
-    return nullthrows(RawNativeDOM).releasePointerCapture(
-      nativeNodeReference,
-      pointerId,
-    );
-  },
-
-  setPointerCapture(nativeNodeReference, pointerId) {
-    return nullthrows(RawNativeDOM).setPointerCapture(
-      nativeNodeReference,
-      pointerId,
-    );
-  },
-
-  /*
-   * Methods from the `HTMLElement` interface (for `ReactNativeElement`).
-   */
-
-  getOffset(nativeNodeReference) {
-    // $FlowExpectedError[incompatible-type]
-    return (nullthrows(RawNativeDOM).getOffset(nativeNodeReference): $ReadOnly<
-      [
-        /* offsetParent: */ ?InstanceHandle,
-        /* top: */ number,
-        /* left: */ number,
-      ],
-    >);
-  },
-
-  /*
-   * Special methods to handle the root node.
-   */
-
-  linkRootNode(rootTag, instanceHandle) {
-    // $FlowExpectedError[incompatible-type]
-    return (nullthrows(RawNativeDOM?.linkRootNode)(
-      // $FlowExpectedError[incompatible-type]
-      rootTag,
-      instanceHandle,
-    ): ?NativeElementReference);
-  },
-
-  /**
-   * Legacy layout APIs
-   */
-
-  measure(nativeNodeReference, callback) {
-    return nullthrows(RawNativeDOM).measure(nativeNodeReference, callback);
-  },
-
-  measureInWindow(nativeNodeReference, callback) {
-    return nullthrows(RawNativeDOM).measureInWindow(
-      nativeNodeReference,
-      callback,
-    );
-  },
-
-  measureLayout(nativeNodeReference, relativeNode, onFail, onSuccess) {
-    return nullthrows(RawNativeDOM).measureLayout(
-      nativeNodeReference,
-      relativeNode,
-      onFail,
-      onSuccess,
-    );
-  },
-
-  /**
-   * Legacy direct manipulation APIs
-   */
-  setNativeProps(nativeNodeReference, updatePayload) {
-    return nullthrows(RawNativeDOM).setNativeProps(
-      nativeNodeReference,
-      updatePayload,
-    );
-  },
-};
-
-export default NativeDOM;
+// We used to implement all methods in RefineSpec, manually refining the types
+// for all methods. However, this is slower as every call to the native module
+// requires an additional call only to handle types. Instead, we do an unsafe
+// casting here. Keep in mind that:
+// 1. We use `get` and not `getEnforcing` because we don't want to fail when
+//    the module is evaluated, only when used. This is necessary because we
+//    don't use inline requires within the `react-native` package and some code
+//    might end up loading this but not using it.
+// 2. We lose automatic backwards compatibility checks because of this.
+// $FlowExpectedError[incompatible-type]
+export default (TurboModuleRegistry.get<Spec>('NativeDOMCxx'): RefinedSpec);

--- a/packages/react-native/src/private/webapis/dom/oldstylecollections/HTMLCollection.js
+++ b/packages/react-native/src/private/webapis/dom/oldstylecollections/HTMLCollection.js
@@ -18,9 +18,16 @@ import {setPlatformObject} from '../../webidl/PlatformObjects';
 // IMPORTANT: The type definition for this module is defined in `HTMLCollection.js.flow`
 // because Flow only supports indexers in classes in declaration files.
 
+const REUSABLE_PROPERTY_DESCRIPTOR: {...PropertyDescriptor<mixed>, ...} = {
+  value: {},
+  enumerable: true,
+  configurable: false,
+  writable: false,
+};
+
 // $FlowFixMe[incompatible-type] Flow doesn't understand [Symbol.iterator]() {} and thinks this class doesn't implement the Iterable<T> interface.
 export default class HTMLCollection<T> implements Iterable<T>, ArrayLike<T> {
-  #length: number;
+  _length: number;
 
   /**
    * Use `createHTMLCollection` to create instances of this class.
@@ -30,23 +37,19 @@ export default class HTMLCollection<T> implements Iterable<T>, ArrayLike<T> {
    */
   constructor(elements: $ReadOnlyArray<T>) {
     for (let i = 0; i < elements.length; i++) {
-      Object.defineProperty(this, i, {
-        value: elements[i],
-        enumerable: true,
-        configurable: false,
-        writable: false,
-      });
+      REUSABLE_PROPERTY_DESCRIPTOR.value = elements[i];
+      Object.defineProperty(this, i, REUSABLE_PROPERTY_DESCRIPTOR);
     }
 
-    this.#length = elements.length;
+    this._length = elements.length;
   }
 
   get length(): number {
-    return this.#length;
+    return this._length;
   }
 
   item(index: number): T | null {
-    if (index < 0 || index >= this.#length) {
+    if (index < 0 || index >= this._length) {
       return null;
     }
 

--- a/packages/react-native/src/private/webapis/dom/oldstylecollections/NodeList.js
+++ b/packages/react-native/src/private/webapis/dom/oldstylecollections/NodeList.js
@@ -22,9 +22,14 @@ import {setPlatformObject} from '../../webidl/PlatformObjects';
 // IMPORTANT: The Flow type definition for this module is defined in `NodeList.js.flow`
 // because Flow only supports indexers in classes in declaration files.
 
+const REUSABLE_PROPERTY_DESCRIPTOR: {...PropertyDescriptor<mixed>, ...} = {
+  value: {},
+  writable: false,
+};
+
 // $FlowFixMe[incompatible-type] Flow doesn't understand [Symbol.iterator]() {} and thinks this class doesn't implement the Iterable<T> interface.
 export default class NodeList<T> implements Iterable<T>, ArrayLike<T> {
-  #length: number;
+  _length: number;
 
   /**
    * Use `createNodeList` to create instances of this class.
@@ -34,20 +39,18 @@ export default class NodeList<T> implements Iterable<T>, ArrayLike<T> {
    */
   constructor(elements: $ReadOnlyArray<T>) {
     for (let i = 0; i < elements.length; i++) {
-      Object.defineProperty(this, i, {
-        value: elements[i],
-        writable: false,
-      });
+      REUSABLE_PROPERTY_DESCRIPTOR.value = elements[i];
+      Object.defineProperty(this, i, REUSABLE_PROPERTY_DESCRIPTOR);
     }
-    this.#length = elements.length;
+    this._length = elements.length;
   }
 
   get length(): number {
-    return this.#length;
+    return this._length;
   }
 
   item(index: number): T | null {
-    if (index < 0 || index >= this.#length) {
+    if (index < 0 || index >= this._length) {
       return null;
     }
 
@@ -71,7 +74,7 @@ export default class NodeList<T> implements Iterable<T>, ArrayLike<T> {
     // eslint-disable-next-line consistent-this
     const arrayLike: ArrayLike<T> = this;
 
-    for (let index = 0; index < this.#length; index++) {
+    for (let index = 0; index < this._length; index++) {
       if (thisArg == null) {
         callbackFn(arrayLike[index], index, this);
       } else {

--- a/packages/react-native/src/private/webapis/performance/Performance.js
+++ b/packages/react-native/src/private/webapis/performance/Performance.js
@@ -29,10 +29,7 @@ import {
   performanceEntryTypeToRaw,
   rawToPerformanceEntry,
 } from './internals/RawPerformanceEntry';
-import {
-  getCurrentTimeStamp,
-  warnNoNativePerformance,
-} from './internals/Utilities';
+import {getCurrentTimeStamp} from './internals/Utilities';
 import MemoryInfo from './MemoryInfo';
 import ReactNativeStartupTiming from './ReactNativeStartupTiming';
 import MaybeNativePerformance from './specs/NativePerformance';
@@ -78,18 +75,16 @@ const MEASURE_OPTIONS_REUSABLE_OBJECT: {...PerformanceMeasureInit} = {
   detail: undefined,
 };
 
-const getMarkTimeForMeasure = cachedGetMarkTime
-  ? (markName: string): number => {
-      const markTime = cachedGetMarkTime(markName);
-      if (markTime == null) {
-        throw new DOMException(
-          `Failed to execute 'measure' on 'Performance': The mark '${markName}' does not exist.`,
-          'SyntaxError',
-        );
-      }
-      return markTime;
-    }
-  : undefined;
+const getMarkTimeForMeasure = (markName: string): number => {
+  const markTime = cachedGetMarkTime(markName);
+  if (markTime == null) {
+    throw new DOMException(
+      `Failed to execute 'measure' on 'Performance': The mark '${markName}' does not exist.`,
+      'SyntaxError',
+    );
+  }
+  return markTime;
+};
 
 /**
  * Partial implementation of the Performance interface for RN,
@@ -150,11 +145,6 @@ export default class Performance {
     // IMPORTANT: this method has been micro-optimized.
     // Please run the benchmarks in `Performance-benchmarks-itest` to ensure
     // changes do not regress performance.
-
-    if (cachedReportMark === undefined) {
-      warnNoNativePerformance();
-      return new PerformanceMark(markName, {startTime: 0});
-    }
 
     if (markName === undefined) {
       throw new TypeError(
@@ -224,14 +214,6 @@ export default class Performance {
     // IMPORTANT: this method has been micro-optimized.
     // Please run the benchmarks in `Performance-benchmarks-itest` to ensure
     // changes do not regress performance.
-
-    if (
-      getMarkTimeForMeasure === undefined ||
-      cachedReportMeasure === undefined
-    ) {
-      warnNoNativePerformance();
-      return new PerformanceMeasure(measureName, {startTime: 0, duration: 0});
-    }
 
     let resolvedMeasureName: string;
     let resolvedStartTime: number;

--- a/packages/react-native/src/private/webapis/performance/specs/NativePerformance.js
+++ b/packages/react-native/src/private/webapis/performance/specs/NativePerformance.js
@@ -54,14 +54,14 @@ export type PerformanceObserverInit = {
 
 export interface Spec extends TurboModule {
   +now: () => number;
-  +reportMark?: (name: string, startTime: number, entry: mixed) => void;
-  +reportMeasure?: (
+  +reportMark: (name: string, startTime: number, entry: mixed) => void;
+  +reportMeasure: (
     name: string,
     startTime: number,
     duration: number,
     entry: mixed,
   ) => void;
-  +getMarkTime?: (name: string) => ?number;
+  +getMarkTime: (name: string) => ?number;
   +clearMarks: (entryName?: string) => void;
   +clearMeasures: (entryName?: string) => void;
   +getEntries: () => $ReadOnlyArray<RawPerformanceEntry>;
@@ -93,7 +93,7 @@ export interface Spec extends TurboModule {
 
   +getSupportedPerformanceEntryTypes: () => $ReadOnlyArray<RawPerformanceEntryType>;
 
-  +clearEventCountsForTesting?: () => void;
+  +clearEventCountsForTesting: () => void;
 }
 
 export default (TurboModuleRegistry.get<Spec>('NativePerformanceCxx'): ?Spec);


### PR DESCRIPTION
Summary:
This implements several optimizations to speed up DOM traversal APIs.

The main changes are:
1. Better caching of renderer methods in `RendererImplementation`.
2. Faster access to public instances from instance handles (avoids `instanceof` checks if the nodes are `ReactNativeElement`, which is the most common case).
3. Avoiding unnecessary function calls in `NativeDOM` but removing the proxy object.
4. Removal of private fields from `HTMLCollection` and `NodeList`, and reuse the object to define object properties.
5. Avoiding unnecessary array copies in `getChildNodes`.

Results:

| Property / method               | Latency before (ns) | Latency after (ns) | Difference |
| ----------------------- | ------------------------- | ------------------------ | ---------- |
| parentNode              | 3996                      | 2203                     | -44.87%   |
| parentElement           | 4347                      | 2524                     | -41.94%   |
| childNodes              | 6590                      | 3886                     | -41.03%   |
| children                | 6950                      | 4126                     | -40.63%   |
| firstChild              | 5008                      | 2975                     | -40.60%   |
| firstElementChild       | 5408                      | 3215                     | -40.55%   |
| lastChild               | 5048                      | 2974                     | -41.09%   |
| lastElementChild        | 5448                      | 3215                     | -40.99%   |
| childElementCount       | 5378                      | 3175                     | -40.96%   |
| previousSibling         | 12118                     | 6780                     | -44.05%   |
| previousElementSibling  | 12148                     | 6850                     | -43.61%   |
| nextSibling             | 12139                     | 6800                     | -43.98%   |
| nextElementSibling      | 12119                     | 6830                     | -43.64%   |
| offsetParent            | 5097                      | 3725                     | -26.92%   |
| isConnected             | 2774                      | 1733                     | -37.53%   |
| ownerDocument           | 691                       | 681                      | -1.45%    |
| getRootNode()           | 3195                      | 2154                     | -32.58%   |
| hasChildNodes()         | 4997                      | 2854                     | -42.89%   |

Differential Revision: D80449030


