### PR TITLE
Support ReadonlyArray in react-native-codegen

### DIFF
--- a/packages/react-native-codegen/src/parsers/flow/components/commands.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/commands.js
@@ -105,11 +105,12 @@ function buildCommandSchema(
         break;
       case 'Array':
       case '$ReadOnlyArray':
+      case 'ReadonlyArray':
         /* $FlowFixMe[invalid-compare] Error discovered during Constant
          * Condition roll out. See https://fburl.com/workplace/4oq3zi07. */
         if (!paramValue.type === 'GenericTypeAnnotation') {
           throw new Error(
-            'Array and $ReadOnlyArray are GenericTypeAnnotation for array',
+            'Array, $ReadOnlyArray and ReadonlyArray are GenericTypeAnnotation for array',
           );
         }
         returnType = {

--- a/packages/react-native-codegen/src/parsers/flow/components/componentsUtils.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/componentsUtils.js
@@ -58,7 +58,10 @@ function getTypeAnnotationForArray<+T>(
       };
     }
 
-    if (objectType.id.name === '$ReadOnlyArray') {
+    if (
+      objectType.id.name === '$ReadOnlyArray' ||
+      objectType.id.name === 'ReadonlyArray'
+    ) {
       // We need to go yet another level deeper to resolve
       // types that may be defined in a type alias
       const nestedObjectType = getValueFromTypes(
@@ -226,7 +229,8 @@ function getTypeAnnotation<+T>(
 
   if (
     typeAnnotation.type === 'GenericTypeAnnotation' &&
-    parser.getTypeAnnotationName(typeAnnotation) === '$ReadOnlyArray'
+    (parser.getTypeAnnotationName(typeAnnotation) === '$ReadOnlyArray' ||
+      parser.getTypeAnnotationName(typeAnnotation) === 'ReadonlyArray')
   ) {
     return {
       type: 'ArrayTypeAnnotation',

--- a/packages/react-native-codegen/src/parsers/flow/components/events.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/events.js
@@ -82,6 +82,7 @@ function getPropertyType(
       return emitMixedProp(name, optional);
     case 'ArrayTypeAnnotation':
     case '$ReadOnlyArray':
+    case 'ReadonlyArray':
       return {
         name,
         optional,
@@ -142,6 +143,7 @@ function extractArrayElementType(
         ),
       };
     case '$ReadOnlyArray':
+    case 'ReadonlyArray':
       const genericParams = typeAnnotation.typeParameters.params;
       if (genericParams.length !== 1) {
         throw new Error(

--- a/packages/react-native-codegen/src/parsers/flow/modules/index.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/index.js
@@ -100,7 +100,8 @@ function translateTypeAnnotation(
           );
         }
         case 'Array':
-        case '$ReadOnlyArray': {
+        case '$ReadOnlyArray':
+        case 'ReadonlyArray': {
           return emitArrayType(
             hasteModuleName,
             typeAnnotation,


### PR DESCRIPTION
Summary: The lint is triggered in D89415612. Not sure what those file do but it seems a good fix

Reviewed By: SamChou19815

Differential Revision: D89418033


