### PR TITLE
fix hit test for components using legacy module interop 

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/LegacyViewManagerInterop/RCTLegacyViewManagerInteropComponentView.mm
@@ -287,4 +287,15 @@ static NSString *const kRCTLegacyInteropChildIndexKey = @"index";
   [_adapter handleCommand:(NSString *)commandName args:(NSArray *)args];
 }
 
+- (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
+{
+  UIView* result = [super hitTest:point withEvent:event];
+
+  if (result == self) {
+    return nil;
+  }
+
+  return result;
+}
+
 @end


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

This fixes hit tests in view using legacy module interop since the interop adds another view surrounding the actual view it needs to delegate the hit test to the actual component it wraps

## Changelog:

[IOS] [FIXED] - Fix legacy module interop not handling hitTest correctly

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
