### PR TITLE
Fix likely bug in maintainVisibleContentPosition

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -1367,7 +1367,7 @@ public class ReactScrollView extends ScrollView
 
         mScroller.fling(getScrollX(), scrollY, 0, (int) flingVelocityY, 0, 0, 0, Integer.MAX_VALUE);
       } else {
-        scrollTo(getScrollX(), scrollY + (mScroller.getCurrX() - scrollerYBeforeTick));
+        scrollTo(getScrollX(), scrollY + (mScroller.getCurrY() - scrollerYBeforeTick));
       }
     }
   }


### PR DESCRIPTION
Summary:
The calculus for active scroll maintainVisibleContentPosition is not isomorphic between ReactHorizontalScrollView and ReactScrollView. Additiionally, it doesn't make sense that we would use an x-offset in a y-offset calculation. This fixes a likely bug where the OverScroller's x-offset is used to compute the scroll animation update in ReactScrollView.recreateFlingAnimation.

## Changelog

[Android][Fixed] - Issue with restarting scroll in maintainVisibleContentPosition

Differential Revision: D86021007


