### PR TITLE
Pressability: Setup w/ Insertion Effect

### DIFF
--- a/packages/react-native/Libraries/Pressability/usePressability.js
+++ b/packages/react-native/Libraries/Pressability/usePressability.js
@@ -8,25 +8,14 @@
  * @format
  */
 
-import * as ReactNativeFeatureFlags from '../../src/private/featureflags/ReactNativeFeatureFlags';
 import Pressability, {
   type EventHandlers,
   type PressabilityConfig,
 } from './Pressability';
-import {useEffect, useInsertionEffect, useRef} from 'react';
+import {useInsertionEffect, useRef} from 'react';
 
 declare function usePressability(config: PressabilityConfig): EventHandlers;
 declare function usePressability(config: null | void): null | EventHandlers;
-
-// Experiments with using `useInsertionEffect` instead of `useEffect`, which
-// changes whether `Pressability` is configured or reset when inm a hidden
-// Activity. With `useInsertionEffect`, `Pressability` behaves more like a
-// platform control (e.g. Pointer Events), especially with respect to events
-// like focus and blur.
-const useConfigurationEffect =
-  ReactNativeFeatureFlags.configurePressabilityDuringInsertion()
-    ? useInsertionEffect
-    : useEffect;
 
 /**
  * Creates a persistent instance of `Pressability` that automatically configures
@@ -51,7 +40,7 @@ export default function usePressability(
 
   // On the initial mount, this is a no-op. On updates, `pressability` will be
   // re-configured to use the new configuration.
-  useConfigurationEffect(() => {
+  useInsertionEffect(() => {
     if (config != null && pressability != null) {
       pressability.configure(config);
     }
@@ -59,7 +48,7 @@ export default function usePressability(
 
   // On unmount, reset pending state and timers inside `pressability`. This is
   // a separate effect because we do not want to reset when `config` changes.
-  useConfigurationEffect(() => {
+  useInsertionEffect(() => {
     if (pressability != null) {
       return () => {
         pressability.reset();

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -989,17 +989,6 @@ const definitions: FeatureFlagDefinitions = {
       },
       ossReleaseStage: 'none',
     },
-    configurePressabilityDuringInsertion: {
-      defaultValue: false,
-      metadata: {
-        dateAdded: '2025-10-27',
-        description:
-          'Configure Pressability during insertion and no longer unmount when hidden.',
-        expectedReleaseValue: true,
-        purpose: 'experimentation',
-      },
-      ossReleaseStage: 'none',
-    },
     deferFlatListFocusChangeRenderUpdate: {
       defaultValue: false,
       metadata: {

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<43e6a2dddd5965011ba166098f90e33f>>
+ * @generated SignedSource<<bf6ca0830458dd53c3d8edf227c1c4d9>>
  * @flow strict
  * @noformat
  */
@@ -31,7 +31,6 @@ export type ReactNativeFeatureFlagsJsOnly = $ReadOnly<{
   jsOnlyTestFlag: Getter<boolean>,
   animatedShouldDebounceQueueFlush: Getter<boolean>,
   animatedShouldUseSingleOp: Getter<boolean>,
-  configurePressabilityDuringInsertion: Getter<boolean>,
   deferFlatListFocusChangeRenderUpdate: Getter<boolean>,
   disableMaintainVisibleContentPosition: Getter<boolean>,
   enableVirtualViewExperimental: Getter<boolean>,
@@ -153,11 +152,6 @@ export const animatedShouldDebounceQueueFlush: Getter<boolean> = createJavaScrip
  * Enables an experimental mega-operation for Animated.js that replaces many calls to native with a single call into native, to reduce JSI/JNI traffic.
  */
 export const animatedShouldUseSingleOp: Getter<boolean> = createJavaScriptFlagGetter('animatedShouldUseSingleOp', false);
-
-/**
- * Configure Pressability during insertion and no longer unmount when hidden.
- */
-export const configurePressabilityDuringInsertion: Getter<boolean> = createJavaScriptFlagGetter('configurePressabilityDuringInsertion', false);
 
 /**
  * Use the deferred cell render update mechanism for focus change in FlatList.


### PR DESCRIPTION
Summary:
Ships the feature flag to use `useInsertionEffect` in `Pressability`, instead of `useEffect`.

Using `useInsertionEffect` enables `Pressability` to behave more predictability in component trees with `<Activity mode="hidden">` because the events are scheduled more similarly to platform controls (e.g. focus and blur events will still fire even when "hidden").

Changelog:
[General][Changed] - `Pressable` no longer unmounts event listeners in a hidden `Activity`.

Differential Revision: D90192717


