### PR TITLE
Allow passing extra arguments in with-environment.sh

### DIFF
--- a/packages/react-native/scripts/xcode/with-environment.sh
+++ b/packages/react-native/scripts/xcode/with-environment.sh
@@ -43,5 +43,5 @@ fi
 
 # Execute argument, if present
 if [ -n "$1" ]; then
-  "$1"
+  "$@"
 fi


### PR DESCRIPTION
## Summary:

Addresses #54140.

This allows adding extra arguments when running a command with `with-environment.sh`.

## Changelog:

[IOS|] [CHANGED] - Allow passing extra arguments in with-environment.sh

## Test Plan:

Tested by changing the "Bundle React Native code and images" build phase in the ReproducerApp template to execute with an extra argument like so:

```
/bin/sh -c "$WITH_ENVIRONMENT $REACT_NATIVE_XCODE index.example"
```

Can observe that the subsequent command picks up the extra argument.

Also tested building normally, without the extra argument, works as expected.

