### PR TITLE
Update ESLint uses to reference eslint-plugin-monorepo explicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@jest/create-cache-key-function": "^29.7.0",
     "@microsoft/api-extractor": "^7.52.2",
     "@octokit/rest": "^22.0.0",
+    "@react-native/eslint-plugin-monorepo": "*",
     "@react-native/metro-babel-transformer": "0.84.0-main",
     "@react-native/metro-config": "0.84.0-main",
     "@tsconfig/node22": "22.0.2",


### PR DESCRIPTION
Summary:
**Background**

`react-native/eslint` was relocated and renamed to `react-native/eslint-plugin-monorepo` in D76088698.

**This diff**

This updates all call sites to correctly address the `react-native/eslint-plugin-monorepo` package, enabling us to remove the monorepo itself from fbsource's `package.json#workspaces` (which was the only reason this kept working before).

Changelog: [Internal]

Differential Revision: D86869721


