### PR TITLE
React Native

### DIFF
--- a/packages/react-native/React/Base/RCTBridgeModule.h
+++ b/packages/react-native/React/Base/RCTBridgeModule.h
@@ -69,6 +69,7 @@ RCT_EXTERN_C_END
  * will be used as the JS module name. If omitted, the JS module name will
  * match the Objective-C class name.
  */
+#ifndef RCT_FIT_RM_OLD_RUNTIME
 #define RCT_EXPORT_MODULE(js_name)          \
   RCT_EXTERN void RCTRegisterModule(Class); \
   +(NSString *)moduleName                   \
@@ -79,6 +80,17 @@ RCT_EXTERN_C_END
   {                                         \
     RCTRegisterModule(self);                \
   }
+
+#else
+
+#define RCT_EXPORT_MODULE(js_name)          \
+  RCT_EXTERN void RCTRegisterModule(Class); \
+  +(NSString *)moduleName                   \
+  {                                         \
+    return @ #js_name;                      \
+  }
+
+#endif // RCT_FIT_RM_OLD_RUNTIME
 
 /**
  * Same as RCT_EXPORT_MODULE, but uses __attribute__((constructor)) for module


### PR DESCRIPTION
Summary:
## Stack
We aim to remove +load methods from the codebase to reduce pre-main startup time and to unblock enabling startup optimizations

# Diff
Diff removes `+load` API from `RCT_EXPORT_MODULE` macro.
It introduces new parameter for `react_native_module_provider` function `eager`, which adds legacy RN modules to newly created socket `REACT_MODULE_EAGER_REGISTRATION_SOCKET`. This socket is invoked right before the RCTBridge is being initialized.

Impact: 137 static loaders are removed from the startup path

Differential Revision: D81727845
