### PR TITLE
fix(android): re-enable mBackPressedCallback after invokeDefaultOnBackPressed

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
@@ -124,6 +124,9 @@ public abstract class ReactActivity extends AppCompatActivity
     // as super.onBackPressed() will call all enabled callbacks in the dispatcher.
     mBackPressedCallback.setEnabled(false);
     super.onBackPressed();
+    // Re-enable callback to ensure custom back handling works after activity resume
+    // Without this, the callback remains disabled when the app returns from background
+    mBackPressedCallback.setEnabled(true);
   }
 
   @Override


### PR DESCRIPTION
## Summary:

Issue  [#54887](https://github.com/facebook/react-native/issues/54887)

Problem:
After backgrounding the app using the hardware back button or BackHandler.exitApp() and then relaunching, custom back button handlers (JS callbacks) stop working. Instead of executing the registered callbacks, pressing the back button immediately backgrounds the app again.

Root Cause:
This issue occurs on Android API 36+ and is related to the recent migration from deprecated onBackPressed() to OnBackPressedCallback in commit bc876fb3b3d.

In invokeDefaultOnBackPressed(), the mBackPressedCallback is disabled to allow Android's default back behavior (finishing the activity), but it's never re-enabled afterward. When the app resumes from the background, the callback remains disabled, preventing JavaScript back handlers from being triggered.

Solution:
Re-enable mBackPressedCallback after calling super.onBackPressed() in invokeDefaultOnBackPressed() to ensure custom back handling continues to work across app lifecycle events.

## Changelog:

[ANDROID] [FIXED] - Fix BackHandler callbacks not working after app resume on API 36+

## Test Plan:

Setup:

Open RN-Tester app and navigate to the Playground example
Press "Override Default BackHandler" button to enable custom back handler
Verify that pressing the back button shows an alert dialog instead of backgrounding the app

Testing the Bug Fix:

1. With custom back handler active, press "Yes" in the alert dialog to exit the app (calls BackHandler.exitApp())
2. Relaunch RN-Tester (resume Activity)
3. Press back button - it should show the alert dialog again (not immediately background the app)

Expected Behavior:

Before fix: After step 3, back button would immediately background the app instead of showing the alert. (hardwareBackPress events not registering) 
After fix: Back button correctly shows the alert dialog, confirming custom handler works after app resume.

Technical Notes:

If the activity is destroyed, mBackPressedCallback.setEnabled(true) has no effect,
If the activity is backgrounded and resumed, the fix ensures the callback remains enabled and functional


```
import RNTesterText from '../../components/RNTesterText';
import React, { useEffect } from 'react';
import { Alert, BackHandler, StyleSheet, View, Pressable } from 'react-native';

function Playground() {
  const [isOverriden, setIsOverriden] = React.useState(false);
  useEffect(() => {
    const backAction = () => {
      Alert.alert('Exit App', 'Do you want to exit the app?', [
        {
          text: 'Cancel',
          onPress: () => null,
          style: 'cancel',
        },
        {
          text: 'Yes',
          onPress: () => BackHandler.exitApp(),
        },
      ]);
      return true;
    };

    const backHandler = isOverriden && BackHandler.addEventListener(
      'hardwareBackPress',
      backAction
    )
    return () => isOverriden && backHandler.remove();
  }, [isOverriden]);


  return (
    <View style={styles.container}>
      <RNTesterText>
        Testing BackHandler
      </RNTesterText>
      {!isOverriden && (
        <Pressable
          onPress={() => {
            setIsOverriden(true)
          }}
          style={{
            marginTop: 20,
            padding: 10,
            backgroundColor: 'lightblue',
            borderRadius: 5,
          }}
        >
          <RNTesterText>
            Overrdide Default BackHandler
          </RNTesterText>
        </Pressable>
      )}
      {isOverriden && <RNTesterText>BackHandler is overridden</RNTesterText>}
    </View >
  );
}

const styles = StyleSheet.create({
  container: {
    padding: 10,
  },
});

```
Before the changes:
https://github.com/user-attachments/assets/c1504848-e1e6-451d-bed3-f3d9c66d6a58

After the changes:
https://github.com/user-attachments/assets/e1e19dda-e867-4281-a9bc-6f72d47d4141