### PR TITLE
Fix 'hermes-compiler' not being resolved correctly

### DIFF
--- a/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
+++ b/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
@@ -72,10 +72,7 @@ Pod::Spec.new do |spec|
     # In other cases, when using Hermes V1, the prebuilt versioned binaries can be used.
     if source_type != HermesEngineSourceType::LOCAL_PREBUILT_TARBALL
       hermes_compiler_path = File.dirname(Pod::Executable.execute_command('node', ['-p',
-        'require.resolve(
-        "hermes-compiler",
-        {paths: [process.argv[1]]}
-        )', __dir__]).strip
+        "require.resolve(\"hermes-compiler\", {paths: [\"#{react_native_path}\"]})", __dir__]).strip
       )
 
       spec.user_target_xcconfig = {


### PR DESCRIPTION
## Summary:

Fixed `hermes-compiler` not being resolved correctly when your repo is set up as a monorepo using pnpm.

## Changelog:

[GENERAL] [FIXED] - Fixed `hermes-compiler` not being resolved correctly when your repo is set up as a monorepo using pnpm.

## Test Plan:

n/a