### PR TITLE
feat(ios): ability to link local spm packages

### DIFF
--- a/packages/react-native/scripts/cocoapods/spm.rb
+++ b/packages/react-native/scripts/cocoapods/spm.rb
@@ -62,20 +62,38 @@ class SPMManager
   end
 
   def clean_spm_dependencies_from_target(project, new_targets)
-    project.root_object.package_references.delete_if { |pkg| (pkg.class == Xcodeproj::Project::Object::XCRemoteSwiftPackageReference) }
+    project.root_object.package_references.delete_if { |pkg| 
+      (pkg.class == Xcodeproj::Project::Object::XCRemoteSwiftPackageReference) ||
+      (pkg.class == Xcodeproj::Project::Object::XCLocalSwiftPackageReference)
+    }
   end
 
   def add_spm_to_target(project, target, url, requirement, products)
-    pkg_class = Xcodeproj::Project::Object::XCRemoteSwiftPackageReference
-    ref_class = Xcodeproj::Project::Object::XCSwiftPackageProductDependency
-    pkg = project.root_object.package_references.find { |p| p.class == pkg_class && p.repositoryURL == url }
-    if !pkg
-      pkg = project.new(pkg_class)
-      pkg.repositoryURL = url
-      pkg.requirement = requirement
-      log(" Adding package to workspace: #{pkg.inspect}")
-      project.root_object.package_references << pkg
+    # Determine if this is a local path or remote URL
+    is_local_path = File.exist?(url)
+    
+    if is_local_path
+      pkg_class = Xcodeproj::Project::Object::XCLocalSwiftPackageReference
+      pkg = project.root_object.package_references.find { |p| p.class == pkg_class && p.relative_path == url }
+      if !pkg
+        pkg = project.new(pkg_class)
+        pkg.relative_path = url
+        log(" Adding local package to workspace: #{pkg.inspect}")
+        project.root_object.package_references << pkg
+      end
+    else
+      pkg_class = Xcodeproj::Project::Object::XCRemoteSwiftPackageReference
+      pkg = project.root_object.package_references.find { |p| p.class == pkg_class && p.repositoryURL == url }
+      if !pkg
+        pkg = project.new(pkg_class)
+        pkg.repositoryURL = url
+        pkg.requirement = requirement
+        log(" Adding remote package to workspace: #{pkg.inspect}")
+        project.root_object.package_references << pkg
+      end
     end
+    
+    ref_class = Xcodeproj::Project::Object::XCSwiftPackageProductDependency
     products.each do |product_name|
       ref = target.package_product_dependencies.find do |r|
         r.class == ref_class && r.package == pkg && r.product_name == product_name


### PR DESCRIPTION
## Summary:

While working on local project in monorepo, I found that `spm_dependency` utility available in CocoaPods does not support local SPM packages, assuming they always come from remote.

This change extends it so that `url` can also be a local path:

```ruby
  spm_dependency(s,
    url: File.join(__dir__, 'shared'),
    requirement: {},
    products: ['FooModule']
  )
```

In the above example, `shared` folder contains a SPM project.

I don't have opinions on the API design here, I am also happy to create `spm_local_dependency` utility in order to clean up the API design. 

## Changelog:

[iOS] - Allow linking local SPM packages in CocoaPods

## Test Plan:

Add local Swift Package to your CocoaPods podspec, then run `pod install`. You should see the project in your Xcode.
