### PR TITLE
fix(codegen): ensure unique c++ variable names to avoid collision for properties with the same name

### DIFF
--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GenerateEventEmitterCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GenerateEventEmitterCpp-test.js.snap
@@ -153,29 +153,29 @@ void EventNestedObjectPropsNativeComponentViewEventEmitter::onChange(OnChange ev
   dispatchEvent(\\"change\\", [event=std::move(event)](jsi::Runtime &runtime) {
     auto payload = jsi::Object(runtime);
     {
-  auto location_codegen1 = jsi::Object(runtime);
+  auto __codegen__1__location = jsi::Object(runtime);
   {
-    auto source_codegen2 = jsi::Object(runtime);
-    source_codegen2.setProperty(runtime, \\"url\\", event.location.source.url);
-    location_codegen1.setProperty(runtime, \\"source\\", source_codegen2);
+    auto __codegen__2__source = jsi::Object(runtime);
+    __codegen__2__source.setProperty(runtime, \\"url\\", event.location.source.url);
+    __codegen__1__location.setProperty(runtime, \\"source\\", __codegen__2__source);
   }
-  location_codegen1.setProperty(runtime, \\"x\\", event.location.x);
-  location_codegen1.setProperty(runtime, \\"y\\", event.location.y);
+  __codegen__1__location.setProperty(runtime, \\"x\\", event.location.x);
+  __codegen__1__location.setProperty(runtime, \\"y\\", event.location.y);
 
-      auto arrayOfObjects_codegen3 = jsi::Array(runtime, event.location.arrayOfObjects.size());
-      size_t arrayOfObjectsIndex_codegen4 = 0;
-      for (auto arrayOfObjectsValue_codegen5 : event.location.arrayOfObjects) {
-        auto arrayOfObjectsObject_codegen6 = jsi::Object(runtime);
+      auto __codegen__3__arrayOfObjects = jsi::Array(runtime, event.location.arrayOfObjects.size());
+      size_t __codegen__4__arrayOfObjectsIndex = 0;
+      for (auto __codegen__5__arrayOfObjectsValue : event.location.arrayOfObjects) {
+        auto __codegen__6__arrayOfObjectsObject = jsi::Object(runtime);
         {
-    auto value_codegen7 = jsi::Object(runtime);
-    value_codegen7.setProperty(runtime, \\"str\\", arrayOfObjectsValue_codegen5.value.str);
-    arrayOfObjectsObject_codegen6.setProperty(runtime, \\"value\\", value_codegen7);
+    auto __codegen__7__value = jsi::Object(runtime);
+    __codegen__7__value.setProperty(runtime, \\"str\\", __codegen__5__arrayOfObjectsValue.value.str);
+    __codegen__6__arrayOfObjectsObject.setProperty(runtime, \\"value\\", __codegen__7__value);
   }
-        arrayOfObjects_codegen3.setValueAtIndex(runtime, arrayOfObjectsIndex_codegen4++, arrayOfObjectsObject_codegen6);
+        __codegen__3__arrayOfObjects.setValueAtIndex(runtime, __codegen__4__arrayOfObjectsIndex++, __codegen__6__arrayOfObjectsObject);
       }
-      location_codegen1.setProperty(runtime, \\"arrayOfObjects\\", arrayOfObjects_codegen3);
+      __codegen__1__location.setProperty(runtime, \\"arrayOfObjects\\", __codegen__3__arrayOfObjects);
     
-  payload.setProperty(runtime, \\"location\\", location_codegen1);
+  payload.setProperty(runtime, \\"location\\", __codegen__1__location);
 }
     return payload;
   });

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GenerateEventEmitterCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GenerateEventEmitterCpp-test.js.snap
@@ -153,29 +153,29 @@ void EventNestedObjectPropsNativeComponentViewEventEmitter::onChange(OnChange ev
   dispatchEvent(\\"change\\", [event=std::move(event)](jsi::Runtime &runtime) {
     auto payload = jsi::Object(runtime);
     {
-  auto location_1 = jsi::Object(runtime);
+  auto location_codegen1 = jsi::Object(runtime);
   {
-    auto source_2 = jsi::Object(runtime);
-    source_2.setProperty(runtime, \\"url\\", event.location.source.url);
-    location_1.setProperty(runtime, \\"source\\", source_2);
+    auto source_codegen2 = jsi::Object(runtime);
+    source_codegen2.setProperty(runtime, \\"url\\", event.location.source.url);
+    location_codegen1.setProperty(runtime, \\"source\\", source_codegen2);
   }
-  location_1.setProperty(runtime, \\"x\\", event.location.x);
-  location_1.setProperty(runtime, \\"y\\", event.location.y);
+  location_codegen1.setProperty(runtime, \\"x\\", event.location.x);
+  location_codegen1.setProperty(runtime, \\"y\\", event.location.y);
 
-      auto arrayOfObjects_3 = jsi::Array(runtime, event.location.arrayOfObjects.size());
-      size_t arrayOfObjectsIndex_4 = 0;
-      for (auto arrayOfObjectsValue_5 : event.location.arrayOfObjects) {
-        auto arrayOfObjectsObject_6 = jsi::Object(runtime);
+      auto arrayOfObjects_codegen3 = jsi::Array(runtime, event.location.arrayOfObjects.size());
+      size_t arrayOfObjectsIndex_codegen4 = 0;
+      for (auto arrayOfObjectsValue_codegen5 : event.location.arrayOfObjects) {
+        auto arrayOfObjectsObject_codegen6 = jsi::Object(runtime);
         {
-    auto value_7 = jsi::Object(runtime);
-    value_7.setProperty(runtime, \\"str\\", arrayOfObjectsValue_5.value.str);
-    arrayOfObjectsObject_6.setProperty(runtime, \\"value\\", value_7);
+    auto value_codegen7 = jsi::Object(runtime);
+    value_codegen7.setProperty(runtime, \\"str\\", arrayOfObjectsValue_codegen5.value.str);
+    arrayOfObjectsObject_codegen6.setProperty(runtime, \\"value\\", value_codegen7);
   }
-        arrayOfObjects_3.setValueAtIndex(runtime, arrayOfObjectsIndex_4++, arrayOfObjectsObject_6);
+        arrayOfObjects_codegen3.setValueAtIndex(runtime, arrayOfObjectsIndex_codegen4++, arrayOfObjectsObject_codegen6);
       }
-      location_1.setProperty(runtime, \\"arrayOfObjects\\", arrayOfObjects_3);
+      location_codegen1.setProperty(runtime, \\"arrayOfObjects\\", arrayOfObjects_codegen3);
     
-  payload.setProperty(runtime, \\"location\\", location_1);
+  payload.setProperty(runtime, \\"location\\", location_codegen1);
 }
     return payload;
   });

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GenerateEventEmitterCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GenerateEventEmitterCpp-test.js.snap
@@ -153,29 +153,29 @@ void EventNestedObjectPropsNativeComponentViewEventEmitter::onChange(OnChange ev
   dispatchEvent(\\"change\\", [event=std::move(event)](jsi::Runtime &runtime) {
     auto payload = jsi::Object(runtime);
     {
-  auto location = jsi::Object(runtime);
+  auto location_1 = jsi::Object(runtime);
   {
-    auto source = jsi::Object(runtime);
-    source.setProperty(runtime, \\"url\\", event.location.source.url);
-    location.setProperty(runtime, \\"source\\", source);
+    auto source_2 = jsi::Object(runtime);
+    source_2.setProperty(runtime, \\"url\\", event.location.source.url);
+    location_1.setProperty(runtime, \\"source\\", source_2);
   }
-  location.setProperty(runtime, \\"x\\", event.location.x);
-  location.setProperty(runtime, \\"y\\", event.location.y);
+  location_1.setProperty(runtime, \\"x\\", event.location.x);
+  location_1.setProperty(runtime, \\"y\\", event.location.y);
 
-      auto arrayOfObjects = jsi::Array(runtime, event.location.arrayOfObjects.size());
-      size_t arrayOfObjectsIndex = 0;
-      for (auto arrayOfObjectsValue : event.location.arrayOfObjects) {
-        auto arrayOfObjectsObject = jsi::Object(runtime);
+      auto arrayOfObjects_3 = jsi::Array(runtime, event.location.arrayOfObjects.size());
+      size_t arrayOfObjectsIndex_4 = 0;
+      for (auto arrayOfObjectsValue_5 : event.location.arrayOfObjects) {
+        auto arrayOfObjectsObject_6 = jsi::Object(runtime);
         {
-    auto value = jsi::Object(runtime);
-    value.setProperty(runtime, \\"str\\", arrayOfObjectsValue.value.str);
-    arrayOfObjectsObject.setProperty(runtime, \\"value\\", value);
+    auto value_7 = jsi::Object(runtime);
+    value_7.setProperty(runtime, \\"str\\", arrayOfObjectsValue_5.value.str);
+    arrayOfObjectsObject_6.setProperty(runtime, \\"value\\", value_7);
   }
-        arrayOfObjects.setValueAtIndex(runtime, arrayOfObjectsIndex++, arrayOfObjectsObject);
+        arrayOfObjects_3.setValueAtIndex(runtime, arrayOfObjectsIndex_4++, arrayOfObjectsObject_6);
       }
-      location.setProperty(runtime, \\"arrayOfObjects\\", arrayOfObjects);
+      location_1.setProperty(runtime, \\"arrayOfObjects\\", arrayOfObjects_3);
     
-  payload.setProperty(runtime, \\"location\\", location);
+  payload.setProperty(runtime, \\"location\\", location_1);
 }
     return payload;
   });

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GenerateEventEmitterCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GenerateEventEmitterCpp-test.js.snap
@@ -153,29 +153,29 @@ void EventNestedObjectPropsNativeComponentViewEventEmitter::onChange(OnChange ev
   dispatchEvent(\\"change\\", [event=std::move(event)](jsi::Runtime &runtime) {
     auto payload = jsi::Object(runtime);
     {
-  auto location_codegen1 = jsi::Object(runtime);
+  auto __codegen__1__location = jsi::Object(runtime);
   {
-    auto source_codegen2 = jsi::Object(runtime);
-    source_codegen2.setProperty(runtime, \\"url\\", event.location.source.url);
-    location_codegen1.setProperty(runtime, \\"source\\", source_codegen2);
+    auto __codegen__2__source = jsi::Object(runtime);
+    __codegen__2__source.setProperty(runtime, \\"url\\", event.location.source.url);
+    __codegen__1__location.setProperty(runtime, \\"source\\", __codegen__2__source);
   }
-  location_codegen1.setProperty(runtime, \\"x\\", event.location.x);
-  location_codegen1.setProperty(runtime, \\"y\\", event.location.y);
+  __codegen__1__location.setProperty(runtime, \\"x\\", event.location.x);
+  __codegen__1__location.setProperty(runtime, \\"y\\", event.location.y);
 
-      auto arrayOfObjects_codegen3 = jsi::Array(runtime, event.location.arrayOfObjects.size());
-      size_t arrayOfObjectsIndex_codegen4 = 0;
-      for (auto arrayOfObjectsValue_codegen5 : event.location.arrayOfObjects) {
-        auto arrayOfObjectsObject_codegen6 = jsi::Object(runtime);
+      auto __codegen__3__arrayOfObjects = jsi::Array(runtime, event.location.arrayOfObjects.size());
+      size_t __codegen__4__arrayOfObjectsIndex = 0;
+      for (auto __codegen__5__arrayOfObjectsValue : event.location.arrayOfObjects) {
+        auto __codegen__6__arrayOfObjectsObject = jsi::Object(runtime);
         {
-    auto value_codegen7 = jsi::Object(runtime);
-    value_codegen7.setProperty(runtime, \\"str\\", arrayOfObjectsValue_codegen5.value.str);
-    arrayOfObjectsObject_codegen6.setProperty(runtime, \\"value\\", value_codegen7);
+    auto __codegen__7__value = jsi::Object(runtime);
+    __codegen__7__value.setProperty(runtime, \\"str\\", __codegen__5__arrayOfObjectsValue.value.str);
+    __codegen__6__arrayOfObjectsObject.setProperty(runtime, \\"value\\", __codegen__7__value);
   }
-        arrayOfObjects_codegen3.setValueAtIndex(runtime, arrayOfObjectsIndex_codegen4++, arrayOfObjectsObject_codegen6);
+        __codegen__3__arrayOfObjects.setValueAtIndex(runtime, __codegen__4__arrayOfObjectsIndex++, __codegen__6__arrayOfObjectsObject);
       }
-      location_codegen1.setProperty(runtime, \\"arrayOfObjects\\", arrayOfObjects_codegen3);
+      __codegen__1__location.setProperty(runtime, \\"arrayOfObjects\\", __codegen__3__arrayOfObjects);
     
-  payload.setProperty(runtime, \\"location\\", location_codegen1);
+  payload.setProperty(runtime, \\"location\\", __codegen__1__location);
 }
     return payload;
   });

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GenerateEventEmitterCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GenerateEventEmitterCpp-test.js.snap
@@ -153,29 +153,29 @@ void EventNestedObjectPropsNativeComponentViewEventEmitter::onChange(OnChange ev
   dispatchEvent(\\"change\\", [event=std::move(event)](jsi::Runtime &runtime) {
     auto payload = jsi::Object(runtime);
     {
-  auto location_1 = jsi::Object(runtime);
+  auto location_codegen1 = jsi::Object(runtime);
   {
-    auto source_2 = jsi::Object(runtime);
-    source_2.setProperty(runtime, \\"url\\", event.location.source.url);
-    location_1.setProperty(runtime, \\"source\\", source_2);
+    auto source_codegen2 = jsi::Object(runtime);
+    source_codegen2.setProperty(runtime, \\"url\\", event.location.source.url);
+    location_codegen1.setProperty(runtime, \\"source\\", source_codegen2);
   }
-  location_1.setProperty(runtime, \\"x\\", event.location.x);
-  location_1.setProperty(runtime, \\"y\\", event.location.y);
+  location_codegen1.setProperty(runtime, \\"x\\", event.location.x);
+  location_codegen1.setProperty(runtime, \\"y\\", event.location.y);
 
-      auto arrayOfObjects_3 = jsi::Array(runtime, event.location.arrayOfObjects.size());
-      size_t arrayOfObjectsIndex_4 = 0;
-      for (auto arrayOfObjectsValue_5 : event.location.arrayOfObjects) {
-        auto arrayOfObjectsObject_6 = jsi::Object(runtime);
+      auto arrayOfObjects_codegen3 = jsi::Array(runtime, event.location.arrayOfObjects.size());
+      size_t arrayOfObjectsIndex_codegen4 = 0;
+      for (auto arrayOfObjectsValue_codegen5 : event.location.arrayOfObjects) {
+        auto arrayOfObjectsObject_codegen6 = jsi::Object(runtime);
         {
-    auto value_7 = jsi::Object(runtime);
-    value_7.setProperty(runtime, \\"str\\", arrayOfObjectsValue_5.value.str);
-    arrayOfObjectsObject_6.setProperty(runtime, \\"value\\", value_7);
+    auto value_codegen7 = jsi::Object(runtime);
+    value_codegen7.setProperty(runtime, \\"str\\", arrayOfObjectsValue_codegen5.value.str);
+    arrayOfObjectsObject_codegen6.setProperty(runtime, \\"value\\", value_codegen7);
   }
-        arrayOfObjects_3.setValueAtIndex(runtime, arrayOfObjectsIndex_4++, arrayOfObjectsObject_6);
+        arrayOfObjects_codegen3.setValueAtIndex(runtime, arrayOfObjectsIndex_codegen4++, arrayOfObjectsObject_codegen6);
       }
-      location_1.setProperty(runtime, \\"arrayOfObjects\\", arrayOfObjects_3);
+      location_codegen1.setProperty(runtime, \\"arrayOfObjects\\", arrayOfObjects_codegen3);
     
-  payload.setProperty(runtime, \\"location\\", location_1);
+  payload.setProperty(runtime, \\"location\\", location_codegen1);
 }
     return payload;
   });

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GenerateEventEmitterCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GenerateEventEmitterCpp-test.js.snap
@@ -153,29 +153,29 @@ void EventNestedObjectPropsNativeComponentViewEventEmitter::onChange(OnChange ev
   dispatchEvent(\\"change\\", [event=std::move(event)](jsi::Runtime &runtime) {
     auto payload = jsi::Object(runtime);
     {
-  auto location = jsi::Object(runtime);
+  auto location_1 = jsi::Object(runtime);
   {
-    auto source = jsi::Object(runtime);
-    source.setProperty(runtime, \\"url\\", event.location.source.url);
-    location.setProperty(runtime, \\"source\\", source);
+    auto source_2 = jsi::Object(runtime);
+    source_2.setProperty(runtime, \\"url\\", event.location.source.url);
+    location_1.setProperty(runtime, \\"source\\", source_2);
   }
-  location.setProperty(runtime, \\"x\\", event.location.x);
-  location.setProperty(runtime, \\"y\\", event.location.y);
+  location_1.setProperty(runtime, \\"x\\", event.location.x);
+  location_1.setProperty(runtime, \\"y\\", event.location.y);
 
-      auto arrayOfObjects = jsi::Array(runtime, event.location.arrayOfObjects.size());
-      size_t arrayOfObjectsIndex = 0;
-      for (auto arrayOfObjectsValue : event.location.arrayOfObjects) {
-        auto arrayOfObjectsObject = jsi::Object(runtime);
+      auto arrayOfObjects_3 = jsi::Array(runtime, event.location.arrayOfObjects.size());
+      size_t arrayOfObjectsIndex_4 = 0;
+      for (auto arrayOfObjectsValue_5 : event.location.arrayOfObjects) {
+        auto arrayOfObjectsObject_6 = jsi::Object(runtime);
         {
-    auto value = jsi::Object(runtime);
-    value.setProperty(runtime, \\"str\\", arrayOfObjectsValue.value.str);
-    arrayOfObjectsObject.setProperty(runtime, \\"value\\", value);
+    auto value_7 = jsi::Object(runtime);
+    value_7.setProperty(runtime, \\"str\\", arrayOfObjectsValue_5.value.str);
+    arrayOfObjectsObject_6.setProperty(runtime, \\"value\\", value_7);
   }
-        arrayOfObjects.setValueAtIndex(runtime, arrayOfObjectsIndex++, arrayOfObjectsObject);
+        arrayOfObjects_3.setValueAtIndex(runtime, arrayOfObjectsIndex_4++, arrayOfObjectsObject_6);
       }
-      location.setProperty(runtime, \\"arrayOfObjects\\", arrayOfObjects);
+      location_1.setProperty(runtime, \\"arrayOfObjects\\", arrayOfObjects_3);
     
-  payload.setProperty(runtime, \\"location\\", location);
+  payload.setProperty(runtime, \\"location\\", location_1);
 }
     return payload;
   });

--- a/packages/react-native-codegen/src/generators/components/GenerateEventEmitterCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateEventEmitterCpp.js
@@ -100,7 +100,7 @@ function generateSetter(
   propertyName: string,
   propertyParts: $ReadOnlyArray<string>,
   usingEvent: boolean,
-  context: { variableSuffix: number },
+  context: {variableSuffix: number},
   valueMapper: string => string = value => value,
 ) {
   const eventChain = usingEvent
@@ -118,7 +118,7 @@ function generateObjectSetter(
   typeAnnotation: ObjectTypeAnnotation<EventTypeAnnotation>,
   extraIncludes: Set<string>,
   usingEvent: boolean,
-  context: { variableSuffix: number },
+  context: {variableSuffix: number},
 ) {
   const objectVariable = variable(`${propertyName}`, context);
   return `
@@ -152,7 +152,7 @@ function setValueAtIndex(
   )});`;
 }
 
-function variable(name: string, context: { variableSuffix: number }): string {
+function variable(name: string, context: {variableSuffix: number}): string {
   // Ensure variable names are unique by adding a suffix.
   // Prevents C++ variable name collisions for properties with the same name.
   // See: https://github.com/facebook/react-native/issues/53839
@@ -167,7 +167,7 @@ function generateArraySetter(
   elementType: EventTypeAnnotation,
   extraIncludes: Set<string>,
   usingEvent: boolean,
-  context: { variableSuffix: number },
+  context: {variableSuffix: number},
 ): string {
   const eventChain = usingEvent
     ? `event.${[...propertyParts, propertyName].join('.')}`
@@ -204,7 +204,7 @@ function handleArrayElementType(
   propertyParts: $ReadOnlyArray<string>,
   extraIncludes: Set<string>,
   usingEvent: boolean,
-  context: { variableSuffix: number },
+  context: {variableSuffix: number},
 ): string {
   switch (elementType.type) {
     case 'BooleanTypeAnnotation':
@@ -271,7 +271,7 @@ function convertObjectTypeArray(
   propertyParts: $ReadOnlyArray<string>,
   objectTypeAnnotation: ObjectTypeAnnotation<EventTypeAnnotation>,
   extraIncludes: Set<string>,
-  context: { variableSuffix: number },
+  context: {variableSuffix: number},
 ): string {
   const variableName = variable(`${propertyName}Object`, context);
   return `auto ${variableName} = jsi::Object(runtime);
@@ -282,7 +282,7 @@ function convertObjectTypeArray(
         [].concat([loopLocalVariable]),
         extraIncludes,
         false,
-        context
+        context,
       )}
       ${setValueAtIndex(arrayVariable, indexVariable, variableName)}`;
 }
@@ -296,7 +296,7 @@ function convertArrayTypeArray(
   eventTypeAnnotation: EventTypeAnnotation,
   extraIncludes: Set<string>,
   usingEvent: boolean,
-  context: { variableSuffix: number },
+  context: {variableSuffix: number},
 ): string {
   if (eventTypeAnnotation.type !== 'ArrayTypeAnnotation') {
     throw new Error(
@@ -329,7 +329,7 @@ function generateSetters(
   propertyParts: $ReadOnlyArray<string>,
   extraIncludes: Set<string>,
   usingEvent: boolean = true,
-  context: { variableSuffix: number },
+  context: {variableSuffix: number},
 ): string {
   const propSetters = properties
     .map(eventProperty => {
@@ -415,7 +415,7 @@ function generateEvent(
       : `${event.name[2].toLowerCase()}${event.name.slice(3)}`;
 
   if (event.typeAnnotation.argument) {
-    const context = { variableSuffix: 0 };
+    const context = {variableSuffix: 0};
     const variableName = 'payload';
     const implementation = `
     auto ${variableName} = jsi::Object(runtime);

--- a/packages/react-native-codegen/src/generators/components/GenerateEventEmitterCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateEventEmitterCpp.js
@@ -157,7 +157,7 @@ function variable(name: string, context: {variableSuffix: number}): string {
   // Prevents C++ variable name collisions for properties with the same name.
   // See: https://github.com/facebook/react-native/issues/53839
   context.variableSuffix++;
-  return `${name}_${context.variableSuffix}`;
+  return `${name}_codegen${context.variableSuffix}`;
 }
 
 function generateArraySetter(

--- a/packages/react-native-codegen/src/generators/components/GenerateEventEmitterCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateEventEmitterCpp.js
@@ -167,7 +167,7 @@ function generateArraySetter(
   elementType: EventTypeAnnotation,
   extraIncludes: Set<string>,
   usingEvent: boolean,
-  context: { numberOfVariables: number },
+  context: { variableSuffix: number },
 ): string {
   const eventChain = usingEvent
     ? `event.${[...propertyParts, propertyName].join('.')}`
@@ -204,7 +204,7 @@ function handleArrayElementType(
   propertyParts: $ReadOnlyArray<string>,
   extraIncludes: Set<string>,
   usingEvent: boolean,
-  context: { numberOfVariables: number },
+  context: { variableSuffix: number },
 ): string {
   switch (elementType.type) {
     case 'BooleanTypeAnnotation':
@@ -271,7 +271,7 @@ function convertObjectTypeArray(
   propertyParts: $ReadOnlyArray<string>,
   objectTypeAnnotation: ObjectTypeAnnotation<EventTypeAnnotation>,
   extraIncludes: Set<string>,
-  context: { numberOfVariables: number },
+  context: { variableSuffix: number },
 ): string {
   const variableName = variable(`${propertyName}Object`, context);
   return `auto ${variableName} = jsi::Object(runtime);
@@ -296,7 +296,7 @@ function convertArrayTypeArray(
   eventTypeAnnotation: EventTypeAnnotation,
   extraIncludes: Set<string>,
   usingEvent: boolean,
-  context: { numberOfVariables: number },
+  context: { variableSuffix: number },
 ): string {
   if (eventTypeAnnotation.type !== 'ArrayTypeAnnotation') {
     throw new Error(

--- a/packages/react-native-codegen/src/generators/components/GenerateEventEmitterCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateEventEmitterCpp.js
@@ -157,7 +157,7 @@ function variable(name: string, context: {variableSuffix: number}): string {
   // Prevents C++ variable name collisions for properties with the same name.
   // See: https://github.com/facebook/react-native/issues/53839
   context.variableSuffix++;
-  return `${name}_codegen${context.variableSuffix}`;
+  return `__codegen__${context.variableSuffix}__${name}`;
 }
 
 function generateArraySetter(

--- a/packages/react-native-codegen/src/generators/components/GenerateEventEmitterCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateEventEmitterCpp.js
@@ -153,6 +153,9 @@ function setValueAtIndex(
 }
 
 function variable(name: string, context: { variableSuffix: number }): string {
+  // Ensure variable names are unique by adding a suffix.
+  // Prevents C++ variable name collisions for properties with the same name.
+  // See: https://github.com/facebook/react-native/issues/53839
   context.variableSuffix++;
   return `${name}_${context.variableSuffix}`;
 }

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateEventEmitterCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateEventEmitterCpp-test.js.snap
@@ -197,15 +197,15 @@ void EventsNestedObjectNativeComponentEventEmitter::onChange(OnChange event) con
   dispatchEvent(\\"change\\", [event=std::move(event)](jsi::Runtime &runtime) {
     auto payload = jsi::Object(runtime);
     {
-  auto location_1 = jsi::Object(runtime);
+  auto location_codegen1 = jsi::Object(runtime);
   {
-    auto source_2 = jsi::Object(runtime);
-    source_2.setProperty(runtime, \\"url\\", event.location.source.url);
-    location_1.setProperty(runtime, \\"source\\", source_2);
+    auto source_codegen2 = jsi::Object(runtime);
+    source_codegen2.setProperty(runtime, \\"url\\", event.location.source.url);
+    location_codegen1.setProperty(runtime, \\"source\\", source_codegen2);
   }
-  location_1.setProperty(runtime, \\"x\\", event.location.x);
-  location_1.setProperty(runtime, \\"y\\", event.location.y);
-  payload.setProperty(runtime, \\"location\\", location_1);
+  location_codegen1.setProperty(runtime, \\"x\\", event.location.x);
+  location_codegen1.setProperty(runtime, \\"y\\", event.location.y);
+  payload.setProperty(runtime, \\"location\\", location_codegen1);
 }
     return payload;
   });
@@ -249,60 +249,60 @@ void EventsNativeComponentEventEmitter::onArrayEventType(OnArrayEventType event)
   dispatchEvent(\\"arrayEventType\\", [event=std::move(event)](jsi::Runtime &runtime) {
     auto payload = jsi::Object(runtime);
     
-    auto bool_array_event_prop_1 = jsi::Array(runtime, event.bool_array_event_prop.size());
-    size_t bool_array_event_propIndex_2 = 0;
-    for (auto bool_array_event_propValue_3 : event.bool_array_event_prop) {
-      bool_array_event_prop_1.setValueAtIndex(runtime, bool_array_event_propIndex_2++, (bool)bool_array_event_propValue_3);
+    auto bool_array_event_prop_codegen1 = jsi::Array(runtime, event.bool_array_event_prop.size());
+    size_t bool_array_event_propIndex_codegen2 = 0;
+    for (auto bool_array_event_propValue_codegen3 : event.bool_array_event_prop) {
+      bool_array_event_prop_codegen1.setValueAtIndex(runtime, bool_array_event_propIndex_codegen2++, (bool)bool_array_event_propValue_codegen3);
     }
-    payload.setProperty(runtime, \\"bool_array_event_prop\\", bool_array_event_prop_1);
+    payload.setProperty(runtime, \\"bool_array_event_prop\\", bool_array_event_prop_codegen1);
   
 
-    auto string_enum_event_prop_4 = jsi::Array(runtime, event.string_enum_event_prop.size());
-    size_t string_enum_event_propIndex_5 = 0;
-    for (auto string_enum_event_propValue_6 : event.string_enum_event_prop) {
-      string_enum_event_prop_4.setValueAtIndex(runtime, string_enum_event_propIndex_5++, toString(string_enum_event_propValue_6));
+    auto string_enum_event_prop_codegen4 = jsi::Array(runtime, event.string_enum_event_prop.size());
+    size_t string_enum_event_propIndex_codegen5 = 0;
+    for (auto string_enum_event_propValue_codegen6 : event.string_enum_event_prop) {
+      string_enum_event_prop_codegen4.setValueAtIndex(runtime, string_enum_event_propIndex_codegen5++, toString(string_enum_event_propValue_codegen6));
     }
-    payload.setProperty(runtime, \\"string_enum_event_prop\\", string_enum_event_prop_4);
+    payload.setProperty(runtime, \\"string_enum_event_prop\\", string_enum_event_prop_codegen4);
   
 
-    auto array_array_event_prop_7 = jsi::Array(runtime, event.array_array_event_prop.size());
-    size_t array_array_event_propIndex_8 = 0;
-    for (auto array_array_event_propValue_9 : event.array_array_event_prop) {
-      auto array_array_event_propArray_10 = jsi::Array(runtime, array_array_event_propValue_9.size());
-      size_t array_array_event_propIndex_8Internal = 0;
-      for (auto array_array_event_propValue_9Internal : array_array_event_propValue_9) {
-        array_array_event_propArray_10.setValueAtIndex(runtime, array_array_event_propIndex_8Internal++, array_array_event_propValue_9Internal);
+    auto array_array_event_prop_codegen7 = jsi::Array(runtime, event.array_array_event_prop.size());
+    size_t array_array_event_propIndex_codegen8 = 0;
+    for (auto array_array_event_propValue_codegen9 : event.array_array_event_prop) {
+      auto array_array_event_propArray_codegen10 = jsi::Array(runtime, array_array_event_propValue_codegen9.size());
+      size_t array_array_event_propIndex_codegen8Internal = 0;
+      for (auto array_array_event_propValue_codegen9Internal : array_array_event_propValue_codegen9) {
+        array_array_event_propArray_codegen10.setValueAtIndex(runtime, array_array_event_propIndex_codegen8Internal++, array_array_event_propValue_codegen9Internal);
       }
-      array_array_event_prop_7.setValueAtIndex(runtime, array_array_event_propIndex_8++, array_array_event_propArray_10);
+      array_array_event_prop_codegen7.setValueAtIndex(runtime, array_array_event_propIndex_codegen8++, array_array_event_propArray_codegen10);
     }
-    payload.setProperty(runtime, \\"array_array_event_prop\\", array_array_event_prop_7);
+    payload.setProperty(runtime, \\"array_array_event_prop\\", array_array_event_prop_codegen7);
   
 
-    auto array_object_event_prop_11 = jsi::Array(runtime, event.array_object_event_prop.size());
-    size_t array_object_event_propIndex_12 = 0;
-    for (auto array_object_event_propValue_13 : event.array_object_event_prop) {
-      auto array_object_event_propObject_14 = jsi::Object(runtime);
-      array_object_event_propObject_14.setProperty(runtime, \\"lat\\", array_object_event_propValue_13.lat);
-array_object_event_propObject_14.setProperty(runtime, \\"lon\\", array_object_event_propValue_13.lon);
+    auto array_object_event_prop_codegen11 = jsi::Array(runtime, event.array_object_event_prop.size());
+    size_t array_object_event_propIndex_codegen12 = 0;
+    for (auto array_object_event_propValue_codegen13 : event.array_object_event_prop) {
+      auto array_object_event_propObject_codegen14 = jsi::Object(runtime);
+      array_object_event_propObject_codegen14.setProperty(runtime, \\"lat\\", array_object_event_propValue_codegen13.lat);
+array_object_event_propObject_codegen14.setProperty(runtime, \\"lon\\", array_object_event_propValue_codegen13.lon);
 
-    auto names_15 = jsi::Array(runtime, array_object_event_propValue_13.names.size());
-    size_t namesIndex_16 = 0;
-    for (auto namesValue_17 : array_object_event_propValue_13.names) {
-      names_15.setValueAtIndex(runtime, namesIndex_16++, namesValue_17);
+    auto names_codegen15 = jsi::Array(runtime, array_object_event_propValue_codegen13.names.size());
+    size_t namesIndex_codegen16 = 0;
+    for (auto namesValue_codegen17 : array_object_event_propValue_codegen13.names) {
+      names_codegen15.setValueAtIndex(runtime, namesIndex_codegen16++, namesValue_codegen17);
     }
-    array_object_event_propObject_14.setProperty(runtime, \\"names\\", names_15);
+    array_object_event_propObject_codegen14.setProperty(runtime, \\"names\\", names_codegen15);
   
-      array_object_event_prop_11.setValueAtIndex(runtime, array_object_event_propIndex_12++, array_object_event_propObject_14);
+      array_object_event_prop_codegen11.setValueAtIndex(runtime, array_object_event_propIndex_codegen12++, array_object_event_propObject_codegen14);
     }
-    payload.setProperty(runtime, \\"array_object_event_prop\\", array_object_event_prop_11);
+    payload.setProperty(runtime, \\"array_object_event_prop\\", array_object_event_prop_codegen11);
   
 
-    auto array_mixed_event_prop_18 = jsi::Array(runtime, event.array_mixed_event_prop.size());
-    size_t array_mixed_event_propIndex_19 = 0;
-    for (auto array_mixed_event_propValue_20 : event.array_mixed_event_prop) {
-      array_mixed_event_prop_18.setValueAtIndex(runtime, array_mixed_event_propIndex_19++, jsi::valueFromDynamic(runtime, array_mixed_event_propValue_20));
+    auto array_mixed_event_prop_codegen18 = jsi::Array(runtime, event.array_mixed_event_prop.size());
+    size_t array_mixed_event_propIndex_codegen19 = 0;
+    for (auto array_mixed_event_propValue_codegen20 : event.array_mixed_event_prop) {
+      array_mixed_event_prop_codegen18.setValueAtIndex(runtime, array_mixed_event_propIndex_codegen19++, jsi::valueFromDynamic(runtime, array_mixed_event_propValue_codegen20));
     }
-    payload.setProperty(runtime, \\"array_mixed_event_prop\\", array_mixed_event_prop_18);
+    payload.setProperty(runtime, \\"array_mixed_event_prop\\", array_mixed_event_prop_codegen18);
   
     return payload;
   });

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateEventEmitterCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateEventEmitterCpp-test.js.snap
@@ -197,15 +197,15 @@ void EventsNestedObjectNativeComponentEventEmitter::onChange(OnChange event) con
   dispatchEvent(\\"change\\", [event=std::move(event)](jsi::Runtime &runtime) {
     auto payload = jsi::Object(runtime);
     {
-  auto location_codegen1 = jsi::Object(runtime);
+  auto __codegen__1__location = jsi::Object(runtime);
   {
-    auto source_codegen2 = jsi::Object(runtime);
-    source_codegen2.setProperty(runtime, \\"url\\", event.location.source.url);
-    location_codegen1.setProperty(runtime, \\"source\\", source_codegen2);
+    auto __codegen__2__source = jsi::Object(runtime);
+    __codegen__2__source.setProperty(runtime, \\"url\\", event.location.source.url);
+    __codegen__1__location.setProperty(runtime, \\"source\\", __codegen__2__source);
   }
-  location_codegen1.setProperty(runtime, \\"x\\", event.location.x);
-  location_codegen1.setProperty(runtime, \\"y\\", event.location.y);
-  payload.setProperty(runtime, \\"location\\", location_codegen1);
+  __codegen__1__location.setProperty(runtime, \\"x\\", event.location.x);
+  __codegen__1__location.setProperty(runtime, \\"y\\", event.location.y);
+  payload.setProperty(runtime, \\"location\\", __codegen__1__location);
 }
     return payload;
   });
@@ -249,60 +249,60 @@ void EventsNativeComponentEventEmitter::onArrayEventType(OnArrayEventType event)
   dispatchEvent(\\"arrayEventType\\", [event=std::move(event)](jsi::Runtime &runtime) {
     auto payload = jsi::Object(runtime);
     
-    auto bool_array_event_prop_codegen1 = jsi::Array(runtime, event.bool_array_event_prop.size());
-    size_t bool_array_event_propIndex_codegen2 = 0;
-    for (auto bool_array_event_propValue_codegen3 : event.bool_array_event_prop) {
-      bool_array_event_prop_codegen1.setValueAtIndex(runtime, bool_array_event_propIndex_codegen2++, (bool)bool_array_event_propValue_codegen3);
+    auto __codegen__1__bool_array_event_prop = jsi::Array(runtime, event.bool_array_event_prop.size());
+    size_t __codegen__2__bool_array_event_propIndex = 0;
+    for (auto __codegen__3__bool_array_event_propValue : event.bool_array_event_prop) {
+      __codegen__1__bool_array_event_prop.setValueAtIndex(runtime, __codegen__2__bool_array_event_propIndex++, (bool)__codegen__3__bool_array_event_propValue);
     }
-    payload.setProperty(runtime, \\"bool_array_event_prop\\", bool_array_event_prop_codegen1);
+    payload.setProperty(runtime, \\"bool_array_event_prop\\", __codegen__1__bool_array_event_prop);
   
 
-    auto string_enum_event_prop_codegen4 = jsi::Array(runtime, event.string_enum_event_prop.size());
-    size_t string_enum_event_propIndex_codegen5 = 0;
-    for (auto string_enum_event_propValue_codegen6 : event.string_enum_event_prop) {
-      string_enum_event_prop_codegen4.setValueAtIndex(runtime, string_enum_event_propIndex_codegen5++, toString(string_enum_event_propValue_codegen6));
+    auto __codegen__4__string_enum_event_prop = jsi::Array(runtime, event.string_enum_event_prop.size());
+    size_t __codegen__5__string_enum_event_propIndex = 0;
+    for (auto __codegen__6__string_enum_event_propValue : event.string_enum_event_prop) {
+      __codegen__4__string_enum_event_prop.setValueAtIndex(runtime, __codegen__5__string_enum_event_propIndex++, toString(__codegen__6__string_enum_event_propValue));
     }
-    payload.setProperty(runtime, \\"string_enum_event_prop\\", string_enum_event_prop_codegen4);
+    payload.setProperty(runtime, \\"string_enum_event_prop\\", __codegen__4__string_enum_event_prop);
   
 
-    auto array_array_event_prop_codegen7 = jsi::Array(runtime, event.array_array_event_prop.size());
-    size_t array_array_event_propIndex_codegen8 = 0;
-    for (auto array_array_event_propValue_codegen9 : event.array_array_event_prop) {
-      auto array_array_event_propArray_codegen10 = jsi::Array(runtime, array_array_event_propValue_codegen9.size());
-      size_t array_array_event_propIndex_codegen8Internal = 0;
-      for (auto array_array_event_propValue_codegen9Internal : array_array_event_propValue_codegen9) {
-        array_array_event_propArray_codegen10.setValueAtIndex(runtime, array_array_event_propIndex_codegen8Internal++, array_array_event_propValue_codegen9Internal);
+    auto __codegen__7__array_array_event_prop = jsi::Array(runtime, event.array_array_event_prop.size());
+    size_t __codegen__8__array_array_event_propIndex = 0;
+    for (auto __codegen__9__array_array_event_propValue : event.array_array_event_prop) {
+      auto __codegen__10__array_array_event_propArray = jsi::Array(runtime, __codegen__9__array_array_event_propValue.size());
+      size_t __codegen__8__array_array_event_propIndexInternal = 0;
+      for (auto __codegen__9__array_array_event_propValueInternal : __codegen__9__array_array_event_propValue) {
+        __codegen__10__array_array_event_propArray.setValueAtIndex(runtime, __codegen__8__array_array_event_propIndexInternal++, __codegen__9__array_array_event_propValueInternal);
       }
-      array_array_event_prop_codegen7.setValueAtIndex(runtime, array_array_event_propIndex_codegen8++, array_array_event_propArray_codegen10);
+      __codegen__7__array_array_event_prop.setValueAtIndex(runtime, __codegen__8__array_array_event_propIndex++, __codegen__10__array_array_event_propArray);
     }
-    payload.setProperty(runtime, \\"array_array_event_prop\\", array_array_event_prop_codegen7);
+    payload.setProperty(runtime, \\"array_array_event_prop\\", __codegen__7__array_array_event_prop);
   
 
-    auto array_object_event_prop_codegen11 = jsi::Array(runtime, event.array_object_event_prop.size());
-    size_t array_object_event_propIndex_codegen12 = 0;
-    for (auto array_object_event_propValue_codegen13 : event.array_object_event_prop) {
-      auto array_object_event_propObject_codegen14 = jsi::Object(runtime);
-      array_object_event_propObject_codegen14.setProperty(runtime, \\"lat\\", array_object_event_propValue_codegen13.lat);
-array_object_event_propObject_codegen14.setProperty(runtime, \\"lon\\", array_object_event_propValue_codegen13.lon);
+    auto __codegen__11__array_object_event_prop = jsi::Array(runtime, event.array_object_event_prop.size());
+    size_t __codegen__12__array_object_event_propIndex = 0;
+    for (auto __codegen__13__array_object_event_propValue : event.array_object_event_prop) {
+      auto __codegen__14__array_object_event_propObject = jsi::Object(runtime);
+      __codegen__14__array_object_event_propObject.setProperty(runtime, \\"lat\\", __codegen__13__array_object_event_propValue.lat);
+__codegen__14__array_object_event_propObject.setProperty(runtime, \\"lon\\", __codegen__13__array_object_event_propValue.lon);
 
-    auto names_codegen15 = jsi::Array(runtime, array_object_event_propValue_codegen13.names.size());
-    size_t namesIndex_codegen16 = 0;
-    for (auto namesValue_codegen17 : array_object_event_propValue_codegen13.names) {
-      names_codegen15.setValueAtIndex(runtime, namesIndex_codegen16++, namesValue_codegen17);
+    auto __codegen__15__names = jsi::Array(runtime, __codegen__13__array_object_event_propValue.names.size());
+    size_t __codegen__16__namesIndex = 0;
+    for (auto __codegen__17__namesValue : __codegen__13__array_object_event_propValue.names) {
+      __codegen__15__names.setValueAtIndex(runtime, __codegen__16__namesIndex++, __codegen__17__namesValue);
     }
-    array_object_event_propObject_codegen14.setProperty(runtime, \\"names\\", names_codegen15);
+    __codegen__14__array_object_event_propObject.setProperty(runtime, \\"names\\", __codegen__15__names);
   
-      array_object_event_prop_codegen11.setValueAtIndex(runtime, array_object_event_propIndex_codegen12++, array_object_event_propObject_codegen14);
+      __codegen__11__array_object_event_prop.setValueAtIndex(runtime, __codegen__12__array_object_event_propIndex++, __codegen__14__array_object_event_propObject);
     }
-    payload.setProperty(runtime, \\"array_object_event_prop\\", array_object_event_prop_codegen11);
+    payload.setProperty(runtime, \\"array_object_event_prop\\", __codegen__11__array_object_event_prop);
   
 
-    auto array_mixed_event_prop_codegen18 = jsi::Array(runtime, event.array_mixed_event_prop.size());
-    size_t array_mixed_event_propIndex_codegen19 = 0;
-    for (auto array_mixed_event_propValue_codegen20 : event.array_mixed_event_prop) {
-      array_mixed_event_prop_codegen18.setValueAtIndex(runtime, array_mixed_event_propIndex_codegen19++, jsi::valueFromDynamic(runtime, array_mixed_event_propValue_codegen20));
+    auto __codegen__18__array_mixed_event_prop = jsi::Array(runtime, event.array_mixed_event_prop.size());
+    size_t __codegen__19__array_mixed_event_propIndex = 0;
+    for (auto __codegen__20__array_mixed_event_propValue : event.array_mixed_event_prop) {
+      __codegen__18__array_mixed_event_prop.setValueAtIndex(runtime, __codegen__19__array_mixed_event_propIndex++, jsi::valueFromDynamic(runtime, __codegen__20__array_mixed_event_propValue));
     }
-    payload.setProperty(runtime, \\"array_mixed_event_prop\\", array_mixed_event_prop_codegen18);
+    payload.setProperty(runtime, \\"array_mixed_event_prop\\", __codegen__18__array_mixed_event_prop);
   
     return payload;
   });

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateEventEmitterCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateEventEmitterCpp-test.js.snap
@@ -197,15 +197,15 @@ void EventsNestedObjectNativeComponentEventEmitter::onChange(OnChange event) con
   dispatchEvent(\\"change\\", [event=std::move(event)](jsi::Runtime &runtime) {
     auto payload = jsi::Object(runtime);
     {
-  auto location = jsi::Object(runtime);
+  auto location_1 = jsi::Object(runtime);
   {
-    auto source = jsi::Object(runtime);
-    source.setProperty(runtime, \\"url\\", event.location.source.url);
-    location.setProperty(runtime, \\"source\\", source);
+    auto source_2 = jsi::Object(runtime);
+    source_2.setProperty(runtime, \\"url\\", event.location.source.url);
+    location_1.setProperty(runtime, \\"source\\", source_2);
   }
-  location.setProperty(runtime, \\"x\\", event.location.x);
-  location.setProperty(runtime, \\"y\\", event.location.y);
-  payload.setProperty(runtime, \\"location\\", location);
+  location_1.setProperty(runtime, \\"x\\", event.location.x);
+  location_1.setProperty(runtime, \\"y\\", event.location.y);
+  payload.setProperty(runtime, \\"location\\", location_1);
 }
     return payload;
   });
@@ -249,60 +249,60 @@ void EventsNativeComponentEventEmitter::onArrayEventType(OnArrayEventType event)
   dispatchEvent(\\"arrayEventType\\", [event=std::move(event)](jsi::Runtime &runtime) {
     auto payload = jsi::Object(runtime);
     
-    auto bool_array_event_prop = jsi::Array(runtime, event.bool_array_event_prop.size());
-    size_t bool_array_event_propIndex = 0;
-    for (auto bool_array_event_propValue : event.bool_array_event_prop) {
-      bool_array_event_prop.setValueAtIndex(runtime, bool_array_event_propIndex++, (bool)bool_array_event_propValue);
+    auto bool_array_event_prop_1 = jsi::Array(runtime, event.bool_array_event_prop.size());
+    size_t bool_array_event_propIndex_2 = 0;
+    for (auto bool_array_event_propValue_3 : event.bool_array_event_prop) {
+      bool_array_event_prop_1.setValueAtIndex(runtime, bool_array_event_propIndex_2++, (bool)bool_array_event_propValue_3);
     }
-    payload.setProperty(runtime, \\"bool_array_event_prop\\", bool_array_event_prop);
+    payload.setProperty(runtime, \\"bool_array_event_prop\\", bool_array_event_prop_1);
   
 
-    auto string_enum_event_prop = jsi::Array(runtime, event.string_enum_event_prop.size());
-    size_t string_enum_event_propIndex = 0;
-    for (auto string_enum_event_propValue : event.string_enum_event_prop) {
-      string_enum_event_prop.setValueAtIndex(runtime, string_enum_event_propIndex++, toString(string_enum_event_propValue));
+    auto string_enum_event_prop_4 = jsi::Array(runtime, event.string_enum_event_prop.size());
+    size_t string_enum_event_propIndex_5 = 0;
+    for (auto string_enum_event_propValue_6 : event.string_enum_event_prop) {
+      string_enum_event_prop_4.setValueAtIndex(runtime, string_enum_event_propIndex_5++, toString(string_enum_event_propValue_6));
     }
-    payload.setProperty(runtime, \\"string_enum_event_prop\\", string_enum_event_prop);
+    payload.setProperty(runtime, \\"string_enum_event_prop\\", string_enum_event_prop_4);
   
 
-    auto array_array_event_prop = jsi::Array(runtime, event.array_array_event_prop.size());
-    size_t array_array_event_propIndex = 0;
-    for (auto array_array_event_propValue : event.array_array_event_prop) {
-      auto array_array_event_propArray = jsi::Array(runtime, array_array_event_propValue.size());
-      size_t array_array_event_propIndexInternal = 0;
-      for (auto array_array_event_propValueInternal : array_array_event_propValue) {
-        array_array_event_propArray.setValueAtIndex(runtime, array_array_event_propIndexInternal++, array_array_event_propValueInternal);
+    auto array_array_event_prop_7 = jsi::Array(runtime, event.array_array_event_prop.size());
+    size_t array_array_event_propIndex_8 = 0;
+    for (auto array_array_event_propValue_9 : event.array_array_event_prop) {
+      auto array_array_event_propArray_10 = jsi::Array(runtime, array_array_event_propValue_9.size());
+      size_t array_array_event_propIndex_8Internal = 0;
+      for (auto array_array_event_propValue_9Internal : array_array_event_propValue_9) {
+        array_array_event_propArray_10.setValueAtIndex(runtime, array_array_event_propIndex_8Internal++, array_array_event_propValue_9Internal);
       }
-      array_array_event_prop.setValueAtIndex(runtime, array_array_event_propIndex++, array_array_event_propArray);
+      array_array_event_prop_7.setValueAtIndex(runtime, array_array_event_propIndex_8++, array_array_event_propArray_10);
     }
-    payload.setProperty(runtime, \\"array_array_event_prop\\", array_array_event_prop);
+    payload.setProperty(runtime, \\"array_array_event_prop\\", array_array_event_prop_7);
   
 
-    auto array_object_event_prop = jsi::Array(runtime, event.array_object_event_prop.size());
-    size_t array_object_event_propIndex = 0;
-    for (auto array_object_event_propValue : event.array_object_event_prop) {
-      auto array_object_event_propObject = jsi::Object(runtime);
-      array_object_event_propObject.setProperty(runtime, \\"lat\\", array_object_event_propValue.lat);
-array_object_event_propObject.setProperty(runtime, \\"lon\\", array_object_event_propValue.lon);
+    auto array_object_event_prop_11 = jsi::Array(runtime, event.array_object_event_prop.size());
+    size_t array_object_event_propIndex_12 = 0;
+    for (auto array_object_event_propValue_13 : event.array_object_event_prop) {
+      auto array_object_event_propObject_14 = jsi::Object(runtime);
+      array_object_event_propObject_14.setProperty(runtime, \\"lat\\", array_object_event_propValue_13.lat);
+array_object_event_propObject_14.setProperty(runtime, \\"lon\\", array_object_event_propValue_13.lon);
 
-    auto names = jsi::Array(runtime, array_object_event_propValue.names.size());
-    size_t namesIndex = 0;
-    for (auto namesValue : array_object_event_propValue.names) {
-      names.setValueAtIndex(runtime, namesIndex++, namesValue);
+    auto names_15 = jsi::Array(runtime, array_object_event_propValue_13.names.size());
+    size_t namesIndex_16 = 0;
+    for (auto namesValue_17 : array_object_event_propValue_13.names) {
+      names_15.setValueAtIndex(runtime, namesIndex_16++, namesValue_17);
     }
-    array_object_event_propObject.setProperty(runtime, \\"names\\", names);
+    array_object_event_propObject_14.setProperty(runtime, \\"names\\", names_15);
   
-      array_object_event_prop.setValueAtIndex(runtime, array_object_event_propIndex++, array_object_event_propObject);
+      array_object_event_prop_11.setValueAtIndex(runtime, array_object_event_propIndex_12++, array_object_event_propObject_14);
     }
-    payload.setProperty(runtime, \\"array_object_event_prop\\", array_object_event_prop);
+    payload.setProperty(runtime, \\"array_object_event_prop\\", array_object_event_prop_11);
   
 
-    auto array_mixed_event_prop = jsi::Array(runtime, event.array_mixed_event_prop.size());
-    size_t array_mixed_event_propIndex = 0;
-    for (auto array_mixed_event_propValue : event.array_mixed_event_prop) {
-      array_mixed_event_prop.setValueAtIndex(runtime, array_mixed_event_propIndex++, jsi::valueFromDynamic(runtime, array_mixed_event_propValue));
+    auto array_mixed_event_prop_18 = jsi::Array(runtime, event.array_mixed_event_prop.size());
+    size_t array_mixed_event_propIndex_19 = 0;
+    for (auto array_mixed_event_propValue_20 : event.array_mixed_event_prop) {
+      array_mixed_event_prop_18.setValueAtIndex(runtime, array_mixed_event_propIndex_19++, jsi::valueFromDynamic(runtime, array_mixed_event_propValue_20));
     }
-    payload.setProperty(runtime, \\"array_mixed_event_prop\\", array_mixed_event_prop);
+    payload.setProperty(runtime, \\"array_mixed_event_prop\\", array_mixed_event_prop_18);
   
     return payload;
   });


### PR DESCRIPTION
## Summary:

Fixes: #53839

Codegen uses object propertyNames as variable names. This breaks if the same property names appears at multiple levels. Also breaks if a property is called `payload` as payload is a variable name already used.

Before the fix codegen could generate code like this:
```tsx
payload.setProperty(runtime, "payload", payload);
```

## Changelog:

[GENERAL] [FIXED] - Fix Codegen to use unique variable names to avoid name collisions in corner cases

## Test Plan:

- jest snapshot tests