### PR TITLE
perf: Move `func` into `CallInvoker::invokeAsync`

### DIFF
--- a/packages/react-native/ReactCommon/callinvoker/ReactCommon/CallInvoker.h
+++ b/packages/react-native/ReactCommon/callinvoker/ReactCommon/CallInvoker.h
@@ -38,11 +38,11 @@ class CallInvoker {
 
   // Backward compatibility only, prefer the CallFunc methods instead
   virtual void invokeAsync(std::function<void()>&& func) noexcept {
-    invokeAsync([func](jsi::Runtime&) { func(); });
+    invokeAsync([func = std::move(func)](jsi::Runtime&) { func(); });
   }
 
   virtual void invokeSync(std::function<void()>&& func) {
-    invokeSync([func](jsi::Runtime&) { func(); });
+    invokeSync([func = std::move(func)](jsi::Runtime&) { func(); });
   }
 
   virtual ~CallInvoker() = default;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Instead of copying the `std::function` into `invokeAsync`, we now move it.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[GENERAL] [CHANGED] - Move `std::function` into `CallInvoker::invokeAsync` instead of copying it

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

Build, run. A lot of code still uses the old `invokeAsync` function.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
