### PR TITLE
Create script to create hard links for headers from a source path to a destination path

### DIFF
--- a/packages/react-native/scripts/swiftpm/__tests__/headers-utils-test.js
+++ b/packages/react-native/scripts/swiftpm/__tests__/headers-utils-test.js
@@ -1,0 +1,418 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @noflow
+ */
+
+'use strict';
+
+const {symlinkHeadersFromPath} = require('../headers-utils');
+
+// Mock all required modules
+jest.mock('../utils');
+jest.mock('fs');
+jest.mock('path');
+
+describe('symlinkHeadersFromPath', () => {
+  let mockUtils;
+  let mockFs;
+  let mockPath;
+  let originalConsoleWarn;
+  let originalConsoleLog;
+
+  beforeEach(() => {
+    // Setup mocks
+    mockUtils = require('../utils');
+    mockFs = require('fs');
+    mockPath = require('path');
+
+    // Mock path functions
+    mockPath.relative.mockImplementation((from, to) => {
+      return to.replace(from + '/', '');
+    });
+    mockPath.join.mockImplementation((...args) => args.join('/'));
+    mockPath.dirname.mockImplementation(filePath => {
+      const parts = filePath.split('/');
+      parts.pop();
+      return parts.join('/');
+    });
+    mockPath.basename.mockImplementation(filePath => {
+      return filePath.split('/').pop();
+    });
+
+    // Mock console methods to prevent test output noise
+    originalConsoleWarn = console.warn;
+    originalConsoleLog = console.log;
+    console.warn = jest.fn();
+    console.log = jest.fn();
+
+    // Reset all mocks
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    // Restore console methods
+    console.warn = originalConsoleWarn;
+    console.log = originalConsoleLog;
+  });
+
+  it('should create symlinks for found header files without preserving structure', () => {
+    // Setup
+    const sourcePath = '/source/path';
+    const outputPath = '/output/path';
+    const headerFiles = [
+      '/source/path/subdir/header1.h',
+      '/source/path/header2.h',
+    ];
+
+    mockUtils.listHeadersInFolder.mockReturnValue(headerFiles);
+    mockFs.existsSync.mockImplementation(filePath => {
+      return (
+        filePath === '/source/path/subdir/header1.h' ||
+        filePath === '/source/path/header2.h'
+      );
+    });
+
+    // Execute
+    const result = symlinkHeadersFromPath(sourcePath, outputPath, false, []);
+
+    // Assert
+    expect(mockUtils.listHeadersInFolder).toHaveBeenCalledWith(sourcePath, []);
+    expect(mockUtils.setupSymlink).toHaveBeenCalledTimes(2);
+    expect(mockUtils.setupSymlink).toHaveBeenCalledWith(
+      '/source/path/subdir/header1.h',
+      '/output/path/header1.h',
+    );
+    expect(mockUtils.setupSymlink).toHaveBeenCalledWith(
+      '/source/path/header2.h',
+      '/output/path/header2.h',
+    );
+    expect(result).toBe(2);
+  });
+
+  it('should preserve directory structure when preserveStructure is true', () => {
+    // Setup
+    const sourcePath = '/source/path';
+    const outputPath = '/output/path';
+    const headerFiles = [
+      '/source/path/subdir/header1.h',
+      '/source/path/another/header2.h',
+    ];
+
+    mockUtils.listHeadersInFolder.mockReturnValue(headerFiles);
+    mockFs.existsSync.mockImplementation(filePath => {
+      return (
+        filePath === '/source/path/subdir/header1.h' ||
+        filePath === '/source/path/another/header2.h'
+      );
+    });
+
+    // Execute
+    const result = symlinkHeadersFromPath(sourcePath, outputPath, true, []);
+
+    // Assert
+    expect(mockUtils.setupSymlink).toHaveBeenCalledWith(
+      '/source/path/subdir/header1.h',
+      '/output/path/subdir/header1.h',
+    );
+    expect(mockUtils.setupSymlink).toHaveBeenCalledWith(
+      '/source/path/another/header2.h',
+      '/output/path/another/header2.h',
+    );
+    expect(result).toBe(2);
+  });
+
+  it('should exclude specified folders from find command', () => {
+    // Setup
+    const sourcePath = '/source/path';
+    const outputPath = '/output/path';
+    const excludeFolders = ['node_modules', 'test'];
+
+    mockUtils.listHeadersInFolder.mockReturnValue([]);
+
+    // Execute
+    symlinkHeadersFromPath(sourcePath, outputPath, false, excludeFolders);
+
+    // Assert
+    expect(mockUtils.listHeadersInFolder).toHaveBeenCalledWith(
+      sourcePath,
+      excludeFolders,
+    );
+  });
+
+  it('should use custom mappings when path matches prefix', () => {
+    // Setup
+    const sourcePath = '/source/path';
+    const outputPath = '/output/path';
+    const customMappings = {
+      'special/': '/custom/output/path',
+    };
+    const headerFiles = [
+      '/source/path/special/header1.h',
+      '/source/path/normal/header2.h',
+    ];
+
+    mockUtils.listHeadersInFolder.mockReturnValue(headerFiles);
+    mockFs.existsSync.mockImplementation(filePath => {
+      return (
+        filePath === '/source/path/special/header1.h' ||
+        filePath === '/source/path/normal/header2.h'
+      );
+    });
+
+    // Execute
+    const result = symlinkHeadersFromPath(
+      sourcePath,
+      outputPath,
+      false,
+      [],
+      customMappings,
+    );
+
+    // Assert
+    expect(mockUtils.setupSymlink).toHaveBeenCalledWith(
+      '/source/path/special/header1.h',
+      '/custom/output/path/header1.h',
+    );
+    expect(mockUtils.setupSymlink).toHaveBeenCalledWith(
+      '/source/path/normal/header2.h',
+      '/output/path/header2.h',
+    );
+    expect(console.log).toHaveBeenCalledWith(
+      '  Custom mapping: special/ -> /custom/output/path',
+    );
+    expect(result).toBe(2);
+  });
+
+  it('should create destination directories if they do not exist', () => {
+    // Setup
+    const sourcePath = '/source/path';
+    const outputPath = '/output/path';
+    const headerFiles = ['/source/path/subdir/header1.h'];
+
+    mockUtils.listHeadersInFolder.mockReturnValue(headerFiles);
+    mockFs.existsSync.mockImplementation(filePath => {
+      return filePath === '/source/path/subdir/header1.h';
+    });
+
+    // Execute
+    symlinkHeadersFromPath(sourcePath, outputPath, true, []);
+
+    // Assert - setupSymlink should be called, which internally handles directory creation
+    expect(mockUtils.setupSymlink).toHaveBeenCalledWith(
+      '/source/path/subdir/header1.h',
+      '/output/path/subdir/header1.h',
+    );
+  });
+
+  it('should remove existing symlink before creating new one', () => {
+    // Setup
+    const sourcePath = '/source/path';
+    const outputPath = '/output/path';
+    const headerFiles = ['/source/path/header1.h'];
+
+    mockUtils.listHeadersInFolder.mockReturnValue(headerFiles);
+    mockFs.existsSync.mockImplementation(filePath => {
+      return filePath === '/source/path/header1.h'; // Only source file exists
+    });
+
+    // Execute
+    symlinkHeadersFromPath(sourcePath, outputPath, false, []);
+
+    // Assert - setupSymlink should be called, which internally handles removing existing links
+    expect(mockUtils.setupSymlink).toHaveBeenCalledWith(
+      '/source/path/header1.h',
+      '/output/path/header1.h',
+    );
+  });
+
+  it('should skip non-existent source files', () => {
+    // Setup
+    const sourcePath = '/source/path';
+    const outputPath = '/output/path';
+    const headerFiles = [
+      '/source/path/header1.h',
+      '/source/path/nonexistent.h',
+    ];
+
+    mockUtils.listHeadersInFolder.mockReturnValue(headerFiles);
+    mockFs.existsSync.mockImplementation(filePath => {
+      return filePath === '/source/path/header1.h'; // Only header1.h exists
+    });
+
+    // Execute
+    const result = symlinkHeadersFromPath(sourcePath, outputPath, false, []);
+
+    // Assert
+    expect(mockUtils.setupSymlink).toHaveBeenCalledTimes(1);
+    expect(mockUtils.setupSymlink).toHaveBeenCalledWith(
+      '/source/path/header1.h',
+      '/output/path/header1.h',
+    );
+    expect(result).toBe(1);
+  });
+
+  it('should handle empty find command output', () => {
+    // Setup
+    const sourcePath = '/source/path';
+    const outputPath = '/output/path';
+
+    mockUtils.listHeadersInFolder.mockReturnValue([]);
+
+    // Execute
+    const result = symlinkHeadersFromPath(sourcePath, outputPath, false, []);
+
+    // Assert
+    expect(mockUtils.setupSymlink).not.toHaveBeenCalled();
+    expect(result).toBe(0);
+  });
+
+  it('should handle whitespace-only find command output', () => {
+    // Setup
+    const sourcePath = '/source/path';
+    const outputPath = '/output/path';
+
+    mockUtils.listHeadersInFolder.mockReturnValue([]);
+
+    // Execute
+    const result = symlinkHeadersFromPath(sourcePath, outputPath, false, []);
+
+    // Assert
+    expect(mockUtils.setupSymlink).not.toHaveBeenCalled();
+    expect(result).toBe(0);
+  });
+
+  it('should handle listHeadersInFolder throwing an error', () => {
+    // Setup
+    const sourcePath = '/source/path';
+    const outputPath = '/output/path';
+    const error = new Error('Command failed');
+
+    mockUtils.listHeadersInFolder.mockImplementation(() => {
+      throw error;
+    });
+
+    // Execute
+    const result = symlinkHeadersFromPath(sourcePath, outputPath, false, []);
+
+    // Assert
+    expect(console.warn).toHaveBeenCalledWith(
+      'Failed to process headers from /source/path:',
+      'Command failed',
+    );
+    expect(result).toBe(0);
+  });
+
+  it('should handle setupSymlink throwing an error', () => {
+    // Setup
+    const sourcePath = '/source/path';
+    const outputPath = '/output/path';
+    const headerFiles = ['/source/path/header1.h'];
+
+    mockUtils.listHeadersInFolder.mockReturnValue(headerFiles);
+    mockFs.existsSync.mockImplementation(filePath => {
+      return filePath === '/source/path/header1.h';
+    });
+    mockUtils.setupSymlink.mockImplementation(() => {
+      throw new Error('Link failed');
+    });
+
+    // Execute
+    const result = symlinkHeadersFromPath(sourcePath, outputPath, false, []);
+
+    // Assert
+    expect(console.warn).toHaveBeenCalledWith(
+      'Failed to process headers from /source/path:',
+      'Link failed',
+    );
+    expect(result).toBe(0);
+  });
+
+  it('should work with multiple custom mappings', () => {
+    // Setup
+    const sourcePath = '/source/path';
+    const outputPath = '/output/path';
+    const customMappings = {
+      'lib1/': '/custom/lib1',
+      'lib2/': '/custom/lib2',
+    };
+    const headerFiles = [
+      '/source/path/lib1/header1.h',
+      '/source/path/lib2/header2.h',
+      '/source/path/other/header3.h',
+    ];
+
+    mockUtils.listHeadersInFolder.mockReturnValue(headerFiles);
+    mockFs.existsSync.mockImplementation(filePath => {
+      return (
+        filePath === '/source/path/lib1/header1.h' ||
+        filePath === '/source/path/lib2/header2.h' ||
+        filePath === '/source/path/other/header3.h'
+      );
+    });
+    // Mock setupSymlink to not throw any errors
+    mockUtils.setupSymlink.mockImplementation(() => {});
+
+    // Execute
+    const result = symlinkHeadersFromPath(
+      sourcePath,
+      outputPath,
+      false,
+      [],
+      customMappings,
+    );
+
+    // Assert
+    expect(mockUtils.setupSymlink).toHaveBeenCalledTimes(3);
+    expect(mockUtils.setupSymlink).toHaveBeenCalledWith(
+      '/source/path/lib1/header1.h',
+      '/custom/lib1/header1.h',
+    );
+    expect(mockUtils.setupSymlink).toHaveBeenCalledWith(
+      '/source/path/lib2/header2.h',
+      '/custom/lib2/header2.h',
+    );
+    expect(mockUtils.setupSymlink).toHaveBeenCalledWith(
+      '/source/path/other/header3.h',
+      '/output/path/header3.h',
+    );
+    expect(result).toBe(3);
+  });
+
+  it('should handle custom mappings with preserved structure', () => {
+    // Setup
+    const sourcePath = '/source/path';
+    const outputPath = '/output/path';
+    const customMappings = {
+      'special/': '/custom/output',
+    };
+    const headerFiles = ['/source/path/special/subdir/header1.h'];
+
+    mockUtils.listHeadersInFolder.mockReturnValue(headerFiles);
+    mockFs.existsSync.mockImplementation(filePath => {
+      return filePath === '/source/path/special/subdir/header1.h';
+    });
+    // Mock setupSymlink to not throw any errors
+    mockUtils.setupSymlink.mockImplementation(() => {});
+
+    // Execute
+    const result = symlinkHeadersFromPath(
+      sourcePath,
+      outputPath,
+      true,
+      [],
+      customMappings,
+    );
+
+    // Assert
+    expect(mockUtils.setupSymlink).toHaveBeenCalledWith(
+      '/source/path/special/subdir/header1.h',
+      '/custom/output/special/subdir/header1.h',
+    );
+    expect(result).toBe(1);
+  });
+});

--- a/packages/react-native/scripts/swiftpm/__tests__/utils-test.js
+++ b/packages/react-native/scripts/swiftpm/__tests__/utils-test.js
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @noflow
+ */
+
+'use strict';
+
+const {setupSymlink} = require('../utils');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+describe('setupSymlink', () => {
+  let tempDir;
+  let sourceFile;
+  let destFile;
+  let destDir;
+
+  beforeEach(() => {
+    // Create a temporary directory for testing
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'utils-test-'));
+    sourceFile = path.join(tempDir, 'source.txt');
+    destDir = path.join(tempDir, 'dest', 'subdir');
+    destFile = path.join(destDir, 'dest.txt');
+
+    // Create a source file
+    fs.writeFileSync(sourceFile, 'test content');
+  });
+
+  afterEach(() => {
+    // Clean up temporary directory
+    if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, {recursive: true, force: true});
+    }
+  });
+
+  it('should create destination directory if it does not exist', () => {
+    expect(fs.existsSync(destDir)).toBe(false);
+
+    setupSymlink(sourceFile, destFile);
+
+    expect(fs.existsSync(destDir)).toBe(true);
+  });
+
+  it('should create symlink when source file exists', () => {
+    setupSymlink(sourceFile, destFile);
+
+    expect(fs.existsSync(destFile)).toBe(true);
+    expect(fs.lstatSync(destFile).isSymbolicLink()).toBe(true);
+    expect(fs.readFileSync(destFile, 'utf8')).toBe('test content');
+  });
+
+  it('should remove existing symlink before creating new one', () => {
+    // Create initial symlink
+    fs.mkdirSync(destDir, {recursive: true});
+    fs.symlinkSync(sourceFile, destFile);
+    expect(fs.existsSync(destFile)).toBe(true);
+
+    // Create another source file
+    const newSourceFile = path.join(tempDir, 'newsource.txt');
+    fs.writeFileSync(newSourceFile, 'new content');
+
+    // Setup symlink should remove the old one and create new one
+    setupSymlink(newSourceFile, destFile);
+
+    expect(fs.existsSync(destFile)).toBe(true);
+    expect(fs.lstatSync(destFile).isSymbolicLink()).toBe(true);
+    expect(fs.readFileSync(destFile, 'utf8')).toBe('new content');
+  });
+
+  it('should remove existing regular file before creating symlink', () => {
+    // Create destination directory and regular file
+    fs.mkdirSync(destDir, {recursive: true});
+    fs.writeFileSync(destFile, 'regular file content');
+    expect(fs.existsSync(destFile)).toBe(true);
+    expect(fs.lstatSync(destFile).isSymbolicLink()).toBe(false);
+
+    setupSymlink(sourceFile, destFile);
+
+    expect(fs.existsSync(destFile)).toBe(true);
+    expect(fs.lstatSync(destFile).isSymbolicLink()).toBe(true);
+    expect(fs.readFileSync(destFile, 'utf8')).toBe('test content');
+  });
+
+  it('should not create symlink when source file does not exist', () => {
+    const nonExistentSource = path.join(tempDir, 'nonexistent.txt');
+
+    setupSymlink(nonExistentSource, destFile);
+
+    expect(fs.existsSync(destDir)).toBe(true); // Directory should still be created
+    expect(fs.existsSync(destFile)).toBe(false); // But no symlink should be created
+  });
+
+  it('should work when destination directory already exists', () => {
+    // Pre-create destination directory
+    fs.mkdirSync(destDir, {recursive: true});
+
+    setupSymlink(sourceFile, destFile);
+
+    expect(fs.existsSync(destFile)).toBe(true);
+    expect(fs.lstatSync(destFile).isSymbolicLink()).toBe(true);
+    expect(fs.readFileSync(destFile, 'utf8')).toBe('test content');
+  });
+});

--- a/packages/react-native/scripts/swiftpm/headers-utils.js
+++ b/packages/react-native/scripts/swiftpm/headers-utils.js
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+const {listHeadersInFolder, setupSymlink} = require('./utils');
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Helper function to create symlinks from a source path
+ * @param {string} sourcePath - Source directory to search for headers
+ * @param {string} outputPath - Default output directory for symlinks
+ * @param {boolean} preserveStructure - Whether to preserve directory structure
+ * @param {Array<string>} excludeFolders - Folder names to exclude
+ * @param {Object} customMappings - Custom path mappings (prefix -> output path)
+ * @returns {number} Number of symlinks created
+ */
+function symlinkHeadersFromPath(
+  sourcePath /*: string */,
+  outputPath /*: string */,
+  preserveStructure /*: boolean */,
+  excludeFolders /*: Array<string> */,
+  customMappings /*: {[string]: string} */ = {},
+) /*: number */ {
+  let linkedCount = 0;
+
+  try {
+    // Build find command with exclusions using -prune
+    const headerFiles = listHeadersInFolder(sourcePath, excludeFolders);
+    headerFiles.forEach(sourceHeaderPath => {
+      if (fs.existsSync(sourceHeaderPath)) {
+        const relativePath = path.relative(sourcePath, sourceHeaderPath);
+        let destPath = '';
+        let mappedOutputPath = outputPath;
+
+        // Check for custom mappings first
+        for (const [prefix, customOutput] of Object.entries(customMappings)) {
+          if (relativePath.startsWith(prefix)) {
+            mappedOutputPath = customOutput;
+            console.log(`  Custom mapping: ${prefix} -> ${customOutput}`);
+            break;
+          }
+        }
+
+        if (preserveStructure) {
+          // Preserve directory structure
+          destPath = path.join(mappedOutputPath, relativePath);
+        } else {
+          // Flatten structure - just use the header filename
+          const headerName = path.basename(sourceHeaderPath);
+          destPath = path.join(mappedOutputPath, headerName);
+        }
+
+        // Create destination directory if it doesn't exist
+        setupSymlink(sourceHeaderPath, destPath);
+        linkedCount++;
+      }
+    });
+  } catch (error) {
+    console.warn(
+      `Failed to process headers from ${sourcePath}:`,
+      error.message,
+    );
+  }
+
+  return linkedCount;
+}
+
+module.exports = {
+  symlinkHeadersFromPath,
+};

--- a/packages/react-native/scripts/swiftpm/utils.js
+++ b/packages/react-native/scripts/swiftpm/utils.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+function setupSymlink(
+  sourceFilePath /*: string */,
+  destFilePath /*: string */,
+) {
+  const destFolderPath = path.dirname(destFilePath);
+  if (!fs.existsSync(destFolderPath)) {
+    fs.mkdirSync(destFolderPath, {recursive: true});
+  }
+
+  // Remove existing symlink if it exists
+  if (fs.existsSync(destFilePath)) {
+    fs.unlinkSync(destFilePath);
+  }
+
+  // Create symlink for umbrella header
+  if (fs.existsSync(sourceFilePath)) {
+    fs.symlinkSync(sourceFilePath, destFilePath);
+  }
+}
+
+module.exports = {
+  setupSymlink,
+};


### PR DESCRIPTION
Summary:
## Context

One of the quirk of SwiftPM is that the packages has to have access to the headers they need. Usually this is solved by properly setting the header_search_path. However, in  SwiftPM, we are not allowed to use headers search path that escape the package itself (basically, header search path can't start with `../`).

To work around this limitation we are recreating the correct Header structure by using hardlinks to the actual headers.

## Changed

In this change we are adding an helper function that creates links between a source folder and a destination folder.

## Changelog:
[Internal] -

Differential Revision: D81778469


