### PR TITLE
[iOS] Fixes: Unwanted gradient appearing when using border|TopEndR|BottomStart|BottomEnd|TopStartRadius

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -730,7 +730,7 @@ static void RCTAddContourEffectToLayer(
     UIEdgeInsets imageCapInsets = image.capInsets;
     CGRect contentsCenter = CGRect{
         CGPoint{imageCapInsets.left / imageSize.width, imageCapInsets.top / imageSize.height},
-        CGSize{(CGFloat)1.0 / imageSize.width, (CGFloat)1.0 / imageSize.height}};
+        0, 0};
     layer.contents = (id)image.CGImage;
     layer.contentsScale = image.scale;
 

--- a/packages/react-native/React/Views/RCTView.m
+++ b/packages/react-native/React/Views/RCTView.m
@@ -856,7 +856,7 @@ static CGFloat RCTDefaultIfNegativeTo(CGFloat defaultValue, CGFloat x)
     CGSize size = image.size;
     UIEdgeInsets insets = image.capInsets;
     CGRectMake(
-        insets.left / size.width, insets.top / size.height, (CGFloat)1.0 / size.width, (CGFloat)1.0 / size.height);
+        insets.left / size.width, insets.top / size.height, 0, 0);
   });
 
   layer.contents = (id)image.CGImage;


### PR DESCRIPTION
## Summary:

A gradient appears when a square has one rounded rect.

Fix: 
1 .https://github.com/facebook/react-native/issues/49442
2. https://github.com/callstack/react-native-paper/issues/4662

This PR (https://github.com/facebook/react-native/pull/49531) provides a workaround, but in my opinion this issue should never occur.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[IOS] [FIXED] - Message

## Test Plan:

I have create a native sample (https://github.com/MichelBahl/MinimalSampleGradient) to reproduce the issue.

