### PR TITLE
Add support for max/min width/height props to Animation Backend

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropSerializer.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropSerializer.cpp
@@ -279,6 +279,10 @@ void packAnimatedProp(
     case FLEX_SHRINK:
     case FLEX_WRAP:
     case JUSTIFY_CONTENT:
+    case MAX_HEIGHT:
+    case MAX_WIDTH:
+    case MIN_HEIGHT:
+    case MIN_WIDTH:
       throw std::runtime_error("Tried to synchronously update layout props");
   }
 }

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedProps.h
@@ -47,7 +47,11 @@ enum PropName {
   FLEX_GROW,
   FLEX_SHRINK,
   FLEX_WRAP,
-  JUSTIFY_CONTENT
+  JUSTIFY_CONTENT,
+  MAX_HEIGHT,
+  MAX_WIDTH,
+  MIN_HEIGHT,
+  MIN_WIDTH
 };
 
 struct AnimatedPropBase {
@@ -333,6 +337,22 @@ inline void cloneProp(BaseViewProps &viewProps, const AnimatedPropBase &animated
 
     case JUSTIFY_CONTENT:
       viewProps.yogaStyle.setJustifyContent(get<yoga::Justify>(animatedProp));
+      break;
+
+    case MAX_HEIGHT:
+      viewProps.yogaStyle.setMaxDimension(yoga::Dimension::Height, get<yoga::Style::SizeLength>(animatedProp));
+      break;
+
+    case MAX_WIDTH:
+      viewProps.yogaStyle.setMaxDimension(yoga::Dimension::Width, get<yoga::Style::SizeLength>(animatedProp));
+      break;
+
+    case MIN_HEIGHT:
+      viewProps.yogaStyle.setMinDimension(yoga::Dimension::Height, get<yoga::Style::SizeLength>(animatedProp));
+      break;
+
+    case MIN_WIDTH:
+      viewProps.yogaStyle.setMinDimension(yoga::Dimension::Width, get<yoga::Style::SizeLength>(animatedProp));
       break;
 
     default:

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropsBuilder.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropsBuilder.h
@@ -152,6 +152,22 @@ struct AnimatedPropsBuilder {
   {
     props.push_back(std::make_unique<AnimatedProp<yoga::Justify>>(JUSTIFY_CONTENT, value));
   }
+  void setMaxHeight(yoga::Style::SizeLength value)
+  {
+    props.push_back(std::make_unique<AnimatedProp<yoga::Style::SizeLength>>(MAX_HEIGHT, value));
+  }
+  void setMaxWidth(yoga::Style::SizeLength value)
+  {
+    props.push_back(std::make_unique<AnimatedProp<yoga::Style::SizeLength>>(MAX_WIDTH, value));
+  }
+  void setMinHeight(yoga::Style::SizeLength value)
+  {
+    props.push_back(std::make_unique<AnimatedProp<yoga::Style::SizeLength>>(MIN_HEIGHT, value));
+  }
+  void setMinWidth(yoga::Style::SizeLength value)
+  {
+    props.push_back(std::make_unique<AnimatedProp<yoga::Style::SizeLength>>(MIN_WIDTH, value));
+  }
   void storeDynamic(folly::dynamic &d)
   {
     rawProps = std::make_unique<RawProps>(std::move(d));

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropsRegistry.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropsRegistry.h
@@ -218,6 +218,26 @@ inline void updateProp(const PropName propName, BaseViewProps &viewProps, const 
     case JUSTIFY_CONTENT:
       viewProps.yogaStyle.setJustifyContent(snapshot.props.yogaStyle.justifyContent());
       break;
+
+    case MAX_HEIGHT:
+      viewProps.yogaStyle.setMaxDimension(
+          yoga::Dimension::Height, snapshot.props.yogaStyle.maxDimension(yoga::Dimension::Height));
+      break;
+
+    case MAX_WIDTH:
+      viewProps.yogaStyle.setMaxDimension(
+          yoga::Dimension::Width, snapshot.props.yogaStyle.maxDimension(yoga::Dimension::Width));
+      break;
+
+    case MIN_HEIGHT:
+      viewProps.yogaStyle.setMinDimension(
+          yoga::Dimension::Height, snapshot.props.yogaStyle.minDimension(yoga::Dimension::Height));
+      break;
+
+    case MIN_WIDTH:
+      viewProps.yogaStyle.setMinDimension(
+          yoga::Dimension::Width, snapshot.props.yogaStyle.minDimension(yoga::Dimension::Width));
+      break;
   }
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackend.cpp
@@ -22,6 +22,8 @@ static const auto layoutProps = std::set<PropName>{
     PropName::DISPLAY,      PropName::FLEX_BASIS,    PropName::FLEX_DIRECTION,
     PropName::ROW_GAP,      PropName::COLUMN_GAP,    PropName::FLEX_GROW,
     PropName::FLEX_SHRINK,  PropName::FLEX_WRAP,     PropName::JUSTIFY_CONTENT,
+    PropName::MAX_HEIGHT,   PropName::MAX_WIDTH,     PropName::MIN_HEIGHT,
+    PropName::MIN_WIDTH,
 };
 
 UIManagerNativeAnimatedDelegateBackendImpl::


### PR DESCRIPTION
Summary:
## Summary:
Adds support for `maxWidth`, `maxHeight`, `minWidth`, and `minHeight` props to be passed as `AnimatedProp` to the animation backend.

## Changelog:
[General][Added] - Added support for `maxWidth`, `maxHeight`, `minWidth`, and `minHeight` props to the AnimationBackend.

Differential Revision: D89543698


