### PR TITLE
VirtualView: Configurable Hidden Layout

### DIFF
--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -839,6 +839,16 @@ const definitions: FeatureFlagDefinitions = {
       },
       ossReleaseStage: 'stable',
     },
+    enableVirtualViewExperimental: {
+      defaultValue: false,
+      metadata: {
+        dateAdded: '2025-08-29',
+        description: 'Enables the experimental version of `VirtualView`.',
+        expectedReleaseValue: true,
+        purpose: 'experimentation',
+      },
+      ossReleaseStage: 'none',
+    },
     fixVirtualizeListCollapseWindowSize: {
       defaultValue: false,
       metadata: {

--- a/packages/react-native/src/private/components/virtualview/VirtualView.js
+++ b/packages/react-native/src/private/components/virtualview/VirtualView.js
@@ -16,7 +16,7 @@ import type {NativeModeChangeEvent} from './VirtualViewNativeComponent';
 import StyleSheet from '../../../../Libraries/StyleSheet/StyleSheet';
 import * as ReactNativeFeatureFlags from '../../featureflags/ReactNativeFeatureFlags';
 import VirtualViewExperimentalNativeComponent from './VirtualViewExperimentalNativeComponent';
-import VirtualViewNativeComponent from './VirtualViewNativeComponent';
+import VirtualViewClassicNativeComponent from './VirtualViewNativeComponent';
 import nullthrows from 'nullthrows';
 import * as React from 'react';
 // $FlowFixMe[missing-export]
@@ -49,6 +49,11 @@ export type ModeChangeEvent = $ReadOnly<{
   target: HostInstance,
 }>;
 
+const VirtualViewNativeComponent: typeof VirtualViewClassicNativeComponent =
+  ReactNativeFeatureFlags.enableVirtualViewExperimental()
+    ? VirtualViewExperimentalNativeComponent
+    : VirtualViewClassicNativeComponent;
+
 type VirtualViewComponent = component(
   children?: React.Node,
   nativeID?: string,
@@ -63,15 +68,8 @@ const NotHidden = null;
 
 type State = HiddenHeight | typeof NotHidden;
 
-function createVirtualView(
-  initialState: State,
-  experimental: boolean,
-): VirtualViewComponent {
+function createVirtualView(initialState: State): VirtualViewComponent {
   const initialHidden = initialState !== NotHidden;
-
-  const NativeComponent = experimental
-    ? VirtualViewExperimentalNativeComponent
-    : VirtualViewNativeComponent;
 
   component VirtualView(
     children?: React.Node,
@@ -124,7 +122,7 @@ function createVirtualView(
     };
 
     return (
-      <NativeComponent
+      <VirtualViewNativeComponent
         initialHidden={initialHidden}
         nativeID={nativeID}
         ref={ref}
@@ -153,24 +151,16 @@ function createVirtualView(
             'no-activity' | _ => isHidden ? null : children,
           }
         }
-      </NativeComponent>
+      </VirtualViewNativeComponent>
     );
   }
   return VirtualView;
 }
 
-export default createVirtualView(NotHidden, false) as VirtualViewComponent;
+export default createVirtualView(NotHidden) as VirtualViewComponent;
 
-export const VirtualViewExperimental = createVirtualView(
-  NotHidden,
-  true,
-) as VirtualViewComponent;
-
-export function createHiddenVirtualView(
-  height: number,
-  experimental: boolean,
-): VirtualViewComponent {
-  return createVirtualView(height as HiddenHeight, experimental);
+export function createHiddenVirtualView(height: number): VirtualViewComponent {
+  return createVirtualView(height as HiddenHeight);
 }
 
 export const _logs: {states?: Array<State>} = {};

--- a/packages/react-native/src/private/components/virtualview/__tests__/VirtualView-itest.js
+++ b/packages/react-native/src/private/components/virtualview/__tests__/VirtualView-itest.js
@@ -119,19 +119,19 @@ describe('mode changes', () => {
 });
 
 describe('styles', () => {
-  test('does not set height when visible', () => {
+  test('does not set styles when visible', () => {
     const root = Fantom.createRoot();
 
     Fantom.runTask(() => {
       root.render(<VirtualView />);
     });
 
-    expect(root.getRenderedOutput({props: ['height']}).toJSX()).toEqual(
-      <rn-virtualView />,
-    );
+    expect(
+      root.getRenderedOutput({props: ['minHeight', 'minWidth']}).toJSX(),
+    ).toEqual(<rn-virtualView />);
   });
 
-  test('does not set height when prerendered', () => {
+  test('does not set styles when prerendered', () => {
     const root = Fantom.createRoot();
     const viewRef = createRef<React.RefOf<VirtualView>>();
 
@@ -141,12 +141,12 @@ describe('styles', () => {
 
     dispatchModeChangeEvent(viewRef.current, VirtualViewMode.Prerender);
 
-    expect(root.getRenderedOutput({props: ['height']}).toJSX()).toEqual(
-      <rn-virtualView />,
-    );
+    expect(
+      root.getRenderedOutput({props: ['minHeight', 'minWidth']}).toJSX(),
+    ).toEqual(<rn-virtualView />);
   });
 
-  test('sets height when hidden', () => {
+  test('sets styles when hidden', () => {
     const root = Fantom.createRoot();
     const viewRef = createRef<React.RefOf<VirtualView>>();
 
@@ -156,9 +156,9 @@ describe('styles', () => {
 
     dispatchModeChangeEvent(viewRef.current, VirtualViewMode.Hidden);
 
-    expect(root.getRenderedOutput({props: ['height']}).toJSX()).toEqual(
-      <rn-virtualView height="100.000000" />,
-    );
+    expect(
+      root.getRenderedOutput({props: ['minHeight', 'minWidth']}).toJSX(),
+    ).toEqual(<rn-virtualView minHeight="100.000000" minWidth="100.000000" />);
   });
 });
 

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<8ac45d7dfef86becd1f0a7ec7ba8e999>>
+ * @generated SignedSource<<22523248acc3e378f3f81ef43406f106>>
  * @flow strict
  * @noformat
  */
@@ -34,6 +34,7 @@ export type ReactNativeFeatureFlagsJsOnly = $ReadOnly<{
   deferFlatListFocusChangeRenderUpdate: Getter<boolean>,
   disableMaintainVisibleContentPosition: Getter<boolean>,
   enableAccessToHostTreeInFabric: Getter<boolean>,
+  enableVirtualViewExperimental: Getter<boolean>,
   fixVirtualizeListCollapseWindowSize: Getter<boolean>,
   isLayoutAnimationEnabled: Getter<boolean>,
   reduceDefaultPropsInImage: Getter<boolean>,
@@ -149,6 +150,11 @@ export const disableMaintainVisibleContentPosition: Getter<boolean> = createJava
  * Enables access to the host tree in Fabric using DOM-compatible APIs.
  */
 export const enableAccessToHostTreeInFabric: Getter<boolean> = createJavaScriptFlagGetter('enableAccessToHostTreeInFabric', true);
+
+/**
+ * Enables the experimental version of `VirtualView`.
+ */
+export const enableVirtualViewExperimental: Getter<boolean> = createJavaScriptFlagGetter('enableVirtualViewExperimental', false);
 
 /**
  * Fixing an edge case where the current window size is not properly calculated with fast scrolling. Window size collapsed to 1 element even if windowSize more than the current amount of elements


### PR DESCRIPTION
Summary:
Changes `VirtualView` so that its layout when hidden can be configured by call sites.

Previously, it was hardcoded to only retain the last known height. However, this logic only works for `VirtualView` children oriented in a column layout.

This change enables the use of `VirtualView` in more flexible abstractions that require different hidden styles (e.g. row or grid orientations).

Also, this changes the default behavior to set `minWidth` and `minHeight`, so that the default behavior is more general and more likely to work in a reasonable manner in more use cases.

NOTE: Ideally, we would be able to default to using `flexBasis` instead. However, the `hiddenStyle` function receives a `Rect` and does not know whether the parent's flex direction is row or column to influence whether to use `targetRect.width` or `targetRect.height`. This is an opportunity for future improvement.

Changelog:
[Internal]

Differential Revision: D81344126
