### PR TITLE
Replace trivial uses of string_view

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/cdp/CdpJson.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/cdp/CdpJson.cpp
@@ -49,7 +49,7 @@ std::string jsonResult(RequestId id, const folly::dynamic& result) {
 }
 
 std::string jsonNotification(
-    std::string_view method,
+    const std::string& method,
     std::optional<folly::dynamic> params) {
   auto dynamicNotification = folly::dynamic::object("method", method);
   if (params) {
@@ -60,7 +60,7 @@ std::string jsonNotification(
 
 std::string jsonRequest(
     RequestId id,
-    std::string_view method,
+    const std::string& method,
     std::optional<folly::dynamic> params) {
   auto dynamicRequest = folly::dynamic::object("id", id)("method", method);
   if (params) {

--- a/packages/react-native/ReactCommon/jsinspector-modern/cdp/CdpJson.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/cdp/CdpJson.h
@@ -118,7 +118,7 @@ std::string jsonResult(
  * \param params Optional payload object.
  */
 std::string jsonNotification(
-    std::string_view method,
+    const std::string& method,
     std::optional<folly::dynamic> params = std::nullopt);
 
 /**
@@ -132,7 +132,7 @@ std::string jsonNotification(
  */
 std::string jsonRequest(
     RequestId id,
-    std::string_view method,
+    const std::string& method,
     std::optional<folly::dynamic> params = std::nullopt);
 
 } // namespace facebook::react::jsinspector_modern::cdp

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
@@ -124,7 +124,7 @@ std::optional<std::vector<TraceEvent>> PerformanceTracer::stopTracing() {
 }
 
 void PerformanceTracer::reportMark(
-    const std::string_view& name,
+    const std::string& name,
     HighResTimeStamp start,
     folly::dynamic&& detail) {
   if (!tracingAtomic_) {
@@ -137,7 +137,7 @@ void PerformanceTracer::reportMark(
   }
 
   enqueueEvent(PerformanceTracerEventMark{
-      .name = std::string(name),
+      .name = name,
       .start = start,
       .detail = std::move(detail),
       .threadId = getCurrentThreadId(),
@@ -145,7 +145,7 @@ void PerformanceTracer::reportMark(
 }
 
 void PerformanceTracer::reportMeasure(
-    const std::string_view& name,
+    const std::string& name,
     HighResTimeStamp start,
     HighResDuration duration,
     folly::dynamic&& detail) {
@@ -159,7 +159,7 @@ void PerformanceTracer::reportMeasure(
   }
 
   enqueueEvent(PerformanceTracerEventMeasure{
-      .name = std::string(name),
+      .name = name,
       .start = start,
       .duration = duration,
       .detail = std::move(detail),
@@ -168,7 +168,7 @@ void PerformanceTracer::reportMeasure(
 }
 
 void PerformanceTracer::reportTimeStamp(
-    std::string name,
+    const std::string& name,
     std::optional<ConsoleTimeStampEntry> start,
     std::optional<ConsoleTimeStampEntry> end,
     std::optional<std::string> trackName,
@@ -184,7 +184,7 @@ void PerformanceTracer::reportTimeStamp(
   }
 
   enqueueEvent(PerformanceTracerEventTimeStamp{
-      .name = std::move(name),
+      .name = name,
       .start = std::move(start),
       .end = std::move(end),
       .trackName = std::move(trackName),

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -65,7 +65,7 @@ class PerformanceTracer {
    * See https://w3c.github.io/user-timing/#mark-method.
    */
   void reportMark(
-      const std::string_view& name,
+      const std::string& name,
       HighResTimeStamp start,
       folly::dynamic&& detail = nullptr);
 
@@ -76,7 +76,7 @@ class PerformanceTracer {
    * See https://w3c.github.io/user-timing/#measure-method.
    */
   void reportMeasure(
-      const std::string_view& name,
+      const std::string& name,
       HighResTimeStamp start,
       HighResDuration duration,
       folly::dynamic&& detail = nullptr);
@@ -89,7 +89,7 @@ class PerformanceTracer {
    https://developer.chrome.com/docs/devtools/performance/extension#inject_your_data_with_consoletimestamp
    */
   void reportTimeStamp(
-      std::string name,
+      const std::string& name,
       std::optional<ConsoleTimeStampEntry> start = std::nullopt,
       std::optional<ConsoleTimeStampEntry> end = std::nullopt,
       std::optional<std::string> trackName = std::nullopt,

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfile.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/RuntimeSamplingProfile.h
@@ -49,8 +49,14 @@ struct RuntimeSamplingProfile {
     /// id of the corresponding script in the VM.
     uint32_t scriptId;
     /// name of the function that represents call frame.
+    /// Storing a std::string_view should be considered safe here, beacause
+    /// the lifetime of the string contents are guaranteed as long as the raw
+    // Sampling Profiler object from Hermes is allocated.
     std::string_view functionName;
     /// source url of the corresponding script in the VM.
+    /// Storing a std::string_view should be considered safe here, beacause
+    /// the lifetime of the string contents are guaranteed as long as the raw
+    // Sampling Profiler object from Hermes is allocated.
     std::optional<std::string_view> scriptURL = std::nullopt;
     /// 0-based line number of the corresponding call frame.
     std::optional<uint32_t> lineNumber = std::nullopt;


### PR DESCRIPTION
Summary:
A refactor to align our C++ code style within `jsinpector-modern`.

We prefer `std::string` and `const std::string&` everywhere (see [C++ Core Guidelines F.15](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rf-conventional)), except for when we are handing potentially very large strings — in which case we must use `string_view` all the way down.

Changelog: [Internal]

Differential Revision: D82446939


