### PR TITLE
Scale type: move from toString() to description()

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ScaleTypeStartInside.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ScaleTypeStartInside.kt
@@ -31,7 +31,7 @@ internal class ScaleTypeStartInside : AbstractScaleType() {
     outTransform.postTranslate(Math.round(dx).toFloat(), Math.round(dy).toFloat())
   }
 
-  override fun toString(): String = "start_inside"
+  override fun getDescription(): String = "start_inside"
 
   companion object {
     val INSTANCE: ScalingUtils.ScaleType = ScaleTypeStartInside()


### PR DESCRIPTION
Summary:
1. Making description() mandatory for all scale type allows us to make sure each scale type provides a name
2. implementing toString for the abstract scale type as a fallback to description()

Differential Revision: D83655571


