### PR TITLE
Suppress DEPRECATION warnings for checking scaledDensity on some tests

### DIFF
--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/DisplayMetricsHolderTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/DisplayMetricsHolderTest.kt
@@ -5,6 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// Suppress deprecation warnings for checking scaledDensity
+@file:Suppress("DEPRECATION")
+
 package com.facebook.react.uimanager
 
 import android.annotation.TargetApi

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/PixelUtilTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/PixelUtilTest.kt
@@ -5,6 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+// Suppress deprecation warnings for checking scaledDensity
+@file:Suppress("DEPRECATION")
+
 package com.facebook.react.uimanager
 
 import android.content.Context


### PR DESCRIPTION
## Summary:

Suppress DEPRECATION warnings for checking scaledDensity on some tests.

## Changelog:

[Internal] Suppress DEPRECATION warnings for checking scaledDensity on some tests.

## Test Plan:

none
