### PR TITLE
use processor flag -DRN_USE_ANIMATION_BACKEND to gate animation backend dep

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/animated/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/animated/CMakeLists.txt
@@ -32,3 +32,4 @@ target_link_libraries(react_renderer_animated
 )
 target_compile_reactnative_options(react_renderer_animated PRIVATE)
 target_compile_options(react_renderer_animated PRIVATE -Wpedantic)
+target_compile_definitions(react_renderer_animated PRIVATE RN_USE_ANIMATION_BACKEND)

--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.cpp
@@ -33,8 +33,11 @@
 #include <react/renderer/animated/nodes/TrackingAnimatedNode.h>
 #include <react/renderer/animated/nodes/TransformAnimatedNode.h>
 #include <react/renderer/animated/nodes/ValueAnimatedNode.h>
-#include <react/renderer/animationbackend/AnimatedPropsBuilder.h>
 #include <react/renderer/core/EventEmitter.h>
+
+#ifdef RN_USE_ANIMATION_BACKEND
+#include <react/renderer/animationbackend/AnimatedPropsBuilder.h>
+#endif
 
 namespace facebook::react {
 
@@ -515,11 +518,13 @@ NativeAnimatedNodesManager::ensureEventEmitterListener() noexcept {
 
 void NativeAnimatedNodesManager::startRenderCallbackIfNeeded() {
   if (ReactNativeFeatureFlags::useSharedAnimatedBackend()) {
+#ifdef RN_USE_ANIMATION_BACKEND
     if (auto animationBackend =
             std::static_pointer_cast<AnimationBackend>(animationBackend_)) {
       animationBackend->start(
           [this](float /*f*/) { return pullAnimationMutations(); });
     }
+#endif
 
     return;
   }
@@ -887,6 +892,7 @@ void NativeAnimatedNodesManager::schedulePropsCommit(
   }
 }
 
+#ifdef RN_USE_ANIMATION_BACKEND
 AnimationMutations NativeAnimatedNodesManager::pullAnimationMutations() {
   if (!ReactNativeFeatureFlags::useSharedAnimatedBackend()) {
     return {};
@@ -1005,6 +1011,7 @@ AnimationMutations NativeAnimatedNodesManager::pullAnimationMutations() {
   }
   return mutations;
 }
+#endif
 
 void NativeAnimatedNodesManager::onRender() {
   if (ReactNativeFeatureFlags::useSharedAnimatedBackend()) {

--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.h
@@ -17,7 +17,9 @@
 #include <react/debug/flags.h>
 #include <react/renderer/animated/EventEmitterListener.h>
 #include <react/renderer/animated/event_drivers/EventAnimationDriver.h>
+#ifdef RN_USE_ANIMATION_BACKEND
 #include <react/renderer/animationbackend/AnimationBackend.h>
+#endif
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/uimanager/UIManagerAnimationBackend.h>
 #include <chrono>
@@ -114,7 +116,9 @@ class NativeAnimatedNodesManager {
 
   void setAnimatedNodeOffset(Tag tag, double offset);
 
+#ifdef RN_USE_ANIMATION_BACKEND
   AnimationMutations pullAnimationMutations();
+#endif
 
 #pragma mark - Drivers
 

--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManagerProvider.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManagerProvider.cpp
@@ -11,7 +11,9 @@
 #include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/animated/MergedValueDispatcher.h>
 #include <react/renderer/animated/internal/AnimatedMountingOverrideDelegate.h>
+#ifdef RN_USE_ANIMATION_BACKEND
 #include <react/renderer/animationbackend/AnimationBackend.h>
+#endif
 #include <react/renderer/uimanager/UIManagerBinding.h>
 
 namespace facebook::react {
@@ -66,6 +68,7 @@ NativeAnimatedNodesManagerProvider::getOrCreate(
         };
 
     if (ReactNativeFeatureFlags::useSharedAnimatedBackend()) {
+#ifdef RN_USE_ANIMATION_BACKEND
       // TODO: this should be initialized outside of animated, but for now it
       // was convenient to do it here
       animationBackend_ = std::make_shared<AnimationBackend>(
@@ -74,6 +77,7 @@ NativeAnimatedNodesManagerProvider::getOrCreate(
           std::move(directManipulationCallback),
           std::move(fabricCommitCallback),
           uiManager);
+#endif
 
       nativeAnimatedNodesManager_ =
           std::make_shared<NativeAnimatedNodesManager>(animationBackend_);

--- a/private/react-native-fantom/runner/executables/tester.js
+++ b/private/react-native-fantom/runner/executables/tester.js
@@ -15,6 +15,7 @@ import {NATIVE_BUILD_OUTPUT_PATH} from '../paths';
 import {
   getBuckModesForPlatform,
   getBuckOptionsForHermes,
+  getConfigForAnimationBackend,
   getDebugInfoFromCommandResult,
   runBuck2,
   runBuck2Sync,
@@ -54,6 +55,7 @@ export function build(options: TesterOptions): void {
       'build',
       ...getBuckModesForPlatform(options.isOptimizedMode),
       ...getBuckOptionsForHermes(options.hermesVariant),
+      ...getConfigForAnimationBackend(),
       FANTOM_TESTER_BUCK_TARGET,
       '--out',
       tmpPath,
@@ -94,6 +96,7 @@ export function run(
         'run',
         ...getBuckModesForPlatform(options.isOptimizedMode),
         ...getBuckOptionsForHermes(options.hermesVariant),
+        ...getConfigForAnimationBackend(),
         FANTOM_TESTER_BUCK_TARGET,
         '--',
         ...args,

--- a/private/react-native-fantom/runner/utils.js
+++ b/private/react-native-fantom/runner/utils.js
@@ -104,6 +104,11 @@ export function getBuckModesForPlatform(
   return ['@//xplat/mode/react-native/granite', osPlatform];
 }
 
+// TODO: T240293839 Remove when we get rid of RN_USE_ANIMATION_BACKEND preprocessor flag
+export function getConfigForAnimationBackend(): $ReadOnlyArray<string> {
+  return ['-c rn.use_animationbackend=true'];
+}
+
 export type AsyncCommandResult = {
   originalCommand: string,
   childProcess: ReturnType<typeof spawn>,


### PR DESCRIPTION
Summary:
## Changelog:

[Internal] [Changed] - use processor flag -DRN_USE_ANIMATION_BACKEND to gate animation backend dep

So it's only enabled for catalyst and fantom when building with BUCK while gated from other meta apps, and enabled by default in oss version

Differential Revision: D84157729


