### PR TITLE
Set anti-alias flag on OutlineDrawable

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/OutlineDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/OutlineDrawable.kt
@@ -82,7 +82,7 @@ internal class OutlineDrawable(
     }
 
   private val outlinePaint: Paint =
-      Paint().apply {
+      Paint(Paint.ANTI_ALIAS_FLAG).apply {
         style = Paint.Style.STROKE
         color = outlineColor
         strokeWidth = outlineWidth


### PR DESCRIPTION
Summary:
Enables anti-aliasing for the `OutlineDrawable`'s `Paint` object. This coincides with the setting being applied to [`BorderDrawable`](https://github.com/facebook/react-native/blob/84ee4d4643d50ae00c381f837fbf628e0ee5acfe/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/BorderDrawable.kt#L89)

Changelog: [Internal]

Differential Revision: D86571281


