### PR TITLE
remove some of no longer necessary `$FlowFixMe` comments

### DIFF
--- a/packages/dev-middleware/src/inspector-proxy/Device.js
+++ b/packages/dev-middleware/src/inspector-proxy/Device.js
@@ -809,8 +809,6 @@ export default class Device {
     }
 
     if (
-      /* $FlowFixMe[invalid-compare] Error discovered during Constant Condition
-       * roll out. See https://fburl.com/workplace/4oq3zi07. */
       payload.method === 'Runtime.executionContextCreated' &&
       this.#isLegacyPageReloading
     ) {

--- a/packages/react-native/Libraries/Animated/Easing.js
+++ b/packages/react-native/Libraries/Animated/Easing.js
@@ -91,8 +91,6 @@ const EasingStatic = {
    * http://cubic-bezier.com/#.42,0,1,1
    */
   ease(t: number): number {
-    /* $FlowFixMe[constant-condition] Error discovered during Constant
-     * Condition roll out. See https://fburl.com/workplace/1v97vimq. */
     if (!ease) {
       ease = EasingStatic.bezier(0.42, 0, 1, 1);
     }

--- a/packages/react-native/Libraries/Animated/animations/TimingAnimation.js
+++ b/packages/react-native/Libraries/Animated/animations/TimingAnimation.js
@@ -49,8 +49,6 @@ export type TimingAnimationConfigSingle = $ReadOnly<{
 
 let _easeInOut;
 function easeInOut() {
-  /* $FlowFixMe[constant-condition] Error discovered during Constant Condition
-   * roll out. See https://fburl.com/workplace/1v97vimq. */
   if (!_easeInOut) {
     const Easing = require('../Easing').default;
     _easeInOut = Easing.inOut(Easing.ease);

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedInterpolation.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedInterpolation.js
@@ -311,11 +311,6 @@ function checkInfiniteRange<OutputT: number | string>(
   invariant(arr.length >= 2, name + ' must have at least 2 elements');
   invariant(
     arr.length !== 2 || arr[0] !== -Infinity || arr[1] !== Infinity,
-    /* $FlowFixMe[incompatible-type] (>=0.13.0) - In the addition expression
-     * below this comment, one or both of the operands may be something that
-     * doesn't cleanly convert to a string, like undefined, null, and object,
-     * etc. If you really mean this implicit string conversion, you can do
-     * something like String(myThing) */
     // $FlowFixMe[unsafe-addition]
     name + 'cannot be ]-infinity;+infinity[ ' + arr,
   );

--- a/packages/react-native/Libraries/AppState/AppState.js
+++ b/packages/react-native/Libraries/AppState/AppState.js
@@ -134,13 +134,9 @@ class AppStateImpl {
         // $FlowFixMe[invalid-tuple-arity] Flow cannot refine handler based on the event type
         const focusOrBlurHandler: () => void = handler;
         return emitter.addListener('appStateFocusChange', hasFocus => {
-          /* $FlowFixMe[invalid-compare] Error discovered during Constant
-           * Condition roll out. See https://fburl.com/workplace/4oq3zi07. */
           if (type === 'blur' && !hasFocus) {
             focusOrBlurHandler();
           }
-          /* $FlowFixMe[invalid-compare] Error discovered during Constant
-           * Condition roll out. See https://fburl.com/workplace/4oq3zi07. */
           if (type === 'focus' && hasFocus) {
             focusOrBlurHandler();
           }

--- a/packages/react-native/Libraries/BatchedBridge/MessageQueue.js
+++ b/packages/react-native/Libraries/BatchedBridge/MessageQueue.js
@@ -163,8 +163,6 @@ class MessageQueue {
 
   getCallableModule(name: string): {...} | null {
     const getValue = this._lazyCallableModules[name];
-    /* $FlowFixMe[constant-condition] Error discovered during Constant
-     * Condition roll out. See https://fburl.com/workplace/1v97vimq. */
     return getValue ? getValue() : null;
   }
 
@@ -469,8 +467,6 @@ class MessageQueue {
       const profileName = debug
         ? '<callback for ' + module + '.' + method + '>'
         : cbID;
-      /* $FlowFixMe[constant-condition] Error discovered during Constant
-       * Condition roll out. See https://fburl.com/workplace/1v97vimq. */
       if (callback && this.__spy) {
         this.__spy({type: TO_JS, module: null, method: profileName, args});
       }

--- a/packages/react-native/Libraries/BatchedBridge/NativeModules.js
+++ b/packages/react-native/Libraries/BatchedBridge/NativeModules.js
@@ -171,8 +171,6 @@ function updateErrorWithErrorData(
   errorData: {message: string, ...},
   error: ExtendedError,
 ): ExtendedError {
-  /* $FlowFixMe[class-object-subtyping] added when improving typing for this
-   * parameters */
   // $FlowFixMe[incompatible-type]
   // $FlowFixMe[unsafe-object-assign]
   return Object.assign(error, errorData || {});

--- a/packages/react-native/Libraries/Blob/URL.js
+++ b/packages/react-native/Libraries/Blob/URL.js
@@ -76,7 +76,6 @@ export class URL {
     // Do nothing.
   }
 
-  // $FlowFixMe[missing-local-annot]
   constructor(url: string, base?: string | URL) {
     let baseUrl = null;
     if (!base || validateBaseUrl(url)) {

--- a/packages/react-native/Libraries/Blob/URLSearchParams.js
+++ b/packages/react-native/Libraries/Blob/URLSearchParams.js
@@ -18,8 +18,6 @@ export class URLSearchParams {
   }
 
   constructor(params?: Record<string, string> | string | [string, string][]) {
-    /* $FlowFixMe[invalid-compare] Error discovered during Constant Condition
-     * roll out. See https://fburl.com/workplace/5whu3i34. */
     if (params === null) {
       return;
     }

--- a/packages/react-native/Libraries/Components/DrawerAndroid/__tests__/DrawerAndroid-test.js
+++ b/packages/react-native/Libraries/Components/DrawerAndroid/__tests__/DrawerAndroid-test.js
@@ -12,9 +12,6 @@
 
 const ReactNativeTestTools = require('../../../Utilities/ReactNativeTestTools');
 const View = require('../../View/View').default;
-/* $FlowFixMe[cannot-resolve-module] (>=0.99.0 site=react_native_ios_fb) This
- * comment suppresses an error found when Flow v0.99 was deployed. To see the
- * error, delete this comment and run Flow. */
 // $FlowFixMe[missing-platform-support]
 const DrawerLayoutAndroid = require('../DrawerLayoutAndroid.android').default;
 const React = require('react');

--- a/packages/react-native/Libraries/Components/ProgressBarAndroid/__tests__/ProgressBarAndroid-test.js
+++ b/packages/react-native/Libraries/Components/ProgressBarAndroid/__tests__/ProgressBarAndroid-test.js
@@ -11,9 +11,6 @@
 'use strict';
 
 const ReactNativeTestTools = require('../../../Utilities/ReactNativeTestTools');
-/* $FlowFixMe[cannot-resolve-module] (>=0.99.0 site=react_native_ios_fb) This
- * comment suppresses an error found when Flow v0.99 was deployed. To see the
- * error, delete this comment and run Flow. */
 // $FlowFixMe[missing-platform-support]
 const ProgressBarAndroid = require('../ProgressBarAndroid.android').default;
 const React = require('react');

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
@@ -656,8 +656,6 @@ type ScrollViewBaseProps = $ReadOnly<{
    *
    * See [RefreshControl](docs/refreshcontrol.html).
    */
-  /* $FlowFixMe[unclear-type] - how to handle generic type without existential
-   * operator? */
   refreshControl?: ?React.MixedElement,
   children?: React.Node,
   /**
@@ -1648,14 +1646,10 @@ class ScrollView extends React.Component<ScrollViewProps, ScrollViewState> {
       this.props.contentContainerStyle,
     ];
     if (__DEV__ && this.props.style !== undefined) {
-      // $FlowFixMe[underconstrained-implicit-instantiation]
       const style = flattenStyle(this.props.style);
       const childLayoutProps = (
         ['alignItems', 'justifyContent'] as const
-      ).filter(
-        // $FlowFixMe[incompatible-use]
-        prop => style && style[prop] !== undefined,
-      );
+      ).filter(prop => style && style[prop] !== undefined);
       invariant(
         childLayoutProps.length === 0,
         'ScrollView child layout (' +

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollViewStickyHeader.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollViewStickyHeader.js
@@ -291,8 +291,6 @@ const ScrollViewStickyHeader: component(
       collapsable={false}
       nativeID={props.nativeID}
       onLayout={_onLayout}
-      /* $FlowFixMe[prop-missing] passthroughAnimatedPropExplicitValues isn't properly
-         included in the Animated.View flow type. */
       ref={ref}
       style={[
         child.props.style,

--- a/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
@@ -252,8 +252,6 @@ class TouchableOpacity extends React.Component<
   }
 
   _getChildStyleOpacityWithDefault(): number {
-    // $FlowFixMe[underconstrained-implicit-instantiation]
-    // $FlowFixMe[prop-missing]
     const opacity = flattenStyle(this.props.style)?.opacity;
     return typeof opacity === 'number' ? opacity : 1;
   }
@@ -356,11 +354,7 @@ class TouchableOpacity extends React.Component<
     this.state.pressability.configure(this._createPressabilityConfig());
     if (
       this.props.disabled !== prevProps.disabled ||
-      // $FlowFixMe[underconstrained-implicit-instantiation]
-      // $FlowFixMe[prop-missing]
       flattenStyle(prevProps.style)?.opacity !==
-        // $FlowFixMe[underconstrained-implicit-instantiation]
-        // $FlowFixMe[prop-missing]
         flattenStyle(this.props.style)?.opacity
     ) {
       this._opacityInactive(250);

--- a/packages/react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -282,6 +282,5 @@ export default function TouchableWithoutFeedback(
     }
   }
 
-  // $FlowFixMe[incompatible-type]
   return cloneElement(element, elementProps, ...children);
 }

--- a/packages/react-native/Libraries/Core/ExceptionsManager.js
+++ b/packages/react-native/Libraries/Core/ExceptionsManager.js
@@ -167,8 +167,6 @@ function handleException(e: mixed, isFatal: boolean) {
     }
     try {
       inExceptionHandler = true;
-      /* $FlowFixMe[class-object-subtyping] added when improving typing for this
-       * parameters */
       // $FlowFixMe[incompatible-type]
       reportException(error, isFatal, reportToConsole);
     } finally {
@@ -242,8 +240,6 @@ function reactConsoleErrorHandler(...args) {
     if (__DEV__) {
       // If we're not reporting to the console in reportException,
       // we need to report it as a console.error here.
-      /* $FlowFixMe[constant-condition] Error discovered during Constant
-       * Condition roll out. See https://fburl.com/workplace/1v97vimq. */
       if (!reportToConsole) {
         require('../LogBox/LogBox').default.addConsoleLog('error', ...args);
       }
@@ -257,8 +253,6 @@ function reactConsoleErrorHandler(...args) {
       return;
     }
     reportException(
-      /* $FlowFixMe[class-object-subtyping] added when improving typing for this
-       * parameters */
       // $FlowFixMe[incompatible-type]
       error,
       isFatal,

--- a/packages/react-native/Libraries/Core/ReactFiberErrorDialog.js
+++ b/packages/react-native/Libraries/Core/ReactFiberErrorDialog.js
@@ -30,18 +30,12 @@ const ReactFiberErrorDialog = {
     // Typically, `errorValue` should be an error. However, other values such as
     // strings (or even null) are sometimes thrown.
     if (errorValue instanceof Error) {
-      /* $FlowFixMe[class-object-subtyping] added when improving typing for
-       * this parameters */
       // $FlowFixMe[incompatible-type]
       error = (errorValue: ExtendedError);
     } else if (typeof errorValue === 'string') {
-      /* $FlowFixMe[class-object-subtyping] added when improving typing for
-       * this parameters */
       // $FlowFixMe[incompatible-type]
       error = (new SyntheticError(errorValue): ExtendedError);
     } else {
-      /* $FlowFixMe[class-object-subtyping] added when improving typing for
-       * this parameters */
       // $FlowFixMe[incompatible-type]
       error = (new SyntheticError('Unspecified error'): ExtendedError);
     }

--- a/packages/react-native/Libraries/Image/ImageBackground.js
+++ b/packages/react-native/Libraries/Image/ImageBackground.js
@@ -68,7 +68,6 @@ class ImageBackground extends React.Component<ImageBackgroundProps> {
       ...props
     } = this.props;
 
-    // $FlowFixMe[underconstrained-implicit-instantiation]
     const flattenedStyle = flattenStyle(style);
     return (
       <View
@@ -90,9 +89,7 @@ class ImageBackground extends React.Component<ImageBackgroundProps> {
               // So, we have to proxy/reapply these styles explicitly for actual <Image> component.
               // This workaround should be removed after implementing proper support of
               // intrinsic content size of the <Image>.
-              // $FlowFixMe[prop-missing]
               width: flattenedStyle?.width,
-              // $FlowFixMe[prop-missing]
               height: flattenedStyle?.height,
             },
             imageStyle,

--- a/packages/react-native/Libraries/LayoutAnimation/LayoutAnimation.js
+++ b/packages/react-native/Libraries/LayoutAnimation/LayoutAnimation.js
@@ -108,8 +108,6 @@ function configureNext(
   if (UIManager?.configureNextLayoutAnimation) {
     UIManager.configureNextLayoutAnimation(
       config,
-      /* $FlowFixMe[constant-condition] Error discovered during Constant
-       * Condition roll out. See https://fburl.com/workplace/1v97vimq. */
       onAnimationComplete ?? function () {},
       onAnimationDidFail ??
         function () {} /* this should never be called in Non-Fabric */,

--- a/packages/react-native/Libraries/Lists/SectionList.js
+++ b/packages/react-native/Libraries/Lists/SectionList.js
@@ -243,10 +243,6 @@ export default class SectionList<
     const stickySectionHeadersEnabled =
       _stickySectionHeadersEnabled ?? Platform.OS === 'ios';
     return (
-      /* $FlowFixMe[incompatible-type] Error revealed after improved builtin
-       * React utility types */
-      /* $FlowFixMe[incompatible-type] Error revealed after improved builtin
-       * React utility types */
       <VirtualizedSectionList
         {...restProps}
         stickySectionHeadersEnabled={stickySectionHeadersEnabled}

--- a/packages/react-native/Libraries/Lists/__tests__/SectionList-test.js
+++ b/packages/react-native/Libraries/Lists/__tests__/SectionList-test.js
@@ -40,9 +40,7 @@ describe('SectionList', () => {
           <defaultItemSeparator v={propStr(props)} />
         )}
         ListEmptyComponent={props => <empty v={propStr(props)} />}
-        // $FlowFixMe[incompatible-type]
         ListFooterComponent={props => <footer v={propStr(props)} />}
-        // $FlowFixMe[incompatible-type]
         ListHeaderComponent={props => <header v={propStr(props)} />}
         SectionSeparatorComponent={props => (
           <sectionSeparator v={propStr(props)} />

--- a/packages/react-native/Libraries/LogBox/Data/LogBoxData.js
+++ b/packages/react-native/Libraries/LogBox/Data/LogBoxData.js
@@ -440,8 +440,6 @@ export function withSubscription(
     }
 
     componentDidCatch(err: Error, errorInfo: {componentStack: string, ...}) {
-      /* $FlowFixMe[class-object-subtyping] added when improving typing for
-       * this parameters */
       // $FlowFixMe[incompatible-type]
       reportLogBoxError(err, errorInfo.componentStack);
     }

--- a/packages/react-native/Libraries/LogBox/Data/__tests__/LogBoxData-test.js
+++ b/packages/react-native/Libraries/LogBox/Data/__tests__/LogBoxData-test.js
@@ -669,8 +669,6 @@ describe('LogBoxData', () => {
 
   it('reportLogBoxError creates a native redbox with a componentStack', () => {
     LogBoxData.reportLogBoxError(
-      /* $FlowFixMe[class-object-subtyping] added when improving typing for
-       * this parameters */
       // $FlowFixMe[incompatible-type]
       new Error('Simulated Error'),
       '    in Component (file.js:1)',
@@ -684,8 +682,6 @@ describe('LogBoxData', () => {
   });
 
   it('reportLogBoxError creates a native redbox without a componentStack', () => {
-    /* $FlowFixMe[class-object-subtyping] added when improving typing for this
-     * parameters */
     // $FlowFixMe[incompatible-type]
     LogBoxData.reportLogBoxError(new Error('Simulated Error'));
 
@@ -697,8 +693,6 @@ describe('LogBoxData', () => {
   });
 
   it('reportLogBoxError creates an error message that is also ignored', () => {
-    /* $FlowFixMe[class-object-subtyping] added when improving typing for this
-     * parameters */
     // $FlowFixMe[incompatible-type]
     LogBoxData.reportLogBoxError(new Error('Simulated Error'));
 

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorCodeFrame.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorCodeFrame.js
@@ -30,13 +30,11 @@ type Props = $ReadOnly<{
 
 function CodeFrameDisplay({codeFrame}: {codeFrame: CodeFrame}): React.Node {
   function getFileName() {
-    // $FlowFixMe[incompatible-use]
     const matches = /[^/]*$/.exec(codeFrame.fileName);
     if (matches && matches.length > 0) {
       return matches[0];
     }
 
-    // $FlowFixMe[incompatible-use]
     return codeFrame.fileName;
   }
 

--- a/packages/react-native/Libraries/Modal/Modal.js
+++ b/packages/react-native/Libraries/Modal/Modal.js
@@ -373,9 +373,6 @@ const styles = StyleSheet.create({
   /* $FlowFixMe[incompatible-type] Natural Inference rollout. See
    * https://fburl.com/workplace/6291gfvu */
   container: {
-    /* $FlowFixMe[invalid-computed-prop] (>=0.111.0 site=react_native_fb) This
-     * comment suppresses an error found when Flow v0.111 was deployed. To see
-     * the error, delete this comment and run Flow. */
     // $FlowFixMe[incompatible-type]
     [side]: 0,
     top: 0,

--- a/packages/react-native/Libraries/NativeComponent/ViewConfig.js
+++ b/packages/react-native/Libraries/NativeComponent/ViewConfig.js
@@ -34,9 +34,7 @@ export function createViewConfig(
     ),
     // $FlowFixMe[incompatible-type]
     validAttributes: composeIndexers(
-      // $FlowFixMe[incompatible-call] `style` property confuses Flow.
       PlatformBaseViewConfig.validAttributes,
-      // $FlowFixMe[incompatible-call] `style` property confuses Flow.
       partialViewConfig.validAttributes,
     ),
   };

--- a/packages/react-native/Libraries/Network/XMLHttpRequest.js
+++ b/packages/react-native/Libraries/Network/XMLHttpRequest.js
@@ -657,8 +657,6 @@ class XMLHttpRequest extends EventTarget {
         this.withCredentials,
       );
     };
-    /* $FlowFixMe[constant-condition] Error discovered during Constant
-     * Condition roll out. See https://fburl.com/workplace/1v97vimq. */
     if (DEBUG_NETWORK_SEND_DELAY) {
       setTimeout(doSend, DEBUG_NETWORK_SEND_DELAY);
     } else {

--- a/packages/react-native/Libraries/Pressability/HoverState.js
+++ b/packages/react-native/Libraries/Pressability/HoverState.js
@@ -12,10 +12,6 @@ import Platform from '../Utilities/Platform';
 
 let isEnabled = false;
 
-/* $FlowFixMe[incompatible-type] Error found due to incomplete typing of
- * Platform.flow.js */
-/* $FlowFixMe[invalid-compare] Error discovered during Constant Condition roll
- * out. See https://fburl.com/workplace/4oq3zi07. */
 if (Platform.OS === 'web') {
   const canUseDOM = Boolean(
     typeof window !== 'undefined' &&

--- a/packages/react-native/Libraries/Pressability/__tests__/Pressability-test.js
+++ b/packages/react-native/Libraries/Pressability/__tests__/Pressability-test.js
@@ -739,9 +739,7 @@ describe('Pressability', () => {
         handlers.onResponderMove(
           createMockPressEvent({
             registrationName: 'onResponderMove',
-            // $FlowFixMe[unsafe-addition]
             pageX: mockRegion.width + mockSlop.right / 2,
-            // $FlowFixMe[unsafe-addition]
             pageY: mockRegion.height + mockSlop.bottom / 2,
           }),
         );
@@ -775,9 +773,7 @@ describe('Pressability', () => {
         handlers.onResponderMove(
           createMockPressEvent({
             registrationName: 'onResponderMove',
-            // $FlowFixMe[unsafe-addition]
             pageX: mockRegion.width + mockSlop.right / 2,
-            // $FlowFixMe[unsafe-addition]
             pageY: mockRegion.height + mockSlop.bottom / 2,
           }),
         );

--- a/packages/react-native/Libraries/ReactNative/AppRegistryImpl.js
+++ b/packages/react-native/Libraries/ReactNative/AppRegistryImpl.js
@@ -222,7 +222,6 @@ export function registerHeadlessTask(
   taskKey: string,
   taskProvider: TaskProvider,
 ): void {
-  // $FlowFixMe[object-this-reference]
   registerCancellableHeadlessTask(taskKey, taskProvider, () => () => {
     /* Cancel is no-op */
   });

--- a/packages/react-native/Libraries/ReactNative/renderApplication.js
+++ b/packages/react-native/Libraries/ReactNative/renderApplication.js
@@ -75,7 +75,6 @@ export default function renderApplication<Props: Object>(
 
   if (useOffscreen && displayMode != null) {
     // $FlowFixMe[incompatible-type]
-    // $FlowFixMe[prop-missing]
     // $FlowFixMe[missing-export]
     const Activity: ActivityType = React.unstable_Activity;
 

--- a/packages/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js
+++ b/packages/react-native/Libraries/ReactPrivate/ReactNativePrivateInterface.js
@@ -85,8 +85,6 @@ module.exports = {
   },
   // TODO: Remove when React has migrated to `createAttributePayload` and `diffAttributePayloads`
   get flattenStyle(): flattenStyle<DangerouslyImpreciseStyleProp> {
-    // $FlowFixMe[underconstrained-implicit-instantiation]
-    // $FlowFixMe[incompatible-type]
     return require('../StyleSheet/flattenStyle').default;
   },
   get ReactFiberErrorDialog(): ReactFiberErrorDialog {

--- a/packages/react-native/Libraries/Renderer/shims/ReactNativeViewConfigRegistry.js
+++ b/packages/react-native/Libraries/Renderer/shims/ReactNativeViewConfigRegistry.js
@@ -82,8 +82,6 @@ export function register(name: string, callback: () => ViewConfig): string {
     typeof callback === 'function',
     'View config getter callback for component `%s` must be a function (received `%s`)',
     name,
-    /* $FlowFixMe[invalid-compare] Error discovered during Constant Condition
-     * roll out. See https://fburl.com/workplace/5whu3i34. */
     callback === null ? 'null' : typeof callback,
   );
   viewConfigCallbacks.set(name, callback);
@@ -105,7 +103,6 @@ export function get(name: string): ViewConfig {
         'View config getter callback for component `%s` must be a function (received `%s`).%s',
         name,
         callback === null ? 'null' : typeof callback,
-        // $FlowFixMe[recursive-definition]
         typeof name[0] === 'string' && /[a-z]/.test(name[0])
           ? ' Make sure to start component names with a capital letter.'
           : '',

--- a/packages/react-native/Libraries/Share/Share.js
+++ b/packages/react-native/Libraries/Share/Share.js
@@ -83,8 +83,6 @@ class Share {
     options?: ShareOptions = {},
   ): Promise<{action: string, activityType: ?string}> {
     invariant(
-      /* $FlowFixMe[invalid-compare] Error discovered during Constant Condition
-       * roll out. See https://fburl.com/workplace/5whu3i34. */
       typeof content === 'object' && content !== null,
       'Content to share must be a valid object',
     );
@@ -93,8 +91,6 @@ class Share {
       'At least one of URL or message is required',
     );
     invariant(
-      /* $FlowFixMe[invalid-compare] Error discovered during Constant Condition
-       * roll out. See https://fburl.com/workplace/5whu3i34. */
       typeof options === 'object' && options !== null,
       'Options must be a valid object',
     );

--- a/packages/react-native/Libraries/StyleSheet/flattenStyle.js
+++ b/packages/react-native/Libraries/StyleSheet/flattenStyle.js
@@ -42,9 +42,7 @@ function flattenStyle<
     if (computedStyle) {
       // $FlowFixMe[invalid-in-rhs]
       for (const key in computedStyle) {
-        // $FlowFixMe[incompatible-use]
         // $FlowFixMe[invalid-computed-prop]
-        // $FlowFixMe[prop-missing]
         result[key] = computedStyle[key];
       }
     }

--- a/packages/react-native/Libraries/StyleSheet/processAspectRatio.js
+++ b/packages/react-native/Libraries/StyleSheet/processAspectRatio.js
@@ -19,8 +19,6 @@ function processAspectRatio(aspectRatio?: number | string): ?number {
   if (typeof aspectRatio !== 'string') {
     if (__DEV__) {
       invariant(
-        /* $FlowFixMe[constant-condition] Error discovered during Constant
-         * Condition roll out. See https://fburl.com/workplace/1v97vimq. */
         !aspectRatio,
         'aspectRatio must either be a number, a ratio string or `auto`. You passed: %s',
         aspectRatio,

--- a/packages/react-native/Libraries/StyleSheet/processTransform.js
+++ b/packages/react-native/Libraries/StyleSheet/processTransform.js
@@ -185,9 +185,6 @@ function _validateTransform(
         value.length === 9 || value.length === 16,
         'Matrix transform must have a length of 9 (2d) or 16 (3d). ' +
           'Provided matrix has a length of %s: %s',
-        /* $FlowFixMe[prop-missing] (>=0.84.0 site=react_native_fb) This
-         * comment suppresses an error found when Flow v0.84 was deployed. To
-         * see the error, delete this comment and run Flow. */
         value.length,
         stringifySafe(transformation),
       );
@@ -196,9 +193,6 @@ function _validateTransform(
       invariant(
         value.length === 2 || value.length === 3,
         'Transform with key translate must be an array of length 2 or 3, found %s: %s',
-        /* $FlowFixMe[prop-missing] (>=0.84.0 site=react_native_fb) This
-         * comment suppresses an error found when Flow v0.84 was deployed. To
-         * see the error, delete this comment and run Flow. */
         value.length,
         stringifySafe(transformation),
       );

--- a/packages/react-native/Libraries/StyleSheet/splitLayoutProps.js
+++ b/packages/react-native/Libraries/StyleSheet/splitLayoutProps.js
@@ -53,14 +53,10 @@ export default function splitLayoutProps(props: ?____ViewStyle_Internal): {
         case 'rowGap':
         case 'columnGap':
         case 'gap':
-          // $FlowFixMe[cannot-write]
-          // $FlowFixMe[incompatible-use]
           // $FlowFixMe[prop-missing]
           outer[prop] = props[prop];
           break;
         default:
-          // $FlowFixMe[cannot-write]
-          // $FlowFixMe[incompatible-use]
           // $FlowFixMe[prop-missing]
           inner[prop] = props[prop];
           break;

--- a/packages/react-native/Libraries/Text/Text.js
+++ b/packages/react-native/Libraries/Text/Text.js
@@ -196,7 +196,6 @@ if (ReactNativeFeatureFlags.reduceDefaultPropsInText()) {
       }
 
       if (overrides != null) {
-        // $FlowFixMe[incompatible-type]
         _style = [_style, overrides];
       }
     }
@@ -445,7 +444,6 @@ if (ReactNativeFeatureFlags.reduceDefaultPropsInText()) {
       }
 
       if (overrides != null) {
-        // $FlowFixMe[incompatible-type]
         _style = [_style, overrides];
       }
     }

--- a/packages/react-native/Libraries/Text/__tests__/Text-test.js
+++ b/packages/react-native/Libraries/Text/__tests__/Text-test.js
@@ -121,7 +121,6 @@ describe('Text compat with web', () => {
       'aria-valuetext': '3',
     };
 
-    // $FlowFixMe[prop-missing]
     // $FlowFixMe[incompatible-type]
     const instance = await create(<Text {...props} />);
 
@@ -196,7 +195,6 @@ describe('Text compat with web', () => {
       verticalAlign: 'middle',
     };
 
-    // $FlowFixMe[prop-missing]
     // $FlowFixMe[incompatible-type]
     const instance = await create(<Text style={style} />);
 

--- a/packages/react-native/Libraries/Utilities/HMRClient.js
+++ b/packages/react-native/Libraries/Utilities/HMRClient.js
@@ -165,8 +165,6 @@ const HMRClient: HMRClientNativeInterface = {
     // Moving to top gives errors due to NativeModules not being initialized
     const DevLoadingView = require('./DevLoadingView').default;
 
-    /* $FlowFixMe[invalid-compare] Error discovered during Constant Condition
-     * roll out. See https://fburl.com/workplace/5whu3i34. */
     const serverHost = port !== null && port !== '' ? `${host}:${port}` : host;
 
     const serverScheme = scheme;

--- a/packages/react-native/Libraries/Utilities/ReactNativeTestTools.js
+++ b/packages/react-native/Libraries/Utilities/ReactNativeTestTools.js
@@ -24,9 +24,6 @@ const {VirtualizedList} = require('@react-native/virtualized-lists').default;
 
 export type ReactTestInstance = ReactTestRendererType['root'];
 export type Predicate = (node: ReactTestInstance) => boolean;
-/* $FlowFixMe[value-as-type] (>=0.125.1 site=react_native_fb) This comment
- * suppresses an error found when Flow v0.125.1 was deployed. To see the error,
- * delete this comment and run Flow. */
 export type ReactTestRendererJSON =
   /* $FlowFixMe[prop-missing] (>=0.125.1 site=react_native_fb) This comment
    * suppresses an error found when Flow v0.125.1 was deployed. To see the error,
@@ -38,21 +35,13 @@ function byClickable(): Predicate {
     node =>
       // note: <Text /> lazy-mounts press handlers after the first press,
       //       so this is a workaround for targeting text nodes.
-      /* $FlowFixMe[invalid-compare] Error discovered during Constant Condition
-       * roll out. See https://fburl.com/workplace/4oq3zi07. */
       (node.type === Text &&
         node.props &&
         typeof node.props.onPress === 'function') ||
       // note: Special casing <Switch /> since it doesn't use touchable
-      /* $FlowFixMe[invalid-compare] Error discovered during Constant Condition
-       * roll out. See https://fburl.com/workplace/4oq3zi07. */
       (node.type === Switch && node.props && node.props.disabled !== true) ||
-      /* $FlowFixMe[invalid-compare] Error discovered during Constant Condition
-       * roll out. See https://fburl.com/workplace/4oq3zi07. */
       (node.type === View &&
         node?.props?.onStartShouldSetResponder?.testOnly_pressabilityConfig) ||
-      /* $FlowFixMe[invalid-compare] Error discovered during Constant Condition
-       * roll out. See https://fburl.com/workplace/4oq3zi07. */
       (node.type === TouchableWithoutFeedback &&
         node.props &&
         typeof node.props.onPress === 'function') ||
@@ -182,12 +171,8 @@ function renderWithStrictMode(element: React.Node): ReactTestRendererType {
 
 function tap(instance: ReactTestInstance) {
   const touchable = instance.find(byClickable());
-  /* $FlowFixMe[invalid-compare] Error discovered during Constant Condition
-   * roll out. See https://fburl.com/workplace/4oq3zi07. */
   if (touchable.type === Text && touchable.props && touchable.props.onPress) {
     touchable.props.onPress();
-    /* $FlowFixMe[invalid-compare] Error discovered during Constant Condition
-     * roll out. See https://fburl.com/workplace/4oq3zi07. */
   } else if (touchable.type === Switch && touchable.props) {
     const value = !touchable.props.value;
     const {onChange, onValueChange} = touchable.props;

--- a/packages/react-native/Libraries/Utilities/createPerformanceLogger.js
+++ b/packages/react-native/Libraries/Utilities/createPerformanceLogger.js
@@ -35,8 +35,6 @@ class PerformanceLogger implements IPerformanceLogger {
     endExtras?: Extras,
   ) {
     if (this._closed) {
-      /* $FlowFixMe[constant-condition] Error discovered during Constant
-       * Condition roll out. See https://fburl.com/workplace/1v97vimq. */
       if (PRINT_TO_CONSOLE && __DEV__) {
         console.log(
           'PerformanceLogger: addTimespan - has closed ignoring: ',
@@ -46,8 +44,6 @@ class PerformanceLogger implements IPerformanceLogger {
       return;
     }
     if (this._timespans[key]) {
-      /* $FlowFixMe[constant-condition] Error discovered during Constant
-       * Condition roll out. See https://fburl.com/workplace/1v97vimq. */
       if (PRINT_TO_CONSOLE && __DEV__) {
         console.log(
           'PerformanceLogger: Attempting to add a timespan that already exists ',
@@ -83,8 +79,6 @@ class PerformanceLogger implements IPerformanceLogger {
     this._timespans = {};
     this._extras = {};
     this._points = {};
-    /* $FlowFixMe[constant-condition] Error discovered during Constant
-     * Condition roll out. See https://fburl.com/workplace/1v97vimq. */
     if (PRINT_TO_CONSOLE) {
       console.log('PerformanceLogger.js', 'clear');
     }
@@ -98,8 +92,6 @@ class PerformanceLogger implements IPerformanceLogger {
     }
     this._extras = {};
     this._points = {};
-    /* $FlowFixMe[constant-condition] Error discovered during Constant
-     * Condition roll out. See https://fburl.com/workplace/1v97vimq. */
     if (PRINT_TO_CONSOLE) {
       console.log('PerformanceLogger.js', 'clearCompleted');
     }
@@ -138,8 +130,6 @@ class PerformanceLogger implements IPerformanceLogger {
   }
 
   logEverything() {
-    /* $FlowFixMe[constant-condition] Error discovered during Constant
-     * Condition roll out. See https://fburl.com/workplace/1v97vimq. */
     if (PRINT_TO_CONSOLE) {
       // log timespans
       for (const key in this._timespans) {
@@ -166,8 +156,6 @@ class PerformanceLogger implements IPerformanceLogger {
     extras?: Extras,
   ) {
     if (this._closed) {
-      /* $FlowFixMe[constant-condition] Error discovered during Constant
-       * Condition roll out. See https://fburl.com/workplace/1v97vimq. */
       if (PRINT_TO_CONSOLE && __DEV__) {
         console.log(
           'PerformanceLogger: markPoint - has closed ignoring: ',
@@ -177,8 +165,6 @@ class PerformanceLogger implements IPerformanceLogger {
       return;
     }
     if (this._points[key] != null) {
-      /* $FlowFixMe[constant-condition] Error discovered during Constant
-       * Condition roll out. See https://fburl.com/workplace/1v97vimq. */
       if (PRINT_TO_CONSOLE && __DEV__) {
         console.log(
           'PerformanceLogger: Attempting to mark a point that has been already logged ',
@@ -201,8 +187,6 @@ class PerformanceLogger implements IPerformanceLogger {
 
   setExtra(key: string, value: ExtraValue) {
     if (this._closed) {
-      /* $FlowFixMe[constant-condition] Error discovered during Constant
-       * Condition roll out. See https://fburl.com/workplace/1v97vimq. */
       if (PRINT_TO_CONSOLE && __DEV__) {
         console.log('PerformanceLogger: setExtra - has closed ignoring: ', key);
       }
@@ -210,8 +194,6 @@ class PerformanceLogger implements IPerformanceLogger {
     }
 
     if (this._extras.hasOwnProperty(key)) {
-      /* $FlowFixMe[constant-condition] Error discovered during Constant
-       * Condition roll out. See https://fburl.com/workplace/1v97vimq. */
       if (PRINT_TO_CONSOLE && __DEV__) {
         console.log(
           'PerformanceLogger: Attempting to set an extra that already exists ',
@@ -229,8 +211,6 @@ class PerformanceLogger implements IPerformanceLogger {
     extras?: Extras,
   ) {
     if (this._closed) {
-      /* $FlowFixMe[constant-condition] Error discovered during Constant
-       * Condition roll out. See https://fburl.com/workplace/1v97vimq. */
       if (PRINT_TO_CONSOLE && __DEV__) {
         console.log(
           'PerformanceLogger: startTimespan - has closed ignoring: ',
@@ -241,8 +221,6 @@ class PerformanceLogger implements IPerformanceLogger {
     }
 
     if (this._timespans[key]) {
-      /* $FlowFixMe[constant-condition] Error discovered during Constant
-       * Condition roll out. See https://fburl.com/workplace/1v97vimq. */
       if (PRINT_TO_CONSOLE && __DEV__) {
         console.log(
           'PerformanceLogger: Attempting to start a timespan that already exists ',
@@ -256,8 +234,6 @@ class PerformanceLogger implements IPerformanceLogger {
       startTime: timestamp,
       startExtras: extras,
     };
-    /* $FlowFixMe[constant-condition] Error discovered during Constant
-     * Condition roll out. See https://fburl.com/workplace/1v97vimq. */
     if (PRINT_TO_CONSOLE) {
       console.log('PerformanceLogger.js', 'start: ' + key);
     }
@@ -269,8 +245,6 @@ class PerformanceLogger implements IPerformanceLogger {
     extras?: Extras,
   ) {
     if (this._closed) {
-      /* $FlowFixMe[constant-condition] Error discovered during Constant
-       * Condition roll out. See https://fburl.com/workplace/1v97vimq. */
       if (PRINT_TO_CONSOLE && __DEV__) {
         console.log(
           'PerformanceLogger: stopTimespan - has closed ignoring: ',
@@ -282,8 +256,6 @@ class PerformanceLogger implements IPerformanceLogger {
 
     const timespan = this._timespans[key];
     if (!timespan || timespan.startTime == null) {
-      /* $FlowFixMe[constant-condition] Error discovered during Constant
-       * Condition roll out. See https://fburl.com/workplace/1v97vimq. */
       if (PRINT_TO_CONSOLE && __DEV__) {
         console.log(
           'PerformanceLogger: Attempting to end a timespan that has not started ',
@@ -293,8 +265,6 @@ class PerformanceLogger implements IPerformanceLogger {
       return;
     }
     if (timespan.endTime != null) {
-      /* $FlowFixMe[constant-condition] Error discovered during Constant
-       * Condition roll out. See https://fburl.com/workplace/1v97vimq. */
       if (PRINT_TO_CONSOLE && __DEV__) {
         console.log(
           'PerformanceLogger: Attempting to end a timespan that has already ended ',
@@ -307,8 +277,6 @@ class PerformanceLogger implements IPerformanceLogger {
     timespan.endExtras = extras;
     timespan.endTime = timestamp;
     timespan.totalTime = timespan.endTime - (timespan.startTime || 0);
-    /* $FlowFixMe[constant-condition] Error discovered during Constant
-     * Condition roll out. See https://fburl.com/workplace/1v97vimq. */
     if (PRINT_TO_CONSOLE) {
       console.log('PerformanceLogger.js', 'end: ' + key);
     }

--- a/packages/react-native/Libraries/Utilities/deepFreezeAndThrowOnMutationInDev.js
+++ b/packages/react-native/Libraries/Utilities/deepFreezeAndThrowOnMutationInDev.js
@@ -33,8 +33,6 @@ function deepFreezeAndThrowOnMutationInDev<T: {...} | Array<mixed>>(
   if (__DEV__) {
     if (
       typeof object !== 'object' ||
-      /* $FlowFixMe[invalid-compare] Error discovered during Constant Condition
-       * roll out. See https://fburl.com/workplace/5whu3i34. */
       object === null ||
       Object.isFrozen(object) ||
       Object.isSealed(object)


### PR DESCRIPTION
## Summary:

Playing with JS code related to one of reported issues, I have spotted that some of the `$FlowFixMe` comments seems no longer necessary. Since Flow does not support detection of unused suppressions, nor have an equivalent of `expect-error` comment, I have created a very rough local script which has helped me to find those cases in the codebase.

Definitely I did not detect all cases, it's just a part of comments which can be removed but still it seems like a nice codebase cleanup. The changeset removes around ~100 comments, bringing down total to 3458 uses.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[INTERNAL][REMOVED] Remove some of no longer necessary `$FlowFixMe` comments in the code.

## Test Plan:

`yarn flow-check` does not output any errors.
