### PR TITLE
Replace `React.ElementProps` in tests and examples

### DIFF
--- a/packages/react-native/jest/mockComponent.js
+++ b/packages/react-native/jest/mockComponent.js
@@ -37,9 +37,7 @@ export default function mockComponent<
     : // $FlowFixMe[incompatible-type]
       jest.requireActual<TComponentModule>(moduleName);
 
-  const SuperClass: typeof React.Component<
-    React.ElementProps<typeof RealComponent>,
-  > =
+  const SuperClass: typeof React.Component<{...}> =
     typeof RealComponent === 'function' &&
     RealComponent.prototype.constructor instanceof React.Component
       ? RealComponent

--- a/packages/rn-tester/js/examples/FlatList/FlatList-BaseOnViewableItemsChanged.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatList-BaseOnViewableItemsChanged.js
@@ -10,15 +10,15 @@
 
 'use strict';
 
-import type {ViewToken} from 'react-native/Libraries/Lists/ViewabilityHelper';
+import type {
+  ViewabilityConfig,
+  ViewToken,
+} from 'react-native/Libraries/Lists/ViewabilityHelper';
 
 import BaseFlatListExample from './BaseFlatListExample';
 import * as React from 'react';
 import {useCallback, useRef, useState} from 'react';
-import {FlatList, StyleSheet, View} from 'react-native';
-
-type FlatListProps = React.ElementProps<typeof FlatList>;
-type ViewabilityConfig = FlatListProps['viewabilityConfig'];
+import {StyleSheet, View} from 'react-native';
 
 const BASE_VIEWABILITY_CONFIG = {
   minimumViewTime: 1000,

--- a/packages/rn-tester/js/examples/SectionList/SectionList-BaseOnViewableItemsChanged.js
+++ b/packages/rn-tester/js/examples/SectionList/SectionList-BaseOnViewableItemsChanged.js
@@ -8,15 +8,15 @@
  * @format
  */
 
-import type {ViewToken} from 'react-native/Libraries/Lists/ViewabilityHelper';
+import type {
+  ViewabilityConfig,
+  ViewToken,
+} from 'react-native/Libraries/Lists/ViewabilityHelper';
 
 import SectionListBaseExample from './SectionListBaseExample';
 import * as React from 'react';
 import {useRef, useState} from 'react';
-import {SectionList, StyleSheet, View} from 'react-native';
-
-type SectionListProps = React.ElementProps<typeof SectionList>;
-type ViewabilityConfig = SectionListProps['viewabilityConfig'];
+import {StyleSheet, View} from 'react-native';
 
 const BASE_VIEWABILITY_CONFIG = {
   minimumViewTime: 1000,

--- a/packages/rn-tester/js/examples/TextInput/ExampleTextInput.js
+++ b/packages/rn-tester/js/examples/TextInput/ExampleTextInput.js
@@ -12,14 +12,9 @@ import {RNTesterThemeContext} from '../../components/RNTesterTheme';
 import React, {useContext} from 'react';
 import {StyleSheet, TextInput} from 'react-native';
 
-type LooseOmit<O: interface {}, K: $Keys<$FlowFixMe>> = Pick<
-  O,
-  Exclude<$Keys<O>, K>,
->;
-
 const ExampleTextInput: component(
   ref?: React.RefSetter<null | React.ElementRef<typeof TextInput>>,
-  ...props: LooseOmit<React.ElementProps<typeof TextInput>, 'ref'>
+  ...props: Omit<React.ElementConfig<typeof TextInput>, 'ref'>
 ) = ({
   ref,
   ...props


### PR DESCRIPTION
Summary:
`React.ElementConfig` is often the better choice. See https://flow.org/en/docs/react/types/#toc-react-elementprops

Changelog: [Internal]

Differential Revision: D83749631


