### PR TITLE
Adding support for unions in Codegen Schema

### DIFF
--- a/packages/react-native-codegen/src/CodegenSchema.d.ts
+++ b/packages/react-native-codegen/src/CodegenSchema.d.ts
@@ -318,10 +318,8 @@ export interface StringLiteralTypeAnnotation {
   readonly value: string;
 }
 
-export interface StringLiteralUnionTypeAnnotation {
-  readonly type: 'StringLiteralUnionTypeAnnotation';
-  readonly types: StringLiteralTypeAnnotation[];
-}
+export type StringLiteralUnionTypeAnnotation =
+  UnionTypeAnnotation<StringLiteralTypeAnnotation>;
 
 export interface NativeModuleNumberTypeAnnotation {
   readonly type: 'NumberTypeAnnotation';
@@ -383,11 +381,6 @@ export interface NativeModulePromiseTypeAnnotation {
   readonly elementType: Nullable<NativeModuleBaseTypeAnnotation> | VoidTypeAnnotation;
 }
 
-export type UnionTypeAnnotationMemberType =
-  | 'NumberTypeAnnotation'
-  | 'ObjectTypeAnnotation'
-  | 'StringTypeAnnotation';
-
 export type NativeModuleUnionTypeAnnotationMemberType =
   | NativeModuleObjectTypeAnnotation
   | StringLiteralTypeAnnotation
@@ -397,10 +390,8 @@ export type NativeModuleUnionTypeAnnotationMemberType =
   | StringTypeAnnotation
   | NumberTypeAnnotation;
 
-export interface NativeModuleUnionTypeAnnotation {
-  readonly type: 'UnionTypeAnnotation';
-  readonly memberType: UnionTypeAnnotationMemberType;
-}
+export type NativeModuleUnionTypeAnnotation =
+  UnionTypeAnnotation<NativeModuleUnionTypeAnnotationMemberType>;
 
 export interface NativeModuleMixedTypeAnnotation {
   readonly type: 'MixedTypeAnnotation';

--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -61,10 +61,8 @@ export type BooleanLiteralTypeAnnotation = $ReadOnly<{
   value: boolean,
 }>;
 
-export type StringLiteralUnionTypeAnnotation = $ReadOnly<{
-  type: 'StringLiteralUnionTypeAnnotation',
-  types: $ReadOnlyArray<StringLiteralTypeAnnotation>,
-}>;
+export type StringLiteralUnionTypeAnnotation =
+  UnionTypeAnnotation<StringLiteralTypeAnnotation>;
 
 export type VoidTypeAnnotation = $ReadOnly<{
   type: 'VoidTypeAnnotation',
@@ -372,11 +370,6 @@ export type NativeModulePromiseTypeAnnotation = $ReadOnly<{
   elementType: VoidTypeAnnotation | Nullable<NativeModuleBaseTypeAnnotation>,
 }>;
 
-export type UnionTypeAnnotationMemberType =
-  | 'NumberTypeAnnotation'
-  | 'ObjectTypeAnnotation'
-  | 'StringTypeAnnotation';
-
 export type NativeModuleUnionTypeAnnotationMemberType =
   | NativeModuleObjectTypeAnnotation
   | StringLiteralTypeAnnotation
@@ -386,10 +379,8 @@ export type NativeModuleUnionTypeAnnotationMemberType =
   | StringTypeAnnotation
   | NumberTypeAnnotation;
 
-export type NativeModuleUnionTypeAnnotation = $ReadOnly<{
-  type: 'UnionTypeAnnotation',
-  memberType: UnionTypeAnnotationMemberType,
-}>;
+export type NativeModuleUnionTypeAnnotation =
+  UnionTypeAnnotation<NativeModuleUnionTypeAnnotationMemberType>;
 
 export type NativeModuleMixedTypeAnnotation = $ReadOnly<{
   type: 'MixedTypeAnnotation',
@@ -473,6 +464,7 @@ export type CompleteTypeAnnotation =
   | UnsafeAnyTypeAnnotation
   | ArrayTypeAnnotation<CompleteTypeAnnotation>
   | ObjectTypeAnnotation<CompleteTypeAnnotation>
+  | NativeModuleUnionTypeAnnotationMemberType
   // Components
   | CommandTypeAnnotation
   | CompleteReservedTypeAnnotation;

--- a/packages/react-native-codegen/src/generators/Utils.js
+++ b/packages/react-native-codegen/src/generators/Utils.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import type {NativeModuleUnionTypeAnnotation} from '../CodegenSchema';
+
 function capitalize(string: string): string {
   return string.charAt(0).toUpperCase() + string.slice(1);
 }
@@ -44,10 +46,66 @@ function getEnumName(moduleName: string, origEnumName: string): string {
   return `${moduleName}${uppercasedPropName}`;
 }
 
+type ValidUnionType = 'boolean' | 'number' | 'object' | 'string';
+const NumberTypes = ['NumberTypeAnnotation', 'NumberLiteralTypeAnnotation'];
+const StringTypes = ['StringTypeAnnotation', 'StringLiteralTypeAnnotation'];
+const ObjectTypes = ['ObjectTypeAnnotation'];
+const BooleanTypes = ['BooleanTypeAnnotation', 'BooleanLiteralTypeAnnotation'];
+const ValidUnionTypes = [
+  ...NumberTypes,
+  ...ObjectTypes,
+  ...StringTypes,
+  ...BooleanTypes,
+];
+
+class HeterogeneousUnionError extends Error {
+  constructor() {
+    super(`Non-homogenous union member types`);
+  }
+}
+
+function parseValidUnionType(
+  annotation: NativeModuleUnionTypeAnnotation,
+): ValidUnionType {
+  const isUnionOfType = (types: $ReadOnlyArray<string>): boolean => {
+    return annotation.types.every(memberTypeAnnotation =>
+      types.includes(memberTypeAnnotation.type),
+    );
+  };
+  if (isUnionOfType(BooleanTypes)) {
+    return 'boolean';
+  }
+  if (isUnionOfType(NumberTypes)) {
+    return 'number';
+  }
+  if (isUnionOfType(ObjectTypes)) {
+    return 'object';
+  }
+  if (isUnionOfType(StringTypes)) {
+    return 'string';
+  }
+
+  const invalidTypes = annotation.types.filter(member => {
+    return !ValidUnionTypes.includes(member.type);
+  });
+
+  // Check if union members are all supported but not homogeneous
+  // (e.g., mix of number and boolean)
+  if (invalidTypes.length === 0) {
+    throw new HeterogeneousUnionError();
+  } else {
+    throw new Error(
+      `Unsupported union member types: ${invalidTypes.join(', ')}"`,
+    );
+  }
+}
+
 module.exports = {
   capitalize,
   indent,
+  parseValidUnionType,
   toPascalCase,
   toSafeCppString,
   getEnumName,
+  HeterogeneousUnionError,
 };

--- a/packages/react-native-codegen/src/generators/components/GenerateEventEmitterCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateEventEmitterCpp.js
@@ -19,6 +19,7 @@ import type {
 } from '../../CodegenSchema';
 
 const {indent} = require('../Utils');
+const {parseValidUnionType} = require('../Utils');
 const {IncludeTemplate, generateEventStructName} = require('./CppHelpers');
 
 // File path -> contents
@@ -207,7 +208,11 @@ function handleArrayElementType(
         loopLocalVariable,
         val => `jsi::valueFromDynamic(runtime, ${val})`,
       );
-    case 'StringLiteralUnionTypeAnnotation':
+    case 'UnionTypeAnnotation':
+      const validUnionType = parseValidUnionType(elementType);
+      if (validUnionType !== 'string') {
+        throw new Error('Invalid since it is a union of non strings');
+      }
       return setValueAtIndex(
         propertyName,
         indexVariable,
@@ -320,7 +325,11 @@ function generateSetters(
             usingEvent,
             prop => `jsi::valueFromDynamic(runtime, ${prop})`,
           );
-        case 'StringLiteralUnionTypeAnnotation':
+        case 'UnionTypeAnnotation':
+          const validUnionType = parseValidUnionType(typeAnnotation);
+          if (validUnionType !== 'string') {
+            throw new Error('Invalid since it is a union of non strings');
+          }
           return generateSetter(
             parentPropertyName,
             eventProperty.name,

--- a/packages/react-native-codegen/src/generators/components/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/generators/components/__test_fixtures__/fixtures.js
@@ -1273,7 +1273,7 @@ const EVENT_PROPS: SchemaType = {
                       typeAnnotation: {
                         type: 'ArrayTypeAnnotation',
                         elementType: {
-                          type: 'StringLiteralUnionTypeAnnotation',
+                          type: 'UnionTypeAnnotation',
                           types: [
                             {
                               type: 'StringLiteralTypeAnnotation',
@@ -1383,7 +1383,7 @@ const EVENT_PROPS: SchemaType = {
                       name: 'orientation',
                       optional: false,
                       typeAnnotation: {
-                        type: 'StringLiteralUnionTypeAnnotation',
+                        type: 'UnionTypeAnnotation',
                         types: [
                           {
                             type: 'StringLiteralTypeAnnotation',

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleJniCpp.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleJniCpp.js
@@ -23,6 +23,7 @@ import type {
 import type {AliasResolver} from './Utils';
 
 const {unwrapNullable} = require('../../parsers/parsers-commons');
+const {parseValidUnionType} = require('../Utils');
 const {createAliasResolver, getModules} = require('./Utils');
 
 type FilesOutput = Map<string, string>;
@@ -167,8 +168,6 @@ function translateReturnTypeToKind(
       return 'StringKind';
     case 'StringLiteralTypeAnnotation':
       return 'StringKind';
-    case 'StringLiteralUnionTypeAnnotation':
-      return 'StringKind';
     case 'BooleanTypeAnnotation':
       return 'BooleanKind';
     case 'BooleanLiteralTypeAnnotation':
@@ -185,17 +184,19 @@ function translateReturnTypeToKind(
           );
       }
     case 'UnionTypeAnnotation':
-      switch (typeAnnotation.memberType) {
-        case 'NumberTypeAnnotation':
+      const validUnionType = parseValidUnionType(realTypeAnnotation);
+      switch (validUnionType) {
+        case 'boolean':
+          return 'BooleanKind';
+        case 'number':
           return 'NumberKind';
-        case 'ObjectTypeAnnotation':
+        case 'object':
           return 'ObjectKind';
-        case 'StringTypeAnnotation':
+        case 'string':
           return 'StringKind';
         default:
-          throw new Error(
-            `Unsupported union member returning value, found: ${realTypeAnnotation.memberType}"`,
-          );
+          (validUnionType: empty);
+          throw new Error(`Unsupported union member type`);
       }
     case 'NumberTypeAnnotation':
       return 'NumberKind';
@@ -254,8 +255,6 @@ function translateParamTypeToJniType(
       return 'Ljava/lang/String;';
     case 'StringLiteralTypeAnnotation':
       return 'Ljava/lang/String;';
-    case 'StringLiteralUnionTypeAnnotation':
-      return 'Ljava/lang/String;';
     case 'BooleanTypeAnnotation':
       return !isRequired ? 'Ljava/lang/Boolean;' : 'Z';
     case 'BooleanLiteralTypeAnnotation':
@@ -272,17 +271,19 @@ function translateParamTypeToJniType(
           );
       }
     case 'UnionTypeAnnotation':
-      switch (typeAnnotation.memberType) {
-        case 'NumberTypeAnnotation':
+      const validUnionType = parseValidUnionType(realTypeAnnotation);
+      switch (validUnionType) {
+        case 'boolean':
+          return !isRequired ? 'Ljava/lang/Boolean;' : 'Z';
+        case 'number':
           return !isRequired ? 'Ljava/lang/Double;' : 'D';
-        case 'ObjectTypeAnnotation':
+        case 'object':
           return 'Lcom/facebook/react/bridge/ReadableMap;';
-        case 'StringTypeAnnotation':
+        case 'string':
           return 'Ljava/lang/String;';
         default:
-          throw new Error(
-            `Unsupported union prop value, found: ${realTypeAnnotation.memberType}"`,
-          );
+          (validUnionType: empty);
+          throw new Error(`Unsupported union member type`);
       }
     case 'NumberTypeAnnotation':
       return !isRequired ? 'Ljava/lang/Double;' : 'D';
@@ -338,8 +339,6 @@ function translateReturnTypeToJniType(
       return 'Ljava/lang/String;';
     case 'StringLiteralTypeAnnotation':
       return 'Ljava/lang/String;';
-    case 'StringLiteralUnionTypeAnnotation':
-      return 'Ljava/lang/String;';
     case 'BooleanTypeAnnotation':
       return nullable ? 'Ljava/lang/Boolean;' : 'Z';
     case 'BooleanLiteralTypeAnnotation':
@@ -356,17 +355,19 @@ function translateReturnTypeToJniType(
           );
       }
     case 'UnionTypeAnnotation':
-      switch (typeAnnotation.memberType) {
-        case 'NumberTypeAnnotation':
+      const validUnionType = parseValidUnionType(realTypeAnnotation);
+      switch (validUnionType) {
+        case 'boolean':
+          return nullable ? 'Ljava/lang/Boolean;' : 'Z';
+        case 'number':
           return nullable ? 'Ljava/lang/Double;' : 'D';
-        case 'ObjectTypeAnnotation':
-          return 'Lcom/facebook/react/bridge/WritableMap;';
-        case 'StringTypeAnnotation':
+        case 'object':
+          return 'Lcom/facebook/react/bridge/ReadableMap;';
+        case 'string':
           return 'Ljava/lang/String;';
         default:
-          throw new Error(
-            `Unsupported union member type, found: ${realTypeAnnotation.memberType}"`,
-          );
+          (validUnionType: empty);
+          throw new Error(`Unsupported union member type`);
       }
     case 'NumberTypeAnnotation':
       return nullable ? 'Ljava/lang/Double;' : 'D';

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/StructCollector.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/StructCollector.js
@@ -23,11 +23,11 @@ import type {
   NativeModuleNumberTypeAnnotation,
   NativeModuleObjectTypeAnnotation,
   NativeModuleTypeAliasTypeAnnotation,
+  NativeModuleUnionTypeAnnotation,
   Nullable,
   NumberLiteralTypeAnnotation,
   ReservedTypeAnnotation,
   StringLiteralTypeAnnotation,
-  StringLiteralUnionTypeAnnotation,
   StringTypeAnnotation,
 } from '../../../CodegenSchema';
 import type {AliasResolver} from '../Utils';
@@ -36,7 +36,11 @@ const {
   unwrapNullable,
   wrapNullable,
 } = require('../../../parsers/parsers-commons');
-const {capitalize} = require('../../Utils');
+const {
+  HeterogeneousUnionError,
+  capitalize,
+  parseValidUnionType,
+} = require('../../Utils');
 
 type StructContext = 'CONSTANTS' | 'REGULAR';
 
@@ -63,7 +67,7 @@ export type StructProperty = $ReadOnly<{
 export type StructTypeAnnotation =
   | StringTypeAnnotation
   | StringLiteralTypeAnnotation
-  | StringLiteralUnionTypeAnnotation
+  | NativeModuleUnionTypeAnnotation
   | NativeModuleNumberTypeAnnotation
   | NumberLiteralTypeAnnotation
   | BooleanLiteralTypeAnnotation
@@ -129,27 +133,38 @@ class StructCollector {
       case 'MixedTypeAnnotation':
         throw new Error('Mixed types are unsupported in structs');
       case 'UnionTypeAnnotation':
-        switch (typeAnnotation.memberType) {
-          case 'StringTypeAnnotation':
-            return wrapNullable(nullable, {
-              type: 'StringTypeAnnotation',
-            });
-          case 'NumberTypeAnnotation':
-            return wrapNullable(nullable, {
-              type: 'NumberTypeAnnotation',
-            });
-          case 'ObjectTypeAnnotation':
-            // This isn't smart enough to actually know how to generate the
-            // options on the native side. So we just treat it as an unknown object type
-            return wrapNullable(nullable, {
-              type: 'GenericObjectTypeAnnotation',
-            });
-          default:
-            (typeAnnotation.memberType: empty);
-            throw new Error(
-              'Union types are unsupported in structs' +
-                JSON.stringify(typeAnnotation),
-            );
+        try {
+          const validUnionType = parseValidUnionType(typeAnnotation);
+          switch (validUnionType) {
+            case 'boolean':
+              return wrapNullable(nullable, {
+                type: 'BooleanTypeAnnotation',
+              });
+            case 'number':
+              return wrapNullable(nullable, {
+                type: 'NumberTypeAnnotation',
+              });
+            case 'object':
+              // This isn't smart enough to actually know how to generate the
+              // options on the native side. So we just treat it as an unknown object type
+              return wrapNullable(nullable, {
+                type: 'GenericObjectTypeAnnotation',
+              });
+            case 'string':
+              return wrapNullable(nullable, {
+                type: 'StringTypeAnnotation',
+              });
+            default:
+              (validUnionType: empty);
+              throw new Error(`Unsupported union member types`);
+          }
+        } catch (ex) {
+          // TODO(T247151345): Implement proper heterogeneous union support.
+          if (ex instanceof HeterogeneousUnionError) {
+            return wrapNullable(nullable, typeAnnotation);
+          }
+
+          throw ex;
         }
       default: {
         return wrapNullable(nullable, typeAnnotation);

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/header/serializeConstantsStruct.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/header/serializeConstantsStruct.js
@@ -96,8 +96,9 @@ function toObjCType(
       return 'NSString *';
     case 'StringLiteralTypeAnnotation':
       return 'NSString *';
-    case 'StringLiteralUnionTypeAnnotation':
-      return 'NSString *';
+    case 'UnionTypeAnnotation':
+      // TODO(T247151345): Implement proper heterogeneous union support. This is unsafe.
+      return 'NSObject *';
     case 'NumberTypeAnnotation':
       return wrapCxxOptional('double', isRequired);
     case 'NumberLiteralTypeAnnotation':
@@ -183,7 +184,7 @@ function toObjCValue(
       return value;
     case 'StringLiteralTypeAnnotation':
       return value;
-    case 'StringLiteralUnionTypeAnnotation':
+    case 'UnionTypeAnnotation':
       return value;
     case 'NumberTypeAnnotation':
       return wrapPrimitive('double');

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/header/serializeRegularStruct.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/header/serializeRegularStruct.js
@@ -87,8 +87,9 @@ function toObjCType(
       return 'NSString *';
     case 'StringLiteralTypeAnnotation':
       return 'NSString *';
-    case 'StringLiteralUnionTypeAnnotation':
-      return 'NSString *';
+    case 'UnionTypeAnnotation':
+      // TODO(T247151345): Implement proper heterogeneous union support. This is unsafe.
+      return 'NSObject *';
     case 'NumberTypeAnnotation':
       return wrapCxxOptional('double', isRequired);
     case 'NumberLiteralTypeAnnotation':
@@ -173,8 +174,10 @@ function toObjCValue(
       return RCTBridgingTo('String');
     case 'StringLiteralTypeAnnotation':
       return RCTBridgingTo('String');
-    case 'StringLiteralUnionTypeAnnotation':
-      return RCTBridgingTo('String');
+    case 'UnionTypeAnnotation':
+      return !isRequired
+        ? `!RCTNilIfNull(${value}) ? std::optional<NSObject *>{} : std::optional<NSObject *>(${value})`
+        : value;
     case 'NumberTypeAnnotation':
       return RCTBridgingTo('Double');
     case 'NumberLiteralTypeAnnotation':

--- a/packages/react-native-codegen/src/generators/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/generators/modules/__test_fixtures__/fixtures.js
@@ -2353,7 +2353,11 @@ const CXX_ONLY_NATIVE_MODULES: SchemaType = {
                   optional: false,
                   typeAnnotation: {
                     type: 'UnionTypeAnnotation',
-                    memberType: 'NumberTypeAnnotation',
+                    types: [
+                      {
+                        type: 'NumberTypeAnnotation',
+                      },
+                    ],
                   },
                 },
                 {
@@ -2361,14 +2365,18 @@ const CXX_ONLY_NATIVE_MODULES: SchemaType = {
                   optional: false,
                   typeAnnotation: {
                     type: 'UnionTypeAnnotation',
-                    memberType: 'StringTypeAnnotation',
+                    types: [
+                      {
+                        type: 'StringTypeAnnotation',
+                      },
+                    ],
                   },
                 },
                 {
                   name: 'y-literal',
                   optional: false,
                   typeAnnotation: {
-                    type: 'StringLiteralUnionTypeAnnotation',
+                    type: 'UnionTypeAnnotation',
                     types: [
                       {
                         type: 'StringLiteralTypeAnnotation',
@@ -2386,7 +2394,11 @@ const CXX_ONLY_NATIVE_MODULES: SchemaType = {
                   optional: false,
                   typeAnnotation: {
                     type: 'UnionTypeAnnotation',
-                    memberType: 'ObjectTypeAnnotation',
+                    types: [
+                      {
+                        type: 'ObjectTypeAnnotation',
+                      },
+                    ],
                   },
                 },
               ],
@@ -2656,7 +2668,20 @@ const UNION_MODULE: SchemaType = {
               type: 'FunctionTypeAnnotation',
               returnTypeAnnotation: {
                 type: 'UnionTypeAnnotation',
-                memberType: 'ObjectTypeAnnotation',
+                types: [
+                  {
+                    type: 'ObjectTypeAnnotation',
+                    properties: [
+                      {
+                        name: 'low',
+                        optional: false,
+                        typeAnnotation: {
+                          type: 'StringTypeAnnotation',
+                        },
+                      },
+                    ],
+                  },
+                ],
               },
               params: [
                 {
@@ -2664,7 +2689,15 @@ const UNION_MODULE: SchemaType = {
                   optional: false,
                   typeAnnotation: {
                     type: 'UnionTypeAnnotation',
-                    memberType: 'NumberTypeAnnotation',
+                    types: [
+                      {
+                        type: 'NumberTypeAnnotation',
+                      },
+                      {
+                        type: 'NumberLiteralTypeAnnotation',
+                        value: 1,
+                      },
+                    ],
                   },
                 },
                 {
@@ -2672,7 +2705,15 @@ const UNION_MODULE: SchemaType = {
                   optional: false,
                   typeAnnotation: {
                     type: 'UnionTypeAnnotation',
-                    memberType: 'NumberTypeAnnotation',
+                    types: [
+                      {
+                        type: 'NumberTypeAnnotation',
+                      },
+                      {
+                        type: 'NumberLiteralTypeAnnotation',
+                        value: 2.88,
+                      },
+                    ],
                   },
                 },
                 {
@@ -2680,7 +2721,20 @@ const UNION_MODULE: SchemaType = {
                   optional: false,
                   typeAnnotation: {
                     type: 'UnionTypeAnnotation',
-                    memberType: 'ObjectTypeAnnotation',
+                    types: [
+                      {
+                        type: 'ObjectTypeAnnotation',
+                        properties: [
+                          {
+                            name: 'low',
+                            optional: false,
+                            typeAnnotation: {
+                              type: 'StringTypeAnnotation',
+                            },
+                          },
+                        ],
+                      },
+                    ],
                   },
                 },
                 {
@@ -2688,14 +2742,22 @@ const UNION_MODULE: SchemaType = {
                   optional: false,
                   typeAnnotation: {
                     type: 'UnionTypeAnnotation',
-                    memberType: 'StringTypeAnnotation',
+                    types: [
+                      {
+                        type: 'StringLiteralTypeAnnotation',
+                        value: 'One',
+                      },
+                      {
+                        type: 'StringTypeAnnotation',
+                      },
+                    ],
                   },
                 },
                 {
                   name: 'chooseStringLiteral',
                   optional: false,
                   typeAnnotation: {
-                    type: 'StringLiteralUnionTypeAnnotation',
+                    type: 'UnionTypeAnnotation',
                     types: [
                       {
                         type: 'StringLiteralTypeAnnotation',

--- a/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleJavaSpec-test.js.snap
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleJavaSpec-test.js.snap
@@ -678,7 +678,7 @@ public abstract class NativeSampleTurboModuleSpec extends ReactContextBaseJavaMo
 
   @ReactMethod(isBlockingSynchronousMethod = true)
   @DoNotStrip
-  public abstract WritableMap getUnion(double chooseInt, double chooseFloat, ReadableMap chooseObject, String chooseString, String chooseStringLiteral);
+  public abstract ReadableMap getUnion(double chooseInt, double chooseFloat, ReadableMap chooseObject, String chooseString, String chooseStringLiteral);
 }
 ",
 }

--- a/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleJniCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleJniCpp-test.js.snap
@@ -571,7 +571,7 @@ namespace facebook::react {
 
 static facebook::jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_getUnion(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
   static jmethodID cachedMethodId = nullptr;
-  return static_cast<JavaTurboModule &>(turboModule).invokeJavaMethod(rt, ObjectKind, \\"getUnion\\", \\"(DDLcom/facebook/react/bridge/ReadableMap;Ljava/lang/String;Ljava/lang/String;)Lcom/facebook/react/bridge/WritableMap;\\", args, count, cachedMethodId);
+  return static_cast<JavaTurboModule &>(turboModule).invokeJavaMethod(rt, ObjectKind, \\"getUnion\\", \\"(DDLcom/facebook/react/bridge/ReadableMap;Ljava/lang/String;Ljava/lang/String;)Lcom/facebook/react/bridge/ReadableMap;\\", args, count, cachedMethodId);
 }
 
 NativeSampleTurboModuleSpecJSI::NativeSampleTurboModuleSpecJSI(const JavaTurboModule::InitParams &params)

--- a/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/parsers-primitives-test.js
@@ -10,13 +10,8 @@
 
 'use-strict';
 
-import type {
-  DoubleTypeAnnotation,
-  NamedShape,
-  UnionTypeAnnotationMemberType,
-} from '../../CodegenSchema';
+import type {DoubleTypeAnnotation, NamedShape} from '../../CodegenSchema';
 
-const {UnsupportedUnionTypeAnnotationParserError} = require('../errors');
 const {extractArrayElementType} = require('../flow/components/events');
 const {FlowParser} = require('../flow/parser');
 const {MockedParser} = require('../parserMock');
@@ -841,8 +836,8 @@ describe('emitUnion', () => {
       const typeAnnotation = {
         type: 'UnionTypeAnnotation',
         types: [
-          {type: 'NumberLiteralTypeAnnotation'},
-          {type: 'NumberLiteralTypeAnnotation'},
+          {type: 'NumberLiteralTypeAnnotation', value: 1},
+          {type: 'NumberLiteralTypeAnnotation', value: 2},
         ],
       };
       describe('when nullable is true', () => {
@@ -851,6 +846,21 @@ describe('emitUnion', () => {
             true,
             hasteModuleName,
             typeAnnotation,
+            /* types: TypeDeclarationMap */
+            {},
+            /* aliasMap: {...NativeModuleAliasMap} */
+            {},
+            /* enumMap: {...NativeModuleEnumMap} */
+            {},
+            /* tryParse: ParserErrorCapturer */
+            // $FlowFixMe[missing-local-annot]
+            function <T>(_: () => T) {
+              return null;
+            },
+            /* cxxOnly: boolean */
+            false,
+            /* the translateTypeAnnotation function */
+            (_, elementType) => elementType,
             flowParser,
           );
 
@@ -858,7 +868,16 @@ describe('emitUnion', () => {
             type: 'NullableTypeAnnotation',
             typeAnnotation: {
               type: 'UnionTypeAnnotation',
-              memberType: 'NumberTypeAnnotation',
+              types: [
+                {
+                  type: 'NumberLiteralTypeAnnotation',
+                  value: 1,
+                },
+                {
+                  type: 'NumberLiteralTypeAnnotation',
+                  value: 2,
+                },
+              ],
             },
           };
 
@@ -872,12 +891,36 @@ describe('emitUnion', () => {
             false,
             hasteModuleName,
             typeAnnotation,
+            /* types: TypeDeclarationMap */
+            {},
+            /* aliasMap: {...NativeModuleAliasMap} */
+            {},
+            /* enumMap: {...NativeModuleEnumMap} */
+            {},
+            /* tryParse: ParserErrorCapturer */
+            // $FlowFixMe[missing-local-annot]
+            function <T>(_: () => T) {
+              return null;
+            },
+            /* cxxOnly: boolean */
+            false,
+            /* the translateTypeAnnotation function */
+            (_, elementType) => elementType,
             flowParser,
           );
 
           const expected = {
             type: 'UnionTypeAnnotation',
-            memberType: 'NumberTypeAnnotation',
+            types: [
+              {
+                type: 'NumberLiteralTypeAnnotation',
+                value: 1,
+              },
+              {
+                type: 'NumberLiteralTypeAnnotation',
+                value: 2,
+              },
+            ],
           };
 
           expect(result).toEqual(expected);
@@ -899,13 +942,28 @@ describe('emitUnion', () => {
             true,
             hasteModuleName,
             typeAnnotation,
+            /* types: TypeDeclarationMap */
+            {},
+            /* aliasMap: {...NativeModuleAliasMap} */
+            {},
+            /* enumMap: {...NativeModuleEnumMap} */
+            {},
+            /* tryParse: ParserErrorCapturer */
+            // $FlowFixMe[missing-local-annot]
+            function <T>(_: () => T) {
+              return null;
+            },
+            /* cxxOnly: boolean */
+            false,
+            /* the translateTypeAnnotation function */
+            (_, elementType) => elementType,
             flowParser,
           );
 
           const expected = {
             type: 'NullableTypeAnnotation',
             typeAnnotation: {
-              type: 'StringLiteralUnionTypeAnnotation',
+              type: 'UnionTypeAnnotation',
               types: [
                 {
                   type: 'StringLiteralTypeAnnotation',
@@ -929,11 +987,26 @@ describe('emitUnion', () => {
             false,
             hasteModuleName,
             typeAnnotation,
+            /* types: TypeDeclarationMap */
+            {},
+            /* aliasMap: {...NativeModuleAliasMap} */
+            {},
+            /* enumMap: {...NativeModuleEnumMap} */
+            {},
+            /* tryParse: ParserErrorCapturer */
+            // $FlowFixMe[missing-local-annot]
+            function <T>(_: () => T) {
+              return null;
+            },
+            /* cxxOnly: boolean */
+            false,
+            /* the translateTypeAnnotation function */
+            (_, elementType) => elementType,
             flowParser,
           );
 
           const expected = {
-            type: 'StringLiteralUnionTypeAnnotation',
+            type: 'UnionTypeAnnotation',
             types: [
               {
                 type: 'StringLiteralTypeAnnotation',
@@ -962,6 +1035,21 @@ describe('emitUnion', () => {
             true,
             hasteModuleName,
             typeAnnotation,
+            /* types: TypeDeclarationMap */
+            {},
+            /* aliasMap: {...NativeModuleAliasMap} */
+            {},
+            /* enumMap: {...NativeModuleEnumMap} */
+            {},
+            /* tryParse: ParserErrorCapturer */
+            // $FlowFixMe[missing-local-annot]
+            function <T>(_: () => T) {
+              return null;
+            },
+            /* cxxOnly: boolean */
+            false,
+            /* the translateTypeAnnotation function */
+            (_, elementType) => elementType,
             flowParser,
           );
 
@@ -969,7 +1057,14 @@ describe('emitUnion', () => {
             type: 'NullableTypeAnnotation',
             typeAnnotation: {
               type: 'UnionTypeAnnotation',
-              memberType: 'ObjectTypeAnnotation',
+              types: [
+                {
+                  type: 'ObjectTypeAnnotation',
+                },
+                {
+                  type: 'ObjectTypeAnnotation',
+                },
+              ],
             },
           };
 
@@ -983,58 +1078,37 @@ describe('emitUnion', () => {
             false,
             hasteModuleName,
             typeAnnotation,
+            /* types: TypeDeclarationMap */
+            {},
+            /* aliasMap: {...NativeModuleAliasMap} */
+            {},
+            /* enumMap: {...NativeModuleEnumMap} */
+            {},
+            /* tryParse: ParserErrorCapturer */
+            // $FlowFixMe[missing-local-annot]
+            function <T>(_: () => T) {
+              return null;
+            },
+            /* cxxOnly: boolean */
+            false,
+            /* the translateTypeAnnotation function */
+            (_, elementType) => elementType,
             flowParser,
           );
 
           const expected = {
             type: 'UnionTypeAnnotation',
-            memberType: 'ObjectTypeAnnotation',
+            types: [
+              {
+                type: 'ObjectTypeAnnotation',
+              },
+              {
+                type: 'ObjectTypeAnnotation',
+              },
+            ],
           };
 
           expect(result).toEqual(expected);
-        });
-      });
-    });
-
-    describe('when members type is mixed', () => {
-      const typeAnnotation = {
-        type: 'UnionTypeAnnotation',
-        types: [
-          {type: 'NumberLiteralTypeAnnotation', value: 'foo'},
-          {type: 'StringLiteralTypeAnnotation', value: 'bar'},
-          {type: 'ObjectTypeAnnotation'},
-        ],
-      };
-      const unionTypes: UnionTypeAnnotationMemberType[] = [
-        'NumberTypeAnnotation',
-        'StringTypeAnnotation',
-        'ObjectTypeAnnotation',
-      ];
-      describe('when nullable is true', () => {
-        it('throws an exception', () => {
-          const expected = new UnsupportedUnionTypeAnnotationParserError(
-            hasteModuleName,
-            typeAnnotation,
-            unionTypes,
-          );
-
-          expect(() => {
-            emitUnion(true, hasteModuleName, typeAnnotation, flowParser);
-          }).toThrow(expected);
-        });
-      });
-
-      describe('when nullable is false', () => {
-        it('throws an exception', () => {
-          const expected = new UnsupportedUnionTypeAnnotationParserError(
-            hasteModuleName,
-            typeAnnotation,
-            unionTypes,
-          );
-
-          expect(() => {
-            emitUnion(false, hasteModuleName, typeAnnotation, flowParser);
-          }).toThrow(expected);
         });
       });
     });
@@ -1055,12 +1129,44 @@ describe('emitUnion', () => {
           },
         ],
       };
+
+      function translateTypeAnnotation(_: $FlowFixMe, memberType: $FlowFixMe) {
+        if (memberType === typeAnnotation.types[0]) {
+          return {
+            type: 'NumberLiteralTypeAnnotation',
+            value: 4,
+          };
+        }
+        if (memberType === typeAnnotation.types[1]) {
+          return {
+            type: 'NumberLiteralTypeAnnotation',
+            value: 5,
+          };
+        }
+        throw new Error('Unexpected member type');
+      }
+
       describe('when nullable is true', () => {
         it('returns nullable type annotation', () => {
           const result = emitUnion(
             true,
             hasteModuleName,
             typeAnnotation,
+            /* types: TypeDeclarationMap */
+            {},
+            /* aliasMap: {...NativeModuleAliasMap} */
+            {},
+            /* enumMap: {...NativeModuleEnumMap} */
+            {},
+            /* tryParse: ParserErrorCapturer */
+            // $FlowFixMe[missing-local-annot]
+            function <T>(_: () => T) {
+              return null;
+            },
+            /* cxxOnly: boolean */
+            false,
+            /* the translateTypeAnnotation function */
+            translateTypeAnnotation,
             typeScriptParser,
           );
 
@@ -1068,7 +1174,16 @@ describe('emitUnion', () => {
             type: 'NullableTypeAnnotation',
             typeAnnotation: {
               type: 'UnionTypeAnnotation',
-              memberType: 'NumberTypeAnnotation',
+              types: [
+                {
+                  type: 'NumberLiteralTypeAnnotation',
+                  value: 4,
+                },
+                {
+                  type: 'NumberLiteralTypeAnnotation',
+                  value: 5,
+                },
+              ],
             },
           };
 
@@ -1082,12 +1197,36 @@ describe('emitUnion', () => {
             false,
             hasteModuleName,
             typeAnnotation,
+            /* types: TypeDeclarationMap */
+            {},
+            /* aliasMap: {...NativeModuleAliasMap} */
+            {},
+            /* enumMap: {...NativeModuleEnumMap} */
+            {},
+            /* tryParse: ParserErrorCapturer */
+            // $FlowFixMe[missing-local-annot]
+            function <T>(_: () => T) {
+              return null;
+            },
+            /* cxxOnly: boolean */
+            false,
+            /* the translateTypeAnnotation function */
+            translateTypeAnnotation,
             typeScriptParser,
           );
 
           const expected = {
             type: 'UnionTypeAnnotation',
-            memberType: 'NumberTypeAnnotation',
+            types: [
+              {
+                type: 'NumberLiteralTypeAnnotation',
+                value: 4,
+              },
+              {
+                type: 'NumberLiteralTypeAnnotation',
+                value: 5,
+              },
+            ],
           };
 
           expect(result).toEqual(expected);
@@ -1109,19 +1248,51 @@ describe('emitUnion', () => {
           },
         ],
       };
+
+      function translateTypeAnnotation(_: $FlowFixMe, memberType: $FlowFixMe) {
+        if (memberType === typeAnnotation.types[0]) {
+          return {
+            type: 'StringLiteralTypeAnnotation',
+            value: 'foo',
+          };
+        }
+        if (memberType === typeAnnotation.types[1]) {
+          return {
+            type: 'StringLiteralTypeAnnotation',
+            value: 'bar',
+          };
+        }
+        throw new Error('Unexpected member type');
+      }
+
       describe('when nullable is true', () => {
         it('returns nullable type annotation', () => {
           const result = emitUnion(
             true,
             hasteModuleName,
             typeAnnotation,
+            /* types: TypeDeclarationMap */
+            {},
+            /* aliasMap: {...NativeModuleAliasMap} */
+            {},
+            /* enumMap: {...NativeModuleEnumMap} */
+            {},
+            /* tryParse: ParserErrorCapturer */
+            // $FlowFixMe[missing-local-annot]
+            function <T>(_: () => T) {
+              return null;
+            },
+            /* cxxOnly: boolean */
+            false,
+            /* the translateTypeAnnotation function */
+            translateTypeAnnotation,
             typeScriptParser,
           );
 
           const expected = {
             type: 'NullableTypeAnnotation',
             typeAnnotation: {
-              type: 'StringLiteralUnionTypeAnnotation',
+              type: 'UnionTypeAnnotation',
               types: [
                 {
                   type: 'StringLiteralTypeAnnotation',
@@ -1145,11 +1316,26 @@ describe('emitUnion', () => {
             false,
             hasteModuleName,
             typeAnnotation,
+            /* types: TypeDeclarationMap */
+            {},
+            /* aliasMap: {...NativeModuleAliasMap} */
+            {},
+            /* enumMap: {...NativeModuleEnumMap} */
+            {},
+            /* tryParse: ParserErrorCapturer */
+            // $FlowFixMe[missing-local-annot]
+            function <T>(_: () => T) {
+              return null;
+            },
+            /* cxxOnly: boolean */
+            false,
+            /* the translateTypeAnnotation function */
+            translateTypeAnnotation,
             typeScriptParser,
           );
 
           const expected = {
-            type: 'StringLiteralUnionTypeAnnotation',
+            type: 'UnionTypeAnnotation',
             types: [
               {
                 type: 'StringLiteralTypeAnnotation',
@@ -1179,12 +1365,44 @@ describe('emitUnion', () => {
           },
         ],
       };
+
+      function translateTypeAnnotation(_: $FlowFixMe, memberType: $FlowFixMe) {
+        if (memberType === typeAnnotation.types[0]) {
+          return {
+            type: 'ObjectTypeAnnotation',
+            properties: [],
+          };
+        }
+        if (memberType === typeAnnotation.types[1]) {
+          return {
+            type: 'ObjectTypeAnnotation',
+            properties: [],
+          };
+        }
+        throw new Error('Unexpected member type');
+      }
+
       describe('when nullable is true', () => {
         it('returns nullable type annotation', () => {
           const result = emitUnion(
             true,
             hasteModuleName,
             typeAnnotation,
+            /* types: TypeDeclarationMap */
+            {},
+            /* aliasMap: {...NativeModuleAliasMap} */
+            {},
+            /* enumMap: {...NativeModuleEnumMap} */
+            {},
+            /* tryParse: ParserErrorCapturer */
+            // $FlowFixMe[missing-local-annot]
+            function <T>(_: () => T) {
+              return null;
+            },
+            /* cxxOnly: boolean */
+            false,
+            /* the translateTypeAnnotation function */
+            translateTypeAnnotation,
             typeScriptParser,
           );
 
@@ -1192,7 +1410,16 @@ describe('emitUnion', () => {
             type: 'NullableTypeAnnotation',
             typeAnnotation: {
               type: 'UnionTypeAnnotation',
-              memberType: 'ObjectTypeAnnotation',
+              types: [
+                {
+                  type: 'ObjectTypeAnnotation',
+                  properties: [],
+                },
+                {
+                  type: 'ObjectTypeAnnotation',
+                  properties: [],
+                },
+              ],
             },
           };
 
@@ -1206,727 +1433,691 @@ describe('emitUnion', () => {
             false,
             hasteModuleName,
             typeAnnotation,
+            /* types: TypeDeclarationMap */
+            {},
+            /* aliasMap: {...NativeModuleAliasMap} */
+            {},
+            /* enumMap: {...NativeModuleEnumMap} */
+            {},
+            /* tryParse: ParserErrorCapturer */
+            // $FlowFixMe[missing-local-annot]
+            function <T>(_: () => T) {
+              return null;
+            },
+            /* cxxOnly: boolean */
+            false,
+            /* the translateTypeAnnotation function */
+            translateTypeAnnotation,
             typeScriptParser,
           );
 
           const expected = {
             type: 'UnionTypeAnnotation',
-            memberType: 'ObjectTypeAnnotation',
+            types: [
+              {
+                type: 'ObjectTypeAnnotation',
+                properties: [],
+              },
+              {
+                type: 'ObjectTypeAnnotation',
+                properties: [],
+              },
+            ],
           };
 
           expect(result).toEqual(expected);
         });
       });
     });
+  });
 
-    describe('when members type is mixed', () => {
+  describe('emitArrayType', () => {
+    function emitArrayTypeForUnitTest(
+      typeAnnotation: $FlowFixMe,
+      nullable: boolean,
+    ): $FlowFixMe {
+      return emitArrayType(
+        hasteModuleName,
+        typeAnnotation,
+        parser,
+        /* types: TypeDeclarationMap */
+        {},
+        /* aliasMap: {...NativeModuleAliasMap} */
+        {},
+        /* enumMap: {...NativeModuleEnumMap} */
+        {},
+        /* cxxOnly: boolean */
+        false,
+        nullable,
+        /* the translateTypeAnnotation function */
+        (_, elementType) => elementType,
+      );
+    }
+
+    describe("when typeAnnotation doesn't have exactly one typeParameter", () => {
+      const nullable = false;
       const typeAnnotation = {
-        type: 'TSUnionType',
-        types: [
-          {
-            type: 'TSLiteralType',
-            literal: {type: 'NumericLiteral', value: 4},
-          },
-          {
-            type: 'TSLiteralType',
-            literal: {type: 'StringLiteral', value: 'foo'},
-          },
-          {
-            type: 'TSLiteralType',
-          },
-        ],
+        typeParameters: {
+          params: [1, 2],
+          type: 'TypeParameterInstantiation',
+        },
+        id: {
+          name: 'typeAnnotationName',
+        },
       };
-      const unionTypes = [
-        'NumberTypeAnnotation',
-        'StringTypeAnnotation',
-        'ObjectTypeAnnotation',
-      ];
+
+      it('throws an IncorrectlyParameterizedGenericParserError error', () => {
+        expect(() =>
+          emitArrayTypeForUnitTest(typeAnnotation, nullable),
+        ).toThrow();
+      });
+    });
+
+    describe('when typeAnnotation has exactly one typeParameter', () => {
+      const typeAnnotation = {
+        typeParameters: {
+          params: [1],
+          type: 'TypeParameterInstantiation',
+        },
+        id: {
+          name: 'typeAnnotationName',
+        },
+      };
+
       describe('when nullable is true', () => {
-        it('throws an exception', () => {
-          const expected = new UnsupportedUnionTypeAnnotationParserError(
-            hasteModuleName,
-            typeAnnotation,
-            /* $FlowFixMe[incompatible-type] Natural Inference rollout. See
-             * https://fburl.com/workplace/6291gfvu */
-            unionTypes,
-          );
+        const nullable = true;
+        it('returns nullable type annotation', () => {
+          const result = emitArrayTypeForUnitTest(typeAnnotation, nullable);
+          const expected = {
+            type: 'NullableTypeAnnotation',
+            typeAnnotation: {
+              type: 'ArrayTypeAnnotation',
+              elementType: 1,
+            },
+          };
 
-          expect(() => {
-            emitUnion(true, hasteModuleName, typeAnnotation, typeScriptParser);
-          }).toThrow(expected);
+          expect(result).toEqual(expected);
         });
       });
-
       describe('when nullable is false', () => {
-        it('throws an exception', () => {
-          const expected = new UnsupportedUnionTypeAnnotationParserError(
-            hasteModuleName,
-            typeAnnotation,
-            /* $FlowFixMe[incompatible-type] Natural Inference rollout. See
-             * https://fburl.com/workplace/6291gfvu */
-            unionTypes,
-          );
-
-          expect(() => {
-            emitUnion(false, hasteModuleName, typeAnnotation, typeScriptParser);
-          }).toThrow(expected);
-        });
-      });
-    });
-  });
-});
-
-describe('emitArrayType', () => {
-  const hasteModuleName = 'SampleTurboModule';
-
-  function emitArrayTypeForUnitTest(
-    typeAnnotation: $FlowFixMe,
-    nullable: boolean,
-  ): $FlowFixMe {
-    return emitArrayType(
-      hasteModuleName,
-      typeAnnotation,
-      parser,
-      /* types: TypeDeclarationMap */
-      {},
-      /* aliasMap: {...NativeModuleAliasMap} */
-      {},
-      /* enumMap: {...NativeModuleEnumMap} */
-      {},
-      /* cxxOnly: boolean */
-      false,
-      nullable,
-      /* the translateTypeAnnotation function */
-      (_, elementType) => elementType,
-    );
-  }
-
-  describe("when typeAnnotation doesn't have exactly one typeParameter", () => {
-    const nullable = false;
-    const typeAnnotation = {
-      typeParameters: {
-        params: [1, 2],
-        type: 'TypeParameterInstantiation',
-      },
-      id: {
-        name: 'typeAnnotationName',
-      },
-    };
-
-    it('throws an IncorrectlyParameterizedGenericParserError error', () => {
-      expect(() =>
-        emitArrayTypeForUnitTest(typeAnnotation, nullable),
-      ).toThrow();
-    });
-  });
-
-  describe('when typeAnnotation has exactly one typeParameter', () => {
-    const typeAnnotation = {
-      typeParameters: {
-        params: [1],
-        type: 'TypeParameterInstantiation',
-      },
-      id: {
-        name: 'typeAnnotationName',
-      },
-    };
-
-    describe('when nullable is true', () => {
-      const nullable = true;
-      it('returns nullable type annotation', () => {
-        const result = emitArrayTypeForUnitTest(typeAnnotation, nullable);
-        const expected = {
-          type: 'NullableTypeAnnotation',
-          typeAnnotation: {
+        const nullable = false;
+        it('returns non nullable type annotation', () => {
+          const result = emitArrayTypeForUnitTest(typeAnnotation, nullable);
+          const expected = {
             type: 'ArrayTypeAnnotation',
             elementType: 1,
-          },
-        };
+          };
 
-        expect(result).toEqual(expected);
+          expect(result).toEqual(expected);
+        });
       });
     });
-    describe('when nullable is false', () => {
+  });
+
+  describe('Visitor', () => {
+    describe('CallExpression', () => {
+      it('sets isComponent to true if callee type is Identifier and callee name is codegenNativeComponent', () => {
+        const infoMap = {isComponent: false, isModule: false};
+        const node = {
+          callee: {type: 'Identifier', name: 'codegenNativeComponent'},
+        };
+        const visitor = Visitor(infoMap);
+        visitor.CallExpression(node);
+
+        expect(infoMap.isComponent).toBe(true);
+      });
+
+      it('should not set isComponent to true if callee type is not Identifier or callee name is not codegenNativeComponent', () => {
+        const infoMap = {isComponent: false, isModule: false};
+        const node = {
+          callee: {type: '', name: ''},
+        };
+        const visitor = Visitor(infoMap);
+        visitor.CallExpression(node);
+
+        expect(infoMap.isComponent).toBe(false);
+      });
+
+      it('sets isModule to true if isModuleRegistryCall', () => {
+        const infoMap = {isComponent: false, isModule: false};
+        const node = {
+          type: 'CallExpression',
+          callee: {
+            type: 'MemberExpression',
+            object: {type: 'Identifier', name: 'TurboModuleRegistry'},
+            property: {type: 'Identifier', name: 'getEnforcing'},
+          },
+        };
+        const visitor = Visitor(infoMap);
+        visitor.CallExpression(node);
+
+        expect(infoMap.isModule).toBe(true);
+      });
+
+      it('should not set isModule to true if not isModuleRegistryCall', () => {
+        const infoMap = {isComponent: false, isModule: false};
+        const node = {
+          callee: {
+            type: 'Expression',
+          },
+        };
+        const visitor = Visitor(infoMap);
+        visitor.CallExpression(node);
+
+        expect(infoMap.isModule).toBe(false);
+      });
+    });
+
+    describe('InterfaceExtends', () => {
+      it('sets isModule to true if module interface extends TurboModule', () => {
+        const infoMap = {isComponent: false, isModule: false};
+        const node = {id: {name: 'TurboModule'}};
+
+        const visitor = Visitor(infoMap);
+        visitor.InterfaceExtends(node);
+
+        expect(infoMap.isModule).toBe(true);
+      });
+
+      it('should not set isModule to true if module interface does not extends TurboModule', () => {
+        const infoMap = {isComponent: false, isModule: false};
+        const node = {id: {name: ''}};
+
+        const visitor = Visitor(infoMap);
+        visitor.InterfaceExtends(node);
+
+        expect(infoMap.isModule).toBe(false);
+      });
+    });
+
+    describe('TSInterfaceDeclaration', () => {
+      it('sets isModule to true if TypeScript Interface Declaration extends TurboModule', () => {
+        const infoMap = {isComponent: false, isModule: false};
+        const node = {extends: [{expression: {name: 'TurboModule'}}]};
+
+        const visitor = Visitor(infoMap);
+        visitor.TSInterfaceDeclaration(node);
+
+        expect(infoMap.isModule).toBe(true);
+      });
+
+      it('should not set isModule to true if TypeScript Interface Declaration does not extends TurboModule', () => {
+        const infoMap = {isComponent: false, isModule: false};
+        const node = {extends: [{expression: {name: ''}}]};
+
+        const visitor = Visitor(infoMap);
+        visitor.TSInterfaceDeclaration(node);
+
+        expect(infoMap.isModule).toBe(false);
+      });
+    });
+  });
+
+  describe('emitPartial', () => {
+    function emitPartialForUnitTest(
+      typeAnnotation: $FlowFixMe,
+      nullable: boolean,
+    ): $FlowFixMe {
+      return emitPartial(
+        nullable,
+        hasteModuleName,
+        typeAnnotation,
+        /* types: TypeDeclarationMap */
+        {},
+        /* aliasMap: {...NativeModuleAliasMap} */
+        {},
+        /* enumMap: {...NativeModuleEnumMap} */
+        {},
+        /* tryParse: ParserErrorCapturer */
+        // $FlowFixMe[missing-local-annot]
+        function <T>(_: () => T) {
+          return null;
+        },
+        /* cxxOnly: boolean */
+        false,
+        parser,
+      );
+    }
+
+    describe("when 'typeAnnotation' doesn't have exactly 'one' typeParameter", () => {
       const nullable = false;
-      it('returns non nullable type annotation', () => {
-        const result = emitArrayTypeForUnitTest(typeAnnotation, nullable);
+      const typeAnnotation = {
+        typeParameters: {
+          params: [1, 2],
+          type: 'TypeParameterInstantiation',
+        },
+        id: {
+          name: 'typeAnnotationName',
+        },
+      };
+
+      it('throws an error', () => {
+        expect(() => emitPartialForUnitTest(typeAnnotation, nullable)).toThrow(
+          'Partials only support annotating exactly one parameter.',
+        );
+      });
+    });
+
+    describe('when Partial Not annotating type parameter', () => {
+      const nullable = false;
+      const typeAnnotation = {
+        typeParameters: {
+          params: [
+            {
+              id: {
+                name: 'TypeDeclaration',
+              },
+            },
+          ],
+        },
+        id: {
+          name: 'typeAnnotationName',
+        },
+      };
+
+      it('throws an error', () => {
+        expect(() => emitPartialForUnitTest(typeAnnotation, nullable)).toThrow(
+          'Partials only support annotating a type parameter.',
+        );
+      });
+    });
+  });
+
+  describe('emitCommonTypes', () => {
+    function emitCommonTypesForUnitTest(
+      typeAnnotation: $FlowFixMe,
+      nullable: boolean,
+    ): $FlowFixMe {
+      return emitCommonTypes(
+        hasteModuleName,
+        /* types: TypeDeclarationMap */
+        {},
+        typeAnnotation,
+        /* aliasMap: {...NativeModuleAliasMap} */
+        {},
+        /* enumMap: {...NativeModuleEnumMap} */
+        {},
+        /* tryParse: ParserErrorCapturer */
+        // $FlowFixMe[missing-local-annot]
+        function <T>(_: () => T) {
+          return null;
+        },
+        /* cxxOnly: boolean */
+        false,
+        nullable,
+        parser,
+      );
+    }
+
+    describe("when 'typeAnnotation.id.name' is 'Stringish'", () => {
+      const typeAnnotation = {
+        typeParameters: {
+          params: [1, 2],
+          type: 'StringTypeAnnotation',
+        },
+        id: {
+          name: 'Stringish',
+        },
+      };
+      const expected = {
+        type: 'StringTypeAnnotation',
+      };
+      const result = emitCommonTypesForUnitTest(typeAnnotation, false);
+
+      it("returns 'StringTypeAnnotation'", () => {
+        expect(result).toEqual(expected);
+      });
+    });
+
+    describe("when 'typeAnnotation.id.name' is 'Int32'", () => {
+      const typeAnnotation = {
+        typeParameters: {
+          params: [1, 2],
+          type: 'Int32TypeAnnotation',
+        },
+        id: {
+          name: 'Int32',
+        },
+      };
+      const expected = {
+        type: 'Int32TypeAnnotation',
+      };
+      const result = emitCommonTypesForUnitTest(typeAnnotation, false);
+
+      it("returns 'Int32TypeAnnotation'", () => {
+        expect(result).toEqual(expected);
+      });
+    });
+
+    describe("when 'typeAnnotation.id.name' is 'Double'", () => {
+      const typeAnnotation = {
+        typeParameters: {
+          params: [1, 2],
+          type: 'DoubleTypeAnnotation',
+        },
+        id: {
+          name: 'Double',
+        },
+      };
+      const expected = {
+        type: 'DoubleTypeAnnotation',
+      };
+      const result = emitCommonTypesForUnitTest(typeAnnotation, false);
+
+      it("returns 'DoubleTypeAnnotation'", () => {
+        expect(result).toEqual(expected);
+      });
+    });
+
+    describe("when 'typeAnnotation.id.name' is 'Float'", () => {
+      const typeAnnotation = {
+        typeParameters: {
+          params: [1, 2],
+          type: 'FloatTypeAnnotation',
+        },
+        id: {
+          name: 'Float',
+        },
+      };
+      const expected = {
+        type: 'FloatTypeAnnotation',
+      };
+      const result = emitCommonTypesForUnitTest(typeAnnotation, false);
+
+      it("returns 'FloatTypeAnnotation'", () => {
+        expect(result).toEqual(expected);
+      });
+    });
+
+    describe("when 'typeAnnotation.id.name' is 'UnsafeObject'", () => {
+      const typeAnnotation = {
+        typeParameters: {
+          params: [1, 2],
+          type: 'GenericObjectTypeAnnotation',
+        },
+        id: {
+          name: 'UnsafeObject',
+        },
+      };
+      const expected = {
+        type: 'GenericObjectTypeAnnotation',
+      };
+      const result = emitCommonTypesForUnitTest(typeAnnotation, false);
+
+      it("returns 'GenericObjectTypeAnnotation'", () => {
+        expect(result).toEqual(expected);
+      });
+    });
+
+    describe("when 'typeAnnotation.id.name' is 'Object'", () => {
+      const typeAnnotation = {
+        typeParameters: {
+          params: [1, 2],
+          type: 'GenericObjectTypeAnnotation',
+        },
+        id: {
+          name: 'Object',
+        },
+      };
+      const expected = {
+        type: 'GenericObjectTypeAnnotation',
+      };
+      const result = emitCommonTypesForUnitTest(typeAnnotation, false);
+
+      it("returns 'GenericObjectTypeAnnotation'", () => {
+        expect(result).toEqual(expected);
+      });
+    });
+
+    describe("when 'typeAnnotation.id.name' is '$Partial' i.e. Object", () => {
+      const typeAnnotation = {
+        typeParameters: {
+          params: [1],
+          type: 'GenericObjectTypeAnnotation',
+        },
+        id: {
+          name: 'Object',
+        },
+      };
+      const expected = {
+        type: 'GenericObjectTypeAnnotation',
+      };
+      const result = emitCommonTypesForUnitTest(typeAnnotation, false);
+
+      it("returns 'GenericObjectTypeAnnotation'", () => {
+        expect(result).toEqual(expected);
+      });
+    });
+
+    describe('when typeAnnotation is invalid', () => {
+      const typeAnnotation = {
+        id: {
+          name: 'InvalidName',
+        },
+      };
+      it('returns null', () => {
+        expect(emitCommonTypesForUnitTest(typeAnnotation, false)).toBeNull();
+      });
+    });
+  });
+
+  describe('emitBoolProp', () => {
+    describe('when optional is true', () => {
+      it('returns optional type annotation', () => {
+        const result = emitBoolProp('someProp', true);
         const expected = {
-          type: 'ArrayTypeAnnotation',
-          elementType: 1,
+          name: 'someProp',
+          optional: true,
+          typeAnnotation: {
+            type: 'BooleanTypeAnnotation',
+          },
+        };
+
+        expect(result).toEqual(expected);
+      });
+    });
+    describe('when optional is false', () => {
+      it('returns required type annotation', () => {
+        const result = emitBoolProp('someProp', false);
+        const expected = {
+          name: 'someProp',
+          optional: false,
+          typeAnnotation: {
+            type: 'BooleanTypeAnnotation',
+          },
         };
 
         expect(result).toEqual(expected);
       });
     });
   });
-});
 
-describe('Visitor', () => {
-  describe('CallExpression', () => {
-    it('sets isComponent to true if callee type is Identifier and callee name is codegenNativeComponent', () => {
-      const infoMap = {isComponent: false, isModule: false};
-      const node = {
-        callee: {type: 'Identifier', name: 'codegenNativeComponent'},
-      };
-      const visitor = Visitor(infoMap);
-      visitor.CallExpression(node);
-
-      expect(infoMap.isComponent).toBe(true);
-    });
-
-    it('should not set isComponent to true if callee type is not Identifier or callee name is not codegenNativeComponent', () => {
-      const infoMap = {isComponent: false, isModule: false};
-      const node = {
-        callee: {type: '', name: ''},
-      };
-      const visitor = Visitor(infoMap);
-      visitor.CallExpression(node);
-
-      expect(infoMap.isComponent).toBe(false);
-    });
-
-    it('sets isModule to true if isModuleRegistryCall', () => {
-      const infoMap = {isComponent: false, isModule: false};
-      const node = {
-        type: 'CallExpression',
-        callee: {
-          type: 'MemberExpression',
-          object: {type: 'Identifier', name: 'TurboModuleRegistry'},
-          property: {type: 'Identifier', name: 'getEnforcing'},
-        },
-      };
-      const visitor = Visitor(infoMap);
-      visitor.CallExpression(node);
-
-      expect(infoMap.isModule).toBe(true);
-    });
-
-    it('should not set isModule to true if not isModuleRegistryCall', () => {
-      const infoMap = {isComponent: false, isModule: false};
-      const node = {
-        callee: {
-          type: 'Expression',
-        },
-      };
-      const visitor = Visitor(infoMap);
-      visitor.CallExpression(node);
-
-      expect(infoMap.isModule).toBe(false);
-    });
-  });
-
-  describe('InterfaceExtends', () => {
-    it('sets isModule to true if module interface extends TurboModule', () => {
-      const infoMap = {isComponent: false, isModule: false};
-      const node = {id: {name: 'TurboModule'}};
-
-      const visitor = Visitor(infoMap);
-      visitor.InterfaceExtends(node);
-
-      expect(infoMap.isModule).toBe(true);
-    });
-
-    it('should not set isModule to true if module interface does not extends TurboModule', () => {
-      const infoMap = {isComponent: false, isModule: false};
-      const node = {id: {name: ''}};
-
-      const visitor = Visitor(infoMap);
-      visitor.InterfaceExtends(node);
-
-      expect(infoMap.isModule).toBe(false);
-    });
-  });
-
-  describe('TSInterfaceDeclaration', () => {
-    it('sets isModule to true if TypeScript Interface Declaration extends TurboModule', () => {
-      const infoMap = {isComponent: false, isModule: false};
-      const node = {extends: [{expression: {name: 'TurboModule'}}]};
-
-      const visitor = Visitor(infoMap);
-      visitor.TSInterfaceDeclaration(node);
-
-      expect(infoMap.isModule).toBe(true);
-    });
-
-    it('should not set isModule to true if TypeScript Interface Declaration does not extends TurboModule', () => {
-      const infoMap = {isComponent: false, isModule: false};
-      const node = {extends: [{expression: {name: ''}}]};
-
-      const visitor = Visitor(infoMap);
-      visitor.TSInterfaceDeclaration(node);
-
-      expect(infoMap.isModule).toBe(false);
-    });
-  });
-});
-
-describe('emitPartial', () => {
-  const hasteModuleName = 'SampleTurboModule';
-  function emitPartialForUnitTest(
-    typeAnnotation: $FlowFixMe,
-    nullable: boolean,
-  ): $FlowFixMe {
-    return emitPartial(
-      nullable,
-      hasteModuleName,
-      typeAnnotation,
-      /* types: TypeDeclarationMap */
-      {},
-      /* aliasMap: {...NativeModuleAliasMap} */
-      {},
-      /* enumMap: {...NativeModuleEnumMap} */
-      {},
-      /* tryParse: ParserErrorCapturer */
-      // $FlowFixMe[missing-local-annot]
-      function <T>(_: () => T) {
-        return null;
-      },
-      /* cxxOnly: boolean */
-      false,
-      parser,
-    );
-  }
-
-  describe("when 'typeAnnotation' doesn't have exactly 'one' typeParameter", () => {
-    const nullable = false;
-    const typeAnnotation = {
-      typeParameters: {
-        params: [1, 2],
-        type: 'TypeParameterInstantiation',
-      },
-      id: {
-        name: 'typeAnnotationName',
-      },
-    };
-
-    it('throws an error', () => {
-      expect(() => emitPartialForUnitTest(typeAnnotation, nullable)).toThrow(
-        'Partials only support annotating exactly one parameter.',
-      );
-    });
-  });
-
-  describe('when Partial Not annotating type parameter', () => {
-    const nullable = false;
-    const typeAnnotation = {
-      typeParameters: {
-        params: [
-          {
-            id: {
-              name: 'TypeDeclaration',
-            },
+  describe('emitObjectProp', () => {
+    const name = 'someProp';
+    describe('when property is optional', () => {
+      it('returns optional Object Prop', () => {
+        const typeAnnotation = {
+          type: 'GenericTypeAnnotation',
+          id: {
+            name: 'ObjectTypeAnnotation',
           },
-        ],
-      },
-      id: {
-        name: 'typeAnnotationName',
-      },
-    };
-
-    it('throws an error', () => {
-      expect(() => emitPartialForUnitTest(typeAnnotation, nullable)).toThrow(
-        'Partials only support annotating a type parameter.',
-      );
-    });
-  });
-});
-
-describe('emitCommonTypes', () => {
-  const hasteModuleName = 'SampleTurboModule';
-
-  function emitCommonTypesForUnitTest(
-    typeAnnotation: $FlowFixMe,
-    nullable: boolean,
-  ): $FlowFixMe {
-    return emitCommonTypes(
-      hasteModuleName,
-      /* types: TypeDeclarationMap */
-      {},
-      typeAnnotation,
-      /* aliasMap: {...NativeModuleAliasMap} */
-      {},
-      /* enumMap: {...NativeModuleEnumMap} */
-      {},
-      /* tryParse: ParserErrorCapturer */
-      // $FlowFixMe[missing-local-annot]
-      function <T>(_: () => T) {
-        return null;
-      },
-      /* cxxOnly: boolean */
-      false,
-      nullable,
-      parser,
-    );
-  }
-
-  describe("when 'typeAnnotation.id.name' is 'Stringish'", () => {
-    const typeAnnotation = {
-      typeParameters: {
-        params: [1, 2],
-        type: 'StringTypeAnnotation',
-      },
-      id: {
-        name: 'Stringish',
-      },
-    };
-    const expected = {
-      type: 'StringTypeAnnotation',
-    };
-    const result = emitCommonTypesForUnitTest(typeAnnotation, false);
-
-    it("returns 'StringTypeAnnotation'", () => {
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe("when 'typeAnnotation.id.name' is 'Int32'", () => {
-    const typeAnnotation = {
-      typeParameters: {
-        params: [1, 2],
-        type: 'Int32TypeAnnotation',
-      },
-      id: {
-        name: 'Int32',
-      },
-    };
-    const expected = {
-      type: 'Int32TypeAnnotation',
-    };
-    const result = emitCommonTypesForUnitTest(typeAnnotation, false);
-
-    it("returns 'Int32TypeAnnotation'", () => {
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe("when 'typeAnnotation.id.name' is 'Double'", () => {
-    const typeAnnotation = {
-      typeParameters: {
-        params: [1, 2],
-        type: 'DoubleTypeAnnotation',
-      },
-      id: {
-        name: 'Double',
-      },
-    };
-    const expected = {
-      type: 'DoubleTypeAnnotation',
-    };
-    const result = emitCommonTypesForUnitTest(typeAnnotation, false);
-
-    it("returns 'DoubleTypeAnnotation'", () => {
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe("when 'typeAnnotation.id.name' is 'Float'", () => {
-    const typeAnnotation = {
-      typeParameters: {
-        params: [1, 2],
-        type: 'FloatTypeAnnotation',
-      },
-      id: {
-        name: 'Float',
-      },
-    };
-    const expected = {
-      type: 'FloatTypeAnnotation',
-    };
-    const result = emitCommonTypesForUnitTest(typeAnnotation, false);
-
-    it("returns 'FloatTypeAnnotation'", () => {
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe("when 'typeAnnotation.id.name' is 'UnsafeObject'", () => {
-    const typeAnnotation = {
-      typeParameters: {
-        params: [1, 2],
-        type: 'GenericObjectTypeAnnotation',
-      },
-      id: {
-        name: 'UnsafeObject',
-      },
-    };
-    const expected = {
-      type: 'GenericObjectTypeAnnotation',
-    };
-    const result = emitCommonTypesForUnitTest(typeAnnotation, false);
-
-    it("returns 'GenericObjectTypeAnnotation'", () => {
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe("when 'typeAnnotation.id.name' is 'Object'", () => {
-    const typeAnnotation = {
-      typeParameters: {
-        params: [1, 2],
-        type: 'GenericObjectTypeAnnotation',
-      },
-      id: {
-        name: 'Object',
-      },
-    };
-    const expected = {
-      type: 'GenericObjectTypeAnnotation',
-    };
-    const result = emitCommonTypesForUnitTest(typeAnnotation, false);
-
-    it("returns 'GenericObjectTypeAnnotation'", () => {
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe("when 'typeAnnotation.id.name' is '$Partial' i.e. Object", () => {
-    const typeAnnotation = {
-      typeParameters: {
-        params: [1],
-        type: 'GenericObjectTypeAnnotation',
-      },
-      id: {
-        name: 'Object',
-      },
-    };
-    const expected = {
-      type: 'GenericObjectTypeAnnotation',
-    };
-    const result = emitCommonTypesForUnitTest(typeAnnotation, false);
-
-    it("returns 'GenericObjectTypeAnnotation'", () => {
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when typeAnnotation is invalid', () => {
-    const typeAnnotation = {
-      id: {
-        name: 'InvalidName',
-      },
-    };
-    it('returns null', () => {
-      expect(emitCommonTypesForUnitTest(typeAnnotation, false)).toBeNull();
-    });
-  });
-});
-
-describe('emitBoolProp', () => {
-  describe('when optional is true', () => {
-    it('returns optional type annotation', () => {
-      const result = emitBoolProp('someProp', true);
-      const expected = {
-        name: 'someProp',
-        optional: true,
-        typeAnnotation: {
-          type: 'BooleanTypeAnnotation',
-        },
-      };
-
-      expect(result).toEqual(expected);
-    });
-  });
-  describe('when optional is false', () => {
-    it('returns required type annotation', () => {
-      const result = emitBoolProp('someProp', false);
-      const expected = {
-        name: 'someProp',
-        optional: false,
-        typeAnnotation: {
-          type: 'BooleanTypeAnnotation',
-        },
-      };
-
-      expect(result).toEqual(expected);
-    });
-  });
-});
-
-describe('emitObjectProp', () => {
-  const name = 'someProp';
-  describe('when property is optional', () => {
-    it('returns optional Object Prop', () => {
-      const typeAnnotation = {
-        type: 'GenericTypeAnnotation',
-        id: {
-          name: 'ObjectTypeAnnotation',
-        },
-        properties: [
-          {
-            key: {
-              name: 'someKey',
-            },
-            optional: true,
-            value: {
-              type: 'StringTypeAnnotation',
-              typeAnnotation: {
-                type: 'StringTypeAnnotation',
-              },
-            },
-          },
-        ],
-      };
-      const result = emitObjectProp(
-        name,
-        true,
-        flowParser,
-        typeAnnotation,
-        extractArrayElementType,
-      );
-      const expected = {
-        name: 'someProp',
-        optional: true,
-        typeAnnotation: {
           properties: [
             {
-              name: 'someKey',
+              key: {
+                name: 'someKey',
+              },
               optional: true,
-              typeAnnotation: {
+              value: {
                 type: 'StringTypeAnnotation',
+                typeAnnotation: {
+                  type: 'StringTypeAnnotation',
+                },
               },
             },
           ],
-          type: 'ObjectTypeAnnotation',
-        },
-      };
-
-      expect(result).toEqual(expected);
-    });
-  });
-
-  describe('when property is required', () => {
-    it('returns required Object Prop', () => {
-      const typeAnnotation = {
-        type: 'GenericTypeAnnotation',
-        id: {
-          name: 'ObjectTypeAnnotation',
-        },
-        properties: [
-          {
-            key: {
-              name: 'someKey',
-            },
-            optional: false,
-            value: {
-              type: 'StringTypeAnnotation',
-              typeAnnotation: {
-                type: 'StringTypeAnnotation',
+        };
+        const result = emitObjectProp(
+          name,
+          true,
+          flowParser,
+          typeAnnotation,
+          extractArrayElementType,
+        );
+        const expected = {
+          name: 'someProp',
+          optional: true,
+          typeAnnotation: {
+            properties: [
+              {
+                name: 'someKey',
+                optional: true,
+                typeAnnotation: {
+                  type: 'StringTypeAnnotation',
+                },
               },
-            },
+            ],
+            type: 'ObjectTypeAnnotation',
           },
-        ],
-      };
-      const result = emitObjectProp(
-        name,
-        false,
-        flowParser,
-        typeAnnotation,
-        extractArrayElementType,
-      );
-      const expected = {
-        name: 'someProp',
-        optional: false,
-        typeAnnotation: {
+        };
+
+        expect(result).toEqual(expected);
+      });
+    });
+
+    describe('when property is required', () => {
+      it('returns required Object Prop', () => {
+        const typeAnnotation = {
+          type: 'GenericTypeAnnotation',
+          id: {
+            name: 'ObjectTypeAnnotation',
+          },
           properties: [
             {
-              name: 'someKey',
+              key: {
+                name: 'someKey',
+              },
               optional: false,
-              typeAnnotation: {
+              value: {
                 type: 'StringTypeAnnotation',
+                typeAnnotation: {
+                  type: 'StringTypeAnnotation',
+                },
               },
             },
           ],
-          type: 'ObjectTypeAnnotation',
-        },
-      };
+        };
+        const result = emitObjectProp(
+          name,
+          false,
+          flowParser,
+          typeAnnotation,
+          extractArrayElementType,
+        );
+        const expected = {
+          name: 'someProp',
+          optional: false,
+          typeAnnotation: {
+            properties: [
+              {
+                name: 'someKey',
+                optional: false,
+                typeAnnotation: {
+                  type: 'StringTypeAnnotation',
+                },
+              },
+            ],
+            type: 'ObjectTypeAnnotation',
+          },
+        };
 
-      expect(result).toEqual(expected);
+        expect(result).toEqual(expected);
+      });
     });
   });
-});
 
-describe('emitUnionProp', () => {
-  describe('when property is optional', () => {
-    it('returns optional type annotation with Flow parser', () => {
-      const typeAnnotation = {
-        types: [
-          {
-            value: 'someValue1',
-          },
-          {
-            value: 'someValue2',
-          },
-        ],
-      };
-      const result = emitUnionProp(
-        'someProp',
-        true,
-        flowParser,
-        typeAnnotation,
-      );
-      const expected = {
-        name: 'someProp',
-        optional: true,
-        typeAnnotation: {
-          type: 'StringLiteralUnionTypeAnnotation',
+  describe('emitUnionProp', () => {
+    describe('when property is optional', () => {
+      it('returns optional type annotation with Flow parser', () => {
+        const typeAnnotation = {
           types: [
             {
-              type: 'StringLiteralTypeAnnotation',
               value: 'someValue1',
             },
             {
-              type: 'StringLiteralTypeAnnotation',
               value: 'someValue2',
             },
           ],
-        },
-      };
+        };
+        const result = emitUnionProp(
+          'someProp',
+          true,
+          flowParser,
+          typeAnnotation,
+        );
+        const expected = {
+          name: 'someProp',
+          optional: true,
+          typeAnnotation: {
+            type: 'UnionTypeAnnotation',
+            types: [
+              {
+                type: 'StringLiteralTypeAnnotation',
+                value: 'someValue1',
+              },
+              {
+                type: 'StringLiteralTypeAnnotation',
+                value: 'someValue2',
+              },
+            ],
+          },
+        };
 
-      expect(result).toEqual(expected);
+        expect(result).toEqual(expected);
+      });
     });
-  });
-  describe('when property is required', () => {
-    it('returns required type annotation with TypeScript parser', () => {
-      const typeAnnotation = {
-        types: [
-          {
-            literal: {
-              value: 'someValue1',
-            },
-          },
-          {
-            literal: {
-              value: 'someValue2',
-            },
-          },
-        ],
-      };
-      const result = emitUnionProp(
-        'someProp',
-        false,
-        typeScriptParser,
-        typeAnnotation,
-      );
-
-      const expected = {
-        name: 'someProp',
-        optional: false,
-        typeAnnotation: {
-          type: 'StringLiteralUnionTypeAnnotation',
+    describe('when property is required', () => {
+      it('returns required type annotation with TypeScript parser', () => {
+        const typeAnnotation = {
           types: [
             {
-              type: 'StringLiteralTypeAnnotation',
-              value: 'someValue1',
+              literal: {
+                value: 'someValue1',
+              },
             },
             {
-              type: 'StringLiteralTypeAnnotation',
-              value: 'someValue2',
+              literal: {
+                value: 'someValue2',
+              },
             },
           ],
-        },
-      };
+        };
+        const result = emitUnionProp(
+          'someProp',
+          false,
+          typeScriptParser,
+          typeAnnotation,
+        );
 
-      expect(result).toEqual(expected);
+        const expected = {
+          name: 'someProp',
+          optional: false,
+          typeAnnotation: {
+            type: 'UnionTypeAnnotation',
+            types: [
+              {
+                type: 'StringLiteralTypeAnnotation',
+                value: 'someValue1',
+              },
+              {
+                type: 'StringLiteralTypeAnnotation',
+                value: 'someValue2',
+              },
+            ],
+          },
+        };
+
+        expect(result).toEqual(expected);
+      });
     });
   });
 });

--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -278,7 +278,7 @@ function throwIfArrayElementTypeAnnotationIsUnsupported(
     PromiseTypeAnnotation: 'Promise',
     // TODO: Added as a work-around for now until TupleTypeAnnotation are fully supported in both flow and TS
     // Right now they are partially treated as UnionTypeAnnotation
-    UnionTypeAnnotation: 'UnionTypeAnnotation',
+    // UnionTypeAnnotation: 'UnionTypeAnnotation',
   };
 
   if (type in TypeMap) {

--- a/packages/react-native-codegen/src/parsers/errors.js
+++ b/packages/react-native-codegen/src/parsers/errors.js
@@ -10,7 +10,6 @@
 
 'use strict';
 
-import type {UnionTypeAnnotationMemberType} from '../CodegenSchema';
 import type {Parser} from './parser';
 
 export type ParserType = 'Flow' | 'TypeScript';
@@ -338,26 +337,6 @@ class UnsupportedEnumDeclarationParserError extends ParserError {
 }
 
 /**
- * Union parsing errors
- */
-
-class UnsupportedUnionTypeAnnotationParserError extends ParserError {
-  constructor(
-    nativeModuleName: string,
-    arrayElementTypeAST: $FlowFixMe,
-    types: UnionTypeAnnotationMemberType[],
-  ) {
-    super(
-      nativeModuleName,
-      arrayElementTypeAST,
-      `Union members must be of the same type, but multiple types were found ${types.join(
-        ', ',
-      )}'.`,
-    );
-  }
-}
-
-/**
  * Module parsing errors
  */
 
@@ -460,7 +439,6 @@ module.exports = {
   UnsupportedFunctionParamTypeAnnotationParserError,
   UnsupportedFunctionReturnTypeAnnotationParserError,
   UnsupportedEnumDeclarationParserError,
-  UnsupportedUnionTypeAnnotationParserError,
   UnsupportedModuleEventEmitterTypePropertyParserError,
   UnsupportedModuleEventEmitterPropertyParserError,
   UnsupportedModulePropertyParserError,

--- a/packages/react-native-codegen/src/parsers/flow/components/__tests__/__snapshots__/component-parser-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/flow/components/__tests__/__snapshots__/component-parser-test.js.snap
@@ -1725,7 +1725,7 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -1742,7 +1742,7 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -1759,7 +1759,7 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -1776,7 +1776,7 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -2176,7 +2176,7 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -2196,7 +2196,7 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -2216,7 +2216,7 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -2236,7 +2236,7 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -2536,7 +2536,7 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -2553,7 +2553,7 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -2570,7 +2570,7 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -2587,7 +2587,7 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -2987,7 +2987,7 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -3007,7 +3007,7 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -3027,7 +3027,7 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -3047,7 +3047,7 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -3346,7 +3346,7 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -3363,7 +3363,7 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -3380,7 +3380,7 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -3397,7 +3397,7 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -3797,7 +3797,7 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -3817,7 +3817,7 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -3837,7 +3837,7 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -3857,7 +3857,7 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -4157,7 +4157,7 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -4174,7 +4174,7 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -4191,7 +4191,7 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -4208,7 +4208,7 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -4608,7 +4608,7 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -4628,7 +4628,7 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -4648,7 +4648,7 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -4668,7 +4668,7 @@ exports[`RN Codegen Flow Parser can generate fixture COMMANDS_EVENTS_TYPES_EXPOR
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -5266,7 +5266,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -5283,7 +5283,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -5300,7 +5300,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -5317,7 +5317,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -5717,7 +5717,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -5737,7 +5737,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -5757,7 +5757,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -5777,7 +5777,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -6076,7 +6076,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -6093,7 +6093,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -6110,7 +6110,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -6127,7 +6127,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -6527,7 +6527,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -6547,7 +6547,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -6567,7 +6567,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -6587,7 +6587,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -6886,7 +6886,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -6903,7 +6903,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -6920,7 +6920,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -6937,7 +6937,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -7337,7 +7337,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -7357,7 +7357,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -7377,7 +7377,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -7397,7 +7397,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -7696,7 +7696,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -7713,7 +7713,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -7730,7 +7730,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -7747,7 +7747,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -8147,7 +8147,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -8167,7 +8167,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -8187,7 +8187,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -8207,7 +8207,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -8507,7 +8507,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -8524,7 +8524,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -8541,7 +8541,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -8558,7 +8558,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -8958,7 +8958,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -8978,7 +8978,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -8998,7 +8998,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -9018,7 +9018,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -9317,7 +9317,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -9334,7 +9334,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -9351,7 +9351,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -9368,7 +9368,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -9768,7 +9768,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -9788,7 +9788,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -9808,7 +9808,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -9828,7 +9828,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -10127,7 +10127,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -10144,7 +10144,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -10161,7 +10161,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -10178,7 +10178,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -10578,7 +10578,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -10598,7 +10598,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -10618,7 +10618,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -10638,7 +10638,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -10937,7 +10937,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -10954,7 +10954,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -10971,7 +10971,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -10988,7 +10988,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -11388,7 +11388,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -11408,7 +11408,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -11428,7 +11428,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -11448,7 +11448,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -11747,7 +11747,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -11764,7 +11764,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -11781,7 +11781,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -11798,7 +11798,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -12198,7 +12198,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -12218,7 +12218,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -12238,7 +12238,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -12258,7 +12258,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -12558,7 +12558,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -12575,7 +12575,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -12592,7 +12592,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -12609,7 +12609,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -13009,7 +13009,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -13029,7 +13029,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -13049,7 +13049,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -13069,7 +13069,7 @@ exports[`RN Codegen Flow Parser can generate fixture EVENTS_DEFINED_INLINE_WITH_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -14916,7 +14916,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_COMMANDS_EVENTS_
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -14933,7 +14933,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_COMMANDS_EVENTS_
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -14950,7 +14950,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_COMMANDS_EVENTS_
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -14967,7 +14967,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_COMMANDS_EVENTS_
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -15367,7 +15367,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_COMMANDS_EVENTS_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -15387,7 +15387,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_COMMANDS_EVENTS_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -15407,7 +15407,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_COMMANDS_EVENTS_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -15427,7 +15427,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_COMMANDS_EVENTS_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -15727,7 +15727,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_COMMANDS_EVENTS_
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -15744,7 +15744,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_COMMANDS_EVENTS_
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -15761,7 +15761,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_COMMANDS_EVENTS_
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -15778,7 +15778,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_COMMANDS_EVENTS_
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -16178,7 +16178,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_COMMANDS_EVENTS_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -16198,7 +16198,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_COMMANDS_EVENTS_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -16218,7 +16218,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_COMMANDS_EVENTS_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -16238,7 +16238,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_COMMANDS_EVENTS_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -16537,7 +16537,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_COMMANDS_EVENTS_
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -16554,7 +16554,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_COMMANDS_EVENTS_
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -16571,7 +16571,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_COMMANDS_EVENTS_
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -16588,7 +16588,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_COMMANDS_EVENTS_
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -16988,7 +16988,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_COMMANDS_EVENTS_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -17008,7 +17008,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_COMMANDS_EVENTS_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -17028,7 +17028,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_COMMANDS_EVENTS_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -17048,7 +17048,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_COMMANDS_EVENTS_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -17348,7 +17348,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_COMMANDS_EVENTS_
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -17365,7 +17365,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_COMMANDS_EVENTS_
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -17382,7 +17382,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_COMMANDS_EVENTS_
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -17399,7 +17399,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_COMMANDS_EVENTS_
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -17799,7 +17799,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_COMMANDS_EVENTS_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -17819,7 +17819,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_COMMANDS_EVENTS_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -17839,7 +17839,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_COMMANDS_EVENTS_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -17859,7 +17859,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_COMMANDS_EVENTS_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -18457,7 +18457,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -18474,7 +18474,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -18491,7 +18491,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -18508,7 +18508,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -18908,7 +18908,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -18928,7 +18928,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -18948,7 +18948,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -18968,7 +18968,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -19267,7 +19267,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -19284,7 +19284,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -19301,7 +19301,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -19318,7 +19318,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -19718,7 +19718,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -19738,7 +19738,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -19758,7 +19758,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -19778,7 +19778,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -20077,7 +20077,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -20094,7 +20094,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -20111,7 +20111,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -20128,7 +20128,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -20528,7 +20528,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -20548,7 +20548,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -20568,7 +20568,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -20588,7 +20588,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -20887,7 +20887,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -20904,7 +20904,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -20921,7 +20921,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -20938,7 +20938,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -21338,7 +21338,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -21358,7 +21358,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -21378,7 +21378,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -21398,7 +21398,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -21698,7 +21698,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -21715,7 +21715,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -21732,7 +21732,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -21749,7 +21749,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -22149,7 +22149,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -22169,7 +22169,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -22189,7 +22189,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -22209,7 +22209,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -22508,7 +22508,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -22525,7 +22525,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -22542,7 +22542,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -22559,7 +22559,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -22959,7 +22959,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -22979,7 +22979,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -22999,7 +22999,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -23019,7 +23019,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -23318,7 +23318,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -23335,7 +23335,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -23352,7 +23352,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -23369,7 +23369,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -23769,7 +23769,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -23789,7 +23789,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -23809,7 +23809,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -23829,7 +23829,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -24128,7 +24128,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -24145,7 +24145,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -24162,7 +24162,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -24179,7 +24179,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -24579,7 +24579,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -24599,7 +24599,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -24619,7 +24619,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -24639,7 +24639,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -24938,7 +24938,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -24955,7 +24955,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -24972,7 +24972,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -24989,7 +24989,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -25389,7 +25389,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -25409,7 +25409,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -25429,7 +25429,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -25449,7 +25449,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -25749,7 +25749,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -25766,7 +25766,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -25783,7 +25783,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -25800,7 +25800,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -26200,7 +26200,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -26220,7 +26220,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -26240,7 +26240,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -26260,7 +26260,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_EVENTS_DEFINED_I
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -27434,7 +27434,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_PROPS_AND_EVENTS
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -27451,7 +27451,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_PROPS_AND_EVENTS
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -27468,7 +27468,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_PROPS_AND_EVENTS
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -27485,7 +27485,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_PROPS_AND_EVENTS
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -27885,7 +27885,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_PROPS_AND_EVENTS
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -27905,7 +27905,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_PROPS_AND_EVENTS
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -27925,7 +27925,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_PROPS_AND_EVENTS
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -27945,7 +27945,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_PROPS_AND_EVENTS
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -28245,7 +28245,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_PROPS_AND_EVENTS
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -28262,7 +28262,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_PROPS_AND_EVENTS
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -28279,7 +28279,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_PROPS_AND_EVENTS
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -28296,7 +28296,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_PROPS_AND_EVENTS
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -28696,7 +28696,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_PROPS_AND_EVENTS
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -28716,7 +28716,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_PROPS_AND_EVENTS
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -28736,7 +28736,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_PROPS_AND_EVENTS
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -28756,7 +28756,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_PROPS_AND_EVENTS
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -29055,7 +29055,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_PROPS_AND_EVENTS
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -29072,7 +29072,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_PROPS_AND_EVENTS
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -29089,7 +29089,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_PROPS_AND_EVENTS
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -29106,7 +29106,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_PROPS_AND_EVENTS
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -29506,7 +29506,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_PROPS_AND_EVENTS
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -29526,7 +29526,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_PROPS_AND_EVENTS
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -29546,7 +29546,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_PROPS_AND_EVENTS
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -29566,7 +29566,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_PROPS_AND_EVENTS
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -29866,7 +29866,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_PROPS_AND_EVENTS
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -29883,7 +29883,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_PROPS_AND_EVENTS
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -29900,7 +29900,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_PROPS_AND_EVENTS
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -29917,7 +29917,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_PROPS_AND_EVENTS
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -30317,7 +30317,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_PROPS_AND_EVENTS
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -30337,7 +30337,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_PROPS_AND_EVENTS
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -30357,7 +30357,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_PROPS_AND_EVENTS
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -30377,7 +30377,7 @@ exports[`RN Codegen Flow Parser can generate fixture NAMESPACED_PROPS_AND_EVENTS
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -31692,7 +31692,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -31709,7 +31709,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -31726,7 +31726,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -31743,7 +31743,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -32143,7 +32143,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -32163,7 +32163,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -32183,7 +32183,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -32203,7 +32203,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -32503,7 +32503,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -32520,7 +32520,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -32537,7 +32537,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -32554,7 +32554,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -32954,7 +32954,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -32974,7 +32974,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -32994,7 +32994,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -33014,7 +33014,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -33313,7 +33313,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -33330,7 +33330,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -33347,7 +33347,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -33364,7 +33364,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -33764,7 +33764,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -33784,7 +33784,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -33804,7 +33804,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -33824,7 +33824,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -34124,7 +34124,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -34141,7 +34141,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -34158,7 +34158,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -34175,7 +34175,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -34575,7 +34575,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -34595,7 +34595,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -34615,7 +34615,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -34635,7 +34635,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROPS_AND_EVENTS_TYPES_EXPO
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',

--- a/packages/react-native-codegen/src/parsers/flow/components/events.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/events.js
@@ -115,7 +115,7 @@ function extractArrayElementType(
       };
     case 'UnionTypeAnnotation':
       return {
-        type: 'StringLiteralUnionTypeAnnotation',
+        type: 'UnionTypeAnnotation',
         types: typeAnnotation.types.map(option => ({
           type: 'StringLiteralTypeAnnotation',
           value: parser.getLiteralValue(option),

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
@@ -401,7 +401,24 @@ exports[`RN Codegen Flow Parser can generate fixture CXX_ONLY_NATIVE_MODULE 1`] 
               'type': 'FunctionTypeAnnotation',
               'returnTypeAnnotation': {
                 'type': 'UnionTypeAnnotation',
-                'memberType': 'ObjectTypeAnnotation'
+                'types': [
+                  {
+                    'type': 'ObjectTypeAnnotation',
+                    'properties': []
+                  },
+                  {
+                    'type': 'ObjectTypeAnnotation',
+                    'properties': [
+                      {
+                        'name': 'low',
+                        'optional': false,
+                        'typeAnnotation': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    ]
+                  }
+                ]
               },
               'params': [
                 {
@@ -409,7 +426,20 @@ exports[`RN Codegen Flow Parser can generate fixture CXX_ONLY_NATIVE_MODULE 1`] 
                   'optional': false,
                   'typeAnnotation': {
                     'type': 'UnionTypeAnnotation',
-                    'memberType': 'NumberTypeAnnotation'
+                    'types': [
+                      {
+                        'type': 'NumberLiteralTypeAnnotation',
+                        'value': 1
+                      },
+                      {
+                        'type': 'NumberLiteralTypeAnnotation',
+                        'value': 2
+                      },
+                      {
+                        'type': 'NumberLiteralTypeAnnotation',
+                        'value': 3
+                      }
+                    ]
                   }
                 },
                 {
@@ -417,7 +447,20 @@ exports[`RN Codegen Flow Parser can generate fixture CXX_ONLY_NATIVE_MODULE 1`] 
                   'optional': false,
                   'typeAnnotation': {
                     'type': 'UnionTypeAnnotation',
-                    'memberType': 'NumberTypeAnnotation'
+                    'types': [
+                      {
+                        'type': 'NumberLiteralTypeAnnotation',
+                        'value': 1.44
+                      },
+                      {
+                        'type': 'NumberLiteralTypeAnnotation',
+                        'value': 2.88
+                      },
+                      {
+                        'type': 'NumberLiteralTypeAnnotation',
+                        'value': 5.76
+                      }
+                    ]
                   }
                 },
                 {
@@ -425,14 +468,31 @@ exports[`RN Codegen Flow Parser can generate fixture CXX_ONLY_NATIVE_MODULE 1`] 
                   'optional': false,
                   'typeAnnotation': {
                     'type': 'UnionTypeAnnotation',
-                    'memberType': 'ObjectTypeAnnotation'
+                    'types': [
+                      {
+                        'type': 'ObjectTypeAnnotation',
+                        'properties': []
+                      },
+                      {
+                        'type': 'ObjectTypeAnnotation',
+                        'properties': [
+                          {
+                            'name': 'low',
+                            'optional': false,
+                            'typeAnnotation': {
+                              'type': 'StringTypeAnnotation'
+                            }
+                          }
+                        ]
+                      }
+                    ]
                   }
                 },
                 {
                   'name': 'chooseString',
                   'optional': false,
                   'typeAnnotation': {
-                    'type': 'StringLiteralUnionTypeAnnotation',
+                    'type': 'UnionTypeAnnotation',
                     'types': [
                       {
                         'type': 'StringLiteralTypeAnnotation',
@@ -1111,7 +1171,18 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_ARRAY_WI
               'returnTypeAnnotation': {
                 'type': 'ArrayTypeAnnotation',
                 'elementType': {
-                  'type': 'AnyTypeAnnotation'
+                  'type': 'UnionTypeAnnotation',
+                  'types': [
+                    {
+                      'type': 'StringTypeAnnotation'
+                    },
+                    {
+                      'type': 'NumberTypeAnnotation'
+                    },
+                    {
+                      'type': 'BooleanTypeAnnotation'
+                    }
+                  ]
                 }
               },
               'params': [
@@ -2686,7 +2757,24 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_UNION 1`
               'type': 'FunctionTypeAnnotation',
               'returnTypeAnnotation': {
                 'type': 'UnionTypeAnnotation',
-                'memberType': 'ObjectTypeAnnotation'
+                'types': [
+                  {
+                    'type': 'ObjectTypeAnnotation',
+                    'properties': []
+                  },
+                  {
+                    'type': 'ObjectTypeAnnotation',
+                    'properties': [
+                      {
+                        'name': 'low',
+                        'optional': false,
+                        'typeAnnotation': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    ]
+                  }
+                ]
               },
               'params': [
                 {
@@ -2694,7 +2782,20 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_UNION 1`
                   'optional': false,
                   'typeAnnotation': {
                     'type': 'UnionTypeAnnotation',
-                    'memberType': 'NumberTypeAnnotation'
+                    'types': [
+                      {
+                        'type': 'NumberLiteralTypeAnnotation',
+                        'value': 1
+                      },
+                      {
+                        'type': 'NumberLiteralTypeAnnotation',
+                        'value': 2
+                      },
+                      {
+                        'type': 'NumberLiteralTypeAnnotation',
+                        'value': 3
+                      }
+                    ]
                   }
                 },
                 {
@@ -2702,7 +2803,20 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_UNION 1`
                   'optional': false,
                   'typeAnnotation': {
                     'type': 'UnionTypeAnnotation',
-                    'memberType': 'NumberTypeAnnotation'
+                    'types': [
+                      {
+                        'type': 'NumberLiteralTypeAnnotation',
+                        'value': 1.44
+                      },
+                      {
+                        'type': 'NumberLiteralTypeAnnotation',
+                        'value': 2.88
+                      },
+                      {
+                        'type': 'NumberLiteralTypeAnnotation',
+                        'value': 5.76
+                      }
+                    ]
                   }
                 },
                 {
@@ -2710,14 +2824,31 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_UNION 1`
                   'optional': false,
                   'typeAnnotation': {
                     'type': 'UnionTypeAnnotation',
-                    'memberType': 'ObjectTypeAnnotation'
+                    'types': [
+                      {
+                        'type': 'ObjectTypeAnnotation',
+                        'properties': []
+                      },
+                      {
+                        'type': 'ObjectTypeAnnotation',
+                        'properties': [
+                          {
+                            'name': 'low',
+                            'optional': false,
+                            'typeAnnotation': {
+                              'type': 'StringTypeAnnotation'
+                            }
+                          }
+                        ]
+                      }
+                    ]
                   }
                 },
                 {
                   'name': 'chooseString',
                   'optional': false,
                   'typeAnnotation': {
-                    'type': 'StringLiteralUnionTypeAnnotation',
+                    'type': 'UnionTypeAnnotation',
                     'types': [
                       {
                         'type': 'StringLiteralTypeAnnotation',
@@ -2761,7 +2892,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_UNION_RE
             'typeAnnotation': {
               'type': 'FunctionTypeAnnotation',
               'returnTypeAnnotation': {
-                'type': 'StringLiteralUnionTypeAnnotation',
+                'type': 'UnionTypeAnnotation',
                 'types': [
                   {
                     'type': 'StringLiteralTypeAnnotation',
@@ -2789,7 +2920,7 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_UNION_RE
                   'name': 'strings',
                   'optional': false,
                   'typeAnnotation': {
-                    'type': 'StringLiteralUnionTypeAnnotation',
+                    'type': 'UnionTypeAnnotation',
                     'types': [
                       {
                         'type': 'StringLiteralTypeAnnotation',
@@ -2812,7 +2943,16 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_UNION_RE
               'type': 'FunctionTypeAnnotation',
               'returnTypeAnnotation': {
                 'type': 'UnionTypeAnnotation',
-                'memberType': 'NumberTypeAnnotation'
+                'types': [
+                  {
+                    'type': 'NumberLiteralTypeAnnotation',
+                    'value': 1
+                  },
+                  {
+                    'type': 'NumberLiteralTypeAnnotation',
+                    'value': 2
+                  }
+                ]
               },
               'params': []
             }
@@ -2831,7 +2971,16 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_UNION_RE
                   'optional': false,
                   'typeAnnotation': {
                     'type': 'UnionTypeAnnotation',
-                    'memberType': 'NumberTypeAnnotation'
+                    'types': [
+                      {
+                        'type': 'NumberLiteralTypeAnnotation',
+                        'value': 1
+                      },
+                      {
+                        'type': 'NumberLiteralTypeAnnotation',
+                        'value': 2
+                      }
+                    ]
                   }
                 }
               ]
@@ -2844,7 +2993,34 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_UNION_RE
               'type': 'FunctionTypeAnnotation',
               'returnTypeAnnotation': {
                 'type': 'UnionTypeAnnotation',
-                'memberType': 'ObjectTypeAnnotation'
+                'types': [
+                  {
+                    'type': 'ObjectTypeAnnotation',
+                    'properties': [
+                      {
+                        'name': 'a',
+                        'optional': false,
+                        'typeAnnotation': {
+                          'type': 'NumberLiteralTypeAnnotation',
+                          'value': 1
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    'type': 'ObjectTypeAnnotation',
+                    'properties': [
+                      {
+                        'name': 'b',
+                        'optional': false,
+                        'typeAnnotation': {
+                          'type': 'NumberLiteralTypeAnnotation',
+                          'value': 2
+                        }
+                      }
+                    ]
+                  }
+                ]
               },
               'params': []
             }
@@ -2863,7 +3039,34 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_UNION_RE
                   'optional': false,
                   'typeAnnotation': {
                     'type': 'UnionTypeAnnotation',
-                    'memberType': 'ObjectTypeAnnotation'
+                    'types': [
+                      {
+                        'type': 'ObjectTypeAnnotation',
+                        'properties': [
+                          {
+                            'name': 'a',
+                            'optional': false,
+                            'typeAnnotation': {
+                              'type': 'NumberLiteralTypeAnnotation',
+                              'value': 1
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        'type': 'ObjectTypeAnnotation',
+                        'properties': [
+                          {
+                            'name': 'b',
+                            'optional': false,
+                            'typeAnnotation': {
+                              'type': 'NumberLiteralTypeAnnotation',
+                              'value': 2
+                            }
+                          }
+                        ]
+                      }
+                    ]
                   }
                 }
               ]
@@ -3032,7 +3235,32 @@ exports[`RN Codegen Flow Parser can generate fixture PROMISE_WITH_COMMONLY_USED_
               'returnTypeAnnotation': {
                 'type': 'PromiseTypeAnnotation',
                 'elementType': {
-                  'type': 'VoidTypeAnnotation'
+                  'type': 'GenericObjectTypeAnnotation',
+                  'dictionaryValueType': {
+                    'type': 'UnionTypeAnnotation',
+                    'types': [
+                      {
+                        'type': 'StringLiteralTypeAnnotation',
+                        'value': 'authorized'
+                      },
+                      {
+                        'type': 'StringLiteralTypeAnnotation',
+                        'value': 'denied'
+                      },
+                      {
+                        'type': 'StringLiteralTypeAnnotation',
+                        'value': 'undetermined'
+                      },
+                      {
+                        'type': 'BooleanLiteralTypeAnnotation',
+                        'value': true
+                      },
+                      {
+                        'type': 'BooleanLiteralTypeAnnotation',
+                        'value': false
+                      }
+                    ]
+                  }
                 }
               },
               'params': []
@@ -3064,7 +3292,7 @@ exports[`RN Codegen Flow Parser can generate fixture PROMISE_WITH_COMMONLY_USED_
               'returnTypeAnnotation': {
                 'type': 'PromiseTypeAnnotation',
                 'elementType': {
-                  'type': 'StringLiteralUnionTypeAnnotation',
+                  'type': 'UnionTypeAnnotation',
                   'types': [
                     {
                       'type': 'StringLiteralTypeAnnotation',

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -245,7 +245,18 @@ function translateTypeAnnotation(
       );
     }
     case 'UnionTypeAnnotation': {
-      return emitUnion(nullable, hasteModuleName, typeAnnotation, parser);
+      return emitUnion(
+        nullable,
+        hasteModuleName,
+        typeAnnotation,
+        types,
+        aliasMap,
+        enumMap,
+        tryParse,
+        cxxOnly,
+        translateTypeAnnotation,
+        parser,
+      );
     }
     case 'NumberLiteralTypeAnnotation': {
       return emitNumberLiteral(nullable, typeAnnotation.value);

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -18,10 +18,10 @@ import type {
   NativeModuleEnumMember,
   NativeModuleEnumMemberType,
   NativeModuleParamTypeAnnotation,
+  NativeModuleUnionTypeAnnotationMemberType,
   Nullable,
   PropTypeAnnotation,
   SchemaType,
-  UnionTypeAnnotationMemberType,
 } from '../../CodegenSchema';
 import type {ParserType} from '../errors';
 import type {
@@ -111,7 +111,7 @@ class FlowParser implements Parser {
 
   remapUnionTypeAnnotationMemberNames(
     membersTypes: $FlowFixMe[],
-  ): UnionTypeAnnotationMemberType[] {
+  ): NativeModuleUnionTypeAnnotationMemberType[] {
     const remapLiteral = (item: $FlowFixMe) => {
       return item.type
         .replace('NumberLiteralTypeAnnotation', 'NumberTypeAnnotation')
@@ -119,12 +119,6 @@ class FlowParser implements Parser {
     };
 
     return [...new Set(membersTypes.map(remapLiteral))];
-  }
-
-  getStringLiteralUnionTypeAnnotationStringLiterals(
-    membersTypes: $FlowFixMe[],
-  ): string[] {
-    return membersTypes.map((item: $FlowFixMe) => item.value);
   }
 
   parseFile(filename: string): SchemaType {

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -18,10 +18,10 @@ import type {
   NativeModuleEnumMember,
   NativeModuleEnumMemberType,
   NativeModuleParamTypeAnnotation,
+  NativeModuleUnionTypeAnnotationMemberType,
   Nullable,
   PropTypeAnnotation,
   SchemaType,
-  UnionTypeAnnotationMemberType,
 } from '../CodegenSchema';
 import type {ParserType} from './errors';
 import type {
@@ -146,15 +146,7 @@ export interface Parser {
    */
   remapUnionTypeAnnotationMemberNames(
     types: $FlowFixMe,
-  ): UnionTypeAnnotationMemberType[];
-  /**
-   * Given a union annotation members types, it returns an array of string literals.
-   * @parameter membersTypes: union annotation members types
-   * @returns: an array of string literals.
-   */
-  getStringLiteralUnionTypeAnnotationStringLiterals(
-    types: $FlowFixMe,
-  ): string[];
+  ): NativeModuleUnionTypeAnnotationMemberType[];
   /**
    * Given the name of a file, it returns a Schema.
    * @parameter filename: the name of the file.

--- a/packages/react-native-codegen/src/parsers/parserMock.js
+++ b/packages/react-native-codegen/src/parsers/parserMock.js
@@ -18,10 +18,10 @@ import type {
   NativeModuleEnumMember,
   NativeModuleEnumMemberType,
   NativeModuleParamTypeAnnotation,
+  NativeModuleUnionTypeAnnotationMemberType,
   Nullable,
   PropTypeAnnotation,
   SchemaType,
-  UnionTypeAnnotationMemberType,
 } from '../CodegenSchema';
 import type {ParserType} from './errors';
 import type {
@@ -105,13 +105,7 @@ export class MockedParser implements Parser {
 
   remapUnionTypeAnnotationMemberNames(
     membersTypes: $FlowFixMe[],
-  ): UnionTypeAnnotationMemberType[] {
-    return [];
-  }
-
-  getStringLiteralUnionTypeAnnotationStringLiterals(
-    membersTypes: $FlowFixMe[],
-  ): string[] {
+  ): NativeModuleUnionTypeAnnotationMemberType[] {
     return [];
   }
 

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -31,12 +31,12 @@ import type {
   NativeModuleTypeAliasTypeAnnotation,
   NativeModuleTypeAnnotation,
   NativeModuleUnionTypeAnnotation,
+  NativeModuleUnionTypeAnnotationMemberType,
   Nullable,
   NumberLiteralTypeAnnotation,
   ObjectTypeAnnotation,
   ReservedTypeAnnotation,
   StringLiteralTypeAnnotation,
-  StringLiteralUnionTypeAnnotation,
   StringTypeAnnotation,
   VoidTypeAnnotation,
 } from '../CodegenSchema';
@@ -52,11 +52,7 @@ const {
   throwIfPartialNotAnnotatingTypeParameter,
   throwIfPartialWithMoreParameter,
 } = require('./error-utils');
-const {
-  ParserError,
-  UnsupportedTypeAnnotationParserError,
-  UnsupportedUnionTypeAnnotationParserError,
-} = require('./errors');
+const {ParserError, UnsupportedTypeAnnotationParserError} = require('./errors');
 const {
   assertGenericTypeAnnotationHasExactlyOneTypeParameter,
   translateFunctionTypeAnnotation,
@@ -431,61 +427,53 @@ function emitUnion(
   nullable: boolean,
   hasteModuleName: string,
   typeAnnotation: $FlowFixMe,
+  types: TypeDeclarationMap,
+  aliasMap: {...NativeModuleAliasMap},
+  enumMap: {...NativeModuleEnumMap},
+  tryParse: ParserErrorCapturer,
+  cxxOnly: boolean,
+  translateTypeAnnotation: $FlowFixMe,
   parser: Parser,
-): Nullable<
-  NativeModuleUnionTypeAnnotation | StringLiteralUnionTypeAnnotation,
-> {
-  // Get all the literals by type
-  // Verify they are all the same
-  // If string, persist as StringLiteralUnionType
-  // If number, persist as NumberTypeAnnotation (TODO: Number literal)
+): Nullable<NativeModuleUnionTypeAnnotation> {
+  const unparsedMemberTypes: $ReadOnlyArray<$FlowFixMe> =
+    (typeAnnotation.types: $ReadOnlyArray<$FlowFixMe>);
 
-  const unionTypes = parser.remapUnionTypeAnnotationMemberNames(
-    typeAnnotation.types,
+  const memberTypes = unparsedMemberTypes.map(
+    (memberType: $FlowFixMe): NativeModuleUnionTypeAnnotationMemberType => {
+      const memberTypeAnnotation = translateTypeAnnotation(
+        hasteModuleName,
+        memberType,
+        types,
+        aliasMap,
+        enumMap,
+        tryParse,
+        cxxOnly,
+        parser,
+      );
+
+      switch (memberTypeAnnotation.type) {
+        case 'StringTypeAnnotation':
+        case 'NumberTypeAnnotation':
+        case 'BooleanTypeAnnotation':
+        case 'NumberLiteralTypeAnnotation':
+        case 'StringLiteralTypeAnnotation':
+        case 'BooleanLiteralTypeAnnotation':
+        case 'ObjectTypeAnnotation':
+        case 'TypeAliasTypeAnnotation':
+          return memberTypeAnnotation;
+        default:
+          throw new UnsupportedTypeAnnotationParserError(
+            hasteModuleName,
+            memberType,
+            parser.language(),
+          );
+      }
+    },
   );
-
-  // Only support unionTypes of the same kind
-  if (unionTypes.length > 1) {
-    throw new UnsupportedUnionTypeAnnotationParserError(
-      hasteModuleName,
-      typeAnnotation,
-      unionTypes,
-    );
-  }
-
-  if (unionTypes[0] === 'StringTypeAnnotation') {
-    // Reprocess as a string literal union
-    return emitStringLiteralUnion(
-      nullable,
-      hasteModuleName,
-      typeAnnotation,
-      parser,
-    );
-  }
 
   return wrapNullable(nullable, {
     type: 'UnionTypeAnnotation',
-    memberType: unionTypes[0],
-  });
-}
-
-function emitStringLiteralUnion(
-  nullable: boolean,
-  hasteModuleName: string,
-  typeAnnotation: $FlowFixMe,
-  parser: Parser,
-): Nullable<StringLiteralUnionTypeAnnotation> {
-  const stringLiterals =
-    parser.getStringLiteralUnionTypeAnnotationStringLiterals(
-      typeAnnotation.types,
-    );
-
-  return wrapNullable(nullable, {
-    type: 'StringLiteralUnionTypeAnnotation',
-    types: stringLiterals.map(stringLiteral => ({
-      type: 'StringLiteralTypeAnnotation',
-      value: stringLiteral,
-    })),
+    types: memberTypes,
   });
 }
 
@@ -675,6 +663,7 @@ function emitCommonTypes(
     VoidTypeAnnotation: emitVoid,
     StringTypeAnnotation: emitString,
     MixedTypeAnnotation: cxxOnly ? emitMixed : emitGenericObject,
+    UnsafeMixed: cxxOnly ? emitMixed : emitGenericObject,
   };
 
   const typeAnnotationName = parser.convertKeywordToTypeAnnotation(
@@ -763,7 +752,7 @@ function emitUnionProp(
     name,
     optional,
     typeAnnotation: {
-      type: 'StringLiteralUnionTypeAnnotation',
+      type: 'UnionTypeAnnotation',
       types: typeAnnotation.types.map(option => ({
         type: 'StringLiteralTypeAnnotation',
         value: parser.getLiteralValue(option),

--- a/packages/react-native-codegen/src/parsers/typescript/components/__tests__/__snapshots__/typescript-component-parser-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/typescript/components/__tests__/__snapshots__/typescript-component-parser-test.js.snap
@@ -2430,7 +2430,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -2447,7 +2447,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -2464,7 +2464,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -2481,7 +2481,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -2881,7 +2881,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -2901,7 +2901,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -2921,7 +2921,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -2941,7 +2941,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -3241,7 +3241,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -3258,7 +3258,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -3275,7 +3275,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -3292,7 +3292,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -3692,7 +3692,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -3712,7 +3712,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -3732,7 +3732,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -3752,7 +3752,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -4051,7 +4051,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -4068,7 +4068,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -4085,7 +4085,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -4102,7 +4102,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -4502,7 +4502,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -4522,7 +4522,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -4542,7 +4542,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -4562,7 +4562,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -4862,7 +4862,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -4879,7 +4879,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -4896,7 +4896,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -4913,7 +4913,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -5313,7 +5313,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -5333,7 +5333,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -5353,7 +5353,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -5373,7 +5373,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture COMMANDS_EVENTS_TYPES
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -5971,7 +5971,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -5988,7 +5988,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -6005,7 +6005,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -6022,7 +6022,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -6422,7 +6422,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -6442,7 +6442,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -6462,7 +6462,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -6482,7 +6482,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -6781,7 +6781,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -6798,7 +6798,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -6815,7 +6815,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -6832,7 +6832,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -7232,7 +7232,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -7252,7 +7252,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -7272,7 +7272,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -7292,7 +7292,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -7591,7 +7591,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -7608,7 +7608,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -7625,7 +7625,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -7642,7 +7642,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -8042,7 +8042,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -8062,7 +8062,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -8082,7 +8082,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -8102,7 +8102,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -8401,7 +8401,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -8418,7 +8418,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -8435,7 +8435,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -8452,7 +8452,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -8852,7 +8852,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -8872,7 +8872,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -8892,7 +8892,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -8912,7 +8912,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -9212,7 +9212,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -9229,7 +9229,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -9246,7 +9246,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -9263,7 +9263,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -9663,7 +9663,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -9683,7 +9683,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -9703,7 +9703,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -9723,7 +9723,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -10022,7 +10022,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -10039,7 +10039,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -10056,7 +10056,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -10073,7 +10073,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -10473,7 +10473,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -10493,7 +10493,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -10513,7 +10513,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -10533,7 +10533,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -10832,7 +10832,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -10849,7 +10849,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -10866,7 +10866,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -10883,7 +10883,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -11283,7 +11283,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -11303,7 +11303,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -11323,7 +11323,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -11343,7 +11343,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -11642,7 +11642,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -11659,7 +11659,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -11676,7 +11676,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -11693,7 +11693,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -12093,7 +12093,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -12113,7 +12113,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -12133,7 +12133,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -12153,7 +12153,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -12452,7 +12452,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -12469,7 +12469,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -12486,7 +12486,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -12503,7 +12503,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -12903,7 +12903,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -12923,7 +12923,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -12943,7 +12943,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -12963,7 +12963,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -13263,7 +13263,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -13280,7 +13280,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -13297,7 +13297,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -13314,7 +13314,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -13714,7 +13714,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -13734,7 +13734,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -13754,7 +13754,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -13774,7 +13774,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture EVENTS_DEFINED_INLINE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -16328,7 +16328,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_COMMANDS_E
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -16345,7 +16345,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_COMMANDS_E
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -16362,7 +16362,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_COMMANDS_E
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -16379,7 +16379,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_COMMANDS_E
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -16779,7 +16779,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_COMMANDS_E
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -16799,7 +16799,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_COMMANDS_E
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -16819,7 +16819,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_COMMANDS_E
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -16839,7 +16839,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_COMMANDS_E
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -17139,7 +17139,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_COMMANDS_E
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -17156,7 +17156,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_COMMANDS_E
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -17173,7 +17173,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_COMMANDS_E
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -17190,7 +17190,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_COMMANDS_E
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -17590,7 +17590,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_COMMANDS_E
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -17610,7 +17610,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_COMMANDS_E
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -17630,7 +17630,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_COMMANDS_E
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -17650,7 +17650,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_COMMANDS_E
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -17949,7 +17949,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_COMMANDS_E
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -17966,7 +17966,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_COMMANDS_E
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -17983,7 +17983,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_COMMANDS_E
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -18000,7 +18000,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_COMMANDS_E
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -18400,7 +18400,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_COMMANDS_E
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -18420,7 +18420,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_COMMANDS_E
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -18440,7 +18440,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_COMMANDS_E
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -18460,7 +18460,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_COMMANDS_E
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -18760,7 +18760,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_COMMANDS_E
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -18777,7 +18777,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_COMMANDS_E
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -18794,7 +18794,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_COMMANDS_E
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -18811,7 +18811,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_COMMANDS_E
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -19211,7 +19211,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_COMMANDS_E
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -19231,7 +19231,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_COMMANDS_E
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -19251,7 +19251,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_COMMANDS_E
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -19271,7 +19271,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_COMMANDS_E
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -19869,7 +19869,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -19886,7 +19886,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -19903,7 +19903,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -19920,7 +19920,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -20320,7 +20320,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -20340,7 +20340,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -20360,7 +20360,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -20380,7 +20380,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -20679,7 +20679,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -20696,7 +20696,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -20713,7 +20713,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -20730,7 +20730,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -21130,7 +21130,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -21150,7 +21150,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -21170,7 +21170,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -21190,7 +21190,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -21489,7 +21489,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -21506,7 +21506,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -21523,7 +21523,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -21540,7 +21540,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -21940,7 +21940,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -21960,7 +21960,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -21980,7 +21980,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -22000,7 +22000,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -22299,7 +22299,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -22316,7 +22316,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -22333,7 +22333,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -22350,7 +22350,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -22750,7 +22750,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -22770,7 +22770,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -22790,7 +22790,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -22810,7 +22810,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -23110,7 +23110,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -23127,7 +23127,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -23144,7 +23144,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -23161,7 +23161,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -23561,7 +23561,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -23581,7 +23581,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -23601,7 +23601,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -23621,7 +23621,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -23920,7 +23920,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -23937,7 +23937,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -23954,7 +23954,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -23971,7 +23971,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -24371,7 +24371,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -24391,7 +24391,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -24411,7 +24411,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -24431,7 +24431,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -24730,7 +24730,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -24747,7 +24747,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -24764,7 +24764,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -24781,7 +24781,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -25181,7 +25181,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -25201,7 +25201,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -25221,7 +25221,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -25241,7 +25241,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -25540,7 +25540,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -25557,7 +25557,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -25574,7 +25574,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -25591,7 +25591,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -25991,7 +25991,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -26011,7 +26011,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -26031,7 +26031,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -26051,7 +26051,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -26350,7 +26350,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -26367,7 +26367,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -26384,7 +26384,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -26401,7 +26401,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -26801,7 +26801,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -26821,7 +26821,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -26841,7 +26841,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -26861,7 +26861,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -27161,7 +27161,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -27178,7 +27178,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -27195,7 +27195,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -27212,7 +27212,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -27612,7 +27612,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -27632,7 +27632,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -27652,7 +27652,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -27672,7 +27672,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_EVENTS_DEF
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -28846,7 +28846,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_PROPS_AND_
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -28863,7 +28863,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_PROPS_AND_
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -28880,7 +28880,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_PROPS_AND_
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -28897,7 +28897,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_PROPS_AND_
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -29297,7 +29297,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_PROPS_AND_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -29317,7 +29317,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_PROPS_AND_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -29337,7 +29337,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_PROPS_AND_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -29357,7 +29357,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_PROPS_AND_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -29657,7 +29657,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_PROPS_AND_
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -29674,7 +29674,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_PROPS_AND_
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -29691,7 +29691,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_PROPS_AND_
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -29708,7 +29708,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_PROPS_AND_
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -30108,7 +30108,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_PROPS_AND_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -30128,7 +30128,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_PROPS_AND_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -30148,7 +30148,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_PROPS_AND_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -30168,7 +30168,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_PROPS_AND_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -30467,7 +30467,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_PROPS_AND_
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -30484,7 +30484,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_PROPS_AND_
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -30501,7 +30501,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_PROPS_AND_
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -30518,7 +30518,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_PROPS_AND_
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -30918,7 +30918,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_PROPS_AND_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -30938,7 +30938,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_PROPS_AND_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -30958,7 +30958,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_PROPS_AND_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -30978,7 +30978,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_PROPS_AND_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -31278,7 +31278,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_PROPS_AND_
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -31295,7 +31295,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_PROPS_AND_
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -31312,7 +31312,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_PROPS_AND_
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -31329,7 +31329,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_PROPS_AND_
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -31729,7 +31729,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_PROPS_AND_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -31749,7 +31749,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_PROPS_AND_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -31769,7 +31769,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_PROPS_AND_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -31789,7 +31789,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NAMESPACED_PROPS_AND_
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -33415,7 +33415,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -33432,7 +33432,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -33449,7 +33449,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -33466,7 +33466,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -33866,7 +33866,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -33886,7 +33886,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -33906,7 +33906,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -33926,7 +33926,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -34226,7 +34226,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -34243,7 +34243,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -34260,7 +34260,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -34277,7 +34277,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -34677,7 +34677,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -34697,7 +34697,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -34717,7 +34717,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -34737,7 +34737,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -35036,7 +35036,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -35053,7 +35053,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -35070,7 +35070,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -35087,7 +35087,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -35487,7 +35487,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -35507,7 +35507,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -35527,7 +35527,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -35547,7 +35547,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -35847,7 +35847,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       'name': 'union_required',
                       'optional': false,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -35864,7 +35864,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       'name': 'union_optional_key',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -35881,7 +35881,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       'name': 'union_optional_value',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -35898,7 +35898,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       'name': 'union_optional_both',
                       'optional': true,
                       'typeAnnotation': {
-                        'type': 'StringLiteralUnionTypeAnnotation',
+                        'type': 'UnionTypeAnnotation',
                         'types': [
                           {
                             'type': 'StringLiteralTypeAnnotation',
@@ -36298,7 +36298,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -36318,7 +36318,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -36338,7 +36338,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',
@@ -36358,7 +36358,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture PROPS_AND_EVENTS_TYPE
                       'typeAnnotation': {
                         'type': 'ArrayTypeAnnotation',
                         'elementType': {
-                          'type': 'StringLiteralUnionTypeAnnotation',
+                          'type': 'UnionTypeAnnotation',
                           'types': [
                             {
                               'type': 'StringLiteralTypeAnnotation',

--- a/packages/react-native-codegen/src/parsers/typescript/components/events.js
+++ b/packages/react-native-codegen/src/parsers/typescript/components/events.js
@@ -127,7 +127,7 @@ function extractArrayElementType(
       };
     case 'TSUnionType':
       return {
-        type: 'StringLiteralUnionTypeAnnotation',
+        type: 'UnionTypeAnnotation',
         types: typeAnnotation.types.map(option => ({
           type: 'StringLiteralTypeAnnotation',
           value: parser.getLiteralValue(option),

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
@@ -388,7 +388,24 @@ exports[`RN Codegen TypeScript Parser can generate fixture CXX_ONLY_NATIVE_MODUL
               'type': 'FunctionTypeAnnotation',
               'returnTypeAnnotation': {
                 'type': 'UnionTypeAnnotation',
-                'memberType': 'ObjectTypeAnnotation'
+                'types': [
+                  {
+                    'type': 'ObjectTypeAnnotation',
+                    'properties': []
+                  },
+                  {
+                    'type': 'ObjectTypeAnnotation',
+                    'properties': [
+                      {
+                        'name': 'low',
+                        'optional': false,
+                        'typeAnnotation': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    ]
+                  }
+                ]
               },
               'params': [
                 {
@@ -396,7 +413,20 @@ exports[`RN Codegen TypeScript Parser can generate fixture CXX_ONLY_NATIVE_MODUL
                   'optional': false,
                   'typeAnnotation': {
                     'type': 'UnionTypeAnnotation',
-                    'memberType': 'NumberTypeAnnotation'
+                    'types': [
+                      {
+                        'type': 'NumberLiteralTypeAnnotation',
+                        'value': 1
+                      },
+                      {
+                        'type': 'NumberLiteralTypeAnnotation',
+                        'value': 2
+                      },
+                      {
+                        'type': 'NumberLiteralTypeAnnotation',
+                        'value': 3
+                      }
+                    ]
                   }
                 },
                 {
@@ -404,7 +434,20 @@ exports[`RN Codegen TypeScript Parser can generate fixture CXX_ONLY_NATIVE_MODUL
                   'optional': false,
                   'typeAnnotation': {
                     'type': 'UnionTypeAnnotation',
-                    'memberType': 'NumberTypeAnnotation'
+                    'types': [
+                      {
+                        'type': 'NumberLiteralTypeAnnotation',
+                        'value': 1.44
+                      },
+                      {
+                        'type': 'NumberLiteralTypeAnnotation',
+                        'value': 2.88
+                      },
+                      {
+                        'type': 'NumberLiteralTypeAnnotation',
+                        'value': 5.76
+                      }
+                    ]
                   }
                 },
                 {
@@ -412,14 +455,31 @@ exports[`RN Codegen TypeScript Parser can generate fixture CXX_ONLY_NATIVE_MODUL
                   'optional': false,
                   'typeAnnotation': {
                     'type': 'UnionTypeAnnotation',
-                    'memberType': 'ObjectTypeAnnotation'
+                    'types': [
+                      {
+                        'type': 'ObjectTypeAnnotation',
+                        'properties': []
+                      },
+                      {
+                        'type': 'ObjectTypeAnnotation',
+                        'properties': [
+                          {
+                            'name': 'low',
+                            'optional': false,
+                            'typeAnnotation': {
+                              'type': 'StringTypeAnnotation'
+                            }
+                          }
+                        ]
+                      }
+                    ]
                   }
                 },
                 {
                   'name': 'chooseString',
                   'optional': false,
                   'typeAnnotation': {
-                    'type': 'StringLiteralUnionTypeAnnotation',
+                    'type': 'UnionTypeAnnotation',
                     'types': [
                       {
                         'type': 'StringLiteralTypeAnnotation',
@@ -1098,7 +1158,18 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_AR
               'returnTypeAnnotation': {
                 'type': 'ArrayTypeAnnotation',
                 'elementType': {
-                  'type': 'AnyTypeAnnotation'
+                  'type': 'UnionTypeAnnotation',
+                  'types': [
+                    {
+                      'type': 'StringTypeAnnotation'
+                    },
+                    {
+                      'type': 'NumberTypeAnnotation'
+                    },
+                    {
+                      'type': 'BooleanTypeAnnotation'
+                    }
+                  ]
                 }
               },
               'params': [
@@ -1184,7 +1255,18 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_AR
               'returnTypeAnnotation': {
                 'type': 'ArrayTypeAnnotation',
                 'elementType': {
-                  'type': 'AnyTypeAnnotation'
+                  'type': 'UnionTypeAnnotation',
+                  'types': [
+                    {
+                      'type': 'StringTypeAnnotation'
+                    },
+                    {
+                      'type': 'NumberTypeAnnotation'
+                    },
+                    {
+                      'type': 'BooleanTypeAnnotation'
+                    }
+                  ]
                 }
               },
               'params': [
@@ -3058,7 +3140,24 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_UN
               'type': 'FunctionTypeAnnotation',
               'returnTypeAnnotation': {
                 'type': 'UnionTypeAnnotation',
-                'memberType': 'ObjectTypeAnnotation'
+                'types': [
+                  {
+                    'type': 'ObjectTypeAnnotation',
+                    'properties': []
+                  },
+                  {
+                    'type': 'ObjectTypeAnnotation',
+                    'properties': [
+                      {
+                        'name': 'low',
+                        'optional': false,
+                        'typeAnnotation': {
+                          'type': 'StringTypeAnnotation'
+                        }
+                      }
+                    ]
+                  }
+                ]
               },
               'params': [
                 {
@@ -3066,7 +3165,20 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_UN
                   'optional': false,
                   'typeAnnotation': {
                     'type': 'UnionTypeAnnotation',
-                    'memberType': 'NumberTypeAnnotation'
+                    'types': [
+                      {
+                        'type': 'NumberLiteralTypeAnnotation',
+                        'value': 1
+                      },
+                      {
+                        'type': 'NumberLiteralTypeAnnotation',
+                        'value': 2
+                      },
+                      {
+                        'type': 'NumberLiteralTypeAnnotation',
+                        'value': 3
+                      }
+                    ]
                   }
                 },
                 {
@@ -3074,7 +3186,20 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_UN
                   'optional': false,
                   'typeAnnotation': {
                     'type': 'UnionTypeAnnotation',
-                    'memberType': 'NumberTypeAnnotation'
+                    'types': [
+                      {
+                        'type': 'NumberLiteralTypeAnnotation',
+                        'value': 1.44
+                      },
+                      {
+                        'type': 'NumberLiteralTypeAnnotation',
+                        'value': 2.88
+                      },
+                      {
+                        'type': 'NumberLiteralTypeAnnotation',
+                        'value': 5.76
+                      }
+                    ]
                   }
                 },
                 {
@@ -3082,14 +3207,31 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_UN
                   'optional': false,
                   'typeAnnotation': {
                     'type': 'UnionTypeAnnotation',
-                    'memberType': 'ObjectTypeAnnotation'
+                    'types': [
+                      {
+                        'type': 'ObjectTypeAnnotation',
+                        'properties': []
+                      },
+                      {
+                        'type': 'ObjectTypeAnnotation',
+                        'properties': [
+                          {
+                            'name': 'low',
+                            'optional': false,
+                            'typeAnnotation': {
+                              'type': 'StringTypeAnnotation'
+                            }
+                          }
+                        ]
+                      }
+                    ]
                   }
                 },
                 {
                   'name': 'chooseString',
                   'optional': false,
                   'typeAnnotation': {
-                    'type': 'StringLiteralUnionTypeAnnotation',
+                    'type': 'UnionTypeAnnotation',
                     'types': [
                       {
                         'type': 'StringLiteralTypeAnnotation',
@@ -3133,7 +3275,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_UN
             'typeAnnotation': {
               'type': 'FunctionTypeAnnotation',
               'returnTypeAnnotation': {
-                'type': 'StringLiteralUnionTypeAnnotation',
+                'type': 'UnionTypeAnnotation',
                 'types': [
                   {
                     'type': 'StringLiteralTypeAnnotation',
@@ -3161,7 +3303,7 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_UN
                   'name': 'strings',
                   'optional': false,
                   'typeAnnotation': {
-                    'type': 'StringLiteralUnionTypeAnnotation',
+                    'type': 'UnionTypeAnnotation',
                     'types': [
                       {
                         'type': 'StringLiteralTypeAnnotation',
@@ -3184,7 +3326,16 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_UN
               'type': 'FunctionTypeAnnotation',
               'returnTypeAnnotation': {
                 'type': 'UnionTypeAnnotation',
-                'memberType': 'NumberTypeAnnotation'
+                'types': [
+                  {
+                    'type': 'NumberLiteralTypeAnnotation',
+                    'value': 1
+                  },
+                  {
+                    'type': 'NumberLiteralTypeAnnotation',
+                    'value': 2
+                  }
+                ]
               },
               'params': []
             }
@@ -3203,7 +3354,16 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_UN
                   'optional': false,
                   'typeAnnotation': {
                     'type': 'UnionTypeAnnotation',
-                    'memberType': 'NumberTypeAnnotation'
+                    'types': [
+                      {
+                        'type': 'NumberLiteralTypeAnnotation',
+                        'value': 1
+                      },
+                      {
+                        'type': 'NumberLiteralTypeAnnotation',
+                        'value': 2
+                      }
+                    ]
                   }
                 }
               ]
@@ -3216,7 +3376,34 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_UN
               'type': 'FunctionTypeAnnotation',
               'returnTypeAnnotation': {
                 'type': 'UnionTypeAnnotation',
-                'memberType': 'ObjectTypeAnnotation'
+                'types': [
+                  {
+                    'type': 'ObjectTypeAnnotation',
+                    'properties': [
+                      {
+                        'name': 'a',
+                        'optional': false,
+                        'typeAnnotation': {
+                          'type': 'NumberLiteralTypeAnnotation',
+                          'value': 1
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    'type': 'ObjectTypeAnnotation',
+                    'properties': [
+                      {
+                        'name': 'b',
+                        'optional': false,
+                        'typeAnnotation': {
+                          'type': 'NumberLiteralTypeAnnotation',
+                          'value': 2
+                        }
+                      }
+                    ]
+                  }
+                ]
               },
               'params': []
             }
@@ -3235,7 +3422,34 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_UN
                   'optional': false,
                   'typeAnnotation': {
                     'type': 'UnionTypeAnnotation',
-                    'memberType': 'ObjectTypeAnnotation'
+                    'types': [
+                      {
+                        'type': 'ObjectTypeAnnotation',
+                        'properties': [
+                          {
+                            'name': 'a',
+                            'optional': false,
+                            'typeAnnotation': {
+                              'type': 'NumberLiteralTypeAnnotation',
+                              'value': 1
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        'type': 'ObjectTypeAnnotation',
+                        'properties': [
+                          {
+                            'name': 'b',
+                            'optional': false,
+                            'typeAnnotation': {
+                              'type': 'NumberLiteralTypeAnnotation',
+                              'value': 2
+                            }
+                          }
+                        ]
+                      }
+                    ]
                   }
                 }
               ]

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -399,7 +399,18 @@ function translateTypeAnnotation(
       );
     }
     case 'TSUnionType': {
-      return emitUnion(nullable, hasteModuleName, typeAnnotation, parser);
+      return emitUnion(
+        nullable,
+        hasteModuleName,
+        typeAnnotation,
+        types,
+        aliasMap,
+        enumMap,
+        tryParse,
+        cxxOnly,
+        translateTypeAnnotation,
+        parser,
+      );
     }
     case 'TSLiteralType': {
       const literal = typeAnnotation.literal;

--- a/packages/react-native-codegen/src/parsers/typescript/parser.js
+++ b/packages/react-native-codegen/src/parsers/typescript/parser.js
@@ -18,10 +18,10 @@ import type {
   NativeModuleEnumMember,
   NativeModuleEnumMemberType,
   NativeModuleParamTypeAnnotation,
+  NativeModuleUnionTypeAnnotationMemberType,
   Nullable,
   PropTypeAnnotation,
   SchemaType,
-  UnionTypeAnnotationMemberType,
 } from '../../CodegenSchema';
 import type {ParserType} from '../errors';
 import type {
@@ -109,7 +109,7 @@ class TypeScriptParser implements Parser {
 
   remapUnionTypeAnnotationMemberNames(
     membersTypes: Array<$FlowFixMe>,
-  ): Array<UnionTypeAnnotationMemberType> {
+  ): Array<NativeModuleUnionTypeAnnotationMemberType> {
     const remapLiteral = (item: $FlowFixMe) => {
       return item.literal
         ? item.literal.type
@@ -121,12 +121,6 @@ class TypeScriptParser implements Parser {
     /* $FlowFixMe[incompatible-type] Natural Inference rollout. See
      * https://fburl.com/workplace/6291gfvu */
     return [...new Set(membersTypes.map(remapLiteral))];
-  }
-
-  getStringLiteralUnionTypeAnnotationStringLiterals(
-    membersTypes: Array<$FlowFixMe>,
-  ): Array<string> {
-    return membersTypes.map((item: $FlowFixMe) => item.literal.value);
   }
 
   parseFile(filename: string): SchemaType {

--- a/packages/react-native-compatibility-check/src/ComparisonResult.js
+++ b/packages/react-native-compatibility-check/src/ComparisonResult.js
@@ -109,6 +109,14 @@ export type MembersComparisonResult = {
     fault?: TypeComparisonError,
   }>,
 };
+export type UnionMembersComparisonResult = {
+  addedMembers?: Array<CompleteTypeAnnotation>,
+  missingMembers?: Array<CompleteTypeAnnotation>,
+  errorMembers?: Array<{
+    member: string,
+    fault?: TypeComparisonError,
+  }>,
+};
 export type NullableComparisonResult = {
   /* Four possible cases of change:
      void goes to T?   :: typeRefined !optionsReduced
@@ -130,6 +138,7 @@ export type ComparisonResult =
   | {status: 'nullableChange', nullableLog: NullableComparisonResult}
   | {status: 'properties', propertyLog: PropertiesComparisonResult}
   | {status: 'members', memberLog: MembersComparisonResult}
+  | {status: 'unionMembers', memberLog: UnionMembersComparisonResult}
   | {status: 'functionChange', functionChangeLog: FunctionComparisonResult}
   | {status: 'positionalTypeChange', changeLog: PositionalComparisonResult}
   | {status: 'error', errorLog: TypeComparisonError};
@@ -148,6 +157,12 @@ export function isPropertyLogEmpty(
 }
 
 export function isMemberLogEmpty(result: MembersComparisonResult): boolean {
+  return !(result.addedMembers || result.missingMembers || result.errorMembers);
+}
+
+export function isUnionMemberLogEmpty(
+  result: UnionMembersComparisonResult,
+): boolean {
   return !(result.addedMembers || result.missingMembers || result.errorMembers);
 }
 

--- a/packages/react-native-compatibility-check/src/SortTypeAnnotations.js
+++ b/packages/react-native-compatibility-check/src/SortTypeAnnotations.js
@@ -136,18 +136,12 @@ export function compareTypeAnnotationForSorting(
     case 'StringLiteralTypeAnnotation':
       invariant(typeB.type === 'StringLiteralTypeAnnotation', EQUALITY_MSG);
       return typeA.value.localeCompare(typeB.value);
-    case 'StringLiteralUnionTypeAnnotation':
-      invariant(
-        typeB.type === 'StringLiteralUnionTypeAnnotation',
-        EQUALITY_MSG,
-      );
+    case 'UnionTypeAnnotation':
+      invariant(typeB.type === 'UnionTypeAnnotation', EQUALITY_MSG);
       return compareAnnotationArraysForSorting(
         [originalPositionA, typeA.types],
         [originalPositionB, typeB.types],
       );
-    case 'UnionTypeAnnotation':
-      invariant(typeB.type === 'UnionTypeAnnotation', EQUALITY_MSG);
-      return 0;
     case 'VoidTypeAnnotation':
       return 0;
     case 'ReservedTypeAnnotation':
@@ -266,8 +260,6 @@ function typeAnnotationArbitraryOrder(annotation: CompleteTypeAnnotation) {
       return 15;
     case 'BooleanLiteralTypeAnnotation':
       return 16;
-    case 'StringLiteralUnionTypeAnnotation':
-      return 17;
     case 'StringTypeAnnotation':
       return 18;
     case 'StringLiteralTypeAnnotation':

--- a/packages/react-native-compatibility-check/src/__tests__/ErrorFormattingTests.js
+++ b/packages/react-native-compatibility-check/src/__tests__/ErrorFormattingTests.js
@@ -119,6 +119,18 @@ export const incompatibleChanges = [
     'native-module-with-union-confusing-string-literals/NativeModule',
   ],
   [
+    'native-module-with-union-number/NativeModule',
+    'native-module-with-union-number-changes/NativeModule',
+  ],
+  [
+    'native-module-with-union-boolean/NativeModule',
+    'native-module-with-union-boolean-changes/NativeModule',
+  ],
+  [
+    'native-module-with-union-object/NativeModule',
+    'native-module-with-union-object-changes/NativeModule',
+  ],
+  [
     'native-component-with-command/NativeComponent',
     'native-component-with-command-changed/NativeComponent',
   ],

--- a/packages/react-native-compatibility-check/src/__tests__/VersionDiffing-test.js
+++ b/packages/react-native-compatibility-check/src/__tests__/VersionDiffing-test.js
@@ -14,12 +14,10 @@ import {schemaDiffExporter} from '../DiffResults.js';
 import {
   addedEnumMessage,
   addedPropertiesMessage,
-  addedUnionMessage,
   buildSchemaDiff,
   hasUpdatesTypes,
   removedEnumMessage,
   removedPropertiesMessage,
-  removedUnionMessage,
   summarizeDiffSet,
   tooOptionalPropertiesMessage,
   typeNullableChangeMessage,
@@ -887,14 +885,43 @@ describe('buildSchemaDiff', () => {
     ).toEqual(
       expect.objectContaining({
         framework: 'ReactNative',
+        name: 'NativeModule',
         status: expect.objectContaining({
           incompatibleSpecs: expect.arrayContaining([
             expect.objectContaining({
               changeInformation: expect.objectContaining({
-                incompatibleChanges: expect.arrayContaining([
+                objectTypeChanges: expect.arrayContaining([
                   expect.objectContaining({
-                    errorInformation: expect.objectContaining({
-                      message: addedUnionMessage,
+                    propertyChange: expect.objectContaining({
+                      nestedPropertyChanges: expect.arrayContaining([
+                        [
+                          'exampleFunction',
+                          expect.objectContaining({
+                            status: 'functionChange',
+                            functionChangeLog: expect.objectContaining({
+                              parameterTypes: expect.objectContaining({
+                                nestedChanges: expect.arrayContaining([
+                                  [
+                                    0,
+                                    0,
+                                    expect.objectContaining({
+                                      status: 'unionMembers',
+                                      memberLog: expect.objectContaining({
+                                        addedMembers: expect.arrayContaining([
+                                          expect.objectContaining({
+                                            type: 'StringLiteralTypeAnnotation',
+                                            value: 'd',
+                                          }),
+                                        ]),
+                                      }),
+                                    }),
+                                  ],
+                                ]),
+                              }),
+                            }),
+                          }),
+                        ],
+                      ]),
                     }),
                   }),
                 ]),
@@ -912,18 +939,47 @@ describe('buildSchemaDiff', () => {
       ),
     ).toEqual(
       expect.objectContaining({
+        framework: 'ReactNative',
+        name: 'NativeModule',
         status: expect.objectContaining({
           incompatibleSpecs: expect.arrayContaining([
             expect.objectContaining({
               changeInformation: expect.objectContaining({
-                newTypes: expect.not.arrayContaining([expect.anything()]),
-                deprecatedTypes: expect.not.arrayContaining([
-                  expect.anything(),
+                objectTypeChanges: expect.arrayContaining([
+                  expect.objectContaining({
+                    propertyChange: expect.objectContaining({
+                      nestedPropertyChanges: expect.arrayContaining([
+                        [
+                          'exampleFunction',
+                          expect.objectContaining({
+                            status: 'functionChange',
+                            functionChangeLog: expect.objectContaining({
+                              parameterTypes: expect.objectContaining({
+                                nestedChanges: expect.arrayContaining([
+                                  [
+                                    0,
+                                    0,
+                                    expect.objectContaining({
+                                      status: 'unionMembers',
+                                      memberLog: expect.objectContaining({
+                                        missingMembers: expect.arrayContaining([
+                                          expect.objectContaining({
+                                            type: 'StringLiteralTypeAnnotation',
+                                            value: 'd',
+                                          }),
+                                        ]),
+                                      }),
+                                    }),
+                                  ],
+                                ]),
+                              }),
+                            }),
+                          }),
+                        ],
+                      ]),
+                    }),
+                  }),
                 ]),
-                incompatibleChanges: expect.not.arrayContaining([
-                  expect.anything(),
-                ]),
-                objectTypeChanges: expect.any(Object),
               }),
             }),
           ]),
@@ -943,18 +999,52 @@ describe('buildSchemaDiff', () => {
       ),
     ).toEqual(
       expect.objectContaining({
+        framework: 'ReactNative',
+        name: 'NativeModule',
         status: expect.objectContaining({
           incompatibleSpecs: expect.arrayContaining([
             expect.objectContaining({
               changeInformation: expect.objectContaining({
-                newTypes: expect.not.arrayContaining([expect.anything()]),
-                deprecatedTypes: expect.not.arrayContaining([
-                  expect.anything(),
+                objectTypeChanges: expect.arrayContaining([
+                  expect.objectContaining({
+                    propertyChange: expect.objectContaining({
+                      nestedPropertyChanges: expect.arrayContaining([
+                        [
+                          'getConstants',
+                          expect.objectContaining({
+                            status: 'functionChange',
+                            functionChangeLog: expect.objectContaining({
+                              returnType: expect.objectContaining({
+                                status: 'properties',
+                                propertyLog: expect.objectContaining({
+                                  nestedPropertyChanges: expect.arrayContaining(
+                                    [
+                                      [
+                                        'exampleConstant',
+                                        expect.objectContaining({
+                                          status: 'unionMembers',
+                                          memberLog: expect.objectContaining({
+                                            addedMembers:
+                                              expect.arrayContaining([
+                                                expect.objectContaining({
+                                                  type: 'StringLiteralTypeAnnotation',
+                                                  value: 'd',
+                                                }),
+                                              ]),
+                                          }),
+                                        }),
+                                      ],
+                                    ],
+                                  ),
+                                }),
+                              }),
+                            }),
+                          }),
+                        ],
+                      ]),
+                    }),
+                  }),
                 ]),
-                incompatibleChanges: expect.not.arrayContaining([
-                  expect.anything(),
-                ]),
-                objectTypeChanges: expect.any(Object),
               }),
             }),
           ]),
@@ -975,14 +1065,48 @@ describe('buildSchemaDiff', () => {
     ).toEqual(
       expect.objectContaining({
         framework: 'ReactNative',
+        name: 'NativeModule',
         status: expect.objectContaining({
           incompatibleSpecs: expect.arrayContaining([
             expect.objectContaining({
               changeInformation: expect.objectContaining({
-                incompatibleChanges: expect.arrayContaining([
+                objectTypeChanges: expect.arrayContaining([
                   expect.objectContaining({
-                    errorInformation: expect.objectContaining({
-                      message: removedUnionMessage,
+                    propertyChange: expect.objectContaining({
+                      nestedPropertyChanges: expect.arrayContaining([
+                        [
+                          'getConstants',
+                          expect.objectContaining({
+                            status: 'functionChange',
+                            functionChangeLog: expect.objectContaining({
+                              returnType: expect.objectContaining({
+                                status: 'properties',
+                                propertyLog: expect.objectContaining({
+                                  nestedPropertyChanges: expect.arrayContaining(
+                                    [
+                                      [
+                                        'exampleConstant',
+                                        expect.objectContaining({
+                                          status: 'unionMembers',
+                                          memberLog: expect.objectContaining({
+                                            missingMembers:
+                                              expect.arrayContaining([
+                                                expect.objectContaining({
+                                                  type: 'StringLiteralTypeAnnotation',
+                                                  value: 'd',
+                                                }),
+                                              ]),
+                                          }),
+                                        }),
+                                      ],
+                                    ],
+                                  ),
+                                }),
+                              }),
+                            }),
+                          }),
+                        ],
+                      ]),
                     }),
                   }),
                 ]),
@@ -1330,17 +1454,33 @@ describe('buildSchemaDiff', () => {
         ).toEqual(
           expect.objectContaining({
             framework: 'ReactNative',
+            name: 'NativeComponent',
             status: expect.objectContaining({
               incompatibleSpecs: expect.arrayContaining([
                 expect.objectContaining({
                   changeInformation: expect.objectContaining({
-                    incompatibleChanges: expect.objectContaining({
-                      '0': expect.objectContaining({
-                        errorInformation: expect.objectContaining({
-                          message: addedUnionMessage,
+                    objectTypeChanges: expect.arrayContaining([
+                      expect.objectContaining({
+                        propertyChange: expect.objectContaining({
+                          nestedPropertyChanges: expect.arrayContaining([
+                            [
+                              'size',
+                              expect.objectContaining({
+                                status: 'unionMembers',
+                                memberLog: expect.objectContaining({
+                                  addedMembers: expect.arrayContaining([
+                                    expect.objectContaining({
+                                      type: 'StringLiteralTypeAnnotation',
+                                      value: 'huge',
+                                    }),
+                                  ]),
+                                }),
+                              }),
+                            ],
+                          ]),
                         }),
                       }),
-                    }),
+                    ]),
                   }),
                 }),
               ]),
@@ -1373,17 +1513,33 @@ describe('buildSchemaDiff', () => {
         ).toEqual(
           expect.objectContaining({
             framework: 'ReactNative',
+            name: 'NativeComponent',
             status: expect.objectContaining({
               incompatibleSpecs: expect.arrayContaining([
                 expect.objectContaining({
                   changeInformation: expect.objectContaining({
-                    incompatibleChanges: expect.objectContaining({
-                      '0': expect.objectContaining({
-                        errorInformation: expect.objectContaining({
-                          message: addedUnionMessage,
+                    objectTypeChanges: expect.arrayContaining([
+                      expect.objectContaining({
+                        propertyChange: expect.objectContaining({
+                          nestedPropertyChanges: expect.arrayContaining([
+                            [
+                              'sizes',
+                              expect.objectContaining({
+                                status: 'unionMembers',
+                                memberLog: expect.objectContaining({
+                                  addedMembers: expect.arrayContaining([
+                                    expect.objectContaining({
+                                      type: 'StringLiteralTypeAnnotation',
+                                      value: 'huge',
+                                    }),
+                                  ]),
+                                }),
+                              }),
+                            ],
+                          ]),
                         }),
                       }),
-                    }),
+                    ]),
                   }),
                 }),
               ]),

--- a/packages/react-native-compatibility-check/src/__tests__/__fixtures__/native-module-before-after-types-type-changed/NativeModuleBeforeAfterTypes.js.flow
+++ b/packages/react-native-compatibility-check/src/__tests__/__fixtures__/native-module-before-after-types-type-changed/NativeModuleBeforeAfterTypes.js.flow
@@ -29,8 +29,10 @@ type SimpleFunction3 = (foo: string) => string;
 type SimpleFunction4 = (a: number) => string;
 
 type SimpleUnion = 'str1' | 'str2';
+type SimpleUnionOrderChanged = 'str2' | 'str1';
 type SimpleUnionLonger = 'str1' | 'str2' | 'str3';
 type SimpleUnion2 = 4 | 5;
+type SimpleUnion2OrderChanged = 5 | 4;
 type SimpleUnion3 = {} | {key: 'value'};
 type SimpleUnion4 = BooleanType | StringType | SimpleObject;
 
@@ -60,7 +62,9 @@ export interface Spec extends TurboModule {
 
     +simpleUnion: (a: SimpleUnion) => void;
     +simpleUnionLonger: (a: SimpleUnionLonger) => void;
+    +simpleUnionOrderChanged: (a: SimpleUnionOrderChanged) => void;
     +simpleUnion2: (a: SimpleUnion2) => void;
+    +simpleUnion2OrderChanged: (a: SimpleUnion2OrderChanged) => void;
     +simpleUnion3: (a: SimpleUnion3) => void;
     +simpleUnion4: (a: SimpleUnion4) => void;
 

--- a/packages/react-native-compatibility-check/src/__tests__/__fixtures__/native-module-before-after-types/NativeModuleBeforeAfterTypes.js.flow
+++ b/packages/react-native-compatibility-check/src/__tests__/__fixtures__/native-module-before-after-types/NativeModuleBeforeAfterTypes.js.flow
@@ -25,8 +25,10 @@ type BooleanType = boolean;
 type StringType = string;
 
 type SimpleUnion = 'str1' | 'str2';
+type SimpleUnionOrderChanged = 'str2' | 'str1';
 type SimpleUnionLonger = 'str1' | 'str2' | 'str3';
 type SimpleUnion2 = 4 | 5;
+type SimpleUnion2OrderChanged = 5 | 4;
 type SimpleUnion3 = {} | {key: 'value'};
 type SimpleUnion4 = BooleanType | StringType | SimpleObject;
 
@@ -53,7 +55,9 @@ export interface Spec extends TurboModule {
 
   +simpleUnion: (a: SimpleUnion) => void;
   +simpleUnionLonger: (a: SimpleUnionLonger) => void;
+  +simpleUnionOrderChanged: (a: SimpleUnionOrderChanged) => void;
   +simpleUnion2: (a: SimpleUnion2) => void;
+  +simpleUnion2OrderChanged: (a: SimpleUnion2OrderChanged) => void;
   +simpleUnion3: (a: SimpleUnion3) => void;
   +simpleUnion4: (a: SimpleUnion4) => void;
 

--- a/packages/react-native-compatibility-check/src/__tests__/__fixtures__/native-module-with-union-boolean-changes/NativeModule.js.flow
+++ b/packages/react-native-compatibility-check/src/__tests__/__fixtures__/native-module-with-union-boolean-changes/NativeModule.js.flow
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
+
+import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';
+
+// Changed to incompatible type
+type BooleanUnion = true | false;
+
+export interface Spec extends TurboModule {
+  +exampleFunction: (a: BooleanUnion, b: number) => void;
+  +getConstants: () => {
+    +exampleConstant: number,
+  };
+}
+
+export default (TurboModuleRegistry.getEnforcing<Spec>(
+  'NativeModuleTest',
+): Spec);

--- a/packages/react-native-compatibility-check/src/__tests__/__fixtures__/native-module-with-union-boolean/NativeModule.js.flow
+++ b/packages/react-native-compatibility-check/src/__tests__/__fixtures__/native-module-with-union-boolean/NativeModule.js.flow
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
+
+import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';
+
+type BooleanUnion = true;
+
+export interface Spec extends TurboModule {
+  +exampleFunction: (a: BooleanUnion, b: number) => void;
+  +getConstants: () => {
+    +exampleConstant: number,
+  };
+}
+
+export default (TurboModuleRegistry.getEnforcing<Spec>(
+  'NativeModuleTest',
+): Spec);

--- a/packages/react-native-compatibility-check/src/__tests__/__fixtures__/native-module-with-union-number-changes/NativeModule.js.flow
+++ b/packages/react-native-compatibility-check/src/__tests__/__fixtures__/native-module-with-union-number-changes/NativeModule.js.flow
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
+
+import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';
+
+type NumberUnion = 4 | 5 | 6;
+
+export interface Spec extends TurboModule {
+  +exampleFunction: (a: NumberUnion, b: number) => void;
+  +getConstants: () => {
+    +exampleConstant: number,
+  };
+}
+
+export default (TurboModuleRegistry.getEnforcing<Spec>(
+  'NativeModuleTest',
+): Spec);

--- a/packages/react-native-compatibility-check/src/__tests__/__fixtures__/native-module-with-union-number/NativeModule.js.flow
+++ b/packages/react-native-compatibility-check/src/__tests__/__fixtures__/native-module-with-union-number/NativeModule.js.flow
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
+
+import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';
+
+type NumberUnion = 1 | 2 | 3;
+
+export interface Spec extends TurboModule {
+  +exampleFunction: (a: NumberUnion, b: number) => void;
+  +getConstants: () => {
+    +exampleConstant: number,
+  };
+}
+
+export default (TurboModuleRegistry.getEnforcing<Spec>(
+  'NativeModuleTest',
+): Spec);

--- a/packages/react-native-compatibility-check/src/__tests__/__fixtures__/native-module-with-union-object-changes/NativeModule.js.flow
+++ b/packages/react-native-compatibility-check/src/__tests__/__fixtures__/native-module-with-union-object-changes/NativeModule.js.flow
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
+
+import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';
+
+type ObjectA = {|
+  kind: 'a',
+  value: number,
+  newField: string, // Added new required field
+|};
+
+type ObjectB = {|
+  kind: 'b',
+  name: string,
+|};
+
+type ObjectUnion = ObjectA | ObjectB;
+
+export interface Spec extends TurboModule {
+  +exampleFunction: (a: ObjectUnion, b: number) => void;
+  +getConstants: () => {
+    +exampleConstant: number,
+  };
+}
+
+export default (TurboModuleRegistry.getEnforcing<Spec>(
+  'NativeModuleTest',
+): Spec);

--- a/packages/react-native-compatibility-check/src/__tests__/__fixtures__/native-module-with-union-object/NativeModule.js.flow
+++ b/packages/react-native-compatibility-check/src/__tests__/__fixtures__/native-module-with-union-object/NativeModule.js.flow
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
+
+import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';
+
+type ObjectA = {|
+  kind: 'a',
+  value: number,
+|};
+
+type ObjectB = {|
+  kind: 'b',
+  name: string,
+|};
+
+type ObjectUnion = ObjectA | ObjectB;
+
+export interface Spec extends TurboModule {
+  +exampleFunction: (a: ObjectUnion, b: number) => void;
+  +getConstants: () => {
+    +exampleConstant: number,
+  };
+}
+
+export default (TurboModuleRegistry.getEnforcing<Spec>(
+  'NativeModuleTest',
+): Spec);

--- a/packages/react-native-compatibility-check/src/__tests__/__snapshots__/ErrorFormatting-test.js.snap
+++ b/packages/react-native-compatibility-check/src/__tests__/__snapshots__/ErrorFormatting-test.js.snap
@@ -196,7 +196,7 @@ Object {
         Object {
           "errorCode": "addedUnionCases",
           "message": "NativeComponent.sizes: Union added items, but native will not expect/support them
-  -- position 2 huge",
+  -- Member \\"huge\\"",
         },
       ],
     },
@@ -237,7 +237,7 @@ Object {
         Object {
           "errorCode": "addedUnionCases",
           "message": "NativeComponent.size: Union added items, but native will not expect/support them
-  -- position 1 huge",
+  -- Member \\"huge\\"",
         },
       ],
     },
@@ -266,9 +266,11 @@ Object {
   -- simpleFunction4
   -- simpleUnion
   -- simpleUnion2
+  -- simpleUnion2OrderChanged
   -- simpleUnion3
   -- simpleUnion4
   -- simpleUnionLonger
+  -- simpleUnionOrderChanged
   -- stringType",
         },
       ],
@@ -709,7 +711,33 @@ Object {
         Object {
           "errorCode": "addedUnionCases",
           "message": "NativeModuleTest.exampleFunction parameter 0: Union added items, but native will not expect/support them
-  -- position 3 d",
+  -- Member \\"d\\"",
+        },
+      ],
+    },
+  },
+  "status": "incompatible",
+}
+`;
+
+exports[`codegen formattedSummarizeDiffSet reports a diff from native-module-with-union-boolean-changes/NativeModule to native-module-with-union-boolean/NativeModule 1`] = `
+Object {
+  "incompatibilityReport": Object {
+    "NativeModule": Object {
+      "framework": "ReactNative",
+      "incompatibleSpecs": Array [
+        Object {
+          "errorCode": "incompatibleTypes",
+          "message": "NativeModuleTest: Object contained a property with a type mismatch
+  -- exampleFunction: has conflicting type changes
+      --new: (a: true, b: number)=>void
+      --old: (a: (true | false), b: number)=>void
+      Parameter at index 0 did not match
+          --new: (a: true, b: number)=>void
+          --old: (a: (true | false), b: number)=>void
+          Type annotations are not the same.
+              --new: true
+              --old: (true | false)",
         },
       ],
     },
@@ -727,8 +755,8 @@ Object {
         Object {
           "errorCode": "addedUnionCases",
           "message": "NativeModuleTest.exampleFunction parameter 0: Union added items, but native will not expect/support them
-  -- position 1 b
-  -- position 2 c",
+  -- Member \\"b\\"
+  -- Member \\"c\\"",
         },
       ],
     },
@@ -746,7 +774,51 @@ Object {
         Object {
           "errorCode": "removedUnionCases",
           "message": "NativeModuleTest.getConstants.exampleConstant: Union removed items, but native may still provide them
-  -- position 3 d",
+  -- Member \\"d\\"",
+        },
+      ],
+    },
+  },
+  "status": "incompatible",
+}
+`;
+
+exports[`codegen formattedSummarizeDiffSet reports a diff from native-module-with-union-number-changes/NativeModule to native-module-with-union-number/NativeModule 1`] = `
+Object {
+  "incompatibilityReport": Object {
+    "NativeModule": Object {
+      "framework": "ReactNative",
+      "incompatibleSpecs": Array [
+        Object {
+          "errorCode": "incompatibleTypes",
+          "message": "NativeModuleTest: Object contained a property with a type mismatch
+  -- exampleFunction: has conflicting type changes
+      --new: (a: (1 | 2 | 3), b: number)=>void
+      --old: (a: (4 | 5 | 6), b: number)=>void
+      Parameter at index 0 did not match
+          --new: (a: (1 | 2 | 3), b: number)=>void
+          --old: (a: (4 | 5 | 6), b: number)=>void
+          Union types do not match.
+              --new: (1 | 2 | 3)
+              --old: (4 | 5 | 6)",
+        },
+      ],
+    },
+  },
+  "status": "incompatible",
+}
+`;
+
+exports[`codegen formattedSummarizeDiffSet reports a diff from native-module-with-union-object-changes/NativeModule to native-module-with-union-object/NativeModule 1`] = `
+Object {
+  "incompatibilityReport": Object {
+    "NativeModule": Object {
+      "framework": "ReactNative",
+      "incompatibleSpecs": Array [
+        Object {
+          "errorCode": "addedUnionCases",
+          "message": "NativeModuleTest.exampleFunction parameter 0: Union added items, but native will not expect/support them
+  -- Member TypeAliasTypeAnnotation",
         },
       ],
     },
@@ -766,13 +838,13 @@ Object {
           "message": "NativeModuleTest: Object contained a property with a type mismatch
   -- exampleFunction: has conflicting type changes
       --new: (a: (a | b | c), b: number)=>void
-      --old: (a: Union<number>, b: number)=>void
+      --old: (a: (1 | 2 | 3), b: number)=>void
       Parameter at index 0 did not match
           --new: (a: (a | b | c), b: number)=>void
-          --old: (a: Union<number>, b: number)=>void
-          Type annotations are not the same.
+          --old: (a: (1 | 2 | 3), b: number)=>void
+          Union types do not match.
               --new: (a | b | c)
-              --old: Union<number>",
+              --old: (1 | 2 | 3)",
         },
       ],
     },

--- a/packages/react-native-compatibility-check/src/convertPropToBasicTypes.js
+++ b/packages/react-native-compatibility-check/src/convertPropToBasicTypes.js
@@ -50,7 +50,7 @@ export default function convertPropToBasicTypes(
       break;
     case 'StringEnumTypeAnnotation':
       resultingType = {
-        type: 'StringLiteralUnionTypeAnnotation',
+        type: 'UnionTypeAnnotation',
         types: inputType.options.map(option => {
           return {
             type: 'StringLiteralTypeAnnotation',


### PR DESCRIPTION
Summary:
Previously, the parser was mapping to Array<any> when the element types of union were different. This caused compat checker to not recognize changes in unions of different types.

`StringLiteralUnionTypeAnnotation`  already had support for `types`, that can be expanded to all Union types so as to incorporate the Unions of different types.
```
{
  type: 'StringLiteralUnionTypeAnnotation',
  types: [
    {
      type: 'StringLiteralTypeAnnotation'
      value: 'light'
    },
    {
      type: 'StringLiteralTypeAnnotation'
      value: 'dark'
    },
  ],
}
```

NOTE: Generators behavior still remain unchanged hence don't allow unions of different types. Only RN Compat Checker consumes this.

The value of this is that the compat checker can now error when the union of different types changes.

Changelog: [Internal]

Differential Revision: D86501597


