### PR TITLE
Fix race condition between experimental_prefetchResources and surface stop

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.java
@@ -821,6 +821,9 @@ public class SurfaceMountingManager {
   @UnstableReactNativeAPI
   public void experimental_prefetchResources(
       int surfaceId, String componentName, MapBuffer params) {
+    if (isStopped()) {
+      return;
+    }
     mViewManagerRegistry
         .get(componentName)
         .experimental_prefetchResources(


### PR DESCRIPTION
Summary:
Changelog: [Internal]

The issue is a race condition in the React Native Fabric mounting system where `experimental_prefetchResources` is called on a `SurfaceMountingManager` after the surface has been stopped.


1.) `experimental_prefetchResources` is called
2.) Concurrently, `stopSurface()` *can be* called, which sets `mThemedReactContext = null`
3.) `experimental_prefetchResources` then tries to access `mThemedReactContext` via `Assertions.assertNotNull(mThemedReactContext)`
4.) Since `mThemedReactContext` is now `null`, the assertion fails and throws an AssertionError

The fix involves adding a guard to check if the surface is stopped before accessing `mThemedReactContext`

Follows existing patterns used by other methods in the same class

https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.java#L201-L213

Differential Revision: D82842572


