### PR TITLE
Add missing AccessibilityProps::role to getDebugProps

### DIFF
--- a/packages/react-native/Libraries/Text/__tests__/Text-itest.js
+++ b/packages/react-native/Libraries/Text/__tests__/Text-itest.js
@@ -18,9 +18,7 @@ import * as Fantom from '@react-native/fantom';
 import * as React from 'react';
 import {createRef} from 'react';
 import {Text} from 'react-native';
-import accessibilityPropsSuite, {
-  rolePropSuite,
-} from 'react-native/src/private/__tests__/utilities/accessibilityPropsSuite';
+import accessibilityPropsSuite from 'react-native/src/private/__tests__/utilities/accessibilityPropsSuite';
 import {testIDPropSuite} from 'react-native/src/private/__tests__/utilities/commonPropsSuite';
 import ReactNativeElement from 'react-native/src/private/webapis/dom/nodes/ReactNativeElement';
 import ReadOnlyText from 'react-native/src/private/webapis/dom/nodes/ReadOnlyText';
@@ -443,7 +441,5 @@ describe('<Text>', () => {
     );
   }
   accessibilityPropsSuite(TestComponent, false);
-  rolePropSuite(TestComponent);
-
   testIDPropSuite(TestComponent);
 });

--- a/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.cpp
@@ -344,6 +344,7 @@ SharedDebugStringConvertibleList AccessibilityProps::getDebugProps() const {
           importantForAccessibility,
           defaultProps.importantForAccessibility),
       debugStringConvertibleItem("testID", testId, defaultProps.testId),
+      debugStringConvertibleItem("role", role, defaultProps.role),
   };
 }
 #endif // RN_DEBUG_STRING_CONVERTIBLE

--- a/packages/react-native/src/private/__tests__/utilities/accessibilityPropsSuite.js
+++ b/packages/react-native/src/private/__tests__/utilities/accessibilityPropsSuite.js
@@ -137,44 +137,6 @@ function getAccessibilityProps(
   return {...props};
 }
 
-export function rolePropSuite(
-  Component: component(...AccessibilityProps),
-): void {
-  describe('role', () => {
-    beforeEach(() => {
-      root = Fantom.createRoot();
-    });
-
-    afterEach(() => {
-      root.destroy();
-    });
-
-    it(`'role' has none by default`, () => {
-      expect(getAccessibilityProps(<Component />, ['role'])).toEqual({});
-    });
-
-    it(`'role' maps invalid values to 'none'`, () => {
-      expect(
-        getAccessibilityProps(
-          // $FlowExpectedError[incompatible-type]
-          <Component role="__some_invalid_value" />,
-          ['role'],
-        ),
-      ).toEqual({['role']: 'none'});
-    });
-
-    describe(`'role' propagation`, () => {
-      ROLE_VALUES.forEach(role => {
-        it(`can be set to ${role}`, () => {
-          expect(
-            getAccessibilityProp(<Component role={role} />, 'role'),
-          ).toEqual(role);
-        });
-      });
-    });
-  });
-}
-
 export default function accessibilityPropsSuite(
   Component: component(...AccessibilityProps),
   accessibleByDefault: boolean = true,
@@ -326,6 +288,32 @@ export default function accessibilityPropsSuite(
             'accessibilityActions',
           ),
         ).toEqual("[activate, spawn: 'open a panel', escape]");
+      });
+    });
+  });
+
+  describe('role', () => {
+    beforeEach(() => {
+      root = Fantom.createRoot();
+    });
+
+    afterEach(() => {
+      root.destroy();
+    });
+
+    it(`'role' has none by default`, () => {
+      expect(getAccessibilityProps(<Component />, ['role'])).toEqual({});
+    });
+
+    describe(`'role' propagation`, () => {
+      ROLE_VALUES.forEach(role => {
+        it(`can be set to ${role}`, () => {
+          if (role !== 'none') {
+            expect(
+              getAccessibilityProp(<Component role={role} />, 'role'),
+            ).toEqual(role);
+          }
+        });
       });
     });
   });


### PR DESCRIPTION
Summary:
## Changelog:
[Internal] - 

This was missing, leading to not being able to get the corresponding value back from native for some of the Fantom tests.

I also modified the corresponding AccessibilityProps related Fantom tests, so that we are now testing the right things for all relevant component types (see the test plan).

Differential Revision: D81786901


