### PR TITLE
feat(JS) - `url` function support in `backgroundImage`

### DIFF
--- a/packages/react-native/Libraries/Components/View/ReactNativeStyleAttributes.js
+++ b/packages/react-native/Libraries/Components/View/ReactNativeStyleAttributes.js
@@ -149,7 +149,9 @@ const ReactNativeStyleAttributes: {[string]: AnyAttributeType, ...} = {
   /**
    * BackgroundImage
    */
-  experimental_backgroundImage: {process: processBackgroundImage},
+  experimental_backgroundImage: ReactNativeFeatureFlags.enableNativeCSSParsing()
+    ? true
+    : {process: processBackgroundImage},
 
   /**
    * BackgroundSize

--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
@@ -777,7 +777,15 @@ type RadialGradientValue = {
   }>,
 };
 
-export type BackgroundImageValue = LinearGradientValue | RadialGradientValue;
+type URLBackgroundImageValue = {
+  type: 'url',
+  uri: string | number,
+};
+
+export type BackgroundImageValue =
+  | LinearGradientValue
+  | RadialGradientValue
+  | URLBackgroundImageValue;
 
 export type BackgroundSizeValue =
   | {

--- a/packages/react-native/Libraries/StyleSheet/__tests__/processBackgroundImage-test.js
+++ b/packages/react-native/Libraries/StyleSheet/__tests__/processBackgroundImage-test.js
@@ -361,6 +361,10 @@ describe('processBackgroundImage', () => {
           {color: 'blue', positions: ['100%']},
         ],
       },
+      {
+        type: 'url',
+        uri: 'https://example.com',
+      },
     ];
     const result = processBackgroundImage(input);
     expect(result).toEqual([
@@ -371,6 +375,10 @@ describe('processBackgroundImage', () => {
           {color: processColor('red'), position: '0%'},
           {color: processColor('blue'), position: '100%'},
         ],
+      },
+      {
+        type: 'url',
+        uri: 'https://example.com',
       },
     ]);
   });
@@ -1152,5 +1160,105 @@ describe('processBackgroundImage', () => {
     const result2 = processBackgroundImage(input2);
     expect(result1).toEqual([]);
     expect(result2).toEqual([]);
+  });
+
+  it('should parse url unquoted', () => {
+    const result = processBackgroundImage('url(https://example.com/image.png)');
+    expect(result).toEqual([
+      {type: 'url', uri: 'https://example.com/image.png'},
+    ]);
+  });
+
+  it('should parse url double quoted', () => {
+    const result = processBackgroundImage(
+      'url("https://example.com/image.png")',
+    );
+    expect(result).toEqual([
+      {type: 'url', uri: 'https://example.com/image.png'},
+    ]);
+  });
+
+  it('should parse url single quoted', () => {
+    const result = processBackgroundImage(
+      "url('https://example.com/image.png')",
+    );
+    expect(result).toEqual([
+      {type: 'url', uri: 'https://example.com/image.png'},
+    ]);
+  });
+
+  it('should parse url case insensitive', () => {
+    const result = processBackgroundImage('UrL(https://example.com/image.png)');
+    expect(result).toEqual([
+      {type: 'url', uri: 'https://example.com/image.png'},
+    ]);
+  });
+
+  it('should parse url with query params', () => {
+    const result = processBackgroundImage(
+      'url(https://example.com/image.png?size=Large&format=webp)',
+    );
+    expect(result).toEqual([
+      {
+        type: 'url',
+        uri: 'https://example.com/image.png?size=Large&format=webp',
+      },
+    ]);
+  });
+
+  it('should parse url with whitespace', () => {
+    const result = processBackgroundImage(
+      'url(  https://example.com/image.png  )',
+    );
+    expect(result).toEqual([
+      {type: 'url', uri: 'https://example.com/image.png'},
+    ]);
+  });
+
+  it('should parse multiple urls', () => {
+    const result = processBackgroundImage(
+      'url(https://example.com/bg1.png), url(https://example.com/bg2.png)',
+    );
+    expect(result).toEqual([
+      {type: 'url', uri: 'https://example.com/bg1.png'},
+      {type: 'url', uri: 'https://example.com/bg2.png'},
+    ]);
+  });
+
+  it('should parse url mixed with gradients', () => {
+    const result = processBackgroundImage(
+      'radial-gradient(circle at top left, red, blue), url(https://example.com/image.png), linear-gradient(to bottom, green, yellow)',
+    );
+    expect(result).toEqual([
+      {
+        type: 'radial-gradient',
+        shape: 'circle',
+        size: 'farthest-corner',
+        position: {top: '0%', left: '0%'},
+        colorStops: [
+          {color: processColor('red'), position: null},
+          {color: processColor('blue'), position: null},
+        ],
+      },
+      {type: 'url', uri: 'https://example.com/image.png'},
+      {
+        type: 'linear-gradient',
+        direction: {type: 'angle', value: 180},
+        colorStops: [
+          {color: processColor('green'), position: null},
+          {color: processColor('yellow'), position: null},
+        ],
+      },
+    ]);
+  });
+
+  it('should return empty for url empty', () => {
+    const result = processBackgroundImage('url()');
+    expect(result).toEqual([]);
+  });
+
+  it('should return empty for url empty quoted', () => {
+    const result = processBackgroundImage('url("")');
+    expect(result).toEqual([]);
   });
 });

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BackgroundImagePropsConversions.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BackgroundImagePropsConversions.cpp
@@ -210,6 +210,14 @@ void parseProcessedBackgroundImage(
       }
 
       backgroundImage.emplace_back(std::move(radialGradient));
+    } else if (type == "url") {
+      auto uriIt = rawBackgroundImageMap.find("uri");
+      if (uriIt != rawBackgroundImageMap.end() &&
+          uriIt->second.hasType<std::string>()) {
+        URLBackgroundImage urlBackgroundImage;
+        urlBackgroundImage.uri = (std::string)(uriIt->second);
+        backgroundImage.emplace_back(std::move(urlBackgroundImage));
+      }
     }
   }
 
@@ -415,6 +423,14 @@ void parseUnprocessedBackgroundImageList(
       }
 
       backgroundImage.emplace_back(std::move(radialGradient));
+    } else if (type == "url") {
+      auto uriIt = rawBackgroundImageMap.find("uri");
+      if (uriIt != rawBackgroundImageMap.end() &&
+          uriIt->second.hasType<std::string>()) {
+        URLBackgroundImage urlBackgroundImage;
+        urlBackgroundImage.uri = (std::string)(uriIt->second);
+        backgroundImage.emplace_back(std::move(urlBackgroundImage));
+      }
     }
   }
 
@@ -478,6 +494,13 @@ void fromCSSColorStop(
 
 std::optional<BackgroundImage> fromCSSBackgroundImage(
     const CSSBackgroundImageVariant& cssBackgroundImage) {
+  if (std::holds_alternative<CSSURLFunction>(cssBackgroundImage)) {
+    const auto& urlFunc = std::get<CSSURLFunction>(cssBackgroundImage);
+    URLBackgroundImage urlBackgroundImage;
+    urlBackgroundImage.uri = urlFunc.url;
+    return BackgroundImage{urlBackgroundImage};
+  }
+
   if (std::holds_alternative<CSSLinearGradientFunction>(cssBackgroundImage)) {
     const auto& gradient =
         std::get<CSSLinearGradientFunction>(cssBackgroundImage);

--- a/packages/react-native/ReactCommon/react/renderer/css/tests/CSSBackgroundImageTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/css/tests/CSSBackgroundImageTest.cpp
@@ -557,4 +557,86 @@ TEST_F(CSSBackgroundImageTest, RadialGradientNegativeRadius) {
   }
 }
 
+TEST_F(CSSBackgroundImageTest, URLBasicUnquoted) {
+  auto result =
+      parseCSSProperty<CSSBackgroundImage>("url(https://example.com/image.png)");
+  decltype(result) expected = CSSURLFunction{.url = "https://example.com/image.png"};
+  ASSERT_EQ(result, expected);
+}
+
+TEST_F(CSSBackgroundImageTest, URLDoubleQuoted) {
+  auto result =
+      parseCSSProperty<CSSBackgroundImage>("url(\"https://example.com/image.png\")");
+  decltype(result) expected = CSSURLFunction{.url = "https://example.com/image.png"};
+  ASSERT_EQ(result, expected);
+}
+
+TEST_F(CSSBackgroundImageTest, URLSingleQuoted) {
+  auto result =
+      parseCSSProperty<CSSBackgroundImage>("url('https://example.com/image.png')");
+  decltype(result) expected = CSSURLFunction{.url = "https://example.com/image.png"};
+  ASSERT_EQ(result, expected);
+}
+
+TEST_F(CSSBackgroundImageTest, URLCaseInsensitive) {
+  auto result =
+      parseCSSProperty<CSSBackgroundImage>("UrL(https://example.com/image.png)");
+  decltype(result) expected = CSSURLFunction{.url = "https://example.com/image.png"};
+  ASSERT_EQ(result, expected);
+}
+
+TEST_F(CSSBackgroundImageTest, URLWithQueryParams) {
+  auto result =
+      parseCSSProperty<CSSBackgroundImage>("url(https://example.com/image.png?size=Large&format=webp)");
+  decltype(result) expected = CSSURLFunction{.url = "https://example.com/image.png?size=Large&format=webp"};
+  ASSERT_EQ(result, expected);
+}
+
+TEST_F(CSSBackgroundImageTest, URLWithWhitespace) {
+  auto result =
+      parseCSSProperty<CSSBackgroundImage>("url(  https://example.com/image.png  )");
+  decltype(result) expected = CSSURLFunction{.url = "https://example.com/image.png"};
+  ASSERT_EQ(result, expected);
+}
+
+TEST_F(CSSBackgroundImageTest, MultipleURLs) {
+  auto result = parseCSSProperty<CSSBackgroundImageList>(
+      "url(https://example.com/bg1.png), url(https://example.com/bg2.png)");
+  decltype(result) expected = CSSBackgroundImageList{
+      {CSSURLFunction{.url = "https://example.com/bg1.png"},
+       CSSURLFunction{.url = "https://example.com/bg2.png"}}};
+  ASSERT_EQ(result, expected);
+}
+
+TEST_F(CSSBackgroundImageTest, URLMixedWithGradients) {
+  auto result = parseCSSProperty<CSSBackgroundImageList>(
+      "radial-gradient(circle at top left, red, blue), url(https://example.com/image.png), linear-gradient(to bottom, green, yellow)");
+  decltype(result) expected = CSSBackgroundImageList{
+      {CSSRadialGradientFunction{
+           .shape = CSSRadialGradientShape::Circle,
+           .size = CSSRadialGradientSizeKeyword::FarthestCorner,
+           .position =
+               CSSRadialGradientPosition{
+                   .top = CSSPercentage{.value = 0.0f},
+                   .left = CSSPercentage{.value = 0.0f}},
+           .items = {makeCSSColorStop(255, 0, 0), makeCSSColorStop(0, 0, 255)}},
+       CSSURLFunction{.url = "https://example.com/image.png"},
+       CSSLinearGradientFunction{
+           .direction =
+               CSSLinearGradientDirection{.value = CSSAngle{.degrees = 180.0f}},
+           .items = {
+               makeCSSColorStop(0, 128, 0), makeCSSColorStop(255, 255, 0)}}}};
+  ASSERT_EQ(result, expected);
+}
+
+TEST_F(CSSBackgroundImageTest, URLEmpty) {
+  auto result = parseCSSProperty<CSSBackgroundImage>("url()");
+  ASSERT_TRUE(std::holds_alternative<std::monostate>(result));
+}
+
+TEST_F(CSSBackgroundImageTest, URLEmptyQuoted) {
+  auto result = parseCSSProperty<CSSBackgroundImage>("url(\"\")");
+  ASSERT_TRUE(std::holds_alternative<std::monostate>(result));
+}
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/graphics/BackgroundImage.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/BackgroundImage.h
@@ -7,12 +7,34 @@
 
 #pragma once
 
+#include <string>
+
 #include <react/renderer/graphics/LinearGradient.h>
 #include <react/renderer/graphics/RadialGradient.h>
 
 namespace facebook::react {
 
-using BackgroundImage = std::variant<LinearGradient, RadialGradient>;
+class ImageSource;
+
+struct URLBackgroundImage {
+  std::string uri{};
+
+  bool operator==(const URLBackgroundImage& rhs) const {
+    return uri == rhs.uri;
+  }
+
+  bool operator!=(const URLBackgroundImage& rhs) const {
+    return !(*this == rhs);
+  }
+
+#if RN_DEBUG_STRING_CONVERTIBLE
+  void toString(std::stringstream& ss) const {
+    ss << "url(" << uri << ")";
+  }
+#endif
+};
+
+using BackgroundImage = std::variant<LinearGradient, RadialGradient, URLBackgroundImage>;
 
 #ifdef RN_SERIALIZABLE_STATE
 folly::dynamic toDynamic(const BackgroundImage &backgroundImage);
@@ -34,6 +56,8 @@ inline std::string toString(std::vector<BackgroundImage> &value)
       std::get<LinearGradient>(backgroundImage).toString(ss);
     } else if (std::holds_alternative<RadialGradient>(backgroundImage)) {
       std::get<RadialGradient>(backgroundImage).toString(ss);
+    } else if (std::holds_alternative<URLBackgroundImage>(backgroundImage)) {
+      std::get<URLBackgroundImage>(backgroundImage).toString(ss);
     }
   }
   ss << "]";

--- a/packages/rn-tester/js/examples/BackgroundImage/BackgroundImageExample.js
+++ b/packages/rn-tester/js/examples/BackgroundImage/BackgroundImageExample.js
@@ -459,4 +459,44 @@ exports.examples = [
       );
     },
   },
+  {
+    title: 'URL Image',
+    name: 'url-image',
+    render(): React.Node {
+      return (
+        <BackgroundImageBox
+          style={{
+            width: 200,
+            height: 200,
+            experimental_backgroundImage:
+              'url(https://reactnative.dev/img/tiny_logo.png)',
+            experimental_backgroundRepeat: 'no-repeat',
+          }}
+          testID="background-image-url"
+        />
+      );
+    },
+  },
+  {
+    title: 'URL Image from local file',
+    name: 'local-image',
+    render(): React.Node {
+      return (
+        <BackgroundImageBox
+          style={{
+            width: 200,
+            height: 200,
+            experimental_backgroundImage: [
+              {
+                type: 'url',
+                uri: require('../../assets/bunny.png'),
+              },
+            ],
+            experimental_backgroundRepeat: 'no-repeat',
+          }}
+          testID="background-image-local"
+        />
+      );
+    },
+  },
 ] as Array<RNTesterModuleExample>;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

- Adds support for loading images with `url` syntax. e.g. `backgroundImage: url("https://example.com/1.png")`.
- This PR only includes JS/native parser code changes. To fully test the PR, merge https://github.com/facebook/react-native/pull/54994 and https://github.com/facebook/react-native/pull/54996 PRs.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[GENERAL] [ADDED] - `url` support with `backgroundImage`

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:


For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

- Merge https://github.com/facebook/react-native/pull/54995,  https://github.com/facebook/react-native/pull/54994 and https://github.com/facebook/react-native/pull/54996 PRs and test example added in JS PR.
- Added testcases for `url` syntax in JS and native parser.


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
