### PR TITLE
Transform all Flow legacy utility types (`$NonMaybeType`) to TypeScript-style types in xplat/js

### DIFF
--- a/packages/dev-middleware/src/inspector-proxy/types.js
+++ b/packages/dev-middleware/src/inspector-proxy/types.js
@@ -56,7 +56,7 @@ export type PageFromDevice = $ReadOnly<{
 
 export type Page = $ReadOnly<{
   ...PageFromDevice,
-  capabilities: $NonMaybeType<PageFromDevice['capabilities']>,
+  capabilities: NonNullable<PageFromDevice['capabilities']>,
 }>;
 
 // Chrome Debugger Protocol message/event passed between device and debugger.

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -149,7 +149,7 @@ type TextInputStateType = $ReadOnly<{
   blurTextInput: (textField: ?HostInstance) => void,
 }>;
 
-type ViewCommands = $NonMaybeType<
+type ViewCommands = NonNullable<
   | typeof AndroidTextInputCommands
   | typeof RCTMultilineTextInputNativeCommands
   | typeof RCTSinglelineTextInputNativeCommands,
@@ -188,8 +188,8 @@ function useTextInputStateSynchronization({
   const [lastNativeText, setLastNativeText] = useState<?Stringish>(props.value);
   const [lastNativeSelectionState, setLastNativeSelection] =
     useState<LastNativeSelection>({
-      selection: {start: -1, end: -1},
-      mostRecentEventCount: mostRecentEventCount,
+      mostRecentEventCount,
+      selection: {end: -1, start: -1},
     });
 
   const lastNativeSelection = lastNativeSelectionState.selection;
@@ -212,7 +212,7 @@ function useTextInputStateSynchronization({
         lastNativeSelection.end !== selection.end)
     ) {
       nativeUpdate.selection = selection;
-      setLastNativeSelection({selection, mostRecentEventCount});
+      setLastNativeSelection({mostRecentEventCount, selection});
     }
 
     if (Object.keys(nativeUpdate).length === 0) {
@@ -240,7 +240,7 @@ function useTextInputStateSynchronization({
     viewCommands,
   ]);
 
-  return {setLastNativeText, setLastNativeSelection};
+  return {setLastNativeSelection, setLastNativeText};
 }
 
 /**
@@ -377,8 +377,8 @@ function InternalTextInput(props: TextInputProps): React.Node {
     propsSelection == null
       ? null
       : {
-          start: propsSelection.start,
           end: propsSelection.end ?? propsSelection.start,
+          start: propsSelection.start,
         };
 
   const text =
@@ -397,9 +397,9 @@ function InternalTextInput(props: TextInputProps): React.Node {
   const [mostRecentEventCount, setMostRecentEventCount] = useState<number>(0);
   const {setLastNativeText, setLastNativeSelection} =
     useTextInputStateSynchronization({
-      props,
       inputRef,
       mostRecentEventCount,
+      props,
       selection,
       text,
       viewCommands,
@@ -469,12 +469,12 @@ function InternalTextInput(props: TextInputProps): React.Node {
               );
             }
           },
+          getNativeRef(): ?TextInputInstance {
+            return inputRef.current;
+          },
           // TODO: Fix this returning true on null === null, when no input is focused
           isFocused(): boolean {
             return TextInputState.currentlyFocusedInput() === inputRef.current;
-          },
-          getNativeRef(): ?TextInputInstance {
-            return inputRef.current;
           },
           setSelection(start: number, end: number): void {
             if (inputRef.current != null) {
@@ -525,8 +525,8 @@ function InternalTextInput(props: TextInputProps): React.Node {
     }
 
     setLastNativeSelection({
-      selection: event.nativeEvent.selection,
       mostRecentEventCount,
+      selection: event.nativeEvent.selection,
     });
   };
 
@@ -590,6 +590,7 @@ function InternalTextInput(props: TextInputProps): React.Node {
 
   const config = useMemo(
     () => ({
+      cancelable: Platform.OS === 'ios' ? !rejectResponderTermination : null,
       hitSlop,
       onPress: (event: GestureResponderEvent) => {
         onPress?.(event);
@@ -599,9 +600,8 @@ function InternalTextInput(props: TextInputProps): React.Node {
           }
         }
       },
-      onPressIn: onPressIn,
-      onPressOut: onPressOut,
-      cancelable: Platform.OS === 'ios' ? !rejectResponderTermination : null,
+      onPressIn,
+      onPressOut,
     }),
     [
       editable,
@@ -740,12 +740,12 @@ function InternalTextInput(props: TextInputProps): React.Node {
     }
     // For consistency with iOS set cursor/selectionHandle color as selectionColor
     const colorProps = {
+      cursorColor: cursorColor === undefined ? selectionColor : cursorColor,
       selectionColor,
       selectionHandleColor:
         selectionHandleColor === undefined
           ? selectionColor
           : selectionHandleColor,
-      cursorColor: cursorColor === undefined ? selectionColor : cursorColor,
     };
     textInput = (
       /* $FlowFixMe[prop-missing] the types for AndroidTextInput don't match up
@@ -799,8 +799,8 @@ function InternalTextInput(props: TextInputProps): React.Node {
 }
 
 const enterKeyHintToReturnTypeMap = {
-  enter: 'default',
   done: 'done',
+  enter: 'default',
   go: 'go',
   next: 'next',
   previous: 'previous',
@@ -809,19 +809,20 @@ const enterKeyHintToReturnTypeMap = {
 } as const;
 
 const inputModeToKeyboardTypeMap = {
-  none: 'default',
-  text: 'default',
   decimal: 'decimal-pad',
+  email: 'email-address',
+  none: 'default',
   numeric: 'number-pad',
-  tel: 'phone-pad',
   search:
     Platform.OS === 'ios' ? ('web-search' as const) : ('default' as const),
-  email: 'email-address',
+  tel: 'phone-pad',
+  text: 'default',
   url: 'url',
 } as const;
 
 // Map HTML autocomplete values to Android autoComplete values
 const autoCompleteWebToAutoCompleteAndroidMap = {
+  'additional-name': 'name-middle',
   'address-line1': 'postal-address-region',
   'address-line2': 'postal-address-locality',
   bday: 'birthdate-full',
@@ -836,12 +837,11 @@ const autoCompleteWebToAutoCompleteAndroidMap = {
   country: 'postal-address-country',
   'current-password': 'password',
   email: 'email',
+  'family-name': 'name-family',
+  'given-name': 'name-given',
   'honorific-prefix': 'name-prefix',
   'honorific-suffix': 'name-suffix',
   name: 'name',
-  'additional-name': 'name-middle',
-  'family-name': 'name-family',
-  'given-name': 'name-given',
   'new-password': 'password-new',
   off: 'off',
   'one-time-code': 'sms-otp',
@@ -856,33 +856,33 @@ const autoCompleteWebToAutoCompleteAndroidMap = {
 
 // Map HTML autocomplete values to iOS textContentType values
 const autoCompleteWebToTextContentTypeMap = {
+  'additional-name': 'middleName',
   'address-line1': 'streetAddressLine1',
   'address-line2': 'streetAddressLine2',
   bday: 'birthdate',
   'bday-day': 'birthdateDay',
   'bday-month': 'birthdateMonth',
   'bday-year': 'birthdateYear',
+  'cc-additional-name': 'creditCardMiddleName',
   'cc-csc': 'creditCardSecurityCode',
+  'cc-exp': 'creditCardExpiration',
   'cc-exp-month': 'creditCardExpirationMonth',
   'cc-exp-year': 'creditCardExpirationYear',
-  'cc-exp': 'creditCardExpiration',
-  'cc-given-name': 'creditCardGivenName',
-  'cc-additional-name': 'creditCardMiddleName',
   'cc-family-name': 'creditCardFamilyName',
+  'cc-given-name': 'creditCardGivenName',
   'cc-name': 'creditCardName',
   'cc-number': 'creditCardNumber',
   'cc-type': 'creditCardType',
-  'current-password': 'password',
   country: 'countryName',
+  'current-password': 'password',
   email: 'emailAddress',
-  name: 'name',
-  'additional-name': 'middleName',
   'family-name': 'familyName',
   'given-name': 'givenName',
-  nickname: 'nickname',
   'honorific-prefix': 'namePrefix',
   'honorific-suffix': 'nameSuffix',
+  name: 'name',
   'new-password': 'newPassword',
+  nickname: 'nickname',
   off: 'none',
   'one-time-code': 'oneTimeCode',
   organization: 'organizationName',
@@ -959,11 +959,10 @@ TextInput.displayName = 'TextInput';
 
 // $FlowFixMe[prop-missing]
 TextInput.State = {
-  currentlyFocusedInput: TextInputState.currentlyFocusedInput,
-
-  currentlyFocusedField: TextInputState.currentlyFocusedField,
-  focusTextInput: TextInputState.focusTextInput,
   blurTextInput: TextInputState.blurTextInput,
+  currentlyFocusedField: TextInputState.currentlyFocusedField,
+  currentlyFocusedInput: TextInputState.currentlyFocusedInput,
+  focusTextInput: TextInputState.focusTextInput,
 };
 
 export type TextInputComponentStatics = $ReadOnly<{
@@ -981,9 +980,9 @@ const styles = StyleSheet.create({
 
 const verticalAlignToTextAlignVerticalMap = {
   auto: 'auto',
-  top: 'top',
   bottom: 'bottom',
   middle: 'center',
+  top: 'top',
 } as const;
 
 // $FlowFixMe[unclear-type] Unclear type. Using `any` type is not safe.

--- a/packages/react-native/Libraries/Utilities/Appearance.js
+++ b/packages/react-native/Libraries/Utilities/Appearance.js
@@ -35,7 +35,7 @@ let lazyState: ?{
 /**
  * Ensures that all state and listeners are lazily initialized correctly.
  */
-function getState(): $NonMaybeType<typeof lazyState> {
+function getState(): NonNullable<typeof lazyState> {
   if (lazyState != null) {
     return lazyState;
   }
@@ -50,7 +50,7 @@ function getState(): $NonMaybeType<typeof lazyState> {
       eventEmitter,
     };
   } else {
-    const state: $NonMaybeType<typeof lazyState> = {
+    const state: NonNullable<typeof lazyState> = {
       NativeAppearance,
       appearance: null,
       eventEmitter,

--- a/packages/react-native/Libraries/promiseRejectionTrackingOptions.js
+++ b/packages/react-native/Libraries/promiseRejectionTrackingOptions.js
@@ -12,8 +12,15 @@ import typeof {enable} from 'promise/setimmediate/rejection-tracking';
 
 import ExceptionsManager from './Core/ExceptionsManager';
 
-let rejectionTrackingOptions: $NonMaybeType<Parameters<enable>[0]> = {
+const rejectionTrackingOptions: NonNullable<Parameters<enable>[0]> = {
   allRejections: true,
+  onHandled: id => {
+    const warning =
+      `Promise rejection handled (id: ${id})\n` +
+      'This means you can ignore any previous messages of the form ' +
+      `"Uncaught (in promise, id: ${id})"`;
+    console.warn(warning);
+  },
   onUnhandled: (id, rejection) => {
     let message: string;
 
@@ -45,13 +52,6 @@ let rejectionTrackingOptions: $NonMaybeType<Parameters<enable>[0]> = {
       ),
       false /* isFatal */,
     );
-  },
-  onHandled: id => {
-    const warning =
-      `Promise rejection handled (id: ${id})\n` +
-      'This means you can ignore any previous messages of the form ' +
-      `"Uncaught (in promise, id: ${id})"`;
-    console.warn(warning);
   },
 };
 

--- a/packages/react-native/src/private/animated/NativeAnimatedHelper.js
+++ b/packages/react-native/src/private/animated/NativeAnimatedHelper.js
@@ -48,10 +48,10 @@ let __nativeAnimationIdCount = 1; /* used for started animations */
 
 let nativeEventEmitter;
 
-let waitingForQueuedOperations = new Set<string>();
+const waitingForQueuedOperations = new Set<string>();
 let queueOperations = false;
-let queue: Array<() => void> = [];
-let singleOpQueue: Array<mixed> = [];
+const queue: Array<() => void> = [];
+const singleOpQueue: Array<mixed> = [];
 
 const isSingleOpBatching =
   Platform.OS === 'android' &&
@@ -71,7 +71,7 @@ let globalEventEmitterAnimationFinishedListener: ?EventSubscription = null;
 const shouldSignalBatch: boolean =
   ReactNativeFeatureFlags.cxxNativeAnimatedEnabled();
 
-function createNativeOperations(): $NonMaybeType<typeof NativeAnimatedModule> {
+function createNativeOperations(): NonNullable<typeof NativeAnimatedModule> {
   const methodNames = [
     'createAnimatedNode', // 1
     'updateAnimatedNodeConfig', // 2
@@ -156,49 +156,35 @@ const NativeOperations = createNativeOperations();
  * the native module methods, and automatic queue management on Android
  */
 const API = {
-  getValue: (isSingleOpBatching
-    ? (tag, saveValueCallback) => {
-        /* $FlowFixMe[constant-condition] Error discovered during Constant
-         * Condition roll out. See https://fburl.com/workplace/1v97vimq. */
-        if (saveValueCallback) {
-          eventListenerGetValueCallbacks[tag] = saveValueCallback;
-        }
-        /* $FlowExpectedError[incompatible-type] - `saveValueCallback` is handled
-            differently when `isSingleOpBatching` is enabled. */
-        NativeOperations.getValue(tag);
-      }
-    : (tag, saveValueCallback) => {
-        NativeOperations.getValue(tag, saveValueCallback);
-      }) as $NonMaybeType<typeof NativeAnimatedModule>['getValue'],
-
-  setWaitingForIdentifier(id: string): void {
-    if (shouldSignalBatch) {
-      return;
-    }
-
-    waitingForQueuedOperations.add(id);
-    queueOperations = true;
-    if (
-      ReactNativeFeatureFlags.animatedShouldDebounceQueueFlush() &&
-      flushQueueImmediate
-    ) {
-      clearImmediate(flushQueueImmediate);
+  addAnimatedEventToView(
+    viewTag: number,
+    eventName: string,
+    eventMapping: EventMapping,
+  ) {
+    NativeOperations.addAnimatedEventToView(viewTag, eventName, eventMapping);
+  },
+  connectAnimatedNodes(parentTag: number, childTag: number): void {
+    NativeOperations.connectAnimatedNodes(parentTag, childTag);
+  },
+  connectAnimatedNodeToShadowNodeFamily(
+    nodeTag: number,
+    shadowNode: Node,
+  ): void {
+    NativeOperations.connectAnimatedNodeToShadowNodeFamily?.(
+      nodeTag,
+      shadowNode,
+    );
+  },
+  connectAnimatedNodeToView(nodeTag: number, viewTag: number): void {
+    NativeOperations.connectAnimatedNodeToView(nodeTag, viewTag);
+  },
+  createAnimatedNode(tag: number, config: AnimatedNodeConfig): void {
+    if (config.disableBatchingForNativeCreate) {
+      NativeAnimatedModule?.createAnimatedNode(tag, config);
+    } else {
+      NativeOperations.createAnimatedNode(tag, config);
     }
   },
-
-  unsetWaitingForIdentifier(id: string): void {
-    if (shouldSignalBatch) {
-      return;
-    }
-
-    waitingForQueuedOperations.delete(id);
-
-    if (waitingForQueuedOperations.size === 0) {
-      queueOperations = false;
-      API.disableQueue();
-    }
-  },
-
   disableQueue(): void {
     invariant(NativeAnimatedModule, 'Native animated module is not available');
 
@@ -210,7 +196,21 @@ const API = {
       API.flushQueue();
     }
   },
-
+  disconnectAnimatedNodeFromView(nodeTag: number, viewTag: number): void {
+    NativeOperations.disconnectAnimatedNodeFromView(nodeTag, viewTag);
+  },
+  disconnectAnimatedNodes(parentTag: number, childTag: number): void {
+    NativeOperations.disconnectAnimatedNodes(parentTag, childTag);
+  },
+  dropAnimatedNode(tag: number): void {
+    NativeOperations.dropAnimatedNode(tag);
+  },
+  extractAnimatedNodeOffset(nodeTag: number): void {
+    NativeOperations.extractAnimatedNodeOffset(nodeTag);
+  },
+  flattenAnimatedNodeOffset(nodeTag: number): void {
+    NativeOperations.flattenAnimatedNodeOffset(nodeTag);
+  },
   flushQueue: (isSingleOpBatching
     ? (): void => {
         invariant(
@@ -257,35 +257,54 @@ const API = {
           NativeAnimatedModule?.finishOperationBatch?.();
         }
       }) as () => void,
+  getValue: (isSingleOpBatching
+    ? (tag, saveValueCallback) => {
+        /* $FlowFixMe[constant-condition] Error discovered during Constant
+         * Condition roll out. See https://fburl.com/workplace/1v97vimq. */
+        if (saveValueCallback) {
+          eventListenerGetValueCallbacks[tag] = saveValueCallback;
+        }
+        /* $FlowExpectedError[incompatible-type] - `saveValueCallback` is handled
+            differently when `isSingleOpBatching` is enabled. */
+        NativeOperations.getValue(tag);
+      }
+    : (tag, saveValueCallback) => {
+        NativeOperations.getValue(tag, saveValueCallback);
+      }) as NonNullable<typeof NativeAnimatedModule>['getValue'],
+  removeAnimatedEventFromView(
+    viewTag: number,
+    eventName: string,
+    animatedNodeTag: number,
+  ) {
+    NativeOperations.removeAnimatedEventFromView(
+      viewTag,
+      eventName,
+      animatedNodeTag,
+    );
+  },
+  restoreDefaultValues(nodeTag: number): void {
+    NativeOperations.restoreDefaultValues?.(nodeTag);
+  },
+  setAnimatedNodeOffset(nodeTag: number, offset: number): void {
+    NativeOperations.setAnimatedNodeOffset(nodeTag, offset);
+  },
+  setAnimatedNodeValue(nodeTag: number, value: number): void {
+    NativeOperations.setAnimatedNodeValue(nodeTag, value);
+  },
+  setWaitingForIdentifier(id: string): void {
+    if (shouldSignalBatch) {
+      return;
+    }
 
-  createAnimatedNode(tag: number, config: AnimatedNodeConfig): void {
-    if (config.disableBatchingForNativeCreate) {
-      NativeAnimatedModule?.createAnimatedNode(tag, config);
-    } else {
-      NativeOperations.createAnimatedNode(tag, config);
+    waitingForQueuedOperations.add(id);
+    queueOperations = true;
+    if (
+      ReactNativeFeatureFlags.animatedShouldDebounceQueueFlush() &&
+      flushQueueImmediate
+    ) {
+      clearImmediate(flushQueueImmediate);
     }
   },
-
-  updateAnimatedNodeConfig(tag: number, config: AnimatedNodeConfig): void {
-    NativeOperations.updateAnimatedNodeConfig?.(tag, config);
-  },
-
-  startListeningToAnimatedNodeValue(tag: number): void {
-    NativeOperations.startListeningToAnimatedNodeValue(tag);
-  },
-
-  stopListeningToAnimatedNodeValue(tag: number): void {
-    NativeOperations.stopListeningToAnimatedNodeValue(tag);
-  },
-
-  connectAnimatedNodes(parentTag: number, childTag: number): void {
-    NativeOperations.connectAnimatedNodes(parentTag, childTag);
-  },
-
-  disconnectAnimatedNodes(parentTag: number, childTag: number): void {
-    NativeOperations.disconnectAnimatedNodes(parentTag, childTag);
-  },
-
   startAnimatingNode: (isSingleOpBatching
     ? (animationId, nodeTag, config, endCallback) => {
         /* $FlowFixMe[constant-condition] Error discovered during Constant
@@ -304,72 +323,30 @@ const API = {
           config,
           endCallback,
         );
-      }) as $NonMaybeType<typeof NativeAnimatedModule>['startAnimatingNode'],
-
+      }) as NonNullable<typeof NativeAnimatedModule>['startAnimatingNode'],
+  startListeningToAnimatedNodeValue(tag: number): void {
+    NativeOperations.startListeningToAnimatedNodeValue(tag);
+  },
   stopAnimation(animationId: number) {
     NativeOperations.stopAnimation(animationId);
   },
-
-  setAnimatedNodeValue(nodeTag: number, value: number): void {
-    NativeOperations.setAnimatedNodeValue(nodeTag, value);
+  stopListeningToAnimatedNodeValue(tag: number): void {
+    NativeOperations.stopListeningToAnimatedNodeValue(tag);
   },
+  unsetWaitingForIdentifier(id: string): void {
+    if (shouldSignalBatch) {
+      return;
+    }
 
-  setAnimatedNodeOffset(nodeTag: number, offset: number): void {
-    NativeOperations.setAnimatedNodeOffset(nodeTag, offset);
+    waitingForQueuedOperations.delete(id);
+
+    if (waitingForQueuedOperations.size === 0) {
+      queueOperations = false;
+      API.disableQueue();
+    }
   },
-
-  flattenAnimatedNodeOffset(nodeTag: number): void {
-    NativeOperations.flattenAnimatedNodeOffset(nodeTag);
-  },
-
-  extractAnimatedNodeOffset(nodeTag: number): void {
-    NativeOperations.extractAnimatedNodeOffset(nodeTag);
-  },
-
-  connectAnimatedNodeToView(nodeTag: number, viewTag: number): void {
-    NativeOperations.connectAnimatedNodeToView(nodeTag, viewTag);
-  },
-
-  connectAnimatedNodeToShadowNodeFamily(
-    nodeTag: number,
-    shadowNode: Node,
-  ): void {
-    NativeOperations.connectAnimatedNodeToShadowNodeFamily?.(
-      nodeTag,
-      shadowNode,
-    );
-  },
-
-  disconnectAnimatedNodeFromView(nodeTag: number, viewTag: number): void {
-    NativeOperations.disconnectAnimatedNodeFromView(nodeTag, viewTag);
-  },
-
-  restoreDefaultValues(nodeTag: number): void {
-    NativeOperations.restoreDefaultValues?.(nodeTag);
-  },
-
-  dropAnimatedNode(tag: number): void {
-    NativeOperations.dropAnimatedNode(tag);
-  },
-
-  addAnimatedEventToView(
-    viewTag: number,
-    eventName: string,
-    eventMapping: EventMapping,
-  ) {
-    NativeOperations.addAnimatedEventToView(viewTag, eventName, eventMapping);
-  },
-
-  removeAnimatedEventFromView(
-    viewTag: number,
-    eventName: string,
-    animatedNodeTag: number,
-  ) {
-    NativeOperations.removeAnimatedEventFromView(
-      viewTag,
-      eventName,
-      animatedNodeTag,
-    );
+  updateAnimatedNodeConfig(tag: number, config: AnimatedNodeConfig): void {
+    NativeOperations.updateAnimatedNodeConfig?.(tag, config);
   },
 };
 
@@ -477,12 +454,9 @@ function transformDataType(value: number | string): number | string {
 
 export default {
   API,
-  generateNewNodeTag,
-  generateNewAnimationId,
   assertNativeAnimatedModule,
-  shouldUseNativeDriver,
-  shouldSignalBatch,
-  transformDataType,
+  generateNewAnimationId,
+  generateNewNodeTag,
   // $FlowExpectedError[unsafe-getters-setters] - unsafe getter lint suppression
   // $FlowExpectedError[missing-type-arg] - unsafe getter lint suppression
   get nativeEventEmitter(): NativeEventEmitter {
@@ -496,4 +470,7 @@ export default {
     }
     return nativeEventEmitter;
   },
+  shouldSignalBatch,
+  shouldUseNativeDriver,
+  transformDataType,
 };

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlagsBase.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlagsBase.js
@@ -67,13 +67,13 @@ export function createJavaScriptFlagGetter<
   );
 }
 
-type NativeFeatureFlags = $NonMaybeType<typeof NativeReactNativeFeatureFlags>;
+type NativeFeatureFlags = NonNullable<typeof NativeReactNativeFeatureFlags>;
 
 export function createNativeFlagGetter<K: $Keys<NativeFeatureFlags>>(
   configName: K,
-  defaultValue: ReturnType<$NonMaybeType<NativeFeatureFlags[K]>>,
+  defaultValue: ReturnType<NonNullable<NativeFeatureFlags[K]>>,
   skipUnavailableNativeModuleError: boolean = false,
-): Getter<ReturnType<$NonMaybeType<NativeFeatureFlags[K]>>> {
+): Getter<ReturnType<NonNullable<NativeFeatureFlags[K]>>> {
   return createGetter(
     configName,
     () => {

--- a/packages/rn-tester/IntegrationTests/ImageCachePolicyTest.js
+++ b/packages/rn-tester/IntegrationTests/ImageCachePolicyTest.js
@@ -32,14 +32,14 @@ const TESTS = ['only-if-cached', 'default', 'reload', 'force-cache'] as const;
 
 function ImageCachePolicyTest(): React.Node {
   const [state, setState] = useState<{[string]: ?boolean}>({
-    'only-if-cached': undefined,
     default: undefined,
-    reload: undefined,
     'force-cache': undefined,
+    'only-if-cached': undefined,
+    reload: undefined,
   });
 
   const testComplete = (
-    name: $NonMaybeType<ImageURISource['cache']>,
+    name: NonNullable<ImageURISource['cache']>,
     pass: boolean,
   ) => {
     setState(prevState => ({
@@ -89,19 +89,19 @@ function ImageCachePolicyTest(): React.Node {
 }
 
 const getImageSource = (cache: ImageURISource['cache']) => ({
+  cache,
   uri:
     'https://raw.githubusercontent.com/facebook/react-native/HEAD/Libraries/NewAppScreen/components/logo.png?cacheBust=notinCache' +
     Date.now(),
-  cache,
 });
 
 const styles = StyleSheet.create({
+  base: {
+    height: 100,
+    width: 100,
+  },
   container: {
     flex: 1,
-  },
-  base: {
-    width: 100,
-    height: 100,
   },
 });
 

--- a/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventClickTouchHierarchyPointerEvents.js
+++ b/packages/rn-tester/js/examples/Experimental/W3CPointerEventPlatformTests/PointerEventClickTouchHierarchyPointerEvents.js
@@ -21,7 +21,7 @@ import {StyleSheet, View} from 'react-native';
 function PointerEventBoxParentChild(props: {
   eventsToTrack: EventTrackerProps['eventsToTrack'],
   eventsRef: EventTrackerProps['eventsRef'],
-  pointerEvents: $NonMaybeType<ViewProps['pointerEvents']>,
+  pointerEvents: NonNullable<ViewProps['pointerEvents']>,
   childStyle: ViewProps['style'],
   parentStyleOverride?: ViewProps['style'],
 }) {
@@ -140,21 +140,26 @@ function PointerEventClickTouchHierarchyPointerEventsTestCase(
 }
 
 const styles = StyleSheet.create({
+  checkResults: {
+    backgroundColor: 'green',
+    height: 50,
+    width: '80%',
+  },
+  parent: {
+    alignItems: 'center',
+    backgroundColor: 'black',
+    display: 'flex',
+    height: 80,
+    justifyContent: 'center',
+    width: '20%',
+  },
   parentContainer: {
     display: 'flex',
     flexDirection: 'row',
     gap: 10,
   },
-  parent: {
-    display: 'flex',
-    backgroundColor: 'black',
-    height: 80,
-    width: '20%',
-    alignItems: 'center',
-    justifyContent: 'center',
-  },
-  targetBoxOnly: {
-    backgroundColor: 'blue',
+  targetAuto: {
+    backgroundColor: 'yellow',
     height: 50,
     width: 50,
   },
@@ -163,8 +168,8 @@ const styles = StyleSheet.create({
     height: 50,
     width: 50,
   },
-  targetAuto: {
-    backgroundColor: 'yellow',
+  targetBoxOnly: {
+    backgroundColor: 'blue',
     height: 50,
     width: 50,
   },
@@ -172,11 +177,6 @@ const styles = StyleSheet.create({
     backgroundColor: 'purple',
     height: 50,
     width: 50,
-  },
-  checkResults: {
-    backgroundColor: 'green',
-    height: 50,
-    width: '80%',
   },
 });
 

--- a/packages/rn-tester/js/examples/Modal/ModalPresentation.js
+++ b/packages/rn-tester/js/examples/Modal/ModalPresentation.js
@@ -53,24 +53,24 @@ function ModalPresentation() {
   }, []);
 
   const [props, setProps] = useState<ModalProps>({
-    animationType: 'none',
-    transparent: false,
-    hardwareAccelerated: false,
-    statusBarTranslucent: false,
-    navigationBarTranslucent: false,
-    presentationStyle: Platform.select({
-      ios: 'fullScreen',
-      default: undefined,
-    }),
     allowSwipeDismissal: false,
-    supportedOrientations: Platform.select({
-      ios: ['portrait'],
-      default: undefined,
-    }),
+    animationType: 'none',
+    backdropColor: undefined,
+    hardwareAccelerated: false,
+    navigationBarTranslucent: false,
     onDismiss: undefined,
     onShow: undefined,
+    presentationStyle: Platform.select({
+      default: undefined,
+      ios: 'fullScreen',
+    }),
+    statusBarTranslucent: false,
+    supportedOrientations: Platform.select({
+      default: undefined,
+      ios: ['portrait'],
+    }),
+    transparent: false,
     visible: false,
-    backdropColor: undefined,
   });
   const presentationStyle = props.presentationStyle;
   const hardwareAccelerated = props.hardwareAccelerated;
@@ -83,7 +83,7 @@ function ModalPresentation() {
   const [currentOrientation, setCurrentOrientation] = useState('unknown');
 
   type OrientationChangeEvent = Parameters<
-    $NonMaybeType<ModalProps['onOrientationChange']>,
+    NonNullable<ModalProps['onOrientationChange']>,
   >[0];
   const onOrientationChange = (event: OrientationChangeEvent) =>
     setCurrentOrientation(event.nativeEvent.orientation);
@@ -99,8 +99,8 @@ function ModalPresentation() {
           onValueChange={enabled =>
             setProps(prev => ({
               ...prev,
-              statusBarTranslucent: enabled,
               navigationBarTranslucent: false,
+              statusBarTranslucent: enabled,
             }))
           }
         />
@@ -114,8 +114,8 @@ function ModalPresentation() {
           onValueChange={enabled => {
             setProps(prev => ({
               ...prev,
-              statusBarTranslucent: enabled,
               navigationBarTranslucent: enabled,
+              statusBarTranslucent: enabled,
             }));
           }}
         />
@@ -336,34 +336,18 @@ function ModalPresentation() {
 }
 
 const styles = StyleSheet.create({
-  row: {
-    flexWrap: 'wrap',
-    flexDirection: 'row',
-  },
-  rowWithSpaceBetween: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-  },
   block: {
-    borderColor: 'rgba(0,0,0, 0.1)',
     borderBottomWidth: 1,
+    borderColor: 'rgba(0,0,0, 0.1)',
     padding: 6,
   },
   inlineBlock: {
-    padding: 6,
+    alignItems: 'center',
+    borderBottomWidth: 1,
+    borderColor: 'rgba(0,0,0, 0.1)',
     flexDirection: 'row',
     justifyContent: 'space-between',
-    alignItems: 'center',
-    borderColor: 'rgba(0,0,0, 0.1)',
-    borderBottomWidth: 1,
-  },
-  title: {
-    margin: 3,
-    fontWeight: 'bold',
-  },
-  option: {
-    marginRight: 8,
-    marginTop: 6,
+    padding: 6,
   },
   modalContainer: {
     flex: 1,
@@ -374,16 +358,32 @@ const styles = StyleSheet.create({
     borderRadius: 10,
     padding: 10,
   },
-  warning: {
+  option: {
+    marginRight: 8,
+    marginTop: 6,
+  },
+  row: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+  },
+  rowWithSpaceBetween: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  title: {
+    fontWeight: 'bold',
     margin: 3,
-    fontSize: 12,
+  },
+  warning: {
     color: 'red',
+    fontSize: 12,
+    margin: 3,
   },
 });
 
 export default ({
-  title: 'Modal Presentation',
-  name: 'basic',
   description: 'Modals can be presented with or without animation',
+  name: 'basic',
   render: (): React.Node => <ModalPresentation />,
+  title: 'Modal Presentation',
 }: RNTesterModuleExample);

--- a/private/react-native-fantom/runner/bundling.js
+++ b/private/react-native-fantom/runner/bundling.js
@@ -18,7 +18,7 @@ type BundleOptions = {
   customTransformOptions: ?{
     collectCoverage: boolean,
   },
-  out: $NonMaybeType<RunBuildOptions['out']>,
+  out: NonNullable<RunBuildOptions['out']>,
   testPath: string,
 };
 

--- a/private/react-native-fantom/runner/global-setup/globalTeardown.js
+++ b/private/react-native-fantom/runner/global-setup/globalTeardown.js
@@ -10,7 +10,7 @@
 
 import type {RunServerResult} from 'metro';
 
-type MetroServer = $NonMaybeType<RunServerResult?.['httpServer']>;
+type MetroServer = NonNullable<RunServerResult?.['httpServer']>;
 
 declare var __FANTOM_METRO_SERVER__: ?RunServerResult;
 


### PR DESCRIPTION
Summary:
We are transforming the following utility types to be more consistent with typescript and better AI integration:

* `$NonMaybeType` -> `NonNullable`
* `$ReadOnly` -> `Readonly`
* `$ReadOnlyArray` -> `ReadonlyArray`
* `$ReadOnlyMap` -> `ReadonlyMap`
* `$ReadOnlySet` -> `ReadonlySet`
* `$Keys` -> `keyof`
* `$Values` -> `Values`
* `mixed` -> `unknown`

See details in https://fb.workplace.com/groups/flowlang/permalink/1837907750148213/.
drop-conflicts

Reviewed By: gkz

Differential Revision: D89494075


