### PR TITLE
Limit WebSocket queue size for packager connection

### DIFF
--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/devsupport/CxxInspectorPackagerConnectionTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/devsupport/CxxInspectorPackagerConnectionTest.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.devsupport
+
+import okhttp3.internal.ws.RealWebSocket
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class CxxInspectorPackagerConnectionTest {
+
+  @Test
+  fun testMaxQueueSizeEquality() {
+    val okHttpRealWebSocketClass = RealWebSocket::class.java
+    val okHttpMaxQueueSizeField = okHttpRealWebSocketClass.getDeclaredField("MAX_QUEUE_SIZE")
+    okHttpMaxQueueSizeField.isAccessible = true
+
+    val okHttpMaxQueueSize = okHttpMaxQueueSizeField.getLong(null)
+    assertThat(okHttpMaxQueueSize).isNotNull
+
+    assertThat(okHttpMaxQueueSize)
+        .isEqualTo(CxxInspectorPackagerConnection.Companion.MAX_QUEUE_SIZE)
+  }
+}


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

Establishes a queue mechanism on top of the OkHttp's WebSocket implementation. This mechanism will control the queue size and guarantee that we don't have more than 16MB scheduled.

This prevents the scenario of when OkHttp forces WS disconnection because of this threshold.

Differential Revision: D85581509


