### PR TITLE
Make TurboModuleBinding constructor private

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.cpp
@@ -19,7 +19,7 @@ namespace facebook::react {
 
 class BridgelessNativeModuleProxy : public jsi::HostObject {
   TurboModuleBinding turboBinding_;
-  std::unique_ptr<TurboModuleBinding> legacyBinding_;
+  std::optional<TurboModuleBinding> legacyBinding_;
 
  public:
   BridgelessNativeModuleProxy(
@@ -32,11 +32,12 @@ class BridgelessNativeModuleProxy : public jsi::HostObject {
             std::move(moduleProvider),
             longLivedObjectCollection),
         legacyBinding_(
-            legacyModuleProvider ? std::make_unique<TurboModuleBinding>(
-                                       runtime,
-                                       std::move(legacyModuleProvider),
-                                       longLivedObjectCollection)
-                                 : nullptr) {}
+            legacyModuleProvider
+                ? std::make_optional<TurboModuleBinding>(TurboModuleBinding(
+                      runtime,
+                      std::move(legacyModuleProvider),
+                      longLivedObjectCollection))
+                : std::nullopt) {}
 
   jsi::Value get(jsi::Runtime& runtime, const jsi::PropNameID& name) override {
     /**

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.h
@@ -33,15 +33,15 @@ class TurboModuleBinding final {
       TurboModuleProviderFunctionType &&legacyModuleProvider = nullptr,
       std::shared_ptr<LongLivedObjectCollection> longLivedObjectCollection = nullptr);
 
-  TurboModuleBinding(
-      jsi::Runtime &runtime,
-      TurboModuleProviderFunctionType &&moduleProvider,
-      std::shared_ptr<LongLivedObjectCollection> longLivedObjectCollection);
-
   ~TurboModuleBinding();
 
  private:
   friend BridgelessNativeModuleProxy;
+
+  TurboModuleBinding(
+      jsi::Runtime &runtime,
+      TurboModuleProviderFunctionType &&moduleProvider,
+      std::shared_ptr<LongLivedObjectCollection> longLivedObjectCollection);
 
   /**
    * A lookup function exposed to JS to get an instance of a TurboModule


### PR DESCRIPTION
Summary:
The TurboModuleBinding constructor actually doesn't need to be private! It's only called from BridgelessTurboModuleProxy or TurboModuleBinding::install.

Changelog: [Internal]

Differential Revision: D89751218


