### PR TITLE
Gate legacy debugger behind a preprocessor directive

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/hermes/reactexecutor/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/hermes/reactexecutor/CMakeLists.txt
@@ -27,4 +27,8 @@ target_link_libraries(
 target_compile_reactnative_options(hermes_executor PRIVATE)
 if(${CMAKE_BUILD_TYPE} MATCHES Debug OR REACT_NATIVE_DEBUG_OPTIMIZED)
   target_compile_options(hermes_executor PRIVATE -DHERMES_ENABLE_DEBUGGER=1)
+
+  if (DEFINED HERMES_V1_ENABLED)
+        target_compile_options(hermes_executor PRIVATE -DHERMES_V1_ENABLED=1)
+  endif()
 endif()

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/hermes/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/hermes/jni/CMakeLists.txt
@@ -29,4 +29,8 @@ target_link_libraries(hermesinstancejni
 target_compile_reactnative_options(hermesinstancejni PRIVATE)
 if(${CMAKE_BUILD_TYPE} MATCHES Debug OR REACT_NATIVE_DEBUG_OPTIMIZED)
   target_compile_options(hermesinstancejni PRIVATE -DHERMES_ENABLE_DEBUGGER=1)
+
+  if (DEFINED HERMES_V1_ENABLED)
+        target_compile_options(hermesinstancejni PRIVATE -DHERMES_V1_ENABLED=1)
+  endif()
 endif ()

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/CMakeLists.txt
@@ -19,6 +19,10 @@ add_library(rninstance
 target_compile_reactnative_options(rninstance PRIVATE)
 if(${CMAKE_BUILD_TYPE} MATCHES Debug OR REACT_NATIVE_DEBUG_OPTIMIZED)
   target_compile_options(rninstance PRIVATE -DHERMES_ENABLE_DEBUGGER=1)
+
+  if (DEFINED HERMES_V1_ENABLED)
+        target_compile_options(rninstance PRIVATE -DHERMES_V1_ENABLED=1)
+  endif()
 endif ()
 
 target_merge_so(rninstance)

--- a/packages/react-native/ReactCommon/hermes/executor/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/hermes/executor/CMakeLists.txt
@@ -32,6 +32,10 @@ if(${CMAKE_BUILD_TYPE} MATCHES Debug OR REACT_NATIVE_DEBUG_OPTIMIZED)
                 PRIVATE
                 -DHERMES_ENABLE_DEBUGGER=1
         )
+
+        if (DEFINED HERMES_V1_ENABLED)
+                target_compile_options(hermes_executor_common PRIVATE -DHERMES_V1_ENABLED=1)
+        endif()
 else()
         target_compile_options(
                 hermes_executor_common

--- a/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.cpp
+++ b/packages/react-native/ReactCommon/hermes/executor/HermesExecutorFactory.cpp
@@ -14,8 +14,11 @@
 #include <jsinspector-modern/InspectorFlags.h>
 
 #include <hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.h>
+
+#if defined(HERMES_ENABLE_DEBUGGER) && !defined(HERMES_V1_ENABLED)
 #include <hermes/inspector-modern/chrome/Registration.h>
 #include <hermes/inspector/RuntimeAdapter.h>
+#endif
 
 using namespace facebook::hermes;
 using namespace facebook::jsi;
@@ -24,7 +27,7 @@ namespace facebook::react {
 
 namespace {
 
-#ifdef HERMES_ENABLE_DEBUGGER
+#if defined(HERMES_ENABLE_DEBUGGER) && !defined(HERMES_V1_ENABLED)
 
 class HermesExecutorRuntimeAdapter
     : public facebook::hermes::inspector_modern::RuntimeAdapter {
@@ -59,7 +62,7 @@ class HermesExecutorRuntimeAdapter
   std::shared_ptr<MessageQueueThread> thread_;
 };
 
-#endif // HERMES_ENABLE_DEBUGGER
+#endif // defined(HERMES_ENABLE_DEBUGGER) && !defined(HERMES_V1_ENABLED)
 
 struct ReentrancyCheck {
 // This is effectively a very subtle and complex assert, so only
@@ -144,7 +147,7 @@ class DecoratedRuntime : public jsi::WithRuntimeDecorator<ReentrancyCheck> {
       const std::string& debuggerName)
       : jsi::WithRuntimeDecorator<ReentrancyCheck>(*runtime, reentrancyCheck_),
         runtime_(std::move(runtime)) {
-#ifdef HERMES_ENABLE_DEBUGGER
+#if defined(HERMES_ENABLE_DEBUGGER) && !defined(HERMES_V1_ENABLED)
     enableDebugger_ = enableDebugger;
     if (enableDebugger_) {
       std::shared_ptr<HermesRuntime> rt(runtime_, &hermesRuntime);
@@ -159,7 +162,7 @@ class DecoratedRuntime : public jsi::WithRuntimeDecorator<ReentrancyCheck> {
   }
 
   ~DecoratedRuntime() {
-#ifdef HERMES_ENABLE_DEBUGGER
+#if defined(HERMES_ENABLE_DEBUGGER) && !defined(HERMES_V1_ENABLED)
     if (enableDebugger_) {
       facebook::hermes::inspector_modern::chrome::disableDebugging(debugToken_);
     }
@@ -176,7 +179,7 @@ class DecoratedRuntime : public jsi::WithRuntimeDecorator<ReentrancyCheck> {
 
   std::shared_ptr<Runtime> runtime_;
   ReentrancyCheck reentrancyCheck_;
-#ifdef HERMES_ENABLE_DEBUGGER
+#if defined(HERMES_ENABLE_DEBUGGER) && !defined(HERMES_V1_ENABLED)
   bool enableDebugger_;
   facebook::hermes::inspector_modern::chrome::DebugSessionToken debugToken_;
 #endif // HERMES_ENABLE_DEBUGGER

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/CMakeLists.txt
@@ -23,6 +23,10 @@ if(${CMAKE_BUILD_TYPE} MATCHES Debug OR REACT_NATIVE_DEBUG_OPTIMIZED)
                 PRIVATE
                 -DHERMES_ENABLE_DEBUGGER=1
         )
+
+        if (DEFINED HERMES_V1_ENABLED)
+                target_compile_options(hermes_inspector_modern PRIVATE -DHERMES_V1_ENABLED=1)
+        endif()
 endif()
 
 target_include_directories(hermes_inspector_modern PUBLIC ${REACT_COMMON_DIR})

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/ConnectionDemux.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/ConnectionDemux.cpp
@@ -7,7 +7,7 @@
 
 #include "ConnectionDemux.h"
 
-#ifdef HERMES_ENABLE_DEBUGGER
+#if defined(HERMES_ENABLE_DEBUGGER) && !defined(HERMES_V1_ENABLED)
 
 #include <hermes/inspector/RuntimeAdapter.h>
 #include <hermes/inspector/chrome/CDPHandler.h>
@@ -139,4 +139,4 @@ void ConnectionDemux::removePage(int pageId) {
 
 } // namespace facebook::hermes::inspector_modern::chrome
 
-#endif // HERMES_ENABLE_DEBUGGER
+#endif // defined(HERMES_ENABLE_DEBUGGER) && !defined(HERMES_V1_ENABLED)

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/ConnectionDemux.h
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/ConnectionDemux.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#ifdef HERMES_ENABLE_DEBUGGER
+#if defined(HERMES_ENABLE_DEBUGGER) && !defined(HERMES_V1_ENABLED)
 
 #include <memory>
 #include <mutex>
@@ -59,4 +59,4 @@ class ConnectionDemux {
 
 } // namespace facebook::hermes::inspector_modern::chrome
 
-#endif // HERMES_ENABLE_DEBUGGER
+#endif // defined(HERMES_ENABLE_DEBUGGER) && !defined(HERMES_V1_ENABLED)

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/Registration.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/Registration.cpp
@@ -8,7 +8,7 @@
 #include "Registration.h"
 #include "ConnectionDemux.h"
 
-#ifdef HERMES_ENABLE_DEBUGGER
+#if defined(HERMES_ENABLE_DEBUGGER) && !defined(HERMES_V1_ENABLED)
 
 namespace facebook::hermes::inspector_modern::chrome {
 
@@ -34,4 +34,4 @@ void disableDebugging(DebugSessionToken session) {
 
 } // namespace facebook::hermes::inspector_modern::chrome
 
-#endif // HERMES_ENABLE_DEBUGGER
+#endif // defined(HERMES_ENABLE_DEBUGGER) && !defined(HERMES_V1_ENABLED)

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/Registration.h
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/Registration.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#ifdef HERMES_ENABLE_DEBUGGER
+#if defined(HERMES_ENABLE_DEBUGGER) && !defined(HERMES_V1_ENABLED)
 
 #include <memory>
 #include <string>
@@ -38,4 +38,4 @@ extern void disableDebugging(DebugSessionToken session);
 
 } // namespace facebook::hermes::inspector_modern::chrome
 
-#endif // HERMES_ENABLE_DEBUGGER
+#endif // defined(HERMES_ENABLE_DEBUGGER) && !defined(HERMES_V1_ENABLED)

--- a/packages/react-native/ReactCommon/react/runtime/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/runtime/CMakeLists.txt
@@ -18,6 +18,10 @@ add_library(bridgeless
 target_compile_reactnative_options(bridgeless PRIVATE)
 if(${CMAKE_BUILD_TYPE} MATCHES Debug OR REACT_NATIVE_DEBUG_OPTIMIZED)
   target_compile_options(bridgeless PRIVATE -DHERMES_ENABLE_DEBUGGER=1)
+
+  if (DEFINED HERMES_V1_ENABLED)
+        target_compile_options(bridgeless PRIVATE -DHERMES_V1_ENABLED=1)
+  endif()
 endif ()
 target_include_directories(bridgeless PUBLIC .)
 

--- a/packages/react-native/ReactCommon/react/runtime/hermes/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/runtime/hermes/CMakeLists.txt
@@ -35,4 +35,8 @@ if(${CMAKE_BUILD_TYPE} MATCHES Debug OR REACT_NATIVE_DEBUG_OPTIMIZED)
                 PRIVATE
                 -DHERMES_ENABLE_DEBUGGER=1
         )
+
+        if (DEFINED HERMES_V1_ENABLED)
+                target_compile_options(bridgelesshermes PRIVATE -DHERMES_V1_ENABLED=1)
+        endif()
 endif()

--- a/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/hermes/HermesInstance.cpp
@@ -14,7 +14,11 @@
 
 #ifdef HERMES_ENABLE_DEBUGGER
 #include <hermes/inspector-modern/chrome/Registration.h>
+
+#ifndef HERMES_V1_ENABLED
 #include <hermes/inspector/RuntimeAdapter.h>
+#endif
+
 #include <jsi/decorator.h>
 #endif
 
@@ -23,7 +27,7 @@ using namespace facebook::jsi;
 
 namespace facebook::react {
 
-#ifdef HERMES_ENABLE_DEBUGGER
+#if defined(HERMES_ENABLE_DEBUGGER) && !defined(HERMES_V1_ENABLED)
 
 // Wrapper that strongly retains the HermesRuntime for on device debugging.
 //
@@ -90,7 +94,7 @@ class DecoratedRuntime : public jsi::RuntimeDecorator<jsi::Runtime> {
   inspector_modern::chrome::DebugSessionToken debugToken_;
 };
 
-#endif
+#endif // defined(HERMES_ENABLE_DEBUGGER) && !defined(HERMES_V1_ENABLED)
 
 class HermesJSRuntime : public JSRuntime {
  public:
@@ -157,7 +161,7 @@ std::unique_ptr<JSRuntime> HermesInstance::createJSRuntime(
                             .getPropertyAsObject(*hermesRuntime, "prototype");
   errorPrototype.setProperty(*hermesRuntime, "jsEngine", "hermes");
 
-#ifdef HERMES_ENABLE_DEBUGGER
+#if defined(HERMES_ENABLE_DEBUGGER) && !defined(HERMES_V1_ENABLED)
   auto& inspectorFlags = jsinspector_modern::InspectorFlags::getInstance();
   if (!inspectorFlags.getFuseboxEnabled()) {
     std::unique_ptr<DecoratedRuntime> decoratedRuntime =


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Adds a new preprocessor directive which should be set when the new Hermes is being used. This directive will disable the legacy debugger which isn't supported by it.

Differential Revision: D81035112


