### PR TITLE
Fix: failing running danger on PR

### DIFF
--- a/.github/actions/diff-js-api-breaking-changes/action.yml
+++ b/.github/actions/diff-js-api-breaking-changes/action.yml
@@ -9,6 +9,9 @@ runs:
         fetch-depth: 0
         ref: ${{ github.event.pull_request.head.sha }}
 
+    - name: Run yarn install
+      uses: ./.github/actions/yarn-install
+
     - name: Get merge base commit with main
       id: merge_base
       shell: bash


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

This fixes running danger on a PR due to not installing packages after the checkout.


## Changelog:

[Internal]

## Test Plan:

Modified the `danger-pr` workflow to run on my react-native fork on `pull_requests` (with modified code from PR). 

https://github.com/coado/react-native/actions/runs/20163980613/job/57882806101 