### PR TITLE
Exclude generated code from lint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -13,6 +13,7 @@ packages/*/dist
 packages/*/types_generated
 packages/debugger-frontend/dist/**/*
 packages/react-native-codegen/lib
+private/react-native-codegen-typescript-test/lib/**/*
 **/Pods/*
 **/*.macos.js
 **/*.windows.js


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

I was experimenting with TS API in the monorepo, and spotted that root lint tries to format generated code.

This small change add exclusion for files in `private/react-native-codegen-typescript-test/lib` which are generated locally when running TS API tests. The path is already ignored in `.gitignore` file:
* https://github.com/facebook/react-native/blob/main/.gitignore#L146-L146

## Changelog:

[INTERNAL] [FIXED] - Exclude generated code from lint checks to avoid unnecessary warnings.

## Test Plan:

Running `yarn lint` at monorepo root no longer outputs warnings.
