### PR TITLE
Fix ActionSheet presented with an interactive background

### DIFF
--- a/packages/react-native/React/CoreModules/RCTActionSheetManager.mm
+++ b/packages/react-native/React/CoreModules/RCTActionSheetManager.mm
@@ -58,8 +58,18 @@ RCT_EXPORT_MODULE()
   } else {
     alertController.popoverPresentationController.permittedArrowDirections = 0;
   }
-  alertController.popoverPresentationController.sourceView = sourceView;
-  alertController.popoverPresentationController.sourceRect = sourceView.bounds;
+
+  if ([UIDevice.currentDevice userInterfaceIdiom] == UIUserInterfaceIdiomPad) {
+    // These information only make sense for iPad, where the action sheet needs
+    // to be presented from a specific anchor point.
+    // Before iOS 26, if these information were passed on an iOS app, the action sheet
+    // was ignoring them. after iOS 26, they are took into consideration and the
+    // sheet behavior changes, for example the user can interact with the background
+    // By applying these informations only to the iPad use case, we revert to the previous
+    // behavior.
+    alertController.popoverPresentationController.sourceView = sourceView;
+    alertController.popoverPresentationController.sourceRect = sourceView.bounds;
+  }
   [parentViewController presentViewController:alertController animated:YES completion:nil];
 }
 


### PR DESCRIPTION
Summary:
iOS 26 changed how the `popoverPresentationController.sourceView`and the `popoverPresentationController.sourceRect` are handled by iOS.

Before iOS 26, those two properties were ignored by iPhones but used by iPads.

After iOS 26, those two properties are used by both iPhones and iPads.

This introduced an issue where users presenting an action sheet were actually able to interact with the back button on iPhone even ehwn they were not supposed to.

This change adds a condition over the idiom used (iPhone/iPad) to make sure that we use the anchors only with the iPad idions as it used to be before.

## Changelog:
[iOS][Fixed] - Revert action sheet behavior not to break apps on iOS 26

Differential Revision: D84842625


