### PR TITLE
fix: upgrade foojay-resolver-convention to 1.0.0

### DIFF
--- a/packages/gradle-plugin/settings.gradle.kts
+++ b/packages/gradle-plugin/settings.gradle.kts
@@ -13,7 +13,7 @@ pluginManagement {
   }
 }
 
-plugins { id("org.gradle.toolchains.foojay-resolver-convention").version("0.5.0") }
+plugins { id("org.gradle.toolchains.foojay-resolver-convention").version("1.0.0") }
 
 include(
     ":react-native-gradle-plugin",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

foojay-resolver-convention's version 0.5.0 is not compatible with Gradle 9. (https://github.com/gradle/foojay-toolchains/issues/151)
When trying to build for Android on React Native 0.8.2, we are presented with
```
java.lang.NoSuchFieldError: Class org.gradle.jvm.toolchain.JvmVendorSpec does not have member field 'org.gradle.jvm.toolchain.JvmVendorSpec IBM_SEMERU'
	at org.gradle.toolchains.foojay.DistributionsKt.<clinit>(distributions.kt:16)
	at org.gradle.toolchains.foojay.FoojayApi.fetchDistributionsIfMissing(FoojayApi.kt:62)
	at org.gradle.toolchains.foojay.FoojayApi.match$foojay_resolver(FoojayApi.kt:49)
	at org.gradle.toolchains.foojay.FoojayApi.toLinks(FoojayApi.kt:41)
```

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID] [CHANGED] - changed foojay-resolver-convetion version to 1.0.0

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

After making the change, the app build without problems.