### PR TITLE
[main] Simplify the jq command used to read version inside build_android

### DIFF
--- a/.github/actions/build-android/action.yml
+++ b/.github/actions/build-android/action.yml
@@ -20,7 +20,7 @@ runs:
       shell: bash
       id: read-rn-version
       run: |
-        echo "rn-version=$(cat packages/react-native/package.json | jq -r 'version')" >> $GITHUB_OUTPUT
+        echo "rn-version=$(jq -r '.version' packages/react-native/package.json)" >> $GITHUB_OUTPUT
     - name: Set React Native Version
       # We don't want to set the version for stable branches, because this has been
       # already set from the 'create release' commits on the release branch.


### PR DESCRIPTION
## Summary:

This is a pick of 4cac35f7d03f4000f100d3e98514b135422c37b6 inside `main`.
The commit is already on the `0.84-stable` branch.

The reasoning here is that `cat` + `jq` failed to run with:

```
Run echo "rn-version=$(cat packages/react-native/package.json | jq -r 'version')" >> $GITHUB_OUTPUT
  echo "rn-version=$(cat packages/react-native/package.json | jq -r 'version')" >> $GITHUB_OUTPUT
  shell: bash --noprofile --norc -e -o pipefail {0}
jq: error: version/0 is not defined at <top-level>, line 1:
version
jq: 1 compile error
```

I'm moving to a single `jq` invocation as it's more resilient.

## Changelog:

[INTERNAL] -

## Test Plan:

N/A