### PR TITLE
Add accessibilityRole=link if Text is pressable

### DIFF
--- a/packages/react-native/Libraries/Text/Text.js
+++ b/packages/react-native/Libraries/Text/Text.js
@@ -45,6 +45,7 @@ if (ReactNativeFeatureFlags.reduceDefaultPropsInText()) {
     ref: forwardedRef,
     accessible,
     accessibilityLabel,
+    accessibilityRole,
     accessibilityState,
     allowFontScaling,
     'aria-busy': ariaBusy,
@@ -71,6 +72,7 @@ if (ReactNativeFeatureFlags.reduceDefaultPropsInText()) {
     onResponderTerminationRequest,
     onStartShouldSetResponder,
     pressRetentionOffset,
+    role,
     selectable,
     selectionColor,
     suppressHighlighting,
@@ -149,6 +151,17 @@ if (ReactNativeFeatureFlags.reduceDefaultPropsInText()) {
         onStartShouldSetResponder != null) &&
       _disabled !== true;
 
+    const shouldUseLinkRole =
+      ReactNativeFeatureFlags.shouldUseLinkRoleForPressableText() &&
+      isPressable &&
+      accessibilityRole == null &&
+      role == null;
+
+    const _accessibilityRole =
+      accessibilityRole ?? (shouldUseLinkRole ? 'link' : undefined);
+
+    const _role = shouldUseLinkRole ? undefined : role;
+
     // TODO: Move this processing to the view configuration.
     const _selectionColor =
       selectionColor != null ? processColor(selectionColor) : undefined;
@@ -206,6 +219,9 @@ if (ReactNativeFeatureFlags.reduceDefaultPropsInText()) {
     if (_accessibilityLabel !== undefined) {
       processedProps.accessibilityLabel = _accessibilityLabel;
     }
+    if (_accessibilityRole !== undefined) {
+      processedProps.accessibilityRole = _accessibilityRole;
+    }
     if (_accessibilityState !== undefined) {
       processedProps.accessibilityState = _accessibilityState;
     }
@@ -223,6 +239,9 @@ if (ReactNativeFeatureFlags.reduceDefaultPropsInText()) {
     }
     if (_selectionColor !== undefined) {
       processedProps.selectionColor = _selectionColor;
+    }
+    if (_role !== undefined) {
+      processedProps.role = _role;
     }
 
     let textPressabilityProps: ?TextPressabilityProps;
@@ -317,6 +336,7 @@ if (ReactNativeFeatureFlags.reduceDefaultPropsInText()) {
     accessibilityElementsHidden,
     importantForAccessibility,
     accessibilityLabel,
+    accessibilityRole,
     accessibilityState,
     allowFontScaling,
     'aria-busy': ariaBusy,
@@ -343,6 +363,7 @@ if (ReactNativeFeatureFlags.reduceDefaultPropsInText()) {
     onResponderTerminationRequest,
     onStartShouldSetResponder,
     pressRetentionOffset,
+    role,
     selectable,
     selectionColor,
     suppressHighlighting,
@@ -397,6 +418,17 @@ if (ReactNativeFeatureFlags.reduceDefaultPropsInText()) {
         onLongPress != null ||
         onStartShouldSetResponder != null) &&
       _disabled !== true;
+
+    const shouldUseLinkRole =
+      ReactNativeFeatureFlags.shouldUseLinkRoleForPressableText() &&
+      isPressable &&
+      accessibilityRole == null &&
+      role == null;
+
+    const _accessibilityRole =
+      accessibilityRole ?? (shouldUseLinkRole ? 'link' : undefined);
+
+    const _role = shouldUseLinkRole ? undefined : role;
 
     // TODO: Move this processing to the view configuration.
     const _selectionColor =
@@ -462,6 +494,7 @@ if (ReactNativeFeatureFlags.reduceDefaultPropsInText()) {
               ...restProps,
               accessibilityElementsHidden: _accessibilityElementsHidden,
               accessibilityLabel: _accessibilityLabel,
+              accessibilityRole: _accessibilityRole,
               accessibilityState: _accessibilityState,
               importantForAccessibility: _importantForAccessibility,
               nativeID: _nativeID,
@@ -470,6 +503,7 @@ if (ReactNativeFeatureFlags.reduceDefaultPropsInText()) {
               selectionColor: _selectionColor,
               style: _style,
               disabled: disabled,
+              role: _role,
               children,
             }}
             textPressabilityProps={{
@@ -495,6 +529,7 @@ if (ReactNativeFeatureFlags.reduceDefaultPropsInText()) {
           {...restProps}
           accessibilityElementsHidden={_accessibilityElementsHidden}
           accessibilityLabel={_accessibilityLabel}
+          accessibilityRole={_accessibilityRole}
           accessibilityState={_accessibilityState}
           importantForAccessibility={_importantForAccessibility}
           nativeID={_nativeID}
@@ -503,7 +538,8 @@ if (ReactNativeFeatureFlags.reduceDefaultPropsInText()) {
           selectable={_selectable}
           selectionColor={_selectionColor}
           style={_style}
-          disabled={disabled}>
+          disabled={disabled}
+          role={_role}>
           {children}
         </NativeVirtualText>
       );
@@ -538,6 +574,7 @@ if (ReactNativeFeatureFlags.reduceDefaultPropsInText()) {
             ...restProps,
             accessibilityElementsHidden: _accessibilityElementsHidden,
             accessibilityLabel: _accessibilityLabel,
+            accessibilityRole: _accessibilityRole,
             accessibilityState: _accessibilityState,
             accessible: _accessible,
             allowFontScaling: allowFontScaling !== false,
@@ -549,6 +586,7 @@ if (ReactNativeFeatureFlags.reduceDefaultPropsInText()) {
             selectable: _selectable,
             selectionColor: _selectionColor,
             style: _style,
+            role: _role,
             children,
           }}
           textPressabilityProps={{
@@ -573,6 +611,7 @@ if (ReactNativeFeatureFlags.reduceDefaultPropsInText()) {
           {...restProps}
           accessibilityElementsHidden={_accessibilityElementsHidden}
           accessibilityLabel={_accessibilityLabel}
+          accessibilityRole={_accessibilityRole}
           accessibilityState={_accessibilityState}
           accessible={_accessible}
           allowFontScaling={allowFontScaling !== false}
@@ -584,7 +623,8 @@ if (ReactNativeFeatureFlags.reduceDefaultPropsInText()) {
           ref={forwardedRef}
           selectable={_selectable}
           selectionColor={_selectionColor}
-          style={_style}>
+          style={_style}
+          role={_role}>
           {children}
         </NativeText>
       );

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -1074,6 +1074,17 @@ const definitions: FeatureFlagDefinitions = {
       },
       ossReleaseStage: 'none',
     },
+    shouldUseLinkRoleForPressableText: {
+      defaultValue: false,
+      metadata: {
+        dateAdded: '2025-11-10',
+        description:
+          'Set accessibilityRole to "link" for pressable Text components by default.',
+        expectedReleaseValue: true,
+        purpose: 'experimentation',
+      },
+      ossReleaseStage: 'none',
+    },
     shouldUseRemoveClippedSubviewsAsDefaultOnIOS: {
       defaultValue: false,
       metadata: {

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<f1901dffe2f41ee22247bb81f493e62f>>
+ * @generated SignedSource<<64e8578585baaed88b48703555520f22>>
  * @flow strict
  * @noformat
  */
@@ -40,6 +40,7 @@ export type ReactNativeFeatureFlagsJsOnly = $ReadOnly<{
   reduceDefaultPropsInImage: Getter<boolean>,
   reduceDefaultPropsInText: Getter<boolean>,
   shouldUseAnimatedObjectForTransform: Getter<boolean>,
+  shouldUseLinkRoleForPressableText: Getter<boolean>,
   shouldUseRemoveClippedSubviewsAsDefaultOnIOS: Getter<boolean>,
   shouldUseSetNativePropsInFabric: Getter<boolean>,
   virtualViewActivityBehavior: Getter<string>,
@@ -196,6 +197,11 @@ export const reduceDefaultPropsInText: Getter<boolean> = createJavaScriptFlagGet
  * Enables use of AnimatedObject for animating transform values.
  */
 export const shouldUseAnimatedObjectForTransform: Getter<boolean> = createJavaScriptFlagGetter('shouldUseAnimatedObjectForTransform', false);
+
+/**
+ * Set accessibilityRole to "link" for pressable Text components by default.
+ */
+export const shouldUseLinkRoleForPressableText: Getter<boolean> = createJavaScriptFlagGetter('shouldUseLinkRoleForPressableText', false);
 
 /**
  * removeClippedSubviews prop will be used as the default in FlatList on iOS to match Android


### PR DESCRIPTION
Summary:
Changelog:
[General][Changed] - Text components with onPress or onLongPress now automatically get accessibilityRole='link' for proper accessibility support

## Background

React Native on Android only generates ClickableSpans when the associated JS element uses `role="link"` or `accessibilityRole="link"`.

Without ClickableSpans, accessibility tools cannot properly identify these interactive text elements.

### This Change

This change makes React Native automatically set `accessibilityRole='link'` on Text components that are pressable, unless an explicit `accessibilityRole`/`role` is already provided.

Reviewed By: javache

Differential Revision: D86657563


