### PR TITLE
Mark virtual text view descendants clickable

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewAccessibilityDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextViewAccessibilityDelegate.kt
@@ -219,6 +219,7 @@ internal class ReactTextViewAccessibilityDelegate(
     node.contentDescription = accessibleTextSpan.description
     node.addAction(AccessibilityNodeInfoCompat.ACTION_CLICK)
     node.setBoundsInParent(bounds)
+    node.setClickable(true)
     node.roleDescription = hostView.resources.getString(R.string.link_description)
     node.className = AccessibilityRole.getValue(AccessibilityRole.BUTTON)
   }


### PR DESCRIPTION
Summary:
Individual accessibility nodes for `ClickableSpan`s should themselves be clickable.

## Changelog:
[ANDROID] [FIXED] a11y: Mark virtual views for links as [`clickable`](https://developer.android.com/reference/android/view/accessibility/AccessibilityNodeInfo#setClickable(boolean%29)

Differential Revision: D88426196


