### PR TITLE
Add ThemePreferences listener for dark mode updates

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -2465,6 +2465,7 @@ public final class com/facebook/react/modules/appearance/AppearanceModule : com/
 	public fun addListener (Ljava/lang/String;)V
 	public final fun emitAppearanceChanged (Ljava/lang/String;)V
 	public fun getColorScheme ()Ljava/lang/String;
+	public fun invalidate ()V
 	public final fun invalidatePlatformColorCache ()V
 	public final fun onConfigurationChanged (Landroid/content/Context;)V
 	public fun removeListeners (D)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/appearance/AppearanceModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/appearance/AppearanceModule.kt
@@ -28,12 +28,14 @@ constructor(
 
   private var lastEmittedColorScheme: String? = null
 
+  private val schemeChangeListener: () -> Unit = {
+    val activity = reactApplicationContext.getCurrentActivity()
+    onConfigurationChanged(activity ?: reactApplicationContext)
+  }
+
   init {
     // Register as a listener for color scheme changes if override is provided
-    overrideColorScheme?.addSchemeChangeListener {
-      val activity = reactApplicationContext.getCurrentActivity()
-      onConfigurationChanged(activity ?: reactApplicationContext)
-    }
+    overrideColorScheme?.addSchemeChangeListener(schemeChangeListener)
   }
 
   /** Optional override to the current color scheme */
@@ -123,6 +125,12 @@ constructor(
   public fun invalidatePlatformColorCache() {
     // call into static invalidatePlatformColorCache?.run() method
     Companion.invalidatePlatformColorCache?.run()
+  }
+
+  public override fun invalidate() {
+    overrideColorScheme?.removeSchemeChangeListener(schemeChangeListener)
+    invalidatePlatformColorCache()
+    super.invalidate()
   }
 
   public companion object {


### PR DESCRIPTION
Summary:
This change implements the internal Facebook-specific listener mechanism for dynamic dark mode updates in FB4A. It builds on the OSS changes in D88427482 which added the `addListener()` API to `OverrideColorScheme` interface.

**Why this is needed:**
Previously, when users toggled dark mode in FB4A Settings, React Native JavaScript would not be notified of the change. The `AppearanceModule` would only reflect the initial color scheme state from instantiation, causing UI inconsistencies when users changed their theme preference in native settings UI.

**How it works:**
1. User toggles dark mode in FB4A Settings → `ThemePreferences.setDarkMode()` is called
2. `ThemePreferences` notifies all registered listeners (including `FB4AThemeOverrideColorScheme`)
3. `FB4AThemeOverrideColorScheme` forwards the notification to `AppearanceModule` via the listener callback
4. `AppearanceModule.onConfigurationChanged()` is invoked (set up in OSS changes)
5. If the color scheme changed, an `appearanceChanged` event is emitted to React Native JavaScript

Reviewed By: xiphirx

Differential Revision: D88431860


