### PR TITLE
Maintain momentum through non-zero velocity when paging is enabled

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -849,8 +849,13 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
                 @Override
                 public void run() {
                   mPostTouchRunnable = null;
-                  // Trigger snap alignment now that scrolling has stopped
-                  handlePostTouchScrolling(0, 0);
+                  // +1/-1 velocity if scrolling right or left. This is to ensure that the
+                  // next/previous page is picked rather than sliding backwards to the current page
+                  int velocityX = (int) Math.signum(hScroll);
+                  if (mDisableIntervalMomentum) {
+                    velocityX = 0;
+                  }
+                  flingAndSnap(velocityX);
                 }
               };
           postOnAnimationDelayed(mPostTouchRunnable, ReactScrollViewHelper.MOMENTUM_DELAY);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -688,8 +688,13 @@ public class ReactScrollView extends ScrollView
                 @Override
                 public void run() {
                   mPostTouchRunnable = null;
-                  // Trigger snap alignment now that scrolling has stopped
-                  handlePostTouchScrolling(0, 0);
+                  // +1/-1 velocity if scrolling down or up. This is to ensure that the
+                  // next/previous page is picked rather than sliding backwards to the current page
+                  int velocityY = (int) -Math.signum(vScroll);
+                  if (mDisableIntervalMomentum) {
+                    velocityY = 0;
+                  }
+                  flingAndSnap(velocityY);
                 }
               };
           postOnAnimationDelayed(mPostTouchRunnable, ReactScrollViewHelper.MOMENTUM_DELAY);


### PR DESCRIPTION
Summary:
We should treat `ACTION_SCROLL` events akin to momentum scrolling--they represent a scroll with non-zero velocity--but not as momentum events themselves--they don't have a real velocity after they've dispatched. When paging is enabled, we should run the same `flingAndSnap` logic and rely on this non-zero velocity to encourage scrolling to the next item in the direction of the scroll rather than immediately picking the nearest offset.

The end effect of this change is that scrolling down will always go to the next item regardless of when scrolling stops. Scrolling up will always go to the previous item. Similar for horizontal scrolling per right/left scrolling.

Changelog: [Internal]

Differential Revision: D86151012


