### PR TITLE
Add performance marker for Fast Refresh update

### DIFF
--- a/packages/react-native/Libraries/Utilities/HMRClient.js
+++ b/packages/react-native/Libraries/Utilities/HMRClient.js
@@ -233,6 +233,15 @@ Error: ${e.message}`;
       pendingUpdatesCount--;
       if (pendingUpdatesCount === 0) {
         DevLoadingView.hide();
+        performance.mark('Fast Refresh - Update done', {
+          detail: {
+            devtools: {
+              dataType: 'marker',
+              color: 'primary',
+              tooltipText: 'Fast Refresh \u269b',
+            },
+          },
+        });
       }
     });
 


### PR DESCRIPTION
Summary:
Adds a prominent vertical "Fast Refresh ⚛︎" marker entry in the performance timeline when a Fast Refresh update is complete.

This is available in apps with `performance.mark()` enabled (Canary feature).

Changelog: [Internal]

Differential Revision: D84624705


