### PR TITLE
Calll the ShadowNode::cloneMultiple callback for each cloned node

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -412,7 +412,6 @@ namespace {
 
 std::shared_ptr<ShadowNode> cloneMultipleRecursive(
     const ShadowNode& shadowNode,
-    const std::unordered_set<const ShadowNodeFamily*>& familiesToUpdate,
     const std::unordered_map<const ShadowNodeFamily*, int>& childrenCount,
     const std::function<std::shared_ptr<
         ShadowNode>(const ShadowNode&, const ShadowNodeFragment&)>& callback) {
@@ -430,16 +429,12 @@ std::shared_ptr<ShadowNode> cloneMultipleRecursive(
             std::make_shared<std::vector<std::shared_ptr<const ShadowNode>>>(
                 children);
       }
-      (*newChildren)[i] = cloneMultipleRecursive(
-          *children[i], familiesToUpdate, childrenCount, callback);
+      (*newChildren)[i] =
+          cloneMultipleRecursive(*children[i], childrenCount, callback);
     }
   }
 
-  ShadowNodeFragment fragment{.children = newChildren};
-  if (familiesToUpdate.contains(family)) {
-    return callback(shadowNode, fragment);
-  }
-  return shadowNode.clone(fragment);
+  return callback(shadowNode, {.children = newChildren});
 }
 
 } // namespace
@@ -479,8 +474,7 @@ std::shared_ptr<ShadowNode> ShadowNode::cloneMultiple(
     return nullptr;
   }
 
-  return cloneMultipleRecursive(
-      *this, familiesToUpdate, childrenCount, callback);
+  return cloneMultipleRecursive(*this, childrenCount, callback);
 }
 
 #pragma mark - DebugStringConvertible

--- a/packages/react-native/ReactCommon/react/renderer/core/tests/ShadowNodeTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/tests/ShadowNodeTest.cpp
@@ -342,3 +342,35 @@ TEST_F(ShadowNodeTest, cloneMultiple) {
   EXPECT_EQ(newNodeABA->getTag(), nodeABA_->getTag());
   EXPECT_EQ(newNodeABA.get(), nodeABA_.get());
 }
+
+TEST_F(ShadowNodeTest, cloneMultipleWithSingleFamily) {
+  auto newProps = std::make_shared<const TestProps>();
+  auto newRoot = nodeA_->cloneMultiple(
+      {&nodeAB_->getFamily()},
+      [&](const ShadowNode& oldShadowNode, const ShadowNodeFragment& fragment) {
+        return oldShadowNode.clone({
+            .props = newProps,
+            .children = fragment.children,
+            .state = fragment.state,
+        });
+      });
+
+  EXPECT_EQ(newRoot->getTag(), nodeA_->getTag());
+  // The callback is called for each cloned node, so the root props are also
+  // updated
+  EXPECT_EQ(newRoot->getProps(), newProps);
+
+  auto newNodeAA = newRoot->getChildren()[0];
+  EXPECT_EQ(newNodeAA->getTag(), nodeAA_->getTag());
+  EXPECT_EQ(newNodeAA->getProps(), nodeAA_->getProps());
+  // AA was cloned when its parent was cloned as it was shared
+  EXPECT_NE(newNodeAA.get(), nodeAA_.get());
+
+  auto newNodeAB = newRoot->getChildren()[1];
+  EXPECT_EQ(newNodeAB->getTag(), nodeAB_->getTag());
+  EXPECT_EQ(newNodeAB->getProps(), newProps);
+
+  auto newNodeABA = newNodeAB->getChildren()[0];
+  EXPECT_EQ(newNodeABA->getTag(), nodeABA_->getTag());
+  EXPECT_EQ(newNodeABA.get(), nodeABA_.get());
+}


### PR DESCRIPTION
Summary:
The original intention by the cloneMultiple method was to give the possibility of defining the cloning method only for the nodes definied by the list of families. But this way it is impossible to for example set the value of `runtimeShadowNodeReference` in the fragment, so instead we now pass the responsibility of cloning to the user for all the cloned nodes.

# Changelog

[General] [Changed] - cloneMultiple now invokes the callback for every cloned node, instead of doing that only for the nodes in `familiesToUpdate`

Differential Revision: D85852143


