### PR TITLE
Restore content offset after background snapshot on iOS

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -650,6 +650,13 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
 
   _avoidAdjustmentForMaintainVisibleContentPosition = enableImmediateUpdateModeForContentOffsetChanges;
 
+#if TARGET_OS_IOS
+  UIWindowScene *scene = self.window.windowScene;
+  if (scene && scene.activationState == UISceneActivationStateBackground) {
+    return;
+  }
+#endif
+
   auto contentOffset = RCTPointFromCGPoint(_scrollView.contentOffset);
   BOOL isAccessibilityAPIUsed = _isAccessibilityAPIUsed;
   _state->updateState(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

In iOS 26, backgrounding an app triggers an app snapshot [1], which will be taken in all supported device orientations. When in landscape mode, the OS will make a layout pass in portrait followed by another in landscape (and vice versa), taking a snapshot of each.

If scrolled to the bottom of a ScrollView in landscape mode, the content offset will be incorrect on resume, as UIScrollView updates the offset during the portrait layout pass to prevent overscroll. When the next layout pass is made, the offset is not reset to the original value.

Store the content offset on update when foregrounded. When backgrounded, override the content offset with the stored content offset, clamped to the content size. When the second snapshot is taken (in the original orientation), the original content offset is restored.

Fixes #54979.

[1] https://developer.apple.com/documentation/uikit/preparing-your-ui-to-run-in-the-background#Prepare-your-UI-for-the-app-snapshot

## Changelog:

[IOS] [FIXED] - Scroll position not maintained after resume on iOS

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Reproducer: https://snack.expo.dev/@mhoran/restless-green-graham-crackers

Per #54979: 
1. Run the reproducer on an iPad simulator with patch applied
1. Rotate the screen to landscape (app must be fullscreen)
1. Scroll to the bottom
1. Background the app
1. Wait a few seconds
1. Open the app
1. See that the ScrollView position remains the same

Without this patch, the ScrollView position will change, due to the background snapshot taken in portrait mode.

Screen recording: https://drive.google.com/file/d/1WrEXNSF2dcYswtKrlM6YJglGiOzoGq8u/view?usp=drive_link.