### PR TITLE
Add JSI_UNSTABLE flag

### DIFF
--- a/packages/react-native/ReactCommon/jsi/jsi/jsi.h
+++ b/packages/react-native/ReactCommon/jsi/jsi/jsi.h
@@ -252,6 +252,12 @@ class JSI_EXPORT NativeState {
   virtual ~NativeState();
 };
 
+// JSI_UNSTABLE gates features that will be released with a Hermes version in
+// the future. Until released, these features may be subject to change. After
+// release, these features will be moved out of JSI_UNSTABLE and become frozen.
+#ifdef JSI_UNSTABLE
+#endif // JSI_UNSTABLE
+
 /// Represents a JS runtime.  Movable, but not copyable.  Note that
 /// this object may not be thread-aware, but cannot be used safely from
 /// multiple threads at once.  The application is responsible for


### PR DESCRIPTION
Summary:
We want to have a proper way of releasing new JSI features, rather than
releasing into JSI as they are added.

To do this, we are adding a new `JSI_UNSTABLE` flag that will gate new
features. Until Hermes releases a new version, all of these "unstable"
features are subject to change. Interfaces may be modified, API behavior
may be changed, etc.

When Hermes release a new version, the new additions will be moved out
of the "unstable" status and become frozen.

This diff adds the `JSI_UNSTABLE` flag to JSI and adds corresponding
changes to the BUCK build. Later diffs will use this gate new APIs.

Changelog: [Internal]

Reviewed By: lavenzg

Differential Revision: D85915163


