### PR TITLE
Change leftover references to hermes.framework

### DIFF
--- a/.github/actions/build-apple-slices-hermes/action.yml
+++ b/.github/actions/build-apple-slices-hermes/action.yml
@@ -71,17 +71,17 @@ runs:
         mv build_"$SLICE" "$FINAL_PATH"
 
         # check whether everything is there
-        if [[ -d "$FINAL_PATH/lib/hermes.framework" ]]; then
-          echo "Successfully built hermes.framework for $SLICE in $FLAVOR"
+        if [[ -d "$FINAL_PATH/lib/hermesvm.framework" ]]; then
+          echo "Successfully built hermesvm.framework for $SLICE in $FLAVOR"
         else
-          echo "Failed to built hermes.framework for $SLICE in $FLAVOR"
+          echo "Failed to built hermesvm.framework for $SLICE in $FLAVOR"
           exit 1
         fi
 
-        if [[ -d "$FINAL_PATH/lib/hermes.framework.dSYM" ]]; then
-          echo "Successfully built hermes.framework.dSYM for $SLICE in $FLAVOR"
+        if [[ -d "$FINAL_PATH/lib/hermesvm.framework.dSYM" ]]; then
+          echo "Successfully built hermesvm.framework.dSYM for $SLICE in $FLAVOR"
         else
-          echo "Failed to built hermes.framework.dSYM for $SLICE in $FLAVOR"
+          echo "Failed to built hermesvm.framework.dSYM for $SLICE in $FLAVOR"
           echo "Please try again"
           exit 1
         fi

--- a/.github/actions/build-hermes-macos/action.yml
+++ b/.github/actions/build-hermes-macos/action.yml
@@ -186,7 +186,7 @@ runs:
 
         cd ./packages/react-native/sdks/hermes || exit 1
 
-        DSYM_FILE_PATH=lib/hermes.framework.dSYM
+        DSYM_FILE_PATH=lib/hermesvm.framework.dSYM
         cp -r build_macosx/$DSYM_FILE_PATH "$WORKING_DIR/macosx/"
         cp -r build_catalyst/$DSYM_FILE_PATH "$WORKING_DIR/catalyst/"
         cp -r build_iphoneos/$DSYM_FILE_PATH "$WORKING_DIR/iphoneos/"
@@ -197,10 +197,10 @@ runs:
         cp -r build_xrsimulator/$DSYM_FILE_PATH "$WORKING_DIR/xrsimulator/"
 
         DEST_DIR="/tmp/hermes/dSYM/$FLAVOR"
-        tar -C "$WORKING_DIR" -czvf "hermes.framework.dSYM" .
+        tar -C "$WORKING_DIR" -czvf "hermesvm.framework.dSYM" .
 
         mkdir -p "$DEST_DIR"
-        mv "hermes.framework.dSYM" "$DEST_DIR"
+        mv "hermesvm.framework.dSYM" "$DEST_DIR"
     - name: Upload hermes dSYM artifacts
       uses: actions/upload-artifact@v4.3.4
       with:

--- a/.github/actions/build-npm-package/action.yml
+++ b/.github/actions/build-npm-package/action.yml
@@ -99,8 +99,8 @@ runs:
         mkdir -p ./packages/react-native/ReactAndroid/external-artifacts/artifacts/
         cp ${{ inputs.hermes-ws-dir }}/hermes-runtime-darwin/hermes-ios-Debug.tar.gz ./packages/react-native/ReactAndroid/external-artifacts/artifacts/hermes-ios-debug.tar.gz
         cp ${{ inputs.hermes-ws-dir }}/hermes-runtime-darwin/hermes-ios-Release.tar.gz ./packages/react-native/ReactAndroid/external-artifacts/artifacts/hermes-ios-release.tar.gz
-        cp ${{ inputs.hermes-ws-dir }}/dSYM/Debug/hermes.framework.dSYM  ./packages/react-native/ReactAndroid/external-artifacts/artifacts/hermes-framework-dSYM-debug.tar.gz
-        cp ${{ inputs.hermes-ws-dir }}/dSYM/Release/hermes.framework.dSYM  ./packages/react-native/ReactAndroid/external-artifacts/artifacts/hermes-framework-dSYM-release.tar.gz
+        cp ${{ inputs.hermes-ws-dir }}/dSYM/Debug/hermesvm.framework.dSYM  ./packages/react-native/ReactAndroid/external-artifacts/artifacts/hermes-framework-dSYM-debug.tar.gz
+        cp ${{ inputs.hermes-ws-dir }}/dSYM/Release/hermesvm.framework.dSYM  ./packages/react-native/ReactAndroid/external-artifacts/artifacts/hermes-framework-dSYM-release.tar.gz
     - name: Download ReactNativeDependencies
       uses: actions/download-artifact@v4
       with:

--- a/packages/react-native/scripts/hermes/__tests__/hermes-utils-test.js
+++ b/packages/react-native/scripts/hermes/__tests__/hermes-utils-test.js
@@ -123,7 +123,7 @@ function populateMockFilesystemWithHermesBuildArtifacts() {
     SDKS_DIR,
     'hermes/destroot/Library/Frameworks',
   );
-  fs.mkdirSync(path.join(frameworksDir, 'macosx/hermes.framework'), {
+  fs.mkdirSync(path.join(frameworksDir, 'macosx/hermesvm.framework'), {
     recursive: true,
   });
   fs.mkdirSync(path.join(frameworksDir, 'universal/hermesvm.xcframework'), {
@@ -138,9 +138,12 @@ function populateMockFilesystemWithHermesBuildArtifacts() {
   ];
 
   for (const dsymsDir of dsymsDirs) {
-    fs.mkdirSync(path.join(frameworksDir, dsymsDir, 'hermes.framework.dSYM'), {
-      recursive: true,
-    });
+    fs.mkdirSync(
+      path.join(frameworksDir, dsymsDir, 'hermesvm.framework.dSYM'),
+      {
+        recursive: true,
+      },
+    );
   }
 }
 

--- a/packages/react-native/scripts/hermes/hermes-utils.js
+++ b/packages/react-native/scripts/hermes/hermes-utils.js
@@ -304,7 +304,7 @@ function createHermesPrebuiltArtifactsTarball(
 function validateHermesFrameworksExist(destrootDir /*: string */) {
   if (
     !fs.existsSync(
-      path.join(destrootDir, 'Library/Frameworks/macosx/hermes.framework'),
+      path.join(destrootDir, 'Library/Frameworks/macosx/hermesvm.framework'),
     )
   ) {
     throw new Error(

--- a/packages/react-native/sdks/hermes-engine/utils/build-mac-framework.sh
+++ b/packages/react-native/sdks/hermes-engine/utils/build-mac-framework.sh
@@ -13,7 +13,7 @@ set -e
 CURR_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 . "${CURR_SCRIPT_DIR}/build-apple-framework.sh"
 
-if [ ! -d destroot/Library/Frameworks/macosx/hermes.framework ]; then
+if [ ! -d destroot/Library/Frameworks/macosx/hermesvm.framework ]; then
     mac_deployment_target=$(get_mac_deployment_target)
 
     build_apple_framework "macosx" "x86_64;arm64" "$mac_deployment_target"

--- a/packages/react-native/sdks/hermes-engine/utils/create-dummy-hermes-xcframework.sh
+++ b/packages/react-native/sdks/hermes-engine/utils/create-dummy-hermes-xcframework.sh
@@ -8,7 +8,7 @@ set -x
 
 # CocoaPods requires vendored frameworks to exist before `pod install` is run,
 # and to be proper Moch-O binaries in order to auto-link them to the user's Xcode project.
-# This script creates dummy hermes.framework for macosx and ios.
+# This script creates dummy hermesvm.framework for macosx and ios.
 # They are then get rewritten by `build-hermes-xcode.sh` during Xcode build.
 
 rm -rf destroot


### PR DESCRIPTION
Summary: Changelog: [General][Fixed] - Change leftover references to `hermes.framework` to `hermesvm.framework`

Differential Revision: D80701257


