### PR TITLE
Add Analyze Performance option to DevMenu

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2223,6 +2223,15 @@ public abstract interface class com/facebook/react/devsupport/interfaces/StackFr
 	public abstract fun toJSON ()Lorg/json/JSONObject;
 }
 
+public final class com/facebook/react/devsupport/interfaces/TracingState : java/lang/Enum {
+	public static final field DISABLED Lcom/facebook/react/devsupport/interfaces/TracingState;
+	public static final field ENABLEDINBACKGROUNDMODE Lcom/facebook/react/devsupport/interfaces/TracingState;
+	public static final field ENABLEDINCDPMODE Lcom/facebook/react/devsupport/interfaces/TracingState;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/facebook/react/devsupport/interfaces/TracingState;
+	public static fun values ()[Lcom/facebook/react/devsupport/interfaces/TracingState;
+}
+
 public final class com/facebook/react/fabric/ComponentFactory {
 	public fun <init> ()V
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/BridgelessDevSupportManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/BridgelessDevSupportManager.kt
@@ -15,6 +15,7 @@ import com.facebook.react.devsupport.interfaces.DevLoadingViewManager
 import com.facebook.react.devsupport.interfaces.DevSupportManager
 import com.facebook.react.devsupport.interfaces.PausedInDebuggerOverlayManager
 import com.facebook.react.devsupport.interfaces.RedBoxHandler
+import com.facebook.react.devsupport.interfaces.TracingState
 import com.facebook.react.packagerconnection.RequestHandler
 
 /**
@@ -79,5 +80,9 @@ internal class BridgelessDevSupportManager(
     // dismiss redbox if exists
     hideRedboxDialog()
     reactInstanceDevHelper.reload("BridgelessDevSupportManager.handleReloadJS()")
+  }
+
+  fun tracingState(): TracingState {
+    return TracingState.DISABLED
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/PerfMonitorOverlayViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/PerfMonitorOverlayViewManager.kt
@@ -26,6 +26,7 @@ import androidx.core.view.WindowInsetsCompat
 import com.facebook.react.R
 import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.devsupport.interfaces.PerfMonitorOverlayManager
+import com.facebook.react.devsupport.interfaces.TracingState
 import com.facebook.react.devsupport.perfmonitor.PerfMonitorInspectorTargetBinding
 import com.facebook.react.devsupport.perfmonitor.PerfMonitorUpdateListener
 import com.facebook.react.uimanager.DisplayMetricsHolder
@@ -66,6 +67,11 @@ internal class PerfMonitorOverlayViewManager(
       hasInteractionData = false
       hideOverlay()
     }
+  }
+
+  override fun onRecordingStateChanged(state: TracingState) {
+    // recordingState = state
+    // view?.updateRecordingState(state)
   }
 
   override fun onNewFocusedEvent(data: PerfMonitorUpdateListener.LongTaskEventData) {
@@ -148,6 +154,8 @@ internal class PerfMonitorOverlayViewManager(
     this.interactionDialog = dialog
   }
 
+  fun updateRecordingState(state: TracingState) {}
+
   private fun createButton(context: Context) {
     val buttonInner = createInnerLayout(context)
     buttonInner.addView(
@@ -177,7 +185,7 @@ internal class PerfMonitorOverlayViewManager(
               dpToPx(8f).toInt(),
           )
           addView(buttonInner)
-          setOnClickListener { inspectorTarget?.pauseAndAnalyzeTrace() }
+          setOnClickListener { inspectorTarget?.pauseAndAnalyzeBackgroundTrace() }
         }
     val dialog =
         createAnchoredDialog(context, dpToPx(0f), dpToPx(0f)).apply { setContentView(buttonView) }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/TracingState.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/TracingState.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.devsupport.interfaces
+
+import com.facebook.proguard.annotations.DoNotStripAny
+
+// Keep in sync with `TracingState.h`
+// JNI wrapper for `jsinspector_modern::Tracing::TracingState`.
+@DoNotStripAny
+public enum class TracingState {
+  DISABLED, // There is no active trace
+  ENABLEDINBACKGROUNDMODE, // Trace is currently running in background mode
+  ENABLEDINCDPMODE, // Trace is currently running in CDP mode
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/TracingStateProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/TracingStateProvider.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.devsupport.interfaces
+
+internal interface TracingStateProvider {
+  fun getTracingState(): TracingState
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/perfmonitor/PerfMonitorInspectorTargetBinding.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/perfmonitor/PerfMonitorInspectorTargetBinding.kt
@@ -12,5 +12,9 @@ package com.facebook.react.devsupport.perfmonitor
  * exposing actions for the V2 Perf Monitor.
  */
 internal interface PerfMonitorInspectorTargetBinding {
-  public fun pauseAndAnalyzeTrace()
+  /** Attempt to pause the current background performance trace, and open in DevTools. */
+  public fun pauseAndAnalyzeBackgroundTrace()
+
+  /** Attempt to start a new background performance trace. */
+  public fun resumeBackgroundTrace()
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/perfmonitor/PerfMonitorUpdateListener.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/perfmonitor/PerfMonitorUpdateListener.kt
@@ -4,8 +4,9 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-
 package com.facebook.react.devsupport.perfmonitor
+
+import com.facebook.react.devsupport.interfaces.TracingState
 
 /** [Experimental] An interface for subscribing to updates for the V2 Perf Monitor. */
 internal interface PerfMonitorUpdateListener {
@@ -17,4 +18,7 @@ internal interface PerfMonitorUpdateListener {
 
   /** Called when a new active performance event should be displayed. */
   fun onNewFocusedEvent(data: LongTaskEventData)
+
+  /** Called when the recording state of the background performance trace has changed. */
+  fun onRecordingStateChanged(state: TracingState)
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.kt
@@ -95,21 +95,30 @@ public class ReactHostImpl(
     private val useDevSupport: Boolean,
     devSupportManagerFactory: DevSupportManagerFactory? = null,
 ) : ReactHost {
+  private val reactHostImplDevHelper = ReactHostImplDevHelper(this)
+
   public override val devSupportManager: DevSupportManager =
-      (devSupportManagerFactory ?: DefaultDevSupportManagerFactory()).create(
-          applicationContext = context.applicationContext,
-          reactInstanceManagerHelper = ReactHostImplDevHelper(this),
-          packagerPathForJSBundleName = reactHostDelegate.jsMainModulePath,
-          enableOnCreate = true,
-          redBoxHandler = null,
-          devBundleDownloadListener = null,
-          minNumShakes = 2,
-          customPackagerCommandHandlers = null,
-          surfaceDelegateFactory = null,
-          devLoadingViewManager = null,
-          pausedInDebuggerOverlayManager = null,
-          useDevSupport = useDevSupport,
-      )
+      (devSupportManagerFactory ?: DefaultDevSupportManagerFactory())
+          .create(
+              applicationContext = context.applicationContext,
+              reactInstanceManagerHelper = reactHostImplDevHelper,
+              packagerPathForJSBundleName = reactHostDelegate.jsMainModulePath,
+              enableOnCreate = true,
+              redBoxHandler = null,
+              devBundleDownloadListener = null,
+              minNumShakes = 2,
+              customPackagerCommandHandlers = null,
+              surfaceDelegateFactory = null,
+              devLoadingViewManager = null,
+              pausedInDebuggerOverlayManager = null,
+              useDevSupport = useDevSupport,
+          )
+          .also { devSupportManager ->
+            // Wire up the tracing state provider
+            if (devSupportManager is DevSupportManagerBase) {
+              devSupportManager.setTracingStateProvider(reactHostImplDevHelper)
+            }
+          }
   public override val memoryPressureRouter: MemoryPressureRouter = MemoryPressureRouter(context)
 
   private val attachedSurfaces: MutableSet<ReactSurfaceImpl> = HashSet()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImplDevHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImplDevHelper.kt
@@ -16,6 +16,8 @@ import com.facebook.react.bridge.ReactContext
 import com.facebook.react.common.annotations.FrameworkAPI
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.devsupport.ReactInstanceDevHelper
+import com.facebook.react.devsupport.interfaces.TracingState
+import com.facebook.react.devsupport.interfaces.TracingStateProvider
 import com.facebook.react.devsupport.perfmonitor.PerfMonitorDevHelper
 import com.facebook.react.devsupport.perfmonitor.PerfMonitorInspectorTarget
 import com.facebook.react.interfaces.TaskInterface
@@ -30,7 +32,7 @@ import com.facebook.react.modules.core.DeviceEventManagerModule
 @UnstableReactNativeAPI
 @OptIn(FrameworkAPI::class)
 internal class ReactHostImplDevHelper(private val delegate: ReactHostImpl) :
-    ReactInstanceDevHelper, PerfMonitorDevHelper {
+    ReactInstanceDevHelper, PerfMonitorDevHelper, TracingStateProvider {
 
   override val currentActivity: Activity?
     get() = delegate.lastUsedActivity
@@ -77,4 +79,8 @@ internal class ReactHostImplDevHelper(private val delegate: ReactHostImpl) :
 
   override fun loadBundle(bundleLoader: JSBundleLoader): TaskInterface<Boolean> =
       delegate.loadBundle(bundleLoader)
+
+  override fun getTracingState(): TracingState {
+    return delegate.reactHostInspectorTarget?.tracingState() ?: TracingState.DISABLED
+  }
 }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.cpp
@@ -204,7 +204,14 @@ void JReactHostInspectorTarget::registerNatives() {
       makeNativeMethod(
           "stopAndDiscardBackgroundTrace",
           JReactHostInspectorTarget::stopAndDiscardBackgroundTrace),
+      makeNativeMethod(
+          "tracingStateAsInt", JReactHostInspectorTarget::tracingState),
   });
+}
+
+jint JReactHostInspectorTarget::tracingState() {
+  auto state = inspectorTarget_->tracingState();
+  return static_cast<jint>(state);
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactHostInspectorTarget.h
@@ -20,6 +20,11 @@ struct JTaskInterface : public jni::JavaClass<JTaskInterface> {
       "Lcom/facebook/react/interfaces/TaskInterface;";
 };
 
+struct JTracingState : public jni::JavaClass<JTracingState> {
+  static constexpr auto kJavaDescriptor =
+      "Lcom/facebook/react/devsupport/TracingState;";
+};
+
 struct JReactHostImpl : public jni::JavaClass<JReactHostImpl> {
   static constexpr auto kJavaDescriptor =
       "Lcom/facebook/react/runtime/ReactHostImpl;";
@@ -88,6 +93,14 @@ class JReactHostInspectorTarget
    * which will be emitted the next time CDP session is created.
    */
   void stopAndStashBackgroundTrace();
+  /**
+   * Get the state of the background trace: running, stopped, or disabled
+   * Background tracing will be disabled if there is no metro connection or if
+   * there is a CDP initiate trace in progress.
+   *
+   * \return the background trace state
+   */
+  jint tracingState();
   /**
    * Stops previously started trace recording and discards the captured trace.
    */

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values/strings.xml
@@ -10,6 +10,9 @@
   <string name="catalyst_change_bundle_location_cancel" project="catalyst" translatable="false">Cancel</string>
   <string name="catalyst_open_debugger_error" project="catalyst" translatable="false">Failed to open DevTools. Please check that the dev server is running and reload the app.</string>
   <string name="catalyst_debug_open" project="catalyst" translatable="false">Open DevTools</string>
+  <string name="catalyst_performance_background" project="catalyst" translatable="false">Finish performance trace</string>
+  <string name="catalyst_performance_disabled" project="catalyst" translatable="false">Start performance trace</string>
+  <string name="catalyst_performance_cdp" project="catalyst" translatable="false">Performance tracing disabled</string>
   <string name="catalyst_debug_open_disabled" project="catalyst" translatable="false">Connect to the bundler to debug JavaScript</string>
   <string name="catalyst_debug_connecting" project="catalyst" translatable="false">Connecting to debugger...</string>
   <string name="catalyst_debug_error" project="catalyst" translatable="false">Failed to connect to debugger!</string>

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
@@ -20,6 +20,7 @@
 #include <string>
 
 #include <jsinspector-modern/tracing/TracingMode.h>
+#include <jsinspector-modern/tracing/TracingState.h>
 
 #ifndef JSINSPECTOR_EXPORT
 #ifdef _MSC_VER
@@ -298,6 +299,11 @@ class JSINSPECTOR_EXPORT HostTarget
    * Stops previously started trace recording.
    */
   tracing::TraceRecordingState stopTracing();
+
+  /**
+   * Returns the state of the background trace, running, stopped, or disabled
+   */
+  tracing::TracingState tracingState() const;
 
  private:
   /**

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTracing.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTargetTracing.cpp
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <jsinspector-modern/tracing/TracingState.h>
+
 #include "HostTarget.h"
 #include "HostTargetTraceRecording.h"
 
@@ -50,6 +52,20 @@ tracing::TraceRecordingState HostTarget::stopTracing() {
   traceRecording_.reset();
 
   return state;
+}
+
+tracing::TracingState HostTarget::tracingState() const {
+  if (traceRecording_ == nullptr) {
+    return tracing::TracingState::Disabled;
+  }
+
+  if (traceRecording_->isBackgroundInitiated()) {
+    return tracing::TracingState::EnabledInBackgroundMode;
+  }
+
+  // This means we have a traceRecording_, but not running in the background.
+  // CDP initiated this trace so we should report as disabled.
+  return tracing::TracingState::EnabledInCDPMode;
 }
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TracingState.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TracingState.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace facebook::react::jsinspector_modern::tracing {
+
+// Keep in sync with `TracingState.kt`
+enum class TracingState : int32_t {
+  // There is no active trace
+  Disabled = 0,
+  // Trace is currently running in background mode
+  EnabledInBackgroundMode = 1,
+  // Trace is currently running in CDP mode
+  EnabledInCDPMode = 2,
+};
+
+} // namespace facebook::react::jsinspector_modern::tracing


### PR DESCRIPTION
Summary:
Adds "Start Recording Performance" and "Analyze Performance" options to the DevMenu based on the performance tracer state.

Changelog:
[Android][Added] - Exposed new performance analyze action through React Native Dev Menu

Differential Revision: D79714164
