### PR TITLE
Remove RCTTurboModuleSyncVoidMethodsEnabled feature flag and related code

### DIFF
--- a/packages/react-native/React/Base/RCTBridge.h
+++ b/packages/react-native/React/Base/RCTBridge.h
@@ -62,10 +62,6 @@ void RCTEnableTurboModuleInteropBridgeProxy(BOOL enabled);
 BOOL RCTFabricInteropLayerEnabled(void);
 void RCTEnableFabricInteropLayer(BOOL enabled);
 
-// Turn on TurboModule sync execution of void methods
-BOOL RCTTurboModuleSyncVoidMethodsEnabled(void);
-void RCTEnableTurboModuleSyncVoidMethods(BOOL enabled);
-
 BOOL RCTUIManagerDispatchAccessibilityManagerInitOntoMain(void);
 void RCTUIManagerSetDispatchAccessibilityManagerInitOntoMain(BOOL enabled);
 

--- a/packages/react-native/React/Base/RCTBridge.mm
+++ b/packages/react-native/React/Base/RCTBridge.mm
@@ -242,17 +242,6 @@ void RCTSetTurboModuleInteropBridgeProxyLogLevel(RCTBridgeProxyLoggingLevel logL
   bridgeProxyLoggingLevel = logLevel;
 }
 
-// Turn on TurboModule sync execution of void methods
-static BOOL gTurboModuleEnableSyncVoidMethods = NO;
-BOOL RCTTurboModuleSyncVoidMethodsEnabled(void)
-{
-  return gTurboModuleEnableSyncVoidMethods;
-}
-void RCTEnableTurboModuleSyncVoidMethods(BOOL enabled)
-{
-  gTurboModuleEnableSyncVoidMethods = enabled;
-}
-
 BOOL kDispatchAccessibilityManagerInitOntoMain = NO;
 BOOL RCTUIManagerDispatchAccessibilityManagerInitOntoMain(void)
 {

--- a/packages/react-native/ReactCommon/react/nativemodule/core/iostests/RCTTurboModuleTests.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/iostests/RCTTurboModuleTests.mm
@@ -58,7 +58,6 @@ class StubNativeMethodCallInvoker : public NativeMethodCallInvoker {
       .jsInvoker = nullptr,
       .nativeMethodCallInvoker = std::make_shared<StubNativeMethodCallInvoker>(),
       .isSyncModule = false,
-      .shouldVoidMethodsExecuteSync = true,
   };
   module_ = std::make_unique<ObjCTurboModule>(params);
 }

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.h
@@ -58,7 +58,6 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
     std::shared_ptr<CallInvoker> jsInvoker;
     std::shared_ptr<NativeMethodCallInvoker> nativeMethodCallInvoker;
     bool isSyncModule;
-    bool shouldVoidMethodsExecuteSync;
   };
 
   ObjCTurboModule(const InitParams &params);
@@ -127,9 +126,6 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
  private:
   // Does the NativeModule dispatch async methods to the JS thread?
   const bool isSyncModule_;
-
-  // Should void methods execute synchronously?
-  const bool shouldVoidMethodsExecuteSync_;
 
   /**
    * TODO(ramanpreet):

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
@@ -397,7 +397,6 @@ typedef struct {
         .jsInvoker = _jsInvoker,
         .nativeMethodCallInvoker = nativeMethodCallInvoker,
         .isSyncModule = methodQueue == RCTJSThread,
-        .shouldVoidMethodsExecuteSync = (bool)RCTTurboModuleSyncVoidMethodsEnabled(),
     };
 
     auto turboModule = [(id<RCTTurboModule>)module getTurboModule:params];
@@ -459,7 +458,6 @@ typedef struct {
       .jsInvoker = _jsInvoker,
       .nativeMethodCallInvoker = std::move(nativeMethodCallInvoker),
       .isSyncModule = methodQueue == RCTJSThread,
-      .shouldVoidMethodsExecuteSync = (bool)RCTTurboModuleSyncVoidMethodsEnabled(),
   };
 
   auto turboModule = std::make_shared<ObjCInteropTurboModule>(params);

--- a/scripts/cxx-api/ReactNativeCPP.api
+++ b/scripts/cxx-api/ReactNativeCPP.api
@@ -2177,8 +2177,6 @@ BOOL RCTTurboModuleInteropBridgeProxyEnabled(void);
 void RCTEnableTurboModuleInteropBridgeProxy(BOOL enabled);
 BOOL RCTFabricInteropLayerEnabled(void);
 void RCTEnableFabricInteropLayer(BOOL enabled);
-BOOL RCTTurboModuleSyncVoidMethodsEnabled(void);
-void RCTEnableTurboModuleSyncVoidMethods(BOOL enabled);
 BOOL RCTUIManagerDispatchAccessibilityManagerInitOntoMain(void);
 void RCTUIManagerSetDispatchAccessibilityManagerInitOntoMain(BOOL enabled);
 typedef enum {
@@ -16571,7 +16569,6 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
     std::shared_ptr<CallInvoker> jsInvoker;
     std::shared_ptr<NativeMethodCallInvoker> nativeMethodCallInvoker;
     bool isSyncModule;
-    bool shouldVoidMethodsExecuteSync;
   };
   ObjCTurboModule(const InitParams &params);
   jsi::Value invokeObjCMethod(
@@ -16648,7 +16645,6 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
     std::shared_ptr<CallInvoker> jsInvoker;
     std::shared_ptr<NativeMethodCallInvoker> nativeMethodCallInvoker;
     bool isSyncModule;
-    bool shouldVoidMethodsExecuteSync;
   };
   ObjCTurboModule(const InitParams &params);
   jsi::Value invokeObjCMethod(
@@ -16681,7 +16677,6 @@ class JSI_EXPORT ObjCTurboModule : public TurboModule {
 
  private:
   const bool isSyncModule_;
-  const bool shouldVoidMethodsExecuteSync_;
   NSMutableDictionary<NSString *, NSMutableArray *> *methodArgConversionSelectors_;
   NSDictionary<NSString *, NSArray<NSString *> *> *methodArgumentTypeNames_;
   bool isMethodSync(TurboModuleMethodValueKind returnType);


### PR DESCRIPTION
Summary:
This diff removes the `RCTTurboModuleSyncVoidMethodsEnabled` feature flag and all related code that allowed TurboModule void methods to execute synchronously.

Changelog: [Internal]

Differential Revision: D87865883
