### PR TITLE
Add KDoc documentation to GuardedFrameCallback

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/GuardedFrameCallback.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/GuardedFrameCallback.kt
@@ -14,12 +14,29 @@ import com.facebook.react.bridge.ReactContext
 /**
  * Abstract base for a Choreographer FrameCallback that should have any RuntimeExceptions it throws
  * handled by the [JSExceptionHandler] registered if the app is in dev mode.
+ *
+ * @property exceptionHandler The handler for RuntimeExceptions thrown during frame callbacks.
+ * @constructor Creates a GuardedFrameCallback with the specified exception handler.
  */
 public abstract class GuardedFrameCallback
 protected constructor(private val exceptionHandler: JSExceptionHandler) :
     Choreographer.FrameCallback {
+  /**
+   * Creates a GuardedFrameCallback using the exception handler from the provided ReactContext.
+   *
+   * @param reactContext The React context whose exception handler will be used.
+   */
   protected constructor(reactContext: ReactContext) : this(reactContext.exceptionHandler)
 
+  /**
+   * Choreographer frame callback implementation that guards [doFrameGuarded] with exception
+   * handling.
+   *
+   * Wraps calls to [doFrameGuarded] in a try-catch block. Any RuntimeExceptions thrown are caught
+   * and passed to the exception handler instead of crashing the app.
+   *
+   * @param frameTimeNanos The time in nanoseconds when the frame started being rendered.
+   */
   public override fun doFrame(frameTimeNanos: Long) {
     try {
       doFrameGuarded(frameTimeNanos)


### PR DESCRIPTION
Summary:
Added comprehensive KDoc comments to GuardedFrameCallback.kt to document all public constructors and the doFrame method. The documentation explains the exception handling behavior, constructor parameters, and frame callback implementation.

changelog: [Android][Changed] Updated documentation for GuardedFrameCallback class

Differential Revision: D90043453


