### PR TITLE
Fix NPE on ReactAccessibilityDelegate.performAccessibilityAction

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactAccessibilityDelegate.kt
@@ -246,7 +246,7 @@ public open class ReactAccessibilityDelegate( // The View this delegate is attac
 
       // In order to make Talkback announce the change of the adjustable's value,
       // schedule to send a TYPE_VIEW_SELECTED event after performing the scroll actions.
-      val accessibilityRole = host.getTag(R.id.accessibility_role) as AccessibilityRole
+      val accessibilityRole = host.getTag(R.id.accessibility_role) as AccessibilityRole?
       val accessibilityValue = host.getTag(R.id.accessibility_value) as ReadableMap?
       if (
           accessibilityRole == AccessibilityRole.ADJUSTABLE &&


### PR DESCRIPTION
Summary:
`host.getTag(R.id.accessibility_role)` can be `null` as per the rest of the file.
However at line 249 we attempt to cast it to a non-null `AccessibilityRole`.

This fixes the NPE and restores the logic to the Java equivalent (see D79749812 for reference).


Changelog:
[Android] [Fixed] - Fix NPE on ReactAccessibilityDelegate.performAccessibilityAction

Differential Revision: D87779007


