### PR TITLE
Run flingAndSnap logic from ACTION_SCROLL events

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -658,6 +658,38 @@ public class ReactScrollView extends ScrollView
       return false;
     }
 
+    // Handle ACTION_SCROLL events (mouse wheel, trackpad, joystick)
+    if (ev.getActionMasked() == MotionEvent.ACTION_SCROLL) {
+      float vScroll = ev.getAxisValue(MotionEvent.AXIS_VSCROLL);
+      if (vScroll != 0) {
+        // Perform the scroll
+        boolean result = super.dispatchGenericMotionEvent(ev);
+        // Schedule snap alignment to run after scrolling stops
+        if (result
+            && (mPagingEnabled
+                || mSnapInterval != 0
+                || mSnapOffsets != null
+                || mSnapToAlignment != SNAP_ALIGNMENT_DISABLED)) {
+          // Cancel any pending post-touch runnable and reschedule
+          if (mPostTouchRunnable != null) {
+            removeCallbacks(mPostTouchRunnable);
+          }
+          mPostTouchRunnable =
+              new Runnable() {
+                @Override
+                public void run() {
+                  mPostTouchRunnable = null;
+                  // Trigger snap alignment now that scrolling has stopped
+                  handlePostTouchScrolling(0, 0);
+                }
+              };
+          ViewCompat.postOnAnimationDelayed(
+              this, mPostTouchRunnable, ReactScrollViewHelper.MOMENTUM_DELAY);
+        }
+        return result;
+      }
+    }
+
     return super.dispatchGenericMotionEvent(ev);
   }
 


### PR DESCRIPTION
Summary:
Joysticks, mouse wheels, and trackpads can issue an `ACTION_SCROLL` event when performing scroll. However, the `ACTION_SCROLL` generic motion event does not run the post touch runnable and paging/snap alignment is not honored when these events are received. To fix this, both ScrollView implementations should call `handlePostTouchScrolling` with a 0 velocity, ensuring that momentum events are sent, fabric scroll state is updated, and `flingAndSnap` is properly called to align to a page. 

This change adds some checks to queue a runnable that calls `handlePostTouchScrolling` after no more `ACTION_SCROLL` events are received in the same 20ms delay it uses to determine a stable frame. The end result is that snap alignments are correctly honored

Changelog: [Android][Fixed] - Controller-driven scroll events now honor paging/snap alignment

Differential Revision: D85172309


