### PR TITLE
Remove unused methods from RuntimeAgent

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.cpp
@@ -145,18 +145,6 @@ RuntimeAgent::~RuntimeAgent() {
   sessionState_.lastRuntimeAgentExportedState = getExportedState();
 }
 
-void RuntimeAgent::enableSamplingProfiler() {
-  targetController_.enableSamplingProfiler();
-}
-
-void RuntimeAgent::disableSamplingProfiler() {
-  targetController_.disableSamplingProfiler();
-}
-
-tracing::RuntimeSamplingProfile RuntimeAgent::collectSamplingProfile() {
-  return targetController_.collectSamplingProfile();
-}
-
 #pragma mark - Tracing
 
 RuntimeTracingAgent::RuntimeTracingAgent(

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.h
@@ -85,21 +85,6 @@ class RuntimeAgent final {
    */
   ExportedState getExportedState();
 
-  /**
-   * Start sampling profiler for the corresponding RuntimeTarget.
-   */
-  void enableSamplingProfiler();
-
-  /**
-   * Stop sampling profiler for the corresponding RuntimeTarget.
-   */
-  void disableSamplingProfiler();
-
-  /**
-   * Return recorded sampling profile for the previous sampling session.
-   */
-  tracing::RuntimeSamplingProfile collectSamplingProfile();
-
  private:
   FrontendChannel frontendChannel_;
   RuntimeTargetController& targetController_;


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

These are actually unused and we've changed the approach - CDP agents do not control tracing status.

Differential Revision: D85436029


