### PR TITLE
Remove `jest` from "types" in `@react-native/typescript-config`

### DIFF
--- a/packages/typescript-config/tsconfig.json
+++ b/packages/typescript-config/tsconfig.json
@@ -4,7 +4,6 @@
     "compilerOptions": {
       "target": "esnext",
       "module": "esnext",
-      "types": ["jest"],
       "lib": [
         "es2019",
         "es2020.bigint",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

See https://github.com/facebook/react-native/issues/53563 for more context.

Drafted to wait for https://github.com/react-native-community/template/pull/177 to merge and release.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[GENERAL] [REMOVED] - Remove explicit use of jest types in tsconfig.json: Apps should declare this themselves.

## Test Plan:

1. Initialize the template `npx @react-native-community/cli@latest init TestApp` (once https://github.com/react-native-community/template/pull/177 is merged and released) 
2. Patch `node_modules/@react-native/typescript-config/tsconfig.json` with this suggested change.
3. Note how this doesn't affect the ability to use describe in source files.
