### PR TITLE
Fix issue with flexShrink

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/CalculateLayout.cpp
@@ -661,7 +661,8 @@ static float distributeFreeSpaceSecondPass(
         float childSize = YGUndefined;
 
         if (yoga::isDefined(flexLine.layout.totalFlexShrinkScaledFactors) &&
-            flexLine.layout.totalFlexShrinkScaledFactors == 0) {
+            yoga::inexactEquals(
+                flexLine.layout.totalFlexShrinkScaledFactors, 0.0f)) {
           childSize = childFlexBasis + flexShrinkScaledFactor;
         } else {
           childSize = childFlexBasis +
@@ -1533,9 +1534,10 @@ static void calculateLayoutImpl(
 
         if (!useLegacyStretchBehaviour &&
             ((yoga::isDefined(flexLine.layout.totalFlexGrowFactors) &&
-              flexLine.layout.totalFlexGrowFactors == 0) ||
+              yoga::inexactEquals(
+                  flexLine.layout.totalFlexGrowFactors, 0.0f)) ||
              (yoga::isDefined(node->resolveFlexGrow()) &&
-              node->resolveFlexGrow() == 0))) {
+              yoga::inexactEquals(node->resolveFlexGrow(), 0.0f)))) {
           // If we don't have any children to flex or we can't flex the node
           // itself, space we've used is all space we need. Root node also
           // should be shrunk to minimum


### PR DESCRIPTION
Summary:
In cases where the remaining space for flex shrink is negative, we can get into a state where the `totalFlexShrinkScaledFactors` get's infintesimally small, but likely should just be floored to zero.

This manifests in issues where flexShrink nodes are suddenly given way too much space, and generally only manifests in an issue if these flexShrink nodes have self-measuring children (such as text).

Checking if the value is approximately zero appears to fix bugs for flexShrink.

Differential Revision: D82313674


