### PR TITLE
Remove "bridgeless" from React Native Dev Menu

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.kt
@@ -444,7 +444,7 @@ public abstract class DevSupportManagerBase(
     header.orientation = LinearLayout.VERTICAL
 
     TextView(context).apply {
-      text = context.getString(R.string.catalyst_dev_menu_header, uniqueTag)
+      text = context.getString(R.string.catalyst_dev_menu_header)
       setPadding(0, 50, 0, 0)
       gravity = Gravity.CENTER
       textSize = 16f

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values/strings.xml
@@ -29,6 +29,6 @@
   <string name="catalyst_report_button" project="catalyst" translatable="false">Report</string>
   <string name="catalyst_loading_from_url" project="catalyst" translatable="false">Loading from %1$s…</string>
   <string name="catalyst_sample_profiler_toggle" project="catalyst" translatable="false">Toggle Sampling Profiler</string>
-  <string name="catalyst_dev_menu_header" project="catalyst" translatable="false">React Native Dev Menu (%1$s)</string>
+  <string name="catalyst_dev_menu_header" project="catalyst" translatable="false">React Native Dev Menu</string>
   <string name="catalyst_dev_menu_sub_header" project="catalyst" translatable="false">Running %1$s</string>
 </resources>


### PR DESCRIPTION
Summary:
No longer needed as bridgeless is enabled everywhere.

Changelog:
[Android][Deprecated] Remove bridge mode string from React Native Dev Menu title

Differential Revision: D80457625


