### PR TITLE
Pass legacy hermes flag for HermesVariant.Hermes

### DIFF
--- a/packages/react-native/src/private/__tests__/MemoryBaseline-itest.js
+++ b/packages/react-native/src/private/__tests__/MemoryBaseline-itest.js
@@ -29,12 +29,12 @@ declare var performance: Performance;
  */
 const MEMORY_LIMITS_KB = {
   environmentSetup: {
-    dev: 1000,
-    opt: 500,
+    dev: 1300,
+    opt: 700,
   },
   basicSurfaceRender: {
-    dev: 1200,
-    opt: 700,
+    dev: 1700,
+    opt: 900,
   },
 };
 

--- a/private/react-native-fantom/runner/getFantomTestConfigs.js
+++ b/private/react-native-fantom/runner/getFantomTestConfigs.js
@@ -11,6 +11,7 @@
 import type {FeatureFlagValue} from '../../../packages/react-native/scripts/featureflags/types';
 
 import ReactNativeFeatureFlags from '../../../packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config';
+import * as EnvironmentOptions from './EnvironmentOptions';
 import {HermesVariant} from './utils';
 // $FlowExpectedError[untyped-import]
 import {extract, parse} from 'jest-docblock';
@@ -59,7 +60,9 @@ export const FantomTestConfigHermesVariant = HermesVariant;
 export const DEFAULT_IS_NATIVE_OPTIMIZED: boolean = false;
 export const DEFAULT_IS_JS_OPTIMIZED: boolean = false;
 export const DEFAULT_IS_JS_BYTECODE: boolean = false;
-export const DEFAULT_HERMES_VARIANT: HermesVariant = HermesVariant.Hermes;
+export const DEFAULT_OSS_HERMES_VARIANT: HermesVariant = HermesVariant.Hermes;
+export const DEFAULT_HERMES_VARIANT: HermesVariant =
+  HermesVariant.StaticHermesStable;
 
 export const DEFAULT_FEATURE_FLAGS: FantomTestConfigFeatureFlags = {
   common: {},
@@ -170,7 +173,9 @@ export default function getFantomTestConfigs(
     isNativeOptimized: DEFAULT_IS_NATIVE_OPTIMIZED,
     isJsOptimized: DEFAULT_IS_JS_OPTIMIZED,
     isJsBytecode: DEFAULT_IS_JS_BYTECODE,
-    hermesVariant: DEFAULT_HERMES_VARIANT,
+    hermesVariant: EnvironmentOptions.isOSS
+      ? DEFAULT_OSS_HERMES_VARIANT
+      : DEFAULT_HERMES_VARIANT,
     flags: {
       common: {
         ...DEFAULT_FEATURE_FLAGS.common,

--- a/private/react-native-fantom/runner/utils.js
+++ b/private/react-native-fantom/runner/utils.js
@@ -32,7 +32,7 @@ export function getBuckOptionsForHermes(
     : [];
   switch (variant) {
     case HermesVariant.Hermes:
-      return baseOptions;
+      return [...baseOptions, '-c hermes.static_hermes=legacy'];
     case HermesVariant.StaticHermesStable:
       return [...baseOptions, '-c hermes.static_hermes=stable'];
     case HermesVariant.StaticHermesExperimental:

--- a/private/react-native-fantom/src/__tests__/__snapshots__/expect-itest.js.snap
+++ b/private/react-native-fantom/src/__tests__/__snapshots__/expect-itest.js.snap
@@ -33,15 +33,6 @@ exports[`expect toMatchSnapshot() complex types 7`] = `[Error]`;
 
 exports[`expect toMatchSnapshot() complex types 8`] = `/asd/`;
 
-exports[`expect toMatchSnapshot() complex types 9`] = `
-Promise {
-  "_h": 0,
-  "_i": 0,
-  "_j": null,
-  "_k": null,
-}
-`;
-
 exports[`expect toMatchSnapshot() named snapshots: named snapshot 1`] = `
 Object {
   "a": "b",

--- a/private/react-native-fantom/src/__tests__/expect-itest.js
+++ b/private/react-native-fantom/src/__tests__/expect-itest.js
@@ -857,7 +857,8 @@ describe('expect', () => {
       expect(new Date('2025-01-02')).toMatchSnapshot();
       expect(new Error()).toMatchSnapshot();
       expect(new RegExp('asd')).toMatchSnapshot();
-      expect(new Promise(() => {})).toMatchSnapshot();
+      // TODO(T245412835): uncomment this once we support Hermes V1 in OSS fantom.
+      // expect(new Promise(() => {})).toMatchSnapshot();
     });
 
     test('named snapshots', () => {


### PR DESCRIPTION
Summary:
Changelog: [Internal]

We are switching to SH as default, so for the current default hermes
variant, we need to pass the legacy hermes falg to continue using it.

Differential Revision: D87082037


