### PR TITLE
Fix binary FormData uploads on Android

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/ProgressRequestBody.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/ProgressRequestBody.kt
@@ -23,10 +23,6 @@ internal class ProgressRequestBody(
 ) : RequestBody() {
   private var contentLength = 0L
 
-  companion object {
-    private const val MAX_BODY_PREVIEW_SIZE = 1024 * 1024 // 1MB
-  }
-
   override fun contentType(): MediaType? {
     return requestBody.contentType()
   }
@@ -84,18 +80,7 @@ internal class ProgressRequestBody(
   }
 
   fun getBodyPreview(): String {
-    return try {
-      val buffer = okio.Buffer()
-      requestBody.writeTo(buffer)
-      val size = buffer.size()
-      if (size <= MAX_BODY_PREVIEW_SIZE) {
-        buffer.readUtf8()
-      } else {
-        buffer.readUtf8(MAX_BODY_PREVIEW_SIZE.toLong()) +
-            "\n... [truncated, showing $MAX_BODY_PREVIEW_SIZE of $size bytes]"
-      }
-    } catch (e: Exception) {
-      ""
-    }
+    // TODO: Safely implement request body previews
+    return "[Preview unavailable]"
   }
 }


### PR DESCRIPTION
Summary:
https://github.com/facebook/react-native/pull/54804 was a late pick into 0.83 following RC feedback, but was insufficiently tested. In https://github.com/facebook/react-native/issues/54881, users report failing requests attributed to this code path when performing image uploads.

Functionally revert this change, as this breaks runtime behaviour.

Changelog: [Internal]

Changelog (0.83): [Android][Fixed] - Fix Network error that could occur for `FormData` uploads with binary data

Differential Revision: D89373824


