### PR TITLE
Fix build race condition with preparePrefab missing 3p headers

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -74,7 +74,14 @@ val GLOG_VERSION = libs.versions.glog.get()
 
 val preparePrefab by
     tasks.registering(PreparePrefabHeadersTask::class) {
-      dependsOn(prepareBoost, prepareDoubleConversion, prepareFolly, prepareGlog)
+      dependsOn(
+          prepareBoost,
+          prepareDoubleConversion,
+          prepareFastFloat,
+          prepareFmt,
+          prepareFolly,
+          prepareGlog,
+      )
       dependsOn("generateCodegenArtifactsFromSchema")
       // To export to a ReactNativePrefabProcessingEntities.kt once all
       // libraries have been moved. We keep it here for now as it make easier to


### PR DESCRIPTION
Summary:
Occasionally, the `preparePrefab` task might run before other tasks that
are responsible of populating the 3p headers, such as `prepareNative3pDependencies`.

This was evident in the latest nightly which is missing the fast_float headers in the
Android prefab.

Adding a dependsOn fixes it.

Changelog:
[Internal] [Changed] -

Differential Revision: D80695212


