### PR TITLE
feat(iOS) - `url` function support in `backgroundImage`

### DIFF
--- a/packages/react-native/Package.swift
+++ b/packages/react-native/Package.swift
@@ -424,6 +424,7 @@ let reactCore = RNTarget(
 let reactFabric = RNTarget(
   name: .reactFabric,
   path: "ReactCommon/react/renderer",
+  searchPaths: ["ReactCommon/react/renderer/imagemanager/platform/ios"],
   excludedPaths: [
     "animations/tests",
     "attributedstring/tests",

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTBackgroundImageURLLoader.h
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTBackgroundImageURLLoader.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <UIKit/UIKit.h>
+#import <React/RCTImageResponseDelegate.h>
+#import <react/renderer/components/view/ViewShadowNode.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol RCTBackgroundImageURLLoaderDelegate <RCTImageResponseDelegate>
+
+- (void)backgroundImagesDidLoad;
+
+@end
+
+@interface RCTBackgroundImageURLLoader : NSObject
+
+@property (nonatomic, weak) id<RCTBackgroundImageURLLoaderDelegate> delegate;
+
+- (void)updateStateWithNewState:(facebook::react::ViewShadowNode::ConcreteState::Shared)state oldState:(facebook::react::ViewShadowNode::ConcreteState::Shared)oldState;
+- (nullable UIImage *)loadedImageForUri:(NSString *)uri;
+- (void)reset;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTBackgroundImageURLLoader.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTBackgroundImageURLLoader.mm
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTBackgroundImageURLLoader.h"
+
+#import <React/RCTLog.h>
+#import <React/RCTImageResponseObserverProxy.h>
+#import <react/renderer/components/view/ViewState.h>
+
+#include <map>
+#include <string>
+
+using namespace facebook::react;
+
+@implementation RCTBackgroundImageURLLoader {
+  ViewShadowNode::ConcreteState::Shared _state;
+  std::map<std::string, RCTImageResponseObserverProxy> _uriToObserver;
+  NSMutableDictionary<NSString *, UIImage *> *_loadedImages;
+  NSMutableSet<NSString *> *_completedUris;
+}
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    _loadedImages = [NSMutableDictionary new];
+    _completedUris = [NSMutableSet new];
+  }
+  return self;
+}
+
+- (void)updateStateWithNewState:(ViewShadowNode::ConcreteState::Shared)state
+                       oldState:(ViewShadowNode::ConcreteState::Shared)oldState
+{
+  const auto* oldRequests = oldState ? &oldState->getData().getBackgroundImageRequests() : nullptr;
+  const auto* newRequests = state ? &state->getData().getBackgroundImageRequests() : nullptr;
+
+  if (oldRequests && newRequests && *oldRequests == *newRequests) {
+    return;
+  }
+
+  if (oldRequests) {
+    for (const auto& request : *oldRequests) {
+      if (request.imageRequest) {
+        auto it = _uriToObserver.find(request.imageSource.uri);
+        if (it != _uriToObserver.end()) {
+          auto& observerCoordinator = request.imageRequest->getObserverCoordinator();
+          observerCoordinator.removeObserver(it->second);
+        }
+      }
+    }
+  }
+
+  _state = state;
+  _uriToObserver.clear();
+  [_loadedImages removeAllObjects];
+  [_completedUris removeAllObjects];
+
+  if (newRequests) {
+    for (const auto &request : *newRequests) {
+      if (request.imageRequest) {
+        const std::string &uri = request.imageSource.uri;
+        auto [it, inserted] = _uriToObserver.emplace(uri, self);
+        if (inserted) {
+          auto& observerCoordinator = request.imageRequest->getObserverCoordinator();
+          observerCoordinator.addObserver(it->second);
+        }
+      }
+    }
+  }
+}
+
+- (UIImage *)loadedImageForUri:(NSString *)uri
+{
+  return _loadedImages[uri];
+}
+
+- (void)reset
+{
+  if (_state) {
+    const auto &requests = _state->getData().getBackgroundImageRequests();
+    for (const auto &request : requests) {
+      if (request.imageRequest) {
+        auto it = _uriToObserver.find(request.imageSource.uri);
+        if (it != _uriToObserver.end()) {
+          auto& observerCoordinator = request.imageRequest->getObserverCoordinator();
+          observerCoordinator.removeObserver(it->second);
+        }
+      }
+    }
+  }
+
+  _state = nullptr;
+  _uriToObserver.clear();
+  [_loadedImages removeAllObjects];
+  [_completedUris removeAllObjects];
+}
+
+#pragma mark - RCTImageResponseDelegate
+
+- (void)didReceiveImage:(UIImage *)image metadata:(id)metadata fromObserver:(const void *)observer
+{
+  for (const auto& [uri, observerProxy] : _uriToObserver) {
+    if (&observerProxy == observer) {
+      NSString *nsUri = [NSString stringWithUTF8String:uri.c_str()];
+      _loadedImages[nsUri] = image;
+      [_completedUris addObject:nsUri];
+      break;
+    }
+  }
+
+  [self notifyDelegateIfAllImagesLoaded];
+}
+
+- (void)didReceiveProgress:(float)progress
+                    loaded:(int64_t)loaded
+                     total:(int64_t)total
+              fromObserver:(const void *)observer
+{
+  // Progress tracking not needed for background images
+}
+
+- (void)didReceiveFailure:(NSError *)error fromObserver:(const void *)observer
+{
+  for (const auto& [uri, observerProxy] : _uriToObserver) {
+    if (&observerProxy == observer) {
+      NSString *nsUri = [NSString stringWithUTF8String:uri.c_str()];
+      RCTLogWarn(@"Failed to load background image: %@ - %@", nsUri, error);
+      [_completedUris addObject:nsUri];
+      break;
+    }
+  }
+
+  [self notifyDelegateIfAllImagesLoaded];
+}
+
+- (void)notifyDelegateIfAllImagesLoaded
+{
+  if (_completedUris.count == _uriToObserver.size()) {
+    [_delegate backgroundImagesDidLoad];
+  }
+}
+
+@end

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.h
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.h
@@ -17,12 +17,14 @@
 #import <react/renderer/core/LayoutMetrics.h>
 #import <react/renderer/core/Props.h>
 
+#import "RCTBackgroundImageURLLoader.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**
  * UIView class for <View> component.
  */
-@interface RCTViewComponentView : UIView <RCTComponentViewProtocol, RCTTouchableComponentViewProtocol> {
+@interface RCTViewComponentView : UIView <RCTComponentViewProtocol, RCTTouchableComponentViewProtocol, RCTBackgroundImageURLLoaderDelegate> {
  @protected
   facebook::react::LayoutMetrics _layoutMetrics;
   facebook::react::SharedViewProps _props;

--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -131,6 +131,9 @@ Pod::Spec.new do |s|
       sss.dependency             "Yoga"
       sss.source_files         = podspec_sources(["react/renderer/components/view/*.{m,mm,cpp,h}", "react/renderer/components/view/platform/cxx/**/*.{m,mm,cpp,h}"], ["react/renderer/components/view/*.{h}", "react/renderer/components/view/platform/cxx/**/*.{h}"])
       sss.header_dir           = "react/renderer/components/view"
+      sss.pod_target_xcconfig  = {
+        "HEADER_SEARCH_PATHS" => "\"$(PODS_TARGET_SRCROOT)/react/renderer/imagemanager/platform/ios\""
+      }
     end
 
     ss.subspec "scrollview" do |sss|

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewComponentDescriptor.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewComponentDescriptor.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ViewComponentDescriptor.h"
+#include <react/renderer/imagemanager/ImageManager.h>
+
+namespace facebook::react {
+
+extern const char ImageManagerKey[];
+
+ViewComponentDescriptor::ViewComponentDescriptor(
+    const ComponentDescriptorParameters& parameters)
+    : ConcreteComponentDescriptor(parameters),
+      imageManager_(
+          getManagerByName<ImageManager>(contextContainer_, ImageManagerKey)) {}
+
+void ViewComponentDescriptor::adopt(ShadowNode& shadowNode) const {
+  ConcreteComponentDescriptor::adopt(shadowNode);
+
+  auto& viewShadowNode = static_cast<ViewShadowNode&>(shadowNode);
+  viewShadowNode.setImageManager(imageManager_);
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewComponentDescriptor.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewComponentDescriptor.h
@@ -12,12 +12,17 @@
 
 namespace facebook::react {
 
-class ViewComponentDescriptor : public ConcreteComponentDescriptor<ViewShadowNode> {
+class ImageManager;
+
+class ViewComponentDescriptor
+    : public ConcreteComponentDescriptor<ViewShadowNode> {
  public:
-  ViewComponentDescriptor(const ComponentDescriptorParameters &parameters)
-      : ConcreteComponentDescriptor<ViewShadowNode>(parameters)
-  {
-  }
+  ViewComponentDescriptor(const ComponentDescriptorParameters &parameters);
+
+  void adopt(ShadowNode &shadowNode) const override;
+
+ private:
+  const std::shared_ptr<ImageManager> imageManager_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.cpp
@@ -8,6 +8,9 @@
 #include "ViewShadowNode.h"
 #include <react/renderer/components/view/HostPlatformViewTraitsInitializer.h>
 #include <react/renderer/components/view/primitives.h>
+#include <react/renderer/graphics/BackgroundImage.h>
+#include <react/renderer/imagemanager/ImageManager.h>
+#include <react/renderer/imagemanager/primitives.h>
 
 namespace facebook::react {
 
@@ -90,6 +93,70 @@ void ViewShadowNode::initialize() noexcept {
   } else {
     traits_.unset(ShadowNodeTraits::Trait::ChildrenFormStackingContext);
   }
+}
+
+void ViewShadowNode::setImageManager(
+    const std::shared_ptr<ImageManager>& imageManager) {
+  ensureUnsealed();
+  imageManager_ = imageManager;
+  updateStateIfNeeded();
+}
+
+void ViewShadowNode::updateStateIfNeeded() {
+  if (!imageManager_) {
+    return;
+  }
+
+  ensureUnsealed();
+
+  const auto& viewProps = static_cast<const ViewProps&>(*props_);
+  const auto& backgroundImages = viewProps.backgroundImage;
+
+  std::vector<BackgroundImageURLRequest> newRequests;
+  for (const auto& bgImage : backgroundImages) {
+    if (std::holds_alternative<URLBackgroundImage>(bgImage)) {
+      const auto& urlBgImage = std::get<URLBackgroundImage>(bgImage);
+      if (!urlBgImage.uri.empty()) {
+        BackgroundImageURLRequest request;
+        request.imageSource.uri = urlBgImage.uri;
+        if (urlBgImage.uri.find("__packager_asset") != std::string::npos) {
+          request.imageSource.type = ImageSource::Type::Local;
+        } else {
+          request.imageSource.type = ImageSource::Type::Remote;
+        }
+        newRequests.push_back(std::move(request));
+      }
+    }
+  }
+
+  if (newRequests.empty()) {
+    return;
+  }
+
+  const auto& savedState = getStateData();
+  const auto& oldRequests = savedState.getBackgroundImageRequests();
+
+  bool requestsChanged = newRequests.size() != oldRequests.size();
+  if (!requestsChanged) {
+    for (size_t i = 0; i < newRequests.size(); ++i) {
+      if (newRequests[i].imageSource != oldRequests[i].imageSource) {
+        requestsChanged = true;
+        break;
+      }
+    }
+  }
+
+  if (!requestsChanged) {
+    return;
+  }
+
+  for (auto& request : newRequests) {
+    request.imageRequest = std::make_shared<ImageRequest>(
+        imageManager_->requestImage(request.imageSource, getSurfaceId()));
+  }
+
+  ViewState state{std::move(newRequests)};
+  setStateData(std::move(state));
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewShadowNode.h
@@ -9,8 +9,11 @@
 
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 #include <react/renderer/components/view/ViewProps.h>
+#include <react/renderer/components/view/ViewState.h>
 
 namespace facebook::react {
+
+class ImageManager;
 
 // NOLINTNEXTLINE(modernize-avoid-c-arrays)
 extern const char ViewComponentName[];
@@ -30,14 +33,19 @@ class ViewShadowNodeProps final : public ViewProps {
 /*
  * `ShadowNode` for <View> component.
  */
-class ViewShadowNode final : public ConcreteViewShadowNode<ViewComponentName, ViewShadowNodeProps, ViewEventEmitter> {
+class ViewShadowNode final : public ConcreteViewShadowNode<ViewComponentName, ViewShadowNodeProps, ViewEventEmitter, ViewState> {
  public:
   ViewShadowNode(const ShadowNodeFragment &fragment, const ShadowNodeFamily::Shared &family, ShadowNodeTraits traits);
 
   ViewShadowNode(const ShadowNode &sourceShadowNode, const ShadowNodeFragment &fragment);
 
+  void setImageManager(const std::shared_ptr<ImageManager> &imageManager);
+
  private:
   void initialize() noexcept;
+  void updateStateIfNeeded();
+
+  std::shared_ptr<ImageManager> imageManager_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewState.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewState.cpp
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ViewState.h"
+
+namespace facebook::react {
+
+const std::vector<BackgroundImageURLRequest>& ViewState::getBackgroundImageRequests()
+    const {
+  return backgroundImageRequests_;
+}
+
+} // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/view/ViewState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/ViewState.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/graphics/BackgroundImage.h>
+#include <react/renderer/imagemanager/ImageRequest.h>
+#include <react/renderer/imagemanager/primitives.h>
+
+#ifdef RN_SERIALIZABLE_STATE
+#include <folly/dynamic.h>
+#endif
+
+namespace facebook::react {
+
+struct BackgroundImageURLRequest {
+  ImageSource imageSource{};
+  std::shared_ptr<ImageRequest> imageRequest{};
+
+  bool operator==(const BackgroundImageURLRequest& rhs) const {
+    return imageSource == rhs.imageSource && imageRequest == rhs.imageRequest;
+  }
+};
+
+class ViewState final {
+ public:
+  ViewState() = default;
+
+  explicit ViewState(std::vector<BackgroundImageURLRequest> backgroundImageRequests)
+      : backgroundImageRequests_(std::move(backgroundImageRequests)) {}
+
+  const std::vector<BackgroundImageURLRequest>& getBackgroundImageRequests() const;
+
+#ifdef RN_SERIALIZABLE_STATE
+  ViewState(const ViewState& previousState, folly::dynamic data) {}
+
+  folly::dynamic getDynamic() const {
+    return {};
+  }
+#endif
+
+ private:
+  std::vector<BackgroundImageURLRequest> backgroundImageRequests_;
+};
+
+} // namespace facebook::react


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

- Adds support for loading images with `url` syntax. e.g. `backgroundImage: url("https://example.com/1.png")`.
- This PR only includes iOS code changes. To fully test the PR, merge https://github.com/facebook/react-native/pull/54995 and https://github.com/facebook/react-native/pull/54994 PRs.

### How:
- The background image fetching on iOS follows a similar approach to the Image component.
- Fetching starts in the `adopt` function. `RCTViewComponentView` attaches itself as a delegate to receive image fetch update via `RCTBackgroundImageURLLoader`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[IOS] [ADDED] - `url` support with `backgroundImage`

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:


For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:
- Merge https://github.com/facebook/react-native/pull/54995,  https://github.com/facebook/react-native/pull/54994 and https://github.com/facebook/react-native/pull/54996 PRs and test example added in JS PR.
- Added testcases for `url` syntax in JS and native parser.

<img width="200" height="auto" alt="simulator_screenshot_78A9F4FD-F5A2-4847-B36E-0BAEE5BCB9A7" src="https://github.com/user-attachments/assets/1bf296ef-255c-4a79-9e2b-8048d32575e5" />


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
