### PR TITLE
Define TracingCategory enum

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TracingCategory.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TracingCategory.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+namespace facebook::react::jsinspector_modern::tracing {
+
+enum class Category {
+  HiddenTimeline, /*     disabled-by-default-devtools.timeline */
+  JavaScriptSampling, /* disabled-by-default-v8.cpu_profiler   */
+  RuntimeExecution, /*   v8.execute                            */
+  Timeline, /*           devtools.timeline                     */
+  UserTiming, /*         blink.user_timing                     */
+};
+
+inline std::string tracingCategoryToString(const Category &category)
+{
+  switch (category) {
+    case Category::Timeline:
+      return "devtools.timeline";
+    case Category::HiddenTimeline:
+      return "disabled-by-default-devtools.timeline";
+    case Category::UserTiming:
+      return "blink.user_timing";
+    case Category::JavaScriptSampling:
+      return "disabled-by-default-v8.cpu_profiler";
+    case Category::RuntimeExecution:
+      return "v8.execute";
+  }
+}
+
+inline std::optional<Category> getTracingCategoryFromString(const std::string &str)
+{
+  if (str == "blink.user_timing") {
+    return Category::UserTiming;
+  } else if (str == "devtools.timeline") {
+    return Category::Timeline;
+  } else if (str == "disabled-by-default-devtools.timeline") {
+    return Category::HiddenTimeline;
+  } else if (str == "disabled-by-default-v8.cpu_profiler") {
+    return Category::JavaScriptSampling;
+  } else if (str == "v8.execute") {
+    return Category::RuntimeExecution;
+  } else {
+    return std::nullopt;
+  }
+}
+
+} // namespace facebook::react::jsinspector_modern::tracing


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

Defines tracing category as a concept.

The end goal is to be able to control these categories from the frontend, so that we only enable what user has requested.

Differential Revision: D85912264


