### PR TITLE
Fix exception in codegen when dependency is not found

### DIFF
--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/utils.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/utils.js
@@ -265,7 +265,8 @@ function findExternalLibraries(
           pkgJson.dependencies[dependency],
           'package.json',
         );
-      } else {
+      }
+      if (!configFilePath) {
         return [];
       }
     }


### PR DESCRIPTION
## Summary:

Fixed an `ENOENT` exception when a dependency does not export `package.json`, and your repo is set up as a monorepo using pnpm.

> [!NOTE]
>
> This does not fix the actual search algorithm. We shouldn't be using `require.main.paths` here because it does not point to the correct starting point, the project root.
>
> This change only fixes the case where we cannot find `package.json` at all.

## Changelog:

[GENERAL] [FIXED] - Fixed an `ENOENT` exception when a dependency does not export `package.json`, and your repo is set up as a monorepo using pnpm

## Test Plan:

**Before:**

```
% node node_modules/react-native/scripts/generate-codegen-artifacts.js -p . -o ios -t ios
[Codegen] Analyzing package.json
[Codegen] Could not find generated autolinking output at: /~/packages/app/example/ios/build/generated/autolinking/autolinking.json
[Codegen] Searching for codegen-enabled libraries in the app.
[Codegen] The "codegenConfig" field is not defined in package.json. Assuming there is nothing to generate at the app level.
[Codegen] Could not find generated autolinking output at: /~/packages/app/example/ios/build/generated/autolinking/autolinking.json
[Codegen] Searching for codegen-enabled libraries in the project dependencies.
[Codegen] Found @react-native-webapis/web-storage
[Codegen] Found react-native
[Codegen] Found react-native-safe-area-context
Trying to find `package.json` for `webdriverio` in [
  '/~/node_modules/.store/react-native-virtual-a5dea7d647/package/scripts/node_modules',
  '/~/node_modules/.store/react-native-virtual-a5dea7d647/package/node_modules',
  '/~/node_modules/.store/react-native-virtual-a5dea7d647/node_modules',
  '/~/node_modules/.store/node_modules',
  '/~/node_modules',
  '/node_modules'
]
[Codegen] Error: ENOENT: no such file or directory, open ''
[Codegen] Done.
```

**After:**

```
% node node_modules/react-native/scripts/generate-codegen-artifacts.js -p . -o ios -t ios
[Codegen] Analyzing package.json
[Codegen] Could not find generated autolinking output at: /~/packages/app/example/ios/build/generated/autolinking/autolinking.json
[Codegen] Searching for codegen-enabled libraries in the app.
[Codegen] The "codegenConfig" field is not defined in package.json. Assuming there is nothing to generate at the app level.
[Codegen] Could not find generated autolinking output at: /~/packages/app/example/ios/build/generated/autolinking/autolinking.json
[Codegen] Searching for codegen-enabled libraries in the project dependencies.
[Codegen] Found @react-native-webapis/web-storage
[Codegen] Found react-native
[Codegen] Found react-native-safe-area-context
Trying to find package.json for webdriverio in [
  '/~/node_modules/.store/react-native-virtual-a5dea7d647/package/scripts/node_modules',
  '/~/node_modules/.store/react-native-virtual-a5dea7d647/package/node_modules',
  '/~/node_modules/.store/react-native-virtual-a5dea7d647/node_modules',
  '/~/node_modules/.store/node_modules',
  '/~/node_modules',
  '/node_modules'
]
[Codegen] Searching for codegen-enabled libraries in react-native.config.js
[Codegen] Processing RNWWebStorageSpec
[Codegen] Searching for podspec in the project dependencies.
[Codegen] Supported Apple platforms: ios, macos, visionos for RNWWebStorageSpec
[Codegen] Processing FBReactNativeSpec
[Codegen] Searching for podspec in the project dependencies.
[Codegen] Processing safeareacontext
[Codegen] Searching for podspec in the project dependencies.
[Codegen] Supported Apple platforms: ios, macos, tvos, visionos for safeareacontext
[Codegen] Generating Native Code for RNWWebStorageSpec - ios
[Codegen] Generated artifacts: ios/build/generated/ios/ReactCodegen
[Codegen] [Codegen - FBReactNativeSpec] Skipping iOS code generation for FBReactNativeSpec as it has been generated already.
[Codegen] Generating Native Code for safeareacontext - ios
[Codegen] Generated artifacts: ios/build/generated/ios/ReactCodegen
[Codegen] Generating RCTThirdPartyComponentsProvider.h
[Codegen] Generated artifact: ios/build/generated/ios/ReactCodegen/RCTThirdPartyComponentsProvider.h
[Codegen] Generating RCTThirdPartyComponentsProvider.mm
[Codegen] Generated artifact: ios/build/generated/ios/ReactCodegen/RCTThirdPartyComponentsProvider.mm
[Codegen] Generating RCTModulesProvider.h
[Codegen] Generated artifact: ios/build/generated/ios/ReactCodegen/RCTModuleProviders.h
[Codegen] Generating RCTModuleProviders.mm
[Codegen] Generated artifact: ios/build/generated/ios/ReactCodegen/RCTModuleProviders.mm
[Codegen] Generating RCTAppDependencyProvider
[Codegen] Generated artifact: ios/build/generated/ios/ReactAppDependencyProvider/RCTAppDependencyProvider.h
[Codegen] Generated artifact: ios/build/generated/ios/ReactAppDependencyProvider/RCTAppDependencyProvider.mm
[Codegen] Generated podspec: ios/build/generated/ios/ReactAppDependencyProvider/ReactAppDependencyProvider.podspec
[Codegen] Generated podspec: ios/build/generated/ios/ReactCodegen/ReactCodegen.podspec
[Codegen] Generating Package.swift
[Codegen] Generated artifact: ios/build/generated/ios/Package.swift
[Codegen] Done.
```