### PR TITLE
Align Flow lib defs for Node.js buffer with v24

### DIFF
--- a/flow-typed/environment/node.js
+++ b/flow-typed/environment/node.js
@@ -198,12 +198,27 @@ declare type Node$Buffer = typeof Buffer;
 declare module 'buffer' {
   declare var kMaxLength: number;
   declare var INSPECT_MAX_BYTES: number;
+
+  declare var constants: $ReadOnly<{
+    MAX_LENGTH: number,
+    MAX_STRING_LENGTH: number,
+  }>;
+
   declare function transcode(
     source: Node$Buffer,
     fromEnc: buffer$Encoding,
     toEnc: buffer$Encoding,
   ): Node$Buffer;
+
+  declare function isUtf8(input: Buffer | ArrayBuffer | $TypedArray): boolean;
+
+  declare function isAscii(input: Buffer | ArrayBuffer | $TypedArray): boolean;
+
+  declare function resolveObjectURL(id: string): Blob | void;
+
   declare var Buffer: Node$Buffer;
+  declare var Blob: typeof globalThis.Blob;
+  declare var File: typeof globalThis.File;
 }
 
 type child_process$execOpts = {


### PR DESCRIPTION
Summary:
This is an AI-assisted change to align the Flow definitions for the `buffer` module with the Node.js docs as at v24.

**New Validation Functions:**

1. **`isUtf8(input)`** - UTF-8 validation (added in v19.4.0, v18.14.0)
   - Validates if Buffer/ArrayBuffer/TypedArray contains only valid UTF-8 data
   - Returns `true` for valid UTF-8 (including empty buffers)
   - Throws error if input is a detached array buffer
   - https://nodejs.org/api/buffer.html#bufferisutf8input

2. **`isAscii(input)`** - ASCII validation (added in v19.6.0, v18.15.0)
   - Validates if Buffer/ArrayBuffer/TypedArray contains only ASCII (0x00-0x7F)
   - Returns `true` for valid ASCII (including empty buffers)
   - Throws error if input is a detached array buffer
   - https://nodejs.org/api/buffer.html#bufferisasciiinput

**Blob URL Resolution:**

3. **`resolveObjectURL(id)`** - Resolve Blob from URL (added in v16.7.0)
   - Resolves `'blob:nodedata:...'` URL to its associated Blob object
   - Returns Blob or `undefined` if URL not found
   - Works with URLs created via `URL.createObjectURL(blob)`
   - https://nodejs.org/api/buffer.html#bufferresolveobjecturlid

**New Constants:**

4. **`constants` object** - Buffer size limits
   - `constants.MAX_LENGTH` - Maximum size of a single Buffer instance
   - `constants.MAX_STRING_LENGTH` - Maximum length for string operations
   - https://nodejs.org/api/buffer.html#bufferconstantsmax_length

**Web API Classes (re-exported):**

5. **`Blob` class** - Exported from buffer module (global in v18.0.0)
   - Web API-compatible Blob for immutable binary data
   - Also available as global (no import needed in v18+)
   - https://nodejs.org/api/buffer.html#class-blob

6. **`File` class** - Exported from buffer module (global in v20.0.0)
   - Web API-compatible File extending Blob
   - Also available as global (no import needed in v20+)
   - https://nodejs.org/api/buffer.html#class-file

**References:**
- Node.js buffer module docs: https://nodejs.org/api/buffer.html

Changelog: [Internal]
---
> Generated by [Confucius Code Assist (CCA)](https://www.internalfb.com/wiki/Confucius/Analect/Shared_Analects/Confucius_Code_Assist_(CCA)/)
[Confucius Session](https://www.internalfb.com/confucius?host=devvm45708.cln0.facebook.com&port=8086&tab=Chat&session_id=1a3aa26e-e5a9-11f0-8d47-71a4a90f0494&entry_name=Code+Assist), [Trace](https://www.internalfb.com/confucius?session_id=1a3aa26e-e5a9-11f0-8d47-71a4a90f0494&tab=Trace)

Reviewed By: vzaidman

Differential Revision: D89942832


