### PR TITLE
fix: color scheme in appearance state after setting it to unspecified

### DIFF
--- a/packages/react-native/Libraries/Utilities/Appearance.js
+++ b/packages/react-native/Libraries/Utilities/Appearance.js
@@ -99,7 +99,7 @@ export function setColorScheme(colorScheme: ColorSchemeName): void {
   if (NativeAppearance != null) {
     NativeAppearance.setColorScheme(colorScheme);
     state.appearance = {
-      colorScheme,
+      colorScheme: NativeAppearance.getColorScheme(),
     };
   }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Fixed the value of the color scheme in the appearance state after setting it to unspecified when state updates. The issue is described here #54959. This is a regression from #53397 and should be reproducible from 0.82 and higher. The `useColorScheme()` hook will return "unspecified" when you change the appearance from system color (dark or light) to system which breaks many apps using the value to determine whether to use dark/light mode colors.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[GENERAL] [FIXED] - Fix color scheme in appearance state after setting it to unspecified

## Test Plan:

1. Run the reproducer app in the issue - use dark mode when launching the app, press "change to dark" and then "change to system". The hook will return "unspecified" although the correct behavior should be dark.
2. Apply the changes in this PR.
3. The correct behavior should be seen.
