### PR TITLE
Mark private static fields as final in ReactHorizontalScrollView

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -83,10 +83,10 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
         HasSmoothScroll,
         VirtualViewContainer {
 
-  private static boolean DEBUG_MODE = false && ReactBuildConfig.DEBUG;
-  private static String TAG = ReactHorizontalScrollView.class.getSimpleName();
+  private static final boolean DEBUG_MODE = false && ReactBuildConfig.DEBUG;
+  private static final String TAG = ReactHorizontalScrollView.class.getSimpleName();
 
-  private static int NO_SCROLL_POSITION = Integer.MIN_VALUE;
+  private static final int NO_SCROLL_POSITION = Integer.MIN_VALUE;
 
   private static @Nullable Field sScrollerField;
   private static boolean sTriedToGetScrollerField = false;


### PR DESCRIPTION
Summary:
Fixed NotWrittenPrivateField lint warnings in ReactHorizontalScrollView.java by marking three private static fields as final:

- DEBUG_MODE: Changed from `private static boolean` to `private static final boolean`
- TAG: Changed from `private static String` to `private static final String`
- NO_SCROLL_POSITION: Changed from `private static int` to `private static final int`

These fields are initialized once and never modified, making them compile-time constants. Marking them as final follows Java best practices and prevents potential issues with Redex code optimization.

Changelog: [Internal]

Differential Revision: D85904890


