### PR TITLE
Allow extending ReactTextViewManager again

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.kt
@@ -51,7 +51,7 @@ import kotlin.math.min
  * constructed in superclass.
  */
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
-public class ReactTextShadowNode
+public open class ReactTextShadowNode
 @JvmOverloads
 public constructor(reactTextViewManagerCallback: ReactTextViewManagerCallback? = null) :
     ReactBaseTextShadowNode(reactTextViewManagerCallback) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewManager.kt
@@ -29,7 +29,7 @@ import java.util.HashMap
  */
 @ReactModule(name = ReactTextViewManager.REACT_CLASS)
 @OptIn(UnstableReactNativeAPI::class)
-public class ReactTextViewManager
+public open class ReactTextViewManager
 @JvmOverloads
 public constructor(
     protected var reactTextViewManagerCallback: ReactTextViewManagerCallback? = null
@@ -92,7 +92,7 @@ public constructor(
   override fun createShadowNodeInstance(): ReactTextShadowNode =
       ReactTextShadowNode(reactTextViewManagerCallback)
 
-  public fun createShadowNodeInstance(
+  public open fun createShadowNodeInstance(
       reactTextViewManagerCallback: ReactTextViewManagerCallback?
   ): ReactTextShadowNode = ReactTextShadowNode(reactTextViewManagerCallback)
 


### PR DESCRIPTION
## Summary:

Since kotlin classes are final by default the migration caused some issues with [a library](https://github.com/axelra-ag/react-native-animateable-text) we're using.

Not being able to extend `ReactTextViewManager` becomes very problematic since this class is pretty big, and also depends on internal APIs, so it isn't just a matter of copying it in the library code as a workaround.

## Changelog:

[ANDROID] [FIXED] - Allow extending ReactTextViewManager again

## Test Plan:

Tested by adding https://github.com/axelra-ag/react-native-animateable-text in RN tester and making sure it builds now.
