### PR TITLE
fix `print-packages` script

### DIFF
--- a/scripts/monorepo/print/index.js
+++ b/scripts/monorepo/print/index.js
@@ -8,7 +8,7 @@
  * @noflow
  */
 
-const {getPackages} = require('../../utils/monorepo');
+const {getPackages} = require('../../shared/monorepoUtils');
 const {exit} = require('shelljs');
 const yargs = require('yargs');
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Running `print-packages` script from monorepo root results in a require error.

This PR updates the import path for `getPackages` utit to fix the script, which now output correct data.

## Changelog:

[INTERNAL] [FIXED] - Fix `print-packages` script

## Test Plan:

<img width="1344" height="602" alt="Screenshot 2026-01-02 at 19 58 51" src="https://github.com/user-attachments/assets/d6dd1ab5-e0da-4878-b622-7e5f5aa0865b" />

