### PR TITLE
FrameTiming module to subscribe to Inspector tracing lifecycle

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.kt
@@ -43,8 +43,11 @@ import com.facebook.react.devsupport.DevMenuConfiguration
 import com.facebook.react.devsupport.DevSupportManagerBase
 import com.facebook.react.devsupport.DevSupportManagerFactory
 import com.facebook.react.devsupport.InspectorFlags
+import com.facebook.react.devsupport.inspector.FrameTimingsObserver
 import com.facebook.react.devsupport.inspector.InspectorNetworkHelper
 import com.facebook.react.devsupport.inspector.InspectorNetworkRequestListener
+import com.facebook.react.devsupport.inspector.TracingState
+import com.facebook.react.devsupport.inspector.TracingStateListener
 import com.facebook.react.devsupport.interfaces.BundleLoadCallback
 import com.facebook.react.devsupport.interfaces.DevSupportManager
 import com.facebook.react.devsupport.interfaces.DevSupportManager.PausedInDebuggerOverlayCommandListener
@@ -147,6 +150,7 @@ public class ReactHostImpl(
   private val beforeDestroyListeners: MutableList<() -> Unit> = CopyOnWriteArrayList()
 
   internal var reactHostInspectorTarget: ReactHostInspectorTarget? = null
+  private var frameTimingsObserver: FrameTimingsObserver? = null
 
   @Volatile private var hostInvalidated = false
 
@@ -1442,8 +1446,7 @@ public class ReactHostImpl(
                 // If the host has been invalidated, now that the current context/instance
                 // has been unregistered, we can safely destroy the host's inspector
                 // target.
-                reactHostInspectorTarget?.close()
-                reactHostInspectorTarget = null
+                destroyReactHostInspectorTarget()
               }
 
               // Step 1: Destroy DevSupportManager
@@ -1554,11 +1557,43 @@ public class ReactHostImpl(
 
   internal fun getOrCreateReactHostInspectorTarget(): ReactHostInspectorTarget? {
     if (reactHostInspectorTarget == null && InspectorFlags.getFuseboxEnabled()) {
-      // NOTE: ReactHostInspectorTarget only retains a weak reference to `this`.
-      reactHostInspectorTarget = ReactHostInspectorTarget(this)
+      reactHostInspectorTarget = createReactHostInspectorTarget()
     }
 
     return reactHostInspectorTarget
+  }
+
+  private fun createReactHostInspectorTarget(): ReactHostInspectorTarget {
+    // NOTE: ReactHostInspectorTarget only retains a weak reference to `this`.
+    val inspectorTarget = ReactHostInspectorTarget(this)
+    inspectorTarget.registerTracingStateListener(
+        TracingStateListener { state: TracingState, _screenshotsEnabled: Boolean ->
+          when (state) {
+            TracingState.ENABLED_IN_BACKGROUND_MODE,
+            TracingState.ENABLED_IN_CDP_MODE -> {
+              currentActivity?.window?.let { window ->
+                val observer = FrameTimingsObserver(window)
+                observer.start()
+                frameTimingsObserver = observer
+              }
+            }
+            TracingState.DISABLED -> {
+              frameTimingsObserver?.stop()
+              frameTimingsObserver = null
+            }
+          }
+        }
+    )
+
+    return inspectorTarget
+  }
+
+  private fun destroyReactHostInspectorTarget() {
+    frameTimingsObserver?.stop()
+    frameTimingsObserver = null
+
+    reactHostInspectorTarget?.close()
+    reactHostInspectorTarget = null
   }
 
   @ThreadConfined(ThreadConfined.UI)

--- a/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/JFrameTiming.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/JFrameTiming.h
@@ -16,7 +16,7 @@ namespace facebook::react::jsinspector_modern {
  */
 class JFrameTiming : public jni::JavaClass<JFrameTiming> {
  public:
-  static constexpr auto kJavaDescriptor = "Lcom/facebook/react/devsupport/FrameTiming;";
+  static constexpr auto kJavaDescriptor = "Lcom/facebook/react/devsupport/inspector/FrameTimingsObserver;";
 
   static void
   reportFrameTiming(jni::alias_ref<jclass> /*unused*/, jint frame, jlong paintStartNanos, jlong paintEndNanos);


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

This introduces a proper lifecycle for a module on Anroid that will emit frames information as part of the trace recording.

Previously we would initialize it on a packager connection, which could be problematic, since there is no guarantee that InspectorTarget exists at  this time.

With the current approach, the lifetime of this object is:
- Bound to lifetime of InspectorTarget, it will never outlive it
- The actual frames listener lifetime will be bound to tracing state. We no longer will be going through `jni` to check if `PerformanceTracer` is enabled.

I've renamed it to `FrameTimingsObserver`and moved to inspector package, since this should be considered as part of the inspector stack. Similarly to `LoadNetworkResource` listeners.

I am keeping the `jni` layer with PerformanceTracer for now, but this is about to be removed in the diffs above. The frames information should be propagated through Host, this would allow us to record Frames even if there is no React Native instance, for example, during reloads.

Differential Revision: D87345177
