### PR TITLE
Allow tests to run against all versions of Hermes

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.cpp
@@ -565,6 +565,10 @@ TYPED_TEST(JsiIntegrationHermesTest, EvaluateExpressionInExecutionContext) {
       std::to_string(executionContextId)));
 }
 
+#if !defined(HERMES_STATIC_HERMES)
+// FIXME(T239924718): Breakpoint resolution in Static Hermes is broken for
+// locations without column numbers under lazy compilation.
+
 TYPED_TEST(JsiIntegrationHermesTest, ResolveBreakpointAfterEval) {
   this->connect();
 
@@ -644,6 +648,8 @@ TYPED_TEST(JsiIntegrationHermesTest, ResolveBreakpointAfterReload) {
       breakpointInfo->value()["params"]["location"]["scriptId"],
       scriptInfo->value()["params"]["scriptId"]);
 }
+
+#endif // !defined(HERMES_STATIC_HERMES)
 
 TYPED_TEST(JsiIntegrationHermesTest, CDPAgentReentrancyRegressionTest) {
   this->connect();

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/ReactInstanceIntegrationTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/ReactInstanceIntegrationTest.cpp
@@ -236,7 +236,9 @@ INSTANTIATE_TEST_SUITE_P(
     ReactInstanceVaryingInspectorBackend,
     ReactInstanceIntegrationTest,
     ::testing::Values(
+#if !defined(HERMES_STATIC_HERMES)
         ReactInstanceIntegrationTestMode::LEGACY_HERMES,
+#endif
         ReactInstanceIntegrationTestMode::FUSEBOX));
 
 } // namespace facebook::react::jsinspector_modern


### PR DESCRIPTION
Summary:
Gets the `jsinspector-modern` (CDP backend) integration tests in React Native to pass when run against all relevant versions of Hermes: Legacy Hermes (`xplat/hermes`), Static Hermes stable (`xplat/shermes/stable`), and Static Hermes trunk (`xplat/static_h`).

This involves disabling the two types of failing test:

1. Tests that should be legitimately disabled because Static Hermes omits the legacy, pre-Fusebox debugger infra (see changes to `ReactInstanceIntegrationTest.cpp`)
2. Tests that should be passing but expose a current bug in Static Hermes (see changes to `JsiIntegrationTest.cpp`)

This provides a useful baseline for upcoming work in CDPDebugAPI (etc) across the different versions of Hermes.

Changelog: [Internal]

Reviewed By: huntie

Differential Revision: D83564896


