### PR TITLE
chore(android): Reproduce TextInput screenreader issue

### DIFF
--- a/packages/rn-tester/js/examples/Playground/RNTesterPlayground.js
+++ b/packages/rn-tester/js/examples/Playground/RNTesterPlayground.js
@@ -8,18 +8,20 @@
  * @format
  */
 
-import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+import type { RNTesterModuleExample } from '../../types/RNTesterTypes';
 
 import RNTesterText from '../../components/RNTesterText';
 import * as React from 'react';
-import {StyleSheet, View} from 'react-native';
+import { StyleSheet, View, TextInput } from 'react-native';
 
 function Playground() {
+  const [text, setText] = React.useState('test');
   return (
     <View style={styles.container}>
-      <RNTesterText>
-        Edit "RNTesterPlayground.js" to change this file
-      </RNTesterText>
+      <TextInput
+        onChangeText={setText}
+        value={text}
+      />
     </View>
   );
 }


### PR DESCRIPTION
## Summary:

This pull request reproduces https://github.com/facebook/react-native/issues/48233 with the latest `main`, as per [contributing/how-to-report-a-bug](https://reactnative.dev/contributing/how-to-report-a-bug#rntesterplaygroundjs).

When adding to the end of a controlled `TextInput` with TalkBack enabled, TalkBack reads "replaced", then the full content of the input. This makes `TextInput`s difficult to use with a screen reader, particularly when the input text is long.

Expected behavior:
- Controlled and uncontrolled `TextInput`s should behave similarly when interacted with by a screen reader.
- React Native `TextInput`s should behave similarly to Android's native edit fields when using a screen reader.

## Screen recording

The below screen recording shows an Android 16 emulator with TalkBack enabled (16.0.0.738667889), editing the controlled `TextInput` from this pull request. Spoken text is shown onscreen; the recording has no audio.

[Screen_recording_20250912_123025.webm](https://github.com/user-attachments/assets/67a79fcf-5f1a-4d46-b23b-38799e23474d)

**Edit**: Be sure to test with TalkBack >= v16 — I cannot reproduce the issue with TalkBack v13 on an older device.

## Changelog:

[ANDROID] This change is a reproducer. Do not merge.

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I'm able to reproduce the issue by:
1. Setting up an Android 16 emulator.
   - My emulator: Pixel 9 Pro Fold/Android 16.0/x86_64
2. Setting up TalkBack:
   - Navigate to system settings > accessibility > talkback.
   - Switch "Use TalkBack" to "On".
   - Optionally show spoken output onscreen (as in the screen recording). To do this, open TalkBack settings, "advanced settings", "developer settings", and enable "display speech output".
3. Running the React Native Tester playground.
4. Opening the playground tab.
5. Focusing the test textinput.
6. Adding text to the end of the input using the onscreen keyboard (GBoard).
