### PR TITLE
Add support for JS coverage

### DIFF
--- a/private/react-native-fantom/config/metro-babel-transformer.flow.js
+++ b/private/react-native-fantom/config/metro-babel-transformer.flow.js
@@ -26,6 +26,24 @@ const transform: BabelTransformer['transform'] = (
       ...(args.plugins ?? []),
       // $FlowExpectedError[untyped-import]
       require('./babel-plugins/inject-debugger-statements-in-tests'),
+      ...(args.options.customTransformOptions?.collectCoverage === 'true'
+        ? [
+            [
+              require.resolve('babel-plugin-istanbul'),
+              {
+                include: [
+                  'packages/react-native/Libraries/**/*.js',
+                  'packages/react-native/src/**/*.js',
+                  'packages/virtualized-lists/**/*.js',
+                ],
+                exclude: [
+                  'packages/react-native/Libraries/Renderer/**',
+                  '**/__tests__/**',
+                ],
+              },
+            ],
+          ]
+        : []),
     ],
   };
   return MetroBabelTransformer.transform(processedArgs);

--- a/private/react-native-fantom/runner/bundling.js
+++ b/private/react-native-fantom/runner/bundling.js
@@ -15,6 +15,9 @@ import path from 'path';
 
 type BundleOptions = {
   ...RunBuildOptions,
+  customTransformOptions: ?{
+    collectCoverage: boolean,
+  },
   out: $NonMaybeType<RunBuildOptions['out']>,
   testPath: string,
 };
@@ -94,6 +97,7 @@ function getBundleBaseURL({
   dev,
   sourceMap,
   sourceMapUrl,
+  customTransformOptions,
 }: BundleOptions): URL {
   const requestPath = path.relative(PROJECT_ROOT, entry).replace(/\.js$/, '');
   const port = getMetroPort();
@@ -118,6 +122,10 @@ function getBundleBaseURL({
 
   if (sourceMapUrl != null) {
     baseURL.searchParams.append('sourceMapUrl', sourceMapUrl);
+  }
+
+  if (customTransformOptions?.collectCoverage) {
+    baseURL.searchParams.append('transform.collectCoverage', 'true');
   }
 
   return baseURL;

--- a/private/react-native-fantom/runner/global-setup/build.js
+++ b/private/react-native-fantom/runner/global-setup/build.js
@@ -78,6 +78,7 @@ async function warmUpMetro(isOptimizedMode: boolean): Promise<void> {
     platform: 'android',
     minify: isOptimizedMode,
     dev: !isOptimizedMode,
+    customTransformOptions: undefined,
   });
 
   try {

--- a/private/react-native-fantom/runtime/setup.js
+++ b/private/react-native-fantom/runtime/setup.js
@@ -36,9 +36,12 @@ export type FailureDetail = {
   cause?: FailureDetail,
 };
 
+export opaque type CoverageMap = mixed;
+
 export type TestSuiteResult =
   | {
       testResults: Array<TestCaseResult>,
+      coverageMap?: CoverageMap,
     }
   | {
       error: FailureDetail,
@@ -465,6 +468,7 @@ global.$$RunTests$$ = () => {
   } else {
     reportTestSuiteResult({
       testResults: runTest(),
+      coverageMap: global.__coverage__,
     });
   }
 };


### PR DESCRIPTION
Summary:
Changelog: [Internal]
Adding babel-istanbul-plugin to instrument bundle code with coverage reporting.
Metro will transform source code only when coverage flag is set up globally in jest.
Coverage map is then provided by runner as part of test result.

Differential Revision: D80716433
