### PR TITLE
Expose unstable_NativeText and unstable_NativeView components

### DIFF
--- a/packages/react-native/Libraries/Components/View/ViewNativeComponent.js
+++ b/packages/react-native/Libraries/Components/View/ViewNativeComponent.js
@@ -29,6 +29,16 @@ export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
   supportedCommands: ['hotspotUpdate', 'setPressed'],
 });
 
+/**
+ * `ViewNativeComponent` is an internal React Native host component, and is
+ * exported to provide lower-level access for libraries.
+ *
+ * @warning `<unstable_NativeView>` provides no semver guarantees and is not
+ *   intended to be used in app code. Please use
+ *   [`<View>`](https://reactnative.dev/docs/view) instead.
+ */
+// Additional note: Our long term plan is to reduce the overhead of the <Text>
+// and <View> wrappers so that we no longer have any reason to export these APIs.
 export default ViewNativeComponent;
 
 export type ViewNativeComponentType = HostComponent<Props>;

--- a/packages/react-native/Libraries/Text/TextNativeComponent.js
+++ b/packages/react-native/Libraries/Text/TextNativeComponent.js
@@ -65,6 +65,16 @@ const virtualTextViewConfig = {
   uiViewClassName: 'RCTVirtualText',
 };
 
+/**
+ * `NativeText` is an internal React Native host component, and is exported to
+ * provide lower-level access for libraries.
+ *
+ * @warning `<unstable_NativeText>` provides no semver guarantees and is not
+ *   intended to be used in app code. Please use
+ *   [`<Text>`](https://reactnative.dev/docs/text) instead.
+ */
+// Additional note: Our long term plan is to reduce the overhead of the <Text>
+// and <View> wrappers so that we no longer have any reason to export these APIs.
 export const NativeText: HostComponent<NativeTextProps> =
   (createReactNativeComponentClass('RCTText', () =>
     /* $FlowFixMe[incompatible-type] Natural Inference rollout. See

--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -66,6 +66,12 @@ module.exports = {
   get Modal() {
     return require('./Libraries/Modal/Modal').default;
   },
+  get unstable_NativeText() {
+    return require('./Libraries/Text/TextNativeComponent').NativeText;
+  },
+  get unstable_NativeView() {
+    return require('./Libraries/Components/View/ViewNativeComponent').default;
+  },
   get Pressable() {
     return require('./Libraries/Components/Pressable/Pressable').default;
   },

--- a/packages/react-native/index.js.flow
+++ b/packages/react-native/index.js.flow
@@ -127,6 +127,8 @@ export {default as Switch} from './Libraries/Components/Switch/Switch';
 
 export type {TextProps} from './Libraries/Text/Text';
 export {default as Text} from './Libraries/Text/Text';
+export type {NativeTextProps as unstable_NativeTextProps} from './Libraries/Text/TextNativeComponent';
+export {NativeText as unstable_NativeText} from './Libraries/Text/TextNativeComponent';
 export {default as unstable_TextAncestorContext} from './Libraries/Text/TextAncestorContext';
 
 export type {
@@ -180,6 +182,7 @@ export type {
   ViewPropsIOS,
 } from './Libraries/Components/View/ViewPropTypes';
 export {default as View} from './Libraries/Components/View/View';
+export {default as unstable_NativeView} from './Libraries/Components/View/ViewNativeComponent';
 
 export type {
   ListRenderItemInfo,


### PR DESCRIPTION
Summary:
Expose `unstable_NativeText` and `unstable_NativeView` components as root exports of the `react-native` package.

These are exposed as `unstable_` APIs which have no semver guarantee.

**Motivation**

There is significant community interest / dependance on the currently private `TextNativeComponent` and `ViewNativeComponent` deep imports, to access the faster-performing inner versions of these UI components.

Using `<Text>` and `<View>`, while recommended and stable, has led to measurable performance overhead in some apps when compared with these `<Native*>` counterparts.

Notably, these APIs are also referenced by low-level libraries such as React Strict DOM.

I am proposing this change in order to:
- Unblock libraries which safely use these.
- Meet users where they are at.
- Unblock us from enabling the Strict TypeScript API (no deep imports).

References:

- https://github.com/react-native-community/discussions-and-proposals/discussions/893#discussioncomment-13452047
- https://javascript.plainenglish.io/optimizing-text-component-rendering-in-react-native-b9d3565659d9
- https://github.com/search?type=code&q=react-native%2FLibraries%2FText%2FTextNativeComponent

**Ideal future state**

We are exposing these as unstable APIs because they should not be part of React Native's final API. The ideal end state is we improve the regular `<Text>` and `<View>` components to eliminate performance overhead and the need to access any lower level API.

Changelog:
[General][Added] - `unstable_NativeText` and `unstable_NativeView` are now exported from the `react-native` package

Reviewed By: javache

Differential Revision: D81588145


