### PR TITLE
make NativeAnimatedNodesManager not copyable and movable

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.h
@@ -72,6 +72,12 @@ class NativeAnimatedNodesManager {
 
   ~NativeAnimatedNodesManager() noexcept;
 
+  // Non-copyable and non-movable to prevent accidental copies or moves of this resource-heavy manager
+  NativeAnimatedNodesManager(const NativeAnimatedNodesManager &) = delete;
+  NativeAnimatedNodesManager &operator=(const NativeAnimatedNodesManager &) = delete;
+  NativeAnimatedNodesManager(NativeAnimatedNodesManager &&) = delete;
+  NativeAnimatedNodesManager &operator=(NativeAnimatedNodesManager &&) = delete;
+
   template <typename T, typename = std::enable_if_t<std::is_base_of_v<AnimatedNode, T>>>
   T *getAnimatedNode(Tag tag) const
     requires(std::is_base_of_v<AnimatedNode, T>)


### PR DESCRIPTION
Summary:
changelog: [internal]

To prevent misuse of the class.

Reviewed By: zeyap

Differential Revision: D87769002


