### PR TITLE
use Dynamic type on DynamicEventPayload

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/DynamicEventPayload.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/DynamicEventPayload.cpp
@@ -19,7 +19,7 @@ jsi::Value DynamicEventPayload::asJSIValue(jsi::Runtime& runtime) const {
 }
 
 EventPayloadType DynamicEventPayload::getType() const {
-  return EventPayloadType::ValueFactory;
+  return EventPayloadType::Dynamic;
 }
 
 std::optional<double> DynamicEventPayload::extractValue(

--- a/packages/react-native/ReactCommon/react/renderer/core/EventPayloadType.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventPayloadType.h
@@ -9,6 +9,6 @@
 
 namespace facebook::react {
 
-enum class EventPayloadType { ValueFactory, PointerEvent, ScrollEvent };
+enum class EventPayloadType { ValueFactory, PointerEvent, ScrollEvent, Dynamic };
 
 }


### PR DESCRIPTION
Summary:
## Changelog:

[General] [Internal] - use Dynamic type on DynamicEventPayload

this EventPayload type was added since D71198197, but it still shares type with ValueFactoryEventPayload, which doesnt seem intentional

Differential Revision: D87092393


