### PR TITLE
[iOS][CI] Move ci to Macos latest

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,7 +41,7 @@ jobs:
           hermes-version-file: ${{ env.HERMES_VERSION_FILE }}
 
   build_hermesc_apple:
-    runs-on: macos-14
+    runs-on: macos-latest
     needs: prepare_hermes_workspace
     env:
       HERMES_WS_DIR: /tmp/hermes
@@ -55,7 +55,7 @@ jobs:
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
 
   build_apple_slices_hermes:
-    runs-on: macos-14
+    runs-on: macos-latest
     needs: [build_hermesc_apple, prepare_hermes_workspace]
     env:
       HERMES_WS_DIR: /tmp/hermes
@@ -81,7 +81,7 @@ jobs:
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
 
   build_hermes_macos:
-    runs-on: macos-14
+    runs-on: macos-latest
     needs: [build_apple_slices_hermes, prepare_hermes_workspace]
     env:
       HERMES_WS_DIR: /tmp/hermes

--- a/.github/workflows/prebuild-ios-core.yml
+++ b/.github/workflows/prebuild-ios-core.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-rn-slice:
-    runs-on: macos-14
+    runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:
@@ -123,7 +123,7 @@ jobs:
             packages/react-native/.build/headers
 
   compose-xcframework:
-    runs-on: macos-14
+    runs-on: macos-latest
     needs: [build-rn-slice]
     strategy:
       fail-fast: false

--- a/.github/workflows/prebuild-ios-dependencies.yml
+++ b/.github/workflows/prebuild-ios-dependencies.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   prepare_workspace:
     name: Prepare workspace
-    runs-on: macos-14
+    runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
 
   build-apple-slices:
     name: Build Apple Slice
-    runs-on: macos-14
+    runs-on: macos-latest
     needs: [prepare_workspace]
     strategy:
       fail-fast: false
@@ -114,7 +114,7 @@ jobs:
 
   create-xcframework:
     name: Prepare XCFramework
-    runs-on: macos-14
+    runs-on: macos-latest
     needs: [build-apple-slices]
     strategy:
       fail-fast: false

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -39,7 +39,7 @@ jobs:
           hermes-version-file: ${{ env.HERMES_VERSION_FILE }}
 
   build_hermesc_apple:
-    runs-on: macos-14
+    runs-on: macos-latest
     needs: prepare_hermes_workspace
     env:
       HERMES_WS_DIR: /tmp/hermes
@@ -52,7 +52,7 @@ jobs:
           hermes-version: ${{ needs.prepare_hermes_workspace.output.hermes-version }}
           react-native-version: ${{ needs.prepare_hermes_workspace.output.react-native-version }}
   build_apple_slices_hermes:
-    runs-on: macos-14
+    runs-on: macos-latest
     needs: [build_hermesc_apple, prepare_hermes_workspace]
     env:
       HERMES_WS_DIR: /tmp/hermes
@@ -78,7 +78,7 @@ jobs:
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
 
   build_hermes_macos:
-    runs-on: macos-14
+    runs-on: macos-latest
     needs: [build_apple_slices_hermes, prepare_hermes_workspace]
     env:
       HERMES_WS_DIR: /tmp/hermes

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -53,7 +53,7 @@ jobs:
           hermes-version-file: ${{ env.HERMES_VERSION_FILE }}
 
   build_hermesc_apple:
-    runs-on: macos-14
+    runs-on: macos-latest
     needs: prepare_hermes_workspace
     env:
       HERMES_WS_DIR: /tmp/hermes
@@ -67,7 +67,7 @@ jobs:
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
 
   build_apple_slices_hermes:
-    runs-on: macos-14
+    runs-on: macos-latest
     needs: [build_hermesc_apple, prepare_hermes_workspace]
     env:
       HERMES_WS_DIR: /tmp/hermes
@@ -93,7 +93,7 @@ jobs:
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
 
   build_hermes_macos:
-    runs-on: macos-14
+    runs-on: macos-latest
     needs: [build_apple_slices_hermes, prepare_hermes_workspace]
     env:
       HERMES_WS_DIR: /tmp/hermes
@@ -124,7 +124,7 @@ jobs:
     needs: [prebuild_apple_dependencies, build_hermes_macos]
 
   test_ios_rntester_ruby_3_2_0:
-    runs-on: macos-14
+    runs-on: macos-latest
     needs:
       [build_apple_slices_hermes, prepare_hermes_workspace, build_hermes_macos, prebuild_apple_dependencies, prebuild_react_native_core]
     env:
@@ -142,7 +142,7 @@ jobs:
           flavor: Debug
 
   test_ios_rntester:
-    runs-on: macos-14-large
+    runs-on: macos-latest-large
     needs:
       [build_apple_slices_hermes, prepare_hermes_workspace, build_hermes_macos, prebuild_apple_dependencies, prebuild_react_native_core]
     env:
@@ -166,7 +166,7 @@ jobs:
           flavor: ${{ matrix.flavor }}
 
   test_e2e_ios_rntester:
-    runs-on: macos-14-large
+    runs-on: macos-latest-large
     needs:
       [test_ios_rntester]
     env:
@@ -199,7 +199,7 @@ jobs:
           flavor: ${{ matrix.flavor }}
 
   test_e2e_ios_templateapp:
-    runs-on: macos-14-large
+    runs-on: macos-latest-large
     needs: [build_npm_package, prebuild_apple_dependencies]
     env:
       HERMES_WS_DIR: /tmp/hermes
@@ -555,7 +555,7 @@ jobs:
           compression-level: 0
 
   test_ios_helloworld_with_ruby_3_2_0:
-    runs-on: macos-14
+    runs-on: macos-latest
     needs: [prepare_hermes_workspace, build_hermes_macos, prebuild_apple_dependencies, prebuild_react_native_core] # prepare_hermes_workspace must be there because we need its reference to retrieve a couple of outputs
     env:
       PROJECT_NAME: iOSTemplateProject
@@ -572,7 +572,7 @@ jobs:
           react-native-version: ${{ needs.prepare_hermes_workspace.outputs.react-native-version }}
 
   test_ios_helloworld:
-    runs-on: macos-14
+    runs-on: macos-latest
     needs: [prepare_hermes_workspace, build_hermes_macos, prebuild_apple_dependencies, prebuild_react_native_core] # prepare_hermes_workspace must be there because we need its reference to retrieve a couple of outputs
     strategy:
       matrix:


### PR DESCRIPTION
## Summary:
This change moves the executors from macos-14 to macos-latest as requested by GH

## Changelog:
[Internal] -

## Test Plan:
GHA