### PR TITLE
Refactor: Rename installJSIBindings

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/turbomodule/core/TurboModuleManager.kt
@@ -59,7 +59,7 @@ public class TurboModuleManager(
 
   init {
 
-    installJSIBindings(runtimeExecutor)
+    dispatchJSBindingInstall(runtimeExecutor)
 
     eagerInitModuleNames = delegate?.getEagerInitModuleNames() ?: emptyList()
 
@@ -282,7 +282,7 @@ public class TurboModuleManager(
       tmmDelegate: TurboModuleManagerDelegate?,
   ): HybridData
 
-  private external fun installJSIBindings(runtimeExecutor: RuntimeExecutor)
+  private external fun dispatchJSBindingInstall(runtimeExecutor: RuntimeExecutor)
 
   override fun invalidate() {
     /*

--- a/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/turbomodule/ReactCommon/TurboModuleManager.h
@@ -55,7 +55,8 @@ class TurboModuleManager : public jni::HybridClass<TurboModuleManager> {
       std::shared_ptr<NativeMethodCallInvoker> nativeMethodCallInvoker,
       jni::alias_ref<TurboModuleManagerDelegate::javaobject> delegate);
 
-  static void installJSIBindings(
+  static void installJSBindings(jsi::Runtime &runtime, jni::alias_ref<jhybridobject> javaPart);
+  static void dispatchJSBindingInstall(
       jni::alias_ref<jhybridobject> javaPart,
       jni::alias_ref<JRuntimeExecutor::javaobject> runtimeExecutor);
 


### PR DESCRIPTION
Summary:
I think dispatchJSBindingInstall is a more apt name.

This will help align ios and android. On ios, installJSBindings is a function that executes on the js thread, with a runtime pointer.

Changelog: [Internal]

Differential Revision: D89709221


