### PR TITLE
fix: fallback alert controller to UIScreen size 

### DIFF
--- a/packages/react-native/React/CoreModules/RCTAlertController.mm
+++ b/packages/react-native/React/CoreModules/RCTAlertController.mm
@@ -20,14 +20,19 @@
 - (UIWindow *)alertWindow
 {
   if (_alertWindow == nil) {
-    _alertWindow = [[UIWindow alloc] initWithWindowScene:RCTKeyWindow().windowScene];
-
+    UIWindowScene *scene = RCTKeyWindow().windowScene;
+    if (scene != nil) {
+      _alertWindow = [[UIWindow alloc] initWithWindowScene:scene];
+    } else {
+      _alertWindow = [[UIWindow alloc] initWithFrame:UIScreen.mainScreen.bounds];
+    }
+    
     if (_alertWindow) {
       _alertWindow.rootViewController = [UIViewController new];
       _alertWindow.windowLevel = UIWindowLevelAlert + 1;
     }
   }
-
+  
   return _alertWindow;
 }
 
@@ -38,9 +43,9 @@
     UIUserInterfaceStyle overriddenStyle = RCTKeyWindow().overrideUserInterfaceStyle;
     style = overriddenStyle ? overriddenStyle : UIUserInterfaceStyleUnspecified;
   }
-
+  
   self.overrideUserInterfaceStyle = style;
-
+  
   [self.alertWindow makeKeyAndVisible];
   [self.alertWindow.rootViewController presentViewController:self animated:animated completion:completion];
 }
@@ -48,9 +53,9 @@
 - (void)hide
 {
   [_alertWindow setHidden:YES];
-
+  
   _alertWindow.windowScene = nil;
-
+  
   _alertWindow = nil;
 }
 


### PR DESCRIPTION
## Summary:

This PR falls back to UIScreen when windowScene is not available.

<img width="500" alt="CleanShot 2025-08-28 at 14 30 59@2x" src="https://github.com/user-attachments/assets/9dda3153-dfe7-48a5-9d0e-5416c2e34c64" />


## Changelog:

[IOS] [FIXED] - Simplify RCTAlertController, don't create additional UIWindow

## Test Plan:

Open the alert multiple times to check if everything works as expected.