### PR TITLE
[iOS] Remove outdated artifacts codegen early return

### DIFF
--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/index.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/index.js
@@ -99,7 +99,6 @@ function execute(
 
     if (codegenEnabledLibraries.length === 0) {
       codegenLog('No codegen-enabled libraries found.', true);
-      return;
     }
 
     let platforms =
@@ -113,10 +112,6 @@ function execute(
       const libraries = codegenEnabledLibraries.filter(
         ({name}) => !disabledLibraries.includes(name),
       );
-
-      if (!libraries.length) {
-        continue;
-      }
 
       const outputPath = computeOutputPath(
         projectRoot,


### PR DESCRIPTION
## Summary:

Follow-up to #53503 for a regression

When no React Native module is present this bail condition stops us from generating the artifacts podspec that's needed to complete build.

## Changelog:

[IOS] [FIXED] - Fix regression that skips artifacts code generation

## Test Plan:

- Create an app **without** any React Native modules, run `pod install`; without this fix the podspec will be missing and the build will fail
  - With expo this can be reproduced using `create-expo-app --template blank-typescript@next` on `react-native@0.81.2`
  - With the community CLI this can be reproduced using `npx @react-native-community/cli@latest init test --skip-install --version 0.81.2` and uninstalling `react-native-safe-area-context`
