### PR TITLE
Add fadingEdgeLength prop android scroll view props

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/android/react/renderer/components/scrollview/HostPlatformScrollViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/android/react/renderer/components/scrollview/HostPlatformScrollViewProps.cpp
@@ -38,7 +38,16 @@ HostPlatformScrollViewProps::HostPlatformScrollViewProps(
                     rawProps,
                     "nestedScrollEnabled",
                     sourceProps.nestedScrollEnabled,
-                    true))
+                    true)),
+      fadingEdgeLength(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.fadingEdgeLength
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "fadingEdgeLength",
+                    sourceProps.fadingEdgeLength,
+                    nullptr))
 
 {}
 
@@ -57,6 +66,7 @@ void HostPlatformScrollViewProps::setProp(
   switch (hash) {
     RAW_SET_PROP_SWITCH_CASE_BASIC(sendMomentumEvents);
     RAW_SET_PROP_SWITCH_CASE_BASIC(nestedScrollEnabled);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(fadingEdgeLength);
   }
 }
 
@@ -346,6 +356,10 @@ folly::dynamic HostPlatformScrollViewProps::getDiffProps(
 
   if (nestedScrollEnabled != oldProps->nestedScrollEnabled) {
     result["nestedScrollEnabled"] = nestedScrollEnabled;
+  }
+
+  if (fadingEdgeLength != oldProps->fadingEdgeLength) {
+    result["fadingEdgeLength"] = fadingEdgeLength;
   }
 
   return result;

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/android/react/renderer/components/scrollview/HostPlatformScrollViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/android/react/renderer/components/scrollview/HostPlatformScrollViewProps.h
@@ -32,6 +32,7 @@ class HostPlatformScrollViewProps : public BaseScrollViewProps {
 
   bool sendMomentumEvents{};
   bool nestedScrollEnabled{};
+  folly::dynamic fadingEdgeLength{};
 
 #pragma mark - DebugStringConvertible
 


### PR DESCRIPTION
Summary:
Adding `fadingEdgeLength` prop to the Android scroll view props together with prop diffing support for Props 2.0.

Changelog: [Internal]

Differential Revision: D84788963


