### PR TITLE
Refactor: Clean up bindings installation

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -354,7 +354,6 @@ public abstract class com/facebook/react/ReactPackageTurboModuleManagerDelegate 
 	public fun getModule (Ljava/lang/String;)Lcom/facebook/react/turbomodule/core/interfaces/TurboModule;
 	public fun unstable_isLegacyModuleRegistered (Ljava/lang/String;)Z
 	public fun unstable_isModuleRegistered (Ljava/lang/String;)Z
-	public fun unstable_shouldEnableLegacyModuleInterop ()Z
 }
 
 public abstract class com/facebook/react/ReactPackageTurboModuleManagerDelegate$Builder {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactPackageTurboModuleManagerDelegate.kt
@@ -105,8 +105,6 @@ public abstract class ReactPackageTurboModuleManagerDelegate : TurboModuleManage
     }
   }
 
-  override fun unstable_shouldEnableLegacyModuleInterop(): Boolean = shouldEnableLegacyModuleInterop
-
   override fun getModule(moduleName: String): TurboModule? {
     var resolvedModule: NativeModule? = null
 
@@ -153,7 +151,7 @@ public abstract class ReactPackageTurboModuleManagerDelegate : TurboModuleManage
   }
 
   override fun getLegacyModule(moduleName: String): NativeModule? {
-    if (!unstable_shouldEnableLegacyModuleInterop()) {
+    if (!shouldEnableLegacyModuleInterop) {
       return null
     }
 
@@ -191,7 +189,7 @@ public abstract class ReactPackageTurboModuleManagerDelegate : TurboModuleManage
     }
   }
 
-  private fun shouldSupportLegacyPackages(): Boolean = unstable_shouldEnableLegacyModuleInterop()
+  private fun shouldSupportLegacyPackages(): Boolean = shouldEnableLegacyModuleInterop
 
   public abstract class Builder {
     private var packages: List<ReactPackage>? = null

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleManager.kt
@@ -60,7 +60,7 @@ public class TurboModuleManager(
 
   init {
 
-    installJSIBindings(shouldEnableLegacyModuleInterop())
+    installJSIBindings()
 
     eagerInitModuleNames = delegate?.getEagerInitModuleNames() ?: emptyList()
 
@@ -72,7 +72,7 @@ public class TurboModuleManager(
             ModuleProvider { moduleName: String -> delegate.getModule(moduleName) as NativeModule? }
 
     legacyModuleProvider =
-        if (delegate == null || !shouldEnableLegacyModuleInterop()) nullProvider
+        if (delegate == null) nullProvider
         else
             ModuleProvider { moduleName: String ->
               val nativeModule = delegate.getLegacyModule(moduleName)
@@ -92,9 +92,6 @@ public class TurboModuleManager(
 
   private fun isLegacyModule(moduleName: String): Boolean =
       delegate?.unstable_isLegacyModuleRegistered(moduleName) == true
-
-  private fun shouldEnableLegacyModuleInterop(): Boolean =
-      delegate?.unstable_shouldEnableLegacyModuleInterop() == true
 
   // used from TurboModuleManager.cpp
   @Suppress("unused")
@@ -287,7 +284,7 @@ public class TurboModuleManager(
       tmmDelegate: TurboModuleManagerDelegate?,
   ): HybridData
 
-  private external fun installJSIBindings(shouldCreateLegacyModules: Boolean)
+  private external fun installJSIBindings()
 
   override fun invalidate() {
     /*

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleManager.kt
@@ -52,7 +52,6 @@ public class TurboModuleManager(
   @DoNotStrip
   private val mHybridData: HybridData =
       initHybrid(
-          runtimeExecutor,
           jsCallInvokerHolder as CallInvokerHolderImpl,
           nativeMethodCallInvokerHolder as NativeMethodCallInvokerHolderImpl,
           delegate,
@@ -60,7 +59,7 @@ public class TurboModuleManager(
 
   init {
 
-    installJSIBindings()
+    installJSIBindings(runtimeExecutor)
 
     eagerInitModuleNames = delegate?.getEagerInitModuleNames() ?: emptyList()
 
@@ -278,13 +277,12 @@ public class TurboModuleManager(
   }
 
   private external fun initHybrid(
-      runtimeExecutor: RuntimeExecutor,
       jsCallInvokerHolder: CallInvokerHolderImpl,
       nativeMethodCallInvoker: NativeMethodCallInvokerHolderImpl,
       tmmDelegate: TurboModuleManagerDelegate?,
   ): HybridData
 
-  private external fun installJSIBindings()
+  private external fun installJSIBindings(runtimeExecutor: RuntimeExecutor)
 
   override fun invalidate() {
     /*

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleManagerDelegate.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleManagerDelegate.kt
@@ -48,9 +48,6 @@ public abstract class TurboModuleManagerDelegate {
 
   public open fun getEagerInitModuleNames(): List<String> = emptyList()
 
-  /** Can the TurboModule system create legacy modules? */
-  public open fun unstable_shouldEnableLegacyModuleInterop(): Boolean = false
-
   // TODO(T171231381): Consider removing this method: could we just use the static initializer
   // of derived classes instead?
   @Synchronized protected fun maybeLoadOtherSoLibraries(): Unit = Unit

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.h
@@ -57,7 +57,7 @@ class TurboModuleManager : public jni::HybridClass<TurboModuleManager> {
       std::shared_ptr<NativeMethodCallInvoker> nativeMethodCallInvoker,
       jni::alias_ref<TurboModuleManagerDelegate::javaobject> delegate);
 
-  static void installJSIBindings(jni::alias_ref<jhybridobject> javaPart, bool shouldCreateLegacyModules);
+  static void installJSIBindings(jni::alias_ref<jhybridobject> javaPart);
 
   static TurboModuleProviderFunctionTypeWithRuntime createTurboModuleProvider(jni::alias_ref<jhybridobject> javaPart);
   std::shared_ptr<TurboModule>

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.h
@@ -59,13 +59,11 @@ class TurboModuleManager : public jni::HybridClass<TurboModuleManager> {
 
   static void installJSIBindings(jni::alias_ref<jhybridobject> javaPart, bool shouldCreateLegacyModules);
 
-  static TurboModuleProviderFunctionType createTurboModuleProvider(
-      jni::alias_ref<jhybridobject> javaPart,
-      jsi::Runtime *runtime);
+  static TurboModuleProviderFunctionTypeWithRuntime createTurboModuleProvider(jni::alias_ref<jhybridobject> javaPart);
   std::shared_ptr<TurboModule>
   getTurboModule(jni::alias_ref<jhybridobject> javaPart, const std::string &name, jsi::Runtime &runtime);
 
-  static TurboModuleProviderFunctionType createLegacyModuleProvider(jni::alias_ref<jhybridobject> javaPart);
+  static TurboModuleProviderFunctionTypeWithRuntime createLegacyModuleProvider(jni::alias_ref<jhybridobject> javaPart);
   std::shared_ptr<TurboModule> getLegacyModule(jni::alias_ref<jhybridobject> javaPart, const std::string &name);
 };
 

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.h
@@ -27,7 +27,6 @@ class TurboModuleManager : public jni::HybridClass<TurboModuleManager> {
   static auto constexpr kJavaDescriptor = "Lcom/facebook/react/internal/turbomodule/core/TurboModuleManager;";
   static jni::local_ref<jhybriddata> initHybrid(
       jni::alias_ref<jhybridobject> /* unused */,
-      jni::alias_ref<JRuntimeExecutor::javaobject> runtimeExecutor,
       jni::alias_ref<CallInvokerHolder::javaobject> jsCallInvokerHolder,
       jni::alias_ref<NativeMethodCallInvokerHolder::javaobject> nativeMethodCallInvokerHolder,
       jni::alias_ref<TurboModuleManagerDelegate::javaobject> delegate);
@@ -52,12 +51,13 @@ class TurboModuleManager : public jni::HybridClass<TurboModuleManager> {
   ModuleCache legacyModuleCache_;
 
   explicit TurboModuleManager(
-      RuntimeExecutor runtimeExecutor,
       std::shared_ptr<CallInvoker> jsCallInvoker,
       std::shared_ptr<NativeMethodCallInvoker> nativeMethodCallInvoker,
       jni::alias_ref<TurboModuleManagerDelegate::javaobject> delegate);
 
-  static void installJSIBindings(jni::alias_ref<jhybridobject> javaPart);
+  static void installJSIBindings(
+      jni::alias_ref<jhybridobject> javaPart,
+      jni::alias_ref<JRuntimeExecutor::javaobject> runtimeExecutor);
 
   static TurboModuleProviderFunctionTypeWithRuntime createTurboModuleProvider(jni::alias_ref<jhybridobject> javaPart);
   std::shared_ptr<TurboModule>

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.h
@@ -143,8 +143,12 @@ class JSI_EXPORT TurboModule : public jsi::HostObject {
 /**
  * An app/platform-specific provider function to get an instance of a module
  * given a name.
+ *
+ * @deprecated Use TurboModuleProviderFunctionTypeWithRuntime instead.
+ * Remove after React Native 0.84 is released.
  */
-using TurboModuleProviderFunctionType = std::function<std::shared_ptr<TurboModule>(const std::string &name)>;
+using TurboModuleProviderFunctionType [[deprecated("Use TurboModuleProviderFunctionTypeWithRuntime instead")]] =
+    std::function<std::shared_ptr<TurboModule>(const std::string &name)>;
 using TurboModuleProviderFunctionTypeWithRuntime =
     std::function<std::shared_ptr<TurboModule>(jsi::Runtime &runtime, const std::string &name)>;
 

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModule.h
@@ -145,5 +145,7 @@ class JSI_EXPORT TurboModule : public jsi::HostObject {
  * given a name.
  */
 using TurboModuleProviderFunctionType = std::function<std::shared_ptr<TurboModule>(const std::string &name)>;
+using TurboModuleProviderFunctionTypeWithRuntime =
+    std::function<std::shared_ptr<TurboModule>(jsi::Runtime &runtime, const std::string &name)>;
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.cpp
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.cpp
@@ -19,7 +19,7 @@ namespace facebook::react {
 
 class BridgelessNativeModuleProxy : public jsi::HostObject {
   TurboModuleBinding turboBinding_;
-  std::unique_ptr<TurboModuleBinding> legacyBinding_;
+  std::optional<TurboModuleBinding> legacyBinding_;
 
  public:
   BridgelessNativeModuleProxy(
@@ -32,11 +32,12 @@ class BridgelessNativeModuleProxy : public jsi::HostObject {
             std::move(moduleProvider),
             longLivedObjectCollection),
         legacyBinding_(
-            legacyModuleProvider ? std::make_unique<TurboModuleBinding>(
-                                       runtime,
-                                       std::move(legacyModuleProvider),
-                                       longLivedObjectCollection)
-                                 : nullptr) {}
+            legacyModuleProvider
+                ? std::make_optional<TurboModuleBinding>(TurboModuleBinding(
+                      runtime,
+                      std::move(legacyModuleProvider),
+                      longLivedObjectCollection))
+                : std::nullopt) {}
 
   jsi::Value get(jsi::Runtime& runtime, const jsi::PropNameID& name) override {
     /**

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.h
@@ -33,6 +33,12 @@ class TurboModuleBinding final {
       TurboModuleProviderFunctionType &&legacyModuleProvider = nullptr,
       std::shared_ptr<LongLivedObjectCollection> longLivedObjectCollection = nullptr);
 
+  static void install(
+      jsi::Runtime &runtime,
+      TurboModuleProviderFunctionTypeWithRuntime &&moduleProvider,
+      TurboModuleProviderFunctionTypeWithRuntime &&legacyModuleProvider = nullptr,
+      std::shared_ptr<LongLivedObjectCollection> longLivedObjectCollection = nullptr);
+
   ~TurboModuleBinding();
 
  private:
@@ -40,7 +46,7 @@ class TurboModuleBinding final {
 
   TurboModuleBinding(
       jsi::Runtime &runtime,
-      TurboModuleProviderFunctionType &&moduleProvider,
+      TurboModuleProviderFunctionTypeWithRuntime &&moduleProvider,
       std::shared_ptr<LongLivedObjectCollection> longLivedObjectCollection);
 
   /**
@@ -50,7 +56,7 @@ class TurboModuleBinding final {
   jsi::Value getModule(jsi::Runtime &runtime, const std::string &moduleName) const;
 
   jsi::Runtime &runtime_;
-  TurboModuleProviderFunctionType moduleProvider_;
+  TurboModuleProviderFunctionTypeWithRuntime moduleProvider_;
   std::shared_ptr<LongLivedObjectCollection> longLivedObjectCollection_;
 };
 

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.h
@@ -26,7 +26,12 @@ class TurboModuleBinding final {
   /*
    * Installs TurboModuleBinding into JavaScript runtime.
    * Thread synchronization must be enforced externally.
+   *
+   * @deprecated Use the overload that takes
+   * TurboModuleProviderFunctionTypeWithRuntime instead.
+   * Remove after React Native 0.84 is released.
    */
+  [[deprecated("Use the overload that takes TurboModuleProviderFunctionTypeWithRuntime instead")]]
   static void install(
       jsi::Runtime &runtime,
       TurboModuleProviderFunctionType &&moduleProvider,

--- a/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.h
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/ReactCommon/TurboModuleBinding.h
@@ -33,15 +33,15 @@ class TurboModuleBinding final {
       TurboModuleProviderFunctionType &&legacyModuleProvider = nullptr,
       std::shared_ptr<LongLivedObjectCollection> longLivedObjectCollection = nullptr);
 
-  TurboModuleBinding(
-      jsi::Runtime &runtime,
-      TurboModuleProviderFunctionType &&moduleProvider,
-      std::shared_ptr<LongLivedObjectCollection> longLivedObjectCollection);
-
   ~TurboModuleBinding();
 
  private:
   friend BridgelessNativeModuleProxy;
+
+  TurboModuleBinding(
+      jsi::Runtime &runtime,
+      TurboModuleProviderFunctionType &&moduleProvider,
+      std::shared_ptr<LongLivedObjectCollection> longLivedObjectCollection);
 
   /**
    * A lookup function exposed to JS to get an instance of a TurboModule

--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModuleManager.mm
@@ -916,8 +916,8 @@ typedef struct {
    * aren't any strong references to it in ObjC. Hence, we give
    * __turboModuleProxy a strong reference to TurboModuleManager.
    */
-  auto turboModuleProvider = [self,
-                              runtime = &runtime](const std::string &name) -> std::shared_ptr<react::TurboModule> {
+  auto turboModuleProvider =
+      [self](jsi::Runtime &runtime, const std::string &name) -> std::shared_ptr<react::TurboModule> {
     auto moduleName = name.c_str();
 
     TurboModulePerfLogger::moduleJSRequireBeginningStart(moduleName);
@@ -931,7 +931,7 @@ typedef struct {
      * Additionally, if a TurboModule with the name `name` isn't found, then we
      * trigger an assertion failure.
      */
-    auto turboModule = [self provideTurboModule:moduleName runtime:runtime];
+    auto turboModule = [self provideTurboModule:moduleName runtime:&runtime];
 
     if (moduleWasNotInitialized && [self moduleIsInitialized:moduleName]) {
       [self->_bridge.performanceLogger markStopForTag:RCTPLTurboModuleSetup];
@@ -946,7 +946,8 @@ typedef struct {
   };
 
   if (RCTTurboModuleInteropEnabled()) {
-    auto legacyModuleProvider = [self](const std::string &name) -> std::shared_ptr<react::TurboModule> {
+    auto legacyModuleProvider =
+        [self](jsi::Runtime & /*runtime*/, const std::string &name) -> std::shared_ptr<react::TurboModule> {
       auto moduleName = name.c_str();
 
       TurboModulePerfLogger::moduleJSRequireBeginningStart(moduleName);


### PR DESCRIPTION
Summary:
The runtime executor is only used to install jsi bindings. So, let's just pass it directly to the installJSIBindings function.

Changelog: [Internal]

Differential Revision: D89709216


