### PR TITLE
remove connection hints from being logged for the user

### DIFF
--- a/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
+++ b/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
@@ -372,12 +372,6 @@ export default class InspectorProxy implements InspectorProxyQueries {
 
         this.#devices.set(deviceId, newDevice);
 
-        this.#logger?.info(
-          "Connection established to app='%s' on device='%s'.",
-          appName,
-          deviceName,
-        );
-
         debug(
           "Got new device connection: name='%s', app=%s, device=%s, via=%s",
           deviceName,
@@ -450,7 +444,7 @@ export default class InspectorProxy implements InspectorProxyQueries {
         );
 
         socket.on('close', (code: number, reason: string) => {
-          this.#logger?.info(
+          debug(
             "Connection closed to device='%s' for app='%s' with code='%s' and reason='%s'.",
             deviceName,
             appName,
@@ -526,7 +520,7 @@ export default class InspectorProxy implements InspectorProxyQueries {
           throw new Error(INTERNAL_ERROR_MESSAGES.UNREGISTERED_DEVICE);
         }
 
-        this.#logger?.info(
+        debug(
           "Connection established to DevTools for app='%s' on device='%s'.",
           device.getApp() || 'unknown',
           device.getName() || 'unknown',
@@ -594,7 +588,7 @@ export default class InspectorProxy implements InspectorProxyQueries {
         });
 
         socket.on('close', (code: number, reason: string) => {
-          this.#logger?.info(
+          debug(
             "Connection closed to DevTools for app='%s' on device='%s' with code='%s' and reason='%s'.",
             device.getApp() || 'unknown',
             device.getName() || 'unknown',

--- a/packages/react-native/Libraries/Utilities/DevLoadingView.js
+++ b/packages/react-native/Libraries/Utilities/DevLoadingView.js
@@ -14,29 +14,37 @@ import NativeDevLoadingView from './NativeDevLoadingView';
 
 const COLOR_SCHEME = {
   dark: {
-    refresh: {
-      backgroundColor: '#2584e8',
-      textColor: '#ffffff',
-    },
     load: {
       backgroundColor: '#fafafa',
       textColor: '#242526',
     },
-  },
-  default: {
     refresh: {
       backgroundColor: '#2584e8',
       textColor: '#ffffff',
     },
+    error: {
+      backgroundColor: '#1065AF',
+      textColor: '#ffffff',
+    },
+  },
+  default: {
     load: {
       backgroundColor: '#404040',
+      textColor: '#ffffff',
+    },
+    refresh: {
+      backgroundColor: '#2584e8',
+      textColor: '#ffffff',
+    },
+    error: {
+      backgroundColor: '#1065AF',
       textColor: '#ffffff',
     },
   },
 };
 
 export default {
-  showMessage(message: string, type: 'load' | 'refresh') {
+  showMessage(message: string, type: 'load' | 'refresh' | 'error') {
     if (NativeDevLoadingView) {
       const colorScheme =
         getColorScheme() === 'dark' ? COLOR_SCHEME.dark : COLOR_SCHEME.default;

--- a/packages/react-native/Libraries/Utilities/HMRClient.js
+++ b/packages/react-native/Libraries/Utilities/HMRClient.js
@@ -232,8 +232,6 @@ Error: ${e.message}`;
     });
 
     client.on('error', data => {
-      DevLoadingView.hide();
-
       if (data.type === 'GraphNotFoundError') {
         client.close();
         setHMRUnavailableReason(
@@ -253,8 +251,6 @@ Error: ${e.message}`;
     });
 
     client.on('close', closeEvent => {
-      DevLoadingView.hide();
-
       // https://www.rfc-editor.org/rfc/rfc6455.html#section-7.4.1
       // https://www.rfc-editor.org/rfc/rfc6455.html#section-7.1.5
       const isNormalOrUnsetCloseReason =
@@ -296,10 +292,17 @@ function setHMRUnavailableReason(reason: string) {
   }
   hmrUnavailableReason = reason;
 
+  const DevLoadingView = require('./DevLoadingView').default;
+  DevLoadingView.hide();
+
   // We only want to show a warning if Fast Refresh is on *and* if we ever
   // previously managed to connect successfully. We don't want to show
   // the warning to native engineers who use cached bundles without Metro.
   if (hmrClient.isEnabled() && didConnect) {
+    DevLoadingView.showMessage(
+      'Fast Refresh disconnected. Reload app to reconnect.',
+      'error',
+    );
     console.warn(reason);
     // (Not using the `warning` module to prevent a Buck cycle.)
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DefaultDevLoadingViewImplementation.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DefaultDevLoadingViewImplementation.kt
@@ -33,10 +33,14 @@ public class DefaultDevLoadingViewImplementation(
   private var devLoadingPopup: PopupWindow? = null
 
   override fun showMessage(message: String) {
+    showMessage(message, color = null, backgroundColor = null)
+  }
+
+  override fun showMessage(message: String, color: Double?, backgroundColor: Double?) {
     if (!isEnabled) {
       return
     }
-    UiThreadUtil.runOnUiThread { showInternal(message) }
+    UiThreadUtil.runOnUiThread { showInternal(message, color, backgroundColor) }
   }
 
   override fun updateProgress(status: String?, done: Int?, total: Int?) {
@@ -59,7 +63,7 @@ public class DefaultDevLoadingViewImplementation(
     }
   }
 
-  private fun showInternal(message: String) {
+  private fun showInternal(message: String, color: Double?, backgroundColor: Double?) {
     if (devLoadingPopup?.isShowing == true) {
       // already showing
       return
@@ -84,6 +88,12 @@ public class DefaultDevLoadingViewImplementation(
           currentActivity.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
       val view = inflater.inflate(R.layout.dev_loading_view, null) as TextView
       view.text = message
+      if (color != null) {
+        view.setTextColor(color.toInt())
+      }
+      if (backgroundColor != null) {
+        view.setBackgroundColor(backgroundColor.toInt())
+      }
       val popup =
           PopupWindow(
               view,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevLoadingViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/interfaces/DevLoadingViewManager.kt
@@ -11,6 +11,8 @@ package com.facebook.react.devsupport.interfaces
 public interface DevLoadingViewManager {
   public fun showMessage(message: String)
 
+  public fun showMessage(message: String, color: Double?, backgroundColor: Double?)
+
   public fun updateProgress(status: String?, done: Int?, total: Int?)
 
   public fun hide()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/devloading/DevLoadingModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/devloading/DevLoadingModule.kt
@@ -31,7 +31,9 @@ internal class DevLoadingModule(reactContext: ReactApplicationContext) :
   }
 
   override fun showMessage(message: String, color: Double?, backgroundColor: Double?) {
-    UiThreadUtil.runOnUiThread { devLoadingViewManager?.showMessage(message) }
+    UiThreadUtil.runOnUiThread {
+      devLoadingViewManager?.showMessage(message, color, backgroundColor)
+    }
   }
 
   override fun hide() {


### PR DESCRIPTION
Summary:
Now that there's a clear display for when HMR is disconnected, we don't want to show messages regardless devices connection and disconnection to the DevServer because they are too partial.

Changelog: [Internal]

Reviewed By: huntie

Differential Revision: D82727105


