### PR TITLE
fix: add 'tabbar' to role type for accessibility

### DIFF
--- a/packages/react-native/Libraries/Components/View/ViewAccessibility.d.ts
+++ b/packages/react-native/Libraries/Components/View/ViewAccessibility.d.ts
@@ -407,6 +407,7 @@ export type Role =
   | 'summary'
   | 'switch'
   | 'tab'
+  | 'tabbar'
   | 'table'
   | 'tablist'
   | 'tabpanel'


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

The `tabbar` role was removed from `AccessibilityRole` in 2018 (commit f39d092) as it was only available on iOS 10+. It was later added back to `AccessibilityRole` once the minimum iOS version increased.

However, when the separate `Role` type was introduced in 2022 for the role prop, `tabbar` was not included despite being present in `AccessibilityRole`. This inconsistency causes TypeScript compilation errors when trying to use role="tabbar" on components, even though it's a valid and working accessibility role that exists in `AccessibilityRole`.

This PR adds `tabbar` to the Role type definition to maintain consistency between AccessibilityRole and Role, allowing developers to use this role without TypeScript errors and for accurate announcements for screen reader users.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[IOS] [FIXED] - Add 'tabbar' to Role type for accessibility

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

Before this change, the following TypeScript code would fail compilation:
```tsx
<View role="tabbar">
  {/* ... */}
</View>
```

After this change, the code compiles successfully. The `tabbar` role also already exists in `AccessibilityRole` (line 213 of `ViewAccessibility.d.ts`) and works correctly at runtime on all currently supported iOS versions.
