### PR TITLE
Use int32_t for color representation on Android

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/HostPlatformColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/HostPlatformColor.h
@@ -12,7 +12,7 @@
 
 namespace facebook::react {
 
-using Color = uint32_t;
+using Color = int32_t;
 
 namespace HostPlatformColor {
 constexpr facebook::react::Color UndefinedColor = 0;


### PR DESCRIPTION
Summary:
This was originally changed from signed to unsigned here: D81230050.

But because Android UI's `Color.valueOf` function uses a signed integer, we need to pass signed values to the android view when defining colors. See https://www.internalfb.com/code/fbsource/xplat/js/react-native-github/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ColorPropConverter.kt?lines=82-82

The color value has to be between Integer.MIN_VALUE and Integer.MAX_VALUE. When passing an unsigned value, the value gets capped to the max signed value and results in another color being represented.

Changelog: [Internal]

Reviewed By: rshest

Differential Revision: D81779878


