### PR TITLE
replace getWindowDisplayMetrics with getScreenDisplayMetrics

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/PixelUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/PixelUtil.kt
@@ -22,7 +22,7 @@ public object PixelUtil {
     return TypedValue.applyDimension(
         TypedValue.COMPLEX_UNIT_DIP,
         value,
-        DisplayMetricsHolder.getWindowDisplayMetrics(),
+        DisplayMetricsHolder.getScreenDisplayMetrics(),
     )
   }
 
@@ -40,7 +40,7 @@ public object PixelUtil {
       return Float.NaN
     }
 
-    val displayMetrics = DisplayMetricsHolder.getWindowDisplayMetrics()
+    val displayMetrics = DisplayMetricsHolder.getScreenDisplayMetrics()
     val scaledValue = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, value, displayMetrics)
 
     if (maxFontScale >= 1) {
@@ -63,13 +63,13 @@ public object PixelUtil {
       return Float.NaN
     }
 
-    return value / DisplayMetricsHolder.getWindowDisplayMetrics().density
+    return value / DisplayMetricsHolder.getScreenDisplayMetrics().density
   }
 
   /** @return [Float] that represents the density of the display metrics for device screen. */
   @JvmStatic
   public fun getDisplayMetricDensity(): Float =
-      DisplayMetricsHolder.getWindowDisplayMetrics().density
+      DisplayMetricsHolder.getScreenDisplayMetrics().density
 
   /* Kotlin extensions */
   public fun Int.dpToPx(): Float = toPixelFromDIP(this.toFloat())

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/fabric/events/TouchEventDispatchTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/fabric/events/TouchEventDispatchTest.kt
@@ -514,7 +514,7 @@ class TouchEventDispatchTest {
     metrics.xdpi = 1f
     metrics.ydpi = 1f
     metrics.density = 1f
-    DisplayMetricsHolder.setWindowDisplayMetrics(metrics)
+    DisplayMetricsHolder.setScreenDisplayMetrics(metrics)
 
     val reactContext = ReactTestHelper.createCatalystContextForTest()
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/style/ColorStopTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/style/ColorStopTest.kt
@@ -25,7 +25,7 @@ class ColorStopTest {
   fun setUp() {
     val metrics = DisplayMetrics()
     metrics.density = 1f
-    DisplayMetricsHolder.setWindowDisplayMetrics(metrics)
+    DisplayMetricsHolder.setScreenDisplayMetrics(metrics)
   }
 
   @Test

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/image/ReactImagePropertyTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/image/ReactImagePropertyTest.kt
@@ -75,14 +75,14 @@ class ReactImagePropertyTest {
     context.initializeWithInstance(catalystInstanceMock)
     themeContext = ThemedReactContext(context, context, null, -1)
     Fresco.initialize(context)
-    DisplayMetricsHolder.setWindowDisplayMetrics(DisplayMetrics())
+    DisplayMetricsHolder.setScreenDisplayMetrics(DisplayMetrics())
 
     ReactNativeFeatureFlagsForTests.setUp()
   }
 
   @After
   fun teardown() {
-    DisplayMetricsHolder.setWindowDisplayMetrics(null)
+    DisplayMetricsHolder.setScreenDisplayMetrics(null)
     rnLog.close()
     flogMock.close()
   }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/textinput/ReactTextInputPropertyTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/textinput/ReactTextInputPropertyTest.kt
@@ -65,7 +65,7 @@ class ReactTextInputPropertyTest {
     context.initializeWithInstance(catalystInstanceMock)
     themedContext = ThemedReactContext(context, context.baseContext, null, ID_NULL)
     manager = ReactTextInputManager()
-    DisplayMetricsHolder.setWindowDisplayMetrics(DisplayMetrics())
+    DisplayMetricsHolder.setScreenDisplayMetrics(DisplayMetrics())
     view = manager.createViewInstance(themedContext)
   }
 

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/virtual/view/ReactVirtualViewTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/views/virtual/view/ReactVirtualViewTest.kt
@@ -47,7 +47,7 @@ class ReactVirtualViewTest {
 
     val displayMetricsHolder = mockStatic(DisplayMetricsHolder::class.java)
     displayMetricsHolder
-        .`when`<DisplayMetrics> { DisplayMetricsHolder.getWindowDisplayMetrics() }
+        .`when`<DisplayMetrics> { DisplayMetricsHolder.getScreenDisplayMetrics() }
         .thenAnswer { DisplayMetrics().apply { density = 1f } }
   }
 


### PR DESCRIPTION
Summary:
update `DisplayMetricsHolder.getWindowDisplayMetrics()` to `getScreenDisplayMetrics()`.

Where window width and height is not needed, prefer to use `screenDisplayMetrics` as with upcoming diff `windowDisplayMetrics` initialization only happen using UiContext and have potential to cause more issues if used unnecessarily.

Changelog: [Internal] Update `DisplayMetricsHolder.getWindowDisplayMetrics()` to use `.getScreenDisplayMetrics()`


---

Differential Revision: D81270196


