### PR TITLE
Move common JSI binding utils to jsitooling

### DIFF
--- a/packages/react-native/Package.swift
+++ b/packages/react-native/Package.swift
@@ -199,21 +199,20 @@ let reactCxxReact = RNTarget(
   searchPaths: [CallInvokerPath],
   excludedPaths: ["tests"],
   dependencies: [.reactNativeDependencies, .jsi, .reactPerfLogger, .logger, .reactDebug, .reactJsInspector]
-
-)
-
-/// React-jsiexecutor.podspec
-let reactJsiExecutor = RNTarget(
-  name: .reactJsiExecutor,
-  path: "ReactCommon/jsiexecutor",
-  dependencies: [.reactNativeDependencies, .jsi, .reactPerfLogger, .reactCxxReact, .reactJsInspector]
 )
 
 /// React-jsitooling.podspec
 let reactJsiTooling = RNTarget(
   name: .reactJsiTooling,
   path: "ReactCommon/jsitooling",
-  dependencies: [.reactNativeDependencies, .reactJsInspector, .reactJsInspectorTracing, .reactCxxReact, .jsi, .reactRuntimeExecutor]
+  dependencies: [.reactNativeDependencies, .jsi, .reactJsInspector, .reactJsInspectorTracing, .reactCxxReact]
+)
+
+/// React-jsiexecutor.podspec
+let reactJsiExecutor = RNTarget(
+  name: .reactJsiExecutor,
+  path: "ReactCommon/jsiexecutor",
+  dependencies: [.reactNativeDependencies, .jsi, .reactCxxReact, .reactJsiTooling]
 )
 
 /// React-hermes.podspec

--- a/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactInstance.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/runtime/jni/JReactInstance.cpp
@@ -13,11 +13,12 @@
 #include <glog/logging.h>
 #include <jni.h>
 #include <jsi/jsi.h>
-#include <jsireact/JSIExecutor.h>
 #include <react/jni/JRuntimeExecutor.h>
 #include <react/jni/JSLogging.h>
 #include <react/renderer/runtimescheduler/RuntimeSchedulerCallInvoker.h>
 #include <react/runtime/BridgelessNativeMethodCallInvoker.h>
+#include <react/runtime/JSRuntimeBindings.h>
+
 #include "JavaTimerRegistry.h"
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/cxxreact/ReactMarker.cpp
+++ b/packages/react-native/ReactCommon/cxxreact/ReactMarker.cpp
@@ -6,7 +6,6 @@
  */
 
 #include "ReactMarker.h"
-#include <cxxreact/JSExecutor.h>
 
 namespace facebook::react::ReactMarker {
 

--- a/packages/react-native/ReactCommon/jsiexecutor/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsiexecutor/CMakeLists.txt
@@ -20,7 +20,9 @@ target_link_libraries(jsireact
         reactperflogger
         folly_runtime
         glog
-        jsi)
+        jserrorhandler
+        jsi
+        jsitooling)
 
 target_compile_reactnative_options(jsireact PRIVATE)
 target_compile_options(jsireact PRIVATE -O3)

--- a/packages/react-native/ReactCommon/jsiexecutor/React-jsiexecutor.podspec
+++ b/packages/react-native/ReactCommon/jsiexecutor/React-jsiexecutor.podspec
@@ -30,7 +30,9 @@ Pod::Spec.new do |s|
   s.header_dir             = "jsireact"
 
   s.dependency "React-cxxreact"
+  s.dependency "React-jserrorhandler"
   s.dependency "React-jsi"
+  s.dependency "React-jsitooling"
   s.dependency "React-perflogger"
   add_dependency(s, "React-debug")
   add_dependency(s, "React-runtimeexecutor", :additional_framework_paths => ["platform/ios"])

--- a/packages/react-native/ReactCommon/jsiexecutor/jsireact/JSIExecutor.cpp
+++ b/packages/react-native/ReactCommon/jsiexecutor/jsireact/JSIExecutor.cpp
@@ -576,44 +576,4 @@ void JSIExecutor::flush() {}
 
 #endif // RCT_REMOVE_LEGACY_ARCH
 
-void bindNativeLogger(Runtime& runtime, Logger logger) {
-  runtime.global().setProperty(
-      runtime,
-      "nativeLoggingHook",
-      Function::createFromHostFunction(
-          runtime,
-          PropNameID::forAscii(runtime, "nativeLoggingHook"),
-          2,
-          [logger = std::move(logger)](
-              jsi::Runtime& runtime,
-              const jsi::Value&,
-              const jsi::Value* args,
-              size_t count) {
-            if (count != 2) {
-              throw std::invalid_argument(
-                  "nativeLoggingHook takes 2 arguments");
-            }
-            logger(
-                args[0].asString(runtime).utf8(runtime),
-                static_cast<unsigned int>(args[1].asNumber()));
-            return Value::undefined();
-          }));
-}
-
-void bindNativePerformanceNow(Runtime& runtime) {
-  runtime.global().setProperty(
-      runtime,
-      "nativePerformanceNow",
-      Function::createFromHostFunction(
-          runtime,
-          PropNameID::forAscii(runtime, "nativePerformanceNow"),
-          0,
-          [](jsi::Runtime& runtime,
-             const jsi::Value&,
-             const jsi::Value* args,
-             size_t /*count*/) {
-            return HighResTimeStamp::now().toDOMHighResTimeStamp();
-          }));
-}
-
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/jsiexecutor/jsireact/JSIExecutor.h
+++ b/packages/react-native/ReactCommon/jsiexecutor/jsireact/JSIExecutor.h
@@ -12,6 +12,7 @@
 #include <cxxreact/RAMBundleRegistry.h>
 #include <jsi/jsi.h>
 #include <jsireact/JSINativeModules.h>
+#include <react/runtime/JSRuntimeBindings.h>
 #include <functional>
 #include <mutex>
 #include <optional>
@@ -127,10 +128,4 @@ class [[deprecated("This API will be removed along with the legacy architecture.
 #endif // RCT_REMOVE_LEGACY_ARCH
 };
 
-using Logger = std::function<void(const std::string &message, unsigned int logLevel)>;
-void bindNativeLogger(jsi::Runtime &runtime, Logger logger);
-
-void bindNativePerformanceNow(jsi::Runtime &runtime);
-
-double performanceNow();
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/ReactInstanceIntegrationTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/ReactInstanceIntegrationTest.cpp
@@ -14,6 +14,7 @@
 #include <glog/logging.h>
 #include <jsinspector-modern/InspectorFlags.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
+#include <react/runtime/JSRuntimeBindings.h>
 #include <react/runtime/hermes/HermesInstance.h>
 
 using namespace ::testing;

--- a/packages/react-native/ReactCommon/jsitooling/react/runtime/JSRuntimeBindings.cpp
+++ b/packages/react-native/ReactCommon/jsitooling/react/runtime/JSRuntimeBindings.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "JSRuntimeBindings.h"
+
+#include <react/timing/primitives.h>
+
+namespace facebook::react {
+
+void bindNativeLogger(jsi::Runtime& runtime, Logger logger) {
+  runtime.global().setProperty(
+      runtime,
+      "nativeLoggingHook",
+      jsi::Function::createFromHostFunction(
+          runtime,
+          jsi::PropNameID::forAscii(runtime, "nativeLoggingHook"),
+          2,
+          [logger = std::move(logger)](
+              jsi::Runtime& runtime,
+              const jsi::Value& /* this */,
+              const jsi::Value* args,
+              size_t count) {
+            if (count != 2) {
+              throw std::invalid_argument(
+                  "nativeLoggingHook takes 2 arguments");
+            }
+            logger(
+                args[0].asString(runtime).utf8(runtime),
+                static_cast<unsigned int>(args[1].asNumber()));
+            return jsi::Value::undefined();
+          }));
+}
+
+void bindNativePerformanceNow(jsi::Runtime& runtime) {
+  runtime.global().setProperty(
+      runtime,
+      "nativePerformanceNow",
+      jsi::Function::createFromHostFunction(
+          runtime,
+          jsi::PropNameID::forAscii(runtime, "nativePerformanceNow"),
+          0,
+          [](jsi::Runtime& /* runtime */,
+             const jsi::Value& /* this */,
+             const jsi::Value* /* args */,
+             size_t /*count*/) {
+            return HighResTimeStamp::now().toDOMHighResTimeStamp();
+          }));
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/jsitooling/react/runtime/JSRuntimeBindings.h
+++ b/packages/react-native/ReactCommon/jsitooling/react/runtime/JSRuntimeBindings.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <jsi/jsi.h>
+#include <string>
+
+namespace facebook::react {
+
+using Logger = std::function<void(const std::string &message, unsigned int logLevel)>;
+void bindNativeLogger(jsi::Runtime &runtime, Logger logger);
+
+void bindNativePerformanceNow(jsi::Runtime &runtime);
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/EventDispatcher.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventDispatcher.cpp
@@ -6,7 +6,7 @@
  */
 
 #include "EventDispatcher.h"
-#include <cxxreact/JSExecutor.h>
+
 #include <react/renderer/core/StateUpdate.h>
 
 #include "EventQueue.h"

--- a/packages/react-native/ReactCommon/react/renderer/core/EventQueueProcessor.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventQueueProcessor.cpp
@@ -5,13 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-#include <cxxreact/JSExecutor.h>
+#include "EventQueueProcessor.h"
+
 #include <logger/react_native_log.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
+
 #include "EventEmitter.h"
 #include "EventLogger.h"
-#include "EventQueue.h"
-#include "ShadowNodeFamily.h"
 
 namespace facebook::react {
 

--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.cpp
@@ -18,10 +18,10 @@
 #include <jsi/hermes.h>
 #include <jsi/instrumentation.h>
 #include <jsinspector-modern/HostTarget.h>
-#include <jsireact/JSIExecutor.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/runtimescheduler/RuntimeSchedulerBinding.h>
+#include <react/runtime/JSRuntimeBindings.h>
 #include <react/timing/primitives.h>
 #include <react/utils/jsi-utils.h>
 #include <iostream>
@@ -46,6 +46,12 @@ std::shared_ptr<RuntimeScheduler> createRuntimeScheduler(
       PerformanceEntryReporter::getInstance().get());
 
   return scheduler;
+}
+
+std::string getSyntheticBundlePath(uint32_t bundleId) {
+  std::array<char, 32> buffer{};
+  std::snprintf(buffer.data(), buffer.size(), "seg-%u.js", bundleId);
+  return buffer.data();
 }
 
 } // namespace
@@ -365,12 +371,8 @@ void ReactInstance::registerSegment(
     }
     LOG(WARNING) << "Starting to evaluate segment " << segmentId
                  << " in ReactInstance::registerSegment";
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     runtime.evaluateJavaScript(
-        std::move(script),
-        JSExecutor::getSyntheticBundlePath(segmentId, segmentPath));
-#pragma clang diagnostic pop
+        std::move(script), getSyntheticBundlePath(segmentId));
     LOG(WARNING) << "Finished evaluating segment " << segmentId
                  << " in ReactInstance::registerSegment";
     if (hasLogger) {

--- a/packages/react-native/ReactCommon/react/runtime/ReactInstance.h
+++ b/packages/react-native/ReactCommon/react/runtime/ReactInstance.h
@@ -13,7 +13,6 @@
 #include <jserrorhandler/JsErrorHandler.h>
 #include <jsi/jsi.h>
 #include <jsinspector-modern/ReactCdp.h>
-#include <jsireact/JSIExecutor.h>
 #include <react/renderer/runtimescheduler/RuntimeScheduler.h>
 #include <react/runtime/BufferedRuntimeExecutor.h>
 #include <react/runtime/JSRuntimeFactory.h>

--- a/packages/react-native/ReactCxxPlatform/react/runtime/ReactHost.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/runtime/ReactHost.cpp
@@ -45,6 +45,7 @@
 #include <react/renderer/scheduler/SurfaceDelegate.h>
 #include <react/renderer/scheduler/SurfaceManager.h>
 #include <react/renderer/uimanager/IMountingManager.h>
+#include <react/runtime/JSRuntimeBindings.h>
 #include <react/runtime/PlatformTimerRegistryImpl.h>
 #include <react/runtime/hermes/HermesInstance.h>
 #include <react/threading/MessageQueueThreadImpl.h>


### PR DESCRIPTION
Summary:
Refactor some dependencies to avoid pulling in `jsireact` (which is deprecated) in new environments which are binary-size constrained.

Changelog: [Internal]

Differential Revision: D86200983


