### PR TITLE
Compile out parts of RCTScrollView

### DIFF
--- a/packages/react-native/React/Base/RCTConvert.h
+++ b/packages/react-native/React/Base/RCTConvert.h
@@ -79,7 +79,9 @@ typedef NSURL RCTFileURL;
 + (UIKeyboardAppearance)UIKeyboardAppearance:(id)json;
 + (UIReturnKeyType)UIReturnKeyType:(id)json;
 + (UIUserInterfaceStyle)UIUserInterfaceStyle:(id)json API_AVAILABLE(ios(12));
+#if !TARGET_OS_TV
 + (UIInterfaceOrientationMask)UIInterfaceOrientationMask:(NSString *)orientation;
+#endif
 + (UIModalPresentationStyle)UIModalPresentationStyle:(id)json;
 
 #if !TARGET_OS_TV

--- a/packages/react-native/React/Base/RCTConvert.mm
+++ b/packages/react-native/React/Base/RCTConvert.mm
@@ -499,6 +499,7 @@ RCT_ENUM_CONVERTER(
     UIUserInterfaceStyleUnspecified,
     integerValue)
 
+#if !TARGET_OS_TV
 RCT_ENUM_CONVERTER(
     UIInterfaceOrientationMask,
     (@{
@@ -510,6 +511,7 @@ RCT_ENUM_CONVERTER(
     }),
     NSNotFound,
     unsignedIntegerValue)
+#endif
 
 RCT_ENUM_CONVERTER(
     UIModalPresentationStyle,

--- a/packages/react-native/React/Base/RCTUtils.h
+++ b/packages/react-native/React/Base/RCTUtils.h
@@ -101,7 +101,9 @@ RCT_EXTERN UIWindow *__nullable RCTKeyWindow(void);
 RCT_EXTERN UIViewController *__nullable RCTPresentedViewController(void);
 
 // Retrieve current window UIStatusBarManager
+#if !TARGET_OS_TV
 RCT_EXTERN UIStatusBarManager *__nullable RCTUIStatusBarManager(void) API_AVAILABLE(ios(13));
+#endif
 
 // Does this device support force touch (aka 3D Touch)?
 RCT_EXTERN BOOL RCTForceTouchAvailable(void);

--- a/packages/react-native/React/Base/RCTUtils.mm
+++ b/packages/react-native/React/Base/RCTUtils.mm
@@ -635,10 +635,12 @@ UIWindow *__nullable RCTKeyWindow(void)
   return nil;
 }
 
+#if !TARGET_OS_TV
 UIStatusBarManager *__nullable RCTUIStatusBarManager(void)
 {
   return RCTKeyWindow().windowScene.statusBarManager;
 }
+#endif
 
 UIViewController *__nullable RCTPresentedViewController(void)
 {

--- a/packages/react-native/React/Views/RCTModalHostView.h
+++ b/packages/react-native/React/Views/RCTModalHostView.h
@@ -38,8 +38,10 @@ __attribute__((deprecated("This API will be removed along with the legacy archit
 
 @property (nonatomic, weak) id<RCTModalHostViewInteractor> delegate;
 
+#if !TARGET_OS_TV
 @property (nonatomic, copy) NSArray<NSString *> *supportedOrientations;
 @property (nonatomic, copy) RCTDirectEventBlock onOrientationChange;
+#endif
 
 // Fabric only
 @property (nonatomic, copy) RCTDirectEventBlock onDismiss;

--- a/packages/react-native/React/Views/RCTModalHostView.m
+++ b/packages/react-native/React/Views/RCTModalHostView.m
@@ -25,7 +25,9 @@
   RCTModalHostViewController *_modalViewController;
   RCTTouchHandler *_touchHandler;
   UIView *_reactSubview;
+#if !TARGET_OS_TV
   UIInterfaceOrientation _lastKnownOrientation;
+#endif
   RCTDirectEventBlock _onRequestClose;
 }
 
@@ -90,6 +92,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : coder)
 
 - (void)notifyForOrientationChange
 {
+#if !TARGET_OS_TV
   if (!_onOrientationChange) {
     return;
   }
@@ -106,6 +109,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : coder)
     @"orientation" : isPortrait ? @"portrait" : @"landscape",
   };
   _onOrientationChange(eventPayload);
+#endif
 }
 
 - (void)insertReactSubview:(UIView *)subview atIndex:(NSInteger)atIndex
@@ -191,7 +195,9 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : coder)
   if (shouldBePresented) {
     RCTAssert(self.reactViewController, @"Can't present modal view controller without a presenting view controller");
 
+#if !TARGET_OS_TV
     _modalViewController.supportedInterfaceOrientations = [self supportedOrientationsMask];
+#endif
 
     if ([self.animationType isEqualToString:@"fade"]) {
       _modalViewController.modalTransitionStyle = UIModalTransitionStyleCrossDissolve;
@@ -224,6 +230,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : coder)
       transparent ? UIModalPresentationOverFullScreen : UIModalPresentationFullScreen;
 }
 
+#if !TARGET_OS_TV
 - (UIInterfaceOrientationMask)supportedOrientationsMask
 {
   if (_supportedOrientations.count == 0) {
@@ -250,6 +257,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : coder)
   }
   return supportedOrientations;
 }
+#endif
 
 @end
 

--- a/packages/react-native/React/Views/RCTModalHostViewController.h
+++ b/packages/react-native/React/Views/RCTModalHostViewController.h
@@ -14,7 +14,9 @@ __attribute__((deprecated("This API will be removed along with the legacy archit
 
 @property (nonatomic, copy) void (^boundsDidChangeBlock)(CGRect newBounds);
 
+#if !TARGET_OS_TV
 @property (nonatomic, assign) UIInterfaceOrientationMask supportedInterfaceOrientations;
+#endif
 
 @end
 

--- a/packages/react-native/React/Views/ScrollView/RCTScrollView.h
+++ b/packages/react-native/React/Views/ScrollView/RCTScrollView.h
@@ -51,10 +51,12 @@ __attribute__((deprecated("This API will be removed along with the legacy archit
 @property (nonatomic, assign) BOOL snapToEnd;
 @property (nonatomic, copy) NSString *snapToAlignment;
 @property (nonatomic, assign) BOOL inverted;
+#if !TARGET_OS_TV
 /** Focus area of newly-activated text input relative to the window to compare against UIKeyboardFrameBegin/End */
 @property (nonatomic, assign) CGRect firstResponderFocus;
 /** newly-activated text input outside of the scroll view */
 @property (nonatomic, weak) UIView *firstResponderViewOutsideScrollView;
+#endif
 
 // NOTE: currently these event props are only declared so we can export the
 // event names to JS - we don't call the blocks directly because scroll events

--- a/packages/react-native/React/Views/ScrollView/RCTScrollView.m
+++ b/packages/react-native/React/Views/ScrollView/RCTScrollView.m
@@ -211,16 +211,22 @@
   if ([_customRefreshControl respondsToSelector:@selector(setScrollView:)]) {
     _customRefreshControl.scrollView = self;
   }
+#if !TARGET_OS_TV
   if ([refreshControl isKindOfClass:UIRefreshControl.class]) {
     self.refreshControl = (UIRefreshControl *)refreshControl;
   } else {
+#endif
     [self addSubview:_customRefreshControl];
+#if !TARGET_OS_TV
   }
+#endif
 }
 
 - (void)setPinchGestureEnabled:(BOOL)pinchGestureEnabled
 {
+#if !TARGET_OS_TV
   self.pinchGestureRecognizer.enabled = pinchGestureEnabled;
+#endif
   _pinchGestureEnabled = pinchGestureEnabled;
 }
 
@@ -229,7 +235,9 @@
   [super didMoveToWindow];
   // ScrollView enables pinch gesture late in its lifecycle. So simply setting it
   // in the setter gets overridden when the view loads.
+#if !TARGET_OS_TV
   self.pinchGestureRecognizer.enabled = _pinchGestureEnabled;
+#endif
 }
 
 - (BOOL)shouldGroupAccessibilityChildren
@@ -260,15 +268,19 @@
 
 - (void)_registerKeyboardListener
 {
+#if !TARGET_OS_TV
   [[NSNotificationCenter defaultCenter] addObserver:self
                                            selector:@selector(_keyboardWillChangeFrame:)
                                                name:UIKeyboardWillChangeFrameNotification
                                              object:nil];
+#endif
 }
 
 - (void)_unregisterKeyboardListener
 {
+#if !TARGET_OS_TV
   [[NSNotificationCenter defaultCenter] removeObserver:self name:UIKeyboardWillChangeFrameNotification object:nil];
+#endif
 }
 
 static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCurve curve)
@@ -283,6 +295,7 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
 
 - (void)_keyboardWillChangeFrame:(NSNotification *)notification
 {
+#if !TARGET_OS_TV
   if (![self automaticallyAdjustKeyboardInsets]) {
     return;
   }
@@ -358,6 +371,7 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
                      [self scrollToOffset:newContentOffset animated:NO];
                    }
                    completion:nil];
+#endif
 }
 
 - (instancetype)initWithEventDispatcher:(id<RCTEventDispatcherProtocol>)eventDispatcher
@@ -428,7 +442,11 @@ static inline void RCTApplyTransformationAccordingLayoutDirection(
   [super insertReactSubview:view atIndex:atIndex];
   if ([view conformsToProtocol:@protocol(RCTCustomRefreshControlProtocol)]) {
     [_scrollView setCustomRefreshControl:(UIView<RCTCustomRefreshControlProtocol> *)view];
+#if !TARGET_OS_TV
     if (![view isKindOfClass:[UIRefreshControl class]] && [view conformsToProtocol:@protocol(UIScrollViewDelegate)]) {
+#else
+    if ([view conformsToProtocol:@protocol(UIScrollViewDelegate)]) {
+#endif
       [self addScrollListener:(UIView<UIScrollViewDelegate> *)view];
     }
   } else {
@@ -449,8 +467,12 @@ static inline void RCTApplyTransformationAccordingLayoutDirection(
   [super removeReactSubview:subview];
   if ([subview conformsToProtocol:@protocol(RCTCustomRefreshControlProtocol)]) {
     [_scrollView setCustomRefreshControl:nil];
+#if !TARGET_OS_TV
     if (![subview isKindOfClass:[UIRefreshControl class]] &&
         [subview conformsToProtocol:@protocol(UIScrollViewDelegate)]) {
+#else
+    if ([subview conformsToProtocol:@protocol(UIScrollViewDelegate)]) {
+#endif
       [self removeScrollListener:(UIView<UIScrollViewDelegate> *)subview];
     }
   } else {
@@ -1083,8 +1105,10 @@ RCT_SET_AND_PRESERVE_OFFSET(setKeyboardDismissMode, keyboardDismissMode, UIScrol
 RCT_SET_AND_PRESERVE_OFFSET(setMaximumZoomScale, maximumZoomScale, CGFloat)
 RCT_SET_AND_PRESERVE_OFFSET(setMinimumZoomScale, minimumZoomScale, CGFloat)
 RCT_SET_AND_PRESERVE_OFFSET(setScrollEnabled, isScrollEnabled, BOOL)
+#if !TARGET_OS_TV
 RCT_SET_AND_PRESERVE_OFFSET(setPagingEnabled, isPagingEnabled, BOOL)
 RCT_SET_AND_PRESERVE_OFFSET(setScrollsToTop, scrollsToTop, BOOL)
+#endif
 RCT_SET_AND_PRESERVE_OFFSET(setShowsHorizontalScrollIndicator, showsHorizontalScrollIndicator, BOOL)
 RCT_SET_AND_PRESERVE_OFFSET(setShowsVerticalScrollIndicator, showsVerticalScrollIndicator, BOOL)
 RCT_SET_AND_PRESERVE_OFFSET(setZoomScale, zoomScale, CGFloat);


### PR DESCRIPTION
Summary:
Parts of RCTScrollView are using APIs unsupported by AppleTV.

Changelog: [Internal]

Differential Revision: D89899914


