### PR TITLE
Fix scroll view FPS listener reset on init

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -166,7 +166,6 @@ public class ReactScrollView extends ScrollView
     mRemoveClippedSubviews = false;
     mScrollEnabled = true;
     mSendMomentumEvents = false;
-    mFpsListener = null;
     mScrollPerfTag = null;
     mEndBackground = null;
     mEndFillColor = Color.TRANSPARENT;


### PR DESCRIPTION
Summary:
The FPS listener is being assigned to all scroll view instances by the scroll view manager. This listener should not be reset when the view is being recycled and should stay assigned at all times.

Changelog: [Internal]

Differential Revision: D82720151


