### PR TITLE
Checkout reporistory with the right token

### DIFF
--- a/.github/workflows/bump-podfile-lock.yml
+++ b/.github/workflows/bump-podfile-lock.yml
@@ -10,6 +10,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
+          token: ${{ secrets.REACT_NATIVE_BOT_GITHUB_TOKEN }}
           fetch-depth: 0
           fetch-tags: true
       - name: Install dependencies

--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          token: ${{ secrets.REACT_NATIVE_BOT_GITHUB_TOKEN }}
           fetch-depth: 0
           fetch-tags: true
       - name: Install dependencies

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -10,6 +10,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          token: ${{ secrets.REACT_NATIVE_BOT_GITHUB_TOKEN }}
           fetch-depth: 0
           fetch-tags: true
       - name: Install dependencies


### PR DESCRIPTION
Summary:
When running a release, we are observing failures due to the Meta CLA check failings for commits pushed by our own CI.

The secrets are inherited by the jobs, but we observed that the repository is not checked out with the right token.

This change should fix that.

## Changelog:
[Internal] -

Reviewed By: cortinico

Differential Revision: D87218058


