### PR TITLE
Fix missing reference updates with syncOnCommit

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/mounting/updateMountedFlag.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/updateMountedFlag.cpp
@@ -65,6 +65,12 @@ void updateMountedFlag(
   for (index = lastIndexAfterFirstStage; index < newChildren.size(); index++) {
     const auto& newChild = newChildren[index];
     newChild->setMounted(true);
+
+    if (commitSource == ShadowTreeCommitSource::React &&
+        ReactNativeFeatureFlags::updateRuntimeShadowNodeReferencesOnCommit()) {
+      newChild->updateRuntimeShadowNodeReference(newChild);
+    }
+
     updateMountedFlag({}, newChild->getChildren(), commitSource);
   }
 


### PR DESCRIPTION
Summary:
When enabling `passChildrenWhenCloningPersistedNodes` and `updateRuntimeShadowNodeReferencesOnCommit`, updates inserting shadow nodes between existing child shadow nodes would result in shadow node reference updates being skipped.

Since `passChildrenWhenCloningPersistedNodes` requires that the react fiber references the mounted shadow node instance at all times, this would result in invalid react renders, bringing back old revisions holding invalid layout metrics.

This diff updates the reference update applied on commit, submitting the updated shadow node references for added shadow nodes. Inserted shadow nodes between existing child shadow nodes will move the previously mounted shadow nodes to the end of the child array. This leads to the `updateMountedFlag` pass to consider these as "added" shadow nodes.

Changelog: [Internal]

Differential Revision: D85406405


