### PR TITLE
BeginDrawing: INTENDED_VSYNC_TIMESTAMP -> VSYNC_TIMESTAMP

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/inspector/FrameTimingsObserver.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/inspector/FrameTimingsObserver.kt
@@ -25,7 +25,7 @@ internal class FrameTimingsObserver(
 
   private val frameMetricsListener =
       Window.OnFrameMetricsAvailableListener { _, frameMetrics, _dropCount ->
-        val beginDrawingTimestamp = frameMetrics.getMetric(FrameMetrics.INTENDED_VSYNC_TIMESTAMP)
+        val beginDrawingTimestamp = frameMetrics.getMetric(FrameMetrics.VSYNC_TIMESTAMP)
         val commitTimestamp =
             beginDrawingTimestamp + frameMetrics.getMetric(FrameMetrics.INPUT_HANDLING_DURATION)
         +frameMetrics.getMetric(FrameMetrics.ANIMATION_DURATION)


### PR DESCRIPTION
Summary:
# Changelog: [Internal]

Looking at the Chrome DevTools Frontend code, the `BeginFrame` trace event represents the actual start of the frame sequence, not the expected one.

Using inteded timestamp doesn't seem right here:
 - [INTENDED_VSYNC_TIMESTAMP](https://developer.android.com/reference/android/view/FrameMetrics#INTENDED_VSYNC_TIMESTAMP)
 - [VSYNC_TIMESTAMP](https://developer.android.com/reference/android/view/FrameMetrics#VSYNC_TIMESTAMP)


INTENDED_VSYNC_TIMESTAMP description says:
> The intended start point for the frame. If this value is different from VSYNC_TIMESTAMP, there was work occurring on the UI thread that prevented it from responding to the vsync signal in a timely fashion.

Differential Revision: D88088882


