### PR TITLE
Fix Crash when rendering Switch component

### DIFF
--- a/packages/react-native/React/Base/RCTUtils.mm
+++ b/packages/react-native/React/Base/RCTUtils.mm
@@ -415,7 +415,9 @@ CGSize RCTSwitchSize(void)
   static CGSize rctSwitchSize;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
-    rctSwitchSize = [UISwitch new].intrinsicContentSize;
+    RCTUnsafeExecuteOnMainQueueSync(^{
+      rctSwitchSize = [UISwitch new].intrinsicContentSize;
+    });
   });
   return rctSwitchSize;
 }

--- a/packages/react-native/ReactCommon/react/renderer/components/switch/iosswitch/react/renderer/components/switch/IOSSwitchShadowNode.mm
+++ b/packages/react-native/ReactCommon/react/renderer/components/switch/iosswitch/react/renderer/components/switch/IOSSwitchShadowNode.mm
@@ -20,7 +20,9 @@ Size SwitchShadowNode::measureContent(
     const LayoutConstraints & /*layoutConstraints*/) const
 {
   CGSize uiSwitchSize = RCTSwitchSize();
-  return {.width = uiSwitchSize.width, .height = uiSwitchSize.height};
+  // Apple has some error when returning the width of the component and it doesn't
+  // account for the borders.
+  return {.width = uiSwitchSize.width + 2, .height = uiSwitchSize.height};
 }
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
When implementing the changes for the Switch component for iOS 26, I didn't realize that the code in [`RCTIntance.mm`](https://www.internalfb.com/code/fbsource/[a54514baccf4e1f828ef46af8180555754c405d8]/xplat/js/react-native-github/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm?lines=344-375) was running behind a feature flag.
This means that all the users not in the experiment where the feature flag is turned on will experience a crash as soon as they navigate to a React Native screen that contains a Switch.

This change fixes the problem by adding a jump to the right queue and it also fixes a measurement issue with the Switch.

## Changelog:
[iOS][Fixed] - Fixed a crash when rendering the Switch component

Differential Revision: D80702245


