### PR TITLE
Transform mixed to unknown in xplat/js

### DIFF
--- a/flow-typed/environment/node.js
+++ b/flow-typed/environment/node.js
@@ -847,7 +847,7 @@ declare class dgram$Socket extends events$EventEmitter {
     msg: Buffer,
     port: number,
     address: string,
-    callback?: (err: ?Error, bytes: any) => mixed,
+    callback?: (err: ?Error, bytes: any) => unknown,
   ): void;
   send(
     msg: Buffer,
@@ -855,7 +855,7 @@ declare class dgram$Socket extends events$EventEmitter {
     length: number,
     port: number,
     address: string,
-    callback?: (err: ?Error, bytes: any) => mixed,
+    callback?: (err: ?Error, bytes: any) => unknown,
   ): void;
   setBroadcast(flag: boolean): void;
   setMulticastLoopback(flag: boolean): void;
@@ -2021,7 +2021,7 @@ declare class http$Server extends net$Server {
     callback?: Function,
   ): this;
   listening: boolean;
-  close(callback?: (error: ?Error) => mixed): this;
+  close(callback?: (error: ?Error) => unknown): this;
   closeAllConnections(): void;
   closeIdleConnections(): void;
   maxHeadersCount: number;
@@ -2057,7 +2057,7 @@ declare class https$Server extends tls$Server {
     },
     callback?: Function,
   ): this;
-  close(callback?: (error: ?Error) => mixed): this;
+  close(callback?: (error: ?Error) => unknown): this;
   closeAllConnections(): void;
   closeIdleConnections(): void;
   keepAliveTimeout: number;
@@ -2070,7 +2070,7 @@ type requestOptions = {|
   auth?: string,
   defaultPort?: number,
   family?: number,
-  headers?: {[key: string]: mixed, ...},
+  headers?: {[key: string]: unknown, ...},
   host?: string,
   hostname?: string,
   localAddress?: string,
@@ -2208,14 +2208,14 @@ declare class net$Socket extends stream$Duplex {
   bufferSize: number;
   bytesRead: number;
   bytesWritten: number;
-  connect(path: string, connectListener?: () => mixed): net$Socket;
+  connect(path: string, connectListener?: () => unknown): net$Socket;
   connect(
     port: number,
     host?: string,
-    connectListener?: () => mixed,
+    connectListener?: () => unknown,
   ): net$Socket;
-  connect(port: number, connectListener?: () => mixed): net$Socket;
-  connect(options: Object, connectListener?: () => mixed): net$Socket;
+  connect(port: number, connectListener?: () => unknown): net$Socket;
+  connect(options: Object, connectListener?: () => unknown): net$Socket;
   destroyed: boolean;
   end(
     chunkOrEncodingOrCallback?:
@@ -2275,7 +2275,7 @@ type net$connectOptions = {
     domain: string,
     options?: ?number | ?Object,
     callback?: (err: ?Error, address: string, family: number) => void,
-  ) => mixed,
+  ) => unknown,
   path?: string,
   ...
 };
@@ -2893,7 +2893,7 @@ type tls$connectOptions = {
     domain: string,
     options?: ?number | ?Object,
     callback?: (err: ?Error, address: string, family: number) => void,
-  ) => mixed,
+  ) => unknown,
   requestOCSP?: boolean,
   ...
 };
@@ -3095,7 +3095,7 @@ declare module 'url' {
         value: string,
         name: string,
         searchParams: URLSearchParams,
-      ) => mixed,
+      ) => unknown,
       thisArg?: This,
     ): void;
     get(name: string): string | null;
@@ -3270,45 +3270,45 @@ declare module 'util' {
   }
 
   declare var types: {
-    isAnyArrayBuffer: (value: mixed) => boolean,
-    isArgumentsObject: (value: mixed) => boolean,
-    isArrayBuffer: (value: mixed) => boolean,
-    isAsyncFunction: (value: mixed) => boolean,
-    isBigInt64Array: (value: mixed) => boolean,
-    isBigUint64Array: (value: mixed) => boolean,
-    isBooleanObject: (value: mixed) => boolean,
-    isBoxedPrimitive: (value: mixed) => boolean,
-    isDataView: (value: mixed) => boolean,
-    isDate: (value: mixed) => boolean,
-    isExternal: (value: mixed) => boolean,
-    isFloat32Array: (value: mixed) => boolean,
-    isFloat64Array: (value: mixed) => boolean,
-    isGeneratorFunction: (value: mixed) => boolean,
-    isGeneratorObject: (value: mixed) => boolean,
-    isInt8Array: (value: mixed) => boolean,
-    isInt16Array: (value: mixed) => boolean,
-    isInt32Array: (value: mixed) => boolean,
-    isMap: (value: mixed) => boolean,
-    isMapIterator: (value: mixed) => boolean,
-    isModuleNamespaceObject: (value: mixed) => boolean,
-    isNativeError: (value: mixed) => boolean,
-    isNumberObject: (value: mixed) => boolean,
-    isPromise: (value: mixed) => boolean,
-    isProxy: (value: mixed) => boolean,
-    isRegExp: (value: mixed) => boolean,
-    isSet: (value: mixed) => boolean,
-    isSetIterator: (value: mixed) => boolean,
-    isSharedArrayBuffer: (value: mixed) => boolean,
-    isStringObject: (value: mixed) => boolean,
-    isSymbolObject: (value: mixed) => boolean,
-    isTypedArray: (value: mixed) => boolean,
-    isUint8Array: (value: mixed) => boolean,
-    isUint8ClampedArray: (value: mixed) => boolean,
-    isUint16Array: (value: mixed) => boolean,
-    isUint32Array: (value: mixed) => boolean,
-    isWeakMap: (value: mixed) => boolean,
-    isWeakSet: (value: mixed) => boolean,
-    isWebAssemblyCompiledModule: (value: mixed) => boolean,
+    isAnyArrayBuffer: (value: unknown) => boolean,
+    isArgumentsObject: (value: unknown) => boolean,
+    isArrayBuffer: (value: unknown) => boolean,
+    isAsyncFunction: (value: unknown) => boolean,
+    isBigInt64Array: (value: unknown) => boolean,
+    isBigUint64Array: (value: unknown) => boolean,
+    isBooleanObject: (value: unknown) => boolean,
+    isBoxedPrimitive: (value: unknown) => boolean,
+    isDataView: (value: unknown) => boolean,
+    isDate: (value: unknown) => boolean,
+    isExternal: (value: unknown) => boolean,
+    isFloat32Array: (value: unknown) => boolean,
+    isFloat64Array: (value: unknown) => boolean,
+    isGeneratorFunction: (value: unknown) => boolean,
+    isGeneratorObject: (value: unknown) => boolean,
+    isInt8Array: (value: unknown) => boolean,
+    isInt16Array: (value: unknown) => boolean,
+    isInt32Array: (value: unknown) => boolean,
+    isMap: (value: unknown) => boolean,
+    isMapIterator: (value: unknown) => boolean,
+    isModuleNamespaceObject: (value: unknown) => boolean,
+    isNativeError: (value: unknown) => boolean,
+    isNumberObject: (value: unknown) => boolean,
+    isPromise: (value: unknown) => boolean,
+    isProxy: (value: unknown) => boolean,
+    isRegExp: (value: unknown) => boolean,
+    isSet: (value: unknown) => boolean,
+    isSetIterator: (value: unknown) => boolean,
+    isSharedArrayBuffer: (value: unknown) => boolean,
+    isStringObject: (value: unknown) => boolean,
+    isSymbolObject: (value: unknown) => boolean,
+    isTypedArray: (value: unknown) => boolean,
+    isUint8Array: (value: unknown) => boolean,
+    isUint8ClampedArray: (value: unknown) => boolean,
+    isUint16Array: (value: unknown) => boolean,
+    isUint32Array: (value: unknown) => boolean,
+    isWeakMap: (value: unknown) => boolean,
+    isWeakSet: (value: unknown) => boolean,
+    isWebAssemblyCompiledModule: (value: unknown) => boolean,
     ...
   };
 
@@ -4047,18 +4047,18 @@ declare class Process extends events$EventEmitter {
   emitWarning(warning: string | Error): void;
   emitWarning(
     warning: string,
-    typeOrCtor: string | ((...empty) => mixed),
+    typeOrCtor: string | ((...empty) => unknown),
   ): void;
   emitWarning(
     warning: string,
     type: string,
-    codeOrCtor: string | ((...empty) => mixed),
+    codeOrCtor: string | ((...empty) => unknown),
   ): void;
   emitWarning(
     warning: string,
     type: string,
     code: string,
-    ctor?: (...empty) => mixed,
+    ctor?: (...empty) => unknown,
   ): void;
   execArgv: Array<string>;
   execPath: string;
@@ -4088,7 +4088,7 @@ declare class Process extends events$EventEmitter {
     },
     rss: () => number,
   };
-  nextTick: <T>(cb: (...T) => mixed, ...T) => void;
+  nextTick: <T>(cb: (...T) => unknown, ...T) => void;
   pid: number;
   platform: string;
   release: {
@@ -4129,7 +4129,7 @@ declare var __filename: string;
 declare var __dirname: string;
 
 declare function setImmediate(
-  callback: (...args: Array<any>) => mixed,
+  callback: (...args: Array<any>) => unknown,
   ...args: Array<any>
 ): Object;
 declare function clearImmediate(immediateObject: any): Object;

--- a/flow-typed/npm/@octokit/rest_v22.x.x.js
+++ b/flow-typed/npm/@octokit/rest_v22.x.x.js
@@ -53,7 +53,7 @@ declare module '@octokit/rest' {
         repo: string,
         asset_id: string,
         ...
-      }) => Promise<mixed>,
+      }) => Promise<unknown>,
     }>;
   }
 

--- a/flow-typed/npm/@react-native-community/cli-server-api_v19.x.x.js
+++ b/flow-typed/npm/@react-native-community/cli-server-api_v19.x.x.js
@@ -32,7 +32,7 @@ declare module '@react-native-community/cli-server-api' {
       server: ws$WebSocketServer,
       broadcast: (
         method: string,
-        params?: Record<string, mixed> | null,
+        params?: Record<string, unknown> | null,
       ) => void,
     },
     eventsSocketEndpoint: {

--- a/flow-typed/npm/babel-traverse_v7.x.x.js
+++ b/flow-typed/npm/babel-traverse_v7.x.x.js
@@ -53,7 +53,7 @@ declare module '@babel/traverse' {
 
     constructor(
       scope: Scope,
-      opts: TraverseOptions<mixed>,
+      opts: TraverseOptions<unknown>,
       state: any,
       parentPath: NodePath<>,
     ): TraversalContext;
@@ -298,12 +298,12 @@ declare module '@babel/traverse' {
     parent: BabelNode;
     hub: HubInterface;
     contexts: Array<TraversalContext>;
-    data: {[key: string]: mixed} | null;
+    data: {[key: string]: unknown} | null;
     shouldSkip: boolean;
     shouldStop: boolean;
     removed: boolean;
-    state: mixed;
-    +opts: $ReadOnly<TraverseOptions<mixed>> | null;
+    state: unknown;
+    +opts: $ReadOnly<TraverseOptions<unknown>> | null;
     skipKeys: null | {[key: string]: boolean};
     parentPath: ?NodePath<>;
     context: TraversalContext;
@@ -338,7 +338,7 @@ declare module '@babel/traverse' {
     getScope(scope: Scope): Scope;
 
     setData<TVal>(key: string, val: TVal): TVal;
-    getData<TVal = mixed>(key: string, def?: TVal): TVal;
+    getData<TVal = unknown>(key: string, def?: TVal): TVal;
 
     buildCodeFrameError<TError: Error>(
       msg: string,
@@ -1881,8 +1881,8 @@ declare module '@babel/traverse' {
   declare export var visitors: Visitors;
 
   declare export type Cache = {
-    path: $ReadOnlyWeakMap<BabelNode, mixed>,
-    scope: $ReadOnlyWeakMap<BabelNode, mixed>,
+    path: $ReadOnlyWeakMap<BabelNode, unknown>,
+    scope: $ReadOnlyWeakMap<BabelNode, unknown>,
     clear(): void,
     clearPath(): void,
     clearScope(): void,

--- a/flow-typed/npm/babel_v7.x.x.js
+++ b/flow-typed/npm/babel_v7.x.x.js
@@ -304,9 +304,9 @@ declare module '@babel/core' {
 
   declare class Store {
     constructor(): Store;
-    setDynamic(key: string, fn: () => mixed): void;
-    set(key: string, val: mixed): void;
-    get(key: string): mixed;
+    setDynamic(key: string, fn: () => unknown): void;
+    set(key: string, val: unknown): void;
+    get(key: string): unknown;
   }
 
   declare export class File extends Store {
@@ -367,7 +367,7 @@ declare module '@babel/core' {
 
     transform(): TransformResult<>;
 
-    wrap(code: string, callback: () => mixed): TransformResult<>;
+    wrap(code: string, callback: () => unknown): TransformResult<>;
 
     addCode(code: string): void;
 
@@ -394,7 +394,7 @@ declare module '@babel/core' {
 
   declare export type PluginObj<TVisitorState = void> = {
     name?: string,
-    inherits?: mixed,
+    inherits?: unknown,
     maniuplateOptions?: (
       opts: BabelCoreOptions,
       parserOpts: ParserOptions,
@@ -411,7 +411,7 @@ declare module '@babel/core' {
   // but have not yet been executed to call functions with options.
   declare export type UnloadedDescriptor = {
     name: string | void,
-    value: PluginObj<mixed> | (() => PluginObj<mixed>),
+    value: PluginObj<unknown> | (() => PluginObj<unknown>),
     options: EntryOptions,
     dirname: string,
     alias: string,
@@ -423,7 +423,7 @@ declare module '@babel/core' {
   };
 
   declare export class ConfigItem {
-    +value: PluginObj<mixed> | (() => PluginObj<mixed>);
+    +value: PluginObj<unknown> | (() => PluginObj<unknown>);
     +options: EntryOptions;
     +dirname: string;
     +name: string | void;
@@ -924,8 +924,8 @@ declare module '@babel/core' {
   |};
 
   declare type TransformCallback<TMetadata> =
-    | ((Error, null) => mixed)
-    | ((null, TransformResult<TMetadata> | null) => mixed);
+    | ((Error, null) => unknown)
+    | ((null, TransformResult<TMetadata> | null) => unknown);
 
   /**
    * Transforms the passed in code. Calling a callback with an object with the generated code, source map, and AST.
@@ -1059,20 +1059,20 @@ declare module '@babel/core' {
 
   declare export type ResolvedConfig = {
     options: BabelCoreOptions,
-    passes: Array<Array<PluginObj<mixed> | (() => PluginObj<mixed>)>>,
+    passes: Array<Array<PluginObj<unknown> | (() => PluginObj<unknown>)>>,
   };
 
   declare export function loadOptions(
-    options?: mixed,
+    options?: unknown,
     callback:
-      | ((error: Error, null) => mixed)
-      | ((null, config: ResolvedConfig | null) => mixed),
+      | ((error: Error, null) => unknown)
+      | ((null, config: ResolvedConfig | null) => unknown),
   ): void;
   declare export function loadOptionsSync(
-    options?: mixed,
+    options?: unknown,
   ): ResolvedConfig | null;
   declare export function loadOptionsAsync(
-    options?: mixed,
+    options?: unknown,
   ): Promise<ResolvedConfig | null>;
 
   // For now
@@ -1090,16 +1090,16 @@ declare module '@babel/core' {
   }
 
   declare export function loadPartialConfig(
-    options?: mixed,
+    options?: unknown,
     callback:
-      | ((error: Error, null) => mixed)
-      | ((null, config: PartialConfig | null) => mixed),
+      | ((error: Error, null) => unknown)
+      | ((null, config: PartialConfig | null) => unknown),
   ): void;
   declare export function loadPartialConfigSync(
-    options?: mixed,
+    options?: unknown,
   ): PartialConfig | null;
   declare export function loadPartialConfigAsync(
-    options?: mixed,
+    options?: unknown,
   ): Promise<PartialConfig | null>;
 }
 
@@ -1189,7 +1189,7 @@ declare module '@babel/generator' {
     jsecsOption?: {...},
 
     decoratorsBeforeExport?: boolean,
-    recordAndTupleSyntaxType?: mixed,
+    recordAndTupleSyntaxType?: unknown,
 
     /**
      * Enable generating source maps
@@ -1283,13 +1283,13 @@ declare module '@babel/template' {
     (tpl: string, opts: ?PublicOpts): (?PublicReplacements) => T,
 
     // Building from a template literal produces an AST builder function by default.
-    (tpl: Array<string>, ...args: Array<mixed>): (?PublicReplacements) => T,
+    (tpl: Array<string>, ...args: Array<unknown>): (?PublicReplacements) => T,
 
     // Allow users to explicitly create templates that produce ASTs, skipping
     // the need for an intermediate function.
     ast: {
       (tpl: string, opts: ?PublicOpts): T,
-      (tpl: Array<string>, ...args: Array<mixed>): T,
+      (tpl: Array<string>, ...args: Array<unknown>): T,
     },
   };
 
@@ -1321,14 +1321,17 @@ declare module '@babel/template' {
     // Building from a template literal produces an AST builder function by default.
     (
       tpl: Array<string>,
-      ...args: Array<mixed>
+      ...args: Array<unknown>
     ): (?PublicReplacements) => Statement | Array<Statement>,
 
     // Allow users to explicitly create templates that produce ASTs, skipping
     // the need for an intermediate function.
     ast: {
       (tpl: string, opts: ?PublicOpts): Statement | Array<Statement>,
-      (tpl: Array<string>, ...args: Array<mixed>): Statement | Array<Statement>,
+      (
+        tpl: Array<string>,
+        ...args: Array<unknown>
+      ): Statement | Array<Statement>,
     },
   };
 

--- a/flow-typed/npm/chrome-launcher_v0.15.x.js
+++ b/flow-typed/npm/chrome-launcher_v0.15.x.js
@@ -16,7 +16,7 @@ declare module 'chrome-launcher' {
   declare export type Options = {
     startingUrl?: string,
     chromeFlags?: Array<string>,
-    prefs?: mixed,
+    prefs?: unknown,
     port?: number,
     handleSIGINT?: boolean,
     chromePath?: string,

--- a/flow-typed/npm/chromium-edge-launcher_v0.2.x.js
+++ b/flow-typed/npm/chromium-edge-launcher_v0.2.x.js
@@ -16,7 +16,7 @@ declare module 'chromium-edge-launcher' {
   declare export type Options = {
     startingUrl?: string,
     edgeFlags?: Array<string>,
-    prefs?: mixed,
+    prefs?: unknown,
     port?: number,
     handleSIGINT?: boolean,
     edgePath?: string,

--- a/flow-typed/npm/connect_v3.x.x.js
+++ b/flow-typed/npm/connect_v3.x.x.js
@@ -13,7 +13,7 @@ declare module 'connect' {
 
   declare export type ServerHandle = HandleFunction | http.Server;
 
-  declare type NextFunction = (err?: mixed) => void;
+  declare type NextFunction = (err?: unknown) => void;
 
   declare export type NextHandleFunction = (
     req: IncomingMessage,

--- a/flow-typed/npm/debug_v4.4.x.js
+++ b/flow-typed/npm/debug_v4.4.x.js
@@ -12,15 +12,15 @@
 
 declare module 'debug' {
   declare interface Formatters {
-    [formatter: string]: (v: mixed) => string;
+    [formatter: string]: (v: unknown) => string;
   }
 
   declare type Debugger = {|
-    (format: mixed, ...args: Array<mixed>): void,
+    (format: unknown, ...args: Array<unknown>): void,
     color: string,
     diff: number,
     enabled: boolean,
-    log: (format: mixed, ...args: Array<mixed>) => mixed,
+    log: (format: unknown, ...args: Array<unknown>) => unknown,
     namespace: string,
     destroy: () => boolean,
     extend: (namespace: string, delimiter?: string) => Debugger,
@@ -28,12 +28,12 @@ declare module 'debug' {
 
   declare type Debug = {|
     (namespace: string): Debugger,
-    coerce: (val: mixed) => mixed,
+    coerce: (val: unknown) => unknown,
     disable: () => string,
     enable: (namespaces: string) => void,
     enabled: (namespaces: string) => boolean,
-    formatArgs: (args: Array<mixed>) => void,
-    log: (format: mixed, ...args: Array<mixed>) => mixed,
+    formatArgs: (args: Array<unknown>) => void,
+    log: (format: unknown, ...args: Array<unknown>) => unknown,
     selectColor: (namespace: string) => string | number,
     // this should be of type require('ms') but it doesn't play nicely with eslint
     // unless we add ms to dependencies, which we don't want to do

--- a/flow-typed/npm/deep-equal_v1.x.x.js
+++ b/flow-typed/npm/deep-equal_v1.x.x.js
@@ -10,8 +10,8 @@
 
 declare module 'deep-equal' {
   declare module.exports: (
-    actual: mixed,
-    expected: mixed,
+    actual: unknown,
+    expected: unknown,
     options?: {strict: boolean},
   ) => boolean;
 }

--- a/flow-typed/npm/jest-diff_v29.x.x.js
+++ b/flow-typed/npm/jest-diff_v29.x.x.js
@@ -32,8 +32,8 @@ declare module 'jest-diff' {
   };
 
   declare export function diff(
-    a: mixed,
-    b: mixed,
+    a: unknown,
+    b: unknown,
     options?: DiffOptions,
   ): string | null;
 }

--- a/flow-typed/npm/jest-snapshot_v29.x.x.js
+++ b/flow-typed/npm/jest-snapshot_v29.x.x.js
@@ -33,7 +33,7 @@ declare module 'jest-snapshot' {
 
   declare export function isSnapshotPath(path: string): boolean;
 
-  type LocalRequire = (module: string) => mixed;
+  type LocalRequire = (module: string) => unknown;
 
   declare export function buildSnapshotResolver(
     config: ProjectConfig,

--- a/flow-typed/npm/jest.js
+++ b/flow-typed/npm/jest.js
@@ -13,7 +13,7 @@
 
 // MODIFIED: Added ESLint suppression comment - no-unused-vars doesn't understand declaration files
 
-type JestMockFn<TArguments: $ReadOnlyArray<mixed>, TReturn> = {
+type JestMockFn<TArguments: $ReadOnlyArray<unknown>, TReturn> = {
   (...args: TArguments): TReturn,
   /**
    * An object for introspecting mock calls
@@ -39,7 +39,7 @@ type JestMockFn<TArguments: $ReadOnlyArray<mixed>, TReturn> = {
     /**
      * An array that contains the contexts for all calls of the mock function.
      */
-    contexts: Array<mixed>,
+    contexts: Array<unknown>,
     /**
      * An array that contains all the object results that have been
      * returned by this mock function call
@@ -129,17 +129,17 @@ type JestAsymmetricEqualityType = {
   /**
    * A custom Jasmine equality tester
    */
-  asymmetricMatch(value: mixed): boolean,
+  asymmetricMatch(value: unknown): boolean,
   ...
 };
 
 type JestCallsType = {
-  allArgs(): mixed,
-  all(): mixed,
+  allArgs(): unknown,
+  all(): unknown,
   any(): boolean,
   count(): number,
-  first(): mixed,
-  mostRecent(): mixed,
+  first(): unknown,
+  mostRecent(): unknown,
   reset(): void,
   ...
 };
@@ -881,7 +881,7 @@ type JestObjectType = {
    * implementation.
    */
   // MODIFIED: Added defaults to type arguments.
-  fn<TArguments: $ReadOnlyArray<mixed> = $ReadOnlyArray<any>, TReturn = any>(
+  fn<TArguments: $ReadOnlyArray<unknown> = $ReadOnlyArray<any>, TReturn = any>(
     implementation?: (...args: TArguments) => TReturn,
   ): JestMockFn<TArguments, TReturn>,
   /**
@@ -1005,22 +1005,22 @@ type JestDoneFn = {
 
 /** Runs this function after every test inside this context */
 declare function afterEach(
-  fn: (done: JestDoneFn) => ?Promise<mixed>,
+  fn: (done: JestDoneFn) => ?Promise<unknown>,
   timeout?: number,
 ): void;
 /** Runs this function before every test inside this context */
 declare function beforeEach(
-  fn: (done: JestDoneFn) => ?Promise<mixed>,
+  fn: (done: JestDoneFn) => ?Promise<unknown>,
   timeout?: number,
 ): void;
 /** Runs this function after all tests have finished inside this context */
 declare function afterAll(
-  fn: (done: JestDoneFn) => ?Promise<mixed>,
+  fn: (done: JestDoneFn) => ?Promise<unknown>,
   timeout?: number,
 ): void;
 /** Runs this function before any tests have started inside this context */
 declare function beforeAll(
-  fn: (done: JestDoneFn) => ?Promise<mixed>,
+  fn: (done: JestDoneFn) => ?Promise<unknown>,
   timeout?: number,
 ): void;
 
@@ -1045,11 +1045,11 @@ declare var describe: {
    */
   each(
     ...table:
-      | $ReadOnlyArray<$ReadOnlyArray<mixed> | mixed>
+      | $ReadOnlyArray<$ReadOnlyArray<unknown> | unknown>
       | [$ReadOnlyArray<string>, string]
   ): (
     name: JestTestName,
-    fn?: (...args: $ReadOnlyArray<any>) => ?Promise<mixed>,
+    fn?: (...args: $ReadOnlyArray<any>) => ?Promise<unknown>,
     timeout?: number,
   ) => void,
   ...
@@ -1066,7 +1066,7 @@ declare var it: {
    */
   (
     name: JestTestName,
-    fn?: (done: JestDoneFn) => ?Promise<mixed>,
+    fn?: (done: JestDoneFn) => ?Promise<unknown>,
     timeout?: number,
   ): void,
   /**
@@ -1079,14 +1079,14 @@ declare var it: {
   only: {
     (
       name: JestTestName,
-      fn?: (done: JestDoneFn) => ?Promise<mixed>,
+      fn?: (done: JestDoneFn) => ?Promise<unknown>,
       timeout?: number,
     ): void,
     each(
-      ...table: Array<Array<mixed> | mixed> | [Array<string>, string]
+      ...table: Array<Array<unknown> | unknown> | [Array<string>, string]
     ): (
       name: JestTestName,
-      fn?: (...args: Array<any>) => ?Promise<mixed>,
+      fn?: (...args: Array<any>) => ?Promise<unknown>,
       timeout?: number,
     ) => void,
   },
@@ -1100,14 +1100,14 @@ declare var it: {
   skip: {
     (
       name: JestTestName,
-      fn?: (done: JestDoneFn) => ?Promise<mixed>,
+      fn?: (done: JestDoneFn) => ?Promise<unknown>,
       timeout?: number,
     ): void,
     each(
-      ...table: Array<Array<mixed> | mixed> | [Array<string>, string]
+      ...table: Array<Array<unknown> | unknown> | [Array<string>, string]
     ): (
       name: JestTestName,
-      fn?: (...args: Array<any>) => ?Promise<mixed>,
+      fn?: (...args: Array<any>) => ?Promise<unknown>,
       timeout?: number,
     ) => void,
   },
@@ -1126,7 +1126,7 @@ declare var it: {
    */
   concurrent(
     name: JestTestName,
-    fn?: (done: JestDoneFn) => ?Promise<mixed>,
+    fn?: (done: JestDoneFn) => ?Promise<unknown>,
     timeout?: number,
   ): void,
   /**
@@ -1136,11 +1136,11 @@ declare var it: {
    */
   each(
     ...table:
-      | $ReadOnlyArray<$ReadOnlyArray<mixed> | mixed>
+      | $ReadOnlyArray<$ReadOnlyArray<unknown> | unknown>
       | [$ReadOnlyArray<string>, string]
   ): (
     name: JestTestName,
-    fn?: (...args: Array<any>) => ?Promise<mixed>,
+    fn?: (...args: Array<any>) => ?Promise<unknown>,
     timeout?: number,
   ) => void,
   ...
@@ -1148,7 +1148,7 @@ declare var it: {
 
 declare function fit(
   name: JestTestName,
-  fn: (done: JestDoneFn) => ?Promise<mixed>,
+  fn: (done: JestDoneFn) => ?Promise<unknown>,
   timeout?: number,
 ): void;
 /** An individual test unit */
@@ -1249,16 +1249,16 @@ declare var expect: {
   addSnapshotSerializer(pluginModule: JestPrettyFormatPlugin): void,
   assertions(expectedAssertions: number): void,
   hasAssertions(): void,
-  any(value: mixed): JestAsymmetricEqualityType,
+  any(value: unknown): JestAsymmetricEqualityType,
   anything(): any,
   // MODIFIED: Array -> $ReadOnlyArray
-  arrayContaining(value: $ReadOnlyArray<mixed>): Array<mixed>,
+  arrayContaining(value: $ReadOnlyArray<unknown>): Array<unknown>,
   objectContaining(value: Object): Object,
   /** Matches any received string that contains the exact expected string. */
   stringContaining(value: string): string,
   stringMatching(value: string | RegExp): string,
   not: {
-    arrayContaining: (value: $ReadOnlyArray<mixed>) => Array<mixed>,
+    arrayContaining: (value: $ReadOnlyArray<unknown>) => Array<unknown>,
     objectContaining: (value: {...}) => Object,
     stringContaining: (value: string) => string,
     stringMatching: (value: string | RegExp) => string,
@@ -1269,7 +1269,7 @@ declare var expect: {
 
 // TODO handle return type
 // http://jasmine.github.io/2.4/introduction.html#section-Spies
-declare function spyOn(value: mixed, method: string): Object;
+declare function spyOn(value: unknown, method: string): Object;
 
 /** Holds all functions related to manipulating test runner */
 declare var jest: JestObjectType;
@@ -1280,9 +1280,9 @@ declare var jest: JestObjectType;
  */
 declare var jasmine: {
   DEFAULT_TIMEOUT_INTERVAL: number,
-  any(value: mixed): JestAsymmetricEqualityType,
+  any(value: unknown): JestAsymmetricEqualityType,
   anything(): any,
-  arrayContaining(value: Array<mixed>): Array<mixed>,
+  arrayContaining(value: Array<unknown>): Array<unknown>,
   clock(): JestClockType,
   createSpy(name: string): JestSpyType,
   createSpyObj(

--- a/flow-typed/npm/listr2_v8.x.x.js
+++ b/flow-typed/npm/listr2_v8.x.x.js
@@ -8,7 +8,7 @@
 declare module 'listr2' {
   declare export type TaskResult<
     ContextT = {__proto__: null},
-    ReturnT = mixed,
+    ReturnT = unknown,
   > =
     | ReturnT
     | Promise<ReturnT>
@@ -35,7 +35,7 @@ declare module 'listr2' {
 
   declare export type TaskSpec<
     ContextT = {__proto__: null},
-    ReturnT = mixed,
+    ReturnT = unknown,
   > = {
     title: string,
     task: TaskFn<ContextT, ReturnT>,

--- a/flow-typed/npm/listr_v14.x.x.js
+++ b/flow-typed/npm/listr_v14.x.x.js
@@ -8,7 +8,7 @@
 declare module 'listr' {
   declare export type TaskResult<
     ContextT = {__proto__: null},
-    ReturnT = mixed,
+    ReturnT = unknown,
   > =
     | ReturnT
     | Promise<ReturnT>
@@ -35,7 +35,7 @@ declare module 'listr' {
 
   declare export type TaskSpec<
     ContextT = {__proto__: null},
-    ReturnT = mixed,
+    ReturnT = unknown,
   > = {
     title: string,
     task: TaskFn<ContextT, ReturnT>,

--- a/flow-typed/npm/node-fetch_v2.x.x.js
+++ b/flow-typed/npm/node-fetch_v2.x.x.js
@@ -20,8 +20,8 @@ declare module 'node-fetch' {
     +aborted: boolean,
     +onabort: (event?: {...}) => void,
 
-    +addEventListener: (name: string, cb: () => mixed) => void,
-    +removeEventListener: (name: string, cb: () => mixed) => void,
+    +addEventListener: (name: string, cb: () => unknown) => void,
+    +removeEventListener: (name: string, cb: () => unknown) => void,
     +dispatchEvent: (event: {...}) => void,
     ...
   };

--- a/flow-typed/npm/pretty-format_v29.x.x.js
+++ b/flow-typed/npm/pretty-format_v29.x.x.js
@@ -4,7 +4,7 @@
  * @flow strict
  * @format
  */
-declare type Print = (value: mixed) => string;
+declare type Print = (value: unknown) => string;
 declare type Indent = (value: string) => string;
 declare type PluginOptions = {
   edgeSpacing: string,
@@ -22,17 +22,17 @@ declare type Colors = {
 declare type PrettyFormatPlugin =
   | {
       print: (
-        value: mixed,
+        value: unknown,
         print?: ?Print,
         indent?: ?Indent,
         options?: ?PluginOptions,
         colors?: ?Colors,
       ) => string,
-      test: (value: mixed) => boolean,
+      test: (value: unknown) => boolean,
     }
   | {
-      serialize: (value: mixed) => string,
-      test: (value: mixed) => boolean,
+      serialize: (value: unknown) => string,
+      test: (value: unknown) => boolean,
     };
 
 declare module 'pretty-format' {
@@ -41,7 +41,7 @@ declare module 'pretty-format' {
     | null
     | void;
   declare export function format(
-    value: mixed,
+    value: unknown,
     options?: ?{
       callToJSON?: ?boolean,
       compareKeys?: CompareKeys,

--- a/flow-typed/npm/promise_v8.x.x.js
+++ b/flow-typed/npm/promise_v8.x.x.js
@@ -19,10 +19,10 @@ declare module 'promise/setimmediate/rejection-tracking' {
   declare module.exports: {
     enable: (
       options?: ?{
-        whitelist?: ?Array<mixed>,
+        whitelist?: ?Array<unknown>,
         allRejections?: ?boolean,
-        onUnhandled?: ?(number, mixed) => void,
-        onHandled?: ?(number, mixed) => void,
+        onUnhandled?: ?(number, unknown) => void,
+        onHandled?: ?(number, unknown) => void,
       },
     ) => void,
     disable: () => void,

--- a/flow-typed/npm/rxjs_v6.x.x.js
+++ b/flow-typed/npm/rxjs_v6.x.x.js
@@ -52,7 +52,7 @@ declare type rxjs$ObservableInput<T> =
   | Iterable<T>;
 
 declare type rxjs$InteropObservable<T> = {
-  [string | mixed]: () => rxjs$Subscribable<T>,
+  [string | unknown]: () => rxjs$Subscribable<T>,
   ...
 };
 /** OBSERVER INTERFACES */
@@ -371,7 +371,7 @@ declare module 'rxjs' {
     iif: typeof rxjs$iif,
     ConnectableObservable: typeof rxjs$ConnectableObservable,
     GroupedObservable: typeof rxjs$GroupedObservable,
-    observable: string | mixed,
+    observable: string | unknown,
     Subject: typeof rxjs$Subject,
     BehaviorSubject: typeof BehaviorSubject,
     ReplaySubject: typeof ReplaySubject,
@@ -598,7 +598,7 @@ declare module 'rxjs' {
     UnsubscriptionError: UnsubscriptionError,
     TimeoutError: TimeoutError,
     fromEvent: <T>(
-      target: mixed,
+      target: unknown,
       eventName: string,
       options?: rxjs$EventListenerOptions | ((...args: any[]) => T),
       // @deprecated resultSelector no longer supported, pipe to map instead
@@ -971,7 +971,7 @@ declare module 'rxjs' {
           ) => any,
         ) => any,
         scheduler?: rxjs$SchedulerLike,
-      ) => () => rxjs$Observable<mixed[]>) &
+      ) => () => rxjs$Observable<unknown[]>) &
       (<R1, R2, R3>(
         callbackFunc: (callback: (res1: R1, res2: R2, res3: R3) => any) => any,
         scheduler?: rxjs$SchedulerLike,
@@ -1000,7 +1000,7 @@ declare module 'rxjs' {
           ) => any,
         ) => any,
         scheduler?: rxjs$SchedulerLike,
-      ) => (arg1: A1) => rxjs$Observable<mixed[]>) &
+      ) => (arg1: A1) => rxjs$Observable<unknown[]>) &
       (<A1, R1, R2, R3>(
         callbackFunc: (
           arg1: A1,
@@ -1033,7 +1033,7 @@ declare module 'rxjs' {
           ) => any,
         ) => any,
         scheduler?: rxjs$SchedulerLike,
-      ) => (arg1: A1, arg2: A2) => rxjs$Observable<mixed[]>) &
+      ) => (arg1: A1, arg2: A2) => rxjs$Observable<unknown[]>) &
       (<A1, A2, R1, R2, R3>(
         callbackFunc: (
           arg1: A1,
@@ -1072,7 +1072,7 @@ declare module 'rxjs' {
           ) => any,
         ) => any,
         scheduler?: rxjs$SchedulerLike,
-      ) => (arg1: A1, arg2: A2, arg3: A3) => rxjs$Observable<mixed[]>) &
+      ) => (arg1: A1, arg2: A2, arg3: A3) => rxjs$Observable<unknown[]>) &
       (<A1, A2, A3, R1, R2, R3>(
         callbackFunc: (
           arg1: A1,
@@ -1129,7 +1129,7 @@ declare module 'rxjs' {
         arg2: A2,
         arg3: A3,
         arg4: A4,
-      ) => rxjs$Observable<mixed[]>) &
+      ) => rxjs$Observable<unknown[]>) &
       (<A1, A2, A3, A4, R1, R2, R3>(
         callbackFunc: (
           arg1: A1,
@@ -1202,7 +1202,7 @@ declare module 'rxjs' {
         arg3: A3,
         arg4: A4,
         arg5: A5,
-      ) => rxjs$Observable<mixed[]>) &
+      ) => rxjs$Observable<unknown[]>) &
       (<A1, A2, A3, A4, A5, R1, R2, R3>(
         callbackFunc: (
           arg1: A1,
@@ -1301,7 +1301,7 @@ declare module 'rxjs' {
           ) => any,
         ) => any,
         scheduler?: rxjs$SchedulerLike,
-      ) => (...args: any[]) => rxjs$Observable<mixed[]>) &
+      ) => (...args: any[]) => rxjs$Observable<unknown[]>) &
       (<R1, R2, R3>(
         callbackFunc: (
           callback: (err: any, res1: R1, res2: R2, res3: R3) => any,
@@ -1370,7 +1370,7 @@ declare module 'rxjs' {
           ) => any,
         ) => any,
         scheduler?: rxjs$SchedulerLike,
-      ) => (...args: any[]) => rxjs$Observable<mixed[]>) &
+      ) => (...args: any[]) => rxjs$Observable<unknown[]>) &
       (<A1, A2, R1, R2, R3>(
         callbackFunc: (
           arg1: A1,
@@ -1467,7 +1467,7 @@ declare module 'rxjs' {
           ) => any,
         ) => any,
         scheduler?: rxjs$SchedulerLike,
-      ) => (...args: any[]) => rxjs$Observable<mixed[]>) &
+      ) => (...args: any[]) => rxjs$Observable<unknown[]>) &
       (<A1, A2, A3, A4, R1, R2, R3>(
         callbackFunc: (
           arg1: A1,
@@ -1535,7 +1535,7 @@ declare module 'rxjs' {
           ) => any,
         ) => any,
         scheduler?: rxjs$SchedulerLike,
-      ) => (...args: any[]) => rxjs$Observable<mixed[]>) &
+      ) => (...args: any[]) => rxjs$Observable<unknown[]>) &
       (<A1, A2, A3, A4, A5, R1, R2, R3>(
         callbackFunc: (
           arg1: A1,
@@ -1607,7 +1607,7 @@ declare module 'rxjs' {
       ((
         callbackFunc: Function,
         scheduler?: rxjs$SchedulerLike,
-      ) => (...args: any[]) => rxjs$Observable<mixed[]>),
+      ) => (...args: any[]) => rxjs$Observable<unknown[]>),
     // @deprecated resultSelector no longer supported, pipe to map instead
     combineLatest: (<T, R>(
       v1: rxjs$ObservableInput<T>,
@@ -1833,12 +1833,12 @@ declare module 'rxjs' {
   }
 
   declare class AsapScheduler extends AsyncScheduler {
-    flush(action?: AsyncAction<mixed>): void;
+    flush(action?: AsyncAction<unknown>): void;
   }
 
   declare class AsyncScheduler extends Scheduler {
     static delegate: Scheduler;
-    actions: Array<AsyncAction<mixed>>;
+    actions: Array<AsyncAction<unknown>>;
     // @deprecated  internal use only
     active: boolean;
     // @deprecated  internal use only
@@ -1849,26 +1849,30 @@ declare module 'rxjs' {
       delay?: number,
       state?: T,
     ): rxjs$Subscription;
-    flush(action: AsyncAction<mixed>): void;
+    flush(action: AsyncAction<unknown>): void;
   }
 
   declare class QueueScheduler extends AsyncScheduler {}
 
   declare class AnimationFrameScheduler extends AsyncScheduler {
-    flush(action?: AsyncAction<mixed>): void;
+    flush(action?: AsyncAction<unknown>): void;
   }
 
   declare class AsyncAction<T> extends Action<T> {
     scheduler: AsyncScheduler;
     work: (state?: T) => void;
-    id: mixed;
+    id: unknown;
     state: T;
     delay: number;
     pending: boolean;
     constructor(scheduler: AsyncScheduler, work: (state?: T) => void): void;
     schedule(state?: T, delay?: number): rxjs$Subscription;
-    requestAsyncId(scheduler: AsyncScheduler, id?: mixed, delay?: number): any;
-    recycleAsyncId(scheduler: AsyncScheduler, id: mixed, delay?: number): any;
+    requestAsyncId(
+      scheduler: AsyncScheduler,
+      id?: unknown,
+      delay?: number,
+    ): any;
+    recycleAsyncId(scheduler: AsyncScheduler, id: unknown, delay?: number): any;
     execute(state: T, delay: number): any;
     _execute(state: T, delay: number): any;
     // @deprecated  This is an internal implementation detail, do not use.
@@ -1883,7 +1887,7 @@ declare module 'rxjs' {
 
 declare module 'rxjs/operators' {
   declare export function audit<T>(
-    durationSelector: (value: T) => rxjs$SubscribableOrPromise<mixed>,
+    durationSelector: (value: T) => rxjs$SubscribableOrPromise<unknown>,
   ): rxjs$MonoTypeOperatorFunction<T>;
 
   declare export function auditTime<T>(
@@ -1920,11 +1924,11 @@ declare module 'rxjs/operators' {
 
   declare export function bufferToggle<T, O>(
     openings: rxjs$SubscribableOrPromise<O>,
-    closingSelector: (value: O) => rxjs$SubscribableOrPromise<mixed>,
+    closingSelector: (value: O) => rxjs$SubscribableOrPromise<unknown>,
   ): rxjs$OperatorFunction<T, T[]>;
 
   declare export function bufferWhen<T>(
-    closingSelector: () => rxjs$Observable<mixed>,
+    closingSelector: () => rxjs$Observable<unknown>,
   ): rxjs$OperatorFunction<T, T[]>;
 
   // declare export function catchError<T>(selector: (err: any, caught: rxjs$Observable<T>) => empty): rxjs$MonoTypeOperatorFunction<T>;
@@ -1938,15 +1942,15 @@ declare module 'rxjs/operators' {
     T[],
   >;
 
-  declare export function combineAll<T>(): rxjs$OperatorFunction<mixed, T[]>;
+  declare export function combineAll<T>(): rxjs$OperatorFunction<unknown, T[]>;
 
   declare export function combineAll<T, R>(
     project: (...values: T[]) => R,
   ): rxjs$OperatorFunction<rxjs$ObservableInput<T>, R>;
 
   declare export function combineAll<R>(
-    project: (...values: Array<mixed>) => R,
-  ): rxjs$OperatorFunction<mixed, R>;
+    project: (...values: Array<unknown>) => R,
+  ): rxjs$OperatorFunction<unknown, R>;
 
   // @deprecated Deprecated in favor of static combineLatest.
   declare export function combineLatest<T, R>(
@@ -2095,7 +2099,7 @@ declare module 'rxjs/operators' {
   ): rxjs$MonoTypeOperatorFunction<T>;
   // @deprecated Deprecated in favor of static concat.
   declare export function concat<T, R>(
-    ...observables: Array<rxjs$ObservableInput<mixed> | rxjs$SchedulerLike>
+    ...observables: Array<rxjs$ObservableInput<unknown> | rxjs$SchedulerLike>
   ): rxjs$OperatorFunction<T, R>;
 
   declare export function concatAll<T>(): rxjs$OperatorFunction<
@@ -2103,7 +2107,7 @@ declare module 'rxjs/operators' {
     T,
   >;
 
-  declare export function concatAll<R>(): rxjs$OperatorFunction<mixed, R>;
+  declare export function concatAll<R>(): rxjs$OperatorFunction<unknown, R>;
 
   declare export function concatMap<T, I, R>(
     project: (value: T, index: number) => rxjs$ObservableInput<I | R>,
@@ -2117,13 +2121,13 @@ declare module 'rxjs/operators' {
 
   declare export function concatMapTo<T>(
     observable: rxjs$ObservableInput<T>,
-  ): rxjs$OperatorFunction<mixed, T>;
+  ): rxjs$OperatorFunction<unknown, T>;
 
   // @deprecated
   declare export function concatMapTo<T>(
     observable: rxjs$ObservableInput<T>,
     resultSelector: void,
-  ): rxjs$OperatorFunction<mixed, T>;
+  ): rxjs$OperatorFunction<unknown, T>;
   // @deprecated
   declare export function concatMapTo<T, I, R>(
     observable: rxjs$ObservableInput<I>,
@@ -2144,7 +2148,7 @@ declare module 'rxjs/operators' {
   ): rxjs$OperatorFunction<T, number>;
 
   declare export function debounce<T>(
-    durationSelector: (value: T) => rxjs$SubscribableOrPromise<mixed>,
+    durationSelector: (value: T) => rxjs$SubscribableOrPromise<unknown>,
   ): rxjs$MonoTypeOperatorFunction<T>;
 
   declare export function debounceTime<T>(
@@ -2162,8 +2166,11 @@ declare module 'rxjs/operators' {
   ): rxjs$MonoTypeOperatorFunction<T>;
 
   declare export function delayWhen<T>(
-    delayDurationSelector: (value: T, index: number) => rxjs$Observable<mixed>,
-    subscriptionDelay?: rxjs$Observable<mixed>,
+    delayDurationSelector: (
+      value: T,
+      index: number,
+    ) => rxjs$Observable<unknown>,
+    subscriptionDelay?: rxjs$Observable<unknown>,
   ): rxjs$MonoTypeOperatorFunction<T>;
 
   declare export function dematerialize<T>(): rxjs$OperatorFunction<
@@ -2173,7 +2180,7 @@ declare module 'rxjs/operators' {
 
   declare export function distinct<T, K>(
     keySelector?: (value: T) => K,
-    flushes?: rxjs$Observable<mixed>,
+    flushes?: rxjs$Observable<unknown>,
   ): rxjs$MonoTypeOperatorFunction<T>;
 
   declare export function distinctUntilChanged<T>(
@@ -2191,7 +2198,7 @@ declare module 'rxjs/operators' {
 
   declare export function distinctUntilKeyChanged<T, K: $Keys<T>>(
     key: K,
-    compare: (x: mixed, y: mixed) => boolean,
+    compare: (x: unknown, y: unknown) => boolean,
   ): rxjs$MonoTypeOperatorFunction<T>;
 
   declare export function elementAt<T>(
@@ -2259,7 +2266,7 @@ declare module 'rxjs/operators' {
     T,
   >;
 
-  declare export function exhaust<R>(): rxjs$OperatorFunction<mixed, R>;
+  declare export function exhaust<R>(): rxjs$OperatorFunction<unknown, R>;
 
   declare export function exhaustMap<T, I, R>(
     project: (value: T, index: number) => rxjs$ObservableInput<I | R>,
@@ -2334,7 +2341,7 @@ declare module 'rxjs/operators' {
     elementSelector: void,
     durationSelector: (
       grouped: rxjs$GroupedObservable<K, T>,
-    ) => rxjs$Observable<mixed>,
+    ) => rxjs$Observable<unknown>,
   ): rxjs$OperatorFunction<T, rxjs$GroupedObservable<K, T>>;
 
   declare export function groupBy<T, K, R>(
@@ -2342,7 +2349,7 @@ declare module 'rxjs/operators' {
     elementSelector?: (value: T) => R,
     durationSelector?: (
       grouped: rxjs$GroupedObservable<K, R>,
-    ) => rxjs$Observable<mixed>,
+    ) => rxjs$Observable<unknown>,
     subjectSelector?: () => rxjs$Subject<R>,
   ): rxjs$OperatorFunction<T, rxjs$GroupedObservable<K, R>>;
 
@@ -2487,7 +2494,7 @@ declare module 'rxjs/operators' {
   // @deprecated Deprecated in favor of static merge.
   declare export function merge<T, R>(
     ...observables: Array<
-      rxjs$ObservableInput<mixed> | rxjs$SchedulerLike | number,
+      rxjs$ObservableInput<unknown> | rxjs$SchedulerLike | number,
     >
   ): rxjs$OperatorFunction<T, R>;
 
@@ -2517,7 +2524,7 @@ declare module 'rxjs/operators' {
   declare export function mergeMapTo<T>(
     innerObservable: rxjs$ObservableInput<T>,
     concurrent?: number,
-  ): rxjs$OperatorFunction<mixed, T>;
+  ): rxjs$OperatorFunction<unknown, T>;
 
   // @deprecated
   declare export function mergeMapTo<T, I, R>(
@@ -2600,12 +2607,12 @@ declare module 'rxjs/operators' {
 
   declare export function onErrorResumeNext<T, R>(
     ...observables: Array<
-      rxjs$ObservableInput<mixed> | ((...values: Array<mixed>) => R),
+      rxjs$ObservableInput<unknown> | ((...values: Array<unknown>) => R),
     >
   ): rxjs$OperatorFunction<T, R>;
 
   declare export function onErrorResumeNext<T, R>(
-    array: rxjs$ObservableInput<mixed>[],
+    array: rxjs$ObservableInput<unknown>[],
   ): rxjs$OperatorFunction<T, R>;
 
   declare export function onErrorResumeNextStatic<R>(
@@ -2640,12 +2647,12 @@ declare module 'rxjs/operators' {
 
   declare export function onErrorResumeNextStatic<R>(
     ...observables: Array<
-      rxjs$ObservableInput<mixed> | ((...values: Array<any>) => R),
+      rxjs$ObservableInput<unknown> | ((...values: Array<any>) => R),
     >
   ): rxjs$Observable<R>;
 
   declare export function onErrorResumeNextStatic<R>(
-    array: rxjs$ObservableInput<mixed>[],
+    array: rxjs$ObservableInput<unknown>[],
   ): rxjs$Observable<R>;
 
   declare export function pairwise<T>(): rxjs$OperatorFunction<T, [T, T]>;
@@ -2722,7 +2729,7 @@ declare module 'rxjs/operators' {
   // @deprecated Deprecated in favor of static race.
   declare export function race<T, R>(
     ...observables: Array<
-      rxjs$Observable<mixed> | Array<rxjs$Observable<mixed>>,
+      rxjs$Observable<unknown> | Array<rxjs$Observable<unknown>>,
     >
   ): rxjs$OperatorFunction<T, R>;
 
@@ -2745,7 +2752,7 @@ declare module 'rxjs/operators' {
   ): rxjs$MonoTypeOperatorFunction<T>;
 
   declare export function repeatWhen<T>(
-    notifier: (notifications: rxjs$Observable<any>) => rxjs$Observable<mixed>,
+    notifier: (notifications: rxjs$Observable<any>) => rxjs$Observable<unknown>,
   ): rxjs$MonoTypeOperatorFunction<T>;
 
   declare export function retry<T>(
@@ -2753,7 +2760,7 @@ declare module 'rxjs/operators' {
   ): rxjs$MonoTypeOperatorFunction<T>;
 
   declare export function retryWhen<T>(
-    notifier: (errors: rxjs$Observable<any>) => rxjs$Observable<mixed>,
+    notifier: (errors: rxjs$Observable<any>) => rxjs$Observable<unknown>,
   ): rxjs$MonoTypeOperatorFunction<T>;
   // @todo - find out why this used to return: (rxjs$Observable<T>) => rxjs$Observable<T>
 
@@ -2900,7 +2907,7 @@ declare module 'rxjs/operators' {
 
   declare export function switchMapTo<R>(
     observable: rxjs$ObservableInput<R>,
-  ): rxjs$OperatorFunction<mixed, R>;
+  ): rxjs$OperatorFunction<unknown, R>;
 
   // @deprecated resultSelector is no longer supported. Switch to using switchMap with an inner map
   declare export function switchMapTo<T, R>(
@@ -2942,9 +2949,9 @@ declare module 'rxjs/operators' {
   ): rxjs$MonoTypeOperatorFunction<T>;
 
   declare export function tap<T>(
-    next?: (x: T) => mixed,
-    error?: (e: any) => mixed,
-    complete?: () => mixed,
+    next?: (x: T) => unknown,
+    error?: (e: any) => unknown,
+    complete?: () => unknown,
   ): rxjs$MonoTypeOperatorFunction<T>;
 
   declare export function tap<T>(
@@ -2957,7 +2964,7 @@ declare module 'rxjs/operators' {
   }
 
   declare export function throttle<T>(
-    durationSelector: (value: T) => rxjs$SubscribableOrPromise<mixed>,
+    durationSelector: (value: T) => rxjs$SubscribableOrPromise<unknown>,
     config?: ThrottleConfig,
   ): rxjs$MonoTypeOperatorFunction<T>;
 
@@ -2993,7 +3000,7 @@ declare module 'rxjs/operators' {
   declare export function toArray<T>(): rxjs$OperatorFunction<T, T[]>;
 
   declare export function window<T>(
-    windowBoundaries: rxjs$Observable<mixed>,
+    windowBoundaries: rxjs$Observable<unknown>,
   ): rxjs$OperatorFunction<T, rxjs$Observable<T>>;
 
   declare export function windowCount<T>(
@@ -3021,11 +3028,11 @@ declare module 'rxjs/operators' {
 
   declare export function windowToggle<T, O>(
     openings: rxjs$Observable<O>,
-    closingSelector: (openValue: O) => rxjs$Observable<mixed>,
+    closingSelector: (openValue: O) => rxjs$Observable<unknown>,
   ): rxjs$OperatorFunction<T, rxjs$Observable<T>>;
 
   declare export function windowWhen<T>(
-    closingSelector: () => rxjs$Observable<mixed>,
+    closingSelector: () => rxjs$Observable<unknown>,
   ): rxjs$OperatorFunction<T, rxjs$Observable<T>>;
 
   declare export function withLatestFrom<T, R>(
@@ -3099,16 +3106,16 @@ declare module 'rxjs/operators' {
 
   declare export function withLatestFrom<T, R>(
     ...observables: Array<
-      rxjs$ObservableInput<mixed> | ((...values: Array<any>) => R),
+      rxjs$ObservableInput<unknown> | ((...values: Array<any>) => R),
     >
   ): rxjs$OperatorFunction<T, R>;
 
   declare export function withLatestFrom<T, R>(
-    array: rxjs$ObservableInput<mixed>[],
+    array: rxjs$ObservableInput<unknown>[],
   ): rxjs$OperatorFunction<T, R>;
 
   declare export function withLatestFrom<T, R>(
-    array: rxjs$ObservableInput<mixed>[],
+    array: rxjs$ObservableInput<unknown>[],
     project: (...values: Array<any>) => R,
   ): rxjs$OperatorFunction<T, R>;
 
@@ -3215,7 +3222,7 @@ declare module 'rxjs/operators' {
     T[],
   >;
 
-  declare export function zipAll<T>(): rxjs$OperatorFunction<mixed, T[]>;
+  declare export function zipAll<T>(): rxjs$OperatorFunction<unknown, T[]>;
 
   declare export function zipAll<T, R>(
     project: (...values: T[]) => R,
@@ -3223,7 +3230,7 @@ declare module 'rxjs/operators' {
 
   declare export function zipAll<R>(
     project: (...values: Array<any>) => R,
-  ): rxjs$OperatorFunction<mixed, R>;
+  ): rxjs$OperatorFunction<unknown, R>;
 
   declare export function iif<T, F>(
     condition: () => boolean,
@@ -3234,7 +3241,7 @@ declare module 'rxjs/operators' {
   declare export function throwError(
     error: any,
     scheduler?: rxjs$SchedulerLike,
-  ): rxjs$Observable<mixed>;
+  ): rxjs$Observable<unknown>;
 }
 
 declare module 'rxjs/ajax' {
@@ -3251,7 +3258,7 @@ declare module 'rxjs/ajax' {
     crossDomain?: boolean;
     withCredentials?: boolean;
     createXHR?: () => XMLHttpRequest;
-    progressSubscriber?: rxjs$Subscriber<mixed>;
+    progressSubscriber?: rxjs$Subscriber<unknown>;
     responseType?: string;
   }
 
@@ -3352,7 +3359,7 @@ declare module 'rxjs/webSocket' {
       subMsg: () => any,
       unsubMsg: () => any,
       messageFilter: (value: T) => boolean,
-    ): rxjs$Observable<mixed>;
+    ): rxjs$Observable<unknown>;
     // @deprecated This is an internal implementation detail, do not use.
     _subscribe(subscriber: rxjs$Subscriber<T>): rxjs$Subscription;
     unsubscribe(): void;

--- a/flow-typed/npm/selfsigned_v2.x.x.js
+++ b/flow-typed/npm/selfsigned_v2.x.x.js
@@ -30,7 +30,7 @@ declare module 'selfsigned' {
     /**
      * additional extensions for the certificate
      */
-    extensions?: mixed[];
+    extensions?: unknown[];
     /**
      * The signature algorithm sha256 or sha1
      * @default "sha1"
@@ -74,7 +74,7 @@ declare module 'selfsigned' {
     attrs?: pki$CertificateField[],
     opts?: SelfsignedOptions,
     /** Optional callback, if not provided the generation is synchronous */
-    done?: (err: void | Error, result: GenerateResult) => mixed,
+    done?: (err: void | Error, result: GenerateResult) => unknown,
   ): void;
 
   // definitions from node-forge's `pki` and `asn1` namespaces
@@ -94,7 +94,7 @@ declare module 'selfsigned' {
   declare interface pki$CertificateField extends pki$CertificateFieldOptions {
     valueConstructed?: boolean | void;
     valueTagClass?: asn1$Class | void;
-    value?: mixed[] | string | void;
-    extensions?: mixed[] | void;
+    value?: unknown[] | string | void;
+    extensions?: unknown[] | void;
   }
 }

--- a/flow-typed/npm/signedsource_v1.x.x.js
+++ b/flow-typed/npm/signedsource_v1.x.x.js
@@ -12,7 +12,7 @@ declare module 'signedsource' {
     isSigned(data: string): boolean,
     signFile(data: string): string,
     verifySignature(data: string): boolean,
-    [key: string]: mixed,
+    [key: string]: unknown,
   };
 
   declare module.exports: SignedSource;

--- a/flow-typed/npm/ws_v7.x.x.js
+++ b/flow-typed/npm/ws_v7.x.x.js
@@ -31,7 +31,7 @@ declare class ws$WebSocketServer extends events$EventEmitter {
     options: {
       backlog?: number,
       clientTracking?: boolean,
-      handleProtocols?: () => mixed,
+      handleProtocols?: () => unknown,
       host?: string,
       maxPayload?: number,
       noServer?: boolean,
@@ -39,28 +39,28 @@ declare class ws$WebSocketServer extends events$EventEmitter {
       perMessageDeflate?: boolean | ws$PerMessageDeflateOptions,
       port?: number,
       server?: http$Server | https$Server,
-      verifyClient?: () => mixed,
+      verifyClient?: () => unknown,
     },
-    callback?: () => mixed,
+    callback?: () => unknown,
   ): this;
 
   /**
    * Emitted when the server closes.
    */
-  on(event: 'close', () => mixed): this;
+  on(event: 'close', () => unknown): this;
 
   /**
    * Emitted when the handshake is complete.
    */
   on(
     event: 'connection',
-    (socket: ws$WebSocket, request: http$IncomingMessage<>) => mixed,
+    (socket: ws$WebSocket, request: http$IncomingMessage<>) => unknown,
   ): this;
 
   /**
    * Emitted when an error occurs on the underlying server.
    */
-  on(event: 'error', (error: Error) => mixed): this;
+  on(event: 'error', (error: Error) => unknown): this;
 
   /**
    * Emitted before the response headers are written to the socket as part of
@@ -68,13 +68,13 @@ declare class ws$WebSocketServer extends events$EventEmitter {
    */
   on(
     event: 'headers',
-    (headers: Array<string>, request: http$IncomingMessage<>) => mixed,
+    (headers: Array<string>, request: http$IncomingMessage<>) => unknown,
   ): this;
 
   /**
    * Emitted when the underlying server has been bound.
    */
-  on(event: 'listening', () => mixed): this;
+  on(event: 'listening', () => unknown): this;
 
   /**
    * Returns the bound address, the address family name, and port of the server
@@ -93,7 +93,7 @@ declare class ws$WebSocketServer extends events$EventEmitter {
   /**
    * Close the server.
    */
-  close(callback?: () => mixed): void;
+  close(callback?: () => unknown): void;
 
   /**
    * Handle a HTTP Upgrade request.
@@ -102,7 +102,7 @@ declare class ws$WebSocketServer extends events$EventEmitter {
     request: http$IncomingMessage<>,
     socket: net$Socket,
     head: Buffer,
-    callback: (?ws$WebSocket) => mixed,
+    callback: (?ws$WebSocket) => unknown,
   ): void;
 
   /**
@@ -122,24 +122,27 @@ declare type ws$WebSocketOptions = {
   ...requestOptions,
   agent?: boolean | http$Agent<> | http$Agent<tls$TLSSocket>,
   createConnection?:
-    | ((options: net$connectOptions, callback?: () => mixed) => net$Socket)
-    | ((options: tls$connectOptions, callback?: () => mixed) => tls$TLSSocket),
+    | ((options: net$connectOptions, callback?: () => unknown) => net$Socket)
+    | ((
+        options: tls$connectOptions,
+        callback?: () => unknown,
+      ) => tls$TLSSocket),
   rejectUnauthorized?: boolean,
 };
 
-declare type ws$CloseListener = (code: number, reason: string) => mixed;
-declare type ws$ErrorListener = (error: Error) => mixed;
+declare type ws$CloseListener = (code: number, reason: string) => unknown;
+declare type ws$ErrorListener = (error: Error) => unknown;
 declare type ws$MessageListener = (
   data: string | Buffer | ArrayBuffer | Array<Buffer>,
-) => mixed;
-declare type ws$OpenListener = () => mixed;
-declare type ws$PingListener = (Buffer) => mixed;
-declare type ws$PongListener = (Buffer) => mixed;
+) => unknown;
+declare type ws$OpenListener = () => unknown;
+declare type ws$PingListener = (Buffer) => unknown;
+declare type ws$PongListener = (Buffer) => unknown;
 declare type ws$UnexpectedResponseListener = (
   request: http$ClientRequest<>,
   response: http$IncomingMessage<>,
-) => mixed;
-declare type ws$UpgradeListener = (response: http$IncomingMessage<>) => mixed;
+) => unknown;
+declare type ws$UpgradeListener = (response: http$IncomingMessage<>) => unknown;
 
 /* $FlowFixMe[incompatible-type] - Found with Flow v0.143.1 upgrade
  * "on" definition failing with string is incompatible with string literal */
@@ -277,16 +280,16 @@ declare class ws$WebSocket extends events$EventEmitter {
   /**
    * Send a ping.
    */
-  ping(data?: any, mask?: boolean, callback?: () => mixed): void;
-  ping(data: any, callback: () => mixed): void;
-  ping(callback: () => mixed): void;
+  ping(data?: any, mask?: boolean, callback?: () => unknown): void;
+  ping(data: any, callback: () => unknown): void;
+  ping(callback: () => unknown): void;
 
   /**
    * Send a pong.
    */
-  pong(data?: any, mask?: boolean, callback?: () => mixed): void;
-  pong(data: any, callback: () => mixed): void;
-  pong(callback: () => mixed): void;
+  pong(data?: any, mask?: boolean, callback?: () => unknown): void;
+  pong(data: any, callback: () => unknown): void;
+  pong(callback: () => unknown): void;
 
   /**
    * The subprotocol selected by the server.
@@ -324,9 +327,9 @@ declare class ws$WebSocket extends events$EventEmitter {
       mask?: boolean,
       fin?: boolean,
     },
-    callback?: () => mixed,
+    callback?: () => unknown,
   ): void;
-  send(data: any, callback: () => mixed): void;
+  send(data: any, callback: () => unknown): void;
 
   /**
    * Forcibly close the connection.

--- a/packages/community-cli-plugin/src/commands/start/OpenDebuggerKeyboardHandler.js
+++ b/packages/community-cli-plugin/src/commands/start/OpenDebuggerKeyboardHandler.js
@@ -153,7 +153,7 @@ export default class OpenDebuggerKeyboardHandler {
     this.#targetsShownForSelection = null;
   }
 
-  #log(level: 'info' | 'warn' | 'error', ...data: Array<mixed>): void {
+  #log(level: 'info' | 'warn' | 'error', ...data: Array<unknown>): void {
     this.#reporter.update({
       type: 'unstable_server_log',
       level,

--- a/packages/community-cli-plugin/src/commands/start/attachKeyHandlers.js
+++ b/packages/community-cli-plugin/src/commands/start/attachKeyHandlers.js
@@ -46,7 +46,7 @@ export default function attachKeyHandlers({
 }: {
   devServerUrl: string,
   messageSocket: $ReadOnly<{
-    broadcast: (type: string, params?: Record<string, mixed> | null) => void,
+    broadcast: (type: string, params?: Record<string, unknown> | null) => void,
     ...
   }>,
   reporter: TerminalReporter,

--- a/packages/community-cli-plugin/src/commands/start/middleware.js
+++ b/packages/community-cli-plugin/src/commands/start/middleware.js
@@ -22,7 +22,10 @@ type MiddlewareReturn = {
   },
   messageSocketEndpoint: {
     server: ws$WebSocketServer,
-    broadcast: (method: string, params?: Record<string, mixed> | null) => void,
+    broadcast: (
+      method: string,
+      params?: Record<string, unknown> | null,
+    ) => void,
   },
   eventsSocketEndpoint: {
     server: ws$WebSocketServer,
@@ -54,7 +57,7 @@ const communityMiddlewareFallback = {
       server: unusedStubWSServer,
       broadcast: (
         method: string,
-        _params?: Record<string, mixed> | null,
+        _params?: Record<string, unknown> | null,
       ): void => {},
     },
     eventsSocketEndpoint: {

--- a/packages/community-cli-plugin/src/utils/createDevMiddlewareLogger.js
+++ b/packages/community-cli-plugin/src/utils/createDevMiddlewareLogger.js
@@ -34,7 +34,7 @@ function makeLogger(
   reporter: TerminalReporter,
   level: 'info' | 'warn' | 'error',
 ): LoggerFn {
-  return (...data: Array<mixed>) =>
+  return (...data: Array<unknown>) =>
     reporter.update({
       type: 'unstable_server_log',
       level,

--- a/packages/core-cli-utils/src/private/types.js
+++ b/packages/core-cli-utils/src/private/types.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-export type Task<R = mixed> = {
+export type Task<R = unknown> = {
   order: number,
   label: string,
   action: () => R,

--- a/packages/debugger-shell/src/electron/SettingsStore.js
+++ b/packages/debugger-shell/src/electron/SettingsStore.js
@@ -91,12 +91,12 @@ export default class SettingsStore {
     }
   }
 
-  get store(): {[string]: mixed} {
+  get store(): {[string]: unknown} {
     try {
       const data = fs.readFileSync(this.path, 'utf8');
       const deserializedData = this._deserialize(data);
       return {
-        ...((deserializedData: any): {[string]: mixed}),
+        ...((deserializedData: any): {[string]: unknown}),
       };
     } catch (error) {
       if (error?.code === 'ENOENT') {
@@ -107,20 +107,20 @@ export default class SettingsStore {
     }
   }
 
-  set store(value: mixed): void {
+  set store(value: unknown): void {
     this._ensureDirectory();
     this._write(value);
   }
 
-  _deserialize = (value: string): mixed => JSON.parse(value);
-  _serialize = (value: mixed): string =>
+  _deserialize = (value: string): unknown => JSON.parse(value);
+  _serialize = (value: unknown): string =>
     JSON.stringify(value, undefined, '\t') ?? '';
 
   _ensureDirectory(): void {
     fs.mkdirSync(path.dirname(this.path), {recursive: true});
   }
 
-  _write(value: mixed): void {
+  _write(value: unknown): void {
     const data = this._serialize(value);
 
     fs.writeFileSync(this.path, data, {mode: 0o666});

--- a/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
+++ b/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
@@ -219,7 +219,7 @@ export default class InspectorProxy implements InspectorProxyQueries {
   processRequest(
     request: IncomingMessage,
     response: ServerResponse,
-    next: (?Error) => mixed,
+    next: (?Error) => unknown,
   ) {
     const pathname = url.parse(request.url).pathname;
     if (

--- a/packages/dev-middleware/src/types/EventReporter.js
+++ b/packages/dev-middleware/src/types/EventReporter.js
@@ -15,7 +15,7 @@ type SuccessResult<Props: {...} | void = {}> = {
   ...Props,
 };
 
-type ErrorResult<ErrorT = mixed, Props: {...} | void = {}> = {
+type ErrorResult<ErrorT = unknown, Props: {...} | void = {}> = {
   status: 'error',
   error: ErrorT,
   prefersFuseboxFrontend?: ?boolean,
@@ -49,7 +49,7 @@ export type ReportableEvent =
             prefersFuseboxFrontend: boolean,
             ...DebuggerSessionIDs,
           }>
-        | ErrorResult<mixed>
+        | ErrorResult<unknown>
         | CodedErrorResult<'NO_APPS_FOUND'>,
     }
   | {
@@ -59,7 +59,7 @@ export type ReportableEvent =
             ...DebuggerSessionIDs,
             frontendUserAgent: string | null,
           }>
-        | ErrorResult<mixed, DebuggerSessionIDs>,
+        | ErrorResult<unknown, DebuggerSessionIDs>,
     }
   | {
       type: 'debugger_command',

--- a/packages/polyfills/error-guard.js
+++ b/packages/polyfills/error-guard.js
@@ -11,7 +11,7 @@
 
 let _inGuard = 0;
 
-type ErrorHandler = (error: mixed, isFatal: boolean) => void;
+type ErrorHandler = (error: unknown, isFatal: boolean) => void;
 type Fn<Args, Return> = (...Args) => Return;
 
 /**
@@ -22,7 +22,7 @@ type Fn<Args, Return> = (...Args) => Return;
 let _globalHandler: ErrorHandler =
   global.RN$useAlwaysAvailableJSErrorHandling === true
     ? global.RN$handleException
-    : (e: mixed, isFatal: boolean) => {
+    : (e: unknown, isFatal: boolean) => {
         throw e;
       };
 
@@ -41,20 +41,20 @@ const ErrorUtils = {
   getGlobalHandler(): ErrorHandler {
     return _globalHandler;
   },
-  reportError(error: mixed): void {
+  reportError(error: unknown): void {
     /* $FlowFixMe[constant-condition] Error discovered during Constant
      * Condition roll out. See https://fburl.com/workplace/1v97vimq. */
     _globalHandler && _globalHandler(error, false);
   },
-  reportFatalError(error: mixed): void {
+  reportFatalError(error: unknown): void {
     // NOTE: This has an untyped call site in Metro.
     /* $FlowFixMe[constant-condition] Error discovered during Constant
      * Condition roll out. See https://fburl.com/workplace/1v97vimq. */
     _globalHandler && _globalHandler(error, true);
   },
-  applyWithGuard<TArgs: $ReadOnlyArray<mixed>, TOut>(
+  applyWithGuard<TArgs: $ReadOnlyArray<unknown>, TOut>(
     fun: Fn<TArgs, TOut>,
-    context?: ?mixed,
+    context?: ?unknown,
     args?: ?TArgs,
     // Unused, but some code synced from www sets it to null.
     unused_onError?: null,
@@ -75,9 +75,9 @@ const ErrorUtils = {
     }
     return null;
   },
-  applyWithGuardIfNeeded<TArgs: $ReadOnlyArray<mixed>, TOut>(
+  applyWithGuardIfNeeded<TArgs: $ReadOnlyArray<unknown>, TOut>(
     fun: Fn<TArgs, TOut>,
-    context?: ?mixed,
+    context?: ?unknown,
     args?: ?TArgs,
   ): ?TOut {
     if (ErrorUtils.inGuard()) {
@@ -94,10 +94,10 @@ const ErrorUtils = {
   inGuard(): boolean {
     return !!_inGuard;
   },
-  guard<TArgs: $ReadOnlyArray<mixed>, TOut>(
+  guard<TArgs: $ReadOnlyArray<unknown>, TOut>(
     fun: Fn<TArgs, TOut>,
     name?: ?string,
-    context?: ?mixed,
+    context?: ?unknown,
   ): ?(...TArgs) => ?TOut {
     // TODO: (moti) T48204753 Make sure this warning is never hit and remove it - types
     // should be sufficient.

--- a/packages/react-native/Libraries/Animated/AnimatedEvent.js
+++ b/packages/react-native/Libraries/Animated/AnimatedEvent.js
@@ -25,7 +25,7 @@ export type Mapping =
   | AnimatedValue
   | AnimatedValueXY;
 export type EventConfig<T> = {
-  listener?: ?(NativeSyntheticEvent<T>) => mixed,
+  listener?: ?(NativeSyntheticEvent<T>) => unknown,
   useNativeDriver: boolean,
   platformConfig?: PlatformConfig,
 };
@@ -40,7 +40,7 @@ export function attachNativeEventImpl(
   // key path inside the `nativeEvent` object. Ex.: ['contentOffset', 'x'].
   const eventMappings: Array<EventMapping> = [];
 
-  const traverse = (value: mixed, path: Array<string>) => {
+  const traverse = (value: unknown, path: Array<string>) => {
     if (value instanceof AnimatedValue) {
       value.__makeNative(platformConfig);
 

--- a/packages/react-native/Libraries/Animated/__tests__/Animated-test.js
+++ b/packages/react-native/Libraries/Animated/__tests__/Animated-test.js
@@ -193,7 +193,7 @@ describe('Animated', () => {
 
     it('renders animated and primitive style correctly', () => {
       const anim = new Animated.Value(0);
-      const staticProps: {[string]: mixed} = {
+      const staticProps: {[string]: unknown} = {
         style: [
           {transform: [{translateX: anim}]},
           {transform: [{translateX: 100}]},

--- a/packages/react-native/Libraries/Animated/__tests__/AnimatedProps-test.js
+++ b/packages/react-native/Libraries/Animated/__tests__/AnimatedProps-test.js
@@ -11,7 +11,7 @@
 import AnimatedProps from '../nodes/AnimatedProps';
 
 describe('AnimatedProps', () => {
-  function getValue(inputProps: {[string]: mixed}) {
+  function getValue(inputProps: {[string]: unknown}) {
     const animatedProps = new AnimatedProps(inputProps, jest.fn());
     return animatedProps.__getValue();
   }

--- a/packages/react-native/Libraries/Animated/createAnimatedComponent.js
+++ b/packages/react-native/Libraries/Animated/createAnimatedComponent.js
@@ -29,7 +29,7 @@ import {useMemo} from 'react';
 
 type Nullable = void | null;
 type Primitive = string | number | boolean | symbol | void;
-type Builtin = (...$ReadOnlyArray<empty>) => mixed | Date | Error | RegExp;
+type Builtin = (...$ReadOnlyArray<empty>) => unknown | Date | Error | RegExp;
 
 export type WithAnimatedValue<+T> = T extends Builtin | Nullable
   ? T
@@ -89,10 +89,10 @@ export type AnimatedBaseProps<Props: {...}> = LooseOmit<
   'ref',
 >;
 
-export type AnimatedComponentType<Props: {...}, +Instance = mixed> = component(
-  ref?: React.RefSetter<Instance>,
-  ...AnimatedProps<Props>
-);
+export type AnimatedComponentType<
+  Props: {...},
+  +Instance = unknown,
+> = component(ref?: React.RefSetter<Instance>, ...AnimatedProps<Props>);
 
 export default function createAnimatedComponent<
   TInstance: React.ComponentType<any>,

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedColor.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedColor.js
@@ -27,7 +27,7 @@ export type AnimatedColorConfig = $ReadOnly<{
   useNativeDriver: boolean,
 }>;
 
-type ColorListenerCallback = (value: ColorValue) => mixed;
+type ColorListenerCallback = (value: ColorValue) => unknown;
 
 export type RgbaValue = {
   +r: number,

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedNode.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedNode.js
@@ -13,7 +13,7 @@ import type {PlatformConfig} from '../AnimatedPlatformConfig';
 import NativeAnimatedHelper from '../../../src/private/animated/NativeAnimatedHelper';
 import invariant from 'invariant';
 
-type ValueListenerCallback = (state: {value: number, ...}) => mixed;
+type ValueListenerCallback = (state: {value: number, ...}) => unknown;
 
 export type AnimatedNodeConfig = $ReadOnly<{
   debugID?: string,
@@ -87,7 +87,7 @@ export default class AnimatedNode {
    *
    * See https://reactnative.dev/docs/animatedvalue#addlistener
    */
-  addListener(callback: (value: any) => mixed): string {
+  addListener(callback: (value: any) => unknown): string {
     const id = String(_uniqueId++);
     this._listeners.set(id, callback);
     return id;
@@ -172,7 +172,7 @@ export default class AnimatedNode {
    * NOTE: This is intended to prevent `JSON.stringify` from throwing "cyclic
    * structure" errors in React DevTools. Avoid depending on this!
    */
-  toJSON(): mixed {
+  toJSON(): unknown {
     return this.__getValue();
   }
 

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedObject.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedObject.js
@@ -20,10 +20,10 @@ import {isValidElement} from 'react';
 const MAX_DEPTH = 5;
 
 export function isPlainObject(
-  value: mixed,
+  value: unknown,
   /* $FlowFixMe[incompatible-type-guard] - Flow does not know that the prototype
      and ReactElement checks preserve the type refinement of `value`. */
-): value is $ReadOnly<{[string]: mixed}> {
+): value is $ReadOnly<{[string]: unknown}> {
   const proto =
     value !== null && typeof value === 'object'
       ? Object.getPrototypeOf(value)
@@ -39,7 +39,7 @@ export function isPlainObject(
 }
 
 function flatAnimatedNodes(
-  value: mixed,
+  value: unknown,
   nodes: Array<AnimatedNode> = [],
   depth: number = 0,
 ): Array<AnimatedNode> {
@@ -88,13 +88,13 @@ function mapAnimatedNodes(value: any, fn: any => any, depth: number = 0): any {
 
 export default class AnimatedObject extends AnimatedWithChildren {
   _nodes: $ReadOnlyArray<AnimatedNode>;
-  _value: mixed;
+  _value: unknown;
 
   /**
    * Creates an `AnimatedObject` if `value` contains `AnimatedNode` instances.
    * Otherwise, returns `null`.
    */
-  static from(value: mixed): ?AnimatedObject {
+  static from(value: unknown): ?AnimatedObject {
     const nodes = flatAnimatedNodes(value);
     if (nodes.length === 0) {
       return null;
@@ -107,7 +107,7 @@ export default class AnimatedObject extends AnimatedWithChildren {
    */
   constructor(
     nodes: $ReadOnlyArray<AnimatedNode>,
-    value: mixed,
+    value: unknown,
     config?: ?AnimatedNodeConfig,
   ) {
     super(config);
@@ -121,7 +121,7 @@ export default class AnimatedObject extends AnimatedWithChildren {
     });
   }
 
-  __getValueWithStaticObject(staticObject: mixed): any {
+  __getValueWithStaticObject(staticObject: unknown): any {
     const nodes = this._nodes;
     let index = 0;
     // NOTE: We can depend on `this._value` and `staticObject` sharing a

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js
@@ -36,12 +36,12 @@ type TargetView = {
 type TargetViewInstance = React.ElementRef<React.ElementType>;
 
 function createAnimatedProps(
-  inputProps: {[string]: mixed},
+  inputProps: {[string]: unknown},
   allowlist: ?AnimatedPropsAllowlist,
-): [$ReadOnlyArray<string>, $ReadOnlyArray<AnimatedNode>, {[string]: mixed}] {
+): [$ReadOnlyArray<string>, $ReadOnlyArray<AnimatedNode>, {[string]: unknown}] {
   const nodeKeys: Array<string> = [];
   const nodes: Array<AnimatedNode> = [];
-  const props: {[string]: mixed} = {};
+  const props: {[string]: unknown} = {};
 
   const keys = Object.keys(inputProps);
   for (let ii = 0, length = keys.length; ii < length; ii++) {
@@ -98,12 +98,12 @@ export default class AnimatedProps extends AnimatedNode {
   _callback: () => void;
   _nodeKeys: $ReadOnlyArray<string>;
   _nodes: $ReadOnlyArray<AnimatedNode>;
-  _props: {[string]: mixed};
+  _props: {[string]: unknown};
   _target: ?TargetView = null;
   _rootTag: ?RootTag = undefined;
 
   constructor(
-    inputProps: {[string]: mixed},
+    inputProps: {[string]: unknown},
     callback: () => void,
     allowlist?: ?AnimatedPropsAllowlist,
     rootTag?: RootTag,
@@ -119,7 +119,7 @@ export default class AnimatedProps extends AnimatedNode {
   }
 
   __getValue(): Object {
-    const props: {[string]: mixed} = {};
+    const props: {[string]: unknown} = {};
 
     const keys = Object.keys(this._props);
     for (let ii = 0, length = keys.length; ii < length; ii++) {
@@ -144,7 +144,7 @@ export default class AnimatedProps extends AnimatedNode {
    * created by this `AnimatedProps` instance.
    */
   __getValueWithStaticProps(staticProps: Object): Object {
-    const props: {[string]: mixed} = {...staticProps};
+    const props: {[string]: unknown} = {...staticProps};
 
     const keys = Object.keys(staticProps);
     for (let ii = 0, length = keys.length; ii < length; ii++) {
@@ -155,7 +155,7 @@ export default class AnimatedProps extends AnimatedNode {
         const staticStyle = staticProps.style;
         const flatStaticStyle = flattenStyle(staticStyle);
         if (maybeNode instanceof AnimatedStyle) {
-          const mutableStyle: {[string]: mixed} =
+          const mutableStyle: {[string]: unknown} =
             flatStaticStyle == null
               ? {}
               : flatStaticStyle === staticStyle
@@ -196,7 +196,7 @@ export default class AnimatedProps extends AnimatedNode {
   }
 
   __getAnimatedValue(): Object {
-    const props: {[string]: mixed} = {};
+    const props: {[string]: unknown} = {};
 
     const nodeKeys = this._nodeKeys;
     const nodes = this._nodes;

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedStyle.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedStyle.js
@@ -21,17 +21,17 @@ import AnimatedWithChildren from './AnimatedWithChildren';
 
 export type AnimatedStyleAllowlist = $ReadOnly<{[string]: true}>;
 
-type FlatStyle = {[string]: mixed};
-type FlatStyleForWeb<TStyle: FlatStyle> = [mixed, TStyle];
+type FlatStyle = {[string]: unknown};
+type FlatStyleForWeb<TStyle: FlatStyle> = [unknown, TStyle];
 
 function createAnimatedStyle(
   flatStyle: FlatStyle,
   allowlist: ?AnimatedStyleAllowlist,
   keepUnanimatedValues: boolean,
-): [$ReadOnlyArray<string>, $ReadOnlyArray<AnimatedNode>, {[string]: mixed}] {
+): [$ReadOnlyArray<string>, $ReadOnlyArray<AnimatedNode>, {[string]: unknown}] {
   const nodeKeys: Array<string> = [];
   const nodes: Array<AnimatedNode> = [];
-  const style: {[string]: mixed} = {};
+  const style: {[string]: unknown} = {};
 
   const keys = Object.keys(flatStyle);
   for (let ii = 0, length = keys.length; ii < length; ii++) {
@@ -82,10 +82,10 @@ function createAnimatedStyle(
 }
 
 export default class AnimatedStyle extends AnimatedWithChildren {
-  _originalStyleForWeb: ?mixed;
+  _originalStyleForWeb: ?unknown;
   _nodeKeys: $ReadOnlyArray<string>;
   _nodes: $ReadOnlyArray<AnimatedNode>;
-  _style: {[string]: mixed};
+  _style: {[string]: unknown};
 
   /**
    * Creates an `AnimatedStyle` if `value` contains `AnimatedNode` instances.
@@ -94,7 +94,7 @@ export default class AnimatedStyle extends AnimatedWithChildren {
   static from(
     flatStyle: ?FlatStyle,
     allowlist: ?AnimatedStyleAllowlist,
-    originalStyleForWeb: ?mixed,
+    originalStyleForWeb: ?unknown,
   ): ?AnimatedStyle {
     if (flatStyle == null) {
       return null;
@@ -115,8 +115,8 @@ export default class AnimatedStyle extends AnimatedWithChildren {
   constructor(
     nodeKeys: $ReadOnlyArray<string>,
     nodes: $ReadOnlyArray<AnimatedNode>,
-    style: {[string]: mixed},
-    originalStyleForWeb: ?mixed,
+    style: {[string]: unknown},
+    originalStyleForWeb: ?unknown,
     config?: ?AnimatedNodeConfig,
   ) {
     super(config);
@@ -134,7 +134,7 @@ export default class AnimatedStyle extends AnimatedWithChildren {
   }
 
   __getValue(): FlatStyleForWeb<FlatStyle> | FlatStyle {
-    const style: {[string]: mixed} = {};
+    const style: {[string]: unknown} = {};
 
     const keys = Object.keys(this._style);
     for (let ii = 0, length = keys.length; ii < length; ii++) {
@@ -164,7 +164,7 @@ export default class AnimatedStyle extends AnimatedWithChildren {
    * Mutates the supplied `style` object such that animated nodes are replaced
    * with rasterized values.
    */
-  __replaceAnimatedNodeWithValues(style: {[string]: mixed}): void {
+  __replaceAnimatedNodeWithValues(style: {[string]: unknown}): void {
     const keys = Object.keys(style);
     for (let ii = 0, length = keys.length; ii < length; ii++) {
       const key = keys[ii];
@@ -185,7 +185,7 @@ export default class AnimatedStyle extends AnimatedWithChildren {
   }
 
   __getAnimatedValue(): Object {
-    const style: {[string]: mixed} = {};
+    const style: {[string]: unknown} = {};
 
     const nodeKeys = this._nodeKeys;
     const nodes = this._nodes;

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedValue.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedValue.js
@@ -134,7 +134,7 @@ export default class AnimatedValue extends AnimatedWithChildren {
     }
   }
 
-  addListener(callback: (value: any) => mixed): string {
+  addListener(callback: (value: any) => unknown): string {
     const id = super.addListener(callback);
     this._listenerCount++;
     if (this.__isNative) {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedValueXY.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedValueXY.js
@@ -21,7 +21,7 @@ export type AnimatedValueXYConfig = $ReadOnly<{
   ...AnimatedNodeConfig,
   useNativeDriver: boolean,
 }>;
-type ValueXYListenerCallback = (value: {x: number, y: number, ...}) => mixed;
+type ValueXYListenerCallback = (value: {x: number, y: number, ...}) => unknown;
 
 let _uniqueId = 1;
 

--- a/packages/react-native/Libraries/BatchedBridge/MessageQueue.js
+++ b/packages/react-native/Libraries/BatchedBridge/MessageQueue.js
@@ -23,7 +23,7 @@ export type SpyData = {
   type: number,
   module: ?string,
   method: string | number,
-  args: mixed[],
+  args: unknown[],
   ...
 };
 
@@ -42,9 +42,9 @@ const DEBUG_INFO_LIMIT = 32;
 
 class MessageQueue {
   _lazyCallableModules: {[key: string]: (void) => {...}, ...};
-  _queue: [number[], number[], mixed[], number];
-  _successCallbacks: Map<number, ?(...mixed[]) => void>;
-  _failureCallbacks: Map<number, ?(...mixed[]) => void>;
+  _queue: [number[], number[], unknown[], number];
+  _successCallbacks: Map<number, ?(...unknown[]) => void>;
+  _failureCallbacks: Map<number, ?(...unknown[]) => void>;
   _callID: number;
   _lastFlush: number;
   _eventLoopStartTime: number;
@@ -109,8 +109,8 @@ class MessageQueue {
   callFunctionReturnFlushedQueue(
     module: string,
     method: string,
-    args: mixed[],
-  ): null | [Array<number>, Array<number>, Array<mixed>, number] {
+    args: unknown[],
+  ): null | [Array<number>, Array<number>, Array<unknown>, number] {
     this.__guard(() => {
       this.__callFunction(module, method, args);
     });
@@ -120,8 +120,8 @@ class MessageQueue {
 
   invokeCallbackAndReturnFlushedQueue(
     cbID: number,
-    args: mixed[],
-  ): null | [Array<number>, Array<number>, Array<mixed>, number] {
+    args: unknown[],
+  ): null | [Array<number>, Array<number>, Array<unknown>, number] {
     this.__guard(() => {
       this.__invokeCallback(cbID, args);
     });
@@ -129,7 +129,9 @@ class MessageQueue {
     return this.flushedQueue();
   }
 
-  flushedQueue(): null | [Array<number>, Array<number>, Array<mixed>, number] {
+  flushedQueue():
+    | null
+    | [Array<number>, Array<number>, Array<unknown>, number] {
     this.__guard(() => {
       this.__callReactNativeMicrotasks();
     });
@@ -171,10 +173,10 @@ class MessageQueue {
   callNativeSyncHook(
     moduleID: number,
     methodID: number,
-    params: mixed[],
-    onFail: ?(...mixed[]) => void,
-    onSucc: ?(...mixed[]) => void,
-  ): mixed {
+    params: unknown[],
+    onFail: ?(...unknown[]) => void,
+    onSucc: ?(...unknown[]) => void,
+  ): unknown {
     if (__DEV__) {
       invariant(
         global.nativeCallSyncHook,
@@ -191,9 +193,9 @@ class MessageQueue {
   processCallbacks(
     moduleID: number,
     methodID: number,
-    params: mixed[],
-    onFail: ?(...mixed[]) => void,
-    onSucc: ?(...mixed[]) => void,
+    params: unknown[],
+    onFail: ?(...unknown[]) => void,
+    onSucc: ?(...unknown[]) => void,
   ): void {
     if (onFail || onSucc) {
       if (__DEV__) {
@@ -242,9 +244,9 @@ class MessageQueue {
   enqueueNativeCall(
     moduleID: number,
     methodID: number,
-    params: mixed[],
-    onFail: ?(...mixed[]) => void,
-    onSucc: ?(...mixed[]) => void,
+    params: unknown[],
+    onFail: ?(...unknown[]) => void,
+    onSucc: ?(...unknown[]) => void,
   ): void {
     this.processCallbacks(moduleID, methodID, params, onFail, onSucc);
 
@@ -256,7 +258,7 @@ class MessageQueue {
       // folly-convertible.  As a special case, if a prop value is a
       // function it is permitted here, and special-cased in the
       // conversion.
-      const isValidArgument = (val: mixed): boolean => {
+      const isValidArgument = (val: unknown): boolean => {
         switch (typeof val) {
           case 'undefined':
           case 'boolean':
@@ -401,7 +403,7 @@ class MessageQueue {
     }
   }
 
-  __callFunction(module: string, method: string, args: mixed[]): void {
+  __callFunction(module: string, method: string, args: unknown[]): void {
     this._lastFlush = Date.now();
     this._eventLoopStartTime = this._lastFlush;
     if (__DEV__ || this.__spy) {
@@ -441,7 +443,7 @@ class MessageQueue {
     }
   }
 
-  __invokeCallback(cbID: number, args: mixed[]): void {
+  __invokeCallback(cbID: number, args: unknown[]): void {
     this._lastFlush = Date.now();
     this._eventLoopStartTime = this._lastFlush;
 

--- a/packages/react-native/Libraries/BatchedBridge/__tests__/MessageQueue-test.js
+++ b/packages/react-native/Libraries/BatchedBridge/__tests__/MessageQueue-test.js
@@ -19,11 +19,11 @@ const METHOD_IDS = 1;
 const PARAMS = 2;
 
 const assertQueue = (
-  flushedQueue: null | [Array<number>, Array<number>, Array<mixed>, number],
+  flushedQueue: null | [Array<number>, Array<number>, Array<unknown>, number],
   index: number,
   moduleID: number,
   methodID: number,
-  params: $ReadOnlyArray<mixed>,
+  params: $ReadOnlyArray<unknown>,
 ) => {
   if (flushedQueue == null) {
     throw new Error('Expected `flushedQueue` to be non-null');

--- a/packages/react-native/Libraries/BatchedBridge/__tests__/NativeModules-test.js
+++ b/packages/react-native/Libraries/BatchedBridge/__tests__/NativeModules-test.js
@@ -21,11 +21,11 @@ const PARAMS = 2;
 const CALL_ID = 3;
 
 const assertQueue = (
-  flushedQueue: null | [Array<number>, Array<number>, Array<mixed>, number],
+  flushedQueue: null | [Array<number>, Array<number>, Array<unknown>, number],
   index: number,
   moduleID: number,
   methodID: number,
-  params: $ReadOnlyArray<mixed>,
+  params: $ReadOnlyArray<unknown>,
 ) => {
   if (flushedQueue == null) {
     throw new Error('Expected `flushedQueue` to be non-null');

--- a/packages/react-native/Libraries/Components/Button.js
+++ b/packages/react-native/Libraries/Components/Button.js
@@ -38,7 +38,7 @@ export type ButtonProps = $ReadOnly<{
     Handler to be called when the user taps the button. The first function
     argument is an event in form of [GestureResponderEvent](pressevent).
    */
-  onPress?: (event?: GestureResponderEvent) => mixed,
+  onPress?: (event?: GestureResponderEvent) => unknown,
 
   /**
     If `true`, doesn't play system sound on touch.
@@ -148,7 +148,7 @@ export type ButtonProps = $ReadOnly<{
    */
   accessible?: ?boolean,
   accessibilityActions?: ?$ReadOnlyArray<AccessibilityActionInfo>,
-  onAccessibilityAction?: ?(event: AccessibilityActionEvent) => mixed,
+  onAccessibilityAction?: ?(event: AccessibilityActionEvent) => unknown,
   accessibilityState?: ?AccessibilityState,
 
   /**

--- a/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
+++ b/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
@@ -67,7 +67,7 @@ class DrawerLayoutAndroid
   extends React.Component<DrawerLayoutAndroidProps, DrawerLayoutAndroidState>
   implements DrawerLayoutAndroidMethods
 {
-  static get positions(): mixed {
+  static get positions(): unknown {
     console.warn(
       'Setting DrawerLayoutAndroid drawerPosition using `DrawerLayoutAndroid.positions` is deprecated. Instead pass the string value "left" or "right"',
     );

--- a/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroidTypes.js
+++ b/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroidTypes.js
@@ -73,7 +73,7 @@ export type DrawerLayoutAndroidProps = $ReadOnly<{
   /**
    * Function called whenever there is an interaction with the navigation view.
    */
-  onDrawerSlide?: ?(event: DrawerSlideEvent) => mixed,
+  onDrawerSlide?: ?(event: DrawerSlideEvent) => unknown,
 
   /**
    * Function called when the drawer state has changed. The drawer can be in 3 states:
@@ -82,17 +82,17 @@ export type DrawerLayoutAndroidProps = $ReadOnly<{
    * - Settling, meaning that there was an interaction with the navigation view, and the
    * navigation view is now finishing its closing or opening animation
    */
-  onDrawerStateChanged?: ?(state: DrawerStates) => mixed,
+  onDrawerStateChanged?: ?(state: DrawerStates) => unknown,
 
   /**
    * Function called whenever the navigation view has been opened.
    */
-  onDrawerOpen?: ?() => mixed,
+  onDrawerOpen?: ?() => unknown,
 
   /**
    * Function called whenever the navigation view has been closed.
    */
-  onDrawerClose?: ?() => mixed,
+  onDrawerClose?: ?() => unknown,
 
   /**
    * The navigation view that will be rendered to the side of the screen and can be pulled in.

--- a/packages/react-native/Libraries/Components/Keyboard/Keyboard.js
+++ b/packages/react-native/Libraries/Components/Keyboard/Keyboard.js
@@ -148,8 +148,8 @@ class KeyboardImpl {
    */
   addListener<K: $Keys<KeyboardEventDefinitions>>(
     eventType: K,
-    listener: (...KeyboardEventDefinitions[K]) => mixed,
-    context?: mixed,
+    listener: (...KeyboardEventDefinitions[K]) => unknown,
+    context?: unknown,
   ): EventSubscription {
     return this._emitter.addListener(eventType, listener);
   }

--- a/packages/react-native/Libraries/Components/Pressable/Pressable.js
+++ b/packages/react-native/Libraries/Components/Pressable/Pressable.js
@@ -80,41 +80,41 @@ type PressableBaseProps = $ReadOnly<{
   /**
    * Called when this view's layout changes.
    */
-  onLayout?: ?(event: LayoutChangeEvent) => mixed,
+  onLayout?: ?(event: LayoutChangeEvent) => unknown,
 
   /**
    * Called when the hover is activated to provide visual feedback.
    */
-  onHoverIn?: ?(event: MouseEvent) => mixed,
+  onHoverIn?: ?(event: MouseEvent) => unknown,
 
   /**
    * Called when the hover is deactivated to undo visual feedback.
    */
-  onHoverOut?: ?(event: MouseEvent) => mixed,
+  onHoverOut?: ?(event: MouseEvent) => unknown,
 
   /**
    * Called when a long-tap gesture is detected.
    */
-  onLongPress?: ?(event: GestureResponderEvent) => mixed,
+  onLongPress?: ?(event: GestureResponderEvent) => unknown,
 
   /**
    * Called when a single tap gesture is detected.
    */
-  onPress?: ?(event: GestureResponderEvent) => mixed,
+  onPress?: ?(event: GestureResponderEvent) => unknown,
 
   /**
    * Called when a touch is engaged before `onPress`.
    */
-  onPressIn?: ?(event: GestureResponderEvent) => mixed,
+  onPressIn?: ?(event: GestureResponderEvent) => unknown,
   /**
    * Called when the press location moves.
    */
-  onPressMove?: ?(event: GestureResponderEvent) => mixed,
+  onPressMove?: ?(event: GestureResponderEvent) => unknown,
 
   /**
    * Called when a touch is released before `onPress`.
    */
-  onPressOut?: ?(event: GestureResponderEvent) => mixed,
+  onPressOut?: ?(event: GestureResponderEvent) => unknown,
 
   /**
    * Whether to prevent any other native components from becoming responder

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
@@ -809,18 +809,18 @@ type TextInputBaseProps = $ReadOnly<{
   /**
    * Callback that is called when the text input is blurred.
    */
-  onBlur?: ?(e: TextInputBlurEvent) => mixed,
+  onBlur?: ?(e: TextInputBlurEvent) => unknown,
 
   /**
    * Callback that is called when the text input's text changes.
    */
-  onChange?: ?(e: TextInputChangeEvent) => mixed,
+  onChange?: ?(e: TextInputChangeEvent) => unknown,
 
   /**
    * Callback that is called when the text input's text changes.
    * Changed text is passed as an argument to the callback handler.
    */
-  onChangeText?: ?(text: string) => mixed,
+  onChangeText?: ?(text: string) => unknown,
 
   /**
    * Callback that is called when the text input's content size changes.
@@ -829,17 +829,17 @@ type TextInputBaseProps = $ReadOnly<{
    *
    * Only called for multiline text inputs.
    */
-  onContentSizeChange?: ?(e: TextInputContentSizeChangeEvent) => mixed,
+  onContentSizeChange?: ?(e: TextInputContentSizeChangeEvent) => unknown,
 
   /**
    * Callback that is called when text input ends.
    */
-  onEndEditing?: ?(e: TextInputEndEditingEvent) => mixed,
+  onEndEditing?: ?(e: TextInputEndEditingEvent) => unknown,
 
   /**
    * Callback that is called when the text input is focused.
    */
-  onFocus?: ?(e: TextInputFocusEvent) => mixed,
+  onFocus?: ?(e: TextInputFocusEvent) => unknown,
 
   /**
    * Callback that is called when a key is pressed.
@@ -848,42 +848,42 @@ type TextInputBaseProps = $ReadOnly<{
    * the typed-in character otherwise including `' '` for space.
    * Fires before `onChange` callbacks.
    */
-  onKeyPress?: ?(e: TextInputKeyPressEvent) => mixed,
+  onKeyPress?: ?(e: TextInputKeyPressEvent) => unknown,
 
   /**
    * Called when a single tap gesture is detected.
    */
-  onPress?: ?(event: GestureResponderEvent) => mixed,
+  onPress?: ?(event: GestureResponderEvent) => unknown,
 
   /**
    * Called when a touch is engaged.
    */
-  onPressIn?: ?(event: GestureResponderEvent) => mixed,
+  onPressIn?: ?(event: GestureResponderEvent) => unknown,
 
   /**
    * Called when a touch is released.
    */
-  onPressOut?: ?(event: GestureResponderEvent) => mixed,
+  onPressOut?: ?(event: GestureResponderEvent) => unknown,
 
   /**
    * Callback that is called when the text input selection is changed.
    * This will be called with
    * `{ nativeEvent: { selection: { start, end } } }`.
    */
-  onSelectionChange?: ?(e: TextInputSelectionChangeEvent) => mixed,
+  onSelectionChange?: ?(e: TextInputSelectionChangeEvent) => unknown,
 
   /**
    * Callback that is called when the text input's submit button is pressed.
    * Invalid if `multiline={true}` is specified.
    */
-  onSubmitEditing?: ?(e: TextInputSubmitEditingEvent) => mixed,
+  onSubmitEditing?: ?(e: TextInputSubmitEditingEvent) => unknown,
 
   /**
    * Invoked on content scroll with `{ nativeEvent: { contentOffset: { x, y } } }`.
    * May also contain other properties from ScrollEvent but on Android contentSize
    * is not provided for performance reasons.
    */
-  onScroll?: ?(e: ScrollEvent) => mixed,
+  onScroll?: ?(e: ScrollEvent) => unknown,
 
   /**
    * The string that will be rendered before text input has been entered.

--- a/packages/react-native/Libraries/Components/Touchable/PooledClass.js
+++ b/packages/react-native/Libraries/Components/Touchable/PooledClass.js
@@ -105,9 +105,9 @@ const addPoolingTo = function <T>(
   pooler: Pooler,
 ): Class<T> & {
   getPooled(
-    ...args: $ReadOnlyArray<mixed>
+    ...args: $ReadOnlyArray<unknown>
   ): /* arguments of the constructor */ T,
-  release(instance: mixed): void,
+  release(instance: unknown): void,
   ...
 } {
   // Casting as any so that flow ignores the actual implementation and trusts

--- a/packages/react-native/Libraries/Components/Touchable/TouchableBounce.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableBounce.js
@@ -211,7 +211,7 @@ class TouchableBounce extends React.Component<
     this.state.pressability.configure(this._createPressabilityConfig());
   }
 
-  componentDidMount(): mixed {
+  componentDidMount(): unknown {
     this.state.pressability.configure(this._createPressabilityConfig());
   }
 
@@ -225,11 +225,11 @@ export default (function TouchableBounceWrapper({
   ref: hostRef,
   ...props
 }: {
-  ref: React.RefSetter<mixed>,
+  ref: React.RefSetter<unknown>,
   ...$ReadOnly<Omit<TouchableBounceProps, 'hostRef'>>,
 }) {
   return <TouchableBounce {...props} hostRef={hostRef} />;
 } as component(
-  ref?: React.RefSetter<mixed>,
+  ref?: React.RefSetter<unknown>,
   ...props: $ReadOnly<Omit<TouchableBounceProps, 'hostRef'>>
 ));

--- a/packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js
@@ -390,7 +390,7 @@ class TouchableNativeFeedback extends React.Component<
     this.state.pressability.configure(this._createPressabilityConfig());
   }
 
-  componentDidMount(): mixed {
+  componentDidMount(): unknown {
     this.state.pressability.configure(this._createPressabilityConfig());
   }
 

--- a/packages/react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -79,32 +79,32 @@ export type TouchableWithoutFeedbackProps = $ReadOnly<
       | 'no-hide-descendants'
     ),
     nativeID?: ?string,
-    onAccessibilityAction?: ?(event: AccessibilityActionEvent) => mixed,
+    onAccessibilityAction?: ?(event: AccessibilityActionEvent) => unknown,
     /**
      * When `accessible` is true (which is the default) this may be called when
      * the OS-specific concept of "blur" occurs, meaning the element lost focus.
      * Some platforms may not have the concept of blur.
      */
-    onBlur?: ?(event: BlurEvent) => mixed,
+    onBlur?: ?(event: BlurEvent) => unknown,
     /**
      * When `accessible` is true (which is the default) this may be called when
      * the OS-specific concept of "focus" occurs. Some platforms may not have
      * the concept of focus.
      */
-    onFocus?: ?(event: FocusEvent) => mixed,
+    onFocus?: ?(event: FocusEvent) => unknown,
     /**
      * Invoked on mount and layout changes with
      * {nativeEvent: {layout: {x, y, width, height}}}
      */
-    onLayout?: ?(event: LayoutChangeEvent) => mixed,
-    onLongPress?: ?(event: GestureResponderEvent) => mixed,
+    onLayout?: ?(event: LayoutChangeEvent) => unknown,
+    onLongPress?: ?(event: GestureResponderEvent) => unknown,
     /**
      * Called when the touch is released,
      * but not if cancelled (e.g. by a scroll that steals the responder lock).
      */
-    onPress?: ?(event: GestureResponderEvent) => mixed,
-    onPressIn?: ?(event: GestureResponderEvent) => mixed,
-    onPressOut?: ?(event: GestureResponderEvent) => mixed,
+    onPress?: ?(event: GestureResponderEvent) => unknown,
+    onPressIn?: ?(event: GestureResponderEvent) => unknown,
+    onPressOut?: ?(event: GestureResponderEvent) => unknown,
     /**
      * When the scroll view is disabled, this defines how far your
      * touch may move off of the button, before deactivating the button.
@@ -250,7 +250,7 @@ export default function TouchableWithoutFeedback(
   // adopting `Pressability`, so preserve that behavior.
   const {onBlur, onFocus, ...eventHandlersWithoutBlurAndFocus} = eventHandlers;
 
-  const elementProps: {[string]: mixed, ...} = {
+  const elementProps: {[string]: unknown, ...} = {
     ...eventHandlersWithoutBlurAndFocus,
     accessible: props.accessible !== false,
     accessibilityState:

--- a/packages/react-native/Libraries/Components/View/ViewPropTypes.js
+++ b/packages/react-native/Libraries/Components/View/ViewPropTypes.js
@@ -39,7 +39,7 @@ type DirectEventProps = $ReadOnly<{
    * when the user performs an accessibility custom action.
    *
    */
-  onAccessibilityAction?: ?(event: AccessibilityActionEvent) => mixed,
+  onAccessibilityAction?: ?(event: AccessibilityActionEvent) => unknown,
 
   /**
    * When `accessible` is true, the system will try to invoke this function
@@ -47,7 +47,7 @@ type DirectEventProps = $ReadOnly<{
    *
    * See https://reactnative.dev/docs/view#onaccessibilitytap
    */
-  onAccessibilityTap?: ?() => mixed,
+  onAccessibilityTap?: ?() => unknown,
 
   /**
    * Invoked on mount and layout changes with:
@@ -60,7 +60,7 @@ type DirectEventProps = $ReadOnly<{
    *
    * See https://reactnative.dev/docs/view#onlayout
    */
-  onLayout?: ?(event: LayoutChangeEvent) => mixed,
+  onLayout?: ?(event: LayoutChangeEvent) => unknown,
 
   /**
    * When `accessible` is `true`, the system will invoke this function when the
@@ -68,7 +68,7 @@ type DirectEventProps = $ReadOnly<{
    *
    * See https://reactnative.dev/docs/view#onmagictap
    */
-  onMagicTap?: ?() => mixed,
+  onMagicTap?: ?() => unknown,
 
   /**
    * When `accessible` is `true`, the system will invoke this function when the
@@ -76,7 +76,7 @@ type DirectEventProps = $ReadOnly<{
    *
    * See https://reactnative.dev/docs/view#onaccessibilityescape
    */
-  onAccessibilityEscape?: ?() => mixed,
+  onAccessibilityEscape?: ?() => unknown,
 }>;
 
 type MouseEventProps = $ReadOnly<{
@@ -353,7 +353,7 @@ export type ViewPropsAndroid = $ReadOnly<{
    *
    * @platform android
    */
-  onClick?: ?(event: GestureResponderEvent) => mixed,
+  onClick?: ?(event: GestureResponderEvent) => unknown,
 }>;
 
 export type TVViewPropsIOS = $ReadOnly<{

--- a/packages/react-native/Libraries/Components/View/__tests__/View-vs-ViewNativeComponent-benchmark-itest.js
+++ b/packages/react-native/Libraries/Components/View/__tests__/View-vs-ViewNativeComponent-benchmark-itest.js
@@ -22,7 +22,7 @@ let testViews: React.MixedElement;
 const NUMBER_OF_VIEWS = 100;
 const NUMBER_OF_ITERATIONS = 1000;
 
-component Noop(children: React.Node, style?: mixed) {
+component Noop(children: React.Node, style?: unknown) {
   return children;
 }
 

--- a/packages/react-native/Libraries/Core/Devtools/loadBundleFromServer.js
+++ b/packages/react-native/Libraries/Core/Devtools/loadBundleFromServer.js
@@ -13,7 +13,10 @@ import DevLoadingView from '../../Utilities/DevLoadingView';
 import HMRClient from '../../Utilities/HMRClient';
 import getDevServer from './getDevServer';
 
-declare var global: {globalEvalWithSourceUrl?: (string, string) => mixed, ...};
+declare var global: {
+  globalEvalWithSourceUrl?: (string, string) => unknown,
+  ...
+};
 
 let pendingRequests = 0;
 
@@ -26,7 +29,7 @@ export class LoadBundleFromServerError extends Error {
     message: string,
     url: string,
     isTimeout: boolean,
-    options?: {cause: mixed, ...},
+    options?: {cause: unknown, ...},
   ): void {
     super(message, options);
     this.url = url;
@@ -40,7 +43,7 @@ export class LoadBundleFromServerRequestError extends LoadBundleFromServerError 
     message: string,
     url: string,
     isTimeout: boolean,
-    options?: {cause: mixed, ...},
+    options?: {cause: unknown, ...},
   ): void {
     super(message, url, isTimeout, options);
     this.name = 'LoadBundleFromServerRequestError';

--- a/packages/react-native/Libraries/Core/Devtools/symbolicateStackTrace.js
+++ b/packages/react-native/Libraries/Core/Devtools/symbolicateStackTrace.js
@@ -31,7 +31,7 @@ export type SymbolicatedStackTrace = $ReadOnly<{
 
 export default async function symbolicateStackTrace(
   stack: Array<StackFrame>,
-  extraData?: mixed,
+  extraData?: unknown,
 ): Promise<SymbolicatedStackTrace> {
   const devServer = getDevServer();
   if (!devServer.bundleLoadedFromServer) {

--- a/packages/react-native/Libraries/Core/ExceptionsManager.js
+++ b/packages/react-native/Libraries/Core/ExceptionsManager.js
@@ -135,8 +135,8 @@ function reportException(
 }
 
 declare var console: {
-  error: (...data: $ReadOnlyArray<mixed>) => void,
-  _errorOriginal: (...data: $ReadOnlyArray<mixed>) => void,
+  error: (...data: $ReadOnlyArray<unknown>) => void,
+  _errorOriginal: (...data: $ReadOnlyArray<unknown>) => void,
   reportErrorsAsExceptions: boolean,
   ...
 };
@@ -148,7 +148,7 @@ let inExceptionHandler = false;
 /**
  * Logs exceptions to the (native) console and displays them
  */
-function handleException(e: mixed, isFatal: boolean) {
+function handleException(e: unknown, isFatal: boolean) {
   // TODO(T196834299): We should really use a c++ turbomodule for this
   const reportToConsole = true;
   if (

--- a/packages/react-native/Libraries/Core/RawEventEmitter.js
+++ b/packages/react-native/Libraries/Core/RawEventEmitter.js
@@ -17,7 +17,7 @@ export type RawEventEmitterEvent = $ReadOnly<{
   // We expect, but do not/cannot require, that nativeEvent is an object
   // with the properties: key, elementType (string), type (string), tag (numeric),
   // and a stateNode of the native element/Fiber the event was emitted to.
-  nativeEvent: {[string]: mixed},
+  nativeEvent: {[string]: unknown},
 }>;
 
 type RawEventDefinitions = {

--- a/packages/react-native/Libraries/Core/ReactFiberErrorDialog.js
+++ b/packages/react-native/Libraries/Core/ReactFiberErrorDialog.js
@@ -14,7 +14,7 @@ import ExceptionsManager, {SyntheticError} from './ExceptionsManager';
 
 export type CapturedError = {
   +componentStack: string,
-  +error: mixed,
+  +error: unknown,
   +errorBoundary: ?{...},
   ...
 };

--- a/packages/react-native/Libraries/Core/__tests__/ExceptionsManager-test.js
+++ b/packages/react-native/Libraries/Core/__tests__/ExceptionsManager-test.js
@@ -38,7 +38,7 @@ describe('checkVersion', () => {
   });
 });
 
-function setDevelopmentModeForTests(dev: mixed) {
+function setDevelopmentModeForTests(dev: unknown) {
   let originalDev;
 
   beforeAll(() => {

--- a/packages/react-native/Libraries/Core/__tests__/ReactNativeVersionCheck-test.js
+++ b/packages/react-native/Libraries/Core/__tests__/ReactNativeVersionCheck-test.js
@@ -22,7 +22,7 @@ describe('checkVersion', () => {
   });
 });
 
-function _setDevelopmentModeForTests(dev: mixed) {
+function _setDevelopmentModeForTests(dev: unknown) {
   let originalDev;
 
   beforeAll(() => {

--- a/packages/react-native/Libraries/Core/setUpDeveloperTools.js
+++ b/packages/react-native/Libraries/Core/setUpDeveloperTools.js
@@ -37,7 +37,7 @@ if (__DEV__) {
         ] as const
       ).forEach(level => {
         const originalFunction = console[level];
-        console[level] = function (...args: $ReadOnlyArray<mixed>) {
+        console[level] = function (...args: $ReadOnlyArray<unknown>) {
           HMRClient.log(level, args);
           originalFunction.apply(console, args);
         };

--- a/packages/react-native/Libraries/Core/setUpErrorHandling.js
+++ b/packages/react-native/Libraries/Core/setUpErrorHandling.js
@@ -20,7 +20,7 @@ if (global.RN$useAlwaysAvailableJSErrorHandling !== true) {
 
   // Set up error handler
   if (!global.__fbDisableExceptionsManager) {
-    const handleError = (e: mixed, isFatal: boolean) => {
+    const handleError = (e: unknown, isFatal: boolean) => {
       try {
         ExceptionsManager.handleException(e, isFatal);
       } catch (ee) {

--- a/packages/react-native/Libraries/EventEmitter/NativeEventEmitter.js
+++ b/packages/react-native/Libraries/EventEmitter/NativeEventEmitter.js
@@ -85,8 +85,8 @@ export default class NativeEventEmitter<
 
   addListener<TEvent: $Keys<TEventToArgsMap>>(
     eventType: TEvent,
-    listener: (...args: TEventToArgsMap[TEvent]) => mixed,
-    context?: mixed,
+    listener: (...args: TEventToArgsMap[TEvent]) => unknown,
+    context?: unknown,
   ): EventSubscription {
     this._nativeModule?.addListener(eventType);
     let subscription: ?EventSubscription = RCTDeviceEventEmitter.addListener(

--- a/packages/react-native/Libraries/EventEmitter/__mocks__/NativeEventEmitter.js
+++ b/packages/react-native/Libraries/EventEmitter/__mocks__/NativeEventEmitter.js
@@ -19,13 +19,13 @@ import RCTDeviceEventEmitter from '../RCTDeviceEventEmitter';
  * Mock `NativeEventEmitter` to ignore Native Modules.
  */
 export default class NativeEventEmitter<
-  TEventToArgsMap: $ReadOnly<Record<string, $ReadOnlyArray<mixed>>>,
+  TEventToArgsMap: $ReadOnly<Record<string, $ReadOnlyArray<unknown>>>,
 > implements IEventEmitter<TEventToArgsMap>
 {
   addListener<TEvent: $Keys<TEventToArgsMap>>(
     eventType: TEvent,
-    listener: (...args: TEventToArgsMap[TEvent]) => mixed,
-    context?: mixed,
+    listener: (...args: TEventToArgsMap[TEvent]) => unknown,
+    context?: unknown,
   ): EventSubscription {
     return RCTDeviceEventEmitter.addListener(eventType, listener, context);
   }

--- a/packages/react-native/Libraries/Image/Image.android.js
+++ b/packages/react-native/Libraries/Image/Image.android.js
@@ -48,7 +48,7 @@ function generateRequestId() {
 function getSize(
   url: string,
   success?: (width: number, height: number) => void,
-  failure?: (error: mixed) => void,
+  failure?: (error: unknown) => void,
 ): void | Promise<ImageSize> {
   const promise = NativeImageLoaderAndroid.getSize(url);
   if (typeof success !== 'function') {
@@ -74,7 +74,7 @@ function getSizeWithHeaders(
   url: string,
   headers: {[string]: string, ...},
   success?: (width: number, height: number) => void,
-  failure?: (error: mixed) => void,
+  failure?: (error: unknown) => void,
 ): void | Promise<ImageSize> {
   const promise = NativeImageLoaderAndroid.getSizeWithHeaders(url, headers);
   if (typeof success !== 'function') {

--- a/packages/react-native/Libraries/Image/Image.ios.js
+++ b/packages/react-native/Libraries/Image/Image.ios.js
@@ -33,7 +33,7 @@ import * as React from 'react';
 function getSize(
   uri: string,
   success?: (width: number, height: number) => void,
-  failure?: (error: mixed) => void,
+  failure?: (error: unknown) => void,
 ): void | Promise<ImageSize> {
   const promise = NativeImageLoaderIOS.getSize(uri).then(([width, height]) => ({
     width,
@@ -56,7 +56,7 @@ function getSizeWithHeaders(
   uri: string,
   headers: {[string]: string, ...},
   success?: (width: number, height: number) => void,
-  failure?: (error: mixed) => void,
+  failure?: (error: unknown) => void,
 ): void | Promise<ImageSize> {
   const promise = NativeImageLoaderIOS.getSizeWithHeaders(uri, headers);
   if (typeof success !== 'function') {

--- a/packages/react-native/Libraries/Image/ImageProps.js
+++ b/packages/react-native/Libraries/Image/ImageProps.js
@@ -220,7 +220,7 @@ export type ImagePropsBase = $ReadOnly<{
    * See https://reactnative.dev/docs/image#onlayout
    */
 
-  onLayout?: ?(event: LayoutChangeEvent) => mixed,
+  onLayout?: ?(event: LayoutChangeEvent) => unknown,
 
   /**
    * Invoked when load completes successfully.

--- a/packages/react-native/Libraries/Image/ImageTypes.flow.js
+++ b/packages/react-native/Libraries/Image/ImageTypes.flow.js
@@ -28,7 +28,7 @@ type ImageComponentStaticsIOS = $ReadOnly<{
   getSize(
     uri: string,
     success: (width: number, height: number) => void,
-    failure?: (error: mixed) => void,
+    failure?: (error: unknown) => void,
   ): void,
 
   getSizeWithHeaders(
@@ -39,7 +39,7 @@ type ImageComponentStaticsIOS = $ReadOnly<{
     uri: string,
     headers: {[string]: string, ...},
     success: (width: number, height: number) => void,
-    failure?: (error: mixed) => void,
+    failure?: (error: unknown) => void,
   ): void,
 
   prefetch(url: string): Promise<boolean>,

--- a/packages/react-native/Libraries/Image/__tests__/Image-itest.js
+++ b/packages/react-native/Libraries/Image/__tests__/Image-itest.js
@@ -683,7 +683,7 @@ describe('<Image>', () => {
             (width, height) => {
               size = {width, height};
             },
-            (e: mixed) => {
+            (e: unknown) => {
               if (e instanceof Error) {
                 err = e;
               }

--- a/packages/react-native/Libraries/Interaction/InteractionManager.js
+++ b/packages/react-native/Libraries/Interaction/InteractionManager.js
@@ -98,7 +98,7 @@ const InteractionManagerStub = {
   runAfterInteractions(task: ?Task): {
     then: <U>(
       onFulfill?: ?(void) => ?(Promise<U> | U),
-      onReject?: ?(error: mixed) => ?(Promise<U> | U),
+      onReject?: ?(error: unknown) => ?(Promise<U> | U),
     ) => Promise<U>,
     cancel: () => void,
     ...
@@ -165,8 +165,8 @@ const InteractionManagerStub = {
   addListener(
     eventType: string,
     // $FlowFixMe[unclear-type]
-    listener: (...args: any) => mixed,
-    context: mixed,
+    listener: (...args: any) => unknown,
+    context: unknown,
   ): EventSubscription {
     return {
       remove() {},

--- a/packages/react-native/Libraries/Interaction/PanResponder.js
+++ b/packages/react-native/Libraries/Interaction/PanResponder.js
@@ -187,7 +187,7 @@ type ActiveCallback = (
 type PassiveCallback = (
   event: GestureResponderEvent,
   gestureState: PanResponderGestureState,
-) => mixed;
+) => unknown;
 
 export type GestureResponderHandlerMethods = {
   onMoveShouldSetResponder: (event: GestureResponderEvent) => boolean,

--- a/packages/react-native/Libraries/LayoutAnimation/LayoutAnimation.js
+++ b/packages/react-native/Libraries/LayoutAnimation/LayoutAnimation.js
@@ -201,7 +201,7 @@ const LayoutAnimation = {
     scaleY: 'scaleY',
     scaleXY: 'scaleXY',
   }) as LayoutAnimationProperties,
-  checkConfig(...args: Array<mixed>) {
+  checkConfig(...args: Array<unknown>) {
     console.error('LayoutAnimation.checkConfig(...) has been disabled.');
   },
   Presets,

--- a/packages/react-native/Libraries/Linking/Linking.js
+++ b/packages/react-native/Libraries/Linking/Linking.js
@@ -34,7 +34,7 @@ class LinkingImpl extends NativeEventEmitter<LinkingEventDefinitions> {
    */
   addEventListener<K: $Keys<LinkingEventDefinitions>>(
     eventType: K,
-    listener: (...LinkingEventDefinitions[K]) => mixed,
+    listener: (...LinkingEventDefinitions[K]) => unknown,
   ): EventSubscription {
     return this.addListener(eventType, listener);
   }

--- a/packages/react-native/Libraries/Lists/FlatList.js
+++ b/packages/react-native/Libraries/Lists/FlatList.js
@@ -172,7 +172,7 @@ function numColumnsOrDefault(numColumns: ?number) {
   return numColumns ?? 1;
 }
 
-function isArrayLike(data: mixed): boolean {
+function isArrayLike(data: unknown): boolean {
   // $FlowExpectedError[incompatible-use]
   return typeof Object(data).length === 'number';
 }
@@ -413,7 +413,7 @@ class FlatList<ItemT = any> extends React.PureComponent<FlatListProps<ItemT>> {
     }
   }
 
-  setNativeProps(props: {[string]: mixed, ...}) {
+  setNativeProps(props: {[string]: unknown, ...}) {
     if (this._listRef) {
       this._listRef.setNativeProps(props);
     }

--- a/packages/react-native/Libraries/LogBox/Data/LogBoxLog.js
+++ b/packages/react-native/Libraries/LogBox/Data/LogBoxLog.js
@@ -65,7 +65,7 @@ export type LogBoxLogData = $ReadOnly<{
   componentStack: ComponentStack,
   codeFrame?: ?CodeFrame,
   isComponentError: boolean,
-  extraData?: mixed,
+  extraData?: unknown,
   onNotificationPress?: ?() => void,
 }>;
 
@@ -81,7 +81,7 @@ class LogBoxLog {
   codeFrame: ?CodeFrame;
   componentCodeFrame: ?CodeFrame;
   isComponentError: boolean;
-  extraData: mixed | void;
+  extraData: unknown | void;
   symbolicated:
     | $ReadOnly<{error: null, stack: null, status: 'NONE'}>
     | $ReadOnly<{error: null, stack: null, status: 'PENDING'}>

--- a/packages/react-native/Libraries/LogBox/Data/LogBoxSymbolication.js
+++ b/packages/react-native/Libraries/LogBox/Data/LogBoxSymbolication.js
@@ -53,7 +53,7 @@ export function deleteStack(stack: Stack): void {
 
 export function symbolicate(
   stack: Stack,
-  extraData?: mixed,
+  extraData?: unknown,
 ): Promise<SymbolicatedStackTrace> {
   let promise = cache.get(stack);
   if (promise == null) {

--- a/packages/react-native/Libraries/LogBox/Data/parseLogBoxLog.js
+++ b/packages/react-native/Libraries/LogBox/Data/parseLogBoxLog.js
@@ -93,7 +93,7 @@ const RE_BABEL_CODE_FRAME_MARKER_PATTERN = new RegExp(
   'm',
 );
 
-export function hasComponentStack(args: $ReadOnlyArray<mixed>): boolean {
+export function hasComponentStack(args: $ReadOnlyArray<unknown>): boolean {
   for (const arg of args) {
     if (typeof arg === 'string' && isComponentStack(arg)) {
       return true;
@@ -136,7 +136,7 @@ export type ComponentStackType = 'legacy' | 'stack';
 
 const SUBSTITUTION = UTFSequence.BOM + '%s';
 
-export function parseInterpolation(args: $ReadOnlyArray<mixed>): $ReadOnly<{
+export function parseInterpolation(args: $ReadOnlyArray<unknown>): $ReadOnly<{
   category: Category,
   message: Message,
 }> {
@@ -444,7 +444,7 @@ export function parseLogBoxException(
   };
 }
 
-export function withoutANSIColorStyles(message: mixed): mixed {
+export function withoutANSIColorStyles(message: unknown): unknown {
   if (typeof message !== 'string') {
     return message;
   }
@@ -456,14 +456,14 @@ export function withoutANSIColorStyles(message: mixed): mixed {
   );
 }
 
-export function parseLogBoxLog(args: $ReadOnlyArray<mixed>): {
+export function parseLogBoxLog(args: $ReadOnlyArray<unknown>): {
   componentStack: ComponentStack,
   componentStackType: ComponentStackType,
   category: Category,
   message: Message,
 } {
   const message = withoutANSIColorStyles(args[0]);
-  let argsWithoutComponentStack: Array<mixed> = [];
+  let argsWithoutComponentStack: Array<unknown> = [];
   let componentStack: ComponentStack = [];
   let componentStackType = 'legacy';
 

--- a/packages/react-native/Libraries/LogBox/LogBox.js
+++ b/packages/react-native/Libraries/LogBox/LogBox.js
@@ -27,7 +27,7 @@ interface ILogBox {
   ignoreAllLogs(value?: boolean): void;
   clearAllLogs(): void;
   addLog(log: LogData): void;
-  addConsoleLog(level: 'warn' | 'error', ...args: Array<mixed>): void;
+  addConsoleLog(level: 'warn' | 'error', ...args: Array<unknown>): void;
   addException(error: ExtendedExceptionData): void;
 }
 
@@ -42,7 +42,7 @@ if (__DEV__) {
   } = require('./Data/parseLogBoxLog');
 
   let originalConsoleWarn;
-  let consoleWarnImpl: (...args: Array<mixed>) => void;
+  let consoleWarnImpl: (...args: Array<unknown>) => void;
 
   let isLogBoxInstalled: boolean = false;
 
@@ -56,7 +56,7 @@ if (__DEV__) {
 
       if (global.RN$registerExceptionListener != null) {
         global.RN$registerExceptionListener(
-          (error: ExtendedExceptionData & {preventDefault: () => mixed}) => {
+          (error: ExtendedExceptionData & {preventDefault: () => unknown}) => {
             if (global.RN$isRuntimeReady?.() || !error.isFatal) {
               error.preventDefault();
               addException(error);
@@ -140,7 +140,7 @@ if (__DEV__) {
       }
     },
 
-    addConsoleLog(level: 'warn' | 'error', ...args: Array<mixed>) {
+    addConsoleLog(level: 'warn' | 'error', ...args: Array<unknown>) {
       if (isLogBoxInstalled) {
         let filteredLevel: 'warn' | 'error' | 'fatal' = level;
         try {
@@ -207,13 +207,13 @@ if (__DEV__) {
     }
   }
 
-  const isRCTLogAdviceWarning = (...args: Array<mixed>) => {
+  const isRCTLogAdviceWarning = (...args: Array<unknown>) => {
     // RCTLogAdvice is a native logging function designed to show users
     // a message in the console, but not show it to them in Logbox.
     return typeof args[0] === 'string' && args[0].startsWith('(ADVICE)');
   };
 
-  const registerWarning = (...args: Array<mixed>): void => {
+  const registerWarning = (...args: Array<unknown>): void => {
     // Let warnings within LogBox itself fall through.
     if (LogBoxData.isLogBoxErrorMessage(String(args[0]))) {
       return;
@@ -271,7 +271,7 @@ if (__DEV__) {
       // Do nothing.
     },
 
-    addConsoleLog(level: 'warn' | 'error', ...args: Array<mixed>): void {
+    addConsoleLog(level: 'warn' | 'error', ...args: Array<unknown>): void {
       // Do nothing.
     },
 

--- a/packages/react-native/Libraries/NativeComponent/StaticViewConfigValidator.js
+++ b/packages/react-native/Libraries/NativeComponent/StaticViewConfigValidator.js
@@ -15,13 +15,13 @@ export type Difference =
   | {
       type: 'missing',
       path: Array<string>,
-      nativeValue: mixed,
+      nativeValue: unknown,
     }
   | {
       type: 'unequal',
       path: Array<string>,
-      nativeValue: mixed,
-      staticValue: mixed,
+      nativeValue: unknown,
+      staticValue: unknown,
     };
 
 export type ValidationResult = ValidResult | InvalidResult;
@@ -143,6 +143,6 @@ function accumulateDifferences(
   }
 }
 
-function ifObject(value: mixed): ?{...} {
+function ifObject(value: unknown): ?{...} {
   return typeof value === 'object' && !Array.isArray(value) ? value : null;
 }

--- a/packages/react-native/Libraries/NativeComponent/ViewConfigIgnore.js
+++ b/packages/react-native/Libraries/NativeComponent/ViewConfigIgnore.js
@@ -43,7 +43,7 @@ export function ConditionallyIgnoredEventHandlers<
   return undefined;
 }
 
-export function isIgnored(value: mixed): boolean {
+export function isIgnored(value: unknown): boolean {
   if (typeof value === 'object' && value != null) {
     return ignoredViewConfigProps.has(value);
   }

--- a/packages/react-native/Libraries/Network/RCTNetworking.android.js
+++ b/packages/react-native/Libraries/Network/RCTNetworking.android.js
@@ -50,8 +50,8 @@ const emitter = new NativeEventEmitter<$FlowFixMe>(
 const RCTNetworking = {
   addListener<K: $Keys<RCTNetworkingEventDefinitions>>(
     eventType: K,
-    listener: (...RCTNetworkingEventDefinitions[K]) => mixed,
-    context?: mixed,
+    listener: (...RCTNetworkingEventDefinitions[K]) => unknown,
+    context?: unknown,
   ): EventSubscription {
     // $FlowFixMe[incompatible-type]
     return emitter.addListener(eventType, listener, context);
@@ -66,7 +66,7 @@ const RCTNetworking = {
     responseType: NativeResponseType,
     incrementalUpdates: boolean,
     timeout: number,
-    callback: (requestId: number) => mixed,
+    callback: (requestId: number) => unknown,
     withCredentials: boolean,
   ) {
     const body = convertRequestBody(data);

--- a/packages/react-native/Libraries/Network/RCTNetworking.ios.js
+++ b/packages/react-native/Libraries/Network/RCTNetworking.ios.js
@@ -20,8 +20,8 @@ import {type NativeResponseType} from './XMLHttpRequest';
 const RCTNetworking = {
   addListener<K: $Keys<RCTNetworkingEventDefinitions>>(
     eventType: K,
-    listener: (...RCTNetworkingEventDefinitions[K]) => mixed,
-    context?: mixed,
+    listener: (...RCTNetworkingEventDefinitions[K]) => unknown,
+    context?: unknown,
   ): EventSubscription {
     // $FlowFixMe[incompatible-type]
     return RCTDeviceEventEmitter.addListener(eventType, listener, context);

--- a/packages/react-native/Libraries/Network/RCTNetworking.js.flow
+++ b/packages/react-native/Libraries/Network/RCTNetworking.js.flow
@@ -19,8 +19,8 @@ declare const RCTNetworking: interface {
   addListener<K: $Keys<RCTNetworkingEventDefinitions>>(
     eventType: K,
     // $FlowFixMe[invalid-computed-prop]
-    listener: (...RCTNetworkingEventDefinitions[K]) => mixed,
-    context?: mixed,
+    listener: (...RCTNetworkingEventDefinitions[K]) => unknown,
+    context?: unknown,
   ): EventSubscription,
 
   sendRequest(


### PR DESCRIPTION
Summary:
We are transforming the following utility types to be more consistent with typescript and better AI integration:

* `$NonMaybeType` -> `NonNullable`
* `$ReadOnly` -> `Readonly`
* `$ReadOnlyArray` -> `ReadonlyArray`
* `$ReadOnlyMap` -> `ReadonlyMap`
* `$ReadOnlySet` -> `ReadonlySet`
* `$Keys` -> `keyof`
* `$Values` -> `Values`
* `mixed` -> `unknown`

See details in https://fb.workplace.com/groups/flowlang/permalink/1837907750148213/.
drop-conflicts

Reviewed By: SamChou19815

Differential Revision: D89581584
