### PR TITLE
Extract cloneProp in animation backend

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedProps.h
@@ -33,8 +33,43 @@ T get(const std::unique_ptr<AnimatedPropBase> &animatedProp)
   return static_cast<AnimatedProp<T> *>(animatedProp.get())->value;
 }
 
+template <typename T>
+T get(const AnimatedPropBase &animatedProp)
+{
+  return static_cast<const AnimatedProp<T> &>(animatedProp).value;
+}
+
 struct AnimatedProps {
   std::vector<std::unique_ptr<AnimatedPropBase>> props;
   std::unique_ptr<RawProps> rawProps;
 };
+
+inline void cloneProp(BaseViewProps &viewProps, const AnimatedPropBase &animatedProp)
+{
+  switch (animatedProp.propName) {
+    case OPACITY:
+      viewProps.opacity = get<Float>(animatedProp);
+      break;
+
+    case WIDTH:
+      viewProps.yogaStyle.setDimension(yoga::Dimension::Width, get<yoga::Style::SizeLength>(animatedProp));
+      break;
+
+    case HEIGHT:
+      viewProps.yogaStyle.setDimension(yoga::Dimension::Height, get<yoga::Style::SizeLength>(animatedProp));
+      break;
+
+    case BORDER_RADII:
+      viewProps.borderRadii = get<CascadedBorderRadii>(animatedProp);
+      break;
+
+    case FLEX:
+      viewProps.yogaStyle.setFlex(get<yoga::FloatOptional>(animatedProp));
+      break;
+
+    case TRANSFORM:
+      viewProps.transform = get<Transform>(animatedProp);
+      break;
+  }
+}
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.cpp
@@ -41,34 +41,7 @@ static inline Props::Shared cloneProps(
   auto viewProps = std::const_pointer_cast<BaseViewProps>(
       std::static_pointer_cast<const BaseViewProps>(newProps));
   for (auto& animatedProp : animatedProps.props) {
-    switch (animatedProp->propName) {
-      case OPACITY:
-        viewProps->opacity = get<Float>(animatedProp);
-        break;
-
-      case WIDTH:
-        viewProps->yogaStyle.setDimension(
-            yoga::Dimension::Width, get<yoga::Style::SizeLength>(animatedProp));
-        break;
-
-      case HEIGHT:
-        viewProps->yogaStyle.setDimension(
-            yoga::Dimension::Height,
-            get<yoga::Style::SizeLength>(animatedProp));
-        break;
-
-      case BORDER_RADII:
-        viewProps->borderRadii = get<CascadedBorderRadii>(animatedProp);
-        break;
-
-      case FLEX:
-        viewProps->yogaStyle.setFlex(get<yoga::FloatOptional>(animatedProp));
-        break;
-
-      case TRANSFORM:
-        viewProps->transform = get<Transform>(animatedProp);
-        break;
-    }
+    cloneProp(*viewProps, *animatedProp);
   }
   return newProps;
 }


### PR DESCRIPTION
Summary:
This diff extracts the `cloneProp` helper from `AnimationBackend::cloneProps` so the logic can be reused

# Changelog
[General] [Changed] - Extracted `cloneProp` from `AnimationBackend.cpp` to `AnimatedProps.h`

Differential Revision: D86414627


