### PR TITLE
Fix incorrectly hardcoded landingView for open debugger action

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.kt
@@ -927,7 +927,7 @@ public abstract class DevSupportManagerBase(
     devServerHelper.openDebugger(
         currentReactContext,
         applicationContext.getString(R.string.catalyst_open_debugger_error),
-        ChromeDevToolsViewKeys.Performance.value,
+        null,
     )
   }
 


### PR DESCRIPTION
Summary:
In D79329081, we accidentally hardcoded the `landingView` parameter in the default Dev Menu handler to open React Native DevTools. Reset this.

Changelog: [Internal]

Differential Revision: D80710487


