### PR TITLE
Transform `mixed` to `unknown` in xplat/js

### DIFF
--- a/flow-typed/environment/node.js
+++ b/flow-typed/environment/node.js
@@ -618,7 +618,7 @@ declare class crypto$Hash extends stream$Duplex {
     data: string | Buffer,
     input_encoding?: 'utf8' | 'ascii' | 'latin1' | 'binary',
   ): crypto$Hash;
-  copy(options?: mixed): crypto$Hash;
+  copy(options?: unknown): crypto$Hash;
 }
 
 declare class crypto$Hmac extends stream$Duplex {
@@ -703,7 +703,7 @@ declare class crypto$KeyObject {
       format: 'der',
     }>,
   ): Buffer;
-  export(options: Readonly<{format: 'jwk'}>): mixed;
+  export(options: Readonly<{format: 'jwk'}>): unknown;
   equals(otherKeyObject: crypto$KeyObject): boolean;
 }
 
@@ -739,7 +739,7 @@ declare class crypto$X509Certificate {
   checkIssued(otherCert: crypto$X509Certificate): boolean;
   checkPrivateKey(privateKey: crypto$KeyObject): boolean;
   toJSON(): string;
-  toLegacyObject(): mixed;
+  toLegacyObject(): unknown;
   toString(): string;
   verify(publicKey: crypto$KeyObject): boolean;
 }
@@ -930,10 +930,10 @@ declare module 'crypto' {
     encoding: buffer$Encoding,
   ): crypto$KeyObject;
   declare function createPublicKey(
-    key: string | Buffer | crypto$KeyObject | mixed,
+    key: string | Buffer | crypto$KeyObject | unknown,
   ): crypto$KeyObject;
   declare function createPrivateKey(
-    key: string | Buffer | mixed,
+    key: string | Buffer | unknown,
   ): crypto$KeyObject;
   declare function generateKeyPair(
     type:
@@ -945,7 +945,7 @@ declare module 'crypto' {
       | 'ed448'
       | 'x25519'
       | 'x448',
-    options: mixed,
+    options: unknown,
     callback: (
       err: ?Error,
       publicKey: crypto$KeyObject,
@@ -962,7 +962,7 @@ declare module 'crypto' {
       | 'ed448'
       | 'x25519'
       | 'x448',
-    options: mixed,
+    options: unknown,
   ): {publicKey: crypto$KeyObject, privateKey: crypto$KeyObject, ...};
   declare function generateKey(
     type: 'hmac' | 'aes',
@@ -2011,8 +2011,8 @@ declare module 'fs' {
       | Buffer
       | Uint8Array
       | DataView
-      | AsyncIterable<mixed>
-      | Iterable<mixed>
+      | AsyncIterable<unknown>
+      | Iterable<unknown>
       | stream$Readable,
     options: WriteOptions | string,
   ) => Promise<void>;

--- a/packages/react-native/Libraries/BatchedBridge/NativeModules.js
+++ b/packages/react-native/Libraries/BatchedBridge/NativeModules.js
@@ -50,7 +50,7 @@ function genModule(
     return {name: moduleName};
   }
 
-  const module: {[string]: mixed} = {};
+  const module: {[string]: unknown} = {};
   methods &&
     methods.forEach((methodName, methodID) => {
       const isPromise =
@@ -99,7 +99,7 @@ function loadModule(name: string, moduleID: number): ?{...} {
 function genMethod(moduleID: number, methodID: number, type: MethodType) {
   let fn = null;
   if (type === 'promise') {
-    fn = function promiseMethodWrapper(...args: Array<mixed>) {
+    fn = function promiseMethodWrapper(...args: Array<unknown>) {
       // In case we reject, capture a useful stack trace here.
       /* $FlowFixMe[class-object-subtyping] added when improving typing for
        * this parameters */
@@ -122,7 +122,7 @@ function genMethod(moduleID: number, methodID: number, type: MethodType) {
       });
     };
   } else {
-    fn = function nonPromiseMethodWrapper(...args: Array<mixed>) {
+    fn = function nonPromiseMethodWrapper(...args: Array<unknown>) {
       const lastArg = args.length > 0 ? args[args.length - 1] : null;
       const secondLastArg = args.length > 1 ? args[args.length - 2] : null;
       const hasSuccessCallback = typeof lastArg === 'function';
@@ -133,9 +133,11 @@ function genMethod(moduleID: number, methodID: number, type: MethodType) {
           'Cannot have a non-function arg after a function arg.',
         );
       // $FlowFixMe[incompatible-type]
-      const onSuccess: ?(mixed) => void = hasSuccessCallback ? lastArg : null;
-      // $FlowFixMe[incompatible-type]
-      const onFail: ?(mixed) => void = hasErrorCallback ? secondLastArg : null;
+      const onSuccess: ?(unknown) => void = hasSuccessCallback ? lastArg : null;
+      const onFail: ?(unknown) => void = hasErrorCallback
+        ? // $FlowFixMe[incompatible-type]
+          secondLastArg
+        : null;
       // $FlowFixMe[unsafe-addition]
       const callbackCount = hasSuccessCallback + hasErrorCallback;
       const newArgs = args.slice(0, args.length - callbackCount);


### PR DESCRIPTION
Summary:
Transform leftovers dropped by conflicts

Command:
```
js1 flow-runner codemod flow/transformUtilityType --legacy-type='mixed' --format-files=false xplat/js
```

drop-conflicts

Differential Revision: D90131601


