### PR TITLE
VirtualViewContainerStateExperimental remove() memory leak fix

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/VirtualViewContainerStateExperimental.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/VirtualViewContainerStateExperimental.kt
@@ -49,6 +49,13 @@ internal class VirtualViewContainerStateExperimental(scrollView: ViewGroup) :
     }
   }
 
+  override fun remove(virtualView: VirtualView) {
+    super.remove(virtualView)
+    HPV.remove(virtualView.virtualViewID)
+    P.remove(virtualView.virtualViewID)
+    V.remove(virtualView.virtualViewID)
+  }
+
   /**
    * Perform mode update check on a single VirtualView. Does not check other VirtualViews in the
    * collection. Use carefully


### PR DESCRIPTION
Summary:
## Changelog: [Internal]

VirtualView ID references (strings) are currently not being removed from the bookkeeping sets V, P, HPV in VirtualViewContainerStateExperimental upon deletion.

This PR provides a fix by extending the parent container's `remove()` function and correctly removing the IDs from the bookkeeping sets.

Reviewed By: yungsters

Differential Revision: D86369358


