### PR TITLE
JSBigString implements jsi::Buffer

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/JSLoader.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/JSLoader.cpp
@@ -72,7 +72,7 @@ loadScriptFromAssets(AAssetManager* manager, const std::string& assetName) {
       }
 
       auto buf = std::make_unique<JSBigBufferString>(script->size());
-      memcpy(buf->data(), script->c_str(), script->size());
+      memcpy(buf->mutableData(), script->c_str(), script->size());
       return buf;
     }
   }

--- a/packages/react-native/ReactCommon/cxxreact/JSIndexedRAMBundle.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/JSIndexedRAMBundle.cpp
@@ -60,8 +60,8 @@ void JSIndexedRAMBundle::init() {
       "header size must exactly match the input file format");
 
   readBundle(reinterpret_cast<char*>(header), sizeof(header));
-  const size_t numTableEntries = folly::Endian::little(header[1]);
-  const size_t startupCodeSize = folly::Endian::little(header[2]);
+  size_t numTableEntries = folly::Endian::little(header[1]);
+  std::streamsize startupCodeSize = folly::Endian::little(header[2]);
 
   // allocate memory for meta data and lookup table.
   m_table = ModuleTable(numTableEntries);
@@ -73,7 +73,7 @@ void JSIndexedRAMBundle::init() {
   // read the startup code
   m_startupCode = std::make_unique<JSBigBufferString>(startupCodeSize - 1);
 
-  readBundle(m_startupCode->data(), startupCodeSize - 1);
+  readBundle(m_startupCode->mutableData(), startupCodeSize - 1);
 }
 
 JSIndexedRAMBundle::Module JSIndexedRAMBundle::getModule(
@@ -109,8 +109,7 @@ std::string JSIndexedRAMBundle::getModuleCode(const uint32_t id) const {
   return ret;
 }
 
-void JSIndexedRAMBundle::readBundle(char* buffer, const std::streamsize bytes)
-    const {
+void JSIndexedRAMBundle::readBundle(char* buffer, std::streamsize bytes) const {
   if (!m_bundle->read(buffer, bytes)) {
     if ((m_bundle->rdstate() & std::ios::eofbit) != 0) {
       throw std::ios_base::failure("Unexpected end of RAM Bundle file");

--- a/packages/react-native/ReactCommon/jsiexecutor/jsireact/JSIExecutor.cpp
+++ b/packages/react-native/ReactCommon/jsiexecutor/jsireact/JSIExecutor.cpp
@@ -168,8 +168,7 @@ void JSIExecutor::loadBundle(
     ReactMarker::logTaggedMarker(
         ReactMarker::RUN_JS_BUNDLE_START, scriptName.c_str());
   }
-  runtime_->evaluateJavaScript(
-      std::make_unique<BigStringBuffer>(std::move(script)), sourceURL);
+  runtime_->evaluateJavaScript(std::move(script), sourceURL);
   flush();
   if (hasLogger) {
     ReactMarker::logTaggedMarker(
@@ -212,7 +211,7 @@ void JSIExecutor::registerBundle(
           "Empty bundle registered with ID " + tag + " from " + bundlePath);
     }
     runtime_->evaluateJavaScript(
-        std::make_unique<BigStringBuffer>(std::move(script)),
+        std::move(script),
         JSExecutor::getSyntheticBundlePath(bundleId, bundlePath));
   }
   ReactMarker::logTaggedMarker(

--- a/packages/react-native/ReactCommon/jsiexecutor/jsireact/JSIExecutor.h
+++ b/packages/react-native/ReactCommon/jsiexecutor/jsireact/JSIExecutor.h
@@ -49,7 +49,7 @@ namespace facebook::react {
 using JSIScopedTimeoutInvoker =
     std::function<void(const std::function<void()> &invokee, std::function<std::string()> errorMessageProducer)>;
 
-class BigStringBuffer : public jsi::Buffer {
+class [[deprecated("JSBigString implements jsi::Buffer directly")]] BigStringBuffer : public jsi::Buffer {
  public:
   BigStringBuffer(std::unique_ptr<const JSBigString> script) : script_(std::move(script)) {}
 
@@ -60,7 +60,7 @@ class BigStringBuffer : public jsi::Buffer {
 
   const uint8_t *data() const override
   {
-    return reinterpret_cast<const uint8_t *>(script_->c_str());
+    return script_->data();
   }
 
  private:


### PR DESCRIPTION
Summary:
We don't need `BigStringBuffer` as a separate abstraction when `JSBigString` implements almost exactly the same interface.

Changelog: [General][Changed] BigStringBuffer is deprecated and will be removed in a future release - use JSBigString instead

Differential Revision: D84458636


