### PR TITLE
Fix ImageProps default values

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp
@@ -98,7 +98,7 @@ ImageProps::ImageProps(
                     rawProps,
                     "resizeMethod",
                     sourceProps.resizeMethod,
-                    {})),
+                    {"auto"})),
       resizeMultiplier(
           ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.resizeMultiplier
@@ -107,7 +107,7 @@ ImageProps::ImageProps(
                     rawProps,
                     "resizeMultiplier",
                     sourceProps.resizeMultiplier,
-                    {})),
+                    1)),
       shouldNotifyLoadEvents(
           ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.shouldNotifyLoadEvents

--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
@@ -33,8 +33,8 @@ class ImageProps final : public ViewProps {
   EdgeInsets capInsets{};
   SharedColor tintColor{};
   std::string internal_analyticTag{};
-  std::string resizeMethod{};
-  Float resizeMultiplier{};
+  std::string resizeMethod{"auto"};
+  Float resizeMultiplier{1.f};
   bool shouldNotifyLoadEvents{};
   SharedColor overlayColor{};
   Float fadeDuration{};


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Currently these default values

https://reactnative.dev/docs/image#resizemethod-android
https://reactnative.dev/docs/image#resizemultiplier-android

are not correctly treated in C++ code as parsing bails out here:

https://github.com/facebook/react-native/blob/main/packages/react-native/ReactCommon/react/renderer/core/propsConversions.h#L176-L177

By setting default values in the struct, we can fix it

Differential Revision: D87083023


