### PR TITLE
Runtime check that NewArchitecture is enabled in DefaultNewArchitectureEntryPoint

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
@@ -120,6 +120,12 @@ public object DefaultNewArchitectureEntryPoint {
   internal fun loadWithFeatureFlags(featureFlags: ReactNativeFeatureFlagsProvider) {
     ReactNativeFeatureFlags.override(featureFlags)
 
+    val (isValid, errorMessage) =
+        isConfigurationValid(turboModulesEnabled, fabricEnabled, bridgelessEnabled)
+    if (!isValid) {
+      error(errorMessage)
+    }
+
     privateFabricEnabled = featureFlags.enableFabricRenderer()
     privateTurboModulesEnabled = featureFlags.useTurboModules()
     privateConcurrentReactEnabled = featureFlags.enableFabricRenderer()
@@ -158,13 +164,13 @@ public object DefaultNewArchitectureEntryPoint {
       fabricEnabled: Boolean,
       bridgelessEnabled: Boolean,
   ): Pair<Boolean, String> =
-      when {
-        fabricEnabled && !turboModulesEnabled ->
-            false to
-                "fabricEnabled=true requires turboModulesEnabled=true (is now false) - Please update your DefaultNewArchitectureEntryPoint.load() parameters."
-        bridgelessEnabled && (!turboModulesEnabled || !fabricEnabled) ->
-            false to
-                "bridgelessEnabled=true requires (turboModulesEnabled=true AND fabricEnabled=true) - Please update your DefaultNewArchitectureEntryPoint.load() parameters."
-        else -> true to ""
+      if (!turboModulesEnabled || !fabricEnabled || !bridgelessEnabled) {
+        false to
+            "You cannot load React Native with the New Architecture disabled. " +
+                "Please use DefaultNewArchitectureEntryPoint.load() instead of " +
+                "DefaultNewArchitectureEntryPoint.load(turboModulesEnabled=$turboModulesEnabled, " +
+                "fabricEnabled=$fabricEnabled, bridgelessEnabled=$bridgelessEnabled)"
+      } else {
+        true to ""
       }
 }

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPointTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPointTest.kt
@@ -13,36 +13,48 @@ import org.junit.Test
 class DefaultNewArchitectureEntryPointTest {
 
   @Test
-  fun isConfigurationValid_withEverythingOff_returnsTrue() {
-    val (isValid, _) =
+  fun isConfigurationValid_withEverythingOff_returnsFalse() {
+    val (isValid, errorMessage) =
         DefaultNewArchitectureEntryPoint.isConfigurationValid(
             turboModulesEnabled = false,
             fabricEnabled = false,
             bridgelessEnabled = false,
         )
-    assertThat(isValid).isTrue()
+    assertThat(isValid).isFalse()
+    assertThat(errorMessage)
+        .isEqualTo(
+            "You cannot load React Native with the New Architecture disabled. Please use DefaultNewArchitectureEntryPoint.load() instead of DefaultNewArchitectureEntryPoint.load(turboModulesEnabled=false, fabricEnabled=false, bridgelessEnabled=false)"
+        )
   }
 
   @Test
-  fun isConfigurationValid_withNewArchOn_returnsTrue() {
-    val (isValid, _) =
+  fun isConfigurationValid_withNewArchOnlyOn_returnsFalse() {
+    val (isValid, errorMessage) =
         DefaultNewArchitectureEntryPoint.isConfigurationValid(
             turboModulesEnabled = true,
             fabricEnabled = true,
             bridgelessEnabled = false,
         )
-    assertThat(isValid).isTrue()
+    assertThat(isValid).isFalse()
+    assertThat(errorMessage)
+        .isEqualTo(
+            "You cannot load React Native with the New Architecture disabled. Please use DefaultNewArchitectureEntryPoint.load() instead of DefaultNewArchitectureEntryPoint.load(turboModulesEnabled=true, fabricEnabled=true, bridgelessEnabled=false)"
+        )
   }
 
   @Test
-  fun isConfigurationValid_withTurboModulesOnlyOn_returnsTrue() {
-    val (isValid, _) =
+  fun isConfigurationValid_withTurboModulesOnlyOn_returnsFalse() {
+    val (isValid, errorMessage) =
         DefaultNewArchitectureEntryPoint.isConfigurationValid(
             turboModulesEnabled = true,
             fabricEnabled = false,
             bridgelessEnabled = false,
         )
-    assertThat(isValid).isTrue()
+    assertThat(isValid).isFalse()
+    assertThat(errorMessage)
+        .isEqualTo(
+            "You cannot load React Native with the New Architecture disabled. Please use DefaultNewArchitectureEntryPoint.load() instead of DefaultNewArchitectureEntryPoint.load(turboModulesEnabled=true, fabricEnabled=false, bridgelessEnabled=false)"
+        )
   }
 
   @Test
@@ -67,7 +79,7 @@ class DefaultNewArchitectureEntryPointTest {
     assertThat(isValid).isFalse()
     assertThat(errorMessage)
         .isEqualTo(
-            "fabricEnabled=true requires turboModulesEnabled=true (is now false) - Please update your DefaultNewArchitectureEntryPoint.load() parameters."
+            "You cannot load React Native with the New Architecture disabled. Please use DefaultNewArchitectureEntryPoint.load() instead of DefaultNewArchitectureEntryPoint.load(turboModulesEnabled=false, fabricEnabled=true, bridgelessEnabled=false)"
         )
   }
 
@@ -82,7 +94,7 @@ class DefaultNewArchitectureEntryPointTest {
     assertThat(isValid).isFalse()
     assertThat(errorMessage)
         .isEqualTo(
-            "fabricEnabled=true requires turboModulesEnabled=true (is now false) - Please update your DefaultNewArchitectureEntryPoint.load() parameters."
+            "You cannot load React Native with the New Architecture disabled. Please use DefaultNewArchitectureEntryPoint.load() instead of DefaultNewArchitectureEntryPoint.load(turboModulesEnabled=false, fabricEnabled=true, bridgelessEnabled=true)"
         )
   }
 
@@ -97,7 +109,7 @@ class DefaultNewArchitectureEntryPointTest {
     assertThat(isValid).isFalse()
     assertThat(errorMessage)
         .isEqualTo(
-            "bridgelessEnabled=true requires (turboModulesEnabled=true AND fabricEnabled=true) - Please update your DefaultNewArchitectureEntryPoint.load() parameters."
+            "You cannot load React Native with the New Architecture disabled. Please use DefaultNewArchitectureEntryPoint.load() instead of DefaultNewArchitectureEntryPoint.load(turboModulesEnabled=true, fabricEnabled=false, bridgelessEnabled=true)"
         )
   }
 }


### PR DESCRIPTION
Summary:
This is a commit we're going to pick in 0.82 as we want to make sure users cannot invoke `load()`
from `DefaultNewArchitectureEntryPoint` with flags that are not true,true,true.

Changelog:
[Android] [Changed] - Runtime check that NewArchitecture is enabled in DefaultNewArchitectureEntryPoint

Differential Revision: D82456975


