### PR TITLE
Read Hermes V1 opt-in flag from the app's properties

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/ProjectUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/ProjectUtils.kt
@@ -23,6 +23,7 @@ import com.facebook.react.utils.PropertyUtils.SCOPED_USE_THIRD_PARTY_JSC
 import com.facebook.react.utils.PropertyUtils.USE_THIRD_PARTY_JSC
 import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty
+import org.jetbrains.kotlin.gradle.plugin.extraProperties
 
 internal object ProjectUtils {
 
@@ -75,7 +76,11 @@ internal object ProjectUtils {
         (project.hasProperty(HERMES_V1_ENABLED) &&
             project.property(HERMES_V1_ENABLED).toString().toBoolean()) ||
             (project.hasProperty(SCOPED_HERMES_V1_ENABLED) &&
-                project.property(SCOPED_HERMES_V1_ENABLED).toString().toBoolean())
+                project.property(SCOPED_HERMES_V1_ENABLED).toString().toBoolean()) ||
+            (project.extraProperties.has(HERMES_V1_ENABLED) &&
+                project.extraProperties.get(HERMES_V1_ENABLED).toString().toBoolean()) ||
+            (project.extraProperties.has(SCOPED_HERMES_V1_ENABLED) &&
+                project.extraProperties.get(SCOPED_HERMES_V1_ENABLED).toString().toBoolean())
 
   internal fun Project.needsCodegenFromPackageJson(rootProperty: DirectoryProperty): Boolean {
     val parsedPackageJson = readPackageJsonFile(this, rootProperty)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -44,3 +44,26 @@ configure<com.facebook.react.ReactSettingsExtension> {
       lockFiles = files("yarn.lock"),
   )
 }
+
+// Gradle properties defined in `gradle.properties` are not inherited by
+// included builds, see https://github.com/gradle/gradle/issues/2534.
+// This is a workaround to read the configuration from the consuming project,
+// and apply relevant properties to the :react-native project.
+buildscript {
+  val properties = java.util.Properties()
+  val propertiesToInherit = listOf("hermesV1Enabled", "react.hermesV1Enabled")
+
+  try {
+    file("../../android/gradle.properties").inputStream().use { properties.load(it) }
+
+    gradle.rootProject {
+      propertiesToInherit.forEach { property ->
+        if (properties.containsKey(property)) {
+          gradle.rootProject.extra.set(property, properties.getProperty(property))
+        }
+      }
+    }
+  } catch (e: Exception) {
+    // fail silently
+  }
+}


### PR DESCRIPTION
Summary: Changelog: [ANDROID][FIXED] - Read the Hermes V1 opt-in flag from the apps properties when building from source

Differential Revision: D82018545


