### PR TITLE
Increase image loading timeout in iOS sync image manager for jeste2e

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTSyncImageManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTSyncImageManager.mm
@@ -90,7 +90,7 @@ using namespace facebook::react;
                                  partialLoadBlock:nil
                                   completionBlock:completionBlock];
 
-  auto result = dispatch_group_wait(imageWaitGroup, dispatch_time(DISPATCH_TIME_NOW, 2 * NSEC_PER_SEC));
+  auto result = dispatch_group_wait(imageWaitGroup, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC));
   if (result != 0) {
     RCTLogError(@"Image timed out in test environment for url: %@", loaderRequest.imageURL);
   }


### PR DESCRIPTION
Summary:
Changelog: [Internal]

The current 2-second timeout in `RCTSyncImageManager` is insufficient for image loading operations in test environments, causing spurious timeout errors. This increases the timeout to 5 seconds to provide more headroom for image loading operations to complete successfully.

The timeout is specifically for synchronous image loading in test scenarios where images need to be fully loaded before proceeding. With the current 2-second limit, images that take slightly longer to load (due to network latency, image size, or system load) fail with "Image timed out in test environment" errors even though the loading would eventually succeed.

Increasing to 5 seconds:
- Reduces flakiness in tests that depend on image loading
- Still maintains a reasonable upper bound to catch actual issues
- Aligns better with real-world image loading times in test infrastructure

Example of isses https://fb.workplace.com/groups/jeste2e/permalink/3821119858179498/
example of flaky test due to timeout https://www.internalfb.com/intern/test/281475220305258?ref_report_id=0

Reviewed By: sammy-SC

Differential Revision: D86862358


