### PR TITLE
remove unused methods from MountingCoordinator

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.cpp
@@ -68,17 +68,6 @@ bool MountingCoordinator::waitForTransaction(
       lock, timeout, [this]() { return lastRevision_.has_value(); });
 }
 
-void MountingCoordinator::updateBaseRevision(
-    const ShadowTreeRevision& baseRevision) const {
-  std::scoped_lock lock(mutex_);
-  baseRevision_ = baseRevision;
-}
-
-void MountingCoordinator::resetLatestRevision() const {
-  std::scoped_lock lock(mutex_);
-  lastRevision_.reset();
-}
-
 std::optional<MountingTransaction> MountingCoordinator::pullTransaction(
     bool willPerformAsynchronously) const {
   TraceSection section("MountingCoordinator::pullTransaction");

--- a/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/MountingCoordinator.h
@@ -101,9 +101,6 @@ class MountingCoordinator final {
    * `MountingOverrideDelegate` only.
    */
  public:
-  void updateBaseRevision(const ShadowTreeRevision &baseRevision) const;
-  void resetLatestRevision() const;
-
   void setMountingOverrideDelegate(std::weak_ptr<const MountingOverrideDelegate> delegate) const;
 
   /*
@@ -123,7 +120,6 @@ class MountingCoordinator final {
    */
   void revoke() const;
 
- private:
   const SurfaceId surfaceId_;
 
   // Protects access to `baseRevision_`, `lastRevision_` and


### PR DESCRIPTION
Summary:
changelog: [internal]

clean up unused methods.

Reviewed By: rubennorte

Differential Revision: D87778293


