### PR TITLE
fix(community-cli-plugin): Add description in target debugs to distinguish RN Bridge and reanimated

### DIFF
--- a/packages/community-cli-plugin/src/commands/start/OpenDebuggerKeyboardHandler.js
+++ b/packages/community-cli-plugin/src/commands/start/OpenDebuggerKeyboardHandler.js
@@ -94,21 +94,20 @@ export default class OpenDebuggerKeyboardHandler {
         const target = targets[0];
         void this.#tryOpenDebuggerForTarget(target);
       } else {
-        this.#targetsShownForSelection = targets;
-
         if (targets.length > 9) {
           this.#log(
             'warn',
             '10 or more debug targets available, showing the first 9.',
           );
         }
-        const firstNineTargets = targets.slice(0, 9);
+        const targetsShown = targets.slice(0, 9);
         const hasDuplicateTitles =
-          new Set(firstNineTargets.map(target => target.title)).size <
-          firstNineTargets.length;
+          new Set(targetsShown.map(target => target.title)).size <
+          targetsShown.length;
+        this.#targetsShownForSelection = targetsShown;
 
         this.#setTerminalMenu(
-          `Multiple debug targets available, please select:\n  ${firstNineTargets
+          `Multiple debug targets available, please select:\n  ${targetsShown
             .map(({title, description}, i) => {
               const descriptionSuffix = hasDuplicateTitles
                 ? ` (${description})`


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

As I point out in this [issue](https://github.com/facebook/react-native/issues/50696#issuecomment-3418457545), when integrating reanimated, we end up with two debug targets having the same title. This can confuse and lead people to think something is wrong.

Adding the description alongside the title to better explain where the second debug target comes from eliminates the confusion.

Changelog: [Internal]

## Test Plan:

Tested in [this RN 82 project](https://github.com/dprevost-LMI/rn82/tree/reanimated) with the latest reanimated by overriding the code in the `node_module`

Before:
<img width="406" height="94" alt="Screenshot 2025-10-18 at 10 52 18 AM" src="https://github.com/user-attachments/assets/e517bf53-5176-479f-9fbb-3f4b46089395" />

After:
<img width="522" height="78" alt="Screenshot 2025-10-18 at 10 56 27 AM" src="https://github.com/user-attachments/assets/aa14aebd-4c13-4249-bb00-63972302ab40" />
