### PR TITLE
Unblock `run_fantom_tests` by pinning react-native-android to v18.0

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -382,7 +382,8 @@ jobs:
     runs-on: 8-core-ubuntu
     needs: [set_release_type]
     container:
-      image: reactnativecommunity/react-native-android:latest
+      # Version is pinned to v18.0 to unblock `run_fantom_tests` - see https://github.com/react-native-community/docker-android/pull/242#issuecomment-3280029122
+      image: reactnativecommunity/react-native-android:v18.0
       env:
         TERM: "dumb"
         GRADLE_OPTS: "-Dorg.gradle.daemon=false"


### PR DESCRIPTION
## Summary:

This temporarly unblocks `run_fantom_tests` till we find a solution for the docker image bump. See:
- https://github.com/react-native-community/docker-android/pull/242#issuecomment-3280029122

## Changelog:

[INTERNAL] - 

## Test Plan:

CI