### PR TITLE
Default init custom C++ TM struct properties

### DIFF
--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/modules/__snapshots__/GenerateModuleH-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/modules/__snapshots__/GenerateModuleH-test.js.snap
@@ -290,10 +290,10 @@ struct NativeEnumTurboModuleStateTypeBridging {
 
 template <typename P0, typename P1, typename P2, typename P3, typename P4>
 struct NativeEnumTurboModuleStateTypeWithEnums {
-  P0 state;
-  P1 regular;
-  P2 str;
-  P3 num;
+  P0 state{};
+  P1 regular{};
+  P2 str{};
+  P3 num{};
   P4 lowerCase;
   bool operator==(const NativeEnumTurboModuleStateTypeWithEnums &other) const {
     return state == other.state && regular == other.regular && str == other.str && num == other.num && lowerCase == other.lowerCase;
@@ -594,7 +594,7 @@ private:
 
 template <typename P0, typename P1>
 struct NativePartialAnnotationTurboModuleSomeObj {
-  P0 a;
+  P0 a{};
   P1 b;
   bool operator==(const NativePartialAnnotationTurboModuleSomeObj &other) const {
     return a == other.a && b == other.b;
@@ -1887,10 +1887,10 @@ struct NativeEnumTurboModuleStateTypeBridging {
 
 template <typename P0, typename P1, typename P2, typename P3, typename P4>
 struct NativeEnumTurboModuleStateTypeWithEnums {
-  P0 state;
-  P1 regular;
-  P2 str;
-  P3 num;
+  P0 state{};
+  P1 regular{};
+  P2 str{};
+  P3 num{};
   P4 lowerCase;
   bool operator==(const NativeEnumTurboModuleStateTypeWithEnums &other) const {
     return state == other.state && regular == other.regular && str == other.str && num == other.num && lowerCase == other.lowerCase;
@@ -2191,7 +2191,7 @@ private:
 
 template <typename P0, typename P1>
 struct NativePartialAnnotationTurboModuleSomeObj {
-  P0 a;
+  P0 a{};
   P1 b;
   bool operator==(const NativePartialAnnotationTurboModuleSomeObj &other) const {
     return a == other.a && b == other.b;

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
@@ -374,7 +374,7 @@ function createStructsString(
 
 template <${templateParameterWithTypename}>
 struct ${structName} {
-${templateMemberTypes.map(v => '  ' + v).join(';\n')};
+${templateMemberTypes.map(v => '  ' + v).join('{};\n')};
   bool operator==(const ${structName} &other) const {
     return ${value.properties
       .map(v => `${v.name} == other.${v.name}`)

--- a/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleH-test.js.snap
@@ -269,8 +269,8 @@ struct Bridging<NativeSampleTurboModuleEnumStr> {
 
 template <typename P0, typename P1, typename P2>
 struct NativeSampleTurboModuleConstantsStruct {
-  P0 const1;
-  P1 const2;
+  P0 const1{};
+  P1 const2{};
   P2 const3;
   bool operator==(const NativeSampleTurboModuleConstantsStruct &other) const {
     return const1 == other.const1 && const2 == other.const2 && const3 == other.const3;
@@ -323,8 +323,8 @@ struct NativeSampleTurboModuleConstantsStructBridging {
 
 template <typename P0>
 struct NativeSampleTurboModuleBinaryTreeNode {
-  std::unique_ptr<NativeSampleTurboModuleBinaryTreeNode<P0>> left;
-  P0 value;
+  std::unique_ptr<NativeSampleTurboModuleBinaryTreeNode<P0>> left{};
+  P0 value{};
   std::unique_ptr<NativeSampleTurboModuleBinaryTreeNode<P0>> right;
   bool operator==(const NativeSampleTurboModuleBinaryTreeNode &other) const {
     return left == other.left && value == other.value && right == other.right;
@@ -380,7 +380,7 @@ struct NativeSampleTurboModuleBinaryTreeNodeBridging {
 
 template <typename P0>
 struct NativeSampleTurboModuleGraphNode {
-  P0 label;
+  P0 label{};
   std::optional<std::vector<NativeSampleTurboModuleGraphNode<P0>>> neighbors;
   bool operator==(const NativeSampleTurboModuleGraphNode &other) const {
     return label == other.label && neighbors == other.neighbors;
@@ -429,8 +429,8 @@ struct NativeSampleTurboModuleGraphNodeBridging {
 
 template <typename P0, typename P1, typename P2>
 struct NativeSampleTurboModuleObjectStruct {
-  P0 a;
-  P1 b;
+  P0 a{};
+  P1 b{};
   P2 c;
   bool operator==(const NativeSampleTurboModuleObjectStruct &other) const {
     return a == other.a && b == other.b && c == other.c;
@@ -484,8 +484,8 @@ struct NativeSampleTurboModuleObjectStructBridging {
 
 template <typename P0, typename P1, typename P2>
 struct NativeSampleTurboModuleValueStruct {
-  P0 x;
-  P1 y;
+  P0 x{};
+  P1 y{};
   P2 z;
   bool operator==(const NativeSampleTurboModuleValueStruct &other) const {
     return x == other.x && y == other.y && z == other.z;
@@ -537,9 +537,9 @@ struct NativeSampleTurboModuleValueStructBridging {
 
 template <typename P0, typename P1, typename P2>
 struct NativeSampleTurboModuleMenuItem {
-  P0 label;
-  P1 onPress;
-  P2 shortcut;
+  P0 label{};
+  P1 onPress{};
+  P2 shortcut{};
   std::optional<std::vector<NativeSampleTurboModuleMenuItem<P0, P1, P2>>> items;
   bool operator==(const NativeSampleTurboModuleMenuItem &other) const {
     return label == other.label && onPress == other.onPress && shortcut == other.shortcut && items == other.items;
@@ -915,8 +915,8 @@ namespace facebook::react {
 
 template <typename P0, typename P1, typename P2>
 struct NativeSampleTurboModuleObjectStruct {
-  P0 a;
-  P1 b;
+  P0 a{};
+  P1 b{};
   P2 c;
   bool operator==(const NativeSampleTurboModuleObjectStruct &other) const {
     return a == other.a && b == other.b && c == other.c;
@@ -1056,10 +1056,10 @@ namespace facebook::react {
 
 template <typename P0, typename P1, typename P2, typename P3, typename P4>
 struct AliasTurboModuleOptions {
-  P0 offset;
-  P1 size;
-  P2 displaySize;
-  P3 resizeMode;
+  P0 offset{};
+  P1 size{};
+  P2 displaySize{};
+  P3 resizeMode{};
   P4 allowExternalStorage;
   bool operator==(const AliasTurboModuleOptions &other) const {
     return offset == other.offset && size == other.size && displaySize == other.displaySize && resizeMode == other.resizeMode && allowExternalStorage == other.allowExternalStorage;
@@ -1178,11 +1178,11 @@ namespace facebook::react {
 
 template <typename P0, typename P1, typename P2, typename P3, typename P4, typename P5>
 struct NativeCameraRollManagerPhotoIdentifierImage {
-  P0 uri;
-  P1 playableDuration;
-  P2 width;
-  P3 height;
-  P4 isStored;
+  P0 uri{};
+  P1 playableDuration{};
+  P2 width{};
+  P3 height{};
+  P4 isStored{};
   P5 filename;
   bool operator==(const NativeCameraRollManagerPhotoIdentifierImage &other) const {
     return uri == other.uri && playableDuration == other.playableDuration && width == other.width && height == other.height && isStored == other.isStored && filename == other.filename;
@@ -1292,7 +1292,7 @@ struct NativeCameraRollManagerPhotoIdentifierBridging {
 
 template <typename P0, typename P1>
 struct NativeCameraRollManagerPhotoIdentifiersPage {
-  P0 edges;
+  P0 edges{};
   P1 page_info;
   bool operator==(const NativeCameraRollManagerPhotoIdentifiersPage &other) const {
     return edges == other.edges && page_info == other.page_info;
@@ -1339,12 +1339,12 @@ struct NativeCameraRollManagerPhotoIdentifiersPageBridging {
 
 template <typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6>
 struct NativeCameraRollManagerGetPhotosParams {
-  P0 first;
-  P1 after;
-  P2 groupName;
-  P3 groupTypes;
-  P4 assetType;
-  P5 maxSize;
+  P0 first{};
+  P1 after{};
+  P2 groupName{};
+  P3 groupTypes{};
+  P4 assetType{};
+  P5 maxSize{};
   P6 mimeTypes;
   bool operator==(const NativeCameraRollManagerGetPhotosParams &other) const {
     return first == other.first && after == other.after && groupName == other.groupName && groupTypes == other.groupTypes && assetType == other.assetType && maxSize == other.maxSize && mimeTypes == other.mimeTypes;
@@ -1475,10 +1475,10 @@ private:
 
 template <typename P0, typename P1, typename P2, typename P3, typename P4>
 struct NativeExceptionsManagerStackFrame {
-  P0 column;
-  P1 file;
-  P2 lineNumber;
-  P3 methodName;
+  P0 column{};
+  P1 file{};
+  P2 lineNumber{};
+  P3 methodName{};
   P4 collapse;
   bool operator==(const NativeExceptionsManagerStackFrame &other) const {
     return column == other.column && file == other.file && lineNumber == other.lineNumber && methodName == other.methodName && collapse == other.collapse;
@@ -1546,13 +1546,13 @@ struct NativeExceptionsManagerStackFrameBridging {
 
 template <typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6, typename P7>
 struct NativeExceptionsManagerExceptionData {
-  P0 message;
-  P1 originalMessage;
-  P2 name;
-  P3 componentStack;
-  P4 stack;
-  P5 id;
-  P6 isFatal;
+  P0 message{};
+  P1 originalMessage{};
+  P2 name{};
+  P3 componentStack{};
+  P4 stack{};
+  P5 id{};
+  P6 isFatal{};
   P7 extraData;
   bool operator==(const NativeExceptionsManagerExceptionData &other) const {
     return message == other.message && originalMessage == other.originalMessage && name == other.name && componentStack == other.componentStack && stack == other.stack && id == other.id && isFatal == other.isFatal && extraData == other.extraData;


### PR DESCRIPTION
Summary:
Changelog: [Internal][Fixed] Default init custom C++ TM struct properties

Right now we don't do it and produce code as:
```
template <typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6>
struct NativeEditableObjectModulePropertyVal {
  P0 classOrList;
  P1 commonFields;
  P2 desc;
  P3 isDefault;
  P4 isSet;
  P5 scriptValue;
  P6 value;
  bool operator==(const NativeEditableObjectModulePropertyVal &other) const {
    return classOrList == other.classOrList && commonFields == other.commonFields && desc == other.desc && isDefault == other.isDefault && isSet == other.isSet && scriptValue == other.scriptValue && value == other.value;
  }
};
```

Now we do:
```
template <typename P0, typename P1, typename P2, typename P3, typename P4, typename P5, typename P6>
struct NativeEditableObjectModulePropertyVal {
  P0 classOrList{};
  P1 commonFields{};
  P2 desc{};
  P3 isDefault{};
  P4 isSet{};
  P5 scriptValue{};
  P6 value{};
  bool operator==(const NativeEditableObjectModulePropertyVal &other) const {
    return classOrList == other.classOrList && commonFields == other.commonFields && desc == other.desc && isDefault == other.isDefault && isSet == other.isSet && scriptValue == other.scriptValue && value == other.value;
  }
};
```

Differential Revision: D86142954


