### PR TITLE
Deprecate RCTHostRuntimeDelegate and merge into RCTHostDelegate

### DIFF
--- a/packages/react-native/ReactCommon/react/runtime/iostests/RCTHostTests.mm
+++ b/packages/react-native/ReactCommon/react/runtime/iostests/RCTHostTests.mm
@@ -163,6 +163,17 @@ static ShimRCTInstance *shimmedRCTInstance;
 
 - (void)testDidInitializeRuntime
 {
+  auto hermesRuntime = facebook::hermes::makeHermesRuntime();
+  facebook::jsi::Runtime *rt = hermesRuntime.get();
+
+  id<RCTInstanceDelegate> instanceDelegate = (id<RCTInstanceDelegate>)_subject;
+  [instanceDelegate instance:[OCMArg any] didInitializeRuntime:*rt];
+
+  OCMVerify(OCMTimes(1), [mockHostDelegate host:_subject didInitializeRuntime:*rt]);
+}
+
+- (void)testDidInitializeRuntime_DEPRECATED
+{
   id<RCTHostRuntimeDelegate> mockRuntimeDelegate = OCMProtocolMock(@protocol(RCTHostRuntimeDelegate));
   _subject.runtimeDelegate = mockRuntimeDelegate;
 

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.h
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.h
@@ -49,11 +49,22 @@ typedef NSURL *_Nullable (^RCTHostBundleURLProvider)(void);
                exceptionId:(NSUInteger)exceptionId
                    isFatal:(BOOL)isFatal
                  extraData:(NSDictionary<NSString *, id> *)extraData __attribute__((deprecated));
+
+/**
+ Delegate method invoked after the host has finished initializing the JavaScript runtime. At this stage,
+ bindings for Turbo Modules and the NativeComponentRegistry are already installed,
+ but the JavaScript bundle has not yet been executed. This method is called on the JavaScript thread;
+ accessing the runtime from any other thread is prohibited and will result in crashes.
+ */
+- (void)host:(RCTHost *)host didInitializeRuntime:(facebook::jsi::Runtime &)runtime;
+
 @end
 
+// `RCTHostRuntimeDelegate` has been merged into `RCTHostDelegate` in 0.84
+[[deprecated("Use 'RCTHostDelegate' instead")]]
 @protocol RCTHostRuntimeDelegate <NSObject>
 
-- (void)host:(RCTHost *)host didInitializeRuntime:(facebook::jsi::Runtime &)runtime;
+- (void)host:(RCTHost *)host didInitializeRuntime:(facebook::jsi::Runtime &)runtime [[deprecated("Use an equivalent method from 'RCTHostDelegate' instead")]];
 
 @end
 
@@ -84,7 +95,7 @@ typedef std::shared_ptr<facebook::react::JSRuntimeFactory> (^RCTHostJSEngineProv
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
 
-@property (nonatomic, weak, nullable) id<RCTHostRuntimeDelegate> runtimeDelegate;
+@property (nonatomic, weak, nullable) id<RCTHostRuntimeDelegate> runtimeDelegate [[deprecated("Use 'RCTHostDelegate' instead")]];
 
 @property (nonatomic, readonly) RCTSurfacePresenter *surfacePresenter;
 

--- a/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
+++ b/packages/react-native/ReactCommon/react/runtime/platform/ios/ReactCommon/RCTHost.mm
@@ -371,6 +371,10 @@ class RCTHostHostTargetDelegate : public facebook::react::jsinspector_modern::Ho
 
 - (void)instance:(RCTInstance *)instance didInitializeRuntime:(facebook::jsi::Runtime &)runtime
 {
+  if ([_hostDelegate respondsToSelector:@selector(host:didInitializeRuntime:)]) {
+    [_hostDelegate host:self didInitializeRuntime:runtime];
+  }
+  // Runtime delegate is deprecated as of 0.84
   [self.runtimeDelegate host:self didInitializeRuntime:runtime];
 }
 


### PR DESCRIPTION
## Summary:

Currently, there are two delegate protocols related to the `RCTHost` class that Frameworks can use: `RCTHostDelegate` and `RCTHostRuntimeDelegate`.
`RCTHostDelegate` is easy to set and use as `RCTReactNativeFactory` already conforms to it. However, using the `RCTHostRuntimeDelegate` is less convenient because it can only be set via the host's `runtimeDelegate` property. This requires access to the host instance first, which in turn means having to wait for `hostDidStart` (see how we currently do this in Expo: https://github.com/expo/expo/blob/cacd14059830c00971d90d39cf8aa9e67f5e6de1/packages/expo/ios/AppDelegates/ExpoReactNativeFactory.mm#L28-L36).
Additionally it's not clear that `hostDidStart` is called before `host:didInitializeRuntime`, especially since both are called from different threads. Relying on this ordering feels unsafe to me.
I'm proposing to merge `RCTHostRuntimeDelegate` into `RCTHostDelegate` as they effectively serve the same purpose.

As part of this change, I've deprecated `RCTHostRuntimeDelegate` and its method. It can be removed in 0.85 or 0.86, depending on which release allows breaking changes. Instead, I've added the same method (optional) to `RCTHostDelegate`.

All call sites and tests have been updated accordingly.

## Changelog:

[IOS] [DEPRECATED] - Deprecate `RCTHostRuntimeDelegate` and merge into `RCTHostDelegate`

## Test Plan:

- Manually added `host:didInitializeRuntime:` to `RCTReactNativeFactory` and confirmed it gets called
- Tested this change in Expo and our own factory
- Native unit tests are passing (for both the deprecated and new method)