### PR TITLE
Enable Network Panel on Android and cocoapods

### DIFF
--- a/packages/react-native/ReactCommon/react/networking/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/networking/CMakeLists.txt
@@ -21,3 +21,10 @@ target_link_libraries(react_networking
         jsinspector_tracing
         react_performance_timeline
         react_timing)
+
+if(${CMAKE_BUILD_TYPE} MATCHES Debug OR REACT_NATIVE_DEBUG_OPTIMIZED)
+  target_compile_options(react_networking PRIVATE
+          -DREACT_NATIVE_DEBUGGER_ENABLED=1
+          -DREACT_NATIVE_DEBUGGER_ENABLED_DEVONLY=1
+  )
+endif ()

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -59,8 +59,10 @@ class ReactNativePodsUtils
     def self.set_gcc_preprocessor_definition_for_debugger(installer)
         self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "REACT_NATIVE_DEBUGGER_ENABLED=1", "React-jsinspector", :debug)
         self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "REACT_NATIVE_DEBUGGER_ENABLED=1", "React-RCTNetwork", :debug)
+        self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "REACT_NATIVE_DEBUGGER_ENABLED=1", "React-networking", :debug)
         self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "REACT_NATIVE_DEBUGGER_ENABLED_DEVONLY=1", "React-jsinspector", :debug)
         self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "REACT_NATIVE_DEBUGGER_ENABLED_DEVONLY=1", "React-RCTNetwork", :debug)
+        self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "REACT_NATIVE_DEBUGGER_ENABLED_DEVONLY=1", "React-networking", :debug)
     end
 
     def self.turn_off_resource_bundle_react_core(installer)


### PR DESCRIPTION
Summary:
This is a port back to main of [this commit](https://github.com/facebook/react-native/commit/eb78fbae27dea9ff840f24da18ce29100b89b270) which landed in 0.83 to make sure that the network panel is enabled for Android and for iOS builds from source.

## Changelog:
[Internal] -

Reviewed By: cortinico

Differential Revision: D87864636


