### PR TITLE
Dispatch mode changes on onSizeChanged

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/virtual/view/ReactVirtualView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/virtual/view/ReactVirtualView.kt
@@ -169,6 +169,11 @@ public class ReactVirtualView(context: Context) :
     }
   }
 
+  override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+    super.onSizeChanged(w, h, oldw, oldh)
+    dispatchOnModeChangeIfNeeded(true)
+  }
+
   private fun dispatchOnModeChangeIfNeeded(checkRectChange: Boolean) {
     modeChangeEmitter ?: return
     val scrollView = parentScrollView ?: return


### PR DESCRIPTION
Summary: Changelog: [Internal] - onSizeChanged can be called independent of onLayoutChange. Right now this hasn't affeced anything because VirtualViews are visible by default.

Reviewed By: yungsters

Differential Revision: D80357397


