### PR TITLE
[iOS] Replace `execSync` with `spawnSync` for tarball extraction paths that need to be escaped

### DIFF
--- a/packages/react-native/scripts/replace-rncore-version.js
+++ b/packages/react-native/scripts/replace-rncore-version.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const {execSync} = require('child_process');
+const {spawnSync} = require('child_process');
 const fs = require('fs');
 const yargs = require('yargs');
 
@@ -67,7 +67,9 @@ function replaceRNCoreConfiguration(
   fs.mkdirSync(finalLocation, {recursive: true});
 
   console.log('Extracting the tarball', tarballURLPath);
-  execSync(`tar -xf ${tarballURLPath} -C ${finalLocation}`);
+  spawnSync('tar', ['-xf', tarballURLPath, '-C', finalLocation], {
+    stdio: 'inherit',
+  });
 }
 
 function updateLastBuildConfiguration(configuration /*: string */) {

--- a/packages/react-native/sdks/hermes-engine/utils/replace_hermes_version.js
+++ b/packages/react-native/sdks/hermes-engine/utils/replace_hermes_version.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const {execSync} = require('child_process');
+const {spawnSync} = require('child_process');
 const fs = require('fs');
 const yargs = require('yargs');
 
@@ -62,7 +62,9 @@ function replaceHermesConfiguration(configuration, version, podsRoot) {
   fs.mkdirSync(finalLocation, {recursive: true});
 
   console.log('Extracting the tarball');
-  execSync(`tar -xf ${tarballURLPath} -C ${finalLocation}`);
+  spawnSync('tar', ['-xf', tarballURLPath, '-C', finalLocation], {
+    stdio: 'inherit',
+  });
 }
 
 function updateLastBuildConfiguration(configuration) {

--- a/packages/react-native/third-party-podspecs/replace_dependencies_version.js
+++ b/packages/react-native/third-party-podspecs/replace_dependencies_version.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const {execSync} = require('child_process');
+const {spawnSync} = require('child_process');
 const fs = require('fs');
 const yargs = require('yargs');
 
@@ -66,7 +66,9 @@ function replaceRNDepsConfiguration(
   fs.mkdirSync(finalLocation, {recursive: true});
 
   console.log('Extracting the tarball', tarballURLPath);
-  execSync(`tar -xf ${tarballURLPath} -C ${finalLocation}`);
+  spawnSync('tar', ['-xf', tarballURLPath, '-C', finalLocation], {
+    stdio: 'inherit',
+  });
 
   // Now we need to remove the extra third-party folder as we do in the podspec's prepare-script
   // We need to take the ReactNativeDependencies.xcframework folder and move it up one level


### PR DESCRIPTION
## Summary:

Follow-up to #53194

This wasn't previously visible in testing without prebuilds and without a release build. This doesn't show up in debug builds.

When testing more against paths that contain spaces, I noticed that release builds can still run into trouble due to the use of `execSync` without escaping paths. While, in other scripts that aren't used in user-projects (afaict), we often escape with quotes and rely on `execSync` calling the shell (due to its `shell: true` default), in some scripts we don't have quote escapes.

That said, since paths could in theory contain quotes, adding quotes wouldn't be sufficient. Instead, since the affected `tar` calls are really trivial, we can instead use `spawnSync` with the `shell: false` default, which escapes arguments automatically.

## Changelog:

[IOS] [FIXED] - fix Node scripts related to prebuilt tarball extraction for paths containing whitespaces

## Test Plan:

- Create a project in a folder `with spaces` and build a release build
