### PR TITLE
Update AbortController to more recent polyfill

### DIFF
--- a/packages/react-native/Libraries/Core/setUpXHR.js
+++ b/packages/react-native/Libraries/Core/setUpXHR.js
@@ -36,9 +36,12 @@ polyfillGlobal('URL', () => require('../Blob/URL').URL);
 polyfillGlobal('URLSearchParams', () => require('../Blob/URL').URLSearchParams);
 polyfillGlobal(
   'AbortController',
-  () => require('abort-controller/dist/abort-controller').AbortController, // flowlint-line untyped-import:off
+  () =>
+    require('abortcontroller-polyfill/dist/abortsignal-ponyfill')
+      .AbortController, // flowlint-line untyped-import:off
 );
 polyfillGlobal(
   'AbortSignal',
-  () => require('abort-controller/dist/abort-controller').AbortSignal, // flowlint-line untyped-import:off
+  () =>
+    require('abortcontroller-polyfill/dist/abortsignal-ponyfill').AbortSignal, // flowlint-line untyped-import:off
 );

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -166,7 +166,7 @@
     "@react-native/js-polyfills": "0.83.0-main",
     "@react-native/normalize-colors": "0.83.0-main",
     "@react-native/virtualized-lists": "0.83.0-main",
-    "abort-controller": "^3.0.0",
+    "abortcontroller-polyfill": "^1.7.7",
     "anser": "^1.4.9",
     "ansi-regex": "^5.0.0",
     "babel-jest": "^29.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1043,7 +1043,20 @@
     "@babel/parser" "^7.27.2"
     "@babel/types" "^7.27.1"
 
-"@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3", "@babel/traverse@^7.25.3", "@babel/traverse@^7.25.9", "@babel/traverse@^7.26.8":
+"@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3":
+  version "7.26.9"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.26.9.tgz#4398f2394ba66d05d988b2ad13c219a2c857461a"
+  integrity sha512-ZYW7L+pL8ahU5fXmNbPF+iZFHCv5scFak7MZ9bwaRPLUhHh7QQEMjZUg0HevihoqCM5iSYHN61EyCoZvqC+bxg==
+  dependencies:
+    "@babel/code-frame" "^7.26.2"
+    "@babel/generator" "^7.26.9"
+    "@babel/parser" "^7.26.9"
+    "@babel/template" "^7.26.9"
+    "@babel/types" "^7.26.9"
+    debug "^4.3.1"
+    globals "^11.1.0"
+
+"@babel/traverse@^7.25.3", "@babel/traverse@^7.25.9", "@babel/traverse@^7.26.8":
   version "7.26.9"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.26.9.tgz#4398f2394ba66d05d988b2ad13c219a2c857461a"
   integrity sha512-ZYW7L+pL8ahU5fXmNbPF+iZFHCv5scFak7MZ9bwaRPLUhHh7QQEMjZUg0HevihoqCM5iSYHN61EyCoZvqC+bxg==
@@ -2668,12 +2681,10 @@
   resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.10.tgz#a1337ca426aa61cef9fe15b5b28e340a72f6fa99"
   integrity sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==
 
-abort-controller@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
-  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
-  dependencies:
-    event-target-shim "^5.0.0"
+abortcontroller-polyfill@^1.7.7:
+  version "1.7.8"
+  resolved "https://registry.yarnpkg.com/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.8.tgz#fe8d4370403f02e2aa37e3d2b0b178bae9d83f49"
+  integrity sha512-9f1iZ2uWh92VcrU9Y8x+LdM4DLj75VE0MJB8zuF1iUnroEptStw+DQ8EQPMUdfe5k+PkB1uUfDQfWbhstH8LrQ==
 
 accepts@^1.3.7, accepts@~1.3.7:
   version "1.3.8"
@@ -4514,11 +4525,6 @@ etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
-
-event-target-shim@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
-  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
 eventemitter3@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

The [`abort-controller`](https://www.npmjs.com/package/abort-controller) package hasn't been updated since 2019, and is missing a number of useful features from the current DOM specification. So, switch to [`abortcontroller-polyfill`](https://www.npmjs.com/package/abortcontroller-polyfill) to get a more modern implementation.

Fixes #42042, fixes #50015.

## Changelog:

[General] [Changed] - Improve AbortController API support

## Test Plan:

I attempted to run `packages/react-native/src/private/webapis/dom/events/__tests__/EventTarget-itest.js`, which exercises AbortController, but encountered problems getting fantom set up correctly; I am therefore relying on CI (and the assumption that the upstream package knows what they’re doing).
