### PR TITLE
Fix transformOrigin conversion ignoring unit type

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/graphics/Transform.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Transform.h
@@ -71,13 +71,12 @@ struct TransformOrigin {
         xy[1].value != 0.0f || xy[1].unit != UnitType::Undefined || z != 0.0f;
   }
 
-#ifdef ANDROID
-
+#ifdef RN_SERIALIZABLE_STATE
   /**
    * Convert to folly::dynamic.
    */
   operator folly::dynamic() const {
-    return folly::dynamic::array(xy[0].value, xy[1].value, z);
+    return folly::dynamic::array(xy[0].toDynamic(), xy[1].toDynamic(), z);
   }
 
 #endif


### PR DESCRIPTION
Summary:
The `transformOrigin` conversion didn't call into the `toDynamic` conversion for the underlying `ValueUnit` instances for the x and y coordinates. This diff fixes the conversion so that percentages would be correctly converted.

Changelog: [Internal]

Differential Revision: D84165034


