### PR TITLE
Address -Wswitch-default issues

### DIFF
--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
@@ -421,6 +421,8 @@ static inline std::string toString(const EnumPropNativeComponentViewAlignment &v
     case EnumPropNativeComponentViewAlignment::Top: return \\"top\\";
     case EnumPropNativeComponentViewAlignment::Center: return \\"center\\";
     case EnumPropNativeComponentViewAlignment::BottomRight: return \\"bottom-right\\";
+    default:
+      abort();
   }
 }
 
@@ -447,8 +449,9 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
     case 60:
       result = EnumPropNativeComponentViewIntervals::Intervals60;
       return;
+    default:
+      abort();
   }
-  abort();
 }
 
 static inline std::string toString(const EnumPropNativeComponentViewIntervals &value) {
@@ -457,6 +460,8 @@ static inline std::string toString(const EnumPropNativeComponentViewIntervals &v
     case EnumPropNativeComponentViewIntervals::Intervals15: return \\"15\\";
     case EnumPropNativeComponentViewIntervals::Intervals30: return \\"30\\";
     case EnumPropNativeComponentViewIntervals::Intervals60: return \\"60\\";
+    default:
+      abort();
   }
 }
 
@@ -467,6 +472,8 @@ static inline folly::dynamic toDynamic(const EnumPropNativeComponentViewInterval
     case EnumPropNativeComponentViewIntervals::Intervals15: return 15;
     case EnumPropNativeComponentViewIntervals::Intervals30: return 30;
     case EnumPropNativeComponentViewIntervals::Intervals60: return 60;
+    default:
+      abort();
   }
 }
 #endif
@@ -926,6 +933,8 @@ static inline std::string toString(const ObjectPropsNativeComponentStringEnumPro
   switch (value) {
     case ObjectPropsNativeComponentStringEnumProp::Small: return \\"small\\";
     case ObjectPropsNativeComponentStringEnumProp::Large: return \\"large\\";
+    default:
+      abort();
   }
 }
 
@@ -946,14 +955,17 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
     case 1:
       result = ObjectPropsNativeComponentIntEnumProp::IntEnumProp1;
       return;
+    default:
+      abort();
   }
-  abort();
 }
 
 static inline std::string toString(const ObjectPropsNativeComponentIntEnumProp &value) {
   switch (value) {
     case ObjectPropsNativeComponentIntEnumProp::IntEnumProp0: return \\"0\\";
     case ObjectPropsNativeComponentIntEnumProp::IntEnumProp1: return \\"1\\";
+    default:
+      abort();
   }
 }
 
@@ -962,6 +974,8 @@ static inline folly::dynamic toDynamic(const ObjectPropsNativeComponentIntEnumPr
   switch (value) {
     case ObjectPropsNativeComponentIntEnumProp::IntEnumProp0: return 0;
     case ObjectPropsNativeComponentIntEnumProp::IntEnumProp1: return 1;
+    default:
+      abort();
   }
 }
 #endif

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GeneratePropsH-test.js.snap
@@ -421,6 +421,8 @@ static inline std::string toString(const EnumPropNativeComponentViewAlignment &v
     case EnumPropNativeComponentViewAlignment::Top: return \\"top\\";
     case EnumPropNativeComponentViewAlignment::Center: return \\"center\\";
     case EnumPropNativeComponentViewAlignment::BottomRight: return \\"bottom-right\\";
+    default:
+      abort();
   }
 }
 
@@ -447,8 +449,9 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
     case 60:
       result = EnumPropNativeComponentViewIntervals::Intervals60;
       return;
+    default:
+      abort();
   }
-  abort();
 }
 
 static inline std::string toString(const EnumPropNativeComponentViewIntervals &value) {
@@ -457,6 +460,8 @@ static inline std::string toString(const EnumPropNativeComponentViewIntervals &v
     case EnumPropNativeComponentViewIntervals::Intervals15: return \\"15\\";
     case EnumPropNativeComponentViewIntervals::Intervals30: return \\"30\\";
     case EnumPropNativeComponentViewIntervals::Intervals60: return \\"60\\";
+    default:
+      abort();
   }
 }
 
@@ -467,6 +472,8 @@ static inline folly::dynamic toDynamic(const EnumPropNativeComponentViewInterval
     case EnumPropNativeComponentViewIntervals::Intervals15: return 15;
     case EnumPropNativeComponentViewIntervals::Intervals30: return 30;
     case EnumPropNativeComponentViewIntervals::Intervals60: return 60;
+    default:
+      abort();
   }
 }
 #endif
@@ -926,6 +933,8 @@ static inline std::string toString(const ObjectPropsNativeComponentStringEnumPro
   switch (value) {
     case ObjectPropsNativeComponentStringEnumProp::Small: return \\"small\\";
     case ObjectPropsNativeComponentStringEnumProp::Large: return \\"large\\";
+    default:
+      abort();
   }
 }
 
@@ -946,14 +955,17 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
     case 1:
       result = ObjectPropsNativeComponentIntEnumProp::IntEnumProp1;
       return;
+    default:
+      abort();
   }
-  abort();
 }
 
 static inline std::string toString(const ObjectPropsNativeComponentIntEnumProp &value) {
   switch (value) {
     case ObjectPropsNativeComponentIntEnumProp::IntEnumProp0: return \\"0\\";
     case ObjectPropsNativeComponentIntEnumProp::IntEnumProp1: return \\"1\\";
+    default:
+      abort();
   }
 }
 
@@ -962,6 +974,8 @@ static inline folly::dynamic toDynamic(const ObjectPropsNativeComponentIntEnumPr
   switch (value) {
     case ObjectPropsNativeComponentIntEnumProp::IntEnumProp0: return 0;
     case ObjectPropsNativeComponentIntEnumProp::IntEnumProp1: return 1;
+    default:
+      abort();
   }
 }
 #endif

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsH.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsH.js
@@ -124,6 +124,8 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 static inline std::string toString(const ${enumName} &value) {
   switch (value) {
     ${toCases}
+    default:
+      abort();
   }
 }
 
@@ -154,13 +156,16 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
   assert(value.hasType<int>());
   auto integerValue = (int)value;
   switch (integerValue) {${fromCases}
+    default:
+      abort();
   }
-  abort();
 }
 
 static inline std::string toString(const ${enumName} &value) {
   switch (value) {
     ${toCases}
+    default:
+      abort();
   }
 }
 
@@ -168,6 +173,8 @@ static inline std::string toString(const ${enumName} &value) {
 static inline folly::dynamic toDynamic(const ${enumName} &value) {
   switch (value) {
     ${toDynamicCases}
+    default:
+      abort();
   }
 }
 #endif

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GeneratePropsH-test.js.snap
@@ -1100,8 +1100,9 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
     case 2:
       result = Int32EnumPropsNativeComponentMaxInterval::MaxInterval2;
       return;
+    default:
+      abort();
   }
-  abort();
 }
 
 static inline std::string toString(const Int32EnumPropsNativeComponentMaxInterval &value) {
@@ -1109,6 +1110,8 @@ static inline std::string toString(const Int32EnumPropsNativeComponentMaxInterva
     case Int32EnumPropsNativeComponentMaxInterval::MaxInterval0: return \\"0\\";
     case Int32EnumPropsNativeComponentMaxInterval::MaxInterval1: return \\"1\\";
     case Int32EnumPropsNativeComponentMaxInterval::MaxInterval2: return \\"2\\";
+    default:
+      abort();
   }
 }
 
@@ -1118,6 +1121,8 @@ static inline folly::dynamic toDynamic(const Int32EnumPropsNativeComponentMaxInt
     case Int32EnumPropsNativeComponentMaxInterval::MaxInterval0: return 0;
     case Int32EnumPropsNativeComponentMaxInterval::MaxInterval1: return 1;
     case Int32EnumPropsNativeComponentMaxInterval::MaxInterval2: return 2;
+    default:
+      abort();
   }
 }
 #endif
@@ -1399,6 +1404,8 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
 static inline std::string toString(const ObjectPropsStringEnumProp &value) {
   switch (value) {
     case ObjectPropsStringEnumProp::Option1: return \\"option1\\";
+    default:
+      abort();
   }
 }
 
@@ -1416,13 +1423,16 @@ static inline void fromRawValue(const PropsParserContext& context, const RawValu
     case 0:
       result = ObjectPropsIntEnumProp::IntEnumProp0;
       return;
+    default:
+      abort();
   }
-  abort();
 }
 
 static inline std::string toString(const ObjectPropsIntEnumProp &value) {
   switch (value) {
     case ObjectPropsIntEnumProp::IntEnumProp0: return \\"0\\";
+    default:
+      abort();
   }
 }
 
@@ -1430,6 +1440,8 @@ static inline std::string toString(const ObjectPropsIntEnumProp &value) {
 static inline folly::dynamic toDynamic(const ObjectPropsIntEnumProp &value) {
   switch (value) {
     case ObjectPropsIntEnumProp::IntEnumProp0: return 0;
+    default:
+      abort();
   }
 }
 #endif
@@ -1870,6 +1882,8 @@ static inline std::string toString(const StringEnumPropsNativeComponentAlignment
     case StringEnumPropsNativeComponentAlignment::Top: return \\"top\\";
     case StringEnumPropsNativeComponentAlignment::Center: return \\"center\\";
     case StringEnumPropsNativeComponentAlignment::BottomRight: return \\"bottom-right\\";
+    default:
+      abort();
   }
 }
 


### PR DESCRIPTION
Summary: Changelog: [iOS] [Fixed] - Fix undefined behavior for values outside of enum range in generated `switch` methods in Objective-C.

Differential Revision: D87282978


