### PR TITLE
Define TracingTestBase class for tests

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/TracingTest.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/TracingTest.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "JsiIntegrationTest.h"
+
+#include <folly/dynamic.h>
+#include <folly/json.h>
+#include <gmock/gmock.h>
+#include <vector>
+
+#include "FollyDynamicMatchers.h"
+
+namespace facebook::react::jsinspector_modern {
+
+/**
+ * Base test class providing tracing-related test utilities for tests.
+ */
+template <typename EngineAdapter, typename Executor>
+class TracingTestBase : public JsiIntegrationPortableTestBase<EngineAdapter, Executor> {
+ protected:
+  using JsiIntegrationPortableTestBase<EngineAdapter, Executor>::JsiIntegrationPortableTestBase;
+
+  /**
+   * Helper method to start tracing via Tracing.start CDP command.
+   */
+  void startTracing()
+  {
+    this->expectMessageFromPage(JsonEq(R"({
+                                          "id": 1,
+                                          "result": {}
+                                        })"));
+
+    this->toPage_->sendMessage(R"({
+                                  "id": 1,
+                                  "method": "Tracing.start"
+                                })");
+  }
+
+  /**
+   * Helper method to end tracing and collect all trace events from potentially
+   * multiple chunked Tracing.dataCollected messages.
+   * \returns A vector containing all collected trace events
+   */
+  std::vector<folly::dynamic> endTracingAndCollectEvents()
+  {
+    testing::InSequence s;
+
+    this->expectMessageFromPage(JsonEq(R"({
+                                          "id": 1,
+                                          "result": {}
+                                        })"));
+
+    std::vector<folly::dynamic> allTraceEvents;
+
+    EXPECT_CALL(this->fromPage(), onMessage(JsonParsed(AtJsonPtr("/method", "Tracing.dataCollected"))))
+        .Times(testing::AtLeast(1))
+        .WillRepeatedly(testing::Invoke([&allTraceEvents](const std::string &message) {
+          auto parsedMessage = folly::parseJson(message);
+          auto &events = parsedMessage.at("params").at("value");
+          allTraceEvents.insert(
+              allTraceEvents.end(), std::make_move_iterator(events.begin()), std::make_move_iterator(events.end()));
+        }));
+
+    this->expectMessageFromPage(JsonParsed(
+        testing::AllOf(AtJsonPtr("/method", "Tracing.tracingComplete"), AtJsonPtr("/params/dataLossOccurred", false))));
+
+    this->toPage_->sendMessage(R"({
+                                  "id": 1,
+                                  "method": "Tracing.end"
+                                })");
+
+    return allTraceEvents;
+  }
+};
+
+} // namespace facebook::react::jsinspector_modern


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

Extracts `startTracing()`, `stopTracing()` helpers from NetworkReporterTest into a re-usable `TracingTestBase` class.

Differential Revision: D86027333


