### PR TITLE
Add lib defs for Node.js fs.glob, etc.

### DIFF
--- a/flow-typed/environment/node.js
+++ b/flow-typed/environment/node.js
@@ -21,6 +21,12 @@ interface ErrnoError extends Error {
   syscall?: string;
 }
 
+type Node$Conditional<T: boolean, IfTrue, IfFalse> = T extends true
+  ? IfTrue
+  : T extends false
+    ? IfFalse
+    : IfTrue | IfFalse;
+
 type buffer$NonBufferEncoding =
   | 'hex'
   | 'HEX'
@@ -1594,6 +1600,71 @@ declare module 'fs' {
     flags?: number,
   ): void;
 
+  declare type GlobOptions<WithFileTypes: boolean> = $ReadOnly<{
+    /**
+     * Current working directory.
+     * @default process.cwd()
+     */
+    cwd?: string | void,
+    /**
+     * `true` if the glob should return paths as `Dirent`s, `false` otherwise.
+     * @default false
+     * @since v22.2.0
+     */
+    withFileTypes?: WithFileTypes,
+    /**
+     * Function to filter out files/directories or a
+     * list of glob patterns to be excluded. If a function is provided, return
+     * `true` to exclude the item, `false` to include it.
+     * @default undefined
+     */
+    exclude?:
+      | ((fileName: Node$Conditional<WithFileTypes, Dirent, string>) => boolean)
+      | $ReadOnlyArray<string>,
+    ...
+  }>;
+
+  /**
+   * Retrieves the files matching the specified pattern.
+   *
+   * ```js
+   * import { glob } from 'node:fs';
+   *
+   * glob('*.js', (err, matches) => {
+   *   if (err) throw err;
+   *   console.log(matches);
+   * });
+   * ```
+   * @since v22.0.0
+   */
+  declare function glob(
+    pattern: string | $ReadOnlyArray<string>,
+    callback: (err: ?ErrnoError, matches: Array<string>) => void,
+  ): void;
+
+  declare function glob<WithFileTypes: boolean = false>(
+    pattern: string | $ReadOnlyArray<string>,
+    options: GlobOptions<WithFileTypes>,
+    callback: (
+      err: ?ErrnoError,
+      matches: Node$Conditional<WithFileTypes, Array<Dirent>, Array<string>>,
+    ) => void,
+  ): void;
+
+  /**
+   * ```js
+   * import { globSync } from 'node:fs';
+   *
+   * console.log(globSync('*.js'));
+   * ```
+   * @since v22.0.0
+   * @returns paths of files that match the pattern.
+   */
+  declare function globSync<WithFileTypes: boolean = false>(
+    pattern: string | $ReadOnlyArray<string>,
+    options?: GlobOptions<WithFileTypes>,
+  ): Node$Conditional<WithFileTypes, Array<Dirent>, Array<string>>;
+
   declare var F_OK: number;
   declare var R_OK: number;
   declare var W_OK: number;
@@ -1725,6 +1796,14 @@ declare module 'fs' {
       atime: number | string | Date,
       mtime: number | string | Date,
     ): Promise<void>,
+    glob<WithFileTypes: boolean = false>(
+      pattern: string | $ReadOnlyArray<string>,
+      options?: GlobOptions<WithFileTypes>,
+    ): Node$Conditional<
+      WithFileTypes,
+      AsyncIterator<Dirent>,
+      AsyncIterator<string>,
+    >,
     lchmod(path: FSPromisePath, mode: number): Promise<void>,
     lchown(path: FSPromisePath, uid: number, guid: number): Promise<void>,
     link(existingPath: FSPromisePath, newPath: FSPromisePath): Promise<void>,


### PR DESCRIPTION
Summary:
Add Flow typing for `fs.glob` APIs introduced in Node v22

Changelog:
[Internal]

Reviewed By: cipolleschi, vzaidman

Differential Revision: D78668287


