### PR TITLE
Fix missing enum values in switch statements

### DIFF
--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
@@ -727,6 +727,9 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
       return @"Join";
     case UIReturnKeyEmergencyCall:
       return @"Emergency Call";
+    case UIReturnKeyDefault:
+    case UIReturnKeyContinue:
+    case UIReturnKeyDone:
     default:
       return @"Done";
   }


### PR DESCRIPTION
Summary:
`-Wswitch-enum` was introduced in 2024 and is beneficial because it will err when switch statement is missing a case for an enum, even with `default:` present.  This helps alert developers when they add an enum value of all the switch statements that need updating.

These diffs are to help progress the codebase so that we can enable `-Wswitch-enum` by default in `fbobjc`

## Changelog:
[Internal] - Make enum exhaustive

Differential Revision: D85956869


