### PR TITLE
Back out "Genalize focus/blur behavior in JS"

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -449,12 +449,6 @@ function InternalTextInput(props: TextInputProps): React.Node {
         before we can get to the long term breaking change.
       */
       if (instance != null) {
-        // Register the input immediately when the ref is set so that focus()
-        // can be called from ref callbacks
-        // Double registering during useLayoutEffect is fine, because the underlying
-        // state is a Set.
-        TextInputState.registerInput(instance);
-
         // $FlowFixMe[prop-missing] - See the explanation above.
         // $FlowFixMe[unsafe-object-assign]
         Object.assign(instance, {

--- a/packages/react-native/Libraries/Components/View/ViewNativeComponent.js
+++ b/packages/react-native/Libraries/Components/View/ViewNativeComponent.js
@@ -21,8 +21,8 @@ const ViewNativeComponent: HostComponent<Props> =
   }));
 
 interface NativeCommands {
-  +focus: (viewRef: HostInstance) => void;
-  +blur: (viewRef: HostInstance) => void;
+  +focus: () => void;
+  +blur: () => void;
   +hotspotUpdate: (viewRef: HostInstance, x: number, y: number) => void;
   +setPressed: (viewRef: HostInstance, pressed: boolean) => void;
 }

--- a/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/ReactFabricPublicInstance-itest.js
+++ b/packages/react-native/Libraries/ReactNative/ReactFabricPublicInstance/__tests__/ReactFabricPublicInstance-itest.js
@@ -14,7 +14,6 @@ import '@react-native/fantom/src/setUpDefaultReactNativeEnvironment';
 import type {HostInstance} from 'react-native';
 
 import ReactNativeElement from '../../../../src/private/webapis/dom/nodes/ReactNativeElement';
-import TextInput from '../../../Components/TextInput/TextInput';
 import TextInputState from '../../../Components/TextInput/TextInputState';
 import View from '../../../Components/View/View';
 import ReactFabricHostComponent from '../ReactFabricHostComponent';
@@ -49,7 +48,7 @@ describe('ReactFabricPublicInstance', () => {
       const nodeRef = createRef<HostInstance>();
 
       Fantom.runTask(() => {
-        root.render(<TextInput ref={nodeRef} />);
+        root.render(<View ref={nodeRef} />);
       });
 
       const node = nullthrows(nodeRef.current);
@@ -74,7 +73,7 @@ describe('ReactFabricPublicInstance', () => {
       const ref = createRef<HostInstance>();
 
       Fantom.runTask(() => {
-        root.render(<TextInput ref={ref} />);
+        root.render(<View ref={ref} />);
       });
 
       const node = nullthrows(ref.current);

--- a/packages/react-native/src/private/webapis/dom/nodes/ReactNativeElement.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/ReactNativeElement.js
@@ -25,10 +25,8 @@ import type {InstanceHandle} from './internals/NodeInternals';
 import type ReactNativeDocument from './ReactNativeDocument';
 
 import TextInputState from '../../../../../Libraries/Components/TextInput/TextInputState';
-import {Commands as ViewCommands} from '../../../../../Libraries/Components/View/ViewNativeComponent';
 import {create as createAttributePayload} from '../../../../../Libraries/ReactNative/ReactFabricPublicInstance/ReactNativeAttributePayload';
 import warnForStyleProps from '../../../../../Libraries/ReactNative/ReactFabricPublicInstance/warnForStyleProps';
-import * as ReactNativeFeatureFlags from '../../../featureflags/ReactNativeFeatureFlags';
 import {
   getNativeElementReference,
   getPublicInstanceFromInstanceHandle,
@@ -142,19 +140,11 @@ class ReactNativeElement extends ReadOnlyElement implements NativeMethods {
    */
 
   blur(): void {
-    if (TextInputState.isTextInput(this)) {
-      TextInputState.blurTextInput(this);
-    } else if (ReactNativeFeatureFlags.enableImperativeFocus()) {
-      ViewCommands.blur(this);
-    }
+    TextInputState.blurTextInput(this);
   }
 
   focus() {
-    if (TextInputState.isTextInput(this)) {
-      TextInputState.focusTextInput(this);
-    } else if (ReactNativeFeatureFlags.enableImperativeFocus()) {
-      ViewCommands.focus(this);
-    }
+    TextInputState.focusTextInput(this);
   }
 
   measure(callback: MeasureOnSuccessCallback) {


### PR DESCRIPTION
Summary:
This reverts a previous change that modified how focus behavior is handled in JavaScript. That change caused hierarchy rows to no longer be focusable, either manually or programmatically as they were before, which in turn broke arrow key navigation in entity lists. Reverting the change restores the expected focus behavior and re-enables proper arrow key functionality within entity lists.

Changelog: [Internal]

Differential Revision: D83390685


