### PR TITLE
Back out "Expose adding handlers API from `RCTDevSettings`"

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDevSettings.h
+++ b/packages/react-native/React/CoreModules/RCTDevSettings.h
@@ -11,12 +11,6 @@
 #import <React/RCTEventEmitter.h>
 #import <React/RCTInitializing.h>
 
-@class RCTPackagerClientResponder;
-typedef uint32_t RCTHandlerToken;
-typedef void (^RCTNotificationHandler)(NSDictionary<NSString *, id> *);
-typedef void (^RCTRequestHandler)(NSDictionary<NSString *, id> *, RCTPackagerClientResponder *);
-typedef void (^RCTConnectedHandler)(void);
-
 @class RCTPackagerConnection;
 
 @protocol RCTPackagerClientMethod;
@@ -114,30 +108,7 @@ typedef void (^RCTConnectedHandler)(void);
 
 #if RCT_DEV_MENU
 - (void)addHandler:(id<RCTPackagerClientMethod>)handler
-    forPackagerMethod:(NSString *)name __deprecated_msg("Use addRequestHandler or addNotificationHandler instead");
-#endif
-
-#if RCT_DEV
-/**
- * Registers a handler for a notification broadcast from the packager. An
- * example is "reload" - an instruction to reload from the packager.
- * If multiple notification handlers are registered for the same method, they
- * will all be invoked sequentially.
- */
-- (RCTHandlerToken)addNotificationHandler:(RCTNotificationHandler)handler
-                                    queue:(dispatch_queue_t)queue
-                                forMethod:(NSString *)method;
-
-/**
- * Registers a handler for a request from the packager. An example is
- * pokeSamplingProfiler; it asks for profile data from the client.
- * Only one handler can be registered for a given method; calling this
- * displaces any previous request handler registered for that method.
- */
-- (RCTHandlerToken)addRequestHandler:(RCTRequestHandler)handler
-                               queue:(dispatch_queue_t)queue
-                           forMethod:(NSString *)method;
-
+    forPackagerMethod:(NSString *)name __deprecated_msg("Use RCTPackagerConnection directly instead");
 #endif
 
 @end

--- a/packages/react-native/React/CoreModules/RCTDevSettings.mm
+++ b/packages/react-native/React/CoreModules/RCTDevSettings.mm
@@ -55,7 +55,7 @@ void RCTDevSettingsSetEnabled(BOOL enabled)
   devSettingsMenuEnabled = enabled;
 }
 
-#if RCT_DEV || RCT_REMOTE_PROFILE
+#if RCT_DEV_MENU || RCT_REMOTE_PROFILE
 
 @interface RCTDevSettingsUserDefaultsDataSource : NSObject <RCTDevSettingsDataSource>
 
@@ -190,7 +190,7 @@ RCT_EXPORT_MODULE()
 
 #if RCT_DEV_SETTINGS_ENABLE_PACKAGER_CONNECTION
   if (numInitializedModules++ == 0) {
-    reloadToken = [self
+    reloadToken = [_packagerConnection
         addNotificationHandler:^(id params) {
           RCTTriggerReloadCommandListeners(@"Global hotkey");
         }
@@ -198,7 +198,7 @@ RCT_EXPORT_MODULE()
                      forMethod:@"reload"];
 #if RCT_DEV_MENU
     __weak __typeof(self) weakSelf = self;
-    devMenuToken = [self
+    devMenuToken = [_packagerConnection
         addNotificationHandler:^(id params) {
           __typeof(self) strongSelf = weakSelf;
           if (strongSelf == nullptr) {
@@ -437,23 +437,6 @@ RCT_EXPORT_METHOD(addMenuItem : (NSString *)title)
   }
 }
 
-#if RCT_DEV
-- (RCTHandlerToken)addNotificationHandler:(RCTNotificationHandler)handler
-                                    queue:(dispatch_queue_t)queue
-                                forMethod:(NSString *)method
-{
-  return [_packagerConnection addNotificationHandler:handler queue:queue forMethod:method];
-}
-
-- (RCTHandlerToken)addRequestHandler:(RCTRequestHandler)handler
-                               queue:(dispatch_queue_t)queue
-                           forMethod:(NSString *)method
-{
-  return [_packagerConnection addRequestHandler:handler queue:queue forMethod:method];
-}
-
-#endif
-
 - (void)addHandler:(id<RCTPackagerClientMethod>)handler forPackagerMethod:(NSString *)name
 {
 #if RCT_DEV_SETTINGS_ENABLE_PACKAGER_CONNECTION
@@ -544,7 +527,7 @@ RCT_EXPORT_METHOD(openDebugger)
 
 @end
 
-#else // #if RCT_DEV || RCT_REMOTE_PROFILE
+#else // #if RCT_DEV_MENU
 
 @interface RCTDevSettings () <NativeDevSettingsSpec>
 @end
@@ -608,10 +591,6 @@ RCT_EXPORT_METHOD(openDebugger)
     (const facebook::react::ObjCTurboModule::InitParams &)params
 {
   return std::make_shared<facebook::react::NativeDevSettingsSpecJSI>(params);
-}
-
-- (void)addHandler:(id<RCTPackagerClientMethod>)handler forPackagerMethod:(NSString *)name
-{
 }
 
 @end


### PR DESCRIPTION
Summary:
I *think* this is to blame for issues with HMRClient::setup() not being called in release builds.

Changelog:
[General][Removed] Revert https://github.com/facebook/react-native/pull/54314

Differential Revision: D87982319


