### PR TITLE
Do not reset the native artifacts version to 1000.0.0 on release branches

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -17,6 +17,9 @@ runs:
     - name: Install node dependencies
       uses: ./.github/actions/yarn-install
     - name: Set React Native Version
+      # We don't want to set the version for stable branches, because this has been
+      # already set from the 'create release' commits on the release branch.
+      if: ${{ !endsWith(github.ref_name, '-stable') }}
       shell: bash
       run: node ./scripts/releases/set-rn-artifacts-version.js --build-type ${{ inputs.release-type }}
     - name: Setup gradle

--- a/scripts/releases-ci/publish-npm.js
+++ b/scripts/releases-ci/publish-npm.js
@@ -25,6 +25,7 @@ const {
 } = require('../releases/utils/release-utils');
 const {REPO_ROOT} = require('../shared/consts');
 const {getPackages} = require('../shared/monorepoUtils');
+const fs = require('fs');
 const path = require('path');
 const yargs = require('yargs');
 
@@ -94,12 +95,24 @@ async function publishNpm(buildType /*: BuildType */) /*: Promise<void> */ {
   const {version, tag} = getNpmInfo(buildType);
 
   // For stable releases, ci job `prepare_package_for_release` handles this
-  if (['dry-run', 'nightly'].includes(buildType)) {
-    if (buildType === 'nightly') {
-      // Set same version for all monorepo packages
-      await setVersion(version);
-      await publishMonorepoPackages(tag);
-    } else {
+  if (buildType === 'nightly') {
+    // Set same version for all monorepo packages
+    await setVersion(version);
+    await publishMonorepoPackages(tag);
+  } else if (buildType === 'dry-run') {
+    // Before updating React Native artifacts versions for dry-run, we check if the version has already been set.
+    // If it has, we don't need to update the artifacts at all (at this will revert them back to 1000.0.0)
+    // If it hasn't, we can update the native artifacts accordingly.
+    const reactNativePackageJson = path.join(
+      REPO_ROOT,
+      'packages',
+      'react-native',
+      'package.json',
+    );
+    const packageJsonContent = fs.readFileSync(reactNativePackageJson, 'utf8');
+    const packageJson = JSON.parse(packageJsonContent);
+
+    if (packageJson.version === '1000.0.0') {
       await updateReactNativeArtifacts(version, buildType);
     }
   }


### PR DESCRIPTION
Summary:
What is currently happening, is that the various commits on the release branches like `0.82-stable` are resetting the version of native artifacts to `1000.0.0-<SHA>`.

The reason is that during the `test-all` workflow, we pass the `dry-run` as release type.
That's to prevent the various tools from calling `npm publish` and so on.

The problem is that on the releases branches, the version was already set at branch cut time.
Therefore, we see the version 1000.0.0 reappearing during Android E2E test in the emulator. Similary this is also affecting iOS prebuilds so I'm attempting to fix it here.

Changelog:
[Internal] [Changed] -

Differential Revision: D82553599


