### PR TITLE
Add default case to EventEmitterH generator switch statement

### DIFF
--- a/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GenerateEventEmitterH-test.js.snap
+++ b/packages/react-native-codegen/e2e/deep_imports/__tests__/components/__snapshots__/GenerateEventEmitterH-test.js.snap
@@ -269,6 +269,7 @@ class EventPropsNativeComponentViewEventEmitter : public ViewEventEmitter {
     switch (value) {
       case OnOrientationChangeOrientation::Landscape: return \\"landscape\\";
       case OnOrientationChangeOrientation::Portrait: return \\"portrait\\";
+      default: return \\"\\";
     }
   }
 

--- a/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GenerateEventEmitterH-test.js.snap
+++ b/packages/react-native-codegen/e2e/namespaced/__tests__/components/__snapshots__/GenerateEventEmitterH-test.js.snap
@@ -269,6 +269,7 @@ class EventPropsNativeComponentViewEventEmitter : public ViewEventEmitter {
     switch (value) {
       case OnOrientationChangeOrientation::Landscape: return \\"landscape\\";
       case OnOrientationChangeOrientation::Portrait: return \\"portrait\\";
+      default: return \\"\\";
     }
   }
 

--- a/packages/react-native-codegen/src/generators/components/GenerateEventEmitterH.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateEventEmitterH.js
@@ -109,6 +109,7 @@ const EnumTemplate = ({
 static char const *toString(const ${enumName} value) {
   switch (value) {
     ${toCases}
+    default: return "";
   }
 }
 `.trim();

--- a/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateEventEmitterH-test.js.snap
+++ b/packages/react-native-codegen/src/generators/components/__tests__/__snapshots__/GenerateEventEmitterH-test.js.snap
@@ -513,6 +513,7 @@ class EventsNativeComponentEventEmitter : public ViewEventEmitter {
     switch (value) {
       case OnArrayEventTypeString_enum_event_prop::YES: return \\"YES\\";
       case OnArrayEventTypeString_enum_event_prop::NO: return \\"NO\\";
+      default: return \\"\\";
     }
   }
 
@@ -543,6 +544,7 @@ class EventsNativeComponentEventEmitter : public ViewEventEmitter {
     switch (value) {
       case OnOrientationChangeOrientation::Landscape: return \\"landscape\\";
       case OnOrientationChangeOrientation::Portrait: return \\"portrait\\";
+      default: return \\"\\";
     }
   }
 


### PR DESCRIPTION
Summary:
Adds a default case to the switch statement in GenerateEventEmitterH.js to fix
compiler warnings about unhandled enum values in upcoming diff


```
[info] buck-out/v2/gen/fbsource/xplat/js/react-native-github/__generate_event_emitter_h-FBReactNativeSpec__/6c08ec662a69b177/out/EventEmitters.h:178:5: error: 'switch' missing 'default' label [-Werror,-Wswitch-default]
[info]   178 |     switch (value) {
[info]       |     ^
[info] 1 error generated.
[info] [2025-12-17T13:42:51.990-08:00]
[info] [2025-12-17T13:42:51.990-08:00] Action sub-errors produced by error handlers:
[info] - [apple_cxx_error][switch_default] buck-out/v2/gen/fbsource/xplat/js/react-native-github/__generate_event_emitter_h-FBReactNativeSpec__/6c08ec662a69b177/out/EventEmitters.h:178:5 'switch' missing 'default' label [-Wswitch-default]
[info]   Hint: https://fburl.com/apple_build_errors/missing_switch_default_label
[info]
[info] BUILD FAILED
```

Changelog: [Internal]

Differential Revision: D89513261


