### PR TITLE
PerfMonitor - Fix enable/disable states

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/perfmonitor/PerfMonitorOverlayManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/perfmonitor/PerfMonitorOverlayManager.kt
@@ -20,18 +20,25 @@ internal class PerfMonitorOverlayManager(
 
   /** Enable the Perf Monitor overlay. */
   fun enable() {
+    if (enabled) {
+      return
+    }
+
     enabled = true
     UiThreadUtil.runOnUiThread {
       val context = devHelper.currentActivity ?: return@runOnUiThread
-      view = PerfMonitorOverlayView(context, ::handleRecordingButtonPress)
+      if (view == null) {
+        view = PerfMonitorOverlayView(context, ::handleRecordingButtonPress)
+      }
+      view?.show()
     }
   }
 
   /** Disable the Perf Monitor overlay. Will remain hidden when updates are received. */
   fun disable() {
-    UiThreadUtil.runOnUiThread { view?.hide() }
-    view = null
     enabled = false
+
+    UiThreadUtil.runOnUiThread { view?.hide() }
   }
 
   /** Start background trace recording. */


### PR DESCRIPTION
Summary:
There are cases where the overlay can get enabled multiple times, creating more than one view. This change no-ops enabling if the overlay is already enabled and just uses enable/disable for showing/hiding the view.
{F1982272836}

Changelog: [Internal]

Reviewed By: hoxyq

Differential Revision: D83275253


