### PR TITLE
Ccomparison between signed and unsigned values, causing a error

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -421,7 +421,7 @@ std::shared_ptr<ShadowNode> cloneMultipleRecursive(
   std::shared_ptr<std::vector<std::shared_ptr<const ShadowNode>>> newChildren;
   auto count = childrenCount.at(family);
 
-  for (int i = 0; count > 0 && i < children.size(); i++) {
+  for (size_t i = 0; count > 0 && i < children.size(); i++) {
     const auto childFamily = &children[i]->getFamily();
     if (childrenCount.contains(childFamily)) {
       count--;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:
We saw this error while integrating  changes in react native windows 
https://github.com/microsoft/react-native-windows/issues/15292
Fixed type consistency in cloneMultipleRecursive by using size_t for loop iterator to properly match vector size type, improving type safety when iterating over children nodes.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:
[GENERAL][FIXED] - Use size_t instead of int for vector iteration in cloneMultipleRecursive
<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

|GENERAL|FIXED|- Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
