### PR TITLE
Back out "Remove RCT_EXPORT_MODULE from Core modules"

### DIFF
--- a/packages/react-native/Libraries/Blob/RCTBlobManager.mm
+++ b/packages/react-native/Libraries/Blob/RCTBlobManager.mm
@@ -42,10 +42,7 @@ static NSString *const kBlobURIScheme = @"blob";
   dispatch_queue_t _processingQueue;
 }
 
-+ (NSString *)moduleName
-{
-  return @"BlobModule";
-}
+RCT_EXPORT_MODULE(BlobModule)
 
 @synthesize bridge = _bridge;
 @synthesize moduleRegistry = _moduleRegistry;

--- a/packages/react-native/Libraries/Blob/RCTFileReaderModule.mm
+++ b/packages/react-native/Libraries/Blob/RCTFileReaderModule.mm
@@ -20,10 +20,7 @@
 
 @implementation RCTFileReaderModule
 
-+ (NSString *)moduleName
-{
-  return @"FileReaderModule";
-}
+RCT_EXPORT_MODULE(FileReaderModule)
 
 @synthesize moduleRegistry = _moduleRegistry;
 

--- a/packages/react-native/Libraries/Image/RCTBundleAssetImageLoader.mm
+++ b/packages/react-native/Libraries/Image/RCTBundleAssetImageLoader.mm
@@ -20,10 +20,7 @@
 
 @implementation RCTBundleAssetImageLoader
 
-+ (NSString *)moduleName
-{
-  return @"BundleAssetImageLoader";
-}
+RCT_EXPORT_MODULE()
 
 - (BOOL)canLoadImageURL:(NSURL *)requestURL
 {

--- a/packages/react-native/Libraries/Image/RCTGIFImageDecoder.mm
+++ b/packages/react-native/Libraries/Image/RCTGIFImageDecoder.mm
@@ -20,10 +20,7 @@
 
 @implementation RCTGIFImageDecoder
 
-+ (NSString *)moduleName
-{
-  return @"GIFImageDecoder";
-}
+RCT_EXPORT_MODULE()
 
 - (BOOL)canDecodeImageData:(NSData *)imageData
 {

--- a/packages/react-native/Libraries/Image/RCTImageEditingManager.mm
+++ b/packages/react-native/Libraries/Image/RCTImageEditingManager.mm
@@ -24,10 +24,7 @@
 
 @implementation RCTImageEditingManager
 
-+ (NSString *)moduleName
-{
-  return @"ImageEditingManager";
-}
+RCT_EXPORT_MODULE()
 
 @synthesize moduleRegistry = _moduleRegistry;
 

--- a/packages/react-native/Libraries/Image/RCTImageLoader.mm
+++ b/packages/react-native/Libraries/Image/RCTImageLoader.mm
@@ -92,10 +92,7 @@ static NSError *addResponseHeadersToError(NSError *originalError, NSHTTPURLRespo
 @synthesize maxConcurrentDecodingTasks = _maxConcurrentDecodingTasks;
 @synthesize maxConcurrentDecodingBytes = _maxConcurrentDecodingBytes;
 
-+ (NSString *)moduleName
-{
-  return @"RCTImageLoader";
-}
+RCT_EXPORT_MODULE()
 
 - (instancetype)init
 {

--- a/packages/react-native/Libraries/Image/RCTImageStoreManager.mm
+++ b/packages/react-native/Libraries/Image/RCTImageStoreManager.mm
@@ -32,10 +32,7 @@ static NSString *const RCTImageStoreURLScheme = @"rct-image-store";
 
 @synthesize methodQueue = _methodQueue;
 
-+ (NSString *)moduleName
-{
-  return @"ImageStoreManager";
-}
+RCT_EXPORT_MODULE()
 
 + (BOOL)requiresMainQueueSetup
 {

--- a/packages/react-native/Libraries/Image/RCTImageViewManager.mm
+++ b/packages/react-native/Libraries/Image/RCTImageViewManager.mm
@@ -20,10 +20,7 @@
 
 @implementation RCTImageViewManager
 
-+ (NSString *)moduleName
-{
-  return @"ImageViewManager";
-}
+RCT_EXPORT_MODULE()
 
 - (RCTShadowView *)shadowView
 {

--- a/packages/react-native/Libraries/Image/RCTLocalAssetImageLoader.mm
+++ b/packages/react-native/Libraries/Image/RCTLocalAssetImageLoader.mm
@@ -20,10 +20,7 @@
 
 @implementation RCTLocalAssetImageLoader
 
-+ (NSString *)moduleName
-{
-  return @"LocalAssetImageLoader";
-}
+RCT_EXPORT_MODULE()
 
 - (BOOL)canLoadImageURL:(NSURL *)requestURL
 {

--- a/packages/react-native/Libraries/LinkingIOS/RCTLinkingManager.mm
+++ b/packages/react-native/Libraries/LinkingIOS/RCTLinkingManager.mm
@@ -27,10 +27,7 @@ static void postNotificationWithURL(NSURL *URL, id sender)
 
 @implementation RCTLinkingManager
 
-+ (NSString *)moduleName
-{
-  return @"LinkingManager";
-}
+RCT_EXPORT_MODULE()
 
 - (dispatch_queue_t)methodQueue
 {

--- a/packages/react-native/Libraries/NativeAnimation/RCTNativeAnimatedModule.mm
+++ b/packages/react-native/Libraries/NativeAnimation/RCTNativeAnimatedModule.mm
@@ -30,10 +30,7 @@ typedef void (^AnimatedOperation)(RCTNativeAnimatedNodesManager *nodesManager);
   NSMutableDictionary<NSNumber *, NSNumber *> *_animIdIsManagedByFabric;
 }
 
-+ (NSString *)moduleName
-{
-  return @"NativeAnimatedModule";
-}
+RCT_EXPORT_MODULE();
 
 + (BOOL)requiresMainQueueSetup
 {

--- a/packages/react-native/Libraries/NativeAnimation/RCTNativeAnimatedTurboModule.mm
+++ b/packages/react-native/Libraries/NativeAnimation/RCTNativeAnimatedTurboModule.mm
@@ -30,10 +30,7 @@ typedef void (^AnimatedOperation)(RCTNativeAnimatedNodesManager *nodesManager);
   NSSet<NSString *> *_userDrivenAnimationEndedEvents;
 }
 
-+ (NSString *)moduleName
-{
-  return @"NativeAnimatedTurboModule";
-}
+RCT_EXPORT_MODULE();
 
 + (BOOL)requiresMainQueueSetup
 {

--- a/packages/react-native/Libraries/Network/RCTDataRequestHandler.mm
+++ b/packages/react-native/Libraries/Network/RCTDataRequestHandler.mm
@@ -20,10 +20,7 @@
   std::mutex _operationHandlerMutexLock;
 }
 
-+ (NSString *)moduleName
-{
-  return @"DataRequestHandler";
-}
+RCT_EXPORT_MODULE()
 
 - (void)invalidate
 {

--- a/packages/react-native/Libraries/Network/RCTFileRequestHandler.mm
+++ b/packages/react-native/Libraries/Network/RCTFileRequestHandler.mm
@@ -24,10 +24,7 @@
   std::mutex _operationHandlerMutexLock;
 }
 
-+ (NSString *)moduleName
-{
-  return @"FileRequestHandler";
-}
+RCT_EXPORT_MODULE()
 
 - (void)invalidate
 {

--- a/packages/react-native/Libraries/Network/RCTHTTPRequestHandler.mm
+++ b/packages/react-native/Libraries/Network/RCTHTTPRequestHandler.mm
@@ -33,10 +33,7 @@ void RCTSetCustomNSURLSessionConfigurationProvider(NSURLSessionConfigurationProv
 
 @synthesize moduleRegistry = _moduleRegistry;
 
-+ (NSString *)moduleName
-{
-  return @"HTTPRequestHandler";
-}
+RCT_EXPORT_MODULE()
 
 - (void)invalidate
 {

--- a/packages/react-native/Libraries/Network/RCTNetworking.mm
+++ b/packages/react-native/Libraries/Network/RCTNetworking.mm
@@ -167,10 +167,7 @@ static NSString *RCTGenerateFormBoundary()
 
 @synthesize methodQueue = _methodQueue;
 
-+ (NSString *)moduleName
-{
-  return @"Networking";
-}
+RCT_EXPORT_MODULE()
 
 + (BOOL)requiresMainQueueSetup
 {

--- a/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.mm
+++ b/packages/react-native/Libraries/PushNotificationIOS/RCTPushNotificationManager.mm
@@ -154,10 +154,7 @@ static BOOL IsNotificationRemote(UNNotification *notification)
   return [notification.request.trigger isKindOfClass:[UNPushNotificationTrigger class]];
 }
 
-+ (NSString *)moduleName
-{
-  return @"PushNotificationManager";
-}
+RCT_EXPORT_MODULE()
 
 - (dispatch_queue_t)methodQueue
 {

--- a/packages/react-native/Libraries/Settings/RCTSettingsManager.mm
+++ b/packages/react-native/Libraries/Settings/RCTSettingsManager.mm
@@ -25,10 +25,7 @@
 
 @synthesize moduleRegistry = _moduleRegistry;
 
-+ (NSString *)moduleName
-{
-  return @"SettingsManager";
-}
+RCT_EXPORT_MODULE()
 
 + (BOOL)requiresMainQueueSetup
 {

--- a/packages/react-native/Libraries/Text/BaseText/RCTBaseTextViewManager.mm
+++ b/packages/react-native/Libraries/Text/BaseText/RCTBaseTextViewManager.mm
@@ -11,10 +11,7 @@
 
 @implementation RCTBaseTextViewManager
 
-+ (NSString *)moduleName
-{
-  return @"BaseText";
-}
+RCT_EXPORT_MODULE(RCTBaseText)
 
 - (UIView *)view
 {

--- a/packages/react-native/Libraries/Text/RawText/RCTRawTextViewManager.mm
+++ b/packages/react-native/Libraries/Text/RawText/RCTRawTextViewManager.mm
@@ -13,10 +13,7 @@
 
 @implementation RCTRawTextViewManager
 
-+ (NSString *)moduleName
-{
-  return @"RawText";
-}
+RCT_EXPORT_MODULE(RCTRawText)
 
 - (UIView *)view
 {

--- a/packages/react-native/Libraries/Text/Text/RCTTextViewManager.mm
+++ b/packages/react-native/Libraries/Text/Text/RCTTextViewManager.mm
@@ -26,10 +26,7 @@
   NSHashTable<RCTTextShadowView *> *_shadowViews;
 }
 
-+ (NSString *)moduleName
-{
-  return @"TextViewManager";
-}
+RCT_EXPORT_MODULE(RCTText)
 
 RCT_REMAP_SHADOW_PROPERTY(numberOfLines, maximumNumberOfLines, NSInteger)
 RCT_REMAP_SHADOW_PROPERTY(ellipsizeMode, lineBreakMode, NSLineBreakMode)

--- a/packages/react-native/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputViewManager.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Multiline/RCTMultilineTextInputViewManager.mm
@@ -12,10 +12,7 @@
 
 @implementation RCTMultilineTextInputViewManager
 
-+ (NSString *)moduleName
-{
-  return @"MultilineTextInputViewManager";
-}
+RCT_EXPORT_MODULE()
 
 - (UIView *)view
 {

--- a/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputViewManager.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputViewManager.mm
@@ -30,10 +30,7 @@
   NSHashTable<RCTBaseTextInputShadowView *> *_shadowViews;
 }
 
-+ (NSString *)moduleName
-{
-  return @"BaseTextInputViewManager";
-}
+RCT_EXPORT_MODULE()
 
 #pragma mark - Unified <TextInput> properties
 

--- a/packages/react-native/Libraries/Text/TextInput/RCTInputAccessoryViewManager.mm
+++ b/packages/react-native/Libraries/Text/TextInput/RCTInputAccessoryViewManager.mm
@@ -14,10 +14,7 @@
 
 @implementation RCTInputAccessoryViewManager
 
-+ (NSString *)moduleName
-{
-  return @"InputAccessoryViewManager";
-}
+RCT_EXPORT_MODULE()
 
 - (UIView *)view
 {

--- a/packages/react-native/Libraries/Text/TextInput/Singleline/RCTSinglelineTextInputViewManager.mm
+++ b/packages/react-native/Libraries/Text/TextInput/Singleline/RCTSinglelineTextInputViewManager.mm
@@ -14,10 +14,7 @@
 
 @implementation RCTSinglelineTextInputViewManager
 
-+ (NSString *)moduleName
-{
-  return @"SinglelineTextInputViewManager";
-}
+RCT_EXPORT_MODULE()
 
 - (RCTShadowView *)shadowView
 {

--- a/packages/react-native/Libraries/Text/VirtualText/RCTVirtualTextViewManager.mm
+++ b/packages/react-native/Libraries/Text/VirtualText/RCTVirtualTextViewManager.mm
@@ -13,10 +13,7 @@
 
 @implementation RCTVirtualTextViewManager
 
-+ (NSString *)moduleName
-{
-  return @"VirtualTextViewManager";
-}
+RCT_EXPORT_MODULE(RCTVirtualText)
 
 - (UIView *)view
 {

--- a/packages/react-native/Libraries/Vibration/RCTVibration.mm
+++ b/packages/react-native/Libraries/Vibration/RCTVibration.mm
@@ -18,10 +18,7 @@
 
 @implementation RCTVibration
 
-+ (NSString *)moduleName
-{
-  return @"Vibration";
-}
+RCT_EXPORT_MODULE()
 
 - (void)vibrate
 {

--- a/packages/react-native/React/CoreModules/RCTAccessibilityManager.mm
+++ b/packages/react-native/React/CoreModules/RCTAccessibilityManager.mm
@@ -33,10 +33,7 @@ NSString *const RCTAccessibilityManagerDidUpdateMultiplierNotification =
 @synthesize moduleRegistry = _moduleRegistry;
 @synthesize multipliers = _multipliers;
 
-+ (NSString *)moduleName
-{
-  return @"AccessibilityManager";
-}
+RCT_EXPORT_MODULE()
 
 + (BOOL)requiresMainQueueSetup
 {

--- a/packages/react-native/React/CoreModules/RCTActionSheetManager.mm
+++ b/packages/react-native/React/CoreModules/RCTActionSheetManager.mm
@@ -42,10 +42,7 @@ using namespace facebook::react;
   return NO;
 }
 
-+ (NSString *)moduleName
-{
-  return @"ActionSheetManager";
-}
+RCT_EXPORT_MODULE()
 
 @synthesize viewRegistry_DEPRECATED = _viewRegistry_DEPRECATED;
 

--- a/packages/react-native/React/CoreModules/RCTAlertManager.mm
+++ b/packages/react-native/React/CoreModules/RCTAlertManager.mm
@@ -40,10 +40,7 @@ RCT_ENUM_CONVERTER(
   NSHashTable *_alertControllers;
 }
 
-+ (NSString *)moduleName
-{
-  return @"AlertManager";
-}
+RCT_EXPORT_MODULE()
 
 - (dispatch_queue_t)methodQueue
 {

--- a/packages/react-native/React/CoreModules/RCTAppState.mm
+++ b/packages/react-native/React/CoreModules/RCTAppState.mm
@@ -43,10 +43,7 @@ static NSString *RCTCurrentAppState()
   facebook::react::ModuleConstants<JS::NativeAppState::Constants> _constants;
 }
 
-+ (NSString *)moduleName
-{
-  return @"AppState";
-}
+RCT_EXPORT_MODULE()
 
 + (BOOL)requiresMainQueueSetup
 {

--- a/packages/react-native/React/CoreModules/RCTAppearance.mm
+++ b/packages/react-native/React/CoreModules/RCTAppearance.mm
@@ -92,10 +92,7 @@ NSString *RCTColorSchemePreference(UITraitCollection *traitCollection)
   return self;
 }
 
-+ (NSString *)moduleName
-{
-  return @"Appearance";
-}
+RCT_EXPORT_MODULE(Appearance)
 
 + (BOOL)requiresMainQueueSetup
 {

--- a/packages/react-native/React/CoreModules/RCTClipboard.mm
+++ b/packages/react-native/React/CoreModules/RCTClipboard.mm
@@ -19,10 +19,7 @@ using namespace facebook::react;
 
 @implementation RCTClipboard
 
-+ (NSString *)moduleName
-{
-  return @"Clipboard";
-}
+RCT_EXPORT_MODULE()
 
 - (dispatch_queue_t)methodQueue
 {

--- a/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
+++ b/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
@@ -37,10 +37,7 @@ using namespace facebook::react;
   dispatch_block_t _initialMessageBlock;
 }
 
-+ (NSString *)moduleName
-{
-  return @"DevLoadingView";
-}
+RCT_EXPORT_MODULE()
 
 - (instancetype)init
 {

--- a/packages/react-native/React/CoreModules/RCTDevMenu.mm
+++ b/packages/react-native/React/CoreModules/RCTDevMenu.mm
@@ -124,10 +124,7 @@ typedef void (^RCTDevMenuAlertActionHandler)(UIAlertAction *action);
 @synthesize callableJSModules = _callableJSModules;
 @synthesize bundleManager = _bundleManager;
 
-+ (NSString *)moduleName
-{
-  return @"DevMenu";
-}
+RCT_EXPORT_MODULE()
 
 + (void)initialize
 {

--- a/packages/react-native/React/CoreModules/RCTDevSettings.mm
+++ b/packages/react-native/React/CoreModules/RCTDevSettings.mm
@@ -134,10 +134,7 @@ static std::atomic<int> numInitializedModules{0};
 @synthesize isInspectable = _isInspectable;
 @synthesize bundleManager = _bundleManager;
 
-+ (NSString *)moduleName
-{
-  return @"RCTDevSettings";
-}
+RCT_EXPORT_MODULE()
 
 - (instancetype)init
 {

--- a/packages/react-native/React/CoreModules/RCTDevToolsRuntimeSettingsModule.mm
+++ b/packages/react-native/React/CoreModules/RCTDevToolsRuntimeSettingsModule.mm
@@ -23,11 +23,7 @@ static Config _config;
 @end
 
 @implementation RCTDevToolsRuntimeSettingsModule
-
-+ (NSString *)moduleName
-{
-  return @"ReactDevToolsRuntimeSettingsModule)";
-}
+RCT_EXPORT_MODULE(ReactDevToolsRuntimeSettingsModule)
 
 RCT_EXPORT_METHOD(
     setReloadAndProfileConfig : (JS::NativeReactDevToolsRuntimeSettingsModule::PartialReloadAndProfileConfig &)config)

--- a/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
+++ b/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
@@ -39,10 +39,7 @@ static NSString *const kFrameKeyPath = @"frame";
 
 @synthesize moduleRegistry = _moduleRegistry;
 
-+ (NSString *)moduleName
-{
-  return @"DeviceInfo";
-}
+RCT_EXPORT_MODULE()
 
 - (instancetype)init
 {

--- a/packages/react-native/React/CoreModules/RCTEventDispatcher.mm
+++ b/packages/react-native/React/CoreModules/RCTEventDispatcher.mm
@@ -44,10 +44,7 @@ static uint16_t RCTUniqueCoalescingKeyGenerator = 0;
 @synthesize dispatchToJSThread = _dispatchToJSThread;
 @synthesize callableJSModules = _callableJSModules;
 
-+ (NSString *)moduleName
-{
-  return @"EventDispatcher";
-}
+RCT_EXPORT_MODULE()
 
 - (void)initialize
 {

--- a/packages/react-native/React/CoreModules/RCTExceptionsManager.mm
+++ b/packages/react-native/React/CoreModules/RCTExceptionsManager.mm
@@ -26,10 +26,7 @@
 
 @synthesize moduleRegistry = _moduleRegistry;
 
-+ (NSString *)moduleName
-{
-  return @"ExceptionManager";
-}
+RCT_EXPORT_MODULE()
 
 - (instancetype)initWithDelegate:(id<RCTExceptionsManagerDelegate>)delegate
 {

--- a/packages/react-native/React/CoreModules/RCTI18nManager.mm
+++ b/packages/react-native/React/CoreModules/RCTI18nManager.mm
@@ -19,10 +19,7 @@ using namespace facebook::react;
 
 @implementation RCTI18nManager
 
-+ (NSString *)moduleName
-{
-  return @"I18nManager";
-}
+RCT_EXPORT_MODULE()
 
 + (BOOL)requiresMainQueueSetup
 {

--- a/packages/react-native/React/CoreModules/RCTKeyboardObserver.mm
+++ b/packages/react-native/React/CoreModules/RCTKeyboardObserver.mm
@@ -20,10 +20,7 @@ static NSDictionary *RCTParseKeyboardNotification(NSNotification *notification);
 
 @implementation RCTKeyboardObserver
 
-+ (NSString *)moduleName
-{
-  return @"KeyboardObserver";
-}
+RCT_EXPORT_MODULE()
 
 - (void)startObserving
 {

--- a/packages/react-native/React/CoreModules/RCTLogBox.mm
+++ b/packages/react-native/React/CoreModules/RCTLogBox.mm
@@ -27,10 +27,7 @@
 
 @synthesize bridge = _bridge;
 
-+ (NSString *)moduleName
-{
-  return @"LogBox";
-}
+RCT_EXPORT_MODULE()
 
 + (BOOL)requiresMainQueueSetup
 {

--- a/packages/react-native/React/CoreModules/RCTPerfMonitor.mm
+++ b/packages/react-native/React/CoreModules/RCTPerfMonitor.mm
@@ -114,10 +114,7 @@ static vm_size_t RCTGetResidentMemorySize(void)
 @synthesize bridge = _bridge;
 @synthesize moduleRegistry = _moduleRegistry;
 
-+ (NSString *)moduleName
-{
-  return @"PerfMonitor";
-}
+RCT_EXPORT_MODULE()
 
 + (BOOL)requiresMainQueueSetup
 {

--- a/packages/react-native/React/CoreModules/RCTPlatform.mm
+++ b/packages/react-native/React/CoreModules/RCTPlatform.mm
@@ -48,10 +48,7 @@ static NSString *interfaceIdiom(UIUserInterfaceIdiom idiom)
   ModuleConstants<JS::NativePlatformConstantsIOS::Constants> _constants;
 }
 
-+ (NSString *)moduleName
-{
-  return @"PlatformConstants";
-}
+RCT_EXPORT_MODULE(PlatformConstants)
 
 + (BOOL)requiresMainQueueSetup
 {

--- a/packages/react-native/React/CoreModules/RCTRedBox.mm
+++ b/packages/react-native/React/CoreModules/RCTRedBox.mm
@@ -480,10 +480,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
 @synthesize moduleRegistry = _moduleRegistry;
 @synthesize bundleManager = _bundleManager;
 
-+ (NSString *)moduleName
-{
-  return @"RedBox";
-}
+RCT_EXPORT_MODULE()
 
 - (void)registerErrorCustomizer:(id<RCTErrorCustomizer>)errorCustomizer
 {

--- a/packages/react-native/React/CoreModules/RCTSourceCode.mm
+++ b/packages/react-native/React/CoreModules/RCTSourceCode.mm
@@ -18,10 +18,7 @@ using namespace facebook::react;
 
 @implementation RCTSourceCode
 
-+ (NSString *)moduleName
-{
-  return @"SourceCode";
-}
+RCT_EXPORT_MODULE()
 
 @synthesize bundleManager = _bundleManager;
 

--- a/packages/react-native/React/CoreModules/RCTStatusBarManager.mm
+++ b/packages/react-native/React/CoreModules/RCTStatusBarManager.mm
@@ -68,10 +68,7 @@ static BOOL RCTViewControllerBasedStatusBarAppearance()
   return value;
 }
 
-+ (NSString *)moduleName
-{
-  return @"StatusBarManager";
-}
+RCT_EXPORT_MODULE()
 
 + (BOOL)requiresMainQueueSetup
 {

--- a/packages/react-native/React/CoreModules/RCTTiming.mm
+++ b/packages/react-native/React/CoreModules/RCTTiming.mm
@@ -107,10 +107,7 @@ static const NSTimeInterval kIdleCallbackFrameDeadline = 0.001;
 @synthesize paused = _paused;
 @synthesize pauseCallback = _pauseCallback;
 
-+ (NSString *)moduleName
-{
-  return @"Timing";
-}
+RCT_EXPORT_MODULE()
 
 - (instancetype)initWithDelegate:(id<RCTTimingDelegate>)delegate
 {

--- a/packages/react-native/React/CoreModules/RCTWebSocketModule.mm
+++ b/packages/react-native/React/CoreModules/RCTWebSocketModule.mm
@@ -39,10 +39,7 @@
   NSMutableDictionary<NSNumber *, id<RCTWebSocketContentHandler>> *_contentHandlers;
 }
 
-+ (NSString *)moduleName
-{
-  return @"WebSocketModule";
-}
+RCT_EXPORT_MODULE()
 
 - (dispatch_queue_t)methodQueue
 {

--- a/packages/react-native/React/Modules/RCTUIManager.mm
+++ b/packages/react-native/React/Modules/RCTUIManager.mm
@@ -179,10 +179,7 @@ NSString *const RCTUIManagerWillUpdateViewsDueToContentSizeMultiplierChangeNotif
 @synthesize bridge = _bridge;
 @synthesize moduleRegistry = _moduleRegistry;
 
-+ (NSString *)moduleName
-{
-  return @"RCTUIManager";
-}
+RCT_EXPORT_MODULE()
 
 + (BOOL)requiresMainQueueSetup
 {

--- a/packages/react-native/React/Views/RCTActivityIndicatorViewManager.m
+++ b/packages/react-native/React/Views/RCTActivityIndicatorViewManager.m
@@ -27,10 +27,7 @@ RCT_ENUM_CONVERTER(
 
 @implementation RCTActivityIndicatorViewManager
 
-+ (NSString *)moduleName
-{
-  return @"ActivityIndicatorViewManager";
-}
+RCT_EXPORT_MODULE()
 
 - (UIView *)view
 {

--- a/packages/react-native/React/Views/RCTDebuggingOverlayManager.m
+++ b/packages/react-native/React/Views/RCTDebuggingOverlayManager.m
@@ -17,10 +17,7 @@
 
 @implementation RCTDebuggingOverlayManager
 
-+ (NSString *)moduleName
-{
-  return @"DebuggingOverlay";
-}
+RCT_EXPORT_MODULE(DebuggingOverlay)
 
 - (UIView *)view
 {

--- a/packages/react-native/React/Views/RCTModalHostViewManager.m
+++ b/packages/react-native/React/Views/RCTModalHostViewManager.m
@@ -40,10 +40,7 @@
   NSPointerArray *_hostViews;
 }
 
-+ (NSString *)moduleName
-{
-  return @"ModalHostViewManager ";
-}
+RCT_EXPORT_MODULE()
 
 - (UIView *)view
 {

--- a/packages/react-native/React/Views/RCTModalManager.m
+++ b/packages/react-native/React/Views/RCTModalManager.m
@@ -17,10 +17,7 @@
 
 @implementation RCTModalManager
 
-+ (NSString *)moduleName
-{
-  return @"ModalManager";
-}
+RCT_EXPORT_MODULE();
 
 - (NSArray<NSString *> *)supportedEvents
 {

--- a/packages/react-native/React/Views/RCTSwitchManager.m
+++ b/packages/react-native/React/Views/RCTSwitchManager.m
@@ -16,10 +16,7 @@
 
 @implementation RCTSwitchManager
 
-+ (NSString *)moduleName
-{
-  return @"SwitchManager";
-}
+RCT_EXPORT_MODULE()
 
 - (UIView *)view
 {

--- a/packages/react-native/React/Views/RCTViewManager.m
+++ b/packages/react-native/React/Views/RCTViewManager.m
@@ -128,10 +128,7 @@ RCT_MULTI_ENUM_CONVERTER(
 
 @synthesize bridge = _bridge;
 
-+ (NSString *)moduleName
-{
-  return @"RCTViewManager";
-}
+RCT_EXPORT_MODULE()
 
 - (dispatch_queue_t)methodQueue
 {

--- a/packages/react-native/React/Views/RefreshControl/RCTRefreshControlManager.m
+++ b/packages/react-native/React/Views/RefreshControl/RCTRefreshControlManager.m
@@ -15,10 +15,7 @@
 
 @implementation RCTRefreshControlManager
 
-+ (NSString *)moduleName
-{
-  return @"RefreshControlManager";
-}
+RCT_EXPORT_MODULE()
 
 - (UIView *)view
 {

--- a/packages/react-native/React/Views/SafeAreaView/RCTSafeAreaViewManager.m
+++ b/packages/react-native/React/Views/SafeAreaView/RCTSafeAreaViewManager.m
@@ -15,10 +15,7 @@
 
 @implementation RCTSafeAreaViewManager
 
-+ (NSString *)moduleName
-{
-  return @"SafeAreaViewManager";
-}
+RCT_EXPORT_MODULE()
 
 - (UIView *)view
 {

--- a/packages/react-native/React/Views/ScrollView/RCTScrollContentViewManager.m
+++ b/packages/react-native/React/Views/ScrollView/RCTScrollContentViewManager.m
@@ -14,10 +14,7 @@
 
 @implementation RCTScrollContentViewManager
 
-+ (NSString *)moduleName
-{
-  return @"ScrollContentViewManager";
-}
+RCT_EXPORT_MODULE()
 
 - (RCTScrollContentView *)view
 {

--- a/packages/react-native/React/Views/ScrollView/RCTScrollViewManager.m
+++ b/packages/react-native/React/Views/ScrollView/RCTScrollViewManager.m
@@ -53,10 +53,7 @@ RCT_ENUM_CONVERTER(
 
 @implementation RCTScrollViewManager
 
-+ (NSString *)moduleName
-{
-  return @"ScrollViewManager";
-}
+RCT_EXPORT_MODULE()
 
 - (UIView *)view
 {

--- a/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/samples/platform/ios/ReactCommon/RCTSampleTurboModule.mm
@@ -24,10 +24,7 @@ using namespace facebook::react;
 }
 
 // Backward-compatible export
-+ (NSString *)moduleName
-{
-  return @"SampleTurboModule";
-}
+RCT_EXPORT_MODULE()
 
 // Backward-compatible queue configuration
 + (BOOL)requiresMainQueueSetup


### PR DESCRIPTION
Summary:
Backing this out because there are a couple of internal tests going in timeout when this land.

I believe that for the tests some of these modules are not registered correctly.

## Changelog:
[Internal] -

## Facebook:

See T244088155. For some reasons, these two tests:

- `buck test @//fbobjc/mode/buck2/ios-tests fbsource//fbobjc/Libraries/FBReactKit:FDSMediaWrapperServerSnapshotTests_Facebook` ([link](https://www.internalfb.com/intern/test/844425131558081))
- `buck test @//fbobjc/mode/buck2/ios-tests fbsource//fbobjc/Libraries/FBReactKit:FDSInlineReactionsServerSnapshotTests_Facebook` ([link](https://www.internalfb.com/intern/test/844425131558078))

timeouts with diff D85580258. I need to investigate which modules make these tests time out. It could be that the test setup is missing some plugin.

I'm also surprised why other FDS tests are actually passing...

Differential Revision: D86401358
