### PR TITLE
Define HostTargetTracingDelegate

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorMocks.h
@@ -113,6 +113,12 @@ class MockInspectorPackagerConnectionDelegate : public InspectorPackagerConnecti
   folly::Executor &executor_;
 };
 
+class MockHostTargetTracingDelegate : public HostTargetTracingDelegate {
+ public:
+  MOCK_METHOD(void, onTracingStarted, (tracing::Mode tracingMode, bool screenshotsCategoryEnabled), (override));
+  MOCK_METHOD(void, onTracingStopped, (), (override));
+};
+
 class MockHostTargetDelegate : public HostTargetDelegate {
  public:
   // HostTargetDelegate methods
@@ -131,6 +137,20 @@ class MockHostTargetDelegate : public HostTargetDelegate {
       loadNetworkResource,
       (const LoadNetworkResourceRequest &params, ScopedExecutor<NetworkRequestListener> executor),
       (override));
+
+  HostTargetTracingDelegate *getTracingDelegate() override
+  {
+    return mockTracingDelegate_.get();
+  }
+
+  MockHostTargetTracingDelegate &getTracingDelegateMock()
+  {
+    return *mockTracingDelegate_;
+  }
+
+ private:
+  std::unique_ptr<MockHostTargetTracingDelegate> mockTracingDelegate_ =
+      std::make_unique<MockHostTargetTracingDelegate>();
 };
 
 class MockInstanceTargetDelegate : public InstanceTargetDelegate {};


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

Introduces a TracingDelegate that will receive tracing-related events on the Host side.

We can't give synchronous access to tracing state to Host directly, since there is no guarantee that this call will happen on the inspector thread.

Example:
- `HostTarget::tracingState()` call may happen on UI thread, or whatever thread the Host is using, which reads `traceRecoding_` value.
- At the same time, the `stopTracing()` call that will invalidate `traceRecording_` could happen on inspector thread.

This is a pre-requisite for a better threading model, since we are going to be doing much frequent write operations from the Host side to record frame timings or screenshots.

Differential Revision: D86205686


