### PR TITLE
Fix keyboard navigation through nested a11y views in ReactHorizontalScrollView with snapToInterval enabled

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -28,6 +28,7 @@ import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.ViewParent;
 import android.view.accessibility.AccessibilityNodeInfo;
 import android.widget.HorizontalScrollView;
 import android.widget.OverScroller;
@@ -740,6 +741,20 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
     return handled;
   }
 
+  private boolean isDescendantOf(View parent, View view) {
+    if (view == null || parent == null) {
+      return false;
+    }
+    ViewParent p = view.getParent();
+    while (p != null && p.getParent() != null) {
+      if (p == parent) {
+        return true;
+      }
+      p = p.getParent();
+    }
+    return false;
+  }
+
   @Override
   public boolean arrowScroll(int direction) {
     boolean handled = false;
@@ -751,7 +766,7 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
         View currentFocused = findFocus();
         View nextFocused = FocusFinder.getInstance().findNextFocus(this, currentFocused, direction);
         View rootChild = getContentView();
-        if (rootChild != null && nextFocused != null && nextFocused.getParent() == rootChild) {
+        if (isDescendantOf(rootChild, nextFocused)) {
           if (!isScrolledInView(nextFocused) && !isMostlyScrolledInView(nextFocused)) {
             smoothScrollToNextPage(direction);
           }


### PR DESCRIPTION
Summary:
Navigating with keyboard through a11y items in horizontal FlatList that are not the direct child of the ScrollView contentView is broken, because instead of focusing the next focusable sibling, arrowScroll scrolls to the next page. This issue only happens when FlatList has snapToInterval enabled.
Fixed the condition that checked if a given focusable view belongs to the contentView.

Changelog: [Android] [Fixed] - Fix keyboard navigation through items in horizontal ScrollView with snapToInterval enabled

Reviewed By: Abbondanzo

Differential Revision: D85261167


