### PR TITLE
Exclude legacy Hermes targets from single host assertion

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
@@ -147,7 +147,7 @@ class HostAgent::Impl final {
     if (InspectorFlags::getInstance().getNetworkInspectionEnabled()) {
       if (req.method == "Network.enable") {
         auto& inspector = getInspectorInstance();
-        if (inspector.getSystemState().registeredPagesCount > 1) {
+        if (inspector.getSystemState().registeredHostsCount > 1) {
           frontendChannel_(
               cdp::jsonError(
                   req.id,
@@ -231,7 +231,7 @@ class HostAgent::Impl final {
               "ReactNativeApplication.metadataUpdated",
               createHostMetadataPayload(hostMetadata_)));
       auto& inspector = getInspectorInstance();
-      bool isSingleHost = inspector.getSystemState().registeredPagesCount <= 1;
+      bool isSingleHost = inspector.getSystemState().registeredHostsCount <= 1;
       if (!isSingleHost) {
         emitSystemStateChanged(isSingleHost);
       }

--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorInterfaces.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorInterfaces.h
@@ -53,7 +53,7 @@ using InspectorPage = InspectorPageDescription;
 
 struct InspectorSystemState {
   /** The total count of pages registered during the app lifetime. */
-  int registeredPagesCount;
+  int registeredHostsCount;
 };
 
 /// IRemoteConnection allows the VM to send debugger messages to the client.
@@ -83,7 +83,7 @@ class JSINSPECTOR_EXPORT ILocalConnection : public IDestructible {
 class JSINSPECTOR_EXPORT IPageStatusListener : public IDestructible {
  public:
   virtual ~IPageStatusListener() = 0;
-  virtual void onPageAdded(int /*pageId*/) {}
+  virtual void unstable_onHostTargetAdded() {}
   virtual void onPageRemoved(int /*pageId*/) {}
 };
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.cpp
@@ -50,7 +50,7 @@ TracingAgent::~TracingAgent() {
 bool TracingAgent::handleRequest(const cdp::PreparsedRequest& req) {
   if (req.method == "Tracing.start") {
     auto& inspector = getInspectorInstance();
-    if (inspector.getSystemState().registeredPagesCount > 1) {
+    if (inspector.getSystemState().registeredHostsCount > 1) {
       frontendChannel_(
           cdp::jsonError(
               req.id,


### PR DESCRIPTION
Summary:
### Context

This is a follow-up to D86201689 following user feedback on `0.83.0-rc.2`: https://github.com/react-native-community/discussions-and-proposals/discussions/954#discussioncomment-15138992.

The problem was that we were incorrectly attributing any and all `IInspector::addPage()` calls to represent a new React Native Host being registered. However, this API also remains common to the legacy Hermes `ConnectionDemux` runtime target setup (which does not represent a host target).

### This diff

We now fork this code path internally based on `InspectorTargetCapabilities.prefersFuseboxFrontend`, in order to track `registeredHostsCount` accurately (i.e. **only** for HostTarget page registrations).

Changelog:
[General][Fixed] - React Native DevTools: Fix a bug where we would incorrectly flag apps using additonal Hermes runtimes (e.g. Reanimated) as being multi-host

Differential Revision: D88386623


