### PR TITLE
Extract TurboModuleManager from ReactHost

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.h
@@ -21,7 +21,7 @@ class BridgelessNativeModuleProxy;
 /**
  * Represents the JavaScript binding for the TurboModule system.
  */
-class TurboModuleBinding {
+class TurboModuleBinding final {
  public:
   /*
    * Installs TurboModuleBinding into JavaScript runtime.
@@ -38,7 +38,7 @@ class TurboModuleBinding {
       TurboModuleProviderFunctionType &&moduleProvider,
       std::shared_ptr<LongLivedObjectCollection> longLivedObjectCollection);
 
-  virtual ~TurboModuleBinding();
+  ~TurboModuleBinding();
 
  private:
   friend BridgelessNativeModuleProxy;

--- a/packages/react-native/ReactCxxPlatform/react/devsupport/DevSettingsModule.h
+++ b/packages/react-native/ReactCxxPlatform/react/devsupport/DevSettingsModule.h
@@ -21,7 +21,7 @@ class DevSettingsModule : public NativeDevSettingsCxxSpec<DevSettingsModule> {
   DevSettingsModule(
       std::shared_ptr<CallInvoker> jsInvoker,
       std::weak_ptr<DevServerHelper> devServerHelper,
-      LiveReloadCallback &&liveReloadCallback)
+      LiveReloadCallback liveReloadCallback)
       : NativeDevSettingsCxxSpec(jsInvoker),
         devServerHelper_(std::move(devServerHelper)),
         liveReloadCallback_(std::move(liveReloadCallback))

--- a/packages/react-native/ReactCxxPlatform/react/runtime/TurboModuleManager.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/runtime/TurboModuleManager.cpp
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "TurboModuleManager.h"
+
+#include <react/coremodules/AppStateModule.h>
+#include <react/coremodules/DeviceInfoModule.h>
+#include <react/coremodules/PlatformConstantsModule.h>
+#include <react/debug/react_native_assert.h>
+#include <react/devsupport/DevLoadingViewModule.h>
+#include <react/devsupport/DevSettingsModule.h>
+#include <react/devsupport/LogBoxModule.h>
+#include <react/devsupport/SourceCodeModule.h>
+#include <react/io/ImageLoaderModule.h>
+#include <react/io/NetworkingModule.h>
+#include <react/io/WebSocketModule.h>
+#include <react/logging/NativeExceptionsManager.h>
+#include <react/nativemodule/defaults/DefaultTurboModules.h>
+#include <react/nativemodule/intersectionobserver/NativeIntersectionObserver.h>
+#include <react/nativemodule/mutationobserver/NativeMutationObserver.h>
+#include <react/nativemodule/webperformance/NativePerformance.h>
+#include <react/renderer/animated/AnimatedModule.h>
+
+using namespace facebook::react;
+
+TurboModuleManager::TurboModuleManager(
+    TurboModuleProviders turboModuleProviders,
+    std::shared_ptr<CallInvoker> jsInvoker,
+    JsErrorHandler::OnJsError onJsError,
+    std::shared_ptr<NativeAnimatedNodesManagerProvider>
+        animatedNodesManagerProvider,
+    std::shared_ptr<DevServerHelper> devServerHelper,
+    std::shared_ptr<IDevUIDelegate> devUIDelegate,
+    std::shared_ptr<SurfaceDelegate> logBoxSurfaceDelegate,
+    HttpClientFactory httpClientFactory,
+    WebSocketClientFactory webSocketClientFactory,
+    std::function<void()> liveReloadCallback)
+    : turboModuleProviders_(std::move(turboModuleProviders)),
+      jsInvoker_(std::move(jsInvoker)),
+      onJsError_(std::move(onJsError)),
+      animatedNodesManagerProvider_(std::move(animatedNodesManagerProvider)),
+      devServerHelper_(std::move(devServerHelper)),
+      devUIDelegate_(std::move(devUIDelegate)),
+      logBoxSurfaceDelegate_(std::move(logBoxSurfaceDelegate)),
+      httpClientFactory_(std::move(httpClientFactory)),
+      webSocketClientFactory_(std::move(webSocketClientFactory)),
+      liveReloadCallback_(std::move(liveReloadCallback)) {}
+
+std::shared_ptr<TurboModule> TurboModuleManager::operator()(
+    const std::string& name) const {
+  react_native_assert(!name.empty() && "TurboModule name must not be empty");
+
+  for (const auto& turboModuleProvider : turboModuleProviders_) {
+    if (turboModuleProvider) {
+      if (auto turboModule = turboModuleProvider(name, jsInvoker_)) {
+        return turboModule;
+      }
+    }
+  }
+
+  if (auto turboModule =
+          DefaultTurboModules::getTurboModule(name, jsInvoker_)) {
+    return turboModule;
+  }
+
+  if (name == AnimatedModule::kModuleName) {
+    return std::make_shared<AnimatedModule>(
+        jsInvoker_, animatedNodesManagerProvider_);
+  } else if (name == AppStateModule::kModuleName) {
+    return std::make_shared<AppStateModule>(jsInvoker_);
+  } else if (name == DeviceInfoModule::kModuleName) {
+    return std::make_shared<DeviceInfoModule>(jsInvoker_);
+  } else if (
+      devUIDelegate_ != nullptr && name == DevLoadingViewModule::kModuleName) {
+    return std::make_shared<DevLoadingViewModule>(jsInvoker_, devUIDelegate_);
+  } else if (devServerHelper_ && name == DevSettingsModule::kModuleName) {
+    return std::make_shared<DevSettingsModule>(
+        jsInvoker_, devServerHelper_, liveReloadCallback_);
+  } else if (name == PlatformConstantsModule::kModuleName) {
+    return std::make_shared<PlatformConstantsModule>(jsInvoker_);
+  } else if (name == ImageLoaderModule::kModuleName) {
+    return std::make_shared<ImageLoaderModule>(jsInvoker_);
+  } else if (name == SourceCodeModule::kModuleName) {
+    return std::make_shared<SourceCodeModule>(jsInvoker_, devServerHelper_);
+  } else if (name == WebSocketModule::kModuleName) {
+    return std::make_shared<WebSocketModule>(
+        jsInvoker_, webSocketClientFactory_);
+  } else if (name == NativeExceptionsManager::kModuleName) {
+    return std::make_shared<NativeExceptionsManager>(onJsError_, jsInvoker_);
+  } else if (name == NativePerformance::kModuleName) {
+    return std::make_shared<NativePerformance>(jsInvoker_);
+  } else if (name == NativeIntersectionObserver::kModuleName) {
+    return std::make_shared<NativeIntersectionObserver>(jsInvoker_);
+  } else if (name == NativeMutationObserver::kModuleName) {
+    return std::make_shared<NativeMutationObserver>(jsInvoker_);
+  } else if (name == NetworkingModule::kModuleName) {
+    return std::make_shared<NetworkingModule>(jsInvoker_, httpClientFactory_);
+  } else if (name == LogBoxModule::kModuleName) {
+    if (logBoxSurfaceDelegate_) {
+      return std::make_shared<LogBoxModule>(jsInvoker_, logBoxSurfaceDelegate_);
+    }
+  }
+
+  LOG(WARNING) << "Failed to load TurboModule: " << name;
+  return nullptr;
+}

--- a/packages/react-native/ReactCxxPlatform/react/runtime/TurboModuleManager.h
+++ b/packages/react-native/ReactCxxPlatform/react/runtime/TurboModuleManager.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <jserrorhandler/JsErrorHandler.h>
+#include <react/http/IHttpClient.h>
+#include <react/http/IWebSocketClient.h>
+#include <react/nativemodule/TurboModuleProvider.h>
+#include <react/renderer/scheduler/SurfaceDelegate.h>
+
+namespace facebook::react {
+
+class CallInvoker;
+class DevServerHelper;
+class NativeAnimatedNodesManagerProvider;
+class SurfaceDelegate;
+struct IDevUIDelegate;
+
+class TurboModuleManager final {
+ public:
+  TurboModuleManager(
+      TurboModuleProviders turboModuleProviders,
+      std::shared_ptr<CallInvoker> jsInvoker,
+      JsErrorHandler::OnJsError onJsError,
+      std::shared_ptr<NativeAnimatedNodesManagerProvider> animatedNodesManagerProvider = nullptr,
+      std::shared_ptr<DevServerHelper> devServerHelper = nullptr,
+      std::shared_ptr<IDevUIDelegate> devUIDelegate = nullptr,
+      std::shared_ptr<SurfaceDelegate> logBoxSurfaceDelegate = nullptr,
+      HttpClientFactory httpClientFactory = nullptr,
+      WebSocketClientFactory webSocketClientFactory = nullptr,
+      std::function<void()> liveReloadCallback = nullptr);
+
+  std::shared_ptr<TurboModule> operator()(const std::string &name) const;
+
+ private:
+  TurboModuleProviders turboModuleProviders_;
+  std::shared_ptr<CallInvoker> jsInvoker_;
+  JsErrorHandler::OnJsError onJsError_;
+  std::shared_ptr<NativeAnimatedNodesManagerProvider> animatedNodesManagerProvider_;
+  std::shared_ptr<DevServerHelper> devServerHelper_;
+  std::shared_ptr<IDevUIDelegate> devUIDelegate_;
+  std::shared_ptr<SurfaceDelegate> logBoxSurfaceDelegate_;
+  HttpClientFactory httpClientFactory_;
+  WebSocketClientFactory webSocketClientFactory_;
+  std::function<void()> liveReloadCallback_;
+};
+
+} // namespace facebook::react


### PR DESCRIPTION
Break up ReactHost and TurboModuleManager, so in the future we can inject this more easily.

Changelog: [Internal]

Differential Revision: D87774276


