### PR TITLE
[ios][precompile] fixed issue with xcconfig being overwritten

### DIFF
--- a/packages/react-native/scripts/cocoapods/new_architecture.rb
+++ b/packages/react-native/scripts/cocoapods/new_architecture.rb
@@ -133,9 +133,13 @@ class NewArchitectureHelper
 
         depend_on_js_engine(spec)
         add_rn_third_party_dependencies(spec)
-        add_rncore_dependency(spec)
 
         spec.pod_target_xcconfig = current_config
+
+        # add_rncore_dependency must be called after setting pod_target_xcconfig
+        # because it reads and modifies the xcconfig. If called before, its changes
+        # would be overwritten by the assignment above.
+        add_rncore_dependency(spec)
     end
 
     def self.extract_react_native_version(react_native_path, file_manager: File, json_parser: JSON)


### PR DESCRIPTION
## Summary:

To be able to change the target xcconfig from within `add_rn_core`, we need to make sure it is not overwritten by the line that sets the config.

This commit fixes this by moving it after the line:

`spec.pod_target_xcconfig = current_config`

Next PR: https://github.com/facebook/react-native/pull/54839

## Changelog:

[IOS] [FIXED] - Moved setting xcconfig to after `add_rn_core` pod function is called.

## Test Plan:

Run RNTester with precompiled binaries.