### PR TITLE
fix: RNGP using node invocation non-compatible with Gradle Compilation Cache

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PathUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PathUtils.kt
@@ -42,6 +42,7 @@ internal fun detectedEntryFile(config: ReactExtension, envVariableOverride: Stri
  */
 internal fun detectedCliFile(config: ReactExtension): File =
     detectCliFile(
+        project = config.project,
         reactNativeRoot = config.root.get().asFile,
         preconfiguredCliFile = config.cliFile.asFile.orNull,
     )
@@ -71,7 +72,11 @@ private fun detectEntryFile(
       else -> File(reactRoot, "index.js")
     }
 
-private fun detectCliFile(reactNativeRoot: File, preconfiguredCliFile: File?): File {
+private fun detectCliFile(
+    project: Project,
+    reactNativeRoot: File,
+    preconfiguredCliFile: File?
+): File {
   // 1. preconfigured path
   if (preconfiguredCliFile != null) {
     if (preconfiguredCliFile.exists()) {
@@ -81,14 +86,11 @@ private fun detectCliFile(reactNativeRoot: File, preconfiguredCliFile: File?): F
 
   // 2. node module path
   val nodeProcess =
-      Runtime.getRuntime()
-          .exec(
-              arrayOf("node", "--print", "require.resolve('react-native/cli');"),
-              emptyArray(),
-              reactNativeRoot,
-          )
+      project.providers.exec {
+        it.commandLine("node", "--print", "require.resolve('react-native/package.json')")
+      }
 
-  val nodeProcessOutput = nodeProcess.inputStream.use { it.bufferedReader().readText().trim() }
+  val nodeProcessOutput = nodeProcess.standardOutput.asText.get().trim()
 
   if (nodeProcessOutput.isNotEmpty()) {
     val nodeModuleCliJs = File(nodeProcessOutput)


### PR DESCRIPTION
## Summary:

Invoking `Runtime.getRuntime().exec()` is not compatible with Gradle Configuration Cache and providers should be used instead.

This error hasn't surfaced yet due to fact that this branch of code is rarely hit as the users usually provide correct path to the CLI in their `app/build.gradle` file. I stumbled upon it accidentally when bumping RN in monorepo and the CLI path was no longer valid.

## Changelog:

[ANDROID] [FIXED] - RNGP using node invocation non-compatible with Gradle Compilation Cache

## Test Plan:

I tested it in a rnc-cli app, where I provided an invalid path for `cliFile` - the error was fixed after applying this patch.
