### PR TITLE
Use TracingCategory in TraceEvent

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/third-party/folly/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/third-party/folly/CMakeLists.txt
@@ -43,6 +43,7 @@ SET(folly_runtime_SRC
         folly/json/json_pointer.cpp
         folly/json/json.cpp
         folly/lang/CString.cpp
+        folly/lang/Exception.cpp
         folly/lang/SafeAssert.cpp
         folly/lang/ToAscii.cpp
         folly/memory/detail/MallocImpl.cpp

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
@@ -8,6 +8,7 @@
 #include "PerformanceTracer.h"
 #include "Timing.h"
 #include "TraceEventSerializer.h"
+#include "TracingCategory.h"
 
 #include <jsinspector-modern/network/CdpNetwork.h>
 #include <jsinspector-modern/network/HttpUtils.h>
@@ -138,7 +139,7 @@ std::optional<std::vector<TraceEvent>> PerformanceTracer::stopTracing() {
   events.emplace_back(
       TraceEvent{
           .name = "TracingStartedInPage",
-          .cat = "disabled-by-default-devtools.timeline",
+          .cat = {Category::HiddenTimeline},
           .ph = 'I',
           .ts = currentTraceStartTime,
           .pid = processId_,
@@ -149,7 +150,7 @@ std::optional<std::vector<TraceEvent>> PerformanceTracer::stopTracing() {
   events.emplace_back(
       TraceEvent{
           .name = "ReactNative-TracingStopped",
-          .cat = "disabled-by-default-devtools.timeline",
+          .cat = {Category::HiddenTimeline},
           .ph = 'I',
           .ts = currentTraceEndTime,
           .pid = processId_,
@@ -409,7 +410,7 @@ void PerformanceTracer::reportFrameTiming(
   return TraceEvent{
       .id = profileId,
       .name = "Profile",
-      .cat = "disabled-by-default-v8.cpu_profiler",
+      .cat = {Category::JavaScriptSampling},
       .ph = 'P',
       .ts = profileTimestamp,
       .pid = processId,
@@ -432,7 +433,7 @@ PerformanceTracer::constructRuntimeProfileChunkTraceEvent(
   return TraceEvent{
       .id = profileId,
       .name = "ProfileChunk",
-      .cat = "disabled-by-default-v8.cpu_profiler",
+      .cat = {Category::JavaScriptSampling},
       .ph = 'P',
       .ts = chunkTimestamp,
       .pid = processId,
@@ -564,7 +565,7 @@ void PerformanceTracer::enqueueTraceEventsFromPerformanceTracerEvent(
             events.emplace_back(
                 TraceEvent{
                     .name = "RunTask",
-                    .cat = "disabled-by-default-devtools.timeline",
+                    .cat = {Category::HiddenTimeline},
                     .ph = 'X',
                     .ts = event.start,
                     .pid = processId_,
@@ -576,7 +577,7 @@ void PerformanceTracer::enqueueTraceEventsFromPerformanceTracerEvent(
             events.emplace_back(
                 TraceEvent{
                     .name = "RunMicrotasks",
-                    .cat = "v8.execute",
+                    .cat = {Category::RuntimeExecution},
                     .ph = 'X',
                     .ts = event.start,
                     .pid = processId_,
@@ -596,7 +597,7 @@ void PerformanceTracer::enqueueTraceEventsFromPerformanceTracerEvent(
             events.emplace_back(
                 TraceEvent{
                     .name = std::move(event.name),
-                    .cat = "blink.user_timing",
+                    .cat = {Category::UserTiming},
                     .ph = 'I',
                     .ts = event.start,
                     .pid = processId_,
@@ -621,7 +622,7 @@ void PerformanceTracer::enqueueTraceEventsFromPerformanceTracerEvent(
                 TraceEvent{
                     .id = eventId,
                     .name = event.name,
-                    .cat = "blink.user_timing",
+                    .cat = {Category::UserTiming},
                     .ph = 'b',
                     .ts = event.start,
                     .pid = processId_,
@@ -632,7 +633,7 @@ void PerformanceTracer::enqueueTraceEventsFromPerformanceTracerEvent(
                 TraceEvent{
                     .id = eventId,
                     .name = std::move(event.name),
-                    .cat = "blink.user_timing",
+                    .cat = {Category::UserTiming},
                     .ph = 'e',
                     .ts = event.start + event.duration,
                     .pid = processId_,
@@ -672,7 +673,7 @@ void PerformanceTracer::enqueueTraceEventsFromPerformanceTracerEvent(
                 events.emplace_back(
                     TraceEvent{
                         .name = "TimeStamp",
-                        .cat = "devtools.timeline",
+                        .cat = {Category::Timeline},
                         .ph = 'I',
                         .ts = event.createdAt,
                         .pid = processId_,
@@ -710,7 +711,7 @@ void PerformanceTracer::enqueueTraceEventsFromPerformanceTracerEvent(
             events.emplace_back(
                 TraceEvent{
                     .name = "TimeStamp",
-                    .cat = "devtools.timeline",
+                    .cat = {Category::Timeline},
                     .ph = 'I',
                     .ts = event.createdAt,
                     .pid = processId_,
@@ -730,7 +731,7 @@ void PerformanceTracer::enqueueTraceEventsFromPerformanceTracerEvent(
             events.emplace_back(
                 TraceEvent{
                     .name = "ResourceSendRequest",
-                    .cat = "devtools.timeline",
+                    .cat = {Category::Timeline},
                     .ph = 'I',
                     .ts = event.start,
                     .pid = processId_,
@@ -756,7 +757,7 @@ void PerformanceTracer::enqueueTraceEventsFromPerformanceTracerEvent(
             events.emplace_back(
                 TraceEvent{
                     .name = "ResourceReceiveResponse",
-                    .cat = "devtools.timeline",
+                    .cat = {Category::Timeline},
                     .ph = 'I',
                     .ts = event.start,
                     .pid = processId_,
@@ -774,7 +775,7 @@ void PerformanceTracer::enqueueTraceEventsFromPerformanceTracerEvent(
             events.emplace_back(
                 TraceEvent{
                     .name = "ResourceFinish",
-                    .cat = "devtools.timeline",
+                    .cat = {Category::Timeline},
                     .ph = 'I',
                     .ts = event.start,
                     .pid = processId_,
@@ -790,7 +791,7 @@ void PerformanceTracer::enqueueTraceEventsFromPerformanceTracerEvent(
             events.emplace_back(
                 TraceEvent{
                     .name = "SetLayerTreeId",
-                    .cat = "devtools.timeline",
+                    .cat = {Category::Timeline},
                     .ph = 'I',
                     .ts = event.start,
                     .pid = processId_,
@@ -806,7 +807,7 @@ void PerformanceTracer::enqueueTraceEventsFromPerformanceTracerEvent(
             events.emplace_back(
                 TraceEvent{
                     .name = "BeginFrame",
-                    .cat = "devtools.timeline",
+                    .cat = {Category::Timeline},
                     .ph = 'I',
                     .ts = event.start,
                     .pid = processId_,
@@ -822,7 +823,7 @@ void PerformanceTracer::enqueueTraceEventsFromPerformanceTracerEvent(
             events.emplace_back(
                 TraceEvent{
                     .name = "Commit",
-                    .cat = "devtools.timeline",
+                    .cat = {Category::Timeline},
                     .ph = 'I',
                     .ts = event.start,
                     .pid = processId_,
@@ -838,7 +839,7 @@ void PerformanceTracer::enqueueTraceEventsFromPerformanceTracerEvent(
             events.emplace_back(
                 TraceEvent{
                     .name = "DrawFrame",
-                    .cat = "devtools.timeline",
+                    .cat = {Category::Timeline},
                     .ph = 'I',
                     .ts = event.start,
                     .pid = processId_,

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEvent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEvent.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <jsinspector-modern/tracing/TracingCategory.h>
 #include <react/timing/primitives.h>
 
 #include <folly/dynamic.h>
@@ -40,7 +41,7 @@ struct TraceEvent {
    * A comma separated list of categories for the event, configuring how
    * events are shown in the Trace Viewer UI.
    */
-  std::string cat;
+  Categories cat;
 
   /**
    * The event type. This is a single character which changes depending on the

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEventSerializer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TraceEventSerializer.cpp
@@ -7,6 +7,7 @@
 
 #include "TraceEventSerializer.h"
 #include "Timing.h"
+#include "TracingCategory.h"
 
 #include <react/timing/primitives.h>
 
@@ -22,7 +23,7 @@ namespace facebook::react::jsinspector_modern::tracing {
     result["id"] = buffer.data();
   }
   result["name"] = std::move(event.name);
-  result["cat"] = std::move(event.cat);
+  result["cat"] = serializeTracingCategories(event.cat);
   result["ph"] = std::string(1, event.ph);
   result["ts"] = highResTimeStampToTracingClockTimeStamp(event.ts);
   result["pid"] = event.pid;

--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TracingCategory.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TracingCategory.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <folly/container/small_vector.h>
+
 #include <optional>
 #include <string>
 
@@ -51,6 +53,28 @@ inline std::optional<Category> getTracingCategoryFromString(const std::string &s
   } else {
     return std::nullopt;
   }
+}
+
+/**
+ * The Trace Event could have multiple categories, but this is extremely rare case.
+ */
+using Categories = folly::small_vector<Category, 1>;
+
+// { Timeline, UserTiming } => "devtools.timeline,blink.user_timing"
+inline std::string serializeTracingCategories(const Categories &categories)
+{
+  if (categories.size() == 1) {
+    return tracingCategoryToString(categories.front());
+  }
+
+  std::string serializedValue;
+  for (size_t i = 0; i < categories.size(); ++i) {
+    serializedValue += tracingCategoryToString(categories[i]);
+    if (i < categories.size() - 1) {
+      serializedValue += ",";
+    }
+  }
+  return serializedValue;
 }
 
 } // namespace facebook::react::jsinspector_modern::tracing


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

According to the only public document that we have about Trace Event format, a single Trace Event could have multiple categories.

However, we don't have yet a single instance of this, that's why I am using `folly:small_vector<..., 1>` to optimize for such case.

Differential Revision: D85973670


