### PR TITLE
Add optional property for bubbling event

### DIFF
--- a/packages/react-native-codegen/src/generators/RNCodegen.js
+++ b/packages/react-native-codegen/src/generators/RNCodegen.js
@@ -257,6 +257,7 @@ module.exports = {
       useLocalIncludePaths,
       includeGetDebugPropsImplementation = false,
       libraryGenerators = LIBRARY_GENERATORS,
+      generateOptionalProperties = false,
     }: LibraryOptions,
     {generators, test}: LibraryConfig,
   ): boolean {
@@ -301,6 +302,7 @@ module.exports = {
           assumeNonnull,
           headerPrefix,
           includeGetDebugPropsImplementation,
+          generateOptionalProperties,
         ).forEach((contents: string, fileName: string) => {
           generatedFiles.push({
             name: fileName,


### PR DESCRIPTION
## Summary:

Add support to codegen to generate native optional props for event bubbling event properties that are defined as optional and have no default value.
Try to solve a part of this issue : https://github.com/facebook/react-native/issues/49920

## Changelog: [INTERNAL] 

Based on https://github.com/facebook/react-native/pull/54724


