### PR TITLE
Fix request permission is not always resolving in Android 16

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
@@ -262,8 +262,12 @@ public class ReactActivityDelegate {
       ReactHost reactHost = getReactHost();
       lifecycle = reactHost != null ? reactHost.getLifecycleState() : LifecycleState.BEFORE_CREATE;
     } else {
-      ReactInstanceManager instanceManager = getReactInstanceManager();
-      lifecycle = instanceManager.getLifecycleState();
+      ReactNativeHost reactNativeHost = getReactNativeHost();
+      if (!reactNativeHost.hasInstance()) {
+        lifecycle = LifecycleState.BEFORE_CREATE;
+      } else {
+        lifecycle = reactNativeHost.getReactInstanceManager().getLifecycleState();
+      }
     }
 
     // If the permission request didn't show a dialog to the user, we can call the callback immediately.


### PR DESCRIPTION
## Summary:

Fixes: https://github.com/facebook/react-native/issues/53887
Fixes: https://github.com/expo/expo/issues/39480

In the latest Android 16 update, requesting permissions does not always change the app's state (the `onPause` and `onResume` functions aren't called). For instance, when you deny permission 3 times, the last promise won't resolve until you move the app to the background. The current logic inside the `ReactActivityDelegate` assumes that Android will call `onResume` after receiving permission state information from the system, which is no longer the case.

Probably connected with [this commit](https://android.googlesource.com/platform/packages/modules/Permission/%2B/5dca0ccb26f2b99d706a1d3e9402f851e849c913)

## Changelog:

[ANDROID] [FIXED] - Fix request permission not always resolving in Android 16

## Test Plan:

- I've tested it in the RNTester by denying the camera permission three times.
- I've also checked if the patch works with the Expo permissions code.