### PR TITLE
use weak_ptr of NativeAnimatedNodesManager in AnimatedModule

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/animated/AnimatedModule.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/AnimatedModule.h
@@ -194,11 +194,11 @@ class AnimatedModule : public NativeAnimatedModuleCxxSpec<AnimatedModule>, publi
 
  private:
   std::shared_ptr<NativeAnimatedNodesManagerProvider> nodesManagerProvider_;
-  std::shared_ptr<NativeAnimatedNodesManager> nodesManager_;
+  std::weak_ptr<NativeAnimatedNodesManager> nodesManager_;
   std::vector<Operation> preOperations_;
   std::vector<Operation> operations_;
 
-  void executeOperation(const Operation &operation);
+  void executeOperation(const Operation &operation, std::weak_ptr<NativeAnimatedNodesManager> nodesManagerWeak);
   void installJSIBindingsWithRuntime(jsi::Runtime &runtime) override;
 };
 


### PR DESCRIPTION
Summary:
## Changelog:

[General] [Internal] - use weak_ptr of NativeAnimatedNodesManager in AnimatedModule

- so NativeAnimatedNodesManagerProvider is the only owner of NodesManager
- Also referencing a nodesManager weak_ptr in the scheduleOnUI call, to prevent AnimatedModule to use a partially destroyed NodesManager

Differential Revision: D87229271


