### PR TITLE
Add support for nextFocus props to View

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
@@ -95,6 +95,51 @@ HostPlatformViewProps::HostPlatformViewProps(
                     rawProps,
                     "screenReaderFocusable",
                     sourceProps.screenReaderFocusable,
+                    {})),
+      nextFocusDown(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.nextFocusDown
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "nextFocusDown",
+                    sourceProps.nextFocusDown,
+                    {})),
+      nextFocusForward(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.nextFocusForward
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "nextFocusForward",
+                    sourceProps.nextFocusForward,
+                    {})),
+      nextFocusLeft(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.nextFocusLeft
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "nextFocusLeft",
+                    sourceProps.nextFocusLeft,
+                    {})),
+      nextFocusRight(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.nextFocusRight
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "nextFocusRight",
+                    sourceProps.nextFocusRight,
+                    {})),
+      nextFocusUp(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.nextFocusUp
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "nextFocusUp",
+                    sourceProps.nextFocusUp,
                     {})) {}
 
 #define VIEW_EVENT_CASE(eventType)                      \
@@ -130,6 +175,11 @@ void HostPlatformViewProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(needsOffscreenAlphaCompositing);
     RAW_SET_PROP_SWITCH_CASE_BASIC(renderToHardwareTextureAndroid);
     RAW_SET_PROP_SWITCH_CASE_BASIC(screenReaderFocusable);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(nextFocusDown);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(nextFocusForward);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(nextFocusLeft);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(nextFocusRight);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(nextFocusUp);
   }
 }
 
@@ -980,6 +1030,46 @@ folly::dynamic HostPlatformViewProps::getDiffProps(
 
   if (importantForAccessibility != oldProps->importantForAccessibility) {
     result["importantForAccessibility"] = toString(importantForAccessibility);
+  }
+
+  if (nextFocusDown != oldProps->nextFocusDown) {
+    if (nextFocusDown.has_value()) {
+      result["nextFocusDown"] = nextFocusDown.value();
+    } else {
+      result["nextFocusDown"] = folly::dynamic(nullptr);
+    }
+  }
+
+  if (nextFocusForward != oldProps->nextFocusForward) {
+    if (nextFocusForward.has_value()) {
+      result["nextFocusForward"] = nextFocusForward.value();
+    } else {
+      result["nextFocusForward"] = folly::dynamic(nullptr);
+    }
+  }
+
+  if (nextFocusLeft != oldProps->nextFocusLeft) {
+    if (nextFocusLeft.has_value()) {
+      result["nextFocusLeft"] = nextFocusLeft.value();
+    } else {
+      result["nextFocusLeft"] = folly::dynamic(nullptr);
+    }
+  }
+
+  if (nextFocusRight != oldProps->nextFocusRight) {
+    if (nextFocusRight.has_value()) {
+      result["nextFocusRight"] = nextFocusRight.value();
+    } else {
+      result["nextFocusRight"] = folly::dynamic(nullptr);
+    }
+  }
+
+  if (nextFocusUp != oldProps->nextFocusUp) {
+    if (nextFocusUp.has_value()) {
+      result["nextFocusUp"] = nextFocusUp.value();
+    } else {
+      result["nextFocusUp"] = folly::dynamic(nullptr);
+    }
   }
 
   return result;

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.h
@@ -49,6 +49,12 @@ class HostPlatformViewProps : public BaseViewProps {
   bool renderToHardwareTextureAndroid{false};
   bool screenReaderFocusable{false};
 
+  std::optional<int> nextFocusDown{};
+  std::optional<int> nextFocusForward{};
+  std::optional<int> nextFocusLeft{};
+  std::optional<int> nextFocusRight{};
+  std::optional<int> nextFocusUp{};
+
 #pragma mark - Convenience Methods
 
   bool getProbablyMoreHorizontalThanVertical_DEPRECATED() const;


### PR DESCRIPTION
Summary:
Adding missing `nextFocus*` props to the View props to enable correct Props 2.0 diffing.

Changelog: [Internal]

Differential Revision: D83714902


