### PR TITLE
View recycling for ScrollView native component on Android

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -5675,6 +5675,8 @@ public class com/facebook/react/views/scroll/ReactHorizontalScrollViewManager : 
 	public fun flashScrollIndicators (Lcom/facebook/react/views/scroll/ReactHorizontalScrollView;)V
 	public synthetic fun flashScrollIndicators (Ljava/lang/Object;)V
 	public fun getName ()Ljava/lang/String;
+	public synthetic fun prepareToRecycleView (Lcom/facebook/react/uimanager/ThemedReactContext;Landroid/view/View;)Landroid/view/View;
+	protected fun prepareToRecycleView (Lcom/facebook/react/uimanager/ThemedReactContext;Lcom/facebook/react/views/scroll/ReactHorizontalScrollView;)Lcom/facebook/react/views/scroll/ReactHorizontalScrollView;
 	public synthetic fun receiveCommand (Landroid/view/View;ILcom/facebook/react/bridge/ReadableArray;)V
 	public synthetic fun receiveCommand (Landroid/view/View;Ljava/lang/String;Lcom/facebook/react/bridge/ReadableArray;)V
 	public fun receiveCommand (Lcom/facebook/react/views/scroll/ReactHorizontalScrollView;ILcom/facebook/react/bridge/ReadableArray;)V
@@ -5938,6 +5940,8 @@ public class com/facebook/react/views/scroll/ReactScrollViewManager : com/facebo
 	public fun getCommandsMap ()Ljava/util/Map;
 	public fun getExportedCustomDirectEventTypeConstants ()Ljava/util/Map;
 	public fun getName ()Ljava/lang/String;
+	public synthetic fun prepareToRecycleView (Lcom/facebook/react/uimanager/ThemedReactContext;Landroid/view/View;)Landroid/view/View;
+	protected fun prepareToRecycleView (Lcom/facebook/react/uimanager/ThemedReactContext;Lcom/facebook/react/views/scroll/ReactScrollView;)Lcom/facebook/react/views/scroll/ReactScrollView;
 	public synthetic fun receiveCommand (Landroid/view/View;ILcom/facebook/react/bridge/ReadableArray;)V
 	public synthetic fun receiveCommand (Landroid/view/View;Ljava/lang/String;Lcom/facebook/react/bridge/ReadableArray;)V
 	public fun receiveCommand (Lcom/facebook/react/views/scroll/ReactScrollView;ILcom/facebook/react/bridge/ReadableArray;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<19022bb7e93ed79a1cbe86c71f34bd50>>
+ * @generated SignedSource<<3c47ba9c7fdbb37f0e06fdca56de3223>>
  */
 
 /**
@@ -99,7 +99,7 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
 
   override fun enableViewRecycling(): Boolean = false
 
-  override fun enableViewRecyclingForScrollView(): Boolean = true
+  override fun enableViewRecyclingForScrollView(): Boolean = false
 
   override fun enableViewRecyclingForText(): Boolean = true
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -96,8 +96,10 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
   private final OnScrollDispatchHelper mOnScrollDispatchHelper = new OnScrollDispatchHelper();
   private final @Nullable OverScroller mScroller;
   private final VelocityHelper mVelocityHelper = new VelocityHelper();
-  private final Rect mOverflowInset = new Rect();
+  private final Rect mTempRect = new Rect();
+  private final ValueAnimator DEFAULT_FLING_ANIMATOR = ObjectAnimator.ofInt(this, "scrollX", 0, 0);
 
+  private Rect mOverflowInset = new Rect();
   private boolean mActivelyScrolling;
   private @Nullable Rect mClippingRect;
   private Overflow mOverflow = Overflow.SCROLL;
@@ -118,11 +120,10 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
   private boolean mSnapToEnd = true;
   private int mSnapToAlignment = SNAP_ALIGNMENT_DISABLED;
   private boolean mPagedArrowScrolling = false;
-  private int pendingContentOffsetX = UNSET_CONTENT_OFFSET;
-  private int pendingContentOffsetY = UNSET_CONTENT_OFFSET;
+  private int mPendingContentOffsetX = UNSET_CONTENT_OFFSET;
+  private int mPendingContentOffsetY = UNSET_CONTENT_OFFSET;
   private @Nullable StateWrapper mStateWrapper = null;
-  private final ReactScrollViewScrollState mReactScrollViewScrollState;
-  private final ValueAnimator DEFAULT_FLING_ANIMATOR = ObjectAnimator.ofInt(this, "scrollX", 0, 0);
+  private ReactScrollViewScrollState mReactScrollViewScrollState;
   private PointerEvents mPointerEvents = PointerEvents.AUTO;
   private long mLastScrollDispatchTime = 0;
   private int mScrollEventThrottle = 0;
@@ -130,8 +131,6 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
   private @Nullable MaintainVisibleScrollPositionHelper mMaintainVisibleContentPositionHelper;
   private int mFadingEdgeLengthStart = 0;
   private int mFadingEdgeLengthEnd = 0;
-
-  private final Rect mTempRect = new Rect();
 
   public ReactHorizontalScrollView(Context context) {
     this(context, null);
@@ -144,11 +143,66 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
     ViewCompat.setAccessibilityDelegate(this, new ReactScrollViewAccessibilityDelegate());
 
     mScroller = getOverScrollerFromParent();
-    mReactScrollViewScrollState = new ReactScrollViewScrollState();
 
     setOnHierarchyChangeListener(this);
     setClipChildren(false);
+    initView();
   }
+
+  /**
+   * Set all default values here as opposed to in the constructor or field defaults. It is important
+   * that these properties are set during the constructor, but also on-demand whenever an existing
+   * ReactTextView is recycled.
+   */
+  private void initView() {
+    mOverflowInset = new Rect();
+    mActivelyScrolling = false;
+    mClippingRect = null;
+    mOverflow = Overflow.SCROLL;
+    mDragging = false;
+    mPagingEnabled = false;
+    mPostTouchRunnable = null;
+    mRemoveClippedSubviews = false;
+    mScrollEnabled = true;
+    mSendMomentumEvents = false;
+    mFpsListener = null;
+    mScrollPerfTag = null;
+    mEndBackground = null;
+    mEndFillColor = Color.TRANSPARENT;
+    mDisableIntervalMomentum = false;
+    mSnapInterval = 0;
+    mSnapOffsets = null;
+    mSnapToStart = true;
+    mSnapToEnd = true;
+    mSnapToAlignment = SNAP_ALIGNMENT_DISABLED;
+    mPagedArrowScrolling = false;
+    mPendingContentOffsetX = UNSET_CONTENT_OFFSET;
+    mPendingContentOffsetY = UNSET_CONTENT_OFFSET;
+    mStateWrapper = null;
+    mReactScrollViewScrollState = new ReactScrollViewScrollState();
+
+    mPointerEvents = PointerEvents.AUTO;
+    mLastScrollDispatchTime = 0;
+    mScrollEventThrottle = 0;
+    mContentView = null;
+    mMaintainVisibleContentPositionHelper = null;
+    mFadingEdgeLengthStart = 0;
+    mFadingEdgeLengthEnd = 0;
+  }
+
+  /* package */ void recycleView() {
+    // Set default field values
+    initView();
+
+    // If the view is still attached to a parent, we need to remove it from the parent
+    // before we can recycle it.
+    if (getParent() != null) {
+      ((ViewGroup) getParent()).removeView(this);
+    }
+    updateView();
+  }
+
+  private void updateView() {}
 
   @Override
   public void onInitializeAccessibilityNodeInfo(AccessibilityNodeInfo info) {
@@ -441,9 +495,9 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
       // If a "pending" content offset value has been set, we restore that value.
       // Upon call to scrollTo, the "pending" values will be re-set.
       int scrollToX =
-          pendingContentOffsetX != UNSET_CONTENT_OFFSET ? pendingContentOffsetX : getScrollX();
+          mPendingContentOffsetX != UNSET_CONTENT_OFFSET ? mPendingContentOffsetX : getScrollX();
       int scrollToY =
-          pendingContentOffsetY != UNSET_CONTENT_OFFSET ? pendingContentOffsetY : getScrollY();
+          mPendingContentOffsetY != UNSET_CONTENT_OFFSET ? mPendingContentOffsetY : getScrollY();
       scrollTo(scrollToX, scrollToY);
     }
 
@@ -1459,11 +1513,11 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
     }
 
     if (isContentReady()) {
-      pendingContentOffsetX = UNSET_CONTENT_OFFSET;
-      pendingContentOffsetY = UNSET_CONTENT_OFFSET;
+      mPendingContentOffsetX = UNSET_CONTENT_OFFSET;
+      mPendingContentOffsetY = UNSET_CONTENT_OFFSET;
     } else {
-      pendingContentOffsetX = x;
-      pendingContentOffsetY = y;
+      mPendingContentOffsetX = x;
+      mPendingContentOffsetY = y;
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.kt
@@ -14,6 +14,7 @@ import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.ReadableType
 import com.facebook.react.bridge.RetryableMountingLayerException
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.BackgroundStyleApplicator.setBorderColor
 import com.facebook.react.uimanager.BackgroundStyleApplicator.setBorderRadius
@@ -55,6 +56,23 @@ public open class ReactHorizontalScrollViewManager
 @JvmOverloads
 constructor(private val fpsListener: FpsListener? = null) :
     ViewGroupManager<ReactHorizontalScrollView>(), ScrollCommandHandler<ReactHorizontalScrollView> {
+  init {
+    if (ReactNativeFeatureFlags.enableViewRecyclingForScrollView()) {
+      setupViewRecycling()
+    }
+  }
+
+  override fun prepareToRecycleView(
+      reactContext: ThemedReactContext,
+      view: ReactHorizontalScrollView,
+  ): ReactHorizontalScrollView? {
+    // BaseViewManager
+    val preparedView = super.prepareToRecycleView(reactContext, view)
+    if (preparedView != null) {
+      preparedView.recycleView()
+    }
+    return preparedView
+  }
 
   override fun getName(): String = REACT_CLASS
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -96,43 +96,41 @@ public class ReactScrollView extends ScrollView
   private final @Nullable OverScroller mScroller;
   private final VelocityHelper mVelocityHelper = new VelocityHelper();
   private final Rect mTempRect = new Rect();
-  private final Rect mOverflowInset = new Rect();
+  private final ValueAnimator DEFAULT_FLING_ANIMATOR = ObjectAnimator.ofInt(this, "scrollY", 0, 0);
 
+  private Rect mOverflowInset;
   private @Nullable VirtualViewContainerState mVirtualViewContainerState;
   private boolean mActivelyScrolling;
   private @Nullable Rect mClippingRect;
-  private Overflow mOverflow = Overflow.SCROLL;
+  private Overflow mOverflow;
   private boolean mDragging;
-  private boolean mPagingEnabled = false;
+  private boolean mPagingEnabled;
   private @Nullable Runnable mPostTouchRunnable;
   private boolean mRemoveClippedSubviews;
-  private boolean mScrollEnabled = true;
+  private boolean mScrollEnabled;
   private boolean mSendMomentumEvents;
-  private @Nullable FpsListener mFpsListener = null;
+  private @Nullable FpsListener mFpsListener;
   private @Nullable String mScrollPerfTag;
   private @Nullable Drawable mEndBackground;
-  private int mEndFillColor = Color.TRANSPARENT;
-  private boolean mDisableIntervalMomentum = false;
-  private int mSnapInterval = 0;
+  private int mEndFillColor;
+  private boolean mDisableIntervalMomentum;
+  private int mSnapInterval;
   private @Nullable List<Integer> mSnapOffsets;
-  private boolean mSnapToStart = true;
-  private boolean mSnapToEnd = true;
-  private int mSnapToAlignment = SNAP_ALIGNMENT_DISABLED;
+  private boolean mSnapToStart;
+  private boolean mSnapToEnd;
+  private int mSnapToAlignment;
   private @Nullable View mContentView;
-  private @Nullable ReadableMap mCurrentContentOffset = null;
-  private int pendingContentOffsetX = UNSET_CONTENT_OFFSET;
-  private int pendingContentOffsetY = UNSET_CONTENT_OFFSET;
-  private @Nullable StateWrapper mStateWrapper = null;
-  private final ReactScrollViewScrollState mReactScrollViewScrollState =
-      new ReactScrollViewScrollState();
-  private final ValueAnimator DEFAULT_FLING_ANIMATOR = ObjectAnimator.ofInt(this, "scrollY", 0, 0);
-  private PointerEvents mPointerEvents = PointerEvents.AUTO;
-  private long mLastScrollDispatchTime = 0;
-  private int mScrollEventThrottle = 0;
-  private @Nullable MaintainVisibleScrollPositionHelper mMaintainVisibleContentPositionHelper =
-      null;
-  private int mFadingEdgeLengthStart = 0;
-  private int mFadingEdgeLengthEnd = 0;
+  private @Nullable ReadableMap mCurrentContentOffset;
+  private int mPendingContentOffsetX;
+  private int mPendingContentOffsetY;
+  private @Nullable StateWrapper mStateWrapper;
+  private ReactScrollViewScrollState mReactScrollViewScrollState;
+  private PointerEvents mPointerEvents;
+  private long mLastScrollDispatchTime;
+  private int mScrollEventThrottle;
+  private @Nullable MaintainVisibleScrollPositionHelper mMaintainVisibleContentPositionHelper;
+  private int mFadingEdgeLengthStart;
+  private int mFadingEdgeLengthEnd;
 
   public ReactScrollView(Context context) {
     this(context, null);
@@ -148,7 +146,63 @@ public class ReactScrollView extends ScrollView
     setClipChildren(false);
 
     ViewCompat.setAccessibilityDelegate(this, new ReactScrollViewAccessibilityDelegate());
+    initView();
   }
+
+  /**
+   * Set all default values here as opposed to in the constructor or field defaults. It is important
+   * that these properties are set during the constructor, but also on-demand whenever an existing
+   * ReactTextView is recycled.
+   */
+  private void initView() {
+    mOverflowInset = new Rect();
+    mVirtualViewContainerState = null;
+    mActivelyScrolling = false;
+    mClippingRect = null;
+    mOverflow = Overflow.SCROLL;
+    mDragging = false;
+    mPagingEnabled = false;
+    mPostTouchRunnable = null;
+    mRemoveClippedSubviews = false;
+    mScrollEnabled = true;
+    mSendMomentumEvents = false;
+    mFpsListener = null;
+    mScrollPerfTag = null;
+    mEndBackground = null;
+    mEndFillColor = Color.TRANSPARENT;
+    mDisableIntervalMomentum = false;
+    mSnapInterval = 0;
+    mSnapOffsets = null;
+    mSnapToStart = true;
+    mSnapToEnd = true;
+    mSnapToAlignment = SNAP_ALIGNMENT_DISABLED;
+    mContentView = null;
+    mCurrentContentOffset = null;
+    mPendingContentOffsetX = UNSET_CONTENT_OFFSET;
+    mPendingContentOffsetY = UNSET_CONTENT_OFFSET;
+    mStateWrapper = null;
+    mReactScrollViewScrollState = new ReactScrollViewScrollState();
+    mPointerEvents = PointerEvents.AUTO;
+    mLastScrollDispatchTime = 0;
+    mScrollEventThrottle = 0;
+    mMaintainVisibleContentPositionHelper = null;
+    mFadingEdgeLengthStart = 0;
+    mFadingEdgeLengthEnd = 0;
+  }
+
+  /* package */ void recycleView() {
+    // Set default field values
+    initView();
+
+    // If the view is still attached to a parent, we need to remove it from the parent
+    // before we can recycle it.
+    if (getParent() != null) {
+      ((ViewGroup) getParent()).removeView(this);
+    }
+    updateView();
+  }
+
+  private void updateView() {}
 
   @Override
   public VirtualViewContainerState getVirtualViewContainerState() {
@@ -368,9 +422,9 @@ public class ReactScrollView extends ScrollView
       // If a "pending" content offset value has been set, we restore that value.
       // Upon call to scrollTo, the "pending" values will be re-set.
       int scrollToX =
-          pendingContentOffsetX != UNSET_CONTENT_OFFSET ? pendingContentOffsetX : getScrollX();
+          mPendingContentOffsetX != UNSET_CONTENT_OFFSET ? mPendingContentOffsetX : getScrollX();
       int scrollToY =
-          pendingContentOffsetY != UNSET_CONTENT_OFFSET ? pendingContentOffsetY : getScrollY();
+          mPendingContentOffsetY != UNSET_CONTENT_OFFSET ? mPendingContentOffsetY : getScrollY();
       scrollTo(scrollToX, scrollToY);
     }
 
@@ -1269,11 +1323,11 @@ public class ReactScrollView extends ScrollView
    */
   private void setPendingContentOffsets(int x, int y) {
     if (isContentReady()) {
-      pendingContentOffsetX = UNSET_CONTENT_OFFSET;
-      pendingContentOffsetY = UNSET_CONTENT_OFFSET;
+      mPendingContentOffsetX = UNSET_CONTENT_OFFSET;
+      mPendingContentOffsetY = UNSET_CONTENT_OFFSET;
     } else {
-      pendingContentOffsetX = x;
-      pendingContentOffsetY = y;
+      mPendingContentOffsetX = x;
+      mPendingContentOffsetY = y;
     }
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.kt
@@ -15,6 +15,7 @@ import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.ReadableType
 import com.facebook.react.bridge.RetryableMountingLayerException
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.BackgroundStyleApplicator.setBorderColor
 import com.facebook.react.uimanager.BackgroundStyleApplicator.setBorderRadius
@@ -55,6 +56,24 @@ public open class ReactScrollViewManager
 @JvmOverloads
 constructor(private val fpsListener: FpsListener? = null) :
     ViewGroupManager<ReactScrollView>(), ScrollCommandHandler<ReactScrollView> {
+
+  init {
+    if (ReactNativeFeatureFlags.enableViewRecyclingForScrollView()) {
+      setupViewRecycling()
+    }
+  }
+
+  override fun prepareToRecycleView(
+      reactContext: ThemedReactContext,
+      view: ReactScrollView,
+  ): ReactScrollView? {
+    // BaseViewManager
+    val preparedView = super.prepareToRecycleView(reactContext, view)
+    if (preparedView != null) {
+      preparedView.recycleView()
+    }
+    return preparedView
+  }
 
   override fun getName(): String = REACT_CLASS
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<5c12d5107de20283dd7a2a899685cfa5>>
+ * @generated SignedSource<<30170e483b919c7bd235bfcfe4174c39>>
  */
 
 /**
@@ -180,7 +180,7 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool enableViewRecyclingForScrollView() override {
-    return true;
+    return false;
   }
 
   bool enableViewRecyclingForText() override {

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -452,7 +452,7 @@ const definitions: FeatureFlagDefinitions = {
       ossReleaseStage: 'none',
     },
     enableViewRecyclingForScrollView: {
-      defaultValue: true,
+      defaultValue: false,
       metadata: {
         dateAdded: '2025-08-20',
         description:

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<825b92d137ed3253e0badd0696605882>>
+ * @generated SignedSource<<6ec32c21e134bd51702d7fcab094c725>>
  * @flow strict
  * @noformat
  */
@@ -336,7 +336,7 @@ export const enableViewRecycling: Getter<boolean> = createNativeFlagGetter('enab
 /**
  * Enables View Recycling for <ScrollView> via ReactViewGroup/ReactViewManager.
  */
-export const enableViewRecyclingForScrollView: Getter<boolean> = createNativeFlagGetter('enableViewRecyclingForScrollView', true);
+export const enableViewRecyclingForScrollView: Getter<boolean> = createNativeFlagGetter('enableViewRecyclingForScrollView', false);
 /**
  * Enables View Recycling for <Text> via ReactTextView/ReactTextViewManager.
  */


### PR DESCRIPTION
Summary:
# Changelog
[Internal] -

This enables view recycling for both ScrollView and HorizontalScrollView on Android.

The feature is gated by the corresponding RN feature flag, `enableViewRecyclingForScrollView` (which is false by default for now, will be enabled in an experiment).

Differential Revision: D80611087
