### PR TITLE
Move using declarations into AnimationBackend class

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.h
@@ -24,16 +24,17 @@ struct AnimationMutation {
 };
 
 using AnimationMutations = std::vector<AnimationMutation>;
-using Callback = std::function<AnimationMutations(float)>;
-using StartOnRenderCallback = std::function<void(std::function<void()>&&)>;
-using StopOnRenderCallback = std::function<void()>;
-using DirectManipulationCallback =
-    std::function<void(Tag, const folly::dynamic&)>;
-using FabricCommitCallback =
-    std::function<void(std::unordered_map<Tag, folly::dynamic>&)>;
 
 class AnimationBackend {
  public:
+  using Callback = std::function<AnimationMutations(float)>;
+  using StartOnRenderCallback = std::function<void(std::function<void()>&&)>;
+  using StopOnRenderCallback = std::function<void()>;
+  using DirectManipulationCallback =
+      std::function<void(Tag, const folly::dynamic&)>;
+  using FabricCommitCallback =
+      std::function<void(std::unordered_map<Tag, folly::dynamic>&)>;
+
   std::vector<Callback> callbacks;
   const StartOnRenderCallback startOnRenderCallback_;
   const StopOnRenderCallback stopOnRenderCallback_;


### PR DESCRIPTION
Summary:
## Changelog:

[General] [Changed] - Move using declarations into AnimationBackend class

names like `facebook::react::Callback` is a bit too generic and it'll be included in the scope whenever AnimationBackend.h is included in; `StartOnRenderCallback` already exists in c++ native animated (there we also nest the `using`s under class)

Differential Revision: D83867098


