### PR TITLE
Fix incorrect validation of feature flags in DefaultNewArchitectureEntryPoint.loadWithFeatureFlags() method

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt
@@ -120,7 +120,11 @@ public object DefaultNewArchitectureEntryPoint {
     privateBridgelessEnabled = featureFlags.enableBridgelessArchitecture()
 
     val (isValid, errorMessage) =
-        isConfigurationValid(turboModulesEnabled, fabricEnabled, bridgelessEnabled)
+        isConfigurationValid(
+            privateTurboModulesEnabled,
+            privateFabricEnabled,
+            privateBridgelessEnabled,
+        )
     if (!isValid) {
       error(errorMessage)
     }


### PR DESCRIPTION
Summary:
In this diff I'm fixing an incorrect validation of feature flags in DefaultNewArchitectureEntryPoint.loadWithFeatureFlags() method.

changelog: [internal] internal

Differential Revision: D82841006


