### PR TITLE
Improve Network trace event field coverage

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -148,7 +148,8 @@ class PerformanceTracer {
       HighResTimeStamp start,
       int statusCode,
       const Headers& headers,
-      int encodedDataLength);
+      int encodedDataLength,
+      folly::dynamic timingData);
 
   /**
    * Record a "ResourceFinish" event. Paired with other "Resource*" events,
@@ -158,7 +159,9 @@ class PerformanceTracer {
    */
   void reportResourceFinish(
       const std::string& devtoolsRequestId,
-      HighResTimeStamp start);
+      HighResTimeStamp start,
+      int encodedDataLength,
+      int decodedBodyLength);
 
   /**
    * Creates "Profile" Trace Event.
@@ -233,13 +236,6 @@ class PerformanceTracer {
     HighResTimeStamp createdAt = HighResTimeStamp::now();
   };
 
-  struct PerformanceTracerResourceWillSendRequest {
-    std::string requestId;
-    HighResTimeStamp start;
-    ThreadId threadId;
-    HighResTimeStamp createdAt = HighResTimeStamp::now();
-  };
-
   struct PerformanceTracerResourceSendRequest {
     std::string requestId;
     std::string url;
@@ -253,6 +249,8 @@ class PerformanceTracer {
   struct PerformanceTracerResourceFinish {
     std::string requestId;
     HighResTimeStamp start;
+    int encodedDataLength;
+    int decodedBodyLength;
     ThreadId threadId;
     HighResTimeStamp createdAt = HighResTimeStamp::now();
   };
@@ -265,6 +263,7 @@ class PerformanceTracer {
     std::string mimeType;
     std::string protocol;
     int statusCode;
+    folly::dynamic timing;
     ThreadId threadId;
     HighResTimeStamp createdAt = HighResTimeStamp::now();
   };
@@ -275,7 +274,6 @@ class PerformanceTracer {
       PerformanceTracerEventEventLoopMicrotask,
       PerformanceTracerEventMark,
       PerformanceTracerEventMeasure,
-      PerformanceTracerResourceWillSendRequest,
       PerformanceTracerResourceSendRequest,
       PerformanceTracerResourceReceiveResponse,
       PerformanceTracerResourceFinish>;

--- a/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.cpp
@@ -75,6 +75,9 @@ NativePerformanceEntry toNativePerformanceEntry(const PerformanceEntry& entry) {
     nativeEntry.responseStart = resourceEntry.responseStart;
     nativeEntry.responseEnd = resourceEntry.responseEnd;
     nativeEntry.responseStatus = resourceEntry.responseStatus;
+    nativeEntry.contentType = resourceEntry.contentType;
+    nativeEntry.encodedBodySize = resourceEntry.encodedBodySize;
+    nativeEntry.decodedBodySize = resourceEntry.decodedBodySize;
   }
 
   return nativeEntry;

--- a/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/webperformance/NativePerformance.h
@@ -68,6 +68,9 @@ struct NativePerformanceEntry {
   std::optional<HighResTimeStamp> responseStart;
   std::optional<HighResTimeStamp> responseEnd;
   std::optional<int> responseStatus;
+  std::optional<std::string> contentType;
+  std::optional<int> encodedBodySize;
+  std::optional<int> decodedBodySize;
 };
 
 template <>

--- a/packages/react-native/ReactCommon/react/networking/NetworkReporter.h
+++ b/packages/react-native/ReactCommon/react/networking/NetworkReporter.h
@@ -33,7 +33,10 @@ struct ResourceTimingData {
   std::optional<HighResTimeStamp> connectStart;
   std::optional<HighResTimeStamp> connectEnd;
   std::optional<HighResTimeStamp> responseStart;
-  std::optional<int> responseStatus;
+  int responseStatus = 0;
+  std::string contentType;
+  int encodedBodySize = 0;
+  int decodedBodySize = 0;
 };
 
 /**

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntry.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntry.h
@@ -69,7 +69,10 @@ struct PerformanceResourceTiming : AbstractPerformanceEntry {
   std::optional<HighResTimeStamp> responseStart;
   /** Aligns with `duration`. */
   std::optional<HighResTimeStamp> responseEnd;
-  std::optional<int> responseStatus;
+  int responseStatus;
+  std::string contentType;
+  int encodedBodySize;
+  int decodedBodySize;
 };
 
 using PerformanceEntry = std::variant<

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.cpp
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.cpp
@@ -307,7 +307,10 @@ void PerformanceEntryReporter::reportResourceTiming(
     std::optional<HighResTimeStamp> connectEnd,
     HighResTimeStamp responseStart,
     HighResTimeStamp responseEnd,
-    const std::optional<int>& responseStatus) {
+    int responseStatus,
+    const std::string& contentType,
+    int encodedBodySize,
+    int decodedBodySize) {
   const auto entry = PerformanceResourceTiming{
       {.name = url, .startTime = fetchStart},
       fetchStart,
@@ -317,6 +320,9 @@ void PerformanceEntryReporter::reportResourceTiming(
       responseStart,
       responseEnd,
       responseStatus,
+      contentType,
+      encodedBodySize,
+      decodedBodySize,
   };
 
   // Add to buffers & notify observers

--- a/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.h
+++ b/packages/react-native/ReactCommon/react/performance/timeline/PerformanceEntryReporter.h
@@ -118,7 +118,10 @@ class PerformanceEntryReporter {
       std::optional<HighResTimeStamp> connectEnd,
       HighResTimeStamp responseStart,
       HighResTimeStamp responseEnd,
-      const std::optional<int>& responseStatus);
+      int responseStatus,
+      const std::string& contentType,
+      int encodedBodySize,
+      int decodedBodySize);
 
  private:
   std::unique_ptr<PerformanceObserverRegistry> observerRegistry_;

--- a/packages/react-native/src/private/webapis/performance/ResourceTiming.js
+++ b/packages/react-native/src/private/webapis/performance/ResourceTiming.js
@@ -25,7 +25,10 @@ export type PerformanceResourceTimingJSON = {
   connectEnd: DOMHighResTimeStamp,
   responseStart: DOMHighResTimeStamp,
   responseEnd: DOMHighResTimeStamp,
-  responseStatus: ?number,
+  responseStatus: number,
+  contentType: string,
+  encodedBodySize: number,
+  decodedBodySize: number,
   ...
 };
 
@@ -39,7 +42,10 @@ export interface PerformanceResourceTimingInit {
   +connectEnd: DOMHighResTimeStamp;
   +responseStart: DOMHighResTimeStamp;
   +responseEnd: DOMHighResTimeStamp;
-  +responseStatus?: number;
+  +responseStatus: number;
+  +contentType: string;
+  +encodedBodySize: number;
+  +decodedBodySize: number;
 }
 
 export class PerformanceResourceTiming extends PerformanceEntry {
@@ -49,7 +55,10 @@ export class PerformanceResourceTiming extends PerformanceEntry {
   #connectEnd: DOMHighResTimeStamp;
   #responseStart: DOMHighResTimeStamp;
   #responseEnd: DOMHighResTimeStamp;
-  #responseStatus: ?number;
+  #responseStatus: number;
+  #contentType: string;
+  #encodedBodySize: number;
+  #decodedBodySize: number;
 
   constructor(init: PerformanceResourceTimingInit) {
     super('resource', init);
@@ -61,6 +70,9 @@ export class PerformanceResourceTiming extends PerformanceEntry {
     this.#responseStart = init.responseStart;
     this.#responseEnd = init.responseEnd;
     this.#responseStatus = init.responseStatus;
+    this.#contentType = init.contentType;
+    this.#encodedBodySize = init.encodedBodySize;
+    this.#decodedBodySize = init.decodedBodySize;
   }
 
   get fetchStart(): DOMHighResTimeStamp {
@@ -87,8 +99,20 @@ export class PerformanceResourceTiming extends PerformanceEntry {
     return this.#responseEnd;
   }
 
-  get responseStatus(): ?number {
+  get responseStatus(): number {
     return this.#responseStatus;
+  }
+
+  get contentType(): string {
+    return this.#contentType;
+  }
+
+  get encodedBodySize(): number {
+    return this.#encodedBodySize;
+  }
+
+  get decodedBodySize(): number {
+    return this.#decodedBodySize;
   }
 
   toJSON(): PerformanceResourceTimingJSON {
@@ -101,6 +125,9 @@ export class PerformanceResourceTiming extends PerformanceEntry {
       responseStart: this.#responseStart,
       responseEnd: this.#responseEnd,
       responseStatus: this.#responseStatus,
+      contentType: this.contentType,
+      encodedBodySize: this.encodedBodySize,
+      decodedBodySize: this.decodedBodySize,
     };
   }
 }

--- a/packages/react-native/src/private/webapis/performance/internals/RawPerformanceEntry.js
+++ b/packages/react-native/src/private/webapis/performance/internals/RawPerformanceEntry.js
@@ -68,7 +68,10 @@ export function rawToPerformanceEntry(
         connectEnd: entry.connectEnd ?? 0,
         responseStart: entry.responseStart ?? 0,
         responseEnd: entry.responseEnd ?? 0,
-        responseStatus: entry.responseStatus,
+        responseStatus: entry.responseStatus ?? 0,
+        contentType: entry.contentType ?? '',
+        encodedBodySize: entry.encodedBodySize ?? 0,
+        decodedBodySize: entry.decodedBodySize ?? 0,
       });
     default:
       return new PerformanceEntry(rawToPerformanceEntryType(entry.entryType), {

--- a/packages/react-native/src/private/webapis/performance/specs/NativePerformance.js
+++ b/packages/react-native/src/private/webapis/performance/specs/NativePerformance.js
@@ -37,6 +37,9 @@ export type RawPerformanceEntry = {
   responseStart?: number,
   responseEnd?: number,
   responseStatus?: number,
+  contentType?: string,
+  encodedBodySize?: number,
+  decodedBodySize?: number,
 };
 
 export opaque type OpaqueNativeObserverHandle = mixed;


### PR DESCRIPTION
Summary:
After this diff, successful network events are displayed as fully hydrated timespans in the Performance panel network track, with all metadata needed to usefully populate the UI.

**Changes**

Adds:
- `"ResourceFinish"`: `encodedDataLength`, `decodedBodyLength`
- `"ResourceReceiveResponse"`: Populates `data.timing` members, which enables *"Request sent and waiting"* to be rendered correctly in the timeline.

Removes:

- `"ResourceWillSendRequest"` events — very rarely emitted by Chrome and are extraneous for our use case.

Changelog: [Internal]

Differential Revision: D82636798


