### PR TITLE
refactor: emit the trace recoding on ReactNativeApplication domain initialization

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
@@ -36,16 +36,13 @@ class HostAgent final {
    * \param hostMetadata Metadata about the host that created this agent.
    * \param sessionState The state of the session that created this agent.
    * \param executor A void executor to be used by async-aware handlers.
-   * \param traceRecordingToEmit If set, this is the trace that Host has
-   * requested to display in the Frontend.
    */
   HostAgent(
       const FrontendChannel& frontendChannel,
       HostTargetController& targetController,
       HostTargetMetadata hostMetadata,
       SessionState& sessionState,
-      VoidExecutor executor,
-      std::optional<tracing::TraceRecordingState> traceRecordingToEmit);
+      VoidExecutor executor);
 
   HostAgent(const HostAgent&) = delete;
   HostAgent(HostAgent&&) = delete;

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
@@ -34,8 +34,7 @@ class HostTargetSession {
       std::unique_ptr<IRemoteConnection> remote,
       HostTargetController& targetController,
       HostTargetMetadata hostMetadata,
-      VoidExecutor executor,
-      std::optional<tracing::TraceRecordingState> traceRecordingToEmit)
+      VoidExecutor executor)
       : remote_(std::make_shared<RAIIRemoteConnection>(std::move(remote))),
         frontendChannel_(
             [remoteWeak = std::weak_ptr(remote_)](std::string_view message) {
@@ -48,8 +47,7 @@ class HostTargetSession {
             targetController,
             std::move(hostMetadata),
             state_,
-            std::move(executor),
-            std::move(traceRecordingToEmit)) {}
+            std::move(executor)) {}
 
   /**
    * Called by CallbackLocalConnection to send a message to this Session's
@@ -205,8 +203,7 @@ std::unique_ptr<ILocalConnection> HostTarget::connect(
       std::move(connectionToFrontend),
       controller_,
       delegate_.getMetadata(),
-      makeVoidExecutor(executorFromThis()),
-      delegate_.unstable_getTraceRecordingThatWillBeEmittedOnInitialization());
+      makeVoidExecutor(executorFromThis()));
   session->setCurrentInstance(currentInstance_.get());
   sessions_.insert(std::weak_ptr(session));
   return std::make_unique<CallbackLocalConnection>(

--- a/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.h
@@ -28,14 +28,11 @@ class TracingAgent {
    * \param hostTargetController An interface to the HostTarget that this agent
    * is attached to. The caller is responsible for ensuring that the
    * HostTargetDelegate and underlying HostTarget both outlive the agent.
-   * \param traceRecordingToEmit If set, this is the trace that Host has
-   * requested to display in the Frontend.
    */
   TracingAgent(
       FrontendChannel frontendChannel,
       SessionState& sessionState,
-      HostTargetController& hostTargetController,
-      std::optional<tracing::TraceRecordingState> traceRecordingToEmit);
+      HostTargetController& hostTargetController);
 
   ~TracingAgent();
 
@@ -45,6 +42,12 @@ class TracingAgent {
    * \param req The parsed request.
    */
   bool handleRequest(const cdp::PreparsedRequest& req);
+
+  /**
+   * Emits the Trace Recording that was stashed externally by the HostTarget.
+   */
+  void emitExternalTraceRecording(
+      tracing::TraceRecordingState traceRecording) const;
 
  private:
   /**
@@ -60,7 +63,7 @@ class TracingAgent {
    * Emits the captured Trace Recording state in a series of
    * Tracing.dataCollected events, followed by a Tracing.tracingComplete event.
    */
-  void emitTraceRecording(tracing::TraceRecordingState state) const;
+  void emitTraceRecording(tracing::TraceRecordingState traceRecording) const;
 };
 
 } // namespace facebook::react::jsinspector_modern


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

This is a different approach from the one that I've introduced initially in [1].

This saves us from the scenario, where any local session could snatch the stashed trace recording. For example, if some session was created for a Runtime binding right after we've stashed the trace and before initializing real CDP session with the Frontend.

Differential Revision: D82316584


