### PR TITLE
Refactor configuration of `REACT_NATIVE_DEBUGGER_ENABLED` C++ flag

### DIFF
--- a/packages/react-native/ReactCommon/cmake-utils/react-native-flags.cmake
+++ b/packages/react-native/ReactCommon/cmake-utils/react-native-flags.cmake
@@ -32,4 +32,11 @@ function(target_compile_reactnative_options target_name scope)
   if(ANDROID)
     target_compile_definitions(${target_name} ${scope} RN_SERIALIZABLE_STATE)
   endif()
+  if(${CMAKE_BUILD_TYPE} MATCHES Debug OR REACT_NATIVE_DEBUG_OPTIMIZED)
+  # We enable REACT_NATIVE_DEBUGGER_ENABLED for Debug builds on the whole codebase.
+  target_compile_options(${target_name} ${scope}
+          -DREACT_NATIVE_DEBUGGER_ENABLED=1
+          -DREACT_NATIVE_DEBUGGER_ENABLED_DEVONLY=1
+  )
+endif ()
 endfunction()

--- a/packages/react-native/ReactCommon/jsinspector-modern/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/jsinspector-modern/CMakeLists.txt
@@ -29,9 +29,4 @@ target_link_libraries(jsinspector
         react_utils
 )
 target_compile_reactnative_options(jsinspector PRIVATE)
-if(${CMAKE_BUILD_TYPE} MATCHES Debug OR REACT_NATIVE_DEBUG_OPTIMIZED)
-  target_compile_options(jsinspector PRIVATE
-          -DREACT_NATIVE_DEBUGGER_ENABLED=1
-          -DREACT_NATIVE_DEBUGGER_ENABLED_DEVONLY=1
-  )
-endif ()
+

--- a/packages/react-native/ReactCommon/react/networking/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/networking/CMakeLists.txt
@@ -21,10 +21,3 @@ target_link_libraries(react_networking
         jsinspector_tracing
         react_performance_timeline
         react_timing)
-
-if(${CMAKE_BUILD_TYPE} MATCHES Debug OR REACT_NATIVE_DEBUG_OPTIMIZED)
-  target_compile_options(react_networking PRIVATE
-          -DREACT_NATIVE_DEBUGGER_ENABLED=1
-          -DREACT_NATIVE_DEBUGGER_ENABLED_DEVONLY=1
-  )
-endif ()


### PR DESCRIPTION
## Summary:

We don't need to set the `REACT_NATIVE_DEBUGGER_ENABLED` for each target.
Instead we should be using the `target_compile_reactnative_options` CMake functiont that we already have.

## Changelog:

[Internal] [Changed] -

## Test Plan:

CI
