### PR TITLE
Propagate RuntimeTargetConsole events to HostTarget

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
@@ -239,7 +239,10 @@ HostTargetDelegate::~HostTargetDelegate() = default;
 InstanceTarget& HostTarget::registerInstance(InstanceTargetDelegate& delegate) {
   assert(!currentInstance_ && "Only one instance allowed");
   currentInstance_ = InstanceTarget::create(
-      executionContextManager_, delegate, makeVoidExecutor(executorFromThis()));
+      executionContextManager_,
+      delegate,
+      makeVoidExecutor(executorFromThis()),
+      delegate_); // Pass HostTargetDelegate reference through
   sessions_.forEach(
       [currentInstance = &*currentInstance_](HostTargetSession& session) {
         session.setCurrentInstance(currentInstance);

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.cpp
@@ -17,18 +17,21 @@ namespace facebook::react::jsinspector_modern {
 std::shared_ptr<InstanceTarget> InstanceTarget::create(
     std::shared_ptr<ExecutionContextManager> executionContextManager,
     InstanceTargetDelegate& delegate,
-    VoidExecutor executor) {
-  std::shared_ptr<InstanceTarget> instanceTarget{
-      new InstanceTarget(executionContextManager, delegate)};
+    VoidExecutor executor,
+    HostTargetDelegate& hostTargetDelegate) {
+  std::shared_ptr<InstanceTarget> instanceTarget{new InstanceTarget(
+      executionContextManager, delegate, hostTargetDelegate)};
   instanceTarget->setExecutor(std::move(executor));
   return instanceTarget;
 }
 
 InstanceTarget::InstanceTarget(
     std::shared_ptr<ExecutionContextManager> executionContextManager,
-    InstanceTargetDelegate& delegate)
+    InstanceTargetDelegate& delegate,
+    HostTargetDelegate& hostTargetDelegate)
     : delegate_(delegate),
-      executionContextManager_(std::move(executionContextManager)) {
+      executionContextManager_(std::move(executionContextManager)),
+      hostTargetDelegate_(hostTargetDelegate) {
   (void)delegate_;
 }
 
@@ -77,7 +80,8 @@ RuntimeTarget& InstanceTarget::registerRuntime(
           .uniqueId = std::nullopt},
       delegate,
       std::move(jsExecutor),
-      makeVoidExecutor(executorFromThis()));
+      makeVoidExecutor(executorFromThis()),
+      hostTargetDelegate_);
 
   agents_.forEach([currentRuntime = &*currentRuntime_](InstanceAgent& agent) {
     agent.setCurrentRuntime(currentRuntime);

--- a/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InstanceTarget.h
@@ -24,6 +24,7 @@ namespace facebook::react::jsinspector_modern {
 class InstanceAgent;
 class InstanceTracingAgent;
 class HostTargetTraceRecording;
+class HostTargetDelegate;
 
 /**
  * Receives events from an InstanceTarget. This is a shared interface that
@@ -55,11 +56,14 @@ class InstanceTarget : public EnableExecutorFromThis<InstanceTarget> {
    * \param executor An executor that may be used to call methods on this
    * InstanceTarget while it exists. \c create additionally guarantees that the
    * executor will not be called after the InstanceTarget is destroyed.
+   * \param hostTargetDelegate Reference to HostTargetDelegate for
+   * passing to RuntimeTarget.
    */
   static std::shared_ptr<InstanceTarget> create(
       std::shared_ptr<ExecutionContextManager> executionContextManager,
       InstanceTargetDelegate& delegate,
-      VoidExecutor executor);
+      VoidExecutor executor,
+      HostTargetDelegate& hostTargetDelegate);
 
   InstanceTarget(const InstanceTarget&) = delete;
   InstanceTarget(InstanceTarget&&) = delete;
@@ -109,10 +113,12 @@ class InstanceTarget : public EnableExecutorFromThis<InstanceTarget> {
    * \param delegate The object that will receive events from this target.
    * The caller is responsible for ensuring that the delegate outlives this
    * object.
+   * \param hostTargetDelegate Reference to HostTargetDelegate.
    */
   InstanceTarget(
       std::shared_ptr<ExecutionContextManager> executionContextManager,
-      InstanceTargetDelegate& delegate);
+      InstanceTargetDelegate& delegate,
+      HostTargetDelegate& hostTargetDelegate);
 
   InstanceTargetDelegate& delegate_;
   std::shared_ptr<RuntimeTarget> currentRuntime_{nullptr};
@@ -125,6 +131,11 @@ class InstanceTarget : public EnableExecutorFromThis<InstanceTarget> {
    * session - HostTargetTraceRecording.
    */
   std::weak_ptr<InstanceTracingAgent> tracingAgent_;
+
+  /**
+   * Reference to HostTargetDelegate for passing to RuntimeTarget.
+   */
+  HostTargetDelegate& hostTargetDelegate_;
 };
 
 } // namespace facebook::react::jsinspector_modern


### PR DESCRIPTION
Summary:
Pipe through console events to HostTarget, so they can be further pushed to the new perf monitor. Console callback currently noops. Event filtering and further propagation to perf monitor to be handled in a future diff.

Changelog: [Internal]

Differential Revision: D82005323


