### PR TITLE
Fix build from source for 0.82 due to Gradle 9.0

### DIFF
--- a/packages/react-native/settings.gradle.kts
+++ b/packages/react-native/settings.gradle.kts
@@ -29,3 +29,12 @@ include(":packages:react-native:ReactAndroid:hermes-engine")
 
 project(":packages:react-native:ReactAndroid:hermes-engine").projectDir =
     file("ReactAndroid/hermes-engine/")
+
+// Since Gradle 9.0, all the projects in the path must have an existing folder.
+// As we build :packages:react-native:ReactAndroid, we need to declare the folders
+// for :packages and :packages:react-native as well as otherwise the build from
+// source will fail with a missing folder exception.
+
+project(":packages").projectDir = file("/tmp")
+
+project(":packages:react-native").projectDir = file("/tmp")


### PR DESCRIPTION
Summary:
Since Gradle 9.0, all the projects in the path must have an existing folder.
As we build :packages:react-native:ReactAndroid, we need to declare the folders
for :packages and :packages:react-native as well as otherwise the build from
source will fail with a missing folder exception.

Changelog:
[Android] [Fixed] - Fix build from source due to missing folder error on Gradle 9.0

Differential Revision: D81482789


