### PR TITLE
Combine hermes and jsc install options

### DIFF
--- a/packages/rn-tester/README.md
+++ b/packages/rn-tester/README.md
@@ -51,14 +51,6 @@ You can build and run RN-Tester by using this command from the root of the repo:
 yarn android
 ```
 
-If you wish to use JSC instead you should invoke:
-
-```sh
-cd packages/rn-tester
-yarn install-android-jsc
-yarn start
-```
-
 > [!NOTE]
 > Building for the first time can take a while.
 

--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -15,8 +15,7 @@
   "scripts": {
     "start": "react-native start",
     "android": "react-native run-android",
-    "install-android-jsc": "../../gradlew :packages:rn-tester:android:app:installDebug",
-    "install-android-hermes": "../../gradlew :packages:rn-tester:android:app:installDebug",
+    "install-android": "../../gradlew :packages:rn-tester:android:app:installDebug",
     "clean-android": "rm -rf android/app/build",
     "prepare-ios": "node ./cli.js bootstrap ios",
     "clean-ios": "rm -rf build/generated/ios Pods Podfile.lock RNTesterPods.xcworkspace/ ../react-native-codegen/lib/",


### PR DESCRIPTION
Summary:
`install-android-jsc` and `install-android-hermes` are now functionally the same. Combining both options.

Changelog: [internal]

Reviewed By: huntie

Differential Revision: D86672866


