### PR TITLE
Fix RCTDevLoadingView banner window sizing and interaction

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
+++ b/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
@@ -220,6 +220,9 @@ RCT_EXPORT_MODULE()
     }
 
     [NSLayoutConstraint activateConstraints:constraints];
+
+    [self->_window layoutIfNeeded];
+    self->_window.frame = CGRectMake(0, 0, mainWindow.frame.size.width, self->_container.frame.size.height);
   });
 }
 


### PR DESCRIPTION
Summary:
The dev loading banner window was previously full-screen height, making the entire screen unresponsive to touches even though only a small banner was visible. Additionally, the dismiss button had a redundant tap handler when the entire banner was already tappable.

This diff fixes two issues:

1. **Window frame sizing**: The window frame is now calculated after Auto Layout completes, ensuring it matches the actual content height (label + padding + safe area). This allows the rest of the screen below the banner to remain interactive.

2. **Redundant button interaction**: The dismiss button's `primaryAction` was removed and `userInteractionEnabled` is set to `NO`, making it purely visual. Taps on the button now pass through to the banner's tap gesture recognizer.

The banner now only blocks interactions within its actual bounds, and the entire banner (including the button area) can be tapped to dismiss.

Differential Revision: D87922708


