### PR TITLE
[ios][precompiled] add SWIFT_ENABLE_EXPLICIT_MODULES to xcode 26

### DIFF
--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -503,6 +503,13 @@ def react_native_post_install(
   ReactNativePodsUtils.updateOSDeploymentTarget(installer)
   ReactNativePodsUtils.set_dynamic_frameworks_flags(installer)
   ReactNativePodsUtils.add_ndebug_flag_to_pods_in_release(installer)
+
+  if !ReactNativeCoreUtils.build_rncore_from_source()
+    # In XCode 26 we need to revert the new setting SWIFT_ENABLE_EXPLICIT_MODULES when building
+    # with precompiled binaries.
+    ReactNativePodsUtils.set_build_setting(installer, build_setting: "SWIFT_ENABLE_EXPLICIT_MODULES", value: "NO")
+  end
+
   SPM.apply_on_post_install(installer)
 
   if privacy_file_aggregation_enabled


### PR DESCRIPTION
## Summary:

XCode 26 introduces building explicit swift modules turned on (SWIFT_ENABLE_EXPLICIT_MODULES). This breaks building with precompiled binaries.

This commit fixes this by adding a step when not building from source where we explicitly set the `SWIFT_ENABLE_EXPLICIT_MODULES` flag to `NO`.

## Changelog:

[IOS] [FIXED] - Added setting SWIFT_ENABLE_EXPLICIT_MODULES=NO when using precompiled to support Xcode 26

## Test Plan:

```bash
npx @react-native-community/cli init MyApp --version nightly --skip-install
cd MyApp
yarn
cd ios
bundle install
RCT_USE_RN_DEP=1 RCT_USE_PREBUILT_RNCORE=1 bundle exec pod install
```

Build above app with Xcode 26 and verify that it no longer fails