### PR TITLE
Update the `source`property to avoid multiple downloads

### DIFF
--- a/packages/react-native/scripts/cocoapods/rncore.rb
+++ b/packages/react-native/scripts/cocoapods/rncore.rb
@@ -66,7 +66,6 @@ class ReactNativeCoreUtils
                 rncore_log("No prebuilt artifacts found, reverting to building from source.")
             end
             rncore_log("Building from source: #{@@build_from_source}")
-            rncore_log("Source: #{self.resolve_podspec_source()}")
         end
     end
 
@@ -89,7 +88,6 @@ class ReactNativeCoreUtils
 
         if ENV["RCT_USE_PREBUILT_RNCORE"] == "1"
             if @@use_nightly
-                rncore_log("Using nightly tarball")
                 begin
                     return self.podspec_source_download_prebuilt_nightly_tarball(@@react_native_version)
                 rescue => e
@@ -210,14 +208,14 @@ class ReactNativeCoreUtils
         if !Object.const_defined?("Pod::UI")
             return
         end
-        log_message = '[ReactNativeCore] ' + message
+        log_message = '[ReactNativeCore] '
         case level
         when :info
-            Pod::UI.puts log_message.green
+            Pod::UI.puts log_message.green + message
         when :error
-            Pod::UI.puts log_message.red
+            Pod::UI.puts log_message.red + message
         else
-            Pod::UI.puts log_message.yellow
+            Pod::UI.puts log_message.yellow + message
         end
     end
 

--- a/packages/react-native/scripts/cocoapods/rndependencies.rb
+++ b/packages/react-native/scripts/cocoapods/rndependencies.rb
@@ -75,7 +75,6 @@ class ReactNativeDependenciesUtils
 
         if ENV["RCT_USE_RN_DEP"] && ENV["RCT_USE_RN_DEP"] == "1"
             if @@use_nightly
-                rndeps_log("Using nightly tarball")
                 begin
                     return self.podspec_source_download_prebuilt_nightly_tarball(@@react_native_version)
                 rescue => e
@@ -84,7 +83,6 @@ class ReactNativeDependenciesUtils
                 end
             end
 
-            rndeps_log("Using release tarball")
             begin
                 return self.podspec_source_download_prebuild_release_tarball()
             rescue => e
@@ -204,7 +202,6 @@ class ReactNativeDependenciesUtils
 
     def self.podspec_source_download_prebuilt_nightly_tarball(version)
         url = nightly_tarball_url(version)
-        rndeps_log("Using nightly tarball from URL: #{url}")
         return {:http => url}
     end
 
@@ -245,14 +242,13 @@ class ReactNativeDependenciesUtils
         if !Object.const_defined?("Pod::UI")
             return
         end
-        log_message = '[ReactNativeDependencies] ' + message
         case level
         when :info
-            Pod::UI.puts log_message.green
+            Pod::UI.puts '[ReactNativeDependencies] '.green + message
         when :error
-            Pod::UI.puts log_message.red
+            Pod::UI.puts '[ReactNativeDependencies] '.red + message
         else
-            Pod::UI.puts log_message.yellow
+            Pod::UI.puts '[ReactNativeDependencies] '.yellow + message
         end
     end
 

--- a/packages/react-native/scripts/cocoapods/rndependencies.rb
+++ b/packages/react-native/scripts/cocoapods/rndependencies.rb
@@ -158,9 +158,10 @@ class ReactNativeDependenciesUtils
 
         url = release_tarball_url(@@react_native_version, :debug)
         rndeps_log("Using tarball from URL: #{url}")
-        download_stable_rndeps(@@react_native_path, @@react_native_version, :debug)
+        destinationDebug = download_stable_rndeps(@@react_native_path, @@react_native_version, :debug)
         download_stable_rndeps(@@react_native_path, @@react_native_version, :release)
-        return {:http => url}
+
+        return {:http => URI::File.build(path: destinationDebug).to_s }
     end
 
     def self.release_tarball_url(version, build_type)


### PR DESCRIPTION
Summary:
This commit updates the cocoapods source for RNDependencies so that the source for the package is the locally downloaded file so we don't download twice!

## Changelog:

[IOS] [FIXED] - Update the `source`property to avoid multiple downloads

Differential Revision: D83753188

Pulled By: cipolleschi
