### PR TITLE
Disable inlining of ColorStop and ValueUnit toDynamic conversion

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/graphics/ColorStop.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/ColorStop.cpp
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ColorStop.h"
+
+namespace facebook::react {
+
+#ifdef RN_SERIALIZABLE_STATE
+folly::dynamic ColorStop::toDynamic() const {
+  folly::dynamic result = folly::dynamic::object();
+  result["color"] = *color;
+  result["position"] = position.toDynamic();
+  return result;
+}
+#endif
+
+}; // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/graphics/ColorStop.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/ColorStop.h
@@ -10,6 +10,7 @@
 #include <react/renderer/graphics/Color.h>
 #include <react/renderer/graphics/Float.h>
 #include <react/renderer/graphics/ValueUnit.h>
+#include <optional>
 
 namespace facebook::react {
 
@@ -19,12 +20,7 @@ struct ColorStop {
   ValueUnit position;
 
 #ifdef RN_SERIALIZABLE_STATE
-  folly::dynamic toDynamic() const {
-    folly::dynamic result = folly::dynamic::object();
-    result["color"] = *color;
-    result["position"] = position.toDynamic();
-    return result;
-  }
+  folly::dynamic toDynamic() const;
 #endif
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/graphics/ValueUnit.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/ValueUnit.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ValueUnit.h"
+
+#ifdef RN_SERIALIZABLE_STATE
+#include <double-conversion/double-conversion.h>
+#include <array>
+#include <string>
+#endif
+
+namespace facebook::react {
+
+#ifdef RN_SERIALIZABLE_STATE
+
+std::string toString(double doubleValue, char suffix) {
+  // Format taken from folly's toString
+  static double_conversion::DoubleToStringConverter conv(
+      0,
+      NULL,
+      NULL,
+      'E',
+      -6, // detail::kConvMaxDecimalInShortestLow,
+      21, // detail::kConvMaxDecimalInShortestHigh,
+      6, // max leading padding zeros
+      1); // max trailing padding zeros
+  std::array<char, 256> buffer{};
+  double_conversion::StringBuilder builder(buffer.data(), buffer.size());
+  if (!conv.ToShortest(doubleValue, &builder)) {
+    // Serialize infinite and NaN as 0%
+    builder.AddCharacter('0');
+    builder.AddCharacter('%');
+  }
+  builder.AddCharacter(suffix);
+  return builder.Finalize();
+}
+
+folly::dynamic ValueUnit::toDynamic() const {
+  switch (unit) {
+    case UnitType::Undefined:
+      return nullptr;
+    case UnitType::Point:
+      return value;
+    case UnitType::Percent:
+      return toString(value, '%');
+    default:
+      return nullptr;
+  }
+}
+#endif
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/graphics/ValueUnit.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/ValueUnit.h
@@ -50,16 +50,7 @@ struct ValueUnit {
   }
 
 #ifdef RN_SERIALIZABLE_STATE
-  folly::dynamic toDynamic() const {
-    switch (unit) {
-      case UnitType::Undefined:
-        return nullptr;
-      case UnitType::Point:
-        return value;
-      case UnitType::Percent:
-        return std::format("{}%", value);
-    }
-  }
+  folly::dynamic toDynamic() const;
 #endif
 };
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
With ColorStop and ValueUnit being used at multiple locations, inlining the `toDynamic` conversion used for RN Android and using `std::format` to convert floating point values to string increased the binary size of RN Android by ~180KiB. This diff declares the functions outside the header to avoid inlining the functions and removes the dependency on `std::format` for the percent value string formatting.

Changelog: [Internal]

Differential Revision: D84349391


