### PR TITLE
Fix copy-paste error in DevToolsRuntimeSettings

### DIFF
--- a/packages/react-native/ReactCommon/devtoolsruntimesettings/DevToolsRuntimeSettings.cpp
+++ b/packages/react-native/ReactCommon/devtoolsruntimesettings/DevToolsRuntimeSettings.cpp
@@ -14,7 +14,7 @@ void DevToolsRuntimeSettings::setReloadAndProfileConfig(
   if (config.shouldReloadAndProfile.has_value()) {
     _config.shouldReloadAndProfile = config.shouldReloadAndProfile.value();
   }
-  if (config.shouldReloadAndProfile.has_value()) {
+  if (config.recordChangeDescriptions.has_value()) {
     _config.recordChangeDescriptions = config.recordChangeDescriptions.value();
   }
 };


### PR DESCRIPTION
## Summary:
Fixes a copy-paste error in `DevToolsRuntimeSettings::setReloadAndProfileConfig` where `recordChangeDescriptions` was guarded by the wrong optional field.
The correct conditional check is already used in https://github.com/facebook/react-native/blob/main/packages/react-native/React/CoreModules/RCTDevToolsRuntimeSettingsModule.mm#L28

## Changelog:
[INTERNAL] [FIXED] Fix incorrect optional field check in DevToolsRuntimeSettings

## Test Plan:
Code inspection only – trivial copy-paste fix with no behavior change outside correctly applying `recordChangeDescriptions` when present.