### PR TITLE
fix(ios-template): escaped-quote form to bundle RN when spaces present in path

### DIFF
--- a/private/helloworld/ios/HelloWorld.xcodeproj/project.pbxproj
+++ b/private/helloworld/ios/HelloWorld.xcodeproj/project.pbxproj
@@ -265,7 +265,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "set -e\n\nexport CONFIG_JSON=$(sed -e \"s|HELLOWORLD_PATH|$(realpath \"${SRCROOT}/../\")|g\" \"${SRCROOT}/../.react-native.config\")\n\nWITH_ENVIRONMENT=\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"$REACT_NATIVE_PATH/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"$WITH_ENVIRONMENT $REACT_NATIVE_XCODE\"\n";
+			shellScript = "set -e\n\nexport CONFIG_JSON=$(sed -e \"s|HELLOWORLD_PATH|$(realpath \"${SRCROOT}/../\")|g\" \"${SRCROOT}/../.react-native.config\")\n\nWITH_ENVIRONMENT=\"$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh\"\nREACT_NATIVE_XCODE=\"$REACT_NATIVE_PATH/scripts/react-native-xcode.sh\"\n\n/bin/sh -c \"\\\"$WITH_ENVIRONMENT\\\" \\\"$REACT_NATIVE_XCODE\\\"\"\n";
 		};
 		A44ED3CC3037C88F69E3AF15 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

By default, if you init an iOS project in a directory that contains spaces, it will fail in the Build Phase of `Bundle React Native code and images`. Removing the space from the directory, the project can successfully build. This is due to an improperly escaped string in the script found in the iOS project file.

- Closes #54167
- Closes #34269 

## Changelog:

[IOS] [FIXED] - iOS project will build successfully if spaces are present in the project path

## Test Plan:

1. `mkdir -p ~/code/test dir`
2. `npx @react-native-community/cli@latest init TestingSpaces`
3. `npm run ios`

Observe the build fails due to the Build Phase of `Bundle React Native code and images`

Modify the shell script in the build phase to:

```bash
set -e

export CONFIG_JSON=$(sed -e "s|HELLOWORLD_PATH|$(realpath "${SRCROOT}/../")|g" "${SRCROOT}/../.react-native.config")

WITH_ENVIRONMENT="$REACT_NATIVE_PATH/scripts/xcode/with-environment.sh"
REACT_NATIVE_XCODE="$REACT_NATIVE_PATH/scripts/react-native-xcode.sh"

/bin/sh -c "\"$WITH_ENVIRONMENT\" \"$REACT_NATIVE_XCODE\""
```

Run the iOS application again and see that it builds successfully