### PR TITLE
Fix type of constantsToExport arg

### DIFF
--- a/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/modules/NativeSampleTurboModule.js
+++ b/packages/react-native-codegen/e2e/deep_imports/__test_fixtures__/modules/NativeSampleTurboModule.js
@@ -35,11 +35,7 @@ export interface Spec extends TurboModule {
   +getObjectShape: (arg: {prop: number}) => {prop: number};
   +getAlias: (arg: Animal) => Animal;
   +getRootTag: (arg: RootTag) => RootTag;
-  +getValue: (
-    x: number,
-    getValuegetValuegetValuegetValuegetValuey: string,
-    z: Object,
-  ) => Object;
+  +getValue: (x: number, y: string, z: Object) => Object;
   +getValueWithCallback: (callback: (value: string) => void) => void;
   +getValueWithPromise: (error: boolean) => Promise<string>;
 }

--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/modules/__snapshots__/GenerateModuleObjCpp-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/modules/__snapshots__/GenerateModuleObjCpp-test.js.snap
@@ -392,8 +392,8 @@ namespace JS {
 - (NSDictionary *)getGenericObjectReadOnly:(NSDictionary *)arg;
 - (NSDictionary *)getGenericObjectWithAlias:(NSDictionary *)arg;
 - (NSDictionary *)difficultObject:(JS::NativeObjectTurboModule::SpecDifficultObjectA &)A;
-- (facebook::react::ModuleConstants<JS::NativeObjectTurboModule::Constants::Builder>)constantsToExport;
-- (facebook::react::ModuleConstants<JS::NativeObjectTurboModule::Constants::Builder>)getConstants;
+- (facebook::react::ModuleConstants<JS::NativeObjectTurboModule::Constants>)constantsToExport;
+- (facebook::react::ModuleConstants<JS::NativeObjectTurboModule::Constants>)getConstants;
 
 @end
 
@@ -534,8 +534,8 @@ namespace JS {
 }
 @protocol NativeOptionalObjectTurboModuleSpec <RCTBridgeModule, RCTTurboModule>
 
-- (facebook::react::ModuleConstants<JS::NativeOptionalObjectTurboModule::Constants::Builder>)constantsToExport;
-- (facebook::react::ModuleConstants<JS::NativeOptionalObjectTurboModule::Constants::Builder>)getConstants;
+- (facebook::react::ModuleConstants<JS::NativeOptionalObjectTurboModule::Constants>)constantsToExport;
+- (facebook::react::ModuleConstants<JS::NativeOptionalObjectTurboModule::Constants>)getConstants;
 
 @end
 
@@ -734,14 +734,14 @@ namespace JS {
 - (NSDictionary *)getAlias:(JS::NativeSampleTurboModule::Animal &)arg;
 - (NSNumber *)getRootTag:(double)arg;
 - (NSDictionary *)getValue:(double)x
-getValuegetValuegetValuegetValuegetValuey:(NSString *)getValuegetValuegetValuegetValuegetValuey
+                         y:(NSString *)y
                          z:(NSDictionary *)z;
 - (void)getValueWithCallback:(RCTResponseSenderBlock)callback;
 - (void)getValueWithPromise:(BOOL)error
                     resolve:(RCTPromiseResolveBlock)resolve
                      reject:(RCTPromiseRejectBlock)reject;
-- (facebook::react::ModuleConstants<JS::NativeSampleTurboModule::Constants::Builder>)constantsToExport;
-- (facebook::react::ModuleConstants<JS::NativeSampleTurboModule::Constants::Builder>)getConstants;
+- (facebook::react::ModuleConstants<JS::NativeSampleTurboModule::Constants>)constantsToExport;
+- (facebook::react::ModuleConstants<JS::NativeSampleTurboModule::Constants>)getConstants;
 
 @end
 
@@ -838,8 +838,8 @@ namespace JS {
 - (void)getValueWithPromise:(NSArray *)error
                     resolve:(RCTPromiseResolveBlock)resolve
                      reject:(RCTPromiseRejectBlock)reject;
-- (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleArrays::Constants::Builder>)constantsToExport;
-- (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleArrays::Constants::Builder>)getConstants;
+- (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleArrays::Constants>)constantsToExport;
+- (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleArrays::Constants>)getConstants;
 
 @end
 
@@ -938,8 +938,8 @@ namespace JS {
 - (void)getValueWithPromise:(NSNumber *)error
                     resolve:(RCTPromiseResolveBlock)resolve
                      reject:(RCTPromiseRejectBlock)reject;
-- (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleNullable::Constants::Builder>)constantsToExport;
-- (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleNullable::Constants::Builder>)getConstants;
+- (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleNullable::Constants>)constantsToExport;
+- (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleNullable::Constants>)getConstants;
 
 @end
 
@@ -1038,8 +1038,8 @@ namespace JS {
 - (void)getValueWithPromise:(NSNumber *)error
                     resolve:(RCTPromiseResolveBlock)resolve
                      reject:(RCTPromiseRejectBlock)reject;
-- (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleNullableAndOptional::Constants::Builder>)constantsToExport;
-- (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleNullableAndOptional::Constants::Builder>)getConstants;
+- (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleNullableAndOptional::Constants>)constantsToExport;
+- (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleNullableAndOptional::Constants>)getConstants;
 
 @end
 
@@ -1138,8 +1138,8 @@ namespace JS {
 - (void)getValueWithPromise:(NSNumber *)error
                     resolve:(RCTPromiseResolveBlock)resolve
                      reject:(RCTPromiseRejectBlock)reject;
-- (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleOptional::Constants::Builder>)constantsToExport;
-- (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleOptional::Constants::Builder>)getConstants;
+- (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleOptional::Constants>)constantsToExport;
+- (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleOptional::Constants>)getConstants;
 
 @end
 
@@ -1904,8 +1904,8 @@ namespace JS {
 - (NSDictionary *)getGenericObjectReadOnly:(NSDictionary *)arg;
 - (NSDictionary *)getGenericObjectWithAlias:(NSDictionary *)arg;
 - (NSDictionary *)difficultObject:(JS::NativeObjectTurboModule::SpecDifficultObjectA &)A;
-- (facebook::react::ModuleConstants<JS::NativeObjectTurboModule::Constants::Builder>)constantsToExport;
-- (facebook::react::ModuleConstants<JS::NativeObjectTurboModule::Constants::Builder>)getConstants;
+- (facebook::react::ModuleConstants<JS::NativeObjectTurboModule::Constants>)constantsToExport;
+- (facebook::react::ModuleConstants<JS::NativeObjectTurboModule::Constants>)getConstants;
 
 @end
 
@@ -2046,8 +2046,8 @@ namespace JS {
 }
 @protocol NativeOptionalObjectTurboModuleSpec <RCTBridgeModule, RCTTurboModule>
 
-- (facebook::react::ModuleConstants<JS::NativeOptionalObjectTurboModule::Constants::Builder>)constantsToExport;
-- (facebook::react::ModuleConstants<JS::NativeOptionalObjectTurboModule::Constants::Builder>)getConstants;
+- (facebook::react::ModuleConstants<JS::NativeOptionalObjectTurboModule::Constants>)constantsToExport;
+- (facebook::react::ModuleConstants<JS::NativeOptionalObjectTurboModule::Constants>)getConstants;
 
 @end
 
@@ -2246,14 +2246,14 @@ namespace JS {
 - (NSDictionary *)getAlias:(JS::NativeSampleTurboModule::Animal &)arg;
 - (NSNumber *)getRootTag:(double)arg;
 - (NSDictionary *)getValue:(double)x
-getValuegetValuegetValuegetValuegetValuey:(NSString *)getValuegetValuegetValuegetValuegetValuey
+                         y:(NSString *)y
                          z:(NSDictionary *)z;
 - (void)getValueWithCallback:(RCTResponseSenderBlock)callback;
 - (void)getValueWithPromise:(BOOL)error
                     resolve:(RCTPromiseResolveBlock)resolve
                      reject:(RCTPromiseRejectBlock)reject;
-- (facebook::react::ModuleConstants<JS::NativeSampleTurboModule::Constants::Builder>)constantsToExport;
-- (facebook::react::ModuleConstants<JS::NativeSampleTurboModule::Constants::Builder>)getConstants;
+- (facebook::react::ModuleConstants<JS::NativeSampleTurboModule::Constants>)constantsToExport;
+- (facebook::react::ModuleConstants<JS::NativeSampleTurboModule::Constants>)getConstants;
 
 @end
 
@@ -2350,8 +2350,8 @@ namespace JS {
 - (void)getValueWithPromise:(NSArray *)error
                     resolve:(RCTPromiseResolveBlock)resolve
                      reject:(RCTPromiseRejectBlock)reject;
-- (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleArrays::Constants::Builder>)constantsToExport;
-- (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleArrays::Constants::Builder>)getConstants;
+- (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleArrays::Constants>)constantsToExport;
+- (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleArrays::Constants>)getConstants;
 
 @end
 
@@ -2450,8 +2450,8 @@ namespace JS {
 - (void)getValueWithPromise:(NSNumber *)error
                     resolve:(RCTPromiseResolveBlock)resolve
                      reject:(RCTPromiseRejectBlock)reject;
-- (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleNullable::Constants::Builder>)constantsToExport;
-- (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleNullable::Constants::Builder>)getConstants;
+- (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleNullable::Constants>)constantsToExport;
+- (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleNullable::Constants>)getConstants;
 
 @end
 
@@ -2550,8 +2550,8 @@ namespace JS {
 - (void)getValueWithPromise:(NSNumber *)error
                     resolve:(RCTPromiseResolveBlock)resolve
                      reject:(RCTPromiseRejectBlock)reject;
-- (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleNullableAndOptional::Constants::Builder>)constantsToExport;
-- (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleNullableAndOptional::Constants::Builder>)getConstants;
+- (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleNullableAndOptional::Constants>)constantsToExport;
+- (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleNullableAndOptional::Constants>)getConstants;
 
 @end
 
@@ -2650,8 +2650,8 @@ namespace JS {
 - (void)getValueWithPromise:(NSNumber *)error
                     resolve:(RCTPromiseResolveBlock)resolve
                      reject:(RCTPromiseRejectBlock)reject;
-- (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleOptional::Constants::Builder>)constantsToExport;
-- (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleOptional::Constants::Builder>)getConstants;
+- (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleOptional::Constants>)constantsToExport;
+- (facebook::react::ModuleConstants<JS::NativeSampleTurboModuleOptional::Constants>)getConstants;
 
 @end
 
@@ -3541,7 +3541,7 @@ namespace facebook::react {
     }
 
     static facebook::jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_getValue(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {
-      return static_cast<ObjCTurboModule&>(turboModule).invokeObjCMethod(rt, ObjectKind, \\"getValue\\", @selector(getValue:getValuegetValuegetValuegetValuegetValuey:z:), args, count);
+      return static_cast<ObjCTurboModule&>(turboModule).invokeObjCMethod(rt, ObjectKind, \\"getValue\\", @selector(getValue:y:z:), args, count);
     }
 
     static facebook::jsi::Value __hostFunction_NativeSampleTurboModuleSpecJSI_getValueWithCallback(facebook::jsi::Runtime& rt, TurboModule &turboModule, const facebook::jsi::Value* args, size_t count) {

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/serializeMethod.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/serializeMethod.js
@@ -513,7 +513,7 @@ function serializeConstantsProtocolMethods(
     "Unable to generate C++ struct from module's getConstants() method return type.",
   );
 
-  const returnObjCType = `facebook::react::ModuleConstants<JS::${hasteModuleName}::Constants::Builder>`;
+  const returnObjCType = `facebook::react::ModuleConstants<JS::${hasteModuleName}::Constants>`;
 
   // $FlowFixMe[missing-type-arg]
   return ['constantsToExport', 'getConstants'].map<MethodSerializationOutput>(

--- a/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleHObjCpp-test.js.snap
+++ b/packages/react-native-codegen/src/generators/modules/__tests__/__snapshots__/GenerateModuleHObjCpp-test.js.snap
@@ -1055,8 +1055,8 @@ namespace JS {
 - (NSString *)getEnums:(double)enumInt
              enumFloat:(double)enumFloat
             enumString:(NSString *)enumString;
-- (facebook::react::ModuleConstants<JS::NativeSampleTurboModule::Constants::Builder>)constantsToExport;
-- (facebook::react::ModuleConstants<JS::NativeSampleTurboModule::Constants::Builder>)getConstants;
+- (facebook::react::ModuleConstants<JS::NativeSampleTurboModule::Constants>)constantsToExport;
+- (facebook::react::ModuleConstants<JS::NativeSampleTurboModule::Constants>)getConstants;
 
 @end
 

--- a/packages/react-native/Libraries/Settings/RCTSettingsManager.mm
+++ b/packages/react-native/Libraries/Settings/RCTSettingsManager.mm
@@ -52,7 +52,7 @@ RCT_EXPORT_MODULE()
 
 - (facebook::react::ModuleConstants<JS::NativeSettingsManager::Constants>)constantsToExport
 {
-  return (facebook::react::ModuleConstants<JS::NativeSettingsManager::Constants>)[self getConstants];
+  return [self getConstants];
 }
 
 - (facebook::react::ModuleConstants<JS::NativeSettingsManager::Constants>)getConstants

--- a/packages/react-native/React/CoreModules/PlatformStubs/RCTStatusBarManager.mm
+++ b/packages/react-native/React/CoreModules/PlatformStubs/RCTStatusBarManager.mm
@@ -35,7 +35,7 @@ RCT_EXPORT_METHOD(setNetworkActivityIndicatorVisible : (BOOL)visible) {}
 
 - (facebook::react::ModuleConstants<JS::NativeStatusBarManagerIOS::Constants>)constantsToExport
 {
-  return (facebook::react::ModuleConstants<JS::NativeStatusBarManagerIOS::Constants>)[self getConstants];
+  return [self getConstants];
 }
 
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:

--- a/packages/react-native/React/CoreModules/RCTAppState.mm
+++ b/packages/react-native/React/CoreModules/RCTAppState.mm
@@ -64,7 +64,7 @@ RCT_EXPORT_MODULE()
 
 - (facebook::react::ModuleConstants<JS::NativeAppState::Constants>)constantsToExport
 {
-  return (facebook::react::ModuleConstants<JS::NativeAppState::Constants>)[self getConstants];
+  return [self getConstants];
 }
 
 - (facebook::react::ModuleConstants<JS::NativeAppState::Constants>)getConstants

--- a/packages/react-native/React/CoreModules/RCTStatusBarManager.mm
+++ b/packages/react-native/React/CoreModules/RCTStatusBarManager.mm
@@ -193,7 +193,7 @@ RCT_EXPORT_METHOD(setNetworkActivityIndicatorVisible : (BOOL)visible)
 
 - (facebook::react::ModuleConstants<JS::NativeStatusBarManagerIOS::Constants>)constantsToExport
 {
-  return (facebook::react::ModuleConstants<JS::NativeStatusBarManagerIOS::Constants>)[self getConstants];
+  return [self getConstants];
 }
 
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:


### PR DESCRIPTION
Summary:
The cast in `constantsToExport` is unnecessary if we actually use the right type here, without the `Builder` suffix.

Not a breaking change, since Objective-C seemingly doesn't enforce these parameter constraints.

Changelog: [Internal]

Differential Revision: D87980865


