### PR TITLE
Animation Backend init

### DIFF
--- a/packages/react-native/Libraries/Animated/__tests__/AnimatedBackend-itest.js
+++ b/packages/react-native/Libraries/Animated/__tests__/AnimatedBackend-itest.js
@@ -1,0 +1,75 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @fantom_flags useSharedAnimatedBackend:true
+ * @flow strict-local
+ * @format
+ */
+
+import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
+
+import type {HostInstance} from 'react-native';
+
+import ensureInstance from '../../../src/private/__tests__/utilities/ensureInstance';
+import * as Fantom from '@react-native/fantom';
+import {createRef} from 'react';
+import {Animated, useAnimatedValue} from 'react-native';
+import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
+
+test('animated opacity', () => {
+  let _opacity;
+  let _opacityAnimation;
+  const viewRef = createRef<HostInstance>();
+
+  function MyApp() {
+    const opacity = useAnimatedValue(1);
+    _opacity = opacity;
+    return (
+      <Animated.View
+        ref={viewRef}
+        style={[
+          {
+            width: 100,
+            height: 100,
+            opacity: opacity,
+          },
+        ]}
+      />
+    );
+  }
+
+  const root = Fantom.createRoot();
+
+  Fantom.runTask(() => {
+    root.render(<MyApp />);
+  });
+
+  const viewElement = ensureInstance(viewRef.current, ReactNativeElement);
+
+  expect(viewElement.getBoundingClientRect().x).toBe(0);
+
+  Fantom.runTask(() => {
+    _opacityAnimation = Animated.timing(_opacity, {
+      toValue: 0,
+      duration: 30,
+      useNativeDriver: true,
+    }).start();
+  });
+
+  Fantom.unstable_produceFramesForDuration(30);
+  expect(Fantom.unstable_getDirectManipulationProps(viewElement).opacity).toBe(
+    0,
+  );
+
+  // TODO: this shouldn't be neccessary since animation should be stopped after duration
+  Fantom.runTask(() => {
+    _opacityAnimation?.stop();
+  });
+
+  expect(root.getRenderedOutput({props: ['opacity']}).toJSX()).toEqual(
+    <rn-view opacity="0" />,
+  );
+});

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlags.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<f707e26d09b6f7962ec97296a1a215b6>>
+ * @generated SignedSource<<8af0aea8bbf4cffaad7d312032bef0e4>>
  */
 
 /**
@@ -455,6 +455,12 @@ public object ReactNativeFeatureFlags {
    */
   @JvmStatic
   public fun useShadowNodeStateOnClone(): Boolean = accessor.useShadowNodeStateOnClone()
+
+  /**
+   * Use shared animation backend in C++ Animated
+   */
+  @JvmStatic
+  public fun useSharedAnimatedBackend(): Boolean = accessor.useSharedAnimatedBackend()
 
   /**
    * In Bridgeless mode, should legacy NativeModules use the TurboModule system?

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<e7cfc5135c7b3c731324297e92e41e3f>>
+ * @generated SignedSource<<5c2aa1e15e7fbe129b8f774d2dc7be70>>
  */
 
 /**
@@ -91,6 +91,7 @@ internal class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAcces
   private var useOptimizedEventBatchingOnAndroidCache: Boolean? = null
   private var useRawPropsJsiValueCache: Boolean? = null
   private var useShadowNodeStateOnCloneCache: Boolean? = null
+  private var useSharedAnimatedBackendCache: Boolean? = null
   private var useTurboModuleInteropCache: Boolean? = null
   private var useTurboModulesCache: Boolean? = null
   private var viewCullingOutsetRatioCache: Double? = null
@@ -732,6 +733,15 @@ internal class ReactNativeFeatureFlagsCxxAccessor : ReactNativeFeatureFlagsAcces
     if (cached == null) {
       cached = ReactNativeFeatureFlagsCxxInterop.useShadowNodeStateOnClone()
       useShadowNodeStateOnCloneCache = cached
+    }
+    return cached
+  }
+
+  override fun useSharedAnimatedBackend(): Boolean {
+    var cached = useSharedAnimatedBackendCache
+    if (cached == null) {
+      cached = ReactNativeFeatureFlagsCxxInterop.useSharedAnimatedBackend()
+      useSharedAnimatedBackendCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsCxxInterop.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<3254fef626b10ef21d8d9ee1bdbb1880>>
+ * @generated SignedSource<<0bd8796f4580322a78690ec4469c07ce>>
  */
 
 /**
@@ -169,6 +169,8 @@ public object ReactNativeFeatureFlagsCxxInterop {
   @DoNotStrip @JvmStatic public external fun useRawPropsJsiValue(): Boolean
 
   @DoNotStrip @JvmStatic public external fun useShadowNodeStateOnClone(): Boolean
+
+  @DoNotStrip @JvmStatic public external fun useSharedAnimatedBackend(): Boolean
 
   @DoNotStrip @JvmStatic public external fun useTurboModuleInterop(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<9f7eb1bb5e24fd8ee87accf60209cce3>>
+ * @generated SignedSource<<7c7796cbe2722f0f6e5b2cc4ed43a0d5>>
  */
 
 /**
@@ -164,6 +164,8 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
   override fun useRawPropsJsiValue(): Boolean = true
 
   override fun useShadowNodeStateOnClone(): Boolean = false
+
+  override fun useSharedAnimatedBackend(): Boolean = false
 
   override fun useTurboModuleInterop(): Boolean = false
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsLocalAccessor.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<9e6e04ca37edd1ad9265b74e251ff4de>>
+ * @generated SignedSource<<f3420de2307aab53b885fa491183d84b>>
  */
 
 /**
@@ -95,6 +95,7 @@ internal class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcc
   private var useOptimizedEventBatchingOnAndroidCache: Boolean? = null
   private var useRawPropsJsiValueCache: Boolean? = null
   private var useShadowNodeStateOnCloneCache: Boolean? = null
+  private var useSharedAnimatedBackendCache: Boolean? = null
   private var useTurboModuleInteropCache: Boolean? = null
   private var useTurboModulesCache: Boolean? = null
   private var viewCullingOutsetRatioCache: Double? = null
@@ -807,6 +808,16 @@ internal class ReactNativeFeatureFlagsLocalAccessor : ReactNativeFeatureFlagsAcc
       cached = currentProvider.useShadowNodeStateOnClone()
       accessedFeatureFlags.add("useShadowNodeStateOnClone")
       useShadowNodeStateOnCloneCache = cached
+    }
+    return cached
+  }
+
+  override fun useSharedAnimatedBackend(): Boolean {
+    var cached = useSharedAnimatedBackendCache
+    if (cached == null) {
+      cached = currentProvider.useSharedAnimatedBackend()
+      accessedFeatureFlags.add("useSharedAnimatedBackend")
+      useSharedAnimatedBackendCache = cached
     }
     return cached
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsProvider.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<65e895433fc609bd7c2b5d7faa507f46>>
+ * @generated SignedSource<<d4370bcde97d3c2b0b8d2a77e42a6031>>
  */
 
 /**
@@ -164,6 +164,8 @@ public interface ReactNativeFeatureFlagsProvider {
   @DoNotStrip public fun useRawPropsJsiValue(): Boolean
 
   @DoNotStrip public fun useShadowNodeStateOnClone(): Boolean
+
+  @DoNotStrip public fun useSharedAnimatedBackend(): Boolean
 
   @DoNotStrip public fun useTurboModuleInterop(): Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7a0a26494846d6b4881bea01beabb9d6>>
+ * @generated SignedSource<<740fec2589997816f17778f57b1d4abf>>
  */
 
 /**
@@ -465,6 +465,12 @@ class ReactNativeFeatureFlagsJavaProvider
     return method(javaProvider_);
   }
 
+  bool useSharedAnimatedBackend() override {
+    static const auto method =
+        getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("useSharedAnimatedBackend");
+    return method(javaProvider_);
+  }
+
   bool useTurboModuleInterop() override {
     static const auto method =
         getReactNativeFeatureFlagsProviderJavaClass()->getMethod<jboolean()>("useTurboModuleInterop");
@@ -854,6 +860,11 @@ bool JReactNativeFeatureFlagsCxxInterop::useShadowNodeStateOnClone(
   return ReactNativeFeatureFlags::useShadowNodeStateOnClone();
 }
 
+bool JReactNativeFeatureFlagsCxxInterop::useSharedAnimatedBackend(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
+  return ReactNativeFeatureFlags::useSharedAnimatedBackend();
+}
+
 bool JReactNativeFeatureFlagsCxxInterop::useTurboModuleInterop(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop> /*unused*/) {
   return ReactNativeFeatureFlags::useTurboModuleInterop();
@@ -1123,6 +1134,9 @@ void JReactNativeFeatureFlagsCxxInterop::registerNatives() {
       makeNativeMethod(
         "useShadowNodeStateOnClone",
         JReactNativeFeatureFlagsCxxInterop::useShadowNodeStateOnClone),
+      makeNativeMethod(
+        "useSharedAnimatedBackend",
+        JReactNativeFeatureFlagsCxxInterop::useSharedAnimatedBackend),
       makeNativeMethod(
         "useTurboModuleInterop",
         JReactNativeFeatureFlagsCxxInterop::useTurboModuleInterop),

--- a/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/featureflags/JReactNativeFeatureFlagsCxxInterop.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<ad2e322ef177ced7eb07412552596a5b>>
+ * @generated SignedSource<<2d4ccbeed5ffafd40715357ff98d83b1>>
  */
 
 /**
@@ -241,6 +241,9 @@ class JReactNativeFeatureFlagsCxxInterop
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool useShadowNodeStateOnClone(
+    facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
+
+  static bool useSharedAnimatedBackend(
     facebook::jni::alias_ref<JReactNativeFeatureFlagsCxxInterop>);
 
   static bool useTurboModuleInterop(

--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -54,11 +54,22 @@ Pod::Spec.new do |s|
   depend_on_js_engine(s)
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
+  
+  s.subspec "animated" do |ss|
+    ss.source_files         = podspec_sources("react/renderer/animated/**/*.{m,mm,cpp,h}", "react/renderer/animated/**/*.{h}")
+    ss.exclude_files        = "react/renderer/animated/tests"
+    ss.header_dir           = "react/renderer/animated"
+  end
 
   s.subspec "animations" do |ss|
     ss.source_files         = podspec_sources("react/renderer/animations/**/*.{m,mm,cpp,h}", "react/renderer/animations/**/*.{h}")
     ss.exclude_files        = "react/renderer/animations/tests"
     ss.header_dir           = "react/renderer/animations"
+  end
+  
+  s.subspec "animationbackend" do |ss|
+    ss.source_files         = podspec_sources("react/renderer/animationbackend/**/*.{m,mm,cpp,h}", "react/renderer/animationbackend/**/*.{h}")
+    ss.header_dir           = "react/renderer/animationbackend"
   end
 
   s.subspec "attributedstring" do |ss|

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<f01f3d1a08880a7fa9d3490e6bd9c61a>>
+ * @generated SignedSource<<287689f62d05f2d27c146856b7857010>>
  */
 
 /**
@@ -308,6 +308,10 @@ bool ReactNativeFeatureFlags::useRawPropsJsiValue() {
 
 bool ReactNativeFeatureFlags::useShadowNodeStateOnClone() {
   return getAccessor().useShadowNodeStateOnClone();
+}
+
+bool ReactNativeFeatureFlags::useSharedAnimatedBackend() {
+  return getAccessor().useSharedAnimatedBackend();
 }
 
 bool ReactNativeFeatureFlags::useTurboModuleInterop() {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<559a8be87c24238e70fceded8ac962a0>>
+ * @generated SignedSource<<ce76bbae9b797c6c1c9a1ceb1350f370>>
  */
 
 /**
@@ -393,6 +393,11 @@ class ReactNativeFeatureFlags {
    * Use the state stored on the source shadow node when cloning it instead of reading in the most recent state on the shadow node family.
    */
   RN_EXPORT static bool useShadowNodeStateOnClone();
+
+  /**
+   * Use shared animation backend in C++ Animated
+   */
+  RN_EXPORT static bool useSharedAnimatedBackend();
 
   /**
    * In Bridgeless mode, should legacy NativeModules use the TurboModule system?

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<379732a049a8539a1cde814996ff4791>>
+ * @generated SignedSource<<57620c5eb3ba6b9fa70f21908c4ea71c>>
  */
 
 /**
@@ -1307,6 +1307,24 @@ bool ReactNativeFeatureFlagsAccessor::useShadowNodeStateOnClone() {
   return flagValue.value();
 }
 
+bool ReactNativeFeatureFlagsAccessor::useSharedAnimatedBackend() {
+  auto flagValue = useSharedAnimatedBackend_.load();
+
+  if (!flagValue.has_value()) {
+    // This block is not exclusive but it is not necessary.
+    // If multiple threads try to initialize the feature flag, we would only
+    // be accessing the provider multiple times but the end state of this
+    // instance and the returned flag value would be the same.
+
+    markFlagAsAccessed(71, "useSharedAnimatedBackend");
+
+    flagValue = currentProvider_->useSharedAnimatedBackend();
+    useSharedAnimatedBackend_ = flagValue;
+  }
+
+  return flagValue.value();
+}
+
 bool ReactNativeFeatureFlagsAccessor::useTurboModuleInterop() {
   auto flagValue = useTurboModuleInterop_.load();
 
@@ -1316,7 +1334,7 @@ bool ReactNativeFeatureFlagsAccessor::useTurboModuleInterop() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(71, "useTurboModuleInterop");
+    markFlagAsAccessed(72, "useTurboModuleInterop");
 
     flagValue = currentProvider_->useTurboModuleInterop();
     useTurboModuleInterop_ = flagValue;
@@ -1334,7 +1352,7 @@ bool ReactNativeFeatureFlagsAccessor::useTurboModules() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(72, "useTurboModules");
+    markFlagAsAccessed(73, "useTurboModules");
 
     flagValue = currentProvider_->useTurboModules();
     useTurboModules_ = flagValue;
@@ -1352,7 +1370,7 @@ double ReactNativeFeatureFlagsAccessor::viewCullingOutsetRatio() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(73, "viewCullingOutsetRatio");
+    markFlagAsAccessed(74, "viewCullingOutsetRatio");
 
     flagValue = currentProvider_->viewCullingOutsetRatio();
     viewCullingOutsetRatio_ = flagValue;
@@ -1370,7 +1388,7 @@ double ReactNativeFeatureFlagsAccessor::virtualViewHysteresisRatio() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(74, "virtualViewHysteresisRatio");
+    markFlagAsAccessed(75, "virtualViewHysteresisRatio");
 
     flagValue = currentProvider_->virtualViewHysteresisRatio();
     virtualViewHysteresisRatio_ = flagValue;
@@ -1388,7 +1406,7 @@ double ReactNativeFeatureFlagsAccessor::virtualViewPrerenderRatio() {
     // be accessing the provider multiple times but the end state of this
     // instance and the returned flag value would be the same.
 
-    markFlagAsAccessed(75, "virtualViewPrerenderRatio");
+    markFlagAsAccessed(76, "virtualViewPrerenderRatio");
 
     flagValue = currentProvider_->virtualViewPrerenderRatio();
     virtualViewPrerenderRatio_ = flagValue;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsAccessor.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<ae0e9dbf8605126b358f776226e68130>>
+ * @generated SignedSource<<6c6458278652bc91570db82b2be6c7f1>>
  */
 
 /**
@@ -103,6 +103,7 @@ class ReactNativeFeatureFlagsAccessor {
   bool useOptimizedEventBatchingOnAndroid();
   bool useRawPropsJsiValue();
   bool useShadowNodeStateOnClone();
+  bool useSharedAnimatedBackend();
   bool useTurboModuleInterop();
   bool useTurboModules();
   double viewCullingOutsetRatio();
@@ -119,7 +120,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::unique_ptr<ReactNativeFeatureFlagsProvider> currentProvider_;
   bool wasOverridden_;
 
-  std::array<std::atomic<const char*>, 76> accessedFeatureFlags_;
+  std::array<std::atomic<const char*>, 77> accessedFeatureFlags_;
 
   std::atomic<std::optional<bool>> commonTestFlag_;
   std::atomic<std::optional<bool>> cdpInteractionMetricsEnabled_;
@@ -192,6 +193,7 @@ class ReactNativeFeatureFlagsAccessor {
   std::atomic<std::optional<bool>> useOptimizedEventBatchingOnAndroid_;
   std::atomic<std::optional<bool>> useRawPropsJsiValue_;
   std::atomic<std::optional<bool>> useShadowNodeStateOnClone_;
+  std::atomic<std::optional<bool>> useSharedAnimatedBackend_;
   std::atomic<std::optional<bool>> useTurboModuleInterop_;
   std::atomic<std::optional<bool>> useTurboModules_;
   std::atomic<std::optional<double>> viewCullingOutsetRatio_;

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<e8eb056e546c41e5863073e460362020>>
+ * @generated SignedSource<<7879aa079d5dc8603faac4dbf40f70c5>>
  */
 
 /**
@@ -308,6 +308,10 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool useShadowNodeStateOnClone() override {
+    return false;
+  }
+
+  bool useSharedAnimatedBackend() override {
     return false;
   }
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDynamicProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<00b4d80631374e0714c8aa9f65060220>>
+ * @generated SignedSource<<b61bcdcabe00ba0e97e42a7ffc2fa8ef>>
  */
 
 /**
@@ -682,6 +682,15 @@ class ReactNativeFeatureFlagsDynamicProvider : public ReactNativeFeatureFlagsDef
     }
 
     return ReactNativeFeatureFlagsDefaults::useShadowNodeStateOnClone();
+  }
+
+  bool useSharedAnimatedBackend() override {
+    auto value = values_["useSharedAnimatedBackend"];
+    if (!value.isNull()) {
+      return value.getBool();
+    }
+
+    return ReactNativeFeatureFlagsDefaults::useSharedAnimatedBackend();
   }
 
   bool useTurboModuleInterop() override {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsProvider.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<fde4b531c2b0f19bef7bc69aaf3c5639>>
+ * @generated SignedSource<<b4b62078cf82f1444cb14af59bc7d2f5>>
  */
 
 /**
@@ -96,6 +96,7 @@ class ReactNativeFeatureFlagsProvider {
   virtual bool useOptimizedEventBatchingOnAndroid() = 0;
   virtual bool useRawPropsJsiValue() = 0;
   virtual bool useShadowNodeStateOnClone() = 0;
+  virtual bool useSharedAnimatedBackend() = 0;
   virtual bool useTurboModuleInterop() = 0;
   virtual bool useTurboModules() = 0;
   virtual double viewCullingOutsetRatio() = 0;

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.cpp
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<27c7bc7a528da06ffe2bcea48211f6bd>>
+ * @generated SignedSource<<e799e5ce5aea7adbef02a7e7431f8a35>>
  */
 
 /**
@@ -397,6 +397,11 @@ bool NativeReactNativeFeatureFlags::useRawPropsJsiValue(
 bool NativeReactNativeFeatureFlags::useShadowNodeStateOnClone(
     jsi::Runtime& /*runtime*/) {
   return ReactNativeFeatureFlags::useShadowNodeStateOnClone();
+}
+
+bool NativeReactNativeFeatureFlags::useSharedAnimatedBackend(
+    jsi::Runtime& /*runtime*/) {
+  return ReactNativeFeatureFlags::useSharedAnimatedBackend();
 }
 
 bool NativeReactNativeFeatureFlags::useTurboModuleInterop(

--- a/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/featureflags/NativeReactNativeFeatureFlags.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<39140c882a6faa0403d3a59806c6bea5>>
+ * @generated SignedSource<<990b6518e7b1d196deb0965e9ada6605>>
  */
 
 /**
@@ -177,6 +177,8 @@ class NativeReactNativeFeatureFlags
   bool useRawPropsJsiValue(jsi::Runtime& runtime);
 
   bool useShadowNodeStateOnClone(jsi::Runtime& runtime);
+
+  bool useSharedAnimatedBackend(jsi::Runtime& runtime);
 
   bool useTurboModuleInterop(jsi::Runtime& runtime);
 

--- a/packages/react-native/ReactCommon/react/renderer/animated/AnimatedModule.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/AnimatedModule.h
@@ -7,7 +7,11 @@
 
 #pragma once
 
+#if __has_include("FBReactNativeSpecJSI.h") // CocoaPod headers on Apple
+#include "FBReactNativeSpecJSI.h"
+#else
 #include <FBReactNativeSpec/FBReactNativeSpecJSI.h>
+#endif
 #include <ReactCommon/TurboModuleWithJSIBindings.h>
 #include <folly/dynamic.h>
 #include <react/renderer/animated/NativeAnimatedNodesManager.h>

--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.h
@@ -7,7 +7,11 @@
 
 #pragma once
 
+#if __has_include("FBReactNativeSpecJSI.h") // CocoaPod headers on Apple
+#include "FBReactNativeSpecJSI.h"
+#else
 #include <FBReactNativeSpec/FBReactNativeSpecJSI.h>
+#endif
 #include <folly/dynamic.h>
 #include <react/bridging/Function.h>
 #include <react/debug/flags.h>

--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.h
@@ -13,6 +13,7 @@
 #include <react/debug/flags.h>
 #include <react/renderer/animated/EventEmitterListener.h>
 #include <react/renderer/animated/event_drivers/EventAnimationDriver.h>
+#include <react/renderer/animationbackend/AnimationBackend.h>
 #include <react/renderer/core/ReactPrimitives.h>
 #include <chrono>
 #include <memory>
@@ -104,6 +105,8 @@ class NativeAnimatedNodesManager {
   void extractAnimatedNodeOffsetOp(Tag tag);
 
   void setAnimatedNodeOffset(Tag tag, double offset);
+
+  AnimationMutations pullAnimationMutations();
 
 #pragma mark - Drivers
 
@@ -201,6 +204,8 @@ class NativeAnimatedNodesManager {
       Tag tag,
       const std::string& eventName,
       const EventPayload& payload) noexcept;
+
+  std::shared_ptr<AnimationBackend> animationBackend_;
 
   std::unique_ptr<AnimatedNode> animatedNode(
       Tag tag,

--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.h
@@ -63,6 +63,9 @@ class NativeAnimatedNodesManager {
       StartOnRenderCallback&& startOnRenderCallback = nullptr,
       StopOnRenderCallback&& stopOnRenderCallback = nullptr) noexcept;
 
+  explicit NativeAnimatedNodesManager(
+      std::shared_ptr<AnimationBackend> animationBackend) noexcept;
+
   ~NativeAnimatedNodesManager() noexcept;
 
   template <

--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManagerProvider.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManagerProvider.cpp
@@ -66,6 +66,8 @@ NativeAnimatedNodesManagerProvider::getOrCreate(
         };
 
     if (ReactNativeFeatureFlags::useSharedAnimatedBackend()) {
+      // TODO: this should be initialized outside of animated, but for now it
+      // was convenient to do it here
       animationBackend_ = std::make_shared<AnimationBackend>(
           std::move(startOnRenderCallback_),
           std::move(stopOnRenderCallback_),
@@ -73,6 +75,8 @@ NativeAnimatedNodesManagerProvider::getOrCreate(
 
       nativeAnimatedNodesManager_ =
           std::make_shared<NativeAnimatedNodesManager>(animationBackend_);
+
+      uiManager->unstable_setAnimationBackend(animationBackend_);
     } else {
       nativeAnimatedNodesManager_ =
           std::make_shared<NativeAnimatedNodesManager>(

--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManagerProvider.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManagerProvider.cpp
@@ -71,7 +71,9 @@ NativeAnimatedNodesManagerProvider::getOrCreate(
       animationBackend_ = std::make_shared<AnimationBackend>(
           std::move(startOnRenderCallback_),
           std::move(stopOnRenderCallback_),
-          std::move(directManipulationCallback));
+          std::move(directManipulationCallback),
+          std::move(fabricCommitCallback),
+          uiManager);
 
       nativeAnimatedNodesManager_ =
           std::make_shared<NativeAnimatedNodesManager>(animationBackend_);

--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManagerProvider.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManagerProvider.h
@@ -46,6 +46,7 @@ class NativeAnimatedNodesManagerProvider {
   std::shared_ptr<EventEmitterListener> getEventEmitterListener();
 
  private:
+  std::shared_ptr<AnimationBackend> animationBackend_;
   std::shared_ptr<NativeAnimatedNodesManager> nativeAnimatedNodesManager_;
 
   std::shared_ptr<EventEmitterListenerContainer> eventEmitterListenerContainer_;

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedProps.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+#include <react/renderer/components/view/BaseViewProps.h>
+
+#include <utility>
+
+namespace facebook::react {
+
+enum PropName { OPACITY, WIDTH, HEIGHT, BORDER_RADII, FLEX, TRANSFORM };
+
+struct AnimatedPropBase {
+  PropName propName;
+  explicit AnimatedPropBase(PropName propName) : propName(propName) {}
+  virtual ~AnimatedPropBase() = default;
+};
+
+template <typename T>
+struct AnimatedProp : AnimatedPropBase {
+  T value;
+  AnimatedProp() = default;
+  AnimatedProp(PropName propName, const T& value)
+      : AnimatedPropBase{propName}, value(std::move(value)) {}
+};
+
+template <typename T>
+T get(const std::unique_ptr<AnimatedPropBase>& animatedProp) {
+  return static_cast<AnimatedProp<T>*>(animatedProp.get())->value;
+}
+
+struct AnimatedProps {
+  std::vector<std::unique_ptr<AnimatedPropBase>> props;
+  std::unique_ptr<RawProps> rawProps;
+};
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropsBuilder.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropsBuilder.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+#include <react/renderer/components/view/BaseViewProps.h>
+#include "AnimatedProps.h"
+
+namespace facebook::react {
+
+struct AnimatedPropsBuilder {
+  std::vector<std::unique_ptr<AnimatedPropBase>> props;
+  std::unique_ptr<RawProps> rawProps;
+
+  void setOpacity(Float value) {
+    props.push_back(std::make_unique<AnimatedProp<Float>>(OPACITY, value));
+  }
+  void setWidth(yoga::Style::SizeLength value) {
+    props.push_back(
+        std::make_unique<AnimatedProp<yoga::Style::SizeLength>>(WIDTH, value));
+  }
+  void setHeight(yoga::Style::SizeLength value) {
+    props.push_back(
+        std::make_unique<AnimatedProp<yoga::Style::SizeLength>>(HEIGHT, value));
+  }
+  void setBorderRadii(CascadedBorderRadii& value) {
+    props.push_back(std::make_unique<AnimatedProp<CascadedBorderRadii>>(
+        BORDER_RADII, value));
+  }
+  void setTransform(Transform& t) {
+    props.push_back(
+        std::make_unique<AnimatedProp<Transform>>(TRANSFORM, std::move(t)));
+  }
+  void storeDynamic(folly::dynamic& d) {
+    rawProps = std::make_unique<RawProps>(std::move(d));
+  }
+  void storeJSI(jsi::Runtime& runtime, jsi::Value& value) {
+    rawProps = std::make_unique<RawProps>(runtime, value);
+  }
+  AnimatedProps get() {
+    return AnimatedProps{std::move(props), std::move(rawProps)};
+  }
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.cpp
@@ -6,34 +6,169 @@
  */
 
 #include "AnimationBackend.h"
+#include <chrono>
 
 namespace facebook::react {
+
+static inline Props::Shared cloneProps(
+    AnimatedProps& animatedProps,
+    const ShadowNode& shadowNode) {
+  PropsParserContext propsParserContext{
+      shadowNode.getSurfaceId(), *shadowNode.getContextContainer()};
+  Props::Shared newProps;
+  if (animatedProps.rawProps) {
+    newProps = shadowNode.getComponentDescriptor().cloneProps(
+        propsParserContext,
+        shadowNode.getProps(),
+        std::move(*animatedProps.rawProps));
+  } else {
+    newProps = shadowNode.getComponentDescriptor().cloneProps(
+        propsParserContext, shadowNode.getProps(), {});
+  }
+
+  auto viewProps = std::const_pointer_cast<BaseViewProps>(
+      std::static_pointer_cast<const BaseViewProps>(newProps));
+  for (auto& animatedProp : animatedProps.props) {
+    switch (animatedProp->propName) {
+      case OPACITY:
+        viewProps->opacity = get<Float>(animatedProp);
+        break;
+
+      case WIDTH:
+        viewProps->yogaStyle.setDimension(
+            yoga::Dimension::Width, get<yoga::Style::SizeLength>(animatedProp));
+        break;
+
+      case HEIGHT:
+        viewProps->yogaStyle.setDimension(
+            yoga::Dimension::Height,
+            get<yoga::Style::SizeLength>(animatedProp));
+        break;
+
+      case BORDER_RADII:
+        viewProps->borderRadii = get<CascadedBorderRadii>(animatedProp);
+        break;
+
+      case FLEX:
+        viewProps->yogaStyle.setFlex(get<yoga::FloatOptional>(animatedProp));
+        break;
+
+      case TRANSFORM:
+        viewProps->transform = get<Transform>(animatedProp);
+        break;
+    }
+  }
+  return newProps;
+}
+
+static inline bool mutationHasLayoutUpdates(
+    facebook::react::AnimationMutation& mutation) {
+  for (auto& animatedProp : mutation.props.props) {
+    // TODO: there should also be a check for the dynamic part
+    if (animatedProp->propName == WIDTH || animatedProp->propName == HEIGHT ||
+        animatedProp->propName == FLEX) {
+      return true;
+    }
+  }
+  return false;
+}
 
 AnimationBackend::AnimationBackend(
     StartOnRenderCallback&& startOnRenderCallback,
     StopOnRenderCallback&& stopOnRenderCallback,
-    DirectManipulationCallback&& directManipulationCallback)
+    DirectManipulationCallback&& directManipulationCallback,
+    FabricCommitCallback&& fabricCommitCallback,
+    UIManager* uiManager)
     : startOnRenderCallback_(std::move(startOnRenderCallback)),
       stopOnRenderCallback_(std::move(stopOnRenderCallback)),
-      directManipulationCallback_(std::move(directManipulationCallback)) {}
+      directManipulationCallback_(std::move(directManipulationCallback)),
+      fabricCommitCallback_(std::move(fabricCommitCallback)),
+      uiManager_(uiManager) {}
 
 void AnimationBackend::onAnimationFrame(double timestamp) {
+  std::unordered_map<Tag, AnimatedProps> updates;
+  std::unordered_set<const ShadowNodeFamily*> families;
+  bool hasAnyLayoutUpdates = false;
   for (auto& callback : callbacks) {
     auto muatations = callback(static_cast<float>(timestamp));
     for (auto& mutation : muatations) {
-      directManipulationCallback_(
-          mutation.tag, folly::dynamic::object("opacity", mutation.opacity));
+      hasAnyLayoutUpdates |= mutationHasLayoutUpdates(mutation);
+      families.insert(mutation.family);
+      updates[mutation.tag] = std::move(mutation.props);
     }
+  }
+
+  if (hasAnyLayoutUpdates) {
+    commitUpdatesWithFamilies(families, updates);
+  } else {
+    synchronouslyUpdateProps(updates);
   }
 }
 
 void AnimationBackend::start(const Callback& callback) {
   callbacks.push_back(callback);
-  // startOnRenderCallback_ should provide the timestamp from the platform
-  startOnRenderCallback_([this]() { onAnimationFrame(0); });
+  // TODO: startOnRenderCallback_ should provide the timestamp from the platform
+  startOnRenderCallback_([this]() {
+    onAnimationFrame(
+        std::chrono::steady_clock::now().time_since_epoch().count() / 1000);
+  });
 }
 void AnimationBackend::stop() {
   stopOnRenderCallback_();
   callbacks.clear();
 }
+
+void AnimationBackend::commitUpdatesWithFamilies(
+    const std::unordered_set<const ShadowNodeFamily*>& families,
+    std::unordered_map<Tag, AnimatedProps>& updates) {
+  uiManager_->getShadowTreeRegistry().enumerate(
+      [families, &updates](const ShadowTree& shadowTree, bool& /*stop*/) {
+        shadowTree.commit(
+            [families, &updates](const RootShadowNode& oldRootShadowNode) {
+              return std::static_pointer_cast<RootShadowNode>(
+                  oldRootShadowNode.cloneMultiple(
+                      families,
+                      [families, &updates](
+                          const ShadowNode& shadowNode,
+                          const ShadowNodeFragment& fragment) {
+                        auto& animatedProps = updates.at(shadowNode.getTag());
+                        auto newProps = cloneProps(animatedProps, shadowNode);
+                        return shadowNode.clone(
+                            {newProps,
+                             fragment.children,
+                             shadowNode.getState()});
+                      }));
+            },
+            {.mountSynchronously = true});
+      });
+}
+
+void AnimationBackend::synchronouslyUpdateProps(
+    const std::unordered_map<Tag, AnimatedProps>& updates) {
+  for (auto& [tag, animatedProps] : updates) {
+    auto dyn = animatedProps.rawProps ? animatedProps.rawProps->toDynamic()
+                                      : folly::dynamic::object();
+    for (auto& animatedProp : animatedProps.props) {
+      // TODO: We shouldn't repack it into dynamic, but for that a rewrite of
+      // directManipulationCallback_ is needed
+      switch (animatedProp->propName) {
+        case OPACITY:
+          dyn.insert("opacity", get<Float>(animatedProp));
+          break;
+
+        case BORDER_RADII:
+        case TRANSFORM:
+          // TODO: handle other things than opacity
+          break;
+
+        case WIDTH:
+        case HEIGHT:
+        case FLEX:
+          throw "Tried to synchronously update layout props";
+      }
+    }
+    directManipulationCallback_(tag, dyn);
+  }
+}
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "AnimationBackend.h"
+
+namespace facebook::react {
+
+AnimationBackend::AnimationBackend(
+    const StartOnRenderCallback& startOnRenderCallback,
+    const StopOnRenderCallback& stopOnRenderCallback,
+    const DirectManipulationCallback& directManipulationCallback)
+    : startOnRenderCallback_(startOnRenderCallback),
+      stopOnRenderCallback_(stopOnRenderCallback),
+      directManipulationCallback_(directManipulationCallback) {}
+
+void AnimationBackend::onAnimationFrame(double timestamp) {
+  for (auto& callback : callbacks) {
+    auto muatations = callback(static_cast<float>(timestamp));
+    for (auto& mutation : muatations) {
+      directManipulationCallback_(
+          mutation.tag, folly::dynamic::object("opacity", mutation.opacity));
+    }
+  }
+}
+
+void AnimationBackend::start(const Callback& callback) {
+  callbacks.push_back(callback);
+  // startOnRenderCallback_ should provide the timestamp from the platform
+  startOnRenderCallback_([this]() { onAnimationFrame(0); });
+}
+void AnimationBackend::stop() {
+  stopOnRenderCallback_();
+  callbacks.clear();
+}
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.cpp
@@ -10,12 +10,12 @@
 namespace facebook::react {
 
 AnimationBackend::AnimationBackend(
-    const StartOnRenderCallback& startOnRenderCallback,
-    const StopOnRenderCallback& stopOnRenderCallback,
-    const DirectManipulationCallback& directManipulationCallback)
-    : startOnRenderCallback_(startOnRenderCallback),
-      stopOnRenderCallback_(stopOnRenderCallback),
-      directManipulationCallback_(directManipulationCallback) {}
+    StartOnRenderCallback&& startOnRenderCallback,
+    StopOnRenderCallback&& stopOnRenderCallback,
+    DirectManipulationCallback&& directManipulationCallback)
+    : startOnRenderCallback_(std::move(startOnRenderCallback)),
+      stopOnRenderCallback_(std::move(stopOnRenderCallback)),
+      directManipulationCallback_(std::move(directManipulationCallback)) {}
 
 void AnimationBackend::onAnimationFrame(double timestamp) {
   for (auto& callback : callbacks) {

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.h
@@ -29,14 +29,14 @@ using DirectManipulationCallback =
 class AnimationBackend {
  public:
   std::vector<Callback> callbacks;
-  const StartOnRenderCallback& startOnRenderCallback_;
-  const StopOnRenderCallback& stopOnRenderCallback_;
-  const DirectManipulationCallback& directManipulationCallback_;
+  const StartOnRenderCallback startOnRenderCallback_;
+  const StopOnRenderCallback stopOnRenderCallback_;
+  const DirectManipulationCallback directManipulationCallback_;
 
   AnimationBackend(
-      const StartOnRenderCallback& startOnRenderCallback,
-      const StopOnRenderCallback& stopOnRenderCallback,
-      const DirectManipulationCallback& directManipulationCallback);
+      StartOnRenderCallback&& startOnRenderCallback,
+      StopOnRenderCallback&& stopOnRenderCallback,
+      DirectManipulationCallback&& directManipulationCallback);
   void onAnimationFrame(double timestamp);
   void start(const Callback& callback);
   void stop();

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/dynamic.h>
+#include <react/renderer/core/ReactPrimitives.h>
+#include <functional>
+#include <vector>
+
+namespace facebook::react {
+
+struct AnimationMutation {
+  Tag tag;
+  double opacity;
+};
+
+using AnimationMutations = std::vector<AnimationMutation>;
+using Callback = std::function<AnimationMutations(float)>;
+using StartOnRenderCallback = std::function<void(std::function<void()>&&)>;
+using StopOnRenderCallback = std::function<void()>;
+using DirectManipulationCallback =
+    std::function<void(Tag, const folly::dynamic&)>;
+
+class AnimationBackend {
+ public:
+  std::vector<Callback> callbacks;
+  const StartOnRenderCallback& startOnRenderCallback_;
+  const StopOnRenderCallback& stopOnRenderCallback_;
+  const DirectManipulationCallback& directManipulationCallback_;
+
+  AnimationBackend(
+      const StartOnRenderCallback& startOnRenderCallback,
+      const StopOnRenderCallback& stopOnRenderCallback,
+      const DirectManipulationCallback& directManipulationCallback);
+  void onAnimationFrame(double timestamp);
+  void start(const Callback& callback);
+  void stop();
+};
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/CMakeLists.txt
@@ -8,17 +8,12 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
-file(GLOB react_renderer_animated_SRC CONFIGURE_DEPENDS
-      *.cpp
-      drivers/*.cpp
-      event_drivers/*.cpp
-      internal/*.cpp
-      nodes/*.cpp)
-add_library(react_renderer_animated OBJECT ${react_renderer_animated_SRC})
+file(GLOB react_renderer_animationbackend_SRC CONFIGURE_DEPENDS *.cpp)
+add_library(react_renderer_animationbackend OBJECT ${react_renderer_animationbackend_SRC})
 
-target_include_directories(react_renderer_animated PUBLIC ${REACT_COMMON_DIR})
+target_include_directories(react_renderer_animationbackend PUBLIC ${REACT_COMMON_DIR})
 
-target_link_libraries(react_renderer_animated
+target_link_libraries(react_renderer_animationbackend
       react_codegen_rncore
       react_debug
       react_renderer_core
@@ -26,9 +21,8 @@ target_link_libraries(react_renderer_animated
       react_renderer_mounting
       react_renderer_uimanager
       react_renderer_scheduler
-      react_renderer_animationbackend
       glog
       folly_runtime
 )
-target_compile_reactnative_options(react_renderer_animated PRIVATE)
-target_compile_options(react_renderer_animated PRIVATE -Wpedantic)
+target_compile_reactnative_options(react_renderer_animationbackend PRIVATE)
+target_compile_options(react_renderer_animationbackend PRIVATE -Wpedantic)

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
@@ -678,6 +678,15 @@ void UIManager::setNativeAnimatedDelegate(
   nativeAnimatedDelegate_ = delegate;
 }
 
+void UIManager::unstable_setAnimationBackend(
+    std::weak_ptr<AnimationBackend> animationBackend) {
+  animationBackend_ = animationBackend;
+}
+
+std::weak_ptr<AnimationBackend> UIManager::unstable_getAnimationBackend() {
+  return animationBackend_;
+}
+
 void UIManager::animationTick() const {
   if (animationDelegate_ != nullptr &&
       animationDelegate_->shouldAnimateFrame()) {

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
@@ -36,6 +36,7 @@ namespace facebook::react {
 class UIManagerBinding;
 class UIManagerCommitHook;
 class UIManagerMountHook;
+class AnimationBackend;
 
 class UIManager final : public ShadowTreeDelegate {
  public:
@@ -62,6 +63,9 @@ class UIManager final : public ShadowTreeDelegate {
    * the pointer before being destroyed.
    */
   void setAnimationDelegate(UIManagerAnimationDelegate* delegate);
+  void unstable_setAnimationBackend(
+      std::weak_ptr<AnimationBackend> animationBackend);
+  std::weak_ptr<AnimationBackend> unstable_getAnimationBackend();
 
   /**
    * Execute stopSurface on any UIMAnagerAnimationDelegate.
@@ -258,6 +262,8 @@ class UIManager final : public ShadowTreeDelegate {
 
   std::unique_ptr<LazyShadowTreeRevisionConsistencyManager>
       lazyShadowTreeRevisionConsistencyManager_;
+
+  std::weak_ptr<AnimationBackend> animationBackend_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCxxPlatform/react/runtime/CMakeLists.txt
+++ b/packages/react-native/ReactCxxPlatform/react/runtime/CMakeLists.txt
@@ -32,6 +32,7 @@ target_link_libraries(react_cxx_platform_react_runtime
       react_cxx_platform_react_logging
       react_cxx_platform_react_nativemodule
       react_renderer_animated
+      react_renderer_animationbackend
       react_cxx_platform_react_renderer_uimanager
       react_cxx_platform_react_threading
       react_cxx_platform_react_utils

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -804,6 +804,16 @@ const definitions: FeatureFlagDefinitions = {
       },
       ossReleaseStage: 'none',
     },
+    useSharedAnimatedBackend: {
+      defaultValue: false,
+      metadata: {
+        dateAdded: '2025-08-2',
+        description: 'Use shared animation backend in C++ Animated',
+        expectedReleaseValue: true,
+        purpose: 'experimentation',
+      },
+      ossReleaseStage: 'none',
+    },
     useTurboModuleInterop: {
       defaultValue: false,
       metadata: {

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<cddccaa2570aa27af142d90430a14044>>
+ * @generated SignedSource<<3507d3aa8ee32332308a94bf932e01c2>>
  * @flow strict
  * @noformat
  */
@@ -121,6 +121,7 @@ export type ReactNativeFeatureFlags = $ReadOnly<{
   useOptimizedEventBatchingOnAndroid: Getter<boolean>,
   useRawPropsJsiValue: Getter<boolean>,
   useShadowNodeStateOnClone: Getter<boolean>,
+  useSharedAnimatedBackend: Getter<boolean>,
   useTurboModuleInterop: Getter<boolean>,
   useTurboModules: Getter<boolean>,
   viewCullingOutsetRatio: Getter<number>,
@@ -491,6 +492,10 @@ export const useRawPropsJsiValue: Getter<boolean> = createNativeFlagGetter('useR
  * Use the state stored on the source shadow node when cloning it instead of reading in the most recent state on the shadow node family.
  */
 export const useShadowNodeStateOnClone: Getter<boolean> = createNativeFlagGetter('useShadowNodeStateOnClone', false);
+/**
+ * Use shared animation backend in C++ Animated
+ */
+export const useSharedAnimatedBackend: Getter<boolean> = createNativeFlagGetter('useSharedAnimatedBackend', false);
 /**
  * In Bridgeless mode, should legacy NativeModules use the TurboModule system?
  */

--- a/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/specs/NativeReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<765a2f99602c00c38047e25ce805af86>>
+ * @generated SignedSource<<da804704d063a7f5eacdf1f5b7a15a6f>>
  * @flow strict
  * @noformat
  */
@@ -96,6 +96,7 @@ export interface Spec extends TurboModule {
   +useOptimizedEventBatchingOnAndroid?: () => boolean;
   +useRawPropsJsiValue?: () => boolean;
   +useShadowNodeStateOnClone?: () => boolean;
+  +useSharedAnimatedBackend?: () => boolean;
   +useTurboModuleInterop?: () => boolean;
   +useTurboModules?: () => boolean;
   +viewCullingOutsetRatio?: () => number;

--- a/private/react-native-fantom/tester/CMakeLists.txt
+++ b/private/react-native-fantom/tester/CMakeLists.txt
@@ -75,6 +75,7 @@ add_react_common_subdir(react/nativemodule/webperformance)
 add_react_common_subdir(react/performance/cdpmetrics)
 add_react_common_subdir(react/performance/timeline)
 add_react_common_subdir(react/renderer/animated)
+add_react_common_subdir(react/renderer/animationbackend)
 add_react_common_subdir(react/renderer/attributedstring)
 add_react_common_subdir(react/renderer/bridging)
 add_react_common_subdir(react/renderer/componentregistry)
@@ -231,6 +232,7 @@ target_link_libraries(fantom_tester
     react_cxx_platform_react_logging
     react_cxx_platform_react_profiling
     react_renderer_animated
+    react_renderer_animationbackend
     react_cxx_platform_react_renderer_scheduler
     react_cxx_platform_react_runtime
     react_cxx_platform_react_threading


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Initialize the Animation Backend - a unified way to modify view styles, that can be used by animation libraries. In it's current design it allows libraries to register a callback on each frame, that pushes a list of mutations to the platform. The idea is to pass the props as diffs to minimize the cost. The current implementation of `AnimatedProps` is subject to change, as it is not really optimised and doesn't cover many props (though there is a `folly::dynamic` fallback) - this is just a starting point. Animation libraries should rely on `AnimatedPropsBuilder`, since it should remain fairly stable over time.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[GENERAL] [ADDED] - AnimationBackend AnimatedProps AnimatedPropsBuilder
[GENERAL] [CHANGED] - NativeAnimatedNodesManagerProvider is (temporarily) responsible for initializing the backend

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

Run the fantom test for the Backend.
