### PR TITLE
fix code snippet text container wrapping text in AnsiHiglight

### DIFF
--- a/packages/react-native/Libraries/LogBox/UI/AnsiHighlight.js
+++ b/packages/react-native/Libraries/LogBox/UI/AnsiHighlight.js
@@ -87,7 +87,7 @@ export default function Ansi({
     <View style={styles.container}>
       {parsedLines.map((items, i) => (
         <View style={styles.line} key={i}>
-          <Text>
+          <Text style={styles.text}>
             {items.map((bundle, key) => {
               const textStyle =
                 bundle.fg && COLORS[bundle.fg]
@@ -121,5 +121,8 @@ const styles = StyleSheet.create({
   },
   line: {
     flexDirection: 'row',
+  },
+  text: {
+    flexGrow: 1,
   },
 });


### PR DESCRIPTION
Summary: Fixing an issue with the error LogBox formatting on windows causing text to wrap

Reviewed By: rickhanlonii, yannickl

Differential Revision: D76845667


