### PR TITLE
always invoke onRender via UIManagerNativeAnimatedDelegate

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.cpp
@@ -539,7 +539,7 @@ void NativeAnimatedNodesManager::startRenderCallbackIfNeeded() {
   }
 
   if (startOnRenderCallback_) {
-    startOnRenderCallback_([this]() { onRender(); });
+    startOnRenderCallback_();
   }
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.h
@@ -61,7 +61,7 @@ class NativeAnimatedNodesManager {
       std::function<void(Tag, const folly::dynamic&)>;
   using FabricCommitCallback =
       std::function<void(std::unordered_map<Tag, folly::dynamic>&)>;
-  using StartOnRenderCallback = std::function<void(std::function<void()>&&)>;
+  using StartOnRenderCallback = std::function<void()>;
   using StopOnRenderCallback = std::function<void()>;
 
   explicit NativeAnimatedNodesManager(

--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManagerProvider.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManagerProvider.h
@@ -13,27 +13,32 @@
 
 namespace facebook::react {
 
+class AnimatedMountingOverrideDelegate;
+
 class UIManagerNativeAnimatedDelegateImpl
     : public UIManagerNativeAnimatedDelegate {
  public:
-  explicit UIManagerNativeAnimatedDelegateImpl(
-      std::weak_ptr<NativeAnimatedNodesManager> nativeAnimatedNodesManager);
+  explicit UIManagerNativeAnimatedDelegateImpl();
 
   void runAnimationFrame() override;
+
+  void setNativeAnimatedNodesManager(
+      std::weak_ptr<NativeAnimatedNodesManager> manager) {
+    nativeAnimatedNodesManager_ = manager;
+  }
 
  private:
   std::weak_ptr<NativeAnimatedNodesManager> nativeAnimatedNodesManager_;
 };
 
-class AnimatedMountingOverrideDelegate;
-
 class NativeAnimatedNodesManagerProvider {
  public:
+  using StartOnRenderCallback = std::function<void(std::function<void()>&&)>;
+  using StopOnRenderCallback = NativeAnimatedNodesManager::StopOnRenderCallback;
+
   NativeAnimatedNodesManagerProvider(
-      NativeAnimatedNodesManager::StartOnRenderCallback startOnRenderCallback =
-          nullptr,
-      NativeAnimatedNodesManager::StopOnRenderCallback stopOnRenderCallback =
-          nullptr);
+      StartOnRenderCallback startOnRenderCallback = nullptr,
+      StopOnRenderCallback stopOnRenderCallback = nullptr);
 
   std::shared_ptr<NativeAnimatedNodesManager> getOrCreate(
       jsi::Runtime& runtime,
@@ -56,8 +61,8 @@ class NativeAnimatedNodesManagerProvider {
   std::shared_ptr<AnimatedMountingOverrideDelegate>
       animatedMountingOverrideDelegate_;
 
-  NativeAnimatedNodesManager::StartOnRenderCallback startOnRenderCallback_;
-  NativeAnimatedNodesManager::StopOnRenderCallback stopOnRenderCallback_;
+  StartOnRenderCallback startOnRenderCallback_;
+  StopOnRenderCallback stopOnRenderCallback_;
 
   std::unique_ptr<MergedValueDispatcher> mergedValueDispatcher_;
 };


### PR DESCRIPTION
Summary:
## Changelog:

[Internal] [Added] - always invoke onRender via UIManagerNativeAnimatedDelegate

Previously only android invokes `onRender` via UIManagerNativeAnimatedDelegate::runAnimationFrame()
consolidating so it's easier for debugging, also in cases where we want to add extra work per frame (e.g. add performance logging) in AnimatedNodesManagerProvider

Reviewed By: sammy-SC

Differential Revision: D85071075


