### PR TITLE
Fix set-version script to update rn-tester

### DIFF
--- a/scripts/releases/set-version.js
+++ b/scripts/releases/set-version.js
@@ -72,19 +72,16 @@ async function setVersion(
   skipReactNativeVersion /*: boolean */ = false,
 ) /*: Promise<void> */ {
   const packages = await getPackages({
-    includePrivate: true,
     includeReactNative: true,
+    forceIncludeRNTester: true,
   });
   const newPackageVersions = Object.fromEntries(
-    Object.entries(packages).map(([packageName, {packageJson}]) => {
-      let packageVersion = version;
-      if (packageName === 'react-native' && skipReactNativeVersion) {
-        packageVersion = '1000.0.0';
-      } else if (packageJson.private === true) {
-        packageVersion = packageJson.version ?? '0.0.0';
-      }
-      return [packageName, packageVersion];
-    }),
+    Object.keys(packages).map(packageName => [
+      packageName,
+      packageName === 'react-native' && skipReactNativeVersion
+        ? '1000.0.0'
+        : version,
+    ]),
   );
 
   const packagesToUpdate = [


### PR DESCRIPTION
Summary:
Restores behaviour pre-D76358273. `rn-tester` is a special case package that we do want to version, even though it's marked as `private: true`.

Changelog: [Internal]

Differential Revision: D86534510


