### PR TITLE
babel-preset: remove no longer needed `plugin-syntax-dynamic-import` plugin

### DIFF
--- a/packages/react-native-babel-preset/package.json
+++ b/packages/react-native-babel-preset/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "@babel/core": "^7.25.2",
     "@babel/plugin-proposal-export-default-from": "^7.24.7",
-    "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/plugin-syntax-export-default-from": "^7.24.7",
     "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
     "@babel/plugin-syntax-optional-chaining": "^7.8.3",

--- a/packages/react-native-babel-preset/src/configs/main.js
+++ b/packages/react-native-babel-preset/src/configs/main.js
@@ -219,7 +219,6 @@ const getPreset = (src, options, babel) => {
             require('@babel/plugin-transform-private-property-in-object'),
             {loose},
           ],
-          [require('@babel/plugin-syntax-dynamic-import')],
           [require('@babel/plugin-syntax-export-default-from')],
           ...passthroughSyntaxPlugins,
           [require('@babel/plugin-transform-unicode-regex')],

--- a/packages/react-native-codegen/.babelrc
+++ b/packages/react-native-codegen/.babelrc
@@ -1,7 +1,6 @@
 {
   "plugins": [
     "@babel/plugin-transform-flow-strip-types",
-    "@babel/plugin-syntax-dynamic-import",
     "@babel/plugin-transform-class-properties",
     "@babel/plugin-transform-nullish-coalescing-operator",
     "@babel/plugin-transform-optional-chaining"

--- a/packages/react-native-codegen/package.json
+++ b/packages/react-native-codegen/package.json
@@ -39,7 +39,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
-    "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/plugin-transform-class-properties": "^7.25.4",
     "@babel/plugin-transform-flow-strip-types": "^7.25.2",
     "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7",

--- a/private/react-native-codegen-typescript-test/package.json
+++ b/private/react-native-codegen-typescript-test/package.json
@@ -21,7 +21,6 @@
     "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7",
     "@babel/plugin-transform-object-rest-spread": "^7.24.7",
     "@babel/plugin-transform-optional-chaining": "^7.24.8",
-    "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/plugin-transform-async-to-generator": "^7.24.7",
     "@babel/plugin-transform-destructuring": "^7.24.8",
     "@babel/plugin-transform-flow-strip-types": "^7.25.2",
@@ -31,6 +30,6 @@
     "rimraf": "^3.0.2"
   },
   "peerDependencies": {
-    "@babel/preset-env": "^7.1.6"
+    "@babel/preset-env": "^7.25.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -328,13 +328,6 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/plugin-syntax-dynamic-import@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz#62bf98b2da3cd21d626154fc96ee5b3cb68eacb3"
-  integrity sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.8.0"
-
 "@babel/plugin-syntax-export-default-from@^7.24.7":
   version "7.25.9"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.25.9.tgz#86614767a9ff140366f0c3766ef218beb32a730a"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

The  `@babel/plugin-syntax-dynamic-import` Babel plugin is no longer required since `@babel/core@7.8.0` and can be safely removed from the preset and direct dependencies.

Refs:
* https://babeljs.io/docs/babel-plugin-syntax-dynamic-import

I have also make sure that we are using at least ES2020 evn preset in the Babel configs across the repository.

## Changelog:

[GENERAL] [REMOVED] - babel-preset: remove no longer needed `plugin-syntax-dynamic-import` plugin

## Test Plan:

All `test-ci` tests are passing, also make sure that codegen and `scripts/run-ci-javascript-tests.js` generates files correctly and all performed checks within that script are fine.
