### PR TITLE
Fix `SoLoader` race condition in `InspectorNetworkRequestListener`

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/inspector/InspectorNetworkRequestListener.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/inspector/InspectorNetworkRequestListener.kt
@@ -10,6 +10,7 @@ package com.facebook.react.devsupport.inspector
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
 import com.facebook.proguard.annotations.DoNotStripAny
+import com.facebook.soloader.SoLoader
 
 /**
  * JNI wrapper for `jsinspectormodern::NetworkRequestListener`. Handles the `ScopedExecutor`
@@ -26,4 +27,10 @@ internal class InspectorNetworkRequestListener(
   external fun onError(message: String?)
 
   external fun onCompletion()
+
+  companion object {
+    init {
+      SoLoader.loadLibrary("reactnativejni")
+    }
+  }
 }


### PR DESCRIPTION
Summary:
Changelog: [Android][Fixed] Fixed `SoLoader` race condition in `InspectorNetworkRequestListener`

When enabling `LoadNetworkResrouce` with flag `nativeSourceCodeFetching` in `InspectorInterfaces.h`, running the app, and opening the debugger, the app was crashing with
```
No implementation found for void com.facebook.react.devsupport.inspector.InspectorNetworkRequestListener.onHeaders(int, java.util.Map) 
(
tried
  Java_com_facebook_react_devsupport_inspector_InspectorNetworkRequestListener_onHeaders
and
  Java_com_facebook_react_devsupport_inspector_InspectorNetworkRequestListener_onHeaders__ILjava_util_Map_2
) - is the library loaded, e.g. System.loadLibrary?
```

Differential Revision: D83741114


