### PR TITLE
Move to use proguard-android-optimize.txt inside RNTester

### DIFF
--- a/packages/react-native/ReactAndroid/proguard-rules.pro
+++ b/packages/react-native/ReactAndroid/proguard-rules.pro
@@ -68,3 +68,8 @@
 -keepclassmembers class * {
     @com.facebook.yoga.annotations.DoNotStrip *;
 }
+
+# fresco
+-keep public class com.facebook.imageutils.** {
+   public *;
+}

--- a/packages/rn-tester/android/app/build.gradle.kts
+++ b/packages/rn-tester/android/app/build.gradle.kts
@@ -122,7 +122,7 @@ android {
   buildTypes {
     release {
       isMinifyEnabled = enableProguardInReleaseBuilds
-      proguardFiles(getDefaultProguardFile("proguard-android.txt"))
+      proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
       signingConfig = signingConfigs.getByName("debug")
     }
   }

--- a/private/helloworld/android/app/build.gradle
+++ b/private/helloworld/android/app/build.gradle
@@ -107,7 +107,7 @@ android {
             // see https://reactnative.dev/docs/signed-apk-android.
             signingConfig signingConfigs.debug
             minifyEnabled enableProguardInReleaseBuilds
-            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro"
         }
     }
 }


### PR DESCRIPTION
Summary:
This will become the default in AGP 9.x so let's update it inside RNTester as well.

Changelog:
[Internal] [Changed] -

Differential Revision: D84548388


