### PR TITLE
Fix newarch ignoring defaultfonthandler

### DIFF
--- a/packages/react-native/React/Views/RCTFont+Private.h
+++ b/packages/react-native/React/Views/RCTFont+Private.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <UIKit/UIKit.h>
+
+#import <React/RCTDefines.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+RCT_EXTERN UIFont *__nullable RCTGetLegacyDefaultFont(CGFloat fontSize, UIFontWeight fontWeight);
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native/React/Views/RCTFont.h
+++ b/packages/react-native/React/Views/RCTFont.h
@@ -17,8 +17,10 @@ typedef CGFloat RCTFontWeight;
  * provide a different base font, use this override. The font weight supplied to your
  * handler will be one of "ultralight", "thin", "light", "regular", "medium",
  * "semibold", "extrabold", "bold", "heavy", or "black".
+ *
+ * @deprecated Use RCTSetDefaultFontResolver
  */
-RCT_EXTERN void RCTSetDefaultFontHandler(RCTFontHandler handler);
+RCT_EXTERN void RCTSetDefaultFontHandler(RCTFontHandler handler) __attribute__((deprecated));
 RCT_EXTERN BOOL RCTHasFontHandlerSet(void);
 RCT_EXTERN RCTFontWeight RCTGetFontWeight(UIFont *font);
 

--- a/packages/react-native/React/Views/RCTFont.mm
+++ b/packages/react-native/React/Views/RCTFont.mm
@@ -6,6 +6,8 @@
  */
 
 #import "RCTFont.h"
+#import "RCTFont+Private.h"
+
 #import "RCTAssert.h"
 #import "RCTLog.h"
 
@@ -122,6 +124,15 @@ static NSString *FontWeightDescriptionFromUIFontWeight(UIFontWeight fontWeight)
   return @"regular";
 }
 
+UIFont *RCTGetLegacyDefaultFont(CGFloat size, UIFontWeight fontWeight)
+{
+  if (defaultFontHandler != nil) {
+    return defaultFontHandler(size, FontWeightDescriptionFromUIFontWeight(fontWeight));
+  } else {
+    return nil;
+  }
+}
+
 static UIFont *cachedSystemFont(CGFloat size, RCTFontWeight weight)
 {
   static NSCache<NSValue *, UIFont *> *fontCache = [NSCache new];
@@ -135,8 +146,8 @@ static UIFont *cachedSystemFont(CGFloat size, RCTFontWeight weight)
   NSValue *cacheKey = [[NSValue alloc] initWithBytes:&key objCType:@encode(CacheKey)];
   UIFont *font = [fontCache objectForKey:cacheKey];
 
-  if (!font) {
-    if (defaultFontHandler) {
+  if (font == nil) {
+    if (defaultFontHandler != nil) {
       NSString *fontWeightDescription = FontWeightDescriptionFromUIFontWeight(weight);
       font = defaultFontHandler(size, fontWeightDescription);
     } else {

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTFontUtils.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTFontUtils.h
@@ -5,15 +5,23 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#import <React/RCTDefines.h>
 #import <UIKit/UIKit.h>
-
 #import <react/renderer/textlayoutmanager/RCTFontProperties.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
+using RCTDefaultFontResolver = UIFont *__nullable (^)(const RCTFontProperties &);
+
+/**
+ * React Native will use the System font for rendering by default. If you want to
+ * provide a different base font, use this override.
+ */
+RCT_EXTERN void RCTSetDefaultFontResolver(RCTDefaultFontResolver handler);
+
 /**
  * Returns UIFont instance corresponded to given font properties.
  */
-UIFont *RCTFontWithFontProperties(RCTFontProperties fontProperties);
+RCT_EXTERN UIFont *RCTFontWithFontProperties(RCTFontProperties fontProperties);
 
 NS_ASSUME_NONNULL_END

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTFontUtils.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTFontUtils.mm
@@ -6,7 +6,9 @@
  */
 
 #import "RCTFontUtils.h"
+
 #import <CoreText/CoreText.h>
+#import <React/RCTFont+Private.h>
 #import <React/RCTFont.h>
 
 #import <algorithm>
@@ -246,7 +248,14 @@ static NSArray *RCTFontFeatures(RCTFontVariant fontVariant)
   return fontFeatures;
 }
 
-static UIFont *RCTDefaultFontWithFontProperties(RCTFontProperties fontProperties)
+static RCTDefaultFontResolver defaultFontResolver;
+
+void RCTSetDefaultFontResolver(RCTDefaultFontResolver handler)
+{
+  defaultFontResolver = handler;
+}
+
+static UIFont *RCTDefaultFontWithFontProperties(const RCTFontProperties &fontProperties)
 {
   static NSCache *fontCache;
   static std::mutex fontCacheMutex;
@@ -261,14 +270,24 @@ static UIFont *RCTDefaultFontWithFontProperties(RCTFontProperties fontProperties
 
   {
     std::lock_guard<std::mutex> lock(fontCacheMutex);
-    if (fontCache == nullptr) {
+    if (fontCache == nil) {
       fontCache = [NSCache new];
     }
     font = [fontCache objectForKey:cacheKey];
   }
 
-  if (font == nullptr) {
-    font = [UIFont systemFontOfSize:effectiveFontSize weight:fontProperties.weight];
+  if (font == nil) {
+    if (defaultFontResolver != nil) {
+      font = defaultFontResolver(fontProperties);
+    }
+
+    if (font == nil) {
+      font = RCTGetLegacyDefaultFont(effectiveFontSize, fontProperties.weight);
+    }
+
+    if (font == nil) {
+      font = [UIFont systemFontOfSize:effectiveFontSize weight:fontProperties.weight];
+    }
 
     BOOL isItalicFont = fontProperties.style == RCTFontStyleItalic;
     BOOL isCondensedFont = [fontProperties.family isEqualToString:@"SystemCondensed"];
@@ -366,7 +385,7 @@ UIFont *RCTFontWithFontProperties(RCTFontProperties fontProperties)
         }
       }
 
-      if (font == nullptr) {
+      if (font == nil) {
         // If we still don't have a match at least return the first font in the
         // fontFamily This is to support built-in font Zapfino and other custom
         // single font families like Impact

--- a/packages/rn-tester/js/examples/Text/TextExample.ios.js
+++ b/packages/rn-tester/js/examples/Text/TextExample.ios.js
@@ -577,42 +577,23 @@ const examples = [
     description:
       ('Shows system font families including system-ui/ui-sans-serif, ui-serif, ui-monospace, and ui-rounded': string),
     render: function (): React.Node {
+      const baseTextStyle = {fontSize: 20};
       return (
-        <View testID={'ios-font-families'}>
-          <Text
-            style={{
-              fontFamily: 'system-ui',
-              fontSize: 32,
-              marginBottom: 20,
-            }}>
-            `fontFamily: system-ui` (same as `ui-sans-serif`)
+        <View testID={'ios-font-families'} style={{gap: 10}}>
+          <Text style={{...baseTextStyle, fontFamily: 'system-ui'}}>
+            system-ui (same as ui-sans-serif)
           </Text>
-          <Text
-            style={{
-              fontFamily: 'ui-sans-serif',
-              fontSize: 32,
-              marginBottom: 20,
-            }}>
-            `fontFamily: ui-sans-serif` (same as `system-ui`)
+          <Text style={{...baseTextStyle, fontFamily: 'ui-sans-serif'}}>
+            ui-sans-serif (same as system-ui)
           </Text>
-          <Text
-            style={{fontFamily: 'ui-serif', fontSize: 32, marginBottom: 20}}>
-            `fontFamily: ui-serif`
+          <Text style={{...baseTextStyle, fontFamily: 'ui-serif'}}>
+            ui-serif
           </Text>
-          <Text
-            style={{
-              fontFamily: 'ui-monospace',
-              fontSize: 32,
-              marginBottom: 20,
-            }}>
-            `fontFamily: ui-monospace`
+          <Text style={{...baseTextStyle, fontFamily: 'ui-monospace'}}>
+            ui-monospace
           </Text>
-          <Text
-            style={{
-              fontFamily: 'ui-rounded',
-              fontSize: 32,
-            }}>
-            `fontFamily: ui-rounded`
+          <Text style={{...baseTextStyle, fontFamily: 'ui-rounded'}}>
+            ui-rounded
           </Text>
         </View>
       );
@@ -767,6 +748,7 @@ const examples = [
             }}>
             Verdana bold
           </Text>
+          <Text style={{fontFamily: 'SystemCondensed'}}>SystemCondensed</Text>
           <Text style={{fontFamily: 'Unknown Font Family'}}>
             Unknown Font Family
           </Text>


### PR DESCRIPTION
Summary: Changelog: [iOS][Fixed] Make `RCTSetDefaultFontHandler` compatible with the new arch, and add a more powerful version as `RCTSetDefaultFontResolver`

Differential Revision: D82207676
