### PR TITLE
Fix -Wswitch-default issues

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/TracingCategory.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/TracingCategory.h
@@ -39,6 +39,9 @@ inline std::string tracingCategoryToString(const Category &category)
       return "v8.execute";
     case Category::Screenshot:
       return "disabled-by-default-devtools.screenshot";
+    default:
+      folly::assume_unreachable();
+      return "unknown";
   }
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/AttributedStringBox.h
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/AttributedStringBox.h
@@ -71,6 +71,9 @@ struct std::hash<facebook::react::AttributedStringBox> {
         return std::hash<facebook::react::AttributedString>()(attributedStringBox.getValue());
       case facebook::react::AttributedStringBox::Mode::OpaquePointer:
         return std::hash<std::shared_ptr<void>>()(attributedStringBox.getOpaquePointer());
+      default:
+        react_native_assert(false && "Invalid AttributedStringBox::Mode");
+        return 0;
     }
   }
 };

--- a/packages/react-native/ReactCommon/react/renderer/components/image/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/conversions.h
@@ -163,6 +163,11 @@ inline std::string toString(const ImageResizeMode &value)
       return "repeat";
     case ImageResizeMode::None:
       return "none";
+    default:
+      LOG(ERROR) << "Unsupported ImageResizeMode value: " << (int)value;
+      react_native_expect(false);
+      // "cover" is default in non-Fabric web and iOS
+      return "cover";
   }
 }
 


### PR DESCRIPTION
Summary: Changelog: [iOS] [Fixed] - Address `-Wswitch-default` warnings for projects that use that compiler flag

Differential Revision: D87817060


