### PR TITLE
Inline lazy fields in core data types

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableNativeArray.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReadableNativeArray.kt
@@ -20,20 +20,48 @@ import kotlin.jvm.JvmStatic
 @DoNotStrip
 public open class ReadableNativeArray protected constructor() : NativeArray(), ReadableArray {
 
-  private val localArray: Array<Any?> by
-      lazy(LazyThreadSafetyMode.SYNCHRONIZED) {
-        jniPassCounter++
-        importArray()
+  private var localArrayStorage: Array<Any?>? = null
+  private val localArray: Array<Any?>
+    get() {
+      var localArray = localArrayStorage
+      if (localArray != null) {
+        return localArray
       }
+
+      synchronized(this) {
+        // Check again with the lock held to prevent duplicate construction
+        localArray = localArrayStorage
+        if (localArray == null) {
+          localArray = importArray()
+          localArrayStorage = localArray
+          jniPassCounter++
+        }
+        return localArray
+      }
+    }
 
   private external fun importArray(): Array<Any?>
 
-  private val localTypeArray: Array<ReadableType> by
-      lazy(LazyThreadSafetyMode.SYNCHRONIZED) {
-        jniPassCounter++
-        val tempArray = importTypeArray()
-        Arrays.copyOf(tempArray, tempArray.size, Array<ReadableType>::class.java)
+  private var localTypeArrayStorage: Array<ReadableType>? = null
+  private val localTypeArray: Array<ReadableType>
+    get() {
+      var localTypeArray = localTypeArrayStorage
+      if (localTypeArray != null) {
+        return localTypeArray
       }
+
+      synchronized(this) {
+        // Check again with the lock held to prevent duplicate construction
+        localTypeArray = localTypeArrayStorage
+        if (localTypeArray == null) {
+          val tempArray = importTypeArray()
+          localTypeArray = Arrays.copyOf(tempArray, tempArray.size, Array<ReadableType>::class.java)
+          localTypeArrayStorage = localTypeArray
+          jniPassCounter++
+        }
+        return localTypeArray
+      }
+    }
 
   private external fun importTypeArray(): Array<Any>
 


### PR DESCRIPTION
Summary:
These data-types are super common in React Native, and the anonymous inner classes add significantly to the GC workload we see. For ReadableMap this means we can save 6 additional object allocations for each LazySynchronizedImpl and the lambda that's passed in to it. On synthetic benchmarks this seems to improve core operations around ~10%.

Changelog: [Internal]

Differential Revision: D83245864


