### PR TITLE
Feat/ios edge effect

### DIFF
--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.d.ts
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.d.ts
@@ -530,37 +530,45 @@ export interface ScrollViewPropsIOS {
    * The style of the top edge effect. Available on iOS 26.0 and later.
    * @platform ios
    */
-  topEdgeEffect?: {
-    style?: 'automatic' | 'soft' | 'hard' | undefined;
-    hidden?: boolean | undefined;
-  } | undefined;
+  topEdgeEffect?:
+    | {
+        style?: 'automatic' | 'soft' | 'hard' | undefined;
+        hidden?: boolean | undefined;
+      }
+    | undefined;
 
   /**
    * The style of the bottom edge effect. Available on iOS 26.0 and later.
    * @platform ios
    */
-  bottomEdgeEffect?: {
-    style?: 'automatic' | 'soft' | 'hard' | undefined;
-    hidden?: boolean | undefined;
-  } | undefined;
+  bottomEdgeEffect?:
+    | {
+        style?: 'automatic' | 'soft' | 'hard' | undefined;
+        hidden?: boolean | undefined;
+      }
+    | undefined;
 
   /**
    * The style of the left edge effect. Available on iOS 26.0 and later.
    * @platform ios
    */
-  leftEdgeEffect?: {
-    style?: 'automatic' | 'soft' | 'hard' | undefined;
-    hidden?: boolean | undefined;
-  } | undefined;
+  leftEdgeEffect?:
+    | {
+        style?: 'automatic' | 'soft' | 'hard' | undefined;
+        hidden?: boolean | undefined;
+      }
+    | undefined;
 
   /**
    * The style of the right edge effect. Available on iOS 26.0 and later.
    * @platform ios
    */
-  rightEdgeEffect?: {
-    style?: 'automatic' | 'soft' | 'hard' | undefined;
-    hidden?: boolean | undefined;
-  } | undefined;
+  rightEdgeEffect?:
+    | {
+        style?: 'automatic' | 'soft' | 'hard' | undefined;
+        hidden?: boolean | undefined;
+      }
+    | undefined;
 
   /**
    * The current scale of the scroll view content. The default value is 1.0.

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.d.ts
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.d.ts
@@ -527,6 +527,42 @@ export interface ScrollViewPropsIOS {
     | undefined;
 
   /**
+   * The style of the top edge effect. Available on iOS 26.0 and later.
+   * @platform ios
+   */
+  topEdgeEffect?: {
+    style?: 'automatic' | 'soft' | 'hard';
+    hidden?: boolean;
+  } | undefined;
+
+  /**
+   * The style of the bottom edge effect. Available on iOS 26.0 and later.
+   * @platform ios
+   */
+  bottomEdgeEffect?: {
+    style?: 'automatic' | 'soft' | 'hard';
+    hidden?: boolean;
+  } | undefined;
+
+  /**
+   * The style of the left edge effect. Available on iOS 26.0 and later.
+   * @platform ios
+   */
+  leftEdgeEffect?: {
+    style?: 'automatic' | 'soft' | 'hard';
+    hidden?: boolean;
+  } | undefined;
+
+  /**
+   * The style of the right edge effect. Available on iOS 26.0 and later.
+   * @platform ios
+   */
+  rightEdgeEffect?: {
+    style?: 'automatic' | 'soft' | 'hard';
+    hidden?: boolean;
+  } | undefined;
+
+  /**
    * The current scale of the scroll view content. The default value is 1.0.
    */
   zoomScale?: number | undefined;

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.d.ts
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.d.ts
@@ -531,8 +531,8 @@ export interface ScrollViewPropsIOS {
    * @platform ios
    */
   topEdgeEffect?: {
-    style?: 'automatic' | 'soft' | 'hard';
-    hidden?: boolean;
+    style?: 'automatic' | 'soft' | 'hard' | undefined;
+    hidden?: boolean | undefined;
   } | undefined;
 
   /**
@@ -540,8 +540,8 @@ export interface ScrollViewPropsIOS {
    * @platform ios
    */
   bottomEdgeEffect?: {
-    style?: 'automatic' | 'soft' | 'hard';
-    hidden?: boolean;
+    style?: 'automatic' | 'soft' | 'hard' | undefined;
+    hidden?: boolean | undefined;
   } | undefined;
 
   /**
@@ -549,8 +549,8 @@ export interface ScrollViewPropsIOS {
    * @platform ios
    */
   leftEdgeEffect?: {
-    style?: 'automatic' | 'soft' | 'hard';
-    hidden?: boolean;
+    style?: 'automatic' | 'soft' | 'hard' | undefined;
+    hidden?: boolean | undefined;
   } | undefined;
 
   /**
@@ -558,8 +558,8 @@ export interface ScrollViewPropsIOS {
    * @platform ios
    */
   rightEdgeEffect?: {
-    style?: 'automatic' | 'soft' | 'hard';
-    hidden?: boolean;
+    style?: 'automatic' | 'soft' | 'hard' | undefined;
+    hidden?: boolean | undefined;
   } | undefined;
 
   /**

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollViewNativeComponent.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollViewNativeComponent.js
@@ -146,6 +146,10 @@ export const __INTERNAL_VIEW_CONFIG: PartialViewConfig =
           snapToInterval: true,
           snapToOffsets: true,
           snapToStart: true,
+          topEdgeEffect: true,
+          bottomEdgeEffect: true,
+          leftEdgeEffect: true,
+          rightEdgeEffect: true,
           verticalScrollIndicatorInsets: {
             diff: require('../../Utilities/differ/insetsDiffer').default,
           },

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollViewNativeComponentType.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollViewNativeComponentType.js
@@ -78,6 +78,22 @@ export type ScrollViewNativeProps = Readonly<{
   snapToInterval?: ?number,
   snapToOffsets?: ?ReadonlyArray<number>,
   snapToStart?: ?boolean,
+  topEdgeEffect?: ?$ReadOnly<{
+    style?: ?('automatic' | 'soft' | 'hard'),
+    hidden?: ?boolean,
+  }>,
+  bottomEdgeEffect?: ?$ReadOnly<{
+    style?: ?('automatic' | 'soft' | 'hard'),
+    hidden?: ?boolean,
+  }>,
+  leftEdgeEffect?: ?$ReadOnly<{
+    style?: ?('automatic' | 'soft' | 'hard'),
+    hidden?: ?boolean,
+  }>,
+  rightEdgeEffect?: ?$ReadOnly<{
+    style?: ?('automatic' | 'soft' | 'hard'),
+    hidden?: ?boolean,
+  }>,
   zoomScale?: ?number,
   // Overrides
   onResponderGrant?: ?(e: GestureResponderEvent) => void | boolean,

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -58,6 +58,32 @@ static UIScrollViewIndicatorStyle RCTUIScrollViewIndicatorStyleFromProps(const S
   }
 }
 
+static UIScrollEdgeEffectStyle *RCTUIScrollEdgeEffectStyleFromProps(ScrollViewEdgeEffectStyle style)
+{
+  switch (style) {
+    case ScrollViewEdgeEffectStyle::Automatic:
+      return UIScrollEdgeEffectStyle.automaticStyle;
+    case ScrollViewEdgeEffectStyle::Soft:
+      return UIScrollEdgeEffectStyle.softStyle;
+    case ScrollViewEdgeEffectStyle::Hard:
+      return UIScrollEdgeEffectStyle.hardStyle;
+  }
+}
+
+static UIScrollEdgeEffect *RCTUIScrollEdgeEffectFromProps(const std::optional<ScrollViewEdgeEffect> &edgeEffect)
+{
+  if (!edgeEffect.has_value()) {
+    return nil;
+  }
+  
+  UIScrollEdgeEffect *uiEdgeEffect = [[UIScrollEdgeEffect alloc] init];
+  if (edgeEffect->style.has_value()) {
+    uiEdgeEffect.style = RCTUIScrollEdgeEffectStyleFromProps(edgeEffect->style.value());
+  }
+  uiEdgeEffect.hidden = edgeEffect->hidden;
+  return uiEdgeEffect;
+}
+
 // Once Fabric implements proper NativeAnimationDriver, this should be removed.
 // This is just a workaround to allow animations based on onScroll event.
 // This is only used to animate sticky headers in ScrollViews, and only the contentOffset and tag is used.
@@ -454,6 +480,21 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
 
   if (oldScrollViewProps.keyboardDismissMode != newScrollViewProps.keyboardDismissMode) {
     scrollView.keyboardDismissMode = RCTUIKeyboardDismissModeFromProps(newScrollViewProps);
+  }
+
+  if (@available(iOS 26.0, *)) {
+    if (oldScrollViewProps.topEdgeEffect != newScrollViewProps.topEdgeEffect) {
+      _scrollView.topEdgeEffect = RCTUIScrollEdgeEffectFromProps(newScrollViewProps.topEdgeEffect);
+    }
+    if (oldScrollViewProps.bottomEdgeEffect != newScrollViewProps.bottomEdgeEffect) {
+      _scrollView.bottomEdgeEffect = RCTUIScrollEdgeEffectFromProps(newScrollViewProps.bottomEdgeEffect);
+    }
+    if (oldScrollViewProps.leftEdgeEffect != newScrollViewProps.leftEdgeEffect) {
+      _scrollView.leftEdgeEffect = RCTUIScrollEdgeEffectFromProps(newScrollViewProps.leftEdgeEffect);
+    }
+    if (oldScrollViewProps.rightEdgeEffect != newScrollViewProps.rightEdgeEffect) {
+      _scrollView.rightEdgeEffect = RCTUIScrollEdgeEffectFromProps(newScrollViewProps.rightEdgeEffect);
+    }
   }
 
   [super updateProps:props oldProps:oldProps];

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -58,6 +58,7 @@ static UIScrollViewIndicatorStyle RCTUIScrollViewIndicatorStyleFromProps(const S
   }
 }
 
+API_AVAILABLE(ios(26.0))
 static UIScrollEdgeEffectStyle *RCTUIScrollEdgeEffectStyleFromProps(ScrollViewEdgeEffectStyle style)
 {
   switch (style) {
@@ -68,20 +69,6 @@ static UIScrollEdgeEffectStyle *RCTUIScrollEdgeEffectStyleFromProps(ScrollViewEd
     case ScrollViewEdgeEffectStyle::Hard:
       return UIScrollEdgeEffectStyle.hardStyle;
   }
-}
-
-static UIScrollEdgeEffect *RCTUIScrollEdgeEffectFromProps(const std::optional<ScrollViewEdgeEffect> &edgeEffect)
-{
-  if (!edgeEffect.has_value()) {
-    return nil;
-  }
-  
-  UIScrollEdgeEffect *uiEdgeEffect = [[UIScrollEdgeEffect alloc] init];
-  if (edgeEffect->style.has_value()) {
-    uiEdgeEffect.style = RCTUIScrollEdgeEffectStyleFromProps(edgeEffect->style.value());
-  }
-  uiEdgeEffect.hidden = edgeEffect->hidden;
-  return uiEdgeEffect;
 }
 
 // Once Fabric implements proper NativeAnimationDriver, this should be removed.
@@ -484,16 +471,36 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
 
   if (@available(iOS 26.0, *)) {
     if (oldScrollViewProps.topEdgeEffect != newScrollViewProps.topEdgeEffect) {
-      _scrollView.topEdgeEffect = RCTUIScrollEdgeEffectFromProps(newScrollViewProps.topEdgeEffect);
+      if (newScrollViewProps.topEdgeEffect.has_value()) {
+        if (newScrollViewProps.topEdgeEffect->style.has_value()) {
+          _scrollView.topEdgeEffect.style = RCTUIScrollEdgeEffectStyleFromProps(newScrollViewProps.topEdgeEffect->style.value());
+        }
+        _scrollView.topEdgeEffect.hidden = newScrollViewProps.topEdgeEffect->hidden;
+      }
     }
     if (oldScrollViewProps.bottomEdgeEffect != newScrollViewProps.bottomEdgeEffect) {
-      _scrollView.bottomEdgeEffect = RCTUIScrollEdgeEffectFromProps(newScrollViewProps.bottomEdgeEffect);
+      if (newScrollViewProps.bottomEdgeEffect.has_value()) {
+        if (newScrollViewProps.bottomEdgeEffect->style.has_value()) {
+          _scrollView.bottomEdgeEffect.style = RCTUIScrollEdgeEffectStyleFromProps(newScrollViewProps.bottomEdgeEffect->style.value());
+        }
+        _scrollView.bottomEdgeEffect.hidden = newScrollViewProps.bottomEdgeEffect->hidden;
+      }
     }
     if (oldScrollViewProps.leftEdgeEffect != newScrollViewProps.leftEdgeEffect) {
-      _scrollView.leftEdgeEffect = RCTUIScrollEdgeEffectFromProps(newScrollViewProps.leftEdgeEffect);
+      if (newScrollViewProps.leftEdgeEffect.has_value()) {
+        if (newScrollViewProps.leftEdgeEffect->style.has_value()) {
+          _scrollView.leftEdgeEffect.style = RCTUIScrollEdgeEffectStyleFromProps(newScrollViewProps.leftEdgeEffect->style.value());
+        }
+        _scrollView.leftEdgeEffect.hidden = newScrollViewProps.leftEdgeEffect->hidden;
+      }
     }
     if (oldScrollViewProps.rightEdgeEffect != newScrollViewProps.rightEdgeEffect) {
-      _scrollView.rightEdgeEffect = RCTUIScrollEdgeEffectFromProps(newScrollViewProps.rightEdgeEffect);
+      if (newScrollViewProps.rightEdgeEffect.has_value()) {
+        if (newScrollViewProps.rightEdgeEffect->style.has_value()) {
+          _scrollView.rightEdgeEffect.style = RCTUIScrollEdgeEffectStyleFromProps(newScrollViewProps.rightEdgeEffect->style.value());
+        }
+        _scrollView.rightEdgeEffect.hidden = newScrollViewProps.rightEdgeEffect->hidden;
+      }
     }
   }
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -58,6 +58,7 @@ static UIScrollViewIndicatorStyle RCTUIScrollViewIndicatorStyleFromProps(const S
   }
 }
 
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 260000
 API_AVAILABLE(ios(26.0))
 static UIScrollEdgeEffectStyle *RCTUIScrollEdgeEffectStyleFromProps(ScrollViewEdgeEffectStyle style)
 {
@@ -70,6 +71,7 @@ static UIScrollEdgeEffectStyle *RCTUIScrollEdgeEffectStyleFromProps(ScrollViewEd
       return UIScrollEdgeEffectStyle.hardStyle;
   }
 }
+#endif
 
 // Once Fabric implements proper NativeAnimationDriver, this should be removed.
 // This is just a workaround to allow animations based on onScroll event.
@@ -469,6 +471,7 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
     scrollView.keyboardDismissMode = RCTUIKeyboardDismissModeFromProps(newScrollViewProps);
   }
 
+#if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 260000
   if (@available(iOS 26.0, *)) {
     if (oldScrollViewProps.topEdgeEffect != newScrollViewProps.topEdgeEffect) {
       if (newScrollViewProps.topEdgeEffect.has_value()) {
@@ -503,6 +506,7 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
       }
     }
   }
+#endif
 
   [super updateProps:props oldProps:oldProps];
 }

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/BaseScrollViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/BaseScrollViewProps.cpp
@@ -372,6 +372,42 @@ BaseScrollViewProps::BaseScrollViewProps(
                     rawProps,
                     "isInvertedVirtualizedList",
                     sourceProps.isInvertedVirtualizedList,
+                    {})),
+      topEdgeEffect(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.topEdgeEffect
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "topEdgeEffect",
+                    sourceProps.topEdgeEffect,
+                    {})),
+      bottomEdgeEffect(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.bottomEdgeEffect
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "bottomEdgeEffect",
+                    sourceProps.bottomEdgeEffect,
+                    {})),
+      leftEdgeEffect(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.leftEdgeEffect
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "leftEdgeEffect",
+                    sourceProps.leftEdgeEffect,
+                    {})),
+      rightEdgeEffect(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.rightEdgeEffect
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "rightEdgeEffect",
+                    sourceProps.rightEdgeEffect,
                     {})) {}
 
 void BaseScrollViewProps::setProp(
@@ -425,6 +461,10 @@ void BaseScrollViewProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(contentInsetAdjustmentBehavior);
     RAW_SET_PROP_SWITCH_CASE_BASIC(scrollToOverflowEnabled);
     RAW_SET_PROP_SWITCH_CASE_BASIC(isInvertedVirtualizedList);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(topEdgeEffect);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(bottomEdgeEffect);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(leftEdgeEffect);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(rightEdgeEffect);
   }
 }
 
@@ -559,7 +599,23 @@ SharedDebugStringConvertibleList BaseScrollViewProps::getDebugProps() const {
           debugStringConvertibleItem(
               "isInvertedVirtualizedList",
               isInvertedVirtualizedList,
-              defaultScrollViewProps.isInvertedVirtualizedList)};
+              defaultScrollViewProps.isInvertedVirtualizedList),
+          debugStringConvertibleItem(
+              "topEdgeEffect",
+              topEdgeEffect,
+              defaultScrollViewProps.topEdgeEffect),
+          debugStringConvertibleItem(
+              "bottomEdgeEffect",
+              bottomEdgeEffect,
+              defaultScrollViewProps.bottomEdgeEffect),
+          debugStringConvertibleItem(
+              "leftEdgeEffect",
+              leftEdgeEffect,
+              defaultScrollViewProps.leftEdgeEffect),
+          debugStringConvertibleItem(
+              "rightEdgeEffect",
+              rightEdgeEffect,
+              defaultScrollViewProps.rightEdgeEffect)};
 }
 #endif
 

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/BaseScrollViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/BaseScrollViewProps.h
@@ -68,6 +68,10 @@ class BaseScrollViewProps : public ViewProps {
   ContentInsetAdjustmentBehavior contentInsetAdjustmentBehavior{ContentInsetAdjustmentBehavior::Never};
   bool scrollToOverflowEnabled{false};
   bool isInvertedVirtualizedList{false};
+  std::optional<ScrollViewEdgeEffect> topEdgeEffect{};
+  std::optional<ScrollViewEdgeEffect> bottomEdgeEffect{};
+  std::optional<ScrollViewEdgeEffect> leftEdgeEffect{};
+  std::optional<ScrollViewEdgeEffect> rightEdgeEffect{};
 
 #pragma mark - DebugStringConvertible
 

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/conversions.h
@@ -188,6 +188,26 @@ inline std::string toString(const ScrollViewEdgeEffectStyle &value)
   }
 }
 
+inline std::string toString(const ScrollViewEdgeEffect &value)
+{
+  std::string result = "{style: ";
+  if (value.style.has_value()) {
+    result += toString(value.style.value());
+  } else {
+    result += "null";
+  }
+  result += ", hidden: " + std::string(value.hidden ? "true" : "false") + "}";
+  return result;
+}
+
+inline std::string toString(const std::optional<ScrollViewEdgeEffect> &value)
+{
+  if (!value) {
+    return "null";
+  }
+  return toString(value.value());
+}
+
 inline std::string toString(const ContentInsetAdjustmentBehavior &value)
 {
   switch (value) {

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/conversions.h
@@ -92,6 +92,37 @@ fromRawValue(const PropsParserContext &context, const RawValue &value, ContentIn
   abort();
 }
 
+inline void fromRawValue(const PropsParserContext &context, const RawValue &value, ScrollViewEdgeEffectStyle &result)
+{
+  auto string = (std::string)value;
+  if (string == "automatic") {
+    result = ScrollViewEdgeEffectStyle::Automatic;
+    return;
+  }
+  if (string == "soft") {
+    result = ScrollViewEdgeEffectStyle::Soft;
+    return;
+  }
+  if (string == "hard") {
+    result = ScrollViewEdgeEffectStyle::Hard;
+    return;
+  }
+  abort();
+}
+
+inline void fromRawValue(const PropsParserContext &context, const RawValue &value, ScrollViewEdgeEffect &result)
+{
+  auto map = (std::unordered_map<std::string, RawValue>)value;
+  auto iterator = map.find("style");
+  if (iterator != map.end()) {
+    fromRawValue(context, iterator->second, result.style.emplace());
+  }
+  iterator = map.find("hidden");
+  if (iterator != map.end()) {
+    fromRawValue(context, iterator->second, result.hidden);
+  }
+}
+
 inline void
 fromRawValue(const PropsParserContext &context, const RawValue &value, ScrollViewMaintainVisibleContentPosition &result)
 {
@@ -142,6 +173,18 @@ inline std::string toString(const ScrollViewKeyboardDismissMode &value)
       return "on-drag";
     case ScrollViewKeyboardDismissMode::Interactive:
       return "interactive";
+  }
+}
+
+inline std::string toString(const ScrollViewEdgeEffectStyle &value)
+{
+  switch (value) {
+    case ScrollViewEdgeEffectStyle::Automatic:
+      return "automatic";
+    case ScrollViewEdgeEffectStyle::Soft:
+      return "soft";
+    case ScrollViewEdgeEffectStyle::Hard:
+      return "hard";
   }
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/primitives.h
@@ -20,6 +20,25 @@ enum class ScrollViewKeyboardDismissMode { None, OnDrag, Interactive };
 
 enum class ContentInsetAdjustmentBehavior { Never, Automatic, ScrollableAxes, Always };
 
+enum class ScrollViewEdgeEffectStyle { Automatic, Soft, Hard };
+
+class ScrollViewEdgeEffect final {
+ public:
+  std::optional<ScrollViewEdgeEffectStyle> style{};
+  bool hidden{false};
+
+  bool operator==(const ScrollViewEdgeEffect &rhs) const
+  {
+    return std::tie(this->style, this->hidden) ==
+        std::tie(rhs.style, rhs.hidden);
+  }
+
+  bool operator!=(const ScrollViewEdgeEffect &rhs) const
+  {
+    return !(*this == rhs);
+  }
+};
+
 class ScrollViewMaintainVisibleContentPosition final {
  public:
   int minIndexForVisible{0};

--- a/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidDebugCxx.api
@@ -1066,6 +1066,8 @@ void facebook::react::fromRawValue(const facebook::react::PropsParserContext& co
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::OutlineStyle& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::PointerEventsMode& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::Role& result);
+void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewEdgeEffect& result);
+void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewEdgeEffectStyle& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewIndicatorStyle& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewKeyboardDismissMode& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewMaintainVisibleContentPosition& result);
@@ -1710,6 +1712,10 @@ class facebook::react::BaseScrollViewProps : public facebook::react::HostPlatfor
   public facebook::react::ScrollViewIndicatorStyle indicatorStyle;
   public facebook::react::ScrollViewKeyboardDismissMode keyboardDismissMode;
   public facebook::react::ScrollViewSnapToAlignment snapToAlignment;
+  public std::optional<facebook::react::ScrollViewEdgeEffect> bottomEdgeEffect;
+  public std::optional<facebook::react::ScrollViewEdgeEffect> leftEdgeEffect;
+  public std::optional<facebook::react::ScrollViewEdgeEffect> rightEdgeEffect;
+  public std::optional<facebook::react::ScrollViewEdgeEffect> topEdgeEffect;
   public std::optional<facebook::react::ScrollViewMaintainVisibleContentPosition> maintainVisibleContentPosition;
   public std::vector<facebook::react::Float> snapToOffsets;
   public void setProp(const facebook::react::PropsParserContext& context, facebook::react::RawPropsPropNameHash hash, const char* propName, const facebook::react::RawValue& value);
@@ -4525,6 +4531,13 @@ class facebook::react::ScopedShadowTreeRevisionLock {
   public ~ScopedShadowTreeRevisionLock() noexcept;
 }
 
+class facebook::react::ScrollViewEdgeEffect {
+  public bool hidden;
+  public bool operator!=(const facebook::react::ScrollViewEdgeEffect& rhs) const;
+  public bool operator==(const facebook::react::ScrollViewEdgeEffect& rhs) const;
+  public std::optional<facebook::react::ScrollViewEdgeEffectStyle> style;
+}
+
 class facebook::react::ScrollViewEventEmitter : public facebook::react::BaseViewEventEmitter {
   public using EndDragMetrics = facebook::react::ScrollEndDragEvent;
   public using Metrics = facebook::react::ScrollEvent;
@@ -6455,6 +6468,12 @@ enum facebook::react::SchedulerPriority : int {
 enum facebook::react::ScriptTag {
   RAMBundle,
   String,
+}
+
+enum facebook::react::ScrollViewEdgeEffectStyle {
+  Automatic,
+  Hard,
+  Soft,
 }
 
 enum facebook::react::ScrollViewIndicatorStyle {

--- a/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidNewarchCxx.api
@@ -1062,6 +1062,8 @@ void facebook::react::fromRawValue(const facebook::react::PropsParserContext& co
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::OutlineStyle& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::PointerEventsMode& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::Role& result);
+void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewEdgeEffect& result);
+void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewEdgeEffectStyle& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewIndicatorStyle& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewKeyboardDismissMode& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewMaintainVisibleContentPosition& result);
@@ -1704,6 +1706,10 @@ class facebook::react::BaseScrollViewProps : public facebook::react::HostPlatfor
   public facebook::react::ScrollViewIndicatorStyle indicatorStyle;
   public facebook::react::ScrollViewKeyboardDismissMode keyboardDismissMode;
   public facebook::react::ScrollViewSnapToAlignment snapToAlignment;
+  public std::optional<facebook::react::ScrollViewEdgeEffect> bottomEdgeEffect;
+  public std::optional<facebook::react::ScrollViewEdgeEffect> leftEdgeEffect;
+  public std::optional<facebook::react::ScrollViewEdgeEffect> rightEdgeEffect;
+  public std::optional<facebook::react::ScrollViewEdgeEffect> topEdgeEffect;
   public std::optional<facebook::react::ScrollViewMaintainVisibleContentPosition> maintainVisibleContentPosition;
   public std::vector<facebook::react::Float> snapToOffsets;
   public void setProp(const facebook::react::PropsParserContext& context, facebook::react::RawPropsPropNameHash hash, const char* propName, const facebook::react::RawValue& value);
@@ -4357,6 +4363,13 @@ class facebook::react::ScopedShadowTreeRevisionLock {
   public ~ScopedShadowTreeRevisionLock() noexcept;
 }
 
+class facebook::react::ScrollViewEdgeEffect {
+  public bool hidden;
+  public bool operator!=(const facebook::react::ScrollViewEdgeEffect& rhs) const;
+  public bool operator==(const facebook::react::ScrollViewEdgeEffect& rhs) const;
+  public std::optional<facebook::react::ScrollViewEdgeEffectStyle> style;
+}
+
 class facebook::react::ScrollViewEventEmitter : public facebook::react::BaseViewEventEmitter {
   public using EndDragMetrics = facebook::react::ScrollEndDragEvent;
   public using Metrics = facebook::react::ScrollEvent;
@@ -6281,6 +6294,12 @@ enum facebook::react::SchedulerPriority : int {
 enum facebook::react::ScriptTag {
   RAMBundle,
   String,
+}
+
+enum facebook::react::ScrollViewEdgeEffectStyle {
+  Automatic,
+  Hard,
+  Soft,
 }
 
 enum facebook::react::ScrollViewIndicatorStyle {

--- a/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAndroidReleaseCxx.api
@@ -1066,6 +1066,8 @@ void facebook::react::fromRawValue(const facebook::react::PropsParserContext& co
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::OutlineStyle& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::PointerEventsMode& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::Role& result);
+void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewEdgeEffect& result);
+void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewEdgeEffectStyle& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewIndicatorStyle& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewKeyboardDismissMode& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewMaintainVisibleContentPosition& result);
@@ -1708,6 +1710,10 @@ class facebook::react::BaseScrollViewProps : public facebook::react::HostPlatfor
   public facebook::react::ScrollViewIndicatorStyle indicatorStyle;
   public facebook::react::ScrollViewKeyboardDismissMode keyboardDismissMode;
   public facebook::react::ScrollViewSnapToAlignment snapToAlignment;
+  public std::optional<facebook::react::ScrollViewEdgeEffect> bottomEdgeEffect;
+  public std::optional<facebook::react::ScrollViewEdgeEffect> leftEdgeEffect;
+  public std::optional<facebook::react::ScrollViewEdgeEffect> rightEdgeEffect;
+  public std::optional<facebook::react::ScrollViewEdgeEffect> topEdgeEffect;
   public std::optional<facebook::react::ScrollViewMaintainVisibleContentPosition> maintainVisibleContentPosition;
   public std::vector<facebook::react::Float> snapToOffsets;
   public void setProp(const facebook::react::PropsParserContext& context, facebook::react::RawPropsPropNameHash hash, const char* propName, const facebook::react::RawValue& value);
@@ -4522,6 +4528,13 @@ class facebook::react::ScopedShadowTreeRevisionLock {
   public ~ScopedShadowTreeRevisionLock() noexcept;
 }
 
+class facebook::react::ScrollViewEdgeEffect {
+  public bool hidden;
+  public bool operator!=(const facebook::react::ScrollViewEdgeEffect& rhs) const;
+  public bool operator==(const facebook::react::ScrollViewEdgeEffect& rhs) const;
+  public std::optional<facebook::react::ScrollViewEdgeEffectStyle> style;
+}
+
 class facebook::react::ScrollViewEventEmitter : public facebook::react::BaseViewEventEmitter {
   public using EndDragMetrics = facebook::react::ScrollEndDragEvent;
   public using Metrics = facebook::react::ScrollEvent;
@@ -6446,6 +6459,12 @@ enum facebook::react::SchedulerPriority : int {
 enum facebook::react::ScriptTag {
   RAMBundle,
   String,
+}
+
+enum facebook::react::ScrollViewEdgeEffectStyle {
+  Automatic,
+  Hard,
+  Soft,
 }
 
 enum facebook::react::ScrollViewIndicatorStyle {

--- a/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleDebugCxx.api
@@ -4286,6 +4286,8 @@ void facebook::react::fromRawValue(const facebook::react::PropsParserContext& co
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::PointerEventsMode& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ReturnKeyType& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::Role& result);
+void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewEdgeEffect& result);
+void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewEdgeEffectStyle& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewIndicatorStyle& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewKeyboardDismissMode& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewMaintainVisibleContentPosition& result);
@@ -4686,6 +4688,10 @@ class facebook::react::BaseScrollViewProps : public facebook::react::HostPlatfor
   public facebook::react::ScrollViewIndicatorStyle indicatorStyle;
   public facebook::react::ScrollViewKeyboardDismissMode keyboardDismissMode;
   public facebook::react::ScrollViewSnapToAlignment snapToAlignment;
+  public std::optional<facebook::react::ScrollViewEdgeEffect> bottomEdgeEffect;
+  public std::optional<facebook::react::ScrollViewEdgeEffect> leftEdgeEffect;
+  public std::optional<facebook::react::ScrollViewEdgeEffect> rightEdgeEffect;
+  public std::optional<facebook::react::ScrollViewEdgeEffect> topEdgeEffect;
   public std::optional<facebook::react::ScrollViewMaintainVisibleContentPosition> maintainVisibleContentPosition;
   public std::vector<facebook::react::Float> snapToOffsets;
   public void setProp(const facebook::react::PropsParserContext& context, facebook::react::RawPropsPropNameHash hash, const char* propName, const facebook::react::RawValue& value);
@@ -7125,6 +7131,13 @@ class facebook::react::ScopedShadowTreeRevisionLock {
   public ~ScopedShadowTreeRevisionLock() noexcept;
 }
 
+class facebook::react::ScrollViewEdgeEffect {
+  public bool hidden;
+  public bool operator!=(const facebook::react::ScrollViewEdgeEffect& rhs) const;
+  public bool operator==(const facebook::react::ScrollViewEdgeEffect& rhs) const;
+  public std::optional<facebook::react::ScrollViewEdgeEffectStyle> style;
+}
+
 class facebook::react::ScrollViewEventEmitter : public facebook::react::BaseViewEventEmitter {
   public using EndDragMetrics = facebook::react::ScrollEndDragEvent;
   public using Metrics = facebook::react::ScrollEvent;
@@ -9040,6 +9053,12 @@ enum facebook::react::SchedulerPriority : int {
 enum facebook::react::ScriptTag {
   RAMBundle,
   String,
+}
+
+enum facebook::react::ScrollViewEdgeEffectStyle {
+  Automatic,
+  Hard,
+  Soft,
 }
 
 enum facebook::react::ScrollViewIndicatorStyle {

--- a/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleNewarchCxx.api
@@ -3907,6 +3907,8 @@ void facebook::react::fromRawValue(const facebook::react::PropsParserContext& co
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::PointerEventsMode& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ReturnKeyType& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::Role& result);
+void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewEdgeEffect& result);
+void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewEdgeEffectStyle& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewIndicatorStyle& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewKeyboardDismissMode& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewMaintainVisibleContentPosition& result);
@@ -4305,6 +4307,10 @@ class facebook::react::BaseScrollViewProps : public facebook::react::HostPlatfor
   public facebook::react::ScrollViewIndicatorStyle indicatorStyle;
   public facebook::react::ScrollViewKeyboardDismissMode keyboardDismissMode;
   public facebook::react::ScrollViewSnapToAlignment snapToAlignment;
+  public std::optional<facebook::react::ScrollViewEdgeEffect> bottomEdgeEffect;
+  public std::optional<facebook::react::ScrollViewEdgeEffect> leftEdgeEffect;
+  public std::optional<facebook::react::ScrollViewEdgeEffect> rightEdgeEffect;
+  public std::optional<facebook::react::ScrollViewEdgeEffect> topEdgeEffect;
   public std::optional<facebook::react::ScrollViewMaintainVisibleContentPosition> maintainVisibleContentPosition;
   public std::vector<facebook::react::Float> snapToOffsets;
   public void setProp(const facebook::react::PropsParserContext& context, facebook::react::RawPropsPropNameHash hash, const char* propName, const facebook::react::RawValue& value);
@@ -6606,6 +6612,13 @@ class facebook::react::ScopedShadowTreeRevisionLock {
   public ~ScopedShadowTreeRevisionLock() noexcept;
 }
 
+class facebook::react::ScrollViewEdgeEffect {
+  public bool hidden;
+  public bool operator!=(const facebook::react::ScrollViewEdgeEffect& rhs) const;
+  public bool operator==(const facebook::react::ScrollViewEdgeEffect& rhs) const;
+  public std::optional<facebook::react::ScrollViewEdgeEffectStyle> style;
+}
+
 class facebook::react::ScrollViewEventEmitter : public facebook::react::BaseViewEventEmitter {
   public using EndDragMetrics = facebook::react::ScrollEndDragEvent;
   public using Metrics = facebook::react::ScrollEvent;
@@ -8515,6 +8528,12 @@ enum facebook::react::SchedulerPriority : int {
 enum facebook::react::ScriptTag {
   RAMBundle,
   String,
+}
+
+enum facebook::react::ScrollViewEdgeEffectStyle {
+  Automatic,
+  Hard,
+  Soft,
 }
 
 enum facebook::react::ScrollViewIndicatorStyle {

--- a/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactAppleReleaseCxx.api
@@ -4286,6 +4286,8 @@ void facebook::react::fromRawValue(const facebook::react::PropsParserContext& co
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::PointerEventsMode& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ReturnKeyType& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::Role& result);
+void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewEdgeEffect& result);
+void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewEdgeEffectStyle& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewIndicatorStyle& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewKeyboardDismissMode& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewMaintainVisibleContentPosition& result);
@@ -4684,6 +4686,10 @@ class facebook::react::BaseScrollViewProps : public facebook::react::HostPlatfor
   public facebook::react::ScrollViewIndicatorStyle indicatorStyle;
   public facebook::react::ScrollViewKeyboardDismissMode keyboardDismissMode;
   public facebook::react::ScrollViewSnapToAlignment snapToAlignment;
+  public std::optional<facebook::react::ScrollViewEdgeEffect> bottomEdgeEffect;
+  public std::optional<facebook::react::ScrollViewEdgeEffect> leftEdgeEffect;
+  public std::optional<facebook::react::ScrollViewEdgeEffect> rightEdgeEffect;
+  public std::optional<facebook::react::ScrollViewEdgeEffect> topEdgeEffect;
   public std::optional<facebook::react::ScrollViewMaintainVisibleContentPosition> maintainVisibleContentPosition;
   public std::vector<facebook::react::Float> snapToOffsets;
   public void setProp(const facebook::react::PropsParserContext& context, facebook::react::RawPropsPropNameHash hash, const char* propName, const facebook::react::RawValue& value);
@@ -7122,6 +7128,13 @@ class facebook::react::ScopedShadowTreeRevisionLock {
   public ~ScopedShadowTreeRevisionLock() noexcept;
 }
 
+class facebook::react::ScrollViewEdgeEffect {
+  public bool hidden;
+  public bool operator!=(const facebook::react::ScrollViewEdgeEffect& rhs) const;
+  public bool operator==(const facebook::react::ScrollViewEdgeEffect& rhs) const;
+  public std::optional<facebook::react::ScrollViewEdgeEffectStyle> style;
+}
+
 class facebook::react::ScrollViewEventEmitter : public facebook::react::BaseViewEventEmitter {
   public using EndDragMetrics = facebook::react::ScrollEndDragEvent;
   public using Metrics = facebook::react::ScrollEvent;
@@ -9031,6 +9044,12 @@ enum facebook::react::SchedulerPriority : int {
 enum facebook::react::ScriptTag {
   RAMBundle,
   String,
+}
+
+enum facebook::react::ScrollViewEdgeEffectStyle {
+  Automatic,
+  Hard,
+  Soft,
 }
 
 enum facebook::react::ScrollViewIndicatorStyle {

--- a/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonDebugCxx.api
@@ -627,6 +627,8 @@ void facebook::react::fromRawValue(const facebook::react::PropsParserContext& co
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::OutlineStyle& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::PointerEventsMode& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::Role& result);
+void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewEdgeEffect& result);
+void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewEdgeEffectStyle& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewIndicatorStyle& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewKeyboardDismissMode& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewMaintainVisibleContentPosition& result);
@@ -1035,6 +1037,10 @@ class facebook::react::BaseScrollViewProps : public facebook::react::HostPlatfor
   public facebook::react::ScrollViewIndicatorStyle indicatorStyle;
   public facebook::react::ScrollViewKeyboardDismissMode keyboardDismissMode;
   public facebook::react::ScrollViewSnapToAlignment snapToAlignment;
+  public std::optional<facebook::react::ScrollViewEdgeEffect> bottomEdgeEffect;
+  public std::optional<facebook::react::ScrollViewEdgeEffect> leftEdgeEffect;
+  public std::optional<facebook::react::ScrollViewEdgeEffect> rightEdgeEffect;
+  public std::optional<facebook::react::ScrollViewEdgeEffect> topEdgeEffect;
   public std::optional<facebook::react::ScrollViewMaintainVisibleContentPosition> maintainVisibleContentPosition;
   public std::vector<Float> snapToOffsets;
   public void setProp(const facebook::react::PropsParserContext& context, facebook::react::RawPropsPropNameHash hash, const char* propName, const facebook::react::RawValue& value);
@@ -3080,6 +3086,13 @@ class facebook::react::ScopedShadowTreeRevisionLock {
   public ~ScopedShadowTreeRevisionLock() noexcept;
 }
 
+class facebook::react::ScrollViewEdgeEffect {
+  public bool hidden;
+  public bool operator!=(const facebook::react::ScrollViewEdgeEffect& rhs) const;
+  public bool operator==(const facebook::react::ScrollViewEdgeEffect& rhs) const;
+  public std::optional<facebook::react::ScrollViewEdgeEffectStyle> style;
+}
+
 class facebook::react::ScrollViewEventEmitter : public facebook::react::BaseViewEventEmitter {
   public using EndDragMetrics = facebook::react::ScrollEndDragEvent;
   public using Metrics = facebook::react::ScrollEvent;
@@ -4792,6 +4805,12 @@ enum facebook::react::SchedulerPriority : int {
 enum facebook::react::ScriptTag {
   RAMBundle,
   String,
+}
+
+enum facebook::react::ScrollViewEdgeEffectStyle {
+  Automatic,
+  Hard,
+  Soft,
 }
 
 enum facebook::react::ScrollViewIndicatorStyle {

--- a/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonNewarchCxx.api
@@ -624,6 +624,8 @@ void facebook::react::fromRawValue(const facebook::react::PropsParserContext& co
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::OutlineStyle& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::PointerEventsMode& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::Role& result);
+void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewEdgeEffect& result);
+void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewEdgeEffectStyle& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewIndicatorStyle& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewKeyboardDismissMode& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewMaintainVisibleContentPosition& result);
@@ -1030,6 +1032,10 @@ class facebook::react::BaseScrollViewProps : public facebook::react::HostPlatfor
   public facebook::react::ScrollViewIndicatorStyle indicatorStyle;
   public facebook::react::ScrollViewKeyboardDismissMode keyboardDismissMode;
   public facebook::react::ScrollViewSnapToAlignment snapToAlignment;
+  public std::optional<facebook::react::ScrollViewEdgeEffect> bottomEdgeEffect;
+  public std::optional<facebook::react::ScrollViewEdgeEffect> leftEdgeEffect;
+  public std::optional<facebook::react::ScrollViewEdgeEffect> rightEdgeEffect;
+  public std::optional<facebook::react::ScrollViewEdgeEffect> topEdgeEffect;
   public std::optional<facebook::react::ScrollViewMaintainVisibleContentPosition> maintainVisibleContentPosition;
   public std::vector<Float> snapToOffsets;
   public void setProp(const facebook::react::PropsParserContext& context, facebook::react::RawPropsPropNameHash hash, const char* propName, const facebook::react::RawValue& value);
@@ -2952,6 +2958,13 @@ class facebook::react::ScopedShadowTreeRevisionLock {
   public ~ScopedShadowTreeRevisionLock() noexcept;
 }
 
+class facebook::react::ScrollViewEdgeEffect {
+  public bool hidden;
+  public bool operator!=(const facebook::react::ScrollViewEdgeEffect& rhs) const;
+  public bool operator==(const facebook::react::ScrollViewEdgeEffect& rhs) const;
+  public std::optional<facebook::react::ScrollViewEdgeEffectStyle> style;
+}
+
 class facebook::react::ScrollViewEventEmitter : public facebook::react::BaseViewEventEmitter {
   public using EndDragMetrics = facebook::react::ScrollEndDragEvent;
   public using Metrics = facebook::react::ScrollEvent;
@@ -4658,6 +4671,12 @@ enum facebook::react::SchedulerPriority : int {
 enum facebook::react::ScriptTag {
   RAMBundle,
   String,
+}
+
+enum facebook::react::ScrollViewEdgeEffectStyle {
+  Automatic,
+  Hard,
+  Soft,
 }
 
 enum facebook::react::ScrollViewIndicatorStyle {

--- a/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
+++ b/scripts/cxx-api/api-snapshots/ReactCommonReleaseCxx.api
@@ -627,6 +627,8 @@ void facebook::react::fromRawValue(const facebook::react::PropsParserContext& co
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::OutlineStyle& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::PointerEventsMode& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::Role& result);
+void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewEdgeEffect& result);
+void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewEdgeEffectStyle& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewIndicatorStyle& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewKeyboardDismissMode& result);
 void facebook::react::fromRawValue(const facebook::react::PropsParserContext& context, const facebook::react::RawValue& value, facebook::react::ScrollViewMaintainVisibleContentPosition& result);
@@ -1033,6 +1035,10 @@ class facebook::react::BaseScrollViewProps : public facebook::react::HostPlatfor
   public facebook::react::ScrollViewIndicatorStyle indicatorStyle;
   public facebook::react::ScrollViewKeyboardDismissMode keyboardDismissMode;
   public facebook::react::ScrollViewSnapToAlignment snapToAlignment;
+  public std::optional<facebook::react::ScrollViewEdgeEffect> bottomEdgeEffect;
+  public std::optional<facebook::react::ScrollViewEdgeEffect> leftEdgeEffect;
+  public std::optional<facebook::react::ScrollViewEdgeEffect> rightEdgeEffect;
+  public std::optional<facebook::react::ScrollViewEdgeEffect> topEdgeEffect;
   public std::optional<facebook::react::ScrollViewMaintainVisibleContentPosition> maintainVisibleContentPosition;
   public std::vector<Float> snapToOffsets;
   public void setProp(const facebook::react::PropsParserContext& context, facebook::react::RawPropsPropNameHash hash, const char* propName, const facebook::react::RawValue& value);
@@ -3077,6 +3083,13 @@ class facebook::react::ScopedShadowTreeRevisionLock {
   public ~ScopedShadowTreeRevisionLock() noexcept;
 }
 
+class facebook::react::ScrollViewEdgeEffect {
+  public bool hidden;
+  public bool operator!=(const facebook::react::ScrollViewEdgeEffect& rhs) const;
+  public bool operator==(const facebook::react::ScrollViewEdgeEffect& rhs) const;
+  public std::optional<facebook::react::ScrollViewEdgeEffectStyle> style;
+}
+
 class facebook::react::ScrollViewEventEmitter : public facebook::react::BaseViewEventEmitter {
   public using EndDragMetrics = facebook::react::ScrollEndDragEvent;
   public using Metrics = facebook::react::ScrollEvent;
@@ -4783,6 +4796,12 @@ enum facebook::react::SchedulerPriority : int {
 enum facebook::react::ScriptTag {
   RAMBundle,
   String,
+}
+
+enum facebook::react::ScrollViewEdgeEffectStyle {
+  Automatic,
+  Hard,
+  Soft,
 }
 
 enum facebook::react::ScrollViewIndicatorStyle {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

iOS 26 introduces [UIScrollEdgeEffect](https://developer.apple.com/documentation/uikit/uiscrolledgeeffect?language=objc), which will add a blur effect to the top of scrollview/flatlist if its top edge is very close to screen top. If we make the flatlist inverted, most of the list will be covered, as #54181 mentioned.

<img width="402" height="874" alt="image" src="https://github.com/user-attachments/assets/b4123315-0c8f-4cc1-8530-e2f2aaf97e6b" />

<img width="402" height="874"  alt="image" src="https://github.com/user-attachments/assets/8bd8eea2-4193-49c3-a456-b6174602505a" />


This PR expose the xxxEdgeEffect properties so we can disable them on need.


## Changelog:

[IOS] [ADDED] - Expose iOS scroll edge effect props on ScrollView.

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

