### PR TITLE
VirtualView: Remove Unnecessary `?.` in `updateClippingRect()`

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/virtual/view/ReactVirtualView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/virtual/view/ReactVirtualView.kt
@@ -188,7 +188,7 @@ public class ReactVirtualView(context: Context) :
     // If no ScrollView, or ScrollView has disabled removeClippedSubviews, use default behavior
     if (
         parentScrollView == null ||
-            !((parentScrollView as ReactClippingViewGroup)?.removeClippedSubviews ?: false)
+            !((parentScrollView as ReactClippingViewGroup).removeClippedSubviews ?: false)
     ) {
       super.updateClippingRect(excludedViews)
       return


### PR DESCRIPTION
Summary:
Refactors `VirtualView` to remove this unnecessary `?.` in `updateClippingRect()`.

Changelog:
[Internal]

Differential Revision: D80600713


