### PR TITLE
Hotfix VirtualViewContainerStateExperimental delete

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/VirtualViewContainerStateExperimental.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/VirtualViewContainerStateExperimental.kt
@@ -275,7 +275,7 @@ internal class IntervalTree(private val horizontal: Boolean) : MutableCollection
     if (bf < -1) {
       if (balanceFactor(node.right) > 0) {
         node.right =
-            rotateLeft(
+            rotateRight(
                 requireNotNull(node.right) {
                   "[IntervalTree] node.right must not be null when performing right rotation around it"
                 }
@@ -324,6 +324,7 @@ internal class IntervalTree(private val horizontal: Boolean) : MutableCollection
       return null
     }
 
+    var nodeToReturn: IntervalNode? = node
     when {
       compareIntervals(target.interval, node.interval) < 0 -> {
         node.left = delete(node.left, target)
@@ -333,26 +334,31 @@ internal class IntervalTree(private val horizontal: Boolean) : MutableCollection
       }
       else -> {
         // Node to delete found
-        return when {
-          node.left == null -> node.right
-          node.right == null -> node.left
-          else -> {
-            val successor =
-                findMin(
-                    requireNotNull(node.right) {
-                      "[IntervalTree] node.right must not be null when finding node's successor"
-                    }
-                )
-            node.virtualView = successor.virtualView
-            node.interval = successor.interval
-            node.right = delete(node.right, successor)
-            node
-          }
-        }
+        nodeToReturn =
+            when {
+              node.left == null -> node.right
+              node.right == null -> node.left
+              else -> {
+                val successor =
+                    findMin(
+                        requireNotNull(node.right) {
+                          "[IntervalTree] node.right must not be null when finding node's successor"
+                        }
+                    )
+                node.virtualView = successor.virtualView
+                node.interval = successor.interval
+                node.right = delete(node.right, successor)
+                node
+              }
+            }
       }
     }
 
-    return balance(node)
+    if (nodeToReturn == null) {
+      return null
+    } else {
+      return balance(nodeToReturn)
+    }
   }
 
   private fun queryHelper(


### PR DESCRIPTION
Summary:
Changelog[Internal] - 
Fix faulty changes made to Interval Tree in previous diff.

The issue was in the right-right rotation case of the internal Interval Tree implementation:

```
// Right heavy
    if (bf < -1) {
      if (balanceFactor(node.right) > 0) {
        node.right =
            rotateRight(...)
```

This diff also includes a minor update to logic in IntervalTree's `delete` operation.  There was previously a missing `balance` operation.

Reviewed By: lunaleaps

Differential Revision: D85263661


