### PR TITLE
do not spellcheck vendored scripts

### DIFF
--- a/.github/workflow-scripts/analyze_scripts.sh
+++ b/.github/workflow-scripts/analyze_scripts.sh
@@ -16,6 +16,7 @@ if [ -x "$(command -v shellcheck)" ]; then
     -type f \
     -not -path "*node_modules*" \
     -not -path "*third-party*" \
+    -not -path "*vendor*" \
     -name '*.sh' \
     -exec sh -c 'shellcheck "$1"' -- {} \;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

While running `yarn spellcheck` I have spotted that scripts located in `/vendor` directory are checked, which lead to a lot of warnings in the output.

This PR adds an exclusion for the `/vendor` path in the spellcheck script which leads to way smaller warnings set and saves ~10s of runtime on my machine.

## Changelog:

[INTERNAL] [FIXED] - Add `/vendor` to excluded paths for spellcheck script.

## Test Plan:

Running `yarn spellcheck` locally.
