### PR TITLE
Promote Web Performance APIs to stable

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<346acf2190f419cc4de64f66cb40f802>>
+ * @generated SignedSource<<afccaed3066598724041c48bfb524234>>
  */
 
 /**
@@ -125,7 +125,7 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
 
   override fun enableVirtualViewWindowFocusDetection(): Boolean = false
 
-  override fun enableWebPerformanceAPIsByDefault(): Boolean = false
+  override fun enableWebPerformanceAPIsByDefault(): Boolean = true
 
   override fun fixMappingOfEventPrioritiesBetweenFabricAndReact(): Boolean = false
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Canary_Android.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Canary_Android.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<4464982256b8ce543d9235fccbf67054>>
+ * @generated SignedSource<<f82b5905d822f8009c054a9443f86e39>>
  */
 
 /**
@@ -26,8 +26,6 @@ public open class ReactNativeFeatureFlagsOverrides_RNOSS_Canary_Android : ReactN
   override fun enableBridgelessArchitecture(): Boolean = true
 
   override fun enableFabricRenderer(): Boolean = true
-
-  override fun enableWebPerformanceAPIsByDefault(): Boolean = true
 
   override fun useNativeViewConfigsInBridgelessMode(): Boolean = true
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<d3786de5c8669d29376f135536f7cbbc>>
+ * @generated SignedSource<<d61394fb8056e5e1a68f9fe7b936985c>>
  */
 
 /**
@@ -232,7 +232,7 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool enableWebPerformanceAPIsByDefault() override {
-    return false;
+    return true;
   }
 
   bool fixMappingOfEventPrioritiesBetweenFabricAndReact() override {

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSCanary.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsOverridesOSSCanary.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<32a03e199994c91c022013d7929bfea5>>
+ * @generated SignedSource<<db8626cf78a3ed226bbbe6bf20cc03a2>>
  */
 
 /**
@@ -32,10 +32,6 @@ class ReactNativeFeatureFlagsOverridesOSSCanary : public ReactNativeFeatureFlags
   }
 
   bool enableFabricRenderer() override {
-    return true;
-  }
-
-  bool enableWebPerformanceAPIsByDefault() override {
     return true;
   }
 

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -593,14 +593,14 @@ const definitions: FeatureFlagDefinitions = {
       ossReleaseStage: 'none',
     },
     enableWebPerformanceAPIsByDefault: {
-      defaultValue: false,
+      defaultValue: true,
       metadata: {
         description:
           'Enable Web Performance APIs (Performance Timeline, User Timings, etc.) by default.',
         expectedReleaseValue: true,
         purpose: 'release',
       },
-      ossReleaseStage: 'canary',
+      ossReleaseStage: 'stable',
     },
     fixMappingOfEventPrioritiesBetweenFabricAndReact: {
       defaultValue: false,

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<25169f72feeaa596faaeb8fc3fffac06>>
+ * @generated SignedSource<<7edda733c47c5e6db0287b8b6325cdfb>>
  * @flow strict
  * @noformat
  */
@@ -425,7 +425,7 @@ export const enableVirtualViewWindowFocusDetection: Getter<boolean> = createNati
 /**
  * Enable Web Performance APIs (Performance Timeline, User Timings, etc.) by default.
  */
-export const enableWebPerformanceAPIsByDefault: Getter<boolean> = createNativeFlagGetter('enableWebPerformanceAPIsByDefault', false);
+export const enableWebPerformanceAPIsByDefault: Getter<boolean> = createNativeFlagGetter('enableWebPerformanceAPIsByDefault', true);
 /**
  * Uses the default event priority instead of the discreet event priority by default when dispatching events from Fabric to React.
  */


### PR DESCRIPTION
Summary:
Changelog: [General][Added] - Enable Web Performance APIs

This promotes the Web Performance APIs from canary to stable.

Differential Revision: D85783108


