### PR TITLE
Add backgroundImage prop diffing to View

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
@@ -663,6 +663,10 @@ folly::dynamic HostPlatformViewProps::getDiffProps(
     result["filter"] = toDynamic(filter);
   }
 
+  if (backgroundImage != oldProps->backgroundImage) {
+    result["experimental_backgroundImage"] = toDynamic(backgroundImage);
+  }
+
   if (mixBlendMode != oldProps->mixBlendMode) {
     result["mixBlendMode"] = toString(mixBlendMode);
   }

--- a/packages/react-native/ReactCommon/react/renderer/graphics/BackgroundImage.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/BackgroundImage.h
@@ -16,4 +16,15 @@ namespace facebook::react {
 
 using BackgroundImage = std::variant<LinearGradient, RadialGradient>;
 
+#ifdef RN_SERIALIZABLE_STATE
+inline folly::dynamic toDynamic(const BackgroundImage& backgroundImage) {
+  if (std::holds_alternative<LinearGradient>(backgroundImage)) {
+    return std::get<LinearGradient>(backgroundImage).toDynamic();
+  } else if (std::holds_alternative<RadialGradient>(backgroundImage)) {
+    return std::get<RadialGradient>(backgroundImage).toDynamic();
+  }
+  return folly::dynamic(nullptr);
+}
+#endif
+
 }; // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/graphics/ColorStop.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/ColorStop.h
@@ -17,6 +17,15 @@ struct ColorStop {
   bool operator==(const ColorStop& other) const = default;
   SharedColor color;
   ValueUnit position;
+
+#ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    result["color"] = *color;
+    result["position"] = position.toDynamic();
+    return result;
+  }
+#endif
 };
 
 struct ProcessedColorStop {

--- a/packages/react-native/ReactCommon/react/renderer/graphics/LinearGradient.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/LinearGradient.h
@@ -18,12 +18,35 @@ namespace facebook::react {
 
 enum class GradientDirectionType { Angle, Keyword };
 
+inline std::string toString(
+    const GradientDirectionType& gradientDirectionType) {
+  switch (gradientDirectionType) {
+    case GradientDirectionType::Angle:
+      return "angle";
+    case GradientDirectionType::Keyword:
+      return "keyword";
+  }
+}
+
 enum class GradientKeyword {
   ToTopRight,
   ToBottomRight,
   ToTopLeft,
   ToBottomLeft,
 };
+
+inline std::string toString(const GradientKeyword& gradientKeyword) {
+  switch (gradientKeyword) {
+    case GradientKeyword::ToTopRight:
+      return "to top right";
+    case GradientKeyword::ToBottomRight:
+      return "to bottom right";
+    case GradientKeyword::ToTopLeft:
+      return "to top left";
+    case GradientKeyword::ToBottomLeft:
+      return "to bottom left";
+  }
+}
 
 struct GradientDirection {
   GradientDirectionType type;
@@ -32,6 +55,20 @@ struct GradientDirection {
   bool operator==(const GradientDirection& other) const {
     return type == other.type && value == other.value;
   }
+
+#ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    result["type"] = toString(type);
+
+    if (std::holds_alternative<Float>(value)) {
+      result["value"] = std::get<Float>(value);
+    } else if (std::holds_alternative<GradientKeyword>(value)) {
+      result["value"] = toString(std::get<GradientKeyword>(value));
+    }
+    return result;
+  }
+#endif
 };
 
 struct LinearGradient {
@@ -41,6 +78,21 @@ struct LinearGradient {
   bool operator==(const LinearGradient& other) const {
     return direction == other.direction && colorStops == other.colorStops;
   }
+
+#ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    result["type"] = "linear-gradient";
+    result["direction"] = direction.toDynamic();
+
+    folly::dynamic colorStopsArray = folly::dynamic::array();
+    for (const auto& colorStop : colorStops) {
+      colorStopsArray.push_back(colorStop.toDynamic());
+    }
+    result["colorStops"] = colorStopsArray;
+    return result;
+  }
+#endif
 };
 
 inline GradientKeyword parseGradientKeyword(const std::string& keyword) {

--- a/packages/react-native/ReactCommon/react/renderer/graphics/RadialGradient.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/RadialGradient.h
@@ -15,9 +15,26 @@
 #include <variant>
 #include <vector>
 
+#ifdef RN_SERIALIZABLE_STATE
+#include <folly/dynamic.h>
+#endif
+
 namespace facebook::react {
 
 enum class RadialGradientShape { Circle, Ellipse };
+
+#ifdef RN_SERIALIZABLE_STATE
+inline std::string toString(const RadialGradientShape& radialGradientShape) {
+  switch (radialGradientShape) {
+    case RadialGradientShape::Circle:
+      return "circle";
+    case RadialGradientShape::Ellipse:
+      return "ellipse";
+  }
+
+  return nullptr;
+}
+#endif
 
 struct RadialGradientSize {
   enum class SizeKeyword {
@@ -37,6 +54,15 @@ struct RadialGradientSize {
     bool operator!=(const Dimensions& other) const {
       return !(*this == other);
     }
+
+#ifdef RN_SERIALIZABLE_STATE
+    folly::dynamic toDynamic() const {
+      folly::dynamic result = folly::dynamic::object();
+      result["x"] = x.toDynamic();
+      result["y"] = y.toDynamic();
+      return result;
+    }
+#endif
   };
 
   std::variant<SizeKeyword, Dimensions> value;
@@ -56,6 +82,27 @@ struct RadialGradientSize {
   bool operator!=(const RadialGradientSize& other) const {
     return !(*this == other);
   }
+
+#ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic toDynamic() const {
+    if (std::holds_alternative<SizeKeyword>(value)) {
+      switch (std::get<SizeKeyword>(value)) {
+        case SizeKeyword::ClosestSide:
+          return "closest-side";
+        case SizeKeyword::FarthestSide:
+          return "farthest-side";
+        case SizeKeyword::ClosestCorner:
+          return "closest-corner";
+        case SizeKeyword::FarthestCorner:
+          return "farthest-corner";
+      }
+    } else if (std::holds_alternative<Dimensions>(value)) {
+      return std::get<Dimensions>(value).toDynamic();
+    }
+
+    return nullptr;
+  }
+#endif
 };
 
 struct RadialGradientPosition {
@@ -72,6 +119,25 @@ struct RadialGradientPosition {
   bool operator!=(const RadialGradientPosition& other) const {
     return !(*this == other);
   }
+
+#ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    if (top.has_value()) {
+      result["top"] = top.value().toDynamic();
+    }
+    if (left.has_value()) {
+      result["left"] = left.value().toDynamic();
+    }
+    if (right.has_value()) {
+      result["right"] = right.value().toDynamic();
+    }
+    if (bottom.has_value()) {
+      result["bottom"] = bottom.value().toDynamic();
+    }
+    return result;
+  }
+#endif
 };
 
 struct RadialGradient {
@@ -87,6 +153,24 @@ struct RadialGradient {
   bool operator!=(const RadialGradient& other) const {
     return !(*this == other);
   }
+
+#ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic toDynamic() const {
+    folly::dynamic result = folly::dynamic::object();
+    result["type"] = "radial-gradient";
+    result["shape"] = toString(shape);
+    result["size"] = size.toDynamic();
+    result["position"] = position.toDynamic();
+
+    folly::dynamic colorStopsArray = folly::dynamic::array();
+    for (const auto& colorStop : colorStops) {
+      colorStopsArray.push_back(colorStop.toDynamic());
+    }
+    result["colorStops"] = colorStopsArray;
+
+    return result;
+  }
+#endif
 };
 
 }; // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/graphics/ValueUnit.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/ValueUnit.h
@@ -7,6 +7,10 @@
 
 #pragma once
 
+#ifdef RN_SERIALIZABLE_STATE
+#include <folly/dynamic.h>
+#endif
+
 namespace facebook::react {
 
 enum class UnitType {
@@ -44,5 +48,18 @@ struct ValueUnit {
   constexpr operator bool() const {
     return unit != UnitType::Undefined;
   }
+
+#ifdef RN_SERIALIZABLE_STATE
+  folly::dynamic toDynamic() const {
+    switch (unit) {
+      case UnitType::Undefined:
+        return nullptr;
+      case UnitType::Point:
+        return value;
+      case UnitType::Percent:
+        return std::format("{}%", value);
+    }
+  }
+#endif
 };
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
Update the View component props to diff the `backgroundImage` property and assign the value to `experimental_backgroundImage` which maps to the `backgroundImage` property on the Android `ReactViewManager`.

Changelog: [Internal]

Differential Revision: D83788008


