### PR TITLE
Work around Electron Windows command-line args quirk

### DIFF
--- a/packages/dev-middleware/src/utils/DefaultBrowserLauncher.js
+++ b/packages/dev-middleware/src/utils/DefaultBrowserLauncher.js
@@ -74,7 +74,7 @@ const DefaultBrowserLauncher = {
     windowKey: string,
   ): Promise<void> {
     return await unstable_spawnDebuggerShellWithArgs(
-      ['--frontendUrl', url, '--windowKey', windowKey],
+      ['--frontendUrl=' + url, '--windowKey=' + windowKey],
       {
         mode: 'detached',
         flavor: process.env.RNDT_DEV === '1' ? 'dev' : 'prebuilt',


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Electron imposes a [strange undocumented limitation](https://github.com/electron/electron/pull/13039) on the format of command-line arguments, which for some reason only affects Windows. Basically, the command line is truncated after the first argument that looks like a URL.

Electron's recommendation for avoiding this is to prefix the argument list with `--`,  but I prefer switching to a different arg format (`--x=y` instead of `--x y`) that will prevent us from ever running into this issue.

NOTE: I will follow up with a diff to harden arg parsing in our Electron code so that it only accepts the `--x=y` format.

Differential Revision: D81237713


