### PR TITLE
Fix prototype check in AnimatedObject.js

### DIFF
--- a/packages/react-native/Libraries/Animated/nodes/AnimatedObject.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedObject.js
@@ -31,7 +31,7 @@ export function isPlainObject(
   }
   return (
     // $FlowFixMe[incompatible-type-guard]
-    (proto === null || proto.isPrototypeOf(Object)) &&
+    (proto == null || proto.isPrototypeOf(Object)) &&
     !isValidElement(value)
   );
 }


### PR DESCRIPTION
## Summary:

`isPlainObject` function defined in `AnimatedObject.js` doesn't handle `Object.create(null)` correctly.

this will throws when encountering objects with null prototype:

```js
Object.getPrototypeOf(Object.create(null)).isPrototypeOf(Object)
// TypeError: Cannot read properties of null (reading 'isPrototypeOf')
```

This breaks compatibility with libraries that use `Object.create(null)` for creating clean dictionary objects.

## Changelog:

[GENERAL] [FIXED] - Handle `Object.create(null)` correctly in AnimatedObject.js' `isPlainObject` function

## Test Plan:
```
import { isPlainObject } from 'react-native/Libraries/Animated/nodes/AnimatedObject';

// Before: throws TypeError
// After: returns true
isPlainObject(Object.create(null));

// Existing behavior unchanged
isPlainObject({});           // true
isPlainObject([]);           // false
isPlainObject(null);         // false
isPlainObject(new Date());   // false
```