### PR TITLE
Remove equivalent NaN float values from diff output

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
@@ -524,7 +524,8 @@ void BaseTextProps::appendTextAttributesProps(
         : nullptr;
   }
 
-  if (textAttributes.opacity != oldProps->textAttributes.opacity) {
+  if (!floatEquality(
+          textAttributes.opacity, oldProps->textAttributes.opacity)) {
     result["opacity"] = textAttributes.opacity;
   }
 


### PR DESCRIPTION
Summary:
With `opacity` being initialized to NaN for text attributes, not having the NaN check would mean adding the `opacity` prop to the Props 2.0 diff output even when it was unchanged and still set to NaN

Changelog: [Internal]

Differential Revision: D86577389


