### PR TITLE
fix: add exception handling to hermes-utils.rb

### DIFF
--- a/packages/react-native/sdks/hermes-engine/hermes-utils.rb
+++ b/packages/react-native/sdks/hermes-engine/hermes-utils.rb
@@ -263,7 +263,7 @@ def nightly_tarball_url(version)
       timestamp = xml.elements['metadata/versioning/snapshot/timestamp'].text
       build_number = xml.elements['metadata/versioning/snapshot/buildNumber'].text
       full_version = "#{version}-#{timestamp}-#{build_number}"
-      final_url = "https://central.sonatype.com/repository/maven-snapshots/com/facebook/react/#{artifact_coordinate}/#{version}-SNAPSHOT/#{artifact_coordinate}-#{full_version}-#{artifact_name}"
+      final_url = "https://central.sonatype.com/repository/maven-snapshots/#{namespace}/#{artifact_coordinate}/#{version}-SNAPSHOT/#{artifact_coordinate}-#{full_version}-#{artifact_name}"
 
       return final_url
     else


### PR DESCRIPTION
## Summary:

While working on the React Native macOS upgrade, I ran into this error while fetching hermes during `pod install`

```
Fetching podspec for `hermes-engine` from `../react-native/sdks/hermes-engine/hermes-engine.podspec`
[!] Failed to load 'hermes-engine' podspec: 
[!] Invalid `hermes-engine.podspec` file: SSL_connect returned=1 errno=0 peeraddr=52.41.8.25:443 state=error: certificate verify failed (unable to get certificate CRL).

 #  from /Users/sanajmi/Developer/react-native-macos/packages/react-native/sdks/hermes-engine/hermes-engine.podspec:26
```

It seemed this simply came from an exception in `nightly_tarball_url`, which would stop the process. This change adds a fallback so that `pod install` can continue.

## Changelog:

[INTERNAL] [FIXED] - add exception handling to hermes-utils.rb


## Test Plan:

CI should pass
