### PR TITLE
Add default return paths in ImageSource toString methods for better type safety

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/primitives.h
@@ -128,8 +128,13 @@ class ImageSource {
         return "remote";
       case ImageSource::Type::Local:
         return "local";
+#if defined(_MSC_VER)
     default:
-        return "Unknown";
+        __assume(0);
+#elif defined(__GNUC__) || defined(__clang__)
+    default:
+        __builtin_unreachable();
+#endif
     }
   }
 
@@ -144,8 +149,13 @@ class ImageSource {
         return "force-cache";
       case ImageSource::CacheStategy::OnlyIfCached:
         return "only-if-cached";
+#if defined(_MSC_VER)
     default:
-        return "Unknown";
+        __assume(0);
+#elif defined(__GNUC__) || defined(__clang__)
+    default:
+        __builtin_unreachable();
+#endif
     }
   }
 #endif


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
While merging upstream changes in react native windows we faced an issue where the switch statement didn't have a default value . https://github.com/microsoft/react-native-windows/issues/15263
Fixed "not all control paths return a value" warning in ImageSource::toString methods by adding proper default case returns. 
## Changelog:
[GENERAL][FIXED] - Add default return paths in ImageSource toString methods for better type safety

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

|GENERAL|FIXED- Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
