### PR TITLE
Fix wrong default for `jsBundleAssetPath` on `DefaultReactHost`

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactHost.kt
@@ -44,7 +44,7 @@ public object DefaultReactHost {
    * @param jsMainModulePath the path to your app's main module on Metro. Usually `index` or
    *   `index.<platform>`
    * @param jsBundleAssetPath the path to the JS bundle relative to the assets directory. Will be
-   *   composed in a `asset://...` URL
+   *   composed in a `asset://...` URL. Usually `index.android.bundle`.
    * @param jsBundleFilePath the path to the JS bundle on the filesystem. Will be composed in a
    *   `file://...` URL
    * @param jsRuntimeFactory the JS engine to use for executing [ReactHost], default to Hermes.
@@ -63,7 +63,7 @@ public object DefaultReactHost {
       context: Context,
       packageList: List<ReactPackage>,
       jsMainModulePath: String = "index",
-      jsBundleAssetPath: String = "index",
+      jsBundleAssetPath: String = "index.android.bundle",
       jsBundleFilePath: String? = null,
       jsRuntimeFactory: JSRuntimeFactory? = null,
       useDevSupport: Boolean = ReactBuildConfig.DEBUG,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactNativeHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultReactNativeHost.kt
@@ -122,7 +122,7 @@ protected constructor(
         context,
         packages,
         jsMainModuleName,
-        bundleAssetName ?: "index",
+        bundleAssetName ?: "index.android.bundle",
         jsBundleFile,
         concreteJSRuntimeFactory,
         useDeveloperSupport,


### PR DESCRIPTION
Summary:
The default for `DefaultReactHost.getDefaultReactHost(...,jsBundleAssetPath,...)` is wrong.
The default should be `index.android.bundle`.

That's the same value we had for the same field in ReactNativeHost:
https://www.internalfb.com/code/fbsource/[76a814c7d27036f7056c9f2c7e1370746ed4ccd4]/xplat/js/react-native-github/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactNativeHost.java?lines=225-227

Having just `index` as default cause the app to instacrash on release because the bundle can't be found.

Differential Revision: D81435921


