### PR TITLE
Fix potential race conditions when executing commitHooks

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/ImageFetcher.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/ImageFetcher.h
@@ -11,17 +11,19 @@
 #include <react/renderer/imagemanager/ImageRequest.h>
 #include <react/renderer/imagemanager/ImageRequestParams.h>
 #include <react/renderer/mounting/ShadowTree.h>
-#include <react/renderer/uimanager/UIManagerCommitHook.h>
 #include <react/utils/ContextContainer.h>
+#include <memory>
 #include <unordered_map>
 #include <vector>
 
 namespace facebook::react {
 
-class ImageFetcher : public UIManagerCommitHook {
+class ImageFetcherCommitHook;
+
+class ImageFetcher {
  public:
   ImageFetcher(std::shared_ptr<const ContextContainer> contextContainer);
-  ~ImageFetcher() override;
+  ~ImageFetcher();
   ImageFetcher(const ImageFetcher&) = delete;
   ImageFetcher& operator=(const ImageFetcher&) = delete;
   ImageFetcher(ImageFetcher&&) = delete;
@@ -33,21 +35,12 @@ class ImageFetcher : public UIManagerCommitHook {
       const ImageRequestParams& imageRequestParams,
       Tag tag);
 
-  void commitHookWasRegistered(const UIManager& uiManager) noexcept override {}
-
-  void commitHookWasUnregistered(const UIManager& uiManager) noexcept override {
-  }
-
-  RootShadowNode::Unshared shadowTreeWillCommit(
-      const ShadowTree& shadowTree,
-      const RootShadowNode::Shared& oldRootShadowNode,
-      const RootShadowNode::Unshared& newRootShadowNode,
-      const ShadowTree::CommitOptions& commitOptions) noexcept override;
-
  private:
+  friend class ImageFetcherCommitHook;
   void flushImageRequests();
 
   std::unordered_map<SurfaceId, std::vector<ImageRequestItem>> items_;
   std::shared_ptr<const ContextContainer> contextContainer_;
+  std::unique_ptr<ImageFetcherCommitHook> commitHook_;
 };
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
Recently we saw use-after-free race condition where the ImageFetcher object was being destroyed while still registered as a UIManagerCommitHook.

The crash occurred in std::vector::size() at line 635 when accessing corrupted memory.
The root cause could be improper lifecycle management between ImageFetcher destruction and commit hook execution.

The fix here modifies UIManager::shadowTreeWillCommit() to create a stable snapshot by copying the commitHooks_ vector while holding the lock.

Changelog: [Internal]

Differential Revision: D82846245


