### PR TITLE
Remove unused exception parameter from ../xplat/js/react-native-github/packages/react-native/React/CxxModule/RCTCxxUtils.mm

### DIFF
--- a/packages/react-native/React/CxxModule/RCTCxxUtils.mm
+++ b/packages/react-native/React/CxxModule/RCTCxxUtils.mm
@@ -68,7 +68,7 @@ NSError *tryAndReturnError(const std::function<void()> &func)
       return nil;
     } @catch (NSException *exception) {
       return RCTErrorWithNSException(exception);
-    } @catch (id exception) {
+    } @catch (id) {
       // This will catch any other ObjC exception, but no C++ exceptions
       return RCTErrorWithMessage(@"non-std ObjC Exception");
     }

--- a/packages/react-native/ReactAndroid/src/main/jni/react/tracing/PerformanceTracerCxxInterop.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/tracing/PerformanceTracerCxxInterop.cpp
@@ -200,7 +200,7 @@ jint PerformanceTracerCxxInterop::subscribeToTracingStateChanges(
               onTracingStateChangedMethod(
                   callback, static_cast<jboolean>(isTracing));
             });
-          } catch (const std::exception& e) {
+          } catch (const std::exception&) {
           }
         }
       });

--- a/packages/react-native/ReactCommon/jsi/jsi/test/testlib.cpp
+++ b/packages/react-native/ReactCommon/jsi/jsi/test/testlib.cpp
@@ -1455,7 +1455,7 @@ TEST_P(JSITest, MicrotasksTest) {
     EXPECT_EQ(
         rt.global().getProperty(rt, "globalValue").asString(rt).utf8(rt),
         "hello world");
-  } catch (const JSINativeException& ex) {
+  } catch (const JSINativeException&) {
     // queueMicrotask() is unimplemented by some runtimes, ignore such failures.
   }
 }
@@ -1550,7 +1550,7 @@ TEST_P(JSITest, ArrayBufferSizeTest) {
   try {
     // Ensure we can safely write some data to the buffer.
     memset(ab.data(rt), 0xab, 10);
-  } catch (const JSINativeException& ex) {
+  } catch (const JSINativeException&) {
     // data() is unimplemented by some runtimes, ignore such failures.
   }
 


### PR DESCRIPTION
Summary:
`-Wunused-exception-parameter` has identified an unused exception parameter. This diff removes it.

This:
```
try {
    ...
} catch (exception& e) {
    // no use of e
}
```
should instead be written as
```
} catch (exception&) {
```

If the code compiles, this is safe to land.

Reviewed By: dtolnay

Differential Revision: D87273133


