### PR TITLE
Stop holding runtime ptr in turbomodule provider

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.h
@@ -59,13 +59,11 @@ class TurboModuleManager : public jni::HybridClass<TurboModuleManager> {
 
   static void installJSIBindings(jni::alias_ref<jhybridobject> javaPart, bool shouldCreateLegacyModules);
 
-  static TurboModuleProviderFunctionType createTurboModuleProvider(
-      jni::alias_ref<jhybridobject> javaPart,
-      jsi::Runtime *runtime);
+  static TurboModuleProviderFunctionTypeWithRuntime createTurboModuleProvider(jni::alias_ref<jhybridobject> javaPart);
   std::shared_ptr<TurboModule>
   getTurboModule(jni::alias_ref<jhybridobject> javaPart, const std::string &name, jsi::Runtime &runtime);
 
-  static TurboModuleProviderFunctionType createLegacyModuleProvider(jni::alias_ref<jhybridobject> javaPart);
+  static TurboModuleProviderFunctionTypeWithRuntime createLegacyModuleProvider(jni::alias_ref<jhybridobject> javaPart);
   std::shared_ptr<TurboModule> getLegacyModule(jni::alias_ref<jhybridobject> javaPart, const std::string &name);
 };
 

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.h
@@ -143,8 +143,12 @@ class JSI_EXPORT TurboModule : public jsi::HostObject {
 /**
  * An app/platform-specific provider function to get an instance of a module
  * given a name.
+ *
+ * @deprecated Use TurboModuleProviderFunctionTypeWithRuntime instead.
+ * Remove after React Native 0.84 is released.
  */
-using TurboModuleProviderFunctionType = std::function<std::shared_ptr<TurboModule>(const std::string &name)>;
+using TurboModuleProviderFunctionType [[deprecated("Use TurboModuleProviderFunctionTypeWithRuntime instead")]] =
+    std::function<std::shared_ptr<TurboModule>(const std::string &name)>;
 using TurboModuleProviderFunctionTypeWithRuntime =
     std::function<std::shared_ptr<TurboModule>(jsi::Runtime &runtime, const std::string &name)>;
 

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.h
@@ -145,5 +145,7 @@ class JSI_EXPORT TurboModule : public jsi::HostObject {
  * given a name.
  */
 using TurboModuleProviderFunctionType = std::function<std::shared_ptr<TurboModule>(const std::string &name)>;
+using TurboModuleProviderFunctionTypeWithRuntime =
+    std::function<std::shared_ptr<TurboModule>(jsi::Runtime &runtime, const std::string &name)>;
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.cpp
@@ -19,7 +19,7 @@ namespace facebook::react {
 
 class BridgelessNativeModuleProxy : public jsi::HostObject {
   TurboModuleBinding turboBinding_;
-  std::unique_ptr<TurboModuleBinding> legacyBinding_;
+  std::optional<TurboModuleBinding> legacyBinding_;
 
  public:
   BridgelessNativeModuleProxy(
@@ -32,11 +32,12 @@ class BridgelessNativeModuleProxy : public jsi::HostObject {
             std::move(moduleProvider),
             longLivedObjectCollection),
         legacyBinding_(
-            legacyModuleProvider ? std::make_unique<TurboModuleBinding>(
-                                       runtime,
-                                       std::move(legacyModuleProvider),
-                                       longLivedObjectCollection)
-                                 : nullptr) {}
+            legacyModuleProvider
+                ? std::make_optional<TurboModuleBinding>(TurboModuleBinding(
+                      runtime,
+                      std::move(legacyModuleProvider),
+                      longLivedObjectCollection))
+                : std::nullopt) {}
 
   jsi::Value get(jsi::Runtime& runtime, const jsi::PropNameID& name) override {
     /**

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.h
@@ -33,6 +33,12 @@ class TurboModuleBinding final {
       TurboModuleProviderFunctionType &&legacyModuleProvider = nullptr,
       std::shared_ptr<LongLivedObjectCollection> longLivedObjectCollection = nullptr);
 
+  static void install(
+      jsi::Runtime &runtime,
+      TurboModuleProviderFunctionTypeWithRuntime &&moduleProvider,
+      TurboModuleProviderFunctionTypeWithRuntime &&legacyModuleProvider = nullptr,
+      std::shared_ptr<LongLivedObjectCollection> longLivedObjectCollection = nullptr);
+
   ~TurboModuleBinding();
 
  private:
@@ -40,7 +46,7 @@ class TurboModuleBinding final {
 
   TurboModuleBinding(
       jsi::Runtime &runtime,
-      TurboModuleProviderFunctionType &&moduleProvider,
+      TurboModuleProviderFunctionTypeWithRuntime &&moduleProvider,
       std::shared_ptr<LongLivedObjectCollection> longLivedObjectCollection);
 
   /**
@@ -50,7 +56,7 @@ class TurboModuleBinding final {
   jsi::Value getModule(jsi::Runtime &runtime, const std::string &moduleName) const;
 
   jsi::Runtime &runtime_;
-  TurboModuleProviderFunctionType moduleProvider_;
+  TurboModuleProviderFunctionTypeWithRuntime moduleProvider_;
   std::shared_ptr<LongLivedObjectCollection> longLivedObjectCollection_;
 };
 

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.h
@@ -26,7 +26,12 @@ class TurboModuleBinding final {
   /*
    * Installs TurboModuleBinding into JavaScript runtime.
    * Thread synchronization must be enforced externally.
+   *
+   * @deprecated Use the overload that takes
+   * TurboModuleProviderFunctionTypeWithRuntime instead.
+   * Remove after React Native 0.84 is released.
    */
+  [[deprecated("Use the overload that takes TurboModuleProviderFunctionTypeWithRuntime instead")]]
   static void install(
       jsi::Runtime &runtime,
       TurboModuleProviderFunctionType &&moduleProvider,

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.h
@@ -33,15 +33,15 @@ class TurboModuleBinding final {
       TurboModuleProviderFunctionType &&legacyModuleProvider = nullptr,
       std::shared_ptr<LongLivedObjectCollection> longLivedObjectCollection = nullptr);
 
-  TurboModuleBinding(
-      jsi::Runtime &runtime,
-      TurboModuleProviderFunctionType &&moduleProvider,
-      std::shared_ptr<LongLivedObjectCollection> longLivedObjectCollection);
-
   ~TurboModuleBinding();
 
  private:
   friend BridgelessNativeModuleProxy;
+
+  TurboModuleBinding(
+      jsi::Runtime &runtime,
+      TurboModuleProviderFunctionType &&moduleProvider,
+      std::shared_ptr<LongLivedObjectCollection> longLivedObjectCollection);
 
   /**
    * A lookup function exposed to JS to get an instance of a TurboModule

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
@@ -916,8 +916,8 @@ typedef struct {
    * aren't any strong references to it in ObjC. Hence, we give
    * __turboModuleProxy a strong reference to TurboModuleManager.
    */
-  auto turboModuleProvider = [self,
-                              runtime = &runtime](const std::string &name) -> std::shared_ptr<react::TurboModule> {
+  auto turboModuleProvider =
+      [self](jsi::Runtime &runtime, const std::string &name) -> std::shared_ptr<react::TurboModule> {
     auto moduleName = name.c_str();
 
     TurboModulePerfLogger::moduleJSRequireBeginningStart(moduleName);
@@ -931,7 +931,7 @@ typedef struct {
      * Additionally, if a TurboModule with the name `name` isn't found, then we
      * trigger an assertion failure.
      */
-    auto turboModule = [self provideTurboModule:moduleName runtime:runtime];
+    auto turboModule = [self provideTurboModule:moduleName runtime:&runtime];
 
     if (moduleWasNotInitialized && [self moduleIsInitialized:moduleName]) {
       [self->_bridge.performanceLogger markStopForTag:RCTPLTurboModuleSetup];
@@ -946,7 +946,8 @@ typedef struct {
   };
 
   if (RCTTurboModuleInteropEnabled()) {
-    auto legacyModuleProvider = [self](const std::string &name) -> std::shared_ptr<react::TurboModule> {
+    auto legacyModuleProvider =
+        [self](jsi::Runtime & /*runtime*/, const std::string &name) -> std::shared_ptr<react::TurboModule> {
       auto moduleName = name.c_str();
 
       TurboModulePerfLogger::moduleJSRequireBeginningStart(moduleName);


### PR DESCRIPTION
Summary:
Holding a reference to the runtime is unsafe. Let's just use the reference provided to the turbomodule binding instead.

Changelog: [Internal]

Differential Revision: D89751220


