### PR TITLE
Override shouldUseLinkRoleForPressableText and shouldSetEnabledBasedOnAccessibilityState in FB4A

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<47b33d1a21af24f369e52d3b8f226d73>>
+ * @generated SignedSource<<3d8a5e00f7211d174b7efc6cfdf65669>>
  */
 
 /**
@@ -159,7 +159,7 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
 
   override fun shouldPressibilityUseW3CPointerEventsForHover(): Boolean = false
 
-  override fun shouldSetEnabledBasedOnAccessibilityState(): Boolean = false
+  override fun shouldSetEnabledBasedOnAccessibilityState(): Boolean = true
 
   override fun shouldTriggerResponderTransferOnScrollAndroid(): Boolean = false
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<bce5d52ac8a180d1750bb64dd21c1bd3>>
+ * @generated SignedSource<<4388b0b1e2c38ba72249c22e804e1925>>
  */
 
 /**
@@ -300,7 +300,7 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool shouldSetEnabledBasedOnAccessibilityState() override {
-    return false;
+    return true;
   }
 
   bool shouldTriggerResponderTransferOnScrollAndroid() override {

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -775,13 +775,12 @@ const definitions: FeatureFlagDefinitions = {
       ossReleaseStage: 'none',
     },
     shouldSetEnabledBasedOnAccessibilityState: {
-      defaultValue: false,
+      defaultValue: true,
       metadata: {
-        dateAdded: '2025-11-11',
         description:
           'Fix BaseViewManager to properly set view.setEnabled() based on accessibilityState.disabled.',
         expectedReleaseValue: true,
-        purpose: 'experimentation',
+        purpose: 'release',
       },
       ossReleaseStage: 'none',
     },
@@ -1098,13 +1097,12 @@ const definitions: FeatureFlagDefinitions = {
       ossReleaseStage: 'none',
     },
     shouldUseLinkRoleForPressableText: {
-      defaultValue: false,
+      defaultValue: true,
       metadata: {
-        dateAdded: '2025-11-10',
         description:
           'Set accessibilityRole to "link" for pressable Text components by default.',
         expectedReleaseValue: true,
-        purpose: 'experimentation',
+        purpose: 'release',
       },
       ossReleaseStage: 'none',
     },

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<11de61ca7deceb1931bf078b9125e97a>>
+ * @generated SignedSource<<fac7b56cca8f16e8a45a8326e6cd5f52>>
  * @flow strict
  * @noformat
  */
@@ -203,7 +203,7 @@ export const shouldUseAnimatedObjectForTransform: Getter<boolean> = createJavaSc
 /**
  * Set accessibilityRole to "link" for pressable Text components by default.
  */
-export const shouldUseLinkRoleForPressableText: Getter<boolean> = createJavaScriptFlagGetter('shouldUseLinkRoleForPressableText', false);
+export const shouldUseLinkRoleForPressableText: Getter<boolean> = createJavaScriptFlagGetter('shouldUseLinkRoleForPressableText', true);
 
 /**
  * removeClippedSubviews prop will be used as the default in FlatList on iOS to match Android
@@ -499,7 +499,7 @@ export const shouldPressibilityUseW3CPointerEventsForHover: Getter<boolean> = cr
 /**
  * Fix BaseViewManager to properly set view.setEnabled() based on accessibilityState.disabled.
  */
-export const shouldSetEnabledBasedOnAccessibilityState: Getter<boolean> = createNativeFlagGetter('shouldSetEnabledBasedOnAccessibilityState', false);
+export const shouldSetEnabledBasedOnAccessibilityState: Getter<boolean> = createNativeFlagGetter('shouldSetEnabledBasedOnAccessibilityState', true);
 /**
  * Do not emit touchcancel from Android ScrollView, instead native topScroll event will trigger responder transfer and terminate in RN renderer.
  */


### PR DESCRIPTION
Summary:
Changelog:
[Android][Changed] - Enabled shouldUseLinkRoleForPressableText and shouldSetEnabledBasedOnAccessibilityState feature flags by default to improve accessibility behavior.

Reviewed By: javache

Differential Revision: D86961734


