### PR TITLE
Remove "Background" from perf overlay title

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/perfmonitor/PerfMonitorOverlayView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/perfmonitor/PerfMonitorOverlayView.kt
@@ -55,11 +55,11 @@ internal class PerfMonitorOverlayView(
 
     if (state == TracingState.ENABLEDINBACKGROUNDMODE) {
       (statusIndicator.background as GradientDrawable).setColor(Color.RED)
-      statusLabel.text = "Background Profiling Active"
+      statusLabel.text = "Profiling Active"
       tooltipLabel.text = "Press ☰ to open"
     } else {
       (statusIndicator.background as GradientDrawable).setColor(Color.GRAY)
-      statusLabel.text = "Background Profiling Stopped"
+      statusLabel.text = "Profiling Stopped"
       tooltipLabel.text = "Press ☰ to restart"
     }
     dialog.show()


### PR DESCRIPTION
Summary:
Removes unnecessary "background" from title, narrowing the width of the overlay.
{F1982191268}

Changelog: [Internal]

Reviewed By: rubennorte

Differential Revision: D83036209


