### PR TITLE
Fix isClickable state for TextViews based on onClickListener

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -16,6 +16,7 @@ import android.view.View.OnFocusChangeListener;
 import android.view.ViewGroup;
 import android.view.ViewParent;
 import android.view.accessibility.AccessibilityEvent;
+import android.widget.TextView;
 import androidx.annotation.ColorInt;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -1025,9 +1026,15 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
       return;
     }
 
-    boolean shouldBeClickable =
-        !(view instanceof ReactPointerEventsView)
-            || PointerEvents.canBeTouchTarget(((ReactPointerEventsView) view).getPointerEvents());
+    boolean shouldBeClickable;
+    if (view instanceof ReactPointerEventsView) {
+      shouldBeClickable =
+          PointerEvents.canBeTouchTarget(((ReactPointerEventsView) view).getPointerEvents());
+    } else if (view instanceof TextView) {
+      shouldBeClickable = view.hasOnClickListeners();
+    } else {
+      shouldBeClickable = true;
+    }
 
     // NOTE: In Android O+, setClickable(true) has the side effect of setting focusable=true.
     // We need to preserve the original focusable state to respect the focusable prop.


### PR DESCRIPTION
Summary:
Changelog:
[Android][Fixed] - Fix isClickable state for TextViews based on onClickListener

This change improves the readability and correctness of the `configureClickableState` method in `BaseViewManager.java`.

**Previous behavior**: TextViews were treated the same as all other non-ReactPointerEventsView views.

**New behavior**: The logic is now clearer:
- For `TextView`: `shouldBeClickable` is set based on whether the view has onClickListeners (prevents TextViews without click handlers from being marked as clickable)
- For `ReactPointerEventsView`: Uses the existing `canBeTouchTarget()` check
- For all other views: Defaults to `true`

This ensures that TextViews are only marked as clickable when they actually have a click listener attached, which is more semantically correct for accessibility and user interaction.

Reviewed By: cortinico

Differential Revision: D87919507


