### PR TITLE
Add invalidation callback for non-recycled component instances on iOS

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/RCTComponentViewProtocol.h
+++ b/packages/react-native/React/Fabric/Mounting/RCTComponentViewProtocol.h
@@ -111,8 +111,9 @@ typedef NS_OPTIONS(NSInteger, RNComponentViewUpdateMask) {
  */
 - (void)prepareForRecycle;
 
-/**
- *
+/*
+ * Called for unmounted components that won't be moved to a recycle pool.
+ * Useful for releasing any associated resources.
  */
 - (void)invalidate;
 

--- a/packages/react-native/React/Fabric/Mounting/RCTComponentViewProtocol.h
+++ b/packages/react-native/React/Fabric/Mounting/RCTComponentViewProtocol.h
@@ -111,6 +111,11 @@ typedef NS_OPTIONS(NSInteger, RNComponentViewUpdateMask) {
  */
 - (void)prepareForRecycle;
 
+/**
+ *
+ */
+- (void)invalidate;
+
 /*
  * Read the last props used to update the view.
  */

--- a/packages/react-native/React/Fabric/Mounting/RCTComponentViewRegistry.mm
+++ b/packages/react-native/React/Fabric/Mounting/RCTComponentViewRegistry.mm
@@ -108,6 +108,7 @@ const NSInteger RCTComponentViewRegistryRecyclePoolMaxSize = 1024;
   auto &recycledViews = _recyclePool[componentHandle];
 
   if (recycledViews.size() > RCTComponentViewRegistryRecyclePoolMaxSize || !componentViewDescriptor.shouldBeRecycled) {
+    [componentViewDescriptor.view invalidate];
     return;
   }
 

--- a/packages/react-native/React/Fabric/Mounting/UIView+ComponentViewProtocol.h
+++ b/packages/react-native/React/Fabric/Mounting/UIView+ComponentViewProtocol.h
@@ -37,6 +37,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)prepareForRecycle;
 
+- (void)invalidate;
+
 - (facebook::react::Props::Shared)props;
 
 - (void)setIsJSResponder:(BOOL)isJSResponder;

--- a/packages/react-native/React/Fabric/Mounting/UIView+ComponentViewProtocol.mm
+++ b/packages/react-native/React/Fabric/Mounting/UIView+ComponentViewProtocol.mm
@@ -129,6 +129,11 @@ using namespace facebook::react;
   // Default implementation does nothing.
 }
 
+- (void)invalidate
+{
+  // Default implementation does nothing.
+}
+
 - (facebook::react::Props::Shared)props
 {
   RCTAssert(NO, @"props access should be implemented by RCTViewComponentView.");


### PR DESCRIPTION
## Summary:

Since the view recycling is optional on iOS [since 0.74](https://github.com/facebook/react-native/commit/613a5a75977d84333df7cbd5701e01a7ab5a3385) when a view (with disabled view recycling) is unmounted / destroyed there is no lifecycle callback for a component view to notify it of such event. Currently we (`react-native-screens`) are forced to scan mutation list of every mounting transaction in every of ours container components. Components with view recycling turned on, get `prepareForRecycle` callback on Fabric & on old architecture, there was `invalidate` message sent (`RCTInvalidating` protocol). It would be nice to have something like this for components with view recycling disabled, or enabled but not recycled due to pool being full.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [ADDED] - Add invalidation callback for non-recycled component instances

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

WIP 
