### PR TITLE
RN: Deprecate `InteractionManager`

### DIFF
--- a/packages/react-native/Libraries/Animated/__tests__/Animated-test.js
+++ b/packages/react-native/Libraries/Animated/__tests__/Animated-test.js
@@ -873,56 +873,6 @@ describe('Animated', () => {
     });
   });
 
-  describe('Animated Interactions', () => {
-    let Animated; // eslint-disable-line no-shadow
-    let InteractionManager;
-
-    beforeEach(() => {
-      jest.mock('../../Interaction/InteractionManager');
-      Animated = require('../Animated').default;
-      InteractionManager =
-        require('../../Interaction/InteractionManager').default;
-    });
-
-    afterEach(() => {
-      jest.unmock('../../Interaction/InteractionManager');
-    });
-
-    it('registers an interaction by default', () => {
-      // $FlowFixMe[prop-missing]
-      InteractionManager.createInteractionHandle.mockReturnValue(777);
-
-      const value = new Animated.Value(0);
-      const callback = jest.fn();
-      Animated.timing(value, {
-        toValue: 100,
-        duration: 100,
-        useNativeDriver: false,
-      }).start(callback);
-      jest.runAllTimers();
-
-      expect(InteractionManager.createInteractionHandle).toBeCalled();
-      expect(InteractionManager.clearInteractionHandle).toBeCalledWith(777);
-      expect(callback).toBeCalledWith({finished: true});
-    });
-
-    it('does not register an interaction when specified', () => {
-      const value = new Animated.Value(0);
-      const callback = jest.fn();
-      Animated.timing(value, {
-        toValue: 100,
-        duration: 100,
-        isInteraction: false,
-        useNativeDriver: false,
-      }).start(callback);
-      jest.runAllTimers();
-
-      expect(InteractionManager.createInteractionHandle).not.toBeCalled();
-      expect(InteractionManager.clearInteractionHandle).not.toBeCalled();
-      expect(callback).toBeCalledWith({finished: true});
-    });
-  });
-
   describe('Animated Tracking', () => {
     it('should track values', () => {
       const value1 = new Animated.Value(0);

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedValue.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedValue.js
@@ -18,7 +18,6 @@ import type {AnimatedNodeConfig} from './AnimatedNode';
 import type AnimatedTracking from './AnimatedTracking';
 
 import NativeAnimatedHelper from '../../../src/private/animated/NativeAnimatedHelper';
-import InteractionManager from '../../Interaction/InteractionManager';
 import AnimatedInterpolation from './AnimatedInterpolation';
 import AnimatedWithChildren from './AnimatedWithChildren';
 
@@ -312,10 +311,6 @@ export default class AnimatedValue extends AnimatedWithChildren {
    * See https://reactnative.dev/docs/animatedvalue#animate
    */
   animate(animation: Animation, callback: ?EndCallback): void {
-    let handle = null;
-    if (animation.__isInteraction) {
-      handle = InteractionManager.createInteractionHandle();
-    }
     const previousAnimation = this._animation;
     this._animation && this._animation.stop();
     this._animation = animation;
@@ -328,9 +323,6 @@ export default class AnimatedValue extends AnimatedWithChildren {
       },
       result => {
         this._animation = null;
-        if (handle !== null) {
-          InteractionManager.clearInteractionHandle(handle);
-        }
         callback && callback(result);
       },
       previousAnimation,

--- a/packages/react-native/Libraries/Interaction/PanResponder.js
+++ b/packages/react-native/Libraries/Interaction/PanResponder.js
@@ -12,7 +12,6 @@
 
 import type {GestureResponderEvent} from '../Types/CoreEventTypes';
 
-const InteractionManager = require('./InteractionManager').default;
 const TouchHistoryMath = require('./TouchHistoryMath').default;
 
 const currentCentroidXOfTouchesChangedAfter =
@@ -30,9 +29,6 @@ const currentCentroidY = TouchHistoryMath.currentCentroidY;
  * `PanResponder` reconciles several touches into a single gesture. It makes
  * single-touch gestures resilient to extra touches, and can be used to
  * recognize simple multi-touch gestures.
- *
- * By default, `PanResponder` holds an `InteractionManager` handle to block
- * long-running JS events from interrupting active gestures.
  *
  * It provides a predictable wrapper of the responder handlers provided by the
  * [gesture responder system](docs/gesture-responder-system.html).
@@ -405,9 +401,6 @@ const PanResponder = {
     getInteractionHandle: () => ?number,
     panHandlers: GestureResponderHandlerMethods,
   } {
-    const interactionState = {
-      handle: (null: ?number),
-    };
     const gestureState: PanResponderGestureState = {
       // Useful for debugging
       stateID: Math.random(),
@@ -464,10 +457,6 @@ const PanResponder = {
       },
 
       onResponderGrant(event: GestureResponderEvent): boolean {
-        if (!interactionState.handle) {
-          interactionState.handle =
-            InteractionManager.createInteractionHandle();
-        }
         gestureState.x0 = currentCentroidX(event.touchHistory);
         gestureState.y0 = currentCentroidY(event.touchHistory);
         gestureState.dx = 0;
@@ -482,21 +471,11 @@ const PanResponder = {
       },
 
       onResponderReject(event: GestureResponderEvent): void {
-        clearInteractionHandle(
-          interactionState,
-          config.onPanResponderReject,
-          event,
-          gestureState,
-        );
+        config.onPanResponderReject?.call(undefined, event, gestureState);
       },
 
       onResponderRelease(event: GestureResponderEvent): void {
-        clearInteractionHandle(
-          interactionState,
-          config.onPanResponderRelease,
-          event,
-          gestureState,
-        );
+        config.onPanResponderRelease?.call(undefined, event, gestureState);
         PanResponder._initializeGestureState(gestureState);
       },
 
@@ -529,21 +508,11 @@ const PanResponder = {
       onResponderEnd(event: GestureResponderEvent): void {
         const touchHistory = event.touchHistory;
         gestureState.numberActiveTouches = touchHistory.numberActiveTouches;
-        clearInteractionHandle(
-          interactionState,
-          config.onPanResponderEnd,
-          event,
-          gestureState,
-        );
+        config.onPanResponderEnd?.call(undefined, event, gestureState);
       },
 
       onResponderTerminate(event: GestureResponderEvent): void {
-        clearInteractionHandle(
-          interactionState,
-          config.onPanResponderTerminate,
-          event,
-          gestureState,
-        );
+        config.onPanResponderTerminate?.call(undefined, event, gestureState);
         PanResponder._initializeGestureState(gestureState);
       },
 
@@ -556,26 +525,12 @@ const PanResponder = {
     return {
       panHandlers,
       getInteractionHandle(): ?number {
-        return interactionState.handle;
+        // TODO: Deprecate and delete this method.
+        return null;
       },
     };
   },
 };
-
-function clearInteractionHandle(
-  interactionState: {handle: ?number, ...},
-  callback: ?(ActiveCallback | PassiveCallback),
-  event: GestureResponderEvent,
-  gestureState: PanResponderGestureState,
-) {
-  if (interactionState.handle) {
-    InteractionManager.clearInteractionHandle(interactionState.handle);
-    interactionState.handle = null;
-  }
-  if (callback) {
-    callback(event, gestureState);
-  }
-}
 
 export type PanResponderInstance = ReturnType<(typeof PanResponder)['create']>;
 

--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -230,6 +230,12 @@ module.exports = {
    * @deprecated
    */
   get InteractionManager() {
+    warnOnce(
+      'interaction-manager-deprecated',
+      'InteractionManager has been deprecated and will be removed in a ' +
+        'future release. Please refactor long tasks into smaller ones, and ' +
+        " use 'requestIdleCallback' instead.",
+    );
     return require('./Libraries/Interaction/InteractionManager').default;
   },
   get Keyboard() {


### PR DESCRIPTION
Summary:
Deprecates `InteractionManager` by adding a warning when it is imported.

Changelog:
[General][Changed] - InteractionManager has been deprecated and no longer respects interaction handles. Instead, it is now recommended to avoid executing long-running JavaScript tasks by breaking them up into smaller tasks and scheduling them using `requestIdleCallback()`.

Differential Revision: D82704809


