### PR TITLE
Fix user facing display name for debugger-shell

### DIFF
--- a/packages/debugger-shell/package.json
+++ b/packages/debugger-shell/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@react-native/debugger-shell",
+  "productName": "React Native DevTools",
   "version": "0.82.0-main",
   "description": "Experimental debugger shell for React Native for use with @react-native/debugger-frontend",
   "keywords": [

--- a/packages/debugger-shell/src/electron/index.flow.js
+++ b/packages/debugger-shell/src/electron/index.flow.js
@@ -16,9 +16,8 @@ const util = require('util');
 // $FlowFixMe[unclear-type] We have no Flow types for the Electron API.
 const {app} = require('electron') as any;
 
-// Set the app name and version early - these are used in --version as well as
-// in the User-Agent string.
-app.setName(pkg.name);
+// Set the application name and version
+app.setName(pkg.productName ?? pkg.name);
 app.setVersion(pkg.version + '-' + buildInfo.revision);
 
 // Handle global command line arguments which don't require a window
@@ -31,7 +30,7 @@ const {
   strict: false,
 });
 if (version) {
-  console.log(`${app.getName()} v${app.getVersion()}`);
+  console.log(`${pkg.name} v${app.getVersion()}`);
   // Not app.quit() - we want to exit immediately without initialising the graphical subsystem.
   app.exit(0);
 }


### PR DESCRIPTION
Summary:
Adjusts user facing app name used by Electron, which previously used `package.json#name` and led to this leaking into unwanted parts of the UI — e.g. "[About|Hide|Quit] @react-native/debugger-shell" in the macOS menu bar.

**Changes**

- Set the `productName` field in `package.json` ([docs](https://www.electronjs.org/docs/latest/api/app#appname:~:text=npm%20modules%20spec.-,You%20should%20usually%20also%20specify%20a%20productName%20field%2C%20which%20is%20your%20application%27s%20full%20capitalized%20name%2C%20and%20which%20will%20be%20preferred%20over%20name%20by%20Electron.,-app.userAgentFallback%E2%80%8B)).

**Notes**

- This **changes** the `User-Agent` header sent by the app, now of the form `"... ReactNativeDevTools/0.82.0-main-dev ..."`.

Changelog: [Internal]

Differential Revision: D82228307


