### PR TITLE
Fix the build for `unknown` annotation

### DIFF
--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -664,6 +664,7 @@ function emitCommonTypes(
     StringTypeAnnotation: emitString,
     MixedTypeAnnotation: cxxOnly ? emitMixed : emitGenericObject,
     UnsafeMixed: cxxOnly ? emitMixed : emitGenericObject,
+    unknown: cxxOnly ? emitMixed : emitGenericObject,
   };
 
   const typeAnnotationName = parser.convertKeywordToTypeAnnotation(


### PR DESCRIPTION
Summary:
`buck build --flagfile fbcode//mode/opt fbcode//cathode/modules/react/lib/tests:app_delegate_test` crashed with
```
Buck build failed for this target, and is likely caused by your changes.
Error message:
[New Failure] Target failed to build.
Action failed: fbsource//xplat/js/RKJSModules/Libraries/CathodeMessaging:FBReactNativeCathodeMessagingSpec-flow-types-ota-safety (cfg:opt-linux-x86_64-fbcode-platform010-clang19-no-san#3224936a2623a72b) (genrule)
Remote command returned non-zero exit code 1
Remote action, reproduce with: `frecli cas download-action 0c073e461a3ae239aa7e24c8a99b39543d365414405d1be1caa2196d7f55a18e:148`
Stdout: <empty>
Stderr:
UnsupportedGenericParserError: Module NativeCathodeMessagingModuleCxx: Unrecognized generic type 'unknown' in NativeModule spec.
    at translateTypeAnnotation (/re_cwd/buck-out/v2/gen/fbsource/xplat/js/tools/flow-schema/__flow-schema__bin_build__/0a63598ffadb2c1e/out/flow-schema__bin_build.zip/node_modules/react-native/codegen/src/parsers/flow/modules/index.js:154:23)
    at /re_cwd/buck-out/v2/gen/fbsource/xplat/js/tools/flow-schema/__flow-schema__bin_build__/0a63598ffadb2c1e/out/flow-schema__bin_build.zip/node_modules/react-native/codegen/src/parsers/parsers-commons.js:343:7
    at guard (/re_cwd/buck-out/v2/gen/fbsource/xplat/js/tools/flow-schema/__flow-schema__bin_build__/0a63598ffadb2c1e/out/flow-schema__bin_build.zip/node_modules/react-native/codegen/src/parsers/utils.js:50:14)
    at translateFunctionTypeAnnotation (/re_cwd/buck-out/v2/gen/fbsource/xplat/js/tools/flow-schema/__flow-schema__bin_build__/0a63598ffadb2c1e/out/flow-schema__bin_build.zip/node_modules/react-native/codegen/src/parsers/parsers-commons.js:334:25)
    at emitFunction (/re_cwd/buck-out/v2/gen/fbsource/xplat/js/tools/flow-schema/__flow-schema__bin_build__/0a63598ffadb2c1e/out/flow-schema__bin_build.zip/node_modules/react-native/codegen/src/parsers/parsers-primitives.js:149:3)
    at translateTypeAnnotation (/re_cwd/buck-out/v2/gen/fbsource/xplat/js/tools/flow-schema/__flow-schema__bin_build__/0a63598ffadb2c1e/out/flow-schema__bin_build.zip/node_modules/react-native/codegen/src/parsers/flow/modules/index.js:236:16)
    at /re_cwd/buck-out/v2/gen/fbsource/xplat/js/tools/flow-schema/__flow-schema__bin_build__/0a63598ffadb2c1e/out/flow-schema__bin_build.zip/node_modules/react-native/codegen/src/parsers/parsers-commons.js:343:7
    at guard (/re_cwd/buck-out/v2/gen/fbsource/xplat/js/tools/flow-schema/__flow-schema__bin_build__/0a63598ffadb2c1e/out/flow-schema__bin_build.zip/node_modules/react-native/codegen/src/parsers/utils.js:50:14)
    at translateFunctionTypeAnnotation (/re_cwd/buck-out/v2/gen/fbsource/xplat/js/tools/flow-schema/__flow-schema__bin_build__/0a63598ffadb2c1e/out/flow-schema__bin_build.zip/node_modules/react-native/codegen/src/parsers/parsers-commons.js:334:25)
    at buildPropertySchema (/re_cwd/buck-out/v2/gen/fbsource/xplat/js/tools/flow-schema/__flow-schema__bin_build__/0a63598ffadb2c1e/out/flow-schema__bin_build.zip/node_modules/react-native/codegen/src/parsers/parsers-commons.js:461:5)
    at /re_cwd/buck-out/v2/gen/fbsource/xplat/js/tools/flow-schema/__flow-schema__bin_build__/0a63598ffadb2c1e/out/flow-schema__bin_build.zip/node_modules/react-native/codegen/src/parsers/parsers-commons.js:845:16
    at guard (/re_cwd/buck-out/v2/gen/fbsource/xplat/js/tools/flow-schema/__flow-schema__bin_build__/0a63598ffadb2c1e/out/flow-schema__bin_build.zip/node_modules/react-native/codegen/src/parsers/utils.js:50:14)
    at /re_cwd/buck-out/v2/gen/fbsource/xplat/js/tools/flow-schema/__flow-schema__bin_build__/0a63598ffadb2c1e/out/flow-schema__bin_build.zip/node_modules/react-native/codegen/src/parsers/parsers-commons.js:825:12
    at Array.map (<anonymous>)
    at buildModuleSchema (/re_cwd/buck-out/v2/gen/fbsource/xplat/js/tools/flow-schema/__flow-schema__bin_build__/0a63598ffadb2c1e/out/flow-schema__bin_build.zip/node_modules/react-native/codegen/src/parsers/parsers-commons.js:811:3)
    at /re_cwd/buck-out/v2/gen/fbsource/xplat/js/tools/flow-schema/__flow-schema__bin_build__/0a63598ffadb2c1e/out/flow-schema__bin_build.zip/node_modules/react-native/codegen/src/parsers/parsers-commons.js:583:9
    at guard (/re_cwd/buck-out/v2/gen/fbsource/xplat/js/tools/flow-schema/__flow-schema__bin_build__/0a63598ffadb2c1e/out/flow-schema__bin_build.zip/node_modules/react-native/codegen/src/parsers/utils.js:50:14)
    at buildSchemaFromConfigType (/re_cwd/buck-out/v2/gen/fbsource/xplat/js/tools/flow-schema/__flow-schema__bin_build__/0a63598ffadb2c1e/out/flow-schema__bin_build.zip/node_modules/react-native/codegen/src/parsers/parsers-commons.js:582:24)
    at buildSchema (/re_cwd/buck-out/v2/gen/fbsource/xplat/js/tools/flow-schema/__flow-schema__bin_build__/0a63598ffadb2c1e/out/flow-schema__bin_build.zip/node_modules/react-native/codegen/src/parsers/parsers-commons.js:648:10)
    at FlowParser.parseString (/re_cwd/buck-out/v2/gen/fbsource/xplat/js/tools/flow-schema/__flow-schema__bin_build__/0a63598ffadb2c1e/out/flow-schema__bin_build.zip/node_modules/react-native/codegen/src/parsers/flow/parser.js:131:12)
    at getSchemasForFiles (/re_cwd/buck-out/v2/gen/fbsource/xplat/js/tools/flow-schema/__flow-schema__bin_build__/0a63598ffadb2c1e/out/flow-schema__bin_build.zip/fb-tools/flow-schema/schema/getSchemasForFiles.js:101:51)
    at TypegenSchemaBuilder.addHackyInputsForReactNativeOnly (/re_cwd/buck-out/v2/gen/fbsource/xplat/js/tools/flow-schema/__flow-schema__bin_build__/0a63598ffadb2c1e/out/flow-schema__bin_build.zip/fb-tools/flow-schema/schema/TypegenSchema.js:94:5)
    at createTypegenSchema (/re_cwd/buck-out/v2/gen/fbsource/xplat/js/tools/flow-schema/__flow-schema__bin_build__/0a63598ffadb2c1e/out/flow-schema__bin_build.zip/fb-tools/flow-schema/commands/ota-safety.js:158:42)
    at Object.handler (/re_cwd/buck-out/v2/gen/fbsource/xplat/js/tools/flow-schema/__flow-schema__bin_build__/0a63598ffadb2c1e/out/flow-schema__bin_build.zip/fb-tools/flow-schema/commands/ota-safety.js:222:25)
    at /re_cwd/buck-out/v2/gen/fbsource/xplat/js/tools/flow-schema/__flow-schema__bin_build__/0a63598ffadb2c1e/out/flow-schema__bin_build.zip/node_modules/yargs/build/index.cjs:1:8993
    at j (/re_cwd/buck-out/v2/gen/fbsource/xplat/js/tools/flow-schema/__flow-schema__bin_build__/0a63598ffadb2c1e/out/flow-schema__bin_build.zip/node_modules/yargs/build/index.cjs:1:4956)
    at _.handleValidationAndGetResult (/re_cwd/buck-out/v2/gen/fbsource/xplat/js/tools/flow-schema/__flow-schema__bin_build__/0a63598ffadb2c1e/out/flow-schema__bin_build.zip/node_modules/yargs/build/index.cjs:1:8962)
    at _.applyMiddlewareAndGetResult (/re_cwd/buck-out/v2/gen/fbsource/xplat/js/tools/flow-schema/__flow-schema__bin_build__/0a63598ffadb2c1e/out/flow-schema__bin_build.zip/node_modules/yargs/build/index.cjs:1:9604)
    at _.runCommand (/re_cwd/buck-out/v2/gen/fbsource/xplat/js/tools/flow-schema/__flow-schema__bin_build__/0a63598ffadb2c1e/out/flow-schema__bin_build.zip/node_modules/yargs/build/index.cjs:1:7231)
    at [runYargsParserAndExecuteCommands] (/re_cwd/buck-out/v2/gen/fbsource/xplat/js/tools/flow-schema/__flow-schema__bin_build__/0a63598ffadb2c1e/out/flow-schema__bin_build.zip/node_modules/yargs/build/index.cjs:1:58544)
    at te.parse (/re_cwd/buck-out/v2/gen/fbsource/xplat/js/tools/flow-schema/__flow-schema__bin_build__/0a63598ffadb2c1e/out/flow-schema__bin_build.zip/node_modules/yargs/build/index.cjs:1:40483)
    at run (/re_cwd/buck-out/v2/gen/fbsource/xplat/js/tools/flow-schema/__flow-schema__bin_build__/0a63598ffadb2c1e/out/flow-schema__bin_build.zip/fb-tools/flow-schema/index.js:22:3)
    at Object.<anonymous> (/re_cwd/buck-out/v2/gen/fbsource/xplat/js/tools/flow-schema/__flow-schema__bin_build__/0a63598ffadb2c1e/out/flow-schema__bin_build.zip/fb-tools/flow-schema/index.js:42:1)
    at Module._compile (node:internal/modules/cjs/loader:1730:14)
    at Object..js (node:internal/modules/cjs/loader:1895:10)
    at Module.load (node:internal/modules/cjs/loader:1465:32)
    at Function._load (node:internal/modules/cjs/loader:1282:12)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:235:24)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:171:5)
    at Object.run (/re_cwd/buck-out/v2/gen/fbsource/xplat/third-party/node/node-zip/__module__/84c2dad32661840d/out/run.js:202:10)
    at Object.<anonymous> (/re_cwd/buck-out/v2/gen/fbsource/xplat/third-party/node/node-zip/__module__/84c2dad32661840d/out/run.js:210:11)
    at Module._compile (node:internal/modules/cjs/loader:1730:14)
    at Object..js (node:internal/modules/cjs/loader:1895:10)
    at Module.load (node:internal/modules/cjs/loader:1465:32)
    at Function._load (node:internal/modules/cjs/loader:1282:12)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:235:24) {
  nodes: [
    {
      type: 'GenericTypeAnnotation',
      loc: [Object],
      id: [Object],
      typeParameters: null,
      range: [Array]
    }
  ]
}

```

Fixing it in this diff

Reviewed By: SamChou19815

Differential Revision: D89519620


