### PR TITLE
Fix missing enum values in switch statements (xplat/js)

### DIFF
--- a/packages/react-native/React/CoreModules/RCTPlatform.mm
+++ b/packages/react-native/React/CoreModules/RCTPlatform.mm
@@ -31,10 +31,11 @@ static NSString *interfaceIdiom(UIUserInterfaceIdiom idiom)
       return @"tv";
     case UIUserInterfaceIdiomCarPlay:
       return @"carplay";
-#if TARGET_OS_VISION
     case UIUserInterfaceIdiomVision:
       return @"vision";
-#endif
+    case UIUserInterfaceIdiomMac:
+      return @"mac";
+    case UIUserInterfaceIdiomUnspecified:
     default:
       return @"unknown";
   }

--- a/packages/react-native/ReactCommon/react/renderer/css/CSSSyntaxParser.h
+++ b/packages/react-native/ReactCommon/react/renderer/css/CSSSyntaxParser.h
@@ -277,7 +277,14 @@ struct CSSComponentValueVisitorDispatcher {
       return {};
     }
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wswitch-enum"
+#endif
     switch (parser.peek().type()) {
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
       case CSSTokenType::Function:
         if (auto ret = visitFunction(visitors...)) {
           return *ret;

--- a/packages/react-native/ReactCommon/yoga/yoga/style/StyleLength.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/style/StyleLength.h
@@ -74,7 +74,14 @@ class StyleLength {
   }
 
   constexpr FloatOptional resolve(float referenceLength) {
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wswitch-enum"
+#endif
     switch (unit_) {
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
       case Unit::Point:
         return value_;
       case Unit::Percent:

--- a/packages/react-native/ReactCommon/yoga/yoga/style/StyleSizeLength.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/style/StyleSizeLength.h
@@ -99,7 +99,14 @@ class StyleSizeLength {
   }
 
   constexpr FloatOptional resolve(float referenceLength) {
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wswitch-enum"
+#endif
     switch (unit_) {
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
       case Unit::Point:
         return value_;
       case Unit::Percent:


### PR DESCRIPTION
Summary: Make improvements so that it is safe to use the `-Wswitch-enum` compiler error in a project consuming RN

Differential Revision: D86026884


