### PR TITLE
Restore NOT_FOCUSABLE flag on Perf Monitor overlay

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/perfmonitor/PerfMonitorOverlayView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/perfmonitor/PerfMonitorOverlayView.kt
@@ -106,7 +106,14 @@ internal class PerfMonitorOverlayView(
     containerLayout.addView(statusIndicator)
     containerLayout.addView(textContainer)
 
-    return createAnchoredDialog(dpToPx(12f), dpToPx(12f)).apply { setContentView(containerLayout) }
+    val dialog =
+        createAnchoredDialog(dpToPx(12f), dpToPx(12f)).apply { setContentView(containerLayout) }
+    dialog.window?.apply {
+      attributes =
+          attributes?.apply { flags = flags or WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE }
+    }
+
+    return dialog
   }
 
   private fun createAnchoredDialog(offsetX: Float, offsetY: Float): Dialog {


### PR DESCRIPTION
Summary:
Fix following D82302063.

Changelog: [Internal]

Differential Revision: D82311593


