### PR TITLE
Track Network domain status in SessionState

### DIFF
--- a/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeAgentDelegate.cpp
+++ b/packages/react-native/ReactCommon/hermes/inspector-modern/chrome/HermesRuntimeAgentDelegate.cpp
@@ -72,10 +72,9 @@ class HermesRuntimeAgentDelegate::Impl final : public RuntimeAgentDelegate {
   }
 
   bool handleRequest(const cdp::PreparsedRequest& req) override {
-    // TODO: Change to string::starts_with when we're on C++20.
-    if (req.method.rfind("Log.", 0) == 0) {
-      // Since we know Hermes doesn't do anything useful with Log messages,
-      // but our containing HostAgent will, bail out early.
+    if (req.method.starts_with("Log.") || req.method.starts_with("Network.")) {
+      // Since we know Hermes doesn't do anything useful with Log or Network
+      // messages, but our containing HostAgent will, bail out early.
       // TODO: We need a way to negotiate this more dynamically with Hermes
       // through the API.
       return false;

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
@@ -9,6 +9,7 @@
 #include "InstanceAgent.h"
 
 #ifdef REACT_NATIVE_DEBUGGER_ENABLED
+#include "InspectorFlags.h"
 #include "NetworkIOAgent.h"
 #include "SessionState.h"
 #include "TracingAgent.h"
@@ -141,6 +142,24 @@ class HostAgent::Impl final {
           .isFinishedHandlingRequest = false,
           .shouldSendOKResponse = true,
       };
+    }
+    if (InspectorFlags::getInstance().getNetworkInspectionEnabled()) {
+      if (req.method == "Network.enable") {
+        sessionState_.isNetworkDomainEnabled = true;
+
+        return {
+            .isFinishedHandlingRequest = false,
+            .shouldSendOKResponse = true,
+        };
+      }
+      if (req.method == "Network.disable") {
+        sessionState_.isNetworkDomainEnabled = false;
+
+        return {
+            .isFinishedHandlingRequest = false,
+            .shouldSendOKResponse = true,
+        };
+      }
     }
 
     // Methods other than domain enables/disables: handle anything we know how

--- a/packages/react-native/ReactCommon/jsinspector-modern/NetworkIOAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/NetworkIOAgent.cpp
@@ -280,15 +280,15 @@ bool NetworkIOAgent::handleRequest(
     if (req.method == "Network.enable") {
       networkHandler.setFrontendChannel(frontendChannel_);
       networkHandler.enable();
-      frontendChannel_(cdp::jsonResult(req.id));
-      return true;
+      // NOTE: Domain enable/disable responses are sent by HostAgent.
+      return false;
     }
 
     // @cdp Network.disable support is experimental.
     if (req.method == "Network.disable") {
       networkHandler.disable();
-      frontendChannel_(cdp::jsonResult(req.id));
-      return true;
+      // NOTE: Domain enable/disable responses are sent by HostAgent.
+      return false;
     }
 
     // @cdp Network.getResponseBody support is experimental.

--- a/packages/react-native/ReactCommon/jsinspector-modern/SessionState.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/SessionState.h
@@ -24,6 +24,7 @@ struct SessionState {
   bool isLogDomainEnabled{false};
   bool isReactNativeApplicationDomainEnabled{false};
   bool isRuntimeDomainEnabled{false};
+  bool isNetworkDomainEnabled{false};
 
   /**
    * Whether the Trace Recording was initialized via CDP Tracing.start method


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Adds a `SessionState::isNetworkDomainEnabled` bit, managed in `HostAgent`, to align with other domains. Network support is still gated behind feature flags as before.

Differential Revision: D83847357


