### PR TITLE
android: Deprecate jni legacy core classes

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/hermes/reactexecutor/OnLoad.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/hermes/reactexecutor/OnLoad.cpp
@@ -44,7 +44,8 @@ static void installBindings(jsi::Runtime& runtime) {
   react::bindNativeLogger(runtime, &reactAndroidLoggingHook);
 }
 
-class HermesExecutorHolder
+class [[deprecated(
+    "This API will be removed along with the legacy architecture.")]] HermesExecutorHolder
     : public jni::HybridClass<HermesExecutorHolder, JavaScriptExecutorHolder> {
  public:
   static constexpr auto kJavaDescriptor =
@@ -110,6 +111,10 @@ class HermesExecutorHolder
 } // namespace facebook::react
 
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved) {
-  return facebook::jni::initialize(
-      vm, [] { facebook::react::HermesExecutorHolder::registerNatives(); });
+  return facebook::jni::initialize(vm, [] {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    facebook::react::HermesExecutorHolder::registerNatives();
+#pragma clang diagnostic pop
+  });
 }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.cpp
@@ -45,7 +45,9 @@ namespace facebook::react {
 
 namespace {
 
-class InstanceCallbackImpl : public InstanceCallback {
+class [[deprecated(
+    "This API will be removed along with the legacy architecture.")]] InstanceCallbackImpl
+    : public InstanceCallback {
  public:
   explicit InstanceCallbackImpl(alias_ref<JInstanceCallback::javaobject> jobj)
       : jobj_(make_global(jobj)) {}

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.h
@@ -29,12 +29,16 @@ class Instance;
 class JavaScriptExecutorHolder;
 class NativeArray;
 
-struct JInstanceCallback : public jni::JavaClass<JInstanceCallback> {
+struct [[deprecated(
+    "This API will be removed along with the legacy architecture.")]] JInstanceCallback
+    : public jni::JavaClass<JInstanceCallback> {
   static constexpr auto kJavaDescriptor =
       "Lcom/facebook/react/bridge/CatalystInstanceImpl$InstanceCallback;";
 };
 
-class CatalystInstanceImpl : public jni::HybridClass<CatalystInstanceImpl> {
+class [[deprecated(
+    "This API will be removed along with the legacy architecture.")]] CatalystInstanceImpl
+    : public jni::HybridClass<CatalystInstanceImpl> {
  public:
   static constexpr auto kJavaDescriptor =
       "Lcom/facebook/react/bridge/CatalystInstanceImpl;";

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/JavaModuleWrapper.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/JavaModuleWrapper.h
@@ -20,7 +20,9 @@ namespace facebook::react {
 class Instance;
 class MessageQueueThread;
 
-struct JMethodDescriptor : public jni::JavaClass<JMethodDescriptor> {
+struct [[deprecated(
+    "This API will be removed along with the legacy architecture.")]] JMethodDescriptor
+    : public jni::JavaClass<JMethodDescriptor> {
   static constexpr auto kJavaDescriptor =
       "Lcom/facebook/react/bridge/JavaModuleWrapper$MethodDescriptor;";
 
@@ -30,7 +32,9 @@ struct JMethodDescriptor : public jni::JavaClass<JMethodDescriptor> {
   std::string getType() const;
 };
 
-struct JavaModuleWrapper : jni::JavaClass<JavaModuleWrapper> {
+struct [[deprecated(
+    "This API will be removed along with the legacy architecture.")]] JavaModuleWrapper
+    : jni::JavaClass<JavaModuleWrapper> {
   static constexpr auto kJavaDescriptor =
       "Lcom/facebook/react/bridge/JavaModuleWrapper;";
 
@@ -59,7 +63,9 @@ struct JavaModuleWrapper : jni::JavaClass<JavaModuleWrapper> {
   }
 };
 
-class JavaNativeModule : public NativeModule {
+class [[deprecated(
+    "This API will be removed along with the legacy architecture.")]] JavaNativeModule
+    : public NativeModule {
  public:
   JavaNativeModule(
       std::weak_ptr<Instance> instance,

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/JavaScriptExecutorHolder.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/JavaScriptExecutorHolder.h
@@ -14,7 +14,8 @@
 
 namespace facebook::react {
 
-class JavaScriptExecutorHolder
+class [[deprecated(
+    "This API will be removed along with the legacy architecture.")]] JavaScriptExecutorHolder
     : public jni::HybridClass<JavaScriptExecutorHolder> {
  public:
   static constexpr auto kJavaDescriptor =

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/JniJSModulesUnbundle.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/JniJSModulesUnbundle.h
@@ -16,7 +16,9 @@
 
 namespace facebook::react {
 
-class JniJSModulesUnbundle : public JSModulesUnbundle {
+class [[deprecated(
+    "This API will be removed along with the legacy architecture.")]] JniJSModulesUnbundle
+    : public JSModulesUnbundle {
   /**
    * This implementation reads modules as single file from the assets of an apk.
    */

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/MethodInvoker.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/MethodInvoker.cpp
@@ -80,7 +80,10 @@ local_ref<JCxxCallbackImpl::jhybridobject> extractCallback(
   if (value.isNull()) {
     return {nullptr};
   } else {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     return JCxxCallbackImpl::newObjectCxxArgs(makeCallback(instance, value));
+#pragma clang diagnostic pop
   }
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/MethodInvoker.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/MethodInvoker.h
@@ -19,7 +19,9 @@ namespace facebook::react {
 
 class Instance;
 
-struct JReflectMethod : public jni::JavaClass<JReflectMethod> {
+struct [[deprecated(
+    "This API will be removed along with the legacy architecture.")]] JReflectMethod
+    : public jni::JavaClass<JReflectMethod> {
   static constexpr auto kJavaDescriptor = "Ljava/lang/reflect/Method;";
 
   jmethodID getMethodID() {
@@ -29,12 +31,15 @@ struct JReflectMethod : public jni::JavaClass<JReflectMethod> {
   }
 };
 
-struct JBaseJavaModule : public jni::JavaClass<JBaseJavaModule> {
+struct [[deprecated(
+    "This API will be removed along with the legacy architecture.")]] JBaseJavaModule
+    : public jni::JavaClass<JBaseJavaModule> {
   static constexpr auto kJavaDescriptor =
       "Lcom/facebook/react/bridge/BaseJavaModule;";
 };
 
-class MethodInvoker {
+class [[deprecated(
+    "This API will be removed along with the legacy architecture.")]] MethodInvoker {
  public:
   MethodInvoker(
       jni::alias_ref<JReflectMethod::javaobject> method,

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/ModuleRegistryBuilder.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/ModuleRegistryBuilder.h
@@ -20,7 +20,9 @@ namespace facebook::react {
 
 class MessageQueueThread;
 
-class ModuleHolder : public jni::JavaClass<ModuleHolder> {
+class [[deprecated(
+    "This API will be removed along with the legacy architecture.")]] ModuleHolder
+    : public jni::JavaClass<ModuleHolder> {
  public:
   static auto constexpr kJavaDescriptor =
       "Lcom/facebook/react/bridge/ModuleHolder;";
@@ -30,6 +32,7 @@ class ModuleHolder : public jni::JavaClass<ModuleHolder> {
       const std::string& moduleName) const;
 };
 
+[[deprecated("This API will be removed along with the legacy architecture.")]]
 std::vector<std::unique_ptr<NativeModule>> buildNativeModuleList(
     std::weak_ptr<Instance> winstance,
     jni::alias_ref<jni::JCollection<JavaModuleWrapper::javaobject>::javaobject>

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/OnLoad.cpp
@@ -37,7 +37,10 @@ extern "C" JNIEXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
     FLAGS_minloglevel = 0;
 #endif
 #ifndef RCT_FIT_RM_OLD_RUNTIME
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     CatalystInstanceImpl::registerNatives();
+#pragma clang diagnostic pop
 #endif
     CxxModuleWrapperBase::registerNatives();
     ReactInstanceManagerInspectorTarget::registerNatives();

--- a/packages/react-native/ReactCommon/cxxreact/CxxNativeModule.h
+++ b/packages/react-native/ReactCommon/cxxreact/CxxNativeModule.h
@@ -23,11 +23,14 @@ class MessageQueueThread;
 
 typedef void (*WarnOnUsageLogger)(std::string message);
 
+[[deprecated("This API will be removed along with the legacy architecture.")]]
 std::function<void(folly::dynamic)> makeCallback(
     std::weak_ptr<Instance> instance,
     const folly::dynamic& callbackId);
 
-class RN_EXPORT CxxNativeModule : public NativeModule {
+class RN_EXPORT [[deprecated(
+    "This API will be removed along with the legacy architecture.")]] CxxNativeModule
+    : public NativeModule {
  public:
   CxxNativeModule(
       std::weak_ptr<Instance> instance,

--- a/packages/react-native/ReactCommon/cxxreact/Instance.h
+++ b/packages/react-native/ReactCommon/cxxreact/Instance.h
@@ -34,14 +34,17 @@ class MessageQueueThread;
 class ModuleRegistry;
 class RAMBundleRegistry;
 
-struct InstanceCallback {
+struct [[deprecated(
+    "This API will be removed along with the legacy architecture.")]] InstanceCallback {
   virtual ~InstanceCallback() = default;
   virtual void onBatchComplete() {}
   virtual void incrementPendingJSCalls() {}
   virtual void decrementPendingJSCalls() {}
 };
 
-class RN_EXPORT Instance : private jsinspector_modern::InstanceTargetDelegate {
+class RN_EXPORT [[deprecated(
+    "This API will be removed along with the legacy architecture.")]] Instance
+    : private jsinspector_modern::InstanceTargetDelegate {
  public:
   ~Instance() override;
   void initializeBridge(

--- a/packages/react-native/ReactCommon/cxxreact/JSExecutor.h
+++ b/packages/react-native/ReactCommon/cxxreact/JSExecutor.h
@@ -31,7 +31,8 @@ class RAMBundleRegistry;
 
 // This interface describes the delegate interface required by
 // Executor implementations to call from JS into native code.
-class ExecutorDelegate {
+class [[deprecated(
+    "This API will be removed along with the legacy architecture.")]] ExecutorDelegate {
  public:
   virtual ~ExecutorDelegate() = default;
 
@@ -48,7 +49,8 @@ class ExecutorDelegate {
       folly::dynamic&& args) = 0;
 };
 
-class JSExecutorFactory {
+class [[deprecated(
+    "This API will be removed along with the legacy architecture.")]] JSExecutorFactory {
  public:
   virtual std::unique_ptr<JSExecutor> createJSExecutor(
       std::shared_ptr<ExecutorDelegate> delegate,
@@ -56,7 +58,8 @@ class JSExecutorFactory {
   virtual ~JSExecutorFactory() = default;
 };
 
-class RN_EXPORT JSExecutor {
+class RN_EXPORT [[deprecated(
+    "This API will be removed along with the legacy architecture.")]] JSExecutor {
  public:
   /**
    * Prepares the JS runtime for React Native by installing global variables.

--- a/packages/react-native/ReactCommon/cxxreact/JSIndexedRAMBundle.h
+++ b/packages/react-native/ReactCommon/cxxreact/JSIndexedRAMBundle.h
@@ -23,7 +23,9 @@
 
 namespace facebook::react {
 
-class RN_EXPORT JSIndexedRAMBundle : public JSModulesUnbundle {
+class RN_EXPORT [[deprecated(
+    "This API will be removed along with the legacy architecture.")]] JSIndexedRAMBundle
+    : public JSModulesUnbundle {
  public:
   static std::function<std::unique_ptr<JSModulesUnbundle>(std::string)>
   buildFactory();

--- a/packages/react-native/ReactCommon/cxxreact/JSModulesUnbundle.h
+++ b/packages/react-native/ReactCommon/cxxreact/JSModulesUnbundle.h
@@ -15,7 +15,8 @@
 
 namespace facebook::react {
 
-class JSModulesUnbundle {
+class [[deprecated(
+    "This API will be removed along with the legacy architecture.")]] JSModulesUnbundle {
   /**
    * Represents the set of JavaScript modules that the application consists of.
    * The source code of each module can be retrieved by module ID.

--- a/packages/react-native/ReactCommon/cxxreact/MethodCall.h
+++ b/packages/react-native/ReactCommon/cxxreact/MethodCall.h
@@ -17,7 +17,8 @@
 
 namespace facebook::react {
 
-struct MethodCall {
+struct [[deprecated(
+    "This API will be removed along with the legacy architecture.")]] MethodCall {
   int moduleId;
   int methodId;
   folly::dynamic arguments;
@@ -31,6 +32,7 @@ struct MethodCall {
 };
 
 /// \throws std::invalid_argument
+[[deprecated("This API will be removed along with the legacy architecture.")]]
 std::vector<MethodCall> parseMethodCalls(folly::dynamic&& jsonData);
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/cxxreact/ModuleRegistry.h
+++ b/packages/react-native/ReactCommon/cxxreact/ModuleRegistry.h
@@ -25,12 +25,14 @@ namespace facebook::react {
 
 class NativeModule;
 
-struct ModuleConfig {
+struct [[deprecated(
+    "This API will be removed along with the legacy architecture.")]] ModuleConfig {
   size_t index;
   folly::dynamic config;
 };
 
-class RN_EXPORT ModuleRegistry {
+class RN_EXPORT [[deprecated(
+    "This API will be removed along with the legacy architecture.")]] ModuleRegistry {
  public:
   // not implemented:
   // onBatchComplete: see

--- a/packages/react-native/ReactCommon/cxxreact/NativeModule.h
+++ b/packages/react-native/ReactCommon/cxxreact/NativeModule.h
@@ -16,7 +16,8 @@
 namespace facebook::react {
 
 #ifndef RCT_FIT_RM_OLD_RUNTIME
-struct MethodDescriptor {
+struct [[deprecated(
+    "This API will be removed along with the legacy architecture.")]] MethodDescriptor {
   std::string name;
   // type is one of js MessageQueue.MethodTypes
   std::string type;
@@ -29,7 +30,8 @@ struct MethodDescriptor {
 using MethodCallResult = std::optional<folly::dynamic>;
 
 #ifndef RCT_FIT_RM_OLD_RUNTIME
-class NativeModule {
+class [[deprecated(
+    "This API will be removed along with the legacy architecture.")]] NativeModule {
  public:
   virtual ~NativeModule() = default;
   virtual std::string getName() = 0;

--- a/packages/react-native/ReactCommon/cxxreact/NativeToJsBridge.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/NativeToJsBridge.cpp
@@ -37,7 +37,9 @@ using fbsystrace::FbSystraceAsyncFlow;
 namespace facebook::react {
 
 // This class manages calls from JS to native code.
-class JsToNativeBridge : public react::ExecutorDelegate {
+class [[deprecated(
+    "This API will be removed along with the legacy architecture.")]] JsToNativeBridge
+    : public react::ExecutorDelegate {
  public:
   JsToNativeBridge(
       std::shared_ptr<ModuleRegistry> registry,

--- a/packages/react-native/ReactCommon/cxxreact/NativeToJsBridge.h
+++ b/packages/react-native/ReactCommon/cxxreact/NativeToJsBridge.h
@@ -38,7 +38,8 @@ class RAMBundleRegistry;
 // Except for loadBundleSync(), all void methods will queue
 // work to run on the jsQueue passed to the ctor, and return
 // immediately.
-class NativeToJsBridge {
+class [[deprecated(
+    "This API will be removed along with the legacy architecture.")]] NativeToJsBridge {
  public:
   friend class JsToNativeBridge;
 

--- a/packages/react-native/ReactCommon/cxxreact/RAMBundleRegistry.h
+++ b/packages/react-native/ReactCommon/cxxreact/RAMBundleRegistry.h
@@ -23,7 +23,8 @@
 
 namespace facebook::react {
 
-class RN_EXPORT RAMBundleRegistry {
+class RN_EXPORT [[deprecated(
+    "This API will be removed along with the legacy architecture.")]] RAMBundleRegistry {
  public:
   constexpr static uint32_t MAIN_BUNDLE_ID = 0;
 

--- a/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.h
+++ b/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.h
@@ -13,7 +13,9 @@
 
 namespace facebook::react {
 
-class HermesExecutorFactory : public JSExecutorFactory {
+class [[deprecated(
+    "This API will be removed along with the legacy architecture.")]] HermesExecutorFactory
+    : public JSExecutorFactory {
  public:
   explicit HermesExecutorFactory(
       JSIExecutor::RuntimeInstaller runtimeInstaller,
@@ -44,7 +46,9 @@ class HermesExecutorFactory : public JSExecutorFactory {
   std::string debuggerName_ = "Hermes React Native";
 };
 
-class HermesExecutor : public JSIExecutor {
+class [[deprecated(
+    "This API will be removed along with the legacy architecture.")]] HermesExecutor
+    : public JSIExecutor {
  public:
   HermesExecutor(
       std::shared_ptr<jsi::Runtime> runtime,

--- a/packages/react-native/ReactCommon/jsiexecutor/jsireact/JSIExecutor.h
+++ b/packages/react-native/ReactCommon/jsiexecutor/jsireact/JSIExecutor.h
@@ -67,7 +67,9 @@ class BigStringBuffer : public jsi::Buffer {
   std::unique_ptr<const JSBigString> script_;
 };
 
-class JSIExecutor : public JSExecutor {
+class [[deprecated(
+    "This API will be removed along with the legacy architecture.")]] JSIExecutor
+    : public JSExecutor {
  public:
   using RuntimeInstaller = std::function<void(jsi::Runtime& runtime)>;
 

--- a/packages/react-native/ReactCommon/jsiexecutor/jsireact/JSINativeModules.h
+++ b/packages/react-native/ReactCommon/jsiexecutor/jsireact/JSINativeModules.h
@@ -21,7 +21,8 @@ namespace facebook::react {
 /**
  * Holds and creates JS representations of the modules in ModuleRegistry
  */
-class JSINativeModules {
+class [[deprecated(
+    "This API will be removed along with the legacy architecture.")]] JSINativeModules {
  public:
   explicit JSINativeModules(std::shared_ptr<ModuleRegistry> moduleRegistry);
   jsi::Value getModule(jsi::Runtime& rt, const jsi::PropNameID& name);

--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
@@ -353,8 +353,11 @@ void ReactInstance::registerSegment(
     }
     LOG(WARNING) << "Starting to evaluate segment " << segmentId
                  << " in ReactInstance::registerSegment";
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     runtime.evaluateJavaScript(
         buffer, JSExecutor::getSyntheticBundlePath(segmentId, segmentPath));
+#pragma clang diagnostic pop
     LOG(WARNING) << "Finished evaluating segment " << segmentId
                  << " in ReactInstance::registerSegment";
     if (hasLogger) {


### PR DESCRIPTION
Summary: Let's deprecate all the classes that aren't used by interop or the new architecture.

Differential Revision: D80575767
