### PR TITLE
[WIP DEBUG] Fix ReactNativeApi.d.ts false positives via Danger bot

### DIFF
--- a/.github/actions/diff-js-api-breaking-changes/action.yml
+++ b/.github/actions/diff-js-api-breaking-changes/action.yml
@@ -10,8 +10,7 @@ runs:
       run: |
         mkdir $SCRATCH_DIR
         git fetch --depth=1 origin ${{ github.event.pull_request.head.sha }}
-        git show ${{ github.event.pull_request.head.sha }}:packages/react-native/ReactNativeApi.d.ts > $SCRATCH_DIR/ReactNativeApi-after.d.ts \
-          || echo "" > $SCRATCH_DIR/ReactNativeApi.d.ts
+        git show ${{ github.event.pull_request.head.sha }}:packages/react-native/ReactNativeApi.d.ts > $SCRATCH_DIR/ReactNativeApi-after.d.ts
     - name: Run breaking change detection
       shell: bash
       env:

--- a/scripts/js-api/diff-api-snapshot/diffApiSnapshot.js
+++ b/scripts/js-api/diff-api-snapshot/diffApiSnapshot.js
@@ -37,13 +37,6 @@ function diffApiSnapshot(prevSnapshot: string, newSnapshot: string): Output {
   const prevSpecHashPair = getExportedSymbols(prevSnapshotAST);
   const newSpecHashPair = getExportedSymbols(newSnapshotAST);
 
-  if (prevSpecHashPair == null || newSpecHashPair == null) {
-    return {
-      result: Result.BREAKING,
-      changedApis: [],
-    };
-  }
-
   return analyzeSpecHashPairs(prevSpecHashPair, newSpecHashPair);
 }
 
@@ -90,9 +83,9 @@ function analyzeSpecHashPairs(
   return output;
 }
 
-function getExportedSymbols(
-  ast: BabelNodeFile,
-): Array<[APISpecifier, Hash]> | null {
+function getExportedSymbols(ast: BabelNodeFile): Array<[APISpecifier, Hash]> {
+  const result: Array<[APISpecifier, Hash]> = [];
+
   for (const nodePath of ast.program.body) {
     if (
       t.isExportNamedDeclaration(nodePath) &&
@@ -100,7 +93,6 @@ function getExportedSymbols(
       nodePath.specifiers != null
     ) {
       const specifiers = nodePath.specifiers;
-      const result: Array<[APISpecifier, Hash]> = [];
       for (let i = 0; i < specifiers.length; i++) {
         const specifier = specifiers[i];
         const name = specifier.exported.name || '';
@@ -121,11 +113,10 @@ function getExportedSymbols(
           ? lastSpec.trailingComments[0]?.value
           : '';
       result[result.length - 1][1] = comment;
-      return result;
     }
   }
 
-  return null;
+  return result;
 }
 
 module.exports = {diffApiSnapshot, Result};


### PR DESCRIPTION
> [!Note]
> Work in progress — Placeholder PR, mostly reminding me to come back to this later(!)

We've seen multiple false positives happen from `diffApiSnapshot.js` on unrelated diffs ([example](https://github.com/facebook/react-native/pull/54198#issuecomment-3497359336)).

Start simplifying control flow in the GH action and scripts behind this to figure out the cause.