### PR TITLE
Bump `chromium-edge-launcher` to drop `rimraf`

### DIFF
--- a/packages/dev-middleware/package.json
+++ b/packages/dev-middleware/package.json
@@ -26,7 +26,7 @@
     "@react-native/debugger-frontend": "0.84.0-main",
     "@react-native/debugger-shell": "0.84.0-main",
     "chrome-launcher": "^0.15.2",
-    "chromium-edge-launcher": "^0.2.0",
+    "chromium-edge-launcher": "^0.3.0",
     "connect": "^3.6.5",
     "debug": "^4.4.0",
     "invariant": "^2.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3403,17 +3403,16 @@ chrome-launcher@^0.15.2:
     is-wsl "^2.2.0"
     lighthouse-logger "^1.0.0"
 
-chromium-edge-launcher@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/chromium-edge-launcher/-/chromium-edge-launcher-0.2.0.tgz#0c378f28c99aefc360705fa155de0113997f62fc"
-  integrity sha512-JfJjUnq25y9yg4FABRRVPmBGWPZZi+AQXT4mxupb67766/0UlhG8PAZCz6xzEMXTbW3CsSoE8PcCWA49n35mKg==
+chromium-edge-launcher@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/chromium-edge-launcher/-/chromium-edge-launcher-0.3.0.tgz#34d5ca8142fc059ea2b4482bdcb184393a399ffe"
+  integrity sha512-p03azHlGjtyRvFEee3cyvtsRYdniSkwjkzmM/KmVnqT5d7QkkwpJBhis/zCLMYdQMVJ5tt140TBNqqrZPaWeFA==
   dependencies:
     "@types/node" "*"
     escape-string-regexp "^4.0.0"
     is-wsl "^2.2.0"
     lighthouse-logger "^1.0.0"
     mkdirp "^1.0.4"
-    rimraf "^3.0.2"
 
 ci-info@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Summary:

Related to #54669

This version bump drops `rimraf`.

This has been raised at a sync before, but it'd be great to instead drop or replace this entirly. I also noticed that it pulls in `@types/node@*`, which isn't necessary for it to function as well, and generally, it'd be nice if we had an alternative here.

cc @huntie

## Changelog:

[GENERAL] [SECURITY] - Bump to `chromium-edge-launcher@^0.3.0` to drop `rimraf`

## Test Plan:

- Package hasn't changed except for `rimraf` having been dropped