### PR TITLE
Explicitly set default values for fields of HostTargetMetadata struct

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
@@ -44,12 +44,12 @@ class HostTarget;
 class HostTargetTraceRecording;
 
 struct HostTargetMetadata {
-  std::optional<std::string> appDisplayName;
-  std::optional<std::string> appIdentifier;
-  std::optional<std::string> deviceName;
+  std::optional<std::string> appDisplayName{};
+  std::optional<std::string> appIdentifier{};
+  std::optional<std::string> deviceName{};
   std::optional<std::string> integrationName;
-  std::optional<std::string> platform;
-  std::optional<std::string> reactNativeVersion;
+  std::optional<std::string> platform{};
+  std::optional<std::string> reactNativeVersion{};
 };
 
 /**


### PR DESCRIPTION
Summary:
Explicitly set default values for fields of HostTargetMetadata struct

changelog: [internal] internal

Reviewed By: cortinico

Differential Revision: D84952243


