### PR TITLE
create UIManagerAnimationBackend to replace forward declare `class AnimationBackend`

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.cpp
@@ -33,6 +33,8 @@
 #include <react/renderer/animated/nodes/TrackingAnimatedNode.h>
 #include <react/renderer/animated/nodes/TransformAnimatedNode.h>
 #include <react/renderer/animated/nodes/ValueAnimatedNode.h>
+#include <react/renderer/animationbackend/AnimatedPropsBuilder.h>
+#include <react/renderer/animationbackend/AnimationBackend.h>
 #include <react/renderer/core/EventEmitter.h>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.h
@@ -10,6 +10,7 @@
 #include <folly/dynamic.h>
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/uimanager/UIManager.h>
+#include <react/renderer/uimanager/UIManagerAnimationBackend.h>
 #include <functional>
 #include <vector>
 #include "AnimatedProps.h"
@@ -25,7 +26,7 @@ struct AnimationMutation {
 
 using AnimationMutations = std::vector<AnimationMutation>;
 
-class AnimationBackend {
+class AnimationBackend : public UIManagerAnimationBackend {
  public:
   using Callback = std::function<AnimationMutations(float)>;
   using StartOnRenderCallback = std::function<void(std::function<void()>&&)>;
@@ -54,8 +55,8 @@ class AnimationBackend {
   void synchronouslyUpdateProps(
       const std::unordered_map<Tag, AnimatedProps>& updates);
 
-  void onAnimationFrame(double timestamp);
+  void onAnimationFrame(double timestamp) override;
   void start(const Callback& callback);
-  void stop();
+  void stop() override;
 };
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.h
@@ -24,16 +24,17 @@ struct AnimationMutation {
 };
 
 using AnimationMutations = std::vector<AnimationMutation>;
-using Callback = std::function<AnimationMutations(float)>;
-using StartOnRenderCallback = std::function<void(std::function<void()>&&)>;
-using StopOnRenderCallback = std::function<void()>;
-using DirectManipulationCallback =
-    std::function<void(Tag, const folly::dynamic&)>;
-using FabricCommitCallback =
-    std::function<void(std::unordered_map<Tag, folly::dynamic>&)>;
 
 class AnimationBackend {
  public:
+  using Callback = std::function<AnimationMutations(float)>;
+  using StartOnRenderCallback = std::function<void(std::function<void()>&&)>;
+  using StopOnRenderCallback = std::function<void()>;
+  using DirectManipulationCallback =
+      std::function<void(Tag, const folly::dynamic&)>;
+  using FabricCommitCallback =
+      std::function<void(std::unordered_map<Tag, folly::dynamic>&)>;
+
   std::vector<Callback> callbacks;
   const StartOnRenderCallback startOnRenderCallback_;
   const StopOnRenderCallback stopOnRenderCallback_;

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
@@ -679,11 +679,12 @@ void UIManager::setNativeAnimatedDelegate(
 }
 
 void UIManager::unstable_setAnimationBackend(
-    std::weak_ptr<AnimationBackend> animationBackend) {
+    std::weak_ptr<UIManagerAnimationBackend> animationBackend) {
   animationBackend_ = animationBackend;
 }
 
-std::weak_ptr<AnimationBackend> UIManager::unstable_getAnimationBackend() {
+std::weak_ptr<UIManagerAnimationBackend>
+UIManager::unstable_getAnimationBackend() {
   return animationBackend_;
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
@@ -23,6 +23,7 @@
 #include <react/renderer/mounting/ShadowTree.h>
 #include <react/renderer/mounting/ShadowTreeDelegate.h>
 #include <react/renderer/mounting/ShadowTreeRegistry.h>
+#include <react/renderer/uimanager/UIManagerAnimationBackend.h>
 #include <react/renderer/uimanager/UIManagerAnimationDelegate.h>
 #include <react/renderer/uimanager/UIManagerDelegate.h>
 #include <react/renderer/uimanager/UIManagerNativeAnimatedDelegate.h>
@@ -36,7 +37,6 @@ namespace facebook::react {
 class UIManagerBinding;
 class UIManagerCommitHook;
 class UIManagerMountHook;
-class AnimationBackend;
 
 class UIManager final : public ShadowTreeDelegate {
  public:
@@ -63,9 +63,13 @@ class UIManager final : public ShadowTreeDelegate {
    * the pointer before being destroyed.
    */
   void setAnimationDelegate(UIManagerAnimationDelegate* delegate);
+
+  /**
+   * Sets and gets UIManager's AnimationBackend reference.
+   */
   void unstable_setAnimationBackend(
-      std::weak_ptr<AnimationBackend> animationBackend);
-  std::weak_ptr<AnimationBackend> unstable_getAnimationBackend();
+      std::weak_ptr<UIManagerAnimationBackend> animationBackend);
+  std::weak_ptr<UIManagerAnimationBackend> unstable_getAnimationBackend();
 
   /**
    * Execute stopSurface on any UIMAnagerAnimationDelegate.
@@ -263,7 +267,7 @@ class UIManager final : public ShadowTreeDelegate {
   std::unique_ptr<LazyShadowTreeRevisionConsistencyManager>
       lazyShadowTreeRevisionConsistencyManager_;
 
-  std::weak_ptr<AnimationBackend> animationBackend_;
+  std::weak_ptr<UIManagerAnimationBackend> animationBackend_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerAnimationBackend.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerAnimationBackend.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/components/view/BaseViewProps.h>
+#include <react/renderer/core/ShadowNodeFamily.h>
+
+namespace facebook::react {
+
+class UIManagerAnimationBackend {
+ public:
+  virtual ~UIManagerAnimationBackend() = default;
+
+  virtual void onAnimationFrame(double timestamp) = 0;
+  // TODO: T240293839 Move over start() function and mutation types
+  virtual void stop() = 0;
+};
+
+} // namespace facebook::react


### PR DESCRIPTION
Summary:
## Changelog:

[Internal] [Changed] - create UIManagerAnimationBackend to replace forward declare `class AnimationBackend`

for other delegates in UIManager, we usually explicitly create an interface in UIManager package with the public APIs we want to expose, we can follow that pattern here, so we avoid the forward declaration without definition situation, and decoupling UIManager with AnimationBackend

also this way, in the future, animation runtimes that consume AnimationBackend can just include `UIManagerAnimationBackend` (where we expose all of public APIs of AnimationBackend) and remain somewhat decoupled too

Differential Revision: D83679693


