### PR TITLE
enable render debug strings to opt mode

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/debug/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/debug/CMakeLists.txt
@@ -15,3 +15,10 @@ target_include_directories(react_renderer_debug PUBLIC ${REACT_COMMON_DIR})
 target_link_libraries(react_renderer_debug folly_runtime react_debug)
 target_compile_reactnative_options(react_renderer_debug PRIVATE)
 target_compile_options(react_renderer_debug PRIVATE -Wpedantic)
+
+# Enable debug string convertible for Debug builds or when explicitly requested
+# This allows getRenderedOutput() to include props in tests
+# Set RN_ENABLE_DEBUG_STRING_CONVERTIBLE=ON to enable for Release builds
+if(${CMAKE_BUILD_TYPE} MATCHES Debug OR RN_ENABLE_DEBUG_STRING_CONVERTIBLE)
+  target_compile_definitions(react_renderer_debug PUBLIC RN_ENABLE_DEBUG_STRING_CONVERTIBLE)
+endif()

--- a/packages/react-native/ReactCommon/react/renderer/debug/flags.h
+++ b/packages/react-native/ReactCommon/react/renderer/debug/flags.h
@@ -29,8 +29,9 @@
 // #define RN_SHADOW_TREE_INTROSPECTION 1
 
 // This enables certain object-to-string debug conversions to be compiled.
-// Enable if `REACT_NATIVE_DEBUG` is enabled.
-#ifdef REACT_NATIVE_DEBUG
+// Enable if either `REACT_NATIVE_DEBUG` or `RN_ENABLE_DEBUG_STRING_CONVERTIBLE`
+// is defined
+#if defined(REACT_NATIVE_DEBUG) || defined(RN_ENABLE_DEBUG_STRING_CONVERTIBLE)
 #define RN_DEBUG_STRING_CONVERTIBLE 1
 #else
 #define RN_DEBUG_STRING_CONVERTIBLE 0

--- a/private/react-native-fantom/build.gradle.kts
+++ b/private/react-native-fantom/build.gradle.kts
@@ -188,6 +188,7 @@ val configureFantomTester by
               "-DREACT_COMMON_DIR=$reactNativeDir/ReactCommon",
               "-DREACT_CXX_PLATFORM_DIR=$reactNativeDir/ReactCxxPlatform",
               "-DREACT_THIRD_PARTY_NDK_DIR=$reactAndroidBuildDir/third-party-ndk",
+              "-DRN_ENABLE_DEBUG_STRING_CONVERTIBLE=ON",
           )
       commandLine(cmdArgs)
       standardOutputFile.set(project.file("$buildDir/reports/configure-fantom_tester.log"))


### PR DESCRIPTION
Summary:
Changelog: [Internal]
This helps us test with opt mode enabled as its the only one available for coverage.

Differential Revision: D87346884


