### PR TITLE
Do not invoke project. inside BundleHermesCTask

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/TaskConfiguration.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/TaskConfiguration.kt
@@ -14,6 +14,7 @@ import com.facebook.react.utils.KotlinStdlibCompatUtils.capitalizeCompat
 import com.facebook.react.utils.NdkConfiguratorUtils.configureJsEnginePackagingOptions
 import com.facebook.react.utils.NdkConfiguratorUtils.configureNewArchPackagingOptions
 import com.facebook.react.utils.ProjectUtils.isHermesEnabled
+import com.facebook.react.utils.ProjectUtils.isHermesV1Enabled
 import com.facebook.react.utils.ProjectUtils.useThirdPartyJSC
 import com.facebook.react.utils.detectedCliFile
 import com.facebook.react.utils.detectedEntryFile
@@ -48,6 +49,7 @@ internal fun Project.configureReactTasks(variant: Variant, config: ReactExtensio
       } else {
         isHermesEnabledInProject
       }
+  val isHermesV1Enabled = project.isHermesV1Enabled || rootProject.isHermesV1Enabled
   val isDebuggableVariant =
       config.debuggableVariants.get().any { it.equals(variant.name, ignoreCase = true) }
   val useThirdPartyJSC = project.useThirdPartyJSC
@@ -78,6 +80,7 @@ internal fun Project.configureReactTasks(variant: Variant, config: ReactExtensio
           task.jsBundleDir.set(jsBundleDir)
           task.resourcesDir.set(resourcesDir)
           task.hermesEnabled.set(isHermesEnabledInThisVariant)
+          task.hermesV1Enabled.set(isHermesV1Enabled)
           task.minifyEnabled.set(!isHermesEnabledInThisVariant)
           task.devEnabled.set(false)
           task.jsIntermediateSourceMapsDir.set(jsIntermediateSourceMapsDir)

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/BundleHermesCTask.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/BundleHermesCTask.kt
@@ -63,6 +63,8 @@ abstract class BundleHermesCTask : DefaultTask() {
 
   @get:Input abstract val hermesEnabled: Property<Boolean>
 
+  @get:Input abstract val hermesV1Enabled: Property<Boolean>
+
   @get:Input abstract val devEnabled: Property<Boolean>
 
   @get:Input abstract val extraPackagerArgs: ListProperty<String>
@@ -94,12 +96,8 @@ abstract class BundleHermesCTask : DefaultTask() {
     runCommand(bundleCommand)
 
     if (hermesEnabled.get()) {
-      val hermesV1Enabled =
-          if (project.rootProject.hasProperty("hermesV1Enabled"))
-              project.rootProject.findProperty("hermesV1Enabled") == "true"
-          else false
       val detectedHermesCommand =
-          detectOSAwareHermesCommand(root.get().asFile, hermesCommand.get(), hermesV1Enabled)
+          detectOSAwareHermesCommand(root.get().asFile, hermesCommand.get(), hermesV1Enabled.get())
       val bytecodeFile = File("${bundleFile}.hbc")
       val outputSourceMap = resolveOutputSourceMap(bundleAssetFilename)
       val compilerSourceMap = resolveCompilerSourceMap(bundleAssetFilename)


### PR DESCRIPTION
Summary:
I've just realized we ended up invoking `project.` inside the execution of `BundleHermesCTask`.
This is an anti-pattern and is breaking Gradle Configuration caching.

Instead we should be checking if hermesV1Enabled is set during the Task registration and pass over this information
to the task.

Changelog:
[Internal] [Changed] -

Differential Revision: D82130643


