### PR TITLE
Remove unused --otp property from release infrastructure

### DIFF
--- a/scripts/releases-ci/__tests__/publish-npm-test.js
+++ b/scripts/releases-ci/__tests__/publish-npm-test.js
@@ -282,8 +282,6 @@ describe('publish-npm', () => {
         code: 0,
       }));
 
-      process.env.NPM_CONFIG_OTP = 'otp';
-
       await publishNpm('release');
 
       expect(setVersionMock).not.toBeCalled();
@@ -303,7 +301,7 @@ describe('publish-npm', () => {
       expect(publishPackageMock.mock.calls).toEqual([
         [
           path.join(REPO_ROOT, 'packages', 'react-native'),
-          {otp: process.env.NPM_CONFIG_OTP, tags: ['0.81-stable']},
+          {tags: ['0.81-stable']},
         ],
       ]);
 
@@ -322,8 +320,6 @@ describe('publish-npm', () => {
         code: 0,
       }));
 
-      process.env.NPM_CONFIG_OTP = 'otp';
-
       await publishNpm('release');
 
       expect(updateReactNativeArtifactsMock).not.toBeCalled();
@@ -341,10 +337,7 @@ describe('publish-npm', () => {
       );
 
       expect(publishPackageMock.mock.calls).toEqual([
-        [
-          path.join(REPO_ROOT, 'packages', 'react-native'),
-          {otp: process.env.NPM_CONFIG_OTP, tags: ['latest']},
-        ],
+        [path.join(REPO_ROOT, 'packages', 'react-native'), {tags: ['latest']}],
       ]);
 
       expect(consoleLogMock.mock.calls).toEqual([
@@ -364,8 +357,6 @@ describe('publish-npm', () => {
 
       execMock.mockReturnValueOnce({code: 1});
       isTaggedLatestMock.mockReturnValueOnce(true);
-
-      process.env.NPM_CONFIG_OTP = 'otp';
 
       await expect(async () => {
         await publishNpm('release');
@@ -388,10 +379,7 @@ describe('publish-npm', () => {
       );
 
       expect(publishPackageMock.mock.calls).toEqual([
-        [
-          path.join(REPO_ROOT, 'packages', 'react-native'),
-          {otp: process.env.NPM_CONFIG_OTP, tags: ['latest']},
-        ],
+        [path.join(REPO_ROOT, 'packages', 'react-native'), {tags: ['latest']}],
       ]);
       expect(consoleLogMock).not.toHaveBeenCalled();
     });
@@ -405,8 +393,6 @@ describe('publish-npm', () => {
       publishPackageMock.mockImplementation(() => ({
         code: 0,
       }));
-
-      process.env.NPM_CONFIG_OTP = 'otp';
 
       await publishNpm('release');
 
@@ -425,10 +411,7 @@ describe('publish-npm', () => {
       );
 
       expect(publishPackageMock.mock.calls).toEqual([
-        [
-          path.join(REPO_ROOT, 'packages', 'react-native'),
-          {otp: process.env.NPM_CONFIG_OTP, tags: ['next']},
-        ],
+        [path.join(REPO_ROOT, 'packages', 'react-native'), {tags: ['next']}],
       ]);
       expect(consoleLogMock.mock.calls).toEqual([
         [`Published react-native@${expectedVersion} to npm`],

--- a/scripts/releases-ci/publish-npm.js
+++ b/scripts/releases-ci/publish-npm.js
@@ -76,7 +76,6 @@ async function publishMonorepoPackages(tag /*: ?string */) {
     console.log(`Publishing ${packageInfo.name}...`);
     const result = publishPackage(packageInfo.path, {
       tags: [tag],
-      otp: process.env.NPM_CONFIG_OTP,
       access: 'public',
     });
 
@@ -122,7 +121,6 @@ async function publishNpm(buildType /*: BuildType */) /*: Promise<void> */ {
   const packagePath = path.join(REPO_ROOT, 'packages', 'react-native');
   const result = publishPackage(packagePath, {
     tags: [tag],
-    otp: process.env.NPM_CONFIG_OTP,
   });
 
   if (result.code) {

--- a/scripts/releases-ci/publish-updated-packages.js
+++ b/scripts/releases-ci/publish-updated-packages.js
@@ -14,7 +14,6 @@ const {execSync} = require('child_process');
 const {parseArgs} = require('util');
 
 const PUBLISH_PACKAGES_TAG = '#publish-packages-to-npm';
-const NPM_CONFIG_OTP = process.env.NPM_CONFIG_OTP;
 
 const config = {
   options: {
@@ -139,7 +138,6 @@ function runPublish(
 ) {
   const result = publishPackage(packagePath, {
     tags,
-    otp: NPM_CONFIG_OTP,
   });
 
   if (result.code !== 0) {

--- a/scripts/releases/utils/__tests__/npm-utils-test.js
+++ b/scripts/releases/utils/__tests__/npm-utils-test.js
@@ -33,37 +33,35 @@ describe('npm-utils', () => {
     it('should run publish command', () => {
       publishPackage(
         'path/to/my-package',
-        {tags: ['latest'], otp: 'otp'},
+        {tags: ['latest']},
         {silent: true, cwd: 'i/expect/this/to/be/overriden'},
       );
-      expect(execMock).toHaveBeenCalledWith(
-        'npm publish --tag latest --otp otp',
-        {silent: true, cwd: 'path/to/my-package'},
-      );
+      expect(execMock).toHaveBeenCalledWith('npm publish --tag latest', {
+        silent: true,
+        cwd: 'path/to/my-package',
+      });
     });
 
     it('should run publish command when no execOptions', () => {
-      publishPackage('path/to/my-package', {tags: ['latest'], otp: 'otp'});
-      expect(execMock).toHaveBeenCalledWith(
-        'npm publish --tag latest --otp otp',
-        {cwd: 'path/to/my-package'},
-      );
+      publishPackage('path/to/my-package', {tags: ['latest']});
+      expect(execMock).toHaveBeenCalledWith('npm publish --tag latest', {
+        cwd: 'path/to/my-package',
+      });
     });
 
     it('should handle multiple tags', () => {
       publishPackage('path/to/my-package', {
         tags: ['next', '0.72-stable'],
-        otp: 'otp',
       });
       expect(execMock).toHaveBeenCalledWith(
-        'npm publish --tag next --tag 0.72-stable --otp otp',
+        'npm publish --tag next --tag 0.72-stable',
         {cwd: 'path/to/my-package'},
       );
     });
 
     it('should handle -no-tag', () => {
-      publishPackage('path/to/my-package', {tags: ['--no-tag'], otp: 'otp'});
-      expect(execMock).toHaveBeenCalledWith('npm publish --no-tag --otp otp', {
+      publishPackage('path/to/my-package', {tags: ['--no-tag']});
+      expect(execMock).toHaveBeenCalledWith('npm publish --no-tag', {
         cwd: 'path/to/my-package',
       });
     });

--- a/scripts/releases/utils/npm-utils.js
+++ b/scripts/releases/utils/npm-utils.js
@@ -35,7 +35,6 @@ type PackageJSON = {
 }
 type NpmPackageOptions = {
   tags: ?Array<string> | ?Array<?string>,
-  otp: ?string,
   access?: ?('public' | 'restricted')
 }
 */
@@ -130,7 +129,7 @@ function publishPackage(
   packageOptions /*: NpmPackageOptions */,
   execOptions /*: ?ExecOptsSync */,
 ) /*: ShellString */ {
-  const {otp, tags, access} = packageOptions;
+  const {tags, access} = packageOptions;
 
   let tagsFlag = '';
   if (tags != null) {
@@ -142,13 +141,12 @@ function publishPackage(
           .join('');
   }
 
-  const otpFlag = otp != null ? ` --otp ${otp}` : '';
   const accessFlag = access != null ? ` --access ${access}` : '';
   const options /*: ExecOptsSync */ = execOptions
     ? {...execOptions, cwd: packagePath}
     : {cwd: packagePath};
 
-  return exec(`npm publish${tagsFlag}${otpFlag}${accessFlag}`, options);
+  return exec(`npm publish${tagsFlag}${accessFlag}`, options);
 }
 
 /**


### PR DESCRIPTION
## Summary:

The `--otp` flag is completely unused now, therefore it can be removed.
We don't pass the `NPM_CONFIG_OTP` env variable either as this was done back in the days of CircleCI so I'm cleaning this up. 

## Changelog:

[INTERNAL] - Remove unused --otp property from release infrastructure

## Test Plan:

CI