### PR TITLE
Flip default value for shouldResetClickableWhenRecyclingView

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<cfdeb7b6ddf02d0eebd04d6fe55d4775>>
+ * @generated SignedSource<<c7c15289a7da56ef403691768489b6f6>>
  */
 
 /**
@@ -163,7 +163,7 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
 
   override fun shouldPressibilityUseW3CPointerEventsForHover(): Boolean = false
 
-  override fun shouldResetClickableWhenRecyclingView(): Boolean = false
+  override fun shouldResetClickableWhenRecyclingView(): Boolean = true
 
   override fun shouldResetOnClickListenerWhenRecyclingView(): Boolean = false
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<a50549b6884d7f4671d5167cd4cb38f2>>
+ * @generated SignedSource<<14228fac25bcaaf06f437b5805ef04ce>>
  */
 
 /**
@@ -308,7 +308,7 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool shouldResetClickableWhenRecyclingView() override {
-    return false;
+    return true;
   }
 
   bool shouldResetOnClickListenerWhenRecyclingView() override {

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -796,7 +796,7 @@ const definitions: FeatureFlagDefinitions = {
       ossReleaseStage: 'none',
     },
     shouldResetClickableWhenRecyclingView: {
-      defaultValue: false,
+      defaultValue: true,
       metadata: {
         description:
           'Reset isClickable to false when recycling views on Android to avoid accessibility tools finding views with incorrect state after recycling.',

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<3e75c668cf91189c87ccc330d5fc1800>>
+ * @generated SignedSource<<0559a11a2edeec64fbc00451614e98d9>>
  * @flow strict
  * @noformat
  */
@@ -512,7 +512,7 @@ export const shouldPressibilityUseW3CPointerEventsForHover: Getter<boolean> = cr
 /**
  * Reset isClickable to false when recycling views on Android to avoid accessibility tools finding views with incorrect state after recycling.
  */
-export const shouldResetClickableWhenRecyclingView: Getter<boolean> = createNativeFlagGetter('shouldResetClickableWhenRecyclingView', false);
+export const shouldResetClickableWhenRecyclingView: Getter<boolean> = createNativeFlagGetter('shouldResetClickableWhenRecyclingView', true);
 /**
  * Reset OnClickListener to null when recycling views on Android to avoid accessibility tools finding views with incorrect state after recycling.
  */


### PR DESCRIPTION
Summary: [Android][Fixed] - Enabled shouldResetClickableWhenRecyclingView by default to reset isClickable to false when recycling views and prevent accessibility tools from detecting incorrect clickable states.

Reviewed By: cortinico

Differential Revision: D87778143


