### PR TITLE
JS: Upgrade to `signedsource@2.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "react-test-renderer": "19.1.1",
     "rimraf": "^3.0.2",
     "shelljs": "^0.8.5",
-    "signedsource": "^1.0.0",
+    "signedsource": "^2.0.0",
     "supports-color": "^7.1.0",
     "temp-dir": "^2.0.0",
     "tinybench": "^4.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8482,10 +8482,10 @@ signal-exit@^4.1.0:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
-signedsource@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/signedsource/-/signedsource-1.0.0.tgz#1ddace4981798f93bd833973803d80d52e93ad6a"
-  integrity sha512-6+eerH9fEnNmi/hyM1DXcRK3pWdoMQtlkQ+ns0ntzunjKqp5i3sKCc80ym8Fib3iaYhdJUOPdhlJWj1tvge2Ww==
+signedsource@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/signedsource/-/signedsource-2.0.0.tgz#f72dc0f98f5bca2763b464a555511a84a4da8eee"
+  integrity sha512-MscTxXbMij5JVgrW1xDiMIc+vFa0+H0+HP+rRrFjwa7ef2VAxIP/4L/E75I5H4xvyb4l1X+a9ch+6Zy5uFu7Fg==
 
 sisteransi@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
Summary:
Upgrades projects to `signedsource@2.0.0`, which includes a critical bug fix to the `isSigned` and `signFile` functions:

```lang=diff
isSigned(data) {
-  return !PATTERN.exec(data);
+  return PATTERN.exec(data) != null;
},
```

Changelog:
[Internal]

Differential Revision: D81723007


