### PR TITLE
fix array type parsing in DynamicEventPayload::extractValue

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/DynamicEventPayload.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/DynamicEventPayload.cpp
@@ -27,10 +27,10 @@ std::optional<double> DynamicEventPayload::extractValue(
   auto dynamic = payload_;
   for (auto& key : path) {
     auto type = dynamic.type();
-    if ((type == folly::dynamic::Type::OBJECT ||
-         type == folly::dynamic::Type::ARRAY) &&
-        !dynamic.empty()) {
+    if (type == folly::dynamic::Type::OBJECT && !dynamic.empty()) {
       dynamic = folly::dynamic(dynamic[key]);
+    } else if (type == folly::dynamic::Type::ARRAY && !dynamic.empty()) {
+      dynamic = folly::dynamic(dynamic[std::stoi(key)]);
     }
   }
   if (dynamic.type() == folly::dynamic::Type::DOUBLE) {


### PR DESCRIPTION
Summary:
## Changelog:

[General] [Fixed] - fix array type parsing in DynamicEventPayload::extractValue

When unwrapping event mapping like `e.nativeEvent.touches[0].locationX` e.g. for Animated.event like below, 

```
onTouchMove={Animated.event(
  [
    {
      nativeEvent: {
        touches: {
          0: {locationX: animatedValue},
        },
      },
    },
  ],
  {useNativeDriver: true},
)}
```
here it'll throw exception `terminating due to uncaught exception of type folly::TypeError: TypeError: expected dynamic type 'object', but had type 'array'` when getting into folly dynamic array, because array index in the event path is string instead of integer

Differential Revision: D82050538


