### PR TITLE
Request layout on configuration change only when the font scale has changed

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.kt
@@ -61,6 +61,7 @@ import com.facebook.react.runtime.internal.bolts.Task
 import com.facebook.react.runtime.internal.bolts.TaskCompletionSource
 import com.facebook.react.turbomodule.core.interfaces.CallInvokerHolder
 import com.facebook.react.uimanager.DisplayMetricsHolder
+import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.uimanager.events.BlackHoleEventDispatcher
 import com.facebook.react.uimanager.events.EventDispatcher
 import com.facebook.react.views.imagehelper.ResourceDrawableIdHelper
@@ -647,10 +648,14 @@ public class ReactHostImpl(
     val currentReactContext = this.currentReactContext
     if (currentReactContext != null) {
       if (ReactNativeFeatureFlags.enableFontScaleChangesUpdatingLayout()) {
+        val previousFontScale = PixelUtil.toPixelFromSP(1.0)
         DisplayMetricsHolder.initDisplayMetrics(currentReactContext)
+        val newFontScale = PixelUtil.toPixelFromSP(1.0)
 
-        synchronized(attachedSurfaces) {
-          attachedSurfaces.forEach { surface -> surface.view?.requestLayout() }
+        if (previousFontScale != newFontScale) {
+          synchronized(attachedSurfaces) {
+            attachedSurfaces.forEach { surface -> surface.view?.requestLayout() }
+          }
         }
       }
 


### PR DESCRIPTION
Summary:
Changelog: [ANDROID][CHANGED] - Request layout on configuration change only when the font scale has changed

Wraps call to `requestLayout` in a condition to only run layout when the font scale has changed to prevent it from executing in response to other configuration changes.

Differential Revision: D83546632


