### PR TITLE
Invalidate displayLink & deallocate RCTAnimatedModuleProvider before ReactHost teardown

### DIFF
--- a/packages/react-native/ReactApple/RCTAnimatedModuleProvider/RCTAnimatedModuleProvider.h
+++ b/packages/react-native/ReactApple/RCTAnimatedModuleProvider/RCTAnimatedModuleProvider.h
@@ -19,6 +19,8 @@ class TurboModule;
 
 @interface RCTAnimatedModuleProvider : NSObject
 
+- (void)invalidate;
+
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const std::string &)name
                                                       jsInvoker:
                                                           (std::shared_ptr<facebook::react::CallInvoker>)jsInvoker;

--- a/packages/react-native/ReactApple/RCTAnimatedModuleProvider/RCTAnimatedModuleProvider.mm
+++ b/packages/react-native/ReactApple/RCTAnimatedModuleProvider/RCTAnimatedModuleProvider.mm
@@ -30,6 +30,11 @@
 
 - (void)dealloc
 {
+  [self invalidate];
+}
+
+- (void)invalidate
+{
   if (_displayLink != nil) {
 #if TARGET_OS_OSX
     RCTPlatformDisplayLink *displayLink = _displayLink;


### PR DESCRIPTION
Summary:
## Changelog:

[iOS] [Added] - Allow invalidateDisplayLink on RCTAnimatedModuleProvider

Reviewed By: sammy-SC

Differential Revision: D87929762


