### PR TITLE
Fix incorrect usage of TypeScript API in validateTypeScriptDefs

### DIFF
--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -429,21 +429,19 @@ function normalizeExportsTarget(target /*: string */) /*: string */ {
 }
 
 function validateTypeScriptDefs(packageName /*: string */) {
-  const files = glob.sync(
-    path.resolve(PACKAGES_DIR, packageName, BUILD_DIR, '**/*.d.ts'),
-  );
+ const files = glob.sync(
+   path.resolve(PACKAGES_DIR, packageName, BUILD_DIR, '**/*.d.ts'),
+ );
   const compilerOptions = {
     ...getTypeScriptCompilerOptions(packageName),
     noEmit: true,
     skipLibCheck: false,
   };
-  const program = ts.createProgram(
-    files,
-    ts.convertCompilerOptionsFromJson(
-      compilerOptions,
-      path.resolve(PACKAGES_DIR, packageName),
-    ),
+  const parsed = ts.convertCompilerOptionsFromJson(
+    compilerOptions,
+    path.resolve(PACKAGES_DIR, packageName),
   );
+  const program = ts.createProgram(files, parsed.options);
   const emitResult = program.emit();
 
   if (emitResult.diagnostics.length) {


### PR DESCRIPTION
This PR fixes a bug in the validateTypeScriptDefs function in scripts/build/build.js. The original code incorrectly passed the entire result of ts.convertCompilerOptionsFromJson to ts.createProgram, but only the options property should be used. Updated the code to extract and use parsed.options, ensuring that TypeScript definitions are validated as intended. No other logic or behavior is changed.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
