### PR TITLE
ReactDelegate: make onBackPressed return correct status

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.kt
@@ -178,13 +178,10 @@ public open class ReactDelegate {
     if (
         ReactNativeNewArchitectureFeatureFlags.enableBridgelessArchitecture() && reactHost != null
     ) {
-      reactHost?.onBackPressed()
+      return reactHost?.onBackPressed() == true
+    } else if (reactNativeHost?.hasInstance() == true) {
+      reactNativeHost?.reactInstanceManager?.onBackPressed()
       return true
-    } else {
-      if (reactNativeHost?.hasInstance() == true) {
-        reactNativeHost?.reactInstanceManager?.onBackPressed()
-        return true
-      }
     }
     return false
   }


### PR DESCRIPTION
Summary:
onBackPressed returns a boolean: whether the back press was handled.

When react is invalid, this method should return false. This diff accomplishes that.

Reviewed By: mdvacca

Differential Revision: D88787192


