### PR TITLE
Add support for PlatformColor type of toValue and interpolation outputRange

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/AnimatedNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/AnimatedNode.kt
@@ -7,6 +7,7 @@
 
 package com.facebook.react.animated
 
+import android.content.Context
 import java.util.ArrayList
 
 /** Base class for all Animated.js library node types that can be created on the "native" side. */
@@ -15,6 +16,22 @@ public abstract class AnimatedNode {
   internal companion object {
     internal const val INITIAL_BFS_COLOR: Int = 0
     internal const val DEFAULT_ANIMATED_NODE_CHILD_COUNT: Int = 1
+
+    internal fun getContextHelper(node: AnimatedNode): Context? {
+      // Search children depth-first until we get to a PropsAnimatedNode, from which we can
+      // get the view and its context
+      node.children?.let { children ->
+        for (child in children) {
+          return if (child is PropsAnimatedNode) {
+            val view = child.connectedView
+            view?.context
+          } else {
+            getContextHelper(child)
+          }
+        }
+      }
+      return null
+    }
   }
 
   // TODO: T196787278 Reduce the visibility of these fields to package once we have

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/ColorAnimatedNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/ColorAnimatedNode.kt
@@ -90,22 +90,4 @@ internal class ColorAnimatedNode(
       // case we will search for a view associated with a PropsAnimatedNode to get the context.
       return reactApplicationContext.currentActivity ?: getContextHelper(this)
     }
-
-  companion object {
-    private fun getContextHelper(node: AnimatedNode): Context? {
-      // Search children depth-first until we get to a PropsAnimatedNode, from which we can
-      // get the view and its context
-      node.children?.let { children ->
-        for (child in children) {
-          return if (child is PropsAnimatedNode) {
-            val view = child.connectedView
-            view?.context
-          } else {
-            getContextHelper(child)
-          }
-        }
-      }
-      return null
-    }
-  }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedNodesManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedNodesManager.kt
@@ -112,7 +112,8 @@ public class NativeAnimatedNodesManager(
           "value" -> ValueAnimatedNode(config)
           "color" -> ColorAnimatedNode(config, this, checkNotNull(reactApplicationContext))
           "props" -> PropsAnimatedNode(config, this)
-          "interpolation" -> InterpolationAnimatedNode(config)
+          "interpolation" ->
+              InterpolationAnimatedNode(config, checkNotNull(reactApplicationContext))
           "addition" -> AdditionAnimatedNode(config, this)
           "subtraction" -> SubtractionAnimatedNode(config, this)
           "division" -> DivisionAnimatedNode(config, this)
@@ -247,7 +248,8 @@ public class NativeAnimatedNodesManager(
 
     val animation =
         when (val type = animationConfig.getString("type")) {
-          "frames" -> FrameBasedAnimationDriver(animationConfig)
+          "frames" ->
+              FrameBasedAnimationDriver(animationConfig, checkNotNull(reactApplicationContext))
           "spring" -> SpringAnimation(animationConfig)
           "decay" -> DecayAnimation(animationConfig)
           else -> {

--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.cpp
@@ -568,10 +568,10 @@ void NativeAnimatedNodesManager::stopRenderCallbackIfNeeded(
   if (isRenderCallbackStarted) {
     if (stopOnRenderCallback_) {
       stopOnRenderCallback_(isAsync);
-    }
 
-    if (frameRateListenerCallback_) {
-      frameRateListenerCallback_(false);
+      if (frameRateListenerCallback_) {
+        frameRateListenerCallback_(false);
+      }
     }
   }
 }

--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManagerProvider.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManagerProvider.cpp
@@ -96,7 +96,8 @@ NativeAnimatedNodesManagerProvider::getOrCreate(
               std::move(directManipulationCallback),
               std::move(fabricCommitCallback),
               std::move(startOnRenderCallback_),
-              std::move(stopOnRenderCallback_));
+              std::move(stopOnRenderCallback_),
+              std::move(frameRateListenerCallback_));
 
       nativeAnimatedDelegate_ =
           std::make_shared<UIManagerNativeAnimatedDelegateImpl>(


### PR DESCRIPTION
Summary:
## Changelog:

[Android] [Added] Add support for PlatformColor type of toValue and interpolation outputRange

Making this change in order to support animation from and to PlatformColor type, in use cases like below
Example 1:
```
const animatedColor = useRef(
  new Animated.Color(PlatformColor('android:color/white')),
);
...
Animated.timing(animatedColor.current, {
  toValue: PlatformColor('android:color/darker_gray'),
  duration: 500,
  useNativeDriver: true,
}).start();
```

Example 2:
```
const animatedValue = useRef(new Animated.Value(0));
...
backgroundColor: animatedValue.current.interpolate({
    inputRange: [0, 1],
    outputRange: [
      PlatformColor('android:color/white'),
      PlatformColor('android:color/darker_gray'),
    ],
}),
```

A nuance here: in the framework js code, usually `AnimatedColor` class will resolve color for each channel (RGBA) and create multiple `AnimatedValue` instances. However for platform color, instead of directly resolving the PlatformColor by calling native module, we could pass down the color string + channel name to native, and defer to AnimatedNode/Driver on the native side to resolve the actual color value when it's necessary.
But this strategy means PlatformColor toValue/outputRange won't work if `useNativeDriver` is turned off.

Note that `fromValue` is already supported (in ColorAnimatedNode.kt)

Differential Revision: D86351284


