### PR TITLE
cipolleschi/fix rctnetworking not building

### DIFF
--- a/packages/react-native/Libraries/Network/React-RCTNetwork.podspec
+++ b/packages/react-native/Libraries/Network/React-RCTNetwork.podspec
@@ -50,6 +50,7 @@ Pod::Spec.new do |s|
   add_dependency(s, "React-jsinspectorcdp", :framework_name => 'jsinspector_moderncdp')
   add_dependency(s, "React-jsinspectornetwork", :framework_name => 'jsinspector_modernnetwork')
   add_dependency(s, "React-NativeModulesApple", :additional_framework_paths => ["build/generated/ios"])
+  add_dependency(s, "React-networking", :framework_name => 'React_networking')
 
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)

--- a/packages/react-native/ReactCommon/react/nativemodule/defaults/React-defaultsnativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/defaults/React-defaultsnativemodule.podspec
@@ -47,9 +47,10 @@ Pod::Spec.new do |s|
   add_rncore_dependency(s)
 
   s.dependency "React-domnativemodule"
-  s.dependency "React-featureflagsnativemodule"
   s.dependency "React-microtasksnativemodule"
   s.dependency "React-idlecallbacksnativemodule"
   s.dependency "React-webperformancenativemodule"
   add_dependency(s, "React-RCTFBReactNativeSpec")
+  add_dependency(s, "React-featureflags")
+  add_dependency(s, "React-featureflagsnativemodule")
 end

--- a/packages/react-native/ReactCommon/react/nativemodule/webperformance/React-webperformancenativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/webperformance/React-webperformancenativemodule.podspec
@@ -45,12 +45,14 @@ Pod::Spec.new do |s|
 
   s.dependency "React-jsi"
   s.dependency "React-jsiexecutor"
+  s.dependency "React-cxxreact"
 
   depend_on_js_engine(s)
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
 
   s.dependency "ReactCommon/turbomodule/core"
+
   add_dependency(s, "React-RCTFBReactNativeSpec")
   add_dependency(s, "React-performancetimeline")
   add_dependency(s, "React-runtimeexecutor", :additional_framework_paths => ["platform/ios"])


### PR DESCRIPTION
## Summary:

Fix Cocoapods builds with static libraries and dynamic frameworks 

## Changelog:
[Internal] -

## Test Plan:
Tested locally on RNTester
