### PR TITLE
Expose frame events on PerformanceTracer

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
@@ -360,6 +360,41 @@ void PerformanceTracer::reportResourceFinish(
       });
 }
 
+void PerformanceTracer::setLayerTreeId(std::string frame, int layerTreeId) {
+  enqueueEvent(
+      PerformanceTracerSetLayerTreeIdEvent{
+          .frame = std::move(frame),
+          .layerTreeId = layerTreeId,
+          .start = HighResTimeStamp::now(),
+          .threadId = getCurrentThreadId(),
+      });
+}
+
+void PerformanceTracer::reportFrameTiming(
+    int frameSeqId,
+    HighResTimeStamp start,
+    HighResTimeStamp end) {
+  ThreadId threadId = getCurrentThreadId();
+  enqueueEvent(
+      PerformanceTracerFrameBeginDrawEvent{
+          .frameSeqId = frameSeqId,
+          .start = start,
+          .threadId = threadId,
+      });
+  enqueueEvent(
+      PerformanceTracerFrameCommitEvent{
+          .frameSeqId = frameSeqId,
+          .start = start,
+          .threadId = threadId,
+      });
+  enqueueEvent(
+      PerformanceTracerFrameDrawEvent{
+          .frameSeqId = frameSeqId,
+          .start = end,
+          .threadId = threadId,
+      });
+}
+
 /* static */ TraceEvent PerformanceTracer::constructRuntimeProfileTraceEvent(
     RuntimeProfileId profileId,
     ProcessId processId,

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -162,6 +162,19 @@ class PerformanceTracer {
       int decodedBodyLength);
 
   /**
+   * Sets the active layer tree ID in Chrome DevTools. This is needed in
+   * order for frames to be parsed.
+   *
+   * https://chromedevtools.github.io/devtools-protocol/tot/LayerTree/
+   */
+  void setLayerTreeId(std::string frame, int layerTreeId);
+
+  /**
+   * Reports the required frame CDP events for a given native frame.
+   */
+  void reportFrameTiming(int frameSeqId, HighResTimeStamp start, HighResTimeStamp end);
+
+  /**
    * Creates "Profile" Trace Event.
    *
    * Can be serialized to JSON with TraceEventSerializer::serialize.


### PR DESCRIPTION
Summary: Expose a couple frame related events on the PerformanceTracer and call setLayerTreeId when tracing starts (needed for DevTools to parse frames)

Differential Revision: D85145809


