### PR TITLE
[iOS][precompile] Support dynamic static linkage with prebuilts

### DIFF
--- a/packages/react-native/React/React-RCTFBReactNativeSpec.podspec
+++ b/packages/react-native/React/React-RCTFBReactNativeSpec.podspec
@@ -45,10 +45,7 @@ Pod::Spec.new do |s|
     "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),
   }
 
-  if ENV['USE_FRAMEWORKS']
-    s.header_mappings_dir  = 'FBReactNativeSpec'
-    s.module_name          = 'React_RCTFBReactNativeSpec'
-  end
+  resolve_use_frameworks(s, header_mappings_dir: 'FBReactNativeSpec', module_name: "React_RCTFBReactNativeSpec")
 
   s.dependency "React-jsi"
   s.dependency "RCTRequired"

--- a/packages/react-native/React/Runtime/React-RCTRuntime.podspec
+++ b/packages/react-native/React/Runtime/React-RCTRuntime.podspec
@@ -35,9 +35,7 @@ Pod::Spec.new do |s|
   s.header_dir             = header_dir
   s.module_name          = module_name
 
-  if ENV['USE_FRAMEWORKS']
-    s.header_mappings_dir = "./"
-  end
+  resolve_use_frameworks(s, header_mappings_dir: "./")
 
   s.pod_target_xcconfig    = {
     "OTHER_CFLAGS" => "$(inherited) " + new_arch_flags,

--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -32,10 +32,7 @@ Pod::Spec.new do |s|
                             "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                             "DEFINES_MODULE" => "YES" }
 
-  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
-    s.header_mappings_dir     = './'
-    s.module_name             = 'React_Fabric'
-  end
+  resolve_use_frameworks(s, header_mappings_dir: "./", module_name: "React_Fabric")
 
   s.dependency "React-jsiexecutor"
   s.dependency "RCTRequired"

--- a/packages/react-native/ReactCommon/React-FabricComponents.podspec
+++ b/packages/react-native/ReactCommon/React-FabricComponents.podspec
@@ -49,10 +49,7 @@ Pod::Spec.new do |s|
                             "HEADER_SEARCH_PATHS" => header_search_path.join(" "),
                           }
 
-  if ENV['USE_FRAMEWORKS']
-    s.header_mappings_dir     = './'
-    s.module_name             = 'React_FabricComponents'
-  end
+  resolve_use_frameworks(s, header_mappings_dir: "./", module_name: "React_FabricComponents")
 
   s.dependency "React-jsiexecutor"
   s.dependency "RCTRequired"

--- a/packages/react-native/ReactCommon/React-FabricImage.podspec
+++ b/packages/react-native/ReactCommon/React-FabricImage.podspec
@@ -50,10 +50,7 @@ Pod::Spec.new do |s|
                             "HEADER_SEARCH_PATHS" => header_search_path.join(" ")
                           }
 
-  if ENV['USE_FRAMEWORKS']
-    s.header_mappings_dir     = './'
-    s.module_name             = 'React_FabricImage'
-  end
+  resolve_use_frameworks(s, header_mappings_dir: './', module_name: "React_FabricImage")
 
   s.dependency "React-jsiexecutor", version
   s.dependency "RCTRequired", version

--- a/packages/react-native/ReactCommon/React-Mapbuffer.podspec
+++ b/packages/react-native/ReactCommon/React-Mapbuffer.podspec
@@ -32,10 +32,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = {  "HEADER_SEARCH_PATHS" => ["\"$(PODS_TARGET_SRCROOT)\""], "USE_HEADERMAP" => "YES",
                             "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard() }
 
-  if ENV['USE_FRAMEWORKS']
-    s.header_mappings_dir     = './'
-    s.module_name             = 'React_Mapbuffer'
-  end
+  resolve_use_frameworks(s, header_mappings_dir: './', module_name: "React_Mapbuffer")
 
   add_dependency(s, "React-debug")
   add_rn_third_party_dependencies(s)

--- a/packages/react-native/ReactCommon/ReactCommon.podspec
+++ b/packages/react-native/ReactCommon/ReactCommon.podspec
@@ -32,9 +32,8 @@ Pod::Spec.new do |s|
                                "DEFINES_MODULE" => "YES",
                                "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                "GCC_WARN_PEDANTIC" => "YES" }
-  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
-    s.header_mappings_dir     = './'
-  end
+
+  resolve_use_frameworks(s, header_mappings_dir: './')
 
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)

--- a/packages/react-native/ReactCommon/hermes/executor/React-jsitracing.podspec
+++ b/packages/react-native/ReactCommon/hermes/executor/React-jsitracing.podspec
@@ -32,10 +32,7 @@ Pod::Spec.new do |s|
                                 "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                 "GCC_WARN_PEDANTIC" => "YES" }
 
-  if ENV['USE_FRAMEWORKS']
-    s.header_mappings_dir     = './'
-    s.module_name             = 'React_jsitracing'
-  end
+  resolve_use_frameworks(s, header_mappings_dir: './', module_name: "React_jsitracing")
 
   s.dependency "React-jsi"
 end

--- a/packages/react-native/ReactCommon/jserrorhandler/React-jserrorhandler.podspec
+++ b/packages/react-native/ReactCommon/jserrorhandler/React-jserrorhandler.podspec
@@ -33,10 +33,8 @@ Pod::Spec.new do |s|
     "USE_HEADERMAP" => "YES",
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard()
   }
-  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
-    s.header_mappings_dir     = '../'
-    s.module_name             = 'React_jserrorhandler'
-  end
+
+  resolve_use_frameworks(s, header_mappings_dir: '../', module_name: "React_jserrorhandler")
 
   s.dependency "React-jsi"
   s.dependency "React-cxxreact"

--- a/packages/react-native/ReactCommon/jsinspector-modern/React-jsinspector.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/React-jsinspector.podspec
@@ -44,10 +44,9 @@ Pod::Spec.new do |s|
     "PUBLIC_HEADERS_FOLDER_PATH" => "#{module_name}.framework/Headers/#{header_dir}"
   } : {})
 
-  if ENV['USE_FRAMEWORKS']
-    s.module_name = module_name
-  end
+  resolve_use_frameworks(s, module_name: module_name)
 
+  add_dependency(s, "React-oscompat") # Needed for USE_FRAMEWORKS=dynamic
   s.dependency "React-featureflags"
   add_dependency(s, "React-runtimeexecutor", :additional_framework_paths => ["platform/ios"])
   s.dependency "React-jsi"

--- a/packages/react-native/ReactCommon/jsinspector-modern/cdp/React-jsinspectorcdp.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/cdp/React-jsinspectorcdp.podspec
@@ -41,10 +41,7 @@ Pod::Spec.new do |s|
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
     "DEFINES_MODULE" => "YES"}
 
-  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
-    s.module_name = module_name
-    s.header_mappings_dir = "../.."
-  end
+  resolve_use_frameworks(s, header_mappings_dir: "../..", module_name: module_name)
 
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/React-jsinspectornetwork.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/React-jsinspectornetwork.podspec
@@ -41,10 +41,7 @@ Pod::Spec.new do |s|
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
     "DEFINES_MODULE" => "YES"}
 
-  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
-    s.module_name = module_name
-    s.header_mappings_dir = "../.."
-  end
+  resolve_use_frameworks(s, header_mappings_dir: "../..", module_name: module_name)
 
   add_dependency(s, "React-jsinspectorcdp", :framework_name => 'jsinspector_moderncdp')
   add_dependency(s, "React-featureflags")

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/React-jsinspectortracing.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/React-jsinspectortracing.podspec
@@ -41,10 +41,7 @@ Pod::Spec.new do |s|
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
     "DEFINES_MODULE" => "YES"}
 
-  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
-    s.module_name = module_name
-    s.header_mappings_dir = "../.."
-  end
+  resolve_use_frameworks(s, header_mappings_dir: "../..", module_name: module_name)
 
   s.dependency "React-oscompat"
   s.dependency "React-timing"

--- a/packages/react-native/ReactCommon/jsitooling/React-jsitooling.podspec
+++ b/packages/react-native/ReactCommon/jsitooling/React-jsitooling.podspec
@@ -28,10 +28,7 @@ Pod::Spec.new do |s|
   s.source_files           = podspec_sources("react/runtime/*.{cpp,h}", "react/runtime/*.h")
   s.header_dir             = "react/runtime"
 
-  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
-    s.module_name            = "JSITooling"
-    s.header_mappings_dir  = "./"
-  end
+  resolve_use_frameworks(s, header_mappings_dir: "./", module_name: "JSITooling")
 
   s.pod_target_xcconfig    = {
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),

--- a/packages/react-native/ReactCommon/react/debug/React-debug.podspec
+++ b/packages/react-native/ReactCommon/react/debug/React-debug.podspec
@@ -30,8 +30,5 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig    = { "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                "DEFINES_MODULE" => "YES" }
 
-  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
-    s.module_name            = "React_debug"
-    s.header_mappings_dir  = "../.."
-  end
+  resolve_use_frameworks(s, header_mappings_dir: "../..", module_name: "React_debug")
 end

--- a/packages/react-native/ReactCommon/react/featureflags/React-featureflags.podspec
+++ b/packages/react-native/ReactCommon/react/featureflags/React-featureflags.podspec
@@ -37,10 +37,7 @@ Pod::Spec.new do |s|
                                "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),
                                "DEFINES_MODULE" => "YES" }
 
-  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
-    s.module_name            = "React_featureflags"
-    s.header_mappings_dir  = "../.."
-  end
+  resolve_use_frameworks(s, header_mappings_dir: "../..", module_name: "React_featureflags")
 
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/React-NativeModulesApple.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/React-NativeModulesApple.podspec
@@ -31,9 +31,8 @@ Pod::Spec.new do |s|
                                 "USE_HEADERMAP" => "YES",
                                 "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                 "GCC_WARN_PEDANTIC" => "YES" }
-    if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
-        s.header_mappings_dir     = './'
-    end
+
+    resolve_use_frameworks(s, header_mappings_dir: './')
 
     s.source_files = podspec_sources("ReactCommon/**/*.{mm,cpp,h}", "ReactCommon/**/*.{h}")
 

--- a/packages/react-native/ReactCommon/react/nativemodule/defaults/React-defaultsnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/defaults/React-defaultsnativemodule.podspec
@@ -38,10 +38,7 @@ Pod::Spec.new do |s|
                                "OTHER_CFLAGS" => "$(inherited)",
                                "DEFINES_MODULE" => "YES" }
 
-  if ENV['USE_FRAMEWORKS']
-    s.module_name            = "React_defaultsnativemodule"
-    s.header_mappings_dir  = "../.."
-  end
+  resolve_use_frameworks(s, header_mappings_dir: "../..", module_name: "React_defaultsnativemodule")
 
   s.dependency "React-jsi"
   s.dependency "React-jsiexecutor"

--- a/packages/react-native/ReactCommon/react/nativemodule/dom/React-domnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/dom/React-domnativemodule.podspec
@@ -40,10 +40,7 @@ Pod::Spec.new do |s|
                                "OTHER_CFLAGS" => "$(inherited)",
                                "DEFINES_MODULE" => "YES" }
 
-  if ENV['USE_FRAMEWORKS']
-    s.module_name            = "React_domnativemodule"
-    s.header_mappings_dir  = "../.."
-  end
+  resolve_use_frameworks(s, header_mappings_dir: "../..", module_name: "React_domnativemodule")
 
   s.dependency "React-jsi"
   s.dependency "React-jsiexecutor"

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/React-featureflagsnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/React-featureflagsnativemodule.podspec
@@ -38,10 +38,7 @@ Pod::Spec.new do |s|
                                "OTHER_CFLAGS" => "$(inherited)",
                                "DEFINES_MODULE" => "YES" }
 
-  if ENV['USE_FRAMEWORKS']
-    s.module_name            = "React_featureflagsnativemodule"
-    s.header_mappings_dir  = "../.."
-  end
+  resolve_use_frameworks(s, header_mappings_dir: "../..", module_name: "React_featureflagsnativemodule")
 
   s.dependency "React-jsi"
   s.dependency "React-jsiexecutor"

--- a/packages/react-native/ReactCommon/react/nativemodule/idlecallbacks/React-idlecallbacksnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/idlecallbacks/React-idlecallbacksnativemodule.podspec
@@ -38,10 +38,7 @@ Pod::Spec.new do |s|
                                "OTHER_CFLAGS" => "$(inherited)",
                                "DEFINES_MODULE" => "YES" }
 
-  if ENV['USE_FRAMEWORKS']
-    s.module_name            = "idlecallbacksnativemodule"
-    s.header_mappings_dir  = "../.."
-  end
+  resolve_use_frameworks(s, header_mappings_dir: "../..", module_name: "idlecallbacksnativemodule")
 
   s.dependency "React-jsi"
   s.dependency "React-jsiexecutor"

--- a/packages/react-native/ReactCommon/react/nativemodule/microtasks/React-microtasksnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/microtasks/React-microtasksnativemodule.podspec
@@ -38,10 +38,7 @@ Pod::Spec.new do |s|
                                "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),
                                "DEFINES_MODULE" => "YES" }
 
-  if ENV['USE_FRAMEWORKS']
-    s.module_name            = "React_microtasksnativemodule"
-    s.header_mappings_dir  = "../.."
-  end
+  resolve_use_frameworks(s, header_mappings_dir: "../..", module_name: "React_microtasksnativemodule")
 
   s.dependency "React-jsi"
   s.dependency "React-jsiexecutor"

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon-Samples.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/ReactCommon-Samples.podspec
@@ -40,6 +40,8 @@ Pod::Spec.new do |s|
   s.framework = "UIKit"
 
   if ENV['USE_FRAMEWORKS']
+    # Do not use resolve_use_frameworks here - since we're including source files.
+    # Then it is not needed.
     s.header_mappings_dir     = './'
   end
 

--- a/packages/react-native/ReactCommon/react/performance/cdpmetrics/React-performancecdpmetrics.podspec
+++ b/packages/react-native/ReactCommon/react/performance/cdpmetrics/React-performancecdpmetrics.podspec
@@ -38,10 +38,7 @@ Pod::Spec.new do |s|
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
     "HEADER_SEARCH_PATHS" => header_search_paths.join(' ')}
 
-  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
-    s.module_name            = "React_performancecdpmetrics"
-    s.header_mappings_dir  = "../../.."
-  end
+  resolve_use_frameworks(s, header_mappings_dir: "../../..", module_name: "React_performancecdpmetrics")
 
   add_dependency(s, "React-runtimeexecutor", :additional_framework_paths => ["platform/ios"])
   s.dependency "React-jsi"

--- a/packages/react-native/ReactCommon/react/performance/timeline/React-performancetimeline.podspec
+++ b/packages/react-native/ReactCommon/react/performance/timeline/React-performancetimeline.podspec
@@ -38,10 +38,7 @@ Pod::Spec.new do |s|
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
     "HEADER_SEARCH_PATHS" => header_search_paths.join(' ')}
 
-  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
-    s.module_name            = "React_performancetimeline"
-    s.header_mappings_dir  = "../../.."
-  end
+  resolve_use_frameworks(s, header_mappings_dir: "../../..", module_name: "React_performancetimeline")
 
   s.dependency "React-featureflags"
   add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')

--- a/packages/react-native/ReactCommon/react/renderer/consistency/React-rendererconsistency.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/consistency/React-rendererconsistency.podspec
@@ -38,8 +38,6 @@ Pod::Spec.new do |s|
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
     "HEADER_SEARCH_PATHS" => header_search_paths.join(' ')}
 
-  if ENV['USE_FRAMEWORKS']
-    s.module_name            = "React_rendererconsistency"
-    s.header_mappings_dir  = "../../.."
-  end
+  resolve_use_frameworks(s, header_mappings_dir: "../../..", module_name: "React_rendererconsistency")
+
 end

--- a/packages/react-native/ReactCommon/react/renderer/css/React-renderercss.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/css/React-renderercss.podspec
@@ -18,7 +18,7 @@ end
 
 header_search_paths = []
 
-if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
+if ENV['USE_FRAMEWORKS']
   header_search_paths << "\"$(PODS_TARGET_SRCROOT)/../../..\"" # this is needed to allow the renderer/css access its own files
 end
 
@@ -40,10 +40,7 @@ Pod::Spec.new do |s|
     "DEFINES_MODULE" => "YES",
   }
 
-  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
-    s.module_name            = "React_renderercss"
-    s.header_mappings_dir  = "../../.."
-  end
+  resolve_use_frameworks(s, header_mappings_dir: "../../..", module_name: "React_renderercss")
 
   add_dependency(s, "React-debug")
   add_dependency(s, "React-utils")

--- a/packages/react-native/ReactCommon/react/renderer/debug/React-rendererdebug.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/debug/React-rendererdebug.podspec
@@ -40,10 +40,7 @@ Pod::Spec.new do |s|
     "DEFINES_MODULE" => "YES"
   }
 
-  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
-    s.module_name            = "React_rendererdebug"
-    s.header_mappings_dir  = "../../.."
-  end
+  resolve_use_frameworks(s, header_mappings_dir: "../../..", module_name: "React_rendererdebug")
 
   add_dependency(s, "React-debug")
   add_rn_third_party_dependencies(s)

--- a/packages/react-native/ReactCommon/react/renderer/graphics/React-graphics.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/React-graphics.podspec
@@ -34,11 +34,11 @@ Pod::Spec.new do |s|
   s.header_dir             = "react/renderer/graphics"
   s.framework = "UIKit"
 
-  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
-    s.module_name            = "React_graphics"
-    s.header_mappings_dir  = "../../.."
+  if ENV['USE_FRAMEWORKS']
     header_search_paths = header_search_paths + ["\"$(PODS_TARGET_SRCROOT)/platform/ios\""]
   end
+
+  resolve_use_frameworks(s, header_mappings_dir: "../../..", module_name: "React_graphics")
 
   s.pod_target_xcconfig  = { "USE_HEADERMAP" => "NO",
                              "HEADER_SEARCH_PATHS" => header_search_paths.join(" "),

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/React-ImageManager.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/React-ImageManager.podspec
@@ -34,10 +34,7 @@ Pod::Spec.new do |s|
   s.source_files           = podspec_sources(source_files, "**/*.h")
   s.header_dir             = "react/renderer/imagemanager"
 
-  if ENV['USE_FRAMEWORKS']
-    s.module_name            = "React_ImageManager"
-    s.header_mappings_dir  = "./"
-  end
+  resolve_use_frameworks(s, header_mappings_dir: "./", module_name: "React_ImageManager")
 
   s.pod_target_xcconfig  = {
     "USE_HEADERMAP" => "NO",

--- a/packages/react-native/ReactCommon/react/renderer/runtimescheduler/React-runtimescheduler.podspec
+++ b/packages/react-native/ReactCommon/react/renderer/runtimescheduler/React-runtimescheduler.podspec
@@ -38,10 +38,7 @@ Pod::Spec.new do |s|
     "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
     "HEADER_SEARCH_PATHS" => header_search_paths.join(' ')}
 
-  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
-    s.module_name            = "React_runtimescheduler"
-    s.header_mappings_dir  = "../../.."
-  end
+  resolve_use_frameworks(s, header_mappings_dir: "../../..", module_name: "React_runtimescheduler")
 
   add_dependency(s, "React-runtimeexecutor", :additional_framework_paths => ["platform/ios"])
   s.dependency "React-callinvoker"

--- a/packages/react-native/ReactCommon/react/runtime/React-RuntimeCore.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/React-RuntimeCore.podspec
@@ -33,10 +33,7 @@ Pod::Spec.new do |s|
                                 "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                 "GCC_WARN_PEDANTIC" => "YES" }
 
-  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
-    s.header_mappings_dir     = '../../'
-    s.module_name             = 'React_RuntimeCore'
-  end
+  resolve_use_frameworks(s, header_mappings_dir: "../..", module_name: "React_RuntimeCore")
 
   s.dependency "React-jsiexecutor"
   s.dependency "React-cxxreact"

--- a/packages/react-native/ReactCommon/react/runtime/React-RuntimeHermes.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/React-RuntimeHermes.podspec
@@ -32,10 +32,7 @@ Pod::Spec.new do |s|
                                 "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                 "GCC_WARN_PEDANTIC" => "YES" }
 
-  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
-    s.header_mappings_dir     = '../../'
-    s.module_name             = 'React_RuntimeHermes'
-  end
+  resolve_use_frameworks(s, header_mappings_dir: "../../", module_name: "React_RuntimeHermes")
 
   s.dependency "React-jsitracing"
   s.dependency "React-jsi"

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/React-RuntimeApple.podspec
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/React-RuntimeApple.podspec
@@ -38,10 +38,7 @@ Pod::Spec.new do |s|
                                 "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),
                                 "GCC_WARN_PEDANTIC" => "YES" }
 
-  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
-    s.header_mappings_dir     = './'
-    s.module_name             = 'React_RuntimeApple'
-  end
+  resolve_use_frameworks(s, header_mappings_dir: "./", module_name: "React_RuntimeApple")
 
   s.dependency "React-jsiexecutor"
   s.dependency "React-cxxreact"

--- a/packages/react-native/ReactCommon/react/timing/React-timing.podspec
+++ b/packages/react-native/ReactCommon/react/timing/React-timing.podspec
@@ -37,10 +37,7 @@ Pod::Spec.new do |s|
                                "HEADER_SEARCH_PATHS" => header_search_paths.join(' '),
                                "DEFINES_MODULE" => "YES" }
 
-  if ENV['USE_FRAMEWORKS']
-    s.module_name            = "React_timing"
-    s.header_mappings_dir  = "./"
-  end
+  resolve_use_frameworks(s, header_mappings_dir: "./", module_name: "React_timing")
 
   add_dependency(s, "React-debug")
 end

--- a/packages/react-native/ReactCommon/react/utils/React-utils.podspec
+++ b/packages/react-native/ReactCommon/react/utils/React-utils.podspec
@@ -34,11 +34,11 @@ Pod::Spec.new do |s|
   s.header_dir             = "react/utils"
   s.exclude_files          = "tests"
 
-  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
-    s.module_name            = "React_utils"
-    s.header_mappings_dir  = "../.."
+  if ENV['USE_FRAMEWORKS']
     header_search_paths = header_search_paths + ["\"$(PODS_TARGET_SRCROOT)/platform/ios\""]
   end
+
+  resolve_use_frameworks(s, header_mappings_dir: "../..", module_name: "React_utils")
 
   s.pod_target_xcconfig    = { "USE_HEADERMAP" => "NO",
                                "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),

--- a/packages/react-native/ReactCommon/runtimeexecutor/React-runtimeexecutor.podspec
+++ b/packages/react-native/ReactCommon/runtimeexecutor/React-runtimeexecutor.podspec
@@ -33,10 +33,11 @@ Pod::Spec.new do |s|
   s.source_files           = podspec_sources(["ReactCommon/*.{m,mm,cpp,h}", "platform/ios/**/*.{m,mm,cpp,h}"], ["ReactCommon/*.h", "platform/ios/**/*.h"])
   s.header_dir             = "ReactCommon"
 
-  if ENV['USE_FRAMEWORKS'] && ReactNativeCoreUtils.build_rncore_from_source()
-    s.header_mappings_dir      = '.'
+  if ENV['USE_FRAMEWORKS']
     header_search_paths = header_search_paths + ["\"$(PODS_TARGET_SRCROOT)/platform/ios\""]
   end
+
+  resolve_use_frameworks(s, header_mappings_dir: ".")
 
   s.pod_target_xcconfig    = { "USE_HEADERMAP" => "NO",
                                "CLANG_CXX_LANGUAGE_STANDARD" => rct_cxx_language_standard(),

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -704,7 +704,7 @@ class ReactNativePodsUtils
     end
 
     def self.resolve_use_frameworks(spec, header_mappings_dir: nil, module_name: nil)
-        if ENV['USE_FRAMEWORKS']
+        return unless ENV['USE_FRAMEWORKS'] 
             if module_name
                 spec.module_name = module_name
             end

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -258,7 +258,8 @@ class ReactNativePodsUtils
         search_paths = []
 
         # When building using the prebuilt rncore we can't use framework folders as search paths since these aren't created
-        if ReactNativeCoreUtils.build_rncore_from_source()
+        # Except for when adding search path for ReactCodegen since it contains source code.
+        if ReactNativeCoreUtils.build_rncore_from_source() || pod_name === "ReactCodegen"
             platforms = $RN_PLATFORMS != nil ? $RN_PLATFORMS : []
 
             if platforms.empty?() || platforms.length() == 1

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -704,14 +704,13 @@ class ReactNativePodsUtils
     end
 
     def self.resolve_use_frameworks(spec, header_mappings_dir: nil, module_name: nil)
-        return unless ENV['USE_FRAMEWORKS'] 
-            if module_name
-                spec.module_name = module_name
-            end
+        return unless ENV['USE_FRAMEWORKS']
+        if module_name
+            spec.module_name = module_name
+        end
 
-            if header_mappings_dir != nil && ReactNativeCoreUtils.build_rncore_from_source()
-                spec.header_mappings_dir = header_mappings_dir
-            end
+        if header_mappings_dir != nil && ReactNativeCoreUtils.build_rncore_from_source()
+            spec.header_mappings_dir = header_mappings_dir
         end
     end
 end

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -701,4 +701,16 @@ class ReactNativePodsUtils
             end
         end
     end
+
+    def self.resolve_use_frameworks(spec, header_mappings_dir: nil, module_name: nil)
+        if ENV['USE_FRAMEWORKS']
+            if module_name
+                spec.module_name = module_name
+            end
+
+            if header_mappings_dir != nil && ReactNativeCoreUtils.build_rncore_from_source()
+                spec.header_mappings_dir = header_mappings_dir
+            end
+        end
+    end
 end

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -231,6 +231,20 @@ def folly_flags()
   return NewArchitectureHelper.folly_compiler_flags
 end
 
+# Resolve the spec for use with the USE_FRAMEWORKS environment variable. To avoid each podspec
+# to manually specify the header mappings and module name, we can use this helper function.
+# This helper will also resolve header mappings if we're building from source. Precompiled
+# React-Core will not generate frameworks since their podspec files only contains the
+# header files and no source code - so header_mappings should be the same as for without USE_FRAMEWORKS
+#
+# Parameters:
+# - s: the spec to modify
+# - header_mappings_dir: the directory to map headers when building Pod header structure
+# - module_name: the name of the module when exposed to swift
+def resolve_use_frameworks(spec, header_mappings_dir: nil, module_name: nil)
+  ReactNativePodsUtils.resolve_use_frameworks(spec, :header_mappings_dir => header_mappings_dir, :module_name => module_name)
+end
+
 # Add a dependency to a spec, making sure that the HEADER_SERACH_PATHS are set properly.
 # This function automate the requirement to specify the HEADER_SEARCH_PATHS which was error prone
 # and hard to pull out properly to begin with.

--- a/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.cpp
+++ b/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.cpp
@@ -7,6 +7,12 @@
 
 #include "NativeCxxModuleExample.h"
 #include <react/debug/react_native_assert.h>
+
+// Include to verify that paths are resolved correctly when using
+// precompiled binaries & USE_FRAMEWORKS is set.
+#include <react/renderer/components/AppSpecs/Props.h>
+#include <react/renderer/components/image/conversions.h>
+
 #include <iomanip>
 #include <ostream>
 #include <sstream>

--- a/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.cpp
+++ b/packages/rn-tester/NativeCxxModuleExample/NativeCxxModuleExample.cpp
@@ -7,12 +7,6 @@
 
 #include "NativeCxxModuleExample.h"
 #include <react/debug/react_native_assert.h>
-
-// Include to verify that paths are resolved correctly when using
-// precompiled binaries & USE_FRAMEWORKS is set.
-#include <react/renderer/components/AppSpecs/Props.h>
-#include <react/renderer/components/image/conversions.h>
-
 #include <iomanip>
 #include <ostream>
 #include <sstream>


### PR DESCRIPTION
## Summary:

To be able to handle cocoapods USE_FRAMEWORKS with both dynamic/static linkage and precompiled we needed a common way to resolve this.

The issue was that when using precompiled and USE_FRAMEWORKS our precompiled framework caused the resulting Pods project to only include header files - hence there where no need to change the header_mappings_dir which a lot of the podspecs did.

When using precompiled and building with frameworks (USE_FRAMEWORKS) we need to explicitly add the correct path to ReactCodegen when calling `create_header_search_path_for_frameworks` to ensure libraries can access their codegen files.

- Added method that handles this in a generic way
- Replaced logic for resolving header mappings and module name using the new method `resolve_use_frameworks` in all podspecs.
- Add an explicit check to make sure we add the correct path when using frameworks and the pod is ReactCodegen.
- Added includes in the NativeCXXModuleExample.cpp file to test this.

## Changelog:

[IOS] [FIXED] - Fixed using USE_FRAMEWORKS (static/dynamic) with precompiled binaries

## Test Plan:

Build RN-Tester with USE_FRAMEWORKS static and dynamic

### Tests ran:

 ✅ Build with source and no USE_FRAMEWORKS
 ✅ Build with source and USE_FRAMEWORKS = static
 🔴 Build with source and USE_FRAMEWORKS = dynamic

 Undefined symbols for architecture arm64:
   "facebook::react::oscompat::getCurrentProcessId()", referenced from:
       facebook::react::jsinspector_modern::HostTargetTraceRecording::start() in HostTargetTraceRecording.o
 ld: symbol(s) not found for architecture arm64
 clang++: error: linker command failed with exit code 1 (use -v to see invocation)

 This fails on `main` as well.

 **FIXED** when adding dep on React-oscompat when USE_FRAMEWORKS=dynamic:

 ✅ Build with source and USE_FRAMEWORKS = dynamic

 ✅ Build with precompiled and no USE_FRAMEWORKS
 ✅ Build with precompiled and USE_FRAMEWORKS = static
 ✅ Build with precompiled and USE_FRAMEWORKS = dynamic