### PR TITLE
explicitly track lifetime of NativeAnimatedNodesManager

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.cpp
@@ -102,6 +102,7 @@ NativeAnimatedNodesManager::NativeAnimatedNodesManager(
     : animationBackend_(animationBackend) {}
 
 NativeAnimatedNodesManager::~NativeAnimatedNodesManager() noexcept {
+  destroyed_->store(true);
   stopRenderCallbackIfNeeded(true);
 }
 
@@ -544,7 +545,13 @@ void NativeAnimatedNodesManager::startRenderCallbackIfNeeded(bool isAsync) {
   }
 
   if (startOnRenderCallback_) {
-    startOnRenderCallback_([this]() { onRender(); }, isAsync);
+    startOnRenderCallback_(
+        [this, destroyed = destroyed_]() {
+          if (!destroyed->load()) {
+            onRender();
+          }
+        },
+        isAsync);
   }
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.h
@@ -261,6 +261,8 @@ class NativeAnimatedNodesManager {
   bool warnedAboutGraphTraversal_ = false;
 #endif
 
+  std::shared_ptr<std::atomic<bool>> destroyed_{std::make_shared<std::atomic<bool>>(false)};
+
   friend class ColorAnimatedNode;
   friend class AnimationDriver;
   friend class AnimationTestsBase;


### PR DESCRIPTION
Summary:
## Changelog:

[General] [Fixed] - explicitly track lifetime of NativeAnimatedNodesManager

mark the instance as destroyed with an atomic bool, and avoid passing down `onRender` to platform via `startOnRenderCallback` if instance is being destroyed

An alternative to this is referencing NativeAnimatedNodesManager instance with shared_from_this() instead of `this`, but that will increase binary size

Differential Revision: D86672542


