### PR TITLE
Deprecate XHRInterceptor and WebSocketInterceptor APIs

### DIFF
--- a/packages/react-native/Libraries/WebSocket/WebSocketInterceptor.js
+++ b/packages/react-native/Libraries/WebSocket/WebSocketInterceptor.js
@@ -33,10 +33,10 @@ let isInterceptorEnabled = false;
 
 /**
  * A network interceptor which monkey-patches RCTWebSocketModule methods
- * to gather all websocket network requests/responses, in order to show
- * their information in the React Native inspector development tool.
+ * to gather all websocket network events.
+ *
+ * @deprecated Since React Native 0.84
  */
-
 const WebSocketInterceptor = {
   /**
    * Invoked when RCTWebSocketModule.close(...) is called.

--- a/packages/react-native/src/private/devsupport/devmenu/elementinspector/XHRInterceptor.js
+++ b/packages/react-native/src/private/devsupport/devmenu/elementinspector/XHRInterceptor.js
@@ -64,10 +64,11 @@ let isInterceptorEnabled = false;
 
 /**
  * A network interceptor which monkey-patches XMLHttpRequest methods
- * to gather all network requests/responses, in order to show their
- * information in the React Native inspector development tool.
+ * to gather all network requests/responses.
  * This supports interception with XMLHttpRequest API, including Fetch API
  * and any other third party libraries that depend on XMLHttpRequest.
+ *
+ * @deprecated Since React Native 0.84
  */
 const XHRInterceptor = {
   /**


### PR DESCRIPTION
Summary:
These APIs are unused within React Native since https://github.com/facebook/react-native/pull/54868, and we now implement the `Network` CDP domain in core (React Native DevTools and other CDP clients).

These APIs are private under the Strict TypeScript API, however have some open source usages in Reactotron and Rozenite, which is why we aren't removing these immediately.

We intend to remove these APIs in future, but with no immediate planned timeline.

Changelog:
[General][Deprecated] - Deprecate `XHRInterceptor` and `WebSocketInterceptor` APIs. Developer tools should use the CDP `Network` domain instead.

Differential Revision: D89051528


