### PR TITLE
Fix https://github.com/facebook/react-native/issues/54102 by wrapping the prettier mock in a try-catch

### DIFF
--- a/packages/react-native/jest/setup.js
+++ b/packages/react-native/jest/setup.js
@@ -70,16 +70,21 @@ Object.defineProperties(global, {
   },
 });
 
-/**
- * Prettier v3 uses import (cjs/mjs) file formats that jest-runtime does not
- * support. To work around this we need to bypass the jest module system by
- * using the orginal node `require` function.
- */
-jest.mock('prettier', () => {
-  // $FlowExpectedError[underconstrained-implicit-instantiation]
-  const module = jest.requireActual('module');
-  return module.prototype.require(require.resolve('prettier'));
-});
+// This setup script will be published in the react-native package.
+// Other people might not have prettier installed, so it will crash the mock below.
+// Therefore, we wrap this mock in a try-catch.
+try {
+  /**
+   * Prettier v3 uses import (cjs/mjs) file formats that jest-runtime does not
+   * support. To work around this we need to bypass the jest module system by
+   * using the orginal node `require` function.
+   */
+  jest.mock('prettier', () => {
+    // $FlowExpectedError[underconstrained-implicit-instantiation]
+    const module = jest.requireActual('module');
+    return module.prototype.require(require.resolve('prettier'));
+  });
+} catch {}
 
 // $FlowFixMe[incompatible-type] - `./mocks/AppState` is incomplete.
 mock('m#../Libraries/AppState/AppState', 'm#./mocks/AppState');


### PR DESCRIPTION
Summary:
This setup script will be published in the react-native package.
Other people might not have prettier installed, so it will crash the mock below.
Therefore, we wrap this mock in a try-catch.

Changelog: [fix] Fixed https://github.com/facebook/react-native/issues/54102

Differential Revision: D84292458


