### PR TITLE
Fix missing enum values in switch statements

### DIFF
--- a/packages/react-native/ReactCommon/jsc/JSCRuntime.cpp
+++ b/packages/react-native/ReactCommon/jsc/JSCRuntime.cpp
@@ -1523,6 +1523,7 @@ jsi::Value JSCRuntime::createValue(JSValueRef value) const {
     }
     case kJSTypeSymbol:
       return jsi::Value(createSymbol(value));
+    case kJSTypeBigInt:
     default:
       // WHAT ARE YOU
       abort();


### PR DESCRIPTION
Summary:
`-Wswitch-enum` was introduced in 2024 and is beneficial because it will err when switch statement is missing a case for an enum, even with `default:` present.  This helps alert developers when they add an enum value of all the switch statements that need updating.

These diffs are to help progress the codebase so that we can enable `-Wswitch-enum` by default in `fbobjc`

## Changelog:
[General] [Fixed] - Add missing value to switch for `-Wswitch-enum` builds

Differential Revision: D85835952


