### PR TITLE
Check value of the Hermes V1 flag instead of whether it's defined

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/hermes/reactexecutor/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/hermes/reactexecutor/CMakeLists.txt
@@ -28,7 +28,7 @@ target_compile_reactnative_options(hermes_executor PRIVATE)
 if(${CMAKE_BUILD_TYPE} MATCHES Debug OR REACT_NATIVE_DEBUG_OPTIMIZED)
   target_compile_options(hermes_executor PRIVATE -DHERMES_ENABLE_DEBUGGER=1)
 
-  if (DEFINED HERMES_V1_ENABLED)
+  if (HERMES_V1_ENABLED)
         target_compile_options(hermes_executor PRIVATE -DHERMES_V1_ENABLED=1)
   endif()
 endif()

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/hermes/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/hermes/jni/CMakeLists.txt
@@ -30,7 +30,7 @@ target_compile_reactnative_options(hermesinstancejni PRIVATE)
 if(${CMAKE_BUILD_TYPE} MATCHES Debug OR REACT_NATIVE_DEBUG_OPTIMIZED)
   target_compile_options(hermesinstancejni PRIVATE -DHERMES_ENABLE_DEBUGGER=1)
 
-  if (DEFINED HERMES_V1_ENABLED)
+  if (HERMES_V1_ENABLED)
         target_compile_options(hermesinstancejni PRIVATE -DHERMES_V1_ENABLED=1)
   endif()
 endif ()

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/CMakeLists.txt
@@ -20,7 +20,7 @@ target_compile_reactnative_options(rninstance PRIVATE)
 if(${CMAKE_BUILD_TYPE} MATCHES Debug OR REACT_NATIVE_DEBUG_OPTIMIZED)
   target_compile_options(rninstance PRIVATE -DHERMES_ENABLE_DEBUGGER=1)
 
-  if (DEFINED HERMES_V1_ENABLED)
+  if (HERMES_V1_ENABLED)
         target_compile_options(rninstance PRIVATE -DHERMES_V1_ENABLED=1)
   endif()
 endif ()

--- a/packages/react-native/ReactCommon/hermes/executor/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/hermes/executor/CMakeLists.txt
@@ -33,7 +33,7 @@ if(${CMAKE_BUILD_TYPE} MATCHES Debug OR REACT_NATIVE_DEBUG_OPTIMIZED)
                 -DHERMES_ENABLE_DEBUGGER=1
         )
 
-        if (DEFINED HERMES_V1_ENABLED)
+        if (HERMES_V1_ENABLED)
                 target_compile_options(hermes_executor_common PRIVATE -DHERMES_V1_ENABLED=1)
         endif()
 else()

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/CMakeLists.txt
@@ -24,7 +24,7 @@ if(${CMAKE_BUILD_TYPE} MATCHES Debug OR REACT_NATIVE_DEBUG_OPTIMIZED)
                 -DHERMES_ENABLE_DEBUGGER=1
         )
 
-        if (DEFINED HERMES_V1_ENABLED)
+        if (HERMES_V1_ENABLED)
                 target_compile_options(hermes_inspector_modern PRIVATE -DHERMES_V1_ENABLED=1)
         endif()
 endif()

--- a/packages/react-native/ReactCommon/react/runtime/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/runtime/CMakeLists.txt
@@ -19,7 +19,7 @@ target_compile_reactnative_options(bridgeless PRIVATE)
 if(${CMAKE_BUILD_TYPE} MATCHES Debug OR REACT_NATIVE_DEBUG_OPTIMIZED)
   target_compile_options(bridgeless PRIVATE -DHERMES_ENABLE_DEBUGGER=1)
 
-  if (DEFINED HERMES_V1_ENABLED)
+  if (HERMES_V1_ENABLED)
         target_compile_options(bridgeless PRIVATE -DHERMES_V1_ENABLED=1)
   endif()
 endif ()

--- a/packages/react-native/ReactCommon/react/runtime/hermes/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/runtime/hermes/CMakeLists.txt
@@ -36,7 +36,7 @@ if(${CMAKE_BUILD_TYPE} MATCHES Debug OR REACT_NATIVE_DEBUG_OPTIMIZED)
                 -DHERMES_ENABLE_DEBUGGER=1
         )
 
-        if (DEFINED HERMES_V1_ENABLED)
+        if (HERMES_V1_ENABLED)
                 target_compile_options(bridgelesshermes PRIVATE -DHERMES_V1_ENABLED=1)
         endif()
 endif()


### PR DESCRIPTION
Summary: Changelog: [ANDROID][FIXED] - Check for the value of the HERMES_V1_ENABLED flag instead of whether it's defined

Differential Revision: D81920483


