### PR TITLE
[RN][CI] Fix validate-dotslash-artifacts jobs

### DIFF
--- a/.github/workflows/validate-dotslash-artifacts.yml
+++ b/.github/workflows/validate-dotslash-artifacts.yml
@@ -34,6 +34,8 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+      - name: Setup node.js
+        uses: ./.github/actions/setup-node
       - name: Install dependencies
         uses: ./.github/actions/yarn-install
       - name: Configure Git


### PR DESCRIPTION
## Summary:
In my prs, Im seeing the [validate-dotslash-artifacts job fail](https://github.com/facebook/react-native/actions/runs/20744929894/job/59559875395?pr=54989#step:3:26) with the error:
```
error react-native@1000.0.0: The engine "node" is incompatible with this module. Expected version ">= 22.11.0". Got "20.19.6"
error Found incompatible module.
```

This change should fix the job by setting up a compatible version of Node

## Changelog:
[Internal] - 

## Test Plan:
GHA
