### PR TITLE
make sure JavaOnlyArray.toArrayList() and JavaOnlyMap.toHashMap deep convert children

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/Arguments.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/Arguments.kt
@@ -25,8 +25,8 @@ public object Arguments {
         value is List<*> -> makeNativeArray(value)
         value is Map<*, *> -> makeNativeMap(value as Map<String, Any?>)
         value is Bundle -> makeNativeMap(value)
-        value is JavaOnlyMap -> makeNativeMap(value.toHashMap())
-        value is JavaOnlyArray -> makeNativeArray(value.toArrayList())
+        value is JavaOnlyMap -> makeNativeMap(value.toHashMapShallow())
+        value is JavaOnlyArray -> makeNativeArray(value.toArrayListShallow())
         else -> value // Boolean, Integer, Double, String, WritableNativeArray, WritableNativeMap
       }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaOnlyArray.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/JavaOnlyArray.kt
@@ -130,7 +130,22 @@ public class JavaOnlyArray : ReadableArray, WritableArray {
     backingList.add(null)
   }
 
-  override fun toArrayList(): ArrayList<Any?> = ArrayList(backingList)
+  internal fun toArrayListShallow(): ArrayList<Any?> = ArrayList(backingList)
+
+  override fun toArrayList(): ArrayList<Any?> {
+    val arrayList = ArrayList<Any?>()
+    repeat(size()) { i ->
+      when (getType(i)) {
+        ReadableType.Null -> arrayList.add(null)
+        ReadableType.Boolean -> arrayList.add(getBoolean(i))
+        ReadableType.Number -> arrayList.add(getDouble(i))
+        ReadableType.String -> arrayList.add(getString(i))
+        ReadableType.Map -> arrayList.add(getMap(i)?.toHashMap())
+        ReadableType.Array -> arrayList.add(getArray(i)?.toArrayList())
+      }
+    }
+    return arrayList
+  }
 
   override fun toString(): String = backingList.toString()
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.java
@@ -60,7 +60,6 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Queue;
@@ -729,34 +728,9 @@ public class SurfaceMountingManager {
     }
   }
 
-  private static Map<String, Object> getHashMapFromPropsReadableMap(ReadableMap readableMap) {
-    HashMap<String, Object> outputMap = new HashMap<>();
-
-    Iterator<Map.Entry<String, Object>> iter = readableMap.getEntryIterator();
-    while (iter.hasNext()) {
-      Map.Entry<String, Object> entry = iter.next();
-      String propKey = entry.getKey();
-      Object propValue = entry.getValue();
-      if (propKey.equals("transform") && propValue instanceof ReadableArray) {
-        ArrayList<HashMap<String, Object>> arrayList = new ArrayList<>();
-        for (int i = 0; i < ((ReadableArray) propValue).size(); i++) {
-          ReadableMap map = ((ReadableArray) propValue).getMap(i);
-          if (map != null) {
-            arrayList.add(map.toHashMap());
-          }
-        }
-        outputMap.put(propKey, arrayList);
-      } else if (propKey.equals("opacity") && propValue instanceof Number) {
-        outputMap.put(propKey, ((Number) propValue).doubleValue());
-      }
-    }
-
-    return outputMap;
-  }
-
   public void storeSynchronousMountPropsOverride(int reactTag, ReadableMap props) {
     if (ReactNativeFeatureFlags.overrideBySynchronousMountPropsAtMountingAndroid()) {
-      Map<String, Object> propsMap = getHashMapFromPropsReadableMap(props);
+      Map<String, Object> propsMap = props.toHashMap();
       if (mTagToSynchronousMountProps.containsKey(reactTag)) {
         Map<String, Object> mergedPropsMap =
             Assertions.assertNotNull(mTagToSynchronousMountProps.get(reactTag));

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/JavaOnlyArrayTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/JavaOnlyArrayTest.kt
@@ -34,4 +34,17 @@ class JavaOnlyArrayTest {
 
     assertThat(values.getLong(0)).isEqualTo(1125899906842623L)
   }
+
+  @Test
+  fun testToArrayList() {
+    val array = JavaOnlyArray.of(1, JavaOnlyArray.of(2), JavaOnlyMap.of("number", 3))
+
+    assertThat(array.toArrayList())
+        .hasSize(3)
+        .containsExactly(1.0, listOf(2.0), mapOf("number" to 3.0))
+
+    assertThat(array.toArrayListShallow())
+        .hasSize(3)
+        .containsExactly(1, JavaOnlyArray.of(2), JavaOnlyMap.of("number", 3))
+  }
 }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/JavaOnlyMapTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/bridge/JavaOnlyMapTest.kt
@@ -53,4 +53,29 @@ class JavaOnlyMapTest {
 
     assertThat(values.getLong("long")).isEqualTo(1125899906842623L)
   }
+
+  @Test
+  fun testToHashMap() {
+    val array =
+        JavaOnlyMap.of(
+            "number",
+            1,
+            "array",
+            JavaOnlyArray.of(2),
+            "map",
+            JavaOnlyMap.of("number", 3),
+        )
+
+    assertThat(array.toHashMap())
+        .hasSize(3)
+        .containsEntry("number", 1.0)
+        .containsEntry("array", listOf(2.0))
+        .containsEntry("map", mapOf("number" to 3.0))
+
+    assertThat(array.toHashMapShallow())
+        .hasSize(3)
+        .containsEntry("number", 1.0)
+        .containsEntry("array", JavaOnlyArray.of(2))
+        .containsEntry("map", JavaOnlyMap.of("number", 3))
+  }
 }


### PR DESCRIPTION
Summary:
## Changelog:

[Android] [Internal] - make sure JavaOnlyArray.toArrayList() and JavaOnlyMap.toHashMap deep convert children

And add `toArrayListShallow`/`toHashMapShallow` to replace existing use case where only shallow conversion is needed

Reviewed By: cortinico

Differential Revision: D82129971


