### PR TITLE
Refactor ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android to enable new arch

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
@@ -98,13 +98,7 @@ public object DefaultNewArchitectureEntryPoint {
         ReactNativeFeatureFlags.override(ReactNativeFeatureFlagsOverrides_RNOSS_Canary_Android())
       }
       ReleaseLevel.STABLE -> {
-        ReactNativeFeatureFlags.override(
-            ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android(
-                fabricEnabled,
-                bridgelessEnabled,
-                turboModulesEnabled,
-            )
-        )
+        ReactNativeFeatureFlags.override(ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android())
       }
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android.kt
@@ -7,16 +7,10 @@
 
 package com.facebook.react.internal.featureflags
 
-public class ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android(
-    private val fabricEnabled: Boolean,
-    private val bridgelessEnabled: Boolean,
-    private val turboModulesEnabled: Boolean,
-) : ReactNativeNewArchitectureFeatureFlagsDefaults(bridgelessEnabled) {
-  override fun useFabricInterop(): Boolean = bridgelessEnabled || fabricEnabled
+public class ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android() :
+    ReactNativeNewArchitectureFeatureFlagsDefaults() {
 
-  override fun enableFabricRenderer(): Boolean = bridgelessEnabled || fabricEnabled
-
-  override fun useTurboModules(): Boolean = bridgelessEnabled || turboModulesEnabled
+  override fun useFabricInterop(): Boolean = true
 
   override fun useShadowNodeStateOnClone(): Boolean = true
 }


### PR DESCRIPTION
Summary:
New architecture should we enabled by default everywhere, Stable releases should use new arch now

changelog: [internal] internal

Reviewed By: cortinico

Differential Revision: D82241551


