### PR TITLE
Make image prefetch JNI batching thread-safe

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/ImageFetcher.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/android/react/renderer/imagemanager/ImageFetcher.h
@@ -11,6 +11,7 @@
 #include <react/renderer/imagemanager/ImageRequestParams.h>
 #include <react/utils/ContextContainer.h>
 #include <memory>
+#include <mutex>
 #include <unordered_map>
 #include <vector>
 
@@ -38,6 +39,7 @@ class ImageFetcher {
       Tag tag);
 
   std::unordered_map<SurfaceId, std::vector<ImageRequestItem>> items_;
+  std::mutex mutex_;
   std::shared_ptr<const ContextContainer> contextContainer_;
 };
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
The JNI batching for image prefetching was leading to SADs regressions due to the following thread-safety issue in the ImageFetcher implementation.

Since image requests are done from the ImageShadowNode layout call, these can happen from any thread.

This while the image flushing happens from `FabricUIManagerBinding::schedulerShouldRenderTransactions()`

A commit could happen while a mount is running. Meaning the image fetcher items read/write has to be synchronized.

Changelog: [Internal]

Differential Revision: D88970631


