### PR TITLE
Update ReactShadowNodeImpl.java

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactShadowNodeImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactShadowNodeImpl.java
@@ -350,15 +350,11 @@ public class ReactShadowNodeImpl implements ReactShadowNode<ReactShadowNodeImpl>
 
     float layoutX = getLayoutX();
     float layoutY = getLayoutY();
-    int newAbsoluteLeft = Math.round(absoluteX + layoutX);
-    int newAbsoluteTop = Math.round(absoluteY + layoutY);
-    int newAbsoluteRight = Math.round(absoluteX + layoutX + getLayoutWidth());
-    int newAbsoluteBottom = Math.round(absoluteY + layoutY + getLayoutHeight());
 
     int newScreenX = Math.round(layoutX);
     int newScreenY = Math.round(layoutY);
-    int newScreenWidth = newAbsoluteRight - newAbsoluteLeft;
-    int newScreenHeight = newAbsoluteBottom - newAbsoluteTop;
+    int newScreenWidth = Math.round(getLayoutWidth());
+    int newScreenHeight = Math.round(getLayoutHeight());
 
     return newScreenX != mScreenX
         || newScreenY != mScreenY


### PR DESCRIPTION
Fix the ±1px loss caused by decimal point calculation In Some model

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:


Fixed the issue([#54866](https://github.com/facebook/react-native/issues/54866)) where the parent-child view could not be closely attached and there was a gap on certain specific models such as Redmi K80 .The root cause is **double rounding**: the original code rounded absolute positions, then computed width/height by subtraction, which can accumulate a 1px error.  

Original code:

```java
int newAbsoluteLeft = Math.round(absoluteX + layoutX);
int newAbsoluteTop = Math.round(absoluteY + layoutY);
int newAbsoluteRight = Math.round(absoluteX + layoutX + getLayoutWidth());
int newAbsoluteBottom = Math.round(absoluteY + layoutY + getLayoutHeight());

int newScreenX = Math.round(layoutX);
int newScreenY = Math.round(layoutY);
int newScreenWidth = newAbsoluteRight - newAbsoluteLeft;
int newScreenHeight = newAbsoluteBottom - newAbsoluteTop; 
```
Fixed code:
```java
int newScreenX = Math.round(layoutX);
int newScreenY = Math.round(layoutY);
int newScreenWidth = Math.round(getLayoutWidth());
int newScreenHeight = Math.round(getLayoutHeight());
```

By rounding the width and height directly, the ±1px discrepancy is eliminated.



## Changelog:

[ANDROID][FIXED] Prevent ±1px layout error on some devices by rounding width/height directly

## Test Plan:

- Verified on devices that previously exhibited the 1px gap (e.g., Redmi K80).
- The triangle arrow in Toast layouts now aligns perfectly with its parent container.
- Verify that the normal view will also render normally on multiple other Android devices.
