### PR TITLE
ensure animatedNodes collection is only accessed on render thread

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/animated/AnimatedModule.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animated/AnimatedModule.cpp
@@ -51,7 +51,7 @@ void AnimatedModule::createAnimatedNode(
   if (auto it = configDynamic.find("disableBatchingForNativeCreate");
       it != configDynamic.items().end() && it->second == true) {
     if (nodesManager_) {
-      nodesManager_->createAnimatedNode(tag, configDynamic);
+      nodesManager_->createAnimatedNodeAsync(tag, configDynamic);
     }
   } else {
     operations_.emplace_back(

--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.h
@@ -80,6 +80,9 @@ class NativeAnimatedNodesManager {
 
 #pragma mark - Graph
 
+  // Called from JS thread
+  void createAnimatedNodeAsync(Tag tag, const folly::dynamic& config) noexcept;
+
   void createAnimatedNode(Tag tag, const folly::dynamic& config) noexcept;
 
   void connectAnimatedNodes(Tag parentTag, Tag childTag) noexcept;
@@ -203,6 +206,11 @@ class NativeAnimatedNodesManager {
       Tag tag,
       const folly::dynamic& config) noexcept;
 
+  static thread_local bool isOnRenderThread_;
+
+  std::mutex animatedNodesCreatedAsyncMutex_;
+  std::unordered_map<Tag, std::unique_ptr<AnimatedNode>>
+      animatedNodesCreatedAsync_;
   std::unordered_map<Tag, std::unique_ptr<AnimatedNode>> animatedNodes_;
   std::unordered_map<Tag, Tag> connectedAnimatedNodes_;
   std::unordered_map<int, std::unique_ptr<AnimationDriver>> activeAnimations_;

--- a/packages/react-native/ReactCommon/react/renderer/animated/tests/AnimationTestsBase.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/tests/AnimationTestsBase.h
@@ -35,6 +35,7 @@ class AnimationTestsBase : public testing::Test {
             lastCommittedProps = nodesProps.begin()->second;
           }
         });
+    NativeAnimatedNodesManager::isOnRenderThread_ = true;
   }
 
   bool nodeNeedsUpdate(Tag nodeTag) const {


### PR DESCRIPTION
Summary:
## Changelog:

[Internal] [Changed] - ensure animatedNodes collection is only accessed on render thread

now `createAnimatedNode` can be called async from js thread (since https://github.com/facebook/react-native/pull/53476), `animatedNodes_` will be written on both threads, there was no proper locking mechanism for read

we can simply add locks wherever we read/write animatedNodes_; but there's way to use fewer locking - since AnimatedNode is created async, but will not be R/W async anywhere else, we can add a new collection to temporarily hold nodes created async and flush it on render thread

Differential Revision: D82119554


