### PR TITLE
Capture idle callback before running it

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/JavaTimerManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/JavaTimerManager.kt
@@ -327,9 +327,11 @@ public open class JavaTimerManager(
       // If the JS thread is busy for multiple frames we cancel any other pending runnable.
       // We also capture the idleCallbackRunnable to tentatively fix:
       // https://github.com/facebook/react-native/issues/44842
+      // https://github.com/facebook/react-native/issues/54983
       currentIdleCallbackRunnable?.cancel()
-      currentIdleCallbackRunnable = IdleCallbackRunnable(frameTimeNanos)
-      reactApplicationContext.runOnJSQueueThread(currentIdleCallbackRunnable)
+      val idleCallbackRunnable = IdleCallbackRunnable(frameTimeNanos)
+      currentIdleCallbackRunnable = idleCallbackRunnable
+      reactApplicationContext.runOnJSQueueThread(idleCallbackRunnable)
       reactChoreographer.postFrameCallback(ReactChoreographer.CallbackType.IDLE_EVENT, this)
     }
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Fixes https://github.com/facebook/react-native/issues/54983

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

https://github.com/facebook/react-native/issues/54983 has more details, but in short, this code here:

```kotlin
currentIdleCallbackRunnable?.cancel()
currentIdleCallbackRunnable = IdleCallbackRunnable(frameTimeNanos)
reactApplicationContext.runOnJSQueueThread(currentIdleCallbackRunnable)
```

If `currentIdleCallbackRunnable` change between line 2 and line 3 (which is known to happen), the wrong runnable would be sent to be run. The fix is to simply capture it in a local variable before passing it to be run

```kotlin
currentIdleCallbackRunnable?.cancel()
val idleCallbackRunnable = IdleCallbackRunnable(frameTimeNanos)
currentIdleCallbackRunnable = idleCallbackRunnable
reactApplicationContext.runOnJSQueueThread(idleCallbackRunnable)
```

## Changelog:

[ANDROID] [FIXED] - Capture idle callback before running it

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Unfortunately this is a pretty speculative change. That said, since the change is so simple, the worst thing that can happen is nothing. I have also run it in production here with no known issues
https://github.com/bluesky-social/social-app/pull/9436