### PR TITLE
Fix performance analyze path from DevMenu

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.kt
@@ -381,8 +381,8 @@ public abstract class DevSupportManagerBase(
                 DevOptionHandler {
                   UiThreadUtil.runOnUiThread {
                     if (reactInstanceDevHelper is PerfMonitorDevHelper) {
-                      reactInstanceDevHelper.inspectorTarget?.let {
-                        if (it.pauseAndAnalyzeBackgroundTrace()) {
+                      reactInstanceDevHelper.inspectorTarget?.let { target ->
+                        if (!target.pauseAndAnalyzeBackgroundTrace()) {
                           openDebugger(DebuggerFrontendPanelName.PERFORMANCE.toString())
                         }
                       }


### PR DESCRIPTION
Summary:
The DevMenu path for perf analyzing no-ops. This is due to incorrectly not inverting the bool result of `pauseAndAnalyzeBackgroundTrace()`. See https://www.internalfb.com/code/fbsource/%5Bfcebbc02e701%5D/xplat/js/react-native-github/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/perfmonitor/PerfMonitorOverlayManager.kt?lines=73-75.

{F1982418482}

Changelog: [Internal]

Differential Revision: D83691623


