### PR TITLE
Cleanup unnecessary logging on ReactHostImpl

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostImpl.kt
@@ -1266,10 +1266,6 @@ public class ReactHostImpl(
     val method = "getOrCreateReloadTask()"
     stateTracker.enterState(method)
 
-    // Log how React Native is destroyed
-    // TODO(T136397487): Remove after Venice is shipped to 100%
-    raiseSoftException(method, reason)
-
     reloadTask?.let {
       return it
     }
@@ -1420,10 +1416,6 @@ public class ReactHostImpl(
   private fun getOrCreateDestroyTask(reason: String, ex: Exception?): Task<Void> {
     val method = "getOrCreateDestroyTask()"
     stateTracker.enterState(method)
-
-    // Log how React Native is destroyed
-    // TODO(T136397487): Remove after Venice is shipped to 100%
-    raiseSoftException(method, reason, ex)
 
     destroyTask?.let {
       return it


### PR DESCRIPTION
Summary:
Those stacktraces are no longer necessary because venice has been rolled out to 100% since a long time. They create noise on logcat as they appear as a crash in red, but they're not.

Created from CodeHub with https://fburl.com/edit-in-codehub

Reviewed By: javache

Differential Revision: D88075839


