### PR TITLE
Update copyright from Facebook to Meta Platforms

### DIFF
--- a/scripts/sync-css-layout.sh
+++ b/scripts/sync-css-layout.sh
@@ -12,7 +12,7 @@ function usage {
 function patchfile {
   # Add React Native copyright
   printf "/**\n"  > /tmp/yogasync.tmp
-  printf " * Copyright (c) 2014-present, Meta Platforms, Inc.\n" >> /tmp/yogasync.tmp
+  printf " * Copyright (c) 2014-present, Meta Platforms, Inc.\n"  >> /tmp/yogasync.tmp
   printf " *\n" >> /tmp/yogasync.tmp
   printf " * This source code is licensed under the MIT license found in the\n"  >> /tmp/yogasync.tmp
   printf " * LICENSE file in the root directory of this source tree.\n"  >> /tmp/yogasync.tmp


### PR DESCRIPTION

## Summary:

Fix sync script to emit “Meta Platforms, Inc.” instead of "Facebook, Inc."

## Changelog:

[General] [Fixed] - Updated sync script to emit “Meta Platforms, Inc.” instead of "Facebook, Inc." in copyright notice.

## Test Plan

Tests Required: No
