### PR TITLE
Clear out mTagToSynchronousMountProps on surface stop

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.java
@@ -83,7 +83,7 @@ public class SurfaceMountingManager {
       new ConcurrentHashMap<>(); // any thread
   private final Queue<MountItem> mOnViewAttachMountItems = new ArrayDeque<>();
   private JSResponderHandler mJSResponderHandler;
-  private ViewManagerRegistry mViewManagerRegistry;
+  private final ViewManagerRegistry mViewManagerRegistry;
   private RootViewManager mRootViewManager;
   private MountItemExecutor mMountItemExecutor;
 
@@ -336,6 +336,7 @@ public class SurfaceMountingManager {
           mMountItemExecutor = null;
           mThemedReactContext = null;
           mOnViewAttachMountItems.clear();
+          mTagToSynchronousMountProps.clear();
 
           FLog.e(TAG, "Surface [" + mSurfaceId + "] was stopped on SurfaceMountingManager.");
         };


### PR DESCRIPTION
Summary:
SurfaceMountingManager stays around even after the surface is stopped - we need to clean these up.

Changelog: [Internal]

Reviewed By: zeyap

Differential Revision: D87875316


