### PR TITLE
Simplify ImageRequest conversion

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/ImageManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/ImageManager.cpp
@@ -12,6 +12,14 @@
 
 namespace facebook::react {
 
+namespace {
+
+constexpr inline bool isInteger(const std::string& str) {
+  return str.find_first_not_of("0123456789") == std::string::npos;
+}
+
+} // namespace
+
 ImageManager::ImageManager(
     const std::shared_ptr<const ContextContainer>& contextContainer)
     : self_(new ImageFetcher(contextContainer)) {}
@@ -26,8 +34,10 @@ ImageRequest ImageManager::requestImage(
     const ImageRequestParams& imageRequestParams,
     Tag tag) const {
   if (ReactNativeFeatureFlags::enableImagePrefetchingAndroid()) {
-    return static_cast<ImageFetcher*>(self_)->requestImage(
-        imageSource, surfaceId, imageRequestParams, tag);
+    if (!isInteger(imageSource.uri)) {
+      return static_cast<ImageFetcher*>(self_)->requestImage(
+          imageSource, surfaceId, imageRequestParams, tag);
+    }
   }
   return {imageSource, nullptr, {}};
 }

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/conversions.h
@@ -58,8 +58,10 @@ inline void serializeImageSource(
     MapBufferBuilder& builder,
     const ImageSource& imageSource) {
   builder.putString(IS_KEY_URI, imageSource.uri);
-  builder.putDouble(IS_KEY_VIEW_WIDTH, imageSource.size.width);
-  builder.putDouble(IS_KEY_VIEW_HEIGHT, imageSource.size.height);
+  builder.putInt(
+      IS_KEY_VIEW_WIDTH, static_cast<int32_t>(imageSource.size.width));
+  builder.putInt(
+      IS_KEY_VIEW_HEIGHT, static_cast<int32_t>(imageSource.size.height));
 }
 
 inline void serializeImageRequestParams(
@@ -69,7 +71,8 @@ inline void serializeImageRequestParams(
   builder.putString(
       IS_KEY_RESIZE_MODE, toString(imageRequestParams.resizeMode));
   builder.putString(IS_KEY_RESIZE_METHOD, imageRequestParams.resizeMethod);
-  builder.putDouble(IS_KEY_BLUR_RADIUS, imageRequestParams.blurRadius);
+  builder.putInt(
+      IS_KEY_BLUR_RADIUS, static_cast<int32_t>(imageRequestParams.blurRadius));
   builder.putDouble(
       IS_KEY_RESIZE_MULTIPLIER, imageRequestParams.resizeMultiplier);
   builder.putBool(
@@ -83,7 +86,9 @@ inline void serializeImageRequestParams(
     builder.putInt(
         IS_KEY_TINT_COLOR, toAndroidRepr(imageRequestParams.tintColor));
   }
-  builder.putDouble(IS_KEY_FADE_DURATION, imageRequestParams.fadeDuration);
+  builder.putInt(
+      IS_KEY_FADE_DURATION,
+      static_cast<int32_t>(imageRequestParams.fadeDuration));
   builder.putBool(
       IS_KEY_PROGRESSIVE_RENDERING_ENABLED,
       imageRequestParams.progressiveRenderingEnabled);

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/tests/MapBufferTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/tests/MapBufferTest.cpp
@@ -95,6 +95,15 @@ TEST(MapBufferTest, testDoubleEntries) {
   EXPECT_EQ(map.getDouble(1), 432.1);
 }
 
+TEST(MapBufferTest, testStringEmpty) {
+  auto builder = MapBufferBuilder();
+
+  builder.putString(0, "");
+  auto map = builder.build();
+
+  EXPECT_EQ(map.getString(0), "");
+}
+
 TEST(MapBufferTest, testStringEntries) {
   auto builder = MapBufferBuilder();
 


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Goal is to simplify code and to lower the JNI payload

- Send values as `int` instead of `Double` if they are converted to `int` on the Java side
- We only have 2 optional values - all others are mandatory

Differential Revision: D81202196


