### PR TITLE
fix: correctly assign name to both begin and end events for measures

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
@@ -445,7 +445,7 @@ void PerformanceTracer::enqueueTraceEventsFromPerformanceTracerEvent(
 
             events.emplace_back(TraceEvent{
                 .id = eventId,
-                .name = std::move(event.name),
+                .name = event.name,
                 .cat = "blink.user_timing",
                 .ph = 'b',
                 .ts = event.start,


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

Since the `name` was already moved for the begin event, there is nothing to be moved for `end` event. Instead, we will be creating a copy for the `begin` event.

This was actually affecting some entries on a timeline, like component triggers (yellow ones).

Reviewed By: vzaidman

Differential Revision: D81589847


