### PR TITLE
Removing all references of hz_tracing V2 from the codebase

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/profiling/tracy_noop.h
+++ b/packages/react-native/ReactCxxPlatform/react/profiling/tracy_noop.h
@@ -12,7 +12,7 @@
 #endif
 
 #if RNCXX_WITH_PROFILING_PROVIDER
-#include <hz_tracing/v2/TracingMacros.h>
+#include <hz_tracing/TracingMacros.h>
 
 #ifndef TRACE_FUNCTION
 #if defined(__GNUC__) || defined(__clang__)
@@ -26,16 +26,16 @@ static inline constexpr char kTraceCategory[] = "react_native";
 
 HZT_DEFINE_TRACING_CATEGORIES(
     facebook::react,
-    horizon::tracing::v2::Category(
+    horizon::tracing::Category(
         kTraceCategory,
         "react_native",
-        horizon::tracing::v2::StrippingLevel::Important));
+        horizon::tracing::StrippingLevel::Important));
 
 #define SCOPED_TRACE_CPU_AUTO() \
-  HZT_TRACE_SCOPE_NS_V2(::facebook::react, kTraceCategory, TRACE_FUNCTION);
+  HZT_TRACE_SCOPE_NS(::facebook::react, kTraceCategory, TRACE_FUNCTION);
 
 #define SCOPED_TRACE_CPU(name) \
-  HZT_TRACE_SCOPE_NS_V2(::facebook::react, kTraceCategory, name);
+  HZT_TRACE_SCOPE_NS(::facebook::react, kTraceCategory, name);
 
 #else
 #ifndef SCOPED_TRACE_CPU_AUTO


### PR DESCRIPTION
Summary:
Renaming every V2 tracing macro so that it no longer has `_V2` suffixed. This diff completes the migration of the hz_tracing V1->V2 API.

This is a very large diff but is comprised of mostly mechanical changes. Most of these files were edited using `find` and `sed`, specifically:
`find . -type f \( -name "*.h" -o -name "*.cpp" \) -exec sed -i 's/HZT_\(.*\)_V2/HZT_\1/g' {} +`.

Since this is just a rename, no difference in functionality is expected.

Differential Revision: D83808657
