### PR TITLE
Delete ScreenshotTestsManagerModule

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoModule.kt
@@ -55,7 +55,7 @@ public class AndroidInfoModule(reactContext: ReactApplicationContext) :
       constants["ServerHost"] =
           AndroidInfoHelpers.getServerHost(reactApplicationContext.applicationContext)
     }
-    constants["isTesting"] = "true" == System.getProperty(IS_TESTING) || isRunningScreenshotTest()
+    constants["isTesting"] = "true" == System.getProperty(IS_TESTING)
     val isDisableAnimations = System.getProperty(IS_DISABLE_ANIMATIONS)
     if (isDisableAnimations != null) {
       constants["isDisableAnimations"] = "true" == isDisableAnimations
@@ -70,15 +70,6 @@ public class AndroidInfoModule(reactContext: ReactApplicationContext) :
   }
 
   override fun invalidate() {}
-
-  private fun isRunningScreenshotTest(): Boolean {
-    return try {
-      Class.forName("com.facebook.testing.react.screenshots.ReactAppScreenshotTestActivity")
-      true
-    } catch (ignored: ClassNotFoundException) {
-      false
-    }
-  }
 
   public companion object {
     public const val NAME: String = NativePlatformConstantsAndroidSpec.NAME


### PR DESCRIPTION
Summary:
ScreenshotTestsManagerModule and ReactAppScreenshotTestActivity are not in use anymore, let's delete them

changelog: [internal] internal

Differential Revision: D82249453


