### PR TITLE
Export `@react-native/typescript-config/strict` shorthand

### DIFF
--- a/packages/typescript-config/README.md
+++ b/packages/typescript-config/README.md
@@ -3,3 +3,26 @@
 This package provides the default `tsconfig.json` used by newly built React Native apps.
 
 This template is customized for specific versions of React Native, and should be updated in sync with the rest of your app.
+
+## Strict TypeScript API
+
+To opt into the new [strict TypeScript API](https://reactnative.dev/blog/2025/06/12/moving-towards-a-stable-javascript-api#strict-typescript-api-opt-in) you can extend from `@react-native/typescript-config/strict`
+
+```jsonc
+{
+  "extends": "@react-native/typescript-config/strict",
+  // ...
+}
+```
+
+or alternatively add the `customConditions` yourself:
+
+```jsonc
+{
+  "extends": "@react-native/typescript-config",
+  "compilerOptions": {
+    // ...
+    "customConditions": ["react-native-strict-api", "react-native"]
+  }
+}
+```

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -15,5 +15,8 @@
     "react-native"
   ],
   "bugs": "https://github.com/facebook/react-native/issues",
-  "main": "tsconfig.json"
+  "exports": {
+    ".": "./tsconfig.json",
+    "./strict": "./tsconfig.strict.json"
+  }
 }

--- a/packages/typescript-config/tsconfig.strict.json
+++ b/packages/typescript-config/tsconfig.strict.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "display": "React Native (Strict)",
+  "compilerOptions": {
+    "customConditions": ["react-native-strict-api", "react-native"]
+  }
+}


### PR DESCRIPTION
## Summary:

Extending a tsconfig seems simpler than adding `compilerOptions` with `customConditions`.

### Before

```jsonc
{
  "extends": "@react-native/typescript-config",
  "compilerOptions": {
    // ...
    "customConditions": ["react-native-strict-api", "react-native"]
  }
}
```

### After

```jsonc
{
  "extends": "@react-native/typescript-config/strict"
  // ...
}
```

## Changelog:

[GENERAL] [ADDED] - Add `@react-native/typescript-config/strict` export enabling the `react-native-strict-api` custom condition.

## Test Plan:

### `package.json`

```
{
  "name": "react-native-ts-test",
  "private": true,
  "version": "0.1.0",
  "scripts": {
    "build": "tsc --noEmit"
  },
  "devDependencies": {
    "@react-native/typescript-config": "^0.81.1",
    "typescript": "^5.9.2",
    "jest": "^30.1.2"
  },
  "dependencies": {
    "react-native": "^0.81.1"
  }
}
```

### `tsconfig.json`

```
{
  "extends": "@react-native/typescript-config/strict",
  "include": ["src/index.ts"]
}
```

### `src/index.ts`

```
import { View } from "react-native";
```

Run `npx resolution-explorer` and select "react-native from src/index.ts to node_modules/react-native/types_generated/index.d.ts" to verify the types are resolved correctly.

```
Explicitly specified module resolution kind: 'Bundler'.                                                                                                                      
Resolving in CJS mode with conditions 'import', 'types', 'react-native-strict-api'.                                                                                          
File '/Users/kraen.hansen/Repositories/react-native-ts-test/src/package.json' does not exist.                                                                                
Found 'package.json' at '/Users/kraen.hansen/Repositories/react-native-ts-test/package.json'.                                                                                
Loading module 'react-native' from 'node_modules' folder, target file types: TypeScript, JavaScript, Declaration, JSON.                                                      
Searching all ancestor node_modules directories for preferred extensions: TypeScript, Declaration.                                                                           
Directory '/Users/kraen.hansen/Repositories/react-native-ts-test/src/node_modules' does not exist, skipping all lookups in it.                                               
Found 'package.json' at '/Users/kraen.hansen/Repositories/react-native-ts-test/node_modules/react-native/package.json'.                                                      
Entering conditional exports.                                                                                                                                                
Matched 'exports' condition 'react-native-strict-api'.                                                                                                                       
Using 'exports' subpath '.' with target './types_generated/index.d.ts'.                                                                                                      
File '/Users/kraen.hansen/Repositories/react-native-ts-test/node_modules/react-native/types_generated/index.d.ts' exists - use it as a name resolution result.               
'package.json' has a 'peerDependencies' field.                                                                                                                               
Resolving real path for '/Users/kraen.hansen/Repositories/react-native-ts-test/node_modules/react-native', result                                                            
'/Users/kraen.hansen/Repositories/react-native-ts-test/node_modules/react-native'.                                                                                           
Failed to find peerDependency '@types/react'.                                                                                                                                
Found 'package.json' at '/Users/kraen.hansen/Repositories/react-native-ts-test/node_modules/react/package.json'.                                                             
Found peerDependency 'react' with '19.1.1' version.                                                                                                                          
Resolved under condition 'react-native-strict-api'.                                                                                                                          
Exiting conditional exports.                                                                                                                                                 
Resolving real path for '/Users/kraen.hansen/Repositories/react-native-ts-test/node_modules/react-native/types_generated/index.d.ts', result                                 
'/Users/kraen.hansen/Repositories/react-native-ts-test/node_modules/react-native/types_generated/index.d.ts'.                                                                
======== Module name 'react-native' was successfully resolved to                                                                                                             
'/Users/kraen.hansen/Repositories/react-native-ts-test/node_modules/react-native/types_generated/index.d.ts' with Package ID                                                 
'react-native/types_generated/index.d.ts@0.81.1+react@19.1.1'. ======== 
```