### PR TITLE
removed unstable functions tracking the existance of connected devices

### DIFF
--- a/packages/dev-middleware/src/createDevMiddleware.js
+++ b/packages/dev-middleware/src/createDevMiddleware.js
@@ -9,7 +9,6 @@
  */
 
 import type {CreateCustomMessageHandlerFn} from './inspector-proxy/CustomMessageHandler';
-import type {HasConnectedDevicesListener} from './inspector-proxy/InspectorProxy';
 import type {BrowserLauncher} from './types/BrowserLauncher';
 import type {EventReporter, ReportableEvent} from './types/EventReporter';
 import type {Experiments, ExperimentsConfig} from './types/Experiments';
@@ -74,8 +73,6 @@ type Options = $ReadOnly<{
 type DevMiddlewareAPI = $ReadOnly<{
   middleware: NextHandleFunction,
   websocketEndpoints: {[path: string]: ws$WebSocketServer},
-  unstable_hasConnectedDevices(): boolean,
-  unstable_addHasConnectedDevicesListener: HasConnectedDevicesListener,
 }>;
 
 export default function createDevMiddleware({
@@ -134,10 +131,6 @@ export default function createDevMiddleware({
   return {
     middleware,
     websocketEndpoints: inspectorProxy.createWebSocketListeners(),
-    unstable_hasConnectedDevices: () =>
-      inspectorProxy.unstable_hasConnectedDevices(),
-    unstable_addHasConnectedDevicesListener: cb =>
-      inspectorProxy.unstable_addHasConnectedDevicesListener(cb),
   };
 }
 


### PR DESCRIPTION
Summary:
Changelog: [Internal] removed an unstable function briefly added in #54447

This was previously added in https://github.com/facebook/react-native/pull/54447, but not needed anymore as we found a different way to get this information without exposing a special API for that.

Differential Revision: D89962175


