### PR TITLE
HelloWorld should not use ReactNativeHost

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1863,10 +1863,8 @@ public class com/facebook/react/defaults/DefaultReactActivityDelegate : com/face
 public final class com/facebook/react/defaults/DefaultReactHost {
 	public static final field INSTANCE Lcom/facebook/react/defaults/DefaultReactHost;
 	public static final fun getDefaultReactHost (Landroid/content/Context;Lcom/facebook/react/ReactNativeHost;Lcom/facebook/react/runtime/JSRuntimeFactory;)Lcom/facebook/react/ReactHost;
-	public static final fun getDefaultReactHost (Landroid/content/Context;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/facebook/react/runtime/JSRuntimeFactory;ZLjava/util/List;)Lcom/facebook/react/ReactHost;
 	public static final fun getDefaultReactHost (Landroid/content/Context;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/facebook/react/runtime/JSRuntimeFactory;ZLjava/util/List;Lkotlin/jvm/functions/Function1;Lcom/facebook/react/runtime/BindingsInstaller;)Lcom/facebook/react/ReactHost;
 	public static synthetic fun getDefaultReactHost$default (Landroid/content/Context;Lcom/facebook/react/ReactNativeHost;Lcom/facebook/react/runtime/JSRuntimeFactory;ILjava/lang/Object;)Lcom/facebook/react/ReactHost;
-	public static synthetic fun getDefaultReactHost$default (Landroid/content/Context;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/facebook/react/runtime/JSRuntimeFactory;ZLjava/util/List;ILjava/lang/Object;)Lcom/facebook/react/ReactHost;
 	public static synthetic fun getDefaultReactHost$default (Landroid/content/Context;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/facebook/react/runtime/JSRuntimeFactory;ZLjava/util/List;Lkotlin/jvm/functions/Function1;Lcom/facebook/react/runtime/BindingsInstaller;ILjava/lang/Object;)Lcom/facebook/react/ReactHost;
 }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHost.kt
@@ -51,50 +51,6 @@ public object DefaultReactHost {
    * @param useDevSupport whether to enable dev support, default to ReactBuildConfig.DEBUG.
    * @param cxxReactPackageProviders a list of cxxreactpackage providers (to register c++ turbo
    *   modules)
-   *
-   * TODO(T186951312): Should this be @UnstableReactNativeAPI?
-   */
-  @OptIn(UnstableReactNativeAPI::class)
-  @JvmStatic
-  public fun getDefaultReactHost(
-      context: Context,
-      packageList: List<ReactPackage>,
-      jsMainModulePath: String = "index",
-      jsBundleAssetPath: String = "index",
-      jsBundleFilePath: String? = null,
-      jsRuntimeFactory: JSRuntimeFactory? = null,
-      useDevSupport: Boolean = ReactBuildConfig.DEBUG,
-      cxxReactPackageProviders: List<(ReactContext) -> CxxReactPackage> = emptyList(),
-  ): ReactHost =
-      getDefaultReactHost(
-          context,
-          packageList,
-          jsMainModulePath,
-          jsBundleAssetPath,
-          jsBundleFilePath,
-          jsRuntimeFactory,
-          useDevSupport,
-          cxxReactPackageProviders,
-          { throw it },
-          null,
-      )
-
-  /**
-   * Util function to create a default [ReactHost] to be used in your application. This method is
-   * used by the New App template.
-   *
-   * @param context the Android [Context] to use for creating the [ReactHost]
-   * @param packageList the list of [ReactPackage]s to use for creating the [ReactHost]
-   * @param jsMainModulePath the path to your app's main module on Metro. Usually `index` or
-   *   `index.<platform>`
-   * @param jsBundleAssetPath the path to the JS bundle relative to the assets directory. Will be
-   *   composed in a `asset://...` URL
-   * @param jsBundleFilePath the path to the JS bundle on the filesystem. Will be composed in a
-   *   `file://...` URL
-   * @param jsRuntimeFactory the JS engine to use for executing [ReactHost], default to Hermes.
-   * @param useDevSupport whether to enable dev support, default to ReactBuildConfig.DEBUG.
-   * @param cxxReactPackageProviders a list of cxxreactpackage providers (to register c++ turbo
-   *   modules)
    * @param exceptionHandler Callback that can be used by React Native host applications to react to
    *   exceptions thrown by the internals of React Native.
    * @param bindingsInstaller that can be used for installing bindings.

--- a/private/helloworld/android/app/src/main/java/com/helloworld/MainApplication.kt
+++ b/private/helloworld/android/app/src/main/java/com/helloworld/MainApplication.kt
@@ -12,28 +12,21 @@ import com.facebook.react.PackageList
 import com.facebook.react.ReactApplication
 import com.facebook.react.ReactHost
 import com.facebook.react.ReactNativeApplicationEntryPoint.loadReactNative
-import com.facebook.react.ReactNativeHost
-import com.facebook.react.ReactPackage
 import com.facebook.react.defaults.DefaultReactHost.getDefaultReactHost
-import com.facebook.react.defaults.DefaultReactNativeHost
 
 class MainApplication : Application(), ReactApplication {
 
-  override val reactNativeHost: ReactNativeHost =
-      object : DefaultReactNativeHost(this) {
-        override fun getPackages(): List<ReactPackage> =
-            PackageList(this).packages.apply {
-              // Packages that cannot be autolinked yet can be added manually here, for example:
-              // add(MyReactNativePackage())
-            }
-
-        override fun getJSMainModuleName(): String = "index"
-
-        override fun getUseDeveloperSupport(): Boolean = BuildConfig.DEBUG
+  override val reactHost: ReactHost by
+      lazy(LazyThreadSafetyMode.NONE) {
+        getDefaultReactHost(
+            context = applicationContext,
+            packageList =
+                PackageList(this).packages.apply {
+                  // Packages that cannot be autolinked yet can be added manually here, for example:
+                  // add(MyReactNativePackage())
+                },
+        )
       }
-
-  override val reactHost: ReactHost
-    get() = getDefaultReactHost(applicationContext, reactNativeHost)
 
   override fun onCreate() {
     super.onCreate()


### PR DESCRIPTION
Summary:
We currently create application template that are still using `ReactNativeHost`.
As this is a legacy arch class, we should remove it from the template ASAP so that
users can organically migrate away from it.

I will also update https://github.com/react-native-community/template with
the same changes I'm applying here.

Changelog:
[Internal] [Changed] -

Differential Revision: D80708461


