### PR TITLE
Mark ReactTextInlineImageShadowNode as @LegacyArchitecture

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.kt
@@ -34,7 +34,6 @@ import com.facebook.react.views.text.ReactTypefaceUtils.parseFontStyle
 import com.facebook.react.views.text.ReactTypefaceUtils.parseFontVariant
 import com.facebook.react.views.text.ReactTypefaceUtils.parseFontWeight
 import com.facebook.react.views.text.TextTransform.Companion.apply
-import com.facebook.react.views.text.internal.ReactTextInlineImageShadowNode
 import com.facebook.react.views.text.internal.span.CustomLetterSpacingSpan
 import com.facebook.react.views.text.internal.span.CustomLineHeightSpan
 import com.facebook.react.views.text.internal.span.CustomStyleSpan
@@ -523,6 +522,7 @@ public constructor(
       while (i < length) {
         val child: ReactShadowNode<*> = textShadowNode.getChildAt(i)
 
+        @Suppress("DEPRECATION")
         if (child is ReactRawTextShadowNode) {
           child.text?.let { sb.append(apply(it, textAttributes.textTransform)) }
         } else if (child is ReactBaseTextShadowNode) {
@@ -535,7 +535,7 @@ public constructor(
               inlineViews,
               sb.length,
           )
-        } else if (child is ReactTextInlineImageShadowNode) {
+        } else if (child is com.facebook.react.views.text.internal.ReactTextInlineImageShadowNode) {
           // We make the image take up 1 character in the span and put a corresponding character
           // into the text so that the image doesn't run over any following text.
           sb.append(INLINE_VIEW_PLACEHOLDER)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/frescosupport/FrescoBasedReactTextInlineImageShadowNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/frescosupport/FrescoBasedReactTextInlineImageShadowNode.kt
@@ -5,6 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.facebook.react.views.text.frescosupport
 
 import android.content.Context

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/ReactTextInlineImageShadowNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/internal/ReactTextInlineImageShadowNode.kt
@@ -9,11 +9,18 @@
 
 package com.facebook.react.views.text.internal
 
+import com.facebook.react.common.annotations.internal.LegacyArchitecture
+import com.facebook.react.common.annotations.internal.LegacyArchitectureLogLevel
 import com.facebook.react.uimanager.LayoutShadowNode
 import com.facebook.react.views.text.internal.span.TextInlineImageSpan
 import com.facebook.yoga.YogaNode
 
 /** Base class for [YogaNode]s that represent inline images. */
+@LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
+@Deprecated(
+    message = "This class is part of Legacy Architecture and will be removed in a future release",
+    level = DeprecationLevel.WARNING,
+)
 internal abstract class ReactTextInlineImageShadowNode : LayoutShadowNode() {
   /**
    * Build a [TextInlineImageSpan] from this node. This will be added to the TextView in place of


### PR DESCRIPTION
Summary:
This class should have been marked as LegacyArchitecture back then but was forgotten.
I'm doing it now.

Changelog:
[Internal] -

Differential Revision: D82219780


