### PR TITLE
fix: iOS issue keyboardType not reload when change keyboardType

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -251,6 +251,7 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
 
   if (newTextInputProps.traits.keyboardType != oldTextInputProps.traits.keyboardType) {
     _backedTextInputView.keyboardType = RCTUIKeyboardTypeFromKeyboardType(newTextInputProps.traits.keyboardType);
+    [_backedTextInputView reloadInputViews];
   }
 
   if (newTextInputProps.traits.returnKeyType != oldTextInputProps.traits.returnKeyType) {


### PR DESCRIPTION

## Summary:

On iOS, changing at runtime (e.g., from default → email-address) does not update the visible keyboard type if the input is already focused. Android updates correctly.

## Changelog:

[IOS] [FIXED] - This PR fix the iOS to call reloadInputViews when keyboardType changed.

## Test Plan:

https://github.com/user-attachments/assets/a753d19c-7a38-4f31-8247-c2983c31a821


