### PR TITLE
Fix isClickable state for TextViews after recycling

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -156,7 +156,8 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
       view.setOnClickListener(null);
     }
     if (ReactNativeFeatureFlags.shouldResetClickableWhenRecyclingView()) {
-      view.setClickable(ReactNativeFeatureFlags.shouldSetIsClickableByDefault());
+      view.setClickable(
+          ReactNativeFeatureFlags.shouldSetIsClickableByDefault() && !(view instanceof TextView));
     }
     view.setFocusable(false);
     view.setFocusableInTouchMode(false);


### PR DESCRIPTION
Summary:
Changelog:
[Android][Fixed] - Fix isClickable state for TextViews after recycling

This change ensures TextViews don't have `isClickable=true` by default when views are recycled. Setting `isClickable=true` on TextViews semantically implies they should occlude what's behind them, which is only correct when the text has a click listener attached.

Reviewed By: cortinico

Differential Revision: D87927350


