### PR TITLE
Back out "Use uint32_t as internal Color representation"

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
@@ -310,7 +310,7 @@ static void updateBorderColorPropValue(
     const std::optional<SharedColor>& newColor,
     const std::optional<SharedColor>& oldColor) {
   if (newColor != oldColor) {
-    result[propName] = *newColor.value_or(SharedColor());
+    result[propName] = newColor.has_value() ? *newColor.value() : NULL;
   }
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/HostPlatformColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/HostPlatformColor.h
@@ -12,7 +12,7 @@
 
 namespace facebook::react {
 
-using Color = uint32_t;
+using Color = int32_t;
 
 namespace HostPlatformColor {
 constexpr facebook::react::Color UndefinedColor = 0;

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/PlatformColorParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/PlatformColorParser.h
@@ -42,7 +42,7 @@ inline SharedColor parsePlatformColor(
     auto color =
         getColorFromJava(fabricUIManager, surfaceId, *javaResourcePaths);
 
-    auto argb = (uint32_t)color;
+    auto argb = (int64_t)color;
     auto ratio = 255.f;
     colorComponents.alpha = ((argb >> 24) & 0xFF) / ratio;
     colorComponents.red = ((argb >> 16) & 0xFF) / ratio;

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/cxx/react/renderer/graphics/HostPlatformColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/cxx/react/renderer/graphics/HostPlatformColor.h
@@ -13,7 +13,7 @@
 
 namespace facebook::react {
 
-using Color = uint32_t;
+using Color = int32_t;
 
 namespace HostPlatformColor {
 constexpr facebook::react::Color UndefinedColor = 0;

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/HostPlatformColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/HostPlatformColor.h
@@ -14,18 +14,18 @@
 namespace facebook::react {
 
 struct DynamicColor {
-  uint32_t lightColor = 0;
-  uint32_t darkColor = 0;
-  uint32_t highContrastLightColor = 0;
-  uint32_t highContrastDarkColor = 0;
+  int32_t lightColor = 0;
+  int32_t darkColor = 0;
+  int32_t highContrastLightColor = 0;
+  int32_t highContrastDarkColor = 0;
 };
 
 struct Color {
-  Color(uint32_t color);
+  Color(int32_t color);
   Color(const DynamicColor& dynamicColor);
   Color(const ColorComponents& components);
   Color() : uiColor_(nullptr){};
-  uint32_t getColor() const;
+  int32_t getColor() const;
   std::size_t getUIColorHash() const;
 
   static Color createSemanticColor(std::vector<std::string>& semanticItems);
@@ -38,7 +38,7 @@ struct Color {
 
   ColorComponents getColorComponents() const {
     float ratio = 255;
-    uint32_t primitiveColor = getColor();
+    int32_t primitiveColor = getColor();
     return ColorComponents{
         .red = (float)((primitiveColor >> 16) & 0xff) / ratio,
         .green = (float)((primitiveColor >> 8) & 0xff) / ratio,
@@ -47,7 +47,7 @@ struct Color {
   }
   bool operator==(const Color& other) const;
   bool operator!=(const Color& other) const;
-  operator uint32_t() const {
+  operator int32_t() const {
     return getColor();
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/HostPlatformColor.mm
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/HostPlatformColor.mm
@@ -36,7 +36,7 @@ bool UIColorIsP3ColorSpace(const std::shared_ptr<void> &uiColor)
   return false;
 }
 
-UIColor *_Nullable UIColorFromInt32(uint32_t intColor)
+UIColor *_Nullable UIColorFromInt32(int32_t intColor)
 {
   CGFloat a = CGFloat((intColor >> 24) & 0xFF) / 255.0;
   CGFloat r = CGFloat((intColor >> 16) & 0xFF) / 255.0;
@@ -49,10 +49,10 @@ UIColor *_Nullable UIColorFromInt32(uint32_t intColor)
 
 UIColor *_Nullable UIColorFromDynamicColor(const facebook::react::DynamicColor &dynamicColor)
 {
-  uint32_t light = dynamicColor.lightColor;
-  uint32_t dark = dynamicColor.darkColor;
-  uint32_t highContrastLight = dynamicColor.highContrastLightColor;
-  uint32_t highContrastDark = dynamicColor.highContrastDarkColor;
+  int32_t light = dynamicColor.lightColor;
+  int32_t dark = dynamicColor.darkColor;
+  int32_t highContrastLight = dynamicColor.highContrastLightColor;
+  int32_t highContrastDark = dynamicColor.highContrastDarkColor;
 
   UIColor *lightColor = UIColorFromInt32(light);
   UIColor *darkColor = UIColorFromInt32(dark);
@@ -83,7 +83,7 @@ UIColor *_Nullable UIColorFromDynamicColor(const facebook::react::DynamicColor &
   return nil;
 }
 
-uint32_t ColorFromColorComponents(const facebook::react::ColorComponents &components)
+int32_t ColorFromColorComponents(const facebook::react::ColorComponents &components)
 {
   float ratio = 255;
   auto color = ((int32_t)round((float)components.alpha * ratio) & 0xff) << 24 |
@@ -92,7 +92,7 @@ uint32_t ColorFromColorComponents(const facebook::react::ColorComponents &compon
   return color;
 }
 
-uint32_t ColorFromUIColor(UIColor *color)
+int32_t ColorFromUIColor(UIColor *color)
 {
   CGFloat rgba[4];
   [color getRed:&rgba[0] green:&rgba[1] blue:&rgba[2] alpha:&rgba[3]];
@@ -100,7 +100,7 @@ uint32_t ColorFromUIColor(UIColor *color)
       {.red = (float)rgba[0], .green = (float)rgba[1], .blue = (float)rgba[2], .alpha = (float)rgba[3]});
 }
 
-uint32_t ColorFromUIColorForSpecificTraitCollection(
+int32_t ColorFromUIColorForSpecificTraitCollection(
     const std::shared_ptr<void> &uiColor,
     UITraitCollection *traitCollection)
 {
@@ -113,7 +113,7 @@ uint32_t ColorFromUIColorForSpecificTraitCollection(
   return 0;
 }
 
-uint32_t ColorFromUIColor(const std::shared_ptr<void> &uiColor)
+int32_t ColorFromUIColor(const std::shared_ptr<void> &uiColor)
 {
   return ColorFromUIColorForSpecificTraitCollection(uiColor, [UITraitCollection currentTraitCollection]);
 }
@@ -172,7 +172,7 @@ std::size_t hashFromUIColor(const std::shared_ptr<void> &uiColor)
 
 } // anonymous namespace
 
-Color::Color(uint32_t color)
+Color::Color(int32_t color)
 {
   uiColor_ = wrapManagedObject(UIColorFromInt32(color));
   uiColorHashValue_ = facebook::react::hash_combine(color, 0);
@@ -217,7 +217,7 @@ bool Color::operator!=(const Color &other) const
   return !(*this == other);
 }
 
-uint32_t Color::getColor() const
+int32_t Color::getColor() const
 {
   return ColorFromUIColor(uiColor_);
 }

--- a/packages/react-native/ReactCxxPlatform/react/devsupport/DevLoadingViewModule.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/devsupport/DevLoadingViewModule.cpp
@@ -9,8 +9,8 @@
 
 namespace facebook::react {
 
-const uint32_t DEFAULT_TEXT_COLOR = 0xFFFFFFFF;
-const uint32_t DEFAULT_BACKGROUND_COLOR = 0xFF2584E8;
+const int32_t DEFAULT_TEXT_COLOR = 0xFFFFFFFF;
+const int32_t DEFAULT_BACKGROUND_COLOR = 0xFF2584E8;
 
 DevLoadingViewModule::DevLoadingViewModule(
     std::shared_ptr<CallInvoker> jsInvoker,
@@ -27,8 +27,8 @@ DevLoadingViewModule::~DevLoadingViewModule() {
 void DevLoadingViewModule::showMessage(
     jsi::Runtime& /*rt*/,
     const std::string& message,
-    std::optional<uint32_t> textColor,
-    std::optional<uint32_t> backgroundColor) {
+    std::optional<int32_t> textColor,
+    std::optional<int32_t> backgroundColor) {
   if (auto devUIDelegate = devUIDelegate_.lock()) {
     devUIDelegate->showLoadingView(
         message,

--- a/packages/react-native/ReactCxxPlatform/react/devsupport/DevLoadingViewModule.h
+++ b/packages/react-native/ReactCxxPlatform/react/devsupport/DevLoadingViewModule.h
@@ -27,8 +27,8 @@ class DevLoadingViewModule
   void showMessage(
       jsi::Runtime& rt,
       const std::string& message,
-      std::optional<uint32_t> textColor,
-      std::optional<uint32_t> backgroundColor);
+      std::optional<int32_t> textColor,
+      std::optional<int32_t> backgroundColor);
 
   void hide(jsi::Runtime& rt);
 


### PR DESCRIPTION
Summary:
Reverting to avoid lossy conversion on hosts expecting signed int values for color conversion.

Changelog: [Internal]

Differential Revision: D81785268


