### PR TITLE
feat(ios): Add a dev menu to RCTSurfaceHostingView 

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppSetupUtils.mm
@@ -124,16 +124,6 @@ std::unique_ptr<facebook::react::JSExecutorFactory> RCTAppSetupDefaultJsExecutor
   // Necessary to allow NativeModules to lookup TurboModules
   [bridge setRCTTurboModuleRegistry:turboModuleManager];
 
-#if RCT_DEV
-  /**
-   * Instantiating DevMenu has the side-effect of registering
-   * shortcuts for CMD + d, CMD + i,  and CMD + n via RCTDevMenu.
-   * Therefore, when TurboModules are enabled, we must manually create this
-   * NativeModule.
-   */
-  [turboModuleManager moduleForName:"RCTDevMenu"];
-#endif // end RCT_DEV
-
   auto runtimeInstallerLambda = [turboModuleManager, bridge, runtimeScheduler](facebook::jsi::Runtime &runtime) {
     if (!bridge || !turboModuleManager) {
       return;

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
@@ -34,6 +34,10 @@
 #import <react/runtime/JSRuntimeFactory.h>
 #import <react/runtime/JSRuntimeFactoryCAPI.h>
 
+#if RCT_DEV_MENU
+#import <React/RCTSurfaceHostingView.h>
+#endif // RCT_DEV_MENU
+
 @implementation RCTRootViewFactoryConfiguration
 
 - (instancetype)initWithBundleURL:(NSURL *)bundleURL newArchEnabled:(BOOL)newArchEnabled
@@ -189,6 +193,12 @@
 
   RCTSurfaceHostingProxyRootView *surfaceHostingProxyRootView =
       [[RCTSurfaceHostingProxyRootView alloc] initWithSurface:surface];
+#if RCT_DEV_MENU
+  RCTDevMenu *devMenu = [self.reactHost.moduleRegistry moduleForClass:[RCTDevMenu class]];
+  if (devMenu) {
+    surfaceHostingProxyRootView.devMenu = devMenu;
+  }
+#endif // RCT_DEV_MENU
 
 #if TARGET_OS_TV
   surfaceHostingProxyRootView.backgroundColor = [UIColor clearColor];
@@ -216,6 +226,16 @@
 #else
   rootView.backgroundColor = [UIColor blackColor];
 #endif
+
+#if RCT_DEV_MENU
+  if ([rootView isKindOfClass:[RCTSurfaceHostingView class]]) {
+    RCTDevMenu *devMenu = [bridge moduleForClass:[RCTDevMenu class]];
+    if (devMenu) {
+      [(RCTSurfaceHostingView *)rootView setDevMenu:devMenu];
+    }
+  }
+#endif // RCT_DEV_MENU
+
   return rootView;
 }
 

--- a/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.h
+++ b/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.h
@@ -12,6 +12,8 @@
 #import <React/RCTSurfaceSizeMeasureMode.h>
 #import <React/RCTSurfaceStage.h>
 
+@class RCTDevMenu;
+
 typedef UIView *_Nullable (^RCTSurfaceHostingViewActivityIndicatorViewFactory)(void);
 
 NS_ASSUME_NONNULL_BEGIN
@@ -60,6 +62,14 @@ NS_ASSUME_NONNULL_BEGIN
  * @param disabled if `YES`, the auto-hide is disabled. Otherwise the loading view will be hidden automatically
  */
 - (void)disableActivityIndicatorAutoHide:(BOOL)disabled;
+
+#if RCT_DEV_MENU
+/**
+ * Dev menu for key command access (Cmd+D, Cmd+I).
+ */
+@property (nonatomic, strong, nullable) RCTDevMenu *devMenu;
+#endif
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.mm
+++ b/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingView.mm
@@ -13,6 +13,10 @@
 #import "RCTSurfaceView.h"
 #import "RCTUtils.h"
 
+#if RCT_DEV_MENU
+#import "RCTDevMenu.h"
+#endif // RCT_DEV_MENU
+
 @interface RCTSurfaceHostingView ()
 
 @property (nonatomic, assign) BOOL isActivityIndicatorViewVisible;
@@ -248,5 +252,36 @@ RCT_NOT_IMPLEMENTED(-(nullable instancetype)initWithCoder : (NSCoder *)coder)
     [self _invalidateLayout];
   });
 }
+
+#pragma mark - Dev Menu
+
+#if RCT_DEV_MENU
+- (BOOL)canBecomeFirstResponder
+{
+  return YES;
+}
+
+- (NSArray<UIKeyCommand *> *)keyCommands
+{
+  return @[
+    [UIKeyCommand keyCommandWithInput:@"d"
+                        modifierFlags:UIKeyModifierCommand
+                               action:@selector(toggleDevMenu)],
+    [UIKeyCommand keyCommandWithInput:@"i"
+                        modifierFlags:UIKeyModifierCommand
+                               action:@selector(toggleElementInspector)],
+  ];
+}
+
+- (void)toggleDevMenu
+{
+  [_devMenu toggle];
+}
+
+- (void)toggleElementInspector
+{
+  [_devMenu toggleElementInspector];
+}
+#endif // RCT_DEV_MENU
 
 @end

--- a/packages/react-native/React/CoreModules/RCTDevMenu.h
+++ b/packages/react-native/React/CoreModules/RCTDevMenu.h
@@ -57,7 +57,7 @@ RCT_EXTERN NSString *const RCTShowDevMenuNotification;
 /**
  * Whether the hotkeys that toggles the developer menu is enabled.
  */
-@property (nonatomic, assign) BOOL hotkeysEnabled;
+@property (nonatomic, assign) BOOL hotkeysEnabled DEPRECATED_ATTRIBUTE;
 
 /**
  * Whether the developer menu is enabled.
@@ -83,6 +83,21 @@ RCT_EXTERN NSString *const RCTShowDevMenuNotification;
  * Manually show the dev menu (can be called from JS).
  */
 - (void)show;
+
+/**
+ * Manually toggle the dev menu.
+ */
+- (void)toggle;
+
+/**
+ * Toggle the element inspector (called by key command).
+ */
+- (void)toggleElementInspector;
+
+/**
+ * Reload from key command (called by key command).
+ */
+- (void)reloadFromKeyCommand;
 
 /**
  * Deprecated, use `RCTReloadCommand` instead.

--- a/packages/react-native/React/CoreModules/RCTDevMenu.mm
+++ b/packages/react-native/React/CoreModules/RCTDevMenu.mm
@@ -12,7 +12,6 @@
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTDefines.h>
 #import <React/RCTDevSettings.h>
-#import <React/RCTKeyCommands.h>
 #import <React/RCTLog.h>
 #import <React/RCTReloadCommand.h>
 #import <React/RCTUtils.h>
@@ -150,72 +149,8 @@ RCT_EXPORT_MODULE()
 
     _keyboardShortcutsEnabled = true;
     _devMenuEnabled = true;
-    [self registerHotkeys];
   }
   return self;
-}
-
-- (void)registerHotkeys
-{
-#if TARGET_OS_SIMULATOR || TARGET_OS_MACCATALYST
-  RCTKeyCommands *commands = [RCTKeyCommands sharedInstance];
-  __weak __typeof(self) weakSelf = self;
-
-  // Toggle debug menu
-  [commands registerKeyCommandWithInput:@"d"
-                          modifierFlags:UIKeyModifierCommand
-                                 action:^(__unused UIKeyCommand *command) {
-                                   [weakSelf toggle];
-                                 }];
-
-  // Toggle element inspector
-  [commands registerKeyCommandWithInput:@"i"
-                          modifierFlags:UIKeyModifierCommand
-                                 action:^(__unused UIKeyCommand *command) {
-                                   [(RCTDevSettings *)[weakSelf.moduleRegistry moduleForName:"DevSettings"]
-                                       toggleElementInspector];
-                                 }];
-#endif
-}
-
-- (void)unregisterHotkeys
-{
-#if TARGET_OS_SIMULATOR || TARGET_OS_MACCATALYST
-  RCTKeyCommands *commands = [RCTKeyCommands sharedInstance];
-
-  [commands unregisterKeyCommandWithInput:@"d" modifierFlags:UIKeyModifierCommand];
-  [commands unregisterKeyCommandWithInput:@"i" modifierFlags:UIKeyModifierCommand];
-#endif
-}
-
-- (BOOL)isHotkeysRegistered
-{
-#if TARGET_OS_SIMULATOR || TARGET_OS_MACCATALYST
-  RCTKeyCommands *commands = [RCTKeyCommands sharedInstance];
-
-  return [commands isKeyCommandRegisteredForInput:@"d" modifierFlags:UIKeyModifierCommand] &&
-      [commands isKeyCommandRegisteredForInput:@"i" modifierFlags:UIKeyModifierCommand];
-#else
-  return NO;
-#endif
-}
-
-- (BOOL)isReloadCommandRegistered
-{
-#if TARGET_OS_SIMULATOR || TARGET_OS_MACCATALYST
-  RCTKeyCommands *commands = [RCTKeyCommands sharedInstance];
-  return [commands isKeyCommandRegisteredForInput:@"r" modifierFlags:UIKeyModifierCommand];
-#else
-  return NO;
-#endif
-}
-
-- (void)unregisterReloadCommand
-{
-#if TARGET_OS_SIMULATOR || TARGET_OS_MACCATALYST
-  RCTKeyCommands *commands = [RCTKeyCommands sharedInstance];
-  [commands unregisterKeyCommandWithInput:@"r" modifierFlags:UIKeyModifierCommand];
-#endif
 }
 
 - (dispatch_queue_t)methodQueue
@@ -525,23 +460,29 @@ RCT_EXPORT_METHOD(setHotLoadingEnabled : (BOOL)enabled)
 
 - (void)setHotkeysEnabled:(BOOL)enabled
 {
-  if (enabled) {
-    [self registerHotkeys];
-  } else {
-    [self unregisterHotkeys];
-  }
+  // Deprecated: hotkeys are now managed via UIKeyCommand on RCTSurfaceHostingView
 }
 
 - (BOOL)hotkeysEnabled
 {
-  return [self isHotkeysRegistered];
+  // Deprecated: hotkeys are now managed via UIKeyCommand on RCTSurfaceHostingView
+  return NO;
 }
 
 - (void)disableReloadCommand
 {
-  if ([self isReloadCommandRegistered]) {
-    [self unregisterReloadCommand];
-  }
+  // Deprecated: reload command is now managed via UIKeyCommand on RCTSurfaceHostingView
+}
+
+- (void)toggleElementInspector
+{
+  RCTDevSettings *devSettings = [_moduleRegistry moduleForName:"DevSettings"];
+  [devSettings toggleElementInspector];
+}
+
+- (void)reloadFromKeyCommand
+{
+  RCTTriggerReloadCommandListeners(@"Dev menu key command");
 }
 
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTInstance.mm
@@ -358,16 +358,6 @@ void RCTInstanceSetRuntimeDiagnosticFlags(NSString *flags)
                                                                  jsInvoker:jsCallInvoker
                                              devMenuConfigurationDecorator:_devMenuConfigurationDecorator];
 
-#if RCT_DEV
-  /**
-   * Instantiating DevMenu has the side-effect of registering
-   * shortcuts for CMD + d, CMD + i,  and CMD + n via RCTDevMenu.
-   * Therefore, when TurboModules are enabled, we must manually create this
-   * NativeModule.
-   */
-  [_turboModuleManager moduleForName:"RCTDevMenu"];
-#endif // end RCT_DEV
-
   // Initialize RCTModuleRegistry so that TurboModules can require other TurboModules.
   [_bridgeModuleDecorator.moduleRegistry setTurboModuleRegistry:_turboModuleManager];
 


### PR DESCRIPTION
## Summary:

Mirrors https://github.com/microsoft/react-native-macos/pull/2749 but implemented upstream for iOS.

Currently, the hotkeys to open the dev menu, toggle element inspector, and reload are registered through `RCTKeyCommands`. This is a global method that swizzles the application methods. This has a couple of issues:

1. Swizzling is an escape hatch, and can get you flagged in app review for using private APIs
2. The hotkeys are registered globally, not per instance. If you have more than one instance of React Native open, I think each of them would try to reload or show a dev menu.

Lets instead set the key commands on the root view of each RN surface (`RCTSurfaceHostingView`). To do this, we need to have access to `RCTDevMenu`, so I added it as a property to `RCTSurfaceHostingView` that `RCTRootViewFactory` can set (since it has access to the module registery.

Note 1: This does not replace the "reload" command yet, as that's registered from `RCTHost`, and would need some more refactoring to switch. 

Note 2: I had originally implemented this by adding a `ContextContainer` to `RCTSurfaceHostingView`, but that proved to be complicated, since that class is in React-Core and must compile as a swift module, which we can't do if we import stuff from ReactCommon. I found a way around this using private headers.. but the latest iteration seems cleaner. You can look at my earlier commits if you want to see what the `ContextContainer` apporach involved. 

## Changelog:

[IOS] [CHANGED] - Add a dev menu to RCTSurfaceHostingView

## Test Plan:

I can launch the dev menu and toggle the element inspector from an iPhone or iPad Simulator
