### PR TITLE
Fix culling of views having no layout breaking embedded Text event handlers

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/text/TextShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/TextShadowNode.h
@@ -31,7 +31,6 @@ class TextShadowNode : public ConcreteShadowNode<
     auto traits = ConcreteShadowNode::BaseTraits();
 #ifdef ANDROID
     traits.set(ShadowNodeTraits::Trait::FormsView);
-    traits.set(ShadowNodeTraits::Trait::Unstable_uncullableView);
 #endif
     return traits;
   }

--- a/packages/react-native/ReactCommon/react/renderer/mounting/internal/sliceChildShadowNodeViewPairs.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/internal/sliceChildShadowNodeViewPairs.cpp
@@ -80,9 +80,16 @@ static void sliceChildShadowNodeViewPairsRecursively(
           overflowInsetFrame =
               overflowInsetFrame * layoutableShadowNode->getTransform();
         }
+
+        // Embedded Text components can have an empty layout, while these still
+        // need to be mounted to set the correct react tags on the text
+        // fragments. These should not be culled.
+        auto hasLayout = overflowInsetFrame.size.width > 0 ||
+            overflowInsetFrame.size.height > 0;
+
         auto doesIntersect =
             Rect::intersect(cullingContext.frame, overflowInsetFrame) != Rect{};
-        if (!doesIntersect) {
+        if (hasLayout && !doesIntersect) {
           continue; // Culling.
         }
       }


### PR DESCRIPTION
Summary:
This is a follow-up on D80631997. When enabling View Culling on Android, wrapped Text components would lead to event handlers set by the inner Text component not being set on the attributed string.

```
<Paragraph>
  <Text onPress={myHandler}>  <- This handler is not set
    <RawText/>
  </Text>
</Paragraph>
```

This was due to the inner Text component having no size and hence being culled by the View Culling algorithm.

This diff disables view culling for views having no size, since no layout means no valid decision can be made as to the visibility of the component within the viewport.

It also removes the change made D80631997, allowing Text views to be culled.

Changelog: [Internal]

Differential Revision: D81044841


