### PR TITLE
: Give THSpinner in .native themed coloring

### DIFF
--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
@@ -878,6 +878,7 @@ export type ____ViewStyle_InternalBase = $ReadOnly<{
   borderRightWidth?: number,
   borderStartWidth?: number,
   borderTopWidth?: number,
+  color?: ____ColorValue_Internal,
   opacity?: number,
   outlineColor?: ____ColorValue_Internal,
   outlineOffset?: number,


### PR DESCRIPTION
Summary:
**__Context__**:
- problem: loading indicator is always only 1 color. This means it can't be seen when its background color is light (depends on the background color used for example in a button, the button color can be the same as the indicator color) -- we need to offer a way to customize the indicator's color to effectively  contrast the background

**__Technical context__**:
- css doesn't cascade and html.divs don't inherit css styles from parents in .native
- THSpinner's xstyle (var(--...)) doesn't apply to the spinner indicator
- this can be mutated through indicatorStyle & passing StyleSheet from react-native for 'color'
- we let the caller decide the color theme/scheme because the caller is the one who decides the UI context in which the spinner appears (eg within a grey-ish or white button)

**__This diff__**:
- add indicatorStyles prop with dark and light mode to give caller the option to determine spinner color based on background of call

Differential Revision: D86532694


