### PR TITLE
Remove unnecessary extra quote on hermesVersionProvider

### DIFF
--- a/packages/react-native/ReactAndroid/hermes-engine/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/hermes-engine/build.gradle.kts
@@ -88,7 +88,7 @@ val hermesVersionProvider: Provider<String> =
       val hermesVersionFile =
           File(
               reactNativeRootDir,
-              if (hermesV1Enabled) "sdks/.hermesv1version" else "\"sdks/.hermesversion\"",
+              if (hermesV1Enabled) "sdks/.hermesv1version" else "sdks/.hermesversion",
           )
 
       if (hermesVersionFile.exists()) {


### PR DESCRIPTION
Summary:
This extra quote is causing the build on the 0.82-stable to fail. The reason is that the Path for the `.hermesversion` file is composed wrongly so we attempt to build hermes from the `main` branch.

Created from CodeHub with https://fburl.com/edit-in-codehub

Differential Revision: D81925624


