### PR TITLE
Consolidate API changes to openDebugger

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -1914,7 +1914,7 @@ public class com/facebook/react/devsupport/DevServerHelper {
 	public fun getSourceUrl (Ljava/lang/String;)Ljava/lang/String;
 	public final fun getWebsocketProxyURL ()Ljava/lang/String;
 	public fun isPackagerRunning (Lcom/facebook/react/devsupport/interfaces/PackagerStatusCallback;)V
-	public final fun openDebugger (Lcom/facebook/react/bridge/ReactContext;Ljava/lang/String;Lcom/facebook/react/devsupport/interfaces/DebuggerFrontendPanelName;)V
+	public final fun openDebugger (Lcom/facebook/react/bridge/ReactContext;Ljava/lang/String;Ljava/lang/String;)V
 	public final fun openInspectorConnection ()V
 	public final fun openPackagerConnection (Ljava/lang/String;Lcom/facebook/react/devsupport/DevServerHelper$PackagerCommandListener;)V
 }
@@ -1962,8 +1962,7 @@ public abstract class com/facebook/react/devsupport/DevSupportManagerBase : com/
 	public fun isPackagerRunning (Lcom/facebook/react/devsupport/interfaces/PackagerStatusCallback;)V
 	public fun onNewReactContextCreated (Lcom/facebook/react/bridge/ReactContext;)V
 	public fun onReactInstanceDestroyed (Lcom/facebook/react/bridge/ReactContext;)V
-	public fun openDebugger ()V
-	public fun openDebugger (Lcom/facebook/react/devsupport/interfaces/DebuggerFrontendPanelName;)V
+	public fun openDebugger (Ljava/lang/String;)V
 	public fun processErrorCustomizers (Landroid/util/Pair;)Landroid/util/Pair;
 	public fun registerErrorCustomizer (Lcom/facebook/react/devsupport/interfaces/ErrorCustomizer;)V
 	public fun reloadJSFromServer (Ljava/lang/String;Lcom/facebook/react/devsupport/interfaces/BundleLoadCallback;)V
@@ -2052,8 +2051,7 @@ public class com/facebook/react/devsupport/ReleaseDevSupportManager : com/facebo
 	public fun isPackagerRunning (Lcom/facebook/react/devsupport/interfaces/PackagerStatusCallback;)V
 	public fun onNewReactContextCreated (Lcom/facebook/react/bridge/ReactContext;)V
 	public fun onReactInstanceDestroyed (Lcom/facebook/react/bridge/ReactContext;)V
-	public fun openDebugger ()V
-	public fun openDebugger (Lcom/facebook/react/devsupport/interfaces/DebuggerFrontendPanelName;)V
+	public fun openDebugger (Ljava/lang/String;)V
 	public fun processErrorCustomizers (Landroid/util/Pair;)Landroid/util/Pair;
 	public fun registerErrorCustomizer (Lcom/facebook/react/devsupport/interfaces/ErrorCustomizer;)V
 	public fun reloadJSFromServer (Ljava/lang/String;Lcom/facebook/react/devsupport/interfaces/BundleLoadCallback;)V
@@ -2112,15 +2110,6 @@ public abstract interface class com/facebook/react/devsupport/interfaces/BundleL
 	public abstract fun onSuccess ()V
 }
 
-public final class com/facebook/react/devsupport/interfaces/DebuggerFrontendPanelName : java/lang/Enum {
-	public static final field PERFORMANCE Lcom/facebook/react/devsupport/interfaces/DebuggerFrontendPanelName;
-	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public final fun getInternalName ()Ljava/lang/String;
-	public fun toString ()Ljava/lang/String;
-	public static fun valueOf (Ljava/lang/String;)Lcom/facebook/react/devsupport/interfaces/DebuggerFrontendPanelName;
-	public static fun values ()[Lcom/facebook/react/devsupport/interfaces/DebuggerFrontendPanelName;
-}
-
 public abstract interface class com/facebook/react/devsupport/interfaces/DevBundleDownloadListener {
 	public abstract fun onFailure (Ljava/lang/Exception;)V
 	public abstract fun onProgress (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;)V
@@ -2162,8 +2151,8 @@ public abstract interface class com/facebook/react/devsupport/interfaces/DevSupp
 	public abstract fun isPackagerRunning (Lcom/facebook/react/devsupport/interfaces/PackagerStatusCallback;)V
 	public abstract fun onNewReactContextCreated (Lcom/facebook/react/bridge/ReactContext;)V
 	public abstract fun onReactInstanceDestroyed (Lcom/facebook/react/bridge/ReactContext;)V
-	public abstract fun openDebugger ()V
-	public abstract fun openDebugger (Lcom/facebook/react/devsupport/interfaces/DebuggerFrontendPanelName;)V
+	public abstract fun openDebugger (Ljava/lang/String;)V
+	public static synthetic fun openDebugger$default (Lcom/facebook/react/devsupport/interfaces/DevSupportManager;Ljava/lang/String;ILjava/lang/Object;)V
 	public abstract fun processErrorCustomizers (Landroid/util/Pair;)Landroid/util/Pair;
 	public abstract fun registerErrorCustomizer (Lcom/facebook/react/devsupport/interfaces/ErrorCustomizer;)V
 	public abstract fun reloadJSFromServer (Ljava/lang/String;Lcom/facebook/react/devsupport/interfaces/BundleLoadCallback;)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevServerHelper.kt
@@ -21,7 +21,6 @@ import com.facebook.react.bridge.ReactContext
 import com.facebook.react.common.ReactConstants
 import com.facebook.react.devsupport.InspectorFlags.getFuseboxEnabled
 import com.facebook.react.devsupport.InspectorFlags.getIsProfilingBuild
-import com.facebook.react.devsupport.interfaces.DebuggerFrontendPanelName
 import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener
 import com.facebook.react.devsupport.interfaces.PackagerStatusCallback
 import com.facebook.react.modules.debug.interfaces.DeveloperSettings
@@ -356,7 +355,7 @@ public open class DevServerHelper(
   public fun openDebugger(
       context: ReactContext?,
       errorMessage: String?,
-      panel: DebuggerFrontendPanelName?,
+      panel: String?,
   ) {
     // TODO(huntie): Requests to dev server should not assume 'http' URL scheme
     val requestUrlBuilder = StringBuilder()
@@ -371,7 +370,7 @@ public open class DevServerHelper(
     )
 
     if (panel != null) {
-      requestUrlBuilder.append("&panel=" + Uri.encode(panel.toString()))
+      requestUrlBuilder.append("&panel=" + Uri.encode(panel))
     }
 
     val request =

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.kt
@@ -52,7 +52,6 @@ import com.facebook.react.devsupport.InspectorFlags.getFuseboxEnabled
 import com.facebook.react.devsupport.StackTraceHelper.convertJavaStackTrace
 import com.facebook.react.devsupport.StackTraceHelper.convertJsStackTrace
 import com.facebook.react.devsupport.interfaces.BundleLoadCallback
-import com.facebook.react.devsupport.interfaces.DebuggerFrontendPanelName
 import com.facebook.react.devsupport.interfaces.DevBundleDownloadListener
 import com.facebook.react.devsupport.interfaces.DevLoadingViewManager
 import com.facebook.react.devsupport.interfaces.DevOptionHandler
@@ -920,15 +919,7 @@ public abstract class DevSupportManagerBase(
     }
   }
 
-  override fun openDebugger() {
-    devServerHelper.openDebugger(
-        currentReactContext,
-        applicationContext.getString(R.string.catalyst_open_debugger_error),
-        null,
-    )
-  }
-
-  override fun openDebugger(panel: DebuggerFrontendPanelName) {
+  override fun openDebugger(panel: String?) {
     devServerHelper.openDebugger(
         currentReactContext,
         applicationContext.getString(R.string.catalyst_open_debugger_error),

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/ReleaseDevSupportManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/ReleaseDevSupportManager.kt
@@ -16,7 +16,6 @@ import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.common.SurfaceDelegate
 import com.facebook.react.devsupport.interfaces.BundleLoadCallback
-import com.facebook.react.devsupport.interfaces.DebuggerFrontendPanelName
 import com.facebook.react.devsupport.interfaces.DevOptionHandler
 import com.facebook.react.devsupport.interfaces.DevSupportManager
 import com.facebook.react.devsupport.interfaces.DevSupportManager.PackagerLocationCustomizer
@@ -143,9 +142,7 @@ public open class ReleaseDevSupportManager : DevSupportManager {
 
   public override fun createSurfaceDelegate(moduleName: String): SurfaceDelegate? = null
 
-  public override fun openDebugger(): Unit = Unit
-
-  public override fun openDebugger(panel: DebuggerFrontendPanelName): Unit = Unit
+  public override fun openDebugger(panel: String?): Unit = Unit
 
   public override fun showPausedInDebuggerOverlay(
       message: String,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DebuggerFrontendPanelName.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DebuggerFrontendPanelName.kt
@@ -7,8 +7,15 @@
 
 package com.facebook.react.devsupport.interfaces
 
-public enum class DebuggerFrontendPanelName(public val internalName: String) {
-  PERFORMANCE("timeline");
+internal enum class DebuggerFrontendPanelName(public val internalName: String) {
+  CONSOLE("console"),
+  MEMORY("heap-profiler"),
+  NETWORK("network"),
+  PERFORMANCE("timeline"),
+  REACT_COMPONENTS("react-devtools-components"),
+  REACT_PROFILER("react-devtools-profiler"),
+  SOURCES("sources"),
+  WELCOME("rn-welcome");
 
   override fun toString(): String = internalName
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.kt
@@ -94,11 +94,14 @@ public interface DevSupportManager : JSExceptionHandler {
    */
   public fun createSurfaceDelegate(moduleName: String): SurfaceDelegate?
 
-  /** Attempt to open the JS debugger on the host machine. */
-  public fun openDebugger()
-
-  /** Attempt to open the JS debugger on the host machine, providing a destination panel name. */
-  public fun openDebugger(panel: DebuggerFrontendPanelName)
+  /**
+   * Attempt to open the JS debugger on the host machine.
+   *
+   * @param panel Optionally provide a destination panel name. This can be a value of
+   *   [DebuggerFrontendPanelName] or a custom string. If omitted, the debugger will open on the
+   *   last used panel (default behaviour).
+   */
+  public fun openDebugger(panel: String? = null)
 
   /** Shows the "paused in debugger" overlay with the given message. */
   public fun showPausedInDebuggerOverlay(


### PR DESCRIPTION
Summary:
Follows D81138169.

- This simplifies the total changes needed on implementing DevSupport classes.
- Widen outer API to accept any `String` panel name (futureproofing).
- Internalise and add complete set of supported values `DebuggerFrontendPanelName`.

Changelog:
[Android][Changed] - DevSupport `openDebugger()` methods now accept a `panel: String?` param. Frameworks directly implementing `DevSupportManager` will need to adjust call signatures.

Differential Revision: D81227870


