### PR TITLE
Check nodesManager_ in AnimatedModule::executeOperation

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/animated/AnimatedModule.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animated/AnimatedModule.cpp
@@ -221,6 +221,9 @@ void AnimatedModule::queueAndExecuteBatchedOperations(
 }
 
 void AnimatedModule::executeOperation(const Operation& operation) {
+  if (nodesManager_ == nullptr) {
+    return;
+  }
   std::visit(
       [&](const auto& op) {
         using T = std::decay_t<decltype(op)>;


### PR DESCRIPTION
Summary:
## Changelog:

[General] [Fixed] - Check nodesManager_ in AnimatedModule::executeOperation

AnimatedModule::executeOperation might be scheduled on ui thread right before nodesManager_ is destroyed

Differential Revision: D86868462


