### PR TITLE
[0.83] Fix remaining missing debugger build flags for open source builds

### DIFF
--- a/packages/react-native/Package.swift
+++ b/packages/react-native/Package.swift
@@ -594,7 +594,11 @@ let reactRCTBlob = RNTarget(
 let reactRCTNetwork = RNTarget(
   name: .reactRCTNetwork,
   path: "Libraries/Network",
-  dependencies: [.yoga, .jsi, .reactTurboModuleCore]
+  dependencies: [.yoga, .jsi, .reactTurboModuleCore],
+  defines: [
+    CXXSetting.define("REACT_NATIVE_DEBUGGER_ENABLED", to: "1", .when(configuration: BuildConfiguration.debug)),
+    CXXSetting.define("REACT_NATIVE_DEBUGGER_ENABLED_DEVONLY", to: "1", .when(configuration: BuildConfiguration.debug)),
+  ]
 )
 
 /// React-RCTVibration.podspec

--- a/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/CMakeLists.txt
@@ -338,3 +338,10 @@ target_include_directories(reactnative
         $<TARGET_PROPERTY:uimanagerjni,INTERFACE_INCLUDE_DIRECTORIES>
         $<TARGET_PROPERTY:yoga,INTERFACE_INCLUDE_DIRECTORIES>
 )
+
+if(${CMAKE_BUILD_TYPE} MATCHES Debug OR REACT_NATIVE_DEBUG_OPTIMIZED)
+  target_compile_options(reactnative PRIVATE
+          -DREACT_NATIVE_DEBUGGER_ENABLED=1
+          -DREACT_NATIVE_DEBUGGER_ENABLED_DEVONLY=1
+  )
+endif ()

--- a/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/CMakeLists.txt
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/devsupport/CMakeLists.txt
@@ -23,3 +23,10 @@ target_link_libraries(react_devsupportjni
         react_networking)
 
 target_compile_reactnative_options(react_devsupportjni PRIVATE)
+
+if(${CMAKE_BUILD_TYPE} MATCHES Debug OR REACT_NATIVE_DEBUG_OPTIMIZED)
+  target_compile_options(react_devsupportjni PRIVATE
+          -DREACT_NATIVE_DEBUGGER_ENABLED=1
+          -DREACT_NATIVE_DEBUGGER_ENABLED_DEVONLY=1
+  )
+endif ()

--- a/packages/react-native/scripts/cocoapods/utils.rb
+++ b/packages/react-native/scripts/cocoapods/utils.rb
@@ -58,9 +58,11 @@ class ReactNativePodsUtils
 
     def self.set_gcc_preprocessor_definition_for_debugger(installer)
         self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "REACT_NATIVE_DEBUGGER_ENABLED=1", "React-jsinspector", :debug)
+        self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "REACT_NATIVE_DEBUGGER_ENABLED=1", "React-jsinspectornetwork", :debug)
         self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "REACT_NATIVE_DEBUGGER_ENABLED=1", "React-RCTNetwork", :debug)
         self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "REACT_NATIVE_DEBUGGER_ENABLED=1", "React-networking", :debug)
         self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "REACT_NATIVE_DEBUGGER_ENABLED_DEVONLY=1", "React-jsinspector", :debug)
+        self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "REACT_NATIVE_DEBUGGER_ENABLED_DEVONLY=1", "React-jsinspectornetwork", :debug)
         self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "REACT_NATIVE_DEBUGGER_ENABLED_DEVONLY=1", "React-RCTNetwork", :debug)
         self.add_build_settings_to_pod(installer, "GCC_PREPROCESSOR_DEFINITIONS", "REACT_NATIVE_DEBUGGER_ENABLED_DEVONLY=1", "React-networking", :debug)
     end


### PR DESCRIPTION
## Summary

Network support for React Native DevTools is in a broken state on `0.83-stable` and this is the fix.

### Cause

Network debugging support depends a number of `REACT_NATIVE_DEBUGGER_ENABLED` preprocessor flags, which we use to compile away any overhead in production builds.

As we unfortunately use a total of **4 native build systems** today (with Buck 2 internally and primarily), the registration of these flags was missing across a number of native ObjC/C++ packages, which are now fixed with this PR.

- https://github.com/facebook/react-native/pull/54617 aimed to address this as we weren't seeing the Network panel at all. However, it was insufficient, as it has only partially enabled network features between platforms.
- As I was away for 2 weeks, this unfortunately got missed until this late in the release (including, predating this, me opening but not landing the original feature flag change to test this feature on RC2 🙏🏻).

> [!Note]
> #### Merge urgently — will necessitate RC5
> ⚠️ RNDT Network inspection is in an **unshippable broken state** without this change  — as different parts of the system are compiled out across platforms, creating undefined behaviour.

### This diff

Add missing preprocessor flags in:

- Android:
	- `src/main/jni/react/devsupport/CMakeLists.txt`
	- `src/main/jni/CMakeLists.txt`
- iOS (Pods):
	- `React-jsinspectorNetwork`
- iOS (`Package.swift`):
	- `Libraries/Network`

Changelog:
[General][Fixed] - Fix remaining Network debugging components that were compiled out under Xcode and Gradle

## Test Plan

Locally apply these changes and build via Xcode and Gradle.

<img width="2908" height="1580" alt="image" src="https://github.com/user-attachments/assets/fb085859-1369-415e-92c6-c706ea8b946c" />

✅ Network previews and extended metadata working on both platforms
