### PR TITLE
Remove RCT_EXPORT_MODULE from ActionSheetManager

### DIFF
--- a/packages/react-native/Libraries/Blob/RCTBlobManager.mm
+++ b/packages/react-native/Libraries/Blob/RCTBlobManager.mm
@@ -42,7 +42,10 @@ static NSString *const kBlobURIScheme = @"blob";
   dispatch_queue_t _processingQueue;
 }
 
-RCT_EXPORT_MODULE(BlobModule)
++ (NSString *)moduleName
+{
+  return @"BlobModule";
+}
 
 @synthesize bridge = _bridge;
 @synthesize moduleRegistry = _moduleRegistry;

--- a/packages/react-native/Libraries/Blob/RCTFileReaderModule.mm
+++ b/packages/react-native/Libraries/Blob/RCTFileReaderModule.mm
@@ -20,7 +20,10 @@
 
 @implementation RCTFileReaderModule
 
-RCT_EXPORT_MODULE(FileReaderModule)
++ (NSString *)moduleName
+{
+  return @"FileReaderModule";
+}
 
 @synthesize moduleRegistry = _moduleRegistry;
 

--- a/packages/react-native/Libraries/Image/RCTBundleAssetImageLoader.mm
+++ b/packages/react-native/Libraries/Image/RCTBundleAssetImageLoader.mm
@@ -20,7 +20,10 @@
 
 @implementation RCTBundleAssetImageLoader
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"BundleAssetImageLoader";
+}
 
 - (BOOL)canLoadImageURL:(NSURL *)requestURL
 {

--- a/packages/react-native/Libraries/Image/RCTGIFImageDecoder.mm
+++ b/packages/react-native/Libraries/Image/RCTGIFImageDecoder.mm
@@ -20,7 +20,10 @@
 
 @implementation RCTGIFImageDecoder
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"GIFImageDecoder";
+}
 
 - (BOOL)canDecodeImageData:(NSData *)imageData
 {

--- a/packages/react-native/Libraries/Image/RCTImageEditingManager.mm
+++ b/packages/react-native/Libraries/Image/RCTImageEditingManager.mm
@@ -24,7 +24,10 @@
 
 @implementation RCTImageEditingManager
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"ImageEditingManager";
+}
 
 @synthesize moduleRegistry = _moduleRegistry;
 

--- a/packages/react-native/Libraries/Image/RCTImageLoader.mm
+++ b/packages/react-native/Libraries/Image/RCTImageLoader.mm
@@ -92,7 +92,10 @@ static NSError *addResponseHeadersToError(NSError *originalError, NSHTTPURLRespo
 @synthesize maxConcurrentDecodingTasks = _maxConcurrentDecodingTasks;
 @synthesize maxConcurrentDecodingBytes = _maxConcurrentDecodingBytes;
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"RCTImageLoader";
+}
 
 - (instancetype)init
 {

--- a/packages/react-native/Libraries/Image/RCTImageStoreManager.mm
+++ b/packages/react-native/Libraries/Image/RCTImageStoreManager.mm
@@ -32,7 +32,10 @@ static NSString *const RCTImageStoreURLScheme = @"rct-image-store";
 
 @synthesize methodQueue = _methodQueue;
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"ImageStoreManager";
+}
 
 + (BOOL)requiresMainQueueSetup
 {

--- a/packages/react-native/Libraries/Image/RCTImageViewManager.mm
+++ b/packages/react-native/Libraries/Image/RCTImageViewManager.mm
@@ -20,7 +20,10 @@
 
 @implementation RCTImageViewManager
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"ImageViewManager";
+}
 
 - (RCTShadowView *)shadowView
 {

--- a/packages/react-native/Libraries/Image/RCTLocalAssetImageLoader.mm
+++ b/packages/react-native/Libraries/Image/RCTLocalAssetImageLoader.mm
@@ -20,7 +20,10 @@
 
 @implementation RCTLocalAssetImageLoader
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"LocalAssetImageLoader";
+}
 
 - (BOOL)canLoadImageURL:(NSURL *)requestURL
 {

--- a/packages/react-native/Libraries/LinkingIOS/RCTLinkingManager.mm
+++ b/packages/react-native/Libraries/LinkingIOS/RCTLinkingManager.mm
@@ -27,7 +27,10 @@ static void postNotificationWithURL(NSURL *URL, id sender)
 
 @implementation RCTLinkingManager
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"LinkingManager";
+}
 
 - (dispatch_queue_t)methodQueue
 {

--- a/packages/react-native/Libraries/NativeAnimation/RCTNativeAnimatedModule.mm
+++ b/packages/react-native/Libraries/NativeAnimation/RCTNativeAnimatedModule.mm
@@ -30,7 +30,10 @@ typedef void (^AnimatedOperation)(RCTNativeAnimatedNodesManager *nodesManager);
   NSMutableDictionary<NSNumber *, NSNumber *> *_animIdIsManagedByFabric;
 }
 
-RCT_EXPORT_MODULE();
++ (NSString *)moduleName
+{
+  return @"NativeAnimatedModule";
+}
 
 + (BOOL)requiresMainQueueSetup
 {

--- a/packages/react-native/Libraries/NativeAnimation/RCTNativeAnimatedTurboModule.mm
+++ b/packages/react-native/Libraries/NativeAnimation/RCTNativeAnimatedTurboModule.mm
@@ -30,7 +30,10 @@ typedef void (^AnimatedOperation)(RCTNativeAnimatedNodesManager *nodesManager);
   NSSet<NSString *> *_userDrivenAnimationEndedEvents;
 }
 
-RCT_EXPORT_MODULE();
++ (NSString *)moduleName
+{
+  return @"NativeAnimatedTurboModule";
+}
 
 + (BOOL)requiresMainQueueSetup
 {

--- a/packages/react-native/Libraries/Network/RCTDataRequestHandler.mm
+++ b/packages/react-native/Libraries/Network/RCTDataRequestHandler.mm
@@ -20,7 +20,10 @@
   std::mutex _operationHandlerMutexLock;
 }
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"DataRequestHandler";
+}
 
 - (void)invalidate
 {

--- a/packages/react-native/Libraries/Network/RCTFileRequestHandler.mm
+++ b/packages/react-native/Libraries/Network/RCTFileRequestHandler.mm
@@ -24,7 +24,10 @@
   std::mutex _operationHandlerMutexLock;
 }
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"FileRequestHandler";
+}
 
 - (void)invalidate
 {

--- a/packages/react-native/Libraries/Network/RCTHTTPRequestHandler.mm
+++ b/packages/react-native/Libraries/Network/RCTHTTPRequestHandler.mm
@@ -33,7 +33,10 @@ void RCTSetCustomNSURLSessionConfigurationProvider(NSURLSessionConfigurationProv
 
 @synthesize moduleRegistry = _moduleRegistry;
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"HTTPRequestHandler";
+}
 
 - (void)invalidate
 {

--- a/packages/react-native/Libraries/Network/RCTNetworking.mm
+++ b/packages/react-native/Libraries/Network/RCTNetworking.mm
@@ -167,7 +167,10 @@ static NSString *RCTGenerateFormBoundary()
 
 @synthesize methodQueue = _methodQueue;
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"Networking";
+}
 
 + (BOOL)requiresMainQueueSetup
 {

--- a/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.mm
+++ b/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.mm
@@ -154,7 +154,10 @@ static BOOL IsNotificationRemote(UNNotification *notification)
   return [notification.request.trigger isKindOfClass:[UNPushNotificationTrigger class]];
 }
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"PushNotificationManager";
+}
 
 - (dispatch_queue_t)methodQueue
 {

--- a/packages/react-native/Libraries/Settings/RCTSettingsManager.mm
+++ b/packages/react-native/Libraries/Settings/RCTSettingsManager.mm
@@ -25,7 +25,10 @@
 
 @synthesize moduleRegistry = _moduleRegistry;
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"SettingsManager";
+}
 
 + (BOOL)requiresMainQueueSetup
 {

--- a/packages/react-native/Libraries/Text/BaseText/RCTBaseTextViewManager.mm
+++ b/packages/react-native/Libraries/Text/BaseText/RCTBaseTextViewManager.mm
@@ -11,7 +11,10 @@
 
 @implementation RCTBaseTextViewManager
 
-RCT_EXPORT_MODULE(RCTBaseText)
++ (NSString *)moduleName
+{
+  return @"BaseText";
+}
 
 - (UIView *)view
 {

--- a/packages/react-native/Libraries/Text/RawText/RCTRawTextViewManager.mm
+++ b/packages/react-native/Libraries/Text/RawText/RCTRawTextViewManager.mm
@@ -13,7 +13,10 @@
 
 @implementation RCTRawTextViewManager
 
-RCT_EXPORT_MODULE(RCTRawText)
++ (NSString *)moduleName
+{
+  return @"RawText";
+}
 
 - (UIView *)view
 {

--- a/packages/react-native/Libraries/Text/Text/RCTTextViewManager.mm
+++ b/packages/react-native/Libraries/Text/Text/RCTTextViewManager.mm
@@ -26,7 +26,10 @@
   NSHashTable<RCTTextShadowView *> *_shadowViews;
 }
 
-RCT_EXPORT_MODULE(RCTText)
++ (NSString *)moduleName
+{
+  return @"TextViewManager";
+}
 
 RCT_REMAP_SHADOW_PROPERTY(numberOfLines, maximumNumberOfLines, NSInteger)
 RCT_REMAP_SHADOW_PROPERTY(ellipsizeMode, lineBreakMode, NSLineBreakMode)

--- a/packages/react-native/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputViewManager.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputViewManager.mm
@@ -12,7 +12,10 @@
 
 @implementation RCTMultilineTextInputViewManager
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"MultilineTextInputViewManager";
+}
 
 - (UIView *)view
 {

--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputViewManager.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputViewManager.mm
@@ -30,7 +30,10 @@
   NSHashTable<RCTBaseTextInputShadowView *> *_shadowViews;
 }
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"BaseTextInputViewManager";
+}
 
 #pragma mark - Unified <TextInput> properties
 

--- a/packages/react-native/Libraries/Text/TextInput/RCTInputAccessoryViewManager.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTInputAccessoryViewManager.mm
@@ -14,7 +14,10 @@
 
 @implementation RCTInputAccessoryViewManager
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"InputAccessoryViewManager";
+}
 
 - (UIView *)view
 {

--- a/packages/react-native/Libraries/Text/TextInput/Singleline/RCTSinglelineTextInputViewManager.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Singleline/RCTSinglelineTextInputViewManager.mm
@@ -14,7 +14,10 @@
 
 @implementation RCTSinglelineTextInputViewManager
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"SinglelineTextInputViewManager";
+}
 
 - (RCTShadowView *)shadowView
 {

--- a/packages/react-native/Libraries/Text/VirtualText/RCTVirtualTextViewManager.mm
+++ b/packages/react-native/Libraries/Text/VirtualText/RCTVirtualTextViewManager.mm
@@ -13,7 +13,10 @@
 
 @implementation RCTVirtualTextViewManager
 
-RCT_EXPORT_MODULE(RCTVirtualText)
++ (NSString *)moduleName
+{
+  return @"VirtualTextViewManager";
+}
 
 - (UIView *)view
 {

--- a/packages/react-native/Libraries/Vibration/RCTVibration.mm
+++ b/packages/react-native/Libraries/Vibration/RCTVibration.mm
@@ -18,7 +18,10 @@
 
 @implementation RCTVibration
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"Vibration";
+}
 
 - (void)vibrate
 {

--- a/packages/react-native/React/CoreModules/RCTAccessibilityManager.mm
+++ b/packages/react-native/React/CoreModules/RCTAccessibilityManager.mm
@@ -33,7 +33,10 @@ NSString *const RCTAccessibilityManagerDidUpdateMultiplierNotification =
 @synthesize moduleRegistry = _moduleRegistry;
 @synthesize multipliers = _multipliers;
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"AccessibilityManager";
+}
 
 + (BOOL)requiresMainQueueSetup
 {

--- a/packages/react-native/React/CoreModules/RCTActionSheetManager.mm
+++ b/packages/react-native/React/CoreModules/RCTActionSheetManager.mm
@@ -42,7 +42,10 @@ using namespace facebook::react;
   return NO;
 }
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"ActionSheetManager";
+}
 
 @synthesize viewRegistry_DEPRECATED = _viewRegistry_DEPRECATED;
 

--- a/packages/react-native/React/CoreModules/RCTAlertManager.mm
+++ b/packages/react-native/React/CoreModules/RCTAlertManager.mm
@@ -40,7 +40,10 @@ RCT_ENUM_CONVERTER(
   NSHashTable *_alertControllers;
 }
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"AlertManager";
+}
 
 - (dispatch_queue_t)methodQueue
 {

--- a/packages/react-native/React/CoreModules/RCTAppState.mm
+++ b/packages/react-native/React/CoreModules/RCTAppState.mm
@@ -43,7 +43,10 @@ static NSString *RCTCurrentAppState()
   facebook::react::ModuleConstants<JS::NativeAppState::Constants> _constants;
 }
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"AppState";
+}
 
 + (BOOL)requiresMainQueueSetup
 {

--- a/packages/react-native/React/CoreModules/RCTAppearance.mm
+++ b/packages/react-native/React/CoreModules/RCTAppearance.mm
@@ -92,7 +92,10 @@ NSString *RCTColorSchemePreference(UITraitCollection *traitCollection)
   return self;
 }
 
-RCT_EXPORT_MODULE(Appearance)
++ (NSString *)moduleName
+{
+  return @"Appearance";
+}
 
 + (BOOL)requiresMainQueueSetup
 {

--- a/packages/react-native/React/CoreModules/RCTClipboard.mm
+++ b/packages/react-native/React/CoreModules/RCTClipboard.mm
@@ -19,7 +19,10 @@ using namespace facebook::react;
 
 @implementation RCTClipboard
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"Clipboard";
+}
 
 - (dispatch_queue_t)methodQueue
 {

--- a/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
+++ b/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
@@ -37,7 +37,10 @@ using namespace facebook::react;
   dispatch_block_t _initialMessageBlock;
 }
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"DevLoadingView";
+}
 
 - (instancetype)init
 {

--- a/packages/react-native/React/CoreModules/RCTDevMenu.mm
+++ b/packages/react-native/React/CoreModules/RCTDevMenu.mm
@@ -124,7 +124,10 @@ typedef void (^RCTDevMenuAlertActionHandler)(UIAlertAction *action);
 @synthesize callableJSModules = _callableJSModules;
 @synthesize bundleManager = _bundleManager;
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"DevMenu";
+}
 
 + (void)initialize
 {

--- a/packages/react-native/React/CoreModules/RCTDevSettings.mm
+++ b/packages/react-native/React/CoreModules/RCTDevSettings.mm
@@ -134,7 +134,10 @@ static std::atomic<int> numInitializedModules{0};
 @synthesize isInspectable = _isInspectable;
 @synthesize bundleManager = _bundleManager;
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"RCTDevSettings";
+}
 
 - (instancetype)init
 {

--- a/packages/react-native/React/CoreModules/RCTDevToolsRuntimeSettingsModule.mm
+++ b/packages/react-native/React/CoreModules/RCTDevToolsRuntimeSettingsModule.mm
@@ -23,7 +23,11 @@ static Config _config;
 @end
 
 @implementation RCTDevToolsRuntimeSettingsModule
-RCT_EXPORT_MODULE(ReactDevToolsRuntimeSettingsModule)
+
++ (NSString *)moduleName
+{
+  return @"ReactDevToolsRuntimeSettingsModule)";
+}
 
 RCT_EXPORT_METHOD(
     setReloadAndProfileConfig : (JS::NativeReactDevToolsRuntimeSettingsModule::PartialReloadAndProfileConfig &)config)

--- a/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
+++ b/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
@@ -39,7 +39,10 @@ static NSString *const kFrameKeyPath = @"frame";
 
 @synthesize moduleRegistry = _moduleRegistry;
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"DeviceInfo";
+}
 
 - (instancetype)init
 {

--- a/packages/react-native/React/CoreModules/RCTEventDispatcher.mm
+++ b/packages/react-native/React/CoreModules/RCTEventDispatcher.mm
@@ -44,7 +44,10 @@ static uint16_t RCTUniqueCoalescingKeyGenerator = 0;
 @synthesize dispatchToJSThread = _dispatchToJSThread;
 @synthesize callableJSModules = _callableJSModules;
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"EventDispatcher";
+}
 
 - (void)initialize
 {

--- a/packages/react-native/React/CoreModules/RCTExceptionsManager.mm
+++ b/packages/react-native/React/CoreModules/RCTExceptionsManager.mm
@@ -26,7 +26,10 @@
 
 @synthesize moduleRegistry = _moduleRegistry;
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"ExceptionManager";
+}
 
 - (instancetype)initWithDelegate:(id<RCTExceptionsManagerDelegate>)delegate
 {

--- a/packages/react-native/React/CoreModules/RCTI18nManager.mm
+++ b/packages/react-native/React/CoreModules/RCTI18nManager.mm
@@ -19,7 +19,10 @@ using namespace facebook::react;
 
 @implementation RCTI18nManager
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"I18nManager";
+}
 
 + (BOOL)requiresMainQueueSetup
 {

--- a/packages/react-native/React/CoreModules/RCTKeyboardObserver.mm
+++ b/packages/react-native/React/CoreModules/RCTKeyboardObserver.mm
@@ -20,7 +20,10 @@ static NSDictionary *RCTParseKeyboardNotification(NSNotification *notification);
 
 @implementation RCTKeyboardObserver
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"KeyboardObserver";
+}
 
 - (void)startObserving
 {

--- a/packages/react-native/React/CoreModules/RCTLogBox.mm
+++ b/packages/react-native/React/CoreModules/RCTLogBox.mm
@@ -27,7 +27,10 @@
 
 @synthesize bridge = _bridge;
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"LogBox";
+}
 
 + (BOOL)requiresMainQueueSetup
 {

--- a/packages/react-native/React/CoreModules/RCTPerfMonitor.mm
+++ b/packages/react-native/React/CoreModules/RCTPerfMonitor.mm
@@ -114,7 +114,10 @@ static vm_size_t RCTGetResidentMemorySize(void)
 @synthesize bridge = _bridge;
 @synthesize moduleRegistry = _moduleRegistry;
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"PerfMonitor";
+}
 
 + (BOOL)requiresMainQueueSetup
 {

--- a/packages/react-native/React/CoreModules/RCTPlatform.mm
+++ b/packages/react-native/React/CoreModules/RCTPlatform.mm
@@ -48,7 +48,10 @@ static NSString *interfaceIdiom(UIUserInterfaceIdiom idiom)
   ModuleConstants<JS::NativePlatformConstantsIOS::Constants> _constants;
 }
 
-RCT_EXPORT_MODULE(PlatformConstants)
++ (NSString *)moduleName
+{
+  return @"PlatformConstants";
+}
 
 + (BOOL)requiresMainQueueSetup
 {

--- a/packages/react-native/React/CoreModules/RCTRedBox.mm
+++ b/packages/react-native/React/CoreModules/RCTRedBox.mm
@@ -480,7 +480,10 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
 @synthesize moduleRegistry = _moduleRegistry;
 @synthesize bundleManager = _bundleManager;
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"RedBox";
+}
 
 - (void)registerErrorCustomizer:(id<RCTErrorCustomizer>)errorCustomizer
 {

--- a/packages/react-native/React/CoreModules/RCTSourceCode.mm
+++ b/packages/react-native/React/CoreModules/RCTSourceCode.mm
@@ -18,7 +18,10 @@ using namespace facebook::react;
 
 @implementation RCTSourceCode
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"SourceCode";
+}
 
 @synthesize bundleManager = _bundleManager;
 

--- a/packages/react-native/React/CoreModules/RCTStatusBarManager.mm
+++ b/packages/react-native/React/CoreModules/RCTStatusBarManager.mm
@@ -68,7 +68,10 @@ static BOOL RCTViewControllerBasedStatusBarAppearance()
   return value;
 }
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"StatusBarManager";
+}
 
 + (BOOL)requiresMainQueueSetup
 {

--- a/packages/react-native/React/CoreModules/RCTTiming.mm
+++ b/packages/react-native/React/CoreModules/RCTTiming.mm
@@ -107,7 +107,10 @@ static const NSTimeInterval kIdleCallbackFrameDeadline = 0.001;
 @synthesize paused = _paused;
 @synthesize pauseCallback = _pauseCallback;
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"Timing";
+}
 
 - (instancetype)initWithDelegate:(id<RCTTimingDelegate>)delegate
 {

--- a/packages/react-native/React/CoreModules/RCTWebSocketModule.mm
+++ b/packages/react-native/React/CoreModules/RCTWebSocketModule.mm
@@ -39,7 +39,10 @@
   NSMutableDictionary<NSNumber *, id<RCTWebSocketContentHandler>> *_contentHandlers;
 }
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"WebSocketModule";
+}
 
 - (dispatch_queue_t)methodQueue
 {

--- a/packages/react-native/React/Modules/RCTUIManager.mm
+++ b/packages/react-native/React/Modules/RCTUIManager.mm
@@ -179,7 +179,10 @@ NSString *const RCTUIManagerWillUpdateViewsDueToContentSizeMultiplierChangeNotif
 @synthesize bridge = _bridge;
 @synthesize moduleRegistry = _moduleRegistry;
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"RCTUIManager";
+}
 
 + (BOOL)requiresMainQueueSetup
 {

--- a/packages/react-native/React/Views/RCTActivityIndicatorViewManager.m
+++ b/packages/react-native/React/Views/RCTActivityIndicatorViewManager.m
@@ -27,7 +27,10 @@ RCT_ENUM_CONVERTER(
 
 @implementation RCTActivityIndicatorViewManager
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"ActivityIndicatorViewManager";
+}
 
 - (UIView *)view
 {

--- a/packages/react-native/React/Views/RCTDebuggingOverlayManager.m
+++ b/packages/react-native/React/Views/RCTDebuggingOverlayManager.m
@@ -17,7 +17,10 @@
 
 @implementation RCTDebuggingOverlayManager
 
-RCT_EXPORT_MODULE(DebuggingOverlay)
++ (NSString *)moduleName
+{
+  return @"DebuggingOverlay";
+}
 
 - (UIView *)view
 {

--- a/packages/react-native/React/Views/RCTModalHostViewManager.m
+++ b/packages/react-native/React/Views/RCTModalHostViewManager.m
@@ -40,7 +40,10 @@
   NSPointerArray *_hostViews;
 }
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"ModalHostViewManager ";
+}
 
 - (UIView *)view
 {

--- a/packages/react-native/React/Views/RCTModalManager.m
+++ b/packages/react-native/React/Views/RCTModalManager.m
@@ -17,7 +17,10 @@
 
 @implementation RCTModalManager
 
-RCT_EXPORT_MODULE();
++ (NSString *)moduleName
+{
+  return @"ModalManager";
+}
 
 - (NSArray<NSString *> *)supportedEvents
 {

--- a/packages/react-native/React/Views/RCTSwitchManager.m
+++ b/packages/react-native/React/Views/RCTSwitchManager.m
@@ -16,7 +16,10 @@
 
 @implementation RCTSwitchManager
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"SwitchManager";
+}
 
 - (UIView *)view
 {

--- a/packages/react-native/React/Views/RCTViewManager.m
+++ b/packages/react-native/React/Views/RCTViewManager.m
@@ -128,7 +128,10 @@ RCT_MULTI_ENUM_CONVERTER(
 
 @synthesize bridge = _bridge;
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"RCTViewManager";
+}
 
 - (dispatch_queue_t)methodQueue
 {

--- a/packages/react-native/React/Views/RefreshControl/RCTRefreshControlManager.m
+++ b/packages/react-native/React/Views/RefreshControl/RCTRefreshControlManager.m
@@ -15,7 +15,10 @@
 
 @implementation RCTRefreshControlManager
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"RefreshControlManager";
+}
 
 - (UIView *)view
 {

--- a/packages/react-native/React/Views/SafeAreaView/RCTSafeAreaViewManager.m
+++ b/packages/react-native/React/Views/SafeAreaView/RCTSafeAreaViewManager.m
@@ -15,7 +15,10 @@
 
 @implementation RCTSafeAreaViewManager
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"SafeAreaViewManager";
+}
 
 - (UIView *)view
 {

--- a/packages/react-native/React/Views/ScrollView/RCTScrollContentViewManager.m
+++ b/packages/react-native/React/Views/ScrollView/RCTScrollContentViewManager.m
@@ -14,7 +14,10 @@
 
 @implementation RCTScrollContentViewManager
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"ScrollContentViewManager";
+}
 
 - (RCTScrollContentView *)view
 {

--- a/packages/react-native/React/Views/ScrollView/RCTScrollViewManager.m
+++ b/packages/react-native/React/Views/ScrollView/RCTScrollViewManager.m
@@ -53,7 +53,10 @@ RCT_ENUM_CONVERTER(
 
 @implementation RCTScrollViewManager
 
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"ScrollViewManager";
+}
 
 - (UIView *)view
 {

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleTurboModule.mm
@@ -24,7 +24,10 @@ using namespace facebook::react;
 }
 
 // Backward-compatible export
-RCT_EXPORT_MODULE()
++ (NSString *)moduleName
+{
+  return @"SampleTurboModule";
+}
 
 // Backward-compatible queue configuration
 + (BOOL)requiresMainQueueSetup


### PR DESCRIPTION
Pull Request resolved: https://github.com/facebook/react-native/pull/54288

This change remove the usage of RCT_EXPORT_MODULE from all the classes of React Native Core.

This allow us to remove the +load method that runs at initialization of React Native and that can slow down the start of React Native itself.

All the classes are still registered due to the [`RCTBridge`'s `getCoreModuleClasses`](https://github.com/facebook/react-native/blob/main/packages/react-native/React/Base/RCTBridge.mm#L46) which manually lists all the classes that got modified.

---

## TODO
There are some classes that should be loaded using the respective plugins. Currently, the OSS implementation only uses the [CoreModulePlugin](https://github.com/facebook/react-native/blob/main/packages/react-native/React/CoreModules/CoreModulesPlugins.mm#L19), but we should add the lookup also in these others plugins:
- RCTBlobPlugins.mm
- RCTImagePlugins.mm
- RCTNetworkPlugins.mm
- RCTSettingsPlugins.mm
- RCTLinkingPlugins.mm
- RCTVibrationPlugins.mm
- RCTAnimationPlugins.mm
- RCTPushNotificationPlugins.mm (if the import is available. The push notification module is not included by default)

## Changelog:
[Internal] - Remove RCT_EXPORT_MODULE from RN Core Modules