### PR TITLE
Use uint32_t as internal Color representation

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
@@ -310,7 +310,7 @@ static void updateBorderColorPropValue(
     const std::optional<SharedColor>& newColor,
     const std::optional<SharedColor>& oldColor) {
   if (newColor != oldColor) {
-    result[propName] = newColor.has_value() ? *newColor.value() : NULL;
+    result[propName] = *newColor.value_or(SharedColor());
   }
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/core/RawValue.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawValue.h
@@ -394,7 +394,8 @@ class RawValue {
 
   static int
   castValue(jsi::Runtime* /*runtime*/, const jsi::Value& value, int* /*type*/) {
-    double number = value.asNumber();
+    // Casting directly from double to int loses precision, go via int64
+    auto number = static_cast<int64_t>(value.asNumber());
     return static_cast<int>(number);
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/RawPropsTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/RawPropsTest.cpp
@@ -12,10 +12,10 @@
 #include <react/debug/flags.h>
 #include <react/renderer/core/ConcreteShadowNode.h>
 #include <react/renderer/core/PropsParserContext.h>
+#include <react/renderer/core/RawProps.h>
+#include <react/renderer/core/RawPropsParser.h>
 #include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/core/propsConversions.h>
-
-#include "TestComponent.h"
 
 using namespace facebook;
 using namespace facebook::react;

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/RawValueTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/RawValueTest.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <memory>
+
+#include <gtest/gtest.h>
+#include <hermes/hermes.h>
+#include <react/renderer/core/RawValue.h>
+
+using namespace facebook;
+using namespace facebook::react;
+
+TEST(RawValueTest, intValueDoesNotOverflow) {
+  auto runtime = facebook::hermes::makeHermesRuntime();
+  auto rawValue = RawValue(*runtime, jsi::Value(*runtime, 4294967040.0));
+  EXPECT_EQ((int64_t)rawValue, 4294967040);
+  EXPECT_EQ((int)rawValue, static_cast<int>(4294967040));
+
+  rawValue = RawValue(folly::dynamic(4294967040.0));
+  EXPECT_EQ((int64_t)rawValue, 4294967040);
+  EXPECT_EQ((int)rawValue, static_cast<int>(4294967040));
+}

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/HostPlatformColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/HostPlatformColor.h
@@ -12,7 +12,7 @@
 
 namespace facebook::react {
 
-using Color = int32_t;
+using Color = uint32_t;
 
 namespace HostPlatformColor {
 constexpr facebook::react::Color UndefinedColor = 0;

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/PlatformColorParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/PlatformColorParser.h
@@ -42,7 +42,7 @@ inline SharedColor parsePlatformColor(
     auto color =
         getColorFromJava(fabricUIManager, surfaceId, *javaResourcePaths);
 
-    auto argb = (int64_t)color;
+    auto argb = (uint32_t)color;
     auto ratio = 255.f;
     colorComponents.alpha = ((argb >> 24) & 0xFF) / ratio;
     colorComponents.red = ((argb >> 16) & 0xFF) / ratio;

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/cxx/react/renderer/graphics/HostPlatformColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/cxx/react/renderer/graphics/HostPlatformColor.h
@@ -13,7 +13,7 @@
 
 namespace facebook::react {
 
-using Color = int32_t;
+using Color = uint32_t;
 
 namespace HostPlatformColor {
 constexpr facebook::react::Color UndefinedColor = 0;

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/HostPlatformColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/HostPlatformColor.h
@@ -14,18 +14,18 @@
 namespace facebook::react {
 
 struct DynamicColor {
-  int32_t lightColor = 0;
-  int32_t darkColor = 0;
-  int32_t highContrastLightColor = 0;
-  int32_t highContrastDarkColor = 0;
+  uint32_t lightColor = 0;
+  uint32_t darkColor = 0;
+  uint32_t highContrastLightColor = 0;
+  uint32_t highContrastDarkColor = 0;
 };
 
 struct Color {
-  Color(int32_t color);
+  Color(uint32_t color);
   Color(const DynamicColor& dynamicColor);
   Color(const ColorComponents& components);
   Color() : uiColor_(nullptr){};
-  int32_t getColor() const;
+  uint32_t getColor() const;
   std::size_t getUIColorHash() const;
 
   static Color createSemanticColor(std::vector<std::string>& semanticItems);
@@ -38,7 +38,7 @@ struct Color {
 
   ColorComponents getColorComponents() const {
     float ratio = 255;
-    int32_t primitiveColor = getColor();
+    uint32_t primitiveColor = getColor();
     return ColorComponents{
         .red = (float)((primitiveColor >> 16) & 0xff) / ratio,
         .green = (float)((primitiveColor >> 8) & 0xff) / ratio,
@@ -47,7 +47,7 @@ struct Color {
   }
   bool operator==(const Color& other) const;
   bool operator!=(const Color& other) const;
-  operator int32_t() const {
+  operator uint32_t() const {
     return getColor();
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/HostPlatformColor.mm
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/HostPlatformColor.mm
@@ -36,7 +36,7 @@ bool UIColorIsP3ColorSpace(const std::shared_ptr<void> &uiColor)
   return false;
 }
 
-UIColor *_Nullable UIColorFromInt32(int32_t intColor)
+UIColor *_Nullable UIColorFromInt32(uint32_t intColor)
 {
   CGFloat a = CGFloat((intColor >> 24) & 0xFF) / 255.0;
   CGFloat r = CGFloat((intColor >> 16) & 0xFF) / 255.0;
@@ -49,10 +49,10 @@ UIColor *_Nullable UIColorFromInt32(int32_t intColor)
 
 UIColor *_Nullable UIColorFromDynamicColor(const facebook::react::DynamicColor &dynamicColor)
 {
-  int32_t light = dynamicColor.lightColor;
-  int32_t dark = dynamicColor.darkColor;
-  int32_t highContrastLight = dynamicColor.highContrastLightColor;
-  int32_t highContrastDark = dynamicColor.highContrastDarkColor;
+  uint32_t light = dynamicColor.lightColor;
+  uint32_t dark = dynamicColor.darkColor;
+  uint32_t highContrastLight = dynamicColor.highContrastLightColor;
+  uint32_t highContrastDark = dynamicColor.highContrastDarkColor;
 
   UIColor *lightColor = UIColorFromInt32(light);
   UIColor *darkColor = UIColorFromInt32(dark);
@@ -83,7 +83,7 @@ UIColor *_Nullable UIColorFromDynamicColor(const facebook::react::DynamicColor &
   return nil;
 }
 
-int32_t ColorFromColorComponents(const facebook::react::ColorComponents &components)
+uint32_t ColorFromColorComponents(const facebook::react::ColorComponents &components)
 {
   float ratio = 255;
   auto color = ((int32_t)round((float)components.alpha * ratio) & 0xff) << 24 |
@@ -92,7 +92,7 @@ int32_t ColorFromColorComponents(const facebook::react::ColorComponents &compone
   return color;
 }
 
-int32_t ColorFromUIColor(UIColor *color)
+uint32_t ColorFromUIColor(UIColor *color)
 {
   CGFloat rgba[4];
   [color getRed:&rgba[0] green:&rgba[1] blue:&rgba[2] alpha:&rgba[3]];
@@ -100,7 +100,7 @@ int32_t ColorFromUIColor(UIColor *color)
       {.red = (float)rgba[0], .green = (float)rgba[1], .blue = (float)rgba[2], .alpha = (float)rgba[3]});
 }
 
-int32_t ColorFromUIColorForSpecificTraitCollection(
+uint32_t ColorFromUIColorForSpecificTraitCollection(
     const std::shared_ptr<void> &uiColor,
     UITraitCollection *traitCollection)
 {
@@ -113,7 +113,7 @@ int32_t ColorFromUIColorForSpecificTraitCollection(
   return 0;
 }
 
-int32_t ColorFromUIColor(const std::shared_ptr<void> &uiColor)
+uint32_t ColorFromUIColor(const std::shared_ptr<void> &uiColor)
 {
   return ColorFromUIColorForSpecificTraitCollection(uiColor, [UITraitCollection currentTraitCollection]);
 }
@@ -172,7 +172,7 @@ std::size_t hashFromUIColor(const std::shared_ptr<void> &uiColor)
 
 } // anonymous namespace
 
-Color::Color(int32_t color)
+Color::Color(uint32_t color)
 {
   uiColor_ = wrapManagedObject(UIColorFromInt32(color));
   uiColorHashValue_ = facebook::react::hash_combine(color, 0);
@@ -217,7 +217,7 @@ bool Color::operator!=(const Color &other) const
   return !(*this == other);
 }
 
-int32_t Color::getColor() const
+uint32_t Color::getColor() const
 {
   return ColorFromUIColor(uiColor_);
 }

--- a/packages/react-native/ReactCxxPlatform/react/devsupport/DevLoadingViewModule.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/devsupport/DevLoadingViewModule.cpp
@@ -9,8 +9,8 @@
 
 namespace facebook::react {
 
-const int32_t DEFAULT_TEXT_COLOR = 0xFFFFFFFF;
-const int32_t DEFAULT_BACKGROUND_COLOR = 0xFF2584E8;
+const uint32_t DEFAULT_TEXT_COLOR = 0xFFFFFFFF;
+const uint32_t DEFAULT_BACKGROUND_COLOR = 0xFF2584E8;
 
 DevLoadingViewModule::DevLoadingViewModule(
     std::shared_ptr<CallInvoker> jsInvoker,
@@ -27,8 +27,8 @@ DevLoadingViewModule::~DevLoadingViewModule() {
 void DevLoadingViewModule::showMessage(
     jsi::Runtime& /*rt*/,
     const std::string& message,
-    std::optional<int32_t> textColor,
-    std::optional<int32_t> backgroundColor) {
+    std::optional<uint32_t> textColor,
+    std::optional<uint32_t> backgroundColor) {
   if (auto devUIDelegate = devUIDelegate_.lock()) {
     devUIDelegate->showLoadingView(
         message,

--- a/packages/react-native/ReactCxxPlatform/react/devsupport/DevLoadingViewModule.h
+++ b/packages/react-native/ReactCxxPlatform/react/devsupport/DevLoadingViewModule.h
@@ -27,8 +27,8 @@ class DevLoadingViewModule
   void showMessage(
       jsi::Runtime& rt,
       const std::string& message,
-      std::optional<int32_t> textColor,
-      std::optional<int32_t> backgroundColor);
+      std::optional<uint32_t> textColor,
+      std::optional<uint32_t> backgroundColor);
 
   void hide(jsi::Runtime& rt);
 


### PR DESCRIPTION
Summary:
We need this to be an unsigned value everywhere but all the API's and interfaces described this a signed number. While this doesn't make a difference in practice, it's better to explicit.

Changelog: [Internal]

Reviewed By: sammy-SC

Differential Revision: D81230050


