### PR TITLE
Fix build with Cocopaods and Dynamic frameworks

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/React-jsinspector.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/React-jsinspector.podspec
@@ -54,6 +54,8 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-jsinspectornetwork", :framework_name => 'jsinspector_modernnetwork')
   add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')
   s.dependency "React-perflogger", version
+  add_dependency(s, "React-oscompat")
+
   if use_hermes()
     s.dependency "hermes-engine"
   end


### PR DESCRIPTION
Summary:
We are missing a dependency in the React-jsinspector podspec that prevents React Native from building with dynamic frameworks.

## Changelog:
[Internal] -

Differential Revision: D80619664


