### PR TITLE
Fixed tint color for action sheets

### DIFF
--- a/packages/react-native/React/CoreModules/RCTActionSheetManager.mm
+++ b/packages/react-native/React/CoreModules/RCTActionSheetManager.mm
@@ -168,8 +168,15 @@ RCT_EXPORT_METHOD(showActionSheetWithOptions
                                                                callback(@[ @(localIndex) ]);
                                                              }
                                                            }];
-      if (isCancelButtonIndex) {
+      if (isCancelButtonIndex && cancelButtonTintColor != NULL) {
         [actionButton setValue:cancelButtonTintColor forKey:@"titleTextColor"];
+      } else if (style != UIAlertActionStyleDestructive) {
+        // iOS 26 does not apply the tint color automatically to all the buttons.
+        // So we ca forcibly apply the tint color to all the buttons that are not
+        // destructive (which usually have a different tint color) nor they are
+        // cancel buttons (which might have a different tint color).
+        // This makes the Action Sheet behave as in iOS < 26.
+        [actionButton setValue:tintColor forKey:@"titleTextColor"];
       }
       [alertController addAction:actionButton];
 


### PR DESCRIPTION
Summary:
in iOS 26, the tintColor prop is not applied by default to the action sheets buttons.

This change fixes it by restoring the same behavior we had before iOS 26.

## Changelog:
[iOS][Fixed] - Apply tint color to Actions sheets buttons

Differential Revision: D84844319


