### PR TITLE
chore: improve codegen error when native project not found

### DIFF
--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/generateReactCodegenPodspec.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/generateReactCodegenPodspec.js
@@ -59,6 +59,11 @@ function getInputFiles(appPath /*: string */, appPkgJson /*: $FlowFixMe */) {
         !projectPath.includes('/Pods/') && // exclude Pods/Pods.xcodeproj
         !projectPath.includes('/node_modules/'), // exclude all the xcodeproj in node_modules of libraries
     )[0];
+  if (!xcodeproj) {
+    throw new Error(
+      `Cannot find .xcodeproj file inside ${appPath}. This is required to determine codegen spec paths relative to native project.`,
+    );
+  }
   const jsFiles = '-name "Native*.js" -or -name "*NativeComponent.js"';
   const tsFiles = '-name "Native*.ts" -or -name "*NativeComponent.ts"';
   const findCommand = `find ${path.join(appPath, jsSrcsDir)} -type f -not -path "*/__mocks__/*" -and \\( ${jsFiles} -or ${tsFiles} \\)`;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

While working on a somewhat non-standard library setup I ran into:

`[Codegen] TypeError [ERR_INVALID_ARG_TYPE]: The "from" argument must be of type string. Received undefined`

which was caused by `xcodeproj` file not found. The issue was on the project side rather than codegen, but the error message was rather unhelpful, so this improves it.

## Changelog:
[General][Changed] - improve codegen error when ios native project not found

## Test Plan:

tested locally, received the improved error message:

`[Codegen] Error: Cannot find .xcodeproj file inside /Users/some_project. This is required to determine codegen spec paths relative to native project.`