### PR TITLE
fix: add clearMarks and clearMeasures to performance global stub

### DIFF
--- a/packages/react-native/Libraries/Core/setUpPerformance.js
+++ b/packages/react-native/Libraries/Core/setUpPerformance.js
@@ -20,7 +20,9 @@ if (NativePerformance) {
     // $FlowExpectedError[cannot-write]
     global.performance = {
       mark: () => {},
+      clearMarks: () => {},
       measure: () => {},
+      clearMeasures: () => {},
       now: () => {
         const performanceNow = global.nativePerformanceNow || Date.now;
         return performanceNow();


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

React started using `clearMeasures` in https://github.com/facebook/react/pull/34803. It only does it if `performance.measure()` is defined. This should be enough for a  feature check of User Timings API presence, but out stub doesn't follow the same spec.

Adding `clearMarks()` and `clearMeasures()` stubs to the object.

Differential Revision: D85082720


