### PR TITLE
Add tests for Tracing domain reporting of network requests

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestHermesEngineAdapter.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/engines/JsiIntegrationTestHermesEngineAdapter.cpp
@@ -17,7 +17,13 @@ JsiIntegrationTestHermesEngineAdapter::JsiIntegrationTestHermesEngineAdapter(
                   ::hermes::vm::CompilationMode::ForceLazyCompilation)
               .build())},
       jsExecutor_{jsExecutor},
-      runtimeTargetDelegate_{runtime_} {}
+      runtimeTargetDelegate_{runtime_} {
+  // NOTE: In React Native, registerForProfiling is called by
+  // HermesInstance::unstable_initializeOnJsThread, called from
+  // ReactInstance::initializeRuntime. Ideally, we should figure out how to
+  // manages this from inside the CDP backend,
+  runtime_->registerForProfiling();
+}
 
 RuntimeTargetDelegate&
 JsiIntegrationTestHermesEngineAdapter::getRuntimeTargetDelegate() {


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Adds an integration test for `NetworkReporter`'s CDP Tracing domain output (via `PerformanceTracer` behind the scenes), i.e. the traces that power the Network track in the Performance panel in React Native DevTools.

The test covers the `Tracing` and `Network` domains being enabled simultaneously, as well as `Tracing` on its own.

Differential Revision: D84337901


