### PR TITLE
Expose jsitooling via prefab

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -104,6 +104,8 @@ val preparePrefab by
                       Pair(File(buildDir, "third-party-ndk/glog/exported/").absolutePath, ""),
                       // jsiinpsector
                       Pair("../ReactCommon/jsinspector-modern/", "jsinspector-modern/"),
+                      // jsitooling
+                      Pair("../ReactCommon/jsitooling/", ""),
                       // mapbufferjni
                       Pair("src/main/jni/react/mapbuffer", ""),
                       // turbomodulejsijni


### PR DESCRIPTION
Summary:
Nightlies for reanimated and worklets started failing after D86200983
That's because the header `JSRuntimeBindings.h` is now exposed via `jsitooling` but such target is not accessible via prefab for libreactnative.so.
This adds back the header and should solve the breakages.

Changelog:
[Internal] [Changed] -

Differential Revision: D86958415


