### PR TITLE
Fix implicit fallthrough in switch statements

### DIFF
--- a/packages/react-native/React/Views/RCTViewManager.m
+++ b/packages/react-native/React/Views/RCTViewManager.m
@@ -341,11 +341,13 @@ RCT_CUSTOM_VIEW_PROPERTY(pointerEvents, RCTPointerEvents, RCTView)
       // Unspecified values do not.
       // This wouldn't override a container view's `userInteractionEnabled = NO`
       view.userInteractionEnabled = YES;
+      break;
     case RCTPointerEventsNone:
       view.userInteractionEnabled = NO;
       break;
     default:
       RCTLogInfo(@"UIView base class does not support pointerEvent value: %@", json);
+      break;
   }
 }
 RCT_CUSTOM_VIEW_PROPERTY(removeClippedSubviews, BOOL, RCTView)


### PR DESCRIPTION
Summary:
A few places where we fall through intentionally are implicit.  We can make those explicit with `NS_FALLTHROUGH`.  Many places, however, are bugs from failing to add a `break` :eek: -- fix those places too.

These are all found via `-Wimplicit-fallthrough`... we will seek to make this an error by default (vs only in `CompilerWarningLevel.MEDIUM` or higher).

Differential Revision: D85583441


