### PR TITLE
Make android frame updates work with AnimationBackend

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.cpp
@@ -992,6 +992,7 @@ AnimationMutations NativeAnimatedNodesManager::pullAnimationMutations() {
             AnimationMutation{tag, nullptr, propsBuilder.get()});
         containsChange = true;
       }
+      updateViewPropsDirect_.clear();
     }
 
     if (!containsChange) {

--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManagerProvider.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManagerProvider.cpp
@@ -80,12 +80,16 @@ NativeAnimatedNodesManagerProvider::getOrCreate(
           std::move(directManipulationCallback),
           std::move(fabricCommitCallback),
           uiManager);
-#endif
 
       nativeAnimatedNodesManager_ =
           std::make_shared<NativeAnimatedNodesManager>(animationBackend_);
 
+      nativeAnimatedDelegate_ =
+          std::make_shared<UIManagerNativeAnimatedDelegateBackendImpl>(
+              animationBackend_);
+
       uiManager->unstable_setAnimationBackend(animationBackend_);
+#endif
     } else {
       nativeAnimatedNodesManager_ =
           std::make_shared<NativeAnimatedNodesManager>(
@@ -93,6 +97,10 @@ NativeAnimatedNodesManagerProvider::getOrCreate(
               std::move(fabricCommitCallback),
               std::move(startOnRenderCallback_),
               std::move(stopOnRenderCallback_));
+
+      nativeAnimatedDelegate_ =
+          std::make_shared<UIManagerNativeAnimatedDelegateImpl>(
+              nativeAnimatedNodesManager_);
     }
 
     addEventEmitterListener(
@@ -116,10 +124,6 @@ NativeAnimatedNodesManagerProvider::getOrCreate(
               }
               return false;
             }));
-
-    nativeAnimatedDelegate_ =
-        std::make_shared<UIManagerNativeAnimatedDelegateImpl>(
-            nativeAnimatedNodesManager_);
 
     uiManager->setNativeAnimatedDelegate(nativeAnimatedDelegate_);
 

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.cpp
@@ -10,6 +10,18 @@
 
 namespace facebook::react {
 
+UIManagerNativeAnimatedDelegateBackendImpl::
+    UIManagerNativeAnimatedDelegateBackendImpl(
+        std::weak_ptr<UIManagerAnimationBackend> animationBackend)
+    : animationBackend_(std::move(animationBackend)) {}
+
+void UIManagerNativeAnimatedDelegateBackendImpl::runAnimationFrame() {
+  if (auto animationBackendStrong = animationBackend_.lock()) {
+    animationBackendStrong->onAnimationFrame(
+        std::chrono::steady_clock::now().time_since_epoch().count() / 1000);
+  }
+}
+
 static inline Props::Shared cloneProps(
     AnimatedProps& animatedProps,
     const ShadowNode& shadowNode) {
@@ -108,15 +120,20 @@ void AnimationBackend::onAnimationFrame(double timestamp) {
 void AnimationBackend::start(const Callback& callback, bool isAsync) {
   callbacks.push_back(callback);
   // TODO: startOnRenderCallback_ should provide the timestamp from the platform
-  startOnRenderCallback_(
-      [this]() {
-        onAnimationFrame(
-            std::chrono::steady_clock::now().time_since_epoch().count() / 1000);
-      },
-      isAsync);
+  if (startOnRenderCallback_) {
+    startOnRenderCallback_(
+        [this]() {
+          onAnimationFrame(
+              std::chrono::steady_clock::now().time_since_epoch().count() /
+              1000);
+        },
+        isAsync);
+  }
 }
 void AnimationBackend::stop(bool isAsync) {
-  stopOnRenderCallback_(isAsync);
+  if (stopOnRenderCallback_) {
+    stopOnRenderCallback_(isAsync);
+  }
   callbacks.clear();
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.h
@@ -18,6 +18,18 @@
 
 namespace facebook::react {
 
+class AnimationBackend;
+
+class UIManagerNativeAnimatedDelegateBackendImpl : public UIManagerNativeAnimatedDelegate {
+ public:
+  explicit UIManagerNativeAnimatedDelegateBackendImpl(std::weak_ptr<UIManagerAnimationBackend> animationBackend);
+
+  void runAnimationFrame() override;
+
+ private:
+  std::weak_ptr<UIManagerAnimationBackend> animationBackend_;
+};
+
 struct AnimationMutation {
   Tag tag;
   const ShadowNodeFamily *family;


### PR DESCRIPTION
Summary: Animation frames on Android are tiggered from UIManagerNativeAnimatedDelegate::runAnimationFrame, so we implement that for the backend

Reviewed By: zeyap

Differential Revision: D84055754


