### PR TITLE
Do not report mount for mount items with empty surfaceId

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -1372,6 +1372,7 @@ public class FabricUIManager
       // Collect surface IDs for all the mount items
       for (MountItem mountItem : mountItems) {
         if (mountItem != null
+            && mountItem.getSurfaceId() != View.NO_ID
             && !mSurfaceIdsWithPendingMountNotification.contains(mountItem.getSurfaceId())) {
           mSurfaceIdsWithPendingMountNotification.add(mountItem.getSurfaceId());
         }


### PR DESCRIPTION
Summary:
Changelog: [internal]

Some mount items dispatched to Fabric don't have an associated surface ID (they use -1), which causes some log spam when we try to validate that the surface ID exist when we report mount for those surfaces.

This checks if the surface ID has a valid surface ID before adding it to the list of surfaces to report mount.

Differential Revision: D80698363


