### PR TITLE
Release PerfMetricsBinding to avoid memory leak

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
@@ -217,6 +217,11 @@ HostTarget::~HostTarget() {
   // HostCommandSender owns a session, so we must release it for the assertion
   // below to be valid.
   commandSender_.reset();
+
+  // HostRuntimeBinding owns a connection, so we must release it for the
+  // assertion
+  perfMetricsBinding_.reset();
+
   // Sessions are owned by InspectorPackagerConnection, not by HostTarget, but
   // they hold a HostTarget& that we must guarantee is valid.
   assert(


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

HostRuntimeBinding owns a connection, which is stored as a session on HostTarget, so we need to release it first in order to satifsy the assertion in the destructor.

Differential Revision: D80778273


