### PR TITLE
Delete unused `DefaultReactHost.getDefaultReactHost()` overload

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1863,10 +1863,8 @@ public class com/facebook/react/defaults/DefaultReactActivityDelegate : com/face
 public final class com/facebook/react/defaults/DefaultReactHost {
 	public static final field INSTANCE Lcom/facebook/react/defaults/DefaultReactHost;
 	public static final fun getDefaultReactHost (Landroid/content/Context;Lcom/facebook/react/ReactNativeHost;Lcom/facebook/react/runtime/JSRuntimeFactory;)Lcom/facebook/react/ReactHost;
-	public static final fun getDefaultReactHost (Landroid/content/Context;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/facebook/react/runtime/JSRuntimeFactory;ZLjava/util/List;)Lcom/facebook/react/ReactHost;
 	public static final fun getDefaultReactHost (Landroid/content/Context;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/facebook/react/runtime/JSRuntimeFactory;ZLjava/util/List;Lkotlin/jvm/functions/Function1;Lcom/facebook/react/runtime/BindingsInstaller;)Lcom/facebook/react/ReactHost;
 	public static synthetic fun getDefaultReactHost$default (Landroid/content/Context;Lcom/facebook/react/ReactNativeHost;Lcom/facebook/react/runtime/JSRuntimeFactory;ILjava/lang/Object;)Lcom/facebook/react/ReactHost;
-	public static synthetic fun getDefaultReactHost$default (Landroid/content/Context;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/facebook/react/runtime/JSRuntimeFactory;ZLjava/util/List;ILjava/lang/Object;)Lcom/facebook/react/ReactHost;
 	public static synthetic fun getDefaultReactHost$default (Landroid/content/Context;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/facebook/react/runtime/JSRuntimeFactory;ZLjava/util/List;Lkotlin/jvm/functions/Function1;Lcom/facebook/react/runtime/BindingsInstaller;ILjava/lang/Object;)Lcom/facebook/react/ReactHost;
 }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHost.kt
@@ -51,50 +51,6 @@ public object DefaultReactHost {
    * @param useDevSupport whether to enable dev support, default to ReactBuildConfig.DEBUG.
    * @param cxxReactPackageProviders a list of cxxreactpackage providers (to register c++ turbo
    *   modules)
-   *
-   * TODO(T186951312): Should this be @UnstableReactNativeAPI?
-   */
-  @OptIn(UnstableReactNativeAPI::class)
-  @JvmStatic
-  public fun getDefaultReactHost(
-      context: Context,
-      packageList: List<ReactPackage>,
-      jsMainModulePath: String = "index",
-      jsBundleAssetPath: String = "index",
-      jsBundleFilePath: String? = null,
-      jsRuntimeFactory: JSRuntimeFactory? = null,
-      useDevSupport: Boolean = ReactBuildConfig.DEBUG,
-      cxxReactPackageProviders: List<(ReactContext) -> CxxReactPackage> = emptyList(),
-  ): ReactHost =
-      getDefaultReactHost(
-          context,
-          packageList,
-          jsMainModulePath,
-          jsBundleAssetPath,
-          jsBundleFilePath,
-          jsRuntimeFactory,
-          useDevSupport,
-          cxxReactPackageProviders,
-          { throw it },
-          null,
-      )
-
-  /**
-   * Util function to create a default [ReactHost] to be used in your application. This method is
-   * used by the New App template.
-   *
-   * @param context the Android [Context] to use for creating the [ReactHost]
-   * @param packageList the list of [ReactPackage]s to use for creating the [ReactHost]
-   * @param jsMainModulePath the path to your app's main module on Metro. Usually `index` or
-   *   `index.<platform>`
-   * @param jsBundleAssetPath the path to the JS bundle relative to the assets directory. Will be
-   *   composed in a `asset://...` URL
-   * @param jsBundleFilePath the path to the JS bundle on the filesystem. Will be composed in a
-   *   `file://...` URL
-   * @param jsRuntimeFactory the JS engine to use for executing [ReactHost], default to Hermes.
-   * @param useDevSupport whether to enable dev support, default to ReactBuildConfig.DEBUG.
-   * @param cxxReactPackageProviders a list of cxxreactpackage providers (to register c++ turbo
-   *   modules)
    * @param exceptionHandler Callback that can be used by React Native host applications to react to
    *   exceptions thrown by the internals of React Native.
    * @param bindingsInstaller that can be used for installing bindings.


### PR DESCRIPTION
Summary:
This overload for `getDefaultReactHost` is missing the last 2 parameters
and provides the same default as the full method.

In OSS is unused as we used the one with `ReactNativeHost`.
I'm removing it as it's causing an overload resolution failure internally.

This won't be a breaking change for Kotlin users are the signatures are compatibles,
but it will be breaking for Java users. I've verified that there are no OSS users.

Developers should use Kotlin default parameters + the method `getDefaultReactHost()`
with all the params + defaults for ease of use of this API.

Changelog:
[Android] [Removed] - Delete unused `DefaultReactHost.getDefaultReactHost()` overload

Differential Revision: D80704987
