### PR TITLE
Android: Image Prefetching send ImageResizeMode as enum value

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -5344,18 +5344,25 @@ public final class com/facebook/react/views/image/ImageLoadEvent$Companion {
 
 public final class com/facebook/react/views/image/ImageResizeMethod : java/lang/Enum {
 	public static final field AUTO Lcom/facebook/react/views/image/ImageResizeMethod;
+	public static final field Companion Lcom/facebook/react/views/image/ImageResizeMethod$Companion;
 	public static final field NONE Lcom/facebook/react/views/image/ImageResizeMethod;
 	public static final field RESIZE Lcom/facebook/react/views/image/ImageResizeMethod;
 	public static final field SCALE Lcom/facebook/react/views/image/ImageResizeMethod;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static final fun parse (Ljava/lang/String;)Lcom/facebook/react/views/image/ImageResizeMethod;
 	public static fun valueOf (Ljava/lang/String;)Lcom/facebook/react/views/image/ImageResizeMethod;
 	public static fun values ()[Lcom/facebook/react/views/image/ImageResizeMethod;
+}
+
+public final class com/facebook/react/views/image/ImageResizeMethod$Companion {
+	public final fun parse (Ljava/lang/String;)Lcom/facebook/react/views/image/ImageResizeMethod;
 }
 
 public final class com/facebook/react/views/image/ImageResizeMode {
 	public static final field INSTANCE Lcom/facebook/react/views/image/ImageResizeMode;
 	public static final fun defaultTileMode ()Landroid/graphics/Shader$TileMode;
 	public static final fun defaultValue ()Lcom/facebook/drawee/drawable/ScalingUtils$ScaleType;
+	public final synthetic fun fromInt (I)Ljava/lang/String;
 	public static final fun toScaleType (Ljava/lang/String;)Lcom/facebook/drawee/drawable/ScalingUtils$ScaleType;
 	public static final fun toTileMode (Ljava/lang/String;)Landroid/graphics/Shader$TileMode;
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ImageResizeMethod.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ImageResizeMethod.kt
@@ -7,9 +7,30 @@
 
 package com.facebook.react.views.image
 
+import com.facebook.common.logging.FLog
+import com.facebook.react.common.ReactConstants
+
 public enum class ImageResizeMethod {
   AUTO,
   RESIZE,
   SCALE,
-  NONE,
+  NONE;
+
+  public companion object {
+    @JvmStatic
+    public fun parse(resizeMethod: String?): ImageResizeMethod {
+      return when (resizeMethod) {
+        null,
+        "",
+        "auto" -> ImageResizeMethod.AUTO
+        "resize" -> ImageResizeMethod.RESIZE
+        "scale" -> ImageResizeMethod.SCALE
+        "none" -> ImageResizeMethod.NONE
+        else -> {
+          FLog.w(ReactConstants.TAG, "Invalid resize method: '$resizeMethod'")
+          ImageResizeMethod.AUTO
+        }
+      }
+    }
+  }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ImageResizeMode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ImageResizeMode.kt
@@ -21,6 +21,19 @@ public object ImageResizeMode {
   private const val RESIZE_MODE_REPEAT = "repeat"
   private const val RESIZE_MODE_NONE = "none"
 
+  @JvmSynthetic
+  public fun fromInt(resizeMode: Int): String {
+    return when (resizeMode) {
+      0 -> RESIZE_MODE_COVER
+      1 -> RESIZE_MODE_CONTAIN
+      2 -> RESIZE_MODE_STRETCH
+      3 -> RESIZE_MODE_CENTER
+      4 -> RESIZE_MODE_REPEAT
+      5 -> RESIZE_MODE_NONE
+      else -> RESIZE_MODE_NONE
+    }
+  }
+
   /** Converts JS resize modes into `ScalingUtils.ScaleType`. See `ImageResizeMode.js`. */
   @JvmStatic
   public fun toScaleType(resizeModeValue: String?): ScalingUtils.ScaleType {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.kt
@@ -188,17 +188,7 @@ public constructor(
 
   @ReactProp(name = ViewProps.RESIZE_METHOD)
   public fun setResizeMethod(view: ReactImageView, resizeMethod: String?) {
-    when (resizeMethod) {
-      null,
-      "auto" -> view.setResizeMethod(ImageResizeMethod.AUTO)
-      "resize" -> view.setResizeMethod(ImageResizeMethod.RESIZE)
-      "scale" -> view.setResizeMethod(ImageResizeMethod.SCALE)
-      "none" -> view.setResizeMethod(ImageResizeMethod.NONE)
-      else -> {
-        view.setResizeMethod(ImageResizeMethod.AUTO)
-        FLog.w(ReactConstants.TAG, "Invalid resize method: '$resizeMethod'")
-      }
-    }
+    view.setResizeMethod(ImageResizeMethod.parse(resizeMethod))
   }
 
   @ReactProp(name = "resizeMultiplier")

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/ImageManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/ImageManager.cpp
@@ -12,6 +12,14 @@
 
 namespace facebook::react {
 
+namespace {
+
+constexpr inline bool isInteger(const std::string& str) {
+  return str.find_first_not_of("0123456789") == std::string::npos;
+}
+
+} // namespace
+
 ImageManager::ImageManager(
     const std::shared_ptr<const ContextContainer>& contextContainer)
     : self_(new ImageFetcher(contextContainer)) {}
@@ -26,8 +34,10 @@ ImageRequest ImageManager::requestImage(
     const ImageRequestParams& imageRequestParams,
     Tag tag) const {
   if (ReactNativeFeatureFlags::enableImagePrefetchingAndroid()) {
-    return static_cast<ImageFetcher*>(self_)->requestImage(
-        imageSource, surfaceId, imageRequestParams, tag);
+    if (!isInteger(imageSource.uri)) {
+      return static_cast<ImageFetcher*>(self_)->requestImage(
+          imageSource, surfaceId, imageRequestParams, tag);
+    }
   }
   return {imageSource, nullptr, {}};
 }

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/conversions.h
@@ -58,8 +58,10 @@ inline void serializeImageSource(
     MapBufferBuilder& builder,
     const ImageSource& imageSource) {
   builder.putString(IS_KEY_URI, imageSource.uri);
-  builder.putDouble(IS_KEY_VIEW_WIDTH, imageSource.size.width);
-  builder.putDouble(IS_KEY_VIEW_HEIGHT, imageSource.size.height);
+  builder.putInt(
+      IS_KEY_VIEW_WIDTH, static_cast<int32_t>(imageSource.size.width));
+  builder.putInt(
+      IS_KEY_VIEW_HEIGHT, static_cast<int32_t>(imageSource.size.height));
 }
 
 inline void serializeImageRequestParams(
@@ -69,7 +71,8 @@ inline void serializeImageRequestParams(
   builder.putString(
       IS_KEY_RESIZE_MODE, toString(imageRequestParams.resizeMode));
   builder.putString(IS_KEY_RESIZE_METHOD, imageRequestParams.resizeMethod);
-  builder.putDouble(IS_KEY_BLUR_RADIUS, imageRequestParams.blurRadius);
+  builder.putInt(
+      IS_KEY_BLUR_RADIUS, static_cast<int32_t>(imageRequestParams.blurRadius));
   builder.putDouble(
       IS_KEY_RESIZE_MULTIPLIER, imageRequestParams.resizeMultiplier);
   builder.putBool(
@@ -83,7 +86,9 @@ inline void serializeImageRequestParams(
     builder.putInt(
         IS_KEY_TINT_COLOR, toAndroidRepr(imageRequestParams.tintColor));
   }
-  builder.putDouble(IS_KEY_FADE_DURATION, imageRequestParams.fadeDuration);
+  builder.putInt(
+      IS_KEY_FADE_DURATION,
+      static_cast<int32_t>(imageRequestParams.fadeDuration));
   builder.putBool(
       IS_KEY_PROGRESSIVE_RENDERING_ENABLED,
       imageRequestParams.progressiveRenderingEnabled);

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/conversions.h
@@ -12,29 +12,12 @@
 #include <react/renderer/imagemanager/primitives.h>
 #include <react/renderer/mapbuffer/MapBuffer.h>
 #include <react/renderer/mapbuffer/MapBufferBuilder.h>
-#include <string>
+#include <react/utils/to_underlying.h>
 #include <vector>
 
 namespace facebook::react {
 
 namespace {
-
-inline std::string toString(const ImageResizeMode& value) {
-  switch (value) {
-    case ImageResizeMode::Cover:
-      return "cover";
-    case ImageResizeMode::Contain:
-      return "contain";
-    case ImageResizeMode::Stretch:
-      return "stretch";
-    case ImageResizeMode::Center:
-      return "center";
-    case ImageResizeMode::Repeat:
-      return "repeat";
-    case ImageResizeMode::None:
-      return "none";
-  }
-}
 
 constexpr MapBuffer::Key IS_KEY_URI = 0;
 constexpr MapBuffer::Key IS_KEY_DEFAULT_SRC = 1;
@@ -68,8 +51,8 @@ inline void serializeImageRequestParams(
     MapBufferBuilder& builder,
     const ImageRequestParams& imageRequestParams) {
   builder.putString(IS_KEY_DEFAULT_SRC, imageRequestParams.defaultSource.uri);
-  builder.putString(
-      IS_KEY_RESIZE_MODE, toString(imageRequestParams.resizeMode));
+  builder.putInt(
+      IS_KEY_RESIZE_MODE, to_underlying(imageRequestParams.resizeMode));
   builder.putString(IS_KEY_RESIZE_METHOD, imageRequestParams.resizeMethod);
   builder.putInt(
       IS_KEY_BLUR_RADIUS, static_cast<int32_t>(imageRequestParams.blurRadius));

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/primitives.h
@@ -162,13 +162,13 @@ inline folly::dynamic toDynamic(const ImageSource& imageSource) {
 
 using ImageSources = std::vector<ImageSource>;
 
-enum class ImageResizeMode {
-  Cover,
-  Contain,
-  Stretch,
-  Center,
-  Repeat,
-  None,
+enum class ImageResizeMode : int8_t {
+  Cover = 0,
+  Contain = 1,
+  Stretch = 2,
+  Center = 3,
+  Repeat = 4,
+  None = 5,
 };
 
 class ImageErrorInfo {

--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/tests/MapBufferTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/tests/MapBufferTest.cpp
@@ -95,6 +95,15 @@ TEST(MapBufferTest, testDoubleEntries) {
   EXPECT_EQ(map.getDouble(1), 432.1);
 }
 
+TEST(MapBufferTest, testStringEmpty) {
+  auto builder = MapBufferBuilder();
+
+  builder.putString(0, "");
+  auto map = builder.build();
+
+  EXPECT_EQ(map.getString(0), "");
+}
+
 TEST(MapBufferTest, testStringEntries) {
   auto builder = MapBufferBuilder();
 


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Idea: Reduce JNI payload by sending int values instead of strings

Differential Revision: D81252246


