### PR TITLE
Fix crash during frame reporting

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.cpp
@@ -379,6 +379,15 @@ void PerformanceTracer::reportFrameTiming(
     int frameSeqId,
     HighResTimeStamp start,
     HighResTimeStamp end) {
+  if (!tracingAtomic_) {
+    return;
+  }
+
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (!tracingAtomic_) {
+    return;
+  }
+
   ThreadId threadId = getCurrentThreadId();
   enqueueEvent(
       PerformanceTracerFrameBeginDrawEvent{


### PR DESCRIPTION
Summary:
`reportFrameTiming` will occasionally crash the app. This diff adds the same mutex guard all other performance events have.

Changelog: [internal]

Reviewed By: rubennorte

Differential Revision: D86644084


