### PR TITLE
Deprecate legacy javascript apis

### DIFF
--- a/packages/react-native/Libraries/BatchedBridge/BatchedBridge.js
+++ b/packages/react-native/Libraries/BatchedBridge/BatchedBridge.js
@@ -6,6 +6,7 @@
  *
  * @flow strict
  * @format
+ * @deprecated
  */
 
 'use strict';

--- a/packages/react-native/Libraries/BatchedBridge/MessageQueue.js
+++ b/packages/react-native/Libraries/BatchedBridge/MessageQueue.js
@@ -6,6 +6,7 @@
  *
  * @flow strict
  * @format
+ * @deprecated
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Core/Timers/JSTimers.js
+++ b/packages/react-native/Libraries/Core/Timers/JSTimers.js
@@ -6,6 +6,7 @@
  *
  * @flow
  * @format
+ * @deprecated
  */
 
 import NativeTiming from './NativeTiming';

--- a/packages/react-native/Libraries/Core/Timers/NativeTiming.js
+++ b/packages/react-native/Libraries/Core/Timers/NativeTiming.js
@@ -6,6 +6,7 @@
  *
  * @flow strict
  * @format
+ * @deprecated
  */
 
 export * from '../../../src/private/specs_DEPRECATED/modules/NativeTiming';

--- a/packages/react-native/Libraries/Core/Timers/immediateShim.js
+++ b/packages/react-native/Libraries/Core/Timers/immediateShim.js
@@ -6,6 +6,7 @@
  *
  * @flow
  * @format
+ * @deprecated
  */
 
 'use strict';

--- a/packages/react-native/src/private/specs_DEPRECATED/modules/NativeTiming.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/modules/NativeTiming.js
@@ -6,6 +6,7 @@
  *
  * @flow strict
  * @format
+ * @deprecated
  */
 
 import type {TurboModule} from '../../../../Libraries/TurboModule/RCTExport';


### PR DESCRIPTION
Summary:
These JavaScript apis were a part of react native's legacy architecture. Let's deprecate them, so that we can eventually remove them in the future.

Changelog: [General][Deprecated] - Deprecate legacy javascript react native apis

Reviewed By: cortinico

Differential Revision: D81795732


