### PR TITLE
pass down isAsync arg to start/stopOnRenderCallback to indicate thread

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.h
@@ -61,8 +61,8 @@ class NativeAnimatedNodesManager {
       std::function<void(Tag, const folly::dynamic&)>;
   using FabricCommitCallback =
       std::function<void(std::unordered_map<Tag, folly::dynamic>&)>;
-  using StartOnRenderCallback = std::function<void()>;
-  using StopOnRenderCallback = std::function<void()>;
+  using StartOnRenderCallback = std::function<void(bool isAsync)>;
+  using StopOnRenderCallback = std::function<void(bool isAsync)>;
 
   explicit NativeAnimatedNodesManager(
       DirectManipulationCallback&& directManipulationCallback,
@@ -183,12 +183,12 @@ class NativeAnimatedNodesManager {
     // Whenever a batch is flushed to the UI thread, start the onRender
     // callbacks to guarantee they run at least once. E.g., to execute
     // setValue calls.
-    startRenderCallbackIfNeeded();
+    startRenderCallbackIfNeeded(true);
   }
 
   void onRender();
 
-  void startRenderCallbackIfNeeded();
+  void startRenderCallbackIfNeeded(bool isAsync);
 
   void updateNodes(
       const std::set<int>& finishedAnimationValueNodes = {}) noexcept;
@@ -202,7 +202,7 @@ class NativeAnimatedNodesManager {
   bool isOnRenderThread() const noexcept;
 
  private:
-  void stopRenderCallbackIfNeeded() noexcept;
+  void stopRenderCallbackIfNeeded(bool isAsync) noexcept;
 
   bool onAnimationFrame(double timestamp);
 

--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManagerProvider.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManagerProvider.h
@@ -19,7 +19,10 @@ class NativeAnimatedNodesManagerProvider {
  public:
   using FrameRateListenerCallback =
       std::function<void(bool /* shouldEnableListener */)>;
-  using StartOnRenderCallback = std::function<void(std::function<void()>&&)>;
+  // when isAsync is true, it means StartOnRenderCallback is invoked from js
+  // thread, otherwise from main thread
+  using StartOnRenderCallback =
+      std::function<void(std::function<void()>&&, bool /* isAsync */)>;
   using StopOnRenderCallback = NativeAnimatedNodesManager::StopOnRenderCallback;
 
   NativeAnimatedNodesManagerProvider(
@@ -49,6 +52,7 @@ class NativeAnimatedNodesManagerProvider {
       animatedMountingOverrideDelegate_;
 
   FrameRateListenerCallback frameRateListenerCallback_;
+
   StartOnRenderCallback startOnRenderCallback_;
   StopOnRenderCallback stopOnRenderCallback_;
 

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.cpp
@@ -105,16 +105,18 @@ void AnimationBackend::onAnimationFrame(double timestamp) {
   }
 }
 
-void AnimationBackend::start(const Callback& callback) {
+void AnimationBackend::start(const Callback& callback, bool isAsync) {
   callbacks.push_back(callback);
   // TODO: startOnRenderCallback_ should provide the timestamp from the platform
-  startOnRenderCallback_([this]() {
-    onAnimationFrame(
-        std::chrono::steady_clock::now().time_since_epoch().count() / 1000);
-  });
+  startOnRenderCallback_(
+      [this]() {
+        onAnimationFrame(
+            std::chrono::steady_clock::now().time_since_epoch().count() / 1000);
+      },
+      isAsync);
 }
-void AnimationBackend::stop() {
-  stopOnRenderCallback_();
+void AnimationBackend::stop(bool isAsync) {
+  stopOnRenderCallback_(isAsync);
   callbacks.clear();
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.h
@@ -29,8 +29,9 @@ using AnimationMutations = std::vector<AnimationMutation>;
 class AnimationBackend : public UIManagerAnimationBackend {
  public:
   using Callback = std::function<AnimationMutations(float)>;
-  using StartOnRenderCallback = std::function<void(std::function<void()>&&)>;
-  using StopOnRenderCallback = std::function<void()>;
+  using StartOnRenderCallback =
+      std::function<void(std::function<void()>&&, bool /* isAsync */)>;
+  using StopOnRenderCallback = std::function<void(bool /* isAsync */)>;
   using DirectManipulationCallback =
       std::function<void(Tag, const folly::dynamic&)>;
   using FabricCommitCallback =
@@ -56,7 +57,7 @@ class AnimationBackend : public UIManagerAnimationBackend {
       const std::unordered_map<Tag, AnimatedProps>& updates);
 
   void onAnimationFrame(double timestamp) override;
-  void start(const Callback& callback);
-  void stop() override;
+  void start(const Callback& callback, bool isAsync);
+  void stop(bool isAsync) override;
 };
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerAnimationBackend.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerAnimationBackend.h
@@ -18,7 +18,7 @@ class UIManagerAnimationBackend {
 
   virtual void onAnimationFrame(double timestamp) = 0;
   // TODO: T240293839 Move over start() function and mutation types
-  virtual void stop() = 0;
+  virtual void stop(bool isAsync) = 0;
 };
 
 } // namespace facebook::react

--- a/private/react-native-fantom/tester/src/TesterAppDelegate.cpp
+++ b/private/react-native-fantom/tester/src/TesterAppDelegate.cpp
@@ -110,10 +110,10 @@ TesterAppDelegate::TesterAppDelegate(
   g_setNativeAnimatedNowTimestampFunction(StubClock::now);
 
   auto provider = std::make_shared<NativeAnimatedNodesManagerProvider>(
-      [this](std::function<void()>&& onRender) {
+      [this](std::function<void()>&& onRender, bool /*isAsync*/) {
         onAnimationRender_ = std::move(onRender);
       },
-      [this]() { onAnimationRender_ = nullptr; });
+      [this](bool /*isAsync*/) { onAnimationRender_ = nullptr; });
 
   reactHost_ = std::make_unique<ReactHost>(
       reactInstanceConfig,


### PR DESCRIPTION
Summary:
## Changelog:

[Internal] [Added] - pass down isAsync arg to start/stopOnRenderCallback to indicate thread

make it more explicit where start/stopOnRenderCallback is invoked so we can handle it on each platform in a more thread safe way

Differential Revision: D85365058


