### PR TITLE
Add RuntimeTargetDelegate::serializeStackTrace API

### DIFF
--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.h
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.h
@@ -60,6 +60,9 @@ class HermesRuntimeTargetDelegate : public RuntimeTargetDelegate {
 
   tracing::RuntimeSamplingProfile collectSamplingProfile() override;
 
+  std::optional<folly::dynamic> serializeStackTrace(
+      const StackTrace& stackTrace) override;
+
  private:
   // We use the private implementation idiom to ensure this class has the same
   // layout regardless of whether HERMES_ENABLE_DEBUGGER is defined. The net

--- a/packages/react-native/ReactCommon/jsinspector-modern/FallbackRuntimeTargetDelegate.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/FallbackRuntimeTargetDelegate.cpp
@@ -58,4 +58,10 @@ FallbackRuntimeTargetDelegate::collectSamplingProfile() {
       "Sampling Profiler capabilities are not supported for Runtime fallback");
 }
 
+std::optional<folly::dynamic>
+FallbackRuntimeTargetDelegate::serializeStackTrace(
+    const StackTrace& /*stackTrace*/) {
+  return std::nullopt;
+}
+
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/FallbackRuntimeTargetDelegate.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/FallbackRuntimeTargetDelegate.h
@@ -46,6 +46,9 @@ class FallbackRuntimeTargetDelegate : public RuntimeTargetDelegate {
 
   tracing::RuntimeSamplingProfile collectSamplingProfile() override;
 
+  std::optional<folly::dynamic> serializeStackTrace(
+      const StackTrace& stackTrace) override;
+
  private:
   std::string engineDescription_;
 };

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
@@ -108,6 +108,14 @@ class RuntimeTargetDelegate {
    * Return recorded sampling profile for the previous sampling session.
    */
   virtual tracing::RuntimeSamplingProfile collectSamplingProfile() = 0;
+
+  /**
+   * \returns a JSON representation of the given stack trace, conforming to the
+   * @cdp Runtime.StackTrace type, if the runtime supports it. Otherwise,
+   * returns std::nullopt.
+   */
+  virtual std::optional<folly::dynamic> serializeStackTrace(
+      const StackTrace& stackTrace) = 0;
 };
 
 /**

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
@@ -169,6 +169,11 @@ class MockRuntimeTargetDelegate : public RuntimeTargetDelegate {
       collectSamplingProfile,
       (),
       (override));
+  MOCK_METHOD(
+      std::optional<folly::dynamic>,
+      serializeStackTrace,
+      (const StackTrace& stackTrace),
+      (override));
 
   inline MockRuntimeTargetDelegate() {
     using namespace testing;

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/JsiIntegrationTest.h
@@ -156,6 +156,14 @@ class JsiIntegrationPortableTestBase : public ::testing::Test,
     return result;
   }
 
+  RuntimeTargetDelegate& dangerouslyGetRuntimeTargetDelegate() {
+    return engineAdapter_->getRuntimeTargetDelegate();
+  }
+
+  jsi::Runtime& dangerouslyGetRuntime() {
+    return engineAdapter_->getRuntime();
+  }
+
   std::shared_ptr<HostTarget> page_;
   InstanceTarget* instance_{};
   RuntimeTarget* runtimeTarget_{};


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Adds an engine-agnostic mechanism for serialising a previously captured stack trace as a CDP [`Runtime.StackTrace`](https://cdpstatus.reactnative.dev/devtools-protocol/tot/Runtime#type-StackTrace). This complements the existing `RuntimeTargetDelegate::captureStackTrace` method, which returns an opaque, engine-specific representation of a stack trace.

This can be used as a building block for implementing higher-level CDP message types like [`Network.Initiator`](https://cdpstatus.reactnative.dev/devtools-protocol/tot/Network#type-Initiator) within React Native, while keeping the underlying stack trace representation private to each engine.

Differential Revision: D83754142


