### PR TITLE
Fix releases and nightlies after moving hermes to Hermes repo

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -60,7 +60,6 @@ jobs:
     needs:
       [
         set_release_type,
-        prepare_workspace,
         build_android,
         prebuild_apple_dependencies,
         prebuild_react_native_core,

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -34,7 +34,6 @@ jobs:
     needs:
       [
         set_release_type,
-        prepare_workspace,
         prebuild_apple_dependencies,
         prebuild_react_native_core,
       ]


### PR DESCRIPTION
Summary:
When moving Hermes to the Hermes repo, we mistakenly updated the nightly and the publish_release job to depend on an non-existing job

## Changelog:
[Internal] - Fix CI jobs for nightlies and releases

Differential Revision: D85422837


