### PR TITLE
Set sweepActiveTouchOnChildNativeGesturesAndroid default feature flag value to true

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<7987eba84c39c6e8cb6494092a94790e>>
+ * @generated SignedSource<<3ab7c812090eec90ebb2bbaffd170729>>
  */
 
 /**
@@ -147,7 +147,7 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
 
   override fun skipActivityIdentityAssertionOnHostPause(): Boolean = false
 
-  override fun sweepActiveTouchOnChildNativeGesturesAndroid(): Boolean = false
+  override fun sweepActiveTouchOnChildNativeGesturesAndroid(): Boolean = true
 
   override fun traceTurboModulePromiseRejectionsOnAndroid(): Boolean = false
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<21049b33fc72200390c6dd6d0ca27c19>>
+ * @generated SignedSource<<2c21515e9a083d91c7ce798f967def86>>
  */
 
 /**
@@ -276,7 +276,7 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool sweepActiveTouchOnChildNativeGesturesAndroid() override {
-    return false;
+    return true;
   }
 
   bool traceTurboModulePromiseRejectionsOnAndroid() override {

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -710,7 +710,7 @@ const definitions: FeatureFlagDefinitions = {
       ossReleaseStage: 'none',
     },
     sweepActiveTouchOnChildNativeGesturesAndroid: {
-      defaultValue: false,
+      defaultValue: true,
       metadata: {
         dateAdded: '2025-07-30',
         description:

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<d8ae80ae606b6cf56ea06866b5e5ac99>>
+ * @generated SignedSource<<67997afcb69af22e40879f7b7923052b>>
  * @flow strict
  * @noformat
  */
@@ -468,7 +468,7 @@ export const skipActivityIdentityAssertionOnHostPause: Getter<boolean> = createN
 /**
  * A flag to tell Fabric to sweep active touches from JSTouchDispatcher in Android when a child native gesture is started.
  */
-export const sweepActiveTouchOnChildNativeGesturesAndroid: Getter<boolean> = createNativeFlagGetter('sweepActiveTouchOnChildNativeGesturesAndroid', false);
+export const sweepActiveTouchOnChildNativeGesturesAndroid: Getter<boolean> = createNativeFlagGetter('sweepActiveTouchOnChildNativeGesturesAndroid', true);
 /**
  * Enables storing js caller stack when creating promise in native module. This is useful in case of Promise rejection and tracing the cause.
  */


### PR DESCRIPTION
Summary:
First of the remaining steps to fully rollout `sweepActiveTouchOnChildNativeGesturesAndroid`. It's already enabled by default everywhere an override is set, letting this bake for a week then going to remove

Changelog: [Internal]

Differential Revision: D85700377
