### PR TITLE
fix(iOS): modal swipe dismissal works only for the first time

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.mm
@@ -106,6 +106,7 @@ static ModalHostViewEventEmitter::OnOrientationChange onOrientationChangeStruct(
   BOOL _shouldAnimatePresentation;
   BOOL _shouldPresent;
   BOOL _isPresented;
+  BOOL _modalInPresentation;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -115,6 +116,7 @@ static ModalHostViewEventEmitter::OnOrientationChange onOrientationChangeStruct(
     _shouldAnimatePresentation = YES;
 
     _isPresented = NO;
+    _modalInPresentation = YES;
   }
 
   return self;
@@ -126,7 +128,7 @@ static ModalHostViewEventEmitter::OnOrientationChange onOrientationChangeStruct(
     _viewController = [RCTFabricModalHostViewController new];
     _viewController.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
     _viewController.delegate = self;
-    _viewController.modalInPresentation = YES;
+    _viewController.modalInPresentation = _modalInPresentation;
   }
   return _viewController;
 }
@@ -152,6 +154,7 @@ static ModalHostViewEventEmitter::OnOrientationChange onOrientationChangeStruct(
   if (shouldBePresented) {
     [self saveAccessibilityFocusedView];
     self.viewController.presentationController.delegate = self;
+    self.viewController.modalInPresentation = _modalInPresentation;
 
     _isPresented = YES;
     [self presentViewController:self.viewController
@@ -276,7 +279,8 @@ static ModalHostViewEventEmitter::OnOrientationChange onOrientationChangeStruct(
   self.viewController.modalPresentationStyle = presentationConfiguration(newProps);
 
   if (oldViewProps.allowSwipeDismissal != newProps.allowSwipeDismissal) {
-    self.viewController.modalInPresentation = !newProps.allowSwipeDismissal;
+    _modalInPresentation = !newProps.allowSwipeDismissal;
+    self.viewController.modalInPresentation = _modalInPresentation;
   }
 
   _shouldPresent = newProps.visible;


### PR DESCRIPTION
## Summary:

This PR fixes swipe dismissal to work each time the modal is shown. Previously modalInPresentation was set on the view controller which gets destroyed every time user dismisses the modal. This makes sure that modal in presentation is correctly preserved when showing multiple modals.


https://github.com/user-attachments/assets/c7f140e5-1c4f-4809-8453-148d4becc9eb


## Changelog:

[IOS] [FIXED] - modal swipe dismissal works only for the first time


## Test Plan:

1. Open RN Tester
2. Check allow swipe dismissal
3. Check closing it multiple times