### PR TITLE
iOS: Add new `RCTCustomBundleConfiguration` for modifying bundle URL

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.h
@@ -24,6 +24,7 @@
 @class RCTBridge;
 @protocol RCTComponentViewProtocol;
 @class RCTSurfacePresenterBridgeAdapter;
+@class RCTCustomBundleConfiguration;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -115,6 +116,8 @@ typedef NS_ENUM(NSInteger, RCTReleaseLevel) { Canary, Experimental, Stable };
 ;
 
 @property (nonatomic, weak) id<RCTReactNativeFactoryDelegate> delegate;
+
+@property (nonatomic, nullable, readonly) RCTCustomBundleConfiguration *customBundleConfiguration;
 
 @end
 

--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.h
@@ -117,7 +117,7 @@ typedef NS_ENUM(NSInteger, RCTReleaseLevel) { Canary, Experimental, Stable };
 
 @property (nonatomic, weak) id<RCTReactNativeFactoryDelegate> delegate;
 
-@property (nonatomic, nullable, readonly) RCTCustomBundleConfiguration *customBundleConfiguration;
+@property (nonatomic, nullable) RCTCustomBundleConfiguration *customBundleConfiguration;
 
 @end
 

--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
@@ -11,6 +11,7 @@
 #import <React/RCTRootView.h>
 #import <React/RCTSurfacePresenterBridgeAdapter.h>
 #import <React/RCTUtils.h>
+#import <React/RCTBundleManager.h>
 #import <ReactCommon/RCTHost.h>
 #import <objc/runtime.h>
 #import <react/featureflags/ReactNativeFeatureFlagsOverridesOSSCanary.h>

--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
@@ -59,6 +59,8 @@ using namespace facebook::react;
     self.rootViewFactory = [self createRCTRootViewFactory];
 
     [RCTComponentViewFactory currentComponentViewFactory].thirdPartyFabricComponentsProvider = self;
+    
+    self.customBundleConfiguration = [[RCTCustomBundleConfiguration alloc] init];
   }
 
   return self;
@@ -83,7 +85,8 @@ using namespace facebook::react;
 {
   UIView *rootView = [self.rootViewFactory viewWithModuleName:moduleName
                                             initialProperties:initialProperties
-                                                launchOptions:launchOptions];
+                                                launchOptions:launchOptions
+                                              customBundleConfiguration:self.customBundleConfiguration];
   UIViewController *rootViewController = [_delegate createRootViewController];
   [_delegate setRootView:rootView toRootViewController:rootViewController];
   window.rootViewController = rootViewController;

--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
@@ -6,12 +6,12 @@
  */
 
 #import "RCTReactNativeFactory.h"
+#import <React/RCTBundleManager.h>
 #import <React/RCTColorSpaceUtils.h>
 #import <React/RCTLog.h>
 #import <React/RCTRootView.h>
 #import <React/RCTSurfacePresenterBridgeAdapter.h>
 #import <React/RCTUtils.h>
-#import <React/RCTBundleManager.h>
 #import <ReactCommon/RCTHost.h>
 #import <objc/runtime.h>
 #import <react/featureflags/ReactNativeFeatureFlagsOverridesOSSCanary.h>

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.h
@@ -18,6 +18,7 @@
 @class RCTHost;
 @class RCTRootView;
 @class RCTSurfacePresenterBridgeAdapter;
+@class RCTCustomBundleConfiguration;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -201,7 +202,13 @@ typedef void (^RCTLoadSourceForBridgeBlock)(RCTBridge *bridge, RCTSourceLoadBloc
  * @parameter: moduleName  - the name of the app, used by Metro to resolve the module.
  * @parameter: initialProperties  -  a set of initial properties.
  * @parameter: launchOptions  - a dictionary with a set of options.
+ * @parameter: customBundleConfiguration  - a configuration for custom bundle source.
  */
+- (UIView *_Nonnull)viewWithModuleName:(NSString *)moduleName
+                     initialProperties:(NSDictionary *__nullable)initialProperties
+                         launchOptions:(NSDictionary *__nullable)launchOptions
+             customBundleConfiguration:(RCTCustomBundleConfiguration *__nullable)customBundleConfiguration;
+
 - (UIView *_Nonnull)viewWithModuleName:(NSString *)moduleName
                      initialProperties:(NSDictionary *__nullable)initialProperties
                          launchOptions:(NSDictionary *__nullable)launchOptions;
@@ -220,7 +227,11 @@ typedef void (^RCTLoadSourceForBridgeBlock)(RCTBridge *bridge, RCTSourceLoadBloc
  *
  * @parameter: launchOptions  - a dictionary with a set of options.
  */
-- (void)initializeReactHostWithLaunchOptions:(NSDictionary *__nullable)launchOptions;
+- (void)initializeReactHostWithLaunchOptions:(NSDictionary *__nullable)launchOptions
+                   customBundleConfiguration:(RCTCustomBundleConfiguration *__nullable)customBundleConfiguration;
+
+- (RCTHost *)createReactHost:(NSDictionary *__nullable)launchOptions
+    customBundleConfiguration:(RCTCustomBundleConfiguration *__nullable)customBundleConfiguration;
 
 - (RCTHost *)createReactHost:(NSDictionary *__nullable)launchOptions;
 

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
@@ -142,6 +142,7 @@
 }
 
 - (void)initializeReactHostWithLaunchOptions:(NSDictionary *)launchOptions
+        customBundleConfiguration:(RCTCustomBundleConfiguration *)customBundleConfiguration
 {
   // Enable TurboModule interop by default in Bridgeless mode
   RCTEnableTurboModuleInterop(YES);
@@ -155,7 +156,15 @@
              initialProperties:(NSDictionary *)initProps
                  launchOptions:(NSDictionary *)launchOptions
 {
-  [self initializeReactHostWithLaunchOptions:launchOptions];
+  return [self viewWithModuleName:moduleName initialProperties:initProps launchOptions:launchOptions customBundleConfiguration:nil];
+}
+
+- (UIView *)viewWithModuleName:(NSString *)moduleName
+             initialProperties:(NSDictionary *)initProps
+                 launchOptions:(NSDictionary *)launchOptions
+     customBundleConfiguration:(RCTCustomBundleConfiguration *)customBundleConfiguration
+{
+  [self initializeReactHostWithLaunchOptions:launchOptions customBundleConfiguration:customBundleConfiguration];
 
   RCTFabricSurface *surface = [self.reactHost createSurfaceWithModuleName:moduleName
                                                         initialProperties:initProps ? initProps : @{}];
@@ -235,6 +244,12 @@
 
 - (RCTHost *)createReactHost:(NSDictionary *)launchOptions
 {
+  return [self createReactHost:launchOptions customBundleConfiguration:nil];
+}
+
+- (RCTHost *)createReactHost:(NSDictionary *)launchOptions
+   customBundleConfiguration:(RCTCustomBundleConfiguration *)customBundleConfiguration
+{
   __weak __typeof(self) weakSelf = self;
   RCTHost *reactHost =
       [[RCTHost alloc] initWithBundleURLProvider:self->_configuration.bundleURLBlock
@@ -243,7 +258,8 @@
                                 jsEngineProvider:^std::shared_ptr<facebook::react::JSRuntimeFactory>() {
                                   return [weakSelf createJSRuntimeFactory];
                                 }
-                                   launchOptions:launchOptions];
+                                   launchOptions:launchOptions
+              customBundleConfiguration:customBundleConfiguration];
   [reactHost setBundleURLProvider:^NSURL *() {
     return [weakSelf bundleURL];
   }];

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
@@ -20,7 +20,6 @@
 #else
 #import <React/CoreModulesPlugins.h>
 #endif
-#import <React/RCTBundleURLProvider.h>
 #import <React/RCTComponentViewFactory.h>
 #import <React/RCTComponentViewProtocol.h>
 #import <React/RCTFabricSurface.h>
@@ -142,13 +141,13 @@
 }
 
 - (void)initializeReactHostWithLaunchOptions:(NSDictionary *)launchOptions
-        customBundleConfiguration:(RCTCustomBundleConfiguration *)customBundleConfiguration
+                   customBundleConfiguration:(RCTCustomBundleConfiguration *)customBundleConfiguration
 {
   // Enable TurboModule interop by default in Bridgeless mode
   RCTEnableTurboModuleInterop(YES);
   RCTEnableTurboModuleInteropBridgeProxy(YES);
 
-  [self createReactHostIfNeeded:launchOptions];
+  [self createReactHostIfNeeded:launchOptions customBundleConfiguration:customBundleConfiguration];
   return;
 }
 
@@ -156,7 +155,10 @@
              initialProperties:(NSDictionary *)initProps
                  launchOptions:(NSDictionary *)launchOptions
 {
-  return [self viewWithModuleName:moduleName initialProperties:initProps launchOptions:launchOptions customBundleConfiguration:nil];
+  return [self viewWithModuleName:moduleName
+                initialProperties:initProps
+                    launchOptions:launchOptions
+        customBundleConfiguration:nil];
 }
 
 - (UIView *)viewWithModuleName:(NSString *)moduleName
@@ -235,11 +237,12 @@
 #pragma mark - New Arch Utilities
 
 - (void)createReactHostIfNeeded:(NSDictionary *)launchOptions
+      customBundleConfiguration:(RCTCustomBundleConfiguration *)customBundleConfiguration
 {
   if (self.reactHost) {
     return;
   }
-  self.reactHost = [self createReactHost:launchOptions];
+  self.reactHost = [self createReactHost:launchOptions customBundleConfiguration:customBundleConfiguration];
 }
 
 - (RCTHost *)createReactHost:(NSDictionary *)launchOptions
@@ -248,7 +251,7 @@
 }
 
 - (RCTHost *)createReactHost:(NSDictionary *)launchOptions
-   customBundleConfiguration:(RCTCustomBundleConfiguration *)customBundleConfiguration
+    customBundleConfiguration:(RCTCustomBundleConfiguration *)customBundleConfiguration
 {
   __weak __typeof(self) weakSelf = self;
   RCTHost *reactHost =
@@ -259,10 +262,7 @@
                                   return [weakSelf createJSRuntimeFactory];
                                 }
                                    launchOptions:launchOptions
-              customBundleConfiguration:customBundleConfiguration];
-  [reactHost setBundleURLProvider:^NSURL *() {
-    return [weakSelf bundleURL];
-  }];
+                       customBundleConfiguration:customBundleConfiguration];
   [reactHost start];
   return reactHost;
 }

--- a/packages/react-native/React/Base/RCTBundleManager.h
+++ b/packages/react-native/React/Base/RCTBundleManager.h
@@ -37,7 +37,13 @@ typedef void (^RCTBridgelessBundleURLSetter)(NSURL *bundleURL);
 - (instancetype)initWithPackagerServerScheme:(NSString *)packagerServerScheme
                           packagerServerHost:(NSString *)packagerServerHost;
 
-- (NSURL *)getBundleURL:(NSMutableArray<NSURLQueryItem *> *)query;
+- (NSURL *)getBundleURL:(NSURL *__nullable (^)(void))fallbackURLProvider;
+
+- (NSString *)getPackagerServerScheme;
+
+- (NSString *)getPackagerServerHost;
+
+- (void)clean;
 
 @end
 

--- a/packages/react-native/React/Base/RCTBundleManager.h
+++ b/packages/react-native/React/Base/RCTBundleManager.h
@@ -13,6 +13,30 @@ typedef NSURL * (^RCTBridgelessBundleURLGetter)(void);
 typedef void (^RCTBridgelessBundleURLSetter)(NSURL *bundleURL);
 
 /**
+ * Configuration class for setting up custom bundle locations
+ */
+@interface RCTCustomBundleConfiguration
+
+/**
+ * The URL of the bundle to load from the file system
+ */
+@property (nonatomic, readonly, nullable) NSURL *bundleFilePath;
+
+/**
+ * The server scheme (e.g. http or https) to use when loading from the packager
+ */
+@property (nonatomic, readonly, nullable) NSString *packagerServerScheme;
+
+/**
+ * The server host (e.g. localhost) to use when loading from the packager
+ */
+@property (nonatomic, readonly, nullable) NSString *packagerServerHost;
+
+- (NSURL *)getBundleURL:(NSMutableArray<NSURLQueryItem *> *)query;
+
+@end
+
+/**
  * A class that allows NativeModules/TurboModules to read/write the bundleURL, with or without the bridge.
  */
 @interface RCTBundleManager : NSObject
@@ -24,4 +48,5 @@ typedef void (^RCTBridgelessBundleURLSetter)(NSURL *bundleURL);
                     andDefaultGetter:(RCTBridgelessBundleURLGetter)defaultGetter;
 - (void)resetBundleURL;
 @property NSURL *bundleURL;
+@property (nonatomic, readonly, nullable) RCTCustomBundleConfiguration *customBundleConfig;
 @end

--- a/packages/react-native/React/Base/RCTBundleManager.h
+++ b/packages/react-native/React/Base/RCTBundleManager.h
@@ -15,7 +15,7 @@ typedef void (^RCTBridgelessBundleURLSetter)(NSURL *bundleURL);
 /**
  * Configuration class for setting up custom bundle locations
  */
-@interface RCTCustomBundleConfiguration
+@interface RCTCustomBundleConfiguration : NSObject
 
 /**
  * The URL of the bundle to load from the file system
@@ -31,6 +31,11 @@ typedef void (^RCTBridgelessBundleURLSetter)(NSURL *bundleURL);
  * The server host (e.g. localhost) to use when loading from the packager
  */
 @property (nonatomic, readonly, nullable) NSString *packagerServerHost;
+
+- (instancetype)initWithBundleFilePath:(NSURL *)bundleFilePath;
+
+- (instancetype)initWithPackagerServerScheme:(NSString *)packagerServerScheme
+                          packagerServerHost:(NSString *)packagerServerHost;
 
 - (NSURL *)getBundleURL:(NSMutableArray<NSURLQueryItem *> *)query;
 
@@ -48,5 +53,5 @@ typedef void (^RCTBridgelessBundleURLSetter)(NSURL *bundleURL);
                     andDefaultGetter:(RCTBridgelessBundleURLGetter)defaultGetter;
 - (void)resetBundleURL;
 @property NSURL *bundleURL;
-@property (nonatomic, readonly, nullable) RCTCustomBundleConfiguration *customBundleConfig;
+@property (nonatomic, nullable) RCTCustomBundleConfiguration *customBundleConfig;
 @end

--- a/packages/react-native/React/Base/RCTBundleManager.m
+++ b/packages/react-native/React/Base/RCTBundleManager.m
@@ -9,6 +9,7 @@
 #import "RCTAssert.h"
 #import "RCTBridge+Private.h"
 #import "RCTBridge.h"
+#import <React/RCTBundleURLProvider.h>
 
 @implementation RCTCustomBundleConfiguration
 
@@ -31,9 +32,47 @@
   return self;
 }
 
-- (NSURL *)getBundleURL:(NSMutableArray<NSURLQueryItem *> *)query
+- (NSString *)getPackagerServerScheme
 {
-  return [NSURL alloc];
+  if (!_packagerServerScheme) {
+    return [[RCTBundleURLProvider sharedSettings] packagerScheme];
+  }
+  
+  return _packagerServerScheme;
+}
+
+- (NSString *)getPackagerServerHost
+{
+  if (!_packagerServerHost) {
+    return [[RCTBundleURLProvider sharedSettings] packagerServerHostPort];
+  }
+  
+  return _packagerServerHost;
+}
+
+- (NSURL *)getBundleURL:(NSURL * (^)(void))fallbackURLProvider
+{
+  if (_packagerServerScheme && _packagerServerHost) {
+    NSArray<NSURLQueryItem *> *jsBundleURLQuery = [[RCTBundleURLProvider sharedSettings] createJSBundleURLQuery:_packagerServerHost packagerScheme:_packagerServerScheme];
+    
+    return [[RCTBundleURLProvider class] resourceURLForResourcePath:@"js/RNTesterApp.ios"
+                                         packagerHost:_packagerServerHost
+                                         scheme:_packagerServerScheme
+                                         queryItems:jsBundleURLQuery];
+  }
+  
+  if (_bundleFilePath) {
+    // TODO: modify bundle path
+  }
+  
+  return fallbackURLProvider();
+}
+
+- (void)clean
+{
+  _packagerServerHost = nil;
+  _packagerServerScheme = nil;
+  _bundleFilePath = nil;
 }
 
 @end

--- a/packages/react-native/React/Base/RCTBundleManager.m
+++ b/packages/react-native/React/Base/RCTBundleManager.m
@@ -10,6 +10,17 @@
 #import "RCTBridge+Private.h"
 #import "RCTBridge.h"
 
+@implementation RCTCustomBundleConfiguration
+@synthesize bundleFilePath;
+@synthesize packagerServerHost;
+@synthesize packagerServerScheme;
+
+- (NSURL *)getBundleURL:(NSMutableArray<NSURLQueryItem *> *)query
+{
+  return [NSURL alloc];
+}
+@end
+
 @implementation RCTBundleManager {
 #ifndef RCT_FIT_RM_OLD_RUNTIME
   __weak RCTBridge *_bridge;
@@ -18,6 +29,7 @@
   RCTBridgelessBundleURLSetter _bridgelessBundleURLSetter;
   RCTBridgelessBundleURLGetter _bridgelessBundleURLDefaultGetter;
 }
+@synthesize customBundleConfig;
 
 #ifndef RCT_FIT_RM_OLD_RUNTIME
 - (void)setBridge:(RCTBridge *)bridge

--- a/packages/react-native/React/Base/RCTBundleManager.m
+++ b/packages/react-native/React/Base/RCTBundleManager.m
@@ -11,14 +11,31 @@
 #import "RCTBridge.h"
 
 @implementation RCTCustomBundleConfiguration
-@synthesize bundleFilePath;
-@synthesize packagerServerHost;
-@synthesize packagerServerScheme;
+
+- (instancetype)initWithBundleFilePath:(NSURL *)bundleFilePath
+{
+  if (self = [super init]) {
+    _bundleFilePath = bundleFilePath;
+  }
+  
+  return self;
+}
+
+- (instancetype)initWithPackagerServerScheme:(NSString *)packagerServerScheme packagerServerHost:(NSString *)packagerServerHost
+{
+  if (self = [super init]) {
+    _packagerServerScheme = packagerServerScheme;
+    _packagerServerHost = packagerServerHost;
+  }
+  
+  return self;
+}
 
 - (NSURL *)getBundleURL:(NSMutableArray<NSURLQueryItem *> *)query
 {
   return [NSURL alloc];
 }
+
 @end
 
 @implementation RCTBundleManager {

--- a/packages/react-native/React/Base/RCTBundleURLProvider.h
+++ b/packages/react-native/React/Base/RCTBundleURLProvider.h
@@ -97,6 +97,19 @@ NS_ASSUME_NONNULL_BEGIN
                               resourceExtension:(NSString *)extension
                                   offlineBundle:(NSBundle *)offlineBundle;
 
+- (NSArray<NSURLQueryItem *> *)createJSBundleURLQuery:(NSString *)packagerHost
+                                       packagerScheme:(NSString *__nullable)scheme;
+
++ (NSArray<NSURLQueryItem *> *)createJSBundleURLQuery:(NSString *)packagerHost
+                packagerScheme:(NSString *__nullable)scheme
+                     enableDev:(BOOL)enableDev
+            enableMinification:(BOOL)enableMinification
+               inlineSourceMap:(BOOL)inlineSourceMap
+                   modulesOnly:(BOOL)modulesOnly
+                     runModule:(BOOL)runModule
+             additionalOptions:(NSDictionary<NSString *, NSString *>
+                                *__nullable)additionalOptions;
+
 /**
  * The IP address or hostname of the packager.
  */

--- a/packages/react-native/React/Base/RCTBundleURLProvider.mm
+++ b/packages/react-native/React/Base/RCTBundleURLProvider.mm
@@ -313,6 +313,44 @@ static NSURL *serverRootWithHostPort(NSString *hostPort, NSString *scheme)
                             additionalOptions:(NSDictionary<NSString *, NSString *> *__nullable)additionalOptions
 {
   NSString *path = [NSString stringWithFormat:@"/%@.bundle", bundleRoot];
+  NSArray<NSURLQueryItem *> *queryItems = [self createJSBundleURLQuery:packagerHost
+                                                packagerScheme:scheme
+                                                enableDev:enableDev
+                                                enableMinification:enableMinification
+                                                inlineSourceMap:inlineSourceMap
+                                                modulesOnly:modulesOnly
+                                                runModule:runModule
+                                                additionalOptions:additionalOptions];
+
+  return [[self class] resourceURLForResourcePath:path
+                                     packagerHost:packagerHost
+                                           scheme:scheme
+                                       queryItems:[queryItems copy]];
+}
+
+- (NSArray<NSURLQueryItem *> *)createJSBundleURLQuery:(NSString *)packagerHost
+                                       packagerScheme:(NSString *__nullable)scheme
+{
+  return [[self class] createJSBundleURLQuery:packagerHost
+                       packagerScheme:scheme
+                       enableDev:[self enableDev]
+                       enableMinification:[self enableMinification]
+                       inlineSourceMap:[self inlineSourceMap]
+                       modulesOnly:NO
+                       runModule:YES
+                       additionalOptions:nil];
+}
+
++ (NSArray<NSURLQueryItem *> *)createJSBundleURLQuery:(NSString *)packagerHost
+                packagerScheme:(NSString *__nullable)scheme
+                     enableDev:(BOOL)enableDev
+            enableMinification:(BOOL)enableMinification
+               inlineSourceMap:(BOOL)inlineSourceMap
+                   modulesOnly:(BOOL)modulesOnly
+                     runModule:(BOOL)runModule
+             additionalOptions:(NSDictionary<NSString *, NSString *>
+                                *__nullable)additionalOptions
+{
   BOOL lazy = enableDev;
   NSMutableArray<NSURLQueryItem *> *queryItems = [[NSMutableArray alloc] initWithArray:@[
     [[NSURLQueryItem alloc] initWithName:@"platform" value:RCTPlatformName],
@@ -344,11 +382,8 @@ static NSURL *serverRootWithHostPort(NSString *hostPort, NSString *scheme)
       [queryItems addObject:[[NSURLQueryItem alloc] initWithName:key value:value]];
     }
   }
-
-  return [[self class] resourceURLForResourcePath:path
-                                     packagerHost:packagerHost
-                                           scheme:scheme
-                                       queryItems:[queryItems copy]];
+  
+  return queryItems;
 }
 
 + (NSURL *)resourceURLForResourcePath:(NSString *)path

--- a/packages/react-native/React/CoreModules/RCTDevSettings.h
+++ b/packages/react-native/React/CoreModules/RCTDevSettings.h
@@ -10,6 +10,7 @@
 #import <React/RCTDefines.h>
 #import <React/RCTEventEmitter.h>
 #import <React/RCTInitializing.h>
+#import <React/RCTPackagerConnection.h>
 
 @protocol RCTPackagerClientMethod;
 
@@ -80,6 +81,8 @@
  */
 @property (nonatomic, assign) BOOL isPerfMonitorShown;
 
+@property (nonatomic, readonly) RCTPackagerConnection* packagerConnection;
+
 /**
  * Toggle the element inspector.
  */
@@ -94,6 +97,8 @@
  * Register additional bundles with the HMRClient.
  */
 - (void)setupHMRClientWithAdditionalBundleURL:(NSURL *)bundleURL;
+
+- (void)startPackagerConnection;
 
 #if RCT_DEV_MENU
 - (void)addHandler:(id<RCTPackagerClientMethod>)handler

--- a/packages/react-native/React/CoreModules/RCTDevSettings.h
+++ b/packages/react-native/React/CoreModules/RCTDevSettings.h
@@ -98,8 +98,6 @@
  */
 - (void)setupHMRClientWithAdditionalBundleURL:(NSURL *)bundleURL;
 
-- (void)startPackagerConnection;
-
 #if RCT_DEV_MENU
 - (void)addHandler:(id<RCTPackagerClientMethod>)handler
     forPackagerMethod:(NSString *)name __deprecated_msg("Use RCTPackagerConnection directly instead");

--- a/packages/react-native/React/CoreModules/RCTDevSettings.mm
+++ b/packages/react-native/React/CoreModules/RCTDevSettings.mm
@@ -145,6 +145,13 @@ RCT_EXPORT_MODULE()
   };
   RCTDevSettingsUserDefaultsDataSource *dataSource =
       [[RCTDevSettingsUserDefaultsDataSource alloc] initWithDefaultValues:defaultValues];
+
+#if RCT_DEV_SETTINGS_ENABLE_PACKAGER_CONNECTION
+
+  _packagerConnection = [[RCTPackagerConnection alloc] init];
+
+#endif
+
   return [self initWithDataSource:dataSource];
 }
 
@@ -179,14 +186,14 @@ RCT_EXPORT_MODULE()
 {
 #if RCT_DEV_SETTINGS_ENABLE_PACKAGER_CONNECTION
   if (numInitializedModules++ == 0) {
-    reloadToken = [[RCTPackagerConnection sharedPackagerConnection]
+    reloadToken = [_packagerConnection
         addNotificationHandler:^(id params) {
           RCTTriggerReloadCommandListeners(@"Global hotkey");
         }
                          queue:dispatch_get_main_queue()
                      forMethod:@"reload"];
 #if RCT_DEV_MENU
-    devMenuToken = [[RCTPackagerConnection sharedPackagerConnection]
+    devMenuToken = [_packagerConnection
         addNotificationHandler:^(id params) {
           [[self.moduleRegistry moduleForName:"DevMenu"] show];
         }
@@ -239,9 +246,9 @@ RCT_EXPORT_MODULE()
   [super invalidate];
 #if RCT_DEV_SETTINGS_ENABLE_PACKAGER_CONNECTION
   if (--numInitializedModules == 0) {
-    [[RCTPackagerConnection sharedPackagerConnection] removeHandler:reloadToken];
+    [_packagerConnection removeHandler:reloadToken];
 #if RCT_DEV_MENU
-    [[RCTPackagerConnection sharedPackagerConnection] removeHandler:devMenuToken];
+    [_packagerConnection removeHandler:devMenuToken];
 #endif
   }
 #endif
@@ -260,6 +267,11 @@ RCT_EXPORT_MODULE()
 - (id)settingForKey:(NSString *)key
 {
   return [_dataSource settingForKey:key];
+}
+
+- (void)startPackagerConnection
+{
+  NSLog(@"Starting Packager Connection from RCTDevSettings");
 }
 
 - (BOOL)isDeviceDebuggingAvailable
@@ -418,7 +430,7 @@ RCT_EXPORT_METHOD(addMenuItem : (NSString *)title)
 - (void)addHandler:(id<RCTPackagerClientMethod>)handler forPackagerMethod:(NSString *)name
 {
 #if RCT_DEV_SETTINGS_ENABLE_PACKAGER_CONNECTION
-  [[RCTPackagerConnection sharedPackagerConnection] addHandler:handler forMethod:name];
+   [_packagerConnection addHandler:handler forMethod:name];
 #endif
 }
 

--- a/packages/react-native/React/CoreModules/RCTDevSettings.mm
+++ b/packages/react-native/React/CoreModules/RCTDevSettings.mm
@@ -185,6 +185,8 @@ RCT_EXPORT_MODULE()
 - (void)initialize
 {
 #if RCT_DEV_SETTINGS_ENABLE_PACKAGER_CONNECTION
+  [_packagerConnection startWithBundleManager:_bundleManager];
+  
   if (numInitializedModules++ == 0) {
     reloadToken = [_packagerConnection
         addNotificationHandler:^(id params) {
@@ -267,11 +269,6 @@ RCT_EXPORT_MODULE()
 - (id)settingForKey:(NSString *)key
 {
   return [_dataSource settingForKey:key];
-}
-
-- (void)startPackagerConnection
-{
-  NSLog(@"Starting Packager Connection from RCTDevSettings");
 }
 
 - (BOOL)isDeviceDebuggingAvailable

--- a/packages/react-native/React/DevSupport/RCTPackagerConnection.h
+++ b/packages/react-native/React/DevSupport/RCTPackagerConnection.h
@@ -8,6 +8,7 @@
 #import <Foundation/Foundation.h>
 
 #import <React/RCTDefines.h>
+#import <React/RCTBundleManager.h>
 
 #if RCT_DEV
 
@@ -24,7 +25,7 @@ typedef void (^RCTConnectedHandler)(void);
 /** Encapsulates singleton connection to React Native packager. */
 @interface RCTPackagerConnection : NSObject
 
-+ (instancetype)sharedPackagerConnection;
+@property (nonatomic, weak, readwrite) RCTBundleManager *bundleManager;
 
 /**
  * Registers a handler for a notification broadcast from the packager. An

--- a/packages/react-native/React/DevSupport/RCTPackagerConnection.h
+++ b/packages/react-native/React/DevSupport/RCTPackagerConnection.h
@@ -63,6 +63,8 @@ typedef void (^RCTConnectedHandler)(void);
 /** Reconnect with given packager server. */
 - (void)reconnect:(NSString *)packagerServerHostPort;
 
+- (void)startWithBundleManager:(RCTBundleManager *)bundleManager;
+
 /**
  * Historically no distinction was made between notification and request
  * handlers. If you use this method, it will be registered as *both* a

--- a/packages/react-native/React/DevSupport/RCTPackagerConnection.mm
+++ b/packages/react-native/React/DevSupport/RCTPackagerConnection.mm
@@ -22,6 +22,7 @@
 #import <React/RCTReconnectingWebSocket.h>
 #import <React/RCTReloadCommand.h>
 #import <React/RCTUtils.h>
+#import <React/RCTBundleManager.h>
 
 #if RCT_DEV
 
@@ -52,15 +53,7 @@ struct Registration {
   std::vector<Registration<RCTConnectedHandler>> _connectedRegistrations;
 }
 
-+ (instancetype)sharedPackagerConnection
-{
-  static RCTPackagerConnection *connection;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    connection = [RCTPackagerConnection new];
-  });
-  return connection;
-}
+@synthesize bundleManager;
 
 - (instancetype)init
 {

--- a/packages/react-native/React/DevSupport/RCTPackagerConnection.mm
+++ b/packages/react-native/React/DevSupport/RCTPackagerConnection.mm
@@ -13,6 +13,7 @@
 
 #import <React/RCTAssert.h>
 #import <React/RCTBridge.h>
+#import <React/RCTBundleManager.h>
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTConstants.h>
 #import <React/RCTConvert.h>
@@ -22,7 +23,6 @@
 #import <React/RCTReconnectingWebSocket.h>
 #import <React/RCTReloadCommand.h>
 #import <React/RCTUtils.h>
-#import <React/RCTBundleManager.h>
 
 #if RCT_DEV
 
@@ -59,27 +59,6 @@ struct Registration {
 {
   if (self = [super init]) {
     _nextToken = 1; // Prevent randomly erasing a handler if you pass a bogus 0 token
-    _serverHostPortForSocket = [[RCTBundleURLProvider sharedSettings] packagerServerHostPort];
-    _serverSchemeForSocket = [[RCTBundleURLProvider sharedSettings] packagerScheme];
-    _socket = socketForLocation(_serverHostPortForSocket, _serverSchemeForSocket);
-    _socket.delegate = self;
-    [_socket start];
-
-    RCTPackagerConnection *const __weak weakSelf = self;
-    _bundleURLChangeObserver =
-        [[NSNotificationCenter defaultCenter] addObserverForName:RCTBundleURLProviderUpdatedNotification
-                                                          object:nil
-                                                           queue:[NSOperationQueue mainQueue]
-                                                      usingBlock:^(NSNotification *_Nonnull __unused note) {
-                                                        [weakSelf bundleURLSettingsChanged];
-                                                      }];
-    _reloadWithPotentiallyNewURLObserver =
-        [[NSNotificationCenter defaultCenter] addObserverForName:RCTTriggerReloadCommandNotification
-                                                          object:nil
-                                                           queue:[NSOperationQueue mainQueue]
-                                                      usingBlock:^(NSNotification *_Nonnull __unused note) {
-                                                        [weakSelf bundleURLSettingsChanged];
-                                                      }];
   }
   return self;
 }
@@ -112,6 +91,31 @@ static RCTReconnectingWebSocket *socketForLocation(NSString *const serverHostPor
   return [[RCTReconnectingWebSocket alloc] initWithURL:components.URL queue:queue];
 }
 
+- (void)startWithBundleManager:(RCTBundleManager *)bundleManager
+{
+  _serverHostPortForSocket = [bundleManager.customBundleConfig getPackagerServerHost];
+  _serverSchemeForSocket = [bundleManager.customBundleConfig getPackagerServerScheme];
+  _socket = socketForLocation(_serverHostPortForSocket, _serverSchemeForSocket);
+  _socket.delegate = self;
+  [_socket start];
+
+  RCTPackagerConnection *const __weak weakSelf = self;
+  _bundleURLChangeObserver =
+      [[NSNotificationCenter defaultCenter] addObserverForName:RCTBundleURLProviderUpdatedNotification
+                                                        object:nil
+                                                         queue:[NSOperationQueue mainQueue]
+                                                    usingBlock:^(NSNotification *_Nonnull __unused note) {
+                                                      [weakSelf bundleURLSettingsChanged];
+                                                    }];
+  _reloadWithPotentiallyNewURLObserver =
+      [[NSNotificationCenter defaultCenter] addObserverForName:RCTTriggerReloadCommandNotification
+                                                        object:nil
+                                                         queue:[NSOperationQueue mainQueue]
+                                                    usingBlock:^(NSNotification *_Nonnull __unused note) {
+                                                      [weakSelf bundleURLSettingsChanged];
+                                                    }];
+}
+
 - (void)stop
 {
   std::lock_guard<std::mutex> l(_mutex);
@@ -137,7 +141,7 @@ static RCTReconnectingWebSocket *socketForLocation(NSString *const serverHostPor
     return; // already stopped
   }
 
-  NSString *const serverScheme = [[RCTBundleURLProvider sharedSettings] packagerScheme];
+  NSString *const serverScheme = [bundleManager.customBundleConfig getPackagerServerScheme];
   if ([packagerServerHostPort isEqual:_serverHostPortForSocket] && [serverScheme isEqual:_serverSchemeForSocket]) {
     return; // unchanged
   }
@@ -153,7 +157,7 @@ static RCTReconnectingWebSocket *socketForLocation(NSString *const serverHostPor
 
 - (void)bundleURLSettingsChanged
 {
-  [self reconnect:[[RCTBundleURLProvider sharedSettings] packagerServerHostPort]];
+  [self reconnect:[bundleManager.customBundleConfig getPackagerServerHost]];
 }
 
 - (RCTHandlerToken)addNotificationHandler:(RCTNotificationHandler)handler

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
@@ -770,11 +770,6 @@ typedef struct {
   if ([module respondsToSelector:@selector(initialize)]) {
     [(id<RCTInitializing>)module initialize];
   }
-  
-  if ([module isKindOfClass:[RCTDevSettings class]]) {
-    RCTDevSettings *devSettings = (RCTDevSettings *)module;
-    [devSettings startPackagerConnection];
-  }
 
   /**
    * Attach method queue to id<RCTBridgeModule> object.

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
@@ -27,6 +27,7 @@
 #import <React/RCTModuleData.h>
 #import <React/RCTPerformanceLogger.h>
 #import <React/RCTUtils.h>
+#import <React/RCTDevSettings.h>
 #import <ReactCommon/CxxTurboModuleUtils.h>
 #import <ReactCommon/RCTTurboModuleWithJSIBindings.h>
 #import <ReactCommon/TurboCxxModule.h>
@@ -768,6 +769,11 @@ typedef struct {
    */
   if ([module respondsToSelector:@selector(initialize)]) {
     [(id<RCTInitializing>)module initialize];
+  }
+  
+  if ([module isKindOfClass:[RCTDevSettings class]]) {
+    RCTDevSettings *devSettings = (RCTDevSettings *)module;
+    [devSettings startPackagerConnection];
   }
 
   /**

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.h
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.h
@@ -18,6 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class RCTFabricSurface;
 @class RCTHost;
 @class RCTModuleRegistry;
+@class RCTCustomBundleConfiguration;
 
 @protocol RCTTurboModuleManagerDelegate;
 
@@ -63,7 +64,14 @@ typedef std::shared_ptr<facebook::react::JSRuntimeFactory> (^RCTHostJSEngineProv
                              hostDelegate:(id<RCTHostDelegate>)hostDelegate
                turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)turboModuleManagerDelegate
                          jsEngineProvider:(RCTHostJSEngineProvider)jsEngineProvider
-                            launchOptions:(nullable NSDictionary *)launchOptions NS_DESIGNATED_INITIALIZER;
+                            launchOptions:(nullable NSDictionary *)launchOptions
+                      customBundleConfiguration:(nullable RCTCustomBundleConfiguration *)customBundleConfiguration NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)initWithBundleURLProvider:(RCTHostBundleURLProvider)provider
+                             hostDelegate:(id<RCTHostDelegate>)hostDelegate
+               turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)turboModuleManagerDelegate
+                         jsEngineProvider:(RCTHostJSEngineProvider)jsEngineProvider
+                            launchOptions:(nullable NSDictionary *)launchOptions;
 
 - (instancetype)initWithBundleURL:(NSURL *)bundleURL
                      hostDelegate:(id<RCTHostDelegate>)hostDelegate

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
@@ -182,8 +182,9 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
     _moduleRegistry = [RCTModuleRegistry new];
     _jsEngineProvider = [jsEngineProvider copy];
     _launchOptions = [launchOptions copy];
-    
     _bundleManager.customBundleConfig = customBundleConfiguration;
+
+    [self setBundleURLProvider:provider];
 
     __weak RCTHost *weakSelf = self;
     auto bundleURLGetter = ^NSURL *() {
@@ -192,7 +193,9 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
         return nil;
       }
 
-      return strongSelf->_bundleURL;
+      return [strongSelf->_bundleManager.customBundleConfig getBundleURL:^NSURL * {
+        return strongSelf->_bundleURL;
+      }];
     };
 
     auto bundleURLSetter = ^(NSURL *bundleURL_) {
@@ -205,7 +208,9 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
         return nil;
       }
 
-      return strongSelf->_bundleURLProvider();
+      return [strongSelf->_bundleManager.customBundleConfig getBundleURL:^NSURL * {
+        return strongSelf->_bundleURLProvider();
+      }];
     };
 
     [_bundleManager setBridgelessBundleURLGetter:bundleURLGetter
@@ -448,7 +453,7 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
   // Sanitize the bundle URL
   _bundleURL = [RCTConvert NSURL:_bundleURL.absoluteString];
 
-  // Update the global bundle URLq
+  // Update the global bundle URL
   RCTReloadCommandSetBundleURL(_bundleURL);
 }
 

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
@@ -150,6 +150,20 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
                    launchOptions:launchOptions];
 }
 
+- (instancetype)initWithBundleURLProvider:(RCTHostBundleURLProvider)provider
+                             hostDelegate:(id<RCTHostDelegate>)hostDelegate
+               turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)turboModuleManagerDelegate
+                         jsEngineProvider:(RCTHostJSEngineProvider)jsEngineProvider
+                            launchOptions:(nullable NSDictionary *)launchOptions
+{
+  return [self initWithBundleURLProvider:provider
+                            hostDelegate:hostDelegate
+              turboModuleManagerDelegate:turboModuleManagerDelegate
+                        jsEngineProvider:jsEngineProvider
+                           launchOptions:launchOptions
+               customBundleConfiguration:nil];
+}
+
 /**
  Host initialization should not be resource intensive. A host may be created before any intention of using React Native
  has been expressed.
@@ -159,6 +173,7 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
                turboModuleManagerDelegate:(id<RCTTurboModuleManagerDelegate>)turboModuleManagerDelegate
                          jsEngineProvider:(RCTHostJSEngineProvider)jsEngineProvider
                             launchOptions:(nullable NSDictionary *)launchOptions
+                customBundleConfiguration:(RCTCustomBundleConfiguration *)customBundleConfiguration
 {
   if (self = [super init]) {
     _hostDelegate = hostDelegate;
@@ -167,6 +182,8 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
     _moduleRegistry = [RCTModuleRegistry new];
     _jsEngineProvider = [jsEngineProvider copy];
     _launchOptions = [launchOptions copy];
+    
+    _bundleManager.customBundleConfig = customBundleConfiguration;
 
     __weak RCTHost *weakSelf = self;
     auto bundleURLGetter = ^NSURL *() {

--- a/packages/rn-tester/RNTester/AppDelegate.mm
+++ b/packages/rn-tester/RNTester/AppDelegate.mm
@@ -9,9 +9,9 @@
 
 #import <UserNotifications/UserNotifications.h>
 
+#import <React/RCTBundleManager.h>
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTDefines.h>
-#import <React/RCTBundleManager.h>
 #import <React/RCTLinkingManager.h>
 #import <ReactCommon/RCTSampleTurboModule.h>
 #import <ReactCommon/RCTTurboModuleManager.h>
@@ -43,9 +43,10 @@ static NSString *kBundlePath = @"js/RNTesterApp.ios";
 #if USE_OSS_CODEGEN
   self.dependencyProvider = [RCTAppDependencyProvider new];
 #endif
-  
-  RCTCustomBundleConfiguration *customBundleConfiguration = [[RCTCustomBundleConfiguration alloc] initWithPackagerServerScheme:@"http" packagerServerHost:@"http"];
-  
+
+  RCTCustomBundleConfiguration *customBundleConfiguration =
+      [[RCTCustomBundleConfiguration alloc] initWithPackagerServerScheme:@"http" packagerServerHost:@"localhost"];
+
   self.reactNativeFactory.customBundleConfiguration = customBundleConfiguration;
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];

--- a/packages/rn-tester/RNTester/AppDelegate.mm
+++ b/packages/rn-tester/RNTester/AppDelegate.mm
@@ -11,6 +11,7 @@
 
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTDefines.h>
+#import <React/RCTBundleManager.h>
 #import <React/RCTLinkingManager.h>
 #import <ReactCommon/RCTSampleTurboModule.h>
 #import <ReactCommon/RCTTurboModuleManager.h>
@@ -42,6 +43,10 @@ static NSString *kBundlePath = @"js/RNTesterApp.ios";
 #if USE_OSS_CODEGEN
   self.dependencyProvider = [RCTAppDependencyProvider new];
 #endif
+  
+  RCTCustomBundleConfiguration *customBundleConfiguration = [[RCTCustomBundleConfiguration alloc] initWithPackagerServerScheme:@"http" packagerServerHost:@"http"];
+  
+  self.reactNativeFactory.customBundleConfiguration = customBundleConfiguration;
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
 

--- a/packages/rn-tester/js/RNTesterAppShared.js
+++ b/packages/rn-tester/js/RNTesterAppShared.js
@@ -292,7 +292,7 @@ const RNTesterApp = ({
           ) : undefined}
         </RNTTitleBar>
       )}
-      <View
+      {/* <View
         style={StyleSheet.compose(styles.container, {
           backgroundColor: theme.GroupedBackgroundColor,
         })}>
@@ -308,7 +308,7 @@ const RNTesterApp = ({
             handleModuleCardPress={handleModuleCardPress}
           />
         )}
-      </View>
+      </View> */}
       {!shouldHideChrome && (
         <View style={styles.bottomNavbar}>
           <RNTesterNavBar


### PR DESCRIPTION
## Summary:

Following the [RFC](https://github.com/react-native-community/discussions-and-proposals/pull/933), this PR introduces a new `RCTCustomBundleConfiguration` interface for modifying the bundle URL and exposes a new API for setting its instance in the `RCTReactNativeFactory`. The configuration object includes:

- bundleFilePath - the URL of the bundle to load from the file system,
- packagerServerScheme - the server scheme (e.g. http or https) to use when loading from the packager,
- packagerServerHost - the server host (e.g. localhost) to use when loading from the packager.

It associates `RCTPackagerConnection` (previously singleton) with the `RCTDevSettings` instance, which has access to the `RCTBundleManager`, which contains the specified configuration object. The connection is now established in the `RCTDevSettings initialize`  method, called after the bundle manager is set by invoking the new `startWithBundleManager` method on the `RCTPackagerConnection`.

The `RCTCustomBundleConfiguration` allows only for either `bundleFilePath` or `(packagerServerScheme, packagerServerHost)` to be set by defining appropriate initializers. 

The logic for creating bundle URL query items is extracted to a separate `createJSBundleURLQuery` method and is used by `RCTBundleManager` to set the configured `packagerServerHost` and `packagerServerScheme`. If the configuration is not defined, the `getBundleURL` method returns the result of the passed `fallbackURLProvider`.


## Changelog:

[IOS][ADDED] - Add new `RCTCustomBundleConfiguration` for modifying bundle URL on `RCTReactNativeFactory`.

## Test Plan:

Tested changing `packagerServerHost` from the `AppDelegate` by re-creating the React Native instance with updated `RCTCustomBundleConfiguration`. I've run two Metro instances, each serving a different JS bundle (changed background) on `8081` and `8082` ports. The native `Restart RN:<current port>` button on top of the screen toggles between ports (used in bundle configuration) and re-creates connections. 

https://github.com/user-attachments/assets/fd57068b-869c-4f45-93be-09d33f691cea



<details>

<summary>code:</summary>

```objc
#import "AppDelegate.h"

#import <UserNotifications/UserNotifications.h>

#import <React/RCTBundleManager.h>
#import <React/RCTBundleURLProvider.h>
#import <React/RCTDefines.h>
#import <React/RCTLinkingManager.h>
#import <ReactCommon/RCTSampleTurboModule.h>
#import <ReactCommon/RCTTurboModuleManager.h>

#import <React/RCTPushNotificationManager.h>

#import <NativeCxxModuleExample/NativeCxxModuleExample.h>
#ifndef RN_DISABLE_OSS_PLUGIN_HEADER
#import <RNTMyNativeViewComponentView.h>
#endif

#if __has_include(<ReactAppDependencyProvider/RCTAppDependencyProvider.h>)
#define USE_OSS_CODEGEN 1
#import <ReactAppDependencyProvider/RCTAppDependencyProvider.h>
#else
#define USE_OSS_CODEGEN 0
#endif

static NSString *kBundlePath = @"js/RNTesterApp.ios";

@interface AppDelegate () <UNUserNotificationCenterDelegate>
@end

@implementation AppDelegate

- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
{
  self.launchOptions = launchOptions;
  self.port = @"8081";
  
#if USE_OSS_CODEGEN
  self.dependencyProvider = [RCTAppDependencyProvider new];
#endif

  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
  
  [self startReactNative];

  [[UNUserNotificationCenter currentNotificationCenter] setDelegate:self];

  return YES;
}

- (void)startReactNative
{
  self.reactNativeFactory = [[RCTReactNativeFactory alloc] initWithDelegate:self];
  
  NSString *packagerServerHost = [NSString stringWithFormat:@"localhost:%@", self.port];
  
  RCTCustomBundleConfiguration *customBundleConfiguration =
      [[RCTCustomBundleConfiguration alloc] initWithPackagerServerScheme:@"http" packagerServerHost:packagerServerHost];

  self.reactNativeFactory.customBundleConfiguration = customBundleConfiguration;
  
  [self.reactNativeFactory startReactNativeWithModuleName:@"RNTesterApp"
                                                 inWindow:self.window
                                        initialProperties:[self prepareInitialProps]
                                            launchOptions:self.launchOptions];
  
  [self createTopButton];
}

- (void)createTopButton
{
  NSString *title = [NSString stringWithFormat:@"Restart RN:%@", self.port];
  
  self.topButton = [UIButton buttonWithType:UIButtonTypeSystem];
  [self.topButton setTitle:title forState:UIControlStateNormal];
  [self.topButton setBackgroundColor:[UIColor colorWithRed:0.0 green:0.5 blue:1.0 alpha:1]];
  [self.topButton setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];

  CGFloat buttonWidth = 120;
  CGFloat buttonHeight = 44;
  CGFloat screenWidth = [UIScreen mainScreen].bounds.size.width;

  self.topButton.frame = CGRectMake((screenWidth - buttonWidth) / 2, 50, buttonWidth, buttonHeight);
  self.topButton.layer.cornerRadius = 8;
  [self.topButton addTarget:self action:@selector(buttonTapped:) forControlEvents:UIControlEventTouchUpInside];
  [self.window addSubview:self.topButton];
  [self.window bringSubviewToFront:self.topButton];
}

- (void)togglePort
{
  self.port = [self.port  isEqual: @"8081"] ? @"8082" : @"8081";
}

- (void)buttonTapped:(UIButton *)sender
{
  self.reactNativeFactory = nil;
  [self togglePort];
  [self startReactNative];
}

- (NSDictionary *)prepareInitialProps
{
  NSMutableDictionary *initProps = [NSMutableDictionary new];

  NSString *_routeUri = [[NSUserDefaults standardUserDefaults] stringForKey:@"route"];
  if (_routeUri) {
    initProps[@"exampleFromAppetizeParams"] = [NSString stringWithFormat:@"rntester://example/%@Example", _routeUri];
  }

  return initProps;
}

- (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
{
  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:kBundlePath];
}

- (BOOL)application:(UIApplication *)app
            openURL:(NSURL *)url
            options:(NSDictionary<UIApplicationOpenURLOptionsKey, id> *)options
{
  return [RCTLinkingManager application:app openURL:url options:options];
}

- (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
                                                      jsInvoker:(std::shared_ptr<facebook::react::CallInvoker>)jsInvoker
{
  if (name == facebook::react::NativeCxxModuleExample::kModuleName) {
    return std::make_shared<facebook::react::NativeCxxModuleExample>(jsInvoker);
  }

  return [super getTurboModule:name jsInvoker:jsInvoker];
}

// Required for the remoteNotificationsRegistered event.
- (void)application:(__unused UIApplication *)application
    didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
{
  [RCTPushNotificationManager didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
}

// Required for the remoteNotificationRegistrationError event.
- (void)application:(__unused UIApplication *)application
    didFailToRegisterForRemoteNotificationsWithError:(NSError *)error
{
  [RCTPushNotificationManager didFailToRegisterForRemoteNotificationsWithError:error];
}

#pragma mark - UNUserNotificationCenterDelegate

// Required for the remoteNotificationReceived and localNotificationReceived events
- (void)userNotificationCenter:(UNUserNotificationCenter *)center
       willPresentNotification:(UNNotification *)notification
         withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler
{
  [RCTPushNotificationManager didReceiveNotification:notification];
  completionHandler(UNNotificationPresentationOptionNone);
}

// Required for the remoteNotificationReceived and localNotificationReceived events
// Called when a notification is tapped from background. (Foreground notification will not be shown per
// the presentation option selected above).
- (void)userNotificationCenter:(UNUserNotificationCenter *)center
    didReceiveNotificationResponse:(UNNotificationResponse *)response
             withCompletionHandler:(void (^)(void))completionHandler
{
  UNNotification *notification = response.notification;

  // This condition will be true if tapping the notification launched the app.
  if ([response.actionIdentifier isEqualToString:UNNotificationDefaultActionIdentifier]) {
    // This can be retrieved with getInitialNotification.
    [RCTPushNotificationManager setInitialNotification:notification];
  }

  [RCTPushNotificationManager didReceiveNotification:notification];
  completionHandler();
}

#pragma mark - New Arch Enabled settings

- (BOOL)bridgelessEnabled
{
  return YES;
}

#pragma mark - RCTComponentViewFactoryComponentProvider

#ifndef RN_DISABLE_OSS_PLUGIN_HEADER
- (nonnull NSDictionary<NSString *, Class<RCTComponentViewProtocol>> *)thirdPartyFabricComponents
{
  NSMutableDictionary *dict = [super thirdPartyFabricComponents].mutableCopy;
  if (!dict[@"RNTMyNativeView"]) {
    dict[@"RNTMyNativeView"] = NSClassFromString(@"RNTMyNativeViewComponentView");
  }
  if (!dict[@"SampleNativeComponent"]) {
    dict[@"SampleNativeComponent"] = NSClassFromString(@"RCTSampleNativeComponentComponentView");
  }
  return dict;
}
#endif

- (NSURL *)bundleURL
{
  return [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:kBundlePath];
}

@end
```
</details>
