### PR TITLE
Fix build using nightlies

### DIFF
--- a/packages/react-native/scripts/ios-prebuild/hermes.js
+++ b/packages/react-native/scripts/ios-prebuild/hermes.js
@@ -204,6 +204,7 @@ async function getNightlyTarballUrl(
   return await computeNightlyTarballURL(
     version,
     buildType,
+    'hermes',
     artifactCoordinate,
     artifactName,
   );

--- a/packages/react-native/scripts/ios-prebuild/reactNativeDependencies.js
+++ b/packages/react-native/scripts/ios-prebuild/reactNativeDependencies.js
@@ -200,6 +200,7 @@ async function getNightlyTarballUrl(
   return await computeNightlyTarballURL(
     version,
     buildType,
+    'react',
     coordinate,
     artifactName,
   );

--- a/packages/react-native/scripts/ios-prebuild/types.js
+++ b/packages/react-native/scripts/ios-prebuild/types.js
@@ -20,6 +20,8 @@ export type Destination =
   'macOS,variant=Mac Catalyst';
 
 export type BuildFlavor = 'Debug' | 'Release';
+
+export type MavenSubGroup = 'hermes' | 'react';
 */
 
 module.exports = {};

--- a/packages/react-native/scripts/ios-prebuild/utils.js
+++ b/packages/react-native/scripts/ios-prebuild/utils.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-/*:: import type {BuildFlavor} from './types'; */
+/*:: import type {BuildFlavor, MavenSubGroup} from './types'; */
 
 const {execSync} = require('child_process');
 const fs = require('fs');
@@ -62,10 +62,11 @@ function createLogger(
 async function computeNightlyTarballURL(
   version /*: string */,
   buildType /*: BuildFlavor */,
+  subGroup /*: MavenSubGroup */,
   artifactCoordinate /*: string */,
   artifactName /*: string */,
 ) /*: Promise<string> */ {
-  const xmlUrl = `https://central.sonatype.com/repository/maven-snapshots/com/facebook/hermes/${artifactCoordinate}/${version}-SNAPSHOT/maven-metadata.xml`;
+  const xmlUrl = `https://central.sonatype.com/repository/maven-snapshots/com/facebook/${subGroup}/${artifactCoordinate}/${version}-SNAPSHOT/maven-metadata.xml`;
 
   const response = await fetch(xmlUrl);
   if (!response.ok) {
@@ -97,7 +98,7 @@ async function computeNightlyTarballURL(
   const buildNumber = buildNumberMatch[1];
 
   const fullVersion = `${version}-${timestamp}-${buildNumber}`;
-  const finalUrl = `https://central.sonatype.com/repository/maven-snapshots/com/facebook/hermes/${artifactCoordinate}/${version}-SNAPSHOT/${artifactCoordinate}-${fullVersion}-${artifactName}`;
+  const finalUrl = `https://central.sonatype.com/repository/maven-snapshots/com/facebook/${subGroup}/${artifactCoordinate}/${version}-SNAPSHOT/${artifactCoordinate}-${fullVersion}-${artifactName}`;
   return finalUrl;
 }
 


### PR DESCRIPTION
Summary:
With the recent changes on where Hermes is published, we couldn't fetch automatically the nightly versions of ReactNativeDependencies because the url were misconfigured.

This diff fixes that.

## Changelog:
[Internal] -

Differential Revision: D86855230


