### PR TITLE
Kill `$FlowExpectedError` as a type across fbsource

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -76,7 +76,6 @@ module.system.haste.module_ref_prefix=m#
 react.runtime=automatic
 
 experimental.error_code_migration=new
-suppress_type=$FlowFixMe
 
 ban_spread_key_props=true
 


### PR DESCRIPTION
Reviewed By: gkz

Differential Revision: D80573556


