### PR TITLE
Include `.hermesv1version` file in the NPM package

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -129,6 +129,7 @@
     "scripts/xcode/ccache.conf",
     "scripts/xcode/with-environment.sh",
     "sdks/.hermesversion",
+    "sdks/.hermesv1version",
     "sdks/hermes-engine",
     "sdks/hermesc",
     "settings.gradle.kts",


### PR DESCRIPTION
Summary:
Changelog: [Internal]

React Native uses `files` field in `package.json` to list everything that should end up in the apckage. `.hermesv1version` file was missing from that list, which is fixed by this diff.

Differential Revision: D86295805


