### PR TITLE
Fix gitignore paths for debugger-frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,6 +176,3 @@ fix_*.patch
 
 # [Experimental] Generated TS type definitions
 /packages/**/types_generated/
-
-/packages/debugger-shell/build/
-/packages/*/dist/

--- a/packages/debugger-shell/.gitignore
+++ b/packages/debugger-shell/.gitignore
@@ -1,0 +1,6 @@
+# Dependencies
+/node_modules
+
+# Build output
+/build
+/dist


### PR DESCRIPTION
Summary:
Move blanket `packages/**/dist/` rule added in D77591742 into scoped `.gitignore` for `debugger-shell`.

This was preventing new files added to `packages/debugger-frontend/dist/` from being staged.

Changelog: [Internal]

Differential Revision: D88172611


