### PR TITLE
Replace CDP messageStr conversion error with assert

### DIFF
--- a/packages/react-native/React/Inspector/RCTCxxInspectorWebSocketAdapter.mm
+++ b/packages/react-native/React/Inspector/RCTCxxInspectorWebSocketAdapter.mm
@@ -9,9 +9,9 @@
 
 #if RCT_DEV || RCT_REMOTE_PROFILE
 
+#import <React/RCTAssert.h>
 #import <React/RCTInspector.h>
 #import <React/RCTInspectorPackagerConnection.h>
-#import <React/RCTLog.h>
 #import <React/RCTUtils.h>
 #import <SocketRocket/SRWebSocket.h>
 #import <jsinspector-modern/InspectorPackagerConnection.h>
@@ -22,7 +22,11 @@ using namespace facebook::react::jsinspector_modern;
 namespace {
 NSString *NSStringFromUTF8StringView(std::string_view view)
 {
-  return [[NSString alloc] initWithBytes:(const char *)view.data() length:view.size() encoding:NSUTF8StringEncoding];
+  NSString *result = [[NSString alloc] initWithBytes:(const char *)view.data()
+                                              length:view.size()
+                                            encoding:NSUTF8StringEncoding];
+  RCTAssert(result != nil, @"string_view contains invalid UTF-8 bytes");
+  return result;
 }
 } // namespace
 @interface RCTCxxInspectorWebSocketAdapter () <SRWebSocketDelegate> {
@@ -47,9 +51,6 @@ NSString *NSStringFromUTF8StringView(std::string_view view)
 {
   __weak RCTCxxInspectorWebSocketAdapter *weakSelf = self;
   NSString *messageStr = NSStringFromUTF8StringView(message);
-  if (messageStr == nil) {
-    RCTLogError(@"Failed to convert CDP message string to NSString, message will be dropped!");
-  }
   dispatch_async(dispatch_get_main_queue(), ^{
     RCTCxxInspectorWebSocketAdapter *strongSelf = weakSelf;
     if (strongSelf != nullptr) {


### PR DESCRIPTION
Summary:
Follows D89659685. An invalid `string_view` should never be passed to the CDP WebSocket — fail harder via a dev-only assert.

Changelog: [Internal]

Differential Revision: D90113888


