### PR TITLE
Reproduce refreshcontrol crash

### DIFF
--- a/packages/rn-tester/js/examples/Playground/RNTesterPlayground.js
+++ b/packages/rn-tester/js/examples/Playground/RNTesterPlayground.js
@@ -28,7 +28,7 @@ function Playground() {
           />
         }
       >
-        <Text>Pull to refresh - this crashes on android with size as number (indicated by TS hint) when docs specify "default" or "large"</Text>
+        <Text>Pull to refresh: this crashes on android with size as number (indicated by TS hint) when docs specify "default" or "large"</Text>
       </ScrollView>
     </View>
   );

--- a/packages/rn-tester/js/examples/Playground/RNTesterPlayground.js
+++ b/packages/rn-tester/js/examples/Playground/RNTesterPlayground.js
@@ -12,14 +12,24 @@ import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 
 import RNTesterText from '../../components/RNTesterText';
 import * as React from 'react';
-import {StyleSheet, View} from 'react-native';
+import {StyleSheet, View, ScrollView} from 'react-native';
 
 function Playground() {
   return (
     <View style={styles.container}>
       <RNTesterText>
-        Edit "RNTesterPlayground.js" to change this file
+        RefreshControl size prop crash test
       </RNTesterText>
+      <ScrollView
+        refreshControl={
+          <RefreshControl
+            refreshing={true}
+            size={80} // only crashes when actually native compiling; see pr
+          />
+        }
+      >
+        <Text>Pull to refresh - this crashes on android with size as number (indicated by TS hint) when docs specify "default" or "large"</Text>
+      </ScrollView>
     </View>
   );
 }


### PR DESCRIPTION
## Summary:

creates a reproducer to show a crash on android when the RefreshControl component's `size` prop is passed as a number instead of a string. The Typescript hints incorrectly indicate that `size` accepts `number | undefined`, but React Native documentation indicates an enum ("default" or "large"). This causes an error when running natively "TypeError: expected dynamic type 'string', but had type 'double'".

## Changelog:
[INTERNAL] [ADDED] - Add RefreshControl size prop crash reproducer to playground

## Test Plan:
1. Build and run on an Android device
2. Go to the playground tab
3. See the crash with error message: "TypeError: expected dynamic type 'string', but had type 'double'"
4. To verify, change line 27 from `size={80}` to `size="large"` and verify it works
5. The crash only occurs during native compilation/execution, not in development mode w/ metro

Example logcat error from adb:
<img width="1919" height="254" alt="image" src="https://github.com/user-attachments/assets/3b07125e-6217-4a9b-acbc-d14df901c5f6" />

Apologies if there's anything wrong with this pr, this is my first time contributing to such a large project