### PR TITLE
Include activeHitPath in payload when it's PointerUp/Down

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/JSPointerDispatcher.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/JSPointerDispatcher.java
@@ -15,6 +15,7 @@ import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.common.ReactConstants;
+import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags;
 import com.facebook.react.uimanager.TouchTargetHelper.ViewTarget;
 import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.react.uimanager.events.PointerEvent;
@@ -133,9 +134,17 @@ public class JSPointerDispatcher {
     boolean listeningForUp =
         isAnyoneListeningForBubblingEvent(activeHitPath, EVENT.UP, EVENT.UP_CAPTURE);
     if (listeningForUp) {
+      List<Integer> activeHitPathViewIds =
+          ReactNativeFeatureFlags.cxxNativeAnimatedEnabled()
+              ? eventState.getHitPathViewIdsForActivePointer()
+              : null;
       eventDispatcher.dispatchEvent(
           PointerEvent.obtain(
-              PointerEventHelper.POINTER_UP, activeTargetTag, eventState, motionEvent));
+              PointerEventHelper.POINTER_UP,
+              activeTargetTag,
+              eventState,
+              motionEvent,
+              activeHitPathViewIds));
     }
 
     boolean supportsHover = mHoveringPointerIds.contains(activePointerId);
@@ -230,9 +239,17 @@ public class JSPointerDispatcher {
     boolean listeningForDown =
         isAnyoneListeningForBubblingEvent(activeHitPath, EVENT.DOWN, EVENT.DOWN_CAPTURE);
     if (listeningForDown) {
+      List<Integer> activeHitPathViewIds =
+          ReactNativeFeatureFlags.cxxNativeAnimatedEnabled()
+              ? eventState.getHitPathViewIdsForActivePointer()
+              : null;
       eventDispatcher.dispatchEvent(
           PointerEvent.obtain(
-              PointerEventHelper.POINTER_DOWN, activeTargetTag, eventState, motionEvent));
+              PointerEventHelper.POINTER_DOWN,
+              activeTargetTag,
+              eventState,
+              motionEvent,
+              activeHitPathViewIds));
     }
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/core/DynamicEventPayload.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/DynamicEventPayload.cpp
@@ -8,11 +8,21 @@
 #include "DynamicEventPayload.h"
 
 #include <jsi/JSIDynamic.h>
+#include <react/renderer/core/DynamicPointerEvent.h>
 
 namespace facebook::react {
 
 DynamicEventPayload::DynamicEventPayload(folly::dynamic&& payload)
     : payload_(std::move(payload)) {}
+
+/* static */ SharedEventPayload DynamicEventPayload::create(
+    folly::dynamic&& payload) {
+  if (payload.find("pointerId") != payload.items().end()) {
+    return std::make_shared<DynamicPointerEvent>(std::move(payload));
+  } else {
+    return std::make_shared<DynamicEventPayload>(std::move(payload));
+  }
+}
 
 jsi::Value DynamicEventPayload::asJSIValue(jsi::Runtime& runtime) const {
   return jsi::valueFromDynamic(runtime, payload_);

--- a/packages/react-native/ReactCommon/react/renderer/core/DynamicEventPayload.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/DynamicEventPayload.h
@@ -12,8 +12,13 @@
 
 namespace facebook::react {
 
+/*
+ * EventPayload sent from android native via JNI.
+ */
 struct DynamicEventPayload : public EventPayload {
   explicit DynamicEventPayload(folly::dynamic &&payload);
+
+  static SharedEventPayload create(folly::dynamic &&payload);
 
   /*
    * EventPayload implementations
@@ -22,7 +27,7 @@ struct DynamicEventPayload : public EventPayload {
   EventPayloadType getType() const override;
   std::optional<double> extractValue(const std::vector<std::string> &path) const override;
 
- private:
+ protected:
   folly::dynamic payload_;
 };
 

--- a/packages/react-native/ReactCommon/react/renderer/core/DynamicPointerEvent.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/DynamicPointerEvent.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "DynamicPointerEvent.h"
+
+#include <jsi/JSIDynamic.h>
+
+namespace facebook::react {
+
+DynamicPointerEvent::DynamicPointerEvent(folly::dynamic&& payload)
+    : DynamicEventPayload(std::move(payload)) {
+  const auto& hitPath = payload_["hitPathForEventListener"];
+  if (hitPath.type() == folly::dynamic::Type::ARRAY) {
+    hitPathForEventListener_ = std::vector<Tag>{};
+    for (const auto& item : hitPath) {
+      hitPathForEventListener_->push_back(static_cast<Tag>(item.asInt()));
+    }
+  }
+}
+
+const std::optional<std::vector<Tag>>&
+DynamicPointerEvent::getHitPathForEventListener() const {
+  return hitPathForEventListener_;
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/DynamicPointerEvent.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/DynamicPointerEvent.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <folly/dynamic.h>
+#include <react/renderer/core/DynamicEventPayload.h>
+#include <react/renderer/core/EventPayload.h>
+#include <react/renderer/core/ReactPrimitives.h>
+
+namespace facebook::react {
+
+/*
+ * Payload of PointerEvent sent from android native via JNI.
+ */
+struct DynamicPointerEvent : public DynamicEventPayload {
+  explicit DynamicPointerEvent(folly::dynamic &&payload);
+
+  const std::optional<std::vector<Tag>> &getHitPathForEventListener() const;
+
+ private:
+  std::optional<std::vector<Tag>> hitPathForEventListener_;
+};
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/EventEmitter.cpp
@@ -10,21 +10,19 @@
 #include <cxxreact/TraceSection.h>
 #include <folly/dynamic.h>
 #include <jsi/jsi.h>
-
-#include "DynamicEventPayload.h"
-#include "RawEvent.h"
+#include <react/renderer/core/DynamicEventPayload.h>
+#include <react/renderer/core/RawEvent.h>
 
 namespace facebook::react {
-
 static bool hasPrefix(const std::string& str, const std::string& prefix) {
   return str.compare(0, prefix.length(), prefix) == 0;
 }
 
 // TODO(T29874519): Get rid of "top" prefix once and for all.
 /*
- * Replaces "on" with "top" if present. Or capitalizes the first letter and adds
- * "top" prefix. E.g. "eventName" becomes "topEventName", "onEventName" also
- * becomes "topEventName".
+ * Replaces "on" with "top" if present. Or capitalizes the first letter and
+ * adds "top" prefix. E.g. "eventName" becomes "topEventName", "onEventName"
+ * also becomes "topEventName".
  */
 /* static */ std::string EventEmitter::normalizeEventType(std::string type) {
   auto prefixedType = std::move(type);
@@ -61,7 +59,7 @@ void EventEmitter::dispatchEvent(
     RawEvent::Category category) const {
   dispatchEvent(
       std::move(type),
-      std::make_shared<DynamicEventPayload>(std::move(payload)),
+      DynamicEventPayload::create(std::move(payload)),
       category);
 }
 
@@ -69,8 +67,7 @@ void EventEmitter::dispatchUniqueEvent(
     std::string type,
     folly::dynamic&& payload) const {
   dispatchUniqueEvent(
-      std::move(type),
-      std::make_shared<DynamicEventPayload>(std::move(payload)));
+      std::move(type), DynamicEventPayload::create(std::move(payload)));
 }
 
 void EventEmitter::dispatchEvent(
@@ -139,10 +136,10 @@ void EventEmitter::setEnabled(bool enabled) const {
     }
   }
 
-  // Note: Initially, the state of `eventTarget_` and the value `enableCounter_`
-  // is mismatched intentionally (it's `non-null` and `0` accordingly). We need
-  // this to support an initial nebula state where the event target must be
-  // retained without any associated mounted node.
+  // Note: Initially, the state of `eventTarget_` and the value
+  // `enableCounter_` is mismatched intentionally (it's `non-null` and `0`
+  // accordingly). We need this to support an initial nebula state where the
+  // event target must be retained without any associated mounted node.
   bool shouldBeRetained = enableCounter_ > 0;
   if (shouldBeRetained != (eventTarget_ != nullptr)) {
     if (!shouldBeRetained) {


### PR DESCRIPTION
Summary:
## Changelog:

[Android] [Added] - Include activeHitPath in payload when it's PointerUp/Down

It's only included when using c++ animated, some native event listener will need the hit path information from the platform before it reaches React. Note that the actual bubbling only doesn't happen until in React so there's no way native code can know where bubbling will reach when the event is intercepted on main thread.

Differential Revision: D87092392


