### PR TITLE
Add grayscale and drop-shadow filter support

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -808,9 +808,9 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
 // SwiftUI wrapper.
 - (UIView *)effectiveContentView
 {
- if (!ReactNativeFeatureFlags::enableSwiftUIBasedFilters()) {
-   return self;
- }
+  if (!ReactNativeFeatureFlags::enableSwiftUIBasedFilters()) {
+    return self;
+  }
 
   UIView *effectiveContentView = self;
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -808,9 +808,9 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
 // SwiftUI wrapper.
 - (UIView *)effectiveContentView
 {
-  if (!ReactNativeFeatureFlags::enableSwiftUIBasedFilters()) {
-    return self;
-  }
+ if (!ReactNativeFeatureFlags::enableSwiftUIBasedFilters()) {
+   return self;
+ }
 
   UIView *effectiveContentView = self;
 
@@ -1047,14 +1047,23 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
   [_filterLayer removeFromSuperlayer];
   _filterLayer = nil;
   if (_swiftUIWrapper != nullptr) {
-    [_swiftUIWrapper updateBlurRadius:@(0)];
+    [_swiftUIWrapper resetStyles];
   }
   self.layer.opacity = (float)_props->opacity;
   if (!_props->filter.empty()) {
     float multiplicativeBrightness = 1;
     bool hasBrightnessFilter = false;
     for (const auto &primitive : _props->filter) {
-      if (std::holds_alternative<Float>(primitive.parameters)) {
+      if (primitive.type == FilterType::DropShadow) {
+        if (_swiftUIWrapper != nullptr && std::holds_alternative<DropShadowParams>(primitive.parameters)) {
+          const auto& dropShadowParams = std::get<DropShadowParams>(primitive.parameters);
+          UIColor *shadowColor = RCTUIColorFromSharedColor(dropShadowParams.color);
+          [_swiftUIWrapper updateDropShadow:@(dropShadowParams.standardDeviation)
+                                          x:@(dropShadowParams.offsetX)
+                                          y:@(dropShadowParams.offsetY)
+                                      color:shadowColor];
+        }
+      } else if (std::holds_alternative<Float>(primitive.parameters)) {
         if (primitive.type == FilterType::Brightness) {
           multiplicativeBrightness *= std::get<Float>(primitive.parameters);
           hasBrightnessFilter = true;
@@ -1064,6 +1073,11 @@ static RCTBorderStyle RCTBorderStyleFromOutlineStyle(OutlineStyle outlineStyle)
           if (_swiftUIWrapper != nullptr) {
             Float blurRadius = std::get<Float>(primitive.parameters);
             [_swiftUIWrapper updateBlurRadius:@(blurRadius)];
+          }
+        } else if (primitive.type == FilterType::Grayscale) {
+          if (_swiftUIWrapper != nullptr) {
+            Float grayscale = std::get<Float>(primitive.parameters);
+            [_swiftUIWrapper updateGrayscale:@(grayscale)];
           }
         }
       }
@@ -1486,7 +1500,9 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
 {
   if (!_props->filter.empty()) {
     for (const auto &primitive : _props->filter) {
-      if (primitive.type == FilterType::Blur) {
+      if (primitive.type == FilterType::Blur
+          || primitive.type == FilterType::Grayscale
+          || primitive.type == FilterType::DropShadow) {
         return YES;
       }
     }

--- a/packages/react-native/ReactApple/RCTSwiftUI/RCTSwiftUIContainerView.swift
+++ b/packages/react-native/ReactApple/RCTSwiftUI/RCTSwiftUIContainerView.swift
@@ -38,6 +38,17 @@ import UIKit
     containerViewModel.blurRadius = blurRadius
   }
 
+  @objc public func updateGrayscale(_ grayscale: NSNumber) {
+    containerViewModel.grayscale = CGFloat(grayscale.floatValue)
+  }
+
+  @objc public func updateDropShadow(standardDeviation: NSNumber, x: NSNumber, y: NSNumber, color: UIColor) {
+    containerViewModel.shadowRadius = CGFloat(standardDeviation.floatValue)
+    containerViewModel.shadowX = CGFloat(x.floatValue)
+    containerViewModel.shadowY = CGFloat(y.floatValue)
+    containerViewModel.shadowColor = Color(color)
+  }
+
   @objc public func updateLayout(withBounds bounds: CGRect) {
     hostingController?.view.frame = bounds
     containerViewModel.contentView?.frame = bounds
@@ -45,11 +56,21 @@ import UIKit
 
   @objc public func resetStyles() {
     containerViewModel.blurRadius = 0
+    containerViewModel.grayscale = 0
+    containerViewModel.shadowRadius = 0
+    containerViewModel.shadowX = 0
+    containerViewModel.shadowY = 0
+    containerViewModel.shadowColor = Color.clear
   }
 }
 
 class ContainerViewModel: ObservableObject {
   @Published var blurRadius: CGFloat = 0
+  @Published var grayscale: CGFloat = 0
+  @Published var shadowRadius: CGFloat = 0
+  @Published var shadowX: CGFloat = 0
+  @Published var shadowY: CGFloat = 0
+  @Published var shadowColor: Color = Color.clear
   @Published var contentView: UIView?
 }
 
@@ -58,8 +79,10 @@ struct SwiftUIContainerView: View {
 
   var body: some View {
     if let contentView = viewModel.contentView {
-      UIViewWrapper(view: contentView)
-        .blur(radius: viewModel.blurRadius)
+        UIViewWrapper(view: contentView)
+          .blur(radius: viewModel.blurRadius)
+          .grayscale(viewModel.grayscale)
+          .shadow(color: viewModel.shadowColor, radius: viewModel.shadowRadius, x: viewModel.shadowX, y: viewModel.shadowY)
     }
   }
 }
@@ -67,9 +90,9 @@ struct SwiftUIContainerView: View {
 struct UIViewWrapper: UIViewRepresentable {
   let view: UIView
 
-  func makeUIView(context: Context) -> UIView {
+func makeUIView(context: Context) -> UIView {
     return view
-  }
+}
 
   func updateUIView(_ uiView: UIView, context: Context) {
   }

--- a/packages/react-native/ReactApple/RCTSwiftUI/RCTSwiftUIContainerView.swift
+++ b/packages/react-native/ReactApple/RCTSwiftUI/RCTSwiftUIContainerView.swift
@@ -90,9 +90,9 @@ struct SwiftUIContainerView: View {
 struct UIViewWrapper: UIViewRepresentable {
   let view: UIView
 
-func makeUIView(context: Context) -> UIView {
+  func makeUIView(context: Context) -> UIView {
     return view
-}
+  }
 
   func updateUIView(_ uiView: UIView, context: Context) {
   }

--- a/packages/react-native/ReactApple/RCTSwiftUIWrapper/RCTSwiftUIContainerViewWrapper.h
+++ b/packages/react-native/ReactApple/RCTSwiftUIWrapper/RCTSwiftUIContainerViewWrapper.h
@@ -14,6 +14,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (UIView *_Nullable)contentView;
 - (void)updateBlurRadius:(NSNumber *)radius;
+- (void)updateGrayscale:(NSNumber *)grayscale;
+- (void)updateDropShadow:(NSNumber *)standardDeviation x:(NSNumber *)x y:(NSNumber *)y color:(UIColor *)color;
 - (void)updateContentView:(UIView *)view;
 - (UIView *_Nullable)hostingView;
 - (void)resetStyles;

--- a/packages/react-native/ReactApple/RCTSwiftUIWrapper/RCTSwiftUIContainerViewWrapper.m
+++ b/packages/react-native/ReactApple/RCTSwiftUIWrapper/RCTSwiftUIContainerViewWrapper.m
@@ -48,6 +48,16 @@
   [self.swiftContainerView updateBlurRadius:radius];
 }
 
+- (void)updateGrayscale:(NSNumber *)grayscale
+{
+  [self.swiftContainerView updateGrayscale:grayscale];
+}
+
+- (void)updateDropShadow:(NSNumber *)standardDeviation x:(NSNumber *)x y:(NSNumber *)y color:(UIColor *)color
+{
+  [self.swiftContainerView updateDropShadowWithStandardDeviation:standardDeviation x:x y:y color:color];
+}
+
 - (void)updateLayoutWithBounds:(CGRect)bounds
 {
   [self.swiftContainerView updateLayoutWithBounds:bounds];

--- a/packages/rn-tester/js/RNTesterAppShared.js
+++ b/packages/rn-tester/js/RNTesterAppShared.js
@@ -275,18 +275,6 @@ const RNTesterApp = ({
   const shouldHideChrome = isScreenTiny && hadDeepLink;
 
   return (
-    <View
-      style={{
-        height: 200,
-        width: 200,
-        margin: 100,
-        backgroundColor: 'blue',
-        // filter: 'drop-shadow(4px 4px 10px red)',
-      }}
-    />
-  );
-
-  return (
     <RNTesterThemeContext.Provider value={theme}>
       {Platform.OS === 'android' ? (
         <StatusBar

--- a/packages/rn-tester/js/RNTesterAppShared.js
+++ b/packages/rn-tester/js/RNTesterAppShared.js
@@ -275,6 +275,18 @@ const RNTesterApp = ({
   const shouldHideChrome = isScreenTiny && hadDeepLink;
 
   return (
+    <View
+      style={{
+        height: 200,
+        width: 200,
+        margin: 100,
+        backgroundColor: 'blue',
+        // filter: 'drop-shadow(4px 4px 10px red)',
+      }}
+    />
+  );
+
+  return (
     <RNTesterThemeContext.Provider value={theme}>
       {Platform.OS === 'android' ? (
         <StatusBar

--- a/packages/rn-tester/js/examples/Filter/FilterExample.js
+++ b/packages/rn-tester/js/examples/Filter/FilterExample.js
@@ -155,7 +155,6 @@ exports.examples = [
     title: 'Grayscale',
     description: 'grayscale(0.5)',
     name: 'grayscale',
-    platform: 'android',
     render(): React.Node {
       return (
         <StaticViewAndImageComparison style={{filter: [{grayscale: 0.5}]}} />
@@ -231,7 +230,6 @@ exports.examples = [
     title: 'Drop Shadow',
     description: 'drop-shadow(30px 10px 4px #4444dd)',
     name: 'drop-shadow',
-    platform: 'android',
     render(): React.Node {
       return (
         <StaticViewAndImageComparison


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

This PR adds support for grayscale and drop-shadow filter support on iOS as discussed here - https://github.com/react-native-community/discussions-and-proposals/issues/927

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[IOS] [ADDED] - Add grayscale and drop-shadow CSS filters

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:


For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

Test Filter screen in RN Tester app. Checkout grayscale and drop-shadow examples. Results are consistent on android and iOS.

<img width="auto" height="300" alt="Screenshot 2025-09-22 at 1 07 28 PM" src="https://github.com/user-attachments/assets/f26fc60a-48f6-4aa2-82e9-56e986082fed" />

<img width="auto" height="300" alt="Screenshot 2025-09-22 at 1 08 08 PM" src="https://github.com/user-attachments/assets/d87925c8-f05c-4ed2-a651-8c7670339f87" />


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
