### PR TITLE
fix: use the first language from context to decide Android directionality

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nUtil.kt
@@ -19,9 +19,18 @@ public class I18nUtil private constructor() {
    * * is forcing RTL layout, regardless of the active language (for development purpose)
    * * allows RTL layout when using RTL locale
    */
-  public fun isRTL(context: Context): Boolean =
-      applicationHasRtlSupport(context) &&
-          (isRTLForced(context) || (isRTLAllowed(context) && isDevicePreferredLanguageRTL))
+  public fun isRTL(context: Context): Boolean {
+    if (!applicationHasRtlSupport(context)) {
+      return false
+    }
+    if (isRTLForced(context)) {
+      return true
+    }
+    if (isRTLAllowed(context) && isApplicationPreferredLanguageRTL(context)) {
+      return true
+    }
+    return false
+  }
 
   /**
    * Android relies on the presence of `android:supportsRtl="true"` being set in order to resolve
@@ -60,13 +69,11 @@ public class I18nUtil private constructor() {
     setPref(context, KEY_FOR_PREFS_FORCERTL, forceRTL)
   }
 
-  private val isDevicePreferredLanguageRTL: Boolean
+  private fun isApplicationPreferredLanguageRTL(context: Context): Boolean {
     // Check if the current device language is RTL
-    get() {
-      val directionality =
-          TextUtilsCompat.getLayoutDirectionFromLocale(Locale.getAvailableLocales()[0])
-      return directionality == View.LAYOUT_DIRECTION_RTL
-    }
+    val directionality = TextUtilsCompat.getLayoutDirectionFromLocale(context.resources.configuration.locales[0])
+    return directionality == View.LAYOUT_DIRECTION_RTL
+  }
 
   private fun isPrefSet(context: Context, key: String, defaultValue: Boolean): Boolean =
       context


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

In #53417 I used `Locale.getAvailableLocales()[0]` to obtain the prioritized locale, which is incorrect according to @mukti107's comment. This returns ["an array of all installed locales"](https://developer.android.com/reference/java/util/Locale#getAvailableLocales()). However, what we want is the preferred locale specified by users, so it should be [`context.resources.configuration.locales[0]`](https://developer.android.com/guide/topics/resources/localization#use-the-android-context-object-for-manual-locale-lookup).

I also renamed this from `isDevicePreferredLanguageRTL` to `isApplicationPreferredLanguageRTL` so it aligns with iOS's implementation (`isDevicePreferredLanguageRTL` is not used anywhere in iOS, and `isApplicationPreferredLanguageRTL` is the one that actually get used) and reflects the usage of this function more accurately (`context.resources.configuration.locales[0]` would also respect per app's language settings, in addition to system language settings).

Note: since 0.76 React Native's minimum Android support SDK version becomes 24, so using [`locales`](https://developer.android.com/reference/kotlin/android/content/res/Configuration#getlocales) which is added in API level 24 should be safe.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID] [FIXED] - use the first language from context to decide Android directionality

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Same as in #53417, I used
```
import { I18nManager } from 'react-native';

I18nManager.allowRTL(true);
I18nManager.swapLeftAndRightInRTL(true);
```

Then I tried to set system's language to English and Hebrew, then set app's language settings to English and Hebrew. The directionality always conforms to the per app settings. If per app settings not set (use "System Default") then it would conform to the system language.