### PR TITLE
Add missing INIT_REACT_RUNTIME_START and APP_STARTUP_START in loadScript

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
@@ -241,6 +241,8 @@ void ReactInstance::loadScript(
     if (hasLogger) {
       ReactMarker::logTaggedMarkerBridgeless(
           ReactMarker::RUN_JS_BUNDLE_START, scriptName.c_str());
+      ReactMarker::logMarkerBridgeless(ReactMarker::INIT_REACT_RUNTIME_START);
+      ReactMarker::logMarkerBridgeless(ReactMarker::APP_STARTUP_START);
     }
 
     // Check if the shermes unit is avaliable.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Resolves #53818

On a freshly init bare react native project, upon booting up the iOS simulator, the logs shows the following warnings:
```
Unbalanced calls start/end for tag 20
Unbalanced calls start/end for tag 19
```

The detailed cause is explained in [this comment in the issue thread](https://github.com/facebook/react-native/issues/53818#issuecomment-3441319443), and I'm copying it here for ease of reading:

> The `Unbalanced calls start/end for tag 20` message comes from [RCTPerformanceLogger.markStartForTag](https://github.com/facebook/react-native/blob/2d980558a616d13c542a1d0f8659beb04d31ab08/packages/react-native/React/Base/RCTPerformanceLogger.mm#L78)
> 
> 19 represents `RCTPLAppStartup` case of `RCTPLTag` (react performance logger tag), and 20 represents `RCTPLInitReactRuntime`
> 
> In C++, they are also referred to as `ReactMarker::APP_STARTUP_STOP` and `ReactMarker::INIT_REACT_RUNTIME_STOP` respectively (see [here](https://github.com/facebook/react-native/blob/2d980558a616d13c542a1d0f8659beb04d31ab08/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTPerformanceLoggerUtils.mm#L21) and [here](https://github.com/facebook/react-native/blob/2d980558a616d13c542a1d0f8659beb04d31ab08/packages/react-native/React/CxxBridge/RCTCxxBridge.mm#L116))
> 
> The performance logger logs these "stop" events inside [ReactInstance::loadScript](https://github.com/facebook/react-native/blob/2d980558a616d13c542a1d0f8659beb04d31ab08/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp#L270-L271).
> 
> Notice that [L267-272](https://github.com/facebook/react-native/blob/2d980558a616d13c542a1d0f8659beb04d31ab08/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp#L267-L272), we have:
> ```
>     if (hasLogger) {
>       ReactMarker::logTaggedMarkerBridgeless(
>           ReactMarker::RUN_JS_BUNDLE_STOP, scriptName.c_str());
>       ReactMarker::logMarkerBridgeless(ReactMarker::INIT_REACT_RUNTIME_STOP);
>       ReactMarker::logMarkerBridgeless(ReactMarker::APP_STARTUP_STOP);
>     }
> ```
> 
> But earlier in [L241-244](https://github.com/facebook/react-native/blob/2d980558a616d13c542a1d0f8659beb04d31ab08/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp#L241-L244), we have:
> ```
>     if (hasLogger) {
>       ReactMarker::logTaggedMarkerBridgeless(
>           ReactMarker::RUN_JS_BUNDLE_START, scriptName.c_str());
>     }
> ```

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [FIXED] - Address unexpected warning about "Unbalanced calls start/end for tag 20/19"

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Steps to reproduce are described by original issue reporter [here](https://github.com/facebook/react-native/issues/53818#issue-3426203510). The issue surfaced in a freshly init bare react native project

1. Create a bare react-native project
2. Run iOS simulator
3. "Unbalanced calls start/end for tag 20/19" does not show up in Xcode terminal
