### PR TITLE
Make TurboModuleBinding accept a provider with a runtime

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.h
@@ -145,5 +145,7 @@ class JSI_EXPORT TurboModule : public jsi::HostObject {
  * given a name.
  */
 using TurboModuleProviderFunctionType = std::function<std::shared_ptr<TurboModule>(const std::string &name)>;
+using TurboModuleProviderFunctionTypeWithRuntime =
+    std::function<std::shared_ptr<TurboModule>(jsi::Runtime &runtime, const std::string &name)>;
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.cpp
@@ -19,7 +19,7 @@ namespace facebook::react {
 
 class BridgelessNativeModuleProxy : public jsi::HostObject {
   TurboModuleBinding turboBinding_;
-  std::unique_ptr<TurboModuleBinding> legacyBinding_;
+  std::optional<TurboModuleBinding> legacyBinding_;
 
  public:
   BridgelessNativeModuleProxy(
@@ -32,11 +32,12 @@ class BridgelessNativeModuleProxy : public jsi::HostObject {
             std::move(moduleProvider),
             longLivedObjectCollection),
         legacyBinding_(
-            legacyModuleProvider ? std::make_unique<TurboModuleBinding>(
-                                       runtime,
-                                       std::move(legacyModuleProvider),
-                                       longLivedObjectCollection)
-                                 : nullptr) {}
+            legacyModuleProvider
+                ? std::make_optional<TurboModuleBinding>(TurboModuleBinding(
+                      runtime,
+                      std::move(legacyModuleProvider),
+                      longLivedObjectCollection))
+                : std::nullopt) {}
 
   jsi::Value get(jsi::Runtime& runtime, const jsi::PropNameID& name) override {
     /**

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.h
@@ -33,6 +33,12 @@ class TurboModuleBinding final {
       TurboModuleProviderFunctionType &&legacyModuleProvider = nullptr,
       std::shared_ptr<LongLivedObjectCollection> longLivedObjectCollection = nullptr);
 
+  static void install(
+      jsi::Runtime &runtime,
+      TurboModuleProviderFunctionTypeWithRuntime &&moduleProvider,
+      TurboModuleProviderFunctionTypeWithRuntime &&legacyModuleProvider = nullptr,
+      std::shared_ptr<LongLivedObjectCollection> longLivedObjectCollection = nullptr);
+
   ~TurboModuleBinding();
 
  private:
@@ -40,7 +46,7 @@ class TurboModuleBinding final {
 
   TurboModuleBinding(
       jsi::Runtime &runtime,
-      TurboModuleProviderFunctionType &&moduleProvider,
+      TurboModuleProviderFunctionTypeWithRuntime &&moduleProvider,
       std::shared_ptr<LongLivedObjectCollection> longLivedObjectCollection);
 
   /**
@@ -50,7 +56,7 @@ class TurboModuleBinding final {
   jsi::Value getModule(jsi::Runtime &runtime, const std::string &moduleName) const;
 
   jsi::Runtime &runtime_;
-  TurboModuleProviderFunctionType moduleProvider_;
+  TurboModuleProviderFunctionTypeWithRuntime moduleProvider_;
   std::shared_ptr<LongLivedObjectCollection> longLivedObjectCollection_;
 };
 

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.h
@@ -33,15 +33,15 @@ class TurboModuleBinding final {
       TurboModuleProviderFunctionType &&legacyModuleProvider = nullptr,
       std::shared_ptr<LongLivedObjectCollection> longLivedObjectCollection = nullptr);
 
-  TurboModuleBinding(
-      jsi::Runtime &runtime,
-      TurboModuleProviderFunctionType &&moduleProvider,
-      std::shared_ptr<LongLivedObjectCollection> longLivedObjectCollection);
-
   ~TurboModuleBinding();
 
  private:
   friend BridgelessNativeModuleProxy;
+
+  TurboModuleBinding(
+      jsi::Runtime &runtime,
+      TurboModuleProviderFunctionType &&moduleProvider,
+      std::shared_ptr<LongLivedObjectCollection> longLivedObjectCollection);
 
   /**
    * A lookup function exposed to JS to get an instance of a TurboModule


### PR DESCRIPTION
Summary:
This way we can stop capturing the runtime pointer inside the providers created by turbomodule manager delegate.

## iOS
https://www.internalfb.com/code/fbsource/[bf6c0a76ea2c967a93b6bc2b8977cac23211ec0d]/xplat/js/react-native-github/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm?lines=919-920%2C946%2C969

## Android
https://www.internalfb.com/code/fbsource/[d226c31f345fd69c8453d4c8270b0df083c64ad5]/xplat/js/react-native-github/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.cpp?lines=128-132%2C144-145

Changelog: [Internal]

Differential Revision: D89751221


