### PR TITLE
[iOS][Fixed][LegacyArch] Fixed Switch component for Legacy Arch

### DIFF
--- a/packages/react-native/React/Base/RCTUtils.mm
+++ b/packages/react-native/React/Base/RCTUtils.mm
@@ -432,7 +432,11 @@ CGSize RCTSwitchSize(void)
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
     RCTUnsafeExecuteOnMainQueueSync(^{
-      rctSwitchSize = [UISwitch new].intrinsicContentSize;
+      CGSize switchSize = [UISwitch new].intrinsicContentSize;
+      // Apple does not take into account the thumb border when returning the
+      // width of the UISwitch component, so we are adding 2 pixels for the border
+      // which is not customizable and it is the same for legacy and liquid glass.
+      rctSwitchSize = CGSizeMake(switchSize.width + 2, switchSize.height);
     });
   });
   return rctSwitchSize;

--- a/packages/react-native/React/Views/RCTSwitchManager.m
+++ b/packages/react-native/React/Views/RCTSwitchManager.m
@@ -8,9 +8,28 @@
 #import "RCTSwitchManager.h"
 
 #import <React/RCTUIManager.h>
+#import <React/RCTUtils.h>
 #import "RCTBridge.h"
+#import "RCTShadowView.h"
 #import "RCTSwitch.h"
 #import "UIView+React.h"
+
+@interface RCTSwitchShadowView : RCTShadowView
+
+@end
+
+@implementation RCTSwitchShadowView
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    self.intrinsicContentSize = RCTSwitchSize();
+  }
+
+  return self;
+}
+
+@end
 
 @implementation RCTSwitchManager
 
@@ -31,6 +50,11 @@ RCT_EXPORT_MODULE()
     }
     sender.wasOn = sender.on;
   }
+}
+
+- (RCTShadowView *)shadowView
+{
+  return [RCTSwitchShadowView new];
 }
 
 RCT_EXPORT_METHOD(setValue : (nonnull NSNumber *)viewTag toValue : (BOOL)value)


### PR DESCRIPTION
## Summary:
The switch component got broken on Legacy Arch after https://github.com/facebook/react-native/pull/53067. That's because the React runtime does not know anymore how big are the switches.

On the new arch, we implemented a way for the native platform to inform React about the switch size, but we forgot to implement the same mechanism in the Legacy Arch.

React Native 0.81 has to support the Legacy Arch anyway, so this PR implements the same mechanism to inform React about the size of the Switch when running on the legacy arch.

This should fix https://github.com/facebook/react-native/issues/53537

## Changelog:
[iOS][Fixed] - Fix Switches on the legacy arch

## Test Plan:
Tested on RNTester, running the legacy arch.

| --- | Before | After |
| --- | --- | --- | 
| iOS 18 | <img width="240" alt="Simulator Screenshot - iPhone 17 Pro - 2025-10-14 at 13 49 15" src="https://github.com/user-attachments/assets/a1dbd670-47e5-413d-833e-1d67a9ef5cc9" /> | <img width="240" alt="Simulator Screenshot - iPhone 17 Pro - 2025-10-14 at 13 47 20" src="https://github.com/user-attachments/assets/23a939b4-2200-4731-b0df-a7a9609ecff9" /> |
| iOS 26 | <img width="240" alt="Simulator Screenshot - iPhone 17 Pro - 2025-10-14 at 13 45 39" src="https://github.com/user-attachments/assets/72620fab-a92c-46c2-8fe6-77dbac10bb4a" /> | <img width="240"  alt="Simulator Screenshot - iPhone 17 Pro - 2025-10-14 at 13 46 01" src="https://github.com/user-attachments/assets/e49fe7b6-62c7-49bb-b77a-0c6bffedd106" /> |
