### PR TITLE
Remove unimplemented

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
@@ -326,11 +326,6 @@ class JSINSPECTOR_EXPORT HostTarget : public EnableExecutorFromThis<HostTarget> 
    */
   void emitTraceRecordingForFirstFuseboxClient(tracing::TraceRecordingState traceRecording) const;
 
-  /**
-   * Emits a system state changed event to all active sessions.
-   */
-  void emitSystemStateChanged(bool isSingleHost) const;
-
  private:
   /**
    * Constructs a new HostTarget.


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

There is no implementation for this method and it is unused. This is actually part of `HostAgent`.

Differential Revision: D87220192


