### PR TITLE
Use artifacts published from the Hermes repository on Android

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -135,8 +135,7 @@ if (project.findProperty("react.internal.useHermesNightly")?.toString()?.toBoole
     configurations.all {
       resolutionStrategy.dependencySubstitution {
         substitute(project(":packages:react-native:ReactAndroid:hermes-engine"))
-            // TODO: T237406039 update coordinates
-            .using(module("com.facebook.react:hermes-android:0.+"))
+            .using(module("com.facebook.hermes:hermes-android:0.+"))
             .because("Users opted to use hermes from nightly")
       }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -135,6 +135,7 @@ if (project.findProperty("react.internal.useHermesNightly")?.toString()?.toBoole
     configurations.all {
       resolutionStrategy.dependencySubstitution {
         substitute(project(":packages:react-native:ReactAndroid:hermes-engine"))
+            // TODO: T237406039 update coordinates
             .using(module("com.facebook.react:hermes-android:0.+"))
             .because("Users opted to use hermes from nightly")
       }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -55,7 +55,7 @@ class ReactPlugin : Plugin<Project> {
                 project,
             )
 
-    if (project.rootProject.isHermesV1Enabled != rootExtension.hermesV1Enabled.get()) {
+    if (project.rootProject.isHermesV1Enabled) {
       rootExtension.hermesV1Enabled.set(project.rootProject.isHermesV1Enabled)
     }
 
@@ -72,10 +72,7 @@ class ReactPlugin : Plugin<Project> {
         val reactNativeDir = extension.reactNativeDir.get().asFile
         val propertiesFile = File(reactNativeDir, "ReactAndroid/gradle.properties")
         val versionAndGroupStrings = readVersionAndGroupStrings(propertiesFile)
-        val hermesV1Enabled =
-            if (project.rootProject.hasProperty("hermesV1Enabled"))
-                project.rootProject.findProperty("hermesV1Enabled") == "true"
-            else false
+        val hermesV1Enabled = rootExtension.hermesV1Enabled.get()
         configureDependencies(project, versionAndGroupStrings, hermesV1Enabled)
         configureRepositories(project)
       }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/BundleHermesCTask.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/BundleHermesCTask.kt
@@ -7,6 +7,7 @@
 
 package com.facebook.react.tasks
 
+import com.facebook.react.internal.PrivateReactExtension
 import com.facebook.react.utils.Os.cliPath
 import com.facebook.react.utils.detectOSAwareHermesCommand
 import com.facebook.react.utils.moveTo
@@ -95,9 +96,10 @@ abstract class BundleHermesCTask : DefaultTask() {
 
     if (hermesEnabled.get()) {
       val hermesV1Enabled =
-          if (project.rootProject.hasProperty("hermesV1Enabled"))
-              project.rootProject.findProperty("hermesV1Enabled") == "true"
-          else false
+          project.rootProject.extensions
+              .getByType(PrivateReactExtension::class.java)
+              .hermesV1Enabled
+              .get()
       val detectedHermesCommand =
           detectOSAwareHermesCommand(root.get().asFile, hermesCommand.get(), hermesV1Enabled)
       val bytecodeFile = File("${bundleFile}.hbc")

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/BundleHermesCTask.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/BundleHermesCTask.kt
@@ -7,7 +7,6 @@
 
 package com.facebook.react.tasks
 
-import com.facebook.react.internal.PrivateReactExtension
 import com.facebook.react.utils.Os.cliPath
 import com.facebook.react.utils.detectOSAwareHermesCommand
 import com.facebook.react.utils.moveTo
@@ -95,13 +94,7 @@ abstract class BundleHermesCTask : DefaultTask() {
     runCommand(bundleCommand)
 
     if (hermesEnabled.get()) {
-      val hermesV1Enabled =
-          project.rootProject.extensions
-              .getByType(PrivateReactExtension::class.java)
-              .hermesV1Enabled
-              .get()
-      val detectedHermesCommand =
-          detectOSAwareHermesCommand(root.get().asFile, hermesCommand.get(), hermesV1Enabled)
+      val detectedHermesCommand = detectOSAwareHermesCommand(root.get().asFile, hermesCommand.get())
       val bytecodeFile = File("${bundleFile}.hbc")
       val outputSourceMap = resolveOutputSourceMap(bundleAssetFilename)
       val compilerSourceMap = resolveCompilerSourceMap(bundleAssetFilename)

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
@@ -13,6 +13,7 @@ import com.facebook.react.utils.PropertyUtils.EXCLUSIVE_ENTEPRISE_REPOSITORY
 import com.facebook.react.utils.PropertyUtils.INCLUDE_JITPACK_REPOSITORY
 import com.facebook.react.utils.PropertyUtils.INCLUDE_JITPACK_REPOSITORY_DEFAULT
 import com.facebook.react.utils.PropertyUtils.INTERNAL_HERMES_PUBLISHING_GROUP
+import com.facebook.react.utils.PropertyUtils.INTERNAL_HERMES_V1_VERSION_NAME
 import com.facebook.react.utils.PropertyUtils.INTERNAL_HERMES_VERSION_NAME
 import com.facebook.react.utils.PropertyUtils.INTERNAL_REACT_NATIVE_MAVEN_LOCAL_REPO
 import com.facebook.react.utils.PropertyUtils.INTERNAL_REACT_PUBLISHING_GROUP
@@ -31,6 +32,7 @@ internal object DependencyUtils {
   internal data class Coordinates(
       val versionString: String,
       val hermesVersionString: String,
+      val hermesV1VersionString: String,
       val reactGroupString: String = DEFAULT_INTERNAL_REACT_PUBLISHING_GROUP,
       val hermesGroupString: String = DEFAULT_INTERNAL_HERMES_PUBLISHING_GROUP,
   )
@@ -133,7 +135,11 @@ internal object DependencyUtils {
           // Contributors only: The hermes-engine version is forced only if the user has
           // not opted into using nightlies for local development.
           configuration.resolutionStrategy.force(
-              "${coordinates.reactGroupString}:hermes-android:${coordinates.versionString}"
+              // TODO: T237406039 update coordinates
+              if (hermesV1Enabled)
+                  "${coordinates.hermesGroupString}:hermes-android:${coordinates.hermesV1VersionString}"
+              else
+                  "${coordinates.reactGroupString}:hermes-android:${coordinates.hermesVersionString}"
           )
         }
       }
@@ -144,12 +150,12 @@ internal object DependencyUtils {
       coordinates: Coordinates,
       hermesV1Enabled: Boolean = false,
   ): List<Triple<String, String, String>> {
-    // TODO: T231755027 update coordinates and versioning
     val dependencySubstitution = mutableListOf<Triple<String, String, String>>()
     val hermesVersionString =
+        // TODO: T237406039 update coordinates
         if (hermesV1Enabled)
-            "${coordinates.hermesGroupString}:hermes-android:${coordinates.versionString}"
-        else "${coordinates.reactGroupString}:hermes-android:${coordinates.versionString}"
+            "${coordinates.hermesGroupString}:hermes-android:${coordinates.hermesV1VersionString}"
+        else "${coordinates.reactGroupString}:hermes-android:${coordinates.hermesVersionString}"
     dependencySubstitution.add(
         Triple(
             "com.facebook.react:react-native",
@@ -172,9 +178,13 @@ internal object DependencyUtils {
               "The react-android dependency was modified to use the correct Maven group.",
           )
       )
+    }
+    if (coordinates.hermesVersionString != DEFAULT_INTERNAL_HERMES_PUBLISHING_GROUP) {
       dependencySubstitution.add(
           Triple(
-              "com.facebook.react:hermes-android",
+              // TODO: T237406039 update coordinates
+              if (hermesV1Enabled) "com.facebook.hermes:hermes-android"
+              else "com.facebook.react:hermes-android",
               hermesVersionString,
               "The hermes-android dependency was modified to use the correct Maven group.",
           )
@@ -187,16 +197,25 @@ internal object DependencyUtils {
     val reactAndroidProperties = Properties()
     propertiesFile.inputStream().use { reactAndroidProperties.load(it) }
     val versionStringFromFile = (reactAndroidProperties[INTERNAL_VERSION_NAME] as? String).orEmpty()
-    // TODO: T231755027 update HERMES_VERSION_NAME in gradle.properties to point to the correct
-    // hermes version
     val hermesVersionStringFromFile =
         (reactAndroidProperties[INTERNAL_HERMES_VERSION_NAME] as? String).orEmpty()
+    val hermesV1VersionStringFromFile =
+        (reactAndroidProperties[INTERNAL_HERMES_V1_VERSION_NAME] as? String).orEmpty()
     // If on a nightly, we need to fetch the -SNAPSHOT artifact from Sonatype.
     val versionString =
         if (versionStringFromFile.startsWith("0.0.0") || "-nightly-" in versionStringFromFile) {
           "$versionStringFromFile-SNAPSHOT"
         } else {
           versionStringFromFile
+        }
+    val hermesVersionString =
+        if (
+            hermesVersionStringFromFile.startsWith("0.0.0") ||
+                "-commitly-" in hermesVersionStringFromFile
+        ) {
+          "$hermesVersionStringFromFile-SNAPSHOT"
+        } else {
+          hermesVersionStringFromFile
         }
     // Returns Maven group for repos using different group for Maven artifacts
     val reactGroupString =
@@ -207,7 +226,8 @@ internal object DependencyUtils {
             ?: DEFAULT_INTERNAL_HERMES_PUBLISHING_GROUP
     return Coordinates(
         versionString,
-        hermesVersionStringFromFile,
+        hermesVersionString,
+        hermesV1VersionStringFromFile,
         reactGroupString,
         hermesGroupString,
     )

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
@@ -135,11 +135,7 @@ internal object DependencyUtils {
           // Contributors only: The hermes-engine version is forced only if the user has
           // not opted into using nightlies for local development.
           configuration.resolutionStrategy.force(
-              // TODO: T237406039 update coordinates
-              if (hermesV1Enabled)
-                  "${coordinates.hermesGroupString}:hermes-android:${coordinates.hermesV1VersionString}"
-              else
-                  "${coordinates.reactGroupString}:hermes-android:${coordinates.hermesVersionString}"
+              "${coordinates.hermesGroupString}:hermes-android:${if (hermesV1Enabled) coordinates.hermesV1VersionString else coordinates.hermesVersionString}"
           )
         }
       }
@@ -152,10 +148,9 @@ internal object DependencyUtils {
   ): List<Triple<String, String, String>> {
     val dependencySubstitution = mutableListOf<Triple<String, String, String>>()
     val hermesVersionString =
-        // TODO: T237406039 update coordinates
         if (hermesV1Enabled)
             "${coordinates.hermesGroupString}:hermes-android:${coordinates.hermesV1VersionString}"
-        else "${coordinates.reactGroupString}:hermes-android:${coordinates.hermesVersionString}"
+        else "${coordinates.hermesGroupString}:hermes-android:${coordinates.hermesVersionString}"
     dependencySubstitution.add(
         Triple(
             "com.facebook.react:react-native",
@@ -182,9 +177,7 @@ internal object DependencyUtils {
     if (coordinates.hermesVersionString != DEFAULT_INTERNAL_HERMES_PUBLISHING_GROUP) {
       dependencySubstitution.add(
           Triple(
-              // TODO: T237406039 update coordinates
-              if (hermesV1Enabled) "com.facebook.hermes:hermes-android"
-              else "com.facebook.react:hermes-android",
+              "com.facebook.hermes:hermes-android",
               hermesVersionString,
               "The hermes-android dependency was modified to use the correct Maven group.",
           )

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PathUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PathUtils.kt
@@ -153,6 +153,7 @@ internal fun detectOSAwareHermesCommand(
 
   // 3. If Hermes V1 is enabled, use hermes-compiler from npm, otherwise, if the
   // react-native contains a pre-built hermesc, use it.
+  // TODO: T237406039 use hermes-compiler from npm for both
   val hermesCPath = if (hermesV1Enabled) HERMES_COMPILER_NPM_DIR else HERMESC_IN_REACT_NATIVE_DIR
   val prebuiltHermesPath =
       hermesCPath

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PathUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PathUtils.kt
@@ -130,7 +130,6 @@ private fun detectCliFile(reactNativeRoot: File, preconfiguredCliFile: File?): F
 internal fun detectOSAwareHermesCommand(
     projectRoot: File,
     hermesCommand: String,
-    hermesV1Enabled: Boolean = false,
 ): String { // 1. If the project specifies a Hermes command, don't second guess it.
   if (hermesCommand.isNotBlank()) {
     val osSpecificHermesCommand =
@@ -151,13 +150,9 @@ internal fun detectOSAwareHermesCommand(
     return builtHermesc.cliPath(projectRoot)
   }
 
-  // 3. If Hermes V1 is enabled, use hermes-compiler from npm, otherwise, if the
-  // react-native contains a pre-built hermesc, use it.
-  // TODO: T237406039 use hermes-compiler from npm for both
-  val hermesCPath = if (hermesV1Enabled) HERMES_COMPILER_NPM_DIR else HERMESC_IN_REACT_NATIVE_DIR
+  // 3. Use hermes-compiler installed from npm
   val prebuiltHermesPath =
-      hermesCPath
-          .plus(getHermesCBin())
+      HERMES_COMPILER_NPM_DIR.plus(getHermesCBin())
           .replace("%OS-BIN%", getHermesOSBin())
           // Execution on Windows fails with / as separator
           .replace('/', File.separatorChar)
@@ -243,6 +238,5 @@ internal fun readPackageJsonFile(
 }
 
 private const val HERMES_COMPILER_NPM_DIR = "node_modules/hermes-compiler/%OS-BIN%/"
-private const val HERMESC_IN_REACT_NATIVE_DIR = "node_modules/react-native/sdks/hermesc/%OS-BIN%/"
 private const val HERMESC_BUILT_FROM_SOURCE_DIR =
     "node_modules/react-native/ReactAndroid/hermes-engine/build/hermes/bin/"

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PropertyUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PropertyUtils.kt
@@ -81,4 +81,6 @@ object PropertyUtils {
   const val INTERNAL_VERSION_NAME = "VERSION_NAME"
   /** Internal property used to control the version name of Hermes Engine */
   const val INTERNAL_HERMES_VERSION_NAME = "HERMES_VERSION_NAME"
+  /** Internal property used to control the version name of Hermes V1 */
+  const val INTERNAL_HERMES_V1_VERSION_NAME = "HERMES_V1_VERSION_NAME"
 }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/DependencyUtilsTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/DependencyUtilsTest.kt
@@ -289,7 +289,7 @@ class DependencyUtilsTest {
     val forcedModules = project.configurations.first().resolutionStrategy.forcedModules
     assertThat(forcedModules.any { it.toString() == "com.facebook.react:react-android:1.2.3" })
         .isTrue()
-    assertThat(forcedModules.any { it.toString() == "com.facebook.react:hermes-android:4.5.6" })
+    assertThat(forcedModules.any { it.toString() == "com.facebook.hermes:hermes-android:4.5.6" })
         .isTrue()
   }
 
@@ -324,11 +324,11 @@ class DependencyUtilsTest {
     val libForcedModules = libProject.configurations.first().resolutionStrategy.forcedModules
     assertThat(appForcedModules.any { it.toString() == "com.facebook.react:react-android:1.2.3" })
         .isTrue()
-    assertThat(appForcedModules.any { it.toString() == "com.facebook.react:hermes-android:4.5.6" })
+    assertThat(appForcedModules.any { it.toString() == "com.facebook.hermes:hermes-android:4.5.6" })
         .isTrue()
     assertThat(libForcedModules.any { it.toString() == "com.facebook.react:react-android:1.2.3" })
         .isTrue()
-    assertThat(libForcedModules.any { it.toString() == "com.facebook.react:hermes-android:4.5.6" })
+    assertThat(libForcedModules.any { it.toString() == "com.facebook.hermes:hermes-android:4.5.6" })
         .isTrue()
   }
 
@@ -381,11 +381,15 @@ class DependencyUtilsTest {
     val libForcedModules = libProject.configurations.first().resolutionStrategy.forcedModules
     assertThat(appForcedModules.any { it.toString() == "io.github.test:react-android:1.2.3" })
         .isTrue()
-    assertThat(appForcedModules.any { it.toString() == "io.github.test:hermes-android:4.5.6" })
+    assertThat(
+            appForcedModules.any { it.toString() == "io.github.test.hermes:hermes-android:4.5.6" }
+        )
         .isTrue()
     assertThat(libForcedModules.any { it.toString() == "io.github.test:react-android:1.2.3" })
         .isTrue()
-    assertThat(libForcedModules.any { it.toString() == "io.github.test:hermes-android:4.5.6" })
+    assertThat(
+            libForcedModules.any { it.toString() == "io.github.test.hermes:hermes-android:4.5.6" }
+        )
         .isTrue()
   }
 
@@ -438,7 +442,7 @@ class DependencyUtilsTest {
         )
         .isEqualTo(dependencySubstitutions[0].third)
     assertThat("com.facebook.react:hermes-engine").isEqualTo(dependencySubstitutions[1].first)
-    assertThat("com.facebook.react:hermes-android:0.42.0")
+    assertThat("com.facebook.hermes:hermes-android:0.42.0")
         .isEqualTo(dependencySubstitutions[1].second)
     assertThat(
             "The hermes-engine artifact was deprecated in favor of hermes-android due to https://github.com/facebook/react-native/issues/35210."
@@ -490,7 +494,8 @@ class DependencyUtilsTest {
         )
         .isEqualTo(dependencySubstitutions[0].third)
     assertThat("com.facebook.react:hermes-engine").isEqualTo(dependencySubstitutions[1].first)
-    assertThat("io.github.test:hermes-android:0.42.0").isEqualTo(dependencySubstitutions[1].second)
+    assertThat("io.github.test.hermes:hermes-android:0.42.0")
+        .isEqualTo(dependencySubstitutions[1].second)
     assertThat(
             "The hermes-engine artifact was deprecated in favor of hermes-android due to https://github.com/facebook/react-native/issues/35210."
         )
@@ -499,8 +504,9 @@ class DependencyUtilsTest {
     assertThat("io.github.test:react-android:0.42.0").isEqualTo(dependencySubstitutions[2].second)
     assertThat("The react-android dependency was modified to use the correct Maven group.")
         .isEqualTo(dependencySubstitutions[2].third)
-    assertThat("com.facebook.react:hermes-android").isEqualTo(dependencySubstitutions[3].first)
-    assertThat("io.github.test:hermes-android:0.42.0").isEqualTo(dependencySubstitutions[3].second)
+    assertThat("com.facebook.hermes:hermes-android").isEqualTo(dependencySubstitutions[3].first)
+    assertThat("io.github.test.hermes:hermes-android:0.42.0")
+        .isEqualTo(dependencySubstitutions[3].second)
     assertThat("The hermes-android dependency was modified to use the correct Maven group.")
         .isEqualTo(dependencySubstitutions[3].third)
   }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/DependencyUtilsTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/DependencyUtilsTest.kt
@@ -271,54 +271,69 @@ class DependencyUtilsTest {
         .isEqualTo(2)
   }
 
-  // TODO: T236767053
-
   @Test
   fun configureDependencies_withEmptyVersion_doesNothing() {
     val project = createProject()
 
-    configureDependencies(project, DependencyUtils.Coordinates("", ""))
+    configureDependencies(project, DependencyUtils.Coordinates("", "", ""))
 
     assertThat(project.configurations.first().resolutionStrategy.forcedModules.isEmpty()).isTrue()
   }
 
   @Test
-  fun configureDependencies_withVersionString_appliesResolutionStrategy() {
+  fun configureDependencies_withVersionString_appliesResolutionStrategy_withClassicHermes() {
     val project = createProject()
 
-    configureDependencies(project, DependencyUtils.Coordinates("1.2.3", "1.2.3"))
+    configureDependencies(project, DependencyUtils.Coordinates("1.2.3", "4.5.6", "7.8.9"))
 
     val forcedModules = project.configurations.first().resolutionStrategy.forcedModules
     assertThat(forcedModules.any { it.toString() == "com.facebook.react:react-android:1.2.3" })
         .isTrue()
-    assertThat(forcedModules.any { it.toString() == "com.facebook.react:hermes-android:1.2.3" })
+    assertThat(forcedModules.any { it.toString() == "com.facebook.react:hermes-android:4.5.6" })
         .isTrue()
   }
 
   @Test
-  fun configureDependencies_withVersionString_appliesOnAllProjects() {
+  fun configureDependencies_withVersionString_appliesResolutionStrategy_withHermesV1() {
+    val project = createProject()
+
+    configureDependencies(
+        project,
+        DependencyUtils.Coordinates("1.2.3", "4.5.6", "7.8.9"),
+        hermesV1Enabled = true,
+    )
+
+    val forcedModules = project.configurations.first().resolutionStrategy.forcedModules
+    assertThat(forcedModules.any { it.toString() == "com.facebook.react:react-android:1.2.3" })
+        .isTrue()
+    assertThat(forcedModules.any { it.toString() == "com.facebook.hermes:hermes-android:7.8.9" })
+        .isTrue()
+  }
+
+  @Test
+  fun configureDependencies_withVersionString_appliesOnAllProjects_withClassicHermes() {
     val rootProject = ProjectBuilder.builder().build()
     val appProject = ProjectBuilder.builder().withName("app").withParent(rootProject).build()
     val libProject = ProjectBuilder.builder().withName("lib").withParent(rootProject).build()
     appProject.plugins.apply("com.android.application")
     libProject.plugins.apply("com.android.library")
 
-    configureDependencies(appProject, DependencyUtils.Coordinates("1.2.3", "1.2.3"))
+    configureDependencies(appProject, DependencyUtils.Coordinates("1.2.3", "4.5.6", "7.8.9"))
 
     val appForcedModules = appProject.configurations.first().resolutionStrategy.forcedModules
     val libForcedModules = libProject.configurations.first().resolutionStrategy.forcedModules
     assertThat(appForcedModules.any { it.toString() == "com.facebook.react:react-android:1.2.3" })
         .isTrue()
-    assertThat(appForcedModules.any { it.toString() == "com.facebook.react:hermes-android:1.2.3" })
+    assertThat(appForcedModules.any { it.toString() == "com.facebook.react:hermes-android:4.5.6" })
         .isTrue()
     assertThat(libForcedModules.any { it.toString() == "com.facebook.react:react-android:1.2.3" })
         .isTrue()
-    assertThat(libForcedModules.any { it.toString() == "com.facebook.react:hermes-android:1.2.3" })
+    assertThat(libForcedModules.any { it.toString() == "com.facebook.react:hermes-android:4.5.6" })
         .isTrue()
   }
 
   @Test
-  fun configureDependencies_withVersionStringAndGroupString_appliesOnAllProjects() {
+  fun configureDependencies_withVersionString_appliesOnAllProjects_withHermesV1() {
     val rootProject = ProjectBuilder.builder().build()
     val appProject = ProjectBuilder.builder().withName("app").withParent(rootProject).build()
     val libProject = ProjectBuilder.builder().withName("lib").withParent(rootProject).build()
@@ -327,25 +342,93 @@ class DependencyUtilsTest {
 
     configureDependencies(
         appProject,
-        DependencyUtils.Coordinates("1.2.3", "1.2.3", "io.github.test"),
+        DependencyUtils.Coordinates("1.2.3", "4.5.6", "7.8.9"),
+        hermesV1Enabled = true,
+    )
+
+    val appForcedModules = appProject.configurations.first().resolutionStrategy.forcedModules
+    val libForcedModules = libProject.configurations.first().resolutionStrategy.forcedModules
+    assertThat(appForcedModules.any { it.toString() == "com.facebook.react:react-android:1.2.3" })
+        .isTrue()
+    assertThat(appForcedModules.any { it.toString() == "com.facebook.hermes:hermes-android:7.8.9" })
+        .isTrue()
+    assertThat(libForcedModules.any { it.toString() == "com.facebook.react:react-android:1.2.3" })
+        .isTrue()
+    assertThat(libForcedModules.any { it.toString() == "com.facebook.hermes:hermes-android:7.8.9" })
+        .isTrue()
+  }
+
+  @Test
+  fun configureDependencies_withVersionStringAndGroupString_appliesOnAllProjects_withClassicHermes() {
+    val rootProject = ProjectBuilder.builder().build()
+    val appProject = ProjectBuilder.builder().withName("app").withParent(rootProject).build()
+    val libProject = ProjectBuilder.builder().withName("lib").withParent(rootProject).build()
+    appProject.plugins.apply("com.android.application")
+    libProject.plugins.apply("com.android.library")
+
+    configureDependencies(
+        appProject,
+        DependencyUtils.Coordinates(
+            "1.2.3",
+            "4.5.6",
+            "7.8.9",
+            "io.github.test",
+            "io.github.test.hermes",
+        ),
     )
 
     val appForcedModules = appProject.configurations.first().resolutionStrategy.forcedModules
     val libForcedModules = libProject.configurations.first().resolutionStrategy.forcedModules
     assertThat(appForcedModules.any { it.toString() == "io.github.test:react-android:1.2.3" })
         .isTrue()
-    assertThat(appForcedModules.any { it.toString() == "io.github.test:hermes-android:1.2.3" })
+    assertThat(appForcedModules.any { it.toString() == "io.github.test:hermes-android:4.5.6" })
         .isTrue()
     assertThat(libForcedModules.any { it.toString() == "io.github.test:react-android:1.2.3" })
         .isTrue()
-    assertThat(libForcedModules.any { it.toString() == "io.github.test:hermes-android:1.2.3" })
+    assertThat(libForcedModules.any { it.toString() == "io.github.test:hermes-android:4.5.6" })
         .isTrue()
   }
 
   @Test
-  fun getDependencySubstitutions_withDefaultGroup_substitutesCorrectly() {
+  fun configureDependencies_withVersionStringAndGroupString_appliesOnAllProjects_withHermesV1() {
+    val rootProject = ProjectBuilder.builder().build()
+    val appProject = ProjectBuilder.builder().withName("app").withParent(rootProject).build()
+    val libProject = ProjectBuilder.builder().withName("lib").withParent(rootProject).build()
+    appProject.plugins.apply("com.android.application")
+    libProject.plugins.apply("com.android.library")
+
+    configureDependencies(
+        appProject,
+        DependencyUtils.Coordinates(
+            "1.2.3",
+            "4.5.6",
+            "7.8.9",
+            "io.github.test",
+            "io.github.test.hermes",
+        ),
+        hermesV1Enabled = true,
+    )
+
+    val appForcedModules = appProject.configurations.first().resolutionStrategy.forcedModules
+    val libForcedModules = libProject.configurations.first().resolutionStrategy.forcedModules
+    assertThat(appForcedModules.any { it.toString() == "io.github.test:react-android:1.2.3" })
+        .isTrue()
+    assertThat(
+            appForcedModules.any { it.toString() == "io.github.test.hermes:hermes-android:7.8.9" }
+        )
+        .isTrue()
+    assertThat(libForcedModules.any { it.toString() == "io.github.test:react-android:1.2.3" })
+        .isTrue()
+    assertThat(
+            libForcedModules.any { it.toString() == "io.github.test.hermes:hermes-android:7.8.9" }
+        )
+        .isTrue()
+  }
+
+  @Test
+  fun getDependencySubstitutions_withDefaultGroup_substitutesCorrectly_withClassicHermes() {
     val dependencySubstitutions =
-        getDependencySubstitutions(DependencyUtils.Coordinates("0.42.0", "0.42.0"))
+        getDependencySubstitutions(DependencyUtils.Coordinates("0.42.0", "0.42.0", "0.43.0"))
 
     assertThat("com.facebook.react:react-native").isEqualTo(dependencySubstitutions[0].first)
     assertThat("com.facebook.react:react-android:0.42.0")
@@ -364,10 +447,40 @@ class DependencyUtilsTest {
   }
 
   @Test
-  fun getDependencySubstitutions_withCustomGroup_substitutesCorrectly() {
+  fun getDependencySubstitutions_withDefaultGroup_substitutesCorrectly_withHermesV1() {
     val dependencySubstitutions =
         getDependencySubstitutions(
-            DependencyUtils.Coordinates("0.42.0", "0.42.0", "io.github.test")
+            DependencyUtils.Coordinates("0.42.0", "0.42.0", "0.43.0"),
+            hermesV1Enabled = true,
+        )
+
+    assertThat("com.facebook.react:react-native").isEqualTo(dependencySubstitutions[0].first)
+    assertThat("com.facebook.react:react-android:0.42.0")
+        .isEqualTo(dependencySubstitutions[0].second)
+    assertThat(
+            "The react-native artifact was deprecated in favor of react-android due to https://github.com/facebook/react-native/issues/35210."
+        )
+        .isEqualTo(dependencySubstitutions[0].third)
+    assertThat("com.facebook.react:hermes-engine").isEqualTo(dependencySubstitutions[1].first)
+    assertThat("com.facebook.hermes:hermes-android:0.43.0")
+        .isEqualTo(dependencySubstitutions[1].second)
+    assertThat(
+            "The hermes-engine artifact was deprecated in favor of hermes-android due to https://github.com/facebook/react-native/issues/35210."
+        )
+        .isEqualTo(dependencySubstitutions[1].third)
+  }
+
+  @Test
+  fun getDependencySubstitutions_withCustomGroup_substitutesCorrectly_withClassicHermes() {
+    val dependencySubstitutions =
+        getDependencySubstitutions(
+            DependencyUtils.Coordinates(
+                "0.42.0",
+                "0.42.0",
+                "0.43.0",
+                "io.github.test",
+                "io.github.test.hermes",
+            )
         )
 
     assertThat("com.facebook.react:react-native").isEqualTo(dependencySubstitutions[0].first)
@@ -393,21 +506,66 @@ class DependencyUtilsTest {
   }
 
   @Test
+  fun getDependencySubstitutions_withCustomGroup_substitutesCorrectly_withHermesV1() {
+    val dependencySubstitutions =
+        getDependencySubstitutions(
+            DependencyUtils.Coordinates(
+                "0.42.0",
+                "0.42.0",
+                "0.43.0",
+                "io.github.test",
+                "io.github.test.hermes",
+            ),
+            hermesV1Enabled = true,
+        )
+
+    assertThat("com.facebook.react:react-native").isEqualTo(dependencySubstitutions[0].first)
+    assertThat("io.github.test:react-android:0.42.0").isEqualTo(dependencySubstitutions[0].second)
+    assertThat(
+            "The react-native artifact was deprecated in favor of react-android due to https://github.com/facebook/react-native/issues/35210."
+        )
+        .isEqualTo(dependencySubstitutions[0].third)
+    assertThat("com.facebook.react:hermes-engine").isEqualTo(dependencySubstitutions[1].first)
+    assertThat("io.github.test.hermes:hermes-android:0.43.0")
+        .isEqualTo(dependencySubstitutions[1].second)
+    assertThat(
+            "The hermes-engine artifact was deprecated in favor of hermes-android due to https://github.com/facebook/react-native/issues/35210."
+        )
+        .isEqualTo(dependencySubstitutions[1].third)
+    assertThat("com.facebook.react:react-android").isEqualTo(dependencySubstitutions[2].first)
+    assertThat("io.github.test:react-android:0.42.0").isEqualTo(dependencySubstitutions[2].second)
+    assertThat("The react-android dependency was modified to use the correct Maven group.")
+        .isEqualTo(dependencySubstitutions[2].third)
+    assertThat("com.facebook.hermes:hermes-android").isEqualTo(dependencySubstitutions[3].first)
+    assertThat("io.github.test.hermes:hermes-android:0.43.0")
+        .isEqualTo(dependencySubstitutions[3].second)
+    assertThat("The hermes-android dependency was modified to use the correct Maven group.")
+        .isEqualTo(dependencySubstitutions[3].third)
+  }
+
+  @Test
   fun readVersionString_withCorrectVersionString_returnsIt() {
     val propertiesFile =
         tempFolder.newFile("gradle.properties").apply {
           writeText(
               """
         VERSION_NAME=1000.0.0
+        HERMES_VERSION_NAME=1000.0.0
+        HERMES_V1_VERSION_NAME=1000.0.0
         ANOTHER_PROPERTY=true
       """
                   .trimIndent()
           )
         }
 
-    val versionString = readVersionAndGroupStrings(propertiesFile).versionString
+    val strings = readVersionAndGroupStrings(propertiesFile)
+    val versionString = strings.versionString
+    val hermesVersionString = strings.hermesVersionString
+    val hermesV1VersionString = strings.hermesV1VersionString
 
     assertThat(versionString).isEqualTo("1000.0.0")
+    assertThat(hermesVersionString).isEqualTo("1000.0.0")
+    assertThat(hermesV1VersionString).isEqualTo("1000.0.0")
   }
 
   @Test
@@ -417,15 +575,22 @@ class DependencyUtilsTest {
           writeText(
               """
         VERSION_NAME=0.0.0-20221101-2019-cfe811ab1
+        HERMES_VERSION_NAME=0.12.0-commitly-20221101-2019-cfe811ab1
+        HERMES_V1_VERSION_NAME=250829098.0.0-stable
         ANOTHER_PROPERTY=true
       """
                   .trimIndent()
           )
         }
 
-    val versionString = readVersionAndGroupStrings(propertiesFile).versionString
+    val strings = readVersionAndGroupStrings(propertiesFile)
+    val versionString = strings.versionString
+    val hermesVersionString = strings.hermesVersionString
+    val hermesV1VersionString = strings.hermesV1VersionString
 
     assertThat(versionString).isEqualTo("0.0.0-20221101-2019-cfe811ab1-SNAPSHOT")
+    assertThat(hermesVersionString).isEqualTo("0.12.0-commitly-20221101-2019-cfe811ab1-SNAPSHOT")
+    assertThat(hermesV1VersionString).isEqualTo("250829098.0.0-stable")
   }
 
   @Test
@@ -440,8 +605,13 @@ class DependencyUtilsTest {
           )
         }
 
-    val versionString = readVersionAndGroupStrings(propertiesFile).versionString
+    val strings = readVersionAndGroupStrings(propertiesFile)
+    val versionString = strings.versionString
+    val hermesVersionString = strings.hermesVersionString
+    val hermesV1VersionString = strings.hermesV1VersionString
     assertThat(versionString).isEqualTo("")
+    assertThat(hermesVersionString).isEqualTo("")
+    assertThat(hermesV1VersionString).isEqualTo("")
   }
 
   @Test
@@ -451,14 +621,21 @@ class DependencyUtilsTest {
           writeText(
               """
         VERSION_NAME=
+        HERMES_VERSION_NAME=
+        HERMES_V1_VERSION_NAME=
         ANOTHER_PROPERTY=true
       """
                   .trimIndent()
           )
         }
 
-    val versionString = readVersionAndGroupStrings(propertiesFile).versionString
+    val strings = readVersionAndGroupStrings(propertiesFile)
+    val versionString = strings.versionString
+    val hermesVersionString = strings.hermesVersionString
+    val hermesV1VersionString = strings.hermesV1VersionString
     assertThat(versionString).isEqualTo("")
+    assertThat(hermesVersionString).isEqualTo("")
+    assertThat(hermesV1VersionString).isEqualTo("")
   }
 
   @Test
@@ -468,15 +645,19 @@ class DependencyUtilsTest {
           writeText(
               """
         react.internal.publishingGroup=io.github.test
+        react.internal.hermesPublishingGroup=io.github.test
         ANOTHER_PROPERTY=true
       """
                   .trimIndent()
           )
         }
 
-    val groupString = readVersionAndGroupStrings(propertiesFile).reactGroupString
+    val strings = readVersionAndGroupStrings(propertiesFile)
+    val reactGroupString = strings.reactGroupString
+    val hermesGroupString = strings.hermesGroupString
 
-    assertThat(groupString).isEqualTo("io.github.test")
+    assertThat(reactGroupString).isEqualTo("io.github.test")
+    assertThat(hermesGroupString).isEqualTo("io.github.test")
   }
 
   @Test
@@ -491,9 +672,12 @@ class DependencyUtilsTest {
           )
         }
 
-    val groupString = readVersionAndGroupStrings(propertiesFile).reactGroupString
+    val strings = readVersionAndGroupStrings(propertiesFile)
+    val reactGroupString = strings.reactGroupString
+    val hermesGroupString = strings.hermesGroupString
 
-    assertThat(groupString).isEqualTo("com.facebook.react")
+    assertThat(reactGroupString).isEqualTo("com.facebook.react")
+    assertThat(hermesGroupString).isEqualTo("com.facebook.hermes")
   }
 
   @Test

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/PathUtilsTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/PathUtilsTest.kt
@@ -166,7 +166,7 @@ class PathUtilsTest {
   @WithOs(OS.MAC)
   fun detectOSAwareHermesCommand_withHermesV1Enabled() {
     tempFolder.newFolder("node_modules/hermes-compiler/osx-bin/")
-    val expected = tempFolder.newFile("node_modules/hermes-compiler/osx-bin//hermesc")
+    val expected = tempFolder.newFile("node_modules/hermes-compiler/osx-bin/hermesc")
 
     assertThat(detectOSAwareHermesCommand(tempFolder.root, "", hermesV1Enabled = true))
         .isEqualTo(expected.toString())

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/PathUtilsTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/PathUtilsTest.kt
@@ -155,21 +155,11 @@ class PathUtilsTest {
 
   @Test
   @WithOs(OS.MAC)
-  fun detectOSAwareHermesCommand_withBundledHermescInsideRN() {
-    tempFolder.newFolder("node_modules/react-native/sdks/hermesc/osx-bin/")
-    val expected = tempFolder.newFile("node_modules/react-native/sdks/hermesc/osx-bin/hermesc")
-
-    assertThat(detectOSAwareHermesCommand(tempFolder.root, "")).isEqualTo(expected.toString())
-  }
-
-  @Test
-  @WithOs(OS.MAC)
-  fun detectOSAwareHermesCommand_withHermesV1Enabled() {
+  fun detectOSAwareHermesCommand_withHermescFromNPM() {
     tempFolder.newFolder("node_modules/hermes-compiler/osx-bin/")
     val expected = tempFolder.newFile("node_modules/hermes-compiler/osx-bin/hermesc")
 
-    assertThat(detectOSAwareHermesCommand(tempFolder.root, "", hermesV1Enabled = true))
-        .isEqualTo(expected.toString())
+    assertThat(detectOSAwareHermesCommand(tempFolder.root, "")).isEqualTo(expected.toString())
   }
 
   @Test(expected = IllegalStateException::class)

--- a/packages/react-native/ReactAndroid/gradle.properties
+++ b/packages/react-native/ReactAndroid/gradle.properties
@@ -1,5 +1,6 @@
 VERSION_NAME=1000.0.0
 HERMES_VERSION_NAME=1000.0.0
+HERMES_V1_VERSION_NAME=1000.0.0
 react.internal.publishingGroup=com.facebook.react
 react.internal.hermesPublishingGroup=com.facebook.hermes
 

--- a/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
+++ b/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
@@ -20,7 +20,7 @@ end
 
 # package.json
 package = JSON.parse(File.read(File.join(react_native_path, "package.json")))
-# TODO: T231755000 use the Hermes V1 version instead of React Native version
+# TODO: T231755000 use the Hermes version instead of React Native version
 version = package['version']
 
 source_type = hermes_source_type(version, react_native_path)
@@ -64,9 +64,8 @@ Pod::Spec.new do |spec|
     end
 
     # When using the local prebuilt tarball, it should include hermesc compatible with the used VM.
-    # In other cases, when using Hermes V1, the prebuilt versioned binaries can be used.
-    # TODO: T236142916 hermesc should be consumed from NPM even when not using Hermes V1
-    if source_type != HermesEngineSourceType::LOCAL_PREBUILT_TARBALL && ENV['RCT_HERMES_V1_ENABLED'] == "1"
+    # In other cases, the prebuilt versioned binaries can be used.
+    if source_type != HermesEngineSourceType::LOCAL_PREBUILT_TARBALL
       hermes_compiler_path = File.dirname(Pod::Executable.execute_command('node', ['-p',
         'require.resolve(
         "hermes-compiler",

--- a/packages/react-native/sdks/hermes-engine/hermes-utils.rb
+++ b/packages/react-native/sdks/hermes-engine/hermes-utils.rb
@@ -224,18 +224,11 @@ def release_tarball_url(version, build_type)
         ENV['ENTERPRISE_REPOSITORY'] != nil && ENV['ENTERPRISE_REPOSITORY'] != "" ?
         ENV['ENTERPRISE_REPOSITORY'] :
         "https://repo1.maven.org/maven2"
+    namespace = "com/facebook/hermes"
 
-    if hermes_v1_enabled()
-        namespace = "com/facebook/hermes"
-        # Sample url from Maven:
-        # https://repo1.maven.org/maven2/com/facebook/hermes/hermes-ios/0.14.0/hermes-ios-0.14.0-debug.tar.gz
-        return "#{maven_repo_url}/#{namespace}/hermes-ios/#{version}/hermes-ios-#{version}-#{build_type.to_s}.tar.gz"
-    else
-        namespace = "com/facebook/react"
-        # Sample url from Maven:
-        # https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.71.0/react-native-artifacts-0.71.0-hermes-ios-debug.tar.gz
-        return "#{maven_repo_url}/#{namespace}/react-native-artifacts/#{version}/react-native-artifacts-#{version}-hermes-ios-#{build_type.to_s}.tar.gz"
-    end
+    # Sample url from Maven:
+    # https://repo1.maven.org/maven2/com/facebook/hermes/hermes-ios/0.14.0/hermes-ios-0.14.0-debug.tar.gz
+    return "#{maven_repo_url}/#{namespace}/hermes-ios/#{version}/hermes-ios-#{version}-#{build_type.to_s}.tar.gz"
 end
 
 def download_stable_hermes(react_native_path, version, configuration)
@@ -257,16 +250,9 @@ def download_hermes_tarball(react_native_path, tarball_url, version, configurati
 end
 
 def nightly_tarball_url(version)
-  # TODO: T231755027 update coordinates and versioning
-  artifact_coordinate = "react-native-artifacts"
+  artifact_coordinate = "hermes-ios"
   artifact_name = "hermes-ios-debug.tar.gz"
-  namespace = "com/facebook/react"
-
-  if hermes_v1_enabled()
-    artifact_coordinate = "hermes-ios"
-    artifact_name = "hermes-ios-debug.tar.gz"
-    namespace = "com/facebook/hermes"
-  end
+  namespace = "com/facebook/hermes"
 
   xml_url = "https://central.sonatype.com/repository/maven-snapshots/#{namespace}/#{artifact_coordinate}/#{version}-SNAPSHOT/maven-metadata.xml"
 

--- a/scripts/releases/set-rn-artifacts-version.js
+++ b/scripts/releases/set-rn-artifacts-version.js
@@ -155,7 +155,7 @@ function updateTestFiles(
 async function updateGradleFile(version /*: string */) /*: Promise<void> */ {
   const contents = await fs.readFile(GRADLE_FILE_PATH, 'utf-8');
 
-  // TODO: T231755027 set HERMES_VERSION_NAME
+  // TODO: T231755027 set HERMES_VERSION_NAME and HERMES_V1_VERSION_NAME
 
   return fs.writeFile(
     GRADLE_FILE_PATH,


### PR DESCRIPTION
Summary: Changelog: [ANDROID][CHANGED] - Use artifacts published from the Hermes repository on Android regardless of which version is used

Differential Revision: D81996204


