### PR TITLE
Extract ValueUnit percent formatting to separate file

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/graphics/DoubleConversions.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/DoubleConversions.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "DoubleConversions.h"
+
+#include <double-conversion/double-conversion.h>
+#include <array>
+
+namespace facebook::react {
+
+std::string toString(double doubleValue, char suffix) {
+  // Format taken from folly's toString
+  static double_conversion::DoubleToStringConverter conv(
+      0,
+      nullptr,
+      nullptr,
+      'E',
+      -6, // detail::kConvMaxDecimalInShortestLow,
+      21, // detail::kConvMaxDecimalInShortestHigh,
+      6, // max leading padding zeros
+      1); // max trailing padding zeros
+  std::array<char, 256> buffer{};
+  double_conversion::StringBuilder builder(buffer.data(), buffer.size());
+  if (!conv.ToShortest(doubleValue, &builder)) {
+    // Serialize infinite and NaN as 0
+    builder.AddCharacter('0');
+  }
+  builder.AddCharacter(suffix);
+  return builder.Finalize();
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/graphics/DoubleConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/DoubleConversions.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace facebook::react {
+
+std::string toString(double doubleValue, char suffix);
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/graphics/ValueUnit.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/ValueUnit.cpp
@@ -8,36 +8,12 @@
 #include "ValueUnit.h"
 
 #ifdef RN_SERIALIZABLE_STATE
-#include <double-conversion/double-conversion.h>
-#include <array>
-#include <string>
+#include "DoubleConversions.h"
 #endif
 
 namespace facebook::react {
 
 #ifdef RN_SERIALIZABLE_STATE
-
-std::string toString(double doubleValue, char suffix) {
-  // Format taken from folly's toString
-  static double_conversion::DoubleToStringConverter conv(
-      0,
-      NULL,
-      NULL,
-      'E',
-      -6, // detail::kConvMaxDecimalInShortestLow,
-      21, // detail::kConvMaxDecimalInShortestHigh,
-      6, // max leading padding zeros
-      1); // max trailing padding zeros
-  std::array<char, 256> buffer{};
-  double_conversion::StringBuilder builder(buffer.data(), buffer.size());
-  if (!conv.ToShortest(doubleValue, &builder)) {
-    // Serialize infinite and NaN as 0%
-    builder.AddCharacter('0');
-    builder.AddCharacter('%');
-  }
-  builder.AddCharacter(suffix);
-  return builder.Finalize();
-}
 
 folly::dynamic ValueUnit::toDynamic() const {
   switch (unit) {


### PR DESCRIPTION
Summary:
This diff extracts the `toString(double, char)` function used to format percent values from `ValueUnit` into a separate `FloatConversions` file.

This was added to graphics directly instead of moving it to core to avoid introducting cyclic dependencies since core depends on graphics.

Changelog: [Internal]

Differential Revision: D84714535


