### PR TITLE
PerfMonitor - Add enable/disable to dev menu

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.kt
@@ -398,6 +398,24 @@ public abstract class DevSupportManagerBase(
           }
     }
 
+    if (ReactNativeFeatureFlags.perfMonitorV2Enabled()) {
+      val isConnected = isPackagerConnected
+
+      val togglePerfMonitorItemString =
+          if (perfMonitorOverlayManager?.isEnabled == true)
+              applicationContext.getString(R.string.catalyst_performance_disable)
+          else applicationContext.getString(R.string.catalyst_performance_enable)
+
+      if (!isConnected) {
+        disabledItemKeys.add(togglePerfMonitorItemString)
+      }
+
+      options[togglePerfMonitorItemString] =
+          if (perfMonitorOverlayManager?.isEnabled == true)
+              DevOptionHandler { perfMonitorOverlayManager?.disable() }
+          else DevOptionHandler { perfMonitorOverlayManager?.enable() }
+    }
+
     options[applicationContext.getString(R.string.catalyst_change_bundle_location)] =
         DevOptionHandler {
           val context = reactInstanceDevHelper.currentActivity

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/perfmonitor/PerfMonitorOverlayManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/perfmonitor/PerfMonitorOverlayManager.kt
@@ -15,6 +15,11 @@ internal class PerfMonitorOverlayManager(
     private val onRequestOpenDevTools: () -> Unit,
 ) : PerfMonitorUpdateListener {
   private var enabled: Boolean = false
+
+  /** Whether the Perf Monitor overlay is currently enabled. */
+  val isEnabled: Boolean
+    get() = enabled
+
   private var view: PerfMonitorOverlayView? = null
   private var tracingState: TracingState = TracingState.ENABLEDINCDPMODE
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/perfmonitor/PerfMonitorOverlayManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/perfmonitor/PerfMonitorOverlayManager.kt
@@ -20,18 +20,25 @@ internal class PerfMonitorOverlayManager(
 
   /** Enable the Perf Monitor overlay. */
   fun enable() {
+    if (enabled) {
+      return
+    }
+
     enabled = true
     UiThreadUtil.runOnUiThread {
       val context = devHelper.currentActivity ?: return@runOnUiThread
-      view = PerfMonitorOverlayView(context, ::handleRecordingButtonPress)
+      if (view == null) {
+        view = PerfMonitorOverlayView(context, ::handleRecordingButtonPress)
+      }
+      view?.show()
     }
   }
 
   /** Disable the Perf Monitor overlay. Will remain hidden when updates are received. */
   fun disable() {
-    UiThreadUtil.runOnUiThread { view?.hide() }
-    view = null
     enabled = false
+
+    UiThreadUtil.runOnUiThread { view?.hide() }
   }
 
   /** Start background trace recording. */

--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values/strings.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values/strings.xml
@@ -13,6 +13,8 @@
   <string name="catalyst_performance_background" project="catalyst" translatable="false">Finish performance trace</string>
   <string name="catalyst_performance_disabled" project="catalyst" translatable="false">Start performance trace</string>
   <string name="catalyst_performance_cdp" project="catalyst" translatable="false">Performance tracing disabled</string>
+  <string name="catalyst_performance_enable" project="catalyst" translatable="false">Show performance overlay</string>
+  <string name="catalyst_performance_disable" project="catalyst" translatable="false">Hide performance overlay</string>
   <string name="catalyst_debug_open_disabled" project="catalyst" translatable="false">Connect to the bundler to debug JavaScript</string>
   <string name="catalyst_debug_connecting" project="catalyst" translatable="false">Connecting to debugger...</string>
   <string name="catalyst_debug_error" project="catalyst" translatable="false">Failed to connect to debugger!</string>


### PR DESCRIPTION
Summary:
Adds a dev menu option to enable/disable the overlay, in case devs want to screenshot/record without disabling it at buildtime.

Changelog: [Internal]

Differential Revision: D83293591


