### PR TITLE
ios: Deprecate legacy core components

### DIFF
--- a/packages/react-native/Libraries/Image/RCTImageShadowView.h
+++ b/packages/react-native/Libraries/Image/RCTImageShadowView.h
@@ -9,6 +9,7 @@
 
 #ifndef RCT_FIT_RM_OLD_COMPONENT
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTImageShadowView : RCTShadowView
 
 @end

--- a/packages/react-native/Libraries/Image/RCTImageView.h
+++ b/packages/react-native/Libraries/Image/RCTImageView.h
@@ -14,6 +14,7 @@
 @class RCTBridge;
 @class RCTImageSource;
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTImageView : RCTView
 
 - (instancetype)initWithBridge:(RCTBridge *)bridge NS_DESIGNATED_INITIALIZER;

--- a/packages/react-native/Libraries/Image/RCTImageViewManager.h
+++ b/packages/react-native/Libraries/Image/RCTImageViewManager.h
@@ -9,6 +9,7 @@
 
 #ifndef RCT_FIT_RM_OLD_COMPONENT
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTImageViewManager : RCTViewManager
 
 @end

--- a/packages/react-native/Libraries/Text/BaseText/RCTBaseTextShadowView.h
+++ b/packages/react-native/Libraries/Text/BaseText/RCTBaseTextShadowView.h
@@ -13,8 +13,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-extern NSString *const RCTBaseTextShadowViewEmbeddedShadowViewAttributeName;
+extern NSString *const RCTBaseTextShadowViewEmbeddedShadowViewAttributeName
+    __attribute__((deprecated("This API will be removed along with the legacy architecture.")));
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTBaseTextShadowView : RCTShadowView {
  @protected
   NSAttributedString *_Nullable cachedAttributedText;

--- a/packages/react-native/Libraries/Text/BaseText/RCTBaseTextViewManager.h
+++ b/packages/react-native/Libraries/Text/BaseText/RCTBaseTextViewManager.h
@@ -11,6 +11,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTBaseTextViewManager : RCTViewManager
 
 @end

--- a/packages/react-native/Libraries/Text/RCTTextAttributes.h
+++ b/packages/react-native/Libraries/Text/RCTTextAttributes.h
@@ -15,15 +15,18 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-extern NSString *const RCTTextAttributesIsHighlightedAttributeName;
-extern NSString *const RCTTextAttributesTagAttributeName;
+extern NSString *const RCTTextAttributesIsHighlightedAttributeName
+    __attribute__((deprecated("This API will be removed along with the legacy architecture.")));
+extern NSString *const RCTTextAttributesTagAttributeName
+    __attribute__((deprecated("This API will be removed along with the legacy architecture.")));
 
 /**
  * Represents knowledge about all supported *text* attributes
  * assigned to some text component such as <Text>, <VirtualText>,
  * and <TextInput>.
  */
-@interface RCTTextAttributes : NSObject <NSCopying>
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
+@interface RCTTextAttributes : NSObject<NSCopying>
 
 // Color
 @property (nonatomic, strong, nullable) UIColor *foregroundColor;

--- a/packages/react-native/Libraries/Text/RawText/RCTRawTextShadowView.h
+++ b/packages/react-native/Libraries/Text/RawText/RCTRawTextShadowView.h
@@ -11,6 +11,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTRawTextShadowView : RCTShadowView
 
 @property (nonatomic, copy, nullable) NSString *text;

--- a/packages/react-native/Libraries/Text/RawText/RCTRawTextViewManager.h
+++ b/packages/react-native/Libraries/Text/RawText/RCTRawTextViewManager.h
@@ -11,6 +11,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTRawTextViewManager : RCTViewManager
 
 @end

--- a/packages/react-native/Libraries/Text/Text/RCTTextShadowView.h
+++ b/packages/react-native/Libraries/Text/Text/RCTTextShadowView.h
@@ -13,6 +13,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTTextShadowView : RCTBaseTextShadowView
 
 - (instancetype)initWithBridge:(RCTBridge *)bridge;

--- a/packages/react-native/Libraries/Text/Text/RCTTextView.h
+++ b/packages/react-native/Libraries/Text/Text/RCTTextView.h
@@ -13,6 +13,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTTextView : UIView
 
 @property (nonatomic, assign) BOOL selectable;

--- a/packages/react-native/Libraries/Text/Text/RCTTextViewManager.h
+++ b/packages/react-native/Libraries/Text/Text/RCTTextViewManager.h
@@ -11,6 +11,7 @@
 
 #import "RCTBaseTextViewManager.h"
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTTextViewManager : RCTBaseTextViewManager
 
 @end

--- a/packages/react-native/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputView.h
+++ b/packages/react-native/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputView.h
@@ -11,6 +11,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTMultilineTextInputView : RCTBaseTextInputView
 
 @end

--- a/packages/react-native/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputViewManager.h
+++ b/packages/react-native/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputViewManager.h
@@ -11,6 +11,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTMultilineTextInputViewManager : RCTBaseTextInputViewManager
 
 @end

--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputShadowView.h
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputShadowView.h
@@ -11,6 +11,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTBaseTextInputShadowView : RCTBaseTextShadowView
 
 - (instancetype)initWithBridge:(RCTBridge *)bridge;

--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.h
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.h
@@ -20,7 +20,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface RCTBaseTextInputView : RCTView <RCTBackedTextInputDelegate>
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
+@interface RCTBaseTextInputView : RCTView<RCTBackedTextInputDelegate>
 
 - (instancetype)initWithBridge:(RCTBridge *)bridge NS_DESIGNATED_INITIALIZER;
 

--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputViewManager.h
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputViewManager.h
@@ -9,6 +9,7 @@
 
 #ifndef RCT_FIT_RM_OLD_COMPONENT
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTBaseTextInputViewManager : RCTBaseTextViewManager
 
 @end

--- a/packages/react-native/Libraries/Text/TextInput/RCTInputAccessoryShadowView.h
+++ b/packages/react-native/Libraries/Text/TextInput/RCTInputAccessoryShadowView.h
@@ -9,6 +9,7 @@
 
 #ifndef RCT_FIT_RM_OLD_COMPONENT
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTInputAccessoryShadowView : RCTShadowView
 
 @end

--- a/packages/react-native/Libraries/Text/TextInput/RCTInputAccessoryView.h
+++ b/packages/react-native/Libraries/Text/TextInput/RCTInputAccessoryView.h
@@ -12,6 +12,7 @@
 @class RCTBridge;
 @class RCTInputAccessoryViewContent;
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTInputAccessoryView : UIView
 
 - (instancetype)initWithBridge:(RCTBridge *)bridge;

--- a/packages/react-native/Libraries/Text/TextInput/RCTInputAccessoryViewContent.h
+++ b/packages/react-native/Libraries/Text/TextInput/RCTInputAccessoryViewContent.h
@@ -9,6 +9,7 @@
 
 #ifndef RCT_FIT_RM_OLD_COMPONENT
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTInputAccessoryViewContent : UIView
 
 @end

--- a/packages/react-native/Libraries/Text/TextInput/RCTInputAccessoryViewManager.h
+++ b/packages/react-native/Libraries/Text/TextInput/RCTInputAccessoryViewManager.h
@@ -9,6 +9,7 @@
 
 #ifndef RCT_FIT_RM_OLD_COMPONENT
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTInputAccessoryViewManager : RCTViewManager
 
 @end

--- a/packages/react-native/Libraries/Text/TextInput/Singleline/RCTSinglelineTextInputView.h
+++ b/packages/react-native/Libraries/Text/TextInput/Singleline/RCTSinglelineTextInputView.h
@@ -11,6 +11,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTSinglelineTextInputView : RCTBaseTextInputView
 
 @end

--- a/packages/react-native/Libraries/Text/TextInput/Singleline/RCTSinglelineTextInputViewManager.h
+++ b/packages/react-native/Libraries/Text/TextInput/Singleline/RCTSinglelineTextInputViewManager.h
@@ -11,6 +11,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTSinglelineTextInputViewManager : RCTBaseTextInputViewManager
 
 @end

--- a/packages/react-native/Libraries/Text/VirtualText/RCTVirtualTextShadowView.h
+++ b/packages/react-native/Libraries/Text/VirtualText/RCTVirtualTextShadowView.h
@@ -9,6 +9,7 @@
 
 #ifndef RCT_FIT_RM_OLD_COMPONENT
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTVirtualTextShadowView : RCTBaseTextShadowView
 
 @end

--- a/packages/react-native/Libraries/Text/VirtualText/RCTVirtualTextView.h
+++ b/packages/react-native/Libraries/Text/VirtualText/RCTVirtualTextView.h
@@ -13,6 +13,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTVirtualTextView : UIView
 
 /**

--- a/packages/react-native/Libraries/Text/VirtualText/RCTVirtualTextViewManager.h
+++ b/packages/react-native/Libraries/Text/VirtualText/RCTVirtualTextViewManager.h
@@ -9,6 +9,7 @@
 
 #ifndef RCT_FIT_RM_OLD_COMPONENT
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTVirtualTextViewManager : RCTBaseTextViewManager
 
 @end

--- a/packages/react-native/Libraries/Wrapper/Example/RCTWrapperExampleView.h
+++ b/packages/react-native/Libraries/Wrapper/Example/RCTWrapperExampleView.h
@@ -11,6 +11,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTWrapperExampleView : UIView
 
 @end

--- a/packages/react-native/Libraries/Wrapper/Example/RCTWrapperExampleViewController.h
+++ b/packages/react-native/Libraries/Wrapper/Example/RCTWrapperExampleViewController.h
@@ -11,6 +11,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTWrapperExampleViewController : UIViewController
 
 @end

--- a/packages/react-native/Libraries/Wrapper/Example/RCTWrapperReactRootViewController.h
+++ b/packages/react-native/Libraries/Wrapper/Example/RCTWrapperReactRootViewController.h
@@ -13,6 +13,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTWrapperReactRootViewController : UIViewController
 
 - (instancetype)initWithBridge:(RCTBridge *)bridge;

--- a/packages/react-native/Libraries/Wrapper/Example/RCTWrapperReactRootViewManager.h
+++ b/packages/react-native/Libraries/Wrapper/Example/RCTWrapperReactRootViewManager.h
@@ -13,6 +13,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTWrapperReactRootViewManager : RCTWrapperViewManager
 
 @end

--- a/packages/react-native/Libraries/Wrapper/RCTWrapper.h
+++ b/packages/react-native/Libraries/Wrapper/RCTWrapper.h
@@ -16,29 +16,29 @@
 // Umbrella header with macros
 
 // RCT_WRAPPER_FOR_VIEW
-#define RCT_WRAPPER_FOR_VIEW(ClassName)         \
-                                                \
-  NS_ASSUME_NONNULL_BEGIN                       \
-                                                \
-  @interface ClassName                          \
-  ##Manager : RCTWrapperViewManager             \
-                                                \
-              @end                              \
-                                                \
-  NS_ASSUME_NONNULL_END                         \
-                                                \
-  @implementation ClassName                     \
-  ##Manager                                     \
-                                                \
-      RCT_EXPORT_MODULE()                       \
-                                                \
-      - (UIView *)view                          \
-  {                                             \
-    RCTWrapperView *wrapperView = [super view]; \
-    wrapperView.contentView = [ClassName new];  \
-    return wrapperView;                         \
-  }                                             \
-                                                \
+#define RCT_WRAPPER_FOR_VIEW(ClassName)                                                       \
+  NS_ASSUME_NONNULL_BEGIN                                                                     \
+                                                                                              \
+  __attribute__((deprecated("This API will be removed along with the legacy architecture."))) \
+  @interface ClassName                                                                        \
+  ##Manager : RCTWrapperViewManager                                                           \
+                                                                                              \
+              @end                                                                            \
+                                                                                              \
+  NS_ASSUME_NONNULL_END                                                                       \
+                                                                                              \
+  @implementation ClassName                                                                   \
+  ##Manager                                                                                   \
+                                                                                              \
+      RCT_EXPORT_MODULE()                                                                     \
+                                                                                              \
+      - (UIView *)view                                                                        \
+  {                                                                                           \
+    RCTWrapperView *wrapperView = [super view];                                               \
+    wrapperView.contentView = [ClassName new];                                                \
+    return wrapperView;                                                                       \
+  }                                                                                           \
+                                                                                              \
   @end
 
 // RCT_WRAPPER_FOR_VIEW_CONTROLLER
@@ -46,6 +46,7 @@
                                                                                                                        \
   NS_ASSUME_NONNULL_BEGIN                                                                                              \
                                                                                                                        \
+  __attribute__((deprecated("This API will be removed along with the legacy architecture.")))                          \
   @interface ClassName                                                                                                 \
   ##Manager : RCTWrapperViewManager                                                                                    \
                                                                                                                        \

--- a/packages/react-native/Libraries/Wrapper/RCTWrapperShadowView.h
+++ b/packages/react-native/Libraries/Wrapper/RCTWrapperShadowView.h
@@ -15,6 +15,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTWrapperShadowView : RCTShadowView
 
 - (instancetype)initWithBridge:(RCTBridge *)bridge NS_DESIGNATED_INITIALIZER;

--- a/packages/react-native/Libraries/Wrapper/RCTWrapperView.h
+++ b/packages/react-native/Libraries/Wrapper/RCTWrapperView.h
@@ -9,12 +9,14 @@
 
 #ifndef RCT_FIT_RM_OLD_COMPONENT
 
-typedef CGSize (^RCTWrapperMeasureBlock)(CGSize minimumSize, CGSize maximumSize);
+typedef CGSize (^RCTWrapperMeasureBlock)(CGSize minimumSize, CGSize maximumSize)
+    __attribute__((deprecated("This API will be removed along with the legacy architecture.")));
 
 @class RCTBridge;
 
 NS_ASSUME_NONNULL_BEGIN
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTWrapperView : UIView
 
 @property (nonatomic, retain, nullable) UIView *contentView;

--- a/packages/react-native/Libraries/Wrapper/RCTWrapperViewControllerHostingView.h
+++ b/packages/react-native/Libraries/Wrapper/RCTWrapperViewControllerHostingView.h
@@ -11,6 +11,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTWrapperViewControllerHostingView : UIView
 
 @property (nonatomic, retain, nullable) UIViewController *contentViewController;

--- a/packages/react-native/Libraries/Wrapper/RCTWrapperViewManager.h
+++ b/packages/react-native/Libraries/Wrapper/RCTWrapperViewManager.h
@@ -13,6 +13,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTWrapperViewManager : RCTViewManager
 
 - (RCTWrapperView *)view NS_REQUIRES_SUPER;

--- a/packages/react-native/React/Base/RCTBridge+Private.h
+++ b/packages/react-native/React/Base/RCTBridge+Private.h
@@ -21,7 +21,8 @@ RCT_EXTERN void RCTRegisterModule(Class);
 - (instancetype)initWithDelegate:(id<RCTBridgeDelegate>)delegate
                        bundleURL:(NSURL *)bundleURL
                   moduleProvider:(RCTBridgeModuleListProvider)block
-                   launchOptions:(NSDictionary *)launchOptions NS_DESIGNATED_INITIALIZER;
+                   launchOptions:(NSDictionary *)launchOptions NS_DESIGNATED_INITIALIZER
+    __deprecated_msg("This API will be removed along with the legacy architecture.");
 
 #endif // RCT_FIT_RM_OLD_RUNTIME
 
@@ -150,7 +151,8 @@ RCT_EXTERN void RCTRegisterModule(Class);
 @property (nonatomic, readonly) void *runtime;
 
 #ifndef RCT_FIT_RM_OLD_RUNTIME
-- (instancetype)initWithParentBridge:(RCTBridge *)bridge NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithParentBridge:(RCTBridge *)bridge NS_DESIGNATED_INITIALIZER
+    __deprecated_msg("This API will be removed along with the legacy architecture.");
 #endif // RCT_FIT_RM_OLD_RUNTIME
 
 @end

--- a/packages/react-native/React/Base/RCTBridge.h
+++ b/packages/react-native/React/Base/RCTBridge.h
@@ -107,7 +107,9 @@ RCT_EXTERN_C_END
  * pre-initialized module instances if they require additional init parameters
  * or configuration.
  */
-- (instancetype)initWithDelegate:(id<RCTBridgeDelegate>)delegate launchOptions:(NSDictionary *)launchOptions;
+- (instancetype)initWithDelegate:(id<RCTBridgeDelegate>)delegate
+                   launchOptions:(NSDictionary *)launchOptions
+    __deprecated_msg("This API will be removed along with the legacy architecture.");
 
 /**
  * DEPRECATED: Use initWithDelegate:launchOptions: instead
@@ -121,7 +123,8 @@ RCT_EXTERN_C_END
  */
 - (instancetype)initWithBundleURL:(NSURL *)bundleURL
                    moduleProvider:(RCTBridgeModuleListProvider)block
-                    launchOptions:(NSDictionary *)launchOptions;
+                    launchOptions:(NSDictionary *)launchOptions
+    __deprecated_msg("This API will be removed along with the legacy architecture.");
 
 /**
  * This method is used to call functions in the JavaScript application context.

--- a/packages/react-native/React/Base/RCTBridgeDelegate.h
+++ b/packages/react-native/React/Base/RCTBridgeDelegate.h
@@ -21,7 +21,8 @@ NS_ASSUME_NONNULL_BEGIN
  * When running from a locally bundled JS file, this should be a `file://` url
  * pointing to a path inside the app resources, e.g. `file://.../main.jsbundle`.
  */
-- (NSURL *__nullable)sourceURLForBridge:(RCTBridge *)bridge;
+- (NSURL *__nullable)sourceURLForBridge:(RCTBridge *)bridge
+    __deprecated_msg("This API will be removed along with the legacy architecture.");
 
 @optional
 
@@ -39,7 +40,8 @@ NS_ASSUME_NONNULL_BEGIN
  * not recommended in most cases - if the module methods and behavior do not
  * match exactly, it may lead to bugs or crashes.
  */
-- (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge;
+- (NSArray<id<RCTBridgeModule>> *)extraModulesForBridge:(RCTBridge *)bridge
+    __deprecated_msg("This API will be removed along with the legacy architecture.");
 
 /**
  * The bridge will call this method when a module been called from JS
@@ -48,7 +50,9 @@ NS_ASSUME_NONNULL_BEGIN
  * in the implementation, and the system must attempt to look for it again among registered.
  * If the module was not registered, return NO to prevent further searches.
  */
-- (BOOL)bridge:(RCTBridge *)bridge didNotFindModule:(NSString *)moduleName;
+- (BOOL)bridge:(RCTBridge *)bridge
+    didNotFindModule:(NSString *)moduleName
+    __deprecated_msg("This API will be removed along with the legacy architecture.");
 
 /**
  * The bridge will automatically attempt to load the JS source code from the
@@ -57,18 +61,22 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)loadSourceForBridge:(RCTBridge *)bridge
                  onProgress:(RCTSourceLoadProgressBlock)onProgress
-                 onComplete:(RCTSourceLoadBlock)loadCallback;
+                 onComplete:(RCTSourceLoadBlock)loadCallback
+    __deprecated_msg("This API will be removed along with the legacy architecture.");
 
 /**
  * Similar to loadSourceForBridge:onProgress:onComplete: but without progress
  * reporting.
  */
-- (void)loadSourceForBridge:(RCTBridge *)bridge withBlock:(RCTSourceLoadBlock)loadCallback;
+- (void)loadSourceForBridge:(RCTBridge *)bridge
+                  withBlock:(RCTSourceLoadBlock)loadCallback
+    __deprecated_msg("This API will be removed along with the legacy architecture.");
 
 /**
  * Retrieve the list of lazy-native-modules names for the given bridge.
  */
-- (NSDictionary<NSString *, Class> *)extraLazyModuleClassesForBridge:(RCTBridge *)bridge;
+- (NSDictionary<NSString *, Class> *)extraLazyModuleClassesForBridge:(RCTBridge *)bridge
+    __deprecated_msg("This API will be removed along with the legacy architecture.");
 
 #endif // RCT_FIT_RM_OLD_RUNTIME
 @end

--- a/packages/react-native/React/Base/RCTJavaScriptExecutor.h
+++ b/packages/react-native/React/Base/RCTJavaScriptExecutor.h
@@ -10,15 +10,18 @@
 #import <React/RCTBridgeModule.h>
 #import <React/RCTInvalidating.h>
 
-typedef void (^RCTJavaScriptCompleteBlock)(NSError *error);
-typedef void (^RCTJavaScriptCallback)(id result, NSError *error);
+typedef void (^RCTJavaScriptCompleteBlock)(NSError *__strong)
+    __deprecated_msg("This api will be removed along with the bridge.");
+typedef void (^RCTJavaScriptCallback)(__strong id, NSError *__strong)
+    __deprecated_msg("This api will be removed along with the bridge.");
 
 #ifndef RCT_FIT_RM_OLD_RUNTIME
 /**
  * Abstracts away a JavaScript execution context - we may be running code in a
  * web view (for debugging purposes), or may be running code in a `JSContext`.
  */
-@protocol RCTJavaScriptExecutor <RCTInvalidating, RCTBridgeModule>
+__deprecated_msg("This api will be removed along with the bridge.")
+    @protocol RCTJavaScriptExecutor<RCTInvalidating, RCTBridgeModule>
 
 /**
  * Used to set up the executor after the bridge has been fully initialized.

--- a/packages/react-native/React/Base/RCTModuleData.h
+++ b/packages/react-native/React/Base/RCTModuleData.h
@@ -34,14 +34,16 @@ typedef id<RCTBridgeModule> (^RCTBridgeModuleProvider)(void);
                      moduleRegistry:(RCTModuleRegistry *)moduleRegistry
             viewRegistry_DEPRECATED:(RCTViewRegistry *)viewRegistry_DEPRECATED
                       bundleManager:(RCTBundleManager *)bundleManager
-                  callableJSModules:(RCTCallableJSModules *)callableJSModules NS_DESIGNATED_INITIALIZER;
+                  callableJSModules:(RCTCallableJSModules *)callableJSModules NS_DESIGNATED_INITIALIZER
+    __deprecated_msg("This API will be removed along with the legacy architecture.");
 
 - (instancetype)initWithModuleInstance:(id<RCTBridgeModule>)instance
                                 bridge:(RCTBridge *)bridge
                         moduleRegistry:(RCTModuleRegistry *)moduleRegistry
                viewRegistry_DEPRECATED:(RCTViewRegistry *)viewRegistry_DEPRECATED
                          bundleManager:(RCTBundleManager *)bundleManager
-                     callableJSModules:(RCTCallableJSModules *)callableJSModules NS_DESIGNATED_INITIALIZER;
+                     callableJSModules:(RCTCallableJSModules *)callableJSModules NS_DESIGNATED_INITIALIZER
+    __deprecated_msg("This API will be removed along with the legacy architecture.");
 
 /**
  * Calls `constantsToExport` on the module and stores the result. Note that
@@ -49,61 +51,73 @@ typedef id<RCTBridgeModule> (^RCTBridgeModuleProvider)(void);
  * can be called on any thread, but may block the main thread briefly if the
  * module implements `constantsToExport`.
  */
-- (void)gatherConstants;
+- (void)gatherConstants __deprecated_msg("This API will be removed along with the legacy architecture.");
 
-@property (nonatomic, strong, readonly) Class moduleClass;
-@property (nonatomic, copy, readonly) NSString *name;
+@property (nonatomic, strong, readonly)
+    Class moduleClass __deprecated_msg("This API will be removed along with the legacy architecture.");
+@property (nonatomic, copy, readonly)
+    NSString *name __deprecated_msg("This API will be removed along with the legacy architecture.");
 
 /**
  * Returns the module methods. Note that this will gather the methods the first
  * time it is called and then memoize the results.
  */
-@property (nonatomic, copy, readonly) NSArray<id<RCTBridgeMethod>> *methods;
+@property (nonatomic, copy, readonly) NSArray<id<RCTBridgeMethod>> *methods __deprecated_msg(
+    "This API will be removed along with the legacy architecture.");
 
 /**
  * Returns a map of the module methods. Note that this will gather the methods the first
  * time it is called and then memoize the results.
  */
-@property (nonatomic, copy, readonly) NSDictionary<NSString *, id<RCTBridgeMethod>> *methodsByName;
+@property (nonatomic, copy, readonly) NSDictionary<NSString *, id<RCTBridgeMethod>> *methodsByName __deprecated_msg(
+    "This API will be removed along with the legacy architecture.");
 
 /**
  * Returns the module's constants, if it exports any
  */
-@property (nonatomic, copy, readonly) NSDictionary<NSString *, id> *exportedConstants;
+@property (nonatomic, copy, readonly) NSDictionary<NSString *, id> *exportedConstants __deprecated_msg(
+    "This API will be removed along with the legacy architecture.");
 
 /**
  * Returns YES if module instance has already been initialized; NO otherwise.
  */
-@property (nonatomic, assign, readonly) BOOL hasInstance;
+@property (nonatomic, assign, readonly)
+    BOOL hasInstance __deprecated_msg("This API will be removed along with the legacy architecture.");
 
 /**
  * Returns YES if module instance must be created on the main thread.
  */
-@property (nonatomic, assign) BOOL requiresMainQueueSetup;
+@property (nonatomic, assign)
+    BOOL requiresMainQueueSetup __deprecated_msg("This API will be removed along with the legacy architecture.");
 
 /**
  * Returns YES if module has constants to export.
  */
-@property (nonatomic, assign, readonly) BOOL hasConstantsToExport;
+@property (nonatomic, assign, readonly)
+    BOOL hasConstantsToExport __deprecated_msg("This API will be removed along with the legacy architecture.");
 
 /**
  * Returns the current module instance. Note that this will init the instance
  * if it has not already been created. To check if the module instance exists
  * without causing it to be created, use `hasInstance` instead.
  */
-@property (nonatomic, strong, readwrite) id<RCTBridgeModule> instance;
+@property (nonatomic, strong, readwrite) id<RCTBridgeModule> instance __deprecated_msg(
+    "This API will be removed along with the legacy architecture.");
 
 /**
  * Returns the module method dispatch queue. Note that this will init both the
  * queue and the module itself if they have not already been created.
  */
-@property (nonatomic, strong, readonly) dispatch_queue_t methodQueue;
+@property (nonatomic, strong, readonly)
+    dispatch_queue_t methodQueue __deprecated_msg("This API will be removed along with the legacy architecture.");
 
 /**
  * Whether the receiver has a valid `instance` which implements -batchDidComplete.
  */
-@property (nonatomic, assign, readonly) BOOL implementsBatchDidComplete;
+@property (nonatomic, assign, readonly)
+    BOOL implementsBatchDidComplete __deprecated_msg("This API will be removed along with the legacy architecture.");
 
-@property (nonatomic, weak, readwrite) id<RCTModuleDataCallInvokerProvider> callInvokerProvider;
+@property (nonatomic, weak, readwrite) id<RCTModuleDataCallInvokerProvider> callInvokerProvider __deprecated_msg(
+    "This API will be removed along with the legacy architecture.");
 
 @end

--- a/packages/react-native/React/Base/RCTRootContentView.h
+++ b/packages/react-native/React/Base/RCTRootContentView.h
@@ -18,18 +18,25 @@
 
 @interface RCTRootContentView : RCTView <RCTInvalidating>
 
-@property (nonatomic, readonly, weak) RCTBridge *bridge;
-@property (nonatomic, readonly, assign) BOOL contentHasAppeared;
-@property (nonatomic, readonly, strong) RCTTouchHandler *touchHandler;
-@property (nonatomic, readonly, assign) CGSize availableSize;
+@property (nonatomic, readonly, weak)
+    RCTBridge *bridge __deprecated_msg("This API will be removed along with the legacy architecture.");
+@property (nonatomic, readonly, assign)
+    BOOL contentHasAppeared __deprecated_msg("This API will be removed along with the legacy architecture.");
+@property (nonatomic, readonly, strong)
+    RCTTouchHandler *touchHandler __deprecated_msg("This API will be removed along with the legacy architecture.");
+@property (nonatomic, readonly, assign)
+    CGSize availableSize __deprecated_msg("This API will be removed along with the legacy architecture.");
 
-@property (nonatomic, assign) BOOL passThroughTouches;
-@property (nonatomic, assign) RCTRootViewSizeFlexibility sizeFlexibility;
+@property (nonatomic, assign)
+    BOOL passThroughTouches __deprecated_msg("This API will be removed along with the legacy architecture.");
+@property (nonatomic, assign) RCTRootViewSizeFlexibility sizeFlexibility __deprecated_msg(
+    "This API will be removed along with the legacy architecture.");
 
 - (instancetype)initWithFrame:(CGRect)frame
                        bridge:(RCTBridge *)bridge
                      reactTag:(NSNumber *)reactTag
-              sizeFlexibility:(RCTRootViewSizeFlexibility)sizeFlexibility NS_DESIGNATED_INITIALIZER;
+              sizeFlexibility:(RCTRootViewSizeFlexibility)sizeFlexibility NS_DESIGNATED_INITIALIZER
+    __deprecated_msg("This API will be removed along with the legacy architecture.");
 
 @end
 

--- a/packages/react-native/React/Base/RCTRootView.h
+++ b/packages/react-native/React/Base/RCTRootView.h
@@ -47,7 +47,7 @@ extern
  * like any ordinary UIView. You can have multiple RCTRootViews on screen at
  * once, all controlled by the same JavaScript application.
  */
-@interface RCTRootView : UIView
+__deprecated_msg("This API will be removed along with the legacy architecture.") @interface RCTRootView : UIView
 
 /**
  * - Designated initializer -

--- a/packages/react-native/React/Base/RCTRootViewInternal.h
+++ b/packages/react-native/React/Base/RCTRootViewInternal.h
@@ -13,7 +13,7 @@
  * The interface provides a set of functions that allow other internal framework
  * classes to change the RCTRootViews's internal state.
  */
-@interface RCTRootView ()
+__deprecated_msg("This API will be removed along with the legacy architecture.") @interface RCTRootView()
 
 /**
  * This setter should be used only by RCTUIManager on react root view

--- a/packages/react-native/React/Base/Surface/RCTSurface.h
+++ b/packages/react-native/React/Base/Surface/RCTSurface.h
@@ -32,7 +32,8 @@ NS_ASSUME_NONNULL_BEGIN
  *  * ability to create a UIView instance on demand (later);
  *  * ability to communicate the current stage of the surface granularly.
  */
-@interface RCTSurface : NSObject <RCTSurfaceProtocol>
+__deprecated_msg("This API will be removed along with the legacy architecture.") @interface RCTSurface
+    : NSObject<RCTSurfaceProtocol>
 
 - (instancetype)initWithBridge:(RCTBridge *)bridge
                     moduleName:(NSString *)moduleName

--- a/packages/react-native/React/Base/Surface/RCTSurfaceRootShadowView.h
+++ b/packages/react-native/React/Base/Surface/RCTSurfaceRootShadowView.h
@@ -9,7 +9,8 @@
 #import <React/RCTSurfaceRootShadowViewDelegate.h>
 #import <yoga/YGEnums.h>
 
-@interface RCTSurfaceRootShadowView : RCTShadowView
+__deprecated_msg("This API will be removed along with the legacy architecture.") @interface RCTSurfaceRootShadowView
+    : RCTShadowView
 
 @property (nonatomic, assign, readonly) CGSize minimumSize;
 @property (nonatomic, assign, readonly) CGSize maximumSize;
@@ -18,7 +19,8 @@
 
 @property (nonatomic, assign, readonly) CGSize intrinsicSize;
 
-@property (nonatomic, weak) id<RCTSurfaceRootShadowViewDelegate> delegate;
+@property (nonatomic, weak) id<RCTSurfaceRootShadowViewDelegate> delegate __deprecated_msg(
+    "This API will be removed along with the legacy architecture.");
 
 /**
  * Layout direction (LTR or RTL) inherited from native environment and

--- a/packages/react-native/React/CxxBridge/RCTJSIExecutorRuntimeInstaller.h
+++ b/packages/react-native/React/CxxBridge/RCTJSIExecutorRuntimeInstaller.h
@@ -17,6 +17,7 @@ namespace facebook::react {
  * Creates a lambda used to bind a JSIRuntime in the context of
  * Apple platforms, such as console logging, performance metrics, etc.
  */
+[[deprecated("This API will be removed along with the legacy architecture.")]]
 JSIExecutor::RuntimeInstaller RCTJSIExecutorRuntimeInstaller(
     JSIExecutor::RuntimeInstaller runtimeInstallerToWrap);
 

--- a/packages/react-native/React/CxxBridge/RCTObjcExecutor.h
+++ b/packages/react-native/React/CxxBridge/RCTObjcExecutor.h
@@ -16,7 +16,9 @@
 
 namespace facebook::react {
 
-class RCTObjcExecutorFactory : public JSExecutorFactory {
+class [[deprecated(
+    "This API will be removed along with the legacy architecture.")]] RCTObjcExecutorFactory
+    : public JSExecutorFactory {
  public:
   RCTObjcExecutorFactory(
       id<RCTJavaScriptExecutor> jse,

--- a/packages/react-native/React/CxxModule/DispatchMessageQueueThread.h
+++ b/packages/react-native/React/CxxModule/DispatchMessageQueueThread.h
@@ -18,7 +18,8 @@ namespace facebook::react {
 // is not the JS thread.  C++ modules don't use RCTNativeModule, so this little
 // adapter does the work.
 
-class DispatchMessageQueueThread : public MessageQueueThread {
+class [[deprecated("This API will be removed along with the legacy architecture.")]] DispatchMessageQueueThread
+    : public MessageQueueThread {
  public:
   DispatchMessageQueueThread(RCTModuleData *moduleData) : moduleData_(moduleData) {}
 

--- a/packages/react-native/React/CxxModule/RCTCxxUtils.h
+++ b/packages/react-native/React/CxxModule/RCTCxxUtils.h
@@ -20,6 +20,7 @@ class NativeModule;
 
 #ifndef RCT_FIT_RM_OLD_RUNTIME
 
+[[deprecated("This API will be removed along with the legacy architecture.")]]
 std::vector<std::unique_ptr<NativeModule>>
 createNativeModules(NSArray<RCTModuleData *> *modules, RCTBridge *bridge, const std::shared_ptr<Instance> &instance);
 

--- a/packages/react-native/React/CxxModule/RCTNativeModule.h
+++ b/packages/react-native/React/CxxModule/RCTNativeModule.h
@@ -12,7 +12,9 @@
 
 namespace facebook::react {
 
-class RCTNativeModule : public NativeModule {
+class [[deprecated(
+    "This API will be removed along with the legacy architecture.")]] RCTNativeModule
+    : public NativeModule {
  public:
   RCTNativeModule(RCTBridge* bridge, RCTModuleData* moduleData);
 

--- a/packages/react-native/React/Profiler/RCTProfile.h
+++ b/packages/react-native/React/Profiler/RCTProfile.h
@@ -19,10 +19,13 @@
  * using it.
  */
 
-RCT_EXTERN NSString *const RCTProfileDidStartProfiling;
-RCT_EXTERN NSString *const RCTProfileDidEndProfiling;
+RCT_EXTERN __deprecated_msg("This API will be removed along with the legacy architecture.") NSString *const
+    RCTProfileDidStartProfiling;
+RCT_EXTERN __deprecated_msg("This API will be removed along with the legacy architecture.") NSString *const
+    RCTProfileDidEndProfiling;
 
-RCT_EXTERN const uint64_t RCTProfileTagAlways;
+RCT_EXTERN __deprecated_msg("This API will be removed along with the legacy architecture.") const uint64_t
+    RCTProfileTagAlways;
 
 #if RCT_PROFILE
 
@@ -35,27 +38,33 @@ RCT_EXTERN const uint64_t RCTProfileTagAlways;
 
 #define RCTProfileEndFlowEvent() _RCTProfileEndFlowEvent(__rct_profile_flow_id)
 
-RCT_EXTERN dispatch_queue_t RCTProfileGetQueue(void);
+RCT_EXTERN dispatch_queue_t RCTProfileGetQueue(void)
+    __deprecated_msg("This API will be removed along with the legacy architecture.");
 
-RCT_EXTERN NSUInteger _RCTProfileBeginFlowEvent(void);
-RCT_EXTERN void _RCTProfileEndFlowEvent(NSUInteger);
+RCT_EXTERN NSUInteger _RCTProfileBeginFlowEvent(void)
+    __deprecated_msg("This API will be removed along with the legacy architecture.");
+RCT_EXTERN void _RCTProfileEndFlowEvent(NSUInteger)
+    __deprecated_msg("This API will be removed along with the legacy architecture.");
 
 /**
  * Returns YES if the profiling information is currently being collected
  */
-RCT_EXTERN BOOL RCTProfileIsProfiling(void);
+RCT_EXTERN BOOL RCTProfileIsProfiling(void)
+    __deprecated_msg("This API will be removed along with the legacy architecture.");
 
 /**
  * Start collecting profiling information
  */
-RCT_EXTERN void RCTProfileInit(RCTBridge *);
+RCT_EXTERN void RCTProfileInit(RCTBridge *)
+    __deprecated_msg("This API will be removed along with the legacy architecture.");
 
 /**
  * Stop profiling and return a JSON string of the collected data - The data
  * returned is compliant with google's trace event format - the format used
  * as input to trace-viewer
  */
-RCT_EXTERN void RCTProfileEnd(RCTBridge *, void (^)(NSString *));
+RCT_EXTERN void RCTProfileEnd(RCTBridge *, void (^)(NSString *))
+    __deprecated_msg("This API will be removed along with the legacy architecture.");
 
 /**
  * Route the RCT_PROFILE_BEGIN_EVENT hooks to our loom tracing.
@@ -79,7 +88,8 @@ RCT_EXTERN void _RCTProfileBeginEvent(
     NSTimeInterval time,
     uint64_t tag,
     NSString *name,
-    NSDictionary<NSString *, NSString *> *args);
+    NSDictionary<NSString *, NSString *> *args)
+    __deprecated_msg("This API will be removed along with the legacy architecture.");
 #define RCT_PROFILE_BEGIN_EVENT(tag, name, args)                      \
   do {                                                                \
     if (_RCTLoomIsProfiling()) {                                      \
@@ -97,12 +107,9 @@ RCT_EXTERN void _RCTProfileBeginEvent(
  * rest of the event information. Just at this point the event will actually be
  * registered
  */
-RCT_EXTERN void _RCTProfileEndEvent(
-    NSThread *calleeThread,
-    NSString *threadName,
-    NSTimeInterval time,
-    uint64_t tag,
-    NSString *category);
+RCT_EXTERN void
+_RCTProfileEndEvent(NSThread *calleeThread, NSString *threadName, NSTimeInterval time, uint64_t tag, NSString *category)
+    __deprecated_msg("This API will be removed along with the legacy architecture.");
 
 #define RCT_PROFILE_END_EVENT(tag, category)                                    \
   do {                                                                          \
@@ -121,7 +128,8 @@ RCT_EXTERN void _RCTProfileEndEvent(
  * Collects the initial event information for the event and returns a reference ID
  */
 RCT_EXTERN NSUInteger
-RCTProfileBeginAsyncEvent(uint64_t tag, NSString *name, NSDictionary<NSString *, NSString *> *args);
+RCTProfileBeginAsyncEvent(uint64_t tag, NSString *name, NSDictionary<NSString *, NSString *> *args)
+    __deprecated_msg("This API will be removed along with the legacy architecture.");
 
 /**
  * The ID returned by BeginEvent should then be passed into EndEvent, with the
@@ -129,12 +137,14 @@ RCTProfileBeginAsyncEvent(uint64_t tag, NSString *name, NSDictionary<NSString *,
  * registered
  */
 RCT_EXTERN void
-RCTProfileEndAsyncEvent(uint64_t tag, NSString *category, NSUInteger cookie, NSString *name, NSString *threadName);
+RCTProfileEndAsyncEvent(uint64_t tag, NSString *category, NSUInteger cookie, NSString *name, NSString *threadName)
+    __deprecated_msg("This API will be removed along with the legacy architecture.");
 
 /**
  * An event that doesn't have a duration (i.e. Notification, VSync, etc)
  */
-RCT_EXTERN void RCTProfileImmediateEvent(uint64_t tag, NSString *name, NSTimeInterval time, char scope);
+RCT_EXTERN void RCTProfileImmediateEvent(uint64_t tag, NSString *name, NSTimeInterval time, char scope)
+    __deprecated_msg("This API will be removed along with the legacy architecture.");
 
 /**
  * Helper to profile the duration of the execution of a block. This method uses
@@ -154,23 +164,27 @@ RCT_EXTERN void RCTProfileImmediateEvent(uint64_t tag, NSString *name, NSTimeInt
 /**
  * Hook into a bridge instance to log all bridge module's method calls
  */
-RCT_EXTERN void RCTProfileHookModules(RCTBridge *);
+RCT_EXTERN void RCTProfileHookModules(RCTBridge *)
+    __deprecated_msg("This API will be removed along with the legacy architecture.");
 
 /**
  * Unhook from a given bridge instance's modules
  */
-RCT_EXTERN void RCTProfileUnhookModules(RCTBridge *);
+RCT_EXTERN void RCTProfileUnhookModules(RCTBridge *)
+    __deprecated_msg("This API will be removed along with the legacy architecture.");
 
 /**
  * Hook into all of a module's methods
  */
-RCT_EXTERN void RCTProfileHookInstance(id instance);
+RCT_EXTERN void RCTProfileHookInstance(id instance)
+    __deprecated_msg("This API will be removed along with the legacy architecture.");
 
 /**
  * Send systrace or cpu profiling information to the packager
  * to present to the user
  */
-RCT_EXTERN void RCTProfileSendResult(RCTBridge *bridge, NSString *route, NSData *profileData);
+RCT_EXTERN void RCTProfileSendResult(RCTBridge *bridge, NSString *route, NSData *profileData)
+    __deprecated_msg("This API will be removed along with the legacy architecture.");
 
 /**
  * Systrace gluecode
@@ -183,7 +197,7 @@ typedef struct {
   unsigned long key_len;
   const char *value;
   unsigned long value_len;
-} systrace_arg_t;
+} systrace_arg_t __deprecated_msg("This API will be removed along with the legacy architecture.");
 
 typedef struct {
   char *(*start)(void);
@@ -199,15 +213,18 @@ typedef struct {
 
   void (*begin_async_flow)(uint64_t tag, const char *name, int cookie);
   void (*end_async_flow)(uint64_t tag, const char *name, int cookie);
-} RCTProfileCallbacks;
+} RCTProfileCallbacks __deprecated_msg("This API will be removed along with the legacy architecture.");
 
-RCT_EXTERN void RCTProfileRegisterCallbacks(RCTProfileCallbacks *);
+RCT_EXTERN void RCTProfileRegisterCallbacks(RCTProfileCallbacks *)
+    __deprecated_msg("This API will be removed along with the legacy architecture.");
 
 /**
  * Systrace control window
  */
-RCT_EXTERN void RCTProfileShowControls(void);
-RCT_EXTERN void RCTProfileHideControls(void);
+RCT_EXTERN void RCTProfileShowControls(void)
+    __deprecated_msg("This API will be removed along with the legacy architecture.");
+RCT_EXTERN void RCTProfileHideControls(void)
+    __deprecated_msg("This API will be removed along with the legacy architecture.");
 
 #else
 

--- a/packages/react-native/React/Views/RCTActivityIndicatorView.h
+++ b/packages/react-native/React/Views/RCTActivityIndicatorView.h
@@ -9,6 +9,7 @@
 
 #ifndef RCT_FIT_RM_OLD_COMPONENT
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTActivityIndicatorView : UIActivityIndicatorView
 @end
 

--- a/packages/react-native/React/Views/RCTActivityIndicatorViewManager.h
+++ b/packages/react-native/React/Views/RCTActivityIndicatorViewManager.h
@@ -9,6 +9,7 @@
 
 #ifndef RCT_FIT_RM_OLD_COMPONENT
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTConvert (UIActivityIndicatorView)
 
 + (UIActivityIndicatorViewStyle)UIActivityIndicatorViewStyle:(id)json;

--- a/packages/react-native/React/Views/RCTDebuggingOverlayManager.h
+++ b/packages/react-native/React/Views/RCTDebuggingOverlayManager.h
@@ -9,6 +9,7 @@
 
 #ifndef RCT_FIT_RM_OLD_COMPONENT
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTDebuggingOverlayManager : RCTViewManager
 
 @end

--- a/packages/react-native/React/Views/RCTModalHostView.h
+++ b/packages/react-native/React/Views/RCTModalHostView.h
@@ -18,7 +18,8 @@
 
 @protocol RCTModalHostViewInteractor;
 
-@interface RCTModalHostView : UIView <RCTInvalidating, UIAdaptivePresentationControllerDelegate>
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
+@interface RCTModalHostView : UIView<RCTInvalidating, UIAdaptivePresentationControllerDelegate>
 
 @property (nonatomic, copy) NSString *animationType;
 @property (nonatomic, assign) UIModalPresentationStyle presentationStyle;

--- a/packages/react-native/React/Views/RCTModalHostViewController.h
+++ b/packages/react-native/React/Views/RCTModalHostViewController.h
@@ -9,6 +9,7 @@
 
 #ifndef RCT_FIT_RM_OLD_COMPONENT
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTModalHostViewController : UIViewController
 
 @property (nonatomic, copy) void (^boundsDidChangeBlock)(CGRect newBounds);

--- a/packages/react-native/React/Views/RCTModalHostViewManager.h
+++ b/packages/react-native/React/Views/RCTModalHostViewManager.h
@@ -15,9 +15,11 @@ typedef void (^RCTModalViewInteractionBlock)(
     UIViewController *reactViewController,
     UIViewController *viewController,
     BOOL animated,
-    dispatch_block_t completionBlock);
+    dispatch_block_t completionBlock)
+    __attribute__((deprecated("This API will be removed along with the legacy architecture.")));
 
-@interface RCTModalHostViewManager : RCTViewManager <RCTInvalidating>
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
+@interface RCTModalHostViewManager : RCTViewManager<RCTInvalidating>
 
 /**
  * `presentationBlock` and `dismissalBlock` allow you to control how a Modal interacts with your case,

--- a/packages/react-native/React/Views/RCTModalManager.h
+++ b/packages/react-native/React/Views/RCTModalManager.h
@@ -12,7 +12,8 @@
 #import <React/RCTBridgeModule.h>
 #import <React/RCTEventEmitter.h>
 
-@interface RCTModalManager : RCTEventEmitter <RCTBridgeModule>
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
+@interface RCTModalManager : RCTEventEmitter<RCTBridgeModule>
 
 - (void)modalDismissed:(NSNumber *)modalID;
 

--- a/packages/react-native/React/Views/RCTRootShadowView.h
+++ b/packages/react-native/React/Views/RCTRootShadowView.h
@@ -8,6 +8,7 @@
 #import <React/RCTShadowView.h>
 #import <yoga/YGEnums.h>
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTRootShadowView : RCTShadowView
 
 /**

--- a/packages/react-native/React/Views/RCTSwitch.h
+++ b/packages/react-native/React/Views/RCTSwitch.h
@@ -11,6 +11,7 @@
 
 #import <React/RCTComponent.h>
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTSwitch : UISwitch
 
 @property (nonatomic, assign) BOOL wasOn;

--- a/packages/react-native/React/Views/RCTSwitchManager.h
+++ b/packages/react-native/React/Views/RCTSwitchManager.h
@@ -9,6 +9,7 @@
 
 #ifndef RCT_FIT_RM_OLD_COMPONENT
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTSwitchManager : RCTViewManager
 
 @end

--- a/packages/react-native/React/Views/RefreshControl/RCTRefreshControl.h
+++ b/packages/react-native/React/Views/RefreshControl/RCTRefreshControl.h
@@ -12,7 +12,8 @@
 #import <React/RCTComponent.h>
 #import <React/RCTScrollableProtocol.h>
 
-@interface RCTRefreshControl : UIRefreshControl <RCTCustomRefreshControlProtocol>
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
+@interface RCTRefreshControl : UIRefreshControl<RCTCustomRefreshControlProtocol>
 
 @property (nonatomic, copy) NSString *title;
 @property (nonatomic, copy) RCTDirectEventBlock onRefresh;

--- a/packages/react-native/React/Views/RefreshControl/RCTRefreshControlManager.h
+++ b/packages/react-native/React/Views/RefreshControl/RCTRefreshControlManager.h
@@ -9,6 +9,7 @@
 
 #ifndef RCT_FIT_RM_OLD_COMPONENT
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTRefreshControlManager : RCTViewManager
 
 @end

--- a/packages/react-native/React/Views/SafeAreaView/RCTSafeAreaShadowView.h
+++ b/packages/react-native/React/Views/SafeAreaView/RCTSafeAreaShadowView.h
@@ -11,6 +11,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTSafeAreaShadowView : RCTShadowView
 
 @end

--- a/packages/react-native/React/Views/SafeAreaView/RCTSafeAreaView.h
+++ b/packages/react-native/React/Views/SafeAreaView/RCTSafeAreaView.h
@@ -15,6 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class RCTBridge;
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTSafeAreaView : RCTView
 
 - (instancetype)initWithBridge:(RCTBridge *)bridge;

--- a/packages/react-native/React/Views/SafeAreaView/RCTSafeAreaViewLocalData.h
+++ b/packages/react-native/React/Views/SafeAreaView/RCTSafeAreaViewLocalData.h
@@ -11,6 +11,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTSafeAreaViewLocalData : NSObject
 
 - (instancetype)initWithInsets:(UIEdgeInsets)insets;

--- a/packages/react-native/React/Views/SafeAreaView/RCTSafeAreaViewManager.h
+++ b/packages/react-native/React/Views/SafeAreaView/RCTSafeAreaViewManager.h
@@ -11,6 +11,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTSafeAreaViewManager : RCTViewManager
 
 @end

--- a/packages/react-native/React/Views/ScrollView/RCTScrollContentShadowView.h
+++ b/packages/react-native/React/Views/ScrollView/RCTScrollContentShadowView.h
@@ -11,6 +11,7 @@
 
 #import <React/RCTShadowView.h>
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTScrollContentShadowView : RCTShadowView
 
 @end

--- a/packages/react-native/React/Views/ScrollView/RCTScrollContentView.h
+++ b/packages/react-native/React/Views/ScrollView/RCTScrollContentView.h
@@ -11,6 +11,7 @@
 
 #import <React/RCTView.h>
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTScrollContentView : RCTView
 
 @end

--- a/packages/react-native/React/Views/ScrollView/RCTScrollContentViewManager.h
+++ b/packages/react-native/React/Views/ScrollView/RCTScrollContentViewManager.h
@@ -9,6 +9,7 @@
 
 #ifndef RCT_FIT_RM_OLD_COMPONENT
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTScrollContentViewManager : RCTViewManager
 
 @end

--- a/packages/react-native/React/Views/ScrollView/RCTScrollView.h
+++ b/packages/react-native/React/Views/ScrollView/RCTScrollView.h
@@ -17,7 +17,8 @@
 
 @protocol UIScrollViewDelegate;
 
-@interface RCTScrollView : RCTView <UIScrollViewDelegate, RCTScrollableProtocol, RCTAutoInsetsProtocol>
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
+@interface RCTScrollView : RCTView<UIScrollViewDelegate, RCTScrollableProtocol, RCTAutoInsetsProtocol>
 
 - (instancetype)initWithEventDispatcher:(id<RCTEventDispatcherProtocol>)eventDispatcher NS_DESIGNATED_INITIALIZER;
 

--- a/packages/react-native/React/Views/ScrollView/RCTScrollViewManager.h
+++ b/packages/react-native/React/Views/ScrollView/RCTScrollViewManager.h
@@ -10,12 +10,14 @@
 
 #ifndef RCT_FIT_RM_OLD_COMPONENT
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTConvert (UIScrollView)
 
 + (UIScrollViewKeyboardDismissMode)UIScrollViewKeyboardDismissMode:(id)json;
 
 @end
 
+__attribute__((deprecated("This API will be removed along with the legacy architecture.")))
 @interface RCTScrollViewManager : RCTViewManager
 
 @end


### PR DESCRIPTION
Summary:
All these components have fabric replacements.

Let's deprecate them, so we can remove them eventually.

Differential Revision: D80973216
