### PR TITLE
fix(ios): dismiss Modal from presenting VC to handle presented view controllers

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.mm
@@ -145,7 +145,15 @@ static ModalHostViewEventEmitter::OnOrientationChange onOrientationChangeStruct(
                      animated:(BOOL)animated
                    completion:(void (^)(void))completion
 {
-  [modalViewController dismissViewControllerAnimated:animated completion:completion];
+  // Dismiss from the presenting view controller to ensure the entire presentation chain is dismissed.
+  // Calling dismissViewControllerAnimated: on a view controller that has a presented view controller
+  // on top of it will only dismiss the topmost presented view controller, not the modal itself.
+  UIViewController *presentingVC = modalViewController.presentingViewController;
+  if (presentingVC) {
+    [presentingVC dismissViewControllerAnimated:animated completion:completion];
+  } else {
+    [modalViewController dismissViewControllerAnimated:animated completion:completion];
+  }
 }
 
 - (void)ensurePresentedOnlyIfNeeded


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

When a Modal has another view controller presented on top of it (e.g., a sheet using `UISheetPresentationController`), calling `dismissViewControllerAnimated:` on the modal itself only dismisses the topmost presented view controller, leaving the modal in an inconsistent state where it remains presented but its React content is unmounted—resulting in a blank screen.

This fix dismisses from the presenting view controller instead, which correctly dismisses the entire presentation chain including any view controllers presented on top of the modal.

This issue affects any library that presents view controllers on top of RN Modal, such as [@lodev09/react-native-true-sheet](https://github.com/lodev09/react-native-true-sheet).

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[iOS] [Fixed] - Modal now correctly dismisses when another view controller is presented on top of it

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

1. Present a React Native `<Modal>`
2. Present another view controller on top of it (e.g., a sheet)
3. Set the Modal's `visible` prop to `false`

**Expected:** Both the sheet and modal dismiss, returning to the original screen  
**Actual:** The sheet dismisses but the modal remains presented with blank/black content

### Before

https://github.com/user-attachments/assets/4be826d8-d277-471a-8922-196b12959a64

### After

https://github.com/user-attachments/assets/989d3155-6239-4fa0-a885-c315d318e4b3

