### PR TITLE
Fix RCTDevLoadingView banner interaction

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
+++ b/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
@@ -158,10 +158,9 @@ RCT_EXPORT_MODULE()
       buttonConfig.background.cornerRadius = 10;
       buttonConfig.baseForegroundColor = color;
 
-      UIAction *dismissAction = [UIAction actionWithHandler:^(__kindof UIAction *_Nonnull action) {
-        [self hide];
-      }];
-      self->_dismissButton = [UIButton buttonWithConfiguration:buttonConfig primaryAction:dismissAction];
+      // Button is a visual cue to tap anywhere on the banner to dismiss so no seperate action is needed
+      self->_dismissButton = [UIButton buttonWithConfiguration:buttonConfig primaryAction:nil];
+      self->_dismissButton.userInteractionEnabled = NO;
       self->_dismissButton.translatesAutoresizingMaskIntoConstraints = NO;
 
       // Prevent button from being compressed - force label to wrap instead


### PR DESCRIPTION
Summary:
Changelog:
[iOS][Fixed] - remove redundant gesture to tap button when the layer beneath is already tappable

The dismiss button had a redundant tap handler when the entire banner was already tappable.

**Redundant button interaction**: The dismiss button's `primaryAction` was removed and `userInteractionEnabled` is set to `NO`, making it purely visual. Taps on the button now pass through to the banner's tap gesture recognizer.

Reviewed By: vzaidman

Differential Revision: D87927449


