### PR TITLE
Fix NullPointerException in PromiseImpl.reject by allowing nullable code

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/Promise.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/Promise.kt
@@ -28,7 +28,7 @@ public interface Promise {
    * @param code String
    * @param message String
    */
-  public fun reject(code: String, message: String?)
+  public fun reject(code: String?, message: String?)
 
   /**
    * Report an exception with a custom code.
@@ -36,7 +36,7 @@ public interface Promise {
    * @param code String
    * @param throwable Throwable
    */
-  public fun reject(code: String, throwable: Throwable?)
+  public fun reject(code: String?, throwable: Throwable?)
 
   /**
    * Report an exception with a custom code and error message.
@@ -45,7 +45,7 @@ public interface Promise {
    * @param message String
    * @param throwable Throwable
    */
-  public fun reject(code: String, message: String?, throwable: Throwable?)
+  public fun reject(code: String?, message: String?, throwable: Throwable?)
 
   /**
    * Report an exception, with default error code. Useful in catch-all scenarios where it's unclear
@@ -73,7 +73,7 @@ public interface Promise {
    * @param code String
    * @param userInfo WritableMap
    */
-  public fun reject(code: String, userInfo: WritableMap)
+  public fun reject(code: String?, userInfo: WritableMap)
 
   /**
    * Report an exception with a custom code and userInfo.
@@ -82,7 +82,7 @@ public interface Promise {
    * @param throwable Throwable
    * @param userInfo WritableMap
    */
-  public fun reject(code: String, throwable: Throwable?, userInfo: WritableMap)
+  public fun reject(code: String?, throwable: Throwable?, userInfo: WritableMap)
 
   /**
    * Report an error with a custom code, error message and userInfo, an error not caused by an
@@ -92,7 +92,7 @@ public interface Promise {
    * @param message String
    * @param userInfo WritableMap
    */
-  public fun reject(code: String, message: String?, userInfo: WritableMap)
+  public fun reject(code: String?, message: String?, userInfo: WritableMap)
 
   /**
    * Report an exception with a custom code, error message and userInfo.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/PromiseImpl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/PromiseImpl.kt
@@ -38,7 +38,7 @@ constructor(private var resolve: Callback?, private var reject: Callback?) : Pro
    * @param code String
    * @param message String
    */
-  override fun reject(code: String, message: String?) {
+  override fun reject(code: String?, message: String?) {
     reject(code, message, null, null)
   }
 
@@ -48,7 +48,7 @@ constructor(private var resolve: Callback?, private var reject: Callback?) : Pro
    * @param code String
    * @param throwable Throwable
    */
-  override fun reject(code: String, throwable: Throwable?) {
+  override fun reject(code: String?, throwable: Throwable?) {
     reject(code, null, throwable, null)
   }
 
@@ -59,7 +59,7 @@ constructor(private var resolve: Callback?, private var reject: Callback?) : Pro
    * @param message String
    * @param throwable Throwable
    */
-  override fun reject(code: String, message: String?, throwable: Throwable?) {
+  override fun reject(code: String?, message: String?, throwable: Throwable?) {
     reject(code, message, throwable, null)
   }
 
@@ -94,7 +94,7 @@ constructor(private var resolve: Callback?, private var reject: Callback?) : Pro
    * @param code String
    * @param userInfo WritableMap
    */
-  override fun reject(code: String, userInfo: WritableMap) {
+  override fun reject(code: String?, userInfo: WritableMap) {
     reject(code, null, null, userInfo)
   }
 
@@ -105,7 +105,7 @@ constructor(private var resolve: Callback?, private var reject: Callback?) : Pro
    * @param throwable Throwable
    * @param userInfo WritableMap
    */
-  override fun reject(code: String, throwable: Throwable?, userInfo: WritableMap) {
+  override fun reject(code: String?, throwable: Throwable?, userInfo: WritableMap) {
     reject(code, null, throwable, userInfo)
   }
 
@@ -117,7 +117,7 @@ constructor(private var resolve: Callback?, private var reject: Callback?) : Pro
    * @param message String
    * @param userInfo WritableMap
    */
-  override fun reject(code: String, message: String?, userInfo: WritableMap) {
+  override fun reject(code: String?, message: String?, userInfo: WritableMap) {
     reject(code, message, null, userInfo)
   }
 


### PR DESCRIPTION
# Fix NullPointerException in PromiseImpl.reject

## Summary

This PR fixes a `NullPointerException` that occurs when `Promise.reject` is called with a `null` code from Java native modules.

The issue arises because `Promise.kt` and `PromiseImpl.kt` defined the `code` parameter as non-nullable `String` in several overloads. However, `PromiseImpl`'s internal logic (specifically the catch-all `reject` method) is designed to handle `null` codes by defaulting to `EUNSPECIFIED`.

When a Java module (such as `react-native-ble-plx`) calls `promise.reject(null, message)`, Kotlin's generated null-checks throw a `NullPointerException` before the method body is executed.

## Changelog

[Android] [Fixed] - Allow nullable `code` in `Promise.reject` to prevent NPEs from Java modules

## Test Plan

1.  Create a native module in Java that calls `promise.reject(null, "Error message")`.
2.  Before this fix, the app crashes with `java.lang.NullPointerException: Parameter specified as non-null is null: method com.facebook.react.bridge.PromiseImpl.reject, parameter code`.
3.  After this fix, the promise is rejected with code `EUNSPECIFIED` and the app does not crash.

## Related Issue

Fixes #54722
