### PR TITLE
feat: handle nested accessible items on iOS

### DIFF
--- a/packages/react-native/Libraries/Components/View/ViewAccessibility.js
+++ b/packages/react-native/Libraries/Components/View/ViewAccessibility.js
@@ -321,6 +321,18 @@ export type AccessibilityPropsIOS = $ReadOnly<{
   accessibilityElementsHidden?: ?boolean,
 
   /**
+   * When true, indicates that this view should act as an accessibility
+   * container, allowing nested interactive elements to be individually
+   * accessible. Use this when you have nested Pressables or other
+   * interactive components that need to be separately accessible.
+   *
+   * When enabled, VoiceOver will be able to navigate to its accessible children.
+   *
+   * @platform ios
+   */
+  accessibilityContainer?: ?boolean,
+
+  /**
    * Indicates to the accessibility services that the UI component is in
    * a specific language. The provided string should be formatted following
    * the BCP 47 specification (https://www.rfc-editor.org/info/bcp47).

--- a/packages/react-native/Libraries/NativeComponent/BaseViewConfig.ios.js
+++ b/packages/react-native/Libraries/NativeComponent/BaseViewConfig.ios.js
@@ -193,6 +193,7 @@ const validAttributesForNonEventProps = {
   accessibilityValue: true,
   accessibilityViewIsModal: true,
   accessibilityElementsHidden: true,
+  accessibilityContainer: true,
   accessibilityIgnoresInvertColors: true,
   accessibilityShowsLargeContentViewer: true,
   accessibilityLargeContentTitle: true,

--- a/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.cpp
@@ -163,6 +163,15 @@ AccessibilityProps::AccessibilityProps(
                     "accessibilityRespondsToUserInteraction",
                     sourceProps.accessibilityRespondsToUserInteraction,
                     true)),
+      accessibilityContainer(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.accessibilityContainer
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "accessibilityContainer",
+                    sourceProps.accessibilityContainer,
+                    false)),
       onAccessibilityTap(
           ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.onAccessibilityTap
@@ -280,6 +289,7 @@ void AccessibilityProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityElementsHidden);
     RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityIgnoresInvertColors);
     RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityRespondsToUserInteraction);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(accessibilityContainer);
     RAW_SET_PROP_SWITCH_CASE_BASIC(onAccessibilityTap);
     RAW_SET_PROP_SWITCH_CASE_BASIC(onAccessibilityMagicTap);
     RAW_SET_PROP_SWITCH_CASE_BASIC(onAccessibilityEscape);
@@ -327,6 +337,10 @@ SharedDebugStringConvertibleList AccessibilityProps::getDebugProps() const {
           "accessibilityElementsHidden",
           accessibilityElementsHidden,
           defaultProps.accessibilityElementsHidden),
+      debugStringConvertibleItem(
+          "accessibilityContainer",
+          accessibilityContainer,
+          defaultProps.accessibilityContainer),
       debugStringConvertibleItem(
           "accessibilityHint",
           accessibilityHint,

--- a/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityProps.h
@@ -53,6 +53,7 @@ class AccessibilityProps {
   // C++ because if not, it will default to false before render which prevents
   // the view from being updated with the correct value.
   bool accessibilityRespondsToUserInteraction{true};
+  bool accessibilityContainer{false};
   bool onAccessibilityTap{};
   bool onAccessibilityMagicTap{};
   bool onAccessibilityEscape{};

--- a/packages/rn-tester/js/examples/Pressable/PressableExample.js
+++ b/packages/rn-tester/js/examples/Pressable/PressableExample.js
@@ -605,6 +605,52 @@ const examples = [
       );
     },
   },
+  {
+    title: 'Nested Pressables with Accessibility Container (iOS)',
+    description: (
+      'Demonstrates accessibilityContainer prop for nested interactive elements': string
+    ),
+    render: function NestedPressablesWithAccessibilityContainer(): React.Node {
+      const [outerPressCount, setOuterPressCount] = useState(0);
+      const [innerPressCount, setInnerPressCount] = useState(0);
+
+      return (
+        <View>
+          <View style={styles.row}>
+            <Text style={styles.text}>
+              Outer: {outerPressCount} | Inner: {innerPressCount}
+            </Text>
+          </View>
+          <View style={styles.row}>
+            <Pressable
+              accessibilityContainer={true}
+              accessibilityLabel="Outer card button"
+              accessibilityRole="button"
+              onPress={() => setOuterPressCount(outerPressCount + 1)}
+              style={{
+                backgroundColor: '#f9c2ff',
+                padding: 16,
+                borderRadius: 8,
+              }}>
+              <Text>Outer Pressable</Text>
+              <Pressable
+                accessibilityLabel="Inner button"
+                accessibilityRole="button"
+                onPress={() => setInnerPressCount(innerPressCount + 1)}
+                style={{
+                  backgroundColor: '#61dafb',
+                  padding: 12,
+                  marginTop: 8,
+                  borderRadius: 6,
+                }}>
+                <Text>Inner Pressable</Text>
+              </Pressable>
+            </Pressable>
+          </View>
+        </View>
+      );
+    },
+  },
   ...PressableExampleFbInternal.examples,
 ];
 


### PR DESCRIPTION
## Summary:

This is an initial idea for how we might solve a longstanding accessibility pain point on iOS: https://github.com/facebook/react-native/issues/24515.

Right now, if you write some React Native code like this:

```js
function AppContent() {
  return (
    <View style={styles.container}>
      <Pressable
        style={styles.outerPressable}
        onPress={() => Alert.alert('outer pressable')}
        role="button"
        accessibilityLabel="outer pressable"
      >
        <Text style={styles.outerText}>Outer Pressable</Text>
        <Pressable
          style={styles.innerPressable}
          onPress={() => Alert.alert('inner pressable')}
          role="button"
          accessibilityLabel="inner pressable"
        >
          <Text style={styles.innerText}>Inner Pressable</Text>
        </Pressable>
      </Pressable>
    </View>
  );
}
```

One of the `Pressable` items will be inaccessible via VoiceOver on iOS. You can't select and interact with both. It works fine on TalkBack on Android, which discovers them independent of one another.

You can fix this manually by using the `accessibilityActions` and `onAccessibilityAction` props, like this:

```patch
diff --git a/App.tsx b/App.tsx
index faebed4..29c2575 100644
--- a/App.tsx
+++ b/App.tsx
@@ -20,19 +20,42 @@ function App() {
 }
 
 function AppContent() {
+  const handleOuterPress = () => {
+    Alert.alert('outer pressable');
+  };
+
+  const handleInnerPress = () => {
+    Alert.alert('inner pressable');
+  };
+
+  const handleAccessibilityAction = (event: { nativeEvent: { actionName: string } }) => {
+    const { actionName } = event.nativeEvent;
+    if (actionName === 'outer') {
+      handleOuterPress();
+    } else if (actionName === 'inner') {
+      handleInnerPress();
+    }
+  };
+
   return (
     <View style={styles.container}>
       <Pressable
         style={styles.outerPressable}
-        onPress={() => Alert.alert('outer pressable')}
-        role="button"
-        accessibilityLabel="outer pressable"
+        onPress={handleOuterPress}
+        accessible={true}
+        accessibilityLabel="Nested Pressables"
+        accessibilityActions={[
+          { name: 'outer', label: 'Activate outer pressable' },
+          { name: 'inner', label: 'Activate inner pressable' },
+        ]}
+        onAccessibilityAction={handleAccessibilityAction}
       >
         <Text style={styles.outerText}>Outer Pressable</Text>
         <Pressable
           style={styles.innerPressable}
-          onPress={() => Alert.alert('inner pressable')}
-          role="button"
+          onPress={handleInnerPress}
+          accessible={false}
+          importantForAccessibility="no-hide-descendants"
         >
           <Text style={styles.innerText}>Inner Pressable</Text>
         </Pressable>
```

This works OK, but you have to *know* to do it, and then take the time to do it well. A lot of developers don't know about this issue, and end up degrading their user's experience because of it. Overall, it means React Native apps start on the back foot as far as accessibility goes. I think we could improve the experience of React Native apps broadly by offering a better built-in behavior.

iOS does have a concept of [accessibility containers](https://medium.com/kinandcartacreated/accessibility-containers-284fff08480c). I think we can leverage that to improve the experience. Thanks to @lindboe for teaching me about accessibility containers (and about this problem in general).

My initial proposal is this:

1. Add a new `accessibilityContainer`, iOS-only prop.
2. Set it to `false` by default, to preserve backwards compatibility, and to make this behavior opt-in. That way, we don't make every single view try to collect all of its children, unless a developer opts in to it (for now). And we also avoid the scenario where this breaks people who are using `accessibilityActions` (I'm not sure how these props might conflict).
3. When a view sets `accessibilityContainer` to a truthy value, it makes child interactive elements independently accessible by adding them to `_accessibilityElements`, along with a proxy for the container itself (so we can toss this prop on a wrapper `Pressable` without requiring additional wrapper `View` components or anything)

In an ideal world, I think this prop should be `true` by default, so devs don't have to know to do this at all, and they'd get a better default experience. But I'm not sure what the performance implications are for it since we have to parse all the subviews. Maybe it's not too bad, but I mostly want to get the conversation started, I'm not married to a given implementation.
I hope a change like this might make the default React Native experience more accessible for many users.

## Changelog:

[IOS] [ADDED] - accessibilityContainer prop to allow easier accessibility grouping

## Test Plan:

1. Pull down this branch and build the `rn-tester` app with `cd packages/rn-tester && yarn prepare-ios`
2. Open it up. The best way to do this is on a real device since VoiceOver has limitations on the simulator. But the accessibility inspector tool does pick up these changes.
3. Go to the Pressable component demo
4. Scroll to the bottom, I added a new nested pressable example
5. Tap the outer and inner pressable. You'll see they increment separate counters.
6. Turn on VoiceOver or check the accessibility inspector
7. Attempt to use both the outer and inner pressables. They should both work and increment their separate counters.

### Videos

#### Physical device/VoiceOver

Here's the fixed behavior with `accessibilityContainer={true}` on a physical device:

https://github.com/user-attachments/assets/a39dda45-b553-4314-b1b9-32dd81d51c96

And here's how it behaves when the prop is `false` (current behavior):

https://github.com/user-attachments/assets/5094008c-16d4-4c00-aa3c-e380a674fb51

#### Simulator/Accessibility Inspector

Here's a video with a simulator, you can see the change when I toggle the prop:

https://github.com/user-attachments/assets/d25b8141-9973-41bb-83a5-e8c9e9549a60