### PR TITLE
Upgrade node-forge to v1.3.2

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7321,9 +7321,9 @@ node-fetch@^2.2.0, node-fetch@^2.6.7:
     whatwg-url "^5.0.0"
 
 node-forge@^1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
-  integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.2.tgz#d0d2659a26eef778bf84d73e7f55c08144ee7750"
+  integrity sha512-6xKiQ+cph9KImrRh0VsjH2d8/GXA4FIMlgU4B757iI1ApvcyA9VlouP0yZJha01V+huImO+kKMU7ih+2+E14fw==
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
Summary:
Asset Path: fbsource/xplat/js/react-native-github/yarn.lock
Asset Name: asset://code.third_party_library/fbsource/xplat%2Fjs%2Freact-native-github%2Fyarn.lock%23pkg:npm%2Fnode-forge@1.3.1
Asset Version: 1.3.1
Asset Vulnerabilities:
CVE-2025-12816, CWEs: Interpretation Conflict
Version to upgrade to: 1.3.2

Differential Revision: D89506698


