### PR TITLE
fix: app‑extension‑safe guard and fallback in RCTFontSizeMultiplier()

### DIFF
--- a/packages/react-native/React/Base/RCTUtils.mm
+++ b/packages/react-native/React/Base/RCTUtils.mm
@@ -378,7 +378,14 @@ CGFloat RCTFontSizeMultiplier(void)
     };
   });
 
-  return mapping[RCTSharedApplication().preferredContentSizeCategory].floatValue;
+  UIApplication *application = RCTSharedApplication();
+  if (!application) {
+    return 1.0;
+  }
+
+  NSNumber *value = mapping[application.preferredContentSizeCategory];
+  CGFloat multiplier = value != nil ? value.floatValue : 1.0;
+  return multiplier > 0.0 ? multiplier : 1.0;
 }
 
 UIDeviceOrientation RCTDeviceOrientation(void)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**This change fixes a text rendering issue on iOS when using the new architecture (Fabric), most notably in app extensions on iOS.**

While migrating an app extension to the new architecture, all the labels in our app became invisible. A bare `<Text>` component initially appeared to work, which made the issue hard to track down.

Text rendered correctly with default styles, but once `fontSize` or `fontFamily` was applied, text would ignore sizing or become invisible. Because text was still visible by default, the problem did not immediately appear to be related to font scaling or measurement, so it took me WEEKS to understand.
Please check out the issue I created almost a month ago: https://github.com/facebook/react-native/issues/54642

After deeper investigation into Fabric text measurement and after using 100 different breakpoint attempts, the root cause turned out to be an invalid font size multiplier coming from `RCTFontSizeMultiplier()` when running inside an app extension.

In app extensions, `RCTSharedApplication()` can (or will!) return `nil`. When that happened, `RCTFontSizeMultiplier()` could return an invalid value, which later caused Fabric text measurement to produce zero-height paragraphs. As a result, `<Text>` components could ignore `fontSize` or become invisible when `fontFamily` was set.

The fix makes `RCTFontSizeMultiplier()` app-extension-safe by returning a positive default (`1.0`) when `UIApplication` or the preferred content size category is unavailable, and by clamping invalid values.

**Related issue:**  
https://github.com/facebook/react-native/issues/54642

---

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[IOS] [FIXED] - Prevent font scaling issue in extension context

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [FIXED] - Make `RCTFontSizeMultiplier()` app-extension-safe by adding a default fallback and clamping invalid values to a positive number, such that fonts are never scaled down to zero

---

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- Reproduced the issue in an iOS app extension using Fabric
- Observed `<Text>` rendering correctly by default but ignoring `fontSize` or becoming invisible when `fontFamily` was applied
- Traced the issue through Fabric text measurement and font size multiplier handling
- Applied the fix to `RCTFontSizeMultiplier()`
- Verified that text renders correctly and respects `fontSize`
- Confirmed no behavior change in a regular iOS app

To test this fix the repro that I provided in the issue above can easily be used.
First run the code without the commit (observe the bad outcome) then run it with the commit (observe the good outcome)
