### PR TITLE
[0.81] Fix codegen using undeclared dependencies

### DIFF
--- a/packages/react-native-codegen/package.json
+++ b/packages/react-native-codegen/package.json
@@ -29,6 +29,8 @@
     "lib"
   ],
   "dependencies": {
+    "@babel/core": "^7.25.2",
+    "@babel/parser": "^7.25.3",
     "glob": "^7.1.1",
     "hermes-parser": "0.29.1",
     "invariant": "^2.2.4",


### PR DESCRIPTION
Cherry-pick of https://github.com/facebook/react-native/commit/a8539190fea3a4dfbdea07404cbbe53da132a07d (https://github.com/facebook/react-native/pull/52884) into `0.81-stable` for https://github.com/reactwg/react-native-releases/issues/1080.