### PR TITLE
[RN][iOS] Add env var to compile-out legacy arch

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
@@ -120,6 +120,7 @@ std::unique_ptr<facebook::react::JSExecutorFactory> RCTAppSetupDefaultJsExecutor
     RCTTurboModuleManager *turboModuleManager,
     const std::shared_ptr<facebook::react::RuntimeScheduler> &runtimeScheduler)
 {
+#ifndef RCT_REMOVE_LEGACY_ARCH
   // Necessary to allow NativeModules to lookup TurboModules
   [bridge setRCTTurboModuleRegistry:turboModuleManager];
 
@@ -146,12 +147,18 @@ std::unique_ptr<facebook::react::JSExecutorFactory> RCTAppSetupDefaultJsExecutor
   return std::make_unique<facebook::react::HermesExecutorFactory>(
       facebook::react::RCTJSIExecutorRuntimeInstaller(runtimeInstallerLambda));
 #endif
+#else
+  // This method should not be invoked in the New Arch. So when Legacy Arch is removed, we can
+  // safly return a nullptr.
+  return nullptr;
+#endif
 }
 
 std::unique_ptr<facebook::react::JSExecutorFactory> RCTAppSetupJsExecutorFactoryForOldArch(
     RCTBridge *bridge,
     const std::shared_ptr<facebook::react::RuntimeScheduler> &runtimeScheduler)
 {
+#ifndef RCT_REMOVE_LEGACY_ARCH
   auto runtimeInstallerLambda = [bridge, runtimeScheduler](facebook::jsi::Runtime &runtime) {
     if (!bridge) {
       return;
@@ -164,4 +171,10 @@ std::unique_ptr<facebook::react::JSExecutorFactory> RCTAppSetupJsExecutorFactory
   return std::make_unique<facebook::react::HermesExecutorFactory>(
       facebook::react::RCTJSIExecutorRuntimeInstaller(runtimeInstallerLambda));
 #endif
+#else
+  // This method should not be invoked in the New Arch. So when Legacy Arch is removed, we can
+  // safly return a nullptr.
+  return nullptr;
+#endif
+  
 }

--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
@@ -259,7 +259,12 @@ using namespace facebook::react;
 
   configuration.sourceURLForBridge = ^NSURL *_Nullable(RCTBridge *_Nonnull bridge)
   {
+#ifndef RCT_REMOVE_LEGACY_ARCH
     return [weakSelf.delegate sourceURLForBridge:bridge];
+#else
+    // When the Legacy Arch is removed, the Delegate does not have a sourceURLForBridge method
+    return [weakSelf.delegate bundleURL];
+#endif
   };
 
   if ([self.delegate respondsToSelector:@selector(extraModulesForBridge:)]) {
@@ -273,13 +278,25 @@ using namespace facebook::react;
     configuration.extraLazyModuleClassesForBridge =
         ^NSDictionary<NSString *, Class> *_Nonnull(RCTBridge *_Nonnull bridge)
     {
+#ifndef RCT_REMOVE_LEGACY_ARCH
       return [weakSelf.delegate extraLazyModuleClassesForBridge:bridge];
+#else
+      // When the Legacy Arch is removed, the Delegate does not have a extraLazyModuleClassesForBridge method
+      return @{};
+#endif
+      
     };
   }
 
   if ([self.delegate respondsToSelector:@selector(bridge:didNotFindModule:)]) {
     configuration.bridgeDidNotFindModule = ^BOOL(RCTBridge *_Nonnull bridge, NSString *_Nonnull moduleName) {
+#ifndef RCT_REMOVE_LEGACY_ARCH
       return [weakSelf.delegate bridge:bridge didNotFindModule:moduleName];
+#else
+      // When the Legacy Arch is removed, the Delegate does not have a bridge:didNotFindModule method
+      // We return NO, because if we have invoked this method is unlikely that the module will be actually registered
+      return NO;
+#endif
     };
   }
 
@@ -288,13 +305,29 @@ using namespace facebook::react;
         ^(RCTBridge *_Nonnull bridge,
           RCTSourceLoadProgressBlock _Nonnull onProgress,
           RCTSourceLoadBlock _Nonnull loadCallback) {
+#ifndef RCT_REMOVE_LEGACY_ARCH
           [weakSelf.delegate loadSourceForBridge:bridge onProgress:onProgress onComplete:loadCallback];
+#else
+          // When the Legacy Arch is removed, the Delegate does not have a
+          // loadSourceForBridge:onProgress:onComplete: method
+          // We then call the loadBundleAtURL:onProgress:onComplete: instead
+          [weakSelf.delegate loadBundleAtURL:self.bundleURL onProgress:onProgress onComplete:loadCallback];
+#endif
         };
   }
 
   if ([self.delegate respondsToSelector:@selector(loadSourceForBridge:withBlock:)]) {
     configuration.loadSourceForBridge = ^(RCTBridge *_Nonnull bridge, RCTSourceLoadBlock _Nonnull loadCallback) {
+#ifndef RCT_REMOVE_LEGACY_ARCH
       [weakSelf.delegate loadSourceForBridge:bridge withBlock:loadCallback];
+#else
+          // When the Legacy Arch is removed, the Delegate does not have a
+          // loadSourceForBridge:withBlock: method
+          // We then call the loadBundleAtURL:onProgress:onComplete: instead
+      [weakSelf.delegate loadBundleAtURL:self.bundleURL
+                              onProgress:^(RCTLoadingProgress *progressData) {}
+                              onComplete:loadCallback];
+#endif
     };
   }
 

--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -36,6 +36,10 @@ static dispatch_queue_t RCTModuleClassesSyncQueue;
 NSArray<Class> *RCTGetModuleClasses(void)
 {
   __block NSArray<Class> *result;
+  
+  // no modules have been registered yet
+  if(!RCTModuleClasses) return @[];
+  
   dispatch_sync(RCTModuleClassesSyncQueue, ^{
     result = [RCTModuleClasses copy];
   });

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -521,6 +521,7 @@ class ReactNativePodsUtils
 
         if current_setting.include?(flag)
             current_setting.slice! flag
+            current_setting.strip!
         end
 
         config.build_settings[key] = current_setting

--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -518,6 +518,12 @@ def react_native_post_install(
   ReactNativePodsUtils.set_build_setting(installer, build_setting: "REACT_NATIVE_PATH", value: File.join("${PODS_ROOT}", "..", react_native_path))
   ReactNativePodsUtils.set_build_setting(installer, build_setting: "SWIFT_ACTIVE_COMPILATION_CONDITIONS", value: ['$(inherited)', 'DEBUG'], config_name: "Debug")
 
+  if (ENV['RCT_REMOVE_LEGACY_ARCH'] == '1')
+    ReactNativePodsUtils.add_compiler_flag_to_project(installer, "-DRCT_REMOVE_LEGACY_ARCH=1")
+  else
+    ReactNativePodsUtils.remove_compiler_flag_from_project(installer, "-DRCT_REMOVE_LEGACY_ARCH=1")
+  end
+
   ReactNativePodsUtils.set_ccache_compiler_and_linker_build_settings(installer, react_native_path, ccache_enabled)
   ReactNativePodsUtils.updateOSDeploymentTarget(installer)
   ReactNativePodsUtils.set_dynamic_frameworks_flags(installer)


### PR DESCRIPTION
## Summary:
In this change, we are allowing users to install cocoapods with the RCT_REMOVE_LEGACY_ARCH flag enabled to compile out the legacy architecture.

For it to work, we had to adjust some part of the framework that we forgot about when working on the internal side of this feature.

## Changelog:
[iOS][Added] - Added way to set the RCT_REMOVE_LEGACY_ARCH flag from Cocoapods to compile ou the legacy arch

## Test Plan:
Tested locally with RNTester and HelloWorld:

```
cd packages/rn-tester
RCT_REMOVE_LEGACY_ARCH=1 bundle exec pod install
open RNTesterPods.xcworkspace
```

Then build and run and verify that the app keeps running.

Same check with Hello World.
