### PR TITLE
Make feature flag "enableViewRecyclingForScrollView" true by default

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<411732d441bacbef37c3474b9041202c>>
+ * @generated SignedSource<<c2662bb149153d80e1b42029f7377eb9>>
  */
 
 /**
@@ -101,7 +101,7 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
 
   override fun enableViewRecyclingForImage(): Boolean = true
 
-  override fun enableViewRecyclingForScrollView(): Boolean = false
+  override fun enableViewRecyclingForScrollView(): Boolean = true
 
   override fun enableViewRecyclingForText(): Boolean = true
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<6d8adaa4b960407540afb1d6e42a3840>>
+ * @generated SignedSource<<203fbd20e17d71ad8aed3e4f9a8a9bae>>
  */
 
 /**
@@ -184,7 +184,7 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool enableViewRecyclingForScrollView() override {
-    return false;
+    return true;
   }
 
   bool enableViewRecyclingForText() override {

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -463,7 +463,7 @@ const definitions: FeatureFlagDefinitions = {
       ossReleaseStage: 'none',
     },
     enableViewRecyclingForScrollView: {
-      defaultValue: false,
+      defaultValue: true,
       metadata: {
         dateAdded: '2025-08-20',
         description:

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<2bef8486b596a7593bbc931da63b2682>>
+ * @generated SignedSource<<043c615bb3aeec8730273826786b336a>>
  * @flow strict
  * @noformat
  */
@@ -359,7 +359,7 @@ export const enableViewRecyclingForImage: Getter<boolean> = createNativeFlagGett
 /**
  * Enables View Recycling for <ScrollView> via ReactViewGroup/ReactViewManager.
  */
-export const enableViewRecyclingForScrollView: Getter<boolean> = createNativeFlagGetter('enableViewRecyclingForScrollView', false);
+export const enableViewRecyclingForScrollView: Getter<boolean> = createNativeFlagGetter('enableViewRecyclingForScrollView', true);
 /**
  * Enables View Recycling for <Text> via ReactTextView/ReactTextViewManager.
  */


### PR DESCRIPTION
Summary:
## Changelog:
[Internal] - 

Noticed that the default value for this one is inconsistent with all the other similar ones, which can cause confusion during setting up the experiment, fixing it.

Note that top level view recycling is still controlled via `enableViewRecycling`, which will also disable all the other ones when false (which it is by default).

bypass-github-export-checks

Reviewed By: lenaic

Differential Revision: D81766029


