### PR TITLE
Refactor ComponentDescriptorConstructor to use a Function instead of a pointer to a method

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorProvider.h
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorProvider.h
@@ -18,7 +18,8 @@ namespace facebook::react {
  * constructor. The callable returns a unique pointer conveniently represents an
  * abstract type and ownership of the newly created object.
  */
-using ComponentDescriptorConstructor = ComponentDescriptor::Unique(const ComponentDescriptorParameters &parameters);
+using ComponentDescriptorConstructor =
+    std::function<ComponentDescriptor::Unique(const ComponentDescriptorParameters &parameters)>;
 
 /*
  * Represents a unified way to construct an instance of a particular stored
@@ -35,7 +36,7 @@ class ComponentDescriptorProvider final {
   ComponentHandle handle;
   ComponentName name;
   ComponentDescriptor::Flavor flavor;
-  ComponentDescriptorConstructor *constructor;
+  ComponentDescriptorConstructor constructor;
 };
 
 /*

--- a/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorRegistry.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/componentregistry/ComponentDescriptorRegistry.cpp
@@ -32,10 +32,11 @@ void ComponentDescriptorRegistry::add(
     const ComponentDescriptorProvider& componentDescriptorProvider) const {
   std::unique_lock lock(mutex_);
 
-  auto componentDescriptor = componentDescriptorProvider.constructor(
-      {.eventDispatcher = parameters_.eventDispatcher,
-       .contextContainer = parameters_.contextContainer,
-       .flavor = componentDescriptorProvider.flavor});
+  auto args = ComponentDescriptorParameters{
+      .eventDispatcher = parameters_.eventDispatcher,
+      .contextContainer = parameters_.contextContainer,
+      .flavor = componentDescriptorProvider.flavor};
+  auto componentDescriptor = componentDescriptorProvider.constructor(args);
   react_native_assert(
       componentDescriptor->getComponentHandle() ==
       componentDescriptorProvider.handle);
@@ -45,6 +46,7 @@ void ComponentDescriptorRegistry::add(
 
   auto sharedComponentDescriptor = std::shared_ptr<const ComponentDescriptor>(
       std::move(componentDescriptor));
+
   _registryByHandle[componentDescriptorProvider.handle] =
       sharedComponentDescriptor;
   _registryByName[componentDescriptorProvider.name] = sharedComponentDescriptor;


### PR DESCRIPTION
Summary:
This diff refactors ComponentDescriptorConstructor to use a Function instead of a pointer to a method.

changelog: [internal] internal

Differential Revision: D88960360


