### PR TITLE
Move trace event handling into NetworkReporter

### DIFF
--- a/packages/react-native/Package.swift
+++ b/packages/react-native/Package.swift
@@ -161,7 +161,7 @@ let reactJsInspectorTracing = RNTarget(
   name: .reactJsInspectorTracing,
   path: "ReactCommon/jsinspector-modern/tracing",
   excludedPaths: ["tests"],
-  dependencies: [.reactNativeDependencies, .reactFeatureFlags, .jsi, .reactOSCompat]
+  dependencies: [.reactNativeDependencies, .reactFeatureFlags, .reactJsInspectorNetwork, .jsi, .reactOSCompat]
 )
 
 /// React-jsinspectornetwork.podspec

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/CdpNetwork.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/CdpNetwork.cpp
@@ -13,13 +13,11 @@ namespace facebook::react::jsinspector_modern::cdp::network {
 
 namespace {
 
-folly::dynamic headersToDynamic(const std::optional<Headers>& headers) {
+folly::dynamic headersToDynamic(const Headers& headers) {
   folly::dynamic result = folly::dynamic::object;
 
-  if (headers) {
-    for (const auto& [key, value] : *headers) {
-      result[key] = value;
-    }
+  for (const auto& [key, value] : headers) {
+    result[key] = value;
   }
 
   return result;
@@ -41,14 +39,14 @@ folly::dynamic Request::toDynamic() const {
 /* static */ Response Response::fromInputParams(
     const std::string& url,
     uint16_t status,
-    const std::optional<Headers>& headers,
+    const Headers& headers,
     int encodedDataLength) {
   return {
       .url = url,
       .status = status,
       .statusText = httpReasonPhrase(status),
       .headers = headers,
-      .mimeType = mimeTypeFromHeaders(headers.value_or(Headers())),
+      .mimeType = mimeTypeFromHeaders(headers),
       .encodedDataLength = encodedDataLength,
   };
 }

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/CdpNetwork.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/CdpNetwork.h
@@ -24,7 +24,7 @@ using Headers = std::map<std::string, std::string>;
 struct Request {
   std::string url;
   std::string method;
-  std::optional<Headers> headers;
+  Headers headers;
   std::optional<std::string> postData;
 
   folly::dynamic toDynamic() const;
@@ -37,7 +37,7 @@ struct Response {
   std::string url;
   uint16_t status;
   std::string statusText;
-  std::optional<Headers> headers;
+  Headers headers;
   std::string mimeType;
   int encodedDataLength;
 
@@ -48,7 +48,7 @@ struct Response {
   static Response fromInputParams(
       const std::string& url,
       uint16_t status,
-      const std::optional<Headers>& headers,
+      const Headers& headers,
       int encodedDataLength);
 
   folly::dynamic toDynamic() const;

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/HttpUtils.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/HttpUtils.h
@@ -12,6 +12,8 @@
 
 namespace facebook::react::jsinspector_modern {
 
+using Headers = std::map<std::string, std::string>;
+
 /**
  * Get the HTTP reason phrase for a given status code (RFC 9110).
  */
@@ -21,7 +23,6 @@ std::string httpReasonPhrase(uint16_t status);
  * Get the MIME type for a response based on the 'Content-Type' header. If
  * the header is not present, returns 'application/octet-stream'.
  */
-std::string mimeTypeFromHeaders(
-    const std::map<std::string, std::string>& headers);
+std::string mimeTypeFromHeaders(const Headers& headers);
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/CMakeLists.txt
@@ -18,6 +18,7 @@ target_include_directories(jsinspector_tracing PUBLIC ${REACT_COMMON_DIR})
 
 target_link_libraries(jsinspector_tracing
         folly_runtime
+        jsinspector_network
         oscompat
         react_timing
 )

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/React-jsinspectortracing.podspec
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/React-jsinspectortracing.podspec
@@ -43,6 +43,7 @@ Pod::Spec.new do |s|
 
   resolve_use_frameworks(s, header_mappings_dir: "../..", module_name: module_name)
 
+  add_dependency(s, "React-jsinspectornetwork", :framework_name => 'jsinspector_modernnetwork')
   s.dependency "React-oscompat"
   s.dependency "React-timing"
 

--- a/packages/react-native/ReactCommon/react/networking/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/networking/CMakeLists.txt
@@ -17,5 +17,7 @@ target_compile_options(react_networking PRIVATE -Wpedantic)
 target_include_directories(react_networking PUBLIC ${REACT_COMMON_DIR})
 target_link_libraries(react_networking
         folly_runtime
+        jsinspector_network
+        jsinspector_tracing
         react_performance_timeline
         react_timing)

--- a/packages/react-native/ReactCommon/react/networking/NetworkReporter.h
+++ b/packages/react-native/ReactCommon/react/networking/NetworkReporter.h
@@ -28,8 +28,6 @@ namespace facebook::react {
  */
 struct ResourceTimingData {
   std::string url;
-  std::string requestMethod;
-  std::optional<std::string> resourceType;
   HighResTimeStamp fetchStart;
   HighResTimeStamp requestStart;
   std::optional<HighResTimeStamp> connectStart;
@@ -56,7 +54,8 @@ class NetworkReporter {
   /**
    * Report a network request that is about to be sent.
    *
-   * - Corresponds to `Network.requestWillBeSent` in CDP.
+   * - Corresponds to `Network.requestWillBeSent` and the
+   *   "ResourceWillSendRequest" trace event in CDP.
    * - Corresponds to `PerformanceResourceTiming.requestStart` (specifically,
    *   marking when the native request was initiated).
    *
@@ -72,7 +71,8 @@ class NetworkReporter {
    * Report timestamp for sending the network request, and (in a debug build)
    * provide final headers to be reported via CDP.
    *
-   * - Corresponds to `Network.requestWillBeSentExtraInfo` in CDP.
+   * - Corresponds to `Network.requestWillBeSentExtraInfo` and the
+   *   "ResourceSendRequest" trace event in CDP.
    * - Corresponds to `PerformanceResourceTiming.domainLookupStart`,
    *   `PerformanceResourceTiming.connectStart`. Defined as "immediately before
    *   the browser starts to establish the connection to the server".
@@ -87,7 +87,8 @@ class NetworkReporter {
    * Report when HTTP response headers have been received, corresponding to
    * when the first byte of the response is available.
    *
-   * - Corresponds to `Network.responseReceived` in CDP.
+   * - Corresponds to `Network.responseReceived` and the
+   *   "ResourceReceiveResponse" trace event in CDP.
    * - Corresponds to `PerformanceResourceTiming.responseStart`.
    *
    * https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-responsestart
@@ -112,7 +113,8 @@ class NetworkReporter {
    * Report when a network request is complete and we are no longer receiving
    * response data.
    *
-   * - Corresponds to `Network.loadingFinished` in CDP.
+   * - Corresponds to `Network.loadingFinished` and the "ResourceFinish" trace
+   *   event in CDP.
    * - Corresponds to `PerformanceResourceTiming.responseEnd`.
    *
    * https://w3c.github.io/resource-timing/#dom-performanceresourcetiming-responseend

--- a/packages/react-native/ReactCommon/react/networking/React-networking.podspec
+++ b/packages/react-native/ReactCommon/react/networking/React-networking.podspec
@@ -43,6 +43,7 @@ Pod::Spec.new do |s|
   end
   add_dependency(s, "React-featureflags")
   add_dependency(s, "React-jsinspectornetwork", :framework_name => 'jsinspector_modernnetwork')
+  add_dependency(s, "React-jsinspectortracing", :framework_name => 'jsinspector_moderntracing')
   s.dependency "React-performancetimeline"
   s.dependency "React-timing"
 

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.cpp
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.cpp
@@ -307,10 +307,7 @@ void PerformanceEntryReporter::reportResourceTiming(
     std::optional<HighResTimeStamp> connectEnd,
     HighResTimeStamp responseStart,
     HighResTimeStamp responseEnd,
-    const std::optional<int>& responseStatus,
-    const std::optional<std::string>& devtoolsRequestId,
-    const std::optional<std::string>& requestMethod,
-    const std::optional<std::string>& resourceType) {
+    const std::optional<int>& responseStatus) {
   const auto entry = PerformanceResourceTiming{
       {.name = url, .startTime = fetchStart},
       fetchStart,
@@ -321,8 +318,6 @@ void PerformanceEntryReporter::reportResourceTiming(
       responseEnd,
       responseStatus,
   };
-
-  traceResourceTiming(entry, devtoolsRequestId, requestMethod, resourceType);
 
   // Add to buffers & notify observers
   {
@@ -372,33 +367,6 @@ void PerformanceEntryReporter::traceMeasure(
       performanceTracer.reportMeasure(
           entry.name, entry.startTime, entry.duration, std::move(detail));
     }
-  }
-}
-
-void PerformanceEntryReporter::traceResourceTiming(
-    const PerformanceResourceTiming& entry,
-    const std::optional<std::string>& devtoolsRequestId,
-    const std::optional<std::string>& requestMethod,
-    const std::optional<std::string>& resourceType) const {
-  if (!entry.responseStart.has_value() || !entry.responseEnd.has_value() ||
-      !entry.responseStatus.has_value() || !devtoolsRequestId.has_value() ||
-      !requestMethod.has_value() || !resourceType.has_value()) {
-    return;
-  }
-
-  auto& performanceTracer =
-      jsinspector_modern::tracing::PerformanceTracer::getInstance();
-
-  if (performanceTracer.isTracing()) {
-    performanceTracer.reportResourceTiming(
-        *devtoolsRequestId,
-        entry.name,
-        entry.fetchStart,
-        *entry.responseStart,
-        *entry.responseEnd,
-        *entry.responseStatus,
-        *requestMethod,
-        *resourceType);
   }
 }
 

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.h
@@ -118,10 +118,7 @@ class PerformanceEntryReporter {
       std::optional<HighResTimeStamp> connectEnd,
       HighResTimeStamp responseStart,
       HighResTimeStamp responseEnd,
-      const std::optional<int>& responseStatus,
-      const std::optional<std::string>& devtoolsRequestId,
-      const std::optional<std::string>& requestMethod,
-      const std::optional<std::string>& resourceType);
+      const std::optional<int>& responseStatus);
 
  private:
   std::unique_ptr<PerformanceObserverRegistry> observerRegistry_;


### PR DESCRIPTION
Summary:
Refactor and improve how we emit CDP trace events for network requests.

Key changes:
- Split up `PerformanceTracer` methods into discrete trace events.
- Move event calls out of `PerformanceEntryReporter` (upwards) into `NetworkReporter`. This now:
    - Aligns better with the matching source `NetworkReporter` events.
    - Removes metadata pieces from `PerformanceEntryReporter` that weren't part of the Web `PerformanceResourceTiming` API.
- Populate additional fields on `ResourceReceiveResponse`.

Changelog: [Internal]

Differential Revision: D82433225


