### PR TITLE
Fix VirtualViewExperimental alignment for empty cases

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTVirtualViewContainerState.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTVirtualViewContainerState.mm
@@ -161,10 +161,7 @@ static BOOL CGRectOverlaps(CGRect rect1, CGRect rect2)
     RCTVirtualViewMode mode = RCTVirtualViewModeHidden;
     CGRect thresholdRect = _emptyRect;
 
-    if (CGRectIsEmpty(rect)) {
-      mode = RCTVirtualViewModeHidden;
-      thresholdRect = _emptyRect;
-    } else if (CGRectOverlaps(rect, visibleRect)) {
+    if (CGRectOverlaps(rect, visibleRect)) {
       thresholdRect = visibleRect;
       mode = RCTVirtualViewModeVisible;
     } else if (CGRectOverlaps(rect, _prerenderRect)) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -440,6 +440,9 @@ public class ReactScrollView extends ScrollView
     if (mRemoveClippedSubviews) {
       updateClippingRect();
     }
+    if (mVirtualViewContainerState != null) {
+      mVirtualViewContainerState.updateState();
+    }
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/VirtualViewContainer.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/VirtualViewContainer.kt
@@ -104,6 +104,15 @@ internal class VirtualViewContainerState {
 
   private fun updateModes(virtualView: VirtualView? = null) {
     scrollView.getDrawingRect(visibleRect)
+
+    // This happens because ScrollView content isn't ready yet. The danger here is if ScrollView
+    // intentionally goes but curently ScrollView and v1 Fling use this check to determine if
+    // "content ready"
+    if (visibleRect.isEmpty()) {
+      debugLog("updateModes", { "scrollView visibleRect is empty" })
+      return
+    }
+
     prerenderRect.set(visibleRect)
     prerenderRect.inset(
         (-prerenderRect.width() * prerenderRatio).toInt(),
@@ -117,7 +126,6 @@ internal class VirtualViewContainerState {
       var mode = VirtualViewMode.Hidden
       var thresholdRect = emptyRect
       when {
-        rect.isEmpty -> {}
         rectsOverlap(rect, visibleRect) -> {
           thresholdRect = visibleRect
           if (onWindowFocusChangeListener != null) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/virtual/viewexperimental/ReactVirtualViewExperimental.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/virtual/viewexperimental/ReactVirtualViewExperimental.kt
@@ -56,6 +56,7 @@ public class ReactVirtualViewExperimental(context: Context) :
       updateParentOffset()
       reportRectChangeToContainer()
     }
+    debugLog("doAttachedToWindow")
   }
 
   /** From [View#onLayout] */
@@ -70,6 +71,7 @@ public class ReactVirtualViewExperimental(context: Context) :
           right + offsetX,
           bottom + offsetY,
       )
+      debugLog("onLayout") { "containerRelativeRect=$containerRelativeRect" }
       reportRectChangeToContainer()
     }
   }
@@ -88,8 +90,21 @@ public class ReactVirtualViewExperimental(context: Context) :
   ) {
     if (oldLeft != left || oldTop != top) {
       updateParentOffset()
+      debugLog("onLayoutChange") { "containerRelativeRect=$containerRelativeRect" }
       reportRectChangeToContainer()
     }
+  }
+
+  override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+    super.onSizeChanged(w, h, oldw, oldh)
+    containerRelativeRect.set(
+        left + offsetX,
+        top + offsetY,
+        right + offsetX,
+        bottom + offsetY,
+    )
+    debugLog("onSizeChanged") { "container=$containerRelativeRect" }
+    reportRectChangeToContainer()
   }
 
   override fun onDetachedFromWindow() {
@@ -110,7 +125,7 @@ public class ReactVirtualViewExperimental(context: Context) :
 
   override val virtualViewID: String
     get() {
-      return "${nativeId ?: "unknown"}:${id}"
+      return "${nativeId ?: "unknown"}:::${id}"
     }
 
   override fun onModeChange(newMode: VirtualViewMode, thresholdRect: Rect) {
@@ -191,7 +206,7 @@ public class ReactVirtualViewExperimental(context: Context) :
 
   private fun reportRectChangeToContainer() {
     if (lastContainerRelativeRect == containerRelativeRect) {
-      debugLog("reportRectChangeToContainer") { "no rect change" }
+      debugLog("reportRectChangeToContainer") { "no rect change $containerRelativeRect" }
       return
     }
     scrollView?.virtualViewContainerState?.onChange(this)
@@ -228,7 +243,7 @@ public class ReactVirtualViewExperimental(context: Context) :
 
   internal inline fun debugLog(subtag: String, block: () -> String = { "" }) {
     if (IS_DEBUG_BUILD && ReactNativeFeatureFlags.enableVirtualViewDebugFeatures()) {
-      FLog.d("$DEBUG_TAG:$subtag", "${block()} [$id][$nativeId]")
+      FLog.d("$DEBUG_TAG:[$virtualViewID]:$subtag", "${block()}")
     }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/virtual/viewexperimental/ReactVirtualViewExperimental.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/virtual/viewexperimental/ReactVirtualViewExperimental.kt
@@ -129,6 +129,9 @@ public class ReactVirtualViewExperimental(context: Context) :
     }
 
   override fun onModeChange(newMode: VirtualViewMode, thresholdRect: Rect) {
+    modeChangeEmitter ?: return
+    scrollView ?: return
+
     if (newMode == mode) {
       return
     }


### PR DESCRIPTION
Summary: Changelog: [Internal] - Remove empty checks on the target rects and early return for empty ScrollView rects -- aligning the implementation with v1 of VirtualView

Reviewed By: yungsters

Differential Revision: D81247994


