### PR TITLE
Fix resizeMethod prop

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
@@ -92,12 +92,12 @@ ImageProps::ImageProps(
                     {})),
       resizeMethod(
           ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
-              ? sourceProps.internal_analyticTag
+              ? sourceProps.resizeMethod
               : convertRawProp(
                     context,
                     rawProps,
                     "resizeMethod",
-                    sourceProps.internal_analyticTag,
+                    sourceProps.resizeMethod,
                     {})),
       resizeMultiplier(
           ReactNativeFeatureFlags::enableCppPropsIteratorSetter()


### PR DESCRIPTION
Summary:
The `resizeMethod` prop was reading from `internal_analyticTag` and not setting on the backing image, this change remaps it

Changelog: [General][Fixed] resizeMethod was not propagated correctly on Android with Props 2.0

Reviewed By: javache

Differential Revision: D84716400


