### PR TITLE
Harden perf monitor to metro connection changes

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DevSupportManagerBase.kt
@@ -898,11 +898,13 @@ public abstract class DevSupportManagerBase(
             override fun onPackagerConnected() {
               isPackagerConnected = true
               perfMonitorOverlayManager?.enable()
+              perfMonitorOverlayManager?.startBackgroundTrace()
             }
 
             override fun onPackagerDisconnected() {
               isPackagerConnected = false
               perfMonitorOverlayManager?.disable()
+              perfMonitorOverlayManager?.stopBackgroundTrace()
             }
 
             override fun onPackagerReloadCommand() {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/perfmonitor/PerfMonitorInspectorTargetBinding.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/perfmonitor/PerfMonitorInspectorTargetBinding.kt
@@ -25,4 +25,7 @@ internal interface PerfMonitorInspectorTargetBinding {
 
   /** Attempt to start a new background performance trace. */
   public fun resumeBackgroundTrace()
+
+  /** Attempt to stop the current performance trace. */
+  public fun stopBackgroundTrace()
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/perfmonitor/PerfMonitorOverlayManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/perfmonitor/PerfMonitorOverlayManager.kt
@@ -58,6 +58,18 @@ internal class PerfMonitorOverlayManager(
     }
   }
 
+  /** Stop background trace recording. */
+  fun stopBackgroundTrace() {
+    if (!enabled) {
+      return
+    }
+
+    devHelper.inspectorTarget?.let { target ->
+      target.stopBackgroundTrace()
+      onRecordingStateChanged(target.getTracingState())
+    }
+  }
+
   override fun onRecordingStateChanged(state: TracingState) {
     tracingState = state
     UiThreadUtil.runOnUiThread {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostInspectorTarget.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostInspectorTarget.kt
@@ -67,6 +67,13 @@ internal class ReactHostInspectorTarget(reactHostImpl: ReactHostImpl) :
     }
   }
 
+  override fun stopBackgroundTrace() {
+    stopAndDiscardBackgroundTrace()
+    perfMonitorListeners.forEach { listener ->
+      listener.onRecordingStateChanged(TracingState.DISABLED)
+    }
+  }
+
   override fun close() {
     mHybridData.resetNative()
   }


### PR DESCRIPTION
Summary:
Perf monitor shows in a broken state if metro is started while the app is running. This change improves the tracing and monitor lifecycle around the metro connection events.

Before:
{F1982430185}

After:
{F1982430062}

Changelog: [Internal]

Differential Revision: D83714223


