### PR TITLE
Split macro for static module registration

### DIFF
--- a/packages/react-native/React/Base/RCTBridgeModule.h
+++ b/packages/react-native/React/Base/RCTBridgeModule.h
@@ -69,7 +69,7 @@ RCT_EXTERN_C_END
  * will be used as the JS module name. If omitted, the JS module name will
  * match the Objective-C class name.
  */
-#ifndef RCT_REMOVE_LEGACY_ARCH
+#ifndef RCT_DISABLE_STATIC_MODULE_REGISTRATION
 #define RCT_EXPORT_MODULE(js_name)          \
   RCT_EXTERN void RCTRegisterModule(Class); \
   +(NSString *)moduleName                   \
@@ -90,7 +90,7 @@ RCT_EXTERN_C_END
     return @ #js_name;                      \
   }
 
-#endif // RCT_REMOVE_LEGACY_ARCH
+#endif // RCT_DISABLE_STATIC_MODULE_REGISTRATION
 
 /**
  * Same as RCT_EXPORT_MODULE, but uses __attribute__((constructor)) for module


### PR DESCRIPTION
Summary:
This change descouple the Static Module registration from the Disable Legacy arch macro

## Changelog:
[Internal] -

Differential Revision: D83554091


