### PR TITLE
Set up modern performance APIs if the native module is available

### DIFF
--- a/packages/react-native/Libraries/Core/setUpPerformance.js
+++ b/packages/react-native/Libraries/Core/setUpPerformance.js
@@ -4,19 +4,17 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow strict
+ * @flow strict-local
  * @format
  */
 
+import setUpPerformanceModern from '../../src/private/setup/setUpPerformanceModern';
 import NativePerformance from '../../src/private/webapis/performance/specs/NativePerformance';
 
 // In case if the native implementation of the Performance API is available, use it,
 // otherwise fall back to the legacy/default one, which only defines 'Performance.now()'
 if (NativePerformance) {
-  const Performance =
-    require('../../src/private/webapis/performance/Performance').default;
-  // $FlowExpectedError[cannot-write]
-  global.performance = new Performance();
+  setUpPerformanceModern();
 } else {
   if (!global.performance) {
     // $FlowExpectedError[cannot-write]

--- a/packages/react-native/flow/bom.js.flow
+++ b/packages/react-native/flow/bom.js.flow
@@ -88,11 +88,168 @@ declare var navigator: Navigator;
 // https://developer.mozilla.org/en-US/docs/Web/API/DOMHighResTimeStamp
 declare type DOMHighResTimeStamp = number;
 
+type PerformanceEntryFilterOptions = {
+  entryType: string,
+  name: string,
+  ...
+};
+
+// https://www.w3.org/TR/performance-timeline-2/
+declare class PerformanceEntry {
+  duration: DOMHighResTimeStamp;
+  entryType: string;
+  name: string;
+  startTime: DOMHighResTimeStamp;
+  toJSON(): string;
+}
+
+// https://w3c.github.io/user-timing/#performancemark
+declare class PerformanceMark extends PerformanceEntry {
+  constructor(name: string, markOptions?: PerformanceMarkOptions): void;
+  +detail: mixed;
+}
+
+// https://w3c.github.io/user-timing/#performancemeasure
+declare class PerformanceMeasure extends PerformanceEntry {
+  +detail: mixed;
+}
+
+// https://w3c.github.io/server-timing/#the-performanceservertiming-interface
+declare class PerformanceServerTiming {
+  description: string;
+  duration: DOMHighResTimeStamp;
+  name: string;
+  toJSON(): string;
+}
+
+// https://www.w3.org/TR/resource-timing-2/#sec-performanceresourcetiming
+// https://w3c.github.io/server-timing/#extension-to-the-performanceresourcetiming-interface
+declare class PerformanceResourceTiming extends PerformanceEntry {
+  connectEnd: number;
+  connectStart: number;
+  decodedBodySize: number;
+  domainLookupEnd: number;
+  domainLookupStart: number;
+  encodedBodySize: number;
+  fetchStart: number;
+  initiatorType: string;
+  nextHopProtocol: string;
+  redirectEnd: number;
+  redirectStart: number;
+  requestStart: number;
+  responseEnd: number;
+  responseStart: number;
+  secureConnectionStart: number;
+  serverTiming: Array<PerformanceServerTiming>;
+  transferSize: number;
+  workerStart: number;
+}
+
+// https://w3c.github.io/event-timing/#sec-performance-event-timing
+declare class PerformanceEventTiming extends PerformanceEntry {
+  cancelable: boolean;
+  interactionId: number;
+  processingEnd: number;
+  processingStart: number;
+  target: ?Node;
+}
+
+// https://w3c.github.io/longtasks/#taskattributiontiming
+declare class TaskAttributionTiming extends PerformanceEntry {
+  containerId: string;
+  containerName: string;
+  containerSrc: string;
+  containerType: string;
+}
+
+// https://w3c.github.io/longtasks/#sec-PerformanceLongTaskTiming
+declare class PerformanceLongTaskTiming extends PerformanceEntry {
+  attribution: $ReadOnlyArray<TaskAttributionTiming>;
+}
+
+// https://www.w3.org/TR/user-timing/#extensions-performance-interface
+declare type PerformanceMarkOptions = {
+  detail?: mixed,
+  startTime?: number,
+};
+
+declare type PerformanceMeasureOptions = {
+  detail?: mixed,
+  duration?: number,
+  end?: number | string,
+  start?: number | string,
+};
+
+type EventCountsForEachCallbackType =
+  | (() => void)
+  | ((value: number) => void)
+  | ((value: number, key: string) => void)
+  | ((value: number, key: string, map: Map<string, number>) => void);
+
+// https://www.w3.org/TR/event-timing/#eventcounts
+declare interface EventCounts {
+  entries(): Iterator<[string, number]>;
+
+  forEach(callback: EventCountsForEachCallbackType): void;
+  get(key: string): ?number;
+  has(key: string): boolean;
+  keys(): Iterator<string>;
+  size: number;
+  values(): Iterator<number>;
+}
+
 declare class Performance {
+  clearMarks(name?: string): void;
+
+  clearMeasures(name?: string): void;
+
+  eventCounts: EventCounts;
+  getEntries: (
+    options?: PerformanceEntryFilterOptions,
+  ) => Array<PerformanceEntry>;
+  getEntriesByName: (name: string, type?: string) => Array<PerformanceEntry>;
+  getEntriesByType: (type: string) => Array<PerformanceEntry>;
+  mark(name: string, options?: PerformanceMarkOptions): PerformanceMark;
+  measure(
+    name: string,
+    startMarkOrOptions?: string | PerformanceMeasureOptions,
+    endMark?: string,
+  ): PerformanceMeasure;
   now: () => DOMHighResTimeStamp;
+  toJSON(): string;
 }
 
 declare var performance: Performance;
+
+type PerformanceEntryList = Array<PerformanceEntry>;
+
+declare interface PerformanceObserverEntryList {
+  getEntries(): PerformanceEntryList;
+  getEntriesByName(name: string, type: ?string): PerformanceEntryList;
+  getEntriesByType(type: string): PerformanceEntryList;
+}
+
+type PerformanceObserverInit = {
+  buffered?: boolean,
+  entryTypes?: Array<string>,
+  type?: string,
+  ...
+};
+
+declare class PerformanceObserver {
+  constructor(
+    callback: (
+      entries: PerformanceObserverEntryList,
+      observer: PerformanceObserver,
+    ) => mixed,
+  ): void;
+
+  disconnect(): void;
+  observe(options: ?PerformanceObserverInit): void;
+  static supportedEntryTypes: Array<string>;
+
+  takeRecords(): PerformanceEntryList;
+}
 
 type FormDataEntryValue = string | File;
 

--- a/packages/react-native/src/private/setup/setUpPerformanceModern.js
+++ b/packages/react-native/src/private/setup/setUpPerformanceModern.js
@@ -12,12 +12,19 @@ import {polyfillGlobal} from '../../../Libraries/Utilities/PolyfillFunctions';
 
 let initialized = false;
 
-export default function setUpPerformanceObserver() {
+export default function setUpPerformanceModern() {
   if (initialized) {
     return;
   }
 
   initialized = true;
+
+  const Performance = require('../webapis/performance/Performance').default;
+
+  // We don't use `polyfillGlobal` to define this lazily because the
+  // `performance` object is always accessed.
+  // $FlowExpectedError[cannot-write]
+  global.performance = new Performance();
 
   polyfillGlobal(
     'EventCounts',

--- a/packages/react-native/src/private/setup/setUpPerformanceObserver.js
+++ b/packages/react-native/src/private/setup/setUpPerformanceObserver.js
@@ -20,21 +20,34 @@ export default function setUpPerformanceObserver() {
   initialized = true;
 
   polyfillGlobal(
-    'PerformanceObserver',
-    () =>
-      require('../webapis/performance/PerformanceObserver').PerformanceObserver,
+    'EventCounts',
+    () => require('../webapis/performance/EventTiming').EventCounts_public,
   );
 
   polyfillGlobal(
-    'PerformanceObserverEntryList',
-    () =>
-      require('../webapis/performance/PerformanceObserver')
-        .PerformanceObserverEntryList,
+    'Performance',
+    () => require('../webapis/performance/Performance').Performance_public,
   );
 
   polyfillGlobal(
     'PerformanceEntry',
-    () => require('../webapis/performance/PerformanceEntry').PerformanceEntry,
+    () =>
+      require('../webapis/performance/PerformanceEntry')
+        .PerformanceEntry_public,
+  );
+
+  polyfillGlobal(
+    'PerformanceEventTiming',
+    () =>
+      require('../webapis/performance/EventTiming')
+        .PerformanceEventTiming_public,
+  );
+
+  polyfillGlobal(
+    'PerformanceLongTaskTiming',
+    () =>
+      require('../webapis/performance/LongTasks')
+        .PerformanceLongTaskTiming_public,
   );
 
   polyfillGlobal(
@@ -44,28 +57,33 @@ export default function setUpPerformanceObserver() {
 
   polyfillGlobal(
     'PerformanceMeasure',
-    () => require('../webapis/performance/UserTiming').PerformanceMeasure,
+    () =>
+      require('../webapis/performance/UserTiming').PerformanceMeasure_public,
   );
 
   polyfillGlobal(
-    'PerformanceEventTiming',
-    () => require('../webapis/performance/EventTiming').PerformanceEventTiming,
+    'PerformanceObserver',
+    () =>
+      require('../webapis/performance/PerformanceObserver').PerformanceObserver,
+  );
+
+  polyfillGlobal(
+    'PerformanceObserverEntryList',
+    () =>
+      require('../webapis/performance/PerformanceObserver')
+        .PerformanceObserverEntryList_public,
   );
 
   polyfillGlobal(
     'PerformanceResourceTiming',
     () =>
       require('../webapis/performance/ResourceTiming')
-        .PerformanceResourceTiming,
+        .PerformanceResourceTiming_public,
   );
 
   polyfillGlobal(
     'TaskAttributionTiming',
-    () => require('../webapis/performance/LongTasks').TaskAttributionTiming,
-  );
-
-  polyfillGlobal(
-    'PerformanceLongTaskTiming',
-    () => require('../webapis/performance/LongTasks').PerformanceLongTaskTiming,
+    () =>
+      require('../webapis/performance/LongTasks').TaskAttributionTiming_public,
   );
 }

--- a/packages/react-native/src/private/webapis/performance/EventTiming.js
+++ b/packages/react-native/src/private/webapis/performance/EventTiming.js
@@ -9,9 +9,9 @@
  */
 
 // flowlint unsafe-getters-setters:off
-
 import type {
   DOMHighResTimeStamp,
+  PerformanceEntryInit,
   PerformanceEntryJSON,
 } from './PerformanceEntry';
 
@@ -29,25 +29,20 @@ export type PerformanceEventTimingJSON = {
   ...
 };
 
+export interface PerformanceEventTimingInit extends PerformanceEntryInit {
+  +processingStart?: DOMHighResTimeStamp;
+  +processingEnd?: DOMHighResTimeStamp;
+  +interactionId?: number;
+}
+
 export class PerformanceEventTiming extends PerformanceEntry {
   #processingStart: DOMHighResTimeStamp;
   #processingEnd: DOMHighResTimeStamp;
   #interactionId: number;
 
-  constructor(init: {
-    name: string,
-    startTime?: DOMHighResTimeStamp,
-    duration?: DOMHighResTimeStamp,
-    processingStart?: DOMHighResTimeStamp,
-    processingEnd?: DOMHighResTimeStamp,
-    interactionId?: number,
-  }) {
-    super({
-      name: init.name,
-      entryType: 'event',
-      startTime: init.startTime ?? 0,
-      duration: init.duration ?? 0,
-    });
+  constructor(init: PerformanceEventTimingInit) {
+    super('event', init);
+
     this.#processingStart = init.processingStart ?? 0;
     this.#processingEnd = init.processingEnd ?? 0;
     this.#interactionId = init.interactionId ?? 0;

--- a/packages/react-native/src/private/webapis/performance/EventTiming.js
+++ b/packages/react-native/src/private/webapis/performance/EventTiming.js
@@ -70,6 +70,18 @@ export class PerformanceEventTiming extends PerformanceEntry {
   }
 }
 
+export const PerformanceEventTiming_public: typeof PerformanceEventTiming =
+  /* eslint-disable no-shadow */
+  // $FlowExpectedError[incompatible-type]
+  function PerformanceEventTiming() {
+    throw new TypeError(
+      "Failed to construct 'PerformanceEventTiming': Illegal constructor",
+    );
+  };
+
+// $FlowExpectedError[prop-missing]
+PerformanceEventTiming_public.prototype = PerformanceEventTiming.prototype;
+
 type EventCountsForEachCallbackType =
   | (() => void)
   | ((value: number) => void)
@@ -134,3 +146,15 @@ export class EventCounts {
     return getCachedEventCounts().values();
   }
 }
+
+export const EventCounts_public: typeof EventCounts =
+  /* eslint-disable no-shadow */
+  // $FlowExpectedError[incompatible-type]
+  function EventCounts() {
+    throw new TypeError(
+      "Failed to construct 'EventCounts': Illegal constructor",
+    );
+  };
+
+// $FlowExpectedError[prop-missing]
+EventCounts_public.prototype = EventCounts.prototype;

--- a/packages/react-native/src/private/webapis/performance/LongTasks.js
+++ b/packages/react-native/src/private/webapis/performance/LongTasks.js
@@ -9,8 +9,10 @@
  */
 
 // flowlint unsafe-getters-setters:off
-
-import type {PerformanceEntryJSON} from './PerformanceEntry';
+import type {
+  PerformanceEntryInit,
+  PerformanceEntryJSON,
+} from './PerformanceEntry';
 
 import {PerformanceEntry} from './PerformanceEntry';
 
@@ -25,7 +27,13 @@ export class TaskAttributionTiming extends PerformanceEntry {}
 const EMPTY_ATTRIBUTION: $ReadOnlyArray<TaskAttributionTiming> =
   Object.preventExtensions([]);
 
+export interface PerformanceLongTaskTimingInit extends PerformanceEntryInit {}
+
 export class PerformanceLongTaskTiming extends PerformanceEntry {
+  constructor(init: PerformanceEntryInit) {
+    super('longtask', init);
+  }
+
   get attribution(): $ReadOnlyArray<TaskAttributionTiming> {
     return EMPTY_ATTRIBUTION;
   }

--- a/packages/react-native/src/private/webapis/performance/LongTasks.js
+++ b/packages/react-native/src/private/webapis/performance/LongTasks.js
@@ -24,6 +24,18 @@ export type PerformanceLongTaskTimingJSON = {
 
 export class TaskAttributionTiming extends PerformanceEntry {}
 
+export const TaskAttributionTiming_public: typeof TaskAttributionTiming =
+  /* eslint-disable no-shadow */
+  // $FlowExpectedError[incompatible-type]
+  function TaskAttributionTiming() {
+    throw new TypeError(
+      "Failed to construct 'TaskAttributionTiming': Illegal constructor",
+    );
+  };
+
+// $FlowExpectedError[prop-missing]
+TaskAttributionTiming_public.prototype = TaskAttributionTiming.prototype;
+
 const EMPTY_ATTRIBUTION: $ReadOnlyArray<TaskAttributionTiming> =
   Object.preventExtensions([]);
 
@@ -45,3 +57,16 @@ export class PerformanceLongTaskTiming extends PerformanceEntry {
     };
   }
 }
+
+export const PerformanceLongTaskTiming_public: typeof PerformanceLongTaskTiming =
+  /* eslint-disable no-shadow */
+  // $FlowExpectedError[incompatible-type]
+  function PerformanceLongTaskTiming() {
+    throw new TypeError(
+      "Failed to construct 'PerformanceLongTaskTiming': Illegal constructor",
+    );
+  };
+
+// $FlowExpectedError[prop-missing]
+PerformanceLongTaskTiming_public.prototype =
+  PerformanceLongTaskTiming.prototype;

--- a/packages/react-native/src/private/webapis/performance/Performance.js
+++ b/packages/react-native/src/private/webapis/performance/Performance.js
@@ -443,4 +443,16 @@ export default class Performance {
   }
 }
 
+export const Performance_public: typeof Performance =
+  /* eslint-disable no-shadow */
+  // $FlowExpectedError[incompatible-type]
+  function Performance() {
+    throw new TypeError(
+      "Failed to construct 'Performance': Illegal constructor",
+    );
+  };
+
+// $FlowExpectedError[prop-missing]
+Performance_public.prototype = Performance.prototype;
+
 setPlatformObject(Performance);

--- a/packages/react-native/src/private/webapis/performance/Performance.js
+++ b/packages/react-native/src/private/webapis/performance/Performance.js
@@ -64,12 +64,13 @@ const cachedGetMarkTime = NativePerformance.getMarkTime;
 const cachedNativeClearMarks = NativePerformance.clearMarks;
 const cachedNativeClearMeasures = NativePerformance.clearMeasures;
 
-const MARK_OPTIONS_REUSABLE_OBJECT: {...PerformanceMarkOptions} = {
+const MARK_OPTIONS_REUSABLE_OBJECT: PerformanceMarkOptions = {
   startTime: 0,
   detail: undefined,
 };
 
-const MEASURE_OPTIONS_REUSABLE_OBJECT: {...PerformanceMeasureInit} = {
+const MEASURE_OPTIONS_REUSABLE_OBJECT: PerformanceMeasureInit = {
+  name: '',
   startTime: 0,
   duration: 0,
   detail: undefined,
@@ -189,7 +190,9 @@ export default class Performance {
       resolvedDetail = structuredClone(detail);
     }
 
+    // $FlowExpectedError[cannot-write]
     MARK_OPTIONS_REUSABLE_OBJECT.startTime = resolvedStartTime;
+    // $FlowExpectedError[cannot-write]
     MARK_OPTIONS_REUSABLE_OBJECT.detail = resolvedDetail;
 
     const entry = new PerformanceMark(
@@ -367,14 +370,16 @@ export default class Performance {
       }
     }
 
+    // $FlowExpectedError[cannot-write]
+    MEASURE_OPTIONS_REUSABLE_OBJECT.name = resolvedMeasureName;
+    // $FlowExpectedError[cannot-write]
     MEASURE_OPTIONS_REUSABLE_OBJECT.startTime = resolvedStartTime;
+    // $FlowExpectedError[cannot-write]
     MEASURE_OPTIONS_REUSABLE_OBJECT.duration = resolvedDuration;
+    // $FlowExpectedError[cannot-write]
     MEASURE_OPTIONS_REUSABLE_OBJECT.detail = resolvedDetail;
 
-    const entry = new PerformanceMeasure(
-      resolvedMeasureName,
-      MEASURE_OPTIONS_REUSABLE_OBJECT,
-    );
+    const entry = new PerformanceMeasure(MEASURE_OPTIONS_REUSABLE_OBJECT);
 
     cachedReportMeasure(
       resolvedMeasureName,

--- a/packages/react-native/src/private/webapis/performance/PerformanceEntry.js
+++ b/packages/react-native/src/private/webapis/performance/PerformanceEntry.js
@@ -77,6 +77,18 @@ export class PerformanceEntry {
   }
 }
 
+export const PerformanceEntry_public: typeof PerformanceEntry =
+  /* eslint-disable no-shadow */
+  // $FlowExpectedError[incompatible-type]
+  function PerformanceEntry() {
+    throw new TypeError(
+      "Failed to construct 'PerformanceEntry': Illegal constructor",
+    );
+  };
+
+// $FlowExpectedError[prop-missing]
+PerformanceEntry_public.prototype = PerformanceEntry.prototype;
+
 setPlatformObject(PerformanceEntry);
 
 export type PerformanceEntryList = $ReadOnlyArray<PerformanceEntry>;

--- a/packages/react-native/src/private/webapis/performance/PerformanceEntry.js
+++ b/packages/react-native/src/private/webapis/performance/PerformanceEntry.js
@@ -28,24 +28,25 @@ export type PerformanceEntryJSON = {
   ...
 };
 
+export interface PerformanceEntryInit {
+  +name: string;
+  +startTime: DOMHighResTimeStamp;
+  +duration: DOMHighResTimeStamp;
+}
+
 export class PerformanceEntry {
   // We don't use private fields because they're significantly slower to
   // initialize on construction and to access.
   // We also need these to be protected so they can be initialized in subclasses
   // where we avoid calling `super()` for performance reasons.
-  __name: string;
   __entryType: PerformanceEntryType;
+  __name: string;
   __startTime: DOMHighResTimeStamp;
   __duration: DOMHighResTimeStamp;
 
-  constructor(init: {
-    name: string,
-    entryType: PerformanceEntryType,
-    startTime: DOMHighResTimeStamp,
-    duration: DOMHighResTimeStamp,
-  }) {
+  constructor(entryType: PerformanceEntryType, init: PerformanceEntryInit) {
+    this.__entryType = entryType;
     this.__name = init.name;
-    this.__entryType = init.entryType;
     this.__startTime = init.startTime;
     this.__duration = init.duration;
   }

--- a/packages/react-native/src/private/webapis/performance/PerformanceObserver.js
+++ b/packages/react-native/src/private/webapis/performance/PerformanceObserver.js
@@ -57,6 +57,19 @@ export class PerformanceObserverEntryList {
   }
 }
 
+export const PerformanceObserverEntryList_public: typeof PerformanceObserverEntryList =
+  /* eslint-disable no-shadow */
+  // $FlowExpectedError[incompatible-type]
+  function PerformanceObserverEntryList() {
+    throw new TypeError(
+      "Failed to construct 'PerformanceObserverEntryList': Illegal constructor",
+    );
+  };
+
+// $FlowExpectedError[prop-missing]
+PerformanceObserverEntryList_public.prototype =
+  PerformanceObserverEntryList.prototype;
+
 export type PerformanceObserverCallbackOptions = {
   droppedEntriesCount: number,
 };

--- a/packages/react-native/src/private/webapis/performance/PerformanceObserver.js
+++ b/packages/react-native/src/private/webapis/performance/PerformanceObserver.js
@@ -145,6 +145,22 @@ export class PerformanceObserver {
     NativePerformance.disconnect(this.#nativeObserverHandle);
   }
 
+  takeRecords(): PerformanceEntryList {
+    let entries: PerformanceEntryList = [];
+
+    if (this.#nativeObserverHandle != null) {
+      const rawEntries = NativePerformance.takeRecords(
+        this.#nativeObserverHandle,
+        true,
+      );
+      if (rawEntries && rawEntries.length > 0) {
+        entries = rawEntries.map(rawToPerformanceEntry);
+      }
+    }
+
+    return entries;
+  }
+
   #createNativeObserver(): OpaqueNativeObserverHandle | null {
     this.#calledAtLeastOnce = false;
 
@@ -154,7 +170,7 @@ export class PerformanceObserver {
           observerHandle,
           true, // sort records
         );
-        if (!rawEntries) {
+        if (!rawEntries || rawEntries.length === 0) {
           return;
         }
 

--- a/packages/react-native/src/private/webapis/performance/ResourceTiming.js
+++ b/packages/react-native/src/private/webapis/performance/ResourceTiming.js
@@ -29,6 +29,19 @@ export type PerformanceResourceTimingJSON = {
   ...
 };
 
+export interface PerformanceResourceTimingInit {
+  +name: string;
+  +startTime: DOMHighResTimeStamp;
+  +duration: DOMHighResTimeStamp;
+  +fetchStart: DOMHighResTimeStamp;
+  +requestStart: DOMHighResTimeStamp;
+  +connectStart: DOMHighResTimeStamp;
+  +connectEnd: DOMHighResTimeStamp;
+  +responseStart: DOMHighResTimeStamp;
+  +responseEnd: DOMHighResTimeStamp;
+  +responseStatus?: number;
+}
+
 export class PerformanceResourceTiming extends PerformanceEntry {
   #fetchStart: DOMHighResTimeStamp;
   #requestStart: DOMHighResTimeStamp;
@@ -38,24 +51,9 @@ export class PerformanceResourceTiming extends PerformanceEntry {
   #responseEnd: DOMHighResTimeStamp;
   #responseStatus: ?number;
 
-  constructor(init: {
-    name: string,
-    startTime: DOMHighResTimeStamp,
-    duration: DOMHighResTimeStamp,
-    fetchStart: DOMHighResTimeStamp,
-    requestStart: DOMHighResTimeStamp,
-    connectStart: DOMHighResTimeStamp,
-    connectEnd: DOMHighResTimeStamp,
-    responseStart: DOMHighResTimeStamp,
-    responseEnd: DOMHighResTimeStamp,
-    responseStatus?: number,
-  }) {
-    super({
-      name: init.name,
-      entryType: 'resource',
-      startTime: init.startTime,
-      duration: init.duration,
-    });
+  constructor(init: PerformanceResourceTimingInit) {
+    super('resource', init);
+
     this.#fetchStart = init.fetchStart;
     this.#requestStart = init.requestStart;
     this.#connectStart = init.connectStart;

--- a/packages/react-native/src/private/webapis/performance/ResourceTiming.js
+++ b/packages/react-native/src/private/webapis/performance/ResourceTiming.js
@@ -104,3 +104,16 @@ export class PerformanceResourceTiming extends PerformanceEntry {
     };
   }
 }
+
+export const PerformanceResourceTiming_public: typeof PerformanceResourceTiming =
+  /* eslint-disable no-shadow */
+  // $FlowExpectedError[incompatible-type]
+  function PerformanceResourceTiming() {
+    throw new TypeError(
+      "Failed to construct 'PerformanceResourceTiming': Illegal constructor",
+    );
+  };
+
+// $FlowExpectedError[prop-missing]
+PerformanceResourceTiming_public.prototype =
+  PerformanceResourceTiming.prototype;

--- a/packages/react-native/src/private/webapis/performance/UserTiming.js
+++ b/packages/react-native/src/private/webapis/performance/UserTiming.js
@@ -9,8 +9,10 @@
  */
 
 // flowlint unsafe-getters-setters:off
-
-import type {DOMHighResTimeStamp} from './PerformanceEntry';
+import type {
+  DOMHighResTimeStamp,
+  PerformanceEntryInit,
+} from './PerformanceEntry';
 import type {
   ExtensionMarkerPayload,
   ExtensionTrackEntryPayload,
@@ -25,18 +27,16 @@ export type DetailType =
   // but we'll use it as documentation for how to use the extensibility API.
   | {devtools?: ExtensionMarkerPayload | ExtensionTrackEntryPayload, ...};
 
-export type PerformanceMarkOptions = $ReadOnly<{
-  detail?: DetailType,
-  startTime?: DOMHighResTimeStamp,
-}>;
+export interface PerformanceMarkOptions {
+  +detail?: DetailType;
+  +startTime?: DOMHighResTimeStamp;
+}
 
 export type TimeStampOrName = DOMHighResTimeStamp | string;
 
-export type PerformanceMeasureInit = $ReadOnly<{
-  detail?: DetailType,
-  startTime: DOMHighResTimeStamp,
-  duration: DOMHighResTimeStamp,
-}>;
+export interface PerformanceMeasureInit extends PerformanceEntryInit {
+  +detail?: DetailType;
+}
 
 class PerformanceMarkTemplate extends PerformanceEntry {
   // We don't use private fields because they're significantly slower to
@@ -45,9 +45,8 @@ class PerformanceMarkTemplate extends PerformanceEntry {
 
   // This constructor isn't really used. See `PerformanceMark` below.
   constructor(markName: string, markOptions?: PerformanceMarkOptions) {
-    super({
+    super('mark', {
       name: markName,
-      entryType: 'mark',
       startTime: markOptions?.startTime ?? getCurrentTimeStamp(),
       duration: 0,
     });
@@ -72,8 +71,8 @@ export const PerformanceMark: typeof PerformanceMarkTemplate =
     markName: string,
     markOptions?: PerformanceMarkOptions,
   ) {
-    this.__name = markName;
     this.__entryType = 'mark';
+    this.__name = markName;
     this.__startTime = markOptions?.startTime ?? getCurrentTimeStamp();
     this.__duration = 0;
 
@@ -89,15 +88,10 @@ class PerformanceMeasureTemplate extends PerformanceEntry {
   __detail: DetailType;
 
   // This constructor isn't really used. See `PerformanceMeasure` below.
-  constructor(measureName: string, measureOptions: PerformanceMeasureInit) {
-    super({
-      name: measureName,
-      entryType: 'measure',
-      startTime: measureOptions.startTime,
-      duration: measureOptions.duration,
-    });
+  constructor(init: PerformanceMeasureInit) {
+    super('measure', init);
 
-    this.__detail = measureOptions?.detail ?? null;
+    this.__detail = init?.detail ?? null;
   }
 
   get detail(): DetailType {
@@ -110,15 +104,14 @@ export const PerformanceMeasure: typeof PerformanceMeasureTemplate =
   // $FlowExpectedError[incompatible-type]
   function PerformanceMeasure(
     this: PerformanceMeasureTemplate,
-    measureName: string,
-    measureOptions: PerformanceMeasureInit,
+    init: PerformanceMeasureInit,
   ) {
-    this.__name = measureName;
     this.__entryType = 'measure';
-    this.__startTime = measureOptions.startTime;
-    this.__duration = measureOptions.duration;
+    this.__name = init.name;
+    this.__startTime = init.startTime;
+    this.__duration = init.duration;
 
-    this.__detail = measureOptions.detail ?? null;
+    this.__detail = init.detail ?? null;
   };
 
 // $FlowExpectedError[prop-missing]

--- a/packages/react-native/src/private/webapis/performance/UserTiming.js
+++ b/packages/react-native/src/private/webapis/performance/UserTiming.js
@@ -116,3 +116,15 @@ export const PerformanceMeasure: typeof PerformanceMeasureTemplate =
 
 // $FlowExpectedError[prop-missing]
 PerformanceMeasure.prototype = PerformanceMeasureTemplate.prototype;
+
+export const PerformanceMeasure_public: typeof PerformanceMeasure =
+  /* eslint-disable no-shadow */
+  // $FlowExpectedError[incompatible-type]
+  function PerformanceMeasure() {
+    throw new TypeError(
+      "Failed to construct 'PerformanceMeasure': Illegal constructor",
+    );
+  };
+
+// $FlowExpectedError[prop-missing]
+PerformanceMeasure_public.prototype = PerformanceMeasure.prototype;

--- a/packages/react-native/src/private/webapis/performance/__tests__/EventTimingAPI-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/EventTimingAPI-itest.js
@@ -244,6 +244,21 @@ describe('Event Timing API', () => {
     expect([...performance.eventCounts.values()]).toEqual([1, 1, 3]);
   });
 
+  it('does NOT allow creating instances of PerformanceEventTiming directly', () => {
+    expect(() => {
+      return new PerformanceEventTiming();
+    }).toThrow(
+      "Failed to construct 'PerformanceEventTiming': Illegal constructor",
+    );
+  });
+
+  it('does NOT allow creating instances of EventCounts directly', () => {
+    expect(() => {
+      // $FlowExpectedError[cannot-resolve-name]
+      return new EventCounts();
+    }).toThrow("Failed to construct 'EventCounts': Illegal constructor");
+  });
+
   describe('durationThreshold option', () => {
     it('works when used with `type`', () => {
       const callback = jest.fn();

--- a/packages/react-native/src/private/webapis/performance/__tests__/EventTimingAPI-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/EventTimingAPI-itest.js
@@ -10,23 +10,16 @@
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
-import type Performance from 'react-native/src/private/webapis/performance/Performance';
-import type {PerformanceObserverEntryList} from 'react-native/src/private/webapis/performance/PerformanceObserver';
-
 import MaybeNativePerformance from '../specs/NativePerformance';
 import * as Fantom from '@react-native/fantom';
 import nullthrows from 'nullthrows';
 import {useState} from 'react';
 import {Text, View} from 'react-native';
 import setUpPerformanceObserver from 'react-native/src/private/setup/setUpPerformanceObserver';
-import {PerformanceEventTiming} from 'react-native/src/private/webapis/performance/EventTiming';
-import {PerformanceObserver} from 'react-native/src/private/webapis/performance/PerformanceObserver';
 
 const NativePerformance = nullthrows(MaybeNativePerformance);
 
 setUpPerformanceObserver();
-
-declare var performance: Performance;
 
 function sleep(ms: number) {
   const end = performance.now() + ms;

--- a/packages/react-native/src/private/webapis/performance/__tests__/EventTimingAPI-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/EventTimingAPI-itest.js
@@ -15,11 +15,8 @@ import * as Fantom from '@react-native/fantom';
 import nullthrows from 'nullthrows';
 import {useState} from 'react';
 import {Text, View} from 'react-native';
-import setUpPerformanceObserver from 'react-native/src/private/setup/setUpPerformanceObserver';
 
 const NativePerformance = nullthrows(MaybeNativePerformance);
-
-setUpPerformanceObserver();
 
 function sleep(ms: number) {
   const end = performance.now() + ms;

--- a/packages/react-native/src/private/webapis/performance/__tests__/LongTasksAPI-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/LongTasksAPI-itest.js
@@ -10,15 +10,10 @@
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
-import type {
-  PerformanceObserverCallbackOptions,
-  PerformanceObserverEntryList,
-} from 'react-native/src/private/webapis/performance/PerformanceObserver';
+import type {PerformanceObserverCallbackOptions} from '../PerformanceObserver';
 
 import * as Fantom from '@react-native/fantom';
 import setUpPerformanceObserver from 'react-native/src/private/setup/setUpPerformanceObserver';
-import {PerformanceLongTaskTiming} from 'react-native/src/private/webapis/performance/LongTasks';
-import {PerformanceObserver} from 'react-native/src/private/webapis/performance/PerformanceObserver';
 
 setUpPerformanceObserver();
 

--- a/packages/react-native/src/private/webapis/performance/__tests__/LongTasksAPI-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/LongTasksAPI-itest.js
@@ -13,9 +13,6 @@ import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 import type {PerformanceObserverCallbackOptions} from '../PerformanceObserver';
 
 import * as Fantom from '@react-native/fantom';
-import setUpPerformanceObserver from 'react-native/src/private/setup/setUpPerformanceObserver';
-
-setUpPerformanceObserver();
 
 function ensurePerformanceLongTaskTiming(
   value: mixed,

--- a/packages/react-native/src/private/webapis/performance/__tests__/LongTasksAPI-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/LongTasksAPI-itest.js
@@ -191,4 +191,20 @@ describe('LongTasks API', () => {
       expect(entry.attribution).toEqual([]);
     });
   });
+
+  it('does NOT allow creating instances of PerformanceLongTaskTiming directly', () => {
+    expect(() => {
+      return new PerformanceLongTaskTiming();
+    }).toThrow(
+      "Failed to construct 'PerformanceLongTaskTiming': Illegal constructor",
+    );
+  });
+
+  it('does NOT allow creating instances of TaskAttributionTiming directly', () => {
+    expect(() => {
+      return new TaskAttributionTiming();
+    }).toThrow(
+      "Failed to construct 'TaskAttributionTiming': Illegal constructor",
+    );
+  });
 });

--- a/packages/react-native/src/private/webapis/performance/__tests__/Performance-benchmark-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/Performance-benchmark-itest.js
@@ -10,11 +10,7 @@
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
-import type Performance from 'react-native/src/private/webapis/performance/Performance';
-
 import * as Fantom from '@react-native/fantom';
-
-declare var performance: Performance;
 
 const clearMarksAndMeasures = () => {
   performance.clearMarks();

--- a/packages/react-native/src/private/webapis/performance/__tests__/Performance-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/Performance-itest.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
+
+import setUpPerformanceObserver from '../../../setup/setUpPerformanceObserver';
+
+setUpPerformanceObserver();
+
+describe('Performance', () => {
+  it('does NOT allow creating instances of Performance directly', () => {
+    expect(() => {
+      return new Performance();
+    }).toThrow("Failed to construct 'Performance': Illegal constructor");
+  });
+
+  it('does NOT allow creating instances of PerformanceEntry directly', () => {
+    expect(() => {
+      return new PerformanceEntry();
+    }).toThrow("Failed to construct 'PerformanceEntry': Illegal constructor");
+  });
+});

--- a/packages/react-native/src/private/webapis/performance/__tests__/Performance-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/Performance-itest.js
@@ -10,10 +10,6 @@
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
-import setUpPerformanceObserver from '../../../setup/setUpPerformanceObserver';
-
-setUpPerformanceObserver();
-
 describe('Performance', () => {
   it('does NOT allow creating instances of Performance directly', () => {
     expect(() => {

--- a/packages/react-native/src/private/webapis/performance/__tests__/PerformanceObserver-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/PerformanceObserver-itest.js
@@ -97,4 +97,24 @@ describe('PerformanceObserver', () => {
     expect(entries1.getEntries()[1]).toBe(measure);
     expect(entries2.getEntries()[1]).toBe(measure);
   });
+
+  describe('takeRecords()', () => {
+    it('provides all buffered events and clears the buffer', () => {
+      const callback = jest.fn();
+      const observer = new PerformanceObserver(callback);
+      observer.observe({entryTypes: ['mark']});
+
+      Fantom.runTask(() => {
+        const entry = performance.mark('mark1');
+
+        const entries = observer.takeRecords();
+        expect(entries.length).toBe(1);
+        // This is not supported yet
+        // expect(entries[0]).toBe(entry);
+        expect(entries[0]).toEqual(entry);
+      });
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/react-native/src/private/webapis/performance/__tests__/PerformanceObserver-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/PerformanceObserver-itest.js
@@ -10,11 +10,8 @@
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
-import setUpPerformanceObserver from '../../../setup/setUpPerformanceObserver';
 import {PerformanceObserverEntryList_public} from '../PerformanceObserver';
 import * as Fantom from '@react-native/fantom';
-
-setUpPerformanceObserver();
 
 describe('PerformanceObserver', () => {
   it('receives notifications for marks and measures', () => {

--- a/packages/react-native/src/private/webapis/performance/__tests__/PerformanceObserver-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/PerformanceObserver-itest.js
@@ -10,19 +10,10 @@
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
-import type Performance from '../Performance';
-import type {
-  PerformanceObserver as PerformanceObserverT,
-  PerformanceObserverEntryList,
-} from '../PerformanceObserver';
-
 import setUpPerformanceObserver from '../../../setup/setUpPerformanceObserver';
 import * as Fantom from '@react-native/fantom';
 
 setUpPerformanceObserver();
-
-declare var performance: Performance;
-declare var PerformanceObserver: Class<PerformanceObserverT>;
 
 describe('PerformanceObserver', () => {
   it('receives notifications for marks and measures', () => {

--- a/packages/react-native/src/private/webapis/performance/__tests__/PerformanceObserver-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/PerformanceObserver-itest.js
@@ -11,6 +11,7 @@
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import setUpPerformanceObserver from '../../../setup/setUpPerformanceObserver';
+import {PerformanceObserverEntryList_public} from '../PerformanceObserver';
 import * as Fantom from '@react-native/fantom';
 
 setUpPerformanceObserver();
@@ -116,5 +117,14 @@ describe('PerformanceObserver', () => {
 
       expect(callback).not.toHaveBeenCalled();
     });
+  });
+
+  it('does NOT allow creating instances of PerformanceObserverEntryList directly', () => {
+    expect(() => {
+      // $FlowExpectedError[incompatible-type]
+      return new PerformanceObserverEntryList_public();
+    }).toThrow(
+      "Failed to construct 'PerformanceObserverEntryList': Illegal constructor",
+    );
   });
 });

--- a/packages/react-native/src/private/webapis/performance/__tests__/UserTiming-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/UserTiming-itest.js
@@ -44,6 +44,24 @@ describe('User Timing', () => {
     mockClock.uninstall();
   });
 
+  it('allows creating instances of PerformanceMark directly', () => {
+    const before = performance.now();
+    const entry = new PerformanceMark('mark-now');
+    const after = performance.now();
+
+    expect(entry).toBeInstanceOf(PerformanceMark);
+    expect(entry.startTime).toBeGreaterThanOrEqual(before);
+    expect(entry.startTime).toBeLessThanOrEqual(after);
+    expect(entry.duration).toBe(0);
+    expect(entry.detail).toBe(null);
+  });
+
+  it('does NOT allow creating instances of PerformanceMeasure directly', () => {
+    expect(() => {
+      return new PerformanceMeasure();
+    }).toThrow("Failed to construct 'PerformanceMeasure': Illegal constructor");
+  });
+
   describe('mark', () => {
     it('works with default timestamp', () => {
       mockClock.setTime(25);

--- a/packages/react-native/src/private/webapis/performance/__tests__/UserTiming-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/UserTiming-itest.js
@@ -10,18 +10,12 @@
 
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
-import type Performance from '../Performance';
-import type {
-  PerformanceEntryJSON,
-  PerformanceEntryList,
-} from '../PerformanceEntry';
-
 import ensureInstance from '../../../__tests__/utilities/ensureInstance';
+import setUpPerformanceObserver from '../../../setup/setUpPerformanceObserver';
 import DOMException from '../../errors/DOMException';
-import {PerformanceMark, PerformanceMeasure} from '../UserTiming';
 import * as Fantom from '@react-native/fantom';
 
-declare var performance: Performance;
+setUpPerformanceObserver();
 
 function getThrownError(fn: () => mixed): mixed {
   try {
@@ -32,7 +26,7 @@ function getThrownError(fn: () => mixed): mixed {
   throw new Error('Expected function to throw');
 }
 
-function toJSON(entries: PerformanceEntryList): Array<PerformanceEntryJSON> {
+function toJSON(entries: PerformanceEntryList): Array<mixed> {
   return entries.map(entry => entry.toJSON());
 }
 

--- a/packages/react-native/src/private/webapis/performance/__tests__/UserTiming-itest.js
+++ b/packages/react-native/src/private/webapis/performance/__tests__/UserTiming-itest.js
@@ -11,11 +11,8 @@
 import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 
 import ensureInstance from '../../../__tests__/utilities/ensureInstance';
-import setUpPerformanceObserver from '../../../setup/setUpPerformanceObserver';
 import DOMException from '../../errors/DOMException';
 import * as Fantom from '@react-native/fantom';
-
-setUpPerformanceObserver();
 
 function getThrownError(fn: () => mixed): mixed {
   try {

--- a/packages/react-native/src/private/webapis/performance/internals/RawPerformanceEntry.js
+++ b/packages/react-native/src/private/webapis/performance/internals/RawPerformanceEntry.js
@@ -44,7 +44,6 @@ export function rawToPerformanceEntry(
     case RawPerformanceEntryTypeValues.LONGTASK:
       return new PerformanceLongTaskTiming({
         name: entry.name,
-        entryType: rawToPerformanceEntryType(entry.entryType),
         startTime: entry.startTime,
         duration: entry.duration,
       });
@@ -53,7 +52,8 @@ export function rawToPerformanceEntry(
         startTime: entry.startTime,
       });
     case RawPerformanceEntryTypeValues.MEASURE:
-      return new PerformanceMeasure(entry.name, {
+      return new PerformanceMeasure({
+        name: entry.name,
         startTime: entry.startTime,
         duration: entry.duration,
       });
@@ -71,9 +71,8 @@ export function rawToPerformanceEntry(
         responseStatus: entry.responseStatus,
       });
     default:
-      return new PerformanceEntry({
+      return new PerformanceEntry(rawToPerformanceEntryType(entry.entryType), {
         name: entry.name,
-        entryType: rawToPerformanceEntryType(entry.entryType),
         startTime: entry.startTime,
         duration: entry.duration,
       });


### PR DESCRIPTION
Summary:
Changelog: [internal]

This renames `setUpPerformanceObserver` as `setUpPerformanceModern` and removes the need to call it manually. If the native module is defined, we define the whole new API.

Differential Revision: D80803626
