### PR TITLE
Remove Array<any> as fallback type for Unsupported Array Element Type

### DIFF
--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -530,12 +530,19 @@ function translateArrayTypeAnnotation(
       elementType: wrapNullable(isElementTypeNullable, _elementType),
     });
   } catch (ex) {
-    return wrapNullable(nullable, {
-      type: 'ArrayTypeAnnotation',
-      elementType: {
-        type: 'AnyTypeAnnotation',
-      },
-    });
+    if (
+      ex instanceof UnsupportedTypeAnnotationParserError &&
+      ex.typeAnnotationType === 'AnyTypeAnnotation'
+    ) {
+      return wrapNullable(nullable, {
+        type: 'ArrayTypeAnnotation',
+        elementType: {
+          type: 'AnyTypeAnnotation',
+        },
+      });
+    } else {
+      throw ex;
+    }
   }
 }
 


### PR DESCRIPTION
Summary:
Changelog:
[Android][Breaking] Remove unsupported array element type

Differential Revision: D84846051


