### PR TITLE
Increase the maximum number of pointers tracked at the same time on iOS to 17

### DIFF
--- a/packages/react-native/React/Fabric/RCTSurfacePointerHandler.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePointerHandler.mm
@@ -437,7 +437,7 @@ struct PointerHasher {
    * We hold the view weakly to prevent a retain cycle.
    */
   __weak UIView *_rootComponentView;
-  RCTIdentifierPool<11> _identifierPool;
+  RCTIdentifierPool<17> _identifierPool;
 
   UIHoverGestureRecognizer *_mouseHoverRecognizer API_AVAILABLE(ios(13.0));
   UIHoverGestureRecognizer *_penHoverRecognizer API_AVAILABLE(ios(13.0));

--- a/packages/react-native/React/Fabric/RCTSurfaceTouchHandler.mm
+++ b/packages/react-native/React/Fabric/RCTSurfaceTouchHandler.mm
@@ -137,7 +137,7 @@ struct PointerHasher {
    * We hold the view weakly to prevent a retain cycle.
    */
   __weak UIView *_rootComponentView;
-  RCTIdentifierPool<11> _identifierPool;
+  RCTIdentifierPool<17> _identifierPool;
 
   RCTSurfacePointerHandler *_pointerHandler;
 }


### PR DESCRIPTION
Summary:
Changelog: [IOS][FIXED] - Raised the maximum number of pointers tracked at the same time to 17

The current pool of pointer ids that can be used at the same time has the size of 11, while the maximum supported by some of the devices is 17 - https://developer.apple.com/forums/thread/17606.

To reproduce this problem use the iPad pro and place more than 11 pointers on the screen - the app becomes unresponsive due to [an infinite loop](https://github.com/facebook/react-native/blob/d93d32547bfadba731999ea251ca5e1d6c6c8912/packages/react-native/React/Fabric/Utils/RCTIdentifierPool.h#L22).

Differential Revision: D85345975


