### PR TITLE
Fix recording for Maestro E2E tests on iOS

### DIFF
--- a/.github/workflow-scripts/maestro-ios.js
+++ b/.github/workflow-scripts/maestro-ios.js
@@ -87,11 +87,11 @@ async function launchAppOnSimulator(appId, udid, isDebug) {
 
 function startVideoRecording(jsengine, currentAttempt) {
   console.log(
-    `Start video record using pid: video_record_${jsengine}_${currentAttempt}.pid`,
+    `Start video record using pid: video_record_${currentAttempt}.pid`,
   );
 
   const recordingArgs =
-    `simctl io booted recordVideo video_record_${jsengine}_${currentAttempt}.mov`.split(
+    `simctl io booted recordVideo video_record_${currentAttempt}.mov`.split(
       ' ',
     );
   const recordingProcess = childProcess.spawn('xcrun', recordingArgs, {


### PR DESCRIPTION
Summary:
As per title, the recordings of iOS E2E tests are broken because we are creating a file that contains the js engine in the name, but we are trying to store a file without the js engine in the name.

## Changelog:
[Internal] -

Reviewed By: cortinico

Differential Revision: D80454067


