### PR TITLE
[ios] Resolve `use_react_native!(path)` param in `react_native_pods.rb` from `Pathname.pwd`

### DIFF
--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -75,10 +75,13 @@ def use_react_native! (
   error_if_try_to_use_jsc_from_core()
   warn_if_new_arch_disabled()
 
+  react_native_path = Pathname.pwd.join(path)
+  prefix = react_native_path.relative_path_from(Pod::Config.instance.installation_root)
+
   hermes_enabled= true
   # Set the app_path as env variable so the podspecs can access it.
   ENV['APP_PATH'] = app_path
-  ENV['REACT_NATIVE_PATH'] = path
+  ENV['REACT_NATIVE_PATH'] = react_native_path.to_s
 
   # We set RCT_SKIP_CODEGEN to true, if the user wants to skip the running Codegen step from Cocoapods.
   # This is needed as part of our migration away from cocoapods
@@ -102,15 +105,12 @@ def use_react_native! (
 
   # We are relying on this flag also in third parties libraries to proper install dependencies.
   # Better to rely and enable this environment flag if the new architecture is turned on using flags.
-  relative_path_from_current = Pod::Config.instance.installation_root.relative_path_from(Pathname.pwd)
-  react_native_version = NewArchitectureHelper.extract_react_native_version(File.join(relative_path_from_current, path))
+  react_native_version = NewArchitectureHelper.extract_react_native_version(react_native_path)
   fabric_enabled = true
 
   ENV['RCT_FABRIC_ENABLED'] = "1"
   ENV['RCT_AGGREGATE_PRIVACY_FILES'] = privacy_file_aggregation_enabled ? "1" : "0"
   ENV["RCT_NEW_ARCH_ENABLED"] = "1"
-
-  prefix = path
 
   ReactNativePodsUtils.warn_if_not_on_arm64()
 


### PR DESCRIPTION
## Summary:

> [!NOTE]
> This is a bit of a speculative fix that's based on trying to get a bare project with `react-native-macos` to link directly against it in an isolated installation, which makes passing `path` set to `require.resolve('react-native-macos/package.json')` more convenient than constructing a relative path first.

The `path` argument in `react_native_pods.rb` is not resolved but instead later joined using `File.join(relative_path_from_current, path)`. This doesn't actually resolve the path, meaning, if `path` is absolute it's appended to this first relative path.

Instead, we should use `Pathname#join` and join the path to the pathname, guaranteeing it to be absolute, then construct relative paths (for the prefix) using `relative_path_from` against the installation root.

If we don't do this, the absolute path gets treated as a relative path (e.g. `./Users`), which leads to errors such as:
> [!] Invalid Podfile file: Couldn't find the React Native package.json file at ./Users/phil/git/expo/expo-pnpm/packages/expo/package.json.

Since absolute paths are unambiguous the change should be safe.

## Changelog:

[IOS] Allow absolute react-native paths to be passed to `use_react_native!` in project podfiles

## Test Plan:

This can be replicated by replacing `path` in the `use_react_native` call with an absolute resolution and running `pod install` after, for example:

```rb
    use_react_native!(
      :path => File.dirname(`node --print "require.resolve('react-native/package.json')"`),
      :hermes_enabled => podfile_properties['expo.jsEngine'] == nil || podfile_properties['expo.jsEngine'] == 'hermes',
      # An absolute path to your application root.
      :app_path => "#{Pod::Config.instance.installation_root}/..",
    )
```

Usually, the `path` argument gets resolved from the react-native-config via `config[:reactNativePath]`. However, this makes the implicit assumption that `use_native_modules!` has already converted this to a relative path.
