### PR TITLE
Temporarily disable prebuilds for template e2e tests on main branch

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -276,7 +276,8 @@ jobs:
           NEW_ARCH_ENABLED=1
 
           export RCT_USE_LOCAL_RN_DEP=/tmp/third-party/ReactNativeDependencies${{ matrix.flavor }}.xcframework.tar.gz
-          export RCT_TESTONLY_RNCORE_TARBALL_PATH="/tmp/ReactCore/ReactCore${{ matrix.flavor }}.xcframework.tar.gz"
+          # Disable prebuilds for now, as they are causing issues with E2E tests for 0.82-stable branch
+          # export RCT_TESTONLY_RNCORE_TARBALL_PATH="/tmp/ReactCore/ReactCore${{ matrix.flavor }}.xcframework.tar.gz"
           HERMES_ENGINE_TARBALL_PATH=$HERMES_PATH RCT_NEW_ARCH_ENABLED=$NEW_ARCH_ENABLED bundle exec pod install
 
           xcodebuild \


### PR DESCRIPTION
Summary:
This is a backport of https://github.com/facebook/react-native/commit/ee08261123ac513941189cf7566337156576d4dd
on `main` as otherwise 0.83 will also be affected by the same problem (CI broken for iOS on the release branch).

Changelog:
[Internal] [Changed] -

Differential Revision: D82119125


