### PR TITLE
remove isomorphic version checks from legacy react native renderers

### DIFF
--- a/packages/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js
@@ -7,9 +7,9 @@
  * @noflow
  * @nolint
  * @preventMunge
- * @generated SignedSource<<90e5b8f55761c6a4805052d5b49689b8>>
  *
- * This file was sync'd from the facebook/react repository.
+ * This file is no longer sync'd from the facebook/react repository.
+ * The version compatability check is removed. Use at your own risk.
  */
 
 "use strict";
@@ -19455,13 +19455,6 @@ __DEV__ &&
     setSuspenseHandler = function (newShouldSuspendImpl) {
       shouldSuspendImpl = newShouldSuspendImpl;
     };
-    var isomorphicReactPackageVersion = React.version;
-    if ("19.2.0" !== isomorphicReactPackageVersion)
-      throw Error(
-        'Incompatible React versions: The "react" and "react-native-renderer" packages must have the exact same version. Instead got:\n  - react:                  ' +
-          (isomorphicReactPackageVersion +
-            "\n  - react-native-renderer:  19.2.0\nLearn more: https://react.dev/warnings/version-mismatch")
-      );
     if (
       "function" !==
       typeof ReactNativePrivateInterface.ReactFiberErrorDialog.showErrorDialog

--- a/packages/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-prod.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-prod.js
@@ -7,9 +7,9 @@
  * @noflow
  * @nolint
  * @preventMunge
- * @generated SignedSource<<14f9eca680f3065d18eda114fb4bea9f>>
  *
- * This file was sync'd from the facebook/react repository.
+ * This file is no longer sync'd from the facebook/react repository.
+ * The version compatability check is removed. Use at your own risk.
  */
 
 "use strict";
@@ -10918,13 +10918,6 @@ function updateContainer(element, container, parentComponent, callback) {
     entangleTransitions(element, parentComponent, lane));
   return lane;
 }
-var isomorphicReactPackageVersion = React.version;
-if ("19.2.0" !== isomorphicReactPackageVersion)
-  throw Error(
-    'Incompatible React versions: The "react" and "react-native-renderer" packages must have the exact same version. Instead got:\n  - react:                  ' +
-      (isomorphicReactPackageVersion +
-        "\n  - react-native-renderer:  19.2.0\nLearn more: https://react.dev/warnings/version-mismatch")
-  );
 if (
   "function" !==
   typeof ReactNativePrivateInterface.ReactFiberErrorDialog.showErrorDialog

--- a/packages/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-profiling.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-profiling.js
@@ -7,9 +7,9 @@
  * @noflow
  * @nolint
  * @preventMunge
- * @generated SignedSource<<238b7d9e5ffe0f30b64b3b5c7c156088>>
  *
- * This file was sync'd from the facebook/react repository.
+ * This file is no longer sync'd from the facebook/react repository.
+ * The version compatability check is removed. Use at your own risk.
  */
 
 "use strict";
@@ -12713,13 +12713,6 @@ function updateContainer(element, container, parentComponent, callback) {
     entangleTransitions(element, parentComponent, lane));
   return lane;
 }
-var isomorphicReactPackageVersion = React.version;
-if ("19.2.0" !== isomorphicReactPackageVersion)
-  throw Error(
-    'Incompatible React versions: The "react" and "react-native-renderer" packages must have the exact same version. Instead got:\n  - react:                  ' +
-      (isomorphicReactPackageVersion +
-        "\n  - react-native-renderer:  19.2.0\nLearn more: https://react.dev/warnings/version-mismatch")
-  );
 if (
   "function" !==
   typeof ReactNativePrivateInterface.ReactFiberErrorDialog.showErrorDialog

--- a/packages/react-native/Libraries/Renderer/shims/ReactNative.js
+++ b/packages/react-native/Libraries/Renderer/shims/ReactNative.js
@@ -7,7 +7,9 @@
  * @noformat
  * @nolint
  * @flow
- * @generated SignedSource<<8f46fdc9267fcc4fdc9e76842fe24066>>
+ *
+ * This file is no longer sync'd from the facebook/react repository.
+ * The version compatability check is removed. Use at your own risk.
  */
 'use strict';
 


### PR DESCRIPTION
Summary:
We're not syncing the legacy renderers, which means the React package will continue to move forward while these stay frozen. That means we need to remove the version compatibility checks between react and the legacy ReactNativeRenderers.

Changelog:
[Internal]

Differential Revision: D85248891


