### PR TITLE
Fix test setup for flag used early in HostTarget, restore value

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorFlags.cpp
@@ -34,10 +34,7 @@ bool InspectorFlags::getNetworkInspectionEnabled() const {
 }
 
 bool InspectorFlags::getPerfMonitorV2Enabled() const {
-  // loadFlagsAndAssertUnchanged().perfMonitorV2Enabled
-  // disabling the feature for now while tests are failing
-  // instead of reverting the whole feature
-  return false;
+  return loadFlagsAndAssertUnchanged().perfMonitorV2Enabled;
 }
 
 void InspectorFlags::dangerouslyResetFlags() {

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.h
@@ -54,6 +54,7 @@ class JsiIntegrationPortableTestBase : public ::testing::Test,
   void SetUp() override {
     // NOTE: Using SetUp() so we can call virtual methods like
     // setupRuntimeBeforeRegistration().
+    page_ = HostTarget::create(*this, inspectorExecutor_);
     instance_ = &page_->registerInstance(instanceTargetDelegate_);
     setupRuntimeBeforeRegistration(engineAdapter_->getRuntime());
     runtimeTarget_ = &instance_->registerRuntime(
@@ -156,8 +157,7 @@ class JsiIntegrationPortableTestBase : public ::testing::Test,
     return result;
   }
 
-  std::shared_ptr<HostTarget> page_ =
-      HostTarget::create(*this, inspectorExecutor_);
+  std::shared_ptr<HostTarget> page_;
   InstanceTarget* instance_{};
   RuntimeTarget* runtimeTarget_{};
 


### PR DESCRIPTION
Summary:
Follows D80000286, where this flag was forcibly disabled to fix tests.

Changelog: [Internal]

Reviewed By: hoxyq

Differential Revision: D80545210


