### PR TITLE
Always join

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/threading/TaskDispatchThread.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/threading/TaskDispatchThread.cpp
@@ -90,11 +90,7 @@ void TaskDispatchThread::quit() noexcept {
   running_ = false;
   loopCv_.notify_one();
   if (thread_.joinable()) {
-    if (!isOnThread()) {
-      thread_.join();
-    } else {
-      thread_.detach();
-    }
+    thread_.join();
   }
 }
 


### PR DESCRIPTION
Summary:
Detaching the thread in the destructor is dangerous:
- The thread may outlive the object, leading to use-after-free.
- Instead, always join the thread in the destructor, or ensure the thread cannot access any members after the destructor starts.

Changelog: [Internal]

Differential Revision: D82878731


