### PR TITLE
feat: Export usePressability hook as public API

### DIFF
--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -338,6 +338,9 @@ module.exports = {
   get useAnimatedValue() {
     return require('./Libraries/Animated/useAnimatedValue').default;
   },
+  get usePressability() {
+    return require('./Libraries/Pressability/usePressability').default;
+  },
   get useColorScheme() {
     return require('./Libraries/Utilities/useColorScheme').default;
   },

--- a/packages/react-native/index.js.flow
+++ b/packages/react-native/index.js.flow
@@ -408,6 +408,11 @@ export * as TurboModuleRegistry from './Libraries/TurboModule/TurboModuleRegistr
 export {default as UIManager} from './Libraries/ReactNative/UIManager';
 export {unstable_batchedUpdates} from './Libraries/ReactNative/RendererProxy';
 export {default as useAnimatedValue} from './Libraries/Animated/useAnimatedValue';
+export type {
+  PressabilityConfig,
+  EventHandlers as PressabilityEventHandlers,
+} from './Libraries/Pressability/Pressability';
+export {default as usePressability} from './Libraries/Pressability/usePressability';
 export {default as useColorScheme} from './Libraries/Utilities/useColorScheme';
 export {default as useWindowDimensions} from './Libraries/Utilities/useWindowDimensions';
 export {default as UTFSequence} from './Libraries/UTFSequence';


### PR DESCRIPTION
## Summary

Exports the `usePressability` hook and related types (`PressabilityConfig`, `PressabilityEventHandlers`) from the public `react-native` API, enabling library authors to implement Pressable-quality press handling on custom components without deep imports.

## Motivation

With deep imports being deprecated in 0.80 and removal planned for 0.82 (Discussion #893), libraries using `usePressability` need a public alternative.

**Why not just use `<Pressable>`?**

Pressable wraps content in a View, which:
- Adds an extra layer to the view hierarchy
- Can interfere with flex layout and styling
- Requires wrapping every pressable element

`usePressability` allows applying press handling directly to existing View/Text components—the same pattern React Native uses internally for `Text` and `TextInput`.

### Use Case

UI libraries like [Tamagui](https://tamagui.dev) use `usePressability` to provide press styles on styled View/Text primitives:
- Smooth press + hold + move out behavior
- Automatic cancellation when scrolling begins
- Hit slop support
- No wrapper View affecting layout

### Internal Usage

Already used by React Native's own components:
- `Pressable.js`
- `Text.js`
- `TextInput.js`

## Changelog

[GENERAL] [ADDED] - Export `usePressability` hook and `PressabilityConfig`/`PressabilityEventHandlers` types from the public API

## Test Plan

- Existing Pressability tests pass
- Export accessible via `import { usePressability } from 'react-native'`
- TypeScript/Flow types correctly exported