### PR TITLE
Compile out UIWindowLevelStatusBar usage

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
+++ b/packages/react-native/React/CoreModules/RCTDevLoadingView.mm
@@ -183,7 +183,9 @@ RCT_EXPORT_MODULE()
       } else {
         self->_window = [[UIWindow alloc] init];
       }
+#if !TARGET_OS_TV
       self->_window.windowLevel = UIWindowLevelStatusBar + 1;
+#endif
       self->_window.rootViewController = [UIViewController new];
       [self->_window.rootViewController.view addSubview:self->_container];
     }


### PR DESCRIPTION
Summary:
`UIWindowLevelStatusBar` is unsupported on AppleTV. Adding a platform guard here.

Changelog: [Internal]

Differential Revision: D89820480


