### PR TITLE
Split Fantom workflow into separate build and test jobs

### DIFF
--- a/.github/actions/build-fantom-runner/action.yml
+++ b/.github/actions/build-fantom-runner/action.yml
@@ -1,0 +1,84 @@
+name: Build Fantom Runner
+inputs:
+  release-type:
+    required: true
+    description: The type of release we are building. It could be nightly, release or dry-run
+  gradle-cache-encryption-key:
+    description: "The encryption key needed to store the Gradle Configuration cache"
+
+runs:
+  using: composite
+  steps:
+    - name: Install dependencies
+      shell: bash
+      run: |
+        sudo apt update
+        sudo apt install -y git cmake openssl libssl-dev clang
+    - name: Setup git safe folders
+      shell: bash
+      run: git config --global --add safe.directory '*'
+    - name: Setup node.js
+      uses: ./.github/actions/setup-node
+    - name: Install node dependencies
+      uses: ./.github/actions/yarn-install
+    - name: Setup gradle
+      uses: ./.github/actions/setup-gradle
+      with:
+        cache-read-only: "false"
+        cache-encryption-key: ${{ inputs.gradle-cache-encryption-key }}
+    - name: Restore Fantom ccache
+      uses: actions/cache/restore@v5
+      with:
+        path: /github/home/.cache/ccache
+        key: v2-ccache-fantom-${{ github.job }}-${{ github.ref }}-${{ hashFiles(
+            'packages/react-native/ReactAndroid/**/*.cpp',
+            'packages/react-native/ReactAndroid/**/*.h',
+            'packages/react-native/ReactAndroid/**/CMakeLists.txt',
+            'packages/react-native/ReactCommon/**/*.cpp',
+            'packages/react-native/ReactCommon/**/*.h',
+            'packages/react-native/ReactCommon/**/CMakeLists.txt',
+            'private/react-native-fantom/tester/**/*.cpp',
+            'private/react-native-fantom/tester/**/*.h',
+            'private/react-native-fantom/tester/**/CMakeLists.txt'
+          ) }}
+        restore-keys: |
+          v2-ccache-fantom-${{ github.job }}-${{ github.ref }}-
+          v2-ccache-fantom-${{ github.job }}-
+          v2-ccache-fantom-
+    - name: Show ccache stats (before)
+      shell: bash
+      run: ccache -s -v
+    - name: Build Fantom Runner
+      shell: bash
+      run: yarn workspace @react-native/fantom build
+      env:
+        CC: clang
+        CXX: clang++
+    - name: Save Fantom ccache
+      if: ${{ github.ref == 'refs/heads/main' || contains(github.ref, '-stable') }}
+      uses: actions/cache/save@v5
+      with:
+        path: /github/home/.cache/ccache
+        key: v2-ccache-fantom-${{ github.job }}-${{ github.ref }}-${{ hashFiles(
+            'packages/react-native/ReactAndroid/**/*.cpp',
+            'packages/react-native/ReactAndroid/**/*.h',
+            'packages/react-native/ReactAndroid/**/CMakeLists.txt',
+            'packages/react-native/ReactCommon/**/*.cpp',
+            'packages/react-native/ReactCommon/**/*.h',
+            'packages/react-native/ReactCommon/**/CMakeLists.txt',
+            'private/react-native-fantom/tester/**/*.cpp',
+            'private/react-native-fantom/tester/**/*.h',
+            'private/react-native-fantom/tester/**/CMakeLists.txt'
+          ) }}
+    - name: Show ccache stats (after)
+      shell: bash
+      run: ccache -s -v
+    - name: Copy shared libraries
+      shell: bash
+      run: cp packages/react-native/ReactAndroid/hermes-engine/build/hermes/lib/libhermesvm.so private/react-native-fantom/build/tester/
+    - name: Upload Fantom Runner binary
+      uses: actions/upload-artifact@v6
+      with:
+        name: fantom-runner-binary
+        compression-level: 1
+        path: private/react-native-fantom/build/tester/

--- a/.github/actions/run-fantom-tests/action.yml
+++ b/.github/actions/run-fantom-tests/action.yml
@@ -1,19 +1,12 @@
 name: Run Fantom Tests
-inputs:
-  release-type:
-    required: true
-    description: The type of release we are building. It could be nightly, release or dry-run
-  gradle-cache-encryption-key:
-    description: "The encryption key needed to store the Gradle Configuration cache"
-
 runs:
   using: composite
   steps:
-    - name: Install dependencies
+    - name: Install runtime dependencies
       shell: bash
       run: |
         sudo apt update
-        sudo apt install -y git cmake openssl libssl-dev clang
+        sudo apt install -y openssl libssl-dev
     - name: Setup git safe folders
       shell: bash
       run: git config --global --add safe.directory '*'
@@ -21,58 +14,30 @@ runs:
       uses: ./.github/actions/setup-node
     - name: Install node dependencies
       uses: ./.github/actions/yarn-install
-    - name: Setup gradle
-      uses: ./.github/actions/setup-gradle
+    - name: Download Fantom Runner binary
+      uses: actions/download-artifact@v7
       with:
-        cache-read-only: "false"
-        cache-encryption-key: ${{ inputs.gradle-cache-encryption-key }}
-    - name: Restore Fantom ccache
-      uses: actions/cache/restore@v5
-      with:
-        path: /github/home/.cache/ccache
-        key: v2-ccache-fantom-${{ github.job }}-${{ github.ref }}-${{ hashFiles(
-            'packages/react-native/ReactAndroid/**/*.cpp',
-            'packages/react-native/ReactAndroid/**/*.h',
-            'packages/react-native/ReactAndroid/**/CMakeLists.txt',
-            'packages/react-native/ReactCommon/**/*.cpp',
-            'packages/react-native/ReactCommon/**/*.h',
-            'packages/react-native/ReactCommon/**/CMakeLists.txt',
-            'private/react-native-fantom/tester/**/*.cpp',
-            'private/react-native-fantom/tester/**/*.h',
-            'private/react-native-fantom/tester/**/CMakeLists.txt'
-          ) }}
-        restore-keys: |
-          v2-ccache-fantom-${{ github.job }}-${{ github.ref }}-
-          v2-ccache-fantom-${{ github.job }}-
-          v2-ccache-fantom-
-    - name: Show ccache stats
+        name: fantom-runner-binary
+        path: private/react-native-fantom/build/tester
+    - name: Make binary executable
       shell: bash
-      run: ccache -s -v
+      run: chmod +x private/react-native-fantom/build/tester/fantom_tester
     - name: Run Fantom Tests
       shell: bash
-      run: yarn fantom
+      run: |
+        for attempt in 1 2 3; do
+          echo "Attempt $attempt of 3"
+          if yarn fantom; then
+            exit 0
+          fi
+          if [ "$attempt" -lt 3 ]; then
+            echo "Attempt $attempt failed. Retrying..."
+          fi
+        done
+        echo "All 3 attempts failed."
+        exit 1
       env:
-        CC: clang
-        CXX: clang++
-    - name: Save Fantom ccache
-      if: ${{ github.ref == 'refs/heads/main' || contains(github.ref, '-stable') }}
-      uses: actions/cache/save@v5
-      with:
-        path: /github/home/.cache/ccache
-        key: v2-ccache-fantom-${{ github.job }}-${{ github.ref }}-${{ hashFiles(
-            'packages/react-native/ReactAndroid/**/*.cpp',
-            'packages/react-native/ReactAndroid/**/*.h',
-            'packages/react-native/ReactAndroid/**/CMakeLists.txt',
-            'packages/react-native/ReactCommon/**/*.cpp',
-            'packages/react-native/ReactCommon/**/*.h',
-            'packages/react-native/ReactCommon/**/CMakeLists.txt',
-            'private/react-native-fantom/tester/**/*.cpp',
-            'private/react-native-fantom/tester/**/*.h',
-            'private/react-native-fantom/tester/**/CMakeLists.txt'
-          ) }}
-    - name: Show ccache stats
-      shell: bash
-      run: ccache -s -v
+        LD_LIBRARY_PATH: ${{ github.workspace }}/private/react-native-fantom/build/tester
     - name: Upload test results
       if: ${{ always() }}
       uses: actions/upload-artifact@v6

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -338,7 +338,7 @@ jobs:
           flavor: ${{ matrix.flavor }}
           working-directory: /tmp/RNTestProject
 
-  run_fantom_tests:
+  build_fantom_runner:
     runs-on: 8-core-ubuntu
     needs: [set_release_type, check_code_changes, lint]
     if: needs.check_code_changes.outputs.any_code_change == 'true'
@@ -356,11 +356,24 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Build and Test Fantom
-        uses: ./.github/actions/run-fantom-tests
+      - name: Build Fantom Runner
+        uses: ./.github/actions/build-fantom-runner
         with:
           release-type: ${{ needs.set_release_type.outputs.RELEASE_TYPE }}
           gradle-cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
+
+  run_fantom_tests:
+    runs-on: 8-core-ubuntu
+    needs: [build_fantom_runner]
+    container:
+      image: reactnativecommunity/react-native-android:latest
+      env:
+        TERM: "dumb"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Run Fantom Tests
+        uses: ./.github/actions/run-fantom-tests
 
   build_android:
     runs-on: 8-core-ubuntu

--- a/scripts/fantom.sh
+++ b/scripts/fantom.sh
@@ -10,7 +10,9 @@ set -e
 if [[ -f "BUCK" && -z "$FANTOM_FORCE_OSS_BUILD" ]]; then
   export JS_DIR='..'
 else
-  yarn workspace @react-native/fantom build
+  if [[ ! -f "private/react-native-fantom/build/tester/fantom_tester" ]]; then
+    yarn workspace @react-native/fantom build
+  fi
   export FANTOM_FORCE_OSS_BUILD=1
 fi
 


### PR DESCRIPTION
Changelog: [Internal]

- Created new build-fantom-runner action to compile the Fantom runner binary
- Modified run-fantom-tests action to download and use pre-built binary
- Updated test-all.yml workflow to run build and test as separate jobs
- Removed build dependencies and ccache configuration from test job