### PR TITLE
Update dev dependency selfsigned to v4, fix Node >=v24.5 compatibility, restore CI

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -479,7 +479,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ["24.4.1", "22", "20.19.4"]
+        node-version: ["24", "22", "20.19.4"]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/packages/dev-middleware/package.json
+++ b/packages/dev-middleware/package.json
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@react-native/debugger-shell": "0.84.0-main",
-    "selfsigned": "^2.4.1",
+    "selfsigned": "^4.0.0",
     "undici": "^5.29.0",
     "wait-for-expect": "^3.0.2"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2334,13 +2334,6 @@
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-2.1.0.tgz#052aa67a48eccc4309d7f0191b7e41434b90bb78"
   integrity sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==
 
-"@types/node-forge@^1.3.0":
-  version "1.3.11"
-  resolved "https://registry.yarnpkg.com/@types/node-forge/-/node-forge-1.3.11.tgz#0972ea538ddb0f4d9c2fa0ec5db5724773a604da"
-  integrity sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==
-  dependencies:
-    "@types/node" "*"
-
 "@types/node@*", "@types/node@^22.7.7":
   version "22.15.18"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-22.15.18.tgz#2f8240f7e932f571c2d45f555ba0b6c3f7a75963"
@@ -8275,12 +8268,11 @@ scheduler@0.27.0, scheduler@^0.27.0:
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.27.0.tgz#0c4ef82d67d1e5c1e359e8fc76d3a87f045fe5bd"
   integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
 
-selfsigned@^2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-2.4.1.tgz#560d90565442a3ed35b674034cec4e95dceb4ae0"
-  integrity sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==
+selfsigned@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-4.0.0.tgz#5b0518735f82fa8eb59b425bc92e29d29e5279f8"
+  integrity sha512-eP/1BEUCziBF/7p96ergE2JlGOMsGj9kIe77pD99G3ValgxDFwHA2oNCYW4rjlmYp8LXc684ypH0836GjSKw0A==
   dependencies:
-    "@types/node-forge" "^1.3.0"
     node-forge "^1"
 
 semver-compare@^1.0.0:


### PR DESCRIPTION
Summary:
CI fails after attempting to update to Node v24 (latest LTS) because our `dev-middleware` dev-only dependency `selfsigned` uses a default key size incompatible with the version of OpenSSL in Node>=24.5. We see lots of:

```
error:0A00018F:SSL routines::ee key too small
```

This was mitigated in OSS CI by pinning our Node tests to before v24.5: https://github.com/facebook/react-native/pull/53013

This default is raised upstream in https://github.com/jfromaniello/selfsigned/commit/bf687c80cfe125b7051c7b2f07e321289c037993 , this bumps to v4 which includes that fix, and removes the temporary mitigation above.

Changelog:
[Internal]

Differential Revision: D87643898
