### PR TITLE
Allow EventEmitters to be reported as optional

### DIFF
--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -540,7 +540,7 @@ function buildEventEmitterSchema(
 
   return {
     name: eventemitterName,
-    optional: false,
+    optional: Boolean(property.optional),
     typeAnnotation: {
       type: 'EventEmitterTypeAnnotation',
       typeAnnotation: eventTypeAnnotation,


### PR DESCRIPTION
Summary:
## Changelog:

[General] [Fixed] - Allow `EventEmitter`s to be optional (for push safety)

Reviewed By: javache

Differential Revision: D82509571


