### PR TITLE
Add overScrollMode prop to scroll view

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/android/react/renderer/components/scrollview/HostPlatformScrollViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/android/react/renderer/components/scrollview/HostPlatformScrollViewProps.cpp
@@ -47,9 +47,16 @@ HostPlatformScrollViewProps::HostPlatformScrollViewProps(
                     rawProps,
                     "fadingEdgeLength",
                     sourceProps.fadingEdgeLength,
-                    nullptr))
-
-{}
+                    nullptr)),
+      overScrollMode(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.overScrollMode
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "overScrollMode",
+                    sourceProps.overScrollMode,
+                    "auto")) {}
 
 void HostPlatformScrollViewProps::setProp(
     const PropsParserContext& context,
@@ -67,6 +74,7 @@ void HostPlatformScrollViewProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(sendMomentumEvents);
     RAW_SET_PROP_SWITCH_CASE_BASIC(nestedScrollEnabled);
     RAW_SET_PROP_SWITCH_CASE_BASIC(fadingEdgeLength);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(overScrollMode);
   }
 }
 
@@ -86,7 +94,11 @@ SharedDebugStringConvertibleList HostPlatformScrollViewProps::getDebugProps()
           debugStringConvertibleItem(
               "nestedScrollEnabled",
               nestedScrollEnabled,
-              defaultScrollViewProps.nestedScrollEnabled)};
+              defaultScrollViewProps.nestedScrollEnabled),
+          debugStringConvertibleItem(
+              "overScrollMode",
+              overScrollMode,
+              defaultScrollViewProps.overScrollMode)};
 }
 #endif
 
@@ -360,6 +372,10 @@ folly::dynamic HostPlatformScrollViewProps::getDiffProps(
 
   if (fadingEdgeLength != oldProps->fadingEdgeLength) {
     result["fadingEdgeLength"] = fadingEdgeLength;
+  }
+
+  if (overScrollMode != oldProps->overScrollMode) {
+    result["overScrollMode"] = overScrollMode;
   }
 
   return result;

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/android/react/renderer/components/scrollview/HostPlatformScrollViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/android/react/renderer/components/scrollview/HostPlatformScrollViewProps.h
@@ -33,6 +33,7 @@ class HostPlatformScrollViewProps : public BaseScrollViewProps {
   bool sendMomentumEvents{};
   bool nestedScrollEnabled{};
   folly::dynamic fadingEdgeLength{};
+  std::string overScrollMode{"auto"};
 
 #pragma mark - DebugStringConvertible
 


### PR DESCRIPTION
Summary:
Adding the `overScrollMode` property to the Android scroll view props.

Changelog: [Internal]

Differential Revision: D85019462


