### PR TITLE
fix(iOS)(Fabric) inline view alignment inside of a Text with line height

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTTextLayoutManager.mm
@@ -410,11 +410,11 @@ static NSLineBreakMode RCTNSLineBreakModeFromEllipsizeMode(EllipsizeMode ellipsi
                 } else {
                   CGSize attachmentSize = attachment.bounds.size;
                   CGRect glyphRect = [layoutManager boundingRectForGlyphRange:range inTextContainer:textContainer];
-
-                  CGRect frame;
-                  CGFloat baseline = [layoutManager locationForGlyphAtIndex:range.location].y;
-
-                  frame = {{glyphRect.origin.x, glyphRect.origin.y + baseline - attachmentSize.height}, attachmentSize};
+                  UIFont *font = [[textStorage attributedSubstringFromRange:range]
+                           attribute:NSFontAttributeName
+                             atIndex:0
+                      effectiveRange:nil];
+                  CGRect frame = {{glyphRect.origin.x, glyphRect.origin.y + glyphRect.size.height - attachmentSize.height + font.descender}, attachmentSize};
 
                   auto rect = facebook::react::Rect{
                       facebook::react::Point{frame.origin.x, frame.origin.y},


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Addresses - https://github.com/facebook/react-native/issues/53092

Fixes inline `View` frame calculation that is nested inside of a `Text` with a `lineHeight`. The calculation for inline view frame is correct on [Paper](https://github.com/facebook/react-native/blob/25104de5c47845c0edbdfb38df30f8c406da832e/packages/react-native/Libraries/Text/Text/RCTTextShadowView.mm#L338). This PR uses the same calculation as Paper (use glyph height instead of baseline from layout manager).

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[IOS] [FIXED] - Inline `View` alignment with `lineHeight` in Text

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:


For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

Make sure Text render is consistent on iOS and android and the View aligns with Text baseline with the provided [repro](https://github.com/facebook/react-native/issues/53092) 

<img width="400" height="766" alt="Screenshot 2025-08-19 at 4 55 01 AM" src="https://github.com/user-attachments/assets/bc4e7473-8fe9-4596-a9ea-fd1204e4b3a3" />


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
