### PR TITLE
fix: use the first available locale to decide directionality on Android

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nUtil.kt
@@ -63,7 +63,7 @@ public class I18nUtil private constructor() {
   private val isDevicePreferredLanguageRTL: Boolean
     // Check if the current device language is RTL
     get() {
-      val directionality = TextUtilsCompat.getLayoutDirectionFromLocale(Locale.getDefault())
+      val directionality = TextUtilsCompat.getLayoutDirectionFromLocale(Locale.getAvailableLocales()[0])
       return directionality == View.LAYOUT_DIRECTION_RTL
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

On iOS, if the default locale is not supported in the app, it will fall back to the first available locale to decide if RTL layout should be enabled or not; however on Android, we use the default locale. So if the first locale is a RTL locale and not supported by the app on Android, the app will fall back to the first available locale which might not be RTL, but the layout would be decided as RTL according to the default locale.


## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID] [FIXED] - use the first available locale instead of the default one to decide `isDevicePreferredLanguageRTL`

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] [FIXED] - use the first available locale instead of the default one to decide `isDevicePreferredLanguageRTL`

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I set my phone's locale to this order: Hebrew, English and enabled RTL layout:
```
import { I18nManager } from 'react-native';

I18nManager.allowRTL(true);
I18nManager.swapLeftAndRightInRTL(true);
```

Prior to my PR, the app would use RTL layout with English on Android which doesn't make much sense (iOS is LTR + English). With my PR Android app will behave exactly the same as the iOS app.