### PR TITLE
Flip default value for shouldResetOnClickListenerWhenRecyclingView

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c7c15289a7da56ef403691768489b6f6>>
+ * @generated SignedSource<<84ba3f1d280afc3636f32952cc906579>>
  */
 
 /**
@@ -165,7 +165,7 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
 
   override fun shouldResetClickableWhenRecyclingView(): Boolean = true
 
-  override fun shouldResetOnClickListenerWhenRecyclingView(): Boolean = false
+  override fun shouldResetOnClickListenerWhenRecyclingView(): Boolean = true
 
   override fun shouldSetEnabledBasedOnAccessibilityState(): Boolean = true
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<14228fac25bcaaf06f437b5805ef04ce>>
+ * @generated SignedSource<<3ed1bd5b83694d078de26f2c65214fac>>
  */
 
 /**
@@ -312,7 +312,7 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool shouldResetOnClickListenerWhenRecyclingView() override {
-    return false;
+    return true;
   }
 
   bool shouldSetEnabledBasedOnAccessibilityState() override {

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -806,7 +806,7 @@ const definitions: FeatureFlagDefinitions = {
       ossReleaseStage: 'none',
     },
     shouldResetOnClickListenerWhenRecyclingView: {
-      defaultValue: false,
+      defaultValue: true,
       metadata: {
         description:
           'Reset OnClickListener to null when recycling views on Android to avoid accessibility tools finding views with incorrect state after recycling.',

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<0559a11a2edeec64fbc00451614e98d9>>
+ * @generated SignedSource<<a324a12013cfab0e52bcdbbea6c6424e>>
  * @flow strict
  * @noformat
  */
@@ -516,7 +516,7 @@ export const shouldResetClickableWhenRecyclingView: Getter<boolean> = createNati
 /**
  * Reset OnClickListener to null when recycling views on Android to avoid accessibility tools finding views with incorrect state after recycling.
  */
-export const shouldResetOnClickListenerWhenRecyclingView: Getter<boolean> = createNativeFlagGetter('shouldResetOnClickListenerWhenRecyclingView', false);
+export const shouldResetOnClickListenerWhenRecyclingView: Getter<boolean> = createNativeFlagGetter('shouldResetOnClickListenerWhenRecyclingView', true);
 /**
  * Fix BaseViewManager to properly set view.setEnabled() based on accessibilityState.disabled.
  */


### PR DESCRIPTION
Summary: [Android][Fixed] – Enabled shouldResetOnClickListenerWhenRecyclingView by default to reset OnClickListener to null when recycling views and prevent accessibility tools from detecting incorrect states.

Differential Revision: D87778728


