### PR TITLE
Align Android with iOS in displaying HMR "refreshing" in color

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DefaultDevLoadingViewImplementation.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DefaultDevLoadingViewImplementation.kt
@@ -33,10 +33,14 @@ public class DefaultDevLoadingViewImplementation(
   private var devLoadingPopup: PopupWindow? = null
 
   override fun showMessage(message: String) {
+    showMessage(message, color = null, backgroundColor = null)
+  }
+
+  override fun showMessage(message: String, color: Double?, backgroundColor: Double?) {
     if (!isEnabled) {
       return
     }
-    UiThreadUtil.runOnUiThread { showInternal(message) }
+    UiThreadUtil.runOnUiThread { showInternal(message, color, backgroundColor) }
   }
 
   override fun updateProgress(status: String?, done: Int?, total: Int?) {
@@ -59,7 +63,7 @@ public class DefaultDevLoadingViewImplementation(
     }
   }
 
-  private fun showInternal(message: String) {
+  private fun showInternal(message: String, color: Double?, backgroundColor: Double?) {
     if (devLoadingPopup?.isShowing == true) {
       // already showing
       return
@@ -84,6 +88,12 @@ public class DefaultDevLoadingViewImplementation(
           currentActivity.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
       val view = inflater.inflate(R.layout.dev_loading_view, null) as TextView
       view.text = message
+      if (color != null) {
+        view.setTextColor(color.toInt())
+      }
+      if (backgroundColor != null) {
+        view.setBackgroundColor(backgroundColor.toInt())
+      }
       val popup =
           PopupWindow(
               view,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevLoadingViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevLoadingViewManager.kt
@@ -11,6 +11,8 @@ package com.facebook.react.devsupport.interfaces
 public interface DevLoadingViewManager {
   public fun showMessage(message: String)
 
+  public fun showMessage(message: String, color: Double?, backgroundColor: Double?)
+
   public fun updateProgress(status: String?, done: Int?, total: Int?)
 
   public fun hide()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/devloading/DevLoadingModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/devloading/DevLoadingModule.kt
@@ -31,7 +31,9 @@ internal class DevLoadingModule(reactContext: ReactApplicationContext) :
   }
 
   override fun showMessage(message: String, color: Double?, backgroundColor: Double?) {
-    UiThreadUtil.runOnUiThread { devLoadingViewManager?.showMessage(message) }
+    UiThreadUtil.runOnUiThread {
+      devLoadingViewManager?.showMessage(message, color, backgroundColor)
+    }
   }
 
   override fun hide() {


### PR DESCRIPTION
Summary:
iOS has a colorful "Refreshing..." banner:
<img width="946" height="776" alt="image" src="https://github.com/user-attachments/assets/d5f0ed62-5ff2-4e89-ab89-a505c3031499" />

While android doesn't respect the color HMR asks it to set up for the banner:
<img width="1024" height="524" alt="image" src="https://github.com/user-attachments/assets/9f94c0dd-5674-4292-845c-0d600a6b4df1" />


Changelog: [Android][Added] - hot reload banner is now displayed in blue background like on iOS

Differential Revision: D82726743


