### PR TITLE
fix: RCTBlobManager crash on nil response

### DIFF
--- a/packages/react-native/Libraries/Blob/RCTBlobManager.mm
+++ b/packages/react-native/Libraries/Blob/RCTBlobManager.mm
@@ -299,12 +299,21 @@ RCT_EXPORT_METHOD(release : (NSString *)blobId)
   // An empty body will have nil for data, in this case we need to return
   // an empty blob as per the XMLHttpRequest spec.
   data = data ?: [NSData new];
+
+  NSString *fileName = nil;
+  NSString *contentType = nil;
+
+  if (response) {
+    fileName = [response suggestedFilename];
+    contentType = [response MIMEType];
+  }
+    
   return @{
     @"blobId" : [self store:data],
     @"offset" : @0,
     @"size" : @(data.length),
-    @"name" : RCTNullIfNil([response suggestedFilename]),
-    @"type" : RCTNullIfNil([response MIMEType]),
+    @"name" : RCTNullIfNil(fileName),
+    @"type" : RCTNullIfNil(contentType),
   };
 }
 


### PR DESCRIPTION
## Summary:

I was working on react-native app and consistently got crashes after letting the app run for quite some time with the following stacktrace.

```
Thread 43 Crashed::  Dispatch queue: com.meta.react.turbomodulemanager.queue
0   libobjc.A.dylib               	       0x18006ac14 objc_msgSend + 20
1   CoreServices                  	       0x18149a34c _LSDatabaseGetStringForCFString + 64
2   CoreServices                  	       0x181554b9c _UTEnumerateTypesForTag + 152
3   CoreServices                  	       0x181554aa4 _UTTypeGetActiveIdentifierForTag + 172
4   CoreServices                  	       0x1815584bc +[UTTypeRecord typeRecordWithTag:ofClass:conformingToIdentifier:] + 324
5   CoreServices                  	       0x1815507c8 UTTypeCreatePreferredIdentifierForTag + 76
6   CFNetwork                     	       0x1849757f8 copyPreferredExtensionForMIMEType + 44
7   CFNetwork                     	       0x1849cda34 URLResponse::copySuggestedFilename() + 248
8   CFNetwork                     	       0x18493d400 -[NSURLResponse suggestedFilename] + 16
9   REDACTED.debug.dylib          	       0x10a67e214 -[RCTBlobManager handleNetworkingResponse:data:] + 472 (RCTBlobManager.mm:323)
10  REDACTED.debug.dylib          	       0x10a80d3a8 -[RCTNetworking sendData:responseType:response:forTask:] + 2216 (RCTNetworking.mm:546)
11  REDACTED.debug.dylib          	       0x10a80fc0c __76-[RCTNetworking sendRequest:responseType:incrementalUpdates:responseSender:]_block_invoke_2 + 264 (RCTNetworking.mm:653)
12  REDACTED.debug.dylib          	       0x10a8148b4 __50-[RCTNetworkTask URLRequest:didCompleteWithError:]_block_invoke + 60 (RCTNetworkTask.mm:222)
13  libdispatch.dylib             	       0x18017c788 _dispatch_call_block_and_release + 24
14  libdispatch.dylib             	       0x180197278 _dispatch_client_callout + 12
15  libdispatch.dylib             	       0x180185ad0 _dispatch_lane_serial_drain + 984
16  libdispatch.dylib             	       0x180186590 _dispatch_lane_invoke + 396
17  libdispatch.dylib             	       0x180191380 _dispatch_root_queue_drain_deferred_wlh + 288
18  libdispatch.dylib             	       0x1801909f4 _dispatch_workloop_worker_thread + 440
19  libsystem_pthread.dylib       	       0x1029eeb8c _pthread_wqthread + 288
20  libsystem_pthread.dylib       	       0x1029ed98c start_wqthread + 8
```

[Full Stacktrace](https://pastebin.com/GYrzubZF)

From the stacktrace you can see that error is caused by the `RCTBlobManager` class calling `[NSURLResponse suggestedFilename]` on an invalid response object.
The function is called only from react-native internals and the issues is not caused by third party code.

I've fixed it by first checking if the response is valid and only then calling `[response suggestedFilename]` and `[response MIMEType]` on it.

## Changelog:

FIXED - crash in RCTBlobManager on nil response

## Test Plan:

Unfortunately I was unable to isolate a reproducible example for this crash, as it only happened after letting my private app run for some time, which then triggered the crash.
I assume its a network request that fails (partially) and isn't handled properly.

