### PR TITLE
Implement PerformanceObserver.takeRecords()

### DIFF
--- a/packages/react-native/flow/bom.js.flow
+++ b/packages/react-native/flow/bom.js.flow
@@ -88,11 +88,168 @@ declare var navigator: Navigator;
 // https://developer.mozilla.org/en-US/docs/Web/API/DOMHighResTimeStamp
 declare type DOMHighResTimeStamp = number;
 
+type PerformanceEntryFilterOptions = {
+  entryType: string,
+  name: string,
+  ...
+};
+
+// https://www.w3.org/TR/performance-timeline-2/
+declare class PerformanceEntry {
+  duration: DOMHighResTimeStamp;
+  entryType: string;
+  name: string;
+  startTime: DOMHighResTimeStamp;
+  toJSON(): string;
+}
+
+// https://w3c.github.io/user-timing/#performancemark
+declare class PerformanceMark extends PerformanceEntry {
+  constructor(name: string, markOptions?: PerformanceMarkOptions): void;
+  +detail: mixed;
+}
+
+// https://w3c.github.io/user-timing/#performancemeasure
+declare class PerformanceMeasure extends PerformanceEntry {
+  +detail: mixed;
+}
+
+// https://w3c.github.io/server-timing/#the-performanceservertiming-interface
+declare class PerformanceServerTiming {
+  description: string;
+  duration: DOMHighResTimeStamp;
+  name: string;
+  toJSON(): string;
+}
+
+// https://www.w3.org/TR/resource-timing-2/#sec-performanceresourcetiming
+// https://w3c.github.io/server-timing/#extension-to-the-performanceresourcetiming-interface
+declare class PerformanceResourceTiming extends PerformanceEntry {
+  connectEnd: number;
+  connectStart: number;
+  decodedBodySize: number;
+  domainLookupEnd: number;
+  domainLookupStart: number;
+  encodedBodySize: number;
+  fetchStart: number;
+  initiatorType: string;
+  nextHopProtocol: string;
+  redirectEnd: number;
+  redirectStart: number;
+  requestStart: number;
+  responseEnd: number;
+  responseStart: number;
+  secureConnectionStart: number;
+  serverTiming: Array<PerformanceServerTiming>;
+  transferSize: number;
+  workerStart: number;
+}
+
+// https://w3c.github.io/event-timing/#sec-performance-event-timing
+declare class PerformanceEventTiming extends PerformanceEntry {
+  cancelable: boolean;
+  interactionId: number;
+  processingEnd: number;
+  processingStart: number;
+  target: ?Node;
+}
+
+// https://w3c.github.io/longtasks/#taskattributiontiming
+declare class TaskAttributionTiming extends PerformanceEntry {
+  containerId: string;
+  containerName: string;
+  containerSrc: string;
+  containerType: string;
+}
+
+// https://w3c.github.io/longtasks/#sec-PerformanceLongTaskTiming
+declare class PerformanceLongTaskTiming extends PerformanceEntry {
+  attribution: $ReadOnlyArray<TaskAttributionTiming>;
+}
+
+// https://www.w3.org/TR/user-timing/#extensions-performance-interface
+declare type PerformanceMarkOptions = {
+  detail?: mixed,
+  startTime?: number,
+};
+
+declare type PerformanceMeasureOptions = {
+  detail?: mixed,
+  duration?: number,
+  end?: number | string,
+  start?: number | string,
+};
+
+type EventCountsForEachCallbackType =
+  | (() => void)
+  | ((value: number) => void)
+  | ((value: number, key: string) => void)
+  | ((value: number, key: string, map: Map<string, number>) => void);
+
+// https://www.w3.org/TR/event-timing/#eventcounts
+declare interface EventCounts {
+  entries(): Iterator<[string, number]>;
+
+  forEach(callback: EventCountsForEachCallbackType): void;
+  get(key: string): ?number;
+  has(key: string): boolean;
+  keys(): Iterator<string>;
+  size: number;
+  values(): Iterator<number>;
+}
+
 declare class Performance {
+  clearMarks(name?: string): void;
+
+  clearMeasures(name?: string): void;
+
+  eventCounts: EventCounts;
+  getEntries: (
+    options?: PerformanceEntryFilterOptions,
+  ) => Array<PerformanceEntry>;
+  getEntriesByName: (name: string, type?: string) => Array<PerformanceEntry>;
+  getEntriesByType: (type: string) => Array<PerformanceEntry>;
+  mark(name: string, options?: PerformanceMarkOptions): PerformanceMark;
+  measure(
+    name: string,
+    startMarkOrOptions?: string | PerformanceMeasureOptions,
+    endMark?: string,
+  ): PerformanceMeasure;
   now: () => DOMHighResTimeStamp;
+  toJSON(): string;
 }
 
 declare var performance: Performance;
+
+type PerformanceEntryList = Array<PerformanceEntry>;
+
+declare interface PerformanceObserverEntryList {
+  getEntries(): PerformanceEntryList;
+  getEntriesByName(name: string, type: ?string): PerformanceEntryList;
+  getEntriesByType(type: string): PerformanceEntryList;
+}
+
+type PerformanceObserverInit = {
+  buffered?: boolean,
+  entryTypes?: Array<string>,
+  type?: string,
+  ...
+};
+
+declare class PerformanceObserver {
+  constructor(
+    callback: (
+      entries: PerformanceObserverEntryList,
+      observer: PerformanceObserver,
+    ) => mixed,
+  ): void;
+
+  disconnect(): void;
+  observe(options: ?PerformanceObserverInit): void;
+  static supportedEntryTypes: Array<string>;
+
+  takeRecords(): PerformanceEntryList;
+}
 
 type FormDataEntryValue = string | File;
 

--- a/packages/react-native/src/private/webapis/performance/PerformanceObserver.js
+++ b/packages/react-native/src/private/webapis/performance/PerformanceObserver.js
@@ -145,6 +145,22 @@ export class PerformanceObserver {
     NativePerformance.disconnect(this.#nativeObserverHandle);
   }
 
+  takeRecords(): PerformanceEntryList {
+    let entries: PerformanceEntryList = [];
+
+    if (this.#nativeObserverHandle != null) {
+      const rawEntries = NativePerformance.takeRecords(
+        this.#nativeObserverHandle,
+        true,
+      );
+      if (rawEntries && rawEntries.length > 0) {
+        entries = rawEntries.map(rawToPerformanceEntry);
+      }
+    }
+
+    return entries;
+  }
+
   #createNativeObserver(): OpaqueNativeObserverHandle | null {
     this.#calledAtLeastOnce = false;
 
@@ -154,7 +170,7 @@ export class PerformanceObserver {
           observerHandle,
           true, // sort records
         );
-        if (!rawEntries) {
+        if (!rawEntries || rawEntries.length === 0) {
           return;
         }
 

--- a/packages/react-native/src/private/webapis/performance/__tests__/EventTimingAPI-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/EventTimingAPI-itest.js
@@ -10,23 +10,16 @@
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
-import type Performance from 'react-native/src/private/webapis/performance/Performance';
-import type {PerformanceObserverEntryList} from 'react-native/src/private/webapis/performance/PerformanceObserver';
-
 import MaybeNativePerformance from '../specs/NativePerformance';
 import * as Fantom from '@react-native/fantom';
 import nullthrows from 'nullthrows';
 import {useState} from 'react';
 import {Text, View} from 'react-native';
 import setUpPerformanceObserver from 'react-native/src/private/setup/setUpPerformanceObserver';
-import {PerformanceEventTiming} from 'react-native/src/private/webapis/performance/EventTiming';
-import {PerformanceObserver} from 'react-native/src/private/webapis/performance/PerformanceObserver';
 
 const NativePerformance = nullthrows(MaybeNativePerformance);
 
 setUpPerformanceObserver();
-
-declare var performance: Performance;
 
 function sleep(ms: number) {
   const end = performance.now() + ms;

--- a/packages/react-native/src/private/webapis/performance/__tests__/LongTasksAPI-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/LongTasksAPI-itest.js
@@ -10,15 +10,10 @@
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
-import type {
-  PerformanceObserverCallbackOptions,
-  PerformanceObserverEntryList,
-} from 'react-native/src/private/webapis/performance/PerformanceObserver';
+import type {PerformanceObserverCallbackOptions} from '../PerformanceObserver';
 
 import * as Fantom from '@react-native/fantom';
 import setUpPerformanceObserver from 'react-native/src/private/setup/setUpPerformanceObserver';
-import {PerformanceLongTaskTiming} from 'react-native/src/private/webapis/performance/LongTasks';
-import {PerformanceObserver} from 'react-native/src/private/webapis/performance/PerformanceObserver';
 
 setUpPerformanceObserver();
 

--- a/packages/react-native/src/private/webapis/performance/__tests__/Performance-benchmark-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/Performance-benchmark-itest.js
@@ -10,11 +10,7 @@
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
-import type Performance from 'react-native/src/private/webapis/performance/Performance';
-
 import * as Fantom from '@react-native/fantom';
-
-declare var performance: Performance;
 
 const clearMarksAndMeasures = () => {
   performance.clearMarks();

--- a/packages/react-native/src/private/webapis/performance/__tests__/PerformanceObserver-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/PerformanceObserver-itest.js
@@ -97,4 +97,24 @@ describe('PerformanceObserver', () => {
     expect(entries1.getEntries()[1]).toBe(measure);
     expect(entries2.getEntries()[1]).toBe(measure);
   });
+
+  describe('takeRecords()', () => {
+    it('provides all buffered events and clears the buffer', () => {
+      const callback = jest.fn();
+      const observer = new PerformanceObserver(callback);
+      observer.observe({entryTypes: ['mark']});
+
+      Fantom.runTask(() => {
+        const entry = performance.mark('mark1');
+
+        const entries = observer.takeRecords();
+        expect(entries.length).toBe(1);
+        // This is not supported yet
+        // expect(entries[0]).toBe(entry);
+        expect(entries[0]).toEqual(entry);
+      });
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/react-native/src/private/webapis/performance/__tests__/PerformanceObserver-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/PerformanceObserver-itest.js
@@ -10,19 +10,10 @@
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
-import type Performance from '../Performance';
-import type {
-  PerformanceObserver as PerformanceObserverT,
-  PerformanceObserverEntryList,
-} from '../PerformanceObserver';
-
 import setUpPerformanceObserver from '../../../setup/setUpPerformanceObserver';
 import * as Fantom from '@react-native/fantom';
 
 setUpPerformanceObserver();
-
-declare var performance: Performance;
-declare var PerformanceObserver: Class<PerformanceObserverT>;
 
 describe('PerformanceObserver', () => {
   it('receives notifications for marks and measures', () => {

--- a/packages/react-native/src/private/webapis/performance/__tests__/UserTiming-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/UserTiming-itest.js
@@ -10,18 +10,12 @@
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
-import type Performance from '../Performance';
-import type {
-  PerformanceEntryJSON,
-  PerformanceEntryList,
-} from '../PerformanceEntry';
-
 import ensureInstance from '../../../__tests__/utilities/ensureInstance';
+import setUpPerformanceObserver from '../../../setup/setUpPerformanceObserver';
 import DOMException from '../../errors/DOMException';
-import {PerformanceMark, PerformanceMeasure} from '../UserTiming';
 import * as Fantom from '@react-native/fantom';
 
-declare var performance: Performance;
+setUpPerformanceObserver();
 
 function getThrownError(fn: () => mixed): mixed {
   try {
@@ -32,7 +26,7 @@ function getThrownError(fn: () => mixed): mixed {
   throw new Error('Expected function to throw');
 }
 
-function toJSON(entries: PerformanceEntryList): Array<PerformanceEntryJSON> {
+function toJSON(entries: PerformanceEntryList): Array<mixed> {
   return entries.map(entry => entry.toJSON());
 }
 


### PR DESCRIPTION
Summary:
Changelog: [internal]

This is the last method in `PerformanceObserver` to implement. For some reason we never added it, even though it was trivial.

Differential Revision: D80717237


