### PR TITLE
Update URL in ImageSource.d.ts documentation

### DIFF
--- a/packages/react-native/Libraries/Image/ImageSource.d.ts
+++ b/packages/react-native/Libraries/Image/ImageSource.d.ts
@@ -8,7 +8,7 @@
  */
 
 /*
- * @see https://github.com/facebook/react-native/blob/master/Libraries/Image/ImageSource.js
+ * @see https://github.com/facebook/react-native/blob/main/packages/react-native/Libraries/Image/ImageSource.js
  */
 export interface ImageURISource {
   /**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

This PR updates the `@see` reference URL in `ImageSource.d.ts` to reflect the current repository structure.

The React Native repository has undergone the following changes:
- The default branch was renamed from `master` to `main`
- The file path changed from `Libraries/Image/ImageSource.js` to `packages/react-native/Libraries/Image/ImageSource.js`

**Before:**
```typescript
/*
 * @see https://github.com/facebook/react-native/blob/master/Libraries/Image/ImageSource.js
 */
```

**After:**
```typescript
/*
 * @see https://github.com/facebook/react-native/blob/main/packages/react-native/Libraries/Image/ImageSource.js
 */
```

## Changelog:

[GENERAL] [FIXED] - Update ImageSource.d.ts @see reference URL to reflect current repository structure

## Test Plan:

CI Green
