### PR TITLE
Fix TypeScript types of `positions` in `GradientValue`

### DIFF
--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
@@ -373,7 +373,7 @@ export type GradientValue = {
   direction?: string | undefined;
   colorStops: ReadonlyArray<{
     color: ColorValue | null;
-    positions?: ReadonlyArray<string[]> | undefined;
+    positions?: ReadonlyArray<string> | undefined;
   }>;
 };
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

The original type of the `positions` property was mistakenly declared as a 2-dimensional array, which is not accepted in runtime. In reality, a flat string array is expected as per [linear gradient examples](https://github.com/facebook/react-native/blob/18ba21149ae46d3fa97fe0dcbe165999009d2a6e/packages/rn-tester/js/examples/LinearGradient/LinearGradientExample.js#L230).

## Changelog:

[General] [Fixed] - TypeScript types of `positions` in `GradientValue`

## Test Plan:

N/A
