### PR TITLE
[iOS][Accessibility][Critical?] #35774: accessibility state race condition 

### DIFF
--- a/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
@@ -308,6 +308,9 @@ class TouchableOpacity extends React.Component<
         accessibilityState={_accessibilityState}
         accessibilityActions={this.props.accessibilityActions}
         onAccessibilityAction={this.props.onAccessibilityAction}
+        onAccessibilityTap={this.props.onAccessibilityTap}
+        onAccessibilityEscape={this.props.onAccessibilityEscape}
+        onMagicTap={this.props.onMagicTap}
         accessibilityValue={accessibilityValue}
         importantForAccessibility={
           this.props['aria-hidden'] === true

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -1475,7 +1475,11 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
 - (BOOL)didActivateAccessibilityCustomAction:(UIAccessibilityCustomAction *)action
 {
   if (_eventEmitter && _props->onAccessibilityAction) {
-    _eventEmitter->onAccessibilityAction(RCTStringFromNSString(action.name));
+    auto emitter = std::static_pointer_cast<const ViewEventEmitter>(_eventEmitter);
+
+    emitter->experimental_flushSync([&emitter, &action]() {
+      emitter->onAccessibilityAction(RCTStringFromNSString(action.name));
+    });
     return YES;
   } else {
     return NO;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -1451,14 +1451,24 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
 - (void)accessibilityIncrement
 {
   if (_eventEmitter && _props->onAccessibilityAction) {
-    _eventEmitter->onAccessibilityAction("increment");
+    auto emitter = std::static_pointer_cast<const ViewEventEmitter>(_eventEmitter);
+    
+    // Dispatch the event synchronously - JS will run and update props immediately
+    emitter->experimental_flushSync([&emitter]() {
+      emitter->onAccessibilityAction("increment");
+    });
   }
 }
 
 - (void)accessibilityDecrement
 {
   if (_eventEmitter && _props->onAccessibilityAction) {
-    _eventEmitter->onAccessibilityAction("decrement");
+    auto emitter = std::static_pointer_cast<const ViewEventEmitter>(_eventEmitter);
+    
+    // Dispatch the event synchronously - JS will run and update props immediately
+    emitter->experimental_flushSync([&emitter]() {
+      emitter->onAccessibilityAction("decrement");
+    });
   }
 }
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -1421,7 +1421,11 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
 - (BOOL)accessibilityActivate
 {
   if (_eventEmitter && _props->onAccessibilityTap) {
-    _eventEmitter->onAccessibilityTap();
+    auto emitter = std::static_pointer_cast<const ViewEventEmitter>(_eventEmitter);
+
+    emitter->experimental_flushSync([&emitter]() {
+      emitter->onAccessibilityTap();
+    });
     return YES;
   } else {
     return NO;
@@ -1431,7 +1435,11 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
 - (BOOL)accessibilityPerformMagicTap
 {
   if (_eventEmitter && _props->onAccessibilityMagicTap) {
-    _eventEmitter->onAccessibilityMagicTap();
+    auto emitter = std::static_pointer_cast<const ViewEventEmitter>(_eventEmitter);
+
+    emitter->experimental_flushSync([&emitter]() {
+      emitter->onAccessibilityMagicTap();
+    });
     return YES;
   } else {
     return NO;
@@ -1441,7 +1449,10 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
 - (BOOL)accessibilityPerformEscape
 {
   if (_eventEmitter && _props->onAccessibilityEscape) {
-    _eventEmitter->onAccessibilityEscape();
+    auto emitter = std::static_pointer_cast<const ViewEventEmitter>(_eventEmitter);
+    emitter->experimental_flushSync([&emitter]() {
+      emitter->onAccessibilityEscape();
+    });
     return YES;
   } else {
     return NO;


### PR DESCRIPTION
Refactor accessibility actions to fix a race condition on iOS. Fixes #35774

## Summary:

I know you will most likely not like my fix, but there currently is a race condition that creates issues for our most vulnerable users. 

Any accessibility action performed on an element on iOS are out of sync, from custom actions, taps, magic taps, increment, decrement or escape.

This is because the VoiceOver on iOS will immediately read the text once an action is called as it expects the function to update accessibilityValue / accessibilityState. The problem is we're emitting an asynchronous event to update this value so there is currently no easy way to fix this.

What I found is working is using this experimental_flushSync function to update the state synchronously. This is obviously bad for performance but i'd argue that for the current context (vision impairment) having 60fps when running an action (that doesn't happen often) is less important than having wrong vocal directions.

## Changelog:

[iOS] [Fixed] - Updated accessibilityIncrement, accessibilityDecrement, accessibilityActivate, accessibilityPerformEscape, accessibilityPerformMagicTap to synchronously update the state when the action is run
[iOS] [Fixed] - Add missing accessibility props to TouchableOpacity

## Test Plan:

Before:

https://github.com/user-attachments/assets/7a3b7dee-c7f8-499a-8087-3d8deb990900


After:
https://github.com/user-attachments/assets/5e31e2de-63e9-4234-bb4c-d46dfe1cabcf

