### PR TITLE
rn-tester: refactor TitleBar, improve content spacing/alignment

### DIFF
--- a/packages/rn-tester/js/RNTesterAppShared.js
+++ b/packages/rn-tester/js/RNTesterAppShared.js
@@ -58,13 +58,11 @@ type BackButton = ({onBack: () => void}) => React.Node;
 
 const RNTesterApp = ({
   testList,
-  customBackButton,
 }: {
   testList?: {
     components?: Array<RNTesterModuleInfo>,
     apis?: Array<RNTesterModuleInfo>,
   },
-  customBackButton?: BackButton,
 }): React.Node => {
   const [state, dispatch] = useReducer(
     RNTesterNavigationReducer,
@@ -260,11 +258,12 @@ const RNTesterApp = ({
         ? 'Components'
         : 'APIs';
 
-  const BackButtonComponent: ?BackButton = customBackButton
-    ? customBackButton
-    : Platform.OS === 'ios'
+  const BackButtonComponent: ?BackButton =
+    Platform.OS === 'ios'
       ? ({onBack}) => (
-          <Button title="Back" onPress={onBack} color={theme.LinkColor} />
+          <View style={styles.backButtonIOS}>
+            <Button title="Back" onPress={onBack} color={theme.LinkColor} />
+          </View>
         )
       : null;
 
@@ -334,5 +333,9 @@ const styles = StyleSheet.create({
   },
   hidden: {
     display: 'none',
+  },
+  backButtonIOS: {
+    position: 'absolute',
+    left: 8,
   },
 });

--- a/packages/rn-tester/js/components/RNTTitleBar.js
+++ b/packages/rn-tester/js/components/RNTTitleBar.js
@@ -13,55 +13,6 @@ import {type RNTesterTheme} from './RNTesterTheme';
 import * as React from 'react';
 import {Platform, StyleSheet, Text, View} from 'react-native';
 
-const HeaderIOS = ({
-  children,
-  title,
-  documentationURL,
-  theme,
-}: {
-  children?: React.Node,
-  title: string,
-  documentationURL?: string,
-  theme: RNTesterTheme,
-}) => {
-  return (
-    <View
-      style={[styles.header, {backgroundColor: theme.SystemBackgroundColor}]}>
-      <View style={styles.headerCenter}>
-        <Text style={{...styles.title, color: theme.LabelColor}}>{title}</Text>
-        {documentationURL && (
-          <RNTesterDocumentationURL documentationURL={documentationURL} />
-        )}
-      </View>
-      {children != null && <View>{children}</View>}
-    </View>
-  );
-};
-
-const HeaderAndroid = ({
-  children,
-  title,
-  documentationURL,
-  theme,
-}: {
-  children?: React.Node,
-  title: string,
-  documentationURL?: string,
-  theme: RNTesterTheme,
-}) => {
-  return (
-    <View style={[styles.toolbar, {backgroundColor: theme.BackgroundColor}]}>
-      <View style={styles.toolbarCenter}>
-        <Text style={[styles.title, {color: theme.LabelColor}]}>{title}</Text>
-        {documentationURL && (
-          <RNTesterDocumentationURL documentationURL={documentationURL} />
-        )}
-      </View>
-      {children != null && <View>{children}</View>}
-    </View>
-  );
-};
-
 export default function RNTTitleBar({
   children,
   title,
@@ -72,22 +23,30 @@ export default function RNTTitleBar({
   title: string,
   documentationURL?: string,
   theme: RNTesterTheme,
-  ...
 }): React.Node {
-  return Platform.OS === 'ios' ? (
-    <HeaderIOS
-      documentationURL={documentationURL}
-      title={title}
-      children={children}
-      theme={theme}
-    />
-  ) : (
-    <HeaderAndroid
-      documentationURL={documentationURL}
-      title={title}
-      children={children}
-      theme={theme}
-    />
+  return (
+    <View
+      style={[
+        styles.header,
+        Platform.select({
+          android: {
+            ...styles.headerAndroid,
+            backgroundColor: theme.BackgroundColor,
+          },
+          ios: {
+            ...styles.headerIOS,
+            backgroundColor: theme.SystemBackgroundColor,
+          },
+        }),
+      ]}>
+      {children}
+      <View style={styles.headerCenter}>
+        <Text style={{...styles.title, color: theme.LabelColor}}>{title}</Text>
+        {documentationURL && (
+          <RNTesterDocumentationURL documentationURL={documentationURL} />
+        )}
+      </View>
+    </View>
   );
 }
 
@@ -96,33 +55,23 @@ const styles = StyleSheet.create({
     borderBottomWidth: StyleSheet.hairlineWidth,
   },
   header: {
-    height: 40,
+    alignItems: 'center',
     flexDirection: 'row',
-    marginTop: Platform.OS === 'ios' ? 50 : 0,
+  },
+  headerAndroid: {
+    height: 40,
+  },
+  headerIOS: {
+    height: 36,
+    marginTop: 36,
   },
   headerCenter: {
     flex: 1,
-    position: 'absolute',
-    top: 7,
-    left: 0,
-    right: 0,
     alignItems: 'center',
   },
   title: {
     fontSize: 19,
     fontWeight: '600',
     textAlign: 'center',
-  },
-  toolbar: {
-    height: 56,
-    flexDirection: 'row',
-  },
-  toolbarCenter: {
-    flex: 1,
-    position: 'absolute',
-    top: 12,
-    left: 0,
-    right: 0,
-    alignItems: 'center',
   },
 });

--- a/packages/rn-tester/js/components/RNTesterComponentTitle.js
+++ b/packages/rn-tester/js/components/RNTesterComponentTitle.js
@@ -9,30 +9,20 @@
  */
 
 import {RNTesterThemeContext} from './RNTesterTheme';
-
-const React = require('react');
-const {StyleSheet, Text} = require('react-native');
+import React from 'react';
+import {StyleSheet, Text} from 'react-native';
 
 type Props = $ReadOnly<{
-  children: string,
+  children: React.Node,
 }>;
 
-class RNTesterComponentTitle extends React.Component<Props> {
-  constructor(props: Props) {
-    super(props);
-  }
-
-  render(): React.Node {
-    return (
-      <RNTesterThemeContext.Consumer>
-        {theme => (
-          <Text style={[styles.titleText, {color: theme.LabelColor}]}>
-            {this.props.children}
-          </Text>
-        )}
-      </RNTesterThemeContext.Consumer>
-    );
-  }
+export default function RNTesterComponentTitle({children}: Props): React.Node {
+  const theme = React.useContext(RNTesterThemeContext);
+  return (
+    <Text style={[styles.titleText, {color: theme.LabelColor}]}>
+      {children}
+    </Text>
+  );
 }
 
 const styles = StyleSheet.create({
@@ -41,5 +31,3 @@ const styles = StyleSheet.create({
     fontWeight: '400',
   },
 });
-
-module.exports = RNTesterComponentTitle;

--- a/packages/rn-tester/js/components/RNTesterDocumentationURL.js
+++ b/packages/rn-tester/js/components/RNTesterDocumentationURL.js
@@ -33,7 +33,7 @@ const styles = StyleSheet.create({
   container: {
     position: 'absolute',
     bottom: 0,
-    right: -15,
+    right: -8,
   },
   icon: {
     height: 24,

--- a/packages/rn-tester/js/components/RNTesterExampleFilter.js
+++ b/packages/rn-tester/js/components/RNTesterExampleFilter.js
@@ -165,8 +165,7 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   searchRow: {
-    paddingHorizontal: 20,
-    paddingVertical: 6,
+    padding: 6,
     alignItems: 'center',
   },
   searchTextInput: {
@@ -176,7 +175,7 @@ const styles = StyleSheet.create({
     height: 35,
     flex: 1,
     alignSelf: 'center',
-    paddingLeft: 35,
+    paddingLeft: 32,
   },
   textInputStyle: {
     flexDirection: 'row',

--- a/packages/rn-tester/js/components/RNTesterModuleList.js
+++ b/packages/rn-tester/js/components/RNTesterModuleList.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
+ * @flow strict-local
  * @format
  */
 
@@ -92,6 +92,7 @@ const RNTesterModuleList: React.ComponentType<any> = memo(
           hideFilterPills={true}
           render={({filteredSections}) => (
             <SectionList
+              stickySectionHeadersEnabled={true}
               sections={filteredSections}
               extraData={filteredSections}
               renderItem={renderListItem}
@@ -99,8 +100,7 @@ const RNTesterModuleList: React.ComponentType<any> = memo(
               automaticallyAdjustContentInsets={false}
               keyboardDismissMode="on-drag"
               renderSectionHeader={renderSectionHeader}
-              // eslint-disable-next-line react/no-unstable-nested-components
-              ListFooterComponent={() => <View style={{height: 80}} />}
+              contentContainerStyle={styles.sectionListContainer}
             />
           )}
         />
@@ -117,6 +117,7 @@ const styles = StyleSheet.create({
     padding: 5,
     fontWeight: '500',
     fontSize: 11,
+    paddingHorizontal: 16,
   },
   topRowStyle: {
     flexDirection: 'row',
@@ -135,6 +136,9 @@ const styles = StyleSheet.create({
   imageStyle: {
     height: 25,
     width: 25,
+  },
+  sectionListContainer: {
+    paddingBottom: 8,
   },
 });
 

--- a/packages/rn-tester/js/examples/Playground/RNTesterPlayground.js
+++ b/packages/rn-tester/js/examples/Playground/RNTesterPlayground.js
@@ -26,7 +26,9 @@ function Playground() {
 
 const styles = StyleSheet.create({
   container: {
-    padding: 10,
+    paddingHorizontal: 10,
+    paddingVertical: 16,
+    alignItems: 'center',
   },
 });
 


### PR DESCRIPTION
## Summary:

While playing with RNTester code I have spotted that TitleBar component code can be simplified, and its appearance and layout can be improved a bit.

The code for both platforms have been unified, absolute positioning has been moved to iOS-only Back button, to match Documentation Button already present on both platform, this change allowed to unify the header code.

Additionally, I have adjusted the spacing of search input, Section list headers, and made headers sticky on both platforms.

## Changelog:

[INTERNAL][CHANGED] RNTester: refactor and simplify Navbar component

## Test Plan:

The RNTester app changes has been validated by running on Android and iOS devices. Both, light and dark, appearance has been tested.

## Preview

<table>
<tr><th>Android</th><th>iOS</th></tr>
<tr>
<td>
<img width="570" alt="Screenshot (10 Sept 2025 19_50_33)" src="https://github.com/user-attachments/assets/4b29f980-3b23-465c-a5a4-d3a9ca7e95e9" />
</td>
<td>
<img width="585" height="1266" alt="IMG_2883" src="https://github.com/user-attachments/assets/ae3f50b8-11e2-4f5d-a231-d6a7decec84c" />
</td>
</tr><tr>
<td>
<img width="570" alt="Screenshot (10 Sept 2025 19_32_47)" src="https://github.com/user-attachments/assets/8ff3fd78-adf5-43e4-8ae6-c2bdc01644d2" />
</td>
<td>
<img width="585" height="1266" alt="IMG_2885" src="https://github.com/user-attachments/assets/2e783d99-a17d-4b40-802d-bc88f0990772" />
</td>
</tr>
</table>



