### PR TITLE
Fix create-draft-release syntax error

### DIFF
--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -37,7 +37,7 @@ jobs:
             const {createDraftRelease} = require('./.github/workflow-scripts/createDraftRelease.js');
             const version = '${{ github.ref_name }}';
             const {isLatest} = require('./.github/workflow-scripts/publishTemplate.js');
-            return (await createDraftRelease(version, isLatest(), '${{secrets.REACT_NATIVE_BOT_GITHUB_TOKEN}}', ${{ inputs.hermesVersion }}, ${{ inputs.hermesV1Version }})).id;
+            return (await createDraftRelease(version, isLatest(), '${{secrets.REACT_NATIVE_BOT_GITHUB_TOKEN}}', '${{ inputs.hermesVersion }}', '${{ inputs.hermesV1Version }}')).id;
           result-encoding: string
       - name: Upload release assets for DotSlash
         uses: actions/github-script@v6


### PR DESCRIPTION
Summary:
This change fix a syntax error in the create-draft-release workflow. We were basically passing the Hermes and HermesV1 versions without wrapping them in `'`.

JS was interpreting them as numbers and making a mess of the syntax.

Wrapping them in `'` should fix the job.

The commit was already picked in the release branch.

## Changelog:
[Internal] -

Differential Revision: D87244325


