### PR TITLE
Align Flow lib defs for Node.js util with v24

### DIFF
--- a/flow-typed/environment/node.js
+++ b/flow-typed/environment/node.js
@@ -3683,31 +3683,33 @@ declare module 'util' {
   declare function stripVTControlCharacters(str: string): string;
 
   declare function parseArgs<
-    TOptions: {+[string]: util$ParseArgsOption} = {||},
-  >(config: {|
+    TOptions: {+[string]: util$ParseArgsOption} = {},
+  >(config: {
     args?: Array<string>,
     options?: TOptions,
     strict?: boolean,
     allowPositionals?: boolean,
+    allowNegative?: boolean,
     tokens?: false,
-  |}): {|
+  }): {
     values: util$ParseArgsOptionsToValues<TOptions>,
     positionals: Array<string>,
-  |};
+  };
 
   declare function parseArgs<
-    TOptions: {[string]: util$ParseArgsOption} = {||},
-  >(config: {|
+    TOptions: {[string]: util$ParseArgsOption} = {},
+  >(config: {
     args?: Array<string>,
     options?: TOptions,
     strict?: boolean,
     allowPositionals?: boolean,
+    allowNegative?: boolean,
     tokens: true,
-  |}): {|
+  }): {
     values: util$ParseArgsOptionsToValues<TOptions>,
     positionals: Array<string>,
     tokens: Array<util$ParseArgsToken>,
-  |};
+  };
 
   declare class TextDecoder {
     constructor(
@@ -3733,6 +3735,46 @@ declare module 'util' {
     encoding: string;
   }
 
+  declare class MIMEType {
+    constructor(input: string): void;
+    type: string;
+    subtype: string;
+    +essence: string;
+    +params: MIMEParams;
+    toString(): string;
+  }
+
+  declare class MIMEParams {
+    delete(name: string): void;
+    get(name: string): ?string;
+    has(name: string): boolean;
+    set(name: string, value: string): void;
+    entries(): Iterator<[string, string]>;
+    keys(): Iterator<string>;
+    values(): Iterator<string>;
+  }
+
+  declare function parseEnv(content: string): {[key: string]: string, ...};
+
+  declare type util$DiffEntry = [operation: -1 | 0 | 1, value: string];
+  declare function diff(
+    actual: string | $ReadOnlyArray<string>,
+    expected: string | $ReadOnlyArray<string>,
+  ): Array<util$DiffEntry>;
+
+  declare function getSystemErrorMessage(err: number): string;
+
+  declare type util$CallSiteObject = {
+    functionName: string,
+    scriptName: string,
+    scriptId: string,
+    lineNumber: number,
+    columnNumber: number,
+  };
+  declare function getCallSites(
+    frameCountOrOptions?: number | Readonly<{frameCount?: number}>,
+  ): Array<util$CallSiteObject>;
+
   declare var types: {
     isAnyArrayBuffer: (value: unknown) => boolean,
     isArgumentsObject: (value: unknown) => boolean,
@@ -3745,6 +3787,7 @@ declare module 'util' {
     isDataView: (value: unknown) => boolean,
     isDate: (value: unknown) => boolean,
     isExternal: (value: unknown) => boolean,
+    isFloat16Array: (value: unknown) => boolean,
     isFloat32Array: (value: unknown) => boolean,
     isFloat64Array: (value: unknown) => boolean,
     isGeneratorFunction: (value: unknown) => boolean,


### PR DESCRIPTION
Summary:
This is an AI-assisted change to align the Flow definitions for the `util` module with the Node.js docs as at v24.

**New v20-v24 APIs:**

1. **`parseEnv(content)`** - Environment file (.env) parser (added in v20.12.0)
   - Parses `.env` file content into key-value object
   - Last value wins for duplicate keys
   - https://nodejs.org/api/util.html#utilparseenvcontent

2. **`diff(actual, expected)`** - String/array comparison (added in v22.15.0) 🧪
   - Uses Myers diff algorithm for comparison
   - Returns array of tuples: `[operation: -1 | 0 | 1, value: string]`
     - `-1` = expected only (deletion)
     - `0` = both (unchanged)
     - `1` = actual only (insertion)
   - Experimental API
   - https://nodejs.org/api/util.html#utildiffactual-expected

3. **`getSystemErrorMessage(err)`** - Error code to message (added in v22.12.0)
   - Returns the error message string for a numeric error code
   - https://nodejs.org/api/util.html#utilgetsystemerrormessageerr

4. **`getCallSites([frameCount | options])`** - Call stack capture (added in v22.9.0)
   - Captures call stack as `CallSiteObject` instances with:
     - `functionName`, `scriptName`, `scriptId`, `lineNumber`, `columnNumber`
   - `scriptId` property added in v22.14.0
   - https://nodejs.org/api/util.html#utilgetcallsitesframecount

5. **`types.isFloat16Array()`** - Type check for Float16Array (added in v24.0.0)
   - Checks if value is a Float16Array instance
   - https://nodejs.org/api/util.html#utiltypesisfloat16arrayvalue

**New Classes (v19):**

6. **`MIMEType` class** - MIME type parsing and manipulation (added in v19.1.0, v18.13.0)
   - Properties: `type`, `subtype`, `essence`, `params`
   - Methods: `toString()`
   - Implements MIMEType proposal spec
   - https://nodejs.org/api/util.html#class-utilmimetype

7. **`MIMEParams` class** - MIME parameters handler (added in v19.1.0, v18.13.0)
   - Methods: `delete()`, `get()`, `has()`, `set()`, `entries()`, `keys()`, `values()`
   - https://nodejs.org/api/util.html#class-utilmimeparams

**Updated APIs:**

8. **`parseArgs()` - Added `allowNegative` option** (added in v22.4.0)
   - Allows explicitly setting boolean options to false with `--no-` prefix
   - Example: `--no-verbose` sets `verbose: false`
   - https://nodejs.org/api/util.html#utilparseargsconfig

**Type Safety Improvements:**

9. **Exact-by-default syntax** - Simplified object types
   - Changed `{|...|}`  `{}` in parseArgs types (Flow configured with exact-by-default)
   - Changed default generic types from `{||}` → `{}`

10. **styleText()** already present with full type definitions
    - 18 foreground colors, 18 background colors, 12 modifiers
    - https://nodejs.org/api/util.html#utilstyletextformat-text

**References:**
- Node.js util module docs: https://nodejs.org/api/util.html
- MIMEType proposal: https://bmeck.github.io/node-proposal-mime-api/

Changelog: [Internal]
---
> Generated by [Confucius Code Assist (CCA)](https://www.internalfb.com/wiki/Confucius/Analect/Shared_Analects/Confucius_Code_Assist_(CCA)/)
[Confucius Session](https://www.internalfb.com/confucius?host=devvm45708.cln0.facebook.com&port=8086&tab=Chat&session_id=1a3aa26e-e5a9-11f0-8d47-71a4a90f0494&entry_name=Code+Assist), [Trace](https://www.internalfb.com/confucius?session_id=1a3aa26e-e5a9-11f0-8d47-71a4a90f0494&tab=Trace)

Reviewed By: vzaidman

Differential Revision: D89942136


