### PR TITLE
Remove CxxModule support from CatalystInstance

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
@@ -157,7 +157,6 @@ public class CatalystInstanceImpl implements CatalystInstance {
         mReactQueueConfiguration.getJSQueueThread(),
         mNativeModulesQueueThread,
         mNativeModuleRegistry.getJavaModules(this),
-        mNativeModuleRegistry.getCxxModules(),
         mInspectorTarget);
     FLog.d(ReactConstants.TAG, "Initializing React Xplat Bridge after initializeBridge");
     Systrace.endSection(TRACE_TAG_REACT);
@@ -212,13 +211,11 @@ public class CatalystInstanceImpl implements CatalystInstance {
     // Extend the Java-visible registry of modules
     mNativeModuleRegistry.registerModules(modules);
     Collection<JavaModuleWrapper> javaModules = modules.getJavaModules(this);
-    Collection<ModuleHolder> cxxModules = modules.getCxxModules();
     // Extend the Cxx-visible registry of modules wrapped in appropriate interfaces
-    jniExtendNativeModules(javaModules, cxxModules);
+    jniExtendNativeModules(javaModules);
   }
 
-  private native void jniExtendNativeModules(
-      Collection<JavaModuleWrapper> javaModules, Collection<ModuleHolder> cxxModules);
+  private native void jniExtendNativeModules(Collection<JavaModuleWrapper> javaModules);
 
   private native void initializeBridge(
       InstanceCallback callback,
@@ -226,7 +223,6 @@ public class CatalystInstanceImpl implements CatalystInstance {
       MessageQueueThread jsQueue,
       MessageQueueThread moduleQueue,
       Collection<JavaModuleWrapper> javaModules,
-      Collection<ModuleHolder> cxxModules,
       @Nullable ReactInstanceManagerInspectorTarget inspectorTarget);
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.cpp
@@ -164,8 +164,6 @@ void CatalystInstanceImpl::initializeBridge(
     jni::alias_ref<JavaMessageQueueThread::javaobject> nativeModulesQueue,
     jni::alias_ref<jni::JCollection<JavaModuleWrapper::javaobject>::javaobject>
         javaModules,
-    jni::alias_ref<jni::JCollection<ModuleHolder::javaobject>::javaobject>
-        cxxModules,
     jni::alias_ref<ReactInstanceManagerInspectorTarget::javaobject>
         inspectorTarget) {
   set_react_native_logfunc(&log);
@@ -196,7 +194,7 @@ void CatalystInstanceImpl::initializeBridge(
   moduleRegistry_ = std::make_shared<ModuleRegistry>(buildNativeModuleList(
       std::weak_ptr<Instance>(instance_),
       javaModules,
-      cxxModules,
+      {},
       moduleMessageQueue_));
 
   instance_->initializeBridge(
@@ -211,13 +209,11 @@ void CatalystInstanceImpl::initializeBridge(
 
 void CatalystInstanceImpl::extendNativeModules(
     jni::alias_ref<jni::JCollection<JavaModuleWrapper::javaobject>::javaobject>
-        javaModules,
-    jni::alias_ref<jni::JCollection<ModuleHolder::javaobject>::javaobject>
-        cxxModules) {
+        javaModules) {
   moduleRegistry_->registerModules(buildNativeModuleList(
       std::weak_ptr<Instance>(instance_),
       javaModules,
-      cxxModules,
+      {},
       moduleMessageQueue_));
 }
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/jni/CatalystInstanceImpl.h
@@ -60,12 +60,9 @@ class [[deprecated("This API will be removed along with the legacy architecture.
       jni::alias_ref<JavaMessageQueueThread::javaobject> jsQueue,
       jni::alias_ref<JavaMessageQueueThread::javaobject> nativeModulesQueue,
       jni::alias_ref<jni::JCollection<JavaModuleWrapper::javaobject>::javaobject> javaModules,
-      jni::alias_ref<jni::JCollection<ModuleHolder::javaobject>::javaobject> cxxModules,
       jni::alias_ref<ReactInstanceManagerInspectorTarget::javaobject> inspectorTarget);
 
-  void extendNativeModules(
-      jni::alias_ref<jni::JCollection<JavaModuleWrapper::javaobject>::javaobject> javaModules,
-      jni::alias_ref<jni::JCollection<ModuleHolder::javaobject>::javaobject> cxxModules);
+  void extendNativeModules(jni::alias_ref<jni::JCollection<JavaModuleWrapper::javaobject>::javaobject> javaModules);
 
   /**
    * Sets the source URL of the underlying bridge without loading any JS code.


### PR DESCRIPTION
Summary:
TSIA

No app a Meta uses `CxxModules` > https://fb.workplace.com/groups/615693552291894/permalink/2130427210818513/

Differential Revision: D85458376


