### PR TITLE
[jest-preset] Fix mock for Linking

### DIFF
--- a/packages/jest-preset/jest/mocks/Linking.js
+++ b/packages/jest-preset/jest/mocks/Linking.js
@@ -9,12 +9,12 @@
  */
 
 const Linking = {
-  openURL: jest.fn() as JestMockFn<$FlowFixMe, $FlowFixMe>,
+  openURL: jest.fn(() => Promise.resolve()) as JestMockFn<$FlowFixMe, $FlowFixMe>,
   canOpenURL: jest.fn(() => Promise.resolve(true)) as JestMockFn<
     $FlowFixMe,
     $FlowFixMe,
   >,
-  openSettings: jest.fn() as JestMockFn<$FlowFixMe, $FlowFixMe>,
+  openSettings: jest.fn(() => Promise.resolve()) as JestMockFn<$FlowFixMe, $FlowFixMe>,
   addEventListener: jest.fn(() => ({
     remove: jest.fn(),
   })) as JestMockFn<$FlowFixMe, $FlowFixMe>,
@@ -22,7 +22,7 @@ const Linking = {
     $FlowFixMe,
     $FlowFixMe,
   >,
-  sendIntent: jest.fn() as JestMockFn<$FlowFixMe, $FlowFixMe>,
+  sendIntent: jest.fn(() => Promise.resolve()) as JestMockFn<$FlowFixMe, $FlowFixMe>,
 };
 
 export default Linking;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

All three patched methods are supposed to return `Promise<any>`. Having the mock return `undefined` for them breaks tests that expect the Promise.

## Changelog:

[General] [Fixed] - Fix mock for Linking methods to return Promises

## Test Plan

I'm using this patch on my own project, it works fine there. I don't think it's worth trying to write an automated test for this.