### PR TITLE
Address -Wswitch-default warnings

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/FlexDirection.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/FlexDirection.h
@@ -60,9 +60,9 @@ inline PhysicalEdge flexStartEdge(FlexDirection flexDirection) {
       return PhysicalEdge::Left;
     case FlexDirection::RowReverse:
       return PhysicalEdge::Right;
+    default:
+      fatalWithMessage("Invalid FlexDirection");
   }
-
-  fatalWithMessage("Invalid FlexDirection");
 }
 
 inline PhysicalEdge flexEndEdge(FlexDirection flexDirection) {
@@ -75,9 +75,9 @@ inline PhysicalEdge flexEndEdge(FlexDirection flexDirection) {
       return PhysicalEdge::Right;
     case FlexDirection::RowReverse:
       return PhysicalEdge::Left;
+    default:
+      fatalWithMessage("Invalid FlexDirection");
   }
-
-  fatalWithMessage("Invalid FlexDirection");
 }
 
 inline PhysicalEdge inlineStartEdge(
@@ -112,9 +112,9 @@ inline Dimension dimension(FlexDirection flexDirection) {
       return Dimension::Width;
     case FlexDirection::RowReverse:
       return Dimension::Width;
+    default:
+      fatalWithMessage("Invalid FlexDirection");
   }
-
-  fatalWithMessage("Invalid FlexDirection");
 }
 
 } // namespace facebook::yoga

--- a/packages/react-native/ReactCommon/yoga/yoga/algorithm/SizingMode.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/algorithm/SizingMode.h
@@ -52,9 +52,9 @@ inline MeasureMode measureMode(SizingMode mode) {
       return MeasureMode::Undefined;
     case SizingMode::FitContent:
       return MeasureMode::AtMost;
+    default:
+      fatalWithMessage("Invalid SizingMode");
   }
-
-  fatalWithMessage("Invalid SizingMode");
 }
 
 inline SizingMode sizingMode(MeasureMode mode) {
@@ -65,9 +65,9 @@ inline SizingMode sizingMode(MeasureMode mode) {
       return SizingMode::MaxContent;
     case MeasureMode::AtMost:
       return SizingMode::FitContent;
+    default:
+      fatalWithMessage("Invalid MeasureMode");
   }
-
-  fatalWithMessage("Invalid MeasureMode");
 }
 
 } // namespace facebook::yoga

--- a/packages/react-native/ReactCommon/yoga/yoga/style/Style.h
+++ b/packages/react-native/ReactCommon/yoga/yoga/style/Style.h
@@ -673,9 +673,9 @@ class YG_EXPORT Style {
         return computeRightEdge(position_, direction);
       case PhysicalEdge::Bottom:
         return computeBottomEdge(position_);
+      default:
+        fatalWithMessage("Invalid physical edge");
     }
-
-    fatalWithMessage("Invalid physical edge");
   }
 
   Style::Length computeMargin(PhysicalEdge edge, Direction direction) const {
@@ -688,9 +688,9 @@ class YG_EXPORT Style {
         return computeRightEdge(margin_, direction);
       case PhysicalEdge::Bottom:
         return computeBottomEdge(margin_);
+      default:
+        fatalWithMessage("Invalid physical edge");
     }
-
-    fatalWithMessage("Invalid physical edge");
   }
 
   Style::Length computePadding(PhysicalEdge edge, Direction direction) const {
@@ -703,9 +703,9 @@ class YG_EXPORT Style {
         return computeRightEdge(padding_, direction);
       case PhysicalEdge::Bottom:
         return computeBottomEdge(padding_);
+      default:
+        fatalWithMessage("Invalid physical edge");
     }
-
-    fatalWithMessage("Invalid physical edge");
   }
 
   Style::Length computeBorder(PhysicalEdge edge, Direction direction) const {
@@ -718,9 +718,9 @@ class YG_EXPORT Style {
         return computeRightEdge(border_, direction);
       case PhysicalEdge::Bottom:
         return computeBottomEdge(border_);
+      default:
+        fatalWithMessage("Invalid physical edge");
     }
-
-    fatalWithMessage("Invalid physical edge");
   }
 
   Direction direction_ : bitCount<Direction>() = Direction::Inherit;


### PR DESCRIPTION
Summary: Improve compatibility with projects that have -Wswitch-default errors/warnings enabled by suppressing those errors/warnings in caffe2 headers.

Differential Revision: D86785452


