### PR TITLE
add UIManagerCommitHook::shadowTreeDidFinishTransaction

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaLayoutableShadowNode.cpp
@@ -668,8 +668,13 @@ void YogaLayoutableShadowNode::layoutTree(
     layoutMetrics.pointScaleFactor = layoutContext.pointScaleFactor;
     layoutMetrics.wasLeftAndRightSwapped = swapLeftAndRight;
     setLayoutMetrics(layoutMetrics);
+    if (layoutContext.includeOriginFromRoot) {
+      setOriginFromRoot(layoutMetrics.frame.origin);
+    }
     yogaNode_.setHasNewLayout(false);
   }
+
+  layoutContext.rootNode = this;
 
   layout(layoutContext);
 }
@@ -727,6 +732,15 @@ void YogaLayoutableShadowNode::layout(LayoutContext layoutContext) {
       }
 
       childNode.setLayoutMetrics(newLayoutMetrics);
+
+      if (layoutContext.includeOriginFromRoot) {
+        childNode.setOriginFromRoot(
+            LayoutableShadowNode::computeOriginFromRoot(
+                originFromRoot_,
+                newLayoutMetrics.frame,
+                childNode.getTransform(),
+                childNode.getContentOriginOffset(true)));
+      }
 
       if (newLayoutMetrics.displayType != DisplayType::None) {
         childNode.layout(layoutContext);

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutContext.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutContext.h
@@ -59,6 +59,19 @@ struct LayoutContext {
    * If React Native takes up entire screen, it will be {0, 0}.
    */
   Point viewportOffset{};
+
+  /*
+   * Flag indicating whether to calculate and store originFromRoot
+   * for each LayoutableShadowNode during layout. This is typically
+   * enabled when laying out children of ViewTransitionViewShadowNode.
+   */
+  bool includeOriginFromRoot{false};
+
+  /*
+   * Pointer to the root node of the layout tree. Set during layoutTree()
+   * and used by nodes that need to compute their position relative to root.
+   */
+  const LayoutableShadowNode *rootNode{nullptr};
 };
 
 inline bool operator==(const LayoutContext &lhs, const LayoutContext &rhs)
@@ -68,13 +81,17 @@ inline bool operator==(const LayoutContext &lhs, const LayoutContext &rhs)
              lhs.affectedNodes,
              lhs.swapLeftAndRightInRTL,
              lhs.fontSizeMultiplier,
-             lhs.viewportOffset) ==
+             lhs.viewportOffset,
+             lhs.includeOriginFromRoot,
+             lhs.rootNode) ==
       std::tie(
              rhs.pointScaleFactor,
              rhs.affectedNodes,
              rhs.swapLeftAndRightInRTL,
              rhs.fontSizeMultiplier,
-             rhs.viewportOffset);
+             rhs.viewportOffset,
+             rhs.includeOriginFromRoot,
+             rhs.rootNode);
 }
 
 inline bool operator!=(const LayoutContext &lhs, const LayoutContext &rhs)

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutMetrics.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutMetrics.h
@@ -14,6 +14,7 @@
 #include <react/renderer/graphics/RectangleEdges.h>
 #include <react/utils/hash_combine.h>
 #include <algorithm>
+#include <limits>
 
 namespace facebook::react {
 
@@ -97,6 +98,16 @@ struct LayoutMetrics {
  */
 static const LayoutMetrics EmptyLayoutMetrics = {
     /* .frame = */ .frame = {.origin = {.x = 0, .y = 0}, .size = {.width = -1.0, .height = -1.0}}};
+
+/*
+ * Represents some undefined, not-yet-computed or meaningless value of
+ * `originFromRoot` (Point type).
+ * Used to indicate that originFromRoot has not been calculated for a node.
+ * The value uses negative infinity to distinguish from valid coordinates.
+ */
+static const Point EmptyOriginFromRoot = {
+    .x = -std::numeric_limits<Float>::infinity(),
+    .y = -std::numeric_limits<Float>::infinity()};
 
 #if RN_DEBUG_STRING_CONVERTIBLE
 

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.cpp
@@ -31,7 +31,10 @@ LayoutableShadowNode::LayoutableShadowNode(
     : ShadowNode(sourceShadowNode, fragment),
       layoutMetrics_(
           static_cast<const LayoutableShadowNode&>(sourceShadowNode)
-              .layoutMetrics_) {}
+              .layoutMetrics_),
+      originFromRoot_(
+          static_cast<const LayoutableShadowNode&>(sourceShadowNode)
+              .originFromRoot_) {}
 
 LayoutMetrics LayoutableShadowNode::computeLayoutMetricsFromRoot(
     const ShadowNodeFamily& descendantNodeFamily,
@@ -197,8 +200,32 @@ LayoutMetrics LayoutableShadowNode::computeRelativeLayoutMetrics(
   return layoutMetrics;
 }
 
+Point LayoutableShadowNode::computeOriginFromRoot(
+    Point parentOriginFromRoot,
+    const Rect& frame,
+    const Transform& transform,
+    Point contentOriginOffset) {
+  if (parentOriginFromRoot == EmptyOriginFromRoot) {
+    return EmptyOriginFromRoot;
+  }
+
+  Point resultOrigin = frame.origin;
+
+  if (transform != Transform::Identity()) {
+    resultOrigin = transform.applyWithCenter(frame, frame.getCenter()).origin;
+  }
+
+  resultOrigin += parentOriginFromRoot + contentOriginOffset;
+
+  return resultOrigin;
+}
+
 LayoutMetrics LayoutableShadowNode::getLayoutMetrics() const {
   return layoutMetrics_;
+}
+
+Point LayoutableShadowNode::getOriginFromRoot() const {
+  return originFromRoot_;
 }
 
 void LayoutableShadowNode::setLayoutMetrics(LayoutMetrics layoutMetrics) {
@@ -209,6 +236,16 @@ void LayoutableShadowNode::setLayoutMetrics(LayoutMetrics layoutMetrics) {
   }
 
   layoutMetrics_ = layoutMetrics;
+}
+
+void LayoutableShadowNode::setOriginFromRoot(Point originFromRoot) {
+  ensureUnsealed();
+
+  if (originFromRoot_ == originFromRoot) {
+    return;
+  }
+
+  originFromRoot_ = originFromRoot;
 }
 
 Transform LayoutableShadowNode::getTransform() const {

--- a/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/LayoutableShadowNode.h
@@ -72,6 +72,18 @@ class LayoutableShadowNode : public ShadowNode {
   static LayoutMetrics computeRelativeLayoutMetrics(const AncestorList &ancestors, LayoutInspectingPolicy policy);
 
   /*
+   * Computes the origin from root for a child node given the parent's origin
+   * from root, the child's layout metrics, transform, and content origin offset.
+   * This is similar to how computeRelativeLayoutMetrics computes positions, but
+   * avoids traversing all the ancestors.
+   */
+  static Point computeOriginFromRoot(
+      Point parentOriginFromRoot,
+      const Rect &frame,
+      const Transform &transform,
+      Point contentOriginOffset);
+
+  /*
    * Performs layout of the tree starting from this node. Usually is being
    * called on the root node.
    * Default implementation does nothing.
@@ -110,6 +122,8 @@ class LayoutableShadowNode : public ShadowNode {
    */
   LayoutMetrics getLayoutMetrics() const;
 
+  Point getOriginFromRoot() const;
+
   /*
    * Returns a transform object that represents transformations that will/should
    * be applied on top of regular layout metrics by mounting layer.
@@ -132,6 +146,8 @@ class LayoutableShadowNode : public ShadowNode {
    * Sets layout metrics for the shadow node.
    */
   void setLayoutMetrics(LayoutMetrics layoutMetrics);
+
+  void setOriginFromRoot(Point originFromRoot);
 
   /*
    * Returns the ShadowNode that is rendered at the Point received as a
@@ -167,6 +183,8 @@ class LayoutableShadowNode : public ShadowNode {
 #endif
 
   LayoutMetrics layoutMetrics_;
+
+  Point originFromRoot_{EmptyOriginFromRoot};
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.cpp
@@ -233,7 +233,10 @@ void ShadowTree::setCommitMode(CommitMode commitMode) const {
   // initial revision never contains any commits so mounting it here is
   // incorrect
   if (commitMode == CommitMode::Normal && revision.number != INITIAL_REVISION) {
-    mount(revision, true);
+    mount(
+        revision,
+        /*mountSynchronously*/ true,
+        /*source */ CommitSource::Unknown);
   }
 }
 
@@ -370,7 +373,10 @@ CommitStatus ShadowTree::tryCommit(
   emitLayoutEvents(affectedLayoutableNodes);
 
   if (commitMode == CommitMode::Normal) {
-    mount(std::move(newRevision), commitOptions.mountSynchronously);
+    mount(
+        std::move(newRevision),
+        commitOptions.mountSynchronously,
+        commitOptions.source);
   }
 
   return CommitStatus::Succeeded;
@@ -381,11 +387,13 @@ ShadowTreeRevision ShadowTree::getCurrentRevision() const {
   return currentRevision_;
 }
 
-void ShadowTree::mount(ShadowTreeRevision revision, bool mountSynchronously)
-    const {
+void ShadowTree::mount(
+    ShadowTreeRevision revision,
+    bool mountSynchronously,
+    ShadowTreeCommitSource source) const {
   mountingCoordinator_->push(std::move(revision));
   delegate_.shadowTreeDidFinishTransaction(
-      mountingCoordinator_, mountSynchronously);
+      mountingCoordinator_, mountSynchronously, source);
 }
 
 void ShadowTree::commitEmptyTree() const {
@@ -423,7 +431,10 @@ void ShadowTree::emitLayoutEvents(
 }
 
 void ShadowTree::notifyDelegatesOfUpdates() const {
-  delegate_.shadowTreeDidFinishTransaction(mountingCoordinator_, true);
+  delegate_.shadowTreeDidFinishTransaction(
+      mountingCoordinator_,
+      /*mountSynchronously*/ true,
+      /*source */ CommitSource::Unknown);
 }
 
 inline ShadowTree::UniqueLock ShadowTree::uniqueCommitLock() const {

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTree.h
@@ -139,7 +139,7 @@ class ShadowTree final {
  private:
   constexpr static ShadowTreeRevision::Number INITIAL_REVISION{0};
 
-  void mount(ShadowTreeRevision revision, bool mountSynchronously) const;
+  void mount(ShadowTreeRevision revision, bool mountSynchronously, ShadowTreeCommitSource source) const;
 
   void emitLayoutEvents(std::vector<const LayoutableShadowNode *> &affectedLayoutableNodes) const;
 

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTreeDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowTreeDelegate.h
@@ -13,6 +13,7 @@ namespace facebook::react {
 
 class ShadowTree;
 struct ShadowTreeCommitOptions;
+enum class ShadowTreeCommitSource;
 
 /*
  * Abstract class for ShadowTree's delegate.
@@ -36,7 +37,8 @@ class ShadowTreeDelegate {
    */
   virtual void shadowTreeDidFinishTransaction(
       std::shared_ptr<const MountingCoordinator> mountingCoordinator,
-      bool mountSynchronously) const = 0;
+      bool mountSynchronously,
+      ShadowTreeCommitSource source) const = 0;
 
   virtual ~ShadowTreeDelegate() noexcept = default;
 };

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowView.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowView.cpp
@@ -20,6 +20,14 @@ static LayoutMetrics layoutMetricsFromShadowNode(const ShadowNode& shadowNode) {
       : EmptyLayoutMetrics;
 }
 
+static Point originFromRootFromShadowNode(const ShadowNode& shadowNode) {
+  auto layoutableShadowNode =
+      dynamic_cast<const LayoutableShadowNode*>(&shadowNode);
+  return layoutableShadowNode != nullptr
+      ? layoutableShadowNode->getOriginFromRoot()
+      : EmptyOriginFromRoot;
+}
+
 ShadowView::ShadowView(const ShadowNode& shadowNode)
     : componentName(shadowNode.getComponentName()),
       componentHandle(shadowNode.getComponentHandle()),
@@ -29,6 +37,7 @@ ShadowView::ShadowView(const ShadowNode& shadowNode)
       props(shadowNode.getProps()),
       eventEmitter(shadowNode.getEventEmitter()),
       layoutMetrics(layoutMetricsFromShadowNode(shadowNode)),
+      originFromRoot(originFromRootFromShadowNode(shadowNode)),
       state(shadowNode.getState()) {}
 
 bool ShadowView::operator==(const ShadowView& rhs) const {
@@ -39,6 +48,7 @@ bool ShadowView::operator==(const ShadowView& rhs) const {
              this->props,
              this->eventEmitter,
              this->layoutMetrics,
+             this->originFromRoot,
              this->state) ==
       std::tie(
              rhs.surfaceId,
@@ -47,6 +57,7 @@ bool ShadowView::operator==(const ShadowView& rhs) const {
              rhs.props,
              rhs.eventEmitter,
              rhs.layoutMetrics,
+             rhs.originFromRoot,
              rhs.state);
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/mounting/ShadowView.h
+++ b/packages/react-native/ReactCommon/react/renderer/mounting/ShadowView.h
@@ -45,6 +45,7 @@ struct ShadowView final {
   Props::Shared props{};
   EventEmitter::Shared eventEmitter{};
   LayoutMetrics layoutMetrics{EmptyLayoutMetrics};
+  Point originFromRoot{};
   State::Shared state{};
 };
 
@@ -73,6 +74,7 @@ struct hash<facebook::react::ShadowView> {
         shadowView.props,
         shadowView.eventEmitter,
         shadowView.layoutMetrics,
+        shadowView.originFromRoot,
         shadowView.state);
   }
 };

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.cpp
@@ -636,12 +636,20 @@ RootShadowNode::Unshared UIManager::shadowTreeWillCommit(
 
 void UIManager::shadowTreeDidFinishTransaction(
     std::shared_ptr<const MountingCoordinator> mountingCoordinator,
-    bool mountSynchronously) const {
+    bool mountSynchronously,
+    ShadowTreeCommitSource source) const {
   TraceSection s("UIManager::shadowTreeDidFinishTransaction");
+  const auto surfaceId = mountingCoordinator->getSurfaceId();
 
   if (delegate_ != nullptr) {
     delegate_->uiManagerDidFinishTransaction(
         std::move(mountingCoordinator), mountSynchronously);
+  }
+
+  std::shared_lock lock(commitHookMutex_);
+
+  for (auto* commitHook : commitHooks_) {
+    commitHook->shadowTreeDidFinishTransaction(surfaceId, source);
   }
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManager.h
@@ -127,7 +127,8 @@ class UIManager final : public ShadowTreeDelegate {
 
   void shadowTreeDidFinishTransaction(
       std::shared_ptr<const MountingCoordinator> mountingCoordinator,
-      bool mountSynchronously) const override;
+      bool mountSynchronously,
+      ShadowTreeCommitSource source) const override;
 
   RootShadowNode::Unshared shadowTreeWillCommit(
       const ShadowTree &shadowTree,

--- a/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerCommitHook.h
+++ b/packages/react-native/ReactCommon/react/renderer/uimanager/UIManagerCommitHook.h
@@ -13,6 +13,7 @@ namespace facebook::react {
 
 class ShadowTree;
 struct ShadowTreeCommitOptions;
+enum class ShadowTreeCommitSource;
 class UIManager;
 
 /*
@@ -53,6 +54,8 @@ class UIManagerCommitHook {
     // flavor instead.
     return newRootShadowNode;
   }
+
+  virtual void shadowTreeDidFinishTransaction(SurfaceId surfaceId, ShadowTreeCommitSource source) const noexcept {}
 
   virtual ~UIManagerCommitHook() noexcept = default;
 };


### PR DESCRIPTION
Summary:
## Changelog:

[General] [Added] - add UIManagerCommitHook::shadowTreeDidFinishTransaction

Added this API so we can tell at end of Fabric mount phase which source the commit comes from. This is useful for identifying that a React update just gets mounted.
* UIManagerMountHook::shadowTreeDidMount is called at similar timing however it doesn't include CommitSource information

Differential Revision: D89573534


