### PR TITLE
[ios][precompiled] add support for symbolication of precompiled React.xcframework

### DIFF
--- a/packages/react-native/scripts/cocoapods/rndependencies.rb
+++ b/packages/react-native/scripts/cocoapods/rndependencies.rb
@@ -75,7 +75,6 @@ class ReactNativeDependenciesUtils
 
         if ENV["RCT_USE_RN_DEP"] && ENV["RCT_USE_RN_DEP"] == "1"
             if @@use_nightly
-                rndeps_log("Using nightly tarball")
                 begin
                     return self.podspec_source_download_prebuilt_nightly_tarball(@@react_native_version)
                 rescue => e
@@ -84,7 +83,6 @@ class ReactNativeDependenciesUtils
                 end
             end
 
-            rndeps_log("Using release tarball")
             begin
                 return self.podspec_source_download_prebuild_release_tarball()
             rescue => e
@@ -160,9 +158,10 @@ class ReactNativeDependenciesUtils
 
         url = release_tarball_url(@@react_native_version, :debug)
         rndeps_log("Using tarball from URL: #{url}")
-        download_stable_rndeps(@@react_native_path, @@react_native_version, :debug)
+        destinationDebug = download_stable_rndeps(@@react_native_path, @@react_native_version, :debug)
         download_stable_rndeps(@@react_native_path, @@react_native_version, :release)
-        return {:http => url}
+
+        return {:http => URI::File.build(path: destinationDebug).to_s }
     end
 
     def self.release_tarball_url(version, build_type)
@@ -204,7 +203,6 @@ class ReactNativeDependenciesUtils
 
     def self.podspec_source_download_prebuilt_nightly_tarball(version)
         url = nightly_tarball_url(version)
-        rndeps_log("Using nightly tarball from URL: #{url}")
         return {:http => url}
     end
 
@@ -245,14 +243,13 @@ class ReactNativeDependenciesUtils
         if !Object.const_defined?("Pod::UI")
             return
         end
-        log_message = '[ReactNativeDependencies] ' + message
         case level
         when :info
-            Pod::UI.puts log_message.green
+            Pod::UI.puts '[ReactNativeDependencies] '.green + message
         when :error
-            Pod::UI.puts log_message.red
+            Pod::UI.puts '[ReactNativeDependencies] '.red + message
         else
-            Pod::UI.puts log_message.yellow
+            Pod::UI.puts '[ReactNativeDependencies] '.yellow + message
         end
     end
 


### PR DESCRIPTION
## Summary:

This commit adds support for symbolication of the XCFrameworks on request.

The reason doing this is that the symbol files are big and only needed if you need to debug React Native itself - f.ex. if you are a framework developer like Expo.

Symbolication can be performed by setting the `RCT_SYMBOLICATE_PREBUILT_FRAMEWORKS` environment variable to the value ''1'. This will cause the `ReactNativeCoreUtils` helper class to download symbol files and symbolicate the XFrameworks by doing the following:

- After downloading the requested React.XCFramework the symbols will also be downloaded and places in the artifacts folder.
- The XCFrameworks will be expanded and the folders in the symbol archive will be extracted into the XCFramework before it is zipped up again.

Some additional parts of this refactoring:
- Aligned logging in both rndependencies.rb and rncore.rb
- Removed uneccessary logging
- RNCore/Deps: Changed so that the source for the package is the locally downloaded file so we don't download twice!

<img width="400" alt="image" src="https://github.com/user-attachments/assets/ec8dd2e1-c7f8-4d5f-a3b6-b8ffbb678c95" />

## Changelog:

[IOS] [FIXED] - Added support for symbolication of precompiled React.xcframework

## Test Plan:

Run pod install with the environment variable `RCT_SYMBOLICATE_PREBUILT_FRAMEWORKS` set to '1'.
Remember to clean (remove the Pods directory) before turning on/off.