### PR TITLE
Align Flow lib defs for Node.js os with v24

### DIFF
--- a/flow-typed/environment/node.js
+++ b/flow-typed/environment/node.js
@@ -2682,9 +2682,7 @@ type os$CPU = {
     nice: number,
     sys: number,
     user: number,
-    ...
   },
-  ...
 };
 
 type os$NetIFAddr = {
@@ -2693,7 +2691,8 @@ type os$NetIFAddr = {
   internal: boolean,
   mac: string,
   netmask: string,
-  ...
+  scopeid?: number,
+  cidr: ?string,
 };
 
 type os$UserInfo$buffer = {
@@ -2702,7 +2701,6 @@ type os$UserInfo$buffer = {
   username: Buffer,
   homedir: Buffer,
   shell: ?Buffer,
-  ...
 };
 
 type os$UserInfo$string = {
@@ -2711,37 +2709,76 @@ type os$UserInfo$string = {
   username: string,
   homedir: string,
   shell: ?string,
-  ...
 };
 
 declare module 'os' {
-  declare function arch(): 'x64' | 'arm' | 'ia32';
+  declare function arch():
+    | 'arm'
+    | 'arm64'
+    | 'ia32'
+    | 'loong64'
+    | 'mips'
+    | 'mipsel'
+    | 'ppc64'
+    | 'riscv64'
+    | 's390x'
+    | 'x64';
   declare function availableParallelism(): number;
   declare function cpus(): Array<os$CPU>;
   declare function endianness(): 'BE' | 'LE';
   declare function freemem(): number;
+  declare function getPriority(pid?: number): number;
   declare function homedir(): string;
   declare function hostname(): string;
   declare function loadavg(): [number, number, number];
+  declare function machine(): string;
   declare function networkInterfaces(): {
     [ifName: string]: Array<os$NetIFAddr>,
-    ...
   };
-  declare function platform(): string;
+  declare function platform():
+    | 'aix'
+    | 'android'
+    | 'darwin'
+    | 'freebsd'
+    | 'haiku'
+    | 'linux'
+    | 'openbsd'
+    | 'sunos'
+    | 'win32'
+    | 'cygwin';
   declare function release(): string;
+  declare function setPriority(priority: number): void;
+  declare function setPriority(pid: number, priority: number): void;
   declare function tmpdir(): string;
   declare function totalmem(): number;
   declare function type(): string;
   declare function uptime(): number;
-  declare function userInfo(options: {
-    encoding: 'buffer',
-    ...
-  }): os$UserInfo$buffer;
-  declare function userInfo(options?: {
-    encoding: 'utf8',
-    ...
-  }): os$UserInfo$string;
+  declare function userInfo(
+    options: Readonly<{
+      encoding: 'buffer',
+    }>,
+  ): os$UserInfo$buffer;
+  declare function userInfo(
+    options?: Readonly<{
+      encoding: 'utf8',
+    }>,
+  ): os$UserInfo$string;
+  declare function version(): string;
   declare var EOL: string;
+  declare var devNull: string;
+  declare var constants: Readonly<{
+    signals: {[key: string]: number, ...},
+    errno: {[key: string]: number, ...},
+    priority: Readonly<{
+      PRIORITY_LOW: number,
+      PRIORITY_BELOW_NORMAL: number,
+      PRIORITY_NORMAL: number,
+      PRIORITY_ABOVE_NORMAL: number,
+      PRIORITY_HIGH: number,
+      PRIORITY_HIGHEST: number,
+    }>,
+    dlopen: {[key: string]: number, ...},
+  }>;
 }
 
 type path$PlatformPath = {


### PR DESCRIPTION
Summary:
This is an AI-assisted change to align the Flow definitions for the `os` module with the Node.js docs as at v24.

**New APIs:**

1. **`machine()`** - Returns machine type (added in v18.9.0, v16.18.0)
   - Returns hardware name: `'x86_64'`, `'arm64'`, `'aarch64'`, etc.
   - Different from `arch()` which returns the architecture Node.js was compiled for
   - https://nodejs.org/api/os.html#osmachine

2. **`version()`** - Returns kernel version string (added in v13.11.0, v12.17.0)
   - Example: `'Linux 5.15.0-1234-generic'`, `'Darwin Kernel Version 21.6.0'`
   - https://nodejs.org/api/os.html#osversion

3. **`setPriority([pid,] priority)`** / **`getPriority([pid])`** - Process priority management
   - Set/get scheduling priority for processes
   - Priority constants available in `os.constants.priority`
   - https://nodejs.org/api/os.html#ossetprioritypid-priority
   - https://nodejs.org/api/os.html#osgetprioritypid

4. **`devNull` constant** - Path to null device (`'/dev/null'` on POSIX, `'\\\\.\\nul'` on Windows)
   - https://nodejs.org/api/os.html#osdevnull

5. **`constants` object** - OS constants (signals, errno, priority, dlopen)
   - `constants.signals` - Process signal constants
   - `constants.errno` - Error number constants  
   - `constants.priority` - Process priority constants (PRIORITY_LOW, PRIORITY_HIGH, etc.) - Readonly
   - `constants.dlopen` - Dynamic library loading constants
   - https://nodejs.org/api/os.html#os-constants

**Type Safety Improvements:**

6. **`arch()` return type** - Now includes all 10 supported architectures:
   - Added: `'loong64'` (LoongArch - newer Chinese CPU architecture)
   - Complete list: `'arm'`, `'arm64'`, `'ia32'`, `'loong64'`, `'mips'`, `'mipsel'`, `'ppc64'`, `'riscv64'`, `'s390x'`, `'x64'`
   - https://nodejs.org/api/os.html#osarch

7. **`platform()` return type** - Now union of 10 specific platforms instead of generic `string`:
   - `'aix'`, `'android'`, `'darwin'`, `'freebsd'`, `'haiku'`, `'linux'`, `'openbsd'`, `'sunos'`, `'win32'`, `'cygwin'`
   - https://nodejs.org/api/os.html#osplatform

8. **Output type definitions made exact** - Removed spread operators (outputs are mutable)
   - `os$CPU` - Removed spread operators from main type and nested `times` object
   - `os$NetIFAddr` - Added missing `scopeid?` and `cidr` properties, removed spread operator
   - `os$UserInfo$*` - Types are mutable (not readonly) so consumers can modify returned values
   - `networkInterfaces()` return type - Removed spread operator for exact type

9. **Input types use Readonly** - Following readonly rules
   - `userInfo()` options: Changed to `Readonly<{encoding: 'buffer' | 'utf8'}>`
   - Allows passing readonly types safely

**References:**
- Node.js os module docs: https://nodejs.org/api/os.html

Changelog: [Internal]
---
> Generated by [Confucius Code Assist (CCA)](https://www.internalfb.com/wiki/Confucius/Analect/Shared_Analects/Confucius_Code_Assist_(CCA)/)
[Confucius Session](https://www.internalfb.com/confucius?host=devvm45708.cln0.facebook.com&port=8086&tab=Chat&session_id=1a3aa26e-e5a9-11f0-8d47-71a4a90f0494&entry_name=Code+Assist), [Trace](https://www.internalfb.com/confucius?session_id=1a3aa26e-e5a9-11f0-8d47-71a4a90f0494&tab=Trace)

Reviewed By: vzaidman

Differential Revision: D89940756


