### PR TITLE
Modifying the Parser logic to handle Unions of different types and remove the special handling of StringLiteralUnionType

### DIFF
--- a/packages/react-native-codegen/src/CodegenSchema.d.ts
+++ b/packages/react-native-codegen/src/CodegenSchema.d.ts
@@ -340,6 +340,12 @@ export interface StringLiteralUnionTypeAnnotation {
   readonly types: NativeModuleStringLiteralTypeAnnotation[];
 }
 
+export type NumberLiteralUnionTypeAnnotation =
+  UnionTypeAnnotation<NumberLiteralTypeAnnotation>;
+
+export type BooleanLiteralUnionTypeAnnotation =
+  UnionTypeAnnotation<BooleanLiteralTypeAnnotation>;
+
 export interface NativeModuleNumberTypeAnnotation {
   readonly type: 'NumberTypeAnnotation';
 }

--- a/packages/react-native-codegen/src/CodegenSchema.d.ts
+++ b/packages/react-native-codegen/src/CodegenSchema.d.ts
@@ -56,6 +56,11 @@ export interface StringLiteralTypeAnnotation {
   readonly value: string;
 }
 
+export interface BooleanLiteralTypeAnnotation {
+  readonly type: 'BooleanLiteralTypeAnnotation';
+  readonly value: boolean;
+}
+
 export interface ObjectTypeAnnotation<T> {
   readonly type: 'ObjectTypeAnnotation';
   readonly properties: readonly NamedShape<T>[];

--- a/packages/react-native-codegen/src/CodegenSchema.d.ts
+++ b/packages/react-native-codegen/src/CodegenSchema.d.ts
@@ -335,10 +335,8 @@ export interface NativeModuleStringLiteralTypeAnnotation {
   readonly value: string;
 }
 
-export interface StringLiteralUnionTypeAnnotation {
-  readonly type: 'StringLiteralUnionTypeAnnotation';
-  readonly types: NativeModuleStringLiteralTypeAnnotation[];
-}
+export type StringLiteralUnionTypeAnnotation =
+  UnionTypeAnnotation<StringLiteralTypeAnnotation>;
 
 export type NumberLiteralUnionTypeAnnotation =
   UnionTypeAnnotation<NumberLiteralTypeAnnotation>;

--- a/packages/react-native-codegen/src/CodegenSchema.d.ts
+++ b/packages/react-native-codegen/src/CodegenSchema.d.ts
@@ -405,6 +405,15 @@ export type UnionTypeAnnotationMemberType =
   | 'ObjectTypeAnnotation'
   | 'StringTypeAnnotation';
 
+export type NativeModuleUnionTypeAnnotationMemberType =
+  | NativeModuleObjectTypeAnnotation
+  | StringLiteralTypeAnnotation
+  | NumberLiteralTypeAnnotation
+  | BooleanLiteralTypeAnnotation
+  | BooleanTypeAnnotation
+  | StringTypeAnnotation
+  | NumberTypeAnnotation;
+
 export interface NativeModuleUnionTypeAnnotation {
   readonly type: 'UnionTypeAnnotation';
   readonly memberType: UnionTypeAnnotationMemberType;

--- a/packages/react-native-codegen/src/CodegenSchema.d.ts
+++ b/packages/react-native-codegen/src/CodegenSchema.d.ts
@@ -68,6 +68,13 @@ export interface UnionTypeAnnotation<T> {
   readonly types: readonly T[];
 }
 
+// TODO(T72031674): TupleTypeAnnotation is added for parity with UnionTypeAnnotation
+// to support future implementation. Currently limited to String and Number literals.
+export interface TupleTypeAnnotation {
+  readonly type: 'TupleTypeAnnotation';
+  readonly types: StringLiteralTypeAnnotation | NumberLiteralTypeAnnotation;
+}
+
 export interface MixedTypeAnnotation {
   readonly type: 'MixedTypeAnnotation';
 }

--- a/packages/react-native-codegen/src/CodegenSchema.d.ts
+++ b/packages/react-native-codegen/src/CodegenSchema.d.ts
@@ -406,11 +406,6 @@ export interface NativeModulePromiseTypeAnnotation {
   readonly elementType: Nullable<NativeModuleBaseTypeAnnotation> | VoidTypeAnnotation;
 }
 
-export type UnionTypeAnnotationMemberType =
-  | 'NumberTypeAnnotation'
-  | 'ObjectTypeAnnotation'
-  | 'StringTypeAnnotation';
-
 export type NativeModuleUnionTypeAnnotationMemberType =
   | NativeModuleObjectTypeAnnotation
   | StringLiteralTypeAnnotation
@@ -420,10 +415,8 @@ export type NativeModuleUnionTypeAnnotationMemberType =
   | StringTypeAnnotation
   | NumberTypeAnnotation;
 
-export interface NativeModuleUnionTypeAnnotation {
-  readonly type: 'UnionTypeAnnotation';
-  readonly memberType: UnionTypeAnnotationMemberType;
-}
+export type NativeModuleUnionTypeAnnotation =
+  UnionTypeAnnotation<NativeModuleUnionTypeAnnotationMemberType>;
 
 export interface NativeModuleMixedTypeAnnotation {
   readonly type: 'MixedTypeAnnotation';

--- a/packages/react-native-codegen/src/CodegenSchema.d.ts
+++ b/packages/react-native-codegen/src/CodegenSchema.d.ts
@@ -46,6 +46,16 @@ export interface VoidTypeAnnotation {
   readonly type: 'VoidTypeAnnotation';
 }
 
+export interface NumberLiteralTypeAnnotation {
+  readonly type: 'NumberLiteralTypeAnnotation';
+  readonly value: number;
+}
+
+export interface StringLiteralTypeAnnotation {
+  readonly type: 'StringLiteralTypeAnnotation';
+  readonly value: string;
+}
+
 export interface ObjectTypeAnnotation<T> {
   readonly type: 'ObjectTypeAnnotation';
   readonly properties: readonly NamedShape<T>[];

--- a/packages/react-native-codegen/src/CodegenSchema.d.ts
+++ b/packages/react-native-codegen/src/CodegenSchema.d.ts
@@ -26,6 +26,10 @@ export interface FloatTypeAnnotation {
   readonly type: 'FloatTypeAnnotation';
 }
 
+export interface NumberTypeAnnotation {
+  readonly type: 'NumberTypeAnnotation';
+}
+
 export interface BooleanTypeAnnotation {
   readonly type: 'BooleanTypeAnnotation';
 }

--- a/packages/react-native-codegen/src/CodegenSchema.d.ts
+++ b/packages/react-native-codegen/src/CodegenSchema.d.ts
@@ -53,6 +53,11 @@ export interface ObjectTypeAnnotation<T> {
   readonly baseTypes?: readonly string[] | undefined;
 }
 
+export interface UnionTypeAnnotation<T> {
+  readonly type: 'UnionTypeAnnotation';
+  readonly types: readonly T[];
+}
+
 export interface MixedTypeAnnotation {
   readonly type: 'MixedTypeAnnotation';
 }

--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -384,6 +384,15 @@ export type UnionTypeAnnotationMemberType =
   | 'ObjectTypeAnnotation'
   | 'StringTypeAnnotation';
 
+export type NativeModuleUnionTypeAnnotationMemberType =
+  | NativeModuleObjectTypeAnnotation
+  | StringLiteralTypeAnnotation
+  | NumberLiteralTypeAnnotation
+  | BooleanLiteralTypeAnnotation
+  | BooleanTypeAnnotation
+  | StringTypeAnnotation
+  | NumberTypeAnnotation;
+
 export type NativeModuleUnionTypeAnnotation = $ReadOnly<{
   type: 'UnionTypeAnnotation',
   memberType: UnionTypeAnnotationMemberType,

--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -432,6 +432,7 @@ export type NativeModuleBaseTypeAnnotation =
   | StringLiteralUnionTypeAnnotation
   | NativeModuleNumberTypeAnnotation
   | NumberLiteralTypeAnnotation
+  | BooleanLiteralTypeAnnotation
   | Int32TypeAnnotation
   | DoubleTypeAnnotation
   | FloatTypeAnnotation

--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -72,6 +72,11 @@ export type ObjectTypeAnnotation<+T> = $ReadOnly<{
   baseTypes?: $ReadOnlyArray<string>,
 }>;
 
+export type UnionTypeAnnotation<+T> = $ReadOnly<{
+  type: 'UnionTypeAnnotation',
+  types: $ReadOnlyArray<T>,
+}>;
+
 export type MixedTypeAnnotation = $ReadOnly<{
   type: 'MixedTypeAnnotation',
 }>;

--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -66,6 +66,12 @@ export type StringLiteralUnionTypeAnnotation = $ReadOnly<{
   types: $ReadOnlyArray<StringLiteralTypeAnnotation>,
 }>;
 
+export type NumberLiteralUnionTypeAnnotation =
+  UnionTypeAnnotation<NumberLiteralTypeAnnotation>;
+
+export type BooleanLiteralUnionTypeAnnotation =
+  UnionTypeAnnotation<BooleanLiteralTypeAnnotation>;
+
 export type VoidTypeAnnotation = $ReadOnly<{
   type: 'VoidTypeAnnotation',
 }>;

--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -56,6 +56,11 @@ export type StringLiteralTypeAnnotation = $ReadOnly<{
   value: string,
 }>;
 
+export type BooleanLiteralTypeAnnotation = $ReadOnly<{
+  type: 'BooleanLiteralTypeAnnotation',
+  value: boolean,
+}>;
+
 export type StringLiteralUnionTypeAnnotation = $ReadOnly<{
   type: 'StringLiteralUnionTypeAnnotation',
   types: $ReadOnlyArray<StringLiteralTypeAnnotation>,

--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -61,10 +61,8 @@ export type BooleanLiteralTypeAnnotation = $ReadOnly<{
   value: boolean,
 }>;
 
-export type StringLiteralUnionTypeAnnotation = $ReadOnly<{
-  type: 'StringLiteralUnionTypeAnnotation',
-  types: $ReadOnlyArray<StringLiteralTypeAnnotation>,
-}>;
+export type StringLiteralUnionTypeAnnotation =
+  UnionTypeAnnotation<StringLiteralTypeAnnotation>;
 
 export type NumberLiteralUnionTypeAnnotation =
   UnionTypeAnnotation<NumberLiteralTypeAnnotation>;

--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -77,6 +77,13 @@ export type UnionTypeAnnotation<+T> = $ReadOnly<{
   types: $ReadOnlyArray<T>,
 }>;
 
+// TODO(T72031674): TupleTypeAnnotation is added for parity with UnionTypeAnnotation
+// to support future implementation. Currently limited to String and Number literals.
+export type TupleTypeAnnotation = $ReadOnly<{
+  type: 'TupleTypeAnnotation',
+  types: StringLiteralTypeAnnotation | NumberLiteralTypeAnnotation,
+}>;
+
 export type MixedTypeAnnotation = $ReadOnly<{
   type: 'MixedTypeAnnotation',
 }>;

--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -385,11 +385,6 @@ export type NativeModulePromiseTypeAnnotation = $ReadOnly<{
   elementType: VoidTypeAnnotation | Nullable<NativeModuleBaseTypeAnnotation>,
 }>;
 
-export type UnionTypeAnnotationMemberType =
-  | 'NumberTypeAnnotation'
-  | 'ObjectTypeAnnotation'
-  | 'StringTypeAnnotation';
-
 export type NativeModuleUnionTypeAnnotationMemberType =
   | NativeModuleObjectTypeAnnotation
   | StringLiteralTypeAnnotation
@@ -399,10 +394,8 @@ export type NativeModuleUnionTypeAnnotationMemberType =
   | StringTypeAnnotation
   | NumberTypeAnnotation;
 
-export type NativeModuleUnionTypeAnnotation = $ReadOnly<{
-  type: 'UnionTypeAnnotation',
-  memberType: UnionTypeAnnotationMemberType,
-}>;
+export type NativeModuleUnionTypeAnnotation =
+  UnionTypeAnnotation<NativeModuleUnionTypeAnnotationMemberType>;
 
 export type NativeModuleMixedTypeAnnotation = $ReadOnly<{
   type: 'MixedTypeAnnotation',

--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -30,6 +30,10 @@ export type FloatTypeAnnotation = $ReadOnly<{
   type: 'FloatTypeAnnotation',
 }>;
 
+export type NumberTypeAnnotation = $ReadOnly<{
+  type: 'NumberTypeAnnotation',
+}>;
+
 export type BooleanTypeAnnotation = $ReadOnly<{
   type: 'BooleanTypeAnnotation',
 }>;

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/StructCollector.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/StructCollector.js
@@ -11,6 +11,7 @@
 'use strict';
 
 import type {
+  BooleanLiteralTypeAnnotation,
   BooleanTypeAnnotation,
   DoubleTypeAnnotation,
   FloatTypeAnnotation,
@@ -65,6 +66,7 @@ export type StructTypeAnnotation =
   | StringLiteralUnionTypeAnnotation
   | NativeModuleNumberTypeAnnotation
   | NumberLiteralTypeAnnotation
+  | BooleanLiteralTypeAnnotation
   | Int32TypeAnnotation
   | DoubleTypeAnnotation
   | FloatTypeAnnotation

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -18,10 +18,10 @@ import type {
   NativeModuleEnumMember,
   NativeModuleEnumMemberType,
   NativeModuleParamTypeAnnotation,
+  NativeModuleUnionTypeAnnotationMemberType,
   Nullable,
   PropTypeAnnotation,
   SchemaType,
-  UnionTypeAnnotationMemberType,
 } from '../CodegenSchema';
 import type {ParserType} from './errors';
 import type {
@@ -146,15 +146,7 @@ export interface Parser {
    */
   remapUnionTypeAnnotationMemberNames(
     types: $FlowFixMe,
-  ): UnionTypeAnnotationMemberType[];
-  /**
-   * Given a union annotation members types, it returns an array of string literals.
-   * @parameter membersTypes: union annotation members types
-   * @returns: an array of string literals.
-   */
-  getStringLiteralUnionTypeAnnotationStringLiterals(
-    types: $FlowFixMe,
-  ): string[];
+  ): NativeModuleUnionTypeAnnotationMemberType[];
   /**
    * Given the name of a file, it returns a Schema.
    * @parameter filename: the name of the file.

--- a/packages/react-native-codegen/src/parsers/parserMock.js
+++ b/packages/react-native-codegen/src/parsers/parserMock.js
@@ -18,10 +18,10 @@ import type {
   NativeModuleEnumMember,
   NativeModuleEnumMemberType,
   NativeModuleParamTypeAnnotation,
+  NativeModuleUnionTypeAnnotationMemberType,
   Nullable,
   PropTypeAnnotation,
   SchemaType,
-  UnionTypeAnnotationMemberType,
 } from '../CodegenSchema';
 import type {ParserType} from './errors';
 import type {
@@ -105,13 +105,7 @@ export class MockedParser implements Parser {
 
   remapUnionTypeAnnotationMemberNames(
     membersTypes: $FlowFixMe[],
-  ): UnionTypeAnnotationMemberType[] {
-    return [];
-  }
-
-  getStringLiteralUnionTypeAnnotationStringLiterals(
-    membersTypes: $FlowFixMe[],
-  ): string[] {
+  ): NativeModuleUnionTypeAnnotationMemberType[] {
     return [];
   }
 


### PR DESCRIPTION
Summary:
- Getting rid of emitStringLiteralUnion logic in parser
- Modifying the emitUnion logic in parser

Changelog: [Internal]

Differential Revision: D87412493


