### PR TITLE
React 19.2.3 sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,8 +108,8 @@
     "nullthrows": "^1.1.1",
     "prettier": "3.6.2",
     "prettier-plugin-hermes-parser": "0.32.0",
-    "react": "19.2.0",
-    "react-test-renderer": "19.2.0",
+    "react": "19.2.3",
+    "react-test-renderer": "19.2.3",
     "rimraf": "^3.0.2",
     "shelljs": "^0.8.5",
     "signedsource": "^2.0.0",
@@ -121,7 +121,7 @@
     "ws": "^7.5.10"
   },
   "resolutions": {
-    "react-is": "19.2.0",
+    "react-is": "19.2.3",
     "on-headers": "1.1.0",
     "compression": "1.8.1"
   }

--- a/packages/react-native/Libraries/Renderer/implementations/ReactFabric-dev.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactFabric-dev.js
@@ -7,7 +7,7 @@
  * @noflow
  * @nolint
  * @preventMunge
- * @generated SignedSource<<d53d779c0308b393f00f3bad2e7e86d4>>
+ * @generated SignedSource<<e7f6759bcc8955193867c6ab42bd07ad>>
  *
  * This file was sync'd from the facebook/react repository.
  */
@@ -18901,10 +18901,10 @@ __DEV__ &&
     (function () {
       var internals = {
         bundleType: 1,
-        version: "19.2.0",
+        version: "19.2.3",
         rendererPackageName: "react-native-renderer",
         currentDispatcherRef: ReactSharedInternals,
-        reconcilerVersion: "19.2.0"
+        reconcilerVersion: "19.2.3"
       };
       null !== extraDevToolsConfig &&
         (internals.rendererConfig = extraDevToolsConfig);

--- a/packages/react-native/Libraries/Renderer/implementations/ReactFabric-prod.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactFabric-prod.js
@@ -7,7 +7,7 @@
  * @noflow
  * @nolint
  * @preventMunge
- * @generated SignedSource<<e8da88ae248e2c108d8595c48ad070ca>>
+ * @generated SignedSource<<8d29d23a1c540d7502dd188e691eb725>>
  *
  * This file was sync'd from the facebook/react repository.
  */
@@ -10495,10 +10495,10 @@ batchedUpdatesImpl = function (fn, a) {
 var roots = new Map(),
   internals$jscomp$inline_1245 = {
     bundleType: 0,
-    version: "19.2.0",
+    version: "19.2.3",
     rendererPackageName: "react-native-renderer",
     currentDispatcherRef: ReactSharedInternals,
-    reconcilerVersion: "19.2.0"
+    reconcilerVersion: "19.2.3"
   };
 null !== extraDevToolsConfig &&
   (internals$jscomp$inline_1245.rendererConfig = extraDevToolsConfig);

--- a/packages/react-native/Libraries/Renderer/implementations/ReactFabric-profiling.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactFabric-profiling.js
@@ -7,7 +7,7 @@
  * @noflow
  * @nolint
  * @preventMunge
- * @generated SignedSource<<e02bd84b9218e9b7cbc92a39eee81f5f>>
+ * @generated SignedSource<<c4dae0f7dbb88147f400089cab897268>>
  *
  * This file was sync'd from the facebook/react repository.
  */
@@ -12298,10 +12298,10 @@ batchedUpdatesImpl = function (fn, a) {
 var roots = new Map(),
   internals$jscomp$inline_1537 = {
     bundleType: 0,
-    version: "19.2.0",
+    version: "19.2.3",
     rendererPackageName: "react-native-renderer",
     currentDispatcherRef: ReactSharedInternals,
-    reconcilerVersion: "19.2.0"
+    reconcilerVersion: "19.2.3"
   };
 null !== extraDevToolsConfig &&
   (internals$jscomp$inline_1537.rendererConfig = extraDevToolsConfig);

--- a/packages/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js
@@ -7,9 +7,9 @@
  * @noflow
  * @nolint
  * @preventMunge
+ * @generated SignedSource<<22737380b5e4280ce3563ac009164f56>>
  *
- * This file is no longer sync'd from the facebook/react repository.
- * The version compatability check is removed. Use at your own risk.
+ * This file was sync'd from the facebook/react repository.
  */
 
 "use strict";
@@ -19455,6 +19455,13 @@ __DEV__ &&
     setSuspenseHandler = function (newShouldSuspendImpl) {
       shouldSuspendImpl = newShouldSuspendImpl;
     };
+    var isomorphicReactPackageVersion = React.version;
+    if ("19.2.3" !== isomorphicReactPackageVersion)
+      throw Error(
+        'Incompatible React versions: The "react" and "react-native-renderer" packages must have the exact same version. Instead got:\n  - react:                  ' +
+          (isomorphicReactPackageVersion +
+            "\n  - react-native-renderer:  19.2.3\nLearn more: https://react.dev/warnings/version-mismatch")
+      );
     if (
       "function" !==
       typeof ReactNativePrivateInterface.ReactFiberErrorDialog.showErrorDialog
@@ -19479,10 +19486,10 @@ __DEV__ &&
     (function () {
       var internals = {
         bundleType: 1,
-        version: "19.2.0",
+        version: "19.2.3",
         rendererPackageName: "react-native-renderer",
         currentDispatcherRef: ReactSharedInternals,
-        reconcilerVersion: "19.2.0"
+        reconcilerVersion: "19.2.3"
       };
       null !== extraDevToolsConfig &&
         (internals.rendererConfig = extraDevToolsConfig);

--- a/packages/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-prod.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-prod.js
@@ -7,9 +7,9 @@
  * @noflow
  * @nolint
  * @preventMunge
+ * @generated SignedSource<<232209f5a157745637191195f25907c7>>
  *
- * This file is no longer sync'd from the facebook/react repository.
- * The version compatability check is removed. Use at your own risk.
+ * This file was sync'd from the facebook/react repository.
  */
 
 "use strict";
@@ -10918,6 +10918,13 @@ function updateContainer(element, container, parentComponent, callback) {
     entangleTransitions(element, parentComponent, lane));
   return lane;
 }
+var isomorphicReactPackageVersion = React.version;
+if ("19.2.3" !== isomorphicReactPackageVersion)
+  throw Error(
+    'Incompatible React versions: The "react" and "react-native-renderer" packages must have the exact same version. Instead got:\n  - react:                  ' +
+      (isomorphicReactPackageVersion +
+        "\n  - react-native-renderer:  19.2.3\nLearn more: https://react.dev/warnings/version-mismatch")
+  );
 if (
   "function" !==
   typeof ReactNativePrivateInterface.ReactFiberErrorDialog.showErrorDialog
@@ -10966,10 +10973,10 @@ batchedUpdatesImpl = function (fn, a) {
 var roots = new Map(),
   internals$jscomp$inline_1296 = {
     bundleType: 0,
-    version: "19.2.0",
+    version: "19.2.3",
     rendererPackageName: "react-native-renderer",
     currentDispatcherRef: ReactSharedInternals,
-    reconcilerVersion: "19.2.0"
+    reconcilerVersion: "19.2.3"
   };
 null !== extraDevToolsConfig &&
   (internals$jscomp$inline_1296.rendererConfig = extraDevToolsConfig);

--- a/packages/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-profiling.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-profiling.js
@@ -7,9 +7,9 @@
  * @noflow
  * @nolint
  * @preventMunge
+ * @generated SignedSource<<9b111e8265a6b1d86607277dbe91d200>>
  *
- * This file is no longer sync'd from the facebook/react repository.
- * The version compatability check is removed. Use at your own risk.
+ * This file was sync'd from the facebook/react repository.
  */
 
 "use strict";
@@ -12713,6 +12713,13 @@ function updateContainer(element, container, parentComponent, callback) {
     entangleTransitions(element, parentComponent, lane));
   return lane;
 }
+var isomorphicReactPackageVersion = React.version;
+if ("19.2.3" !== isomorphicReactPackageVersion)
+  throw Error(
+    'Incompatible React versions: The "react" and "react-native-renderer" packages must have the exact same version. Instead got:\n  - react:                  ' +
+      (isomorphicReactPackageVersion +
+        "\n  - react-native-renderer:  19.2.3\nLearn more: https://react.dev/warnings/version-mismatch")
+  );
 if (
   "function" !==
   typeof ReactNativePrivateInterface.ReactFiberErrorDialog.showErrorDialog
@@ -12761,10 +12768,10 @@ batchedUpdatesImpl = function (fn, a) {
 var roots = new Map(),
   internals$jscomp$inline_1588 = {
     bundleType: 0,
-    version: "19.2.0",
+    version: "19.2.3",
     rendererPackageName: "react-native-renderer",
     currentDispatcherRef: ReactSharedInternals,
-    reconcilerVersion: "19.2.0"
+    reconcilerVersion: "19.2.3"
   };
 null !== extraDevToolsConfig &&
   (internals$jscomp$inline_1588.rendererConfig = extraDevToolsConfig);

--- a/packages/react-native/Libraries/Renderer/shims/ReactFabric.js
+++ b/packages/react-native/Libraries/Renderer/shims/ReactFabric.js
@@ -7,7 +7,9 @@
  * @noformat
  * @nolint
  * @flow
- * @generated SignedSource<<cf323fc5ca893bab5669c7d321660412>>
+ * @generated SignedSource<<16b364e89f43b8a47832b0dfb98af11e>>
+ *
+ * This file was sync'd from the facebook/react repository.
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Renderer/shims/ReactFeatureFlags.js
+++ b/packages/react-native/Libraries/Renderer/shims/ReactFeatureFlags.js
@@ -7,7 +7,9 @@
  * @noformat
  * @nolint
  * @flow strict-local
- * @generated SignedSource<<908f5fb85384725318e261f40e49d9a6>>
+ * @generated SignedSource<<1dd9e9c3f20e37ae14e485fc6ee3d9e9>>
+ *
+ * This file was sync'd from the facebook/react repository.
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Renderer/shims/ReactNative.js
+++ b/packages/react-native/Libraries/Renderer/shims/ReactNative.js
@@ -7,9 +7,9 @@
  * @noformat
  * @nolint
  * @flow
+ * @generated SignedSource<<e2c46705ed927302dbe9332dafba459d>>
  *
- * This file is no longer sync'd from the facebook/react repository.
- * The version compatability check is removed. Use at your own risk.
+ * This file was sync'd from the facebook/react repository.
  */
 'use strict';
 

--- a/packages/react-native/Libraries/Renderer/shims/ReactNativeTypes.js
+++ b/packages/react-native/Libraries/Renderer/shims/ReactNativeTypes.js
@@ -7,7 +7,9 @@
  * @noformat
  * @nolint
  * @flow strict
- * @generated SignedSource<<c0e57723772ea5f1aa8c3c897ac3c216>>
+ * @generated SignedSource<<989e6e2e860dc2af7ba983849111bda8>>
+ *
+ * This file was sync'd from the facebook/react repository.
  */
 
 import type {

--- a/packages/react-native/Libraries/Renderer/shims/ReactNativeViewConfigRegistry.js
+++ b/packages/react-native/Libraries/Renderer/shims/ReactNativeViewConfigRegistry.js
@@ -7,7 +7,9 @@
  * @noformat
  * @nolint
  * @flow strict-local
- * @generated SignedSource<<1f7876c0dc0b05685a730513dc410236>>
+ * @generated SignedSource<<67d18226984338ab9301147ce0a7d414>>
+ *
+ * This file was sync'd from the facebook/react repository.
  */
 
 'use strict';

--- a/packages/react-native/Libraries/Renderer/shims/createReactNativeComponentClass.js
+++ b/packages/react-native/Libraries/Renderer/shims/createReactNativeComponentClass.js
@@ -7,7 +7,9 @@
  * @noformat
  * @nolint
  * @flow strict-local
- * @generated SignedSource<<52163887de05f1cff05388145cf85b3b>>
+ * @generated SignedSource<<556d1487de0b9e4a09cbc67dd130a884>>
+ *
+ * This file was sync'd from the facebook/react repository.
  */
 
 'use strict';

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -151,7 +151,7 @@
   },
   "peerDependencies": {
     "@types/react": "^19.1.1",
-    "react": "^19.2.0"
+    "react": "^19.2.3"
   },
   "peerDependenciesMeta": {
     "@types/react": {

--- a/packages/rn-tester/package.json
+++ b/packages/rn-tester/package.json
@@ -32,7 +32,7 @@
     "nullthrows": "^1.1.1"
   },
   "peerDependencies": {
-    "react": "19.2.0",
+    "react": "19.2.3",
     "react-native": "*"
   },
   "codegenConfig": {

--- a/packages/virtualized-lists/package.json
+++ b/packages/virtualized-lists/package.json
@@ -48,7 +48,7 @@
     "nullthrows": "^1.1.1"
   },
   "devDependencies": {
-    "react-test-renderer": "19.2.0"
+    "react-test-renderer": "19.2.3"
   },
   "peerDependencies": {
     "@types/react": "^19.2.0",

--- a/private/helloworld/package.json
+++ b/private/helloworld/package.json
@@ -12,7 +12,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "react": "19.2.0",
+    "react": "19.2.3",
     "react-native": "1000.0.0"
   },
   "devDependencies": {
@@ -29,7 +29,7 @@
     "eslint": "^8.19.0",
     "jest": "^29.7.0",
     "listr2": "^8.2.1",
-    "react-test-renderer": "19.2.0",
+    "react-test-renderer": "19.2.3",
     "rxjs": "^7.8.1"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7942,28 +7942,28 @@ react-devtools-core@^6.1.5:
     shell-quote "^1.6.1"
     ws "^7"
 
-react-is@19.2.0, react-is@^16.13.1, react-is@^18.0.0, react-is@^19.2.0:
-  version "19.2.0"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-19.2.0.tgz#ddc3b4a4e0f3336c3847f18b806506388d7b9973"
-  integrity sha512-x3Ax3kNSMIIkyVYhWPyO09bu0uttcAIoecO/um/rKGQ4EltYWVYtyiGkS/3xMynrbVQdS69Jhlv8FXUEZehlzA==
+react-is@19.2.3, react-is@^16.13.1, react-is@^18.0.0, react-is@^19.2.3:
+  version "19.2.3"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-19.2.3.tgz#eec2feb69c7fb31f77d0b5c08c10ae1c88886b29"
+  integrity sha512-qJNJfu81ByyabuG7hPFEbXqNcWSU3+eVus+KJs+0ncpGfMyYdvSmxiJxbWR65lYi1I+/0HBcliO029gc4F+PnA==
 
 react-refresh@^0.14.0:
   version "0.14.2"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.2.tgz#3833da01ce32da470f1f936b9d477da5c7028bf9"
   integrity sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==
 
-react-test-renderer@19.2.0:
-  version "19.2.0"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-19.2.0.tgz#5c9782b4a4ba0630a77d7ce092779fdf9ccde209"
-  integrity sha512-zLCFMHFE9vy/w3AxO0zNxy6aAupnCuLSVOJYDe/Tp+ayGI1f2PLQsFVPANSD42gdSbmYx5oN+1VWDhcXtq7hAQ==
+react-test-renderer@19.2.3:
+  version "19.2.3"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-19.2.3.tgz#d20f5193867c98b2df9e13b4e72bb83f311f6a43"
+  integrity sha512-TMR1LnSFiWZMJkCgNf5ATSvAheTT2NvKIwiVwdBPHxjBI7n/JbWd4gaZ16DVd9foAXdvDz+sB5yxZTwMjPRxpw==
   dependencies:
-    react-is "^19.2.0"
+    react-is "^19.2.3"
     scheduler "^0.27.0"
 
-react@19.2.0:
-  version "19.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-19.2.0.tgz#d33dd1721698f4376ae57a54098cb47fc75d93a5"
-  integrity sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==
+react@19.2.3:
+  version "19.2.3"
+  resolved "https://registry.yarnpkg.com/react/-/react-19.2.3.tgz#d83e5e8e7a258cf6b4fe28640515f99b87cd19b8"
+  integrity sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==
 
 read-pkg-up@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Summary:
Sync of React 19.2.3 into React Native

Changelog:
[General][Changed] - Sync React 19.2.3 into React Native

jest_e2e[run_all_tests]
bypass-github-export-checks

Differential Revision: D89719053


