### PR TITLE
Add script to add the RN Swift packages to xcodeproject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,7 @@ vendor/
 # Swift Package build folder
 /packages/react-native/.build
 /packages/react-native/.swiftpm
+/packages/react-native/React/includes/
 
 # @react-native/codegen
 /packages/react-native/React/FBReactNativeSpec/

--- a/packages/react-native/scripts/swiftpm/__tests__/headers-utils-test.js
+++ b/packages/react-native/scripts/swiftpm/__tests__/headers-utils-test.js
@@ -10,7 +10,10 @@
 
 'use strict';
 
-const {symlinkHeadersFromPath} = require('../headers-utils');
+const {
+  symlinkHeadersFromPath,
+  symlinkReactAppleHeaders,
+} = require('../headers-utils');
 
 // Mock all required modules
 jest.mock('../utils');
@@ -412,6 +415,226 @@ describe('symlinkHeadersFromPath', () => {
     expect(mockUtils.setupSymlink).toHaveBeenCalledWith(
       '/source/path/special/subdir/header1.h',
       '/custom/output/special/subdir/header1.h',
+    );
+    expect(result).toBe(1);
+  });
+});
+
+describe('symlinkReactAppleHeaders', () => {
+  let mockUtils;
+  let mockPath;
+  let originalConsoleWarn;
+  let originalConsoleLog;
+
+  beforeEach(() => {
+    // Setup mocks
+    mockUtils = require('../utils');
+    mockPath = require('path');
+
+    // Mock path functions
+    mockPath.relative.mockImplementation((from, to) => {
+      return to.replace(from + '/', '');
+    });
+    mockPath.join.mockImplementation((...args) => args.join('/'));
+    mockPath.dirname.mockImplementation(filePath => {
+      const parts = filePath.split('/');
+      parts.pop();
+      return parts.join('/');
+    });
+    mockPath.basename.mockImplementation(filePath => {
+      return filePath.split('/').pop();
+    });
+    mockPath.sep = '/';
+
+    // Mock console methods to prevent test output noise
+    originalConsoleWarn = console.warn;
+    originalConsoleLog = console.log;
+    console.warn = jest.fn();
+    console.log = jest.fn();
+
+    // Reset all mocks
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    // Restore console methods
+    console.warn = originalConsoleWarn;
+    console.log = originalConsoleLog;
+  });
+
+  it('should create symlinks for ReactApple headers with Exported folder structure', () => {
+    // Setup
+    const reactApplePath = '/path/to/ReactApple';
+    const headersOutput = '/output/headers';
+    const headerFiles = [
+      '/path/to/ReactApple/Libraries/RCTFoundation/RCTDeprecation/Exported/RCTDeprecation.h',
+    ];
+
+    mockUtils.listHeadersInFolder.mockReturnValue(headerFiles);
+    mockUtils.setupSymlink.mockImplementation(() => {});
+
+    // Execute
+    const result = symlinkReactAppleHeaders(reactApplePath, headersOutput);
+
+    // Assert
+    expect(mockUtils.listHeadersInFolder).toHaveBeenCalledWith(
+      '/path/to/ReactApple/Libraries/RCTFoundation/RCTDeprecation/Exported',
+      ['tests'],
+    );
+    expect(mockUtils.setupSymlink).toHaveBeenCalledWith(
+      '/path/to/ReactApple/Libraries/RCTFoundation/RCTDeprecation/Exported/RCTDeprecation.h',
+      '/output/headers/RCTDeprecation/RCTDeprecation.h',
+    );
+    expect(result).toBe(1);
+  });
+
+  it('should handle empty header files from mapping', () => {
+    // Setup
+    const reactApplePath = '/path/to/ReactApple';
+    const headersOutput = '/output/headers';
+
+    mockUtils.listHeadersInFolder.mockReturnValue([]);
+    mockUtils.setupSymlink.mockImplementation(() => {});
+
+    // Execute
+    const result = symlinkReactAppleHeaders(reactApplePath, headersOutput);
+
+    // Assert
+    expect(mockUtils.listHeadersInFolder).toHaveBeenCalledWith(
+      '/path/to/ReactApple/Libraries/RCTFoundation/RCTDeprecation/Exported',
+      ['tests'],
+    );
+    expect(mockUtils.setupSymlink).not.toHaveBeenCalled();
+    expect(result).toBe(0);
+  });
+
+  it('should handle multiple header files in the same mapping', () => {
+    // Setup
+    const reactApplePath = '/path/to/ReactApple';
+    const headersOutput = '/output/headers';
+    const headerFiles = [
+      '/path/to/ReactApple/Libraries/RCTFoundation/RCTDeprecation/Exported/RCTDeprecation.h',
+      '/path/to/ReactApple/Libraries/RCTFoundation/RCTDeprecation/Exported/RCTUtility.h',
+    ];
+
+    mockUtils.listHeadersInFolder.mockReturnValue(headerFiles);
+    mockUtils.setupSymlink.mockImplementation(() => {});
+
+    // Execute
+    const result = symlinkReactAppleHeaders(reactApplePath, headersOutput);
+
+    // Assert
+    expect(mockUtils.setupSymlink).toHaveBeenCalledTimes(2);
+    expect(mockUtils.setupSymlink).toHaveBeenCalledWith(
+      '/path/to/ReactApple/Libraries/RCTFoundation/RCTDeprecation/Exported/RCTDeprecation.h',
+      '/output/headers/RCTDeprecation/RCTDeprecation.h',
+    );
+    expect(mockUtils.setupSymlink).toHaveBeenCalledWith(
+      '/path/to/ReactApple/Libraries/RCTFoundation/RCTDeprecation/Exported/RCTUtility.h',
+      '/output/headers/RCTDeprecation/RCTUtility.h',
+    );
+    expect(result).toBe(2);
+  });
+
+  it('should handle setupSymlink throwing an error', () => {
+    // Setup
+    const reactApplePath = '/path/to/ReactApple';
+    const headersOutput = '/output/headers';
+    const headerFiles = [
+      '/path/to/ReactApple/Libraries/RCTFoundation/RCTDeprecation/Exported/RCTDeprecation.h',
+    ];
+
+    mockUtils.listHeadersInFolder.mockReturnValue(headerFiles);
+    mockUtils.setupSymlink.mockImplementation(() => {
+      throw new Error('Link failed');
+    });
+
+    // Execute and Assert - function throws the error from setupSymlink
+    expect(() => {
+      symlinkReactAppleHeaders(reactApplePath, headersOutput);
+    }).toThrow('Link failed');
+  });
+
+  it('should work correctly with the hardcoded mapping structure', () => {
+    // Setup
+    const reactApplePath = '/path/to/ReactApple';
+    const headersOutput = '/output/headers';
+    const headerFiles = [
+      '/path/to/ReactApple/Libraries/RCTFoundation/RCTDeprecation/Exported/RCTDeprecation.h',
+    ];
+
+    mockUtils.listHeadersInFolder.mockReturnValue(headerFiles);
+    mockUtils.setupSymlink.mockImplementation(() => {});
+
+    // Execute
+    const result = symlinkReactAppleHeaders(reactApplePath, headersOutput);
+
+    // Assert - setupSymlink handles removing existing files and creating new ones internally
+    expect(mockUtils.setupSymlink).toHaveBeenCalledWith(
+      '/path/to/ReactApple/Libraries/RCTFoundation/RCTDeprecation/Exported/RCTDeprecation.h',
+      '/output/headers/RCTDeprecation/RCTDeprecation.h',
+    );
+    expect(result).toBe(1);
+  });
+
+  it('should handle listHeadersInFolder returning empty array', () => {
+    // Setup
+    const reactApplePath = '/path/to/ReactApple';
+    const headersOutput = '/output/headers';
+
+    mockUtils.listHeadersInFolder.mockReturnValue([]);
+    mockUtils.setupSymlink.mockImplementation(() => {});
+
+    // Execute
+    const result = symlinkReactAppleHeaders(reactApplePath, headersOutput);
+
+    // Assert
+    expect(mockUtils.listHeadersInFolder).toHaveBeenCalledWith(
+      '/path/to/ReactApple/Libraries/RCTFoundation/RCTDeprecation/Exported',
+      ['tests'],
+    );
+    expect(mockUtils.setupSymlink).not.toHaveBeenCalled();
+    expect(result).toBe(0);
+  });
+
+  it('should handle listHeadersInFolder throwing an error', () => {
+    // Setup
+    const reactApplePath = '/path/to/ReactApple';
+    const headersOutput = '/output/headers';
+    const error = new Error('Command failed');
+
+    mockUtils.listHeadersInFolder.mockImplementation(() => {
+      throw error;
+    });
+
+    // Execute and Assert - function throws the error from listHeadersInFolder
+    expect(() => {
+      symlinkReactAppleHeaders(reactApplePath, headersOutput);
+    }).toThrow('Command failed');
+  });
+
+  it('should work correctly with single hardcoded mapping', () => {
+    // Setup - Test the specific mapping defined in the function
+    const reactApplePath = '/path/to/ReactApple';
+    const headersOutput = '/output/headers';
+    const headerFiles = [
+      '/path/to/ReactApple/Libraries/RCTFoundation/RCTDeprecation/Exported/RCTDeprecation.h',
+    ];
+
+    mockUtils.listHeadersInFolder.mockReturnValue(headerFiles);
+    mockUtils.setupSymlink.mockImplementation(() => {});
+
+    // Execute
+    const result = symlinkReactAppleHeaders(reactApplePath, headersOutput);
+
+    // Assert - Test the specific mapping that's hardcoded
+    expect(mockUtils.listHeadersInFolder).toHaveBeenCalledWith(
+      '/path/to/ReactApple/Libraries/RCTFoundation/RCTDeprecation/Exported',
+      ['tests'],
+    );
+    expect(mockUtils.setupSymlink).toHaveBeenCalledWith(
+      '/path/to/ReactApple/Libraries/RCTFoundation/RCTDeprecation/Exported/RCTDeprecation.h',
+      '/output/headers/RCTDeprecation/RCTDeprecation.h',
     );
     expect(result).toBe(1);
   });

--- a/packages/react-native/scripts/swiftpm/__tests__/headers-utils-test.js
+++ b/packages/react-native/scripts/swiftpm/__tests__/headers-utils-test.js
@@ -1,0 +1,418 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @noflow
+ */
+
+'use strict';
+
+const {symlinkHeadersFromPath} = require('../headers-utils');
+
+// Mock all required modules
+jest.mock('../utils');
+jest.mock('fs');
+jest.mock('path');
+
+describe('symlinkHeadersFromPath', () => {
+  let mockUtils;
+  let mockFs;
+  let mockPath;
+  let originalConsoleWarn;
+  let originalConsoleLog;
+
+  beforeEach(() => {
+    // Setup mocks
+    mockUtils = require('../utils');
+    mockFs = require('fs');
+    mockPath = require('path');
+
+    // Mock path functions
+    mockPath.relative.mockImplementation((from, to) => {
+      return to.replace(from + '/', '');
+    });
+    mockPath.join.mockImplementation((...args) => args.join('/'));
+    mockPath.dirname.mockImplementation(filePath => {
+      const parts = filePath.split('/');
+      parts.pop();
+      return parts.join('/');
+    });
+    mockPath.basename.mockImplementation(filePath => {
+      return filePath.split('/').pop();
+    });
+
+    // Mock console methods to prevent test output noise
+    originalConsoleWarn = console.warn;
+    originalConsoleLog = console.log;
+    console.warn = jest.fn();
+    console.log = jest.fn();
+
+    // Reset all mocks
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    // Restore console methods
+    console.warn = originalConsoleWarn;
+    console.log = originalConsoleLog;
+  });
+
+  it('should create symlinks for found header files without preserving structure', () => {
+    // Setup
+    const sourcePath = '/source/path';
+    const outputPath = '/output/path';
+    const headerFiles = [
+      '/source/path/subdir/header1.h',
+      '/source/path/header2.h',
+    ];
+
+    mockUtils.listHeadersInFolder.mockReturnValue(headerFiles);
+    mockFs.existsSync.mockImplementation(filePath => {
+      return (
+        filePath === '/source/path/subdir/header1.h' ||
+        filePath === '/source/path/header2.h'
+      );
+    });
+
+    // Execute
+    const result = symlinkHeadersFromPath(sourcePath, outputPath, false, []);
+
+    // Assert
+    expect(mockUtils.listHeadersInFolder).toHaveBeenCalledWith(sourcePath, []);
+    expect(mockUtils.setupSymlink).toHaveBeenCalledTimes(2);
+    expect(mockUtils.setupSymlink).toHaveBeenCalledWith(
+      '/source/path/subdir/header1.h',
+      '/output/path/header1.h',
+    );
+    expect(mockUtils.setupSymlink).toHaveBeenCalledWith(
+      '/source/path/header2.h',
+      '/output/path/header2.h',
+    );
+    expect(result).toBe(2);
+  });
+
+  it('should preserve directory structure when preserveStructure is true', () => {
+    // Setup
+    const sourcePath = '/source/path';
+    const outputPath = '/output/path';
+    const headerFiles = [
+      '/source/path/subdir/header1.h',
+      '/source/path/another/header2.h',
+    ];
+
+    mockUtils.listHeadersInFolder.mockReturnValue(headerFiles);
+    mockFs.existsSync.mockImplementation(filePath => {
+      return (
+        filePath === '/source/path/subdir/header1.h' ||
+        filePath === '/source/path/another/header2.h'
+      );
+    });
+
+    // Execute
+    const result = symlinkHeadersFromPath(sourcePath, outputPath, true, []);
+
+    // Assert
+    expect(mockUtils.setupSymlink).toHaveBeenCalledWith(
+      '/source/path/subdir/header1.h',
+      '/output/path/subdir/header1.h',
+    );
+    expect(mockUtils.setupSymlink).toHaveBeenCalledWith(
+      '/source/path/another/header2.h',
+      '/output/path/another/header2.h',
+    );
+    expect(result).toBe(2);
+  });
+
+  it('should exclude specified folders from find command', () => {
+    // Setup
+    const sourcePath = '/source/path';
+    const outputPath = '/output/path';
+    const excludeFolders = ['node_modules', 'test'];
+
+    mockUtils.listHeadersInFolder.mockReturnValue([]);
+
+    // Execute
+    symlinkHeadersFromPath(sourcePath, outputPath, false, excludeFolders);
+
+    // Assert
+    expect(mockUtils.listHeadersInFolder).toHaveBeenCalledWith(
+      sourcePath,
+      excludeFolders,
+    );
+  });
+
+  it('should use custom mappings when path matches prefix', () => {
+    // Setup
+    const sourcePath = '/source/path';
+    const outputPath = '/output/path';
+    const customMappings = {
+      'special/': '/custom/output/path',
+    };
+    const headerFiles = [
+      '/source/path/special/header1.h',
+      '/source/path/normal/header2.h',
+    ];
+
+    mockUtils.listHeadersInFolder.mockReturnValue(headerFiles);
+    mockFs.existsSync.mockImplementation(filePath => {
+      return (
+        filePath === '/source/path/special/header1.h' ||
+        filePath === '/source/path/normal/header2.h'
+      );
+    });
+
+    // Execute
+    const result = symlinkHeadersFromPath(
+      sourcePath,
+      outputPath,
+      false,
+      [],
+      customMappings,
+    );
+
+    // Assert
+    expect(mockUtils.setupSymlink).toHaveBeenCalledWith(
+      '/source/path/special/header1.h',
+      '/custom/output/path/header1.h',
+    );
+    expect(mockUtils.setupSymlink).toHaveBeenCalledWith(
+      '/source/path/normal/header2.h',
+      '/output/path/header2.h',
+    );
+    expect(console.log).toHaveBeenCalledWith(
+      '  Custom mapping: special/ -> /custom/output/path',
+    );
+    expect(result).toBe(2);
+  });
+
+  it('should create destination directories if they do not exist', () => {
+    // Setup
+    const sourcePath = '/source/path';
+    const outputPath = '/output/path';
+    const headerFiles = ['/source/path/subdir/header1.h'];
+
+    mockUtils.listHeadersInFolder.mockReturnValue(headerFiles);
+    mockFs.existsSync.mockImplementation(filePath => {
+      return filePath === '/source/path/subdir/header1.h';
+    });
+
+    // Execute
+    symlinkHeadersFromPath(sourcePath, outputPath, true, []);
+
+    // Assert - setupSymlink should be called, which internally handles directory creation
+    expect(mockUtils.setupSymlink).toHaveBeenCalledWith(
+      '/source/path/subdir/header1.h',
+      '/output/path/subdir/header1.h',
+    );
+  });
+
+  it('should remove existing symlink before creating new one', () => {
+    // Setup
+    const sourcePath = '/source/path';
+    const outputPath = '/output/path';
+    const headerFiles = ['/source/path/header1.h'];
+
+    mockUtils.listHeadersInFolder.mockReturnValue(headerFiles);
+    mockFs.existsSync.mockImplementation(filePath => {
+      return filePath === '/source/path/header1.h'; // Only source file exists
+    });
+
+    // Execute
+    symlinkHeadersFromPath(sourcePath, outputPath, false, []);
+
+    // Assert - setupSymlink should be called, which internally handles removing existing links
+    expect(mockUtils.setupSymlink).toHaveBeenCalledWith(
+      '/source/path/header1.h',
+      '/output/path/header1.h',
+    );
+  });
+
+  it('should skip non-existent source files', () => {
+    // Setup
+    const sourcePath = '/source/path';
+    const outputPath = '/output/path';
+    const headerFiles = [
+      '/source/path/header1.h',
+      '/source/path/nonexistent.h',
+    ];
+
+    mockUtils.listHeadersInFolder.mockReturnValue(headerFiles);
+    mockFs.existsSync.mockImplementation(filePath => {
+      return filePath === '/source/path/header1.h'; // Only header1.h exists
+    });
+
+    // Execute
+    const result = symlinkHeadersFromPath(sourcePath, outputPath, false, []);
+
+    // Assert
+    expect(mockUtils.setupSymlink).toHaveBeenCalledTimes(1);
+    expect(mockUtils.setupSymlink).toHaveBeenCalledWith(
+      '/source/path/header1.h',
+      '/output/path/header1.h',
+    );
+    expect(result).toBe(1);
+  });
+
+  it('should handle empty find command output', () => {
+    // Setup
+    const sourcePath = '/source/path';
+    const outputPath = '/output/path';
+
+    mockUtils.listHeadersInFolder.mockReturnValue([]);
+
+    // Execute
+    const result = symlinkHeadersFromPath(sourcePath, outputPath, false, []);
+
+    // Assert
+    expect(mockUtils.setupSymlink).not.toHaveBeenCalled();
+    expect(result).toBe(0);
+  });
+
+  it('should handle whitespace-only find command output', () => {
+    // Setup
+    const sourcePath = '/source/path';
+    const outputPath = '/output/path';
+
+    mockUtils.listHeadersInFolder.mockReturnValue([]);
+
+    // Execute
+    const result = symlinkHeadersFromPath(sourcePath, outputPath, false, []);
+
+    // Assert
+    expect(mockUtils.setupSymlink).not.toHaveBeenCalled();
+    expect(result).toBe(0);
+  });
+
+  it('should handle listHeadersInFolder throwing an error', () => {
+    // Setup
+    const sourcePath = '/source/path';
+    const outputPath = '/output/path';
+    const error = new Error('Command failed');
+
+    mockUtils.listHeadersInFolder.mockImplementation(() => {
+      throw error;
+    });
+
+    // Execute
+    const result = symlinkHeadersFromPath(sourcePath, outputPath, false, []);
+
+    // Assert
+    expect(console.warn).toHaveBeenCalledWith(
+      'Failed to process headers from /source/path:',
+      'Command failed',
+    );
+    expect(result).toBe(0);
+  });
+
+  it('should handle setupSymlink throwing an error', () => {
+    // Setup
+    const sourcePath = '/source/path';
+    const outputPath = '/output/path';
+    const headerFiles = ['/source/path/header1.h'];
+
+    mockUtils.listHeadersInFolder.mockReturnValue(headerFiles);
+    mockFs.existsSync.mockImplementation(filePath => {
+      return filePath === '/source/path/header1.h';
+    });
+    mockUtils.setupSymlink.mockImplementation(() => {
+      throw new Error('Link failed');
+    });
+
+    // Execute
+    const result = symlinkHeadersFromPath(sourcePath, outputPath, false, []);
+
+    // Assert
+    expect(console.warn).toHaveBeenCalledWith(
+      'Failed to process headers from /source/path:',
+      'Link failed',
+    );
+    expect(result).toBe(0);
+  });
+
+  it('should work with multiple custom mappings', () => {
+    // Setup
+    const sourcePath = '/source/path';
+    const outputPath = '/output/path';
+    const customMappings = {
+      'lib1/': '/custom/lib1',
+      'lib2/': '/custom/lib2',
+    };
+    const headerFiles = [
+      '/source/path/lib1/header1.h',
+      '/source/path/lib2/header2.h',
+      '/source/path/other/header3.h',
+    ];
+
+    mockUtils.listHeadersInFolder.mockReturnValue(headerFiles);
+    mockFs.existsSync.mockImplementation(filePath => {
+      return (
+        filePath === '/source/path/lib1/header1.h' ||
+        filePath === '/source/path/lib2/header2.h' ||
+        filePath === '/source/path/other/header3.h'
+      );
+    });
+    // Mock setupSymlink to not throw any errors
+    mockUtils.setupSymlink.mockImplementation(() => {});
+
+    // Execute
+    const result = symlinkHeadersFromPath(
+      sourcePath,
+      outputPath,
+      false,
+      [],
+      customMappings,
+    );
+
+    // Assert
+    expect(mockUtils.setupSymlink).toHaveBeenCalledTimes(3);
+    expect(mockUtils.setupSymlink).toHaveBeenCalledWith(
+      '/source/path/lib1/header1.h',
+      '/custom/lib1/header1.h',
+    );
+    expect(mockUtils.setupSymlink).toHaveBeenCalledWith(
+      '/source/path/lib2/header2.h',
+      '/custom/lib2/header2.h',
+    );
+    expect(mockUtils.setupSymlink).toHaveBeenCalledWith(
+      '/source/path/other/header3.h',
+      '/output/path/header3.h',
+    );
+    expect(result).toBe(3);
+  });
+
+  it('should handle custom mappings with preserved structure', () => {
+    // Setup
+    const sourcePath = '/source/path';
+    const outputPath = '/output/path';
+    const customMappings = {
+      'special/': '/custom/output',
+    };
+    const headerFiles = ['/source/path/special/subdir/header1.h'];
+
+    mockUtils.listHeadersInFolder.mockReturnValue(headerFiles);
+    mockFs.existsSync.mockImplementation(filePath => {
+      return filePath === '/source/path/special/subdir/header1.h';
+    });
+    // Mock setupSymlink to not throw any errors
+    mockUtils.setupSymlink.mockImplementation(() => {});
+
+    // Execute
+    const result = symlinkHeadersFromPath(
+      sourcePath,
+      outputPath,
+      true,
+      [],
+      customMappings,
+    );
+
+    // Assert
+    expect(mockUtils.setupSymlink).toHaveBeenCalledWith(
+      '/source/path/special/subdir/header1.h',
+      '/custom/output/special/subdir/header1.h',
+    );
+    expect(result).toBe(1);
+  });
+});

--- a/packages/react-native/scripts/swiftpm/__tests__/prepare-app-dependencies-headers-test.js
+++ b/packages/react-native/scripts/swiftpm/__tests__/prepare-app-dependencies-headers-test.js
@@ -1,0 +1,476 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @noflow
+ */
+
+'use strict';
+
+// Mock the headers-utils module before importing anything
+jest.mock('../headers-utils', () => ({
+  hardlinkHeadersFromPath: jest.fn(),
+  hardlinkReactAppleHeaders: jest.fn(),
+  hardlinkReactCommonHeaders: jest.fn(),
+}));
+
+// Mock fs and path modules
+jest.mock('fs');
+jest.mock('path');
+
+const {
+  hardlinkHeadersFromPath,
+  hardlinkReactAppleHeaders,
+  hardlinkReactCommonHeaders,
+} = require('../headers-utils');
+const {
+  hardlinkReactNativeHeaders,
+} = require('../prepare-app-dependencies-headers');
+const fs = require('fs');
+const path = require('path');
+
+describe('hardlinkReactNativeHeaders', () => {
+  let originalConsoleLog;
+
+  beforeEach(() => {
+    // Mock path.join to simply join with '/'
+    path.join.mockImplementation((...args) => args.join('/'));
+
+    // Setup mock return values
+    hardlinkHeadersFromPath.mockReturnValue(5);
+    hardlinkReactAppleHeaders.mockReturnValue(3);
+    hardlinkReactCommonHeaders.mockReturnValue(7);
+
+    // Mock console.log to prevent test output noise
+    originalConsoleLog = console.log;
+    console.log = jest.fn();
+
+    // Reset all mocks
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    // Restore console.log
+    console.log = originalConsoleLog;
+  });
+
+  it('should create headers directory and call all processing functions with correct paths', () => {
+    // Setup
+    const reactNativePath = '/path/to/react-native';
+    const outputFolder = '/output';
+    const folderName = 'headers';
+
+    // Mock fs.existsSync to return true for all React Native subdirectories
+    fs.existsSync.mockImplementation(filePath => {
+      if (filePath === '/output/headers') return false; // headers dir doesn't exist
+      if (filePath === '/output/headers/React') return false; // React dir doesn't exist
+      if (filePath === '/path/to/react-native/React') return true;
+      if (filePath === '/path/to/react-native/Libraries') return true;
+      if (filePath === '/path/to/react-native/ReactApple') return true;
+      if (filePath === '/path/to/react-native/ReactCommon') return true;
+      return false;
+    });
+    fs.mkdirSync.mockImplementation(() => {});
+
+    // Execute
+    hardlinkReactNativeHeaders(reactNativePath, outputFolder, folderName);
+
+    // Assert - Verify directories are created
+    expect(fs.mkdirSync).toHaveBeenCalledWith('/output/headers', {
+      recursive: true,
+    });
+    expect(fs.mkdirSync).toHaveBeenCalledWith('/output/headers/React', {
+      recursive: true,
+    });
+
+    // Assert - Verify React folder processing
+    expect(hardlinkHeadersFromPath).toHaveBeenCalledWith(
+      '/path/to/react-native/React',
+      '/output/headers/React',
+      false,
+      ['includes', 'headers', 'tests'],
+      {'FBReactNativeSpec/': '/output/headers/FBReactNativeSpec'},
+    );
+
+    // Assert - Verify Libraries folder processing
+    expect(hardlinkHeadersFromPath).toHaveBeenCalledWith(
+      '/path/to/react-native/Libraries',
+      '/output/headers/React',
+      false,
+      ['tests'],
+      {
+        'Required/': '/output/headers/RCTRequired',
+        'TypeSafety/': '/output/headers/RCTTypeSafety',
+        'FBLazyVector/': '/output/headers/FBLazyVector',
+      },
+    );
+
+    // Assert - Verify ReactApple folder processing
+    expect(hardlinkReactAppleHeaders).toHaveBeenCalledWith(
+      '/path/to/react-native/ReactApple',
+      '/output/headers',
+    );
+
+    // Assert - Verify ReactCommon folder processing
+    expect(hardlinkReactCommonHeaders).toHaveBeenCalledWith(
+      '/path/to/react-native/ReactCommon',
+      '/output/headers',
+      ['react/nativemodule/core/platform/ios'],
+      {
+        'yoga/': 'yoga',
+        'cxxreact/': 'cxxreact',
+        'jsinspector-modern/': 'jsinspector-modern',
+        'jserrorhandler/': 'jserrorhandler',
+        'oscompat/': 'oscompat',
+      },
+    );
+
+    // Assert - Verify logging
+    expect(console.log).toHaveBeenCalledWith(
+      'Creating hard links for React Native headers...',
+    );
+    expect(console.log).toHaveBeenCalledWith('Processing React folder...');
+    expect(console.log).toHaveBeenCalledWith(
+      'Created 5 hard links from React folder',
+    );
+    expect(console.log).toHaveBeenCalledWith('Processing Libraries folder...');
+    expect(console.log).toHaveBeenCalledWith(
+      'Created 5 hard links from Libraries folder',
+    );
+    expect(console.log).toHaveBeenCalledWith('Processing ReactApple folder...');
+    expect(console.log).toHaveBeenCalledWith(
+      'Created 3 hard links from ReactApple folder',
+    );
+    expect(console.log).toHaveBeenCalledWith(
+      'Processing ReactCommon folder...',
+    );
+    expect(console.log).toHaveBeenCalledWith(
+      'Created 7 hard links from ReactCommon folder',
+    );
+    expect(console.log).toHaveBeenCalledWith(
+      'Created hard links for 20 React Native headers total',
+    );
+  });
+
+  it('should use default folderName "headers" when not provided', () => {
+    // Setup
+    const reactNativePath = '/path/to/react-native';
+    const outputFolder = '/output';
+    // Note: not providing folderName parameter
+
+    fs.existsSync.mockReturnValue(false); // No directories exist
+    fs.mkdirSync.mockImplementation(() => {});
+
+    // Execute
+    hardlinkReactNativeHeaders(reactNativePath, outputFolder);
+
+    // Assert - Should use default "headers" folder name
+    expect(fs.mkdirSync).toHaveBeenCalledWith('/output/headers', {
+      recursive: true,
+    });
+    expect(fs.mkdirSync).toHaveBeenCalledWith('/output/headers/React', {
+      recursive: true,
+    });
+  });
+
+  it('should use custom folderName when provided', () => {
+    // Setup
+    const reactNativePath = '/path/to/react-native';
+    const outputFolder = '/output';
+    const customFolderName = 'custom-headers';
+
+    fs.existsSync.mockReturnValue(false); // No directories exist
+    fs.mkdirSync.mockImplementation(() => {});
+
+    // Execute
+    hardlinkReactNativeHeaders(reactNativePath, outputFolder, customFolderName);
+
+    // Assert - Should use custom folder name
+    expect(fs.mkdirSync).toHaveBeenCalledWith('/output/custom-headers', {
+      recursive: true,
+    });
+    expect(fs.mkdirSync).toHaveBeenCalledWith('/output/custom-headers/React', {
+      recursive: true,
+    });
+  });
+
+  it('should skip processing folders that do not exist', () => {
+    // Setup
+    const reactNativePath = '/path/to/react-native';
+    const outputFolder = '/output';
+
+    // Mock fs.existsSync to return false for some React Native subdirectories
+    fs.existsSync.mockImplementation(filePath => {
+      if (filePath === '/output/headers') return false;
+      if (filePath === '/output/headers/React') return false;
+      if (filePath === '/path/to/react-native/React') return false; // React doesn't exist
+      if (filePath === '/path/to/react-native/Libraries') return true; // Libraries exists
+      if (filePath === '/path/to/react-native/ReactApple') return false; // ReactApple doesn't exist
+      if (filePath === '/path/to/react-native/ReactCommon') return true; // ReactCommon exists
+      return false;
+    });
+    fs.mkdirSync.mockImplementation(() => {});
+
+    // Execute
+    hardlinkReactNativeHeaders(reactNativePath, outputFolder);
+
+    // Assert - Should only process existing folders
+    expect(hardlinkHeadersFromPath).toHaveBeenCalledTimes(1); // Only Libraries
+    expect(hardlinkHeadersFromPath).toHaveBeenCalledWith(
+      '/path/to/react-native/Libraries',
+      '/output/headers/React',
+      false,
+      ['tests'],
+      {
+        'Required/': '/output/headers/RCTRequired',
+        'TypeSafety/': '/output/headers/RCTTypeSafety',
+        'FBLazyVector/': '/output/headers/FBLazyVector',
+      },
+    );
+
+    expect(hardlinkReactAppleHeaders).not.toHaveBeenCalled();
+    expect(hardlinkReactCommonHeaders).toHaveBeenCalledTimes(1); // Only ReactCommon
+
+    // Assert - Should not log processing for non-existent folders
+    expect(console.log).not.toHaveBeenCalledWith('Processing React folder...');
+    expect(console.log).not.toHaveBeenCalledWith(
+      'Processing ReactApple folder...',
+    );
+    expect(console.log).toHaveBeenCalledWith('Processing Libraries folder...');
+    expect(console.log).toHaveBeenCalledWith(
+      'Processing ReactCommon folder...',
+    );
+  });
+
+  it('should not create directories that already exist', () => {
+    // Setup
+    const reactNativePath = '/path/to/react-native';
+    const outputFolder = '/output';
+
+    // Mock fs.existsSync to return true for directories (they already exist)
+    fs.existsSync.mockImplementation(filePath => {
+      if (filePath === '/output/headers') return true; // headers dir exists
+      if (filePath === '/output/headers/React') return true; // React dir exists
+      if (filePath === '/path/to/react-native/React') return true;
+      if (filePath === '/path/to/react-native/Libraries') return true;
+      if (filePath === '/path/to/react-native/ReactApple') return true;
+      if (filePath === '/path/to/react-native/ReactCommon') return true;
+      return false;
+    });
+    fs.mkdirSync.mockImplementation(() => {});
+
+    // Execute
+    hardlinkReactNativeHeaders(reactNativePath, outputFolder);
+
+    // Assert - Should not create directories that already exist
+    expect(fs.mkdirSync).not.toHaveBeenCalledWith('/output/headers', {
+      recursive: true,
+    });
+    expect(fs.mkdirSync).not.toHaveBeenCalledWith('/output/headers/React', {
+      recursive: true,
+    });
+  });
+
+  it('should aggregate total linked count correctly from all functions', () => {
+    // Setup
+    const reactNativePath = '/path/to/react-native';
+    const outputFolder = '/output';
+
+    // Set up different return values for each function
+    hardlinkHeadersFromPath.mockReturnValueOnce(3).mockReturnValueOnce(8); // React: 3, Libraries: 8
+    hardlinkReactAppleHeaders.mockReturnValue(2);
+    hardlinkReactCommonHeaders.mockReturnValue(12);
+
+    fs.existsSync.mockImplementation(filePath => {
+      return (
+        filePath.includes('/path/to/react-native/') ||
+        filePath === '/output/headers' ||
+        filePath === '/output/headers/React'
+      );
+    });
+    fs.mkdirSync.mockImplementation(() => {});
+
+    // Execute
+    hardlinkReactNativeHeaders(reactNativePath, outputFolder);
+
+    // Assert - Should aggregate all counts: 3 + 8 + 2 + 12 = 25
+    expect(console.log).toHaveBeenCalledWith(
+      'Created hard links for 25 React Native headers total',
+    );
+  });
+
+  it('should handle case where only some functions are called due to missing directories', () => {
+    // Setup
+    const reactNativePath = '/path/to/react-native';
+    const outputFolder = '/output';
+
+    // Only ReactCommon exists
+    fs.existsSync.mockImplementation(filePath => {
+      if (filePath === '/output/headers') return false;
+      if (filePath === '/output/headers/React') return false;
+      if (filePath === '/path/to/react-native/ReactCommon') return true;
+      return false; // All other paths don't exist
+    });
+    fs.mkdirSync.mockImplementation(() => {});
+
+    hardlinkReactCommonHeaders.mockReturnValue(4);
+
+    // Execute
+    hardlinkReactNativeHeaders(reactNativePath, outputFolder);
+
+    // Assert - Should only call ReactCommon function
+    expect(hardlinkHeadersFromPath).not.toHaveBeenCalled();
+    expect(hardlinkReactAppleHeaders).not.toHaveBeenCalled();
+    expect(hardlinkReactCommonHeaders).toHaveBeenCalledTimes(1);
+
+    // Assert - Should only show total from ReactCommon
+    expect(console.log).toHaveBeenCalledWith(
+      'Created hard links for 4 React Native headers total',
+    );
+  });
+
+  it('should pass correct custom mappings for React and Libraries folders', () => {
+    // Setup
+    const reactNativePath = '/path/to/react-native';
+    const outputFolder = '/output';
+
+    fs.existsSync.mockImplementation(filePath => {
+      return (
+        filePath.includes('/path/to/react-native/') ||
+        filePath === '/output/headers' ||
+        filePath === '/output/headers/React'
+      );
+    });
+    fs.mkdirSync.mockImplementation(() => {});
+
+    // Execute
+    hardlinkReactNativeHeaders(reactNativePath, outputFolder);
+
+    // Assert - Check React folder custom mappings
+    expect(hardlinkHeadersFromPath).toHaveBeenNthCalledWith(
+      1, // First call
+      '/path/to/react-native/React',
+      '/output/headers/React',
+      false,
+      ['includes', 'headers', 'tests'],
+      {'FBReactNativeSpec/': '/output/headers/FBReactNativeSpec'},
+    );
+
+    // Assert - Check Libraries folder custom mappings
+    expect(hardlinkHeadersFromPath).toHaveBeenNthCalledWith(
+      2, // Second call
+      '/path/to/react-native/Libraries',
+      '/output/headers/React',
+      false,
+      ['tests'],
+      {
+        'Required/': '/output/headers/RCTRequired',
+        'TypeSafety/': '/output/headers/RCTTypeSafety',
+        'FBLazyVector/': '/output/headers/FBLazyVector',
+      },
+    );
+  });
+
+  it('should pass correct parameters to ReactCommon processing function', () => {
+    // Setup
+    const reactNativePath = '/path/to/react-native';
+    const outputFolder = '/output';
+
+    fs.existsSync.mockImplementation(filePath => {
+      return (
+        filePath === '/path/to/react-native/ReactCommon' ||
+        filePath.includes('/output/headers')
+      );
+    });
+    fs.mkdirSync.mockImplementation(() => {});
+
+    // Execute
+    hardlinkReactNativeHeaders(reactNativePath, outputFolder);
+
+    // Assert - Check ReactCommon function is called with correct parameters
+    expect(hardlinkReactCommonHeaders).toHaveBeenCalledWith(
+      '/path/to/react-native/ReactCommon',
+      '/output/headers',
+      ['react/nativemodule/core/platform/ios'],
+      {
+        'yoga/': 'yoga',
+        'cxxreact/': 'cxxreact',
+        'jsinspector-modern/': 'jsinspector-modern',
+        'jserrorhandler/': 'jserrorhandler',
+        'oscompat/': 'oscompat',
+      },
+    );
+  });
+
+  it('should handle the function being called without any React Native subdirectories', () => {
+    // Setup
+    const reactNativePath = '/path/to/react-native';
+    const outputFolder = '/output';
+
+    // None of the React Native subdirectories exist
+    fs.existsSync.mockImplementation(filePath => {
+      if (filePath === '/output/headers') return false;
+      if (filePath === '/output/headers/React') return false;
+      return false; // No React Native subdirectories exist
+    });
+    fs.mkdirSync.mockImplementation(() => {});
+
+    // Execute
+    hardlinkReactNativeHeaders(reactNativePath, outputFolder);
+
+    // Assert - Should still create base directories
+    expect(fs.mkdirSync).toHaveBeenCalledWith('/output/headers', {
+      recursive: true,
+    });
+    expect(fs.mkdirSync).toHaveBeenCalledWith('/output/headers/React', {
+      recursive: true,
+    });
+
+    // Assert - Should not call any processing functions
+    expect(hardlinkHeadersFromPath).not.toHaveBeenCalled();
+    expect(hardlinkReactAppleHeaders).not.toHaveBeenCalled();
+    expect(hardlinkReactCommonHeaders).not.toHaveBeenCalled();
+
+    // Assert - Should show zero total
+    expect(console.log).toHaveBeenCalledWith(
+      'Created hard links for 0 React Native headers total',
+    );
+  });
+
+  it('should properly log the orchestration process', () => {
+    // Setup
+    const reactNativePath = '/path/to/react-native';
+    const outputFolder = '/output';
+
+    fs.existsSync.mockImplementation(filePath => {
+      return (
+        filePath.includes('/path/to/react-native/') ||
+        filePath === '/output/headers' ||
+        filePath === '/output/headers/React'
+      );
+    });
+    fs.mkdirSync.mockImplementation(() => {});
+
+    // Execute
+    hardlinkReactNativeHeaders(reactNativePath, outputFolder);
+
+    // Assert - Check logging sequence
+    const logCalls = console.log.mock.calls.map(call => call[0]);
+
+    expect(logCalls[0]).toBe('Creating hard links for React Native headers...');
+    expect(logCalls[1]).toBe('Processing React folder...');
+    expect(logCalls[2]).toBe('Created 5 hard links from React folder');
+    expect(logCalls[3]).toBe('Processing Libraries folder...');
+    expect(logCalls[4]).toBe('Created 5 hard links from Libraries folder');
+    expect(logCalls[5]).toBe('Processing ReactApple folder...');
+    expect(logCalls[6]).toBe('Created 3 hard links from ReactApple folder');
+    expect(logCalls[7]).toBe('Processing ReactCommon folder...');
+    expect(logCalls[8]).toBe('Created 7 hard links from ReactCommon folder');
+    expect(logCalls[9]).toBe(
+      'Created hard links for 20 React Native headers total',
+    );
+  });
+});

--- a/packages/react-native/scripts/swiftpm/__tests__/update-xcodeproject-test.js
+++ b/packages/react-native/scripts/swiftpm/__tests__/update-xcodeproject-test.js
@@ -1,0 +1,288 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @noflow
+ */
+
+'use strict';
+
+const {integrateSwiftPackagesInXcode} = require('../update-xcodeproject');
+const fs = require('fs');
+const path = require('path');
+
+// Mock fs module
+jest.mock('fs');
+
+// Mock xcodeproj-utils module
+jest.mock('../xcodeproj-utils', () => ({
+  addLocalSwiftPM: jest.fn(),
+  convertXcodeProjectToJSON: jest.fn(),
+  deintegrateSwiftPM: jest.fn(),
+  updateXcodeProject: jest.fn(),
+}));
+
+describe('integrateSwiftPackagesInXcode', () => {
+  let mockConvertXcodeProjectToJSON;
+  let mockDeintegrateSwiftPM;
+  let mockAddLocalSwiftPM;
+  let mockUpdateXcodeProject;
+  let mockExistsSync;
+  let mockWriteFileSync;
+
+  beforeEach(() => {
+    // Setup mocks
+    const xcodeprjUtils = require('../xcodeproj-utils');
+    mockConvertXcodeProjectToJSON = xcodeprjUtils.convertXcodeProjectToJSON;
+    mockDeintegrateSwiftPM = xcodeprjUtils.deintegrateSwiftPM;
+    mockAddLocalSwiftPM = xcodeprjUtils.addLocalSwiftPM;
+    mockUpdateXcodeProject = xcodeprjUtils.updateXcodeProject;
+
+    mockExistsSync = fs.existsSync;
+    mockWriteFileSync = fs.writeFileSync;
+
+    // Reset all mocks
+    jest.clearAllMocks();
+  });
+
+  it('should integrate single Swift package into Xcode project', () => {
+    // Setup
+    const xcodeProjectPath = '/path/to/MyApp.xcodeproj';
+    const packageSwiftObjects = [
+      {
+        relativePath: '../MyPackage',
+        targets: ['MyLibrary'],
+      },
+    ];
+    const appTargetName = 'MyApp';
+
+    const mockXcodeProject = {
+      objects: {
+        PROJECT1: {
+          isa: 'PBXProject',
+        },
+      },
+    };
+
+    const mockUpdatedProjectContent = 'UPDATED_PROJECT_CONTENT';
+
+    mockExistsSync.mockReturnValue(true);
+    mockConvertXcodeProjectToJSON.mockReturnValue(mockXcodeProject);
+    mockUpdateXcodeProject.mockReturnValue(mockUpdatedProjectContent);
+
+    // Execute
+    integrateSwiftPackagesInXcode(
+      xcodeProjectPath,
+      packageSwiftObjects,
+      appTargetName,
+    );
+
+    // Assert
+    expect(mockExistsSync).toHaveBeenCalledWith(
+      path.join(xcodeProjectPath, 'project.pbxproj'),
+    );
+    expect(mockConvertXcodeProjectToJSON).toHaveBeenCalledWith(
+      path.join(xcodeProjectPath, 'project.pbxproj'),
+    );
+    expect(mockDeintegrateSwiftPM).toHaveBeenCalledWith(mockXcodeProject);
+    expect(mockAddLocalSwiftPM).toHaveBeenCalledTimes(1);
+    expect(mockAddLocalSwiftPM).toHaveBeenCalledWith(
+      '../MyPackage',
+      ['MyLibrary'],
+      mockXcodeProject,
+      appTargetName,
+    );
+    expect(mockUpdateXcodeProject).toHaveBeenCalledWith(
+      mockXcodeProject,
+      path.join(xcodeProjectPath, 'project.pbxproj'),
+    );
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      path.join(xcodeProjectPath, 'project.pbxproj'),
+      mockUpdatedProjectContent,
+    );
+  });
+
+  it('should integrate multiple Swift packages into Xcode project', () => {
+    // Setup
+    const xcodeProjectPath = '/path/to/MyApp.xcodeproj';
+    const packageSwiftObjects = [
+      {
+        relativePath: '../Package1',
+        targets: ['Library1'],
+      },
+      {
+        relativePath: '../Package2',
+        targets: ['Library2A', 'Library2B'],
+      },
+      {
+        relativePath: '../Package3',
+        targets: ['Library3'],
+      },
+    ];
+    const appTargetName = 'MyApp';
+
+    const mockXcodeProject = {
+      objects: {
+        PROJECT1: {
+          isa: 'PBXProject',
+        },
+      },
+    };
+
+    const mockUpdatedProjectContent = 'UPDATED_PROJECT_CONTENT';
+
+    mockExistsSync.mockReturnValue(true);
+    mockConvertXcodeProjectToJSON.mockReturnValue(mockXcodeProject);
+    mockUpdateXcodeProject.mockReturnValue(mockUpdatedProjectContent);
+
+    // Execute
+    integrateSwiftPackagesInXcode(
+      xcodeProjectPath,
+      packageSwiftObjects,
+      appTargetName,
+    );
+
+    // Assert
+    expect(mockAddLocalSwiftPM).toHaveBeenCalledTimes(3);
+    expect(mockAddLocalSwiftPM).toHaveBeenNthCalledWith(
+      1,
+      '../Package1',
+      ['Library1'],
+      mockXcodeProject,
+      appTargetName,
+    );
+    expect(mockAddLocalSwiftPM).toHaveBeenNthCalledWith(
+      2,
+      '../Package2',
+      ['Library2A', 'Library2B'],
+      mockXcodeProject,
+      appTargetName,
+    );
+    expect(mockAddLocalSwiftPM).toHaveBeenNthCalledWith(
+      3,
+      '../Package3',
+      ['Library3'],
+      mockXcodeProject,
+      appTargetName,
+    );
+  });
+
+  it('should handle empty package list without errors', () => {
+    // Setup
+    const xcodeProjectPath = '/path/to/MyApp.xcodeproj';
+    const packageSwiftObjects = [];
+    const appTargetName = 'MyApp';
+
+    const mockXcodeProject = {
+      objects: {
+        PROJECT1: {
+          isa: 'PBXProject',
+        },
+      },
+    };
+
+    const mockUpdatedProjectContent = 'UPDATED_PROJECT_CONTENT';
+
+    mockExistsSync.mockReturnValue(true);
+    mockConvertXcodeProjectToJSON.mockReturnValue(mockXcodeProject);
+    mockUpdateXcodeProject.mockReturnValue(mockUpdatedProjectContent);
+
+    // Execute
+    integrateSwiftPackagesInXcode(
+      xcodeProjectPath,
+      packageSwiftObjects,
+      appTargetName,
+    );
+
+    // Assert
+    expect(mockDeintegrateSwiftPM).toHaveBeenCalledWith(mockXcodeProject);
+    expect(mockAddLocalSwiftPM).not.toHaveBeenCalled();
+    expect(mockUpdateXcodeProject).toHaveBeenCalledWith(
+      mockXcodeProject,
+      path.join(xcodeProjectPath, 'project.pbxproj'),
+    );
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      path.join(xcodeProjectPath, 'project.pbxproj'),
+      mockUpdatedProjectContent,
+    );
+  });
+
+  it('should throw error when project.pbxproj file does not exist', () => {
+    // Setup
+    const xcodeProjectPath = '/path/to/NonExistent.xcodeproj';
+    const packageSwiftObjects = [
+      {
+        relativePath: '../MyPackage',
+        targets: ['MyLibrary'],
+      },
+    ];
+    const appTargetName = 'MyApp';
+
+    mockExistsSync.mockReturnValue(false);
+
+    // Execute & Assert
+    expect(() =>
+      integrateSwiftPackagesInXcode(
+        xcodeProjectPath,
+        packageSwiftObjects,
+        appTargetName,
+      ),
+    ).toThrow(
+      'Project file not found: /path/to/NonExistent.xcodeproj/project.pbxproj',
+    );
+
+    expect(mockExistsSync).toHaveBeenCalledWith(
+      '/path/to/NonExistent.xcodeproj/project.pbxproj',
+    );
+    expect(mockConvertXcodeProjectToJSON).not.toHaveBeenCalled();
+    expect(mockDeintegrateSwiftPM).not.toHaveBeenCalled();
+    expect(mockAddLocalSwiftPM).not.toHaveBeenCalled();
+    expect(mockUpdateXcodeProject).not.toHaveBeenCalled();
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+  });
+
+  it('should handle package with multiple targets correctly', () => {
+    // Setup
+    const xcodeProjectPath = '/path/to/MyApp.xcodeproj';
+    const packageSwiftObjects = [
+      {
+        relativePath: '../MultiTargetPackage',
+        targets: ['Core', 'Extensions', 'Utils', 'TestHelpers'],
+      },
+    ];
+    const appTargetName = 'MyApp';
+
+    const mockXcodeProject = {
+      objects: {
+        PROJECT1: {
+          isa: 'PBXProject',
+        },
+      },
+    };
+
+    const mockUpdatedProjectContent = 'UPDATED_PROJECT_CONTENT';
+
+    mockExistsSync.mockReturnValue(true);
+    mockConvertXcodeProjectToJSON.mockReturnValue(mockXcodeProject);
+    mockUpdateXcodeProject.mockReturnValue(mockUpdatedProjectContent);
+
+    // Execute
+    integrateSwiftPackagesInXcode(
+      xcodeProjectPath,
+      packageSwiftObjects,
+      appTargetName,
+    );
+
+    // Assert
+    expect(mockAddLocalSwiftPM).toHaveBeenCalledTimes(1);
+    expect(mockAddLocalSwiftPM).toHaveBeenCalledWith(
+      '../MultiTargetPackage',
+      ['Core', 'Extensions', 'Utils', 'TestHelpers'],
+      mockXcodeProject,
+      appTargetName,
+    );
+  });
+});

--- a/packages/react-native/scripts/swiftpm/__tests__/utils-test.js
+++ b/packages/react-native/scripts/swiftpm/__tests__/utils-test.js
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @noflow
+ */
+
+'use strict';
+
+const {setupSymlink} = require('../utils');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+describe('setupSymlink', () => {
+  let tempDir;
+  let sourceFile;
+  let destFile;
+  let destDir;
+
+  beforeEach(() => {
+    // Create a temporary directory for testing
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'utils-test-'));
+    sourceFile = path.join(tempDir, 'source.txt');
+    destDir = path.join(tempDir, 'dest', 'subdir');
+    destFile = path.join(destDir, 'dest.txt');
+
+    // Create a source file
+    fs.writeFileSync(sourceFile, 'test content');
+  });
+
+  afterEach(() => {
+    // Clean up temporary directory
+    if (fs.existsSync(tempDir)) {
+      fs.rmSync(tempDir, {recursive: true, force: true});
+    }
+  });
+
+  it('should create destination directory if it does not exist', () => {
+    expect(fs.existsSync(destDir)).toBe(false);
+
+    setupSymlink(sourceFile, destFile);
+
+    expect(fs.existsSync(destDir)).toBe(true);
+  });
+
+  it('should create symlink when source file exists', () => {
+    setupSymlink(sourceFile, destFile);
+
+    expect(fs.existsSync(destFile)).toBe(true);
+    expect(fs.lstatSync(destFile).isSymbolicLink()).toBe(true);
+    expect(fs.readFileSync(destFile, 'utf8')).toBe('test content');
+  });
+
+  it('should remove existing symlink before creating new one', () => {
+    // Create initial symlink
+    fs.mkdirSync(destDir, {recursive: true});
+    fs.symlinkSync(sourceFile, destFile);
+    expect(fs.existsSync(destFile)).toBe(true);
+
+    // Create another source file
+    const newSourceFile = path.join(tempDir, 'newsource.txt');
+    fs.writeFileSync(newSourceFile, 'new content');
+
+    // Setup symlink should remove the old one and create new one
+    setupSymlink(newSourceFile, destFile);
+
+    expect(fs.existsSync(destFile)).toBe(true);
+    expect(fs.lstatSync(destFile).isSymbolicLink()).toBe(true);
+    expect(fs.readFileSync(destFile, 'utf8')).toBe('new content');
+  });
+
+  it('should remove existing regular file before creating symlink', () => {
+    // Create destination directory and regular file
+    fs.mkdirSync(destDir, {recursive: true});
+    fs.writeFileSync(destFile, 'regular file content');
+    expect(fs.existsSync(destFile)).toBe(true);
+    expect(fs.lstatSync(destFile).isSymbolicLink()).toBe(false);
+
+    setupSymlink(sourceFile, destFile);
+
+    expect(fs.existsSync(destFile)).toBe(true);
+    expect(fs.lstatSync(destFile).isSymbolicLink()).toBe(true);
+    expect(fs.readFileSync(destFile, 'utf8')).toBe('test content');
+  });
+
+  it('should not create symlink when source file does not exist', () => {
+    const nonExistentSource = path.join(tempDir, 'nonexistent.txt');
+
+    setupSymlink(nonExistentSource, destFile);
+
+    expect(fs.existsSync(destDir)).toBe(true); // Directory should still be created
+    expect(fs.existsSync(destFile)).toBe(false); // But no symlink should be created
+  });
+
+  it('should work when destination directory already exists', () => {
+    // Pre-create destination directory
+    fs.mkdirSync(destDir, {recursive: true});
+
+    setupSymlink(sourceFile, destFile);
+
+    expect(fs.existsSync(destFile)).toBe(true);
+    expect(fs.lstatSync(destFile).isSymbolicLink()).toBe(true);
+    expect(fs.readFileSync(destFile, 'utf8')).toBe('test content');
+  });
+});

--- a/packages/react-native/scripts/swiftpm/__tests__/xcodeproj-core-utils-test.js
+++ b/packages/react-native/scripts/swiftpm/__tests__/xcodeproj-core-utils-test.js
@@ -10,7 +10,10 @@
 
 'use strict';
 
-const {generateXcodeObjectId} = require('../xcodeproj-core-utils');
+const {
+  generateXcodeObjectId,
+  printFilesForBuildPhase,
+} = require('../xcodeproj-core-utils');
 
 // Mock crypto module
 jest.mock('crypto');
@@ -116,5 +119,76 @@ describe('generateXcodeObjectId', () => {
 
     // Execute & Assert
     expect(() => generateXcodeObjectId()).toThrow('Crypto error');
+  });
+});
+
+describe('printFilesForBuildPhase', () => {
+  it('should format build file with productRef correctly', () => {
+    // Setup
+    const objectId = 'BUILDFILE123';
+    const objectData = {
+      isa: 'PBXBuildFile',
+      productRef: 'PRODUCT456',
+    };
+    const allObjects = {
+      PRODUCT456: {
+        isa: 'XCSwiftPackageProductDependency',
+        productName: 'Alamofire',
+      },
+    };
+
+    // Execute
+    const result = printFilesForBuildPhase(objectId, objectData, allObjects);
+
+    // Assert
+    expect(result).toBe(
+      '\t\t\t\tBUILDFILE123 /* Alamofire in Frameworks */,\n',
+    );
+  });
+
+  it('should format build file with fileRef correctly', () => {
+    // Setup
+    const objectId = 'BUILDFILE789';
+    const objectData = {
+      isa: 'PBXBuildFile',
+      fileRef: 'FILEREF123',
+    };
+    const allObjects = {
+      FILEREF123: {
+        isa: 'PBXFileReference',
+        name: 'MyFramework.framework',
+      },
+    };
+
+    // Execute
+    const result = printFilesForBuildPhase(objectId, objectData, allObjects);
+
+    // Assert
+    expect(result).toBe(
+      '\t\t\t\tBUILDFILE789 /* MyFramework.framework in Frameworks */,\n',
+    );
+  });
+
+  it('should use file path when name is not available', () => {
+    // Setup
+    const objectId = 'BUILDFILE789';
+    const objectData = {
+      isa: 'PBXBuildFile',
+      fileRef: 'FILEREF456',
+    };
+    const allObjects = {
+      FILEREF456: {
+        isa: 'PBXFileReference',
+        path: 'path/to/MyLib.framework',
+      },
+    };
+
+    // Execute
+    const result = printFilesForBuildPhase(objectId, objectData, allObjects);
+
+    // Assert
+    expect(result).toBe(
+      '\t\t\t\tBUILDFILE789 /* path/to/MyLib.framework in Frameworks */,\n',
+    );
   });
 });

--- a/packages/react-native/scripts/swiftpm/__tests__/xcodeproj-core-utils-test.js
+++ b/packages/react-native/scripts/swiftpm/__tests__/xcodeproj-core-utils-test.js
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @noflow
+ */
+
+'use strict';
+
+const {generateXcodeObjectId} = require('../xcodeproj-core-utils');
+
+// Mock crypto module
+jest.mock('crypto');
+
+describe('generateXcodeObjectId', () => {
+  let mockCrypto;
+
+  beforeEach(() => {
+    // Setup mock
+    mockCrypto = require('crypto');
+
+    // Reset all mocks
+    jest.clearAllMocks();
+  });
+
+  it('should generate a 24-character uppercase hexadecimal string', () => {
+    // Setup - Mock crypto.randomBytes to return predictable data
+    mockCrypto.randomBytes.mockReturnValue(
+      Buffer.from([
+        0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67,
+      ]),
+    );
+
+    // Execute
+    const result = generateXcodeObjectId();
+
+    // Assert
+    expect(result).toBe('0123456789ABCDEF01234567');
+    expect(result).toHaveLength(24);
+    expect(result).toMatch(/^[0-9A-F]+$/);
+  });
+
+  it('should call crypto.randomBytes with 12 bytes', () => {
+    // Setup
+    mockCrypto.randomBytes.mockReturnValue(
+      Buffer.from([
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      ]),
+    );
+
+    // Execute
+    generateXcodeObjectId();
+
+    // Assert
+    expect(mockCrypto.randomBytes).toHaveBeenCalledWith(12);
+    expect(mockCrypto.randomBytes).toHaveBeenCalledTimes(1);
+  });
+
+  it('should convert to uppercase hexadecimal', () => {
+    // Setup - Mock with bytes that would produce lowercase hex
+    mockCrypto.randomBytes.mockReturnValue(
+      Buffer.from([
+        0xab, 0xcd, 0xef, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x11,
+      ]),
+    );
+
+    // Execute
+    const result = generateXcodeObjectId();
+
+    // Assert
+    expect(result).toBe('ABCDEF123456789ABCDEF011');
+    expect(result).not.toMatch(/[a-z]/); // Should not contain lowercase letters
+  });
+
+  it('should return a string type', () => {
+    // Setup
+    mockCrypto.randomBytes.mockReturnValue(
+      Buffer.from([
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
+      ]),
+    );
+
+    // Execute
+    const result = generateXcodeObjectId();
+
+    // Assert
+    expect(typeof result).toBe('string');
+  });
+
+  it('should not contain any non-hexadecimal characters', () => {
+    // Setup
+    mockCrypto.randomBytes.mockReturnValue(
+      Buffer.from([
+        0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x11, 0x22, 0x33, 0x44,
+      ]),
+    );
+
+    // Execute
+    const result = generateXcodeObjectId();
+
+    // Assert
+    expect(result).toMatch(/^[0-9A-F]{24}$/);
+    expect(result).not.toMatch(/[G-Z]/); // Should not contain letters beyond F
+    expect(result).not.toMatch(/[a-z]/); // Should not contain lowercase letters
+    expect(result).not.toMatch(/[\s\-_]/); // Should not contain whitespace or special chars
+  });
+
+  it('should handle crypto.randomBytes errors gracefully', () => {
+    // Setup
+    mockCrypto.randomBytes.mockImplementation(() => {
+      throw new Error('Crypto error');
+    });
+
+    // Execute & Assert
+    expect(() => generateXcodeObjectId()).toThrow('Crypto error');
+  });
+});

--- a/packages/react-native/scripts/swiftpm/__tests__/xcodeproj-utils-test.js
+++ b/packages/react-native/scripts/swiftpm/__tests__/xcodeproj-utils-test.js
@@ -12,6 +12,7 @@
 
 const {
   convertXcodeProjectToJSON,
+  deintegrateSwiftPM,
   generateXcodeObjectId,
 } = require('../xcodeproj-utils');
 
@@ -193,5 +194,381 @@ describe('convertXcodeProjectToJSON', () => {
 
     // Assert
     expect(result).toEqual(expectedResult);
+  });
+});
+
+describe('deintegrateSwiftPM', () => {
+  let consoleLogSpy;
+
+  beforeEach(() => {
+    // Mock console.log to avoid output during tests
+    consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+  });
+
+  it('should handle empty project without errors', () => {
+    // Setup
+    const emptyProject = {
+      objects: {},
+    };
+
+    // Execute
+    expect(() => deintegrateSwiftPM(emptyProject)).not.toThrow();
+
+    // Assert
+    expect(emptyProject.objects).toEqual({});
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      '✓ Removed 0 SwiftPM-related objects from Xcode project',
+    );
+  });
+
+  it('should handle project with no SwiftPM dependencies', () => {
+    // Setup
+    const projectWithoutSwiftPM = {
+      objects: {
+        TARGET1: {
+          isa: 'PBXNativeTarget',
+          buildPhases: ['BUILDPHASE1'],
+        },
+        BUILDPHASE1: {
+          isa: 'PBXFrameworksBuildPhase',
+          files: ['FILE1'],
+        },
+        FILE1: {
+          isa: 'PBXBuildFile',
+          fileRef: 'FILEREF1',
+        },
+        FILEREF1: {
+          isa: 'PBXFileReference',
+          path: 'some_library.framework',
+        },
+        PROJECT1: {
+          isa: 'PBXProject',
+          packageReferences: [],
+        },
+      },
+    };
+
+    const originalObjects = JSON.parse(
+      JSON.stringify(projectWithoutSwiftPM.objects),
+    );
+
+    // Execute
+    deintegrateSwiftPM(projectWithoutSwiftPM);
+
+    // Assert - No objects should be removed
+    expect(projectWithoutSwiftPM.objects).toEqual(originalObjects);
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      '✓ Removed 0 SwiftPM-related objects from Xcode project',
+    );
+  });
+
+  it('should remove XCSwiftPackageProductDependency and related objects', () => {
+    // Setup
+    const projectWithSwiftPM = {
+      objects: {
+        TARGET1: {
+          isa: 'PBXNativeTarget',
+          buildPhases: ['BUILDPHASE1'],
+        },
+        BUILDPHASE1: {
+          isa: 'PBXFrameworksBuildPhase',
+          files: ['BUILDFILE1', 'BUILDFILE2'],
+        },
+        BUILDFILE1: {
+          isa: 'PBXBuildFile',
+          productRef: 'SWIFTPACKAGE1',
+        },
+        BUILDFILE2: {
+          isa: 'PBXBuildFile',
+          fileRef: 'NORMALFILE1',
+        },
+        SWIFTPACKAGE1: {
+          isa: 'XCSwiftPackageProductDependency',
+          packageName: 'SomeSwiftPackage',
+        },
+        NORMALFILE1: {
+          isa: 'PBXFileReference',
+          path: 'normal_file.framework',
+        },
+        PROJECT1: {
+          isa: 'PBXProject',
+          packageReferences: ['PACKAGEREF1'],
+        },
+        PACKAGEREF1: {
+          isa: 'XCLocalSwiftPackageReference',
+          relativePath: '../SomeSwiftPackage',
+        },
+      },
+    };
+
+    // Execute
+    deintegrateSwiftPM(projectWithSwiftPM);
+
+    // Assert
+    expect(projectWithSwiftPM.objects).toEqual({
+      TARGET1: {
+        isa: 'PBXNativeTarget',
+        buildPhases: ['BUILDPHASE1'],
+      },
+      BUILDPHASE1: {
+        isa: 'PBXFrameworksBuildPhase',
+        files: ['BUILDFILE2'],
+      },
+      BUILDFILE2: {
+        isa: 'PBXBuildFile',
+        fileRef: 'NORMALFILE1',
+      },
+      NORMALFILE1: {
+        isa: 'PBXFileReference',
+        path: 'normal_file.framework',
+      },
+      PROJECT1: {
+        isa: 'PBXProject',
+        packageReferences: [],
+      },
+    });
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      '✓ Removed 3 SwiftPM-related objects from Xcode project',
+    );
+  });
+
+  it('should handle multiple targets with SwiftPM dependencies', () => {
+    // Setup
+    const projectWithMultipleTargets = {
+      objects: {
+        TARGET1: {
+          isa: 'PBXNativeTarget',
+          buildPhases: ['BUILDPHASE1'],
+        },
+        TARGET2: {
+          isa: 'PBXNativeTarget',
+          buildPhases: ['BUILDPHASE2'],
+        },
+        BUILDPHASE1: {
+          isa: 'PBXFrameworksBuildPhase',
+          files: ['BUILDFILE1'],
+        },
+        BUILDPHASE2: {
+          isa: 'PBXFrameworksBuildPhase',
+          files: ['BUILDFILE2'],
+        },
+        BUILDFILE1: {
+          isa: 'PBXBuildFile',
+          productRef: 'SWIFTPACKAGE1',
+        },
+        BUILDFILE2: {
+          isa: 'PBXBuildFile',
+          productRef: 'SWIFTPACKAGE2',
+        },
+        SWIFTPACKAGE1: {
+          isa: 'XCSwiftPackageProductDependency',
+          packageName: 'Package1',
+        },
+        SWIFTPACKAGE2: {
+          isa: 'XCSwiftPackageProductDependency',
+          packageName: 'Package2',
+        },
+        PROJECT1: {
+          isa: 'PBXProject',
+          packageReferences: ['PACKAGEREF1', 'PACKAGEREF2'],
+        },
+        PACKAGEREF1: {
+          isa: 'XCLocalSwiftPackageReference',
+          relativePath: '../Package1',
+        },
+        PACKAGEREF2: {
+          isa: 'XCLocalSwiftPackageReference',
+          relativePath: '../Package2',
+        },
+      },
+    };
+
+    // Execute
+    deintegrateSwiftPM(projectWithMultipleTargets);
+
+    // Assert
+    expect(projectWithMultipleTargets.objects).toEqual({
+      TARGET1: {
+        isa: 'PBXNativeTarget',
+        buildPhases: ['BUILDPHASE1'],
+      },
+      TARGET2: {
+        isa: 'PBXNativeTarget',
+        buildPhases: ['BUILDPHASE2'],
+      },
+      BUILDPHASE1: {
+        isa: 'PBXFrameworksBuildPhase',
+        files: [],
+      },
+      BUILDPHASE2: {
+        isa: 'PBXFrameworksBuildPhase',
+        files: [],
+      },
+      PROJECT1: {
+        isa: 'PBXProject',
+        packageReferences: [],
+      },
+    });
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      '✓ Removed 6 SwiftPM-related objects from Xcode project',
+    );
+  });
+
+  it('should preserve non-SwiftPM package references', () => {
+    // Setup
+    const projectWithMixedPackages = {
+      objects: {
+        PROJECT1: {
+          isa: 'PBXProject',
+          packageReferences: ['LOCALPACKAGE1', 'REMOTEPACKAGE1'],
+        },
+        LOCALPACKAGE1: {
+          isa: 'XCLocalSwiftPackageReference',
+          relativePath: '../LocalPackage',
+        },
+        REMOTEPACKAGE1: {
+          isa: 'XCRemoteSwiftPackageReference',
+          repositoryURL: 'https://github.com/example/package.git',
+        },
+      },
+    };
+
+    // Execute
+    deintegrateSwiftPM(projectWithMixedPackages);
+
+    // Assert
+    expect(projectWithMixedPackages.objects).toEqual({
+      PROJECT1: {
+        isa: 'PBXProject',
+        packageReferences: ['REMOTEPACKAGE1'],
+      },
+      REMOTEPACKAGE1: {
+        isa: 'XCRemoteSwiftPackageReference',
+        repositoryURL: 'https://github.com/example/package.git',
+      },
+    });
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      '✓ Removed 1 SwiftPM-related objects from Xcode project',
+    );
+  });
+
+  it('should handle missing referenced objects gracefully', () => {
+    // Setup - Project with references to non-existent objects
+    const projectWithMissingRefs = {
+      objects: {
+        TARGET1: {
+          isa: 'PBXNativeTarget',
+          buildPhases: ['MISSING_BUILDPHASE'],
+        },
+        BUILDPHASE1: {
+          isa: 'PBXFrameworksBuildPhase',
+          files: ['MISSING_BUILDFILE'],
+        },
+        BUILDFILE1: {
+          isa: 'PBXBuildFile',
+          productRef: 'MISSING_PRODUCT',
+        },
+        PROJECT1: {
+          isa: 'PBXProject',
+          packageReferences: ['MISSING_PACKAGE'],
+        },
+      },
+    };
+
+    const originalObjects = JSON.parse(
+      JSON.stringify(projectWithMissingRefs.objects),
+    );
+
+    // Execute
+    expect(() => deintegrateSwiftPM(projectWithMissingRefs)).not.toThrow();
+
+    // Assert - No changes should be made to existing objects
+    expect(projectWithMissingRefs.objects).toEqual(originalObjects);
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      '✓ Removed 0 SwiftPM-related objects from Xcode project',
+    );
+  });
+
+  it('should handle non-PBXFrameworksBuildPhase build phases', () => {
+    // Setup
+    const projectWithMixedBuildPhases = {
+      objects: {
+        TARGET1: {
+          isa: 'PBXNativeTarget',
+          buildPhases: ['SOURCES_PHASE', 'FRAMEWORKS_PHASE'],
+        },
+        SOURCES_PHASE: {
+          isa: 'PBXSourcesBuildPhase',
+          files: ['SOURCE_FILE1'],
+        },
+        FRAMEWORKS_PHASE: {
+          isa: 'PBXFrameworksBuildPhase',
+          files: ['BUILDFILE1'],
+        },
+        SOURCE_FILE1: {
+          isa: 'PBXBuildFile',
+          fileRef: 'SOURCE_REF1',
+        },
+        BUILDFILE1: {
+          isa: 'PBXBuildFile',
+          productRef: 'SWIFTPACKAGE1',
+        },
+        SOURCE_REF1: {
+          isa: 'PBXFileReference',
+          path: 'source.swift',
+        },
+        SWIFTPACKAGE1: {
+          isa: 'XCSwiftPackageProductDependency',
+          packageName: 'Package1',
+        },
+        PROJECT1: {
+          isa: 'PBXProject',
+          packageReferences: [],
+        },
+      },
+    };
+
+    // Execute
+    deintegrateSwiftPM(projectWithMixedBuildPhases);
+
+    // Assert - Only frameworks build phase should be affected
+    expect(projectWithMixedBuildPhases.objects).toEqual({
+      TARGET1: {
+        isa: 'PBXNativeTarget',
+        buildPhases: ['SOURCES_PHASE', 'FRAMEWORKS_PHASE'],
+      },
+      SOURCES_PHASE: {
+        isa: 'PBXSourcesBuildPhase',
+        files: ['SOURCE_FILE1'],
+      },
+      FRAMEWORKS_PHASE: {
+        isa: 'PBXFrameworksBuildPhase',
+        files: [],
+      },
+      SOURCE_FILE1: {
+        isa: 'PBXBuildFile',
+        fileRef: 'SOURCE_REF1',
+      },
+      SOURCE_REF1: {
+        isa: 'PBXFileReference',
+        path: 'source.swift',
+      },
+      PROJECT1: {
+        isa: 'PBXProject',
+        packageReferences: [],
+      },
+    });
+
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      '✓ Removed 2 SwiftPM-related objects from Xcode project',
+    );
   });
 });

--- a/packages/react-native/scripts/swiftpm/__tests__/xcodeproj-utils-test.js
+++ b/packages/react-native/scripts/swiftpm/__tests__/xcodeproj-utils-test.js
@@ -14,6 +14,10 @@ const {
   convertXcodeProjectToJSON,
   deintegrateSwiftPM,
   generateXcodeObjectId,
+  printFilesForBuildPhase,
+  printPBXBuildFile,
+  printXCLocalSwiftPackageReference,
+  printXCSwiftPackageProductDependency,
 } = require('../xcodeproj-utils');
 
 // Mock child_process module
@@ -570,5 +574,286 @@ describe('deintegrateSwiftPM', () => {
     expect(consoleLogSpy).toHaveBeenCalledWith(
       '✓ Removed 2 SwiftPM-related objects from Xcode project',
     );
+  });
+});
+
+describe('printPBXBuildFile', () => {
+  it('should format PBXBuildFile with productRef correctly', () => {
+    // Setup
+    const objectId = 'BUILDFILE123';
+    const objectData = {
+      isa: 'PBXBuildFile',
+      productRef: 'PRODUCT456',
+    };
+    const allObjects = {
+      PRODUCT456: {
+        isa: 'XCSwiftPackageProductDependency',
+        productName: 'Alamofire',
+      },
+    };
+
+    // Execute
+    const result = printPBXBuildFile(objectId, objectData, allObjects);
+
+    // Assert
+    expect(result).toBe(
+      '\t\tBUILDFILE123 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = PRODUCT456 /* Alamofire */; };\n',
+    );
+  });
+
+  it('should format PBXBuildFile with fileRef correctly', () => {
+    // Setup
+    const objectId = 'BUILDFILE789';
+    const objectData = {
+      isa: 'PBXBuildFile',
+      fileRef: 'FILEREF123',
+    };
+    const allObjects = {
+      FILEREF123: {
+        isa: 'PBXFileReference',
+        name: 'MyFramework.framework',
+      },
+      FRAMEWORKS_PHASE: {
+        isa: 'PBXFrameworksBuildPhase',
+        files: ['BUILDFILE789'],
+      },
+    };
+
+    // Execute
+    const result = printPBXBuildFile(objectId, objectData, allObjects);
+
+    // Assert
+    expect(result).toBe(
+      '\t\tBUILDFILE789 /* MyFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FILEREF123 /* MyFramework.framework */; };\n',
+    );
+  });
+
+  it('should use file path when name is not available', () => {
+    // Setup
+    const objectId = 'BUILDFILE789';
+    const objectData = {
+      isa: 'PBXBuildFile',
+      fileRef: 'FILEREF456',
+    };
+    const allObjects = {
+      FILEREF456: {
+        isa: 'PBXFileReference',
+        path: 'path/to/MyLib.framework',
+      },
+      SOURCES_PHASE: {
+        isa: 'PBXSourcesBuildPhase',
+        files: ['BUILDFILE789'],
+      },
+    };
+
+    // Execute
+    const result = printPBXBuildFile(objectId, objectData, allObjects);
+
+    // Assert
+    expect(result).toBe(
+      '\t\tBUILDFILE789 /* path/to/MyLib.framework in Sources */ = {isa = PBXBuildFile; fileRef = FILEREF456 /* path/to/MyLib.framework */; };\n',
+    );
+  });
+
+  it('should identify different build phase types correctly', () => {
+    // Setup
+    const objectId = 'BUILDFILE999';
+    const objectData = {
+      isa: 'PBXBuildFile',
+      fileRef: 'FILEREF999',
+    };
+    const allObjects = {
+      FILEREF999: {
+        isa: 'PBXFileReference',
+        name: 'Script.sh',
+      },
+      SHELL_PHASE: {
+        isa: 'PBXShellScriptBuildPhase',
+        files: ['BUILDFILE999'],
+      },
+    };
+
+    // Execute
+    const result = printPBXBuildFile(objectId, objectData, allObjects);
+
+    // Assert
+    expect(result).toBe(
+      '\t\tBUILDFILE999 /* Script.sh in ShellScript */ = {isa = PBXBuildFile; fileRef = FILEREF999 /* Script.sh */; };\n',
+    );
+  });
+});
+
+describe('printFilesForBuildPhase', () => {
+  it('should format build file with productRef correctly', () => {
+    // Setup
+    const objectId = 'BUILDFILE123';
+    const objectData = {
+      isa: 'PBXBuildFile',
+      productRef: 'PRODUCT456',
+    };
+    const allObjects = {
+      PRODUCT456: {
+        isa: 'XCSwiftPackageProductDependency',
+        productName: 'Alamofire',
+      },
+    };
+
+    // Execute
+    const result = printFilesForBuildPhase(objectId, objectData, allObjects);
+
+    // Assert
+    expect(result).toBe(
+      '\t\t\t\tBUILDFILE123 /* Alamofire in Frameworks */,\n',
+    );
+  });
+
+  it('should format build file with fileRef correctly', () => {
+    // Setup
+    const objectId = 'BUILDFILE789';
+    const objectData = {
+      isa: 'PBXBuildFile',
+      fileRef: 'FILEREF123',
+    };
+    const allObjects = {
+      FILEREF123: {
+        isa: 'PBXFileReference',
+        name: 'MyFramework.framework',
+      },
+    };
+
+    // Execute
+    const result = printFilesForBuildPhase(objectId, objectData, allObjects);
+
+    // Assert
+    expect(result).toBe(
+      '\t\t\t\tBUILDFILE789 /* MyFramework.framework in Frameworks */,\n',
+    );
+  });
+
+  it('should use file path when name is not available', () => {
+    // Setup
+    const objectId = 'BUILDFILE789';
+    const objectData = {
+      isa: 'PBXBuildFile',
+      fileRef: 'FILEREF456',
+    };
+    const allObjects = {
+      FILEREF456: {
+        isa: 'PBXFileReference',
+        path: 'path/to/MyLib.framework',
+      },
+    };
+
+    // Execute
+    const result = printFilesForBuildPhase(objectId, objectData, allObjects);
+
+    // Assert
+    expect(result).toBe(
+      '\t\t\t\tBUILDFILE789 /* path/to/MyLib.framework in Frameworks */,\n',
+    );
+  });
+});
+
+describe('printXCLocalSwiftPackageReference', () => {
+  it('should format XCLocalSwiftPackageReference correctly', () => {
+    // Setup
+    const objectId = 'PACKAGE123';
+    const objectData = {
+      isa: 'XCLocalSwiftPackageReference',
+      relativePath: '../MySwiftPackage',
+    };
+    const allObjects = {};
+
+    // Execute
+    const result = printXCLocalSwiftPackageReference(
+      objectId,
+      objectData,
+      allObjects,
+    );
+
+    // Assert
+    const expected = `\t\tPACKAGE123 /* XCLocalSwiftPackageReference "../MySwiftPackage" */ = {
+\t\t\tisa = XCLocalSwiftPackageReference;
+\t\t\trelativePath = ../MySwiftPackage;
+\t\t};
+`;
+    expect(result).toBe(expected);
+  });
+
+  it('should escape path with quotes when it contains spaces', () => {
+    // Setup
+    const objectId = 'PACKAGE456';
+    const objectData = {
+      isa: 'XCLocalSwiftPackageReference',
+      relativePath: '../My Swift Package',
+    };
+    const allObjects = {};
+
+    // Execute
+    const result = printXCLocalSwiftPackageReference(
+      objectId,
+      objectData,
+      allObjects,
+    );
+
+    // Assert
+    const expected = `\t\tPACKAGE456 /* XCLocalSwiftPackageReference "../My Swift Package" */ = {
+\t\t\tisa = XCLocalSwiftPackageReference;
+\t\t\trelativePath = "../My Swift Package";
+\t\t};
+`;
+    expect(result).toBe(expected);
+  });
+
+  it('should handle absolute path', () => {
+    // Setup
+    const objectId = 'PACKAGE999';
+    const objectData = {
+      isa: 'XCLocalSwiftPackageReference',
+      relativePath: '/absolute/path/to/package',
+    };
+    const allObjects = {};
+
+    // Execute
+    const result = printXCLocalSwiftPackageReference(
+      objectId,
+      objectData,
+      allObjects,
+    );
+
+    // Assert
+    const expected = `\t\tPACKAGE999 /* XCLocalSwiftPackageReference "/absolute/path/to/package" */ = {
+\t\t\tisa = XCLocalSwiftPackageReference;
+\t\t\trelativePath = /absolute/path/to/package;
+\t\t};
+`;
+    expect(result).toBe(expected);
+  });
+});
+
+describe('printXCSwiftPackageProductDependency', () => {
+  it('should format XCSwiftPackageProductDependency correctly', () => {
+    // Setup
+    const objectId = 'PRODUCT123';
+    const objectData = {
+      isa: 'XCSwiftPackageProductDependency',
+      productName: 'Alamofire',
+    };
+    const allObjects = {};
+
+    // Execute
+    const result = printXCSwiftPackageProductDependency(
+      objectId,
+      objectData,
+      allObjects,
+    );
+
+    // Assert
+    const expected = `\t\tPRODUCT123 /* Alamofire */ = {
+\t\t\tisa = XCSwiftPackageProductDependency;
+\t\t\tproductName = Alamofire;
+\t\t};
+`;
+    expect(result).toBe(expected);
   });
 });

--- a/packages/react-native/scripts/swiftpm/__tests__/xcodeproj-utils-test.js
+++ b/packages/react-native/scripts/swiftpm/__tests__/xcodeproj-utils-test.js
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @noflow
+ */
+
+'use strict';
+
+const {generateXcodeObjectId} = require('../xcodeproj-utils');
+
+// Mock crypto module
+jest.mock('crypto');
+
+describe('generateXcodeObjectId', () => {
+  let mockCrypto;
+
+  beforeEach(() => {
+    // Setup mock
+    mockCrypto = require('crypto');
+
+    // Reset all mocks
+    jest.clearAllMocks();
+  });
+
+  it('should generate a 24-character uppercase hexadecimal string', () => {
+    // Setup - Mock crypto.randomBytes to return predictable data
+    mockCrypto.randomBytes.mockReturnValue(
+      Buffer.from([
+        0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67,
+      ]),
+    );
+
+    // Execute
+    const result = generateXcodeObjectId();
+
+    // Assert
+    expect(result).toBe('0123456789ABCDEF01234567');
+    expect(result).toHaveLength(24);
+    expect(result).toMatch(/^[0-9A-F]+$/);
+  });
+
+  it('should call crypto.randomBytes with 12 bytes', () => {
+    // Setup
+    mockCrypto.randomBytes.mockReturnValue(
+      Buffer.from([
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      ]),
+    );
+
+    // Execute
+    generateXcodeObjectId();
+
+    // Assert
+    expect(mockCrypto.randomBytes).toHaveBeenCalledWith(12);
+    expect(mockCrypto.randomBytes).toHaveBeenCalledTimes(1);
+  });
+
+  it('should convert to uppercase hexadecimal', () => {
+    // Setup - Mock with bytes that would produce lowercase hex
+    mockCrypto.randomBytes.mockReturnValue(
+      Buffer.from([
+        0xab, 0xcd, 0xef, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x11,
+      ]),
+    );
+
+    // Execute
+    const result = generateXcodeObjectId();
+
+    // Assert
+    expect(result).toBe('ABCDEF123456789ABCDEF011');
+    expect(result).not.toMatch(/[a-z]/); // Should not contain lowercase letters
+  });
+
+  it('should return a string type', () => {
+    // Setup
+    mockCrypto.randomBytes.mockReturnValue(
+      Buffer.from([
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
+      ]),
+    );
+
+    // Execute
+    const result = generateXcodeObjectId();
+
+    // Assert
+    expect(typeof result).toBe('string');
+  });
+
+  it('should not contain any non-hexadecimal characters', () => {
+    // Setup
+    mockCrypto.randomBytes.mockReturnValue(
+      Buffer.from([
+        0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x11, 0x22, 0x33, 0x44,
+      ]),
+    );
+
+    // Execute
+    const result = generateXcodeObjectId();
+
+    // Assert
+    expect(result).toMatch(/^[0-9A-F]{24}$/);
+    expect(result).not.toMatch(/[G-Z]/); // Should not contain letters beyond F
+    expect(result).not.toMatch(/[a-z]/); // Should not contain lowercase letters
+    expect(result).not.toMatch(/[\s\-_]/); // Should not contain whitespace or special chars
+  });
+
+  it('should handle crypto.randomBytes errors gracefully', () => {
+    // Setup
+    mockCrypto.randomBytes.mockImplementation(() => {
+      throw new Error('Crypto error');
+    });
+
+    // Execute & Assert
+    expect(() => generateXcodeObjectId()).toThrow('Crypto error');
+  });
+});

--- a/packages/react-native/scripts/swiftpm/headers-mappings.js
+++ b/packages/react-native/scripts/swiftpm/headers-mappings.js
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+const path = require('path');
+
+/*::
+type MappingOption = {
+  destination: string;
+  excludeFolders: Array<string>;
+  preserveStructure: boolean
+}
+*/
+
+function reactCommonMappings(
+  reactCommonPath /*: string */,
+  headersOutput /*: string */,
+) /*: { [string]: MappingOption } */ {
+  let mappings /*: { [string]: MappingOption } */ = {};
+  mappings[`${reactCommonPath}/react`] = {
+    destination: path.join(headersOutput, 'react'),
+    excludeFolders: [],
+    preserveStructure: true,
+  };
+  mappings[`${reactCommonPath}/react/renderer/components/view/platform/cxx`] = {
+    destination: path.join(headersOutput, 'React/renderer/components/view'),
+    excludeFolders: [],
+    preserveStructure: false,
+  };
+  mappings[`${reactCommonPath}/react/renderer/graphics/platform/ios`] = {
+    destination: path.join(headersOutput, 'react/renderer/graphics'),
+    excludeFolders: [],
+    preserveStructure: false,
+  };
+  mappings[`${reactCommonPath}/react/runtime/platform/ios/ReactCommon`] = {
+    destination: path.join(headersOutput, 'ReactCommon'),
+    excludeFolders: [],
+    preserveStructure: true,
+  };
+  mappings[`${reactCommonPath}/react/nativemodule/core/platform/ios`] = {
+    destination: headersOutput,
+    excludeFolders: [],
+    preserveStructure: true,
+  };
+  mappings[`${reactCommonPath}/react/nativemodule/samples/platform/ios`] = {
+    destination: headersOutput,
+    excludeFolders: [],
+    preserveStructure: true,
+  };
+  mappings[`${reactCommonPath}/callinvoker`] = {
+    destination: headersOutput,
+    excludeFolders: ['tests'],
+    preserveStructure: true,
+  };
+  mappings[`${reactCommonPath}/cxxreact`] = {
+    destination: path.join(headersOutput, 'cxxreact'),
+    excludeFolders: [],
+    preserveStructure: true,
+  };
+  mappings[`${reactCommonPath}/jserrorhandler`] = {
+    destination: path.join(headersOutput, 'jserrorhandler'),
+    excludeFolders: [],
+    preserveStructure: true,
+  };
+  mappings[`${reactCommonPath}/jsinspector-modern`] = {
+    destination: path.join(headersOutput, 'jsinspector-modern'),
+    excludeFolders: [],
+    preserveStructure: true,
+  };
+  mappings[`${reactCommonPath}/oscompat`] = {
+    destination: path.join(headersOutput, 'oscompat'),
+    excludeFolders: [],
+    preserveStructure: true,
+  };
+  mappings[`${reactCommonPath}/runtimeexecutor`] = {
+    destination: headersOutput,
+    excludeFolders: [],
+    preserveStructure: true,
+  };
+  mappings[`${reactCommonPath}/yoga/yoga`] = {
+    destination: path.join(headersOutput, 'yoga'),
+    excludeFolders: [],
+    preserveStructure: true,
+  };
+
+  return mappings;
+}
+
+module.exports = {
+  reactCommonMappings,
+};

--- a/packages/react-native/scripts/swiftpm/headers-utils.js
+++ b/packages/react-native/scripts/swiftpm/headers-utils.js
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+const {listHeadersInFolder, setupSymlink} = require('./utils');
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Helper function to create symlinks from a source path
+ * @param {string} sourcePath - Source directory to search for headers
+ * @param {string} outputPath - Default output directory for symlinks
+ * @param {boolean} preserveStructure - Whether to preserve directory structure
+ * @param {Array<string>} excludeFolders - Folder names to exclude
+ * @param {Object} customMappings - Custom path mappings (prefix -> output path)
+ * @returns {number} Number of symlinks created
+ */
+function symlinkHeadersFromPath(
+  sourcePath /*: string */,
+  outputPath /*: string */,
+  preserveStructure /*: boolean */,
+  excludeFolders /*: Array<string> */,
+  customMappings /*: {[string]: string} */ = {},
+) /*: number */ {
+  let linkedCount = 0;
+
+  try {
+    // Build find command with exclusions using -prune
+    const headerFiles = listHeadersInFolder(sourcePath, excludeFolders);
+    headerFiles.forEach(sourceHeaderPath => {
+      if (fs.existsSync(sourceHeaderPath)) {
+        const relativePath = path.relative(sourcePath, sourceHeaderPath);
+        let destPath = '';
+        let mappedOutputPath = outputPath;
+
+        // Check for custom mappings first
+        for (const [prefix, customOutput] of Object.entries(customMappings)) {
+          if (relativePath.startsWith(prefix)) {
+            mappedOutputPath = customOutput;
+            console.log(`  Custom mapping: ${prefix} -> ${customOutput}`);
+            break;
+          }
+        }
+
+        if (preserveStructure) {
+          // Preserve directory structure
+          destPath = path.join(mappedOutputPath, relativePath);
+        } else {
+          // Flatten structure - just use the header filename
+          const headerName = path.basename(sourceHeaderPath);
+          destPath = path.join(mappedOutputPath, headerName);
+        }
+
+        // Create destination directory if it doesn't exist
+        setupSymlink(sourceHeaderPath, destPath);
+        linkedCount++;
+      }
+    });
+  } catch (error) {
+    console.warn(
+      `Failed to process headers from ${sourcePath}:`,
+      error.message,
+    );
+  }
+
+  return linkedCount;
+}
+
+module.exports = {
+  symlinkHeadersFromPath,
+};

--- a/packages/react-native/scripts/swiftpm/headers-utils.js
+++ b/packages/react-native/scripts/swiftpm/headers-utils.js
@@ -72,6 +72,54 @@ function symlinkHeadersFromPath(
   return linkedCount;
 }
 
+/**
+ * Create symlinks for ReactApple headers with special path logic.
+ * ReactApple has a custom structure, which is:
+ *
+ * ReactApple
+ * ├── Libraries
+ * │   └── RCTFoundation
+ * │       ├── RCTDeprecation
+ * │       │   ├── BUCK
+ * │       │   ├── Exported
+ * │       │   │   └── RCTDeprecation.h
+ * │       │   ├── RCTDeprecation.m
+ * │       │   ├── RCTDeprecation.podspec
+ * │       │   └── README.md
+ * │       └── README.md
+ * └── README.md
+ *
+ * We need to create symlinks for the headers in the "Exported" folder to
+ * the headersOutput/<parent-of-Exported> folder.
+ * @param {string} reactApplePath - Path to ReactApple directory
+ * @param {string} headersOutput - Base headers output directory
+ * @returns {number} Number of symlinks created
+ */
+function symlinkReactAppleHeaders(
+  reactApplePath /*: string */,
+  headersOutput /*: string */,
+) /*: number */ {
+  let linkedCount = 0;
+
+  const mappings /*: {[string]: string } */ = {};
+  mappings[
+    `${reactApplePath}/Libraries/RCTFoundation/RCTDeprecation/Exported`
+  ] = `${headersOutput}/RCTDeprecation`;
+
+  // Iterate over the key-value pairs of the mappings object
+  for (const [sourceDir, destDir] of Object.entries(mappings)) {
+    const headerFiles = listHeadersInFolder(sourceDir, ['tests']);
+    headerFiles.forEach(sourceHeaderPath => {
+      const destFilePath = path.join(destDir, path.basename(sourceHeaderPath));
+      setupSymlink(sourceHeaderPath, destFilePath);
+      linkedCount++;
+    });
+  }
+
+  return linkedCount;
+}
+
 module.exports = {
   symlinkHeadersFromPath,
+  symlinkReactAppleHeaders,
 };

--- a/packages/react-native/scripts/swiftpm/prepare-app-dependencies-headers.js
+++ b/packages/react-native/scripts/swiftpm/prepare-app-dependencies-headers.js
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+const {
+  hardlinkHeadersFromPath,
+  hardlinkReactAppleHeaders,
+  hardlinkReactCommonHeaders,
+} = require('./headers-utils');
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Create hard links for React Native headers in the output folder.
+ * This function orchestrate the creation of all the headers required by React Native:
+ * 1. It explores the `react-native/React` folder and creates links in the `output/React` folder
+ *   i. While exploring the `react-native/React` folder, it special maps the FBReactNativeSpec folder
+ * to `output/FBReactNativeSpec` folder
+ * 2. It explores the `react-native/Libraries` folder, creating links to the headers in the
+ * `output/React` folder
+ *   i. While exploring the `react-native/Libraries` folder, it applies special mappings for: Required,
+ * TypeSafety, FBLazyVector
+ * 3. Then it calls the previously defined hardlinkReactAppleHeaders to setup the ReactApple headers
+ * 4. Then it calls the previously defined hardlinkReactCommonHeaders to setup the ReactCommon headers
+ *
+ * @param {string} reactNativePath - Path to the React Native directory
+ * @param {string} outputFolder - Path to the output folder
+ * @param {string} folderName - Name of the folder where headers will be created (default: 'headers')
+ */
+function hardlinkReactNativeHeaders(
+  reactNativePath /*: string */,
+  outputFolder /*: string */,
+  folderName /*: string */ = 'headers',
+) /*: void */ {
+  console.log('Creating hard links for React Native headers...');
+
+  const headersOutput = path.join(outputFolder, folderName);
+  if (!fs.existsSync(headersOutput)) {
+    fs.mkdirSync(headersOutput, {recursive: true});
+  }
+
+  let totalLinkedCount = 0;
+
+  // Create React subdirectory for React and Libraries headers
+  const reactHeadersOutput = path.join(headersOutput, 'React');
+  if (!fs.existsSync(reactHeadersOutput)) {
+    fs.mkdirSync(reactHeadersOutput, {recursive: true});
+  }
+
+  // Define custom mappings for Libraries folder
+  const reactMappings = {
+    'FBReactNativeSpec/': path.join(headersOutput, 'FBReactNativeSpec'),
+  };
+
+  // 1. Process React folder - flatten structure, exclude 'includes', 'headers', and 'tests' folders
+  const reactPath = path.join(reactNativePath, 'React');
+  if (fs.existsSync(reactPath)) {
+    console.log('Processing React folder...');
+    const reactCount = hardlinkHeadersFromPath(
+      reactPath,
+      reactHeadersOutput,
+      false,
+      ['includes', 'headers', 'tests'],
+      reactMappings,
+    );
+    totalLinkedCount += reactCount;
+    console.log(`Created ${reactCount} hard links from React folder`);
+  }
+
+  // 2. Process Libraries folder with custom mapping for RCTRequired
+  const librariesPath = path.join(reactNativePath, 'Libraries');
+  if (fs.existsSync(librariesPath)) {
+    console.log('Processing Libraries folder...');
+
+    // Define custom mappings for Libraries folder
+    const librariesMappings = {
+      'Required/': path.join(headersOutput, 'RCTRequired'),
+      'TypeSafety/': path.join(headersOutput, 'RCTTypeSafety'),
+      'FBLazyVector/': path.join(headersOutput, 'FBLazyVector'),
+    };
+
+    const librariesCount = hardlinkHeadersFromPath(
+      librariesPath,
+      reactHeadersOutput,
+      false,
+      ['tests'],
+      librariesMappings,
+    );
+    totalLinkedCount += librariesCount;
+    console.log(`Created ${librariesCount} hard links from Libraries folder`);
+  }
+
+  // 3. Process ReactApple folder - special structure preservation
+  const reactApplePath = path.join(reactNativePath, 'ReactApple');
+  if (fs.existsSync(reactApplePath)) {
+    console.log('Processing ReactApple folder...');
+    const reactAppleCount = hardlinkReactAppleHeaders(
+      reactApplePath,
+      headersOutput,
+    );
+    totalLinkedCount += reactAppleCount;
+    console.log(`Created ${reactAppleCount} hard links from ReactApple folder`);
+  }
+
+  // 4. Process ReactCommon folder - conditional structure preservation
+  const reactCommonPath = path.join(reactNativePath, 'ReactCommon');
+  if (fs.existsSync(reactCommonPath)) {
+    console.log('Processing ReactCommon folder...');
+    // Define paths that should be flattened in ReactCommon folder
+    const flattenPaths = ['react/nativemodule/core/platform/ios'];
+    // Define special mappings for flattening specific directories
+    const specialMapping = {
+      'yoga/': 'yoga',
+      'cxxreact/': 'cxxreact',
+      'jsinspector-modern/': 'jsinspector-modern',
+      'jserrorhandler/': 'jserrorhandler',
+      'oscompat/': 'oscompat',
+    };
+    const reactCommonCount = hardlinkReactCommonHeaders(
+      reactCommonPath,
+      headersOutput,
+      flattenPaths,
+      specialMapping,
+    );
+    totalLinkedCount += reactCommonCount;
+    console.log(
+      `Created ${reactCommonCount} hard links from ReactCommon folder`,
+    );
+  }
+
+  console.log(
+    `Created hard links for ${totalLinkedCount} React Native headers total`,
+  );
+}
+
+module.exports = {
+  hardlinkReactNativeHeaders,
+};

--- a/packages/react-native/scripts/swiftpm/prepare-app-dependencies-headers.js
+++ b/packages/react-native/scripts/swiftpm/prepare-app-dependencies-headers.js
@@ -9,12 +9,98 @@
  */
 
 const {
+  hardlinkCodegenHeaders,
   hardlinkHeadersFromPath,
   hardlinkReactAppleHeaders,
   hardlinkReactCommonHeaders,
+  hardlinkThirdPartyDependenciesHeaders,
 } = require('./headers-utils');
 const fs = require('fs');
 const path = require('path');
+
+/*::
+type RequiredHeaders = 'react-native' | 'codegen' | 'third-party-dependencies' | 'all';
+*/
+
+/**
+ * Prepares app dependencies headers for SwiftPM integration
+ * @param {string} reactNativePath - Path to the React Native directory
+ * @param {string} iosAppPath - Path to the iOS app directory
+ * @param {string} outputFolder - Path to the output folder where headers will be hard linked
+ * @param {string} requiredHeaders - Type of headers to include: 'react-native', 'codegen', 'third-party-dependencies', or 'all'
+ */
+function prepareAppDependenciesHeaders(
+  reactNativePath /*: string */,
+  iosAppPath /*: string */,
+  outputFolder /*: string */,
+  requiredHeaders /*: RequiredHeaders */,
+) /*: void */ {
+  // Validate parameters
+  if (!reactNativePath || !iosAppPath || !outputFolder || !requiredHeaders) {
+    throw new Error(
+      'Missing required parameters. Usage: prepareAppDependenciesHeaders(reactNativePath, iosAppPath, outputFolder, requiredHeaders)',
+    );
+  }
+
+  if (
+    !['react-native', 'codegen', 'third-party-dependencies', 'all'].includes(
+      requiredHeaders,
+    )
+  ) {
+    throw new Error(
+      "requiredHeaders must be one of: 'react-native', 'codegen', 'third-party-dependencies', 'all'",
+    );
+  }
+
+  // Validate paths exist
+  if (!fs.existsSync(reactNativePath)) {
+    throw new Error(`React Native path does not exist: ${reactNativePath}`);
+  }
+
+  if (!fs.existsSync(iosAppPath)) {
+    throw new Error(`iOS app path does not exist: ${iosAppPath}`);
+  }
+
+  // Create output folder if it doesn't exist
+  if (!fs.existsSync(outputFolder)) {
+    fs.mkdirSync(outputFolder, {recursive: true});
+    console.log(`Created output folder: ${outputFolder}`);
+  }
+
+  console.log('Preparing app dependencies headers...');
+  console.log(`React Native path: ${reactNativePath}`);
+  console.log(`iOS app path: ${iosAppPath}`);
+  console.log(`Output folder: ${outputFolder}`);
+  console.log(`Required headers: ${requiredHeaders}`);
+
+  try {
+    switch (requiredHeaders) {
+      case 'react-native':
+        hardlinkReactNativeHeaders(reactNativePath, outputFolder);
+        break;
+      case 'codegen':
+        hardlinkCodegenHeaders(reactNativePath, iosAppPath, outputFolder);
+        break;
+      case 'third-party-dependencies':
+        hardlinkThirdPartyDependenciesHeaders(reactNativePath, outputFolder);
+        break;
+      case 'all':
+        hardlinkReactNativeHeaders(reactNativePath, outputFolder);
+        hardlinkCodegenHeaders(reactNativePath, iosAppPath, outputFolder);
+        hardlinkThirdPartyDependenciesHeaders(reactNativePath, outputFolder);
+        break;
+      default:
+        throw new Error(
+          `Unsupported requiredHeaders value: ${requiredHeaders}`,
+        );
+    }
+
+    console.log('Successfully prepared app dependencies headers');
+  } catch (error) {
+    console.error('Error preparing app dependencies headers:', error.message);
+    throw error;
+  }
+}
 
 /**
  * Create hard links for React Native headers in the output folder.
@@ -140,5 +226,6 @@ function hardlinkReactNativeHeaders(
 }
 
 module.exports = {
+  prepareAppDependenciesHeaders,
   hardlinkReactNativeHeaders,
 };

--- a/packages/react-native/scripts/swiftpm/update-xcodeproject.js
+++ b/packages/react-native/scripts/swiftpm/update-xcodeproject.js
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+/**
+ * Script to update Xcode project settings for SwiftPM build from source
+ *
+ * This script handles updating Xcode project configurations, particularly:
+ * - REACT_NATIVE_PATH settings
+ * - Build settings for SwiftPM compatibility
+ * - Other project-specific configurations
+ */
+
+const {
+  addLocalSwiftPM,
+  convertXcodeProjectToJSON,
+  deintegrateSwiftPM,
+  updateXcodeProject,
+} = require('./xcodeproj-utils');
+const fs = require('fs');
+const path = require('path');
+
+/*::
+type SwiftPackage = {
+  relativePath: string,
+  targets: Array<string>,
+};
+*/
+
+/**
+ * Integrate Swift packages into Xcode project
+ * @param {string} xcodeProjectPath - Path to the app.xcodeproj file
+ * @param {Array<Object>} packageSwiftObjects - List of PackageSwift objects with relativePath and targets
+ * @param {string} appTargetName - Name of the app target
+ */
+function integrateSwiftPackagesInXcode(
+  xcodeProjectPath /*: string */,
+  packageSwiftObjects /*: Array<SwiftPackage> */,
+  appTargetName /*: string */,
+) /*: void */ {
+  // Construct path to project.pbxproj
+  const projectPbxprojPath = path.join(xcodeProjectPath, 'project.pbxproj');
+
+  if (!fs.existsSync(projectPbxprojPath)) {
+    throw new Error(`Project file not found: ${projectPbxprojPath}`);
+  }
+
+  // Convert to JSON
+  const xcodeProject = convertXcodeProjectToJSON(projectPbxprojPath);
+
+  // Remove any existing SwiftPM integrations first
+  deintegrateSwiftPM(xcodeProject);
+
+  // Iterate over PackageSwift objects and execute addLocalSwiftPM
+  for (const packageSwift of packageSwiftObjects) {
+    addLocalSwiftPM(
+      packageSwift.relativePath,
+      packageSwift.targets,
+      xcodeProject,
+      appTargetName,
+    );
+  }
+
+  // Convert back to text format and write to project.pbxproj file
+  fs.writeFileSync(
+    projectPbxprojPath,
+    updateXcodeProject(xcodeProject, projectPbxprojPath),
+  );
+}
+
+module.exports = {
+  integrateSwiftPackagesInXcode,
+};

--- a/packages/react-native/scripts/swiftpm/utils.js
+++ b/packages/react-native/scripts/swiftpm/utils.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+function setupSymlink(
+  sourceFilePath /*: string */,
+  destFilePath /*: string */,
+) {
+  const destFolderPath = path.dirname(destFilePath);
+  if (!fs.existsSync(destFolderPath)) {
+    fs.mkdirSync(destFolderPath, {recursive: true});
+  }
+
+  // Remove existing symlink if it exists
+  if (fs.existsSync(destFilePath)) {
+    fs.unlinkSync(destFilePath);
+  }
+
+  // Create symlink for umbrella header
+  if (fs.existsSync(sourceFilePath)) {
+    fs.symlinkSync(sourceFilePath, destFilePath);
+  }
+}
+
+module.exports = {
+  setupSymlink,
+};

--- a/packages/react-native/scripts/swiftpm/xcodeproj-core-utils.js
+++ b/packages/react-native/scripts/swiftpm/xcodeproj-core-utils.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+const crypto = require('crypto');
+
+/**
+ * Generate a random string of 24 HEX characters (capital letters) for Xcode object IDs
+ * @returns {string} A 24-character hexadecimal string in uppercase
+ */
+function generateXcodeObjectId() /*: string */ {
+  return crypto.randomBytes(12).toString('hex').toUpperCase();
+}
+
+module.exports = {
+  generateXcodeObjectId,
+};

--- a/packages/react-native/scripts/swiftpm/xcodeproj-core-utils.js
+++ b/packages/react-native/scripts/swiftpm/xcodeproj-core-utils.js
@@ -10,6 +10,19 @@
 
 const crypto = require('crypto');
 
+/*::
+type XcodeObject = {
+  isa: string,
+  // $FlowFixMe[unclear-type]
+  [string]: any,
+};
+
+type SectionToAdd = {
+  sectionType: string,
+  replacementText: string,
+};
+*/
+
 /**
  * Generate a random string of 24 HEX characters (capital letters) for Xcode object IDs
  * @returns {string} A 24-character hexadecimal string in uppercase
@@ -49,7 +62,172 @@ function printFilesForBuildPhase(
   return `\t\t\t\t${objectId} /* ${productName} in Frameworks */,\n`;
 }
 
+/**
+ * Print PBXBuildFile object
+ * @param {string} objectId - The object ID
+ * @param {Object} objectData - The object data
+ * @param {Object} allObjects - All objects for reference lookup
+ * @returns {string} Formatted string for this object type
+ */
+function printPBXBuildFile(
+  objectId /*: string */,
+  objectData /*: XcodeObject */,
+  allObjects /*: {[string]: XcodeObject} */,
+) /*: string */ {
+  // Handle productRef case for Swift Package dependencies
+  if (objectData.productRef) {
+    const productRefObject = allObjects[objectData.productRef];
+    const productName = productRefObject
+      ? productRefObject.productName
+      : 'Unknown';
+    return `\t\t${objectId} /* ${productName} in Frameworks */ = {isa = PBXBuildFile; productRef = ${objectData.productRef} /* ${productName} */; };\n`;
+  }
+
+  // Handle fileRef case for regular files
+  const referencedFile = allObjects[objectData.fileRef];
+  const filename = referencedFile
+    ? referencedFile.name || referencedFile.path || 'Unknown'
+    : 'Unknown';
+
+  // Determine the type by searching build phases
+  let type = 'Unknown';
+  for (const [, phaseObject] of Object.entries(allObjects)) {
+    if (phaseObject.files && phaseObject.files.includes(objectId)) {
+      // Check if the isa property ends up with "BuildPhase"
+      if (phaseObject.isa.endsWith('BuildPhase')) {
+        // remove the PBX prefix and the BuildPhase suffix
+        type = phaseObject.isa.substring(3, phaseObject.isa.length - 10);
+        break;
+      }
+    }
+  }
+
+  // Format the output as a single line
+  return `\t\t${objectId} /* ${filename} in ${type} */ = {isa = PBXBuildFile; fileRef = ${objectData.fileRef} /* ${filename} */; };\n`;
+}
+
+/**
+ * Print XCLocalSwiftPackageReference object
+ * @param {string} objectId - The object ID
+ * @param {Object} objectData - The object data
+ * @param {Object} allObjects - All objects for reference lookup
+ * @returns {string} Formatted string for this object type
+ */
+function printXCLocalSwiftPackageReference(
+  objectId /*: string */,
+  objectData /*: XcodeObject */,
+  allObjects /*: {[string]: XcodeObject} */,
+) /*: string */ {
+  const relativePath = objectData.relativePath;
+
+  // Escape path with quotes if it contains spaces
+  const escapedPath = relativePath.includes(' ')
+    ? `"${relativePath}"`
+    : relativePath;
+
+  return `\t\t${objectId} /* XCLocalSwiftPackageReference "${relativePath}" */ = {
+\t\t\tisa = XCLocalSwiftPackageReference;
+\t\t\trelativePath = ${escapedPath};
+\t\t};
+`;
+}
+
+/**
+ * Print XCSwiftPackageProductDependency object
+ * @param {string} objectId - The object ID
+ * @param {Object} objectData - The object data
+ * @param {Object} allObjects - All objects for reference lookup
+ * @returns {string} Formatted string for this object type
+ */
+function printXCSwiftPackageProductDependency(
+  objectId /*: string */,
+  objectData /*: XcodeObject */,
+  allObjects /*: {[string]: XcodeObject} */,
+) /*: string */ {
+  const productName = objectData.productName;
+
+  return `\t\t${objectId} /* ${productName} */ = {
+\t\t\tisa = XCSwiftPackageProductDependency;
+\t\t\tproductName = ${productName};
+\t\t};
+`;
+}
+
+/**
+ * Add missing sections to the textual project in the correct order
+ * @param {string} textualProject - The textual representation of the Xcode project
+ * @param {Array} sectionsToAdd - Array of sections to add with their content
+ * @returns {string} Updated textual project with new sections added
+ */
+function addMissingSections(
+  textualProject /*: string */,
+  sectionsToAdd /*: Array<SectionToAdd> */,
+) /*: string */ {
+  // Define the order of sections - PBXBuildFile first, then XCLocalSwiftPackageReference, then XCSwiftPackageProductDependency
+  const sectionOrder = [
+    'PBXBuildFile',
+    'XCLocalSwiftPackageReference',
+    'XCSwiftPackageProductDependency',
+  ];
+
+  // Sort sections according to the defined order
+  sectionsToAdd.sort((a, b) => {
+    const indexA = sectionOrder.indexOf(a.sectionType);
+    const indexB = sectionOrder.indexOf(b.sectionType);
+    return indexA - indexB;
+  });
+
+  // Find the insertion points for each section type
+  const lines = textualProject.split('\n');
+  let insertionIndex = -1;
+
+  for (const sectionToAdd of sectionsToAdd) {
+    const {sectionType, replacementText} = sectionToAdd;
+
+    if (sectionType === 'PBXBuildFile') {
+      // PBXBuildFile should be first in the objects array
+      // Find the first existing section after "objects = {"
+      for (let i = 0; i < lines.length; i++) {
+        if (lines[i].includes('objects = {')) {
+          insertionIndex = i + 1;
+          break;
+        }
+      }
+    } else if (sectionType === 'XCLocalSwiftPackageReference') {
+      // Should be second-last before rootObject
+      // Find the rootObject line and go back to find a good insertion point
+      for (let i = lines.length - 1; i >= 0; i--) {
+        if (lines[i].includes('rootObject =')) {
+          insertionIndex = i - 1;
+          break;
+        }
+      }
+    } else if (sectionType === 'XCSwiftPackageProductDependency') {
+      // Should be last before rootObject
+      for (let i = lines.length - 1; i >= 0; i--) {
+        if (lines[i].includes('rootObject =')) {
+          insertionIndex = i - 1;
+          break;
+        }
+      }
+    }
+
+    // Insert the section at the determined index
+    if (insertionIndex !== -1) {
+      lines.splice(insertionIndex, 0, replacementText);
+      // Update insertion index for subsequent sections
+      insertionIndex += replacementText.split('\n').length;
+    }
+  }
+
+  return lines.join('\n');
+}
+
 module.exports = {
   generateXcodeObjectId,
+  printPBXBuildFile,
   printFilesForBuildPhase,
+  printXCLocalSwiftPackageReference,
+  printXCSwiftPackageProductDependency,
+  addMissingSections,
 };

--- a/packages/react-native/scripts/swiftpm/xcodeproj-core-utils.js
+++ b/packages/react-native/scripts/swiftpm/xcodeproj-core-utils.js
@@ -18,6 +18,38 @@ function generateXcodeObjectId() /*: string */ {
   return crypto.randomBytes(12).toString('hex').toUpperCase();
 }
 
+/**
+ * Generates a formatted string representation of a file for a build phase in Xcode project
+ *
+ * @param {string} objectId - The unique identifier of the Xcode object
+ * @param {Object} objectData - The data associated with the Xcode object
+ * @param {Object} allObjects - Dictionary of all Xcode objects indexed by their IDs
+ * @returns {string} A formatted string representing the file in a build phase
+ */
+function printFilesForBuildPhase(
+  objectId /*: string */,
+  objectData /*: XcodeObject */,
+  allObjects /*: {[string]: XcodeObject} */,
+) /*: string */ {
+  // Get the product name from the productRef in the PBXBuildFile
+  let productName = 'Unknown';
+
+  if (objectData.productRef) {
+    const productRefObject = allObjects[objectData.productRef];
+    if (productRefObject && productRefObject.productName) {
+      productName = productRefObject.productName;
+    }
+  } else if (objectData.fileRef) {
+    const fileRefObject = allObjects[objectData.fileRef];
+    if (fileRefObject) {
+      productName = fileRefObject.name || fileRefObject.path || 'Unknown';
+    }
+  }
+
+  return `\t\t\t\t${objectId} /* ${productName} in Frameworks */,\n`;
+}
+
 module.exports = {
   generateXcodeObjectId,
+  printFilesForBuildPhase,
 };

--- a/packages/react-native/scripts/swiftpm/xcodeproj-utils.js
+++ b/packages/react-native/scripts/swiftpm/xcodeproj-utils.js
@@ -8,7 +8,17 @@
  * @format
  */
 
+const {execSync} = require('child_process');
 const crypto = require('crypto');
+
+/*::
+type XcodeProject = {
+  // $FlowFixMe[unclear-type]
+  objects: {[string]: any},
+  // $FlowFixMe[unclear-type]
+  [string]: any,
+};
+*/
 
 /**
  * Generate a random string of 24 HEX characters (capital letters) for Xcode object IDs
@@ -18,6 +28,20 @@ function generateXcodeObjectId() /*: string */ {
   return crypto.randomBytes(12).toString('hex').toUpperCase();
 }
 
+/**
+ * Convert Xcode project.pbxproj file to JSON format
+ * @param {string} projectPath - Path to the project.pbxproj file
+ * @returns {Object} Parsed JSON object of the Xcode project
+ */
+function convertXcodeProjectToJSON(
+  projectPath /*: string */,
+) /*: XcodeProject */ {
+  const command = `plutil -convert json -o - "${projectPath}"`;
+  const jsonOutput = execSync(command, {encoding: 'utf8'});
+  return JSON.parse(jsonOutput);
+}
+
 module.exports = {
   generateXcodeObjectId,
+  convertXcodeProjectToJSON,
 };

--- a/packages/react-native/scripts/swiftpm/xcodeproj-utils.js
+++ b/packages/react-native/scripts/swiftpm/xcodeproj-utils.js
@@ -41,7 +41,105 @@ function convertXcodeProjectToJSON(
   return JSON.parse(jsonOutput);
 }
 
+/**
+ * Remove all existing local SwiftPM package references and dependencies from Xcode project
+ * @param {Object} xcodeProject - The xcode project converted in JSON format
+ */
+function deintegrateSwiftPM(xcodeProject /*: XcodeProject */) /*: void */ {
+  const objects = xcodeProject.objects;
+  const objectsToRemove = [];
+
+  // Step 1: Find all PBXNativeTarget objects and clean up their SwiftPM dependencies
+  for (const objectId in objects) {
+    const object = objects[objectId];
+    if (object.isa !== 'PBXNativeTarget') continue;
+
+    // Find PBXFrameworksBuildPhase
+    for (const buildPhaseId of object.buildPhases || []) {
+      const buildPhaseObject = objects[buildPhaseId];
+      if (
+        !buildPhaseObject ||
+        buildPhaseObject.isa !== 'PBXFrameworksBuildPhase'
+      )
+        continue;
+
+      const filesToRemove /*: Array<string> */ = [];
+
+      // Check each file in the build phase
+      for (const fileId of buildPhaseObject.files || []) {
+        const buildFileObject = objects[fileId];
+        if (
+          !buildFileObject ||
+          buildFileObject.isa !== 'PBXBuildFile' ||
+          !buildFileObject.productRef
+        )
+          continue;
+
+        const productRefObject = objects[buildFileObject.productRef];
+        if (
+          !productRefObject ||
+          productRefObject.isa !== 'XCSwiftPackageProductDependency'
+        )
+          continue;
+
+        // Mark for removal: the product dependency, the build file, and remove from files list
+        objectsToRemove.push(buildFileObject.productRef);
+        objectsToRemove.push(fileId);
+        filesToRemove.push(fileId);
+      }
+
+      // Remove files from the build phase
+      if (filesToRemove.length > 0) {
+        buildPhaseObject.files = (buildPhaseObject.files || []).filter(
+          fileId => !filesToRemove.includes(fileId),
+        );
+      }
+    }
+  }
+
+  // Step 2: Find PBXProject and clean up packageReferences
+  for (const objectId in objects) {
+    const object = objects[objectId];
+    if (object.isa !== 'PBXProject') continue;
+
+    const packageReferencesToRemove = [];
+
+    // Check each package reference
+    for (const packageRefId of object.packageReferences || []) {
+      const packageRefObject = objects[packageRefId];
+      if (
+        !packageRefObject ||
+        packageRefObject.isa !== 'XCLocalSwiftPackageReference'
+      )
+        continue;
+
+      // Mark for removal
+      objectsToRemove.push(packageRefId);
+      packageReferencesToRemove.push(packageRefId);
+    }
+
+    // Remove package references from the project
+    if (packageReferencesToRemove.length > 0) {
+      object.packageReferences = (object.packageReferences || []).filter(
+        refId => !packageReferencesToRemove.includes(refId),
+      );
+    }
+
+    break;
+  }
+
+  // Step 3: Remove all marked objects
+  for (const objectId of objectsToRemove) {
+    delete objects[objectId];
+  }
+
+  console.log(
+    `✓ Removed ${objectsToRemove.length} SwiftPM-related objects from Xcode project`,
+  );
+}
+
 module.exports = {
   generateXcodeObjectId,
   convertXcodeProjectToJSON,
+  deintegrateSwiftPM,
 };

--- a/packages/react-native/scripts/swiftpm/xcodeproj-utils.js
+++ b/packages/react-native/scripts/swiftpm/xcodeproj-utils.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+const crypto = require('crypto');
+
+/**
+ * Generate a random string of 24 HEX characters (capital letters) for Xcode object IDs
+ * @returns {string} A 24-character hexadecimal string in uppercase
+ */
+function generateXcodeObjectId() /*: string */ {
+  return crypto.randomBytes(12).toString('hex').toUpperCase();
+}
+
+module.exports = {
+  generateXcodeObjectId,
+};


### PR DESCRIPTION
Summary:
## Context

Apple does not have a tool from CLI to add a package to
a project, therefore we need to manually modify the Xcodeproject to integrate some Swift packages into it.

## Changed

This change adds an higeher level function that can be used to integrate local swift packages into Xcodeproject files.

This will also be helpful for autolinking packages.

## Changelog:
[Internal] -

Differential Revision: D81778453
