### PR TITLE
Add Hermes version to the new app screen

### DIFF
--- a/packages/new-app-screen/src/NewAppScreen.js
+++ b/packages/new-app-screen/src/NewAppScreen.js
@@ -123,7 +123,8 @@ function getHermesLabel(): React.Node {
 
   return (
     <ThemedText color="secondary" style={styles.label}>
-      JS Engine: Hermes
+      JS Engine: Hermes (
+      {global.HermesInternal.getRuntimeProperties?.()['OSS Release Version']})
     </ThemedText>
   );
 }


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Added Hermes version besides information that the app is running using Hermes. This information will be helpful now that Hermes is being published independently from React Native and users are able to choose between two versions at a time (current and V1).

Differential Revision: D85333735


