### PR TITLE
Disable batch operations debounce under feature flag

### DIFF
--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -797,6 +797,17 @@ const definitions: FeatureFlagDefinitions = {
       },
       ossReleaseStage: 'none',
     },
+    cxxAnimatedDebounceQueueFlushDisabled: {
+      defaultValue: false,
+      metadata: {
+        dateAdded: '2025-08-21',
+        description:
+          'Disable debounce queue flush if C++ Native Animated is enabled.',
+        expectedReleaseValue: true,
+        purpose: 'experimentation',
+      },
+      ossReleaseStage: 'none',
+    },
     deferFlatListFocusChangeRenderUpdate: {
       defaultValue: false,
       metadata: {

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<825b92d137ed3253e0badd0696605882>>
+ * @generated SignedSource<<8c13ccfed8750e3a8d5259e4b8ce3021>>
  * @flow strict
  * @noformat
  */
@@ -31,6 +31,7 @@ export type ReactNativeFeatureFlagsJsOnly = $ReadOnly<{
   jsOnlyTestFlag: Getter<boolean>,
   animatedShouldDebounceQueueFlush: Getter<boolean>,
   animatedShouldUseSingleOp: Getter<boolean>,
+  cxxAnimatedDebounceQueueFlushDisabled: Getter<boolean>,
   deferFlatListFocusChangeRenderUpdate: Getter<boolean>,
   enableAccessToHostTreeInFabric: Getter<boolean>,
   fixVirtualizeListCollapseWindowSize: Getter<boolean>,
@@ -131,6 +132,11 @@ export const animatedShouldDebounceQueueFlush: Getter<boolean> = createJavaScrip
  * Enables an experimental mega-operation for Animated.js that replaces many calls to native with a single call into native, to reduce JSI/JNI traffic.
  */
 export const animatedShouldUseSingleOp: Getter<boolean> = createJavaScriptFlagGetter('animatedShouldUseSingleOp', false);
+
+/**
+ * Disable debounce queue flush if C++ Native Animated is enabled.
+ */
+export const cxxAnimatedDebounceQueueFlushDisabled: Getter<boolean> = createJavaScriptFlagGetter('cxxAnimatedDebounceQueueFlushDisabled', false);
 
 /**
  * Use the deferred cell render update mechanism for focus change in FlatList.


### PR DESCRIPTION
Summary:
## Changelog:

[General] [Added] - Disable batch operations debounce under feature flag

With c++ animation, there's less the perf benefit from debouncing operations since the TM calls don't need to cross JNI anymore.
Debouncing schedules the call to NativeModule on microtasks queue instead of running it on js call stack, as a result these TM calls are delayed, and can cause some issues in edge case
* note that in NativeViewEvents, the registration operation runs immediately on js thread; but in Animated runtime, the TM call will again schedule this operation on main thread, which finally gets executed at next android vsync. So there's even more delay

Differential Revision: D80645373
