### PR TITLE
Pass families to Native Animated

### DIFF
--- a/packages/react-native/Libraries/NativeAnimation/RCTNativeAnimatedTurboModule.mm
+++ b/packages/react-native/Libraries/NativeAnimation/RCTNativeAnimatedTurboModule.mm
@@ -10,6 +10,7 @@
 #import <React/RCTInitializing.h>
 #import <React/RCTNativeAnimatedNodesManager.h>
 #import <React/RCTNativeAnimatedTurboModule.h>
+#import <react/debug/react_native_assert.h>
 #import <react/featureflags/ReactNativeFeatureFlags.h>
 
 #import "RCTAnimationPlugins.h"
@@ -163,6 +164,12 @@ RCT_EXPORT_METHOD(connectAnimatedNodeToView : (double)nodeTag viewTag : (double)
                                     viewTag:[NSNumber numberWithDouble:viewTag]
                                    viewName:nil];
   }];
+}
+
+RCT_EXPORT_METHOD(connectAnimatedNodeToShadowNodeFamily : (double)nodeTag shadowNode : (NSDictionary *)shadowNode)
+{
+  // This method should only be called when using CxxNativeAnimated
+  react_native_assert(false);
 }
 
 RCT_EXPORT_METHOD(disconnectAnimatedNodeFromView : (double)nodeTag viewTag : (double)viewTag)

--- a/packages/react-native/Libraries/NativeAnimation/React-RCTAnimation.podspec
+++ b/packages/react-native/Libraries/NativeAnimation/React-RCTAnimation.podspec
@@ -48,6 +48,7 @@ Pod::Spec.new do |s|
   add_dependency(s, "ReactCommon", :subspec => "turbomodule/core", :additional_framework_paths => ["react/nativemodule/core"])
   add_dependency(s, "React-NativeModulesApple")
   add_dependency(s, "React-featureflags")
+  add_dependency(s, "React-debug")
 
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)

--- a/packages/react-native/ReactCommon/react/renderer/animated/AnimatedModule.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/AnimatedModule.h
@@ -87,6 +87,11 @@ class AnimatedModule : public NativeAnimatedModuleCxxSpec<AnimatedModule>, publi
     Tag viewTag{};
   };
 
+  struct ConnectAnimatedNodeToShadowNodeFamilyOp {
+    Tag nodeTag{};
+    std::shared_ptr<const ShadowNodeFamily> shadowNodeFamily{};
+  };
+
   struct DisconnectAnimatedNodeFromViewOp {
     Tag nodeTag{};
     Tag viewTag{};
@@ -124,6 +129,7 @@ class AnimatedModule : public NativeAnimatedModuleCxxSpec<AnimatedModule>, publi
       SetAnimatedNodeOffsetOp,
       SetAnimatedNodeValueOp,
       ConnectAnimatedNodeToViewOp,
+      ConnectAnimatedNodeToShadowNodeFamilyOp,
       DisconnectAnimatedNodeFromViewOp,
       RestoreDefaultValuesOp,
       FlattenAnimatedNodeOffsetOp,
@@ -175,6 +181,8 @@ class AnimatedModule : public NativeAnimatedModuleCxxSpec<AnimatedModule>, publi
   void extractAnimatedNodeOffset(jsi::Runtime &rt, Tag nodeTag);
 
   void connectAnimatedNodeToView(jsi::Runtime &rt, Tag nodeTag, Tag viewTag);
+
+  void connectAnimatedNodeToShadowNodeFamily(jsi::Runtime &rt, Tag nodeTag, jsi::Object shadowNode);
 
   void disconnectAnimatedNodeFromView(jsi::Runtime &rt, Tag nodeTag, Tag viewTag);
 

--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.cpp
@@ -238,6 +238,20 @@ void NativeAnimatedNodesManager::connectAnimatedNodeToView(
   }
 }
 
+void NativeAnimatedNodesManager::connectAnimatedNodeToShadowNodeFamily(
+    Tag propsNodeTag,
+    std::shared_ptr<const ShadowNodeFamily> family) noexcept {
+  react_native_assert(propsNodeTag);
+  auto node = getAnimatedNode<PropsAnimatedNode>(propsNodeTag);
+  if (node != nullptr && family != nullptr) {
+    std::lock_guard<std::mutex> lock(tagToShadowNodeFamilyMutex_);
+    tagToShadowNodeFamily_[family->getTag()] = family;
+  } else {
+    LOG(WARNING)
+        << "Cannot ConnectAnimatedNodeToShadowNodeFamily, animated node has to be props type";
+  }
+}
+
 void NativeAnimatedNodesManager::disconnectAnimatedNodeFromView(
     Tag propsNodeTag,
     Tag viewTag) noexcept {
@@ -250,6 +264,10 @@ void NativeAnimatedNodesManager::disconnectAnimatedNodeFromView(
     {
       std::lock_guard<std::mutex> lock(connectedAnimatedNodesMutex_);
       connectedAnimatedNodes_.erase(viewTag);
+    }
+    {
+      std::lock_guard<std::mutex> lock(tagToShadowNodeFamilyMutex_);
+      tagToShadowNodeFamily_.erase(viewTag);
     }
     updatedNodeTags_.insert(node->tag());
 
@@ -989,15 +1007,47 @@ AnimationMutations NativeAnimatedNodesManager::pullAnimationMutations() {
       }
 
       for (auto& [tag, props] : updateViewPropsDirect_) {
-        // TODO: also handle layout props (updateViewProps_). It is skipped for
-        // now, because the backend requires shadowNodeFamilies to be able to
-        // commit to the ShadowTree
         propsBuilder.storeDynamic(props);
         mutations.push_back(
             AnimationMutation{tag, nullptr, propsBuilder.get()});
         containsChange = true;
       }
-      updateViewPropsDirect_.clear();
+      {
+        std::lock_guard<std::mutex> lock(tagToShadowNodeFamilyMutex_);
+        for (auto& [tag, props] : updateViewProps_) {
+          auto familyIt = tagToShadowNodeFamily_.find(tag);
+          if (familyIt == tagToShadowNodeFamily_.end()) {
+            continue;
+          }
+          if (auto family = familyIt->second.lock()) {
+            // C++ Animated produces props in the form of a folly::dynamic, so
+            // it wouldn't make sense to unpack it here. However, for the
+            // purposes of testing, we want to be able to use the statically
+            // typed AnimationMutation. At a later stage we will instead just
+            // pass the dynamic directly to propsBuilder and the new API could
+            // be used by 3rd party libraries or in the fututre by Animated.
+            if (props.find("width") != props.items().end()) {
+              propsBuilder.setWidth(
+                  yoga::Style::SizeLength::points(props["width"].asDouble()));
+            }
+            if (props.find("height") != props.items().end()) {
+              propsBuilder.setHeight(
+                  yoga::Style::SizeLength::points(props["height"].asDouble()));
+            }
+            mutations.push_back(
+                AnimationMutation{
+                    .tag = tag,
+                    .family = family,
+                    .props = propsBuilder.get(),
+                });
+          }
+          containsChange = true;
+        }
+      }
+      if (containsChange) {
+        updateViewPropsDirect_.clear();
+        updateViewProps_.clear();
+      }
     }
 
     if (!containsChange) {
@@ -1017,16 +1067,38 @@ AnimationMutations NativeAnimatedNodesManager::pullAnimationMutations() {
         }
       }
 
-      // Step 2: update all nodes that are connected to the finished animations.
+      // Step 2: update all nodes that are connected to the finished
+      // animations.
       updateNodes(finishedAnimationValueNodes);
 
       isEventAnimationInProgress_ = false;
 
       for (auto& [tag, props] : updateViewPropsDirect_) {
-        // TODO: handle layout props
         propsBuilder.storeDynamic(props);
         mutations.push_back(
-            AnimationMutation{tag, nullptr, propsBuilder.get()});
+            AnimationMutation{
+                .tag = tag,
+                .family = nullptr,
+                .props = propsBuilder.get(),
+            });
+      }
+      {
+        std::lock_guard<std::mutex> lock(tagToShadowNodeFamilyMutex_);
+        for (auto& [tag, props] : updateViewProps_) {
+          auto familyIt = tagToShadowNodeFamily_.find(tag);
+          if (familyIt == tagToShadowNodeFamily_.end()) {
+            continue;
+          }
+          if (auto family = familyIt->second.lock()) {
+            propsBuilder.storeDynamic(props);
+            mutations.push_back(
+                AnimationMutation{
+                    .tag = tag,
+                    .family = family,
+                    .props = propsBuilder.get(),
+                });
+          }
+        }
       }
     }
   } else {
@@ -1107,7 +1179,8 @@ void NativeAnimatedNodesManager::onRender() {
         }
       }
 
-      // Step 2: update all nodes that are connected to the finished animations.
+      // Step 2: update all nodes that are connected to the finished
+      // animations.
       updateNodes(finishedAnimationValueNodes);
 
       isEventAnimationInProgress_ = false;

--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.h
@@ -21,6 +21,7 @@
 #include <react/renderer/animationbackend/AnimationBackend.h>
 #endif
 #include <react/renderer/core/ReactPrimitives.h>
+#include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/uimanager/UIManagerAnimationBackend.h>
 #include <chrono>
 #include <memory>
@@ -100,6 +101,8 @@ class NativeAnimatedNodesManager {
   void connectAnimatedNodes(Tag parentTag, Tag childTag) noexcept;
 
   void connectAnimatedNodeToView(Tag propsNodeTag, Tag viewTag) noexcept;
+
+  void connectAnimatedNodeToShadowNodeFamily(Tag propsNodeTag, std::shared_ptr<const ShadowNodeFamily> family) noexcept;
 
   void disconnectAnimatedNodes(Tag parentTag, Tag childTag) noexcept;
 
@@ -257,6 +260,9 @@ class NativeAnimatedNodesManager {
 
   std::unordered_map<Tag, folly::dynamic> updateViewProps_{};
   std::unordered_map<Tag, folly::dynamic> updateViewPropsDirect_{};
+
+  mutable std::mutex tagToShadowNodeFamilyMutex_;
+  std::unordered_map<Tag, std::weak_ptr<const ShadowNodeFamily>> tagToShadowNodeFamily_{};
 
   /*
    * Sometimes a view is not longer connected to a PropsAnimatedNode, but

--- a/packages/react-native/ReactCommon/react/renderer/animated/nodes/PropsAnimatedNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/nodes/PropsAnimatedNode.h
@@ -14,6 +14,7 @@
 #include "AnimatedNode.h"
 
 #include <react/renderer/animated/internal/primitives.h>
+#include <react/renderer/core/ShadowNode.h>
 #include <mutex>
 
 namespace facebook::react {

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.cpp
@@ -83,7 +83,7 @@ void AnimationBackend::onAnimationFrame(double timestamp) {
       hasAnyLayoutUpdates |= mutationHasLayoutUpdates(mutation);
       const auto family = mutation.family;
       if (family != nullptr) {
-        surfaceToFamilies[family->getSurfaceId()].insert(family);
+        surfaceToFamilies[family->getSurfaceId()].insert(family.get());
       }
       updates[mutation.tag] = std::move(mutation.props);
     }

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.h
@@ -32,7 +32,7 @@ class UIManagerNativeAnimatedDelegateBackendImpl : public UIManagerNativeAnimate
 
 struct AnimationMutation {
   Tag tag;
-  const ShadowNodeFamily *family;
+  std::shared_ptr<const ShadowNodeFamily> family;
   AnimatedProps props;
 };
 

--- a/packages/react-native/src/private/specs_DEPRECATED/modules/NativeAnimatedModule.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/modules/NativeAnimatedModule.js
@@ -49,6 +49,10 @@ export interface Spec extends TurboModule {
   +flattenAnimatedNodeOffset: (nodeTag: number) => void;
   +extractAnimatedNodeOffset: (nodeTag: number) => void;
   +connectAnimatedNodeToView: (nodeTag: number, viewTag: number) => void;
+  +connectAnimatedNodeToShadowNodeFamily?: (
+    nodeTag: number,
+    shadowNode: Object,
+  ) => void;
   +disconnectAnimatedNodeFromView: (nodeTag: number, viewTag: number) => void;
   +restoreDefaultValues: (nodeTag: number) => void;
   +dropAnimatedNode: (tag: number) => void;


### PR DESCRIPTION
Summary:
This PR allows C++ Native Animated to use `ShadowNodeFamily` instances to use the `cloneMultiple` method when pushing updates through the `ShadowTree` in `AnimationBackend`

# Changelog
[General] [Added] - Add `connectAnimatedNodeToShadowNodeFamily` method to `NativeAnimatedModule` and `NativeAnimatedTurboModule`

Differential Revision: D84055752


