### PR TITLE
Remove repeat checkout step from diff-js-api-changes (fix CI)

### DIFF
--- a/.github/actions/diff-js-api-changes/action.yml
+++ b/.github/actions/diff-js-api-changes/action.yml
@@ -1,38 +1,34 @@
-name: diff-js-api-breaking-changes
+name: diff-js-api-changes
 description: Check for breaking changes in the public React Native JS API
 runs:
   using: composite
   steps:
-    - name: Checkout PR branch
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-        ref: ${{ github.event.pull_request.head.sha }}
-
     - name: Get merge base commit with main
       id: merge_base
       shell: bash
       run: |
+        git fetch origin main
+        git fetch origin ${{ github.event.pull_request.head.sha }} --depth=100
         BASE=$(git merge-base ${{ github.event.pull_request.head.sha }} origin/main)
         echo "merge_base=$BASE" >> $GITHUB_OUTPUT
 
     - name: Fetch snapshots from PR head and merge base
       shell: bash
       env:
-        SCRATCH_DIR: ${{ runner.temp }}/diff-js-api-breaking-changes
+        SCRATCH_DIR: ${{ runner.temp }}/diff-js-api-changes
       run: |
         mkdir -p $SCRATCH_DIR
-        # Fetch from PR head
-        git show ${{ github.event.pull_request.head.sha }}:packages/react-native/ReactNativeApi.d.ts > $SCRATCH_DIR/ReactNativeApi-after.d.ts \
-          || echo "" > $SCRATCH_DIR/ReactNativeApi-after.d.ts
         # Fetch from merge base
         git show ${{ steps.merge_base.outputs.merge_base }}:packages/react-native/ReactNativeApi.d.ts > $SCRATCH_DIR/ReactNativeApi-before.d.ts \
           || echo "" > $SCRATCH_DIR/ReactNativeApi-before.d.ts
+        # Fetch from PR head
+        git show ${{ github.event.pull_request.head.sha }}:packages/react-native/ReactNativeApi.d.ts > $SCRATCH_DIR/ReactNativeApi-after.d.ts \
+          || echo "" > $SCRATCH_DIR/ReactNativeApi-after.d.ts
 
     - name: Run breaking change detection
       shell: bash
       env:
-        SCRATCH_DIR: ${{ runner.temp }}/diff-js-api-breaking-changes
+        SCRATCH_DIR: ${{ runner.temp }}/diff-js-api-changes
       run: |
         node ./scripts/js-api/diff-api-snapshot \
         $SCRATCH_DIR/ReactNativeApi-before.d.ts \

--- a/.github/workflows/danger-pr.yml
+++ b/.github/workflows/danger-pr.yml
@@ -22,8 +22,8 @@ jobs:
         uses: ./.github/actions/setup-node
       - name: Run yarn install
         uses: ./.github/actions/yarn-install
-      - name: Run diff-js-api-breaking-changes
-        uses: ./.github/actions/diff-js-api-breaking-changes
+      - name: Run diff-js-api-changes
+        uses: ./.github/actions/diff-js-api-changes
       - name: Danger
         run: yarn danger ci --use-github-checks --failOnErrors
         working-directory: private/react-native-bots

--- a/private/react-native-bots/dangerfile.js
+++ b/private/react-native-bots/dangerfile.js
@@ -32,10 +32,7 @@ const includesSummary = body_contains('## summary', 'summary:');
 
 const snapshot_output = JSON.parse(
   fs.readFileSync(
-    path.join(
-      process.env.RUNNER_TEMP,
-      'diff-js-api-breaking-changes/output.json',
-    ),
+    path.join(process.env.RUNNER_TEMP, 'diff-js-api-changes/output.json'),
     'utf8',
   ),
 );


### PR DESCRIPTION
Summary:
Removes introduced in D88654826, replaced with a `git fetch` with `--depth`.

This should fix CI runs on `main` (where we believe the extra checkout is clobbering the `yarn-install` step), and improve execution time.

Also shorten action name.

Changelog: [Internal]

Differential Revision: D89044330


