### PR TITLE
Move files from arvr/js/apps/Store to xplat/js/RKJSModules/public/HzStoreVR

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -69,7 +69,7 @@ munge_underscores=true
 module.name_mapper='^react-native$' -> '<PROJECT_ROOT>/packages/react-native/index.js'
 module.name_mapper='^react-native/\(.*\)$' -> '<PROJECT_ROOT>/packages/react-native/\1'
 module.name_mapper='^@react-native/dev-middleware$' -> '<PROJECT_ROOT>/packages/dev-middleware'
-module.name_mapper='^@?[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|webp\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|aac\|aiff\|caf\|m4a\|mp3\|wav\|html\|pdf\|xml\)$' -> '<PROJECT_ROOT>/packages/react-native/Libraries/Image/RelativeImageStub'
+module.name_mapper='^@?[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|webp\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|aac\|aiff\|caf\|m4a\|mp3\|wav\|html\|pdf\|xml\|ktx\)$' -> '<PROJECT_ROOT>/packages/react-native/Libraries/Image/RelativeImageStub'
 
 module.system.haste.module_ref_prefix=m#
 


### PR DESCRIPTION
Summary:
# What

Moving Store from `arvr/js` to `xplat/js`.
This will enable Store to use xplat modern infra. Being on arvr/js legacy infra has created many problems [over the years](https://fb.workplace.com/groups/storecore/posts/2344707442611890/?comment_id=2345657702516864). Examples:

**2025**: https://fb.workplace.com/groups/storecore/permalink/2344707442611890/
**2024**: https://fb.workplace.com/groups/oculusjs/permalink/3366314690341563/
**2023**: https://fb.workplace.com/groups/xplatreact.engineering/permalink/730125568732098/

# How
## Previous Diff
* Remove usage of the legacy `react-router-3`. We don't want to carry this as a dependency to xplat/js.

## This Diff
This diff is the combination of several diffs (created to facilitate reviewing):

1. - D82581768 - Just move files from arvr/js/apps/Store to xplat/js/RKJSModules/public/HzStoreVR (Except for the index file and some mockUtils)
2. - D82581767 - Setup getConfig.js to generate a single BUCK for HzStoreVR and remove circular dependencies
3. - D82581769 - Fix location/import of assets
4. - D82581766 - Fix relay imports that were not using Haste
5. - D82664586 - Remove usage of old url module
6. - D83156829 - Fix buck: run js1 build buckfiles and build_and_run.sh
7. - D82844768 - Make arvr/js tests run with xplat Store
8. - D83005059 - Fix Flow errors
9. - D83259512 - Delete duplicated test files to make flow happy
10. - D83005098 - Fix Relay config for new Store VR location in xplat
11. - D83005073 - Enable React Forget on new HzStoreVR directory
12. - D83345573 - Fix arc lint -a

## Next diffs
* Migrate tests to xplat jest config (renaming from *-rntest.js to *-test.js)
* Migrate other source code like arvr/js/libraries/store

Reviewed By: Tom910, mullender

Differential Revision: D82781491
