### PR TITLE
Use panel query param instead of landingView

### DIFF
--- a/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
+++ b/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
@@ -67,7 +67,7 @@ export default function openDebuggerMiddleware({
         launchId?: string,
         telemetryInfo?: string,
         target?: string,
-        landingView?: string,
+        panel?: string,
         ...
       } = parsedUrl.query;
 
@@ -152,7 +152,7 @@ export default function openDebuggerMiddleware({
                 telemetryInfo: query.telemetryInfo,
                 appId: target.appId,
                 useFuseboxEntryPoint,
-                landingView: query.landingView,
+                panel: query.panel,
               },
             );
             if (

--- a/packages/dev-middleware/src/utils/getDevToolsFrontendUrl.js
+++ b/packages/dev-middleware/src/utils/getDevToolsFrontendUrl.js
@@ -24,7 +24,7 @@ export default function getDevToolsFrontendUrl(
     /** Whether to use the modern `rn_fusebox.html` entry point. */
     useFuseboxEntryPoint?: boolean,
     appId?: string,
-    landingView?: string,
+    panel?: string,
   }>,
 ): string {
   const wsParam = getWsParam({
@@ -55,8 +55,8 @@ export default function getDevToolsFrontendUrl(
   if (options?.telemetryInfo != null && options.telemetryInfo !== '') {
     searchParams.append('telemetryInfo', options.telemetryInfo);
   }
-  if (options?.landingView != null && options.landingView !== '') {
-    searchParams.append('landingView', options.landingView);
+  if (options?.panel != null && options.panel !== '') {
+    searchParams.append('panel', options.panel);
   }
 
   return appUrl + '?' + searchParams.toString();

--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1887,14 +1887,6 @@ public final class com/facebook/react/devsupport/BundleDownloader$BundleInfo$Com
 public final class com/facebook/react/devsupport/BundleDownloader$Companion {
 }
 
-public final class com/facebook/react/devsupport/ChromeDevToolsViewKeys : java/lang/Enum {
-	public static final field Performance Lcom/facebook/react/devsupport/ChromeDevToolsViewKeys;
-	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public final fun getValue ()Ljava/lang/String;
-	public static fun valueOf (Ljava/lang/String;)Lcom/facebook/react/devsupport/ChromeDevToolsViewKeys;
-	public static fun values ()[Lcom/facebook/react/devsupport/ChromeDevToolsViewKeys;
-}
-
 public final class com/facebook/react/devsupport/DefaultDevLoadingViewImplementation : com/facebook/react/devsupport/interfaces/DevLoadingViewManager {
 	public static final field Companion Lcom/facebook/react/devsupport/DefaultDevLoadingViewImplementation$Companion;
 	public fun <init> (Lcom/facebook/react/devsupport/ReactInstanceDevHelper;)V
@@ -1922,7 +1914,7 @@ public class com/facebook/react/devsupport/DevServerHelper {
 	public fun getSourceUrl (Ljava/lang/String;)Ljava/lang/String;
 	public final fun getWebsocketProxyURL ()Ljava/lang/String;
 	public fun isPackagerRunning (Lcom/facebook/react/devsupport/interfaces/PackagerStatusCallback;)V
-	public final fun openDebugger (Lcom/facebook/react/bridge/ReactContext;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun openDebugger (Lcom/facebook/react/bridge/ReactContext;Ljava/lang/String;Lcom/facebook/react/devsupport/interfaces/DebuggerFrontendPanelName;)V
 	public final fun openInspectorConnection ()V
 	public final fun openPackagerConnection (Ljava/lang/String;Lcom/facebook/react/devsupport/DevServerHelper$PackagerCommandListener;)V
 }
@@ -2116,6 +2108,15 @@ public final class com/facebook/react/devsupport/StackTraceHelper$StackFrameImpl
 public abstract interface class com/facebook/react/devsupport/interfaces/BundleLoadCallback {
 	public fun onError (Ljava/lang/Exception;)V
 	public abstract fun onSuccess ()V
+}
+
+public final class com/facebook/react/devsupport/interfaces/DebuggerFrontendPanelName : java/lang/Enum {
+	public static final field PERFORMANCE Lcom/facebook/react/devsupport/interfaces/DebuggerFrontendPanelName;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getInternalName ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lcom/facebook/react/devsupport/interfaces/DebuggerFrontendPanelName;
+	public static fun values ()[Lcom/facebook/react/devsupport/interfaces/DebuggerFrontendPanelName;
 }
 
 public abstract interface class com/facebook/react/devsupport/interfaces/DevBundleDownloadListener {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.kt
@@ -21,6 +21,7 @@ import com.facebook.react.bridge.ReactContext
 import com.facebook.react.common.ReactConstants
 import com.facebook.react.devsupport.InspectorFlags.getFuseboxEnabled
 import com.facebook.react.devsupport.InspectorFlags.getIsProfilingBuild
+import com.facebook.react.devsupport.interfaces.DebuggerFrontendPanelName
 import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener
 import com.facebook.react.devsupport.interfaces.PackagerStatusCallback
 import com.facebook.react.modules.debug.interfaces.DeveloperSettings
@@ -352,7 +353,11 @@ public open class DevServerHelper(
   }
 
   /** Attempt to open the JS debugger on the host machine (on-device CDP debugging). */
-  public fun openDebugger(context: ReactContext?, errorMessage: String?, landingView: String?) {
+  public fun openDebugger(
+      context: ReactContext?,
+      errorMessage: String?,
+      panel: DebuggerFrontendPanelName?,
+  ) {
     // TODO(huntie): Requests to dev server should not assume 'http' URL scheme
     val requestUrlBuilder = StringBuilder()
 
@@ -365,8 +370,8 @@ public open class DevServerHelper(
         )
     )
 
-    if (landingView != null) {
-      requestUrlBuilder.append("&landingView=" + Uri.encode(landingView))
+    if (panel != null) {
+      requestUrlBuilder.append("&panel=" + Uri.encode(panel.toString()))
     }
 
     val request =

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.kt
@@ -75,10 +75,6 @@ import java.net.MalformedURLException
 import java.net.URL
 import java.util.Locale
 
-public enum class ChromeDevToolsViewKeys(public val value: String) {
-  Performance("timeline")
-}
-
 public abstract class DevSupportManagerBase(
     protected val applicationContext: Context,
     public val reactInstanceDevHelper: ReactInstanceDevHelper,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DebuggerFrontendPanelName.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DebuggerFrontendPanelName.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.devsupport.interfaces
+
+public enum class DebuggerFrontendPanelName(public val internalName: String) {
+  PERFORMANCE("timeline");
+
+  override fun toString(): String = internalName
+}


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

I've just discovered today that Chrome DevTools has a native support for `panel` query parameter, we don't need a custom one.

Reviewed By: alanleedev

Differential Revision: D81052828


