### PR TITLE
Android: Add new configuration for `DevSupportManager`

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.kt
@@ -393,7 +393,7 @@ public open class ReactDelegate {
   public fun shouldShowDevMenuOrReload(keyCode: Int, event: KeyEvent?): Boolean {
     val devSupportManager = devSupportManager
     // shouldShowDevMenuOrReload is a Dev API and not supported in RELEASE mode.
-    if (devSupportManager == null || devSupportManager is ReleaseDevSupportManager) {
+    if (devSupportManager == null || devSupportManager is ReleaseDevSupportManager || !devSupportManager.keyboardShortcutsEnabled) {
       return false
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactHost.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactHost.kt
@@ -14,6 +14,7 @@ import android.os.Bundle
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.queue.ReactQueueConfiguration
 import com.facebook.react.common.LifecycleState
+import com.facebook.react.devsupport.DevMenuConfiguration
 import com.facebook.react.devsupport.interfaces.DevSupportManager
 import com.facebook.react.interfaces.TaskInterface
 import com.facebook.react.interfaces.fabric.ReactSurface
@@ -189,4 +190,7 @@ public interface ReactHost {
 
   /** Remove a listener previously added with [addReactInstanceEventListener]. */
   public fun removeReactInstanceEventListener(listener: ReactInstanceEventListener)
+
+  /** Set the DevMenu configuration. */
+  public fun setDevMenuConfiguration(config: DevMenuConfiguration)
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevMenuConfiguration.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevMenuConfiguration.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+ package com.facebook.react.devsupport
+
+import com.facebook.react.BuildConfig
+
+
+public data class DevMenuConfiguration(
+  val isDevMenuEnabled: Boolean = BuildConfig.DEBUG,
+  val isShakeGestureEnabled: Boolean = true,
+  val areKeyboardShortcutsEnabled: Boolean = true,
+ )

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.kt
@@ -144,6 +144,12 @@ public abstract class DevSupportManagerBase(
       }
     }
 
+  final override var keyboardShortcutsEnabled: Boolean
+    get() = areKeyboardShortcutsEnabled
+    set(areKeyboardShortcutsEnabled) {
+      this.areKeyboardShortcutsEnabled = areKeyboardShortcutsEnabled
+    }
+
   override val sourceMapUrl: String
     get() = jsAppBundleName?.let { devServerHelper.getSourceMapUrl(it) } ?: ""
 
@@ -189,6 +195,7 @@ public abstract class DevSupportManagerBase(
   private var isDevSupportEnabled = false
   private var isDevMenuEnabled = true
   private var isShakeGestureEnabled = true
+  private var areKeyboardShortcutsEnabled = true
   private var isPackagerConnected = false
   private val errorCustomizers: MutableList<ErrorCustomizer> = mutableListOf()
   private var packagerLocationCustomizer: PackagerLocationCustomizer? = null

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.kt
@@ -129,6 +129,21 @@ public abstract class DevSupportManagerBase(
       reloadSettings()
     }
 
+  final override var devMenuEnabled: Boolean
+    get() = isDevMenuEnabled
+    set(isDevMenuEnabled) {
+      this.isDevMenuEnabled = isDevMenuEnabled
+    }
+
+  final override var shakeGestureEnabled: Boolean
+    get() = isShakeGestureEnabled
+    set(isShakeGestureEnabled) {
+      this.isShakeGestureEnabled = isShakeGestureEnabled
+      if (!isShakeGestureEnabled && isShakeDetectorStarted) {
+        stopShakeDetector()
+      }
+    }
+
   override val sourceMapUrl: String
     get() = jsAppBundleName?.let { devServerHelper.getSourceMapUrl(it) } ?: ""
 
@@ -172,6 +187,8 @@ public abstract class DevSupportManagerBase(
   private var isReceiverRegistered = false
   private var isShakeDetectorStarted = false
   private var isDevSupportEnabled = false
+  private var isDevMenuEnabled = true
+  private var isShakeGestureEnabled = true
   private var isPackagerConnected = false
   private val errorCustomizers: MutableList<ErrorCustomizer> = mutableListOf()
   private var packagerLocationCustomizer: PackagerLocationCustomizer? = null
@@ -330,7 +347,7 @@ public abstract class DevSupportManagerBase(
   }
 
   override fun showDevOptionsDialog() {
-    if (devOptionsDialog != null || !isDevSupportEnabled || ActivityManager.isUserAMonkey()) {
+    if (devOptionsDialog != null || !isDevSupportEnabled || ActivityManager.isUserAMonkey() || !isDevMenuEnabled) {
       return
     }
     val options = LinkedHashMap<String, DevOptionHandler>()
@@ -801,6 +818,11 @@ public abstract class DevSupportManagerBase(
     }
   }
 
+  private fun stopShakeDetector() {
+    shakeDetector.stop()
+    isShakeDetectorStarted = false
+  }
+
   private fun reload() {
     UiThreadUtil.assertOnUiThread()
 
@@ -810,7 +832,7 @@ public abstract class DevSupportManagerBase(
       debugOverlayController?.setFpsDebugViewVisible(devSettings.isFpsDebugEnabled)
 
       // start shake gesture detector
-      if (!isShakeDetectorStarted) {
+      if (!isShakeDetectorStarted && isShakeGestureEnabled) {
         val sensorManager =
             applicationContext.getSystemService(Context.SENSOR_SERVICE) as SensorManager
         shakeDetector.start(sensorManager)
@@ -867,8 +889,7 @@ public abstract class DevSupportManagerBase(
 
       // stop shake gesture detector
       if (isShakeDetectorStarted) {
-        shakeDetector.stop()
-        isShakeDetectorStarted = false
+        stopShakeDetector()
       }
 
       // unregister app reload broadcast receiver

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/ReleaseDevSupportManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/ReleaseDevSupportManager.kt
@@ -72,6 +72,14 @@ public open class ReleaseDevSupportManager : DevSupportManager {
     get() = false
     @Suppress("UNUSED_PARAMETER") set(isDevSupportEnabled: Boolean): Unit = Unit
 
+  public override var devMenuEnabled: Boolean
+    get() = false
+    @Suppress("UNUSED_PARAMETER") set(isDevMenuEnabled: Boolean): Unit = Unit
+
+  public override var shakeGestureEnabled: Boolean
+    get() = false
+    @Suppress("UNUSED_PARAMETER") set(isShakeGestureEnabled: Boolean): Unit = Unit
+
   public override val devSettings: DeveloperSettings?
     get() = null
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/ReleaseDevSupportManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/ReleaseDevSupportManager.kt
@@ -80,6 +80,10 @@ public open class ReleaseDevSupportManager : DevSupportManager {
     get() = false
     @Suppress("UNUSED_PARAMETER") set(isShakeGestureEnabled: Boolean): Unit = Unit
 
+  public override var keyboardShortcutsEnabled: Boolean
+    get() = false
+    @Suppress("UNUSED_PARAMETER") set(areKeyboardShortcutsEnabled: Boolean): Unit = Unit
+
   public override val devSettings: DeveloperSettings?
     get() = null
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.kt
@@ -35,6 +35,9 @@ public interface DevSupportManager : JSExceptionHandler {
   public val lastErrorCookie: Int
   public val currentActivity: Activity?
   public val currentReactContext: ReactContext?
+  public var devMenuEnabled: Boolean
+
+  public var shakeGestureEnabled: Boolean
 
   public var devSupportEnabled: Boolean
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevSupportManager.kt
@@ -39,6 +39,8 @@ public interface DevSupportManager : JSExceptionHandler {
 
   public var shakeGestureEnabled: Boolean
 
+  public var keyboardShortcutsEnabled: Boolean
+
   public var devSupportEnabled: Boolean
 
   public fun showNewJavaError(message: String?, e: Throwable)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.kt
@@ -41,6 +41,7 @@ import com.facebook.react.common.build.ReactBuildConfig
 import com.facebook.react.devsupport.DefaultDevSupportManagerFactory
 import com.facebook.react.devsupport.DevSupportManagerBase
 import com.facebook.react.devsupport.DevSupportManagerFactory
+import com.facebook.react.devsupport.DevMenuConfiguration
 import com.facebook.react.devsupport.InspectorFlags
 import com.facebook.react.devsupport.inspector.InspectorNetworkHelper
 import com.facebook.react.devsupport.inspector.InspectorNetworkRequestListener
@@ -359,6 +360,11 @@ public class ReactHostImpl(
   /** Remove a listener previously added with [addReactInstanceEventListener]. */
   override fun removeReactInstanceEventListener(listener: ReactInstanceEventListener) {
     reactInstanceEventListeners.remove(listener)
+  }
+
+  override fun setDevMenuConfiguration(config: DevMenuConfiguration) {
+    devSupportManager.devMenuEnabled = config.isDevMenuEnabled
+    devSupportManager.shakeGestureEnabled = config.isShakeGestureEnabled
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.kt
@@ -365,6 +365,7 @@ public class ReactHostImpl(
   override fun setDevMenuConfiguration(config: DevMenuConfiguration) {
     devSupportManager.devMenuEnabled = config.isDevMenuEnabled
     devSupportManager.shakeGestureEnabled = config.isShakeGestureEnabled
+    devSupportManager.keyboardShortcutsEnabled = config.areKeyboardShortcutsEnabled
   }
 
   /**

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterActivity.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterActivity.kt
@@ -19,6 +19,7 @@ import com.facebook.react.FBRNTesterEndToEndHelper
 import com.facebook.react.ReactActivity
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
 import com.facebook.react.defaults.DefaultReactActivityDelegate
+import com.facebook.react.devsupport.DevMenuConfiguration
 import java.io.FileDescriptor
 import java.io.PrintWriter
 
@@ -30,6 +31,8 @@ internal class RNTesterActivity : ReactActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
       // Get remote param before calling super which uses it
+
+
       val bundle = activity.intent?.extras
 
       if (bundle != null && bundle.containsKey(PARAM_ROUTE)) {
@@ -65,6 +68,14 @@ internal class RNTesterActivity : ReactActivity() {
 
     fullyDrawnReporter.addReporter()
     maybeUpdateBackgroundColor()
+
+    reactDelegate?.reactHost?.let { reactHost ->
+      val devMenuConfiguration = DevMenuConfiguration(
+        isDevMenuEnabled = true,
+        isShakeGestureEnabled = false,
+      )
+      reactHost.setDevMenuConfiguration(devMenuConfiguration)
+    }
 
     // register insets listener to update margins on the ReactRootView to avoid overlap w/ system
     // bars

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterActivity.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterActivity.kt
@@ -73,6 +73,7 @@ internal class RNTesterActivity : ReactActivity() {
       val devMenuConfiguration = DevMenuConfiguration(
         isDevMenuEnabled = true,
         isShakeGestureEnabled = false,
+        areKeyboardShortcutsEnabled = false,
       )
       reactHost.setDevMenuConfiguration(devMenuConfiguration)
     }


### PR DESCRIPTION
## Summary:

WIP

Following the [RFC](https://github.com/react-native-community/discussions-and-proposals/pull/925), this PR adds new `DevMenuConfiguration` object and extends `ReactHost` API for passing settings to the particular `DevSupportManager`.  The `DevMenuConfiguration` includes ]:

- isDevMenuEnabled,
- isShakeGestureEnabled,
- areKeyboardShortcutsEnabled,

## Changelog:

[ANDROID][ADDED] - Add new configuration for `RCTDevMenu` 

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
