### PR TITLE
Implement support for Network trace events

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -109,6 +109,21 @@ class PerformanceTracer {
   void reportEventLoopMicrotasks(HighResTimeStamp start, HighResTimeStamp end);
 
   /**
+   * Record a "ResourceSendRequest"/"ResourceFinish" event pair - a labelled
+   * duration in the Performance timeline Network track. If not currently
+   * tracing, this is a no-op.
+   */
+  void reportResourceTiming(
+      const std::string& requestId,
+      const std::string& url,
+      HighResTimeStamp fetchStart,
+      HighResTimeStamp responseStart,
+      HighResTimeStamp responseEnd,
+      int statusCode,
+      const std::string& requestMethod,
+      const std::string& resourceType);
+
+  /**
    * Creates "Profile" Trace Event.
    *
    * Can be serialized to JSON with TraceEventSerializer::serialize.
@@ -181,12 +196,48 @@ class PerformanceTracer {
     HighResTimeStamp createdAt = HighResTimeStamp::now();
   };
 
+  struct PerformanceTracerResourceWillSendRequest {
+    std::string requestId;
+    HighResTimeStamp start;
+    ThreadId threadId;
+    HighResTimeStamp createdAt = HighResTimeStamp::now();
+  };
+
+  struct PerformanceTracerResourceSendRequest {
+    std::string requestId;
+    std::string url;
+    HighResTimeStamp start;
+    std::string requestMethod;
+    std::string resourceType;
+    ThreadId threadId;
+    HighResTimeStamp createdAt = HighResTimeStamp::now();
+  };
+
+  struct PerformanceTracerResourceFinish {
+    std::string requestId;
+    HighResTimeStamp start;
+    ThreadId threadId;
+    HighResTimeStamp createdAt = HighResTimeStamp::now();
+  };
+
+  struct PerformanceTracerResourceReceiveResponse {
+    std::string requestId;
+    HighResTimeStamp start;
+    int statusCode;
+    ThreadId threadId;
+    HighResTimeStamp createdAt = HighResTimeStamp::now();
+  };
+
   using PerformanceTracerEvent = std::variant<
       PerformanceTracerEventTimeStamp,
       PerformanceTracerEventEventLoopTask,
       PerformanceTracerEventEventLoopMicrotask,
       PerformanceTracerEventMark,
-      PerformanceTracerEventMeasure>;
+      PerformanceTracerEventMeasure,
+      PerformanceTracerResourceWillSendRequest,
+      PerformanceTracerResourceSendRequest,
+      PerformanceTracerResourceReceiveResponse,
+      PerformanceTracerResourceFinish>;
 
 #pragma mark - Private fields and methods
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEvent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEvent.h
@@ -55,6 +55,12 @@ struct TraceEvent {
   /** The ID for the process that output this event. */
   ProcessId pid;
 
+  /**
+   * The scope of the event, either global (g), process (p), or thread (t).
+   * Only applicable to instant events ("ph": "i").
+   */
+  std::optional<char> s;
+
   /** The ID for the thread that output this event. */
   ThreadId tid;
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEventSerializer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEventSerializer.cpp
@@ -26,6 +26,9 @@ namespace facebook::react::jsinspector_modern::tracing {
   result["ph"] = std::string(1, event.ph);
   result["ts"] = highResTimeStampToTracingClockTimeStamp(event.ts);
   result["pid"] = event.pid;
+  if (event.s.has_value()) {
+    result["s"] = std::string(1, event.s.value());
+  }
   result["tid"] = event.tid;
   result["args"] = std::move(event.args);
   if (event.dur.has_value()) {

--- a/packages/react-native/ReactCommon/react/networking/NetworkReporter.h
+++ b/packages/react-native/ReactCommon/react/networking/NetworkReporter.h
@@ -28,6 +28,8 @@ namespace facebook::react {
  */
 struct ResourceTimingData {
   std::string url;
+  std::string requestMethod;
+  std::optional<std::string> resourceType;
   HighResTimeStamp fetchStart;
   HighResTimeStamp requestStart;
   std::optional<HighResTimeStamp> connectStart;

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.cpp
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.cpp
@@ -307,7 +307,10 @@ void PerformanceEntryReporter::reportResourceTiming(
     std::optional<HighResTimeStamp> connectEnd,
     HighResTimeStamp responseStart,
     HighResTimeStamp responseEnd,
-    const std::optional<int>& responseStatus) {
+    const std::optional<int>& responseStatus,
+    const std::optional<std::string>& devtoolsRequestId,
+    const std::optional<std::string>& requestMethod,
+    const std::optional<std::string>& resourceType) {
   const auto entry = PerformanceResourceTiming{
       {.name = url, .startTime = fetchStart},
       fetchStart,
@@ -318,6 +321,8 @@ void PerformanceEntryReporter::reportResourceTiming(
       responseEnd,
       responseStatus,
   };
+
+  traceResourceTiming(entry, devtoolsRequestId, requestMethod, resourceType);
 
   // Add to buffers & notify observers
   {
@@ -367,6 +372,33 @@ void PerformanceEntryReporter::traceMeasure(
       performanceTracer.reportMeasure(
           entry.name, entry.startTime, entry.duration, std::move(detail));
     }
+  }
+}
+
+void PerformanceEntryReporter::traceResourceTiming(
+    const PerformanceResourceTiming& entry,
+    const std::optional<std::string>& devtoolsRequestId,
+    const std::optional<std::string>& requestMethod,
+    const std::optional<std::string>& resourceType) const {
+  if (!entry.responseStart.has_value() || !entry.responseEnd.has_value() ||
+      !entry.responseStatus.has_value() || !devtoolsRequestId.has_value() ||
+      !requestMethod.has_value() || !resourceType.has_value()) {
+    return;
+  }
+
+  auto& performanceTracer =
+      jsinspector_modern::tracing::PerformanceTracer::getInstance();
+
+  if (performanceTracer.isTracing()) {
+    performanceTracer.reportResourceTiming(
+        *devtoolsRequestId,
+        entry.name,
+        entry.fetchStart,
+        *entry.responseStart,
+        *entry.responseEnd,
+        *entry.responseStatus,
+        *requestMethod,
+        *resourceType);
   }
 }
 

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.h
@@ -118,7 +118,10 @@ class PerformanceEntryReporter {
       std::optional<HighResTimeStamp> connectEnd,
       HighResTimeStamp responseStart,
       HighResTimeStamp responseEnd,
-      const std::optional<int>& responseStatus);
+      const std::optional<int>& responseStatus,
+      const std::optional<std::string>& devtoolsRequestId,
+      const std::optional<std::string>& requestMethod,
+      const std::optional<std::string>& resourceType);
 
  private:
   std::unique_ptr<PerformanceObserverRegistry> observerRegistry_;
@@ -182,6 +185,11 @@ class PerformanceEntryReporter {
   void traceMeasure(
       const PerformanceMeasure& entry,
       UserTimingDetailProvider&& detailProvider) const;
+  void traceResourceTiming(
+      const PerformanceResourceTiming& entry,
+      const std::optional<std::string>& devtoolsRequestId,
+      const std::optional<std::string>& requestMethod,
+      const std::optional<std::string>& resourceType) const;
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
Updates `NetworkReporter` and `PerformanceEntryReporter` to populate (minimal) `"ResourceSendRequest"` and `"ResourceFinished"` events when a CDP performance trace is active. This allows the Chrome DevTools Performance panel to display the "Network" track.

**Notes**

- The trace events that Chrome requires need extra fields which aren't present on `PerformanceResourceTiming`, hence the new + optional `devtoolsRequestId`, `requestMethod`, `resourceType` params. We only populate these in debug builds.

**Limitations**

- We emit a *complete trace event set* within `reportResourceTiming`, implementing basic initial support in the Performance panel Network track. This means 1/ either all/no events are sent for a given request (rather than incrementally), 2/ we aren't yet handling failed/cancelled requests in this pipeline.

Changelog: [Internal]

Differential Revision: D82212362


