### PR TITLE
fix: iOS version mismatch when using nightly prebuilds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,6 +30,7 @@ jobs:
     uses: ./.github/workflows/prebuild-ios-core.yml
     with:
       use-hermes-nightly: true
+      version-type: nightly
     secrets: inherit
     needs: [prebuild_apple_dependencies]
 

--- a/.github/workflows/prebuild-ios-core.yml
+++ b/.github/workflows/prebuild-ios-core.yml
@@ -1,8 +1,13 @@
-name: Prebuild iOS Dependencies
+name: Prebuild iOS Core
 
 on:
   workflow_call: # this directive allow us to call this workflow from other workflows
     inputs:
+      version-type:
+        description: 'The version type to set for the prebuild (nightly or release)'
+        type: string
+        required: false
+        default: ''
       use-hermes-nightly:
         description: 'Whether to use the hermes nightly build or read the version from the versions.properties file'
         type: boolean
@@ -51,6 +56,12 @@ jobs:
           fi
           echo "Using Hermes version: $HERMES_VERSION"
           echo "HERMES_VERSION=$HERMES_VERSION" >> $GITHUB_ENV
+      - name: Set React Native version
+        shell: bash
+        run: |
+          if [ "${{ inputs.version-type }}" != "" ]; then
+            node ./scripts/releases/set-rn-artifacts-version.js --build-type "${{ inputs.version-type }}"
+          fi
       - name: Download ReactNativeDependencies
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary:

Setting `ENV['RCT_USE_PREBUILT_RNCORE'] = '1'` when running nightlies on iOS will result in the following error:

<img height="608" alt="image" src="https://github.com/user-attachments/assets/130112d7-d4d8-4934-be56-c020a4b204a6" />

The reason for this happening is that we precompile the iOS artifacts on CI using whatever version is set on main (by default version 1000). This works fine when using RCs and stable versions because before the publishing step we do a release commit (e.g https://github.com/facebook/react-native/commit/57ff54492f4a5a0e9d331e880b3c2264a2bd81f7), which updates the react-native version. 

This can be easily mitigated by invoking the `set-rn-artifacts-version` CLI right before building the iOS prebuilds.

## Changelog:

[IOS] [FIXED] - Fix iOS version mismatch when using nightly prebuilds


## Test Plan:

Run `node ./scripts/releases/set-rn-artifacts-version.js --build-type` locally
