### PR TITLE
Transform all Flow legacy utility types (`$Keys`) to TypeScript-style types in xplat/js

### DIFF
--- a/flow-typed/npm/babel-traverse_v7.x.x.js
+++ b/flow-typed/npm/babel-traverse_v7.x.x.js
@@ -558,24 +558,24 @@ declare module '@babel/traverse' {
      * Check whether we have the input `key`. If the `key` references an array then we check
      * if the array has any items, otherwise we just check if it's falsy.
      */
-    has(key: $Keys<TNode>): boolean;
+    has(key: keyof TNode): boolean;
 
     isStatic(): boolean;
 
     /**
      * Alias of `has`.
      */
-    is(key: $Keys<TNode>): boolean;
+    is(key: keyof TNode): boolean;
 
     /**
      * Opposite of `has`.
      */
-    isnt(key: $Keys<TNode>): boolean;
+    isnt(key: keyof TNode): boolean;
 
     /**
      * Check whether the path node `key` strict equals `value`.
      */
-    equals(key: $Keys<TNode>, value: any): boolean;
+    equals(key: keyof TNode, value: any): boolean;
 
     /**
      * Check the type against our stored internal type of the node. This is handy when a node has
@@ -726,7 +726,7 @@ declare module '@babel/traverse' {
 
     getAllPrevSiblings(): Array<NodePath<>>;
 
-    get<TKey: $Keys<TNode>>(
+    get<TKey: keyof TNode>(
       key: TKey,
       context?: boolean | TraversalContext,
     ): TNode[TKey] extends BabelNode ? NodePath<> : Array<NodePath<>>;

--- a/flow-typed/npm/rxjs_v6.x.x.js
+++ b/flow-typed/npm/rxjs_v6.x.x.js
@@ -2186,10 +2186,10 @@ declare module 'rxjs/operators' {
   ): rxjs$MonoTypeOperatorFunction<T>;
 
   declare export function distinctUntilKeyChanged<T>(
-    key: $Keys<T>,
+    key: keyof T,
   ): rxjs$MonoTypeOperatorFunction<T>;
 
-  declare export function distinctUntilKeyChanged<T, K: $Keys<T>>(
+  declare export function distinctUntilKeyChanged<T, K: keyof T>(
     key: K,
     compare: (x: mixed, y: mixed) => boolean,
   ): rxjs$MonoTypeOperatorFunction<T>;

--- a/packages/dev-middleware/src/inspector-proxy/cdp-types/messages.js
+++ b/packages/dev-middleware/src/inspector-proxy/cdp-types/messages.js
@@ -12,18 +12,18 @@ import type {JSONSerializable} from '../types';
 import type {Commands, Events} from './protocol';
 
 // Note: A CDP event is a JSON-RPC notification with no `id` member.
-export type CDPEvent<TEvent: $Keys<Events> = 'unknown'> = {
+export type CDPEvent<TEvent: keyof Events = 'unknown'> = {
   method: TEvent,
   params: Events[TEvent],
 };
 
-export type CDPRequest<TCommand: $Keys<Commands> = 'unknown'> = {
+export type CDPRequest<TCommand: keyof Commands = 'unknown'> = {
   method: TCommand,
   params: Commands[TCommand]['paramsType'],
   id: number,
 };
 
-export type CDPResponse<TCommand: $Keys<Commands> = 'unknown'> =
+export type CDPResponse<TCommand: keyof Commands = 'unknown'> =
   | {
       result: Commands[TCommand]['resultType'],
       id: number,

--- a/packages/react-native/Libraries/Animated/createAnimatedComponent.js
+++ b/packages/react-native/Libraries/Animated/createAnimatedComponent.js
@@ -65,9 +65,9 @@ type PassThroughProps = $ReadOnly<{
   passthroughAnimatedPropExplicitValues?: ViewProps | null,
 }>;
 
-type LooseOmit<O: interface {}, K: $Keys<$FlowFixMe>> = Pick<
+type LooseOmit<O: interface {}, K: keyof $FlowFixMe> = Pick<
   O,
-  Exclude<$Keys<O>, K>,
+  Exclude<keyof O, K>,
 >;
 
 export type AnimatedProps<Props: {...}> = LooseOmit<

--- a/packages/react-native/Libraries/AppState/AppState.js
+++ b/packages/react-native/Libraries/AppState/AppState.js
@@ -42,7 +42,7 @@ type AppStateEventDefinitions = {
   focus: [],
 };
 
-export type AppStateEvent = $Keys<AppStateEventDefinitions>;
+export type AppStateEvent = keyof AppStateEventDefinitions;
 
 type NativeAppStateEventDefinitions = {
   appStateDidChange: [{app_state: AppStateStatus}],

--- a/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
+++ b/packages/react-native/Libraries/Components/AccessibilityInfo/AccessibilityInfo.js
@@ -45,30 +45,28 @@ type AccessibilityEventDefinitions = {
 type AccessibilityEventTypes = 'click' | 'focus' | 'viewHoverEnter';
 
 // Mapping of public event names to platform-specific event names.
-const EventNames: Map<
-  $Keys<AccessibilityEventDefinitions>,
-  string,
-> = Platform.OS === 'android'
-  ? new Map([
-      ['change', 'touchExplorationDidChange'],
-      ['reduceMotionChanged', 'reduceMotionDidChange'],
-      ['highTextContrastChanged', 'highTextContrastDidChange'],
-      ['screenReaderChanged', 'touchExplorationDidChange'],
-      ['accessibilityServiceChanged', 'accessibilityServiceDidChange'],
-      ['invertColorsChanged', 'invertColorDidChange'],
-      ['grayscaleChanged', 'grayscaleModeDidChange'],
-    ])
-  : new Map([
-      ['announcementFinished', 'announcementFinished'],
-      ['boldTextChanged', 'boldTextChanged'],
-      ['change', 'screenReaderChanged'],
-      ['grayscaleChanged', 'grayscaleChanged'],
-      ['invertColorsChanged', 'invertColorsChanged'],
-      ['reduceMotionChanged', 'reduceMotionChanged'],
-      ['reduceTransparencyChanged', 'reduceTransparencyChanged'],
-      ['screenReaderChanged', 'screenReaderChanged'],
-      ['darkerSystemColorsChanged', 'darkerSystemColorsChanged'],
-    ]);
+const EventNames: Map<keyof AccessibilityEventDefinitions, string> =
+  Platform.OS === 'android'
+    ? new Map([
+        ['change', 'touchExplorationDidChange'],
+        ['reduceMotionChanged', 'reduceMotionDidChange'],
+        ['highTextContrastChanged', 'highTextContrastDidChange'],
+        ['screenReaderChanged', 'touchExplorationDidChange'],
+        ['accessibilityServiceChanged', 'accessibilityServiceDidChange'],
+        ['invertColorsChanged', 'invertColorDidChange'],
+        ['grayscaleChanged', 'grayscaleModeDidChange'],
+      ])
+    : new Map([
+        ['announcementFinished', 'announcementFinished'],
+        ['boldTextChanged', 'boldTextChanged'],
+        ['change', 'screenReaderChanged'],
+        ['grayscaleChanged', 'grayscaleChanged'],
+        ['invertColorsChanged', 'invertColorsChanged'],
+        ['reduceMotionChanged', 'reduceMotionChanged'],
+        ['reduceTransparencyChanged', 'reduceTransparencyChanged'],
+        ['screenReaderChanged', 'screenReaderChanged'],
+        ['darkerSystemColorsChanged', 'darkerSystemColorsChanged'],
+      ]);
 
 /**
  * Sometimes it's useful to know whether or not the device has a screen reader
@@ -80,305 +78,6 @@ const EventNames: Map<
  * See https://reactnative.dev/docs/accessibilityinfo
  */
 const AccessibilityInfo = {
-  /**
-   * Query whether bold text is currently enabled.
-   *
-   * Returns a promise which resolves to a boolean.
-   * The result is `true` when bold text is enabled and `false` otherwise.
-   *
-   * See https://reactnative.dev/docs/accessibilityinfo#isBoldTextEnabled
-   */
-  isBoldTextEnabled(): Promise<boolean> {
-    if (Platform.OS === 'android') {
-      return Promise.resolve(false);
-    } else {
-      return new Promise((resolve, reject) => {
-        if (NativeAccessibilityManagerIOS != null) {
-          NativeAccessibilityManagerIOS.getCurrentBoldTextState(
-            resolve,
-            reject,
-          );
-        } else {
-          reject(new Error('NativeAccessibilityManagerIOS is not available'));
-        }
-      });
-    }
-  },
-
-  /**
-   * Query whether grayscale is currently enabled.
-   *
-   * Returns a promise which resolves to a boolean.
-   * The result is `true` when grayscale is enabled and `false` otherwise.
-   *
-   * See https://reactnative.dev/docs/accessibilityinfo#isGrayscaleEnabled
-   */
-  isGrayscaleEnabled(): Promise<boolean> {
-    if (Platform.OS === 'android') {
-      return new Promise((resolve, reject) => {
-        if (NativeAccessibilityInfoAndroid?.isGrayscaleEnabled != null) {
-          NativeAccessibilityInfoAndroid.isGrayscaleEnabled(resolve);
-        } else {
-          reject(
-            new Error(
-              'NativeAccessibilityInfoAndroid.isGrayscaleEnabled is not available',
-            ),
-          );
-        }
-      });
-    } else {
-      return new Promise((resolve, reject) => {
-        if (NativeAccessibilityManagerIOS != null) {
-          NativeAccessibilityManagerIOS.getCurrentGrayscaleState(
-            resolve,
-            reject,
-          );
-        } else {
-          reject(new Error('AccessibilityInfo native module is not available'));
-        }
-      });
-    }
-  },
-
-  /**
-   * Query whether inverted colors are currently enabled.
-   *
-   * Returns a promise which resolves to a boolean.
-   * The result is `true` when invert color is enabled and `false` otherwise.
-   *
-   * See https://reactnative.dev/docs/accessibilityinfo#isInvertColorsEnabled
-   */
-  isInvertColorsEnabled(): Promise<boolean> {
-    if (Platform.OS === 'android') {
-      return new Promise((resolve, reject) => {
-        if (NativeAccessibilityInfoAndroid?.isInvertColorsEnabled != null) {
-          NativeAccessibilityInfoAndroid.isInvertColorsEnabled(resolve);
-        } else {
-          reject(
-            new Error(
-              'NativeAccessibilityInfoAndroid.isInvertColorsEnabled is not available',
-            ),
-          );
-        }
-      });
-    } else {
-      return new Promise((resolve, reject) => {
-        if (NativeAccessibilityManagerIOS != null) {
-          NativeAccessibilityManagerIOS.getCurrentInvertColorsState(
-            resolve,
-            reject,
-          );
-        } else {
-          reject(new Error('AccessibilityInfo native module is not available'));
-        }
-      });
-    }
-  },
-
-  /**
-   * Query whether reduced motion is currently enabled.
-   *
-   * Returns a promise which resolves to a boolean.
-   * The result is `true` when a reduce motion is enabled and `false` otherwise.
-   *
-   * See https://reactnative.dev/docs/accessibilityinfo#isReduceMotionEnabled
-   */
-  isReduceMotionEnabled(): Promise<boolean> {
-    return new Promise((resolve, reject) => {
-      if (Platform.OS === 'android') {
-        if (NativeAccessibilityInfoAndroid != null) {
-          NativeAccessibilityInfoAndroid.isReduceMotionEnabled(resolve);
-        } else {
-          reject(new Error('AccessibilityInfo native module is not available'));
-        }
-      } else {
-        if (NativeAccessibilityManagerIOS != null) {
-          NativeAccessibilityManagerIOS.getCurrentReduceMotionState(
-            resolve,
-            reject,
-          );
-        } else {
-          reject(new Error('NativeAccessibilityManagerIOS is not available'));
-        }
-      }
-    });
-  },
-
-  /**
-   * Query whether high text contrast is currently enabled. Android only.
-   *
-   * Returns a promise which resolves to a boolean.
-   * The result is `true` when high text contrast is enabled and `false` otherwise.
-   */
-  isHighTextContrastEnabled(): Promise<boolean> {
-    return new Promise((resolve, reject) => {
-      if (Platform.OS === 'android') {
-        if (NativeAccessibilityInfoAndroid?.isHighTextContrastEnabled != null) {
-          NativeAccessibilityInfoAndroid.isHighTextContrastEnabled(resolve);
-        } else {
-          reject(
-            new Error(
-              'NativeAccessibilityInfoAndroid.isHighTextContrastEnabled is not available',
-            ),
-          );
-        }
-      } else {
-        return Promise.resolve(false);
-      }
-    });
-  },
-
-  /**
-   * Query whether dark system colors is currently enabled. iOS only.
-   *
-   * Returns a promise which resolves to a boolean.
-   * The result is `true` when dark system colors is enabled and `false` otherwise.
-   */
-  isDarkerSystemColorsEnabled(): Promise<boolean> {
-    return new Promise((resolve, reject) => {
-      if (Platform.OS === 'android') {
-        return Promise.resolve(false);
-      } else {
-        if (
-          NativeAccessibilityManagerIOS?.getCurrentDarkerSystemColorsState !=
-          null
-        ) {
-          NativeAccessibilityManagerIOS.getCurrentDarkerSystemColorsState(
-            resolve,
-            reject,
-          );
-        } else {
-          reject(
-            new Error(
-              'NativeAccessibilityManagerIOS.getCurrentDarkerSystemColorsState is not available',
-            ),
-          );
-        }
-      }
-    });
-  },
-
-  /**
-   * Query whether reduce motion and prefer cross-fade transitions settings are currently enabled.
-   *
-   * Returns a promise which resolves to a boolean.
-   * The result is `true` when  prefer cross-fade transitions is enabled and `false` otherwise.
-   *
-   * See https://reactnative.dev/docs/accessibilityinfo#prefersCrossFadeTransitions
-   */
-  prefersCrossFadeTransitions(): Promise<boolean> {
-    return new Promise((resolve, reject) => {
-      if (Platform.OS === 'android') {
-        return Promise.resolve(false);
-      } else {
-        if (
-          NativeAccessibilityManagerIOS?.getCurrentPrefersCrossFadeTransitionsState !=
-          null
-        ) {
-          NativeAccessibilityManagerIOS.getCurrentPrefersCrossFadeTransitionsState(
-            resolve,
-            reject,
-          );
-        } else {
-          reject(
-            new Error(
-              'NativeAccessibilityManagerIOS.getCurrentPrefersCrossFadeTransitionsState is not available',
-            ),
-          );
-        }
-      }
-    });
-  },
-
-  /**
-   * Query whether reduced transparency is currently enabled.
-   *
-   * Returns a promise which resolves to a boolean.
-   * The result is `true` when a reduce transparency is enabled and `false` otherwise.
-   *
-   * See https://reactnative.dev/docs/accessibilityinfo#isReduceTransparencyEnabled
-   */
-  isReduceTransparencyEnabled(): Promise<boolean> {
-    if (Platform.OS === 'android') {
-      return Promise.resolve(false);
-    } else {
-      return new Promise((resolve, reject) => {
-        if (NativeAccessibilityManagerIOS != null) {
-          NativeAccessibilityManagerIOS.getCurrentReduceTransparencyState(
-            resolve,
-            reject,
-          );
-        } else {
-          reject(new Error('NativeAccessibilityManagerIOS is not available'));
-        }
-      });
-    }
-  },
-
-  /**
-   * Query whether a screen reader is currently enabled.
-   *
-   * Returns a promise which resolves to a boolean.
-   * The result is `true` when a screen reader is enabled and `false` otherwise.
-   *
-   * See https://reactnative.dev/docs/accessibilityinfo#isScreenReaderEnabled
-   */
-  isScreenReaderEnabled(): Promise<boolean> {
-    return new Promise((resolve, reject) => {
-      if (Platform.OS === 'android') {
-        if (NativeAccessibilityInfoAndroid != null) {
-          NativeAccessibilityInfoAndroid.isTouchExplorationEnabled(resolve);
-        } else {
-          reject(new Error('NativeAccessibilityInfoAndroid is not available'));
-        }
-      } else {
-        if (NativeAccessibilityManagerIOS != null) {
-          NativeAccessibilityManagerIOS.getCurrentVoiceOverState(
-            resolve,
-            reject,
-          );
-        } else {
-          reject(new Error('NativeAccessibilityManagerIOS is not available'));
-        }
-      }
-    });
-  },
-
-  /**
-   * Query whether Accessibility Service is currently enabled.
-   *
-   * Returns a promise which resolves to a boolean.
-   * The result is `true` when any service is enabled and `false` otherwise.
-   *
-   * @platform android
-   *
-   * See https://reactnative.dev/docs/accessibilityinfo/#isaccessibilityserviceenabled-android
-   */
-  isAccessibilityServiceEnabled(): Promise<boolean> {
-    return new Promise((resolve, reject) => {
-      if (Platform.OS === 'android') {
-        if (
-          NativeAccessibilityInfoAndroid != null &&
-          NativeAccessibilityInfoAndroid.isAccessibilityServiceEnabled != null
-        ) {
-          NativeAccessibilityInfoAndroid.isAccessibilityServiceEnabled(resolve);
-        } else {
-          reject(
-            new Error(
-              'NativeAccessibilityInfoAndroid.isAccessibilityServiceEnabled is not available',
-            ),
-          );
-        }
-      } else {
-        reject(
-          new Error(
-            'isAccessibilityServiceEnabled is only available on Android',
-          ),
-        );
-      }
-    });
-  },
-
   /**
    * Add an event handler. Supported events:
    *
@@ -422,7 +121,7 @@ const AccessibilityInfo = {
    *
    * See https://reactnative.dev/docs/accessibilityinfo#addeventlistener
    */
-  addEventListener<K: $Keys<AccessibilityEventDefinitions>>(
+  addEventListener<K: keyof AccessibilityEventDefinitions>(
     eventName: K,
     // $FlowFixMe[incompatible-type] - Flow bug with unions and generics (T128099423)
     handler: (...AccessibilityEventDefinitions[K]) => void,
@@ -433,31 +132,6 @@ const AccessibilityInfo = {
       : // $FlowFixMe[incompatible-type]
         RCTDeviceEventEmitter.addListener(deviceEventName, handler);
   },
-
-  /**
-   * Set accessibility focus to a React component.
-   *
-   * See https://reactnative.dev/docs/accessibilityinfo#setaccessibilityfocus
-   */
-  setAccessibilityFocus(reactTag: number): void {
-    legacySendAccessibilityEvent(reactTag, 'focus');
-  },
-
-  /**
-   * Send a named accessibility event to a HostComponent.
-   */
-  sendAccessibilityEvent(
-    handle: HostInstance,
-    eventType: AccessibilityEventTypes,
-  ) {
-    // iOS only supports 'focus' event types
-    if (Platform.OS === 'ios' && eventType === 'click') {
-      return;
-    }
-    // route through React renderer to distinguish between Fabric and non-Fabric handles
-    sendAccessibilityEvent(handle, eventType);
-  },
-
   /**
    * Post a string to be announced by the screen reader.
    *
@@ -470,7 +144,6 @@ const AccessibilityInfo = {
       NativeAccessibilityManagerIOS?.announceForAccessibility(announcement);
     }
   },
-
   /**
    * Post a string to be announced by the screen reader.
    * - `announcement`: The string announced by the screen reader.
@@ -499,7 +172,6 @@ const AccessibilityInfo = {
       }
     }
   },
-
   /**
    * Get the recommended timeout for changes to the UI needed by this user.
    *
@@ -520,6 +192,317 @@ const AccessibilityInfo = {
     } else {
       return Promise.resolve(originalTimeout);
     }
+  },
+  /**
+   * Query whether Accessibility Service is currently enabled.
+   *
+   * Returns a promise which resolves to a boolean.
+   * The result is `true` when any service is enabled and `false` otherwise.
+   *
+   * @platform android
+   *
+   * See https://reactnative.dev/docs/accessibilityinfo/#isaccessibilityserviceenabled-android
+   */
+  isAccessibilityServiceEnabled(): Promise<boolean> {
+    return new Promise((resolve, reject) => {
+      if (Platform.OS === 'android') {
+        if (
+          NativeAccessibilityInfoAndroid != null &&
+          NativeAccessibilityInfoAndroid.isAccessibilityServiceEnabled != null
+        ) {
+          NativeAccessibilityInfoAndroid.isAccessibilityServiceEnabled(resolve);
+        } else {
+          reject(
+            new Error(
+              'NativeAccessibilityInfoAndroid.isAccessibilityServiceEnabled is not available',
+            ),
+          );
+        }
+      } else {
+        reject(
+          new Error(
+            'isAccessibilityServiceEnabled is only available on Android',
+          ),
+        );
+      }
+    });
+  },
+  /**
+   * Query whether bold text is currently enabled.
+   *
+   * Returns a promise which resolves to a boolean.
+   * The result is `true` when bold text is enabled and `false` otherwise.
+   *
+   * See https://reactnative.dev/docs/accessibilityinfo#isBoldTextEnabled
+   */
+  isBoldTextEnabled(): Promise<boolean> {
+    if (Platform.OS === 'android') {
+      return Promise.resolve(false);
+    } else {
+      return new Promise((resolve, reject) => {
+        if (NativeAccessibilityManagerIOS != null) {
+          NativeAccessibilityManagerIOS.getCurrentBoldTextState(
+            resolve,
+            reject,
+          );
+        } else {
+          reject(new Error('NativeAccessibilityManagerIOS is not available'));
+        }
+      });
+    }
+  },
+  /**
+   * Query whether dark system colors is currently enabled. iOS only.
+   *
+   * Returns a promise which resolves to a boolean.
+   * The result is `true` when dark system colors is enabled and `false` otherwise.
+   */
+  isDarkerSystemColorsEnabled(): Promise<boolean> {
+    return new Promise((resolve, reject) => {
+      if (Platform.OS === 'android') {
+        return Promise.resolve(false);
+      } else {
+        if (
+          NativeAccessibilityManagerIOS?.getCurrentDarkerSystemColorsState !=
+          null
+        ) {
+          NativeAccessibilityManagerIOS.getCurrentDarkerSystemColorsState(
+            resolve,
+            reject,
+          );
+        } else {
+          reject(
+            new Error(
+              'NativeAccessibilityManagerIOS.getCurrentDarkerSystemColorsState is not available',
+            ),
+          );
+        }
+      }
+    });
+  },
+  /**
+   * Query whether grayscale is currently enabled.
+   *
+   * Returns a promise which resolves to a boolean.
+   * The result is `true` when grayscale is enabled and `false` otherwise.
+   *
+   * See https://reactnative.dev/docs/accessibilityinfo#isGrayscaleEnabled
+   */
+  isGrayscaleEnabled(): Promise<boolean> {
+    if (Platform.OS === 'android') {
+      return new Promise((resolve, reject) => {
+        if (NativeAccessibilityInfoAndroid?.isGrayscaleEnabled != null) {
+          NativeAccessibilityInfoAndroid.isGrayscaleEnabled(resolve);
+        } else {
+          reject(
+            new Error(
+              'NativeAccessibilityInfoAndroid.isGrayscaleEnabled is not available',
+            ),
+          );
+        }
+      });
+    } else {
+      return new Promise((resolve, reject) => {
+        if (NativeAccessibilityManagerIOS != null) {
+          NativeAccessibilityManagerIOS.getCurrentGrayscaleState(
+            resolve,
+            reject,
+          );
+        } else {
+          reject(new Error('AccessibilityInfo native module is not available'));
+        }
+      });
+    }
+  },
+  /**
+   * Query whether high text contrast is currently enabled. Android only.
+   *
+   * Returns a promise which resolves to a boolean.
+   * The result is `true` when high text contrast is enabled and `false` otherwise.
+   */
+  isHighTextContrastEnabled(): Promise<boolean> {
+    return new Promise((resolve, reject) => {
+      if (Platform.OS === 'android') {
+        if (NativeAccessibilityInfoAndroid?.isHighTextContrastEnabled != null) {
+          NativeAccessibilityInfoAndroid.isHighTextContrastEnabled(resolve);
+        } else {
+          reject(
+            new Error(
+              'NativeAccessibilityInfoAndroid.isHighTextContrastEnabled is not available',
+            ),
+          );
+        }
+      } else {
+        return Promise.resolve(false);
+      }
+    });
+  },
+  /**
+   * Query whether inverted colors are currently enabled.
+   *
+   * Returns a promise which resolves to a boolean.
+   * The result is `true` when invert color is enabled and `false` otherwise.
+   *
+   * See https://reactnative.dev/docs/accessibilityinfo#isInvertColorsEnabled
+   */
+  isInvertColorsEnabled(): Promise<boolean> {
+    if (Platform.OS === 'android') {
+      return new Promise((resolve, reject) => {
+        if (NativeAccessibilityInfoAndroid?.isInvertColorsEnabled != null) {
+          NativeAccessibilityInfoAndroid.isInvertColorsEnabled(resolve);
+        } else {
+          reject(
+            new Error(
+              'NativeAccessibilityInfoAndroid.isInvertColorsEnabled is not available',
+            ),
+          );
+        }
+      });
+    } else {
+      return new Promise((resolve, reject) => {
+        if (NativeAccessibilityManagerIOS != null) {
+          NativeAccessibilityManagerIOS.getCurrentInvertColorsState(
+            resolve,
+            reject,
+          );
+        } else {
+          reject(new Error('AccessibilityInfo native module is not available'));
+        }
+      });
+    }
+  },
+  /**
+   * Query whether reduced motion is currently enabled.
+   *
+   * Returns a promise which resolves to a boolean.
+   * The result is `true` when a reduce motion is enabled and `false` otherwise.
+   *
+   * See https://reactnative.dev/docs/accessibilityinfo#isReduceMotionEnabled
+   */
+  isReduceMotionEnabled(): Promise<boolean> {
+    return new Promise((resolve, reject) => {
+      if (Platform.OS === 'android') {
+        if (NativeAccessibilityInfoAndroid != null) {
+          NativeAccessibilityInfoAndroid.isReduceMotionEnabled(resolve);
+        } else {
+          reject(new Error('AccessibilityInfo native module is not available'));
+        }
+      } else {
+        if (NativeAccessibilityManagerIOS != null) {
+          NativeAccessibilityManagerIOS.getCurrentReduceMotionState(
+            resolve,
+            reject,
+          );
+        } else {
+          reject(new Error('NativeAccessibilityManagerIOS is not available'));
+        }
+      }
+    });
+  },
+  /**
+   * Query whether reduced transparency is currently enabled.
+   *
+   * Returns a promise which resolves to a boolean.
+   * The result is `true` when a reduce transparency is enabled and `false` otherwise.
+   *
+   * See https://reactnative.dev/docs/accessibilityinfo#isReduceTransparencyEnabled
+   */
+  isReduceTransparencyEnabled(): Promise<boolean> {
+    if (Platform.OS === 'android') {
+      return Promise.resolve(false);
+    } else {
+      return new Promise((resolve, reject) => {
+        if (NativeAccessibilityManagerIOS != null) {
+          NativeAccessibilityManagerIOS.getCurrentReduceTransparencyState(
+            resolve,
+            reject,
+          );
+        } else {
+          reject(new Error('NativeAccessibilityManagerIOS is not available'));
+        }
+      });
+    }
+  },
+  /**
+   * Query whether a screen reader is currently enabled.
+   *
+   * Returns a promise which resolves to a boolean.
+   * The result is `true` when a screen reader is enabled and `false` otherwise.
+   *
+   * See https://reactnative.dev/docs/accessibilityinfo#isScreenReaderEnabled
+   */
+  isScreenReaderEnabled(): Promise<boolean> {
+    return new Promise((resolve, reject) => {
+      if (Platform.OS === 'android') {
+        if (NativeAccessibilityInfoAndroid != null) {
+          NativeAccessibilityInfoAndroid.isTouchExplorationEnabled(resolve);
+        } else {
+          reject(new Error('NativeAccessibilityInfoAndroid is not available'));
+        }
+      } else {
+        if (NativeAccessibilityManagerIOS != null) {
+          NativeAccessibilityManagerIOS.getCurrentVoiceOverState(
+            resolve,
+            reject,
+          );
+        } else {
+          reject(new Error('NativeAccessibilityManagerIOS is not available'));
+        }
+      }
+    });
+  },
+  /**
+   * Query whether reduce motion and prefer cross-fade transitions settings are currently enabled.
+   *
+   * Returns a promise which resolves to a boolean.
+   * The result is `true` when  prefer cross-fade transitions is enabled and `false` otherwise.
+   *
+   * See https://reactnative.dev/docs/accessibilityinfo#prefersCrossFadeTransitions
+   */
+  prefersCrossFadeTransitions(): Promise<boolean> {
+    return new Promise((resolve, reject) => {
+      if (Platform.OS === 'android') {
+        return Promise.resolve(false);
+      } else {
+        if (
+          NativeAccessibilityManagerIOS?.getCurrentPrefersCrossFadeTransitionsState !=
+          null
+        ) {
+          NativeAccessibilityManagerIOS.getCurrentPrefersCrossFadeTransitionsState(
+            resolve,
+            reject,
+          );
+        } else {
+          reject(
+            new Error(
+              'NativeAccessibilityManagerIOS.getCurrentPrefersCrossFadeTransitionsState is not available',
+            ),
+          );
+        }
+      }
+    });
+  },
+  /**
+   * Send a named accessibility event to a HostComponent.
+   */
+  sendAccessibilityEvent(
+    handle: HostInstance,
+    eventType: AccessibilityEventTypes,
+  ) {
+    // iOS only supports 'focus' event types
+    if (Platform.OS === 'ios' && eventType === 'click') {
+      return;
+    }
+    // route through React renderer to distinguish between Fabric and non-Fabric handles
+    sendAccessibilityEvent(handle, eventType);
+  },
+  /**
+   * Set accessibility focus to a React component.
+   *
+   * See https://reactnative.dev/docs/accessibilityinfo#setaccessibilityfocus
+   */
+  setAccessibilityFocus(reactTag: number): void {
+    legacySendAccessibilityEvent(reactTag, 'focus');
   },
 };
 

--- a/packages/react-native/Libraries/Components/Keyboard/Keyboard.js
+++ b/packages/react-native/Libraries/Components/Keyboard/Keyboard.js
@@ -16,7 +16,7 @@ import dismissKeyboard from '../../Utilities/dismissKeyboard';
 import Platform from '../../Utilities/Platform';
 import NativeKeyboardObserver from './NativeKeyboardObserver';
 
-export type KeyboardEventName = $Keys<KeyboardEventDefinitions>;
+export type KeyboardEventName = keyof KeyboardEventDefinitions;
 
 export type KeyboardEventEasing =
   | 'easeIn'
@@ -146,7 +146,7 @@ class KeyboardImpl {
    *
    * @param {function} callback function to be called when the event fires.
    */
-  addListener<K: $Keys<KeyboardEventDefinitions>>(
+  addListener<K: keyof KeyboardEventDefinitions>(
     eventType: K,
     listener: (...KeyboardEventDefinitions[K]) => mixed,
     context?: mixed,
@@ -159,7 +159,7 @@ class KeyboardImpl {
    *
    * @param {string} eventType The native event string listeners are watching which will be removed.
    */
-  removeAllListeners<K: $Keys<KeyboardEventDefinitions>>(eventType: ?K): void {
+  removeAllListeners<K: keyof KeyboardEventDefinitions>(eventType: ?K): void {
     this._emitter.removeAllListeners(eventType);
   }
 
@@ -192,9 +192,9 @@ class KeyboardImpl {
     const {duration, easing} = event;
     if (duration != null && duration !== 0) {
       LayoutAnimation.configureNext({
-        duration: duration,
+        duration,
         update: {
-          duration: duration,
+          duration,
           type: (easing != null && LayoutAnimation.Types[easing]) || 'keyboard',
         },
       });

--- a/packages/react-native/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.js
+++ b/packages/react-native/Libraries/Components/ProgressBarAndroid/ProgressBarAndroid.js
@@ -21,7 +21,7 @@ export type {ProgressBarAndroidProps};
 // of ProgressBarAndroidProps. TS's Omit does not distribute over unions, so
 // we define our own version which does. This does not affect Flow.
 // $FlowExpectedError[unclear-type]
-type Omit<T, K> = T extends any ? Pick<T, Exclude<$Keys<T>, K>> : T;
+type Omit<T, K> = T extends any ? Pick<T, Exclude<keyof T, K>> : T;
 
 /**
  * ProgressBarAndroid has been extracted from react-native core and will be removed in a future release.

--- a/packages/react-native/Libraries/Components/StatusBar/StatusBar.js
+++ b/packages/react-native/Libraries/Components/StatusBar/StatusBar.js
@@ -20,7 +20,7 @@ import * as React from 'react';
 /**
  * Status bar style
  */
-export type StatusBarStyle = $Keys<{
+export type StatusBarStyle = keyof {
   /**
    * Default status bar style (dark for iOS, light for Android)
    */
@@ -34,12 +34,12 @@ export type StatusBarStyle = $Keys<{
    */
   'dark-content': string,
   ...
-}>;
+};
 
 /**
  * Status bar animation
  */
-export type StatusBarAnimation = $Keys<{
+export type StatusBarAnimation = keyof {
   /**
    * No animation
    */
@@ -53,7 +53,7 @@ export type StatusBarAnimation = $Keys<{
    */
   slide: string,
   ...
-}>;
+};
 
 export type StatusBarPropsAndroid = $ReadOnly<{
   /**
@@ -163,27 +163,27 @@ function createStackEntry(props: StatusBarProps): StackProps {
     backgroundColor:
       props.backgroundColor != null
         ? {
-            value: props.backgroundColor,
             animated,
+            value: props.backgroundColor,
           }
         : null,
     barStyle:
       props.barStyle != null
         ? {
-            value: props.barStyle,
             animated,
+            value: props.barStyle,
           }
         : null,
-    translucent: props.translucent,
     hidden:
       props.hidden != null
         ? {
-            value: props.hidden,
             animated,
             transition: showHideTransition,
+            value: props.hidden,
           }
         : null,
     networkActivityIndicatorVisible: props.networkActivityIndicatorVisible,
+    translucent: props.translucent,
   };
 }
 
@@ -239,9 +239,9 @@ class StatusBar extends React.Component<StatusBarProps> {
             .DEFAULT_BACKGROUND_COLOR ?? 'black')
         : 'black',
     barStyle: 'default',
-    translucent: false,
     hidden: false,
     networkActivityIndicatorVisible: false,
+    translucent: false,
   });
 
   // Timer for updating the native module values at the end of the frame.

--- a/packages/react-native/Libraries/EventEmitter/NativeEventEmitter.js
+++ b/packages/react-native/Libraries/EventEmitter/NativeEventEmitter.js
@@ -83,7 +83,7 @@ export default class NativeEventEmitter<
     }
   }
 
-  addListener<TEvent: $Keys<TEventToArgsMap>>(
+  addListener<TEvent: keyof TEventToArgsMap>(
     eventType: TEvent,
     listener: (...args: TEventToArgsMap[TEvent]) => mixed,
     context?: mixed,
@@ -107,7 +107,7 @@ export default class NativeEventEmitter<
     };
   }
 
-  emit<TEvent: $Keys<TEventToArgsMap>>(
+  emit<TEvent: keyof TEventToArgsMap>(
     eventType: TEvent,
     ...args: TEventToArgsMap[TEvent]
   ): void {
@@ -116,9 +116,7 @@ export default class NativeEventEmitter<
     RCTDeviceEventEmitter.emit(eventType, ...args);
   }
 
-  removeAllListeners<TEvent: $Keys<TEventToArgsMap>>(
-    eventType?: ?TEvent,
-  ): void {
+  removeAllListeners<TEvent: keyof TEventToArgsMap>(eventType?: ?TEvent): void {
     invariant(
       eventType != null,
       '`NativeEventEmitter.removeAllListener()` requires a non-null argument.',
@@ -127,7 +125,7 @@ export default class NativeEventEmitter<
     RCTDeviceEventEmitter.removeAllListeners(eventType);
   }
 
-  listenerCount<TEvent: $Keys<TEventToArgsMap>>(eventType: TEvent): number {
+  listenerCount<TEvent: keyof TEventToArgsMap>(eventType: TEvent): number {
     return RCTDeviceEventEmitter.listenerCount(eventType);
   }
 }

--- a/packages/react-native/Libraries/EventEmitter/RCTDeviceEventEmitter.js
+++ b/packages/react-native/Libraries/EventEmitter/RCTDeviceEventEmitter.js
@@ -25,7 +25,7 @@ type RCTDeviceEventDefinitions = {[name: string]: Array<any>};
  */
 class RCTDeviceEventEmitterImpl extends EventEmitter<RCTDeviceEventDefinitions> {
   // Add systrace to RCTDeviceEventEmitter.emit method for debugging
-  emit<TEvent: $Keys<RCTDeviceEventDefinitions>>(
+  emit<TEvent: keyof RCTDeviceEventDefinitions>(
     eventType: TEvent,
     ...args: RCTDeviceEventDefinitions[TEvent]
   ): void {

--- a/packages/react-native/Libraries/EventEmitter/__mocks__/NativeEventEmitter.js
+++ b/packages/react-native/Libraries/EventEmitter/__mocks__/NativeEventEmitter.js
@@ -22,7 +22,7 @@ export default class NativeEventEmitter<
   TEventToArgsMap: $ReadOnly<Record<string, $ReadOnlyArray<mixed>>>,
 > implements IEventEmitter<TEventToArgsMap>
 {
-  addListener<TEvent: $Keys<TEventToArgsMap>>(
+  addListener<TEvent: keyof TEventToArgsMap>(
     eventType: TEvent,
     listener: (...args: TEventToArgsMap[TEvent]) => mixed,
     context?: mixed,
@@ -30,20 +30,18 @@ export default class NativeEventEmitter<
     return RCTDeviceEventEmitter.addListener(eventType, listener, context);
   }
 
-  emit<TEvent: $Keys<TEventToArgsMap>>(
+  emit<TEvent: keyof TEventToArgsMap>(
     eventType: TEvent,
     ...args: TEventToArgsMap[TEvent]
   ): void {
     RCTDeviceEventEmitter.emit(eventType, ...args);
   }
 
-  removeAllListeners<TEvent: $Keys<TEventToArgsMap>>(
-    eventType?: ?TEvent,
-  ): void {
+  removeAllListeners<TEvent: keyof TEventToArgsMap>(eventType?: ?TEvent): void {
     RCTDeviceEventEmitter.removeAllListeners(eventType);
   }
 
-  listenerCount<TEvent: $Keys<TEventToArgsMap>>(eventType: TEvent): number {
+  listenerCount<TEvent: keyof TEventToArgsMap>(eventType: TEvent): number {
     return RCTDeviceEventEmitter.listenerCount(eventType);
   }
 }

--- a/packages/react-native/Libraries/Linking/Linking.js
+++ b/packages/react-native/Libraries/Linking/Linking.js
@@ -32,7 +32,7 @@ class LinkingImpl extends NativeEventEmitter<LinkingEventDefinitions> {
    *
    * See https://reactnative.dev/docs/linking#addeventlistener
    */
-  addEventListener<K: $Keys<LinkingEventDefinitions>>(
+  addEventListener<K: keyof LinkingEventDefinitions>(
     eventType: K,
     listener: (...LinkingEventDefinitions[K]) => mixed,
   ): EventSubscription {

--- a/packages/react-native/Libraries/Network/RCTNetworking.android.js
+++ b/packages/react-native/Libraries/Network/RCTNetworking.android.js
@@ -48,7 +48,10 @@ const emitter = new NativeEventEmitter<$FlowFixMe>(
  * requestId to each network request that can be used to abort that request later on.
  */
 const RCTNetworking = {
-  addListener<K: $Keys<RCTNetworkingEventDefinitions>>(
+  abortRequest(requestId: number) {
+    NativeNetworkingAndroid.abortRequest(requestId);
+  },
+  addListener<K: keyof RCTNetworkingEventDefinitions>(
     eventType: K,
     listener: (...RCTNetworkingEventDefinitions[K]) => mixed,
     context?: mixed,
@@ -56,7 +59,9 @@ const RCTNetworking = {
     // $FlowFixMe[incompatible-type]
     return emitter.addListener(eventType, listener, context);
   },
-
+  clearCookies(callback: (result: boolean) => void) {
+    NativeNetworkingAndroid.clearCookies(callback);
+  },
   sendRequest(
     method: string,
     trackingName: string | void,
@@ -84,21 +89,13 @@ const RCTNetworking = {
       url,
       requestId,
       convertHeadersMapToArray(headers),
-      {...body, trackingName, devToolsRequestId},
+      {...body, devToolsRequestId, trackingName},
       responseType,
       incrementalUpdates,
       timeout,
       withCredentials,
     );
     callback(requestId);
-  },
-
-  abortRequest(requestId: number) {
-    NativeNetworkingAndroid.abortRequest(requestId);
-  },
-
-  clearCookies(callback: (result: boolean) => void) {
-    NativeNetworkingAndroid.clearCookies(callback);
   },
 };
 

--- a/packages/react-native/Libraries/Network/RCTNetworking.ios.js
+++ b/packages/react-native/Libraries/Network/RCTNetworking.ios.js
@@ -18,7 +18,10 @@ import {type RCTNetworkingEventDefinitions} from './RCTNetworkingEventDefinition
 import {type NativeResponseType} from './XMLHttpRequest';
 
 const RCTNetworking = {
-  addListener<K: $Keys<RCTNetworkingEventDefinitions>>(
+  abortRequest(requestId: number) {
+    NativeNetworkingIOS.abortRequest(requestId);
+  },
+  addListener<K: keyof RCTNetworkingEventDefinitions>(
     eventType: K,
     listener: (...RCTNetworkingEventDefinitions[K]) => mixed,
     context?: mixed,
@@ -26,7 +29,9 @@ const RCTNetworking = {
     // $FlowFixMe[incompatible-type]
     return RCTDeviceEventEmitter.addListener(eventType, listener, context);
   },
-
+  clearCookies(callback: (result: boolean) => void) {
+    NativeNetworkingIOS.clearCookies(callback);
+  },
   sendRequest(
     method: string,
     trackingName: string | void,
@@ -44,26 +49,18 @@ const RCTNetworking = {
       global.__NETWORK_REPORTER__?.createDevToolsRequestId();
     NativeNetworkingIOS.sendRequest(
       {
-        method,
-        url,
         data: {...body, trackingName},
         headers,
-        responseType,
         incrementalUpdates,
+        method,
+        responseType,
         timeout,
-        withCredentials,
         unstable_devToolsRequestId: devToolsRequestId,
+        url,
+        withCredentials,
       },
       callback,
     );
-  },
-
-  abortRequest(requestId: number) {
-    NativeNetworkingIOS.abortRequest(requestId);
-  },
-
-  clearCookies(callback: (result: boolean) => void) {
-    NativeNetworkingIOS.clearCookies(callback);
   },
 };
 

--- a/packages/react-native/Libraries/Network/RCTNetworking.js.flow
+++ b/packages/react-native/Libraries/Network/RCTNetworking.js.flow
@@ -16,7 +16,7 @@ import type {RCTNetworkingEventDefinitions} from './RCTNetworkingEventDefinition
 import type {NativeResponseType} from './XMLHttpRequest';
 
 declare const RCTNetworking: interface {
-  addListener<K: $Keys<RCTNetworkingEventDefinitions>>(
+  addListener<K: keyof RCTNetworkingEventDefinitions>(
     eventType: K,
     // $FlowFixMe[invalid-computed-prop]
     listener: (...RCTNetworkingEventDefinitions[K]) => mixed,

--- a/packages/react-native/Libraries/PushNotificationIOS/PushNotificationIOS.js
+++ b/packages/react-native/Libraries/PushNotificationIOS/PushNotificationIOS.js
@@ -89,7 +89,7 @@ export type FetchResult = {
 /**
  * An event emitted by PushNotificationIOS.
  */
-export type PushNotificationEventName = $Keys<{
+export type PushNotificationEventName = keyof {
   /**
    * Fired when a remote notification is received. The handler will be invoked
    * with an instance of `PushNotificationIOS`. This will handle notifications
@@ -116,7 +116,7 @@ export type PushNotificationEventName = $Keys<{
    */
   registrationError: string,
   ...
-}>;
+};
 
 export interface PushNotification {
   /**

--- a/packages/react-native/Libraries/ReactNative/RendererImplementation.js
+++ b/packages/react-native/Libraries/ReactNative/RendererImplementation.js
@@ -37,11 +37,11 @@ function getPaperRenderer(): ReactNativeType {
   return cachedPaperRenderer;
 }
 
-const getMethod: (<MethodName: $Keys<ReactFabricType>>(
+const getMethod: (<MethodName: keyof ReactFabricType>(
   () => ReactFabricType,
   MethodName,
 ) => ReactFabricType[MethodName]) &
-  (<MethodName: $Keys<ReactNativeType>>(
+  (<MethodName: keyof ReactNativeType>(
     () => ReactNativeType,
     MethodName,
   ) => ReactNativeType[MethodName]) = (getRenderer, methodName) => {
@@ -59,13 +59,13 @@ const getMethod: (<MethodName: $Keys<ReactFabricType>>(
   };
 };
 
-function getFabricMethod<MethodName: $Keys<ReactFabricType>>(
+function getFabricMethod<MethodName: keyof ReactFabricType>(
   methodName: MethodName,
 ): ReactFabricType[MethodName] {
   return getMethod(getFabricRenderer, methodName);
 }
 
-function getPaperMethod<MethodName: $Keys<ReactNativeType>>(
+function getPaperMethod<MethodName: keyof ReactNativeType>(
   methodName: MethodName,
 ): ReactNativeType[MethodName] {
   return getMethod(getPaperRenderer, methodName);
@@ -92,8 +92,8 @@ export function renderElement({
 
     cachedFabricRender(element, rootTag, null, useConcurrentRoot, {
       onCaughtError,
-      onUncaughtError,
       onRecoverableError,
+      onUncaughtError,
     });
   } else {
     if (cachedPaperRender == null) {
@@ -102,8 +102,8 @@ export function renderElement({
 
     cachedPaperRender(element, rootTag, undefined, {
       onCaughtError,
-      onUncaughtError,
       onRecoverableError,
+      onUncaughtError,
     });
   }
 }

--- a/packages/react-native/Libraries/StyleSheet/StyleSheet.js
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheet.js
@@ -118,7 +118,7 @@ export type DangerouslyImpreciseStyleProp =
  * This will correctly give you the type 'absolute' | 'relative'
  */
 export type TypeForStyleKey<
-  +key: $Keys<____DangerouslyImpreciseStyle_Internal>,
+  +key: keyof ____DangerouslyImpreciseStyle_Internal,
 > = ____DangerouslyImpreciseStyle_Internal[key];
 
 /**

--- a/packages/react-native/Libraries/StyleSheet/StyleSheet.js.flow
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheet.js.flow
@@ -119,7 +119,7 @@ export type DangerouslyImpreciseStyleProp =
  * This will correctly give you the type 'absolute' | 'relative'
  */
 export type TypeForStyleKey<
-  +key: $Keys<____DangerouslyImpreciseStyle_Internal>,
+  +key: keyof ____DangerouslyImpreciseStyle_Internal,
 > = ____DangerouslyImpreciseStyle_Internal[key];
 
 /**

--- a/packages/react-native/Libraries/StyleSheet/private/_TransformStyle.js
+++ b/packages/react-native/Libraries/StyleSheet/private/_TransformStyle.js
@@ -13,10 +13,10 @@ import type AnimatedNode from '../../Animated/nodes/AnimatedNode';
 // Helper types to enforce that a single key is used in a transform object
 // after generating a TypeScript definition file from the Flow types.
 // $FlowExpectedError[unclear-type]
-type KeysOfUnion<T> = T extends any ? $Keys<T> : empty;
+type KeysOfUnion<T> = T extends any ? keyof T : empty;
 // $FlowExpectedError[unclear-type]
 type ValueOfUnion<T, K> = T extends any
-  ? K extends $Keys<T>
+  ? K extends keyof T
     ? T[K]
     : empty
   : empty;

--- a/packages/react-native/Libraries/Types/ReactDevToolsTypes.js
+++ b/packages/react-native/Libraries/Types/ReactDevToolsTypes.js
@@ -34,12 +34,12 @@ export type ReactDevToolsAgentEvents = {
 export type ReactDevToolsAgent = {
   selectNode(node: mixed): void,
   stopInspectingNative(value: boolean): void,
-  addListener<Event: $Keys<ReactDevToolsAgentEvents>>(
+  addListener<Event: keyof ReactDevToolsAgentEvents>(
     event: Event,
     listener: (...ReactDevToolsAgentEvents[Event]) => void,
   ): void,
   removeListener(
-    event: $Keys<ReactDevToolsAgentEvents>,
+    event: keyof ReactDevToolsAgentEvents,
     listener: () => void,
   ): void,
 };

--- a/packages/react-native/Libraries/Utilities/codegenNativeCommands.js
+++ b/packages/react-native/Libraries/Utilities/codegenNativeCommands.js
@@ -15,9 +15,9 @@ type NativeCommandsOptions<T = string> = $ReadOnly<{
 }>;
 
 function codegenNativeCommands<T: interface {}>(
-  options: NativeCommandsOptions<$Keys<T>>,
+  options: NativeCommandsOptions<keyof T>,
 ): T {
-  const commandObj: {[$Keys<T>]: (...$ReadOnlyArray<mixed>) => void} = {};
+  const commandObj: {[keyof T]: (...$ReadOnlyArray<mixed>) => void} = {};
 
   options.supportedCommands.forEach(command => {
     // $FlowFixMe[missing-local-annot]

--- a/packages/react-native/Libraries/vendor/emitter/EventEmitter.js
+++ b/packages/react-native/Libraries/vendor/emitter/EventEmitter.js
@@ -18,20 +18,20 @@ export interface EventSubscription {
 export interface IEventEmitter<
   TEventToArgsMap: $ReadOnly<Record<string, $ReadOnlyArray<UnsafeEventObject>>>,
 > {
-  addListener<TEvent: $Keys<TEventToArgsMap>>(
+  addListener<TEvent: keyof TEventToArgsMap>(
     eventType: TEvent,
     listener: (...args: TEventToArgsMap[TEvent]) => mixed,
     context?: mixed,
   ): EventSubscription;
 
-  emit<TEvent: $Keys<TEventToArgsMap>>(
+  emit<TEvent: keyof TEventToArgsMap>(
     eventType: TEvent,
     ...args: TEventToArgsMap[TEvent]
   ): void;
 
-  removeAllListeners<TEvent: $Keys<TEventToArgsMap>>(eventType?: ?TEvent): void;
+  removeAllListeners<TEvent: keyof TEventToArgsMap>(eventType?: ?TEvent): void;
 
-  listenerCount<TEvent: $Keys<TEventToArgsMap>>(eventType: TEvent): number;
+  listenerCount<TEvent: keyof TEventToArgsMap>(eventType: TEvent): number;
 }
 
 interface Registration<TArgs> {
@@ -83,7 +83,7 @@ export default class EventEmitter<
    * Registers a listener that is called when the supplied event is emitted.
    * Returns a subscription that has a `remove` method to undo registration.
    */
-  addListener<TEvent: $Keys<TEventToArgsMap>>(
+  addListener<TEvent: keyof TEventToArgsMap>(
     eventType: TEvent,
     listener: (...args: TEventToArgsMap[TEvent]) => mixed,
     context: mixed,
@@ -95,7 +95,7 @@ export default class EventEmitter<
     }
     const registrations = allocate<
       TEventToArgsMap,
-      $Keys<TEventToArgsMap>,
+      keyof TEventToArgsMap,
       TEventToArgsMap[TEvent],
     >(this.#registry, eventType);
     const registration: Registration<TEventToArgsMap[TEvent]> = {
@@ -116,7 +116,7 @@ export default class EventEmitter<
    * If a listener modifies the listeners registered for the same event, those
    * changes will not be reflected in the current invocation of `emit`.
    */
-  emit<TEvent: $Keys<TEventToArgsMap>>(
+  emit<TEvent: keyof TEventToArgsMap>(
     eventType: TEvent,
     ...args: TEventToArgsMap[TEvent]
   ): void {
@@ -135,9 +135,7 @@ export default class EventEmitter<
   /**
    * Removes all registered listeners.
    */
-  removeAllListeners<TEvent: $Keys<TEventToArgsMap>>(
-    eventType?: ?TEvent,
-  ): void {
+  removeAllListeners<TEvent: keyof TEventToArgsMap>(eventType?: ?TEvent): void {
     if (eventType == null) {
       // $FlowFixMe[incompatible-type]
       this.#registry = {};
@@ -149,7 +147,7 @@ export default class EventEmitter<
   /**
    * Returns the number of registered listeners for the supplied event.
    */
-  listenerCount<TEvent: $Keys<TEventToArgsMap>>(eventType: TEvent): number {
+  listenerCount<TEvent: keyof TEventToArgsMap>(eventType: TEvent): number {
     const registrations: ?Set<Registration<TEventToArgsMap[TEvent]>> =
       this.#registry[eventType];
     return registrations == null ? 0 : registrations.size;
@@ -158,7 +156,7 @@ export default class EventEmitter<
 
 function allocate<
   TEventToArgsMap: $ReadOnly<Record<string, $ReadOnlyArray<UnsafeEventObject>>>,
-  TEvent: $Keys<TEventToArgsMap>,
+  TEvent: keyof TEventToArgsMap,
   TEventArgs: TEventToArgsMap[TEvent],
 >(
   registry: Registry<TEventToArgsMap>,

--- a/packages/react-native/src/private/__tests__/MemoryBaseline-itest.js
+++ b/packages/react-native/src/private/__tests__/MemoryBaseline-itest.js
@@ -28,17 +28,17 @@ declare var performance: Performance;
  * and set a new baseline. Otherwise, please try to optimize your code.
  */
 const MEMORY_LIMITS_KB = {
-  environmentSetup: {
-    dev: 1000,
-    opt: 500,
-  },
   basicSurfaceRender: {
     dev: 1200,
     opt: 700,
   },
+  environmentSetup: {
+    dev: 1000,
+    opt: 500,
+  },
 };
 
-function limitFor(scenario: $Keys<typeof MEMORY_LIMITS_KB>): number {
+function limitFor(scenario: keyof typeof MEMORY_LIMITS_KB): number {
   return MEMORY_LIMITS_KB[scenario][__DEV__ ? 'dev' : 'opt'];
 }
 

--- a/packages/react-native/src/private/__tests__/utilities/accessibilityPropsSuite.js
+++ b/packages/react-native/src/private/__tests__/utilities/accessibilityPropsSuite.js
@@ -118,7 +118,7 @@ let root: Root;
 
 function getAccessibilityProp(
   content: React.MixedElement,
-  name: $Keys<AccessibilityProps>,
+  name: keyof AccessibilityProps,
 ) {
   Fantom.runTask(() => {
     root.render(content);
@@ -128,7 +128,7 @@ function getAccessibilityProp(
 
 function getAccessibilityProps(
   content: React.MixedElement,
-  names: $ReadOnlyArray<$Keys<AccessibilityProps>>,
+  names: $ReadOnlyArray<keyof AccessibilityProps>,
 ) {
   Fantom.runTask(() => {
     root.render(content);
@@ -238,8 +238,8 @@ export default function accessibilityPropsSuite(
             ['accessibilityLabel', 'accessibilityHint'],
           ),
         ).toEqual({
-          accessibilityLabel: 'Touchable',
           accessibilityHint: 'Can be pressed to interact',
+          accessibilityLabel: 'Touchable',
         });
       });
     });
@@ -319,7 +319,7 @@ export default function accessibilityPropsSuite(
             <Component
               accessibilityActions={[
                 {name: 'activate'},
-                {name: 'spawn', label: 'open a panel'},
+                {label: 'open a panel', name: 'spawn'},
                 {name: 'escape'},
               ]}
             />,

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlagsBase.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlagsBase.js
@@ -52,7 +52,7 @@ function createGetter<T: boolean | number | string>(
 }
 
 export function createJavaScriptFlagGetter<
-  K: $Keys<ReactNativeFeatureFlagsJsOnly>,
+  K: keyof ReactNativeFeatureFlagsJsOnly,
 >(
   configName: K,
   defaultValue: ReturnType<ReactNativeFeatureFlagsJsOnly[K]>,
@@ -69,7 +69,7 @@ export function createJavaScriptFlagGetter<
 
 type NativeFeatureFlags = $NonMaybeType<typeof NativeReactNativeFeatureFlags>;
 
-export function createNativeFlagGetter<K: $Keys<NativeFeatureFlags>>(
+export function createNativeFlagGetter<K: keyof NativeFeatureFlags>(
   configName: K,
   defaultValue: ReturnType<$NonMaybeType<NativeFeatureFlags[K]>>,
   skipUnavailableNativeModuleError: boolean = false,

--- a/packages/rn-tester/js/utils/RNTesterNavigationReducer.js
+++ b/packages/rn-tester/js/utils/RNTesterNavigationReducer.js
@@ -14,12 +14,12 @@ import type {
 } from '../types/RNTesterTypes';
 
 export const RNTesterNavigationActionsType = {
-  NAVBAR_PRESS: 'NAVBAR_PRESS',
   BACK_BUTTON_PRESS: 'BACK_BUTTON_PRESS',
-  MODULE_CARD_PRESS: 'MODULE_CARD_PRESS',
   EXAMPLE_CARD_PRESS: 'EXAMPLE_CARD_PRESS',
   EXAMPLE_OPEN_URL_REQUEST: 'EXAMPLE_OPEN_URL_REQUEST',
+  MODULE_CARD_PRESS: 'MODULE_CARD_PRESS',
   NAVBAR_OPEN_MODULE_PRESS: 'NAVBAR_OPEN_MODULE_PRESS',
+  NAVBAR_PRESS: 'NAVBAR_PRESS',
 } as const;
 
 const getUpdatedRecentlyUsed = ({
@@ -34,7 +34,7 @@ const getUpdatedRecentlyUsed = ({
   const updatedRecentlyUsed = recentlyUsed
     ? {...recentlyUsed}
     : // $FlowFixMe[missing-empty-array-annot]
-      {components: [], apis: []};
+      {apis: [], components: []};
 
   if (!exampleType || !key) {
     return updatedRecentlyUsed;
@@ -55,7 +55,7 @@ const getUpdatedRecentlyUsed = ({
 
 export const RNTesterNavigationReducer = (
   state: RNTesterNavigationState,
-  action: {type: $Keys<typeof RNTesterNavigationActionsType>, data?: any},
+  action: {type: keyof typeof RNTesterNavigationActionsType, data?: any},
 ): RNTesterNavigationState => {
   const {
     data: {
@@ -71,34 +71,34 @@ export const RNTesterNavigationReducer = (
     case RNTesterNavigationActionsType.NAVBAR_PRESS:
       return {
         ...state,
+        activeModuleExampleKey: null,
         activeModuleKey: null,
         activeModuleTitle: null,
-        activeModuleExampleKey: null,
-        screen,
         hadDeepLink: false,
+        screen,
       };
 
     case RNTesterNavigationActionsType.NAVBAR_OPEN_MODULE_PRESS:
       return {
         ...state,
+        activeModuleExampleKey: null,
         activeModuleKey: key,
         activeModuleTitle: title,
-        activeModuleExampleKey: null,
-        screen,
         hadDeepLink: false,
+        screen,
       };
 
     case RNTesterNavigationActionsType.MODULE_CARD_PRESS:
       return {
         ...state,
+        activeModuleExampleKey: null,
         activeModuleKey: key,
         activeModuleTitle: title,
-        activeModuleExampleKey: null,
         hadDeepLink: false,
         // $FlowFixMe[incompatible-return]
         recentlyUsed: getUpdatedRecentlyUsed({
-          exampleType: exampleType,
-          key: key,
+          exampleType,
+          key,
           recentlyUsed: state.recentlyUsed,
         }),
       };
@@ -106,8 +106,8 @@ export const RNTesterNavigationReducer = (
     case RNTesterNavigationActionsType.EXAMPLE_CARD_PRESS:
       return {
         ...state,
-        hadDeepLink: false,
         activeModuleExampleKey: key,
+        hadDeepLink: false,
       };
 
     case RNTesterNavigationActionsType.BACK_BUTTON_PRESS:
@@ -131,9 +131,9 @@ export const RNTesterNavigationReducer = (
     case RNTesterNavigationActionsType.EXAMPLE_OPEN_URL_REQUEST:
       return {
         ...state,
+        activeModuleExampleKey: exampleKey,
         activeModuleKey: key,
         activeModuleTitle: title,
-        activeModuleExampleKey: exampleKey,
         hadDeepLink: true,
         screen: 'components',
       };

--- a/packages/virtualized-lists/Lists/StateSafePureComponent.js
+++ b/packages/virtualized-lists/Lists/StateSafePureComponent.js
@@ -32,7 +32,7 @@ export default class StateSafePureComponent<
   }
 
   // $FlowFixMe[incompatible-type]
-  setState<K: $Keys<State>>(
+  setState<K: keyof State>(
     partialState: ?(Pick<State, K> | ((State, Props) => ?Pick<State, K>)),
     callback?: () => mixed,
   ): void {

--- a/scripts/build/config.js
+++ b/scripts/build/config.js
@@ -70,7 +70,7 @@ const defaultBuildOptions = {
 };
 
 function getBuildOptions(
-  packageName: $Keys<BuildConfig['packages']>,
+  packageName: keyof BuildConfig['packages'],
 ): Required<BuildOptions> {
   return {
     ...defaultBuildOptions,
@@ -79,7 +79,7 @@ function getBuildOptions(
 }
 
 function getBabelConfig(
-  packageName: $Keys<BuildConfig['packages']>,
+  packageName: keyof BuildConfig['packages'],
 ): BabelCoreOptions {
   const {target} = getBuildOptions(packageName);
 
@@ -90,7 +90,7 @@ function getBabelConfig(
 }
 
 function getTypeScriptCompilerOptions(
-  packageName: $Keys<BuildConfig['packages']>,
+  packageName: keyof BuildConfig['packages'],
 ): Object {
   const {target} = getBuildOptions(packageName);
 


### PR DESCRIPTION
Summary:
We are transforming the following utility types to be more consistent with typescript and better AI integration:

* `$NonMaybeType` -> `NonNullable`
* `$ReadOnly` -> `Readonly`
* `$ReadOnlyArray` -> `ReadonlyArray`
* `$ReadOnlyMap` -> `ReadonlyMap`
* `$ReadOnlySet` -> `ReadonlySet`
* `$Keys` -> `keyof`
* `$Values` -> `Values`
* `mixed` -> `unknown`

See details in https://fb.workplace.com/groups/flowlang/permalink/1837907750148213/.
drop-conflicts

Reviewed By: SamChou19815

Differential Revision: D89486050
