### PR TITLE
Remove move constructor from SurfaceHandler

### DIFF
--- a/packages/react-native/React/Fabric/Surface/RCTFabricSurface.mm
+++ b/packages/react-native/React/Fabric/Surface/RCTFabricSurface.mm
@@ -57,7 +57,7 @@ using namespace facebook::react;
   if (self = [super init]) {
     _surfacePresenter = surfacePresenter;
 
-    _surfaceHandler = SurfaceHandler{RCTStringFromNSString(moduleName), getNextRootViewTag()};
+    _surfaceHandler.emplace(RCTStringFromNSString(moduleName), getNextRootViewTag());
     _surfaceHandler->setProps(convertIdToFollyDynamic(initialProperties));
 
     [_surfacePresenter registerSurface:self];

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceHandler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceHandler.cpp
@@ -23,26 +23,6 @@ SurfaceHandler::SurfaceHandler(
   parameters_.surfaceId = surfaceId;
 }
 
-SurfaceHandler::SurfaceHandler(SurfaceHandler&& other) noexcept {
-  operator=(std::move(other));
-}
-
-SurfaceHandler& SurfaceHandler::operator=(SurfaceHandler&& other) noexcept {
-  std::unique_lock lock1(linkMutex_, std::defer_lock);
-  std::unique_lock lock2(parametersMutex_, std::defer_lock);
-  std::unique_lock lock3(other.linkMutex_, std::defer_lock);
-  std::unique_lock lock4(other.parametersMutex_, std::defer_lock);
-  std::lock(lock1, lock2, lock3, lock4);
-
-  link_ = other.link_;
-  parameters_ = other.parameters_;
-
-  other.link_ = Link{};
-  other.parameters_ = Parameters{};
-  other.parameters_.contextContainer = parameters_.contextContainer;
-  return *this;
-}
-
 #pragma mark - Surface Life-Cycle Management
 
 void SurfaceHandler::setContextContainer(

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceHandler.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceHandler.h
@@ -67,11 +67,11 @@ class SurfaceHandler {
   virtual ~SurfaceHandler() noexcept;
 
   /*
-   * Movable-only.
+   * Not moveable or copyable
    */
-  SurfaceHandler(SurfaceHandler &&other) noexcept;
+  SurfaceHandler(SurfaceHandler &&other) noexcept = delete;
   SurfaceHandler(const SurfaceHandler &SurfaceHandler) noexcept = delete;
-  SurfaceHandler &operator=(SurfaceHandler &&other) noexcept;
+  SurfaceHandler &operator=(SurfaceHandler &&other) noexcept = delete;
   SurfaceHandler &operator=(const SurfaceHandler &other) noexcept = delete;
 
 #pragma mark - Surface Life-Cycle Management

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SurfaceManager.cpp
@@ -29,9 +29,8 @@ void SurfaceManager::startSurface(
     const LayoutContext& layoutContext) noexcept {
   {
     std::unique_lock lock(mutex_);
-    auto surfaceHandler = SurfaceHandler{moduleName, surfaceId};
-    surfaceHandler.setContextContainer(scheduler_.getContextContainer());
-    registry_.emplace(surfaceId, std::move(surfaceHandler));
+    auto [it, _] = registry_.try_emplace(surfaceId, moduleName, surfaceId);
+    it->second.setContextContainer(scheduler_.getContextContainer());
   }
 
   visit(surfaceId, [&](const SurfaceHandler& surfaceHandler) {


### PR DESCRIPTION
Summary:
Removed SurfaceHandler's move constructor, to avoid any potential issues with referencing moved-from instances.

Changelog: [Internal]

Reviewed By: mdvacca

Differential Revision: D83977790


