### PR TITLE
[precompile][ios] fixed cp command to work with gnu coreutils

### DIFF
--- a/packages/react-native/third-party-podspecs/ReactNativeDependencies.podspec
+++ b/packages/react-native/third-party-podspecs/ReactNativeDependencies.podspec
@@ -62,7 +62,7 @@ Pod::Spec.new do |spec|
       exit 0
     fi
 
-    cp -R "$HEADERS_PATH/" Headers
+    cp -R "$HEADERS_PATH/." Headers
     mkdir -p framework/packages/react-native
     cp -R "$XCFRAMEWORK_PATH/../." framework/packages/react-native/
     find "$XCFRAMEWORK_PATH/.." -type f -exec rm {} +


### PR DESCRIPTION
## Summary:

When using gnu coreutils, installation of ReactNativeDependenices on iOS fails at compile time with errors like in the following issue (in the Expo repo):

https://github.com/expo/expo/issues/38992

This is caused by a missing `.` in the end of the path name that the built-in MacOS cp command handles well, but that will create an extra Headers folder when using cp from gnu coreutils.

This commit fixes this by adding the missing `.`

## Changelog:

[IOS] [FIXED] - Fixed issue when using gnu coreutils cp command when using precompiled binaries causing compilation error

## Test Plan:

- Verify that you're running gnu coreutils (`cp --version`)
- Create new expo app `npx create-expo-app`
- Build on iOS - should error without this fix, should work with the fix.
