### PR TITLE
Fix deprecation message

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContextBaseJavaModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContextBaseJavaModule.kt
@@ -25,7 +25,7 @@ public abstract class ReactContextBaseJavaModule : BaseJavaModule {
    * this method whenever you actually need the Activity and make sure to check for `null`.
    */
   @Deprecated(
-      "Deprecated in 0.80.0. Use getReactApplicationContext.getCurrentActivity() instead.",
+      "Deprecated in 0.80.0. Use getReactApplicationContext().getCurrentActivity() instead.",
       ReplaceWith("reactApplicationContext.currentActivity"),
   )
   protected fun getCurrentActivity(): Activity? {


### PR DESCRIPTION
## Summary:

This pull request fixes a small error in the deprecation message for `ReactContextBaseJavaModule#getCurrentActivity()`, where the reference to `getReactApplicationContext().getCurrentActivity()` contained a syntax error.

## Changelog:

[ANDROID] [FIXED] - Correct deprecation message for `ReactContextBaseJavaModule#getCurrentActivity()`
