### PR TITLE
Fix scrollview overflow prop not set with Props 2.0

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -159,7 +159,13 @@ public class ReactScrollView extends ScrollView
     mVirtualViewContainerState = null;
     mActivelyScrolling = false;
     mClippingRect = null;
-    mOverflow = Overflow.SCROLL;
+
+    // The default value for `overflow` is set to `Visible` in the Yoga style props.
+    mOverflow =
+        ReactNativeFeatureFlags.enablePropsUpdateReconciliationAndroid()
+            ? Overflow.VISIBLE
+            : Overflow.SCROLL;
+
     mDragging = false;
     mPagingEnabled = false;
     mPostTouchRunnable = null;
@@ -362,7 +368,12 @@ public class ReactScrollView extends ScrollView
       mOverflow = Overflow.SCROLL;
     } else {
       @Nullable Overflow parsedOverflow = Overflow.fromString(overflow);
-      mOverflow = parsedOverflow == null ? Overflow.SCROLL : parsedOverflow;
+      mOverflow =
+          parsedOverflow == null
+              ? (ReactNativeFeatureFlags.enablePropsUpdateReconciliationAndroid()
+                  ? Overflow.VISIBLE
+                  : Overflow.SCROLL)
+              : parsedOverflow;
     }
 
     invalidate();


### PR DESCRIPTION
Summary:
The props defined in `YogaStylableProps` define the overflow to be set to `Overflow::Visible` by default.

The scroll view initialized the overflow setting to `Overflow.SCROLL`. This meant that Props 2.0 would only set the overflow prop if it was different from Visible, leading to the scroll view not being configured correctly when asking for the overflow to be visible.

This diff assigns the correct initial value to the scrollview overflow setting only when enabling Props 2.0 to avoid any unexpected behavior changes when not using Props 2.0.

Changelog: [Internal]

Differential Revision: D82919286


