### PR TITLE
Move generated code to ReactCodegen and ReactappDependencyProvider folder

### DIFF
--- a/packages/react-native/scripts/codegen/__tests__/__snapshots__/generate-artifacts-executor-test.js.snap
+++ b/packages/react-native/scripts/codegen/__tests__/__snapshots__/generate-artifacts-executor-test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`execute test-app "RCTAppDependencyProvider.h" should match snapshot 1`] = `
+exports[`execute test-app "ReactAppDependencyProvider/RCTAppDependencyProvider.h" should match snapshot 1`] = `
 "/*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_END
 "
 `;
 
-exports[`execute test-app "RCTAppDependencyProvider.mm" should match snapshot 1`] = `
+exports[`execute test-app "ReactAppDependencyProvider/RCTAppDependencyProvider.mm" should match snapshot 1`] = `
 "/*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
@@ -73,7 +73,45 @@ exports[`execute test-app "RCTAppDependencyProvider.mm" should match snapshot 1`
 "
 `;
 
-exports[`execute test-app "RCTModuleProviders.h" should match snapshot 1`] = `
+exports[`execute test-app "ReactAppDependencyProvider/ReactAppDependencyProvider.podspec" should match snapshot 1`] = `
+"# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+version = \\"1000.0.0\\"
+source = { :git => 'https://github.com/facebook/react-native.git' }
+if version == '1000.0.0'
+  # This is an unpublished version, use the latest commit hash of the react-native repo, which we’re presumably in.
+  source[:commit] = \`git rev-parse HEAD\`.strip if system(\\"git rev-parse --git-dir > /dev/null 2>&1\\")
+else
+  source[:tag] = \\"v#{version}\\"
+end
+
+Pod::Spec.new do |s|
+  s.name                   = \\"ReactAppDependencyProvider\\"
+  s.version                = version
+  s.summary                = \\"The third party dependency provider for the app\\"
+  s.homepage               = \\"https://reactnative.dev/\\"
+  s.documentation_url      = \\"https://reactnative.dev/\\"
+  s.license                = \\"MIT\\"
+  s.author                 = \\"Meta Platforms, Inc. and its affiliates\\"
+  s.platforms              = min_supported_versions
+  s.source                 = source
+  s.source_files           = \\"**/RCTAppDependencyProvider.{h,mm}\\"
+
+  # This guard prevent to install the dependencies when we run \`pod install\` in the old architecture.
+  s.pod_target_xcconfig    = {
+    \\"CLANG_CXX_LANGUAGE_STANDARD\\" => rct_cxx_language_standard(),
+    \\"DEFINES_MODULE\\" => \\"YES\\"
+  }
+
+  s.dependency \\"ReactCodegen\\"
+end
+"
+`;
+
+exports[`execute test-app "ReactCodegen/RCTModuleProviders.h" should match snapshot 1`] = `
 "/*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
@@ -93,7 +131,7 @@ exports[`execute test-app "RCTModuleProviders.h" should match snapshot 1`] = `
 "
 `;
 
-exports[`execute test-app "RCTModuleProviders.mm" should match snapshot 1`] = `
+exports[`execute test-app "ReactCodegen/RCTModuleProviders.mm" should match snapshot 1`] = `
 "/*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
@@ -159,7 +197,7 @@ exports[`execute test-app "RCTModuleProviders.mm" should match snapshot 1`] = `
 "
 `;
 
-exports[`execute test-app "RCTModulesConformingToProtocolsProvider.h" should match snapshot 1`] = `
+exports[`execute test-app "ReactCodegen/RCTModulesConformingToProtocolsProvider.h" should match snapshot 1`] = `
 "/*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
@@ -181,7 +219,7 @@ exports[`execute test-app "RCTModulesConformingToProtocolsProvider.h" should mat
 "
 `;
 
-exports[`execute test-app "RCTModulesConformingToProtocolsProvider.mm" should match snapshot 1`] = `
+exports[`execute test-app "ReactCodegen/RCTModulesConformingToProtocolsProvider.mm" should match snapshot 1`] = `
 "/*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
@@ -248,7 +286,7 @@ exports[`execute test-app "RCTModulesConformingToProtocolsProvider.mm" should ma
 "
 `;
 
-exports[`execute test-app "RCTThirdPartyComponentsProvider.h" should match snapshot 1`] = `
+exports[`execute test-app "ReactCodegen/RCTThirdPartyComponentsProvider.h" should match snapshot 1`] = `
 "/*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
@@ -268,7 +306,7 @@ exports[`execute test-app "RCTThirdPartyComponentsProvider.h" should match snaps
 "
 `;
 
-exports[`execute test-app "RCTThirdPartyComponentsProvider.mm" should match snapshot 1`] = `
+exports[`execute test-app "ReactCodegen/RCTThirdPartyComponentsProvider.mm" should match snapshot 1`] = `
 "/*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
@@ -303,7 +341,7 @@ exports[`execute test-app "RCTThirdPartyComponentsProvider.mm" should match snap
 "
 `;
 
-exports[`execute test-app "RCTUnstableModulesRequiringMainQueueSetupProvider.h" should match snapshot 1`] = `
+exports[`execute test-app "ReactCodegen/RCTUnstableModulesRequiringMainQueueSetupProvider.h" should match snapshot 1`] = `
 "/*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
@@ -321,7 +359,7 @@ exports[`execute test-app "RCTUnstableModulesRequiringMainQueueSetupProvider.h" 
 "
 `;
 
-exports[`execute test-app "RCTUnstableModulesRequiringMainQueueSetupProvider.mm" should match snapshot 1`] = `
+exports[`execute test-app "ReactCodegen/RCTUnstableModulesRequiringMainQueueSetupProvider.mm" should match snapshot 1`] = `
 "/*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
@@ -355,45 +393,7 @@ exports[`execute test-app "RCTUnstableModulesRequiringMainQueueSetupProvider.mm"
 "
 `;
 
-exports[`execute test-app "ReactAppDependencyProvider.podspec" should match snapshot 1`] = `
-"# Copyright (c) Meta Platforms, Inc. and affiliates.
-#
-# This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree.
-
-version = \\"1000.0.0\\"
-source = { :git => 'https://github.com/facebook/react-native.git' }
-if version == '1000.0.0'
-  # This is an unpublished version, use the latest commit hash of the react-native repo, which we’re presumably in.
-  source[:commit] = \`git rev-parse HEAD\`.strip if system(\\"git rev-parse --git-dir > /dev/null 2>&1\\")
-else
-  source[:tag] = \\"v#{version}\\"
-end
-
-Pod::Spec.new do |s|
-  s.name                   = \\"ReactAppDependencyProvider\\"
-  s.version                = version
-  s.summary                = \\"The third party dependency provider for the app\\"
-  s.homepage               = \\"https://reactnative.dev/\\"
-  s.documentation_url      = \\"https://reactnative.dev/\\"
-  s.license                = \\"MIT\\"
-  s.author                 = \\"Meta Platforms, Inc. and its affiliates\\"
-  s.platforms              = min_supported_versions
-  s.source                 = source
-  s.source_files           = \\"**/RCTAppDependencyProvider.{h,mm}\\"
-
-  # This guard prevent to install the dependencies when we run \`pod install\` in the old architecture.
-  s.pod_target_xcconfig    = {
-    \\"CLANG_CXX_LANGUAGE_STANDARD\\" => rct_cxx_language_standard(),
-    \\"DEFINES_MODULE\\" => \\"YES\\"
-  }
-
-  s.dependency \\"ReactCodegen\\"
-end
-"
-`;
-
-exports[`execute test-app "ReactCodegen.podspec" should match snapshot 1`] = `
+exports[`execute test-app "ReactCodegen/ReactCodegen.podspec" should match snapshot 1`] = `
 "# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
@@ -507,7 +507,7 @@ end
 "
 `;
 
-exports[`execute test-app-legacy "RCTAppDependencyProvider.h" should match snapshot 1`] = `
+exports[`execute test-app-legacy "ReactAppDependencyProvider/RCTAppDependencyProvider.h" should match snapshot 1`] = `
 "/*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
@@ -536,7 +536,7 @@ NS_ASSUME_NONNULL_END
 "
 `;
 
-exports[`execute test-app-legacy "RCTAppDependencyProvider.mm" should match snapshot 1`] = `
+exports[`execute test-app-legacy "ReactAppDependencyProvider/RCTAppDependencyProvider.mm" should match snapshot 1`] = `
 "/*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
@@ -580,7 +580,45 @@ exports[`execute test-app-legacy "RCTAppDependencyProvider.mm" should match snap
 "
 `;
 
-exports[`execute test-app-legacy "RCTModuleProviders.h" should match snapshot 1`] = `
+exports[`execute test-app-legacy "ReactAppDependencyProvider/ReactAppDependencyProvider.podspec" should match snapshot 1`] = `
+"# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+version = \\"1000.0.0\\"
+source = { :git => 'https://github.com/facebook/react-native.git' }
+if version == '1000.0.0'
+  # This is an unpublished version, use the latest commit hash of the react-native repo, which we’re presumably in.
+  source[:commit] = \`git rev-parse HEAD\`.strip if system(\\"git rev-parse --git-dir > /dev/null 2>&1\\")
+else
+  source[:tag] = \\"v#{version}\\"
+end
+
+Pod::Spec.new do |s|
+  s.name                   = \\"ReactAppDependencyProvider\\"
+  s.version                = version
+  s.summary                = \\"The third party dependency provider for the app\\"
+  s.homepage               = \\"https://reactnative.dev/\\"
+  s.documentation_url      = \\"https://reactnative.dev/\\"
+  s.license                = \\"MIT\\"
+  s.author                 = \\"Meta Platforms, Inc. and its affiliates\\"
+  s.platforms              = min_supported_versions
+  s.source                 = source
+  s.source_files           = \\"**/RCTAppDependencyProvider.{h,mm}\\"
+
+  # This guard prevent to install the dependencies when we run \`pod install\` in the old architecture.
+  s.pod_target_xcconfig    = {
+    \\"CLANG_CXX_LANGUAGE_STANDARD\\" => rct_cxx_language_standard(),
+    \\"DEFINES_MODULE\\" => \\"YES\\"
+  }
+
+  s.dependency \\"ReactCodegen\\"
+end
+"
+`;
+
+exports[`execute test-app-legacy "ReactCodegen/RCTModuleProviders.h" should match snapshot 1`] = `
 "/*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
@@ -600,7 +638,7 @@ exports[`execute test-app-legacy "RCTModuleProviders.h" should match snapshot 1`
 "
 `;
 
-exports[`execute test-app-legacy "RCTModuleProviders.mm" should match snapshot 1`] = `
+exports[`execute test-app-legacy "ReactCodegen/RCTModuleProviders.mm" should match snapshot 1`] = `
 "/*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
@@ -657,7 +695,7 @@ exports[`execute test-app-legacy "RCTModuleProviders.mm" should match snapshot 1
 "
 `;
 
-exports[`execute test-app-legacy "RCTModulesConformingToProtocolsProvider.h" should match snapshot 1`] = `
+exports[`execute test-app-legacy "ReactCodegen/RCTModulesConformingToProtocolsProvider.h" should match snapshot 1`] = `
 "/*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
@@ -679,7 +717,7 @@ exports[`execute test-app-legacy "RCTModulesConformingToProtocolsProvider.h" sho
 "
 `;
 
-exports[`execute test-app-legacy "RCTModulesConformingToProtocolsProvider.mm" should match snapshot 1`] = `
+exports[`execute test-app-legacy "ReactCodegen/RCTModulesConformingToProtocolsProvider.mm" should match snapshot 1`] = `
 "/*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
@@ -737,7 +775,7 @@ exports[`execute test-app-legacy "RCTModulesConformingToProtocolsProvider.mm" sh
 "
 `;
 
-exports[`execute test-app-legacy "RCTThirdPartyComponentsProvider.h" should match snapshot 1`] = `
+exports[`execute test-app-legacy "ReactCodegen/RCTThirdPartyComponentsProvider.h" should match snapshot 1`] = `
 "/*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
@@ -757,7 +795,7 @@ exports[`execute test-app-legacy "RCTThirdPartyComponentsProvider.h" should matc
 "
 `;
 
-exports[`execute test-app-legacy "RCTThirdPartyComponentsProvider.mm" should match snapshot 1`] = `
+exports[`execute test-app-legacy "ReactCodegen/RCTThirdPartyComponentsProvider.mm" should match snapshot 1`] = `
 "/*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
@@ -791,7 +829,7 @@ exports[`execute test-app-legacy "RCTThirdPartyComponentsProvider.mm" should mat
 "
 `;
 
-exports[`execute test-app-legacy "RCTUnstableModulesRequiringMainQueueSetupProvider.h" should match snapshot 1`] = `
+exports[`execute test-app-legacy "ReactCodegen/RCTUnstableModulesRequiringMainQueueSetupProvider.h" should match snapshot 1`] = `
 "/*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
@@ -809,7 +847,7 @@ exports[`execute test-app-legacy "RCTUnstableModulesRequiringMainQueueSetupProvi
 "
 `;
 
-exports[`execute test-app-legacy "RCTUnstableModulesRequiringMainQueueSetupProvider.mm" should match snapshot 1`] = `
+exports[`execute test-app-legacy "ReactCodegen/RCTUnstableModulesRequiringMainQueueSetupProvider.mm" should match snapshot 1`] = `
 "/*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
@@ -834,45 +872,7 @@ exports[`execute test-app-legacy "RCTUnstableModulesRequiringMainQueueSetupProvi
 "
 `;
 
-exports[`execute test-app-legacy "ReactAppDependencyProvider.podspec" should match snapshot 1`] = `
-"# Copyright (c) Meta Platforms, Inc. and affiliates.
-#
-# This source code is licensed under the MIT license found in the
-# LICENSE file in the root directory of this source tree.
-
-version = \\"1000.0.0\\"
-source = { :git => 'https://github.com/facebook/react-native.git' }
-if version == '1000.0.0'
-  # This is an unpublished version, use the latest commit hash of the react-native repo, which we’re presumably in.
-  source[:commit] = \`git rev-parse HEAD\`.strip if system(\\"git rev-parse --git-dir > /dev/null 2>&1\\")
-else
-  source[:tag] = \\"v#{version}\\"
-end
-
-Pod::Spec.new do |s|
-  s.name                   = \\"ReactAppDependencyProvider\\"
-  s.version                = version
-  s.summary                = \\"The third party dependency provider for the app\\"
-  s.homepage               = \\"https://reactnative.dev/\\"
-  s.documentation_url      = \\"https://reactnative.dev/\\"
-  s.license                = \\"MIT\\"
-  s.author                 = \\"Meta Platforms, Inc. and its affiliates\\"
-  s.platforms              = min_supported_versions
-  s.source                 = source
-  s.source_files           = \\"**/RCTAppDependencyProvider.{h,mm}\\"
-
-  # This guard prevent to install the dependencies when we run \`pod install\` in the old architecture.
-  s.pod_target_xcconfig    = {
-    \\"CLANG_CXX_LANGUAGE_STANDARD\\" => rct_cxx_language_standard(),
-    \\"DEFINES_MODULE\\" => \\"YES\\"
-  }
-
-  s.dependency \\"ReactCodegen\\"
-end
-"
-`;
-
-exports[`execute test-app-legacy "ReactCodegen.podspec" should match snapshot 1`] = `
+exports[`execute test-app-legacy "ReactCodegen/ReactCodegen.podspec" should match snapshot 1`] = `
 "# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the

--- a/packages/react-native/scripts/codegen/__tests__/generate-artifacts-executor-test.js
+++ b/packages/react-native/scripts/codegen/__tests__/generate-artifacts-executor-test.js
@@ -42,18 +42,18 @@ const packageJson = JSON.stringify({
     });
 
     [
-      'RCTAppDependencyProvider.h',
-      'RCTAppDependencyProvider.mm',
-      'RCTModuleProviders.h',
-      'RCTModuleProviders.mm',
-      'RCTModulesConformingToProtocolsProvider.h',
-      'RCTModulesConformingToProtocolsProvider.mm',
-      'RCTThirdPartyComponentsProvider.h',
-      'RCTThirdPartyComponentsProvider.mm',
-      'ReactAppDependencyProvider.podspec',
-      'ReactCodegen.podspec',
-      'RCTUnstableModulesRequiringMainQueueSetupProvider.h',
-      'RCTUnstableModulesRequiringMainQueueSetupProvider.mm',
+      'ReactAppDependencyProvider/RCTAppDependencyProvider.h',
+      'ReactAppDependencyProvider/RCTAppDependencyProvider.mm',
+      'ReactCodegen/RCTModuleProviders.h',
+      'ReactCodegen/RCTModuleProviders.mm',
+      'ReactCodegen/RCTModulesConformingToProtocolsProvider.h',
+      'ReactCodegen/RCTModulesConformingToProtocolsProvider.mm',
+      'ReactCodegen/RCTThirdPartyComponentsProvider.h',
+      'ReactCodegen/RCTThirdPartyComponentsProvider.mm',
+      'ReactAppDependencyProvider/ReactAppDependencyProvider.podspec',
+      'ReactCodegen/ReactCodegen.podspec',
+      'ReactCodegen/RCTUnstableModulesRequiringMainQueueSetupProvider.h',
+      'ReactCodegen/RCTUnstableModulesRequiringMainQueueSetupProvider.mm',
     ].forEach(file => {
       it(`"${file}" should match snapshot`, () => {
         const generatedFileDir = path.join(outputDir, 'build/generated/ios');

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/index.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/index.js
@@ -125,10 +125,15 @@ function execute(
         platform,
       );
 
+      const reactCodegenOutputPath =
+        platform === 'android'
+          ? outputPath
+          : path.join(outputPath, 'ReactCodegen');
+
       if (runReactNativeCodegen) {
         const schemaInfos = generateSchemaInfos(libraries);
         generateNativeCode(
-          outputPath,
+          reactCodegenOutputPath,
           schemaInfos.filter(schemaInfo =>
             mustGenerateNativeCode(projectRoot, schemaInfo),
           ),
@@ -139,18 +144,25 @@ function execute(
 
       if (source === 'app' && platform !== 'android') {
         // These components are only required by apps, not by libraries and are Apple specific.
-        generateRCTThirdPartyComponents(libraries, outputPath);
-        generateRCTModuleProviders(projectRoot, pkgJson, libraries, outputPath);
-        generateCustomURLHandlers(libraries, outputPath);
+        generateRCTThirdPartyComponents(libraries, reactCodegenOutputPath);
+        generateRCTModuleProviders(
+          projectRoot,
+          pkgJson,
+          libraries,
+          reactCodegenOutputPath,
+        );
+        generateCustomURLHandlers(libraries, reactCodegenOutputPath);
         generateUnstableModulesRequiringMainQueueSetupProvider(
           libraries,
-          outputPath,
+          reactCodegenOutputPath,
         );
-        generateAppDependencyProvider(outputPath);
+        generateAppDependencyProvider(
+          path.join(outputPath, 'ReactAppDependencyProvider'),
+        );
         generateReactCodegenPodspec(
           projectRoot,
           pkgJson,
-          outputPath,
+          reactCodegenOutputPath,
           baseOutputPath,
         );
       }

--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/utils.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/utils.js
@@ -461,6 +461,17 @@ function findDisabledLibrariesByPlatform(
   );
 }
 
+function findReactNativeRootPath(projectRoot /* : string */) /* : string */ {
+  const reactNativePackageJsonPath = require.resolve(
+    path.join('react-native', 'package.json'),
+    {
+      paths: [projectRoot],
+    },
+  );
+
+  return path.dirname(reactNativePackageJsonPath);
+}
+
 module.exports = {
   buildCodegenIfNeeded,
   pkgJsonIncludesGeneratedCode,
@@ -474,4 +485,5 @@ module.exports = {
   parseiOSAnnotations,
   readReactNativeConfig,
   findDisabledLibrariesByPlatform,
+  findReactNativeRootPath,
 };

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -24,7 +24,8 @@ require_relative './cocoapods/rncore.rb'
 # Importing to expose use_native_modules!
 require_relative './cocoapods/autolinking.rb'
 
-$CODEGEN_OUTPUT_DIR = 'build/generated/ios'
+$CODEGEN_OUTPUT_DIR = 'build/generated/ios/ReactCodegen'
+$APP_DEPENDENCY_PROVIDER_OUTPUT_DIR = 'build/generated/ios/ReactAppDependencyProvider'
 $CODEGEN_COMPONENT_DIR = 'react/renderer/components'
 $CODEGEN_MODULE_DIR = '.'
 
@@ -200,7 +201,7 @@ def use_react_native! (
   end
 
   pod 'ReactCodegen', :path => $CODEGEN_OUTPUT_DIR, :modular_headers => true
-  pod 'ReactAppDependencyProvider', :path => $CODEGEN_OUTPUT_DIR, :modular_headers => true
+  pod 'ReactAppDependencyProvider', :path => $APP_DEPENDENCY_PROVIDER_OUTPUT_DIR, :modular_headers => true
   # Not needed, but run_codegen expects this to be set.
   folly_config = get_folly_config()
   run_codegen!(


### PR DESCRIPTION
Summary:
This change makes sure that we generate the codegen files in the ReactCodegen and ReactAppDependencyProvider folder.

This is necessary as Swift PM needs the source code of packages to be grouped in folders that are children of where the Package.swift is located.

This is not a breaking change, because Cocoapods has been updated accordingly, import/include paths are not changed and the folder layout should not be accessed by anybody directly

## Changelog:
[Internal] -

Differential Revision: D81769522


