### PR TITLE
RN: Remove Feature Flag Override Argument

### DIFF
--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlagsBase.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlagsBase.js
@@ -24,10 +24,10 @@ const clearCachedValuesFns: Array<() => void> = [];
 
 export type Getter<T> = () => T;
 
-// This defines the types for the overrides object, whose methods also receive
-// the default value as a parameter.
+// This defines the types for the overrides object, whose methods can return
+// null or undefined to fallback to the default value.
 export type OverridesFor<T> = Partial<{
-  [key in keyof T]: (ReturnType<T[key]>) => ReturnType<T[key]>,
+  [key in keyof T]: Getter<?ReturnType<T[key]>>,
 }>;
 
 function createGetter<T: boolean | number | string>(
@@ -61,8 +61,7 @@ export function createJavaScriptFlagGetter<
     configName,
     () => {
       accessedFeatureFlags.add(configName);
-      // $FlowFixMe[incompatible-type] - `defaultValue` is not refined.
-      return overrides?.[configName]?.(defaultValue);
+      return overrides?.[configName]?.();
     },
     defaultValue,
   );

--- a/packages/react-native/src/private/featureflags/__tests__/ReactNativeFeatureFlags-test.js
+++ b/packages/react-native/src/private/featureflags/__tests__/ReactNativeFeatureFlags-test.js
@@ -61,7 +61,7 @@ describe('ReactNativeFeatureFlags', () => {
   it('should access and cache overridden JS-only flags', () => {
     const ReactNativeFeatureFlags = require('../ReactNativeFeatureFlags');
 
-    const jsOnlyTestFlagFn = jest.fn((defaultValue: boolean) => true);
+    const jsOnlyTestFlagFn = jest.fn(() => true);
     ReactNativeFeatureFlags.override({
       jsOnlyTestFlag: jsOnlyTestFlagFn,
     });
@@ -117,17 +117,24 @@ describe('ReactNativeFeatureFlags', () => {
     ).toThrow('Feature flags cannot be overridden more than once');
   });
 
-  it('should pass the default value of the feature flag to the function that provides its override', () => {
+  it('should evaluate to default value if the override returns null', () => {
     const ReactNativeFeatureFlags = require('../ReactNativeFeatureFlags');
 
     ReactNativeFeatureFlags.override({
-      jsOnlyTestFlag: (defaultValue: boolean) => {
-        expect(defaultValue).toBe(false);
-        return true;
-      },
+      jsOnlyTestFlag: () => null,
     });
 
-    expect(ReactNativeFeatureFlags.jsOnlyTestFlag()).toBe(true);
+    expect(ReactNativeFeatureFlags.jsOnlyTestFlag()).toBe(false);
+  });
+
+  it('should evaluate to default value if the override returns undefined', () => {
+    const ReactNativeFeatureFlags = require('../ReactNativeFeatureFlags');
+
+    ReactNativeFeatureFlags.override({
+      jsOnlyTestFlag: () => undefined,
+    });
+
+    expect(ReactNativeFeatureFlags.jsOnlyTestFlag()).toBe(false);
   });
 
   describe('when the native module is NOT available', () => {


### PR DESCRIPTION
Summary:
D62853299 introduced the `defaultValue` argument to feature flag override functions, with the intent of enabling override functions to do something like this:

```
myFeatureFlag: (defaultValueForFlag) => someCondition ? value : defaultValueForFlag
```

However, there are no current use cases for this. This particular use case can also be solved by expanding support for override functions to return `null` or `undefined` which falls back to using the default value.

Furthermore, the type system has a difficult time representing the constraints when there are non-boolean JavaScript-only overrides (which was introduced recently).

This diff removes the argument and adds support for override functions to return `null` or `undefined`.

Changelog:
[Internal]

Differential Revision: D81163557


