### PR TITLE
Remove name and metadata from root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,5 @@
 {
-  "name": "@react-native/monorepo",
   "private": true,
-  "version": "1000.0.0",
-  "license": "MIT",
   "packageManager": "yarn@1.22.22",
   "scripts": {
     "android": "yarn --cwd packages/rn-tester android",

--- a/scripts/releases/set-version.js
+++ b/scripts/releases/set-version.js
@@ -89,7 +89,7 @@ async function setVersion(
     ...Object.values(packages),
   ];
 
-  // Update all workspace packages
+  // Update dependency versions in workspace packages
   await Promise.all(
     packagesToUpdate.map(pkg => updatePackageJson(pkg, newPackageVersions)),
   );


### PR DESCRIPTION
Summary:
Following D86869721, this removes the unused `name`, `version`, and `license` fields from the project level `package.json` (previously named `react-native/monorepo`).

**Motivation**

- **Simplicity**: Our root package.json is a Yarn project manifest, not a package, with the `version` field serving no functional purpose. `react-native/monorepo` was never published to npm, and so `name`, `version`, and `license` were never read.
- **Correctness**: Since D86869721 and our recent work to formalise monorepo dependencies in `private/`, the workspace root no longer needs to be referenced by any part of our containing fbsource codebase — and this is a conceptual footgun (Yarn-installing a package that is itself a workspace). `react-native/monorepo` no longer needs to be named, addressable, or installable.

Or, phrased another way:

- Delete `name` — never try to reference this as an npm package!
- Delete `version` — never think about versioning this file!
- Delete `license` — unread, duplicate of `LICENSE.md`.

Changelog: [Internal]

Reviewed By: yungsters

Differential Revision: D86869720
