### PR TITLE
Avoid data loss during conversion

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
@@ -535,7 +535,8 @@ inline std::optional<Float> toRadians(const RawValue& value) {
 
   auto angle = parseCSSProperty<CSSAngle>((std::string)value);
   if (std::holds_alternative<CSSAngle>(angle)) {
-    return std::get<CSSAngle>(angle).degrees * M_PI / 180.0f;
+    return static_cast<float>(
+        std::get<CSSAngle>(angle).degrees * M_PI / 180.0f);
   }
 
   return {};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Avoid data loss during conversion which fixes https://github.com/microsoft/react-native-windows/issues/14698

## Changelog:

Added a one-line fix to static_cast to a float

Pick one each for the category and type tags:

[GENERAL] [FIXED] - Avoid data loss during conversion

## Test Plan

Working in react native windows


