### PR TITLE
[android][text] Fix text clipping on Android 15+ due to useBoundsForWidth change

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.kt
@@ -620,56 +620,56 @@ internal object TextLayoutManager {
       )
     }
 
-      // Pre-Android 15: Use existing advance-based logic
-      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
-          val desiredWidth = ceil(Layout.getDesiredWidth(text, paint)).toInt()
+    // Pre-Android 15: Use existing advance-based logic
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.VANILLA_ICE_CREAM) {
+        val desiredWidth = ceil(Layout.getDesiredWidth(text, paint)).toInt()
 
-          val layoutWidth =
-              when (widthYogaMeasureMode) {
-                YogaMeasureMode.EXACTLY -> floor(width).toInt()
-                YogaMeasureMode.AT_MOST -> min(desiredWidth, floor(width).toInt())
-              else -> desiredWidth
-          }
-          return buildLayout(
-              text, layoutWidth, includeFontPadding, textBreakStrategy,
-              hyphenationFrequency, alignment, justificationMode, ellipsizeMode,
-              maxNumberOfLines, paint
-          )
-      }
+        val layoutWidth =
+            when (widthYogaMeasureMode) {
+              YogaMeasureMode.EXACTLY -> floor(width).toInt()
+              YogaMeasureMode.AT_MOST -> min(desiredWidth, floor(width).toInt())
+            else -> desiredWidth
+        }
+        return buildLayout(
+            text, layoutWidth, includeFontPadding, textBreakStrategy,
+            hyphenationFrequency, alignment, justificationMode, ellipsizeMode,
+            maxNumberOfLines, paint
+        )
+    }
 
-      // Android 15+: Need to account for visual bounds
-      // Step 1: Create unconstrained layout to get visual bounds width
-      val unconstrainedLayout = buildLayout(
-          text,
-          Int.MAX_VALUE / 2,
-          includeFontPadding,
-          textBreakStrategy,
-          hyphenationFrequency,
-          alignment,
-          justificationMode,
-          null,
-          ReactConstants.UNSET,
-          paint
-      )
+    // Android 15+: Need to account for visual bounds
+    // Step 1: Create unconstrained layout to get visual bounds width
+    val unconstrainedLayout = buildLayout(
+        text,
+        Int.MAX_VALUE / 2,
+        includeFontPadding,
+        textBreakStrategy,
+        hyphenationFrequency,
+        alignment,
+        justificationMode,
+        null,
+        ReactConstants.UNSET,
+        paint
+    )
 
-      // Calculate visual bounds width from unconstrained layout
-      var desiredVisualWidth = 0f
-      for (i in 0 until unconstrainedLayout.lineCount) {
-          val lineWidth = unconstrainedLayout.getLineRight(i) - unconstrainedLayout.getLineLeft(i)
-          desiredVisualWidth = max(desiredVisualWidth, lineWidth)
-      }
+    // Calculate visual bounds width from unconstrained layout
+    var desiredVisualWidth = 0f
+    for (i in 0 until unconstrainedLayout.lineCount) {
+        val lineWidth = unconstrainedLayout.getLineRight(i) - unconstrainedLayout.getLineLeft(i)
+        desiredVisualWidth = max(desiredVisualWidth, lineWidth)
+    }
 
-      val layoutWidth = when (widthYogaMeasureMode) {
-          YogaMeasureMode.AT_MOST -> min(ceil(desiredVisualWidth).toInt(), floor(width).toInt())
-          else -> ceil(desiredVisualWidth).toInt()
-      }
+    val layoutWidth = when (widthYogaMeasureMode) {
+        YogaMeasureMode.AT_MOST -> min(ceil(desiredVisualWidth).toInt(), floor(width).toInt())
+        else -> ceil(desiredVisualWidth).toInt()
+    }
 
-      // Step 2: Create final layout with correct width
-      return buildLayout(
-          text, layoutWidth, includeFontPadding, textBreakStrategy,
-          hyphenationFrequency, alignment, justificationMode, ellipsizeMode,
-          maxNumberOfLines, paint
-      )
+    // Step 2: Create final layout with correct width
+    return buildLayout(
+        text, layoutWidth, includeFontPadding, textBreakStrategy,
+        hyphenationFrequency, alignment, justificationMode, ellipsizeMode,
+        maxNumberOfLines, paint
+    )
   }
 
   private fun buildLayout(
@@ -692,19 +692,19 @@ internal object TextLayoutManager {
         .setHyphenationFrequency(hyphenationFrequency)
 
     if (maxNumberOfLines != ReactConstants.UNSET && maxNumberOfLines != 0) {
-        builder.setEllipsize(ellipsizeMode).setMaxLines(maxNumberOfLines)
+      builder.setEllipsize(ellipsizeMode).setMaxLines(maxNumberOfLines)
     }
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        builder.setJustificationMode(justificationMode)
+      builder.setJustificationMode(justificationMode)
     }
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-        builder.setUseLineSpacingFromFallbacks(true)
+      builder.setUseLineSpacingFromFallbacks(true)
     }
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM) {
-        builder.setUseBoundsForWidth(true)
+      builder.setUseBoundsForWidth(true)
     }
 
     return builder.build()


### PR DESCRIPTION
## Summary:

Android 15 (API 35) changed TextView's default behavior to use visual glyph bounds for width calculation (useBoundsForWidth=true).  This causes text clipping for italic fonts and other typefaces where glyphs extend beyond their advance width:

https://developer.android.com/about/versions/15/behavior-changes-15

This PR uses a two-pass layout approach on Android 15+:

1. Create an unconstrained layout with setUseBoundsForWidth(true) to measure the actual visual bounds width
2. Create the final layout using the visual bounds width as layoutWidth

This ensures the container is sized correctly to accommodate the full visual extent of the text, preventing clipping while maintaining backwards compatibility with earlier Android versions.

Performance impact:
- On Android 14 and below: No change
- On Android 15+: Creates two StaticLayout instances instead of one for text with unconstrained or AT_MOST width.  This overhead is mitigated by React Native's text measurement caching in the C++ layer, which avoids redundant measurements.  

Text with EXACTLY width mode is unaffected as it only requires a single layout pass.

Closes #53286

Thanks a lot to @intergalacticspacehighway for finding the root cause and creating a proof of concept fix.

## Changelog:

[ANDROID] [FIXED] - Fix text clipping on Android 15+ due to useBoundsForWidth change

## Test Plan:

Run the tests from #53286 to verify.

**Images from original issue:**

<img width="800" alt="image" src="https://github.com/user-attachments/assets/db6fa569-f6d6-4526-90ff-a3d71bfbb7c6" />


**With fix (with some additional text spans for testing):**

_Android 16_
<img width="220" alt="image" src="https://github.com/user-attachments/assets/43b7e648-a38f-4100-9186-a4efa14e3e04" />


_Android Pre 15_
<img width="220" alt="image" src="https://github.com/user-attachments/assets/75fb34cd-2455-439b-a12d-a2c15577008c" />
