### PR TITLE
Refactor ReactNativeNewArchitectureFeatureFlagsDefaults to remove legacy architecture configuration

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
@@ -98,13 +98,7 @@ public object DefaultNewArchitectureEntryPoint {
         ReactNativeFeatureFlags.override(ReactNativeFeatureFlagsOverrides_RNOSS_Canary_Android())
       }
       ReleaseLevel.STABLE -> {
-        ReactNativeFeatureFlags.override(
-            ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android(
-                fabricEnabled,
-                bridgelessEnabled,
-                turboModulesEnabled,
-            )
-        )
+        ReactNativeFeatureFlags.override(ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android())
       }
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android.kt
@@ -7,16 +7,10 @@
 
 package com.facebook.react.internal.featureflags
 
-public class ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android(
-    private val fabricEnabled: Boolean,
-    private val bridgelessEnabled: Boolean,
-    private val turboModulesEnabled: Boolean,
-) : ReactNativeNewArchitectureFeatureFlagsDefaults(bridgelessEnabled) {
-  override fun useFabricInterop(): Boolean = bridgelessEnabled || fabricEnabled
+public class ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android() :
+    ReactNativeNewArchitectureFeatureFlagsDefaults() {
 
-  override fun enableFabricRenderer(): Boolean = bridgelessEnabled || fabricEnabled
-
-  override fun useTurboModules(): Boolean = bridgelessEnabled || turboModulesEnabled
+  override fun useFabricInterop(): Boolean = true
 
   override fun useShadowNodeStateOnClone(): Boolean = true
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeNewArchitectureFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeNewArchitectureFeatureFlagsDefaults.kt
@@ -20,9 +20,11 @@ package com.facebook.react.internal.featureflags
  * When the new architecture is enabled, we want to set the default values of the flags for Fabric,
  * TurboModules and Bridgeless as enabled by default.
  */
-public open class ReactNativeNewArchitectureFeatureFlagsDefaults(
-    private val newArchitectureEnabled: Boolean = true
-) : ReactNativeFeatureFlagsDefaults() {
+public open class ReactNativeNewArchitectureFeatureFlagsDefaults() :
+    ReactNativeFeatureFlagsDefaults() {
+
+  private val newArchitectureEnabled: Boolean = true
+
   override fun enableBridgelessArchitecture(): Boolean = newArchitectureEnabled
 
   override fun enableFabricRenderer(): Boolean = newArchitectureEnabled


### PR DESCRIPTION
Summary:
I'm removing parameter to configure new architecture in ReactNativeNewArchitectureFeatureFlagsDefaults because the new architecture is enabled by default everywhere.

changelog: [internal] internal

Reviewed By: cortinico

Differential Revision: D82241552


