### PR TITLE
Fix crash by implementing scrollViewDidScroll in RCTEnhancedScrollView

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTEnhancedScrollView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTEnhancedScrollView.mm
@@ -156,6 +156,12 @@
 
 #pragma mark - UIScrollViewDelegate
 
+- (void)scrollViewDidScroll:(__unused UIScrollView *)scrollView
+{
+  // Empty implementation. This method exists to prevent crashes when the delegate splitter
+  // forwards scrollViewDidScroll: messages to RCTEnhancedScrollView.
+}
+
 - (void)scrollViewWillEndDragging:(UIScrollView *)scrollView
                      withVelocity:(CGPoint)velocity
               targetContentOffset:(inout CGPoint *)targetContentOffset


### PR DESCRIPTION
Summary:
Fix crash by implementing the missing `scrollViewDidScroll:` method in `RCTEnhancedScrollView`.

## Root Cause

`RCTEnhancedScrollView` conforms to `UIScrollViewDelegate` and adds itself as a delegate to its delegate splitter, but only implements two delegate methods:
- `scrollViewWillEndDragging:withVelocity:targetContentOffset:`
- `scrollViewDidZoom:`

It was missing `scrollViewDidScroll:`, which is the most commonly called delegate method. When the splitter has multiple delegates, it sets itself as the UIScrollView's delegate and forwards messages to all registered delegates. When `UIScrollView` calls `scrollViewDidScroll:` on the splitter, the splitter attempts to forward it to `RCTEnhancedScrollView`, which doesn't implement it → crash: "unrecognized selector sent to instance".

## Solution

Implement an empty `scrollViewDidScroll:` method in `RCTEnhancedScrollView`.

## Changelog:
[iOS][Fixed] - Fix crash in RCTEnhancedScrollView when scrollViewDidScroll is called

Reviewed By: cipolleschi

Differential Revision: D86813725


