### PR TITLE
add comments regarding RCTPackagerConnection's reconnect 

### DIFF
--- a/packages/react-native/React/DevSupport/RCTPackagerConnection.h
+++ b/packages/react-native/React/DevSupport/RCTPackagerConnection.h
@@ -59,7 +59,7 @@ typedef void (^RCTConnectedHandler)(void);
 /** Disconnects and removes all handlers. */
 - (void)stop;
 
-/** Reconnect with given packager server. */
+/** Reconnect with given packager server, if packagerServerHostPort has changed. */
 - (void)reconnect:(NSString *)packagerServerHostPort;
 
 /**

--- a/packages/react-native/React/DevSupport/RCTPackagerConnection.mm
+++ b/packages/react-native/React/DevSupport/RCTPackagerConnection.mm
@@ -160,6 +160,7 @@ static RCTReconnectingWebSocket *socketForLocation(NSString *const serverHostPor
 
 - (void)bundleURLSettingsChanged
 {
+  // Will only reconnect if `packagerServerHostPort` has actually changed
   [self reconnect:[[RCTBundleURLProvider sharedSettings] packagerServerHostPort]];
 }
 


### PR DESCRIPTION
Changelog: [Internal]
Got confused regarding why "reconnect" does not actually trigger a reconnect. It turns out, it only triggers a reconnect if the URL has changed.

Differential Revision: D80629308


