### PR TITLE
Fix iOS font weight regression due to boolean coercion

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTFontUtils.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/RCTFontUtils.mm
@@ -361,7 +361,7 @@ UIFont *RCTFontWithFontProperties(RCTFontProperties fontProperties)
       font = [UIFont fontWithName:fontProperties.family size:effectiveFontSize];
       if (font != nullptr) {
         fontNames = [UIFont fontNamesForFamilyName:font.familyName];
-        fontWeight = (fontWeight != 0.0) ?: RCTGetFontWeight(font);
+        fontWeight = fontWeight ?: RCTGetFontWeight(font);
       } else {
         // Failback to system font.
         font = RCTDefaultFontWithFontProperties(fontProperties);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This PR fixes a regression introduced in version 0.83.1 regarding font weight handling on iOS.

The Issue: In a recent change to font handling logic (likely intended for cleanup), a logic error was introduced using the Elvis operator combined with a boolean comparison.
https://github.com/facebook/react-native/issues/54934

```
// 🐛 Buggy logic in 0.83.1
fontWeight = (fontWeight != 0.0) ?: RCTGetFontWeight(font);
```


## Changelog:
[IOS] [FIXED] - Fix regression where custom fonts with specific weights rendered as Black/ExtraBold due to incorrect boolean coercion

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags: 

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I verified this fix using a reproduction app with a custom font (e.g., Pretendard) that has multiple weights.

Environment: React Native 0.83.1


Before Fix: The text rendered as UIFontWeightBlack (extremely thick) because fontWeight was coerced to 1.0.

After Fix: The text correctly renders with the intended weight ('Pretendard-SemiBold'/600).

<img width="300" height="700" alt="IMG_6045" src="https://github.com/user-attachments/assets/4a91c66a-a47b-48ff-ae36-85026660cff1" />
<img width="300" height="700" alt="IMG_6044" src="https://github.com/user-attachments/assets/0ae5bd32-7bff-4dae-bccd-f3865c8f6e7e" />

