### PR TITLE
Hold lock while changing atomic variable

### DIFF
--- a/packages/react-native/ReactCxxPlatform/react/threading/TaskDispatchThread.h
+++ b/packages/react-native/ReactCxxPlatform/react/threading/TaskDispatchThread.h
@@ -61,7 +61,7 @@ class TaskDispatchThread {
 
   void loop() noexcept;
 
-  std::mutex queueLock_;
+  std::mutex mutex_;
   std::condition_variable loopCv_;
   std::priority_queue<Task> queue_;
   std::atomic<bool> running_{true};


### PR DESCRIPTION
Summary:
Fixed a bug in TaskDispatchThread. 

According to https://en.cppreference.com/w/cpp/thread/condition_variable.html:
> Even if the shared variable is atomic, it must be modified while owning the mutex to correctly publish the modification to the waiting thread.

So we need to own a lock when changing running_ in quit(). Otherwise, there is a chance that signal will get lost, which leads to deadlock on quit().

Differential Revision: D88640446


