### PR TITLE
Fix CURRENT_ARCH for Apple Silicon simulator

### DIFF
--- a/packages/react-native/scripts/ios-configure-glog.sh
+++ b/packages/react-native/scripts/ios-configure-glog.sh
@@ -14,7 +14,12 @@ if [ -z "$CURRENT_ARCH" ] || [ "$CURRENT_ARCH" == "undefined_arch" ]; then
     # it's better to rely on platform name as fallback because architecture differs between simulator and device
 
     if [[ "$PLATFORM_NAME" == *"simulator"* ]]; then
-        CURRENT_ARCH="x86_64"
+        if [[ "$(uname -m)" == "arm64" ]]; then
+            # Apple Silicon Mac -> arm64 simulator
+            CURRENT_ARCH="arm64"
+        else
+            CURRENT_ARCH="x86_64"
+        fi
     else
         CURRENT_ARCH="arm64"
     fi


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:
Fix the arch issue when running `pod install` on M4
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:
[iOS] [Fixed] - Set the `CURRENT_ARCH=arm64` on M4
<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[IOS][Fixed] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Issue log
```shell
Installing glog (0.3.5)
[!] /bin/bash -c 
set -e
#!/bin/bash
# Copyright (c) Facebook, Inc. and its affiliates.
#
# This source code is licensed under the MIT license found in the
# LICENSE file in the root directory of this source tree.

set -e

PLATFORM_NAME="${PLATFORM_NAME:-iphoneos}"
CURRENT_ARCH="${CURRENT_ARCH}"

if [ -z "$CURRENT_ARCH" ] || [ "$CURRENT_ARCH" == "undefined_arch" ]; then
    # Xcode 10 beta sets CURRENT_ARCH to "undefined_arch", this leads to incorrect linker arg.
    # it's better to rely on platform name as fallback because architecture differs between simulator and device

    if [[ "$PLATFORM_NAME" == *"simulator"* ]]; then
        CURRENT_ARCH="x86_64"
    else
        CURRENT_ARCH="armv7"
    fi
fi

export CC="$(xcrun -find -sdk $PLATFORM_NAME cc) -arch $CURRENT_ARCH -isysroot $(xcrun -sdk $PLATFORM_NAME --show-sdk-path)"
export CXX="$CC"

# Remove automake symlink if it exists
if [ -h "test-driver" ]; then
    rm test-driver
fi

./configure --host arm-apple-darwin

# Fix build for tvOS
cat << EOF >> src/config.h

/* Add in so we have Apple Target Conditionals */
#ifdef __APPLE__
#include <TargetConditionals.h>
#include <Availability.h>
#endif

/* Special configuration for AppleTVOS */
#if TARGET_OS_TV
#undef HAVE_SYSCALL_H
#undef HAVE_SYS_SYSCALL_H
#undef OS_MACOSX
#endif

/* Special configuration for ucontext */
#undef HAVE_UCONTEXT_H
#undef PC_FROM_UCONTEXT
#if defined(__x86_64__)
#define PC_FROM_UCONTEXT uc_mcontext->__ss.__rip
#elif defined(__i386__)
#define PC_FROM_UCONTEXT uc_mcontext->__ss.__eip
#endif
EOF

# Prepare exported header include
EXPORTED_INCLUDE_DIR="exported/glog"
mkdir -p exported/glog
cp -f src/glog/log_severity.h "$EXPORTED_INCLUDE_DIR/"
cp -f src/glog/logging.h "$EXPORTED_INCLUDE_DIR/"
cp -f src/glog/raw_logging.h "$EXPORTED_INCLUDE_DIR/"
cp -f src/glog/stl_logging.h "$EXPORTED_INCLUDE_DIR/"
cp -f src/glog/vlog_is_on.h "$EXPORTED_INCLUDE_DIR/"

checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for arm-apple-darwin-strip... no
checking for strip... strip
checking for a thread-safe mkdir -p... ./install-sh -c -d
checking for gawk... no
checking for mawk... no
checking for nawk... no
checking for awk... awk
checking whether make sets $(MAKE)... yes
checking whether make supports nested variables... yes
checking for arm-apple-darwin-gcc... /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -arch armv7 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS26.0.sdk
checking whether the C compiler works... no
/Library/Caches/CocoaPods/Pods/Release/glog/0.3.5-bc4e6/missing: Unknown `--is-lightweight' option
Try `/Library/Caches/CocoaPods/Pods/Release/glog/0.3.5-bc4e6/missing --help' for more information
configure: WARNING: 'missing' script is too old or missing
configure: error: in `/Library/Caches/CocoaPods/Pods/Release/glog/0.3.5-bc4e6':
configure: error: C compiler cannot create executables
See `config.log' for more details
```

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
