### PR TITLE
fix(type): `color` and `blurRadius` of BoxShadowValue mistakenly swapped

### DIFF
--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts
@@ -343,8 +343,8 @@ export type DropShadowValue = {
 export type BoxShadowValue = {
   offsetX: number | string;
   offsetY: number | string;
-  color?: string | undefined;
-  blurRadius?: ColorValue | number | undefined;
+  color?: ColorValue | undefined;
+  blurRadius?: string | number | undefined;
   spreadDistance?: number | string | undefined;
   inset?: boolean | undefined;
 };


### PR DESCRIPTION
Fix #54400

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

This PR fixes a type definition error.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[GENERAL] [FIXED] - `color` and `blurRadius` of BoxShadowValue mistakenly swapped

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[GENERAL] [FIXED] - `color` and `blurRadius` of BoxShadowValue mistakenly swapped

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
use `tsc` to check
