### PR TITLE
chore(ci): update GitHub Actions to latest versions with Node.js 24 support

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -28,7 +28,7 @@ runs:
         cache-read-only: "false"
         cache-encryption-key: ${{ inputs.gradle-cache-encryption-key }}
     - name: Restore Android ccache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: /github/home/.cache/ccache
         key: v2-ccache-android-${{ github.job }}-${{ github.ref }}-${{ hashFiles('packages/react-native/ReactAndroid/**/*.cpp', 'packages/react-native/ReactAndroid/**/*.h', 'packages/react-native/ReactCommon/**/*.cpp', 'packages/react-native/ReactAndroid/**/CMakeLists.txt', 'packages/react-native/ReactCommon/**/CMakeLists.txt') }}
@@ -57,7 +57,7 @@ runs:
         ./gradlew $TASKS -PenableWarningsAsErrors=true
     - name: Save Android ccache
       if: ${{ github.ref == 'refs/heads/main' || contains(github.ref, '-stable') }}
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: /github/home/.cache/ccache
         key: v2-ccache-android-${{ github.job }}-${{ github.ref }}-${{ hashFiles('packages/react-native/ReactAndroid/**/*.cpp', 'packages/react-native/ReactAndroid/**/*.h', 'packages/react-native/ReactCommon/**/*.cpp', 'packages/react-native/ReactAndroid/**/CMakeLists.txt', 'packages/react-native/ReactCommon/**/CMakeLists.txt') }}
@@ -65,13 +65,13 @@ runs:
       shell: bash
       run: ccache -s -v
     - name: Upload Maven Artifacts
-      uses: actions/upload-artifact@v4.3.4
+      uses: actions/upload-artifact@v6
       with:
         name: maven-local
         path: /tmp/maven-local
     - name: Upload test results
       if: ${{ always() }}
-      uses: actions/upload-artifact@v4.3.4
+      uses: actions/upload-artifact@v6
       with:
         name: build-android-results
         compression-level: 1
@@ -81,14 +81,14 @@ runs:
           packages/react-native/ReactAndroid/build/reports
     - name: Upload RNTester APK - hermes-debug
       if: ${{ always() }}
-      uses: actions/upload-artifact@v4.3.4
+      uses: actions/upload-artifact@v6
       with:
         name: rntester-debug
         path: packages/rn-tester/android/app/build/outputs/apk/debug/
         compression-level: 0
     - name: Upload RNTester APK - hermes-release
       if: ${{ always() }}
-      uses: actions/upload-artifact@v4.3.4
+      uses: actions/upload-artifact@v6
       with:
         name: rntester-release
         path: packages/rn-tester/android/app/build/outputs/apk/release/

--- a/.github/actions/build-npm-package/action.yml
+++ b/.github/actions/build-npm-package/action.yml
@@ -18,13 +18,13 @@ runs:
       shell: bash
       run: git config --global --add safe.directory '*'
     - name: Download ReactNativeDependencies
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         pattern: ReactNativeDependencies*
         path: ./packages/react-native/ReactAndroid/external-artifacts/artifacts
         merge-multiple: true
     - name: Download ReactCore artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         pattern: ReactCore*
         path: ./packages/react-native/ReactAndroid/external-artifacts/artifacts
@@ -65,7 +65,7 @@ runs:
         fi
         node ./scripts/releases-ci/publish-npm.js -t ${{ inputs.release-type }}
     - name: Upload npm logs
-      uses: actions/upload-artifact@v4.3.4
+      uses: actions/upload-artifact@v6
       with:
         name: npm-logs
         path: ~/.npm/_logs
@@ -80,7 +80,7 @@ runs:
 
         echo "$FILENAME" > build/react-native-package-version
     - name: Upload release package
-      uses: actions/upload-artifact@v4.3.4
+      uses: actions/upload-artifact@v6
       if: ${{ inputs.release-type == 'dry-run' }}
       with:
         name: react-native-package

--- a/.github/actions/maestro-android/action.yml
+++ b/.github/actions/maestro-android/action.yml
@@ -35,7 +35,7 @@ runs:
       run: export MAESTRO_VERSION=1.40.0; curl -Ls "https://get.maestro.mobile.dev" | bash
     - name: Set up JDK 17
       if: ${{ inputs.install-java == 'true' }}
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: '17'
         distribution: 'zulu'
@@ -73,7 +73,7 @@ runs:
         NORM_APP_ID=$(echo "${{ inputs.app-id }}" | tr '.' '-')
         echo "app-id=$NORM_APP_ID" >> $GITHUB_OUTPUT
     - name: Store tests result
-      uses: actions/upload-artifact@v4.3.4
+      uses: actions/upload-artifact@v6
       if: always()
       with:
         name: e2e_android_${{ steps.normalize-app-id.outputs.app-id }}_report_${{ inputs.flavor }}_${{ inputs.emulator-arch }}_NewArch
@@ -82,7 +82,7 @@ runs:
           screen.mp4
     - name: Store Logs
       if: steps.run-tests.outcome == 'failure'
-      uses: actions/upload-artifact@v4.3.4
+      uses: actions/upload-artifact@v6
       with:
         name: maestro-logs-android-${{ steps.normalize-app-id.outputs.app-id }}-${{ inputs.flavor }}-${{ inputs.emulator-arch }}-NewArch
         path: /tmp/MaestroLogs

--- a/.github/actions/maestro-ios/action.yml
+++ b/.github/actions/maestro-ios/action.yml
@@ -31,7 +31,7 @@ runs:
         brew tap facebook/fb
         brew install facebook/fb/idb-companion
     - name: Set up JDK 11
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v5
       with:
         java-version: '17'
         distribution: 'zulu'
@@ -66,7 +66,7 @@ runs:
           "${{ inputs.working-directory }}"
     - name: Store video record
       if: always()
-      uses: actions/upload-artifact@v4.3.4
+      uses: actions/upload-artifact@v6
       with:
         name: e2e_ios_${{ inputs.app-id }}_report_${{ inputs.flavor }}_NewArch
         path: |
@@ -78,7 +78,7 @@ runs:
           report.xml
     - name: Store Logs
       if: failure() && steps.run-tests.outcome == 'failure'
-      uses: actions/upload-artifact@v4.3.4
+      uses: actions/upload-artifact@v6
       with:
         name: maestro-logs-${{ inputs.app-id }}-${{ inputs.flavor }}-NewArch
         path: /tmp/MaestroLogs

--- a/.github/actions/run-fantom-tests/action.yml
+++ b/.github/actions/run-fantom-tests/action.yml
@@ -27,7 +27,7 @@ runs:
         cache-read-only: "false"
         cache-encryption-key: ${{ inputs.gradle-cache-encryption-key }}
     - name: Restore Fantom ccache
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v5
       with:
         path: /github/home/.cache/ccache
         key: v2-ccache-fantom-${{ github.job }}-${{ github.ref }}-${{ hashFiles(
@@ -56,7 +56,7 @@ runs:
         CXX: clang++
     - name: Save Fantom ccache
       if: ${{ github.ref == 'refs/heads/main' || contains(github.ref, '-stable') }}
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v5
       with:
         path: /github/home/.cache/ccache
         key: v2-ccache-fantom-${{ github.job }}-${{ github.ref }}-${{ hashFiles(
@@ -75,7 +75,7 @@ runs:
       run: ccache -s -v
     - name: Upload test results
       if: ${{ always() }}
-      uses: actions/upload-artifact@v4.3.4
+      uses: actions/upload-artifact@v6
       with:
         name: run-fantom-tests-results
         compression-level: 1

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -9,7 +9,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
         cache: yarn

--- a/.github/actions/test-ios-helloworld/action.yml
+++ b/.github/actions/test-ios-helloworld/action.yml
@@ -32,7 +32,7 @@ runs:
     - name: Run yarn install again, with the correct hermes version
       uses: ./.github/actions/yarn-install
     - name: Download ReactNativeDependencies
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: ReactNativeDependencies${{ inputs.flavor }}.xcframework.tar.gz
         path: /tmp/third-party
@@ -40,7 +40,7 @@ runs:
       shell: bash
       run: ls -lR /tmp/third-party
     - name: Download React Native Prebuilds
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: ReactCore${{ inputs.flavor }}.xcframework.tar.gz
         path: /tmp/ReactCore

--- a/.github/actions/test-ios-rntester/action.yml
+++ b/.github/actions/test-ios-rntester/action.yml
@@ -45,7 +45,7 @@ runs:
       uses: ./.github/actions/prepare-ios-tests
     - name: Download ReactNativeDependencies
       if: ${{ inputs.use-frameworks == 'false' }}
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: ReactNativeDependencies${{ inputs.flavor }}.xcframework.tar.gz
         path: /tmp/third-party/
@@ -55,7 +55,7 @@ runs:
       run: ls -lR /tmp/third-party
     - name: Download React Native Prebuilds
       if: ${{ inputs.use-frameworks == 'false' }}
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: ReactCore${{ inputs.flavor }}.xcframework.tar.gz
         path: /tmp/ReactCore
@@ -107,20 +107,20 @@ runs:
         cd /Users/runner/Library/Developer/Xcode
         tar -zcvf xcresults.tar.gz "/tmp/RNTesterTestResults"
     - name: Upload artifact
-      uses: actions/upload-artifact@v4.3.4
+      uses: actions/upload-artifact@v6
       if: ${{ inputs.run-unit-tests == 'true' }}
       with:
         name: xcresults-${{ inputs.flavor }}-${{ inputs.use-frameworks == 'true' && 'dynamic-frameworks' || 'static-libraries' }}-Ruby${{ inputs.ruby-version }}
         path: /Users/runner/Library/Developer/Xcode/xcresults.tar.gz
     - name: Upload RNTester App
       if: ${{ inputs.use-frameworks == 'false' && inputs.ruby-version == '2.6.10' }} # This is needed to avoid conflicts with the artifacts
-      uses: actions/upload-artifact@v4.3.4
+      uses: actions/upload-artifact@v6
       with:
         name: RNTesterApp-NewArch-${{ inputs.flavor }}
         path: ${{ env.app-path }}
     - name: Store test results
       if: ${{ inputs.run-unit-tests == 'true' }}
-      uses: actions/upload-artifact@v4.3.4
+      uses: actions/upload-artifact@v6
       with:
         name: test-results-${{ inputs.flavor }}-${{ inputs.use-frameworks == 'true' && 'dynamic-frameworks' || 'static-libraries' }}-Ruby${{ inputs.ruby-version }}
         path: ./reports/junit

--- a/.github/actions/test-js/action.yml
+++ b/.github/actions/test-js/action.yml
@@ -19,7 +19,7 @@ runs:
       run: node ./scripts/run-ci-javascript-tests.js --maxWorkers 2
     - name: Upload test results
       if: ${{ always() }}
-      uses: actions/upload-artifact@v4.3.4
+      uses: actions/upload-artifact@v6
       with:
         name: test-js-results
         compression-level: 1

--- a/.github/workflows/autorebase.yml
+++ b/.github/workflows/autorebase.yml
@@ -17,7 +17,7 @@ jobs:
     if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
     steps:
       - name: Checkout the latest code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo

--- a/.github/workflows/bump-podfile-lock.yml
+++ b/.github/workflows/bump-podfile-lock.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.REACT_NATIVE_BOT_GITHUB_TOKEN }}
           fetch-depth: 0

--- a/.github/workflows/cache-reaper.yml
+++ b/.github/workflows/cache-reaper.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Node.js
         uses: ./.github/actions/setup-node
       - name: Trim the cache

--- a/.github/workflows/check-for-reproducer.yml
+++ b/.github/workflows/check-for-reproducer.yml
@@ -10,8 +10,8 @@ jobs:
     if: |
       github.repository == 'facebook/react-native' && github.event.issue.pull_request == null && github.event.issue.state == 'open' && !contains(github.event.issue.labels.*.name, ':open_umbrella: Umbrella')
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/github-script@v6
+      - uses: actions/checkout@v6
+      - uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.REACT_NATIVE_BOT_GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/close-pr.yml
+++ b/.github/workflows/close-pr.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'facebook/react-native'
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.REACT_NATIVE_BOT_GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.REACT_NATIVE_BOT_GITHUB_TOKEN }}
           fetch-depth: 0
@@ -30,7 +30,7 @@ jobs:
           git config --local user.email "bot@reactnative.dev"
           git config --local user.name "React Native Bot"
       - name: Create draft release
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         id: create-draft-release
         with:
           script: |
@@ -40,7 +40,7 @@ jobs:
             return (await createDraftRelease(version, isLatest(), '${{secrets.REACT_NATIVE_BOT_GITHUB_TOKEN}}', '${{ inputs.hermesVersion }}', '${{ inputs.hermesV1Version }}')).id;
           result-encoding: string
       - name: Upload release assets for DotSlash
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         env:
           RELEASE_ID: ${{ steps.create-draft-release.outputs.result }}
         with:

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.REACT_NATIVE_BOT_GITHUB_TOKEN }}
           fetch-depth: 0

--- a/.github/workflows/danger-pr.yml
+++ b/.github/workflows/danger-pr.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'facebook/react-native'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup Node.js
         uses: ./.github/actions/setup-node
       - name: Run yarn install

--- a/.github/workflows/generate-changelog.yml
+++ b/.github/workflows/generate-changelog.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.REACT_NATIVE_BOT_GITHUB_TOKEN }}
           fetch-depth: 0
@@ -21,7 +21,7 @@ jobs:
           git config --local user.email "bot@reactnative.dev"
           git config --local user.name "React Native Bot"
       - name: Generate Changelog
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           script: |
             const {generateChangelog} = require('./.github/workflow-scripts/generateChangelog');

--- a/.github/workflows/monitor-new-issues.yml
+++ b/.github/workflows/monitor-new-issues.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.repository == 'facebook/react-native'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Node.js
         uses: ./.github/actions/setup-node
       - name: Install dependencies

--- a/.github/workflows/needs-attention.yml
+++ b/.github/workflows/needs-attention.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'facebook/react-native'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Apply Needs Attention Label
         uses: react-native-community/needs-attention@v2.0.0
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -49,7 +49,7 @@ jobs:
         ORG_GRADLE_PROJECT_SONATYPE_PASSWORD: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_PASSWORD }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Build Android
         uses: ./.github/actions/build-android
         with:
@@ -80,7 +80,7 @@ jobs:
       ORG_GRADLE_PROJECT_SONATYPE_PASSWORD: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_PASSWORD }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Build and Publish NPM Package
         uses: ./.github/actions/build-npm-package
         with:

--- a/.github/workflows/on-issue-labeled.yml
+++ b/.github/workflows/on-issue-labeled.yml
@@ -16,10 +16,10 @@ jobs:
     if: "${{ github.repository == 'facebook/react-native' && contains(github.event.label.name, 'Needs: Triage :mag:') }}"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Verify RN version
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.REACT_NATIVE_BOT_GITHUB_TOKEN }}
           script: |
@@ -39,7 +39,7 @@ jobs:
             }
 
       - name: Add descriptive label
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.REACT_NATIVE_BOT_GITHUB_TOKEN }}
           script: |
@@ -51,8 +51,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'facebook/react-native'
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/github-script@v6
+      - uses: actions/checkout@v6
+      - uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.REACT_NATIVE_BOT_GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/prebuild-ios-core.yml
+++ b/.github/workflows/prebuild-ios-core.yml
@@ -28,10 +28,10 @@ jobs:
         ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Restore cache if present
         id: restore-ios-slice
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           key: v3-ios-core-${{ matrix.slice }}-${{ matrix.flavor }}-${{ hashFiles('packages/react-native/Package.swift', 'packages/react-native/scripts/ios-prebuild/*.js', 'packages/react-native/scripts/ios-prebuild.js', 'packages/react-native/React/**/*', 'packages/react-native/ReactCommon/**/*', 'packages/react-native/Libraries/**/*') }}
           path: packages/react-native/
@@ -63,7 +63,7 @@ jobs:
             node ./scripts/releases/set-rn-artifacts-version.js --build-type "${{ inputs.version-type }}"
           fi
       - name: Download ReactNativeDependencies
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ReactNativeDependencies${{ matrix.flavor }}.xcframework.tar.gz
           path: /tmp/third-party/
@@ -99,19 +99,19 @@ jobs:
           cd packages/react-native
           node scripts/ios-prebuild -b -f "${{ matrix.flavor }}" -p "${{ matrix.slice }}"
       - name: Upload headers
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: prebuild-ios-core-headers-${{ matrix.flavor }}-${{ matrix.slice }}
           path:
             packages/react-native/.build/headers
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4.3.4
+        uses: actions/upload-artifact@v6
         with:
           name: prebuild-ios-core-slice-${{ matrix.flavor }}-${{ matrix.slice }}
           path: |
             packages/react-native/.build/output/spm/${{ matrix.flavor }}/Build/Products
       - name: Save Cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         if: ${{ github.ref == 'refs/heads/main' }} # To avoid that the cache explode
         with:
           key: v3-ios-core-${{ matrix.slice }}-${{ matrix.flavor }}-${{ hashFiles('packages/react-native/Package.swift', 'packages/react-native/scripts/ios-prebuild/*.js', 'packages/react-native/scripts/ios-prebuild.js', 'packages/react-native/React/**/*', 'packages/react-native/ReactCommon/**/*', 'packages/react-native/Libraries/**/*') }}
@@ -131,10 +131,10 @@ jobs:
       REACT_ORG_CODE_SIGNING_P12_CERT_PWD: ${{ secrets.REACT_ORG_CODE_SIGNING_P12_CERT_PWD }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Restore cache if present
         id: restore-ios-xcframework
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: packages/react-native/.build/output/xcframeworks
           key: v2-ios-core-xcframework-${{ matrix.flavor }}-${{ hashFiles('packages/react-native/Package.swift', 'packages/react-native/scripts/ios-prebuild/*.js', 'packages/react-native/scripts/ios-prebuild.js', 'packages/react-native/React/**/*', 'packages/react-native/ReactCommon/**/*', 'packages/react-native/Libraries/**/*') }}
@@ -151,14 +151,14 @@ jobs:
         uses: ./.github/actions/yarn-install
       - name: Download slice artifacts
         if: steps.restore-ios-xcframework.outputs.cache-hit != 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: prebuild-ios-core-slice-${{ matrix.flavor }}-*
           path: packages/react-native/.build/output/spm/${{ matrix.flavor }}/Build/Products
           merge-multiple: true
       - name: Download headers
         if: steps.restore-ios-xcframework.outputs.cache-hit != 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: prebuild-ios-core-headers-${{ matrix.flavor }}-*
           path: packages/react-native/.build/headers
@@ -190,18 +190,18 @@ jobs:
           cd packages/react-native/.build/output/xcframeworks/${{matrix.flavor}}/Symbols
           tar -cz -f ../../ReactCore${{ matrix.flavor }}.framework.dSYM.tar.gz .
       - name: Upload XCFramework Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ReactCore${{ matrix.flavor }}.xcframework.tar.gz
           path: packages/react-native/.build/output/xcframeworks/ReactCore${{matrix.flavor}}.xcframework.tar.gz
       - name: Upload dSYM Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ReactCore${{ matrix.flavor }}.framework.dSYM.tar.gz
           path: packages/react-native/.build/output/xcframeworks/ReactCore${{matrix.flavor}}.framework.dSYM.tar.gz
       - name: Save cache if present
         if: ${{ github.ref == 'refs/heads/main' }} # To avoid that the cache explode
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: |
             packages/react-native/.build/output/xcframeworks/ReactCore${{matrix.flavor}}.xcframework.tar.gz

--- a/.github/workflows/prebuild-ios-dependencies.yml
+++ b/.github/workflows/prebuild-ios-dependencies.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup node.js
         uses: ./.github/actions/setup-node
       - name: Restore cache if present
         id: restore-ios-prebuilds
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: packages/react-native/third-party/
           key: v3-ios-dependencies-${{ hashfiles('scripts/releases/ios-prebuild/configuration.js') }}
@@ -32,12 +32,12 @@ jobs:
         run: |
           node scripts/releases/prepare-ios-prebuilds.js -w
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4.3.4
+        uses: actions/upload-artifact@v6
         with:
           name: ios-prebuilds-workspace
           path: packages/react-native/third-party/
       - name: Save Cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         if: ${{ github.ref == 'refs/heads/main' }} # To avoid that the cache explode
         with:
           key: v3-ios-dependencies-${{ hashfiles('scripts/releases/ios-prebuild/configuration.js') }}
@@ -62,12 +62,12 @@ jobs:
                 'xros-simulator']
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup node.js
         uses: ./.github/actions/setup-node
       - name: Restore slice folder
         id: restore-slice-folder
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: packages/react-native/third-party/.build/Build/Products
           key: v3-ios-dependencies-slice-folder-${{ matrix.slice }}-${{ matrix.flavor }}-${{ hashfiles('scripts/releases/ios-prebuild/configuration.js') }}
@@ -81,7 +81,7 @@ jobs:
         uses: ./.github/actions/yarn-install
       - name: Restore workspace
         if: steps.restore-slice-folder.outputs.cache-hit != 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ios-prebuilds-workspace
           path: packages/react-native/third-party/
@@ -92,13 +92,13 @@ jobs:
         if: steps.restore-slice-folder.outputs.cache-hit != 'true'
         run:  node scripts/releases/prepare-ios-prebuilds.js -b -p ${{ matrix.slice }} -r ${{ matrix.flavor }}
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4.3.4
+        uses: actions/upload-artifact@v6
         with:
           name: prebuild-slice-${{ matrix.flavor }}-${{ matrix.slice }}
           path: |
             packages/react-native/third-party/.build/Build/Products
       - name: Save Cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         if: ${{ github.ref == 'refs/heads/main' }} # To avoid that the cache explode
         with:
           key: v3-ios-dependencies-slice-folder-${{ matrix.slice }}-${{ matrix.flavor }}-${{ hashfiles('scripts/releases/ios-prebuild/configuration.js') }}
@@ -119,7 +119,7 @@ jobs:
       REACT_ORG_CODE_SIGNING_P12_CERT_PWD: ${{ secrets.REACT_ORG_CODE_SIGNING_P12_CERT_PWD }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup node.js
         uses: ./.github/actions/setup-node
       - name: Setup xcode
@@ -128,7 +128,7 @@ jobs:
           xcode-version: '16.1'
       - name: Restore XCFramework
         id: restore-xcframework
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: |
             packages/react-native/third-party/
@@ -139,13 +139,13 @@ jobs:
         uses: ./.github/actions/yarn-install
       - name: Restore workspace
         if: steps.restore-xcframework.outputs.cache-hit != 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ios-prebuilds-workspace
           path: packages/react-native/third-party/
       - name: Download slices
         if: steps.restore-xcframework.outputs.cache-hit != 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: prebuild-slice-${{ matrix.flavor }}-*
           path: packages/react-native/third-party/.build/Build/Products
@@ -177,19 +177,19 @@ jobs:
           tar -cz -f ../ReactNativeDependencies${{ matrix.flavor }}.framework.dSYM.tar.gz .
           mv ../ReactNativeDependencies${{ matrix.flavor }}.framework.dSYM.tar.gz ./ReactNativeDependencies${{ matrix.flavor }}.framework.dSYM.tar.gz
       - name: Upload XCFramework Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ReactNativeDependencies${{ matrix.flavor }}.xcframework.tar.gz
           path: packages/react-native/third-party/ReactNativeDependencies${{ matrix.flavor }}.xcframework.tar.gz
       - name: Upload dSYM Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ReactNativeDependencies${{ matrix.flavor }}.framework.dSYM.tar.gz
           path: |
             packages/react-native/third-party/Symbols/ReactNativeDependencies${{ matrix.flavor }}.framework.dSYM.tar.gz
       - name: Save XCFramework in Cache
         if: ${{ github.ref == 'refs/heads/main' }} # To avoid that the cache explode
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: |
             packages/react-native/third-party/ReactNativeDependencies${{ matrix.flavor }}.xcframework.tar.gz

--- a/.github/workflows/publish-bumped-packages.yml
+++ b/.github/workflows/publish-bumped-packages.yml
@@ -14,7 +14,7 @@ jobs:
       GHA_NPM_TOKEN: ${{ secrets.GHA_NPM_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup node.js
         uses: ./.github/actions/setup-node
       - name: Run Yarn Install

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -27,7 +27,7 @@ jobs:
       HERMES_V1_VERSION: ${{ steps.set_hermes_versions.outputs.HERMES_V1_VERSION }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - id: set_hermes_versions
         run: |
           echo "Setting hermes versions to latest"
@@ -75,7 +75,7 @@ jobs:
       REACT_NATIVE_BOT_GITHUB_TOKEN: ${{ secrets.REACT_NATIVE_BOT_GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -87,7 +87,7 @@ jobs:
           gradle-cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
       - name: Publish @react-native-community/template
         id: publish-template-to-npm
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.REACT_NATIVE_BOT_GITHUB_TOKEN }}
           script: |
@@ -97,7 +97,7 @@ jobs:
             await publishTemplate(github, version, isDryRun);
       - name: Wait for template to be published
         timeout-minutes: 3
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.REACT_NATIVE_BOT_GITHUB_TOKEN }}
           script: |
@@ -112,7 +112,7 @@ jobs:
             -d "{\"event_type\": \"publish\", \"client_payload\": { \"version\": \"${{ github.ref_name }}\" }}"
       - name: Verify Release is on NPM
         timeout-minutes: 3
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.REACT_NATIVE_BOT_GITHUB_TOKEN }}
           script: |
@@ -121,7 +121,7 @@ jobs:
             const version = "${{ github.ref_name }}";
             await verifyReleaseOnNpm(version, isLatest());
       - name: Verify that artifacts are on Maven
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           script: |
             const {verifyArtifactsAreOnMaven} = require('./.github/workflow-scripts/verifyArtifactsAreOnMaven.js');

--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -10,7 +10,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           repo-token: ${{ secrets.REACT_NATIVE_BOT_GITHUB_TOKEN }}
           days-before-stale: 180
@@ -27,7 +27,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           ascending: true
           repo-token: ${{ secrets.REACT_NATIVE_BOT_GITHUB_TOKEN }}
@@ -45,7 +45,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           repo-token: ${{ secrets.REACT_NATIVE_BOT_GITHUB_TOKEN }}
           any-of-labels: 'Needs: Author Feedback'
@@ -63,7 +63,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           ascending: true
           repo-token: ${{ secrets.REACT_NATIVE_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -51,7 +51,7 @@ jobs:
       [prebuild_apple_dependencies, prebuild_react_native_core]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run it
         uses: ./.github/actions/test-ios-rntester
         with:
@@ -66,7 +66,7 @@ jobs:
         flavor: [Debug, Release]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run it
         uses: ./.github/actions/test-ios-rntester
         with:
@@ -86,7 +86,7 @@ jobs:
         frameworks: [false, true]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run it
         uses: ./.github/actions/test-ios-rntester
         with:
@@ -103,11 +103,11 @@ jobs:
         flavor: [Debug, Release]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node.js
         uses: ./.github/actions/setup-node
       - name: Download App
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: RNTesterApp-NewArch-${{ matrix.flavor }}
           path: /tmp/RNTesterBuild/RNTester.app
@@ -134,7 +134,7 @@ jobs:
         flavor: [Debug, Release]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup xcode
         uses: ./.github/actions/setup-xcode
         with:
@@ -148,14 +148,14 @@ jobs:
         with:
           ruby-version: 2.6.10
       - name: Download React Native Package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: react-native-package
           path: /tmp/react-native-tmp
       - name: Print /tmp folder
         run: ls -lR /tmp/react-native-tmp
       - name: Download ReactNativeDependencies
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ReactNativeDependencies${{ matrix.flavor }}.xcframework.tar.gz
           path: /tmp/third-party
@@ -163,7 +163,7 @@ jobs:
         shell: bash
         run: ls -lR /tmp/third-party
       - name: Download React Native Prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: ReactCore${{ matrix.flavor }}.xcframework.tar.gz
           path: /tmp/ReactCore
@@ -223,23 +223,23 @@ jobs:
         flavor: [debug, release]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup node.js
         uses: ./.github/actions/setup-node
       - name: Run yarn
         uses: ./.github/actions/yarn-install
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'zulu'
       - name: Download Maven Local
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: maven-local
           path: /tmp/react-native-tmp/maven-local
       - name: Download React Native Package
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: react-native-package
           path: /tmp/react-native-tmp
@@ -294,7 +294,7 @@ jobs:
         ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Build and Test Fantom
         uses: ./.github/actions/run-fantom-tests
         with:
@@ -313,7 +313,7 @@ jobs:
         ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Build Android
         uses: ./.github/actions/build-android
         with:
@@ -329,13 +329,13 @@ jobs:
         flavor: [debug, release]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup node.js
         uses: ./.github/actions/setup-node
       - name: Install node dependencies
         uses: ./.github/actions/yarn-install
       - name: Download APK
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: rntester-${{ matrix.flavor }}
           path: ./packages/rn-tester/android/app/build/outputs/apk/${{ matrix.flavor }}/
@@ -366,7 +366,7 @@ jobs:
         GRADLE_OPTS: "-Dorg.gradle.daemon=false"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Build NPM Package
         uses: ./.github/actions/build-npm-package
         with:
@@ -393,16 +393,16 @@ jobs:
         flavor: [Debug, Release]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup git safe folders
         run: git config --global --add safe.directory '*'
       - name: Download npm package artifact
-        uses: actions/download-artifact@v4.1.3
+        uses: actions/download-artifact@v7
         with:
           name: react-native-package
           path: build
       - name: Download maven-local artifact
-        uses: actions/download-artifact@v4.1.3
+        uses: actions/download-artifact@v7
         with:
           name: maven-local
           path: /tmp/maven-local
@@ -431,7 +431,7 @@ jobs:
           fi
           yarn build android "${args[@]}" -P reactNativeArchitectures="$TARGET_ARCHITECTURE" -P react.internal.mavenLocalRepo="/tmp/maven-local"
       - name: Upload artifact
-        uses: actions/upload-artifact@v4.3.4
+        uses: actions/upload-artifact@v6
         with:
           name: helloworld-apk-${{ matrix.flavor }}-NewArch-hermes
           path: ./private/helloworld/android/app/build/outputs/apk/
@@ -445,7 +445,7 @@ jobs:
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: ./.github/actions/test-ios-helloworld
         with:
           ruby-version: 3.2.0
@@ -467,7 +467,7 @@ jobs:
       YARN_ENABLE_IMMUTABLE_INSTALLS: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: ./.github/actions/test-ios-helloworld
         with:
           flavor: ${{ matrix.flavor }}
@@ -482,7 +482,7 @@ jobs:
         node-version: ["24", "22", "20.19.4"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Test JS
         uses: ./.github/actions/test-js
         with:
@@ -495,7 +495,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run all the linters
         uses: ./.github/actions/lint
         with:
@@ -516,7 +516,7 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' && always() }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Rerun failed jobs in the current workflow
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/test-hermes-v1-android.yml
+++ b/.github/workflows/test-hermes-v1-android.yml
@@ -18,16 +18,16 @@ jobs:
         flavor: [debug, release]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.14.0'
           cache: yarn
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'zulu'

--- a/.github/workflows/test-hermes-v1-ios.yml
+++ b/.github/workflows/test-hermes-v1-ios.yml
@@ -18,10 +18,10 @@ jobs:
         flavor: [debug, release]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.14.0'
           cache: yarn

--- a/.github/workflows/test-hermes-v1.yml
+++ b/.github/workflows/test-hermes-v1.yml
@@ -17,7 +17,7 @@ jobs:
     if: github.repository == 'facebook/react-native'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Check nightly
         run: |
           TODAY=$(date "+%Y%m%d")

--- a/.github/workflows/validate-dotslash-artifacts.yml
+++ b/.github/workflows/validate-dotslash-artifacts.yml
@@ -30,7 +30,7 @@ jobs:
     if: github.repository == 'facebook/react-native'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -42,7 +42,7 @@ jobs:
           git config --local user.email "bot@reactnative.dev"
           git config --local user.name "React Native Bot"
       - name: Validate DotSlash artifacts
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           script: |
             const {validateDotSlashArtifacts} = require('./scripts/releases/validate-dotslash-artifacts.js');


### PR DESCRIPTION
## Summary

Updates all `actions/*` GitHub Actions to their latest versions to ensure compatibility with Node.js 24 and prepare for the [deprecation of Node.js 20 on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

## Changelog:

[Internal] [Changed] - Updated GitHub Actions to latest versions with Node.js 24 support

## Version Updates

| Action | Previous | Current | Release Notes |
|--------|----------|---------|---------------|
| `actions/checkout` | v4 | **v6** | [v6.0.0](https://github.com/actions/checkout/releases/tag/v6.0.0) |
| `actions/github-script` | v6 | **v8** | [v8.0.0](https://github.com/actions/github-script/releases/tag/v8.0.0) |
| `actions/setup-node` | v4 | **v6** | [v6.0.0](https://github.com/actions/setup-node/releases/tag/v6.0.0) |
| `actions/setup-java` | v2/v4 | **v5** | [v5.0.0](https://github.com/actions/setup-java/releases/tag/v5.0.0) |
| `actions/upload-artifact` | v4/v4.3.4 | **v6** | [v6.0.0](https://github.com/actions/upload-artifact/releases/tag/v6.0.0) |
| `actions/download-artifact` | v4/v4.1.3 | **v7** | [v7.0.0](https://github.com/actions/download-artifact/releases/tag/v7.0.0) |
| `actions/cache` | v4 | **v5** | [v5.0.0](https://github.com/actions/cache/releases/tag/v5.0.0) |
| `actions/stale` | v9 | **v10** | [v10.0.0](https://github.com/actions/stale/releases/tag/v10.0.0) |

## Why

GitHub is [deprecating Node.js 20](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) on Actions runners. The new versions of these actions now run on Node.js 24 by default (`runs.using: node24`).

## Requirements

- Minimum Actions Runner version: **v2.327.1**
- Self-hosted runners should be updated before merging

## Test Plan

- PR-triggered workflows (`test-all.yml`, `danger-pr.yml`) will validate core CI
- Other workflows will be validated when their respective triggers occur (schedules, releases, issue events)