### PR TITLE
Add feature check to disable manual JS Network performance track

### DIFF
--- a/packages/react-native/Libraries/Network/XMLHttpRequest.js
+++ b/packages/react-native/Libraries/Network/XMLHttpRequest.js
@@ -17,6 +17,7 @@ import type {
 import type Performance from '../../src/private/webapis/performance/Performance';
 import type {IPerformanceLogger} from '../Utilities/createPerformanceLogger';
 
+import * as ReactNativeFeatureFlags from '../../src/private/featureflags/ReactNativeFeatureFlags';
 import Event from '../../src/private/webapis/dom/events/Event';
 import {
   getEventHandlerAttribute,
@@ -183,6 +184,10 @@ class XMLHttpRequest extends EventTarget {
   }
 
   static enableProfiling(enableProfiling: boolean): void {
+    if (ReactNativeFeatureFlags.enableNetworkEventReporting) {
+      // Disable manual event creation if network event reporting is enabled
+      return;
+    }
     XMLHttpRequest._profiling = enableProfiling;
   }
 


### PR DESCRIPTION
Summary:
Update our `XMLHttpRequest` implementation to avoid emitting profiling events (legacy approach) when our new `enableNetworkEventReporting` functionality is enabled.

This avoids us from populating a duplicate events track in the RNDT Performance panel.

Changelog: [Internal]

Differential Revision: D83061882


