### PR TITLE
[ios][accessibility] Add support for UIAccessibilityPriority

### DIFF
--- a/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.d.ts
+++ b/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.d.ts
@@ -150,10 +150,15 @@ export interface AccessibilityInfoStatic {
    * - `announcement`: The string announced by the screen reader.
    * - `options`: An object that configures the reading options.
    *   - `queue`: The announcement will be queued behind existing announcements. iOS only.
+   *   - `priority`: The priority of the announcement. Possible values: 'low' | 'default' | 'high'.
+   *     High priority announcements will interrupt any ongoing speech and cannot be interrupted.
+   *     Default priority announcements will interrupt any ongoing speech but can be interrupted.
+   *     Low priority announcements will not interrupt ongoing speech and can be interrupted.
+   *     (iOS only).
    */
   announceForAccessibilityWithOptions(
     announcement: string,
-    options: {queue?: boolean | undefined},
+    options: {queue?: boolean | undefined, priority?: 'low' | 'default' | 'high' | undefined},
   ): void;
 
   /**

--- a/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
+++ b/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
@@ -476,10 +476,15 @@ const AccessibilityInfo = {
    * - `announcement`: The string announced by the screen reader.
    * - `options`: An object that configures the reading options.
    *   - `queue`: The announcement will be queued behind existing announcements. iOS only.
+   *   - `priority`: The priority of the announcement. Possible values: 'low' | 'default' | 'high'.
+   *     High priority announcements will interrupt any ongoing speech and cannot be interrupted.
+   *     Default priority announcements will interrupt any ongoing speech but can be interrupted.
+   *     Low priority announcements will not interrupt ongoing speech and can be interrupted.
+   *     (iOS only).
    */
   announceForAccessibilityWithOptions(
     announcement: string,
-    options: {queue?: boolean},
+    options: {queue?: boolean, priority?: 'low' | 'default' | 'high'},
   ): void {
     if (Platform.OS === 'android') {
       NativeAccessibilityInfoAndroid?.announceForAccessibility(announcement);

--- a/packages/react-native/React/CoreModules/RCTAccessibilityManager.mm
+++ b/packages/react-native/React/CoreModules/RCTAccessibilityManager.mm
@@ -325,9 +325,26 @@ RCT_EXPORT_METHOD(
     announceForAccessibilityWithOptions : (NSString *)announcement options : (
         JS::NativeAccessibilityManager::SpecAnnounceForAccessibilityWithOptionsOptions &)options)
 {
-  NSMutableDictionary<NSString *, NSNumber *> *attrsDictionary = [NSMutableDictionary new];
+  NSMutableDictionary<NSString *, id> *attrsDictionary = [NSMutableDictionary new];
   if (options.queue()) {
     attrsDictionary[UIAccessibilitySpeechAttributeQueueAnnouncement] = @(*(options.queue()) ? YES : NO);
+  }
+
+  if (options.priority()) {
+    NSString *priorityString = options.priority();
+    if (@available(iOS 17.0, *)) {
+      NSString *priorityValue = nil;
+      if ([priorityString isEqualToString:@"low"]) {
+        priorityValue = UIAccessibilityPriorityLow;
+      } else if ([priorityString isEqualToString:@"default"]) {
+        priorityValue = UIAccessibilityPriorityDefault;
+      } else if ([priorityString isEqualToString:@"high"]) {
+        priorityValue = UIAccessibilityPriorityHigh;
+      }
+      if (priorityValue != nil) {
+        attrsDictionary[UIAccessibilitySpeechAttributeAnnouncementPriority] = priorityValue;
+      }
+    }
   }
 
   if (attrsDictionary.count > 0) {

--- a/packages/react-native/src/private/specs_DEPRECATED/modules/NativeAccessibilityManager.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/modules/NativeAccessibilityManager.js
@@ -63,7 +63,7 @@ export interface Spec extends TurboModule {
   +announceForAccessibility: (announcement: string) => void;
   +announceForAccessibilityWithOptions?: (
     announcement: string,
-    options: {queue?: boolean},
+    options: {queue?: boolean, priority?: 'low' | 'default' | 'high'},
   ) => void;
 }
 

--- a/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
+++ b/packages/rn-tester/js/examples/Accessibility/AccessibilityExample.js
@@ -1293,6 +1293,44 @@ class AnnounceForAccessibility extends React.Component<{}> {
     );
   };
 
+  _handleOnPressHighPriority = (): TimeoutID => {
+    setTimeout(
+      () =>
+        AccessibilityInfo.announceForAccessibilityWithOptions(
+          'High Priority Announcement Test',
+          {priority: 'high'},
+        ),
+      1000,
+    );
+
+    setTimeout(
+      () =>
+        AccessibilityInfo.announceForAccessibility(
+          'Normal Priority Announcement',
+        ),
+      1100,
+    );
+  };
+
+  _handleOnPressLowPriority = (): TimeoutID => {
+    setTimeout(
+      () =>
+        AccessibilityInfo.announceForAccessibilityWithOptions(
+          'Low Priority Announcement Test',
+          {priority: 'low'},
+        ),
+      1000,
+    );
+
+    setTimeout(
+      () =>
+        AccessibilityInfo.announceForAccessibility(
+          'Normal Priority Announcement',
+        ),
+      1100,
+    );
+  }
+
   render(): React.Node {
     return Platform.OS === 'ios' ? (
       <View>
@@ -1307,6 +1345,14 @@ class AnnounceForAccessibility extends React.Component<{}> {
         <Button
           onPress={this._handleOnPressQueueMultiple}
           title="Announce for Accessibility Queue Multiple"
+        />
+        <Button 
+          onPress={this._handleOnPressHighPriority}
+          title="Announce for Accessibility High Priority"
+        />
+        <Button
+          onPress={this._handleOnPressLowPriority}
+          title="Announce for Accessibility Low Priority"
         />
       </View>
     ) : (


### PR DESCRIPTION
## Summary:

Adds support for UIAccessibilityPriority on iOS. This is important because we want to be able to set high-priority announcements that cannot be interrupted. 

Use case: a modal opens, user performs an action that closes the modal and returns to the previous page. We need to announce it but the voiceover engine will target an element as we've just navigated and cancel the announcement because the default announcement priority is interruptible. 

https://developer.apple.com/videos/play/wwdc2023/10036/?time=293 Here's a talk about this in wwdc 2023.
<img width="1813" height="981" alt="Screenshot 2025-10-27 at 11 12 18" src="https://github.com/user-attachments/assets/8306d6f6-a5a9-4834-a5d9-c5b2e014c258" />

## Changelog:

[IOS][ADDED] - Add support for UIAccessibilityPriority in announcements

## Test Plan:

Open the rn-tester app, go to Accessibility -> Check if the screen reader announces. 

Press: Announce for accessibility High Priority. You will hear "High Priority Announcement Test, Normal Priority Announcement". The second announcement did not cancel the first announcement (expected behavior)

Press: Announce for accessibility Low Priority: You will only hear "Normal Priority Announcement". The low priority announcement was successfully interrupted.