### PR TITLE
[android][text] Fix text layout width calculation on Android 15 plus

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.kt
@@ -666,12 +666,13 @@ internal object TextLayoutManager {
     // Calculate visual bounds width from unconstrained layout
     var desiredVisualWidth = 0f
     for (i in 0 until unconstrainedLayout.lineCount) {
-      val lineWidth = unconstrainedLayout.getLineRight(i) - unconstrainedLayout.getLineLeft(i)
+      val lineWidth = unconstrainedLayout.getLineMax(i)
       desiredVisualWidth = max(desiredVisualWidth, lineWidth)
     }
 
     val layoutWidth =
         when (widthYogaMeasureMode) {
+          YogaMeasureMode.EXACTLY -> floor(width).toInt()
           YogaMeasureMode.AT_MOST -> min(ceil(desiredVisualWidth).toInt(), floor(width).toInt())
           else -> ceil(desiredVisualWidth).toInt()
         }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
After testing the patch from #54721, I noticed text-rendering issues in rn-tester on Android: some text is truncated and some lines do not wrap to the next line because the measured layout width calculation is inconsistent with how Android actually renders the text. This PR fixes two issues affecting text rendering on Android 15+

1. Missing handling for `YogaMeasureMode.EXACTLY` When the `createLayout` specifies an exact width constraint (`EXACTLY` mode), the current code falls through to the else and returns `ceil(desiredVisualWidth)` instead of respecting the exact width constraint. This causes the measured width to not match the container width, breaking layout calculation  https://github.com/facebook/react-native/pull/54871#discussion_r2616256604
2. The second bug, I couldn’t reproduce this in `rn‑tester`. In the [Expensify App](https://github.com/Expensify/App), when text has a specific `lineHeight` then the computed width is incorrect, which causes labels to `clip` or be `truncated` (see screenshot 2). While debugging I found the `line-width` calculation was wrong, then i replacing the `getLineRight/getLineLeft` approach with `getLineMax` for computing line width resolves the issue. https://github.com/facebook/react-native/pull/54871#discussion_r2616262990

Screenshot 1 | Screenshot 2
-- | --
<img width="383" alt="Screenshot 2025-12-12 at 21 25 03" src="https://github.com/user-attachments/assets/8bc518bb-39ad-4ff7-be4a-c162f8d29784" /> | <img width="383"  alt="Image" src="https://github.com/user-attachments/assets/6c7ff21a-9f41-4e15-a584-7da730e83eab" /> 

## Changelog:

[ANDROID] [FIXED] - Fix text layout calculation on Android 15+

## Test Plan:
- Precondition: Set the font size to minimum on the test device/emulator.
<img width="1080" height="2400" alt="Screenshot_1765548594" src="https://github.com/user-attachments/assets/83b85e76-07ab-4c53-86c2-d295b1b215f0" />

**Tests**
- Run the tests from https://github.com/facebook/react-native/issues/53286 to verify the original issue.
- Run rn-tester and navigate to the Text component examples then verify that the text is not truncated and lines wrap 

**Results:**

https://github.com/user-attachments/assets/c0c7b31c-ddaa-4031-a6b9-238beeacf288


