### PR TITLE
pass down frameRateListenerCallback from Provider to nativeAnimatedNodesManager

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.cpp
@@ -568,10 +568,10 @@ void NativeAnimatedNodesManager::stopRenderCallbackIfNeeded(
   if (isRenderCallbackStarted) {
     if (stopOnRenderCallback_) {
       stopOnRenderCallback_(isAsync);
-    }
 
-    if (frameRateListenerCallback_) {
-      frameRateListenerCallback_(false);
+      if (frameRateListenerCallback_) {
+        frameRateListenerCallback_(false);
+      }
     }
   }
 }

--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManagerProvider.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManagerProvider.cpp
@@ -96,7 +96,8 @@ NativeAnimatedNodesManagerProvider::getOrCreate(
               std::move(directManipulationCallback),
               std::move(fabricCommitCallback),
               std::move(startOnRenderCallback_),
-              std::move(stopOnRenderCallback_));
+              std::move(stopOnRenderCallback_),
+              std::move(frameRateListenerCallback_));
 
       nativeAnimatedDelegate_ =
           std::make_shared<UIManagerNativeAnimatedDelegateImpl>(


### PR DESCRIPTION
Summary:
## Changelog:

[Internal] [Changed] pass down frameRateListenerCallback from Provider to nativeAnimatedNodesManager

Mistakenly missed this in an earlier commit

Reviewed By: christophpurrer

Differential Revision: D86433598


