### PR TITLE
Deprecate `BridgelessReactContext.getCatalystInstance()`

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/BridgelessReactContext.kt
@@ -64,6 +64,9 @@ internal class BridgelessReactContext(context: Context, private val reactHost: R
   override fun getFabricUIManager(): UIManager? = reactHost.uiManager
 
   @OptIn(FrameworkAPI::class)
+  @Deprecated(
+      "This method is deprecated in the New Architecture. You should not be invoking directly as we're going to remove it in the future."
+  )
   override fun getCatalystInstance(): CatalystInstance {
     if (ReactBuildConfig.UNSTABLE_ENABLE_MINIFY_LEGACY_ARCHITECTURE) {
       throw UnsupportedOperationException(


### PR DESCRIPTION
Summary:
This method is deprecated and should not be invoked in NewArch, therefore I'm deprecating it now.

Changelog:
[Android] [Deprecated] - Deprecate `BridgelessReactContext.getCatalystInstance()` method

Reviewed By: cipolleschi

Differential Revision: D80626638


