### PR TITLE
Fix maxLength condition to check for non-zero value

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -451,7 +451,7 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
     }
   }
 
-  if (props.maxLength < std::numeric_limits<int>::max()) {
+  if (props.maxLength < std::numeric_limits<int>::max() && props.maxLength) {
     NSInteger allowedLength = props.maxLength - _backedTextInputView.attributedText.string.length + range.length;
 
     if (allowedLength > 0 && text.length > allowedLength) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Using a textInput with a null or undefined value are treated as 0 on iOS, so essentially you can't enter anything unless maxLength is >0. I traced this down to this relatively recent PR - https://github.com/facebook/react-native/pull/52890

## Changelog:

[IOS][FIXED] - Correct null/undefined maxInput behaviour for textInput

## Test Plan:

Text input works and didn't before, not sure how much this demo really helps though, but I've confirmed it's working with 

<TextInput
    maxInput={null}
    ....
/>

as well as truthy values

https://github.com/user-attachments/assets/82415835-51e4-4858-98dd-de7f3f65b77f


