### PR TITLE
Fix overflow with Props 2.0 in horizonal scroll view

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -158,7 +158,12 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
     mOverflowInset = new Rect();
     mActivelyScrolling = false;
     mClippingRect = null;
-    mOverflow = Overflow.SCROLL;
+    // The default value for `overflow` is set to `Visible` in the Yoga style props.
+    mOverflow =
+        ReactNativeFeatureFlags.enablePropsUpdateReconciliationAndroid()
+            ? Overflow.VISIBLE
+            : Overflow.SCROLL;
+
     mDragging = false;
     mPagingEnabled = false;
     mPostTouchRunnable = null;
@@ -381,7 +386,12 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
       mOverflow = Overflow.SCROLL;
     } else {
       @Nullable Overflow parsedOverflow = Overflow.fromString(overflow);
-      mOverflow = parsedOverflow == null ? Overflow.SCROLL : parsedOverflow;
+      mOverflow =
+          parsedOverflow == null
+              ? (ReactNativeFeatureFlags.enablePropsUpdateReconciliationAndroid()
+                  ? Overflow.VISIBLE
+                  : Overflow.SCROLL)
+              : parsedOverflow;
     }
 
     invalidate();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -159,7 +159,13 @@ public class ReactScrollView extends ScrollView
     mVirtualViewContainerState = null;
     mActivelyScrolling = false;
     mClippingRect = null;
-    mOverflow = Overflow.SCROLL;
+
+    // The default value for `overflow` is set to `Visible` in the Yoga style props.
+    mOverflow =
+        ReactNativeFeatureFlags.enablePropsUpdateReconciliationAndroid()
+            ? Overflow.VISIBLE
+            : Overflow.SCROLL;
+
     mDragging = false;
     mPagingEnabled = false;
     mPostTouchRunnable = null;
@@ -362,7 +368,12 @@ public class ReactScrollView extends ScrollView
       mOverflow = Overflow.SCROLL;
     } else {
       @Nullable Overflow parsedOverflow = Overflow.fromString(overflow);
-      mOverflow = parsedOverflow == null ? Overflow.SCROLL : parsedOverflow;
+      mOverflow =
+          parsedOverflow == null
+              ? (ReactNativeFeatureFlags.enablePropsUpdateReconciliationAndroid()
+                  ? Overflow.VISIBLE
+                  : Overflow.SCROLL)
+              : parsedOverflow;
     }
 
     invalidate();


### PR DESCRIPTION
Summary:
This diff fixes the mismatch between the overflow initial value between the horizontal scroll view component initialization and the React core props instance initial value by applying the same correction as for the vertical scroll view component.

Changelog: [Internal]

Differential Revision: D82919365


