### PR TITLE
Introduce BooleanLiteralTypeAnnotation

### DIFF
--- a/packages/react-native-codegen/src/CodegenSchema.d.ts
+++ b/packages/react-native-codegen/src/CodegenSchema.d.ts
@@ -46,6 +46,11 @@ export interface VoidTypeAnnotation {
   readonly type: 'VoidTypeAnnotation';
 }
 
+export interface BooleanLiteralTypeAnnotation {
+  readonly type: 'BooleanLiteralTypeAnnotation';
+  readonly value: boolean;
+}
+
 export interface ObjectTypeAnnotation<T> {
   readonly type: 'ObjectTypeAnnotation';
   readonly properties: readonly NamedShape<T>[];
@@ -399,6 +404,7 @@ export type NativeModuleEventEmitterBaseTypeAnnotation =
   | NativeModuleInt32TypeAnnotation
   | NativeModuleNumberTypeAnnotation
   | NumberLiteralTypeAnnotation
+  | BooleanLiteralTypeAnnotation
   | NativeModuleStringTypeAnnotation
   | StringLiteralTypeAnnotation
   | StringLiteralUnionTypeAnnotation
@@ -416,6 +422,7 @@ export type NativeModuleBaseTypeAnnotation =
   | StringLiteralUnionTypeAnnotation
   | NativeModuleNumberTypeAnnotation
   | NumberLiteralTypeAnnotation
+  | BooleanLiteralTypeAnnotation
   | NativeModuleInt32TypeAnnotation
   | NativeModuleDoubleTypeAnnotation
   | NativeModuleFloatTypeAnnotation

--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -56,6 +56,11 @@ export type StringLiteralTypeAnnotation = $ReadOnly<{
   value: string,
 }>;
 
+export type BooleanLiteralTypeAnnotation = $ReadOnly<{
+  type: 'BooleanLiteralTypeAnnotation',
+  value: boolean,
+}>;
+
 export type StringLiteralUnionTypeAnnotation = $ReadOnly<{
   type: 'StringLiteralUnionTypeAnnotation',
   types: $ReadOnlyArray<StringLiteralTypeAnnotation>,
@@ -388,6 +393,7 @@ type NativeModuleEventEmitterBaseTypeAnnotation =
   | Int32TypeAnnotation
   | NativeModuleNumberTypeAnnotation
   | NumberLiteralTypeAnnotation
+  | BooleanLiteralTypeAnnotation
   | StringTypeAnnotation
   | StringLiteralTypeAnnotation
   | StringLiteralUnionTypeAnnotation
@@ -405,6 +411,7 @@ export type NativeModuleBaseTypeAnnotation =
   | StringLiteralUnionTypeAnnotation
   | NativeModuleNumberTypeAnnotation
   | NumberLiteralTypeAnnotation
+  | BooleanLiteralTypeAnnotation
   | Int32TypeAnnotation
   | DoubleTypeAnnotation
   | FloatTypeAnnotation

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
@@ -96,6 +96,8 @@ function serializeArg(
       return wrap(val => `${val}.asString(rt)`);
     case 'BooleanTypeAnnotation':
       return wrap(val => `${val}.asBool()`);
+    case 'BooleanLiteralTypeAnnotation':
+      return wrap(val => `${val}.asBool()`);
     case 'EnumDeclaration':
       switch (realTypeAnnotation.memberType) {
         case 'NumberTypeAnnotation':
@@ -264,6 +266,8 @@ function translatePrimitiveJSTypeToCpp(
     case 'Int32TypeAnnotation':
       return wrapOptional('int', isRequired);
     case 'BooleanTypeAnnotation':
+      return wrapOptional('bool', isRequired);
+    case 'BooleanLiteralTypeAnnotation':
       return wrapOptional('bool', isRequired);
     case 'EnumDeclaration':
       switch (realTypeAnnotation.memberType) {

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleJavaSpec.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleJavaSpec.js
@@ -142,6 +142,7 @@ function translateEventEmitterTypeToJavaType(
     case 'Int32TypeAnnotation':
       return 'double';
     case 'BooleanTypeAnnotation':
+    case 'BooleanLiteralTypeAnnotation':
       return 'boolean';
     case 'GenericObjectTypeAnnotation':
     case 'ObjectTypeAnnotation':
@@ -213,6 +214,8 @@ function translateFunctionParamToJavaType(
     case 'Int32TypeAnnotation':
       return wrapOptional('double', isRequired);
     case 'BooleanTypeAnnotation':
+      return wrapOptional('boolean', isRequired);
+    case 'BooleanLiteralTypeAnnotation':
       return wrapOptional('boolean', isRequired);
     case 'EnumDeclaration':
       switch (realTypeAnnotation.memberType) {
@@ -310,6 +313,8 @@ function translateFunctionReturnTypeToJavaType(
       return wrapOptional('double', isRequired);
     case 'BooleanTypeAnnotation':
       return wrapOptional('boolean', isRequired);
+    case 'BooleanLiteralTypeAnnotation':
+      return wrapOptional('boolean', isRequired);
     case 'EnumDeclaration':
       switch (realTypeAnnotation.memberType) {
         case 'NumberTypeAnnotation':
@@ -387,6 +392,8 @@ function getFalsyReturnStatementFromReturnType(
     case 'Int32TypeAnnotation':
       return nullable ? 'return null;' : 'return 0;';
     case 'BooleanTypeAnnotation':
+      return nullable ? 'return null;' : 'return false;';
+    case 'BooleanLiteralTypeAnnotation':
       return nullable ? 'return null;' : 'return false;';
     case 'EnumDeclaration':
       switch (realTypeAnnotation.memberType) {

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleJniCpp.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleJniCpp.js
@@ -171,6 +171,8 @@ function translateReturnTypeToKind(
       return 'StringKind';
     case 'BooleanTypeAnnotation':
       return 'BooleanKind';
+    case 'BooleanLiteralTypeAnnotation':
+      return 'BooleanKind';
     case 'EnumDeclaration':
       switch (typeAnnotation.memberType) {
         case 'NumberTypeAnnotation':
@@ -256,6 +258,8 @@ function translateParamTypeToJniType(
       return 'Ljava/lang/String;';
     case 'BooleanTypeAnnotation':
       return !isRequired ? 'Ljava/lang/Boolean;' : 'Z';
+    case 'BooleanLiteralTypeAnnotation':
+      return !isRequired ? 'Ljava/lang/Boolean;' : 'Z';
     case 'EnumDeclaration':
       switch (typeAnnotation.memberType) {
         case 'NumberTypeAnnotation':
@@ -337,6 +341,8 @@ function translateReturnTypeToJniType(
     case 'StringLiteralUnionTypeAnnotation':
       return 'Ljava/lang/String;';
     case 'BooleanTypeAnnotation':
+      return nullable ? 'Ljava/lang/Boolean;' : 'Z';
+    case 'BooleanLiteralTypeAnnotation':
       return nullable ? 'Ljava/lang/Boolean;' : 'Z';
     case 'EnumDeclaration':
       switch (typeAnnotation.memberType) {

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/StructCollector.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/StructCollector.js
@@ -11,6 +11,7 @@
 'use strict';
 
 import type {
+  BooleanLiteralTypeAnnotation,
   BooleanTypeAnnotation,
   DoubleTypeAnnotation,
   FloatTypeAnnotation,
@@ -65,6 +66,7 @@ export type StructTypeAnnotation =
   | StringLiteralUnionTypeAnnotation
   | NativeModuleNumberTypeAnnotation
   | NumberLiteralTypeAnnotation
+  | BooleanLiteralTypeAnnotation
   | Int32TypeAnnotation
   | DoubleTypeAnnotation
   | FloatTypeAnnotation

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/header/serializeConstantsStruct.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/header/serializeConstantsStruct.js
@@ -110,6 +110,8 @@ function toObjCType(
       return wrapCxxOptional('double', isRequired);
     case 'BooleanTypeAnnotation':
       return wrapCxxOptional('bool', isRequired);
+    case 'BooleanLiteralTypeAnnotation':
+      return wrapCxxOptional('bool', isRequired);
     case 'EnumDeclaration':
       switch (typeAnnotation.memberType) {
         case 'NumberTypeAnnotation':
@@ -194,6 +196,8 @@ function toObjCValue(
     case 'DoubleTypeAnnotation':
       return wrapPrimitive('double');
     case 'BooleanTypeAnnotation':
+      return wrapPrimitive('BOOL');
+    case 'BooleanLiteralTypeAnnotation':
       return wrapPrimitive('BOOL');
     case 'EnumDeclaration':
       switch (typeAnnotation.memberType) {

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/header/serializeRegularStruct.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/header/serializeRegularStruct.js
@@ -101,6 +101,8 @@ function toObjCType(
       return wrapCxxOptional('double', isRequired);
     case 'BooleanTypeAnnotation':
       return wrapCxxOptional('bool', isRequired);
+    case 'BooleanLiteralTypeAnnotation':
+      return wrapCxxOptional('bool', isRequired);
     case 'EnumDeclaration':
       switch (typeAnnotation.memberType) {
         case 'NumberTypeAnnotation':
@@ -184,6 +186,8 @@ function toObjCValue(
     case 'DoubleTypeAnnotation':
       return RCTBridgingTo('Double');
     case 'BooleanTypeAnnotation':
+      return RCTBridgingTo('Bool');
+    case 'BooleanLiteralTypeAnnotation':
       return RCTBridgingTo('Bool');
     case 'EnumDeclaration':
       switch (typeAnnotation.memberType) {

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/serializeEventEmitter.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/serializeEventEmitter.js
@@ -28,6 +28,7 @@ function getEventEmitterTypeObjCType(
     case 'NumberLiteralTypeAnnotation':
       return 'NSNumber *_Nonnull';
     case 'BooleanTypeAnnotation':
+    case 'BooleanLiteralTypeAnnotation':
       return 'BOOL';
     case 'GenericObjectTypeAnnotation':
     case 'ObjectTypeAnnotation':

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/serializeMethod.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/serializeMethod.js
@@ -273,6 +273,8 @@ function getParamObjCType(
       return notStruct(isRequired ? 'NSInteger' : 'NSNumber *');
     case 'BooleanTypeAnnotation':
       return notStruct(isRequired ? 'BOOL' : 'NSNumber *');
+    case 'BooleanLiteralTypeAnnotation':
+      return notStruct(isRequired ? 'BOOL' : 'NSNumber *');
     case 'EnumDeclaration':
       switch (typeAnnotation.memberType) {
         case 'NumberTypeAnnotation':
@@ -356,6 +358,8 @@ function getReturnObjCType(
       return wrapOptional('NSNumber *', isRequired);
     case 'BooleanTypeAnnotation':
       return wrapOptional('NSNumber *', isRequired);
+    case 'BooleanLiteralTypeAnnotation':
+      return wrapOptional('NSNumber *', isRequired);
     case 'EnumDeclaration':
       switch (typeAnnotation.memberType) {
         case 'NumberTypeAnnotation':
@@ -427,6 +431,8 @@ function getReturnJSType(
     case 'Int32TypeAnnotation':
       return 'NumberKind';
     case 'BooleanTypeAnnotation':
+      return 'BooleanKind';
+    case 'BooleanLiteralTypeAnnotation':
       return 'BooleanKind';
     case 'GenericObjectTypeAnnotation':
       return 'ObjectKind';

--- a/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__test_fixtures__/fixtures.js
@@ -126,6 +126,7 @@ import * as TurboModuleRegistry from '../TurboModuleRegistry';
 export interface Spec extends TurboModule {
   +passBool?: (arg: boolean) => void;
   +passNumber: (arg: number) => void;
+  +passBooleanLiteral: (arg: true) => void;
   +passNumberLiteral: (arg: 4) => void;
   +passString: (arg: string) => void;
   +passStringish: (arg: Stringish) => void;

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/__snapshots__/module-parser-snapshot-test.js.snap
@@ -1253,6 +1253,26 @@ exports[`RN Codegen Flow Parser can generate fixture NATIVE_MODULE_WITH_BASIC_PA
             }
           },
           {
+            'name': 'passBooleanLiteral',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'VoidTypeAnnotation'
+              },
+              'params': [
+                {
+                  'name': 'arg',
+                  'optional': false,
+                  'typeAnnotation': {
+                    'type': 'BooleanLiteralTypeAnnotation',
+                    'value': true
+                  }
+                }
+              ]
+            }
+          },
+          {
             'name': 'passNumberLiteral',
             'optional': false,
             'typeAnnotation': {

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -35,6 +35,7 @@ const {
 } = require('../../parsers-commons');
 const {
   emitArrayType,
+  emitBooleanLiteral,
   emitCommonTypes,
   emitDictionary,
   emitFunction,
@@ -248,6 +249,9 @@ function translateTypeAnnotation(
     }
     case 'NumberLiteralTypeAnnotation': {
       return emitNumberLiteral(nullable, typeAnnotation.value);
+    }
+    case 'BooleanLiteralTypeAnnotation': {
+      return emitBooleanLiteral(nullable, typeAnnotation.value);
     }
     case 'StringLiteralTypeAnnotation': {
       return wrapNullable(nullable, {

--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -11,6 +11,7 @@
 'use strict';
 
 import type {
+  BooleanLiteralTypeAnnotation,
   BooleanTypeAnnotation,
   DoubleTypeAnnotation,
   EventTypeAnnotation,
@@ -177,6 +178,16 @@ function emitNumberLiteral(
 ): Nullable<NumberLiteralTypeAnnotation> {
   return wrapNullable(nullable, {
     type: 'NumberLiteralTypeAnnotation',
+    value,
+  });
+}
+
+function emitBooleanLiteral(
+  nullable: boolean,
+  value: boolean,
+): Nullable<BooleanLiteralTypeAnnotation> {
+  return wrapNullable(nullable, {
+    type: 'BooleanLiteralTypeAnnotation',
     value,
   });
 }
@@ -764,6 +775,7 @@ function emitUnionProp(
 module.exports = {
   emitArrayType,
   emitBoolean,
+  emitBooleanLiteral,
   emitBoolProp,
   emitDouble,
   emitDoubleProp,

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/fixtures.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__test_fixtures__/fixtures.js
@@ -113,6 +113,7 @@ import * as TurboModuleRegistry from '../TurboModuleRegistry';
 export interface Spec extends TurboModule {
   readonly passBool?: (arg: boolean) => void;
   readonly passNumber: (arg: number) => void;
+  readonly passBooleanLiteral: (arg: true) => void;
   readonly passNumberLiteral: (arg: 4) => void;
   readonly passString: (arg: string) => void;
   readonly passStringish: (arg: Stringish) => void;

--- a/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/__tests__/__snapshots__/typescript-module-parser-snapshot-test.js.snap
@@ -1394,6 +1394,26 @@ exports[`RN Codegen TypeScript Parser can generate fixture NATIVE_MODULE_WITH_BA
             }
           },
           {
+            'name': 'passBooleanLiteral',
+            'optional': false,
+            'typeAnnotation': {
+              'type': 'FunctionTypeAnnotation',
+              'returnTypeAnnotation': {
+                'type': 'VoidTypeAnnotation'
+              },
+              'params': [
+                {
+                  'name': 'arg',
+                  'optional': false,
+                  'typeAnnotation': {
+                    'type': 'BooleanLiteralTypeAnnotation',
+                    'value': true
+                  }
+                }
+              ]
+            }
+          },
+          {
             'name': 'passNumberLiteral',
             'optional': false,
             'typeAnnotation': {

--- a/packages/react-native-codegen/src/parsers/typescript/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/typescript/modules/index.js
@@ -34,6 +34,7 @@ const {
 const {parseObjectProperty} = require('../../parsers-commons');
 const {
   emitArrayType,
+  emitBooleanLiteral,
   emitCommonTypes,
   emitDictionary,
   emitFunction,
@@ -408,6 +409,9 @@ function translateTypeAnnotation(
         }
         case 'NumericLiteral': {
           return emitNumberLiteral(nullable, literal.value);
+        }
+        case 'BooleanLiteral': {
+          return emitBooleanLiteral(nullable, literal.value);
         }
         default: {
           throw new UnsupportedTypeAnnotationParserError(

--- a/packages/react-native-compatibility-check/src/ErrorFormatting.js
+++ b/packages/react-native-compatibility-check/src/ErrorFormatting.js
@@ -173,6 +173,8 @@ function formatTypeAnnotation(annotation: CompleteTypeAnnotation): string {
       return 'int';
     case 'NumberLiteralTypeAnnotation':
       return annotation.value.toString();
+    case 'BooleanLiteralTypeAnnotation':
+      return annotation.value.toString();
     case 'ObjectTypeAnnotation':
       return (
         '{' +

--- a/packages/react-native-compatibility-check/src/SortTypeAnnotations.js
+++ b/packages/react-native-compatibility-check/src/SortTypeAnnotations.js
@@ -116,6 +116,9 @@ export function compareTypeAnnotationForSorting(
     case 'NumberLiteralTypeAnnotation':
       invariant(typeB.type === 'NumberLiteralTypeAnnotation', EQUALITY_MSG);
       return typeA.value - typeB.value;
+    case 'BooleanLiteralTypeAnnotation':
+      invariant(typeB.type === 'BooleanLiteralTypeAnnotation', EQUALITY_MSG);
+      return originalPositionA - originalPositionB;
     case 'ObjectTypeAnnotation':
       invariant(typeB.type === 'ObjectTypeAnnotation', EQUALITY_MSG);
       return compareNameAnnotationArraysForSorting(
@@ -261,6 +264,8 @@ function typeAnnotationArbitraryOrder(annotation: CompleteTypeAnnotation) {
       return 14;
     case 'ObjectTypeAnnotation':
       return 15;
+    case 'BooleanLiteralTypeAnnotation':
+      return 16;
     case 'StringLiteralUnionTypeAnnotation':
       return 17;
     case 'StringTypeAnnotation':

--- a/packages/react-native-compatibility-check/src/TypeDiffing.js
+++ b/packages/react-native-compatibility-check/src/TypeDiffing.js
@@ -17,6 +17,7 @@ import type {
   TypeComparisonError,
 } from './ComparisonResult';
 import type {
+  BooleanLiteralTypeAnnotation,
   CompleteReservedTypeAnnotation,
   CompleteTypeAnnotation,
   EventEmitterTypeAnnotation,
@@ -237,6 +238,12 @@ export function compareTypeAnnotation(
         EQUALITY_MSG,
       );
       return compareNumberLiteralTypes(newerAnnotation, olderAnnotation);
+    case 'BooleanLiteralTypeAnnotation':
+      invariant(
+        olderAnnotation.type === 'BooleanLiteralTypeAnnotation',
+        EQUALITY_MSG,
+      );
+      return compareBooleanLiteralTypes(newerAnnotation, olderAnnotation);
     case 'StringLiteralUnionTypeAnnotation':
       invariant(
         olderAnnotation.type === 'StringLiteralUnionTypeAnnotation',
@@ -901,6 +908,21 @@ export function compareStringLiteralTypes(
     : makeError(
         typeAnnotationComparisonError(
           'String literals are not equal',
+          newerType,
+          olderType,
+        ),
+      );
+}
+
+export function compareBooleanLiteralTypes(
+  newerType: BooleanLiteralTypeAnnotation,
+  olderType: BooleanLiteralTypeAnnotation,
+): ComparisonResult {
+  return newerType.value === olderType.value
+    ? {status: 'matching'}
+    : makeError(
+        typeAnnotationComparisonError(
+          'Boolean literals are not equal',
           newerType,
           olderType,
         ),

--- a/packages/react-native-compatibility-check/src/__tests__/TypeDiffing-test.js
+++ b/packages/react-native-compatibility-check/src/__tests__/TypeDiffing-test.js
@@ -905,6 +905,30 @@ describe('compareTypes on string literals', () => {
   });
 });
 
+describe('compareTypes on boolean literals', () => {
+  it('matches literals that are the same', () => {
+    expect(
+      compareTypes(
+        nativeTypeDiffingTypesMethodParamLookup('booleanLiteral0'),
+        nativeTypeDiffingTypesMethodParamLookup('booleanLiteral0'),
+        nativeTypeDiffingTypesAliases,
+        nativeTypeDiffingTypesAliases,
+      ).status,
+    ).toBe('matching');
+  });
+
+  it('fails on literals that are not the same', () => {
+    expect(
+      compareTypes(
+        nativeTypeDiffingTypesMethodParamLookup('booleanLiteral0'),
+        nativeTypeDiffingTypesMethodParamLookup('booleanLiteral1'),
+        nativeTypeDiffingTypesAliases,
+        nativeTypeDiffingTypesAliases,
+      ),
+    ).toHaveErrorWithMessage('Boolean literals are not equal');
+  });
+});
+
 describe('compareTypes on numeric literals', () => {
   it('matches literals that are the same', () => {
     expect(

--- a/packages/react-native-compatibility-check/src/__tests__/__fixtures__/native-module-type-diffing-types/NativeTypeDiffingTypes.js.flow
+++ b/packages/react-native-compatibility-check/src/__tests__/__fixtures__/native-module-type-diffing-types/NativeTypeDiffingTypes.js.flow
@@ -17,6 +17,9 @@ import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboMo
 type StringLiteral0 = 'foo';
 type StringLiteral1 = 'bar';
 
+type BooleanLiteral0 = true;
+type BooleanLiteral1 = false;
+
 type NumericLiteral0 = 1;
 type NumericLiteral1 = 2;
 
@@ -169,6 +172,9 @@ enum EnumUnsorted {
 export interface Spec extends TurboModule {
   +stringLiteral0: (a: StringLiteral0) => void;
   +stringLiteral1: (a: StringLiteral1) => void;
+
+  +booleanLiteral0: (a: BooleanLiteral0) => void;
+  +booleanLiteral1: (a: BooleanLiteral1) => void;
 
   +numericLiteral0: (a: NumericLiteral0) => void;
   +numericLiteral1: (a: NumericLiteral1) => void;


### PR DESCRIPTION
Summary:
Introduce `BooleanLiteralTypeAnnotation` in Flow & TypeScript to match the existing `StringLiteralTypeAnnotation` & `NumberLiteralTypeAnnotation` since Unions will be supporting Booleans along with String & Number

Changelog: [Internal]

Differential Revision: D87384473


