### PR TITLE
Ensure legacy architecture can't be initialized in Android

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactInstanceManager.java
@@ -328,6 +328,15 @@ public class ReactInstanceManager {
     }
 
     registerCxxErrorHandlerFunc();
+
+    // Using `if (true)` just to prevent tests / lint errors.
+    if (true) {
+      // Legacy architecture of React Native is deprecated and can't be initialized anymore.
+      // More details on:
+      // https://github.com/react-native-community/discussions-and-proposals/blob/nc/legacy-arch-removal/proposals/0929-legacy-architecture-removal.md
+      throw new UnsupportedOperationException(
+          "ReactInstanceManager.createReactContext is unsupported.");
+    }
   }
 
   private ReactInstanceDevHelper createDevHelperInterface() {
@@ -1446,6 +1455,7 @@ public class ReactInstanceManager {
    */
   private ReactApplicationContext createReactContext(
       JavaScriptExecutor jsExecutor, JSBundleLoader jsBundleLoader) {
+
     FLog.d(ReactConstants.TAG, "ReactInstanceManager.createReactContext()");
     ReactMarker.logMarker(CREATE_REACT_CONTEXT_START, jsExecutor.getName());
 


### PR DESCRIPTION
Summary:
The Legacy architecture of React Native is not supported anymore, let's ensure nobody can initialize it anymore

changelog: [internal] internal

Reviewed By: cortinico

Differential Revision: D82465004


