### PR TITLE
fix flow typing of mockComponent

### DIFF
--- a/packages/react-native/jest/mockComponent.js
+++ b/packages/react-native/jest/mockComponent.js
@@ -22,11 +22,12 @@ type TComponentType = React.ComponentType<{...}>;
  */
 export default function mockComponent<
   TComponentModule: Modulish<TComponentType>,
+  TIsESModule: boolean,
 >(
   moduleName: string,
   instanceMethods: ?interface {},
-  isESModule: boolean,
-): typeof isESModule extends true
+  isESModule: TIsESModule,
+): TIsESModule extends true
   ? ModuleDefault<TComponentModule & typeof instanceMethods>
   : TComponentModule & typeof instanceMethods {
   const RealComponent: TComponentType = isESModule


### PR DESCRIPTION
Summary:
The previous condition `typeof isESModule extends true` in the definition of `mockComponent` is always `true` (this is expected by semantics of conditional types).

See [try-Flow](https://flow.org/try/#1N4Igxg9gdgZglgcxALlAIwIZoKYBsD6uEEAztvhgE6UYCe+JADpdhgCYowa5kA0I2KAFcAtiRQAXSkOz9sADwxgJ+NPTbYuQ3BMnTZA+Y2yU4IwRO4A6SFBIrGVDGM7c+h46fNRLuKxJIGWh8MeT0ZfhYlCStpHzNsFBAMIQkIEQwJODAQfiEyfBE4eWw2fDgofDBMsAALfAA3KjgsXGxxZC4eAw0G-GhcWn9aY3wWZldu-g1mbGqJUoBaCRHEzrcDEgBrbAk62kXhXFxJ923d-cPRHEpTgyEoMDaqZdW7vKgoOfaSKgOKpqmDA+d4gB5fMA-P6LCCMLLQbiLOoYCqgh6-GDYRYIXYLSgkRZkCR4jpddwPfJLZjpOBkUEKTwJEJ+DAkMiUFSwkyZCC3dbdAC+-EgGiSAB1YA9lHBoAACXmICrcAAUAEpZcAJbLtbKYFL4VBdVBlWhkLK0MRnlBVWaVsYIDBzbKFAsoGwSLKpDJZQB+WUARllZoATBrZSwJEJKIbgwBuWUCiVanW2eyy+SBgC8RuVXuwqvjAHpC7LM2XZcHk9qM7LWQGiyWTJReVX04G63Gk4aU9A0-JQ9mYMayfmG6Xy5Xu9XQ3X-WOmy2p+mZx7O1BE1AuxK9Y8DbriqU1RrWzvpXKhwAeABCZotECtAD4TWarzbZVfnfJXe7PfpfQGgwrMMIyjQ1lQABlrD1gVoAtZULAAqWUHjtVg0DaWUEJLDdW1TCQ21LHM8zg4tx2zf1WxrWdY0o9tV3nahF1w3t8P7Qih2VEcSJLMts0nHVlyg+t4MbRjKEolcK3jCUBVyEAGhMEgZSgJIGnAqxgwADn9KxwJAAUgA)

A bug in Flow made it so that when this type was exported `typeof isESModule` became `any`, which made it so that the conditional always evaluated to the first part. The bug is fixed in D82193099.

This diff uses a type parameter, which can be correctly instantiated at the call site.

Changelog: [internal]

Differential Revision: D82226987


