### PR TITLE
Fix excessive emits of keyboardDidShow event on iOS

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -300,6 +300,13 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
 
   if (newTextInputProps.inputAccessoryViewID != oldTextInputProps.inputAccessoryViewID) {
     _backedTextInputView.inputAccessoryViewID = RCTNSStringFromString(newTextInputProps.inputAccessoryViewID);
+  
+    // InputAccessoryView component sets the inputAccessoryView when inputAccessoryViewID exists
+    if (_backedTextInputView.inputAccessoryViewID) {
+      if (_backedTextInputView.isFirstResponder) {
+        [_backedTextInputView reloadInputViews];
+      }
+    }
   }
 
   if (newTextInputProps.inputAccessoryViewButtonLabel != oldTextInputProps.inputAccessoryViewButtonLabel) {
@@ -639,9 +646,6 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
 {
   // InputAccessoryView component sets the inputAccessoryView when inputAccessoryViewID exists
   if (_backedTextInputView.inputAccessoryViewID) {
-    if (_backedTextInputView.isFirstResponder) {
-      [_backedTextInputView reloadInputViews];
-    }
     return;
   }
 


### PR DESCRIPTION
## Summary:

This PR fixes this issue: https://github.com/facebook/react-native/issues/54542

When we assign **inputAccessoryViewID** prop to **TextInput** - **setDefaultInputAccessoryView** is being called on every prop check, which is calling **reloadInputViews**, which is causing **keyboardDidShow** event to be emitted again and again.

## Changelog:

[IOS] [FIXED] - Moved **if** condition related to **inputAccessoryViewID** in a different place to reduce **reloadInputViews** calls

## Test Plan:

Use the most basic listener to check how often the event is being fired:
```
  useEffect(() => {
    const showSubscription = Keyboard.addListener('keyboardDidShow', () => {
      console.log('Keyboard Shown');
    });
    return () => {
      showSubscription.remove();
    };
  }, []);
```

Would be appreciated if anyone hinted whether this change might cause the "input views were not reloaded at the right time" problem.