### PR TITLE
Harden lifecycle handling for Perf Monitor

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/perfmonitor/PerfMonitorDevHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/perfmonitor/PerfMonitorDevHelper.kt
@@ -7,11 +7,15 @@
 
 package com.facebook.react.devsupport.perfmonitor
 
+import android.app.Activity
+
 /**
  * Interface implemented by [com.facebook.react.runtime.ReactHostImplDevHelper] exposing additional
  * hooks used to implement the V2 Perf Monitor overlay (experimental).
  */
 internal interface PerfMonitorDevHelper {
+  public val currentActivity: Activity?
+
   /**
    * The inspector target object. Matches the lifetime of the ReactHost. May be null if modern JS
    * debugging is disabled.


### PR DESCRIPTION
Summary:
Updates `PerfMonitorOverlayManager` so that it is minimally and correctly integrated in the `DevSupportManagerBase` reload cycle — attempting to fix a bug where the background profiling state on startup / subsequent packager connections would be out of sync.

Also tweak tooltip text for pause+open trace action.

Changelog: [Internal]

Differential Revision: D83058519


