### PR TITLE
[RN][iOS] Connect New Arch Modules to React Native

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeCoreModulesProvider.h
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeCoreModulesProvider.h
@@ -1,0 +1,18 @@
+//
+//  RCTReactNativeCoreModulesProvider.h
+//  React-RCTAppDelegate
+//
+//  Created by Riccardo Cipolleschi on 10/11/2025.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface RCTReactNativeCoreModulesProvider : NSObject
+
++ (Class) reactNativeCoreModuleForName:(const char *)name;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeCoreModulesProvider.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeCoreModulesProvider.mm
@@ -1,0 +1,65 @@
+//
+//  RCTReactNativeCoreModulesProvider.m
+//  React-RCTAppDelegate
+//
+//  Created by Riccardo Cipolleschi on 10/11/2025.
+//
+
+#import "RCTReactNativeCoreModulesProvider.h"
+
+#if !RN_DISABLE_OSS_PLUGIN_HEADER
+#import <React/CoreModulesPlugins.h>
+#import <RCTBlob/RCTBlobPlugins.h>
+#import <React/RCTImagePlugins.h>
+#import <React/RCTNetworkPlugins.h>
+#import <React/RCTSettingsPlugins.h>
+#import <React/RCTLinkingPlugins.h>
+#import <React/RCTVibrationPlugins.h>
+#import <React/RCTAnimationPlugins.h>
+
+#endif
+
+@implementation RCTReactNativeCoreModulesProvider
+
++ (Class) reactNativeCoreModuleForName:(const char *)name
+{
+#if !RN_DISABLE_OSS_PLUGIN_HEADER
+  Class clazz = RCTCoreModulesClassProvider(name);
+  if (clazz != NULL) {
+    return clazz;
+  }
+  clazz = RCTBlobClassProvider(name);
+  if (clazz != NULL) {
+    return clazz;
+  }
+  clazz = RCTImageClassProvider(name);
+  if (clazz != NULL) {
+    return clazz;
+  }
+  clazz = RCTNetworkClassProvider(name);
+  if (clazz != NULL) {
+    return clazz;
+  }
+  clazz = RCTSettingsClassProvider(name);
+  if (clazz != NULL) {
+    return clazz;
+  }
+  clazz = RCTLinkingClassProvider(name);
+  if (clazz != NULL) {
+    return clazz;
+  }
+  clazz = RCTVibrationClassProvider(name);
+  if (clazz != NULL) {
+    return clazz;
+  }
+  clazz = RCTAnimationClassProvider(name);
+  if (clazz != NULL) {
+    return clazz;
+  }
+  
+#endif
+
+  return NULL;
+}
+
+@end

--- a/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTReactNativeFactory.mm
@@ -6,6 +6,7 @@
  */
 
 #import "RCTReactNativeFactory.h"
+#import "RCTReactNativeCoreModulesProvider.h"
 #import <React/RCTBundleManager.h>
 #import <React/RCTColorSpaceUtils.h>
 #import <React/RCTDevMenu.h>
@@ -166,7 +167,7 @@ using namespace facebook::react;
       return moduleClass;
     }
   }
-  return RCTCoreModulesClassProvider(name);
+  return [RCTReactNativeCoreModulesProvider reactNativeCoreModuleForName:name];
 #endif
 }
 

--- a/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
+++ b/packages/react-native/Libraries/AppDelegate/React-RCTAppDelegate.podspec
@@ -62,6 +62,12 @@ Pod::Spec.new do |s|
   s.dependency "React-CoreModules"
   s.dependency "React-RCTFBReactNativeSpec"
   s.dependency "React-defaultsnativemodule"
+  s.dependency "React-RCTAnimation"
+  s.dependency "React-RCTBlob"
+  s.dependency "React-RCTLinking"
+  s.dependency "React-RCTSettings"
+  s.dependency "React-RCTVibration"
+
   if use_hermes()
     s.dependency 'React-hermes'
   end


### PR DESCRIPTION
## Summary:
Several of the React Native core module where registered in the React Native core runtime using the legacy architecture approach, rather than the New Architecture one. This mechanism will fail as soon as we remove the Interop Layers 

## Changelog:
[Internal] - Update how modules are registered

## Test Plan:
Tested locally on RNTester with both static libraries and dynamic frameworks
