### PR TITLE
Add optional props generation support

### DIFF
--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -128,6 +128,10 @@ export type OptionsShape = $ReadOnly<{
   // Use for components currently being renamed in paper
   // Will use new name if it is available and fallback to this name
   paperComponentNameDeprecated?: string,
+  // Use to generate C++ Props with optional types for properties defined as optional
+  generateOptionalProperties?: boolean,
+  // Use to generate C++ Props with optional types for object properties defined as optional
+  generateOptionalObjectProperties?: boolean,
 }>;
 
 export type ExtendsPropsShape = $ReadOnly<{

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsH.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsH.js
@@ -529,6 +529,7 @@ function generatePropsString(
   componentName: string,
   props: $ReadOnlyArray<NamedShape<PropTypeAnnotation>>,
   nameParts: $ReadOnlyArray<string>,
+  generateOptionalProperties?: boolean = false,
 ) {
   return props
     .map(prop => {
@@ -541,6 +542,14 @@ function generatePropsString(
         componentName,
         prop,
       );
+
+      if (
+        prop.optional &&
+        prop.typeAnnotation.default == null &&
+        generateOptionalProperties
+      ) {
+        return `std::optional<${nativeType}> ${prop.name}${defaultInitializer};`;
+      }
 
       return `${nativeType} ${prop.name}${defaultInitializer};`;
     })
@@ -834,6 +843,7 @@ module.exports = {
               componentName,
               component.props,
               [],
+              component.generateOptionalProperties,
             );
             const extendString = getClassExtendString(component);
             const extendsImports = getExtendsImports(component.extendsProps);


### PR DESCRIPTION
Summary:
Add support to codegen to generate native optional props for component properties that are defined as optional and have no default value.

Changelog: [Internal]

Differential Revision: D87843978


