### PR TITLE
Add TextInput layout issue example to RNTester (#54304)

### DIFF
--- a/packages/rn-tester/js/examples/TextInputLayoutBug/TextInputLayoutBugExample.js
+++ b/packages/rn-tester/js/examples/TextInputLayoutBug/TextInputLayoutBugExample.js
@@ -1,0 +1,120 @@
+import * as React from 'react';
+import {
+  TextInput,
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  ScrollView,
+} from 'react-native';
+
+exports.title = 'TextInput Layout Issue';
+exports.category = 'UI';
+exports.description =
+  'Reproduces layout issue in multiline TextInput (#54304)';
+exports.examples = [
+  {
+    title: 'Basic Multiline fixed-height TextInput',
+    render: function (): React.Node {
+      return (
+        <View style={styles.container}>
+          <TextInput
+            style={styles.input}
+            multiline
+            textAlignVertical="top"
+            value={'Long text line\n'.repeat(10)}
+          />
+        </View>
+      );
+    },
+  },
+  {
+    title: 'Navigation Reproduction (Long Note → Short Note → Long Note)',
+    render: function (): React.Node {
+      const [screen, setScreen] = React.useState('home');
+      const [note, setNote] = React.useState('');
+
+      const longNote = `This is a long note.\nIt should overflow the visible area of the TextInput.\nWhen this screen first loads, the text may appear squashed at the top.\n\nIf you navigate back and open a short note first, and then come back here, the text alignment will fix itself.\nTry reproducing the behavior mentioned in issue #54304.`;
+      const shortNote = `Short`;
+
+      if (screen === 'home') {
+        return (
+          <View style={styles.home}>
+            <Text style={styles.title}>Select a Note</Text>
+            <TouchableOpacity
+              onPress={() => {
+                setNote(longNote);
+                setScreen('editor');
+              }}>
+              <Text style={styles.button}>Long Note</Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              onPress={() => {
+                setNote(shortNote);
+                setScreen('editor');
+              }}>
+              <Text style={styles.button}>Short Note</Text>
+            </TouchableOpacity>
+          </View>
+        );
+      }
+
+      return (
+        <ScrollView contentContainerStyle={styles.container}>
+          <Text style={styles.label}>TextInput Reproduction Example</Text>
+          <TextInput
+            multiline
+            textAlignVertical="top"
+            style={styles.textInput}
+            value={note}
+            onChangeText={setNote}
+          />
+          <TouchableOpacity onPress={() => setScreen('home')}>
+            <Text style={styles.button}>Back</Text>
+          </TouchableOpacity>
+        </ScrollView>
+      );
+    },
+  },
+];
+
+const styles = StyleSheet.create({
+  home: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 22,
+    marginBottom: 20,
+    fontWeight: '600',
+  },
+  button: {
+    fontSize: 18,
+    color: '#007AFF',
+    marginVertical: 10,
+  },
+  container: {
+    flex: 1,
+    padding: 20,
+  },
+  label: {
+    fontSize: 18,
+    fontWeight: '600',
+    marginBottom: 10,
+  },
+  input: {
+    height: 200,
+    borderWidth: 1,
+    borderColor: '#888',
+    borderRadius: 5,
+  },
+  textInput: {
+    height: 150,
+    borderWidth: 1,
+    borderColor: '#999',
+    borderRadius: 8,
+    padding: 10,
+    fontSize: 16,
+  },
+});

--- a/packages/rn-tester/js/utils/RNTesterList.ios.js
+++ b/packages/rn-tester/js/utils/RNTesterList.ios.js
@@ -126,6 +126,11 @@ const Components: Array<RNTesterModuleInfo> = [
     category: 'Basic',
   },
   {
+    key: 'TextInputLayoutBugExample',
+    module: require('../examples/TextInputLayoutBug/TextInputLayoutBugExample'),
+    category: 'Basic',
+  },
+  {
     key: 'TouchableExample',
     module: require('../examples/Touchable/TouchableExample'),
   },


### PR DESCRIPTION
## Summary:
This pull request adds a new example to **RNTester** named **`TextInputLayoutBugExample`**, which reproduces the layout issue in `TextInput` where multiline inputs with a fixed height and `textAlignVertical="top"` display text inconsistently on the first render.

The example makes it easier for maintainers and contributors to visualize, debug, and verify fixes for the problem reported in #54304


## Changelog:
[INTERNAL] [ADDED] - Add TextInput layout issue example to RNTester (#54304)


## Test Plan:
1. Build and run RNTester on iOS.
2. Navigate to **Components → TextInput Layout Issue**.
3. Tap **“Long Note”** and observe that the text appears squashed near the top of the `TextInput`.
4. Tap **“Back”**, then open **“Short Note”**, and return to **“Long Note”** —  
   the text now displays correctly, demonstrating the layout inconsistency.

This confirms that the example reliably reproduces the issue described in (#54304)
Attached below are two screenshots — one showing the bug (initial render) and another after navigation, where the text alignment corrects itself.

<img width="329" height="312" alt="Screenshot 2025-11-08 at 9 20 47 PM" src="https://github.com/user-attachments/assets/e51487e0-722e-4942-8cad-a0c29dd07264" />
<img width="335" height="315" alt="Screenshot 2025-11-08 at 9 21 13 PM" src="https://github.com/user-attachments/assets/5c843d81-9140-4b9c-8a9a-56ac4af324c2" />
