### PR TITLE
Refactor PerformanceEntry and subclasses to use interfaces for initialization

### DIFF
--- a/packages/react-native/flow/bom.js.flow
+++ b/packages/react-native/flow/bom.js.flow
@@ -88,11 +88,168 @@ declare var navigator: Navigator;
 // https://developer.mozilla.org/en-US/docs/Web/API/DOMHighResTimeStamp
 declare type DOMHighResTimeStamp = number;
 
+type PerformanceEntryFilterOptions = {
+  entryType: string,
+  name: string,
+  ...
+};
+
+// https://www.w3.org/TR/performance-timeline-2/
+declare class PerformanceEntry {
+  duration: DOMHighResTimeStamp;
+  entryType: string;
+  name: string;
+  startTime: DOMHighResTimeStamp;
+  toJSON(): string;
+}
+
+// https://w3c.github.io/user-timing/#performancemark
+declare class PerformanceMark extends PerformanceEntry {
+  constructor(name: string, markOptions?: PerformanceMarkOptions): void;
+  +detail: mixed;
+}
+
+// https://w3c.github.io/user-timing/#performancemeasure
+declare class PerformanceMeasure extends PerformanceEntry {
+  +detail: mixed;
+}
+
+// https://w3c.github.io/server-timing/#the-performanceservertiming-interface
+declare class PerformanceServerTiming {
+  description: string;
+  duration: DOMHighResTimeStamp;
+  name: string;
+  toJSON(): string;
+}
+
+// https://www.w3.org/TR/resource-timing-2/#sec-performanceresourcetiming
+// https://w3c.github.io/server-timing/#extension-to-the-performanceresourcetiming-interface
+declare class PerformanceResourceTiming extends PerformanceEntry {
+  connectEnd: number;
+  connectStart: number;
+  decodedBodySize: number;
+  domainLookupEnd: number;
+  domainLookupStart: number;
+  encodedBodySize: number;
+  fetchStart: number;
+  initiatorType: string;
+  nextHopProtocol: string;
+  redirectEnd: number;
+  redirectStart: number;
+  requestStart: number;
+  responseEnd: number;
+  responseStart: number;
+  secureConnectionStart: number;
+  serverTiming: Array<PerformanceServerTiming>;
+  transferSize: number;
+  workerStart: number;
+}
+
+// https://w3c.github.io/event-timing/#sec-performance-event-timing
+declare class PerformanceEventTiming extends PerformanceEntry {
+  cancelable: boolean;
+  interactionId: number;
+  processingEnd: number;
+  processingStart: number;
+  target: ?Node;
+}
+
+// https://w3c.github.io/longtasks/#taskattributiontiming
+declare class TaskAttributionTiming extends PerformanceEntry {
+  containerId: string;
+  containerName: string;
+  containerSrc: string;
+  containerType: string;
+}
+
+// https://w3c.github.io/longtasks/#sec-PerformanceLongTaskTiming
+declare class PerformanceLongTaskTiming extends PerformanceEntry {
+  attribution: $ReadOnlyArray<TaskAttributionTiming>;
+}
+
+// https://www.w3.org/TR/user-timing/#extensions-performance-interface
+declare type PerformanceMarkOptions = {
+  detail?: mixed,
+  startTime?: number,
+};
+
+declare type PerformanceMeasureOptions = {
+  detail?: mixed,
+  duration?: number,
+  end?: number | string,
+  start?: number | string,
+};
+
+type EventCountsForEachCallbackType =
+  | (() => void)
+  | ((value: number) => void)
+  | ((value: number, key: string) => void)
+  | ((value: number, key: string, map: Map<string, number>) => void);
+
+// https://www.w3.org/TR/event-timing/#eventcounts
+declare interface EventCounts {
+  entries(): Iterator<[string, number]>;
+
+  forEach(callback: EventCountsForEachCallbackType): void;
+  get(key: string): ?number;
+  has(key: string): boolean;
+  keys(): Iterator<string>;
+  size: number;
+  values(): Iterator<number>;
+}
+
 declare class Performance {
+  clearMarks(name?: string): void;
+
+  clearMeasures(name?: string): void;
+
+  eventCounts: EventCounts;
+  getEntries: (
+    options?: PerformanceEntryFilterOptions,
+  ) => Array<PerformanceEntry>;
+  getEntriesByName: (name: string, type?: string) => Array<PerformanceEntry>;
+  getEntriesByType: (type: string) => Array<PerformanceEntry>;
+  mark(name: string, options?: PerformanceMarkOptions): PerformanceMark;
+  measure(
+    name: string,
+    startMarkOrOptions?: string | PerformanceMeasureOptions,
+    endMark?: string,
+  ): PerformanceMeasure;
   now: () => DOMHighResTimeStamp;
+  toJSON(): string;
 }
 
 declare var performance: Performance;
+
+type PerformanceEntryList = Array<PerformanceEntry>;
+
+declare interface PerformanceObserverEntryList {
+  getEntries(): PerformanceEntryList;
+  getEntriesByName(name: string, type: ?string): PerformanceEntryList;
+  getEntriesByType(type: string): PerformanceEntryList;
+}
+
+type PerformanceObserverInit = {
+  buffered?: boolean,
+  entryTypes?: Array<string>,
+  type?: string,
+  ...
+};
+
+declare class PerformanceObserver {
+  constructor(
+    callback: (
+      entries: PerformanceObserverEntryList,
+      observer: PerformanceObserver,
+    ) => mixed,
+  ): void;
+
+  disconnect(): void;
+  observe(options: ?PerformanceObserverInit): void;
+  static supportedEntryTypes: Array<string>;
+
+  takeRecords(): PerformanceEntryList;
+}
 
 type FormDataEntryValue = string | File;
 

--- a/packages/react-native/src/private/webapis/performance/EventTiming.js
+++ b/packages/react-native/src/private/webapis/performance/EventTiming.js
@@ -9,9 +9,9 @@
  */
 
 // flowlint unsafe-getters-setters:off
-
 import type {
   DOMHighResTimeStamp,
+  PerformanceEntryInit,
   PerformanceEntryJSON,
 } from './PerformanceEntry';
 
@@ -29,25 +29,20 @@ export type PerformanceEventTimingJSON = {
   ...
 };
 
+export interface PerformanceEventTimingInit extends PerformanceEntryInit {
+  +processingStart?: DOMHighResTimeStamp;
+  +processingEnd?: DOMHighResTimeStamp;
+  +interactionId?: number;
+}
+
 export class PerformanceEventTiming extends PerformanceEntry {
   #processingStart: DOMHighResTimeStamp;
   #processingEnd: DOMHighResTimeStamp;
   #interactionId: number;
 
-  constructor(init: {
-    name: string,
-    startTime?: DOMHighResTimeStamp,
-    duration?: DOMHighResTimeStamp,
-    processingStart?: DOMHighResTimeStamp,
-    processingEnd?: DOMHighResTimeStamp,
-    interactionId?: number,
-  }) {
-    super({
-      name: init.name,
-      entryType: 'event',
-      startTime: init.startTime ?? 0,
-      duration: init.duration ?? 0,
-    });
+  constructor(init: PerformanceEventTimingInit) {
+    super('event', init);
+
     this.#processingStart = init.processingStart ?? 0;
     this.#processingEnd = init.processingEnd ?? 0;
     this.#interactionId = init.interactionId ?? 0;

--- a/packages/react-native/src/private/webapis/performance/LongTasks.js
+++ b/packages/react-native/src/private/webapis/performance/LongTasks.js
@@ -9,8 +9,10 @@
  */
 
 // flowlint unsafe-getters-setters:off
-
-import type {PerformanceEntryJSON} from './PerformanceEntry';
+import type {
+  PerformanceEntryInit,
+  PerformanceEntryJSON,
+} from './PerformanceEntry';
 
 import {PerformanceEntry} from './PerformanceEntry';
 
@@ -25,7 +27,13 @@ export class TaskAttributionTiming extends PerformanceEntry {}
 const EMPTY_ATTRIBUTION: $ReadOnlyArray<TaskAttributionTiming> =
   Object.preventExtensions([]);
 
+export interface PerformanceLongTaskTimingInit extends PerformanceEntryInit {}
+
 export class PerformanceLongTaskTiming extends PerformanceEntry {
+  constructor(init: PerformanceEntryInit) {
+    super('longtask', init);
+  }
+
   get attribution(): $ReadOnlyArray<TaskAttributionTiming> {
     return EMPTY_ATTRIBUTION;
   }

--- a/packages/react-native/src/private/webapis/performance/Performance.js
+++ b/packages/react-native/src/private/webapis/performance/Performance.js
@@ -64,12 +64,13 @@ const cachedGetMarkTime = NativePerformance.getMarkTime;
 const cachedNativeClearMarks = NativePerformance.clearMarks;
 const cachedNativeClearMeasures = NativePerformance.clearMeasures;
 
-const MARK_OPTIONS_REUSABLE_OBJECT: {...PerformanceMarkOptions} = {
+const MARK_OPTIONS_REUSABLE_OBJECT: PerformanceMarkOptions = {
   startTime: 0,
   detail: undefined,
 };
 
-const MEASURE_OPTIONS_REUSABLE_OBJECT: {...PerformanceMeasureInit} = {
+const MEASURE_OPTIONS_REUSABLE_OBJECT: PerformanceMeasureInit = {
+  name: '',
   startTime: 0,
   duration: 0,
   detail: undefined,
@@ -189,7 +190,9 @@ export default class Performance {
       resolvedDetail = structuredClone(detail);
     }
 
+    // $FlowExpectedError[cannot-write]
     MARK_OPTIONS_REUSABLE_OBJECT.startTime = resolvedStartTime;
+    // $FlowExpectedError[cannot-write]
     MARK_OPTIONS_REUSABLE_OBJECT.detail = resolvedDetail;
 
     const entry = new PerformanceMark(
@@ -367,14 +370,16 @@ export default class Performance {
       }
     }
 
+    // $FlowExpectedError[cannot-write]
+    MEASURE_OPTIONS_REUSABLE_OBJECT.name = resolvedMeasureName;
+    // $FlowExpectedError[cannot-write]
     MEASURE_OPTIONS_REUSABLE_OBJECT.startTime = resolvedStartTime;
+    // $FlowExpectedError[cannot-write]
     MEASURE_OPTIONS_REUSABLE_OBJECT.duration = resolvedDuration;
+    // $FlowExpectedError[cannot-write]
     MEASURE_OPTIONS_REUSABLE_OBJECT.detail = resolvedDetail;
 
-    const entry = new PerformanceMeasure(
-      resolvedMeasureName,
-      MEASURE_OPTIONS_REUSABLE_OBJECT,
-    );
+    const entry = new PerformanceMeasure(MEASURE_OPTIONS_REUSABLE_OBJECT);
 
     cachedReportMeasure(
       resolvedMeasureName,

--- a/packages/react-native/src/private/webapis/performance/PerformanceEntry.js
+++ b/packages/react-native/src/private/webapis/performance/PerformanceEntry.js
@@ -28,24 +28,25 @@ export type PerformanceEntryJSON = {
   ...
 };
 
+export interface PerformanceEntryInit {
+  +name: string;
+  +startTime: DOMHighResTimeStamp;
+  +duration: DOMHighResTimeStamp;
+}
+
 export class PerformanceEntry {
   // We don't use private fields because they're significantly slower to
   // initialize on construction and to access.
   // We also need these to be protected so they can be initialized in subclasses
   // where we avoid calling `super()` for performance reasons.
-  __name: string;
   __entryType: PerformanceEntryType;
+  __name: string;
   __startTime: DOMHighResTimeStamp;
   __duration: DOMHighResTimeStamp;
 
-  constructor(init: {
-    name: string,
-    entryType: PerformanceEntryType,
-    startTime: DOMHighResTimeStamp,
-    duration: DOMHighResTimeStamp,
-  }) {
+  constructor(entryType: PerformanceEntryType, init: PerformanceEntryInit) {
+    this.__entryType = entryType;
     this.__name = init.name;
-    this.__entryType = init.entryType;
     this.__startTime = init.startTime;
     this.__duration = init.duration;
   }

--- a/packages/react-native/src/private/webapis/performance/PerformanceObserver.js
+++ b/packages/react-native/src/private/webapis/performance/PerformanceObserver.js
@@ -145,6 +145,22 @@ export class PerformanceObserver {
     NativePerformance.disconnect(this.#nativeObserverHandle);
   }
 
+  takeRecords(): PerformanceEntryList {
+    let entries: PerformanceEntryList = [];
+
+    if (this.#nativeObserverHandle != null) {
+      const rawEntries = NativePerformance.takeRecords(
+        this.#nativeObserverHandle,
+        true,
+      );
+      if (rawEntries && rawEntries.length > 0) {
+        entries = rawEntries.map(rawToPerformanceEntry);
+      }
+    }
+
+    return entries;
+  }
+
   #createNativeObserver(): OpaqueNativeObserverHandle | null {
     this.#calledAtLeastOnce = false;
 
@@ -154,7 +170,7 @@ export class PerformanceObserver {
           observerHandle,
           true, // sort records
         );
-        if (!rawEntries) {
+        if (!rawEntries || rawEntries.length === 0) {
           return;
         }
 

--- a/packages/react-native/src/private/webapis/performance/ResourceTiming.js
+++ b/packages/react-native/src/private/webapis/performance/ResourceTiming.js
@@ -29,6 +29,19 @@ export type PerformanceResourceTimingJSON = {
   ...
 };
 
+export interface PerformanceResourceTimingInit {
+  +name: string;
+  +startTime: DOMHighResTimeStamp;
+  +duration: DOMHighResTimeStamp;
+  +fetchStart: DOMHighResTimeStamp;
+  +requestStart: DOMHighResTimeStamp;
+  +connectStart: DOMHighResTimeStamp;
+  +connectEnd: DOMHighResTimeStamp;
+  +responseStart: DOMHighResTimeStamp;
+  +responseEnd: DOMHighResTimeStamp;
+  +responseStatus?: number;
+}
+
 export class PerformanceResourceTiming extends PerformanceEntry {
   #fetchStart: DOMHighResTimeStamp;
   #requestStart: DOMHighResTimeStamp;
@@ -38,24 +51,9 @@ export class PerformanceResourceTiming extends PerformanceEntry {
   #responseEnd: DOMHighResTimeStamp;
   #responseStatus: ?number;
 
-  constructor(init: {
-    name: string,
-    startTime: DOMHighResTimeStamp,
-    duration: DOMHighResTimeStamp,
-    fetchStart: DOMHighResTimeStamp,
-    requestStart: DOMHighResTimeStamp,
-    connectStart: DOMHighResTimeStamp,
-    connectEnd: DOMHighResTimeStamp,
-    responseStart: DOMHighResTimeStamp,
-    responseEnd: DOMHighResTimeStamp,
-    responseStatus?: number,
-  }) {
-    super({
-      name: init.name,
-      entryType: 'resource',
-      startTime: init.startTime,
-      duration: init.duration,
-    });
+  constructor(init: PerformanceResourceTimingInit) {
+    super('resource', init);
+
     this.#fetchStart = init.fetchStart;
     this.#requestStart = init.requestStart;
     this.#connectStart = init.connectStart;

--- a/packages/react-native/src/private/webapis/performance/UserTiming.js
+++ b/packages/react-native/src/private/webapis/performance/UserTiming.js
@@ -9,8 +9,10 @@
  */
 
 // flowlint unsafe-getters-setters:off
-
-import type {DOMHighResTimeStamp} from './PerformanceEntry';
+import type {
+  DOMHighResTimeStamp,
+  PerformanceEntryInit,
+} from './PerformanceEntry';
 import type {
   ExtensionMarkerPayload,
   ExtensionTrackEntryPayload,
@@ -25,18 +27,16 @@ export type DetailType =
   // but we'll use it as documentation for how to use the extensibility API.
   | {devtools?: ExtensionMarkerPayload | ExtensionTrackEntryPayload, ...};
 
-export type PerformanceMarkOptions = $ReadOnly<{
-  detail?: DetailType,
-  startTime?: DOMHighResTimeStamp,
-}>;
+export interface PerformanceMarkOptions {
+  +detail?: DetailType;
+  +startTime?: DOMHighResTimeStamp;
+}
 
 export type TimeStampOrName = DOMHighResTimeStamp | string;
 
-export type PerformanceMeasureInit = $ReadOnly<{
-  detail?: DetailType,
-  startTime: DOMHighResTimeStamp,
-  duration: DOMHighResTimeStamp,
-}>;
+export interface PerformanceMeasureInit extends PerformanceEntryInit {
+  +detail?: DetailType;
+}
 
 class PerformanceMarkTemplate extends PerformanceEntry {
   // We don't use private fields because they're significantly slower to
@@ -45,9 +45,8 @@ class PerformanceMarkTemplate extends PerformanceEntry {
 
   // This constructor isn't really used. See `PerformanceMark` below.
   constructor(markName: string, markOptions?: PerformanceMarkOptions) {
-    super({
+    super('mark', {
       name: markName,
-      entryType: 'mark',
       startTime: markOptions?.startTime ?? getCurrentTimeStamp(),
       duration: 0,
     });
@@ -72,8 +71,8 @@ export const PerformanceMark: typeof PerformanceMarkTemplate =
     markName: string,
     markOptions?: PerformanceMarkOptions,
   ) {
-    this.__name = markName;
     this.__entryType = 'mark';
+    this.__name = markName;
     this.__startTime = markOptions?.startTime ?? getCurrentTimeStamp();
     this.__duration = 0;
 
@@ -89,15 +88,10 @@ class PerformanceMeasureTemplate extends PerformanceEntry {
   __detail: DetailType;
 
   // This constructor isn't really used. See `PerformanceMeasure` below.
-  constructor(measureName: string, measureOptions: PerformanceMeasureInit) {
-    super({
-      name: measureName,
-      entryType: 'measure',
-      startTime: measureOptions.startTime,
-      duration: measureOptions.duration,
-    });
+  constructor(init: PerformanceMeasureInit) {
+    super('measure', init);
 
-    this.__detail = measureOptions?.detail ?? null;
+    this.__detail = init?.detail ?? null;
   }
 
   get detail(): DetailType {
@@ -110,15 +104,14 @@ export const PerformanceMeasure: typeof PerformanceMeasureTemplate =
   // $FlowExpectedError[incompatible-type]
   function PerformanceMeasure(
     this: PerformanceMeasureTemplate,
-    measureName: string,
-    measureOptions: PerformanceMeasureInit,
+    init: PerformanceMeasureInit,
   ) {
-    this.__name = measureName;
     this.__entryType = 'measure';
-    this.__startTime = measureOptions.startTime;
-    this.__duration = measureOptions.duration;
+    this.__name = init.name;
+    this.__startTime = init.startTime;
+    this.__duration = init.duration;
 
-    this.__detail = measureOptions.detail ?? null;
+    this.__detail = init.detail ?? null;
   };
 
 // $FlowExpectedError[prop-missing]

--- a/packages/react-native/src/private/webapis/performance/__tests__/EventTimingAPI-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/EventTimingAPI-itest.js
@@ -10,23 +10,16 @@
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
-import type Performance from 'react-native/src/private/webapis/performance/Performance';
-import type {PerformanceObserverEntryList} from 'react-native/src/private/webapis/performance/PerformanceObserver';
-
 import MaybeNativePerformance from '../specs/NativePerformance';
 import * as Fantom from '@react-native/fantom';
 import nullthrows from 'nullthrows';
 import {useState} from 'react';
 import {Text, View} from 'react-native';
 import setUpPerformanceObserver from 'react-native/src/private/setup/setUpPerformanceObserver';
-import {PerformanceEventTiming} from 'react-native/src/private/webapis/performance/EventTiming';
-import {PerformanceObserver} from 'react-native/src/private/webapis/performance/PerformanceObserver';
 
 const NativePerformance = nullthrows(MaybeNativePerformance);
 
 setUpPerformanceObserver();
-
-declare var performance: Performance;
 
 function sleep(ms: number) {
   const end = performance.now() + ms;

--- a/packages/react-native/src/private/webapis/performance/__tests__/LongTasksAPI-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/LongTasksAPI-itest.js
@@ -10,15 +10,10 @@
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
-import type {
-  PerformanceObserverCallbackOptions,
-  PerformanceObserverEntryList,
-} from 'react-native/src/private/webapis/performance/PerformanceObserver';
+import type {PerformanceObserverCallbackOptions} from '../PerformanceObserver';
 
 import * as Fantom from '@react-native/fantom';
 import setUpPerformanceObserver from 'react-native/src/private/setup/setUpPerformanceObserver';
-import {PerformanceLongTaskTiming} from 'react-native/src/private/webapis/performance/LongTasks';
-import {PerformanceObserver} from 'react-native/src/private/webapis/performance/PerformanceObserver';
 
 setUpPerformanceObserver();
 

--- a/packages/react-native/src/private/webapis/performance/__tests__/Performance-benchmark-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/Performance-benchmark-itest.js
@@ -10,11 +10,7 @@
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
-import type Performance from 'react-native/src/private/webapis/performance/Performance';
-
 import * as Fantom from '@react-native/fantom';
-
-declare var performance: Performance;
 
 const clearMarksAndMeasures = () => {
   performance.clearMarks();

--- a/packages/react-native/src/private/webapis/performance/__tests__/PerformanceObserver-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/PerformanceObserver-itest.js
@@ -97,4 +97,24 @@ describe('PerformanceObserver', () => {
     expect(entries1.getEntries()[1]).toBe(measure);
     expect(entries2.getEntries()[1]).toBe(measure);
   });
+
+  describe('takeRecords()', () => {
+    it('provides all buffered events and clears the buffer', () => {
+      const callback = jest.fn();
+      const observer = new PerformanceObserver(callback);
+      observer.observe({entryTypes: ['mark']});
+
+      Fantom.runTask(() => {
+        const entry = performance.mark('mark1');
+
+        const entries = observer.takeRecords();
+        expect(entries.length).toBe(1);
+        // This is not supported yet
+        // expect(entries[0]).toBe(entry);
+        expect(entries[0]).toEqual(entry);
+      });
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/react-native/src/private/webapis/performance/__tests__/PerformanceObserver-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/PerformanceObserver-itest.js
@@ -10,19 +10,10 @@
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
-import type Performance from '../Performance';
-import type {
-  PerformanceObserver as PerformanceObserverT,
-  PerformanceObserverEntryList,
-} from '../PerformanceObserver';
-
 import setUpPerformanceObserver from '../../../setup/setUpPerformanceObserver';
 import * as Fantom from '@react-native/fantom';
 
 setUpPerformanceObserver();
-
-declare var performance: Performance;
-declare var PerformanceObserver: Class<PerformanceObserverT>;
 
 describe('PerformanceObserver', () => {
   it('receives notifications for marks and measures', () => {

--- a/packages/react-native/src/private/webapis/performance/__tests__/UserTiming-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/UserTiming-itest.js
@@ -10,18 +10,12 @@
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
-import type Performance from '../Performance';
-import type {
-  PerformanceEntryJSON,
-  PerformanceEntryList,
-} from '../PerformanceEntry';
-
 import ensureInstance from '../../../__tests__/utilities/ensureInstance';
+import setUpPerformanceObserver from '../../../setup/setUpPerformanceObserver';
 import DOMException from '../../errors/DOMException';
-import {PerformanceMark, PerformanceMeasure} from '../UserTiming';
 import * as Fantom from '@react-native/fantom';
 
-declare var performance: Performance;
+setUpPerformanceObserver();
 
 function getThrownError(fn: () => mixed): mixed {
   try {
@@ -32,7 +26,7 @@ function getThrownError(fn: () => mixed): mixed {
   throw new Error('Expected function to throw');
 }
 
-function toJSON(entries: PerformanceEntryList): Array<PerformanceEntryJSON> {
+function toJSON(entries: PerformanceEntryList): Array<mixed> {
   return entries.map(entry => entry.toJSON());
 }
 

--- a/packages/react-native/src/private/webapis/performance/internals/RawPerformanceEntry.js
+++ b/packages/react-native/src/private/webapis/performance/internals/RawPerformanceEntry.js
@@ -44,7 +44,6 @@ export function rawToPerformanceEntry(
     case RawPerformanceEntryTypeValues.LONGTASK:
       return new PerformanceLongTaskTiming({
         name: entry.name,
-        entryType: rawToPerformanceEntryType(entry.entryType),
         startTime: entry.startTime,
         duration: entry.duration,
       });
@@ -53,7 +52,8 @@ export function rawToPerformanceEntry(
         startTime: entry.startTime,
       });
     case RawPerformanceEntryTypeValues.MEASURE:
-      return new PerformanceMeasure(entry.name, {
+      return new PerformanceMeasure({
+        name: entry.name,
         startTime: entry.startTime,
         duration: entry.duration,
       });
@@ -71,9 +71,8 @@ export function rawToPerformanceEntry(
         responseStatus: entry.responseStatus,
       });
     default:
-      return new PerformanceEntry({
+      return new PerformanceEntry(rawToPerformanceEntryType(entry.entryType), {
         name: entry.name,
-        entryType: rawToPerformanceEntryType(entry.entryType),
         startTime: entry.startTime,
         duration: entry.duration,
       });


### PR DESCRIPTION
Summary:
Changelog: [internal]

This is a refactor of the types in `PerformanceEntry` and subclasses to accept interfaces instead of objects. This allows us to pass down the init object from subclasses to the superclass without having to create intermediate objects.

Additionally, this is also more semantically correct, as existing APIs don't need those options to be own properties of the init object.

Existing benchmark for Performance doesn't show any significant impact.

Differential Revision: D80800075


