### PR TITLE
emit scroll event once on overscrolled

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -135,6 +135,7 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
   private @Nullable MaintainVisibleScrollPositionHelper mMaintainVisibleContentPositionHelper;
   private int mFadingEdgeLengthStart = 0;
   private int mFadingEdgeLengthEnd = 0;
+  private boolean mEmittedOverScrollSinceScrollBegin = false;
 
   public ReactHorizontalScrollView(Context context) {
     this(context, null);
@@ -730,6 +731,7 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
     }
     ReactScrollViewHelper.emitScrollBeginDragEvent(this);
     mDragging = true;
+    mEmittedOverScrollSinceScrollBegin = false;
     enableFpsListener();
     getFlingAnimator().cancel();
   }
@@ -1074,6 +1076,13 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
       }
 
       // END FB SCROLLVIEW CHANGE
+    }
+
+    if (ReactNativeFeatureFlags.shouldTriggerResponderTransferOnScrollAndroid()
+        && clampedX
+        && mEmittedOverScrollSinceScrollBegin == false) {
+      ReactScrollViewHelper.emitScrollEvent(this, 0f, 0f);
+      mEmittedOverScrollSinceScrollBegin = true;
     }
 
     super.onOverScrolled(scrollX, scrollY, clampedX, clampedY);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -132,6 +132,7 @@ public class ReactScrollView extends ScrollView
   private @Nullable MaintainVisibleScrollPositionHelper mMaintainVisibleContentPositionHelper;
   private int mFadingEdgeLengthStart;
   private int mFadingEdgeLengthEnd;
+  private boolean mEmittedOverScrollSinceScrollBegin;
 
   public ReactScrollView(Context context) {
     this(context, null);
@@ -194,6 +195,7 @@ public class ReactScrollView extends ScrollView
     mMaintainVisibleContentPositionHelper = null;
     mFadingEdgeLengthStart = 0;
     mFadingEdgeLengthEnd = 0;
+    mEmittedOverScrollSinceScrollBegin = false;
   }
 
   /* package */ void recycleView() {
@@ -621,6 +623,7 @@ public class ReactScrollView extends ScrollView
     }
     ReactScrollViewHelper.emitScrollBeginDragEvent(this);
     mDragging = true;
+    mEmittedOverScrollSinceScrollBegin = false;
     enableFpsListener();
     getFlingAnimator().cancel();
   }
@@ -1278,6 +1281,13 @@ public class ReactScrollView extends ScrollView
       }
 
       // END FB SCROLLVIEW CHANGE
+    }
+
+    if (ReactNativeFeatureFlags.shouldTriggerResponderTransferOnScrollAndroid()
+        && clampedY
+        && mEmittedOverScrollSinceScrollBegin == false) {
+      ReactScrollViewHelper.emitScrollEvent(this, 0f, 0f);
+      mEmittedOverScrollSinceScrollBegin = true;
     }
 
     super.onOverScrolled(scrollX, scrollY, clampedX, clampedY);


### PR DESCRIPTION
Summary:
## Changelog:

[Android] [Fixed] - emit scroll event once on overscrolled

when FeatureFlag `shouldTriggerResponderTransferOnScrollAndroid` is on, RN Renderer relies on scroll event dispatched from JS to terminate responder - this is a behavior consistent with ios
however at overscroll, ios will still keep emitting topScroll but android will stop. This result in a regression on android, which is that a Tap will always go through when end is reached for a scrollview. Solution here is to emit one scroll event at overscroll
* here we're not emitting endlessly to avoid performance regression
* another nuance is android's 'onOverScrolled' will keep being called whenever there's overscroll gesture, but scrollX/Y value stays the same; while on ios, during a overscroll the scrollview actually scrolls the content so scrollX/Y have meaningful values. Because of this I think it makes no sense to keep dispatching scroll event to js on android at overscroll.

Differential Revision: D87657147


