### PR TITLE
Button docs cleanup

### DIFF
--- a/packages/react-native/Libraries/Components/Button.js
+++ b/packages/react-native/Libraries/Components/Button.js
@@ -184,9 +184,6 @@ export type ButtonProps = $ReadOnly<{
   [button:source]:
   https://github.com/facebook/react-native/blob/HEAD/Libraries/Components/Button.js
 
-  [button:examples]:
-  https://js.coach/?menu%5Bcollections%5D=React%20Native&page=1&query=button
-
   ```jsx
   <Button
     onPress={onPressLearnMore}


### PR DESCRIPTION
Summary:
Button links to js.coach, but this domain is up for sale. Let's clean it up

Changelog: [Internal]

Reviewed By: cipolleschi

Differential Revision: D86418236


