### PR TITLE
fix(types): add missing standard properties to URL and URLSearchParams

### DIFF
--- a/packages/react-native/src/types/globals.d.ts
+++ b/packages/react-native/src/types/globals.d.ts
@@ -461,8 +461,18 @@ declare global {
     | 'text';
 
   interface URL {
-    href: string;
+    readonly hash: string;
+    readonly host: string;
+    readonly hostname: string;
+    readonly href: string;
+    readonly origin: string;
+    readonly password: string;
+    readonly pathname: string;
+    readonly port: string;
+    readonly protocol: string;
+    search: string;
     readonly searchParams: URLSearchParams;
+    readonly username: string;
 
     toJSON(): string;
     toString(): string;
@@ -479,8 +489,27 @@ declare global {
    * Based on definitions of lib.dom and lib.dom.iterable
    */
   interface URLSearchParams {
+    /**
+     * Returns the number of search parameter entries.
+     */
+    readonly size: number;
+
     append(key: string, value: string): void;
+    delete(name: string): void;
+    get(name: string): string | null;
+    getAll(name: string): string[];
+    has(name: string): boolean;
+    set(name: string, value: string): void;
+    sort(): void;
     toString(): string;
+    forEach(
+      callbackfn: (value: string, key: string, parent: URLSearchParams) => void,
+      thisArg?: any,
+    ): void;
+
+    keys(): IterableIterator<string>;
+    values(): IterableIterator<string>;
+    entries(): IterableIterator<[string, string]>;
 
     [Symbol.iterator](): IterableIterator<[string, string]>;
   }


### PR DESCRIPTION
## Summary:
This PR related to issue #54789 updates the `URL` and `URLSearchParams` definitions in `globals.d.ts` to include missing standard properties and methods that are already supported by the runtime implementation.
**Motivation:**
I noticed that while the runtime supports standard URL operations (backed by `whatwg-url`), the TypeScript definitions were incomplete, causing unnecessary type errors when using standard Web APIs.
## Changelog:
[GENERAL] [FIXED] - Added missing standard properties to `URL` (hash, host, pathname, etc.) and methods to `URLSearchParams` (get, set, delete, etc.).
## Test Plan:
1.  Open `globals.d.ts`.
2.  Verify that `URL` interface now includes all standard properties.
3.  Verify that `URLSearchParams` interface now includes all standard methods.
4.  Verify that no new TypeScript errors are introduced.
Screenshot:
Before making changes 
<img width="1512" height="982" alt="Screenshot 2025-12-04 at 11 38 58 PM" src="https://github.com/user-attachments/assets/1b3bd18e-0f3e-476c-824f-a6b537092755" />
After making changes 
![Uploading Screenshot 2025-12-04 at 11.39.42 PM.png…]()
