### PR TITLE
fix: stale RCTModalHostViewController blocks touch inputs

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.mm
@@ -145,7 +145,7 @@ static ModalHostViewEventEmitter::OnOrientationChange onOrientationChangeStruct(
                      animated:(BOOL)animated
                    completion:(void (^)(void))completion
 {
-  [modalViewController dismissViewControllerAnimated:animated completion:completion];
+  [modalViewController.presentingViewController dismissViewControllerAnimated:animated completion:completion];
 }
 
 - (void)ensurePresentedOnlyIfNeeded


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Resolves #54856
Resolves #50152

Fixes a but when `RCTModalHostViewController` tries to dismiss itself using the following code:
```objc
- (void)dismissViewController:(UIViewController *)modalViewController
                     animated:(BOOL)animated
                   completion:(void (^)(void))completion
{
  [modalViewController dismissViewControllerAnimated:animated completion:completion];
}
```

But since it's already presenting another VC on top of it (e.g., login web view VC, photo picker VC, etc), it dismisses that view but not itself, which results in a transparent modal VC (all the UI is unmounted) that is the top VC blocking all touch input.

<img width="724" height="1126" alt="image" src="https://github.com/user-attachments/assets/644b8b72-586e-49e0-b270-706f9ae07dc8" />

The change is minimal: instead of calling `dismissViewControllerAnimated:completion:` on `modalViewController`, which has two different behaviors depending on whether that VC is presenting another VC, it calls it on `modalViewController.presentingViewController`, which has a unique behavior of dismissing `modalViewController`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[IOS] [FIXED] - Stale RCTModalHostViewController blocks touch inputs

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

1. Run Modal examples in the RN Tester app to confirm that this code still works ok in the base case.
2. Run the reproducer from #54856  with and without the change to confirm this code fixes the issue.