### PR TITLE
Add support for border width props to AnimationBackend

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropSerializer.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropSerializer.cpp
@@ -110,6 +110,32 @@ void packShadowRadius(
   dyn.insert("shadowRadius", get<Float>(animatedProp));
 }
 
+void packBorderColorEdge(
+    folly::dynamic& dyn,
+    const std::string& propName,
+    const std::optional<SharedColor>& colorValue) {
+  if (colorValue.has_value() && colorValue.value()) {
+    dyn.insert(propName, static_cast<int32_t>(*colorValue.value()));
+  }
+}
+
+void packBorderColor(
+    folly::dynamic& dyn,
+    const AnimatedPropBase& animatedProp) {
+  const auto& borderColors = get<CascadedBorderColors>(animatedProp);
+
+  packBorderColorEdge(dyn, "borderLeftColor", borderColors.left);
+  packBorderColorEdge(dyn, "borderTopColor", borderColors.top);
+  packBorderColorEdge(dyn, "borderRightColor", borderColors.right);
+  packBorderColorEdge(dyn, "borderBottomColor", borderColors.bottom);
+  packBorderColorEdge(dyn, "borderStartColor", borderColors.start);
+  packBorderColorEdge(dyn, "borderEndColor", borderColors.end);
+
+  if (borderColors.all.has_value() && borderColors.all.value()) {
+    dyn.insert("borderColor", static_cast<int32_t>(*borderColors.all.value()));
+  }
+}
+
 void packAnimatedProp(
     folly::dynamic& dyn,
     const std::unique_ptr<AnimatedPropBase>& animatedProp) {
@@ -146,12 +172,17 @@ void packAnimatedProp(
       packShadowRadius(dyn, *animatedProp);
       break;
 
+    case BORDER_COLOR:
+      packBorderColor(dyn, *animatedProp);
+      break;
+
     case WIDTH:
     case HEIGHT:
     case FLEX:
     case PADDING:
     case MARGIN:
     case POSITION:
+    case BORDER_WIDTH:
       throw std::runtime_error("Tried to synchronously update layout props");
   }
 }

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedProps.h
@@ -17,6 +17,8 @@ enum PropName {
   WIDTH,
   HEIGHT,
   BORDER_RADII,
+  BORDER_WIDTH,
+  BORDER_COLOR,
   MARGIN,
   PADDING,
   POSITION,
@@ -76,6 +78,42 @@ inline void cloneProp(BaseViewProps &viewProps, const AnimatedPropBase &animated
 
     case BORDER_RADII:
       viewProps.borderRadii = get<CascadedBorderRadii>(animatedProp);
+      break;
+
+    case BORDER_WIDTH: {
+      const auto &borderWidths = get<CascadedRectangleEdges<yoga::StyleLength>>(animatedProp);
+      if (borderWidths.left.has_value()) {
+        viewProps.yogaStyle.setBorder(yoga::Edge::Left, borderWidths.left.value());
+      }
+      if (borderWidths.top.has_value()) {
+        viewProps.yogaStyle.setBorder(yoga::Edge::Top, borderWidths.top.value());
+      }
+      if (borderWidths.right.has_value()) {
+        viewProps.yogaStyle.setBorder(yoga::Edge::Right, borderWidths.right.value());
+      }
+      if (borderWidths.bottom.has_value()) {
+        viewProps.yogaStyle.setBorder(yoga::Edge::Bottom, borderWidths.bottom.value());
+      }
+      if (borderWidths.start.has_value()) {
+        viewProps.yogaStyle.setBorder(yoga::Edge::Start, borderWidths.start.value());
+      }
+      if (borderWidths.end.has_value()) {
+        viewProps.yogaStyle.setBorder(yoga::Edge::End, borderWidths.end.value());
+      }
+      if (borderWidths.horizontal.has_value()) {
+        viewProps.yogaStyle.setBorder(yoga::Edge::Horizontal, borderWidths.horizontal.value());
+      }
+      if (borderWidths.vertical.has_value()) {
+        viewProps.yogaStyle.setBorder(yoga::Edge::Vertical, borderWidths.vertical.value());
+      }
+      if (borderWidths.all.has_value()) {
+        viewProps.yogaStyle.setBorder(yoga::Edge::All, borderWidths.all.value());
+      }
+      break;
+    }
+
+    case BORDER_COLOR:
+      viewProps.borderColors = get<CascadedBorderColors>(animatedProp);
       break;
 
     case MARGIN: {

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropsBuilder.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropsBuilder.h
@@ -31,6 +31,14 @@ struct AnimatedPropsBuilder {
   {
     props.push_back(std::make_unique<AnimatedProp<CascadedBorderRadii>>(BORDER_RADII, value));
   }
+  void setBorderWidth(CascadedRectangleEdges<yoga::StyleLength> &value)
+  {
+    props.push_back(std::make_unique<AnimatedProp<CascadedRectangleEdges<yoga::StyleLength>>>(BORDER_WIDTH, value));
+  }
+  void setBorderColor(CascadedBorderColors &value)
+  {
+    props.push_back(std::make_unique<AnimatedProp<CascadedBorderColors>>(BORDER_COLOR, value));
+  }
   void setMargin(CascadedRectangleEdges<yoga::StyleLength> &value)
   {
     props.push_back(std::make_unique<AnimatedProp<CascadedRectangleEdges<yoga::StyleLength>>>(MARGIN, value));

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropsRegistry.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropsRegistry.h
@@ -127,6 +127,21 @@ inline void updateProp(const PropName propName, BaseViewProps &viewProps, const 
           yoga::Edge::Horizontal, snapshot.props.yogaStyle.position(yoga::Edge::Horizontal));
       viewProps.yogaStyle.setPosition(yoga::Edge::Vertical, snapshot.props.yogaStyle.position(yoga::Edge::Vertical));
       break;
+
+    case BORDER_WIDTH:
+      viewProps.yogaStyle.setBorder(yoga::Edge::Left, snapshot.props.yogaStyle.border(yoga::Edge::Left));
+      viewProps.yogaStyle.setBorder(yoga::Edge::Right, snapshot.props.yogaStyle.border(yoga::Edge::Right));
+      viewProps.yogaStyle.setBorder(yoga::Edge::Top, snapshot.props.yogaStyle.border(yoga::Edge::Top));
+      viewProps.yogaStyle.setBorder(yoga::Edge::Bottom, snapshot.props.yogaStyle.border(yoga::Edge::Bottom));
+      viewProps.yogaStyle.setBorder(yoga::Edge::Start, snapshot.props.yogaStyle.border(yoga::Edge::Start));
+      viewProps.yogaStyle.setBorder(yoga::Edge::End, snapshot.props.yogaStyle.border(yoga::Edge::End));
+      viewProps.yogaStyle.setBorder(yoga::Edge::Horizontal, snapshot.props.yogaStyle.border(yoga::Edge::Horizontal));
+      viewProps.yogaStyle.setBorder(yoga::Edge::Vertical, snapshot.props.yogaStyle.border(yoga::Edge::Vertical));
+      break;
+
+    case BORDER_COLOR:
+      viewProps.borderColors = snapshot.props.borderColors;
+      break;
   }
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.cpp
@@ -56,7 +56,8 @@ static inline bool mutationHasLayoutUpdates(
     if (animatedProp->propName == WIDTH || animatedProp->propName == HEIGHT ||
         animatedProp->propName == FLEX || animatedProp->propName == MARGIN ||
         animatedProp->propName == PADDING ||
-        animatedProp->propName == POSITION) {
+        animatedProp->propName == POSITION ||
+        animatedProp->propName == BORDER_WIDTH) {
       return true;
     }
   }


### PR DESCRIPTION
## Summary:
Adds support for border width prop to be passed as `AnimatedProp` to the animation backend.

## Changelog:
[General][Added] - Added support for border width props to the animation backend.

Differential Revision: D88159049
