### PR TITLE
Manually preserve ordering for Scheduler and Components tracks

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -310,6 +310,10 @@ class PerformanceTracer {
   std::vector<PerformanceTracerEvent>* previousBuffer_{};
   HighResTimeStamp currentBufferStartTime_;
 
+  // A flag that is used to ensure we only emit one auxiliary entry for the
+  // ordering of Scheduler / Component tracks.
+  bool alreadyEmittedEntryForComponentsTrackOrdering_ = false;
+
   /**
    * Protects data members of this class for concurrent access, including
    * the tracingAtomic_, in order to eliminate potential "logic" races.


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

Chrome DevTools orders tracks based on the timestamp of the first entry.

For React on Web we emit a few entries to establish the ordering:
https://github.com/facebook/react/blob/6eda534718d09a26d58d65c0a376e05d7e2a3358/packages/react-reconciler/src/ReactFiberPerformanceTrack.js#L57-L96

We are doing the same thing here, but in C++.

Differential Revision: D82811889


