### PR TITLE
Pass `unstable_transformProfile` through Babel `caller` API and fall back to it in `@react-native/babel-preset`

### DIFF
--- a/packages/react-native-babel-preset/src/index.js
+++ b/packages/react-native-babel-preset/src/index.js
@@ -14,7 +14,7 @@ const {version: packageVersion} = require('../package.json');
 const main = require('./configs/main');
 
 module.exports = function (babel, options) {
-  return main(options);
+  return main(options, babel);
 };
 
 let cacheKey;

--- a/packages/react-native-babel-transformer/src/index.js
+++ b/packages/react-native-babel-transformer/src/index.js
@@ -193,7 +193,14 @@ const transform /*: BabelTransformer['transform'] */ = ({
       // ES modules require sourceType='module' but OSS may not always want that
       sourceType: 'unambiguous',
       ...buildBabelConfig(filename, options, plugins),
-      caller: {name: 'metro', bundler: 'metro', platform: options.platform},
+      caller: {
+        // Varies Babel's config cache - presets will be re-initialized
+        // if they use caller information.
+        name: 'metro',
+        bundler: 'metro',
+        platform: options.platform,
+        unstable_transformProfile: options.unstable_transformProfile,
+      },
       ast: true,
 
       // NOTE(EvanBacon): We split the parse/transform steps up to accommodate


### PR DESCRIPTION
Summary:
`unstable_transformProfile` is used by Metro to hint at the appropriate set of Babel transforms for the target engine.

To be effective in `react-native/babel-preset`, it must currently be passed in the preset config.

When the user does not use a custom Babel config, `react-native/metro-babel-transformer` detects that and auto-configures the preset with options from Metro - that's fine.

But if the user has their own Babel config, building on top of `react-native/babel-preset`, the preset for the config is fixed - so `unstable_transformProfile` has no effect.

Ideally, `unstable_transformProfile` should be a function of the target engine - it's totally reasonable for one instance of Metro to build for multiple engines - so this should instead be passed programmatically to the engine by Metro for each transform job.

Babel provides a mechanism to do this efficiently, without reinitialising the preset unnecessarily, via the `caller` API.

This passes `unstable_transformProfile` through `caller`.

Changelog: [Internal]

(This is part of using a more optimised transform profiles for Hermes V1, which is still an experimental opt-in. When we stabilise Hermes V1 in RN, we should stabilise this API)

Differential Revision: D82625477


