### PR TITLE
Fix RCTDevLoadingView crash when adding button constraints

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
+++ b/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
@@ -195,7 +195,7 @@ RCT_EXPORT_MODULE()
     ]];
 
     // Add button-specific constraints if button exists
-    if (dismissButton) {
+    if (self->_dismissButton != nullptr) {
       [constraints addObjectsFromArray:@[
         [self->_dismissButton.trailingAnchor constraintEqualToAnchor:self->_container.trailingAnchor constant:-10],
         [self->_dismissButton.centerYAnchor constraintEqualToAnchor:self->_label.centerYAnchor],


### PR DESCRIPTION
Summary:
D86420230 added a dismiss button feature to RCTDevLoadingView. However, when adding layout constraints on line 198, it incorrectly checked the `dismissButton` parameter instead of the `self->_dismissButton` instance variable. This caused NSLayoutConstraint crashes when the parameter was nil/false but the instance variable existed from a previous call, or vice versa.

This changes line 198 to check `self->_dismissButton` (the instance variable) instead of `dismissButton` (the function parameter) to properly verify if the button exists before adding constraints to it.

Differential Revision: D87871856


