### PR TITLE
Remove unused exception parameter from js/react-native-github/packages/react-native/React/CxxModule/RCTCxxUtils.mm

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
@@ -694,7 +694,7 @@ typedef struct {
       } else if (_bridgeProxy) {
         [(id)module setValue:_bridgeProxy forKey:@"bridge"];
       }
-    } @catch (NSException *exception) {
+    } @catch (NSException *) {
       RCTLogError(
           @"%@ has no setter or ivar for its bridge, which is not "
            "permitted. You must either @synthesize the bridge property, "
@@ -742,7 +742,7 @@ typedef struct {
 
       @try {
         [(id)module setValue:methodQueue forKey:@"methodQueue"];
-      } @catch (NSException *exception) {
+      } @catch (NSException *) {
         RCTLogError(
             @"%@ has no setter or ivar for its methodQueue, which is not "
              "permitted. You must either @synthesize the methodQueue property, "


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Differential Revision: D85813832


