### PR TITLE
Default to including all devDependencies in the Electron build

### DIFF
--- a/scripts/debugger-shell/build-binary.js
+++ b/scripts/debugger-shell/build-binary.js
@@ -97,6 +97,8 @@ async function main() {
       ...IGNORE_PREFIXES.map(prefix => new RegExp('^' + escapeRegex(prefix))),
       ...IGNORE_FILES.map(file => new RegExp('^' + escapeRegex(file) + '$')),
     ],
+    // Include devDependencies in the build.
+    prune: false,
   });
 }
 


### PR DESCRIPTION
Summary:
Adds `prune: false` to the `electron/packager`-based build script for the DevTools standalone shell. This would have stopped D82236159 from causing a regression. We may want to iterate further on a mechanism for keeping the following sets of dependencies separate in `react-native/debugger-shell`:

1. Build-time, Electron-only dependencies (currently in `devDependencies`)
2. Test-only dependencies (currently also in `devDependencies`)
3. Node dependencies (currently in `dependencies`)


Changelog: [Internal]

Reviewed By: vzaidman

Differential Revision: D82538084


