### PR TITLE
Fix custom prebuilt binary handling in unstable_prepareDebuggerShell

### DIFF
--- a/packages/debugger-shell/src/node/index.flow.js
+++ b/packages/debugger-shell/src/node/index.flow.js
@@ -116,16 +116,12 @@ async function unstable_prepareDebuggerShell(
   flavor: DebuggerShellFlavor,
   {prebuiltBinaryPath}: {prebuiltBinaryPath?: string} = {},
 ): Promise<DebuggerShellPreparationResult> {
-  const [binaryPath, baseArgs] = getShellBinaryAndArgs(
-    flavor,
-    prebuiltBinaryPath,
-  );
-
   try {
     switch (flavor) {
       case 'prebuilt':
-        const prebuiltResult =
-          await prepareDebuggerShellFromDotSlashFile(binaryPath);
+        const prebuiltResult = await prepareDebuggerShellFromDotSlashFile(
+          prebuiltBinaryPath ?? DEVTOOLS_BINARY_DOTSLASH_FILE,
+        );
         if (prebuiltResult.code !== 'success') {
           return prebuiltResult;
         }
@@ -136,6 +132,11 @@ async function unstable_prepareDebuggerShell(
         flavor as empty;
         throw new Error(`Unknown flavor: ${flavor}`);
     }
+
+    const [binaryPath, baseArgs] = getShellBinaryAndArgs(
+      flavor,
+      prebuiltBinaryPath,
+    );
     const {code, stderr} = await spawnAndGetStderr(binaryPath, [
       ...baseArgs,
       '--version',


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Fixes a bug that broke `unstable_prepareDebuggerShell` (and therefore the RNDT shell) in OSS.

Differential Revision: D83178777


