### PR TITLE
Crash the app when Legacy Arch is enabled

### DIFF
--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -380,6 +380,11 @@ static RCTBridge *RCTCurrentBridgeInstance = nil;
                   moduleProvider:(RCTBridgeModuleListProvider)block
                    launchOptions:(NSDictionary *)launchOptions
 {
+  // Only enabld this assertion in OSS
+#if COCOAPODS
+  [RCTBridge throwIfOnLegacyArch];
+#endif
+
   if (self = [super init]) {
     RCTEnforceNewArchitectureValidation(RCTNotAllowedInBridgeless, self, nil);
     _delegate = delegate;
@@ -391,6 +396,17 @@ static RCTBridge *RCTCurrentBridgeInstance = nil;
     [self setUp];
   }
   return self;
+}
+
+// Wrap the exception throwing in a static method to avoid the warning: "The code following the exception will never be
+// executed". This might create build failures internally where we treat warnings as errors.
++ (void)throwIfOnLegacyArch
+{
+  @throw [NSException
+      exceptionWithName:NSInternalInconsistencyException
+                 reason:
+                     @"You are trying to initialize the legacy architecture. This is not supported anymore and will be removed in the next version of React Native. Please use the New Architecture instead."
+               userInfo:nil];
 }
 
 RCT_NOT_IMPLEMENTED(-(instancetype)init)


### PR DESCRIPTION
Summary:
This change mimics what we implemented on Android to crash the app.

This is in general never going t be triggered. It will be triggered only if users are actually going through the old way to initialize React Native, i.e. by using the RCTRootView class which creates thebridge, or if they are creating the bridge themselves.

## Changelog:
[iOS][Added] - Crash the app if they force the legacy architecture.

Reviewed By: RSNara

Differential Revision: D83066377


