### PR TITLE
Fix flipped accessiblityState diffing

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
@@ -936,7 +936,7 @@ folly::dynamic HostPlatformViewProps::getDiffProps(
 
   if (accessibilityState != oldProps->accessibilityState) {
     updateAccessibilityStateProp(
-        result, oldProps->accessibilityState, accessibilityState);
+        result, accessibilityState, oldProps->accessibilityState);
   }
 
   if (accessibilityLabel != oldProps->accessibilityLabel) {


### PR DESCRIPTION
Summary:
Props 2.0 diffing had the old and new accessibilityState flipped in the HostPlatformViewProps implementation, which resulted in the disabled state output being flipped on change.

Changelog: [Internal]

Differential Revision: D87293652


