### PR TITLE
Add configure iOS prebuilds (hermes and dependencies)

### DIFF
--- a/packages/react-native/scripts/swiftpm/prepare-app-utils.js
+++ b/packages/react-native/scripts/swiftpm/prepare-app-utils.js
@@ -60,7 +60,33 @@ async function runPodDeintegrate(
   }
 }
 
+/**
+ * Run iOS prebuild with environment variables
+ */
+async function runIosPrebuild(
+  reactNativePath /*: string */,
+) /*: Promise<void> */ {
+  console.log('Running iOS prebuild with nightly versions...');
+
+  const env = {
+    ...process.env,
+    RN_DEP_VERSION: 'nightly',
+    HERMES_VERSION: 'nightly',
+  };
+
+  try {
+    execSync('node scripts/ios-prebuild -s', {
+      cwd: reactNativePath,
+      env: env,
+      stdio: 'inherit',
+    });
+    console.log('✓ iOS prebuild completed');
+  } catch (error) {
+    throw new Error(`iOS prebuild failed: ${error.message}`);
+  }
+}
 module.exports = {
   findXcodeProjectDirectory,
   runPodDeintegrate,
+  runIosPrebuild,
 };


### PR DESCRIPTION
Summary:
## Context

When configuring an app to build with SwiftPM from source, there is a sequence of operations we need to run in order to prepare the project correctly.

## Changed

Add a function that prepares the prebuilds for ios so we can leverage them when building from source

## Changelog:
[Internal] -

Differential Revision: D81778467
