### PR TITLE
Always use Hermes artifacts published from Hermes repository

### DIFF
--- a/.github/actions/create-release/action.yml
+++ b/.github/actions/create-release/action.yml
@@ -4,6 +4,12 @@ inputs:
   version:
     description: "The version of React Native we want to release. For example 0.75.0-rc.0"
     required: true
+  hermes-version:
+    description: "The version of Hermes to be used in this release. For example 0.14.0"
+    required: true
+  hermes-v1-version:
+    description: "The version of Hermes V1 to be used in this release. For example 250829098.0.0"
+    required: true
   is-latest-on-npm:
     description: "Whether we want to tag this release as latest on NPM"
     required: true
@@ -28,6 +34,8 @@ runs:
       run: |
         node scripts/releases/create-release-commit.js \
           --reactNativeVersion "${{ inputs.version }}" \
+          --hermesVersion "${{ inputs.hermes-version }}" \
+          --hermesV1Version "${{ inputs.hermes-v1-version }}" \
           --tagAsLatestRelease "${{ inputs.is-latest-on-npm }}" \
           --dryRun "${{ inputs.dry-run }}"
         GIT_PAGER=cat git show HEAD

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -7,6 +7,12 @@ on:
         description: "The version of React Native we want to release. For example 0.75.0-rc.0"
         required: true
         type: string
+      hermes-version:
+        description: "The version of Hermes to be used in this release. For example 0.14.0"
+        required: true
+      hermes-v1-version:
+        description: "The version of Hermes V1 to be used in this release. For example 250829098.0.0"
+        required: true
       is-latest-on-npm:
         description: "Whether we want to tag this release as latest on NPM"
         required: true
@@ -53,5 +59,7 @@ jobs:
         uses: ./.github/actions/create-release
         with:
           version: ${{ inputs.version }}
+          hermes-version: ${{ inputs.hermes-version }}
+          hermes-v1-version: ${{ inputs.hermes-v1-version }}
           is-latest-on-npm: ${{ inputs.is-latest-on-npm }}
           dry-run: ${{ inputs.dry-run }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -135,8 +135,7 @@ if (project.findProperty("react.internal.useHermesNightly")?.toString()?.toBoole
     configurations.all {
       resolutionStrategy.dependencySubstitution {
         substitute(project(":packages:react-native:ReactAndroid:hermes-engine"))
-            // TODO: T237406039 update coordinates
-            .using(module("com.facebook.react:hermes-android:0.+"))
+            .using(module("com.facebook.hermes:hermes-android:0.+"))
             .because("Users opted to use hermes from nightly")
       }
     }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/TaskConfiguration.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/TaskConfiguration.kt
@@ -14,7 +14,6 @@ import com.facebook.react.utils.KotlinStdlibCompatUtils.capitalizeCompat
 import com.facebook.react.utils.NdkConfiguratorUtils.configureJsEnginePackagingOptions
 import com.facebook.react.utils.NdkConfiguratorUtils.configureNewArchPackagingOptions
 import com.facebook.react.utils.ProjectUtils.isHermesEnabled
-import com.facebook.react.utils.ProjectUtils.isHermesV1Enabled
 import com.facebook.react.utils.ProjectUtils.useThirdPartyJSC
 import com.facebook.react.utils.detectedCliFile
 import com.facebook.react.utils.detectedEntryFile
@@ -49,7 +48,6 @@ internal fun Project.configureReactTasks(variant: Variant, config: ReactExtensio
       } else {
         isHermesEnabledInProject
       }
-  val isHermesV1Enabled = project.isHermesV1Enabled || rootProject.isHermesV1Enabled
   val isDebuggableVariant =
       config.debuggableVariants.get().any { it.equals(variant.name, ignoreCase = true) }
   val useThirdPartyJSC = project.useThirdPartyJSC
@@ -80,7 +78,6 @@ internal fun Project.configureReactTasks(variant: Variant, config: ReactExtensio
           task.jsBundleDir.set(jsBundleDir)
           task.resourcesDir.set(resourcesDir)
           task.hermesEnabled.set(isHermesEnabledInThisVariant)
-          task.hermesV1Enabled.set(isHermesV1Enabled)
           task.minifyEnabled.set(!isHermesEnabledInThisVariant)
           task.devEnabled.set(false)
           task.jsIntermediateSourceMapsDir.set(jsIntermediateSourceMapsDir)

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/BundleHermesCTask.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/tasks/BundleHermesCTask.kt
@@ -63,8 +63,6 @@ abstract class BundleHermesCTask : DefaultTask() {
 
   @get:Input abstract val hermesEnabled: Property<Boolean>
 
-  @get:Input abstract val hermesV1Enabled: Property<Boolean>
-
   @get:Input abstract val devEnabled: Property<Boolean>
 
   @get:Input abstract val extraPackagerArgs: ListProperty<String>
@@ -96,8 +94,7 @@ abstract class BundleHermesCTask : DefaultTask() {
     runCommand(bundleCommand)
 
     if (hermesEnabled.get()) {
-      val detectedHermesCommand =
-          detectOSAwareHermesCommand(root.get().asFile, hermesCommand.get(), hermesV1Enabled.get())
+      val detectedHermesCommand = detectOSAwareHermesCommand(root.get().asFile, hermesCommand.get())
       val bytecodeFile = File("${bundleFile}.hbc")
       val outputSourceMap = resolveOutputSourceMap(bundleAssetFilename)
       val compilerSourceMap = resolveCompilerSourceMap(bundleAssetFilename)

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
@@ -191,6 +191,14 @@ internal object DependencyUtils {
               "The hermes-android dependency was modified to use the correct Maven group.",
           )
       )
+    } else if (hermesV1Enabled) {
+      dependencySubstitution.add(
+          Triple(
+              "com.facebook.react:hermes-android",
+              hermesVersionString,
+              "The hermes-android dependency was modified to use Hermes V1.",
+          )
+      )
     }
     return dependencySubstitution
   }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
@@ -14,6 +14,7 @@ import com.facebook.react.utils.PropertyUtils.INCLUDE_JITPACK_REPOSITORY
 import com.facebook.react.utils.PropertyUtils.INCLUDE_JITPACK_REPOSITORY_DEFAULT
 import com.facebook.react.utils.PropertyUtils.INTERNAL_HERMES_PUBLISHING_GROUP
 import com.facebook.react.utils.PropertyUtils.INTERNAL_HERMES_V1_VERSION_NAME
+import com.facebook.react.utils.PropertyUtils.INTERNAL_HERMES_VERSION_NAME
 import com.facebook.react.utils.PropertyUtils.INTERNAL_REACT_NATIVE_MAVEN_LOCAL_REPO
 import com.facebook.react.utils.PropertyUtils.INTERNAL_REACT_PUBLISHING_GROUP
 import com.facebook.react.utils.PropertyUtils.INTERNAL_USE_HERMES_NIGHTLY
@@ -139,11 +140,7 @@ internal object DependencyUtils {
           // Contributors only: The hermes-engine version is forced only if the user has
           // not opted into using nightlies for local development.
           configuration.resolutionStrategy.force(
-              // TODO: T237406039 update coordinates
-              if (hermesV1Enabled)
-                  "${coordinates.hermesGroupString}:hermes-android:${coordinates.hermesV1VersionString}"
-              else
-                  "${coordinates.reactGroupString}:hermes-android:${coordinates.hermesVersionString}"
+              "${coordinates.hermesGroupString}:hermes-android:${coordinates.hermesV1VersionString}"
           )
         }
       }
@@ -154,13 +151,11 @@ internal object DependencyUtils {
       coordinates: Coordinates,
       hermesV1Enabled: Boolean = false,
   ): List<Triple<String, String, String>> {
-    // TODO: T231755027 update coordinates and versioning
     val dependencySubstitution = mutableListOf<Triple<String, String, String>>()
-    // TODO: T237406039 update coordinates
     val hermesVersionString =
         if (hermesV1Enabled)
             "${coordinates.hermesGroupString}:hermes-android:${coordinates.hermesV1VersionString}"
-        else "${coordinates.reactGroupString}:hermes-android:${coordinates.hermesVersionString}"
+        else "${coordinates.hermesGroupString}:hermes-android:${coordinates.hermesVersionString}"
     dependencySubstitution.add(
         Triple(
             "com.facebook.react:react-native",
@@ -183,7 +178,6 @@ internal object DependencyUtils {
               "The react-android dependency was modified to use the correct Maven group.",
           )
       )
-      // TODO: T237406039 update coordinates
       dependencySubstitution.add(
           Triple(
               "com.facebook.react:hermes-android",
@@ -222,11 +216,21 @@ internal object DependencyUtils {
     val hermesGroupString =
         reactAndroidProperties[INTERNAL_HERMES_PUBLISHING_GROUP] as? String
             ?: DEFAULT_INTERNAL_HERMES_PUBLISHING_GROUP
-    // TODO: T237406039 read both versions from the same file
+
     val hermesVersionProperties = Properties()
     hermesVersionFile.inputStream().use { hermesVersionProperties.load(it) }
 
-    val hermesVersion = versionString
+    // TODO: Should this logic related to adding -SNAPSHOT be kept, or should that be set
+    // explicitly in the version string? Remember to also update the logic for iOS
+    val hermesVersionString =
+        (hermesVersionProperties[INTERNAL_HERMES_VERSION_NAME] as? String).orEmpty()
+    val hermesVersion =
+        if (hermesVersionString.startsWith("0.0.0") || "-commitly-" in hermesVersionString) {
+          "$hermesVersionString-SNAPSHOT"
+        } else {
+          hermesVersionString
+        }
+
     val hermesV1Version =
         (hermesVersionProperties[INTERNAL_HERMES_V1_VERSION_NAME] as? String).orEmpty()
 

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
@@ -192,6 +192,7 @@ internal object DependencyUtils {
           )
       )
     } else if (hermesV1Enabled) {
+      // TODO: remove this?
       dependencySubstitution.add(
           Triple(
               "com.facebook.react:hermes-android",

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PathUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PathUtils.kt
@@ -130,7 +130,6 @@ private fun detectCliFile(reactNativeRoot: File, preconfiguredCliFile: File?): F
 internal fun detectOSAwareHermesCommand(
     projectRoot: File,
     hermesCommand: String,
-    hermesV1Enabled: Boolean = false,
 ): String { // 1. If the project specifies a Hermes command, don't second guess it.
   if (hermesCommand.isNotBlank()) {
     val osSpecificHermesCommand =
@@ -151,13 +150,9 @@ internal fun detectOSAwareHermesCommand(
     return builtHermesc.cliPath(projectRoot)
   }
 
-  // 3. If Hermes V1 is enabled, use hermes-compiler from npm, otherwise, if the
-  // react-native contains a pre-built hermesc, use it.
-  // TODO: T237406039 use hermes-compiler from npm for both
-  val hermesCPath = if (hermesV1Enabled) HERMES_COMPILER_NPM_DIR else HERMESC_IN_REACT_NATIVE_DIR
+  // 3. Use hermes-compiler from npm
   val prebuiltHermesPath =
-      hermesCPath
-          .plus(getHermesCBin())
+      HERMES_COMPILER_NPM_DIR.plus(getHermesCBin())
           .replace("%OS-BIN%", getHermesOSBin())
           // Execution on Windows fails with / as separator
           .replace('/', File.separatorChar)
@@ -243,6 +238,5 @@ internal fun readPackageJsonFile(
 }
 
 private const val HERMES_COMPILER_NPM_DIR = "node_modules/hermes-compiler/hermesc/%OS-BIN%/"
-private const val HERMESC_IN_REACT_NATIVE_DIR = "node_modules/react-native/sdks/hermesc/%OS-BIN%/"
 private const val HERMESC_BUILT_FROM_SOURCE_DIR =
     "node_modules/react-native/ReactAndroid/hermes-engine/build/hermes/bin/"

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PathUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PathUtils.kt
@@ -242,7 +242,7 @@ internal fun readPackageJsonFile(
   return packageJson?.let { JsonUtils.fromPackageJson(it) }
 }
 
-private const val HERMES_COMPILER_NPM_DIR = "node_modules/hermes-compiler/%OS-BIN%/"
+private const val HERMES_COMPILER_NPM_DIR = "node_modules/hermes-compiler/hermesc/%OS-BIN%/"
 private const val HERMESC_IN_REACT_NATIVE_DIR = "node_modules/react-native/sdks/hermesc/%OS-BIN%/"
 private const val HERMESC_BUILT_FROM_SOURCE_DIR =
     "node_modules/react-native/ReactAndroid/hermes-engine/build/hermes/bin/"

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PropertyUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PropertyUtils.kt
@@ -81,8 +81,9 @@ object PropertyUtils {
   const val INTERNAL_VERSION_NAME = "VERSION_NAME"
 
   /**
-   * Internal property, shared with iOS, used to control the version name of Hermes Engine. This is
-   * stored in sdks/hermes-engine/version.properties
+   * Internal properties, shared with iOS, used to control the version name of Hermes Engine. They
+   * are stored in sdks/hermes-engine/version.properties
    */
+  const val INTERNAL_HERMES_VERSION_NAME = "HERMES_VERSION_NAME"
   const val INTERNAL_HERMES_V1_VERSION_NAME = "HERMES_V1_VERSION_NAME"
 }

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/DependencyUtilsTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/DependencyUtilsTest.kt
@@ -289,7 +289,7 @@ class DependencyUtilsTest {
     val forcedModules = project.configurations.first().resolutionStrategy.forcedModules
     assertThat(forcedModules.any { it.toString() == "com.facebook.react:react-android:1.2.3" })
         .isTrue()
-    assertThat(forcedModules.any { it.toString() == "com.facebook.react:hermes-android:4.5.6" })
+    assertThat(forcedModules.any { it.toString() == "com.facebook.hermes:hermes-android:4.5.6" })
         .isTrue()
   }
 
@@ -324,11 +324,11 @@ class DependencyUtilsTest {
     val libForcedModules = libProject.configurations.first().resolutionStrategy.forcedModules
     assertThat(appForcedModules.any { it.toString() == "com.facebook.react:react-android:1.2.3" })
         .isTrue()
-    assertThat(appForcedModules.any { it.toString() == "com.facebook.react:hermes-android:4.5.6" })
+    assertThat(appForcedModules.any { it.toString() == "com.facebook.hermes:hermes-android:4.5.6" })
         .isTrue()
     assertThat(libForcedModules.any { it.toString() == "com.facebook.react:react-android:1.2.3" })
         .isTrue()
-    assertThat(libForcedModules.any { it.toString() == "com.facebook.react:hermes-android:4.5.6" })
+    assertThat(libForcedModules.any { it.toString() == "com.facebook.hermes:hermes-android:4.5.6" })
         .isTrue()
   }
 
@@ -381,11 +381,15 @@ class DependencyUtilsTest {
     val libForcedModules = libProject.configurations.first().resolutionStrategy.forcedModules
     assertThat(appForcedModules.any { it.toString() == "io.github.test:react-android:1.2.3" })
         .isTrue()
-    assertThat(appForcedModules.any { it.toString() == "io.github.test:hermes-android:4.5.6" })
+    assertThat(
+            appForcedModules.any { it.toString() == "io.github.test.hermes:hermes-android:4.5.6" }
+        )
         .isTrue()
     assertThat(libForcedModules.any { it.toString() == "io.github.test:react-android:1.2.3" })
         .isTrue()
-    assertThat(libForcedModules.any { it.toString() == "io.github.test:hermes-android:4.5.6" })
+    assertThat(
+            libForcedModules.any { it.toString() == "io.github.test.hermes:hermes-android:4.5.6" }
+        )
         .isTrue()
   }
 
@@ -438,7 +442,7 @@ class DependencyUtilsTest {
         )
         .isEqualTo(dependencySubstitutions[0].third)
     assertThat("com.facebook.react:hermes-engine").isEqualTo(dependencySubstitutions[1].first)
-    assertThat("com.facebook.react:hermes-android:0.42.0")
+    assertThat("com.facebook.hermes:hermes-android:0.42.0")
         .isEqualTo(dependencySubstitutions[1].second)
     assertThat(
             "The hermes-engine artifact was deprecated in favor of hermes-android due to https://github.com/facebook/react-native/issues/35210."
@@ -489,7 +493,7 @@ class DependencyUtilsTest {
             "The react-native artifact was deprecated in favor of react-android due to https://github.com/facebook/react-native/issues/35210."
         )
         .isEqualTo(dependencySubstitutions[0].third)
-    assertThat("com.facebook.react:hermes-engine").isEqualTo(dependencySubstitutions[1].first)
+    assertThat("com.facebook.hermes:hermes-engine").isEqualTo(dependencySubstitutions[1].first)
     assertThat("io.github.test:hermes-android:0.42.0").isEqualTo(dependencySubstitutions[1].second)
     assertThat(
             "The hermes-engine artifact was deprecated in favor of hermes-android due to https://github.com/facebook/react-native/issues/35210."
@@ -499,7 +503,7 @@ class DependencyUtilsTest {
     assertThat("io.github.test:react-android:0.42.0").isEqualTo(dependencySubstitutions[2].second)
     assertThat("The react-android dependency was modified to use the correct Maven group.")
         .isEqualTo(dependencySubstitutions[2].third)
-    assertThat("com.facebook.react:hermes-android").isEqualTo(dependencySubstitutions[3].first)
+    assertThat("com.facebook.hermes:hermes-android").isEqualTo(dependencySubstitutions[3].first)
     assertThat("io.github.test:hermes-android:0.42.0").isEqualTo(dependencySubstitutions[3].second)
     assertThat("The hermes-android dependency was modified to use the correct Maven group.")
         .isEqualTo(dependencySubstitutions[3].third)

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/PathUtilsTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/PathUtilsTest.kt
@@ -155,21 +155,11 @@ class PathUtilsTest {
 
   @Test
   @WithOs(OS.MAC)
-  fun detectOSAwareHermesCommand_withBundledHermescInsideRN() {
-    tempFolder.newFolder("node_modules/react-native/sdks/hermesc/osx-bin/")
-    val expected = tempFolder.newFile("node_modules/react-native/sdks/hermesc/osx-bin/hermesc")
-
-    assertThat(detectOSAwareHermesCommand(tempFolder.root, "")).isEqualTo(expected.toString())
-  }
-
-  @Test
-  @WithOs(OS.MAC)
-  fun detectOSAwareHermesCommand_withHermesV1Enabled() {
+  fun detectOSAwareHermesCommand_withHermescFromNPM() {
     tempFolder.newFolder("node_modules/hermes-compiler/hermesc/osx-bin/")
     val expected = tempFolder.newFile("node_modules/hermes-compiler/hermesc/osx-bin/hermesc")
 
-    assertThat(detectOSAwareHermesCommand(tempFolder.root, "", hermesV1Enabled = true))
-        .isEqualTo(expected.toString())
+    assertThat(detectOSAwareHermesCommand(tempFolder.root, "")).isEqualTo(expected.toString())
   }
 
   @Test(expected = IllegalStateException::class)

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/PathUtilsTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/PathUtilsTest.kt
@@ -165,8 +165,8 @@ class PathUtilsTest {
   @Test
   @WithOs(OS.MAC)
   fun detectOSAwareHermesCommand_withHermesV1Enabled() {
-    tempFolder.newFolder("node_modules/hermes-compiler/osx-bin/")
-    val expected = tempFolder.newFile("node_modules/hermes-compiler/osx-bin/hermesc")
+    tempFolder.newFolder("node_modules/hermes-compiler/hermesc/osx-bin/")
+    val expected = tempFolder.newFile("node_modules/hermes-compiler/hermesc/osx-bin/hermesc")
 
     assertThat(detectOSAwareHermesCommand(tempFolder.root, "", hermesV1Enabled = true))
         .isEqualTo(expected.toString())

--- a/packages/react-native/scripts/hermes/__tests__/hermes-utils-test.js
+++ b/packages/react-native/scripts/hermes/__tests__/hermes-utils-test.js
@@ -22,6 +22,7 @@ const {
   getHermesTagSHA,
   getHermesTarballDownloadPath,
   readHermesTag,
+  readHermesV1Tag,
   setHermesTag,
   shouldUsePrebuiltHermesC,
 } = require('../hermes-utils');
@@ -31,6 +32,7 @@ const os = require('os');
 
 const hermesTag =
   'hermes-2022-04-28-RNv0.69.0-15d07c2edd29a4ea0b8f15ab0588a0c1adb1200f';
+const hermesV1Tag = '250829098.0.0';
 const tarballContents = 'dummy string';
 const hermescContents = 'dummy string';
 const hermesTagSha = '5244f819b2f3949ca94a3a1bf75d54a8ed59d94a';
@@ -183,17 +185,25 @@ describe('hermes-utils', () => {
 
     describe('setHermesTag', () => {
       it('should write tag to .hermesversion file', () => {
-        setHermesTag(hermesTag);
+        setHermesTag(hermesTag, hermesV1Tag);
         expect(
           fs.readFileSync(path.join(SDKS_DIR, '.hermesversion'), {
             encoding: 'utf8',
             flag: 'r',
           }),
         ).toEqual(hermesTag);
+
+        expect(
+          fs.readFileSync(path.join(SDKS_DIR, '.hermesv1version'), {
+            encoding: 'utf8',
+            flag: 'r',
+          }),
+        ).toEqual(hermesV1Tag);
       });
       it('should set Hermes tag and read it back', () => {
-        setHermesTag(hermesTag);
+        setHermesTag(hermesTag, hermesV1Tag);
         expect(readHermesTag()).toEqual(hermesTag);
+        expect(readHermesV1Tag()).toEqual(hermesV1Tag);
       });
     });
 

--- a/packages/react-native/scripts/hermes/bump-hermes-version.js
+++ b/packages/react-native/scripts/hermes/bump-hermes-version.js
@@ -21,20 +21,29 @@ const inquirer = require('inquirer');
 const {exit} = require('shelljs');
 const yargs = require('yargs');
 
-let argv = yargs.option('t', {
-  alias: 'tag',
-  describe:
-    'Hermes release tag to use for this React Native release, ex. hermes-2022-02-21-RNv0.68.0',
-  required: true,
-}).argv;
+let argv = yargs
+  .option('t', {
+    alias: 'tag',
+    describe:
+      'Hermes release tag to use for this React Native release, ex. hermes-2022-02-21-RNv0.68.0',
+    required: true,
+  })
+  .option('s', {
+    alias: 'v1Tag',
+    describe:
+      'Hermes V1 release tag to use for this React Native release, ex. 250829098.0.0',
+    required: true,
+  }).argv;
 
 async function main() {
   // $FlowFixMe[prop-missing]
   const hermesTag = argv.tag;
+  // $FlowFixMe[prop-missing]
+  const hermesV1Tag = argv.v1Tag;
   const {confirmHermesTag} = await inquirer.prompt({
     type: 'confirm',
     name: 'confirmHermesTag',
-    message: `Do you want to use the Hermes release tagged "${hermesTag}"?`,
+    message: `Do you want to use the Hermes release tagged "${hermesTag}" and Hermes V1 release tagged "${hermesV1Tag}"?`,
   });
 
   if (!confirmHermesTag) {
@@ -42,7 +51,7 @@ async function main() {
     return;
   }
 
-  setHermesTag(hermesTag);
+  setHermesTag(hermesTag, hermesV1Tag);
 }
 
 void main().then(() => {

--- a/packages/react-native/scripts/hermes/hermes-utils.js
+++ b/packages/react-native/scripts/hermes/hermes-utils.js
@@ -22,6 +22,7 @@ type BuildType = 'dry-run' | 'release' | 'nightly';
 const SDKS_DIR = path.normalize(path.join(__dirname, '..', '..', 'sdks'));
 const HERMES_DIR = path.join(SDKS_DIR, 'hermes');
 const HERMES_TAG_FILE_PATH = path.join(SDKS_DIR, '.hermesversion');
+const HERMES_V1_TAG_FILE_PATH = path.join(SDKS_DIR, '.hermesv1version');
 const HERMES_SOURCE_TARBALL_BASE_URL =
   'https://github.com/facebook/hermes/tarball/';
 const HERMES_TARBALL_DOWNLOAD_DIR = path.join(SDKS_DIR, 'download');
@@ -66,7 +67,27 @@ function readHermesTag() /*: string */ {
   return 'main';
 }
 
-function setHermesTag(hermesTag /*: string */) {
+function readHermesV1Tag() /*: string */ {
+  if (fs.existsSync(HERMES_V1_TAG_FILE_PATH)) {
+    const data = fs
+      .readFileSync(HERMES_V1_TAG_FILE_PATH, {
+        encoding: 'utf8',
+        flag: 'r',
+      })
+      .trim();
+
+    if (data.length > 0) {
+      return data;
+    } else {
+      throw new Error('[Hermes] .hermesv1version file is empty.');
+    }
+  }
+
+  // TODO: what should be the default here?
+  return 'main';
+}
+
+function setHermesTag(hermesTag /*: string */, hermesV1Tag /*: string */) {
   if (readHermesTag() === hermesTag) {
     // No need to update.
     return;
@@ -76,6 +97,7 @@ function setHermesTag(hermesTag /*: string */) {
     fs.mkdirSync(SDKS_DIR, {recursive: true});
   }
   fs.writeFileSync(HERMES_TAG_FILE_PATH, hermesTag.trim());
+  fs.writeFileSync(HERMES_V1_TAG_FILE_PATH, hermesV1Tag.trim());
   console.log('Hermes tag has been updated. Please commit your changes.');
 }
 
@@ -337,6 +359,7 @@ module.exports = {
   getHermesTarballDownloadPath,
   getHermesPrebuiltArtifactsTarballName,
   readHermesTag,
+  readHermesV1Tag,
   setHermesTag,
   shouldBuildHermesFromSource,
   shouldUsePrebuiltHermesC,

--- a/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
+++ b/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
@@ -80,7 +80,7 @@ Pod::Spec.new do |spec|
       )
 
       spec.user_target_xcconfig = {
-        'HERMES_CLI_PATH' => "#{hermes_compiler_path}/osx-bin/hermesc"
+        'HERMES_CLI_PATH' => "#{hermes_compiler_path}/hermesc/osx-bin/hermesc"
       }
     end
 

--- a/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
+++ b/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
@@ -20,12 +20,14 @@ end
 
 # package.json
 package = JSON.parse(File.read(File.join(react_native_path, "package.json")))
-# TODO: T231755000 read hermes version from version.properties when consuming hermes
-version = package['version']
+versionProperties = Hash[*File.read("version.properties").split(/[=\n]+/)]
 
+# TODO: Should this include the logic related to adding -SNAPSHOT, or should that be set
+# explicitly in the version string? Remember to also update the logic for Android
 if ENV['RCT_HERMES_V1_ENABLED'] == "1"
-  versionProperties = Hash[*File.read("version.properties").split(/[=\n]+/)]
   version = versionProperties['HERMES_V1_VERSION_NAME']
+else
+  version = versionProperties['HERMES_VERSION_NAME']
 end
 
 source_type = hermes_source_type(version, react_native_path)
@@ -70,8 +72,7 @@ Pod::Spec.new do |spec|
 
     # When using the local prebuilt tarball, it should include hermesc compatible with the used VM.
     # In other cases, when using Hermes V1, the prebuilt versioned binaries can be used.
-    # TODO: T236142916 hermesc should be consumed from NPM even when not using Hermes V1
-    if source_type != HermesEngineSourceType::LOCAL_PREBUILT_TARBALL && ENV['RCT_HERMES_V1_ENABLED'] == "1"
+    if source_type != HermesEngineSourceType::LOCAL_PREBUILT_TARBALL
       hermes_compiler_path = File.dirname(Pod::Executable.execute_command('node', ['-p',
         'require.resolve(
         "hermes-compiler",

--- a/packages/react-native/sdks/hermes-engine/hermes-utils.rb
+++ b/packages/react-native/sdks/hermes-engine/hermes-utils.rb
@@ -228,8 +228,8 @@ def release_tarball_url(version, build_type)
     if hermes_v1_enabled()
         namespace = "com/facebook/hermes"
         # Sample url from Maven:
-        # https://repo1.maven.org/maven2/com/facebook/hermes/hermes-ios/0.14.0/hermes-ios-0.14.0-debug.tar.gz
-        return "#{maven_repo_url}/#{namespace}/hermes-ios/#{version}/hermes-ios-#{version}-#{build_type.to_s}.tar.gz"
+        # https://repo1.maven.org/maven2/com/facebook/hermes/hermes-ios/0.14.0/hermes-ios-0.14.0-hermes-ios-debug.tar.gz
+        return "#{maven_repo_url}/#{namespace}/hermes-ios/#{version}/hermes-ios-#{version}-hermes-ios-#{build_type.to_s}.tar.gz"
     else
         namespace = "com/facebook/react"
         # Sample url from Maven:

--- a/packages/react-native/sdks/hermes-engine/hermes-utils.rb
+++ b/packages/react-native/sdks/hermes-engine/hermes-utils.rb
@@ -225,17 +225,10 @@ def release_tarball_url(version, build_type)
         ENV['ENTERPRISE_REPOSITORY'] :
         "https://repo1.maven.org/maven2"
 
-    if hermes_v1_enabled()
-        namespace = "com/facebook/hermes"
-        # Sample url from Maven:
-        # https://repo1.maven.org/maven2/com/facebook/hermes/hermes-ios/0.14.0/hermes-ios-0.14.0-hermes-ios-debug.tar.gz
-        return "#{maven_repo_url}/#{namespace}/hermes-ios/#{version}/hermes-ios-#{version}-hermes-ios-#{build_type.to_s}.tar.gz"
-    else
-        namespace = "com/facebook/react"
-        # Sample url from Maven:
-        # https://repo1.maven.org/maven2/com/facebook/react/react-native-artifacts/0.71.0/react-native-artifacts-0.71.0-hermes-ios-debug.tar.gz
-        return "#{maven_repo_url}/#{namespace}/react-native-artifacts/#{version}/react-native-artifacts-#{version}-hermes-ios-#{build_type.to_s}.tar.gz"
-    end
+    namespace = "com/facebook/hermes"
+    # Sample url from Maven:
+    # https://repo1.maven.org/maven2/com/facebook/hermes/hermes-ios/0.14.0/hermes-ios-0.14.0-hermes-ios-debug.tar.gz
+    return "#{maven_repo_url}/#{namespace}/hermes-ios/#{version}/hermes-ios-#{version}-hermes-ios-#{build_type.to_s}.tar.gz"
 end
 
 def download_stable_hermes(react_native_path, version, configuration)
@@ -257,16 +250,9 @@ def download_hermes_tarball(react_native_path, tarball_url, version, configurati
 end
 
 def nightly_tarball_url(version)
-  # TODO: T231755027 update coordinates and versioning
-  artifact_coordinate = "react-native-artifacts"
+  artifact_coordinate = "hermes-ios"
   artifact_name = "hermes-ios-debug.tar.gz"
-  namespace = "com/facebook/react"
-
-  if hermes_v1_enabled()
-    artifact_coordinate = "hermes-ios"
-    artifact_name = "hermes-ios-debug.tar.gz"
-    namespace = "com/facebook/hermes"
-  end
+  namespace = "com/facebook/hermes"
 
   xml_url = "https://central.sonatype.com/repository/maven-snapshots/#{namespace}/#{artifact_coordinate}/#{version}-SNAPSHOT/maven-metadata.xml"
 

--- a/packages/react-native/settings.gradle.kts
+++ b/packages/react-native/settings.gradle.kts
@@ -38,3 +38,26 @@ project(":packages:react-native:ReactAndroid:hermes-engine").projectDir =
 project(":packages").projectDir = file("/tmp")
 
 project(":packages:react-native").projectDir = file("/tmp")
+
+// Gradle properties defined in `gradle.properties` are not inherited by
+// included builds, see https://github.com/gradle/gradle/issues/2534.
+// This is a workaround to read the configuration from the consuming project,
+// and apply relevant properties to the :react-native project.
+buildscript {
+  val properties = java.util.Properties()
+  val propertiesToInherit = listOf("hermesV1Enabled", "react.hermesV1Enabled")
+
+  try {
+    file("../../android/gradle.properties").inputStream().use { properties.load(it) }
+
+    gradle.rootProject {
+      propertiesToInherit.forEach { property ->
+        if (properties.containsKey(property)) {
+          gradle.rootProject.extra.set(property, properties.getProperty(property))
+        }
+      }
+    }
+  } catch (e: Exception) {
+    // fail silently
+  }
+}

--- a/scripts/releases-ci/publish-npm.js
+++ b/scripts/releases-ci/publish-npm.js
@@ -15,9 +15,16 @@ import type {BuildType} from '../releases/utils/version-utils';
 */
 
 const {
+  updateHermesCompilerVersion,
+  updateHermesRuntimeDependenciesVersions,
+} = require('../releases/set-hermes-versions');
+const {
   updateReactNativeArtifacts,
 } = require('../releases/set-rn-artifacts-version');
 const {setVersion} = require('../releases/set-version');
+const {
+  getLatestHermesNightlyVersion,
+} = require('../releases/utils/hermes-utils');
 const {getNpmInfo, publishPackage} = require('../releases/utils/npm-utils');
 const {
   publishAndroidArtifactsToMaven,
@@ -95,6 +102,14 @@ async function publishNpm(buildType /*: BuildType */) /*: Promise<void> */ {
 
   // For stable releases, ci job `prepare_package_for_release` handles this
   if (['dry-run', 'nightly'].includes(buildType)) {
+    // Set hermes versions to latest available
+    const hermesVersions = await getLatestHermesNightlyVersion();
+    await updateHermesCompilerVersion(hermesVersions.compilerVersion);
+    await updateHermesRuntimeDependenciesVersions(
+      hermesVersions.runtimeVersion,
+      hermesVersions.runtimeV1Version,
+    );
+
     if (buildType === 'nightly') {
       // Set same version for all monorepo packages
       await setVersion(version);

--- a/scripts/releases/__tests__/__fixtures__/set-hermes-versions/package.json
+++ b/scripts/releases/__tests__/__fixtures__/set-hermes-versions/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@react-native/monorepo",
+  "private": true,
+  "version": "1000.0.0"
+}

--- a/scripts/releases/__tests__/__fixtures__/set-hermes-versions/packages/react-native/package.json
+++ b/scripts/releases/__tests__/__fixtures__/set-hermes-versions/packages/react-native/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "react-native",
+  "version": "1000.0.0",
+  "description": "fake react native package",
+  "dependencies": {
+    "hermes-compiler": "0.0.0"
+  }
+}

--- a/scripts/releases/__tests__/__snapshots__/set-hermes-versions-test.js.snap
+++ b/scripts/releases/__tests__/__snapshots__/set-hermes-versions-test.js.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`setHermesVersions updates monorepo for with hermes runtime and compiler versons separately: set-hermes-versions/package.json 1`] = `
+"{
+  \\"name\\": \\"@react-native/monorepo\\",
+  \\"private\\": true,
+  \\"version\\": \\"1000.0.0\\"
+}
+"
+`;
+
+exports[`setHermesVersions updates monorepo for with hermes runtime and compiler versons separately: set-hermes-versions/packages/react-native/package.json 1`] = `
+"{
+  \\"name\\": \\"react-native\\",
+  \\"version\\": \\"1000.0.0\\",
+  \\"description\\": \\"fake react native package\\",
+  \\"dependencies\\": {
+    \\"hermes-compiler\\": \\"0.1.0\\"
+  }
+}
+"
+`;
+
+exports[`setHermesVersions updates monorepo for with hermes runtime and compiler versons separately: set-hermes-versions/packages/react-native/sdks/hermes-engine/version.properties 1`] = `
+"HERMES_VERSION_NAME=0.14.0
+HERMES_V1_VERSION_NAME=250829098.0.0
+"
+`;
+
+exports[`setHermesVersions updates monorepo for with set hermes versions: set-hermes-versions/package.json 1`] = `
+"{
+  \\"name\\": \\"@react-native/monorepo\\",
+  \\"private\\": true,
+  \\"version\\": \\"1000.0.0\\"
+}
+"
+`;
+
+exports[`setHermesVersions updates monorepo for with set hermes versions: set-hermes-versions/packages/react-native/package.json 1`] = `
+"{
+  \\"name\\": \\"react-native\\",
+  \\"version\\": \\"1000.0.0\\",
+  \\"description\\": \\"fake react native package\\",
+  \\"dependencies\\": {
+    \\"hermes-compiler\\": \\"0.14.0\\"
+  }
+}
+"
+`;
+
+exports[`setHermesVersions updates monorepo for with set hermes versions: set-hermes-versions/packages/react-native/sdks/hermes-engine/version.properties 1`] = `
+"HERMES_VERSION_NAME=0.14.0
+HERMES_V1_VERSION_NAME=250829098.0.0
+"
+`;

--- a/scripts/releases/__tests__/set-hermes-versions-test.js
+++ b/scripts/releases/__tests__/set-hermes-versions-test.js
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+const {
+  setHermesVersions,
+  updateHermesCompilerVersion,
+  updateHermesRuntimeDependenciesVersions,
+} = require('../set-hermes-versions');
+const path = require('path');
+
+jest.mock('../../shared/consts', () => ({
+  REPO_ROOT: path.join(__dirname, '__fixtures__', 'set-hermes-versions'),
+  PACKAGES_DIR: path.join(
+    __dirname,
+    '__fixtures__',
+    'set-hermes-versions',
+    'packages',
+  ),
+  REACT_NATIVE_PACKAGE_DIR: path.join(
+    __dirname,
+    '__fixtures__',
+    'set-hermes-versions',
+    'packages',
+    'react-native',
+  ),
+}));
+
+const writeFileMock = jest.fn().mockImplementation((filePath, content) => {
+  const normalizedFilePath = path
+    .relative(path.join(__dirname, '__fixtures__'), filePath)
+    .split(path.sep)
+    .join('/');
+
+  expect(content).toMatchSnapshot(normalizedFilePath);
+});
+
+describe('setHermesVersions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  beforeAll(() => {
+    jest.mock('fs', () => {
+      // $FlowFixMe[underconstrained-implicit-instantiation]
+      const originalFs = jest.requireActual('fs');
+
+      return {
+        ...originalFs,
+        writeFileSync: writeFileMock,
+        promises: {
+          ...originalFs.promises,
+          writeFile: writeFileMock,
+        },
+      };
+    });
+  });
+
+  test('updates monorepo for with set hermes versions', async () => {
+    await setHermesVersions('0.14.0', '250829098.0.0');
+  });
+
+  test('updates monorepo for with hermes runtime and compiler versons separately', async () => {
+    await updateHermesCompilerVersion('0.1.0');
+    await updateHermesRuntimeDependenciesVersions('0.14.0', '250829098.0.0');
+  });
+});

--- a/scripts/releases/create-release-commit.js
+++ b/scripts/releases/create-release-commit.js
@@ -8,6 +8,7 @@
  * @format
  */
 
+const {setHermesVersions} = require('../releases/set-hermes-versions');
 const {setVersion} = require('../releases/set-version');
 const {getBranchName} = require('../releases/utils/scm-utils');
 const {
@@ -21,6 +22,16 @@ async function main() {
   const argv = await yargs
     .option('reactNativeVersion', {
       describe: 'The new React Native version.',
+      type: 'string',
+      required: true,
+    })
+    .option('hermesVersion', {
+      describe: 'Version of Hermes to use in this release.',
+      type: 'string',
+      required: true,
+    })
+    .option('hermesV1Version', {
+      describe: 'Version of Hermes V1 to use in this release.',
       type: 'string',
       required: true,
     })
@@ -38,6 +49,8 @@ async function main() {
 
   const buildType = 'release';
   const version = argv.reactNativeVersion;
+  const hermesVersion = argv.hermesVersion;
+  const hermesV1Version = argv.hermesV1Version;
   const latest = argv.tagAsLatestRelease;
   const dryRun = argv.dryRun;
   const branch = getBranchName();
@@ -51,6 +64,9 @@ async function main() {
 
   console.info('Setting version for monorepo packages and react-native');
   await setVersion(version, false); // version, skip-react-native
+
+  console.info('Setting Hermes versions');
+  await setHermesVersions(hermesVersion, hermesV1Version);
 
   console.info('Writing release asset URLs to DotSlash files');
   await writeReleaseAssetUrlsToDotSlashFiles(version);

--- a/scripts/releases/set-hermes-versions.js
+++ b/scripts/releases/set-hermes-versions.js
@@ -1,0 +1,130 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+const {REACT_NATIVE_PACKAGE_DIR} = require('../shared/consts');
+const {
+  getPackages,
+  getWorkspaceRoot,
+  updatePackageJson,
+} = require('../shared/monorepoUtils');
+const {promises: fs} = require('fs');
+const path = require('path');
+const {parseArgs} = require('util');
+
+const MAVEN_VERSIONS_FILE_PATH = path.join(
+  REACT_NATIVE_PACKAGE_DIR,
+  'sdks',
+  'hermes-engine',
+  'version.properties',
+);
+
+const config = {
+  options: {
+    'hermes-version': {
+      type: 'string',
+      short: 'h',
+    },
+    'hermes-v1-version': {
+      type: 'string',
+      short: 's',
+    },
+    help: {type: 'boolean'},
+  },
+};
+
+/**
+ * @deprecated This script entry point is deprecated. Please use `set-version`
+ * instead.
+ */
+async function main() {
+  const {
+    values: {
+      help,
+      'hermes-version': hermesVersion,
+      'hermes-v1-version': hermesV1Version,
+    },
+    /* $FlowFixMe[incompatible-type] Natural Inference rollout. See
+     * https://fburl.com/workplace/6291gfvu */
+  } = parseArgs(config);
+
+  if (help) {
+    console.log(`
+  Usage: node ./scripts/releases/set-hermes-versions.js [OPTIONS]
+
+  Updates relevant files, including package.json, in the react-native
+  package to change the Hermes versions.
+
+  Options:
+    --hermes-version       The new Hermes version string.
+    --hermes-v1-version    The new Hermes v1 version string.
+    `);
+    return;
+  }
+
+  if (!hermesVersion) {
+    throw new Error('Missing --hermes-version argument');
+  }
+
+  if (!hermesV1Version) {
+    throw new Error('Missing --hermes-v1-version argument');
+  }
+
+  await setHermesVersions(hermesVersion, hermesV1Version);
+}
+
+async function setHermesVersions(
+  hermesVersion /*: string */,
+  hermesV1Version /*: string */,
+) /*: Promise<void> */ {
+  await updateHermesCompilerVersion(hermesVersion);
+  await updateHermesRuntimeDependenciesVersions(hermesVersion, hermesV1Version);
+}
+
+async function updateHermesCompilerVersion(
+  hermesVersion /*: string */,
+) /*: Promise<void> */ {
+  const packages = await getPackages({
+    includePrivate: true,
+    includeReactNative: true,
+  });
+
+  const packagesToUpdate = [
+    await getWorkspaceRoot(),
+    ...Object.values(packages),
+  ];
+
+  // Update generated files in packages/react-native/
+  await Promise.all(
+    packagesToUpdate.map(pkg =>
+      updatePackageJson(pkg, {'hermes-compiler': hermesVersion}),
+    ),
+  );
+}
+
+async function updateHermesRuntimeDependenciesVersions(
+  hermesVersion /*: string */,
+  hermesV1Version /*: string */,
+) /*: Promise<void> */ {
+  const newVersionsFile =
+    `HERMES_VERSION_NAME=${hermesVersion}\n` +
+    `HERMES_V1_VERSION_NAME=${hermesV1Version}`;
+
+  await fs.writeFile(MAVEN_VERSIONS_FILE_PATH, newVersionsFile.trim() + '\n');
+}
+
+module.exports = {
+  updateHermesCompilerVersion,
+  updateHermesRuntimeDependenciesVersions,
+  setHermesVersions,
+};
+
+if (require.main === module) {
+  void main();
+}

--- a/scripts/releases/set-rn-artifacts-version.js
+++ b/scripts/releases/set-rn-artifacts-version.js
@@ -155,8 +155,6 @@ function updateTestFiles(
 async function updateGradleFile(version /*: string */) /*: Promise<void> */ {
   const contents = await fs.readFile(GRADLE_FILE_PATH, 'utf-8');
 
-  // TODO: T231755027 set HERMES_VERSION_NAME
-
   return fs.writeFile(
     GRADLE_FILE_PATH,
     contents.replace(/^VERSION_NAME=.*/, `VERSION_NAME=${version}`),

--- a/scripts/releases/utils/hermes-utils.js
+++ b/scripts/releases/utils/hermes-utils.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+const {getLatestMavenSnapshotVersion} = require('./maven-utils');
+const {getPackageVersionStrByTag} = require('./npm-utils');
+
+async function getLatestHermesNightlyVersion() /*: Promise<{
+  compilerVersion: string,
+  runtimeVersion: string,
+  runtimeV1Version: string,
+}> */ {
+  const compilerVersion = await getPackageVersionStrByTag(
+    'hermes-compiler',
+    'nightly',
+  );
+  const runtimeVersion = await getLatestMavenSnapshotVersion(
+    'com.facebook.hermes',
+    'hermes-android',
+  );
+
+  // TODO: also fetch latest Hermes V1 runtime version
+
+  return {
+    compilerVersion,
+    runtimeVersion,
+    runtimeV1Version: '250829098.0.0',
+  };
+}
+
+module.exports = {
+  getLatestHermesNightlyVersion,
+};

--- a/scripts/releases/utils/maven-utils.js
+++ b/scripts/releases/utils/maven-utils.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+const {getWithCurl} = require('./curl-utils');
+
+async function getLatestMavenSnapshotVersion(
+  groupId /*: string */,
+  artifactId /*: string */,
+  repository /*: string */ = 'https://central.sonatype.com/repository/maven-snapshots',
+) /*: Promise<string> */ {
+  const groupPath = groupId.replace(/\./g, '/');
+  const metadataUrl = `${repository}/${groupPath}/${artifactId}/maven-metadata.xml`;
+  const {data} = await getWithCurl(metadataUrl);
+  const xml = data.toString('utf8');
+
+  const regex = new RegExp(`<latest>([^<]+)</latest>`);
+  const match = xml.match(regex);
+
+  if (!match) {
+    throw new Error(
+      `Failed to find latest version for ${groupId}:${artifactId} in ${metadataUrl}`,
+    );
+  }
+
+  return match[1];
+}
+
+module.exports = {
+  getLatestMavenSnapshotVersion,
+};

--- a/scripts/releases/utils/npm-utils.js
+++ b/scripts/releases/utils/npm-utils.js
@@ -174,4 +174,5 @@ function getPackageVersionStrByTag(
 module.exports = {
   getNpmInfo,
   publishPackage,
+  getPackageVersionStrByTag,
 };

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -44,26 +44,3 @@ configure<com.facebook.react.ReactSettingsExtension> {
       lockFiles = files("yarn.lock"),
   )
 }
-
-// Gradle properties defined in `gradle.properties` are not inherited by
-// included builds, see https://github.com/gradle/gradle/issues/2534.
-// This is a workaround to read the configuration from the consuming project,
-// and apply relevant properties to the :react-native project.
-buildscript {
-  val properties = java.util.Properties()
-  val propertiesToInherit = listOf("hermesV1Enabled", "react.hermesV1Enabled")
-
-  try {
-    file("../../android/gradle.properties").inputStream().use { properties.load(it) }
-
-    gradle.rootProject {
-      propertiesToInherit.forEach { property ->
-        if (properties.containsKey(property)) {
-          gradle.rootProject.extra.set(property, properties.getProperty(property))
-        }
-      }
-    }
-  } catch (e: Exception) {
-    // fail silently
-  }
-}


### PR DESCRIPTION
Summary: Changelog: [GENERAL][CHANGED] - Use Hermes artifacts published independently from React Native

Differential Revision: D82626463
