### PR TITLE
Remove enable_eager_alternate_state_node_cleanup param

### DIFF
--- a/packages/react-native/src/private/components/virtualview/__tests__/VirtualView-enableEagerAlternateStateNodeCleanup-itest.js
+++ b/packages/react-native/src/private/components/virtualview/__tests__/VirtualView-enableEagerAlternateStateNodeCleanup-itest.js
@@ -4,7 +4,6 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @fantom_react_fb_flags enableEagerAlternateStateNodeCleanup:true
  * @flow strict-local
  * @format
  */


### PR DESCRIPTION
Summary: Changelog: [Internal] - Remove usage of `enableEagerAlternateStateNodeCleanup`  as it is default true now

Reviewed By: yungsters

Differential Revision: D81962955


