### PR TITLE
fix C++ in-code docs comments to silence warnings

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
@@ -357,7 +357,7 @@ class HostAgent::Impl final {
 
   /**
    * Send a simple Log.entryAdded notification with the given
-   * \param text. You must ensure that the frontend has enabled Log
+   * \param text You must ensure that the frontend has enabled Log
    * notifications (using Log.enable) prior to calling this function. In Chrome
    * DevTools, the message will appear in the Console tab along with regular
    * console messages. The difference between Log.entryAdded and

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSSyntaxParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSSyntaxParser.h
@@ -147,7 +147,7 @@ class CSSSyntaxParser {
    *
    * https://www.w3.org/TR/css-syntax-3/#consume-component-value
    *
-   * @param <ReturnT> caller-specified return type of visitors. This type will
+   * @tparam ReturnT caller-specified return type of visitors. This type will
    * be set to its default constructed state if consuming a component value with
    * no matching visitors, or syntax error
    * @param visitors A unique list of CSSComponentValueVisitor to be called on a


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Address invalid C++ in-code docs comments to silence few warnings. Ref:
* https://www.doxygen.nl/manual/commands.html#cmdtparam

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[INTERNAL][FIXED] - Address invalid C++ in-code docs comments to silence the warnings.

## Test Plan:

Building RNTester app locally does not output the warnings related to in-code docs comments.
