### PR TITLE
Demote `electron` to devDependency

### DIFF
--- a/packages/debugger-shell/__tests__/__snapshots__/dotslash-test.js.snap
+++ b/packages/debugger-shell/__tests__/__snapshots__/dotslash-test.js.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`prepareDebuggerShellFromDotSlashFile fails with the expected error message for a missing dotslash file 1`] = `
+Object {
+  "code": "unexpected_error",
+  "humanReadableMessage": "An unexpected error occured while installing the latest version of React Native DevTools. Using a fallback version instead.",
+  "verboseInfo": Any<String>,
+}
+`;
+
+exports[`prepareDebuggerShellFromDotSlashFile fails with the expected error message for missing platforms 1`] = `
+Object {
+  "code": "platform_not_supported",
+  "humanReadableMessage": "The latest version of React Native DevTools is not supported on this platform. Using a fallback version instead.",
+  "verboseInfo": Any<String>,
+}
+`;
+
+exports[`prepareDebuggerShellFromDotSlashFile scenarios requiring a local HTTP server fails with the expected error message for a corrupted tarball 1`] = `
+Object {
+  "code": "possible_corruption",
+  "humanReadableMessage": "Failed to verify the latest version of React Native DevTools. Using a fallback version instead. ",
+  "verboseInfo": Any<String>,
+}
+`;
+
+exports[`prepareDebuggerShellFromDotSlashFile scenarios requiring a local HTTP server fails with the expected error message for a network error 1`] = `
+Object {
+  "code": "likely_offline",
+  "humanReadableMessage": "Failed to download the latest version of React Native DevTools. Using a fallback version instead. Connect to the internet or check your network settings.",
+  "verboseInfo": Any<String>,
+}
+`;

--- a/packages/debugger-shell/__tests__/dotslash-file-simulating-data-corruption.jsonc
+++ b/packages/debugger-shell/__tests__/dotslash-file-simulating-data-corruption.jsonc
@@ -1,0 +1,59 @@
+#!/usr/bin/env dotslash
+
+{
+    "name": "React Native DevTools",
+    "platforms": {
+        "linux-aarch64": {
+            "size": 113510892,
+            "hash": "sha256",
+            "digest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "providers": [
+                {
+                    "type": "http",
+                    "url": "http://$HOST:$PORT/corrupted.tar.gz"
+                }
+            ],
+            "format": "tar.gz",
+            "path": "React Native DevTools-linux-arm64/React Native DevTools"
+        },
+        "linux-x86_64": {
+            "size": 113243910,
+            "hash": "sha256",
+            "digest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "providers": [
+                {
+                    "type": "http",
+                    "url": "http://$HOST:$PORT/corrupted.tar.gz"
+                }
+            ],
+            "format": "tar.gz",
+            "path": "React Native DevTools-linux-x64/React Native DevTools"
+        },
+        "macos-aarch64": {
+            "size": 108810433,
+            "hash": "sha256",
+            "digest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "providers": [
+                {
+                    "type": "http",
+                    "url": "http://$HOST:$PORT/corrupted.tar.gz"
+                }
+            ],
+            "format": "tar.gz",
+            "path": "React Native DevTools.app/Contents/MacOS/React Native DevTools"
+        },
+        "macos-x86_64": {
+            "size": 113769989,
+            "hash": "sha256",
+            "digest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "providers": [
+                {
+                    "type": "http",
+                    "url": "http://$HOST:$PORT/corrupted.tar.gz"
+                }
+            ],
+            "format": "tar.gz",
+            "path": "React Native DevTools.app/Contents/MacOS/React Native DevTools"
+        }
+    }
+}

--- a/packages/debugger-shell/__tests__/dotslash-file-simulating-network-error.jsonc
+++ b/packages/debugger-shell/__tests__/dotslash-file-simulating-network-error.jsonc
@@ -1,0 +1,59 @@
+#!/usr/bin/env dotslash
+
+{
+    "name": "React Native DevTools",
+    "platforms": {
+        "linux-aarch64": {
+            "size": 113510892,
+            "hash": "sha256",
+            "digest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "providers": [
+                {
+                    "type": "http",
+                    "url": "https://$HOST:$PORT/does-not-exist"
+                }
+            ],
+            "format": "tar.gz",
+            "path": "React Native DevTools-linux-arm64/React Native DevTools"
+        },
+        "linux-x86_64": {
+            "size": 113243910,
+            "hash": "sha256",
+            "digest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "providers": [
+                {
+                    "type": "http",
+                    "url": "https://$HOST:$PORT/does-not-exist"
+                }
+            ],
+            "format": "tar.gz",
+            "path": "React Native DevTools-linux-x64/React Native DevTools"
+        },
+        "macos-aarch64": {
+            "size": 108810433,
+            "hash": "sha256",
+            "digest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "providers": [
+                {
+                    "type": "http",
+                    "url": "https://$HOST:$PORT/does-not-exist"
+                }
+            ],
+            "format": "tar.gz",
+            "path": "React Native DevTools.app/Contents/MacOS/React Native DevTools"
+        },
+        "macos-x86_64": {
+            "size": 113769989,
+            "hash": "sha256",
+            "digest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "providers": [
+                {
+                    "type": "http",
+                    "url": "https://$HOST:$PORT/does-not-exist"
+                }
+            ],
+            "format": "tar.gz",
+            "path": "React Native DevTools.app/Contents/MacOS/React Native DevTools"
+        }
+    }
+}

--- a/packages/debugger-shell/__tests__/dotslash-file-with-missing-platforms.jsonc
+++ b/packages/debugger-shell/__tests__/dotslash-file-with-missing-platforms.jsonc
@@ -1,0 +1,6 @@
+#!/usr/bin/env dotslash
+
+{
+    "name": "React Native DevTools",
+    "platforms": {}
+}

--- a/packages/debugger-shell/__tests__/dotslash-test.js
+++ b/packages/debugger-shell/__tests__/dotslash-test.js
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+const {
+  prepareDebuggerShellFromDotSlashFile,
+} = require('../src/node/private/LaunchUtils');
+const fs = require('fs').promises;
+const http = require('http');
+const os = require('os');
+const path = require('path');
+
+// The implementation of prepareDebuggerShellFromDotSlashFile relies on
+// details of DotSlash that are not guaranteed to be stable (support for
+// `dotslash -- fetch <file>`, certain strings being printed to stderr).
+// This (admittedly elaborate) test suite ensures we'll fail loudly if we
+// try to upgrade DotSlash to a version that breaks our assumptions.
+describe('prepareDebuggerShellFromDotSlashFile', () => {
+  test('fails with the expected error message for missing platforms', async () => {
+    const result = await prepareDebuggerShellFromDotSlashFile(
+      path.join(__dirname, 'dotslash-file-with-missing-platforms.jsonc'),
+    );
+    expect(result).toMatchSnapshot({
+      verboseInfo: expect.any(String),
+    });
+  });
+
+  test('fails with the expected error message for a missing dotslash file', async () => {
+    const result = await prepareDebuggerShellFromDotSlashFile(
+      path.join(__dirname, 'dotslash-file-that-does-not-exist.jsonc'),
+    );
+    expect(result).toMatchSnapshot({
+      verboseInfo: expect.any(String),
+    });
+  });
+
+  describe('scenarios requiring a local HTTP server', () => {
+    let server, scratchDir;
+
+    beforeEach(async () => {
+      scratchDir = await fs.mkdtemp(path.join(os.tmpdir(), 'dotslash-test-'));
+      server = http.createServer((request, response) => {
+        if (request.url === '/corrupted.tar.gz') {
+          response.writeHead(200, {'Content-Type': 'application/gzip'});
+          response.end(
+            'Hello, world!\n' + 'This simulated a corrupted tarball.',
+          );
+        } else {
+          response.writeHead(404);
+          response.end();
+        }
+      });
+      await new Promise((resolve, reject) => {
+        server.on('error', reject);
+        server.listen(0, 'localhost', () => {
+          server.removeListener('error', reject);
+          resolve();
+        });
+      });
+    });
+
+    afterEach(async () => {
+      await fs.rm(scratchDir, {recursive: true, force: true});
+      if (server.listening) {
+        await new Promise((resolve, reject) => {
+          server.close(error => {
+            if (error) {
+              reject(error);
+            } else {
+              resolve();
+            }
+          });
+        });
+      }
+    });
+
+    test('fails with the expected error message for a corrupted tarball', async () => {
+      const dotslashFileContents = injectHostPort(
+        await fs.readFile(
+          path.join(
+            __dirname,
+            'dotslash-file-simulating-data-corruption.jsonc',
+          ),
+          'utf8',
+        ),
+        server.address(),
+      );
+
+      await fs.writeFile(
+        path.join(scratchDir, 'dotslash-file.jsonc'),
+        dotslashFileContents,
+      );
+      const result = await prepareDebuggerShellFromDotSlashFile(
+        path.join(scratchDir, 'dotslash-file.jsonc'),
+      );
+      expect(result).toMatchSnapshot({
+        verboseInfo: expect.any(String),
+      });
+    });
+
+    test('fails with the expected error message for a network error', async () => {
+      const dotslashFileContents = injectHostPort(
+        await fs.readFile(
+          path.join(__dirname, 'dotslash-file-simulating-network-error.jsonc'),
+          'utf8',
+        ),
+        server.address(),
+      );
+
+      await fs.writeFile(
+        path.join(scratchDir, 'dotslash-file.jsonc'),
+        dotslashFileContents,
+      );
+      const result = await prepareDebuggerShellFromDotSlashFile(
+        path.join(scratchDir, 'dotslash-file.jsonc'),
+      );
+      expect(result).toMatchSnapshot({
+        verboseInfo: expect.any(String),
+      });
+    });
+  });
+});
+
+function injectHostPort(
+  dotslashFileContents: string,
+  address: net$Socket$address,
+) {
+  const host =
+    address.family === 'IPv6' ? `[${address.address}]` : address.address;
+  return dotslashFileContents
+    .replaceAll('$HOST', host)
+    .replaceAll('$PORT', address.port.toString());
+}

--- a/packages/debugger-shell/__tests__/electron-dependency-test.js
+++ b/packages/debugger-shell/__tests__/electron-dependency-test.js
@@ -22,7 +22,7 @@ describe('Electron dependency', () => {
     // $FlowFixMe[untyped-import] - package.json is not typed
     const ourPackageJson = require('../package.json');
 
-    const declaredElectronVersion = ourPackageJson.dependencies.electron;
+    const declaredElectronVersion = ourPackageJson.devDependencies.electron;
     expect(declaredElectronVersion).toBeTruthy();
 
     // $FlowFixMe[untyped-import] - package.json is not typed

--- a/packages/debugger-shell/package.json
+++ b/packages/debugger-shell/package.json
@@ -26,12 +26,12 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">= 20.19.4",
-    "electron": ">=37.2.6"
+    "node": ">= 20.19.4"
   },
   "dependencies": {
     "cross-spawn": "^7.0.6",
-    "electron": "37.2.6"
+    "electron": "37.2.6",
+    "fb-dotslash": "0.5.8"
   },
   "devDependencies": {
     "semver": "^7.1.3"

--- a/packages/debugger-shell/package.json
+++ b/packages/debugger-shell/package.json
@@ -30,10 +30,16 @@
   },
   "dependencies": {
     "cross-spawn": "^7.0.6",
-    "electron": "37.2.6",
     "fb-dotslash": "0.5.8"
   },
   "devDependencies": {
+    "electron": "37.2.6",
     "semver": "^7.1.3"
-  }
+  },
+  "files": [
+    "!**/__tests__/**",
+    "bin",
+    "dist",
+    "!src/electron"
+  ]
 }

--- a/packages/debugger-shell/src/node/__tests__/debugger-shell-test.js
+++ b/packages/debugger-shell/src/node/__tests__/debugger-shell-test.js
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall react_native
+ */
+
+const {unstable_spawnDebuggerShellWithArgs} = require('../../');
+
+describe('debugger-shell Node package', () => {
+  test('can spawn in detached+prebuilt mode without crashing', async () => {
+    await expect(
+      unstable_spawnDebuggerShellWithArgs(['--version'], {
+        flavor: 'prebuilt',
+        mode: 'detached',
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  // When running in the internal react-native-oss-js job, Electron isn't
+  // installed correctly (postinstall scripts don't run) but the internal
+  // `electron` workspace isn't available either. Detecting this dynamically
+  // weakens the test somewhat in environments where it *should* pass, but this
+  // is a dev-only feature anyway so this is fine.
+  if (isElectronInstalled()) {
+    test('can spawn in detached+dev mode without crashing', async () => {
+      await expect(
+        unstable_spawnDebuggerShellWithArgs(['--version'], {
+          flavor: 'dev',
+          mode: 'detached',
+        }),
+      ).resolves.toBeUndefined();
+    });
+  }
+});
+
+function isElectronInstalled() {
+  try {
+    require('electron');
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/debugger-shell/src/node/index.flow.js
+++ b/packages/debugger-shell/src/node/index.flow.js
@@ -9,43 +9,43 @@
  */
 
 const {spawn} = require('cross-spawn');
+const path = require('path');
+
+// The 'prebuilt' flavor will use the prebuilt shell binary (and the JavaScript embedded in it).
+// The 'dev' flavor will use a stock Electron binary and run the shell code from the `electron/` directory.
+type DebuggerShellFlavor = 'prebuilt' | 'dev';
 
 async function unstable_spawnDebuggerShellWithArgs(
   args: string[],
   {
     mode = 'detached',
+    flavor = 'dev',
   }: $ReadOnly<{
     // In 'syncAndExit' mode, the current process will block until the spawned process exits, and then it will exit
     // with the same exit code as the spawned process.
     // In 'detached' mode, the spawned process will be detached from the current process and the current process will
     // continue to run normally.
     mode?: 'syncThenExit' | 'detached',
+    flavor?: DebuggerShellFlavor,
   }> = {},
 ): Promise<void> {
-  // NOTE: Internally at Meta, this is aliased to a workspace that is
-  // API-compatible with the 'electron' package, but contains prebuilt binaries
-  // that do not need to be downloaded in a postinstall action.
-  const electronPath = require('electron');
+  const [binaryPath, baseArgs] = getShellBinaryAndArgs(flavor);
 
   return new Promise((resolve, reject) => {
-    const child = spawn(
-      electronPath,
-      [require.resolve('../electron'), ...args],
-      {
-        stdio: 'inherit',
-        windowsHide: true,
-        detached: mode === 'detached',
-      },
-    );
+    const child = spawn(binaryPath, [...baseArgs, ...args], {
+      stdio: 'inherit',
+      windowsHide: true,
+      detached: mode === 'detached',
+    });
     if (mode === 'detached') {
       child.on('spawn', () => {
         resolve();
       });
-      child.on('close', (code /*: number */) => {
+      child.on('close', (code: number) => {
         if (code !== 0) {
           reject(
             new Error(
-              `Failed to open debugger shell: ${electronPath} exited with code ${code}`,
+              `Failed to open debugger shell: exited with code ${code}`,
             ),
           );
         }
@@ -54,7 +54,7 @@ async function unstable_spawnDebuggerShellWithArgs(
     } else if (mode === 'syncThenExit') {
       child.on('close', function (code, signal) {
         if (code === null) {
-          console.error(electronPath, 'exited with signal', signal);
+          console.error('Debugger shell exited with signal', signal);
           process.exit(1);
         }
         process.exit(code);
@@ -72,6 +72,30 @@ async function unstable_spawnDebuggerShellWithArgs(
       handleTerminationSignal('SIGTERM');
     }
   });
+}
+
+function getShellBinaryAndArgs(
+  flavor: DebuggerShellFlavor,
+): [string, Array<string>] {
+  switch (flavor) {
+    case 'prebuilt':
+      return [
+        // $FlowIssue[cannot-resolve-module] fb-dotslash includes Flow types but Flow does not pick them up
+        require('fb-dotslash'),
+        [path.join(__dirname, '../../bin/react-native-devtools')],
+      ];
+    case 'dev':
+      return [
+        // NOTE: Internally at Meta, this is aliased to a workspace that is
+        // API-compatible with the 'electron' package, but contains prebuilt binaries
+        // that do not need to be downloaded in a postinstall action.
+        require('electron'),
+        [require.resolve('../electron')],
+      ];
+    default:
+      flavor as empty;
+      throw new Error(`Unknown flavor: ${flavor}`);
+  }
 }
 
 export {unstable_spawnDebuggerShellWithArgs};

--- a/packages/debugger-shell/src/node/index.flow.js
+++ b/packages/debugger-shell/src/node/index.flow.js
@@ -87,6 +87,7 @@ async function unstable_spawnDebuggerShellWithArgs(
 export type DebuggerShellPreparationResult = $ReadOnly<{
   code:
     | 'success'
+    | 'not_implemented'
     | 'likely_offline'
     | 'platform_not_supported'
     | 'possible_corruption'

--- a/packages/debugger-shell/src/node/index.flow.js
+++ b/packages/debugger-shell/src/node/index.flow.js
@@ -29,7 +29,7 @@ async function unstable_spawnDebuggerShellWithArgs(
   args: string[],
   {
     mode = 'detached',
-    flavor = 'dev',
+    flavor = 'prebuilt',
   }: $ReadOnly<{
     // In 'syncAndExit' mode, the current process will block until the spawned process exits, and then it will exit
     // with the same exit code as the spawned process.

--- a/packages/debugger-shell/src/node/private/LaunchUtils.js
+++ b/packages/debugger-shell/src/node/private/LaunchUtils.js
@@ -1,0 +1,98 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {DebuggerShellPreparationResult} from '../';
+
+const {spawn} = require('cross-spawn');
+
+async function spawnAndGetStderr(
+  command: string,
+  args: string[],
+): Promise<{
+  code: number,
+  stderr: string,
+}> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: ['ignore', 'ignore', 'pipe'],
+      encoding: 'utf8',
+      windowsHide: true,
+    });
+    let stderr = '';
+    child.stderr.on('data', data => {
+      stderr += data;
+    });
+    child.on('error', error => {
+      reject(error);
+    });
+    child.on('close', (code, signal) => {
+      resolve({
+        code,
+        stderr,
+      });
+    });
+  });
+}
+
+async function prepareDebuggerShellFromDotSlashFile(
+  filePath: string,
+): Promise<DebuggerShellPreparationResult> {
+  const {code, stderr} = await spawnAndGetStderr(
+    // $FlowIssue[cannot-resolve-module] fb-dotslash includes Flow types but Flow does not pick them up
+    require('fb-dotslash'),
+    ['--', 'fetch', filePath],
+  );
+  if (code === 0) {
+    return {code: 'success'};
+  }
+  if (
+    stderr.includes('dotslash error') &&
+    stderr.includes('no providers succeeded')
+  ) {
+    if (stderr.includes('failed to verify artifact')) {
+      return {
+        code: 'possible_corruption',
+        humanReadableMessage:
+          'Failed to verify the latest version of React Native DevTools. ' +
+          'Using a fallback version instead. ',
+        verboseInfo: stderr,
+      };
+    }
+    return {
+      code: 'likely_offline',
+      humanReadableMessage:
+        'Failed to download the latest version of React Native DevTools. ' +
+        'Using a fallback version instead. ' +
+        'Connect to the internet or check your network settings.',
+      verboseInfo: stderr,
+    };
+  }
+  if (
+    stderr.includes('dotslash error') &&
+    stderr.includes('platform not supported')
+  ) {
+    return {
+      code: 'platform_not_supported',
+      humanReadableMessage:
+        'The latest version of React Native DevTools is not supported on this platform. ' +
+        'Using a fallback version instead.',
+      verboseInfo: stderr,
+    };
+  }
+  return {
+    code: 'unexpected_error',
+    humanReadableMessage:
+      'An unexpected error occured while installing the latest version of React Native DevTools. ' +
+      'Using a fallback version instead.',
+    verboseInfo: stderr,
+  };
+}
+
+export {spawnAndGetStderr, prepareDebuggerShellFromDotSlashFile};

--- a/packages/dev-middleware/package.json
+++ b/packages/dev-middleware/package.json
@@ -38,6 +38,7 @@
     "node": ">= 20.19.4"
   },
   "devDependencies": {
+    "@react-native/debugger-shell": "0.82.0-main",
     "selfsigned": "^2.4.1",
     "undici": "^5.29.0",
     "wait-for-expect": "^3.0.2"

--- a/packages/dev-middleware/src/createDevMiddleware.js
+++ b/packages/dev-middleware/src/createDevMiddleware.js
@@ -170,6 +170,35 @@ function createWrappedEventReporter(
               '\u001B[27m',
           );
           break;
+        case 'fusebox_shell_preparation_attempt':
+          switch (event.result.code) {
+            case 'success':
+            case 'not_implemented':
+              break;
+            case 'unexpected_error': {
+              let message =
+                event.result.humanReadableMessage ??
+                'An unknown error occurred while installing React Native DevTools.';
+              if (event.result.verboseInfo != null) {
+                message += ` Details:\n\n${event.result.verboseInfo}`;
+              } else {
+                message += '.';
+              }
+              logger?.error(message);
+              break;
+            }
+            case 'possible_corruption':
+            case 'platform_not_supported':
+            case 'likely_offline':
+              logger?.warn(
+                event.result.humanReadableMessage ??
+                  `An error of type ${event.result.code} occurred while installing React Native DevTools.`,
+              );
+              break;
+            default:
+              (event.result.code: empty);
+              break;
+          }
       }
 
       reporter?.logEvent(event);

--- a/packages/dev-middleware/src/index.flow.js
+++ b/packages/dev-middleware/src/index.flow.js
@@ -10,7 +10,10 @@
 
 export {default as createDevMiddleware} from './createDevMiddleware';
 
-export type {BrowserLauncher} from './types/BrowserLauncher';
+export type {
+  BrowserLauncher,
+  DebuggerShellPreparationResult,
+} from './types/BrowserLauncher';
 export type {EventReporter, ReportableEvent} from './types/EventReporter';
 export type {
   CustomMessageHandler,

--- a/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
+++ b/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
@@ -10,7 +10,10 @@
 
 import type {InspectorProxyQueries} from '../inspector-proxy/InspectorProxy';
 import type {PageDescription} from '../inspector-proxy/types';
-import type {BrowserLauncher} from '../types/BrowserLauncher';
+import type {
+  BrowserLauncher,
+  DebuggerShellPreparationResult,
+} from '../types/BrowserLauncher';
 import type {EventReporter} from '../types/EventReporter';
 import type {Experiments} from '../types/Experiments';
 import type {Logger} from '../types/Logger';
@@ -48,6 +51,19 @@ export default function openDebuggerMiddleware({
   experiments,
   inspectorProxy,
 }: Options): NextHandleFunction {
+  let shellPreparationPromise: Promise<DebuggerShellPreparationResult>;
+  if (experiments.enableStandaloneFuseboxShell) {
+    shellPreparationPromise =
+      browserLauncher?.unstable_prepareFuseboxShell?.() ??
+      Promise.resolve({code: 'not_implemented'});
+    shellPreparationPromise = shellPreparationPromise.then(result => {
+      eventReporter?.logEvent({
+        type: 'fusebox_shell_preparation_attempt',
+        result,
+      });
+      return result;
+    });
+  }
   return async (
     req: IncomingMessage,
     res: ServerResponse,
@@ -155,10 +171,25 @@ export default function openDebuggerMiddleware({
                 landingView: query.landingView,
               },
             );
-            if (
-              useFuseboxEntryPoint &&
-              experiments.enableStandaloneFuseboxShell
-            ) {
+            let shouldUseStandaloneFuseboxShell =
+              useFuseboxEntryPoint && experiments.enableStandaloneFuseboxShell;
+            if (shouldUseStandaloneFuseboxShell) {
+              const shellPreparationResult = await shellPreparationPromise;
+              switch (shellPreparationResult.code) {
+                case 'success':
+                case 'not_implemented':
+                  break;
+                case 'platform_not_supported':
+                case 'possible_corruption':
+                case 'likely_offline':
+                case 'unexpected_error':
+                  shouldUseStandaloneFuseboxShell = false;
+                  break;
+                default:
+                  (shellPreparationResult.code: empty);
+              }
+            }
+            if (shouldUseStandaloneFuseboxShell) {
               const windowKey = [
                 serverBaseUrl,
                 target.webSocketDebuggerUrl,

--- a/packages/dev-middleware/src/types/BrowserLauncher.js
+++ b/packages/dev-middleware/src/types/BrowserLauncher.js
@@ -8,6 +8,10 @@
  * @format
  */
 
+import type {DebuggerShellPreparationResult} from '@react-native/debugger-shell';
+
+export type {DebuggerShellPreparationResult};
+
 /**
  * An interface for integrators to provide a custom implementation for
  * opening URLs in a web browser.
@@ -43,4 +47,17 @@ export interface BrowserLauncher {
    * this as necessary where the server is remote.
    */
   unstable_showFuseboxShell?: (url: string, windowKey: string) => Promise<void>;
+
+  /**
+   * Attempt to prepare the debugger shell for use and returns a coded result
+   * that can be used to advise the user on how to proceed in case of failure.
+   *
+   * This function MAY be called multiple times or not at all. Implementers
+   * SHOULD use the opportunity to prefetch and cache any expensive resources (e.g
+   * platform-specific binaries needed in order to show the Fusebox shell). After a
+   * successful call, subsequent calls SHOULD complete quickly. The implementation
+   * SHOULD NOT return a rejecting promise in any case, and instead SHOULD report
+   * errors via the returned result object.
+   */
+  unstable_prepareFuseboxShell?: () => Promise<DebuggerShellPreparationResult>;
 }

--- a/packages/dev-middleware/src/types/EventReporter.js
+++ b/packages/dev-middleware/src/types/EventReporter.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+import type {DebuggerShellPreparationResult} from './BrowserLauncher';
+
 type SuccessResult<Props: {...} | void = {}> = {
   status: 'success',
   ...Props,
@@ -132,6 +134,10 @@ export type ReportableEvent =
       duration: number,
       ...ConnectionUptime,
       ...DebuggerSessionIDs,
+    }
+  | {
+      type: 'fusebox_shell_preparation_attempt',
+      result: DebuggerShellPreparationResult,
     };
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -4507,6 +4507,11 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
+fb-dotslash@0.5.8:
+  version "0.5.8"
+  resolved "https://registry.yarnpkg.com/fb-dotslash/-/fb-dotslash-0.5.8.tgz#c5ef3dacd75e1ddb2197c367052464ddde0115f5"
+  integrity sha512-XHYLKk9J4BupDxi9bSEhkfss0m+Vr9ChTrjhf9l2iw3jB5C7BnY4GVPoMcqbrTutsKJso6yj2nAB6BI/F2oZaA==
+
 fb-watchman@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.2.tgz#e9524ee6b5c77e9e5001af0f85f3adbb8623255c"


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Makes `flavor: 'prebuilt'` the default mode of launching the RNDT standalone shell, and the *only* mode supported in the published version of the package. See D78351931 for more context.

With this, we can demote `electron` from `dependencies` to `devDependencies`. This makes it possible to make `debugger-shell` a dependency of `dev-middleware` (and thus of all major frameworks) without significantly impacting `npm install` times. We'll add this dependency on `debugger-shell` in an upcoming diff (D78351937).

We also stop publishing the `dist/electron` subdirectory (and `src/electron` for good measure) since the corresponding code will always be bundled into the prebuilt binary instead.

Differential Revision: D78351934
