### PR TITLE
Fix crash in RCTExceptionManager

### DIFF
--- a/packages/react-native/React/CoreModules/RCTExceptionsManager.mm
+++ b/packages/react-native/React/CoreModules/RCTExceptionsManager.mm
@@ -77,8 +77,11 @@ RCT_EXPORT_MODULE()
     RCTTriggerReloadCommandListeners(@"JS Crash Reload");
   } else if (!RCT_DEV) {
     NSString *description = [@"Unhandled JS Exception: " stringByAppendingString:message];
-    NSDictionary *errorInfo =
-        @{NSLocalizedDescriptionKey : description, RCTJSStackTraceKey : stack, RCTJSExtraDataKey : extraDataAsJSON};
+    NSDictionary *errorInfo = @{
+      NSLocalizedDescriptionKey : description,
+      RCTJSStackTraceKey : stack == nil ? (id)kCFNull : stack,
+      RCTJSExtraDataKey : extraDataAsJSON == nil ? (id)kCFNull : extraDataAsJSON
+    };
     RCTFatal([NSError errorWithDomain:RCTErrorDomain code:0 userInfo:errorInfo]);
   }
 }


### PR DESCRIPTION
Summary:
# Summary

This diff resolves a crash in RCTExceptionManager by modifying error handling. It fixes the issue by checking if `RCTJSExtraDataKey` and `RCTJSStackTraceKey` are null or not in a dictionary initializer.

Also, `RCTJSExtraDataKey` is marked as nullable but its nullability is not checked.

## Changelog:
[iOS][Fixed] - A Crash when some error information are nil

Differential Revision: D87140823


