### PR TITLE
[ios][precompile] fix wrong symbolication mapping

### DIFF
--- a/packages/react-native/scripts/cocoapods/rncore.rb
+++ b/packages/react-native/scripts/cocoapods/rncore.rb
@@ -271,9 +271,10 @@ class ReactNativeCoreUtils
         return if dsym_bundles.empty?
 
         # Define source path mappings - from absolute build paths to relative framework paths
+        # Expand the path relative to the installation root (project root, parent of ios/)
+        react_native_absolute_path = File.expand_path(@@react_native_path, Pod::Config.instance.installation_root)
         mappings = [
-            # Make sure to make react_native_path absolute
-            ["/Users/runner/work/react-native/react-native/packages/react-native", "#{File.expand_path(@@react_native_path)}"],
+            ["/Users/runner/work/react-native/react-native/packages/react-native", react_native_absolute_path],
         ]
 
         dsym_bundles.each do |dsym_path| begin


### PR DESCRIPTION
## Summary:

When RCT_SYMBOLICATE_PREBUILT_FRAMEWORKS is enabled, source file paths in dSYMs were incorrectly resolved with extra path segments:

double node_modules (e.g., /path/node_modules/node_modules/...)

The root cause was using File.expand_path(@@react_native_path) without the correct base directory. The path was first expanded without a base (causing double node_modules), then fixed to use project_pods_root (ios/Pods/), which still resulted in incorrect paths with an extra ios/ folder.

Fixed by expanding the path relative to Pod::Config.instance.installation_root, which correctly points to the ios/ directory, allowing relative paths like ../node_modules/react-native to resolve properly to the project root's node_modules directory.

## Changelog:

[IOS] [FIXED] - Fix incorrect source path resolution in dSYM remapping in precompiled framework scripts

## Test Plan:

```
rm -rf ./Pods
pod cache clean --all
RCT_USE_RN_DEP=1 RCT_USE_PREBUILT_RNCORE=1 RCT_SYMBOLICATE_PREBUILT_FRAMEWORKS=1 bundle exec pod install
```

✅ Tested with RN-Tester
✅ Tested in 0.83.rc0 project