### PR TITLE
Remove unused exception parameter from react

### DIFF
--- a/packages/react-native/React/Base/RCTAssert.m
+++ b/packages/react-native/React/Base/RCTAssert.m
@@ -146,7 +146,7 @@ void RCTFatal(NSError *error)
       // userInfo: <underlying error userinfo, plus untruncated description plus JS stack trace>
       @throw [[NSException alloc] initWithName:name reason:message userInfo:userInfo];
 #if DEBUG
-    } @catch (NSException *e) {
+    } @catch (NSException *) {
     }
 #endif
   }
@@ -216,7 +216,7 @@ void RCTFatalException(NSException *exception)
 #endif
       @throw exception;
 #if DEBUG
-    } @catch (NSException *e) {
+    } @catch (NSException *) {
     }
 #endif
   }

--- a/packages/react-native/React/Base/RCTModuleData.mm
+++ b/packages/react-native/React/Base/RCTModuleData.mm
@@ -241,7 +241,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init);
     RCT_PROFILE_BEGIN_EVENT(RCTProfileTagAlways, @"[RCTModuleData setBridgeForInstance]", nil);
     @try {
       [(id)_instance setValue:_bridge forKey:@"bridge"];
-    } @catch (NSException *exception) {
+    } @catch (NSException *) {
       RCTLogError(
           @"%@ has no setter or ivar for its bridge, which is not "
            "permitted. You must either @synthesize the bridge property, "
@@ -291,7 +291,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init);
       if (implementsMethodQueue) {
         @try {
           [(id)_instance setValue:_methodQueue forKey:@"methodQueue"];
-        } @catch (NSException *exception) {
+        } @catch (NSException *) {
           RCTLogError(
               @"%@ is returning nil for its methodQueue, which is not "
                "permitted. You must either return a pre-initialized "

--- a/packages/react-native/React/CxxModule/RCTCxxMethod.mm
+++ b/packages/react-native/React/CxxModule/RCTCxxMethod.mm
@@ -129,7 +129,7 @@ using namespace facebook::react;
       // TODO: we should convert this to JSValue directly
       return convertFollyDynamicToId(result);
     }
-  } catch (const facebook::xplat::JsArgumentException &ex) {
+  } catch ([[maybe_unused]] const facebook::xplat::JsArgumentException &ex) {
     RCTLogError(
         @"Method %@.%s argument error: %s",
         RCTBridgeModuleNameForClass([module class]),


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Differential Revision: D86823891


