### PR TITLE
c++: Simplify module lookup

### DIFF
--- a/packages/react-native/Libraries/TurboModule/TurboModuleRegistry.js
+++ b/packages/react-native/Libraries/TurboModule/TurboModuleRegistry.js
@@ -24,15 +24,9 @@ function requireModule<T: TurboModule>(name: string): ?T {
     }
   }
 
-  if (
-    global.RN$Bridgeless !== true ||
-    global.RN$TurboInterop === true ||
-    global.RN$UnifiedNativeModuleProxy === true
-  ) {
-    const legacyModule: ?T = NativeModules[name];
-    if (legacyModule != null) {
-      return legacyModule;
-    }
+  const legacyModule: ?T = NativeModules[name];
+  if (legacyModule != null) {
+    return legacyModule;
   }
 
   return null;

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.cpp
@@ -128,7 +128,6 @@ void TurboModuleBinding::install(
     return;
   }
 
-  defineReadOnlyGlobal(runtime, "RN$UnifiedNativeModuleProxy", true);
   defineReadOnlyGlobal(
       runtime,
       "nativeModuleProxy",


### PR DESCRIPTION
Summary:
All these flags were introduced for rollout purposes. We no longer need them. Let's get rid of them


Changelog: [Internal]

Reviewed By: christophpurrer

Differential Revision: D85171189


