### PR TITLE
Fix: loading bundle using `debug_http_host` preferences

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/PackagerConnectionSettings.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/packagerconnection/PackagerConnectionSettings.kt
@@ -5,13 +5,19 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+@file:Suppress("DEPRECATION") // PreferenceManager should be migrated to androidx
+
 package com.facebook.react.packagerconnection
 
 import android.content.Context
+import android.content.SharedPreferences
+import android.preference.PreferenceManager
 import com.facebook.common.logging.FLog
 import com.facebook.react.modules.systeminfo.AndroidInfoHelpers
 
 public open class PackagerConnectionSettings(private val appContext: Context) {
+  private val preferences: SharedPreferences =
+      PreferenceManager.getDefaultSharedPreferences(appContext)
   public val packageName: String = appContext.packageName
   private val _additionalOptionsForPackager: MutableMap<String, String> = mutableMapOf()
   private var _packagerOptionsUpdater: (Map<String, String>) -> Map<String, String> = { it }
@@ -24,6 +30,12 @@ public open class PackagerConnectionSettings(private val appContext: Context) {
       cachedHost?.let {
         return it
       }
+
+      val hostFromSettings = preferences.getString(PREFS_DEBUG_SERVER_HOST_KEY, null)
+      if (!hostFromSettings.isNullOrEmpty()) {
+        return hostFromSettings
+      }
+
       val host = AndroidInfoHelpers.getServerHost(appContext)
       if (host == AndroidInfoHelpers.DEVICE_LOCALHOST) {
         FLog.w(
@@ -63,5 +75,6 @@ public open class PackagerConnectionSettings(private val appContext: Context) {
 
   private companion object {
     private val TAG = PackagerConnectionSettings::class.java.simpleName
+    private const val PREFS_DEBUG_SERVER_HOST_KEY = "debug_http_host"
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

In #54139 I have removed checking shared preferences for `debug_http_host`. The diff reverts this removal because it is used for changing the bundle source before the app starts. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[ANDROID][FIXED] - revert removal of checking shared preferences for `debug_http_host`.


## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I have run the `rn-tester` app and swapped a default prefs file on Android emulator located in:  `/data/data/com.facebook.react.uiapp/shared_prefs/com.facebook.react.uiapp_preferences.xml` with one that had updated port in `debug_http_host` setting to `8082`:

```xml
<?xml version='1.0' encoding='utf-8' standalone='yes' ?>
<map>
    <boolean name="fps_debug" value="true" />
    <string name="debug_http_host">10.0.2.2:8082</string>
    <boolean name="inspector_debug" value="true" />
</map>
```

Then, I have run the app and checked if the bundle is loaded from the Metro instance invoked using `yarn start --port 8082`.


