### PR TITLE
Allow to disable coverage via flag & disable it for benchmarks

### DIFF
--- a/packages/react-native/src/private/__tests__/MemoryBaseline-itest.js
+++ b/packages/react-native/src/private/__tests__/MemoryBaseline-itest.js
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @fantom_mode *
+ * @fantom_disable_coverage
  * @flow strict-local
  * @format
  */

--- a/private/react-native-fantom/__docs__/README.md
+++ b/private/react-native-fantom/__docs__/README.md
@@ -147,6 +147,9 @@ Available pragmas:
   - Possible values:
     - `true`: using Hermes bytecode
     - `false`: not using Hermes bytecode
+- `@fantom_disable_coverage`: used to disable coverage collection for the test.
+  - Example: `@fantom_disable_coverage`
+  - Does not require a value.
 - `@fantom_react_fb_flags`: used to set overrides for internal React flags set
   in ReactNativeInternalFeatureFlags (Meta use only)
 

--- a/private/react-native-fantom/runner/coverageUtils.js
+++ b/private/react-native-fantom/runner/coverageUtils.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+// $FlowExpectedError[untyped-import]
+import {extract, parse} from 'jest-docblock';
+
+type DocblockPragmas = {[key: string]: string | string[]};
+
+const FANTOM_BENCHMARK_FILENAME_RE = /[Bb]enchmark-itest\./g;
+
+export function shouldCollectCoverage(
+  testPath: string,
+  testContents: string,
+  globalConfig: {collectCoverage: boolean, ...},
+): boolean {
+  if (FANTOM_BENCHMARK_FILENAME_RE.test(testPath)) {
+    return false;
+  }
+
+  const docblock = extract(testContents);
+  const pragmas = parse(docblock) as DocblockPragmas;
+
+  if (pragmas.fantom_disable_coverage != null) {
+    return false;
+  }
+
+  return globalConfig.collectCoverage;
+}

--- a/private/react-native-fantom/runner/getFantomTestConfigs.js
+++ b/private/react-native-fantom/runner/getFantomTestConfigs.js
@@ -85,6 +85,7 @@ const VALID_FANTOM_PRAGMAS = [
   'fantom_flags',
   'fantom_hermes_variant',
   'fantom_react_fb_flags',
+  'fantom_disable_coverage',
 ];
 
 export function getOverrides(

--- a/private/react-native-fantom/runner/runner.js
+++ b/private/react-native-fantom/runner/runner.js
@@ -24,6 +24,7 @@ import type {
 
 import {printBenchmarkResultsRanking} from './benchmarkUtils';
 import {createBundle, createSourceMap} from './bundling';
+import {shouldCollectCoverage} from './coverageUtils';
 import entrypointTemplate from './entrypoint-template';
 import * as EnvironmentOptions from './EnvironmentOptions';
 import {run as runHermesCompiler} from './executables/hermesc';
@@ -343,7 +344,11 @@ module.exports = async function runTest(
       sourceMap: true,
       sourceMapUrl: sourceMapPath,
       customTransformOptions: {
-        collectCoverage: globalConfig.collectCoverage,
+        collectCoverage: shouldCollectCoverage(
+          testPath,
+          testContents,
+          globalConfig,
+        ),
       },
     };
 


### PR DESCRIPTION
Summary:
Changelog: [Internal]
Add new fantom flag `fantom_disable_coverage` to be used in tests that are sensitive to things like memory allocation.
Also disable coverage for any benchmark test.

Differential Revision: D83070065


