### PR TITLE
Fix data race condition in NetworkHandler

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkHandler.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkHandler.h
@@ -100,7 +100,7 @@ class NetworkHandler {
   /**
    * @cdp Network.loadingFailed
    */
-  void onLoadingFailed(const std::string& requestId, bool cancelled) const;
+  void onLoadingFailed(const std::string& requestId, bool cancelled);
 
   /**
    * Store the fetched response body for a text or image network response.
@@ -139,8 +139,9 @@ class NetworkHandler {
   FrontendChannel frontendChannel_;
 
   std::map<std::string, std::string> resourceTypeMap_{};
+  std::mutex resourceTypeMapMutex_{};
 
-  BoundedRequestBuffer requestBodyBuffer_{};
+  BoundedRequestBuffer responseBodyBuffer_{};
   std::mutex requestBodyMutex_;
 };
 


### PR DESCRIPTION
Summary:
Fix thread safety issue due to member variable  in `NetworkHandler` singleton without mutex.

Also intend to un-singleton this class in the imminent future.

Changelog: [Internal]

Differential Revision: D82460574


