### PR TITLE
Add ResourceReceivedData trace event for Performance timeline

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tracing/PerformanceTracer.h
@@ -137,6 +137,12 @@ class PerformanceTracer {
       const Headers &headers);
 
   /**
+   * Record a "ResourceReceivedData" event.
+   * If not currently tracing, this is a no-op.
+   */
+  void reportResourceReceivedData(const std::string &devtoolsRequestId, HighResTimeStamp start, int encodedDataLength);
+
+  /**
    * Record a "ResourceReceiveResponse" event. Paired with other "Resource*"
    * events, renders a network request timeline in the Performance panel Network
    * track.
@@ -281,6 +287,14 @@ class PerformanceTracer {
     HighResTimeStamp createdAt = HighResTimeStamp::now();
   };
 
+  struct PerformanceTracerResourceReceivedData {
+    std::string requestId;
+    HighResTimeStamp start;
+    int encodedDataLength;
+    ThreadId threadId;
+    HighResTimeStamp createdAt = HighResTimeStamp::now();
+  };
+
   struct PerformanceTracerResourceReceiveResponse {
     std::string requestId;
     HighResTimeStamp start;
@@ -302,6 +316,7 @@ class PerformanceTracer {
       PerformanceTracerEventMeasure,
       PerformanceTracerResourceSendRequest,
       PerformanceTracerResourceReceiveResponse,
+      PerformanceTracerResourceReceivedData,
       PerformanceTracerResourceFinish>;
 
 #pragma mark - Private fields and methods

--- a/packages/react-native/ReactCommon/react/networking/NetworkReporter.cpp
+++ b/packages/react-native/ReactCommon/react/networking/NetworkReporter.cpp
@@ -168,9 +168,16 @@ void NetworkReporter::reportDataReceived(
     int dataLength,
     const std::optional<int>& encodedDataLength) {
 #ifdef REACT_NATIVE_DEBUGGER_ENABLED
+  auto now = HighResTimeStamp::now();
+
   // Debugger enabled: CDP event handling
   jsinspector_modern::NetworkHandler::getInstance().onDataReceived(
       requestId, dataLength, encodedDataLength.value_or(dataLength));
+
+  // Debugger enabled: Add trace event to Performance timeline
+  jsinspector_modern::tracing::PerformanceTracer::getInstance()
+      .reportResourceReceivedData(
+          requestId, now, encodedDataLength.value_or(dataLength));
 #endif
 }
 


### PR DESCRIPTION
Summary:
Changelog: [General][Added] - Add ResourceReceivedData trace events for network data chunks in Performance timeline

Wire up `NetworkReporter::reportDataReceived` to emit `ResourceReceivedData` trace events for the React Native DevTools Performance panel.

This adds a new trace event type that captures when chunked response data is received during network requests. The event is emitted when React Native treats a response as incremental/chunked (when `incrementalUpdates && responseType == "text"`), matching the existing behavior of CDP's `Network.dataReceived` event.

The implementation follows the same pattern as the existing `ResourceSendRequest`, `ResourceReceiveResponse`, and `ResourceFinish` events in PerformanceTracer.

Differential Revision: D89050646


