### PR TITLE
Add 'es2022.error' to TypeScript lib options

### DIFF
--- a/packages/typescript-config/tsconfig.json
+++ b/packages/typescript-config/tsconfig.json
@@ -17,6 +17,7 @@
         "es2021.string",
         "es2021.weakref",
         "es2022.array",
+        "es2022.error",
         "es2022.object",
         "es2022.string"
       ],


### PR DESCRIPTION


## Summary:

This adds support for the `cause` parameter, which Hermes supports. The motivation is to be able to use `cause` on errors without getting TypeScript errors.

## Changelog:

```text
[GENERAL] [ADDED] - Add TypeScript support for Error `cause` property
```

## Test Plan:

I've tested this by adding `es2022.error` to my local TypeScript lib options, and that makes the type checking work 🎉 
