### PR TITLE
add the nodejs type for process.memoryUsage.rss()

### DIFF
--- a/flow-typed/environment/node.js
+++ b/flow-typed/environment/node.js
@@ -3995,13 +3995,16 @@ declare class Process extends events$EventEmitter {
   initgroups?: (user: number | string, extra_group: number | string) => void;
   kill(pid: number, signal?: string | number): void;
   mainModule: Object;
-  memoryUsage(): {
-    arrayBuffers: number,
-    rss: number,
-    heapTotal: number,
-    heapUsed: number,
-    external: number,
-    ...
+  memoryUsage: {
+    (): {
+      arrayBuffers: number,
+      rss: number,
+      heapTotal: number,
+      heapUsed: number,
+      external: number,
+      ...
+    },
+    rss: () => number,
   };
   nextTick: <T>(cb: (...T) => mixed, ...T) => void;
   pid: number;


### PR DESCRIPTION
Summary:
Changelog: [Internal]

https://nodejs.org/docs/latest-v24.x/api/process.html#processmemoryusagerss

Differential Revision: D82550739


