### PR TITLE
change(android): make `FabricUIManager#resolveView` not thread specific

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -1032,8 +1032,6 @@ public class FabricUIManager
 
   @Override
   public @Nullable View resolveView(int reactTag) {
-    UiThreadUtil.assertOnUiThread();
-
     SurfaceMountingManager surfaceManager = mMountingManager.getSurfaceManagerForView(reactTag);
     return surfaceManager == null ? null : surfaceManager.getView(reactTag);
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

`FabricUIManager#resolveView` is not using any thread specific annotation, but has a `UiThreadUtil.assertOnUiThread()` check:

https://github.com/facebook/react-native/blob/d9262c60f4c02d66417008970dc9c34b742aaa75/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java#L1034-L1037

However, after checking all data structures used, it appears that all of them are `ConcurrentHashMaps` and thus `FabricUIManager#resolveView` is actually thread safe:

https://github.com/facebook/react-native/blob/d93d32547bfadba731999ea251ca5e1d6c6c8912/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java#L1038

https://github.com/facebook/react-native/blob/d93d32547bfadba731999ea251ca5e1d6c6c8912/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.java#L81

https://github.com/facebook/react-native/blob/d93d32547bfadba731999ea251ca5e1d6c6c8912/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/MountingManager.kt#L43

I am proposing to remove the `UiThreadUtil.assertOnUiThread()` check here.

**Motivation:**

From another thread we want to check if a certain react tag is already mounted in the native view hierarchy. It should be the callers responsibility to make sure to only operate on that view from the UI thread.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] [CHANGED] Make `FabricUIManager#resolveView` not thread specific

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- Run the example app and make sure everything still works
- We tested this change and calling this method from another thread and it works without any weirdnesses 
