### PR TITLE
Add openDebugger overload with target panel name

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1963,6 +1963,7 @@ public abstract class com/facebook/react/devsupport/DevSupportManagerBase : com/
 	public fun onNewReactContextCreated (Lcom/facebook/react/bridge/ReactContext;)V
 	public fun onReactInstanceDestroyed (Lcom/facebook/react/bridge/ReactContext;)V
 	public fun openDebugger ()V
+	public fun openDebugger (Lcom/facebook/react/devsupport/interfaces/DebuggerFrontendPanelName;)V
 	public fun processErrorCustomizers (Landroid/util/Pair;)Landroid/util/Pair;
 	public fun registerErrorCustomizer (Lcom/facebook/react/devsupport/interfaces/ErrorCustomizer;)V
 	public fun reloadJSFromServer (Ljava/lang/String;Lcom/facebook/react/devsupport/interfaces/BundleLoadCallback;)V
@@ -2052,6 +2053,7 @@ public class com/facebook/react/devsupport/ReleaseDevSupportManager : com/facebo
 	public fun onNewReactContextCreated (Lcom/facebook/react/bridge/ReactContext;)V
 	public fun onReactInstanceDestroyed (Lcom/facebook/react/bridge/ReactContext;)V
 	public fun openDebugger ()V
+	public fun openDebugger (Lcom/facebook/react/devsupport/interfaces/DebuggerFrontendPanelName;)V
 	public fun processErrorCustomizers (Landroid/util/Pair;)Landroid/util/Pair;
 	public fun registerErrorCustomizer (Lcom/facebook/react/devsupport/interfaces/ErrorCustomizer;)V
 	public fun reloadJSFromServer (Ljava/lang/String;Lcom/facebook/react/devsupport/interfaces/BundleLoadCallback;)V
@@ -2161,6 +2163,7 @@ public abstract interface class com/facebook/react/devsupport/interfaces/DevSupp
 	public abstract fun onNewReactContextCreated (Lcom/facebook/react/bridge/ReactContext;)V
 	public abstract fun onReactInstanceDestroyed (Lcom/facebook/react/bridge/ReactContext;)V
 	public abstract fun openDebugger ()V
+	public abstract fun openDebugger (Lcom/facebook/react/devsupport/interfaces/DebuggerFrontendPanelName;)V
 	public abstract fun processErrorCustomizers (Landroid/util/Pair;)Landroid/util/Pair;
 	public abstract fun registerErrorCustomizer (Lcom/facebook/react/devsupport/interfaces/ErrorCustomizer;)V
 	public abstract fun reloadJSFromServer (Ljava/lang/String;Lcom/facebook/react/devsupport/interfaces/BundleLoadCallback;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.kt
@@ -52,6 +52,7 @@ import com.facebook.react.devsupport.InspectorFlags.getFuseboxEnabled
 import com.facebook.react.devsupport.StackTraceHelper.convertJavaStackTrace
 import com.facebook.react.devsupport.StackTraceHelper.convertJsStackTrace
 import com.facebook.react.devsupport.interfaces.BundleLoadCallback
+import com.facebook.react.devsupport.interfaces.DebuggerFrontendPanelName
 import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener
 import com.facebook.react.devsupport.interfaces.DevLoadingViewManager
 import com.facebook.react.devsupport.interfaces.DevOptionHandler
@@ -924,6 +925,14 @@ public abstract class DevSupportManagerBase(
         currentReactContext,
         applicationContext.getString(R.string.catalyst_open_debugger_error),
         null,
+    )
+  }
+
+  override fun openDebugger(panel: DebuggerFrontendPanelName) {
+    devServerHelper.openDebugger(
+        currentReactContext,
+        applicationContext.getString(R.string.catalyst_open_debugger_error),
+        panel,
     )
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/ReleaseDevSupportManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/ReleaseDevSupportManager.kt
@@ -16,6 +16,7 @@ import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.common.SurfaceDelegate
 import com.facebook.react.devsupport.interfaces.BundleLoadCallback
+import com.facebook.react.devsupport.interfaces.DebuggerFrontendPanelName
 import com.facebook.react.devsupport.interfaces.DevOptionHandler
 import com.facebook.react.devsupport.interfaces.DevSupportManager
 import com.facebook.react.devsupport.interfaces.DevSupportManager.PackagerLocationCustomizer
@@ -143,6 +144,8 @@ public open class ReleaseDevSupportManager : DevSupportManager {
   public override fun createSurfaceDelegate(moduleName: String): SurfaceDelegate? = null
 
   public override fun openDebugger(): Unit = Unit
+
+  public override fun openDebugger(panel: DebuggerFrontendPanelName): Unit = Unit
 
   public override fun showPausedInDebuggerOverlay(
       message: String,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.kt
@@ -97,6 +97,9 @@ public interface DevSupportManager : JSExceptionHandler {
   /** Attempt to open the JS debugger on the host machine. */
   public fun openDebugger()
 
+  /** Attempt to open the JS debugger on the host machine, providing a destination panel name. */
+  public fun openDebugger(panel: DebuggerFrontendPanelName)
+
   /** Shows the "paused in debugger" overlay with the given message. */
   public fun showPausedInDebuggerOverlay(
       message: String,


### PR DESCRIPTION
Summary:
Adds new `openDebugger(panel)` overload on `DevSupportManager` (following D79329081).

Changelog:
[Android][Added] - `DevSupportManager::openDebugger` now supports an optional `panel` param

Differential Revision: D81138169


