### PR TITLE
fix: add configurable:true to Event phase constant property descriptors

### DIFF
--- a/packages/react-native/src/private/webapis/dom/events/Event.js
+++ b/packages/react-native/src/private/webapis/dom/events/Event.js
@@ -184,48 +184,56 @@ export default class Event {
 
 // $FlowExpectedError[cannot-write]
 Object.defineProperty(Event, 'NONE', {
+  configurable: true,
   enumerable: true,
   value: 0,
 });
 
 // $FlowExpectedError[cannot-write]
 Object.defineProperty(Event.prototype, 'NONE', {
+  configurable: true,
   enumerable: true,
   value: 0,
 });
 
 // $FlowExpectedError[cannot-write]
 Object.defineProperty(Event, 'CAPTURING_PHASE', {
+  configurable: true,
   enumerable: true,
   value: 1,
 });
 
 // $FlowExpectedError[cannot-write]
 Object.defineProperty(Event.prototype, 'CAPTURING_PHASE', {
+  configurable: true,
   enumerable: true,
   value: 1,
 });
 
 // $FlowExpectedError[cannot-write]
 Object.defineProperty(Event, 'AT_TARGET', {
+  configurable: true,
   enumerable: true,
   value: 2,
 });
 
 // $FlowExpectedError[cannot-write]
 Object.defineProperty(Event.prototype, 'AT_TARGET', {
+  configurable: true,
   enumerable: true,
   value: 2,
 });
 
 // $FlowExpectedError[cannot-write]
 Object.defineProperty(Event, 'BUBBLING_PHASE', {
+  configurable: true,
   enumerable: true,
   value: 3,
 });
 
 // $FlowExpectedError[cannot-write]
 Object.defineProperty(Event.prototype, 'BUBBLING_PHASE', {
+  configurable: true,
   enumerable: true,
   value: 3,
 });


### PR DESCRIPTION
## Summary

Fixes #54732

The Event class defines phase constants (`NONE`, `CAPTURING_PHASE`, `AT_TARGET`, `BUBBLING_PHASE`) using `Object.defineProperty` without `configurable: true`. This causes the `event-target-shim` library to fail when it tries to redefine these properties, which in turn breaks `abort-controller` and consequently `fetch()` in New Architecture apps.

This PR adds `configurable: true` to all 8 property definitions (4 on Event class, 4 on Event.prototype) to match the standard behavior expected by DOM polyfills.

## Changelog:

[GENERAL] [FIXED] - Add configurable:true to Event phase constant property descriptors to fix event-target-shim compatibility

## Test Plan

1. Create a React Native app with New Architecture enabled
2. Execute any `fetch()` request
3. Verify the error `Cannot assign to read-only property 'NONE'` no longer occurs