### PR TITLE
Add endFillColor prop to scroll view

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/android/react/renderer/components/scrollview/HostPlatformScrollViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/android/react/renderer/components/scrollview/HostPlatformScrollViewProps.cpp
@@ -56,7 +56,16 @@ HostPlatformScrollViewProps::HostPlatformScrollViewProps(
                     rawProps,
                     "overScrollMode",
                     sourceProps.overScrollMode,
-                    "auto")) {}
+                    "auto")),
+      endFillColor(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.endFillColor
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "endFillColor",
+                    sourceProps.endFillColor,
+                    clearColor())) {}
 
 void HostPlatformScrollViewProps::setProp(
     const PropsParserContext& context,
@@ -75,6 +84,7 @@ void HostPlatformScrollViewProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(nestedScrollEnabled);
     RAW_SET_PROP_SWITCH_CASE_BASIC(fadingEdgeLength);
     RAW_SET_PROP_SWITCH_CASE_BASIC(overScrollMode);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(endFillColor);
   }
 }
 
@@ -98,7 +108,11 @@ SharedDebugStringConvertibleList HostPlatformScrollViewProps::getDebugProps()
           debugStringConvertibleItem(
               "overScrollMode",
               overScrollMode,
-              defaultScrollViewProps.overScrollMode)};
+              defaultScrollViewProps.overScrollMode),
+          debugStringConvertibleItem(
+              "endFillColor",
+              endFillColor,
+              defaultScrollViewProps.endFillColor)};
 }
 #endif
 
@@ -376,6 +390,10 @@ folly::dynamic HostPlatformScrollViewProps::getDiffProps(
 
   if (overScrollMode != oldProps->overScrollMode) {
     result["overScrollMode"] = overScrollMode;
+  }
+
+  if (endFillColor != oldProps->endFillColor) {
+    result["endFillColor"] = *endFillColor;
   }
 
   return result;

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/android/react/renderer/components/scrollview/HostPlatformScrollViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/android/react/renderer/components/scrollview/HostPlatformScrollViewProps.h
@@ -34,6 +34,7 @@ class HostPlatformScrollViewProps : public BaseScrollViewProps {
   bool nestedScrollEnabled{};
   folly::dynamic fadingEdgeLength{};
   std::string overScrollMode{"auto"};
+  SharedColor endFillColor{clearColor()};
 
 #pragma mark - DebugStringConvertible
 


### PR DESCRIPTION
Summary:
Adding the Android `endFillColor` property to the scroll view props, setting the default value to `TRANSPARENT`.

Changelog: [Internal]

Differential Revision: D85021077


