### PR TITLE
Fix dateAdded date for enableAndroidAntialiasedBorderRadiusClipping

### DIFF
--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -204,7 +204,7 @@ const definitions: FeatureFlagDefinitions = {
     enableAndroidAntialiasedBorderRadiusClipping: {
       defaultValue: false,
       metadata: {
-        dateAdded: '2025-01-31',
+        dateAdded: '2025-11-14',
         description:
           'Enable antialiased border radius clipping for Android API 28 and below using manual masking with Porter-Duff compositing',
         expectedReleaseValue: true,


### PR DESCRIPTION
Summary:
Fixes date on a feature flag landed Nov 14

Changelog: [Internal]

Differential Revision: D87248079


