### PR TITLE
Add function to run pod deintegrate

### DIFF
--- a/packages/react-native/scripts/swiftpm/prepare-app-utils.js
+++ b/packages/react-native/scripts/swiftpm/prepare-app-utils.js
@@ -40,7 +40,27 @@ function findXcodeProjectDirectory(
     );
   }
 }
+/**
+ * Run pod deintegrate from app directory
+ */
+async function runPodDeintegrate(
+  appIosPath /*: string */,
+) /*: Promise<void> */ {
+  try {
+    console.log(`Running pod deintegrate in: ${appIosPath}`);
+    execSync('pod deintegrate', {
+      cwd: appIosPath,
+      stdio: 'inherit',
+    });
+    console.log('✓ Pod deintegrate completed');
+  } catch (error) {
+    console.warn(
+      '⚠️  Pod deintegrate failed (this might be expected if no Podfile.lock exists)',
+    );
+  }
+}
 
 module.exports = {
   findXcodeProjectDirectory,
+  runPodDeintegrate,
 };


### PR DESCRIPTION
Summary:
## Context

When configuring an app to build with SwiftPM from source, there is a sequence of operations we need to run in order to prepare the project correctly.

## Changed

Add a function that runs `pod deintegrate` to remove remainings of cocoapods

## Changelog:
[Internal] -

Differential Revision: D81778468
