### PR TITLE
Fix serialization for vector of primitive type

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/propsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/propsConversions.h
@@ -34,6 +34,30 @@ inline folly::dynamic toDynamic(const std::vector<std::string>& arrayValue) {
   return resultArray;
 }
 
+inline folly::dynamic toDynamic(const std::vector<int>& arrayValue) {
+  folly::dynamic resultArray = folly::dynamic::array();
+  for (auto value : arrayValue) {
+    resultArray.push_back(value);
+  }
+  return resultArray;
+}
+
+inline folly::dynamic toDynamic(const std::vector<double>& arrayValue) {
+  folly::dynamic resultArray = folly::dynamic::array();
+  for (auto value : arrayValue) {
+    resultArray.push_back(value);
+  }
+  return resultArray;
+}
+
+inline folly::dynamic toDynamic(const std::vector<Float>& arrayValue) {
+  folly::dynamic resultArray = folly::dynamic::array();
+  for (auto value : arrayValue) {
+    resultArray.push_back(value);
+  }
+  return resultArray;
+}
+
 inline folly::dynamic toDynamic(const std::vector<folly::dynamic>& arrayValue) {
   folly::dynamic resultArray = folly::dynamic::array();
   for (auto& value : arrayValue) {


### PR DESCRIPTION
Summary:
This diffs adds specific `toDynamic` conversions for props defined as arrays holding primitive types. This fixes the serialization of `std::vector<Float>` that was failing to correctly convert to a `folly::dynamic` type when using Props 2.0.

Changelog: [Internal]

Differential Revision: D83520605


