### PR TITLE
Make OnBatchCompleteListener interface internal

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1018,10 +1018,6 @@ public abstract interface class com/facebook/react/bridge/NotThreadSafeBridgeIdl
 	public abstract fun onTransitionToBridgeIdle ()V
 }
 
-public abstract interface class com/facebook/react/bridge/OnBatchCompleteListener {
-	public abstract fun onBatchComplete ()V
-}
-
 public abstract interface class com/facebook/react/bridge/PerformanceCounter {
 	public abstract fun getPerformanceCounters ()Ljava/util/Map;
 	public abstract fun profileNextBatch ()V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/OnBatchCompleteListener.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/OnBatchCompleteListener.kt
@@ -16,6 +16,6 @@ import com.facebook.react.common.annotations.internal.LegacyArchitectureLogLevel
     message = "This class is part of Legacy Architecture and will be removed in a future release",
     level = DeprecationLevel.WARNING,
 )
-public fun interface OnBatchCompleteListener {
-  public fun onBatchComplete()
+internal fun interface OnBatchCompleteListener {
+  fun onBatchComplete()
 }


### PR DESCRIPTION
Summary:
This interface is public and is part of Legacy Architecture.

Having this interface as `public` was a mistake, as users can't really do much with it.
There is only one old library that is going to be affected by this change:
https://github.com/spoke-ph/react-native-threads
The library appears unmaintained since RN 0.69 + no NewArch support so I won't consider this a breaking change
given this will land in 0.82.

I'm making it internal so we can remove it more easily later.

Changelog:
[Android] [Changed] - Make OnBatchCompleteListener interface internal

Differential Revision: D80715625


