### PR TITLE
Refactor how we promote shadow tree revisions as latest for JS consistency

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/uimanager/consistency/LazyShadowTreeRevisionConsistencyManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/consistency/LazyShadowTreeRevisionConsistencyManager.h
@@ -28,11 +28,11 @@ class LazyShadowTreeRevisionConsistencyManager : public ShadowTreeRevisionConsis
  public:
   explicit LazyShadowTreeRevisionConsistencyManager(ShadowTreeRegistry &shadowTreeRegistry);
 
-  void updateCurrentRevision(SurfaceId surfaceId, RootShadowNode::Shared rootShadowNode);
+  std::shared_ptr<const RootShadowNode> updateCurrentRevision(SurfaceId surfaceId);
 
 #pragma mark - ShadowTreeRevisionProvider
 
-  RootShadowNode::Shared getCurrentRevision(SurfaceId surfaceId) override;
+  std::shared_ptr<const RootShadowNode> getCurrentRevision(SurfaceId surfaceId) override;
 
 #pragma mark - ShadowTreeRevisionConsistencyManager
 

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/consistency/tests/LazyShadowTreeRevisionConsistencyManagerTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/consistency/tests/LazyShadowTreeRevisionConsistencyManagerTest.cpp
@@ -141,7 +141,7 @@ TEST_F(
 
   EXPECT_EQ(consistencyManager_.getCurrentRevision(0), nullptr);
 
-  consistencyManager_.updateCurrentRevision(0, newRootShadowNode);
+  consistencyManager_.updateCurrentRevision(0);
 
   EXPECT_NE(consistencyManager_.getCurrentRevision(0), nullptr);
   EXPECT_EQ(
@@ -176,7 +176,7 @@ TEST_F(
 
   EXPECT_EQ(consistencyManager_.getCurrentRevision(0), nullptr);
 
-  consistencyManager_.updateCurrentRevision(0, newRootShadowNode);
+  consistencyManager_.updateCurrentRevision(0);
 
   EXPECT_EQ(
       consistencyManager_.getCurrentRevision(0).get(), newRootShadowNode.get());
@@ -192,7 +192,7 @@ TEST_F(
             {});
       });
 
-  consistencyManager_.updateCurrentRevision(0, newRootShadowNode2);
+  consistencyManager_.updateCurrentRevision(0);
 
   EXPECT_EQ(
       consistencyManager_.getCurrentRevision(0).get(),
@@ -265,7 +265,7 @@ TEST_F(
   EXPECT_EQ(
       consistencyManager_.getCurrentRevision(0).get(), newRootShadowNode.get());
 
-  consistencyManager_.updateCurrentRevision(0, newRootShadowNode2);
+  consistencyManager_.updateCurrentRevision(0);
 
   // Updated
   EXPECT_EQ(
@@ -344,7 +344,9 @@ TEST_F(LazyShadowTreeRevisionConsistencyManagerTest, testUpdateToUnmounted) {
   EXPECT_EQ(
       consistencyManager_.getCurrentRevision(0).get(), newRootShadowNode.get());
 
-  consistencyManager_.updateCurrentRevision(0, nullptr);
+  shadowTreeRegistry_.remove(0);
+
+  consistencyManager_.updateCurrentRevision(0);
 
   // Updated
   EXPECT_EQ(consistencyManager_.getCurrentRevision(0).get(), nullptr);


### PR DESCRIPTION
Summary:
Changelog: [General][Changed] - Refactor how shadow tree revisions are promoted as latest for JS consistency

Changes `LazyShadowTreeRevisionConsistencyManager::updateCurrentRevision` to pull the latest commited revision for a given surface id instead of accepting the new revision as a parameter.

This way, the new revision is read from the same place for every update, which opens up the way to implement commit branching. This change will allow to always read from the JS tree revision, if it exists.

Differential Revision: D88151490


