### PR TITLE
Ensure JVM thread is attached when destroying FabricMountingManager

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.h
@@ -25,6 +25,7 @@ class FabricMountingManager final {
   FabricMountingManager(
       jni::global_ref<JFabricUIManager::javaobject>& javaUIManager);
   FabricMountingManager(const FabricMountingManager&) = delete;
+  ~FabricMountingManager();
 
   void onSurfaceStart(SurfaceId surfaceId);
 


### PR DESCRIPTION
Summary:
Observed some crashes coming from `schedulerDidRequestPreliminaryViewAllocation` which seemed to point at the FabricMountingManager being destroyed from the Hades GC thread. That thread is not attached to the JVM, so would crash when trying to destroy this global_ref.

Changelog: [Internal]

Differential Revision: D85143603


