### PR TITLE
Fix DefaultNewArchitectureEntryPoint config validation

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
@@ -120,16 +120,16 @@ public object DefaultNewArchitectureEntryPoint {
   internal fun loadWithFeatureFlags(featureFlags: ReactNativeFeatureFlagsProvider) {
     ReactNativeFeatureFlags.override(featureFlags)
 
+    privateFabricEnabled = featureFlags.enableFabricRenderer()
+    privateTurboModulesEnabled = featureFlags.useTurboModules()
+    privateConcurrentReactEnabled = featureFlags.enableFabricRenderer()
+    privateBridgelessEnabled = featureFlags.enableBridgelessArchitecture()
+
     val (isValid, errorMessage) =
         isConfigurationValid(turboModulesEnabled, fabricEnabled, bridgelessEnabled)
     if (!isValid) {
       error(errorMessage)
     }
-
-    privateFabricEnabled = featureFlags.enableFabricRenderer()
-    privateTurboModulesEnabled = featureFlags.useTurboModules()
-    privateConcurrentReactEnabled = featureFlags.enableFabricRenderer()
-    privateBridgelessEnabled = featureFlags.enableBridgelessArchitecture()
 
     DefaultSoLoader.maybeLoadSoLibrary()
   }


### PR DESCRIPTION
Summary:
We need to read the values off feature flags before checking them.

## Changelog
[Internal]

Differential Revision: D82572898


