### PR TITLE
Fix large image crash in RNTester

### DIFF
--- a/packages/rn-tester/js/examples/Image/ImageExample.js
+++ b/packages/rn-tester/js/examples/Image/ImageExample.js
@@ -18,7 +18,14 @@ import RNTesterText from '../../components/RNTesterText';
 import ImageCapInsetsExample from './ImageCapInsetsExample';
 import React from 'react';
 import {useEffect, useState} from 'react';
-import {Image, ImageBackground, StyleSheet, Text, View} from 'react-native';
+import {
+  Image,
+  ImageBackground,
+  Platform,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
 
 const IMAGE1 =
   'https://www.facebook.com/assets/fb_lite_messaging/E2EE-settings@3x.png';
@@ -1013,6 +1020,16 @@ exports.examples = [
   {
     title: 'Error Handler for Large Images',
     render: function (): React.Node {
+      if (Platform.OS === 'android' && parseInt(Platform.Version, 10) < 27) {
+        return (
+          <View>
+            <RNTesterText>
+              Large images are only supported on Android API 27+
+            </RNTesterText>
+          </View>
+        );
+      }
+
       return (
         <NetworkImageExample
           resizeMethod="none"
@@ -1703,6 +1720,16 @@ exports.examples = [
       'Demonstrating the effects of loading a large image with different resize methods',
     scrollable: true,
     render: function (): React.Node {
+      if (parseInt(Platform.Version, 10) < 27) {
+        return (
+          <View>
+            <RNTesterText>
+              Large images are only supported on Android API 27+
+            </RNTesterText>
+          </View>
+        );
+      }
+
       const methods: Array<ImageProps['resizeMethod']> = [
         'auto',
         'resize',


### PR DESCRIPTION
Summary:
Older devices don't gracefully handle large bitmaps, let's just disable them for now

```
java.lang.OutOfMemoryError: Failed to allocate a 128160012 byte allocation with 3918448 free bytes and 3MB until OOM
```

Changelog: [Internal]

Differential Revision: D89334975


