### PR TITLE
Allow Heif/Heic Assets

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -69,7 +69,7 @@ munge_underscores=true
 module.name_mapper='^react-native$' -> '<PROJECT_ROOT>/packages/react-native/index.js'
 module.name_mapper='^react-native/\(.*\)$' -> '<PROJECT_ROOT>/packages/react-native/\1'
 module.name_mapper='^@react-native/dev-middleware$' -> '<PROJECT_ROOT>/packages/dev-middleware'
-module.name_mapper='^@?[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|webp\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|aac\|aiff\|caf\|m4a\|mp3\|wav\|html\|pdf\|xml\|ktx\)$' -> '<PROJECT_ROOT>/packages/react-native/Libraries/Image/RelativeImageStub'
+module.name_mapper='^@?[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|webp\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|aac\|aiff\|caf\|m4a\|mp3\|wav\|html\|pdf\|xml\|ktx\|heic\|heif\)$' -> '<PROJECT_ROOT>/packages/react-native/Libraries/Image/RelativeImageStub'
 
 module.system.haste.module_ref_prefix=m#
 

--- a/packages/assets/path-support.js
+++ b/packages/assets/path-support.js
@@ -43,6 +43,8 @@ function getAndroidAssetSuffix(scale /*: number */) /*: string */ {
 // See https://developer.android.com/guide/topics/resources/drawable-resource.html
 const drawableFileTypes = new Set([
   'gif',
+  'heic',
+  'heif',
   'jpeg',
   'jpg',
   'ktx',

--- a/packages/community-cli-plugin/src/commands/bundle/assetPathUtils.js
+++ b/packages/community-cli-plugin/src/commands/bundle/assetPathUtils.js
@@ -41,6 +41,8 @@ function getAndroidAssetSuffix(scale: number): string {
 // See https://developer.android.com/guide/topics/resources/drawable-resource.html
 const drawableFileTypes: Set<string> = new Set<string>([
   'gif',
+  'heic',
+  'heif',
   'jpeg',
   'jpg',
   'png',


### PR DESCRIPTION
Summary:
# Summary:
Trying to add heif/heic files to an app bundle but they're not included

Changelog:
[General][Added] - Bundle support for heic and heif files
___

overriding_review_checks_triggers_an_audit_and_retroactive_review
Oncall Short Name: vr_metacam

Reviewed By: lenaic, robhogan, javache

Differential Revision: D86807752


