### PR TITLE
make run-ci-javascript-tests.js use `flow full-check`

### DIFF
--- a/scripts/run-ci-javascript-tests.js
+++ b/scripts/run-ci-javascript-tests.js
@@ -65,7 +65,7 @@ try {
   const flowCommand =
     FLOW_BINARY == null
       ? `${YARN_BINARY} run flow-check`
-      : `${FLOW_BINARY} check`;
+      : `${FLOW_BINARY} full-check`;
   execAndLog(flowCommand);
 
   /*


### PR DESCRIPTION
Summary: `flow full-check` has been available since Flow v0.292.0

Differential Revision: D89097999


