### PR TITLE
Mitigate int overflow in findNextFocusableElement

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FocusOrderingHelper.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FocusOrderingHelper.cpp
@@ -55,8 +55,10 @@ int minorAxisDistance(FocusDirection direction, Rect source, Rect dest) {
 // 13 is a magic number that comes from Android's implementation. We opt to use
 // this to get the same focus ordering as Android. See:
 // https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/core/java/android/view/FocusFinder.java;l=547
-int getWeightedDistanceFor(int majorAxisDistance, int minorAxisDistance) {
-  return 13 * majorAxisDistance * majorAxisDistance +
+double getWeightedDistanceFor(
+    double majorAxisDistance,
+    double minorAxisDistance) {
+  return 13.0 * majorAxisDistance * majorAxisDistance +
       minorAxisDistance * minorAxisDistance;
 }
 
@@ -113,8 +115,8 @@ bool isBetterCandidate(
     return false;
   }
 
-  int candidateWeightedDistance = 0;
-  int currentWeightedDistance = 0;
+  double candidateWeightedDistance = 0;
+  double currentWeightedDistance = 0;
 
   switch (focusDirection) {
     case FocusDirection::FocusLeft:


### PR DESCRIPTION
Summary:
We are computing a weighted distance by squaring the major and minor axis distance. For particularly long lists, this means that items that are quite far away have a tendency to overflow the int value when squared, producing a negative number that becomes the smallest weighted distance.

Switching the computed value to double should mitigate the issue, since MAX_DOUBLE >>> MAX_INT ^ 2.

## Changelog

[Android][Fixed] - Resolves an int overflow in findNextFocusableElement

Differential Revision: D85598005


