### PR TITLE
fix: Android OOM by eliminating intermediate buffer copies

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/BundleDownloader.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/BundleDownloader.kt
@@ -168,13 +168,13 @@ public class BundleDownloader public constructor(private val client: OkHttpClien
       callback.onFailure(
           DebugServerException(
               ("""
-              Error while reading multipart response.
-              
-              Response body was empty: ${response.code()}
-              
-              URL: $url
-              
-              
+                    Error while reading multipart response.
+                    
+                    Response body was empty: ${response.code()}
+                    
+                    URL: $url
+                    
+                    
                     """
                   .trimIndent())
           )

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/MultipartStreamReader.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/MultipartStreamReader.kt
@@ -134,8 +134,8 @@ internal class MultipartStreamReader(
       listener: ChunkListener
   ) {
       val marker: ByteString = ByteString.encodeUtf8(CRLF + CRLF)
-      val indexOfMarker = content.indexOf(marker, 0, chunkLength)
-      if (indexOfMarker == -1L) {
+      val indexOfMarker = content.indexOf(marker, 0)
+      if (indexOfMarker == -1L || indexOfMarker >= chunkLength) {
           val body = Buffer()
           content.read(body, chunkLength)
           listener.onChunkComplete(emptyMap(), body, done)

--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/devsupport/MultipartStreamReaderTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/devsupport/MultipartStreamReaderTest.kt
@@ -8,6 +8,7 @@
 package com.facebook.react.devsupport
 
 import okio.Buffer
+import okio.BufferedSource
 import okio.ByteString
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -34,7 +35,7 @@ class MultipartStreamReaderTest {
 
     val callback: CallCountTrackingChunkCallback =
         object : CallCountTrackingChunkCallback() {
-          override fun onChunkComplete(headers: Map<String, String>, body: Buffer, done: Boolean) {
+          override fun onChunkComplete(headers: Map<String, String>, body: BufferedSource, done: Boolean) {
             super.onChunkComplete(headers, body, done)
 
             assertThat(done).isTrue
@@ -70,7 +71,7 @@ class MultipartStreamReaderTest {
 
     val callback: CallCountTrackingChunkCallback =
         object : CallCountTrackingChunkCallback() {
-          override fun onChunkComplete(headers: Map<String, String>, body: Buffer, done: Boolean) {
+          override fun onChunkComplete(headers: Map<String, String>, body: BufferedSource, done: Boolean) {
             super.onChunkComplete(headers, body, done)
 
             assertThat(done).isEqualTo(callCount == 3)
@@ -128,7 +129,7 @@ class MultipartStreamReaderTest {
     var callCount = 0
       private set
 
-    override fun onChunkComplete(headers: Map<String, String>, body: Buffer, isLastChunk: Boolean) {
+    override fun onChunkComplete(headers: Map<String, String>, body: BufferedSource, isLastChunk: Boolean) {
       callCount++
     }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

During JS bundle downloads from Metro, the multipart stream reader was copying each chunk into a new Buffer before passing it to listeners. For large bundles, this resulted in elevated peak memory usage due to duplicating chunk data (Okio read buffer + intermediate Buffer copy, plus downstream buffering), which can exceed emulator heap limits for large bundles.
Example: #52818 
Repro: https://github.com/facebook/react-native/pull/52797

### Changes
- Multipart parsing: pass a **bounded** `BufferedSource` per part (prevents reading past the part into the next boundary) and **drain unread bytes** after callbacks so listeners don’t need to fully consume the body.
- BundleDownloader: keep streaming download behavior while restoring **atomic writes** (`.tmp` + rename) to avoid partial bundles on interruption.
- Make Content-Type checks tolerant of parameters, parse `X-Http-Status` safely.


## Changelog:

[ANDROID] [FIXED] - Reduced memory usage during JS bundle downloads by eliminating intermediate buffer copies

## Test Plan:
- [x] Verified multipart bundle downloads work correctly with progress callbacks displayed
- [x] Verified non-multipart fallback path still functions
- [x] Verified error responses are handled correctly
- [x] Tested with large bundles (repro above) and confirmed reduced memory pressure and no crashes
