### PR TITLE
Back out + fix of Back out "[react-native][PR] Expose adding handlers API from `RCTDevSettings`"

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDevSettings.h
+++ b/packages/react-native/React/CoreModules/RCTDevSettings.h
@@ -11,6 +11,12 @@
 #import <React/RCTEventEmitter.h>
 #import <React/RCTInitializing.h>
 
+@class RCTPackagerClientResponder;
+typedef uint32_t RCTHandlerToken;
+typedef void (^RCTNotificationHandler)(NSDictionary<NSString *, id> *);
+typedef void (^RCTRequestHandler)(NSDictionary<NSString *, id> *, RCTPackagerClientResponder *);
+typedef void (^RCTConnectedHandler)(void);
+
 @class RCTPackagerConnection;
 
 @protocol RCTPackagerClientMethod;
@@ -108,7 +114,30 @@
 
 #if RCT_DEV_MENU
 - (void)addHandler:(id<RCTPackagerClientMethod>)handler
-    forPackagerMethod:(NSString *)name __deprecated_msg("Use RCTPackagerConnection directly instead");
+    forPackagerMethod:(NSString *)name __deprecated_msg("Use addRequestHandler or addNotificationHandler instead");
+#endif
+
+#if RCT_DEV
+/**
+ * Registers a handler for a notification broadcast from the packager. An
+ * example is "reload" - an instruction to reload from the packager.
+ * If multiple notification handlers are registered for the same method, they
+ * will all be invoked sequentially.
+ */
+- (RCTHandlerToken)addNotificationHandler:(RCTNotificationHandler)handler
+                                    queue:(dispatch_queue_t)queue
+                                forMethod:(NSString *)method;
+
+/**
+ * Registers a handler for a request from the packager. An example is
+ * pokeSamplingProfiler; it asks for profile data from the client.
+ * Only one handler can be registered for a given method; calling this
+ * displaces any previous request handler registered for that method.
+ */
+- (RCTHandlerToken)addRequestHandler:(RCTRequestHandler)handler
+                               queue:(dispatch_queue_t)queue
+                           forMethod:(NSString *)method;
+
 #endif
 
 @end

--- a/packages/react-native/React/CoreModules/RCTDevSettings.mm
+++ b/packages/react-native/React/CoreModules/RCTDevSettings.mm
@@ -190,7 +190,7 @@ RCT_EXPORT_MODULE()
 
 #if RCT_DEV_SETTINGS_ENABLE_PACKAGER_CONNECTION
   if (numInitializedModules++ == 0) {
-    reloadToken = [_packagerConnection
+    reloadToken = [self
         addNotificationHandler:^(id params) {
           RCTTriggerReloadCommandListeners(@"Global hotkey");
         }
@@ -198,7 +198,7 @@ RCT_EXPORT_MODULE()
                      forMethod:@"reload"];
 #if RCT_DEV_MENU
     __weak __typeof(self) weakSelf = self;
-    devMenuToken = [_packagerConnection
+    devMenuToken = [self
         addNotificationHandler:^(id params) {
           __typeof(self) strongSelf = weakSelf;
           if (strongSelf == nullptr) {
@@ -437,6 +437,23 @@ RCT_EXPORT_METHOD(addMenuItem : (NSString *)title)
   }
 }
 
+#if RCT_DEV
+- (RCTHandlerToken)addNotificationHandler:(RCTNotificationHandler)handler
+                                    queue:(dispatch_queue_t)queue
+                                forMethod:(NSString *)method
+{
+  return [_packagerConnection addNotificationHandler:handler queue:queue forMethod:method];
+}
+
+- (RCTHandlerToken)addRequestHandler:(RCTRequestHandler)handler
+                               queue:(dispatch_queue_t)queue
+                           forMethod:(NSString *)method
+{
+  return [_packagerConnection addRequestHandler:handler queue:queue forMethod:method];
+}
+
+#endif
+
 - (void)addHandler:(id<RCTPackagerClientMethod>)handler forPackagerMethod:(NSString *)name
 {
 #if RCT_DEV_SETTINGS_ENABLE_PACKAGER_CONNECTION
@@ -527,7 +544,7 @@ RCT_EXPORT_METHOD(openDebugger)
 
 @end
 
-#else // #if RCT_DEV_MENU
+#else // #if RCT_DEV_MENU || RCT_REMOTE_PROFILE
 
 @interface RCTDevSettings () <NativeDevSettingsSpec>
 @end
@@ -591,6 +608,10 @@ RCT_EXPORT_METHOD(openDebugger)
     (const facebook::react::ObjCTurboModule::InitParams &)params
 {
   return std::make_shared<facebook::react::NativeDevSettingsSpecJSI>(params);
+}
+
+- (void)addHandler:(id<RCTPackagerClientMethod>)handler forPackagerMethod:(NSString *)name
+{
 }
 
 @end


### PR DESCRIPTION
Summary: Changelog: [iOS][Fixed] - Fixed crashing due to FastRefresh not being initialized for non debug builds with RCT_DEV_MENU=1

Differential Revision: D87982434


