### PR TITLE
Updated copyright header from Facebook to Meta in yoga-config.cmake.in

### DIFF
--- a/packages/react-native/ReactCommon/yoga/cmake/yoga-config.cmake.in
+++ b/packages/react-native/ReactCommon/yoga/cmake/yoga-config.cmake.in
@@ -1,4 +1,4 @@
-# Copyright (c) Facebook, Inc. and its affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:
Update the copyright header in packages/react-native/ReactCommon/yoga/cmake/yoga-config.cmake.in from 
``` 
# Copyright (c) Facebook, Inc. and its affiliates.
``` 
 to 
 ```
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 ```
 for consistency with the rest of the codebase. This change does not affect functionality.
 
 close #54086 

## Changelog:
[GENERAL] [CHANGED] - Updated copyright header in Yoga CMake file from Facebook to Meta.

## Test Plan:
Tests Required: No
