### PR TITLE
Fix modal hover interception to call the correct super method

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
@@ -593,7 +593,7 @@ public class ReactModalHostView(context: ThemedReactContext) :
 
     override fun onInterceptHoverEvent(event: MotionEvent): Boolean {
       eventDispatcher?.let { jSPointerDispatcher?.handleMotionEvent(event, it, true) }
-      return super.onHoverEvent(event)
+      return super.onInterceptHoverEvent(event)
     }
 
     override fun onHoverEvent(event: MotionEvent): Boolean {


### PR DESCRIPTION
## Summary:

Fixes an incorrect super call in `ReactModalHostView.onInterceptHoverEvent`. The method was returning `super.onHoverEvent(event)`, which bypasses the intended interception behavior and can cause inconsistent hover/pointer dispatching for modals. This change ensures the intercept hook delegates to the correct superclass implementation.

## Changelog:

[ANDROID] [FIXED] - Fix `ReactModalHostView` hover interception to call `super.onInterceptHoverEvent` instead of `super.onHoverEvent`.

## Test Plan:

* Built Android locally:

  * `./gradlew :packages:react-native:ReactAndroid:assembleDebug`