### PR TITLE
Support recording request initiator call stacks in NetworkHandler

### DIFF
--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.cpp
@@ -78,6 +78,14 @@ class HermesRuntimeTargetDelegate::Impl final : public RuntimeTargetDelegate {
       return &hermesStackTrace_;
     }
 
+    const HermesStackTrace& operator*() const {
+      return hermesStackTrace_;
+    }
+
+    const HermesStackTrace* operator->() const {
+      return &hermesStackTrace_;
+    }
+
    private:
     HermesStackTrace hermesStackTrace_;
   };
@@ -216,6 +224,16 @@ class HermesRuntimeTargetDelegate::Impl final : public RuntimeTargetDelegate {
     return samplingProfileDelegate_->collectSamplingProfile();
   }
 
+  std::optional<folly::dynamic> serializeStackTrace(
+      const StackTrace& stackTrace) override {
+    if (auto* hermesStackTraceWrapper =
+            dynamic_cast<const HermesStackTraceWrapper*>(&stackTrace)) {
+      return folly::parseJson(cdpDebugAPI_->serializeStackTraceToJsonStr(
+          **hermesStackTraceWrapper));
+    }
+    return std::nullopt;
+  }
+
  private:
   HermesRuntimeTargetDelegate& delegate_;
   std::shared_ptr<HermesRuntime> runtime_;
@@ -309,6 +327,11 @@ void HermesRuntimeTargetDelegate::disableSamplingProfiler() {
 tracing::RuntimeSamplingProfile
 HermesRuntimeTargetDelegate::collectSamplingProfile() {
   return impl_->collectSamplingProfile();
+}
+
+std::optional<folly::dynamic> HermesRuntimeTargetDelegate::serializeStackTrace(
+    const StackTrace& stackTrace) {
+  return impl_->serializeStackTrace(stackTrace);
 }
 
 #ifdef HERMES_ENABLE_DEBUGGER

--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.h
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeTargetDelegate.h
@@ -60,6 +60,9 @@ class HermesRuntimeTargetDelegate : public RuntimeTargetDelegate {
 
   tracing::RuntimeSamplingProfile collectSamplingProfile() override;
 
+  std::optional<folly::dynamic> serializeStackTrace(
+      const StackTrace& stackTrace) override;
+
  private:
   // We use the private implementation idiom to ensure this class has the same
   // layout regardless of whether HERMES_ENABLE_DEBUGGER is defined. The net

--- a/packages/react-native/ReactCommon/jsinspector-modern/FallbackRuntimeTargetDelegate.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/FallbackRuntimeTargetDelegate.cpp
@@ -58,4 +58,10 @@ FallbackRuntimeTargetDelegate::collectSamplingProfile() {
       "Sampling Profiler capabilities are not supported for Runtime fallback");
 }
 
+std::optional<folly::dynamic>
+FallbackRuntimeTargetDelegate::serializeStackTrace(
+    const StackTrace& /*stackTrace*/) {
+  return std::nullopt;
+}
+
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/FallbackRuntimeTargetDelegate.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/FallbackRuntimeTargetDelegate.h
@@ -46,6 +46,9 @@ class FallbackRuntimeTargetDelegate : public RuntimeTargetDelegate {
 
   tracing::RuntimeSamplingProfile collectSamplingProfile() override;
 
+  std::optional<folly::dynamic> serializeStackTrace(
+      const StackTrace& stackTrace) override;
+
  private:
   std::string engineDescription_;
 };

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
@@ -108,6 +108,14 @@ class RuntimeTargetDelegate {
    * Return recorded sampling profile for the previous sampling session.
    */
   virtual tracing::RuntimeSamplingProfile collectSamplingProfile() = 0;
+
+  /**
+   * \returns a JSON representation of the given stack trace, conforming to the
+   * @cdp Runtime.StackTrace type, if the runtime supports it. Otherwise,
+   * returns std::nullopt.
+   */
+  virtual std::optional<folly::dynamic> serializeStackTrace(
+      const StackTrace& stackTrace) = 0;
 };
 
 /**

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkHandler.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkHandler.h
@@ -124,6 +124,13 @@ class NetworkHandler {
   std::optional<std::tuple<std::string, bool>> getResponseBody(
       const std::string& requestId);
 
+  /**
+   * Associate the given stack trace with the given request ID.
+   */
+  void recordRequestInitiatorStack(
+      const std::string& requestId,
+      folly::dynamic stackTrace);
+
  private:
   NetworkHandler() = default;
   NetworkHandler(const NetworkHandler&) = delete;
@@ -136,10 +143,14 @@ class NetworkHandler {
     return enabled_.load(std::memory_order_relaxed);
   }
 
+  std::optional<folly::dynamic> consumeStoredRequestInitiator(
+      const std::string& requestId);
+
   FrontendChannel frontendChannel_;
 
   std::map<std::string, std::string> resourceTypeMap_{};
-  std::mutex resourceTypeMapMutex_{};
+  std::map<std::string, folly::dynamic> requestInitiatorById_{};
+  std::mutex requestMetadataMutex_{};
 
   BoundedRequestBuffer responseBodyBuffer_{};
   std::mutex requestBodyMutex_;

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
@@ -169,6 +169,11 @@ class MockRuntimeTargetDelegate : public RuntimeTargetDelegate {
       collectSamplingProfile,
       (),
       (override));
+  MOCK_METHOD(
+      std::optional<folly::dynamic>,
+      serializeStackTrace,
+      (const StackTrace& stackTrace),
+      (override));
 
   inline MockRuntimeTargetDelegate() {
     using namespace testing;


### PR DESCRIPTION
Summary:
Changelog: [Internal]

A naive approach to keeping track of request initiators inside the `NetworkHandler` singleton for CDP reporting purposes:

1. Expose a new `recordRequestInitiatorStack` method.
2. Keep the CDP-formatted stack trace (as a `folly::dynamic`) in a map keyed by request ID.
3. Destructively consume the stack trace during `onRequestWillBeSent`.

Differential Revision: D83754143


