### PR TITLE
Reset zoomscale to 1 in Fabric RCTScrollViewComponentView

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -680,6 +680,8 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
 
   const auto &props = static_cast<const ScrollViewProps &>(*_props);
   _scrollView.contentOffset = RCTCGPointFromPoint(props.contentOffset);
+  // Reset zoom scale to default
+  _scrollView.zoomScale = 1.0;
   // We set the default behavior to "never" so that iOS
   // doesn't do weird things to UIScrollView insets automatically
   // and keeps it as an opt-in behavior.


### PR DESCRIPTION
## Summary:

Fixes https://github.com/facebook/react-native/issues/48772 and https://github.com/expo/expo/issues/39984

Resets the UIScrollView zoomScale to 1 before recycling the RCTScrollViewComponentView in Fabric.

## Changelog:

[IOS] [FIXED] - Reset zoomScale to 1 before recycling UIScrollView in Fabric

## Test Plan:

Try the snack attached in https://github.com/expo/expo/issues/39984 or the steps to reproduce in the same issue.
