### PR TITLE
Mark JavaTimerManager idle callback methods as @LegacyArchitecture

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/JavaTimerManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/JavaTimerManager.kt
@@ -18,6 +18,7 @@ import com.facebook.react.bridge.WritableArray
 import com.facebook.react.common.SystemClock.currentTimeMillis
 import com.facebook.react.common.SystemClock.nanoTime
 import com.facebook.react.common.SystemClock.uptimeMillis
+import com.facebook.react.common.annotations.internal.LegacyArchitecture
 import com.facebook.react.devsupport.interfaces.DevSupportManager
 import com.facebook.react.jstasks.HeadlessJsTaskContext
 import com.facebook.react.jstasks.HeadlessJsTaskEventListener
@@ -110,6 +111,7 @@ public open class JavaTimerManager(
     clearChoreographerIdleCallback()
   }
 
+  @LegacyArchitecture
   private fun maybeSetChoreographerIdleCallback() {
     synchronized(idleCallbackGuard) {
       if (sendIdleEvents) {
@@ -118,6 +120,7 @@ public open class JavaTimerManager(
     }
   }
 
+  @LegacyArchitecture
   private fun maybeIdleCallback() {
     if (isPaused.get() && !isRunningTasks.get()) {
       clearFrameCallback()
@@ -145,6 +148,7 @@ public open class JavaTimerManager(
     }
   }
 
+  @LegacyArchitecture
   private fun setChoreographerIdleCallback() {
     if (!frameIdleCallbackPosted) {
       reactChoreographer.postFrameCallback(
@@ -155,6 +159,7 @@ public open class JavaTimerManager(
     }
   }
 
+  @LegacyArchitecture
   private fun clearChoreographerIdleCallback() {
     if (frameIdleCallbackPosted) {
       reactChoreographer.removeFrameCallback(
@@ -235,6 +240,7 @@ public open class JavaTimerManager(
   }
 
   @DoNotStrip
+  @LegacyArchitecture
   public open fun setSendIdleEvents(sendIdleEvents: Boolean) {
     synchronized(idleCallbackGuard) { this.sendIdleEvents = sendIdleEvents }
     UiThreadUtil.runOnUiThread {
@@ -328,6 +334,7 @@ public open class JavaTimerManager(
     }
   }
 
+  @LegacyArchitecture
   private inner class IdleCallbackRunnable(private val frameStartTime: Long) : Runnable {
     @Volatile private var isCancelled = false
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/JSTimerExecutor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/JSTimerExecutor.kt
@@ -7,15 +7,20 @@
 
 package com.facebook.react.runtime
 
-import com.facebook.jni.HybridData
-import com.facebook.jni.annotations.DoNotStripAny
+import com.facebook.jni.HybridClassBase
+import com.facebook.jni.annotations.DoNotStrip
 import com.facebook.react.bridge.WritableArray
 import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.modules.core.JavaScriptTimerExecutor
 import com.facebook.soloader.SoLoader
 
-@DoNotStripAny
-internal class JSTimerExecutor(private val mHybridData: HybridData) : JavaScriptTimerExecutor {
+@DoNotStrip
+internal class JSTimerExecutor() : HybridClassBase(), JavaScriptTimerExecutor {
+  init {
+    initHybrid()
+  }
+
+  private external fun initHybrid()
 
   private external fun callTimers(timerIDs: WritableNativeArray)
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.kt
@@ -76,7 +76,6 @@ import java.util.ArrayList
 import java.util.HashMap
 import java.util.HashSet
 import kotlin.collections.Collection
-import kotlin.jvm.JvmStatic
 
 /**
  * A replacement for [com.facebook.react.bridge.CatalystInstance] responsible for creating and
@@ -126,7 +125,7 @@ internal class ReactInstance(
     ReactChoreographer.initialize(AndroidChoreographerProvider.getInstance())
     devSupportManager.startInspector()
 
-    val jsTimerExecutor = createJSTimerExecutor()
+    val jsTimerExecutor = JSTimerExecutor()
     javaTimerManager =
         JavaTimerManager(
             context,
@@ -182,7 +181,6 @@ internal class ReactInstance(
             getJSCallInvokerHolder(),
             getNativeMethodCallInvokerHolder(),
         )
-
     Systrace.endSection(Systrace.TRACE_TAG_REACT)
 
     // Set up Fabric
@@ -633,7 +631,5 @@ internal class ReactInstance(
         SystraceMessage.endSection(Systrace.TRACE_TAG_REACT).flush()
       }
     }
-
-    @JvmStatic @DoNotStrip private external fun createJSTimerExecutor(): JSTimerExecutor
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JJSTimerExecutor.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JJSTimerExecutor.cpp
@@ -12,6 +12,11 @@
 
 namespace facebook::react {
 
+void JJSTimerExecutor::initHybrid(
+    jni::alias_ref<JJSTimerExecutor::jhybridobject> jobj) {
+  setCxxInstance(jobj);
+}
+
 void JJSTimerExecutor::setTimerManager(
     std::weak_ptr<TimerManager> timerManager) {
   timerManager_ = timerManager;
@@ -28,6 +33,7 @@ void JJSTimerExecutor::callTimers(WritableNativeArray* timerIDs) {
 void JJSTimerExecutor::registerNatives() {
   registerHybrid({
       makeNativeMethod("callTimers", JJSTimerExecutor::callTimers),
+      makeNativeMethod("initHybrid", JJSTimerExecutor::initHybrid),
   });
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JJSTimerExecutor.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JJSTimerExecutor.h
@@ -17,18 +17,20 @@ namespace facebook::react {
 
 class JJSTimerExecutor : public jni::HybridClass<JJSTimerExecutor> {
  public:
-  JJSTimerExecutor() = default;
-
   constexpr static auto kJavaDescriptor =
       "Lcom/facebook/react/runtime/JSTimerExecutor;";
 
   static void registerNatives();
+
+  static void initHybrid(jni::alias_ref<jhybridobject> jobj);
 
   void setTimerManager(std::weak_ptr<TimerManager> timerManager);
 
   void callTimers(WritableNativeArray* timerIDs);
 
  private:
+  JJSTimerExecutor() = default;
+
   friend HybridBase;
 
   std::weak_ptr<TimerManager> timerManager_;

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactInstance.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactInstance.cpp
@@ -168,12 +168,6 @@ JReactInstance::getNativeMethodCallInvokerHolder() {
   return nativeMethodCallInvokerHolder_;
 }
 
-jni::global_ref<JJSTimerExecutor::javaobject>
-JReactInstance::createJSTimerExecutor(
-    jni::alias_ref<jhybridobject> /* unused */) {
-  return jni::make_global(JJSTimerExecutor::newObjectCxxArgs());
-}
-
 void JReactInstance::callFunctionOnModule(
     const std::string& moduleName,
     const std::string& methodName,
@@ -217,8 +211,6 @@ void JReactInstance::unregisterFromInspector() {
 void JReactInstance::registerNatives() {
   registerHybrid({
       makeNativeMethod("initHybrid", JReactInstance::initHybrid),
-      makeNativeMethod(
-          "createJSTimerExecutor", JReactInstance::createJSTimerExecutor),
       makeNativeMethod(
           "loadJSBundleFromAssets", JReactInstance::loadJSBundleFromAssets),
       makeNativeMethod(

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactInstance.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactInstance.h
@@ -50,12 +50,6 @@ class JReactInstance : public jni::HybridClass<JReactInstance> {
       jni::alias_ref<JReactHostInspectorTarget::javaobject>
           jReactHostInspectorTarget);
 
-  /*
-   * Instantiates and returns an instance of `JSTimerExecutor`.
-   */
-  static jni::global_ref<JJSTimerExecutor::javaobject> createJSTimerExecutor(
-      jni::alias_ref<jhybridobject> /* unused */);
-
   static void registerNatives();
 
   void loadJSBundleFromAssets(


### PR DESCRIPTION
Summary: Idle callbacks are implemented as a C++ module in the new architecture, this code should not be used.

Differential Revision: D81485912


