### PR TITLE
RNGP - Move matchingFallbacks to be called inside `maybeCreate("debugOptimized")`

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/AgpConfiguratorUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/AgpConfiguratorUtils.kt
@@ -44,12 +44,8 @@ internal object AgpConfiguratorUtils {
                   maybeCreate("debugOptimized").apply {
                     manifestPlaceholders["usesCleartextTraffic"] = "true"
                     initWith(debug)
-                    externalNativeBuild {
-                      cmake {
-                        arguments("-DCMAKE_BUILD_TYPE=Release")
-                        matchingFallbacks += listOf("release")
-                      }
-                    }
+                    matchingFallbacks += listOf("release")
+                    externalNativeBuild { cmake { arguments("-DCMAKE_BUILD_TYPE=Release") } }
                   }
                 }
               }


### PR DESCRIPTION
Summary:
The `marchingFallback` directive is applied directly on the build type.
However here is invoked inside the `externalNativeBuild` making it confusing, because in reality
it has nothing to do with `externalNativeBuild`. So I'm moving it to the correct location
(this has no effect on the build setup, is just to make the code easier to read).

Changelog:
[Internal] [Changed] -

Differential Revision: D84921628


