### PR TITLE
Add function to create hard links for the app

### DIFF
--- a/packages/react-native/scripts/swiftpm/prepare-app-utils.js
+++ b/packages/react-native/scripts/swiftpm/prepare-app-utils.js
@@ -8,6 +8,10 @@
  * @format
  */
 
+const {symlinkThirdPartyDependenciesHeaders} = require('./headers-utils');
+const {
+  symlinkReactNativeHeaders,
+} = require('./prepare-app-dependencies-headers');
 const {execSync} = require('child_process');
 const fs = require('fs');
 const path = require('path');
@@ -206,10 +210,37 @@ async function setBuildFromSource(
   }
 }
 
+/**
+ * Create hard links for React Native headers in React/includes
+ */
+async function createHardlinks(
+  reactNativePath /*: string */,
+) /*: Promise<void> */ {
+  try {
+    console.log('Creating hard links for React Native headers...');
+    const reactIncludesPath = path.join(reactNativePath, 'React');
+    symlinkReactNativeHeaders(reactNativePath, reactIncludesPath, 'includes');
+    console.log('✓ React Native hard links created in React/includes');
+
+    console.log('Creating hard links for third-party dependencies...');
+    symlinkThirdPartyDependenciesHeaders(
+      reactNativePath,
+      reactIncludesPath,
+      'includes',
+    );
+    console.log(
+      '✓ Third-party dependencies hard links created in React/includes',
+    );
+  } catch (error) {
+    throw new Error(`Hard link creation failed: ${error.message}`);
+  }
+}
+
 module.exports = {
   findXcodeProjectDirectory,
   runPodDeintegrate,
   runIosPrebuild,
   configureAppForSwift,
   setBuildFromSource,
+  createHardlinks,
 };


### PR DESCRIPTION
Summary:
## Context

When configuring an app to build with SwiftPM from source, there is a sequence of operations we need to run in order to prepare the project correctly.

## Changed

Add a function that create hardlinks for React Native so it can build from source

## Changelog:
[Internal] -

Differential Revision: D81778454
