### PR TITLE
Update `publish-npm` script not to change Hermes versions on stable branches

### DIFF
--- a/scripts/releases-ci/publish-npm.js
+++ b/scripts/releases-ci/publish-npm.js
@@ -26,6 +26,7 @@ const {
   publishAndroidArtifactsToMaven,
   publishExternalArtifactsToMaven,
 } = require('../releases/utils/release-utils');
+const {getBranchName} = require('../releases/utils/scm-utils');
 const {REPO_ROOT} = require('../shared/consts');
 const {getPackages} = require('../shared/monorepoUtils');
 const fs = require('fs');
@@ -119,8 +120,11 @@ async function publishNpm(buildType /*: BuildType */) /*: Promise<void> */ {
     const packageJson = JSON.parse(packageJsonContent);
 
     if (packageJson.version === '1000.0.0') {
-      // Set hermes versions to latest available
-      await updateHermesVersionsToNightly();
+      // Set hermes versions to latest available if not on a stable branch
+      if (!/.*-stable/.test(getBranchName())) {
+        await updateHermesVersionsToNightly();
+      }
+
       await updateReactNativeArtifacts(version, buildType);
     }
   }


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Updates the `publish-npm` script, so that it doesn't try to use the latest (nightly) releases of Hermes when invoked on a stable branch before a version is updated from 1000.0.0.

This is the same change as the one used for 0.83 release: https://github.com/facebook/react-native/pull/54402.

Differential Revision: D86201041


