### PR TITLE
[RN][Releases] Use the right package.json when comparing react-native's versions

### DIFF
--- a/scripts/releases-ci/__tests__/publish-npm-test.js
+++ b/scripts/releases-ci/__tests__/publish-npm-test.js
@@ -96,7 +96,9 @@ describe('publish-npm', () => {
     beforeEach(() => {
       jest.mock('../../shared/monorepoUtils', () => ({
         ...jest.requireActual('../../shared/monorepoUtils'),
-        getWorkspaceRoot: jest.fn().mockResolvedValue({version: '1000.0.0'}),
+        getReactNativePackage: jest
+          .fn()
+          .mockResolvedValue({version: '1000.0.0'}),
       }));
     });
 
@@ -167,7 +169,7 @@ describe('publish-npm', () => {
         getBranchName.mockReturnValueOnce('0.83-stable');
         jest.mock('../../shared/monorepoUtils', () => ({
           ...jest.requireActual('../../shared/monorepoUtils'),
-          getWorkspaceRoot: jest
+          getReactNativePackage: jest
             .fn()
             .mockResolvedValue({version: '0.83.0-rc.0'}),
         }));

--- a/scripts/releases-ci/publish-npm.js
+++ b/scripts/releases-ci/publish-npm.js
@@ -27,9 +27,8 @@ const {
   publishExternalArtifactsToMaven,
 } = require('../releases/utils/release-utils');
 const {getBranchName} = require('../releases/utils/scm-utils');
-const {REPO_ROOT} = require('../shared/consts');
-const {getPackages, getWorkspaceRoot} = require('../shared/monorepoUtils');
-const path = require('path');
+const {REACT_NATIVE_PACKAGE_DIR} = require('../shared/consts');
+const {getPackages, getReactNativePackage} = require('../shared/monorepoUtils');
 const yargs = require('yargs');
 
 /**
@@ -109,7 +108,7 @@ async function publishNpm(buildType /*: BuildType */) /*: Promise<void> */ {
     // Before updating React Native artifacts versions for dry-run, we check if the version has already been set.
     // If it has, we don't need to update the artifacts at all (at this will revert them back to 1000.0.0)
     // If it hasn't, we can update the native artifacts accordingly.
-    const projectInfo = await getWorkspaceRoot();
+    const projectInfo = await getReactNativePackage();
 
     if (projectInfo.version === '1000.0.0') {
       // Set hermes versions to latest available if not on a stable branch
@@ -135,8 +134,7 @@ async function publishNpm(buildType /*: BuildType */) /*: Promise<void> */ {
   // NPM publishing is done just after.
   publishExternalArtifactsToMaven(version, buildType);
 
-  const packagePath = path.join(REPO_ROOT, 'packages', 'react-native');
-  const result = publishPackage(packagePath, {
+  const result = publishPackage(REACT_NATIVE_PACKAGE_DIR, {
     tags: [tag],
   });
 

--- a/scripts/shared/monorepoUtils.js
+++ b/scripts/shared/monorepoUtils.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-const {REPO_ROOT} = require('./consts');
+const {REACT_NATIVE_PACKAGE_DIR, REPO_ROOT} = require('./consts');
 const {promises: fs} = require('fs');
 const glob = require('glob');
 const path = require('path');
@@ -103,6 +103,16 @@ async function getWorkspaceRoot() /*: Promise<PackageInfo> */ {
   return packageInfo;
 }
 
+/**
+ * Get the parsed package metadata for the main react-native package.
+ */
+async function getReactNativePackage() /*: Promise<PackageInfo> */ {
+  const [, packageInfo] = await parsePackageInfo(
+    path.join(REACT_NATIVE_PACKAGE_DIR, 'package.json'),
+  );
+  return packageInfo;
+}
+
 async function parsePackageInfo(
   packageJsonPath /*: string */,
 ) /*: Promise<[string, PackageInfo]> */ {
@@ -172,4 +182,5 @@ module.exports = {
   getPackages,
   getWorkspaceRoot,
   updatePackageJson,
+  getReactNativePackage,
 };


### PR DESCRIPTION
## Summary:
This is a port back in main of the commit a0e40ec09f1b4920e9a4353758a36b7dfe281bd2 we landed in the 0.83-stable branch to fix the release process of React Native.

## Changelog:
[Internal] - 

## Test Plan:
GHA + tested while doing the release
