### PR TITLE
fix: use ThreadId when event is captured, not when transformed

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
@@ -190,6 +190,7 @@ void PerformanceTracer::reportTimeStamp(
       .trackName = std::move(trackName),
       .trackGroup = std::move(trackGroup),
       .color = std::move(color),
+      .threadId = getCurrentThreadId(),
   });
 }
 
@@ -399,7 +400,7 @@ void PerformanceTracer::enqueueTraceEventsFromPerformanceTracerEvent(
                 .ph = 'X',
                 .ts = event.start,
                 .pid = processId_,
-                .tid = getCurrentThreadId(),
+                .tid = event.threadId,
                 .dur = event.end - event.start,
             });
           },
@@ -410,7 +411,7 @@ void PerformanceTracer::enqueueTraceEventsFromPerformanceTracerEvent(
                 .ph = 'X',
                 .ts = event.start,
                 .pid = processId_,
-                .tid = getCurrentThreadId(),
+                .tid = event.threadId,
                 .dur = event.end - event.start,
             });
           },
@@ -429,7 +430,7 @@ void PerformanceTracer::enqueueTraceEventsFromPerformanceTracerEvent(
                 .ph = 'I',
                 .ts = event.start,
                 .pid = processId_,
-                .tid = getCurrentThreadId(),
+                .tid = event.threadId,
                 .args = std::move(eventArgs),
             });
           },
@@ -449,7 +450,7 @@ void PerformanceTracer::enqueueTraceEventsFromPerformanceTracerEvent(
                 .ph = 'b',
                 .ts = event.start,
                 .pid = processId_,
-                .tid = getCurrentThreadId(),
+                .tid = event.threadId,
                 .args = std::move(beginEventArgs),
             });
             events.emplace_back(TraceEvent{
@@ -459,7 +460,7 @@ void PerformanceTracer::enqueueTraceEventsFromPerformanceTracerEvent(
                 .ph = 'e',
                 .ts = event.start + event.duration,
                 .pid = processId_,
-                .tid = getCurrentThreadId(),
+                .tid = event.threadId,
             });
           },
           [&](PerformanceTracerEventTimeStamp&& event) {
@@ -500,7 +501,7 @@ void PerformanceTracer::enqueueTraceEventsFromPerformanceTracerEvent(
                 .ph = 'I',
                 .ts = event.createdAt,
                 .pid = processId_,
-                .tid = getCurrentThreadId(),
+                .tid = event.threadId,
                 .args = folly::dynamic::object("data", std::move(data)),
             });
           },


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

This regressed after D80263154, when we introduced a local struct for PerforamanceTracerEvent.

We should use id of the thread where event was captured (registered), not where the transform to TraceEvent happened.

This makes sure that events like Event Loop tick or Microtasks phase tick are correctly point to JavaScript thread, not the thread where the transform could've taken place.

Differential Revision: D80728931


