### PR TITLE
Do not crash inside getEncodedScreenSizeWithoutVerticalInsets if SurfaceMountingManager is null

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -99,7 +99,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -738,11 +737,17 @@ public class FabricUIManager
    *     vertical insets.
    */
   private long getEncodedScreenSizeWithoutVerticalInsets(int surfaceId) {
-    SurfaceMountingManager surfaceMountingManager = mMountingManager.getSurfaceManager(surfaceId);
-    Objects.requireNonNull(surfaceMountingManager);
-    ThemedReactContext context = Objects.requireNonNull(surfaceMountingManager.getContext());
-    return DisplayMetricsHolder.getEncodedScreenSizeWithoutVerticalInsets(
-        context.getCurrentActivity());
+    ThemedReactContext context =
+        mMountingManager
+            .getSurfaceManagerEnforced(surfaceId, "getEncodedScreenSizeWithoutVerticalInsets")
+            .getContext();
+    if (context == null) {
+      FLog.w(TAG, "Couldn't get context from SurfaceMountingManager for surfaceId %d", surfaceId);
+      return 0;
+    } else {
+      return DisplayMetricsHolder.getEncodedScreenSizeWithoutVerticalInsets(
+          context.getCurrentActivity());
+    }
   }
 
   @Override


### PR DESCRIPTION
Summary:
Currently we `Objects.requireNotNull` on the `SurfaceMountingManager` inside the `getEncodedScreenSizeWithoutVerticalInsets`
function. However the `SurfaceMountingManager` could be null.
In that scenario, I'm returning 0 here (that will restore the old broken behavior, with the modal rendering on the top left corner for the first frame), instead of letting the app crash.

Changelog:
[Android] [Fixed] - Do not crash inside getEncodedScreenSizeWithoutVerticalInsets if SurfaceMountingManager is null

Reviewed By: javache

Differential Revision: D82225855


