### PR TITLE
fix: RNGP trying to configure deleted generated CMake projects when executing cleaning task

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -80,7 +80,9 @@ class ReactPlugin : Plugin<Project> {
         configureRepositories(project)
       }
 
-      configureReactNativeNdk(project, extension)
+      if(!project.gradle.startParameter.taskNames.any { it.contains("clean") }) {
+        configureReactNativeNdk(project, extension)
+      }
       configureBuildConfigFieldsForApp(project, extension)
       configureDevServerLocation(project)
       configureBackwardCompatibilityReactMap(project)


### PR DESCRIPTION
## Summary:

I noticed that in Reanimated monorepo executing a `clean` task in an example app results in an error due to RNGP trying to configure codegen-generated CMake targets after they have been removed.

<img width="1580" height="1361" alt="Screenshot 2025-11-24 at 20 50 21" src="https://github.com/user-attachments/assets/a7670cbf-0b83-4cf5-a208-408a1675902e" />

I think the error happens because `configureReactNativeNdk` is called on every task and it indiscriminately changes CMake configs in https://github.com/facebook/react-native/blob/87a77964e4b738fbbfb389a3fb2e043e6720c1f3/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/NdkConfiguratorUtils.kt#L29-L35

You can reproduce it with a brand new community CLI app:
1. `npx @react-native-community/cli@latest init --skip-install --install-pods false --version 0.82 App82`
2. `cd App82`
3. `yarn`
4. `yarn add `@react-native-community/clipboard` (or any other library with codegen)
5. Build the app in Android Studio
6. Use `Build` -> `Clean Project` in Android Studio.

Alternatively, after building, you can add the following anywhere in `android/app/build/generated/autolinking/src/main/jni/Android-autolinking.cmake`

```cmake
message(FATAL_ERROR "Reading codegen CMakeLists.txt during cleanup")
```

I think that since the cleanup process can be parallelized `add_subdirectory` for codegen-generated CMakeLists.txt shouldn't be picked up in the cleaning task.

## Changelog:

[ANDROID] [FIXED] - RNGP trying to configure deleted generated CMake projects when executing cleaning task

## Test Plan:

Applying the fix in a brand-new community CLI app fixes the issue.
