### PR TITLE
add dealloc function to RCTAnimatedModuleProvider

### DIFF
--- a/packages/react-native/ReactApple/RCTAnimatedModuleProvider/RCTAnimatedModuleProvider.mm
+++ b/packages/react-native/ReactApple/RCTAnimatedModuleProvider/RCTAnimatedModuleProvider.mm
@@ -26,6 +26,26 @@
   std::function<void()> _onRender;
 }
 
+- (void)dealloc
+{
+  if (_displayLink != nil) {
+#if TARGET_OS_OSX
+    RCTPlatformDisplayLink *displayLink = _displayLink;
+#else
+    CADisplayLink *displayLink = _displayLink;
+#endif
+    _displayLink = nil;
+    if ([NSThread isMainThread]) {
+      [displayLink invalidate];
+    } else {
+      dispatch_sync(dispatch_get_main_queue(), ^{
+        [displayLink invalidate];
+      });
+    }
+    _onRender = nullptr;
+  }
+}
+
 - (void)_onDisplayLinkTick
 {
   if (_displayLink != nullptr && _onRender != nullptr) {
@@ -69,11 +89,16 @@
             const auto stop_render = [weakSelf]() {
               RCTAnimatedModuleProvider *strongSelf = weakSelf;
               if (strongSelf) {
-                if (strongSelf->_displayLink != nil) {
-                  [strongSelf->_displayLink invalidate];
-                  strongSelf->_displayLink = nil;
-                  strongSelf->_onRender = nullptr;
+#if TARGET_OS_OSX
+                RCTPlatformDisplayLink *displayLink = strongSelf->_displayLink;
+#else
+                CADisplayLink *displayLink = strongSelf->_displayLink;
+#endif
+                strongSelf->_displayLink = nil;
+                if (displayLink != nil) {
+                  [displayLink invalidate];
                 }
+                strongSelf->_onRender = nullptr;
               }
             };
 


### PR DESCRIPTION
Summary:
## Changelog:

[Internal] [Changed] - add dealloc function to RCTAnimatedModuleProvider

just in case RCTAnimatedModuleProvider is destroyed earlier than AnimatedModule when react instance tears down, then when AnimatedModule (which owns NativeAnimatedNodesManager) is destroyed, even if StopOnRenderCallback is invoked, it doesn't invalidate displayLink (since strongSelf is nullptr)

Differential Revision: D86459439


