### PR TITLE
Android: Schedule image prefetching on tree commit

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageShadowNode.cpp
@@ -5,13 +5,15 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include "ImageState.h"
+
 #include <cstdlib>
 #include <limits>
 
+#include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/components/image/ImageShadowNode.h>
 #include <react/renderer/core/LayoutContext.h>
 #include <react/renderer/imagemanager/ImageRequestParams.h>
-#include "ImageState.h"
 
 namespace facebook::react {
 
@@ -28,7 +30,8 @@ void ImageShadowNode::setImageManager(
   // layout, if the image source was changed we have to initiate the image
   // request now since there is no guarantee that layout will run for the shadow
   // node at a later time.
-  if (getIsLayoutClean()) {
+  if (getIsLayoutClean() ||
+      ReactNativeFeatureFlags::enableImagePrefetchingAndroid()) {
     auto sources = getConcreteProps().sources;
     auto layoutMetric = getLayoutMetrics();
     if (sources.size() <= 1 ||

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/ImageFetcher.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/ImageFetcher.h
@@ -7,22 +7,40 @@
 
 #pragma once
 
+#include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/imagemanager/ImageRequest.h>
 #include <react/renderer/imagemanager/ImageRequestParams.h>
+#include <react/renderer/mounting/ShadowTree.h>
+#include <react/renderer/uimanager/UIManagerCommitHook.h>
 #include <react/utils/ContextContainer.h>
 
 namespace facebook::react {
 
-class ImageFetcher {
+class ImageFetcher : public UIManagerCommitHook {
  public:
-  ImageFetcher(std::shared_ptr<const ContextContainer> contextContainer)
-      : contextContainer_(std::move(contextContainer)) {}
+  ImageFetcher(std::shared_ptr<const ContextContainer> contextContainer);
+  ~ImageFetcher() override;
+  ImageFetcher(const ImageFetcher&) = delete;
+  ImageFetcher& operator=(const ImageFetcher&) = delete;
+  ImageFetcher(ImageFetcher&&) = delete;
+  ImageFetcher& operator=(ImageFetcher&&) = delete;
 
   ImageRequest requestImage(
       const ImageSource& imageSource,
       SurfaceId surfaceId,
       const ImageRequestParams& imageRequestParams,
       Tag tag);
+
+  void commitHookWasRegistered(const UIManager& uiManager) noexcept override {}
+
+  void commitHookWasUnregistered(const UIManager& uiManager) noexcept override {
+  }
+
+  RootShadowNode::Unshared shadowTreeWillCommit(
+      const ShadowTree& shadowTree,
+      const RootShadowNode::Shared& oldRootShadowNode,
+      const RootShadowNode::Unshared& newRootShadowNode,
+      const ShadowTree::CommitOptions& commitOptions) noexcept override;
 
  private:
   std::vector<ImageRequestItem> items_;

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -24,6 +24,33 @@
 
 namespace facebook::react {
 
+namespace {
+
+class UIManagerCommitHookManagerImpl : public UIManagerCommitHookManager {
+ public:
+  explicit UIManagerCommitHookManagerImpl(std::weak_ptr<UIManager> uiManager)
+      : uiManager_(std::move(uiManager)) {}
+
+  ~UIManagerCommitHookManagerImpl() override = default;
+
+  void registerCommitHook(UIManagerCommitHook& commitHook) override {
+    if (auto uiManager = uiManager_.lock()) {
+      uiManager->registerCommitHook(commitHook);
+    }
+  }
+
+  void unregisterCommitHook(UIManagerCommitHook& commitHook) override {
+    if (auto uiManager = uiManager_.lock()) {
+      uiManager->unregisterCommitHook(commitHook);
+    }
+  }
+
+ private:
+  std::weak_ptr<UIManager> uiManager_;
+};
+
+} // namespace
+
 Scheduler::Scheduler(
     const SchedulerToolbox& schedulerToolbox,
     UIManagerAnimationDelegate* animationDelegate,
@@ -49,6 +76,12 @@ Scheduler::Scheduler(
 
   auto uiManager =
       std::make_shared<UIManager>(runtimeExecutor_, contextContainer_);
+  if (ReactNativeFeatureFlags::enableImagePrefetchingAndroid()) {
+    contextContainer_->insert(
+        std::string(UIManagerCommitHookManagerKey),
+        std::make_shared<UIManagerCommitHookManagerImpl>(uiManager));
+  }
+
   auto eventOwnerBox = std::make_shared<EventBeat::OwnerBox>();
   eventOwnerBox->owner = eventDispatcher_;
 

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerCommitHook.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerCommitHook.h
@@ -57,4 +57,15 @@ class UIManagerCommitHook {
   virtual ~UIManagerCommitHook() noexcept = default;
 };
 
+constexpr std::string_view UIManagerCommitHookManagerKey =
+    "UIManagerCommitHookManager";
+
+class UIManagerCommitHookManager {
+ public:
+  virtual ~UIManagerCommitHookManager() = default;
+
+  virtual void registerCommitHook(UIManagerCommitHook& commitHook) = 0;
+  virtual void unregisterCommitHook(UIManagerCommitHook& commitHook) = 0;
+};
+
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
NOTE: This does **NOT** work.

It seems a shadowTreeWillCommit hook https://www.internalfb.com/code/search?q=filepath%3Areact-native-github%20repo%3Afbsource%20shadowTreeWillCommit on RN Android is called after the host views (in this case ReactVitoImageView is created)

Rollback Plan:

Differential Revision: D81106112


