### PR TITLE
Fix: keyboard not updating when keyboardType changes while focused

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -251,6 +251,7 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
 
   if (newTextInputProps.traits.keyboardType != oldTextInputProps.traits.keyboardType) {
     _backedTextInputView.keyboardType = RCTUIKeyboardTypeFromKeyboardType(newTextInputProps.traits.keyboardType);
+    [_backedTextInputView reloadInputViews];
   }
 
   if (newTextInputProps.traits.returnKeyType != oldTextInputProps.traits.returnKeyType) {


### PR DESCRIPTION

## Summary:

On iOS, changing <TextInput keyboardType> at runtime (e.g., from default → email-address) does not update the visible keyboard type if the input is already focused. Android updates correctly.

## Reproduce
- Platform: iOS
- React Native 0.82
- newArch, bridgeless mode enable

## Changelog:

This PR updates the iOS implementation to call reloadInputViews when keyboardType changed.

## Test Plan:

https://github.com/user-attachments/assets/ba634aea-0430-477c-be95-37b1b970a0e9


