### PR TITLE
only remove the Fast Refresh "Refreshing..." toast when all bundles being loaded finished loading.

### DIFF
--- a/packages/react-native/Libraries/Utilities/HMRClient.js
+++ b/packages/react-native/Libraries/Utilities/HMRClient.js
@@ -211,7 +211,9 @@ Error: ${e.message}`;
       setHMRUnavailableReason(error);
     });
 
+    let pendingUpdatesCount = 0;
     client.on('update-start', ({isInitialUpdate}) => {
+      pendingUpdatesCount++;
       currentCompileErrorMessage = null;
       didConnect = true;
 
@@ -228,7 +230,10 @@ Error: ${e.message}`;
     });
 
     client.on('update-done', () => {
-      DevLoadingView.hide();
+      pendingUpdatesCount--;
+      if (pendingUpdatesCount === 0) {
+        DevLoadingView.hide();
+      }
     });
 
     client.on('error', data => {


### PR DESCRIPTION
Summary: Changelog: [General][Fixed] only remove the Fast Refresh "Refreshing..." toast when all bundles being loaded finished loading.

Reviewed By: huntie

Differential Revision: D83246895


