### PR TITLE
Add function to coordinate the headers preparation for the app

### DIFF
--- a/packages/react-native/scripts/swiftpm/prepare-app-utils.js
+++ b/packages/react-native/scripts/swiftpm/prepare-app-utils.js
@@ -11,6 +11,7 @@
 const codegenExecutor = require('../codegen/generate-artifacts-executor');
 const {symlinkThirdPartyDependenciesHeaders} = require('./headers-utils');
 const {
+  prepareAppDependenciesHeaders,
   symlinkReactNativeHeaders,
 } = require('./prepare-app-dependencies-headers');
 const {execSync} = require('child_process');
@@ -257,6 +258,63 @@ async function generateCodegenArtifacts(
   }
 }
 
+/**
+ * Prepare app dependencies headers (3 separate calls)
+ */
+async function prepareHeaders(
+  reactNativePath /*: string */,
+  appIosPath /*: string */,
+) /*: Promise<void> */ {
+  const outputFolder = path.join(
+    appIosPath,
+    'build',
+    'generated',
+    'ios',
+    'ReactAppDependencyProvider',
+  );
+  const codegenOutputFolder = path.join(
+    appIosPath,
+    'build',
+    'generated',
+    'ios',
+    'ReactCodegen',
+  );
+
+  try {
+    // 1. Prepare codegen headers
+    console.log('Preparing codegen headers...');
+    prepareAppDependenciesHeaders(
+      reactNativePath,
+      appIosPath,
+      outputFolder,
+      'codegen',
+    );
+    console.log('✓ Codegen headers prepared');
+
+    // 2. Prepare react-native headers
+    console.log('Preparing react-native headers...');
+    prepareAppDependenciesHeaders(
+      reactNativePath,
+      appIosPath,
+      codegenOutputFolder,
+      'react-native',
+    );
+    console.log('✓ React Native headers prepared');
+
+    // 3. Prepare third-party dependencies headers
+    console.log('Preparing third-party dependencies headers...');
+    prepareAppDependenciesHeaders(
+      reactNativePath,
+      appIosPath,
+      codegenOutputFolder,
+      'third-party-dependencies',
+    );
+    console.log('✓ Third-party dependencies headers prepared');
+  } catch (error) {
+    throw new Error(`Header preparation failed: ${error.message}`);
+  }
+}
+
 module.exports = {
   findXcodeProjectDirectory,
   runPodDeintegrate,
@@ -265,4 +323,5 @@ module.exports = {
   setBuildFromSource,
   createHardlinks,
   generateCodegenArtifacts,
+  prepareHeaders,
 };


### PR DESCRIPTION
Summary:
## Context

When configuring an app to build with SwiftPM from source, there is a sequence of operations we need to run in order to prepare the project correctly.

## Changed

Add a function that runs `prepareHeaders` that configures the headers for React Native and Codegen targets.

## Changelog:
[Internal] -

Differential Revision: D81778440
