### PR TITLE
Fix JSI `isArray` method to match JS `Array.isArray`

### DIFF
--- a/packages/react-native/ReactCommon/jsc/JSCRuntime.cpp
+++ b/packages/react-native/ReactCommon/jsc/JSCRuntime.cpp
@@ -1047,7 +1047,14 @@ void JSCRuntime::setPropertyValue(
 }
 
 bool JSCRuntime::isArray(const jsi::Object& obj) const {
-  return JSValueIsArray(ctx_, objectRef(obj));
+  // JSValueIsArray only returns true if the object is a JS array. There's no
+  // public JSC API equivalent to Array.isArray, so we call the JS function
+  // through JSI directly.
+  auto constRt = const_cast<JSCRuntime*>(this);
+  auto isArrayFn = constRt->global()
+                       .getPropertyAsObject(*constRt, "Array")
+                       .getPropertyAsFunction(*constRt, "isArray");
+  return isArrayFn.call(*constRt, obj).asBool();
 }
 
 bool JSCRuntime::isArrayBuffer(const jsi::Object& obj) const {


### PR DESCRIPTION
Summary:
As the previous few diffs, JSI `isArray` API should follow
`Array.isArray` from the JS spec.

The current implementation does not consider Proxy objects, only Array
exotic objects.

Differential Revision: D83391784


