### PR TITLE
feat: Export getDevServer function as public API

### DIFF
--- a/packages/react-native/Libraries/Core/Devtools/getDevServer.js
+++ b/packages/react-native/Libraries/Core/Devtools/getDevServer.js
@@ -14,7 +14,7 @@ let _cachedDevServerURL: ?string;
 let _cachedFullBundleURL: ?string;
 const FALLBACK = 'http://localhost:8081/';
 
-type DevServerInfo = {
+export type DevServerInfo = {
   url: string,
   fullBundleUrl: ?string,
   bundleLoadedFromServer: boolean,

--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -223,6 +223,9 @@ module.exports = {
   get findNodeHandle() {
     return require('./Libraries/ReactNative/RendererProxy').findNodeHandle;
   },
+  get getDevServer() {
+    return require('./Libraries/Core/Devtools/getDevServer').default;
+  },
   get I18nManager() {
     return require('./Libraries/ReactNative/I18nManager').default;
   },

--- a/packages/react-native/index.js.flow
+++ b/packages/react-native/index.js.flow
@@ -275,6 +275,9 @@ export {default as Easing} from './Libraries/Animated/Easing';
 
 export {findNodeHandle} from './Libraries/ReactNative/RendererProxy';
 
+export type {DevServerInfo} from './Libraries/Core/Devtools/getDevServer';
+export {default as getDevServer} from './Libraries/Core/Devtools/getDevServer';
+
 export {default as I18nManager} from './Libraries/ReactNative/I18nManager';
 
 export type {


### PR DESCRIPTION
## Summary

Exports the `getDevServer` function and `DevServerInfo` type from React Native's public API, making them available without deep imports.

## Motivation

Deep imports are deprecated in v0.80 and will be removed in v0.82. Library authors currently rely on internal imports to use `getDevServer`:

```javascript
// Current (deprecated)
import getDevServer from 'react-native/Libraries/Core/Devtools/getDevServer'

// After this PR
import { getDevServer, DevServerInfo } from 'react-native'
```

## Use Cases

- **HMR clients**: Tools like vxrn use `getDevServer()` to establish WebSocket connections to the dev server for hot module replacement
- **Dev tooling**: Libraries need to know the dev server URL for error symbolication, bundle loading, and debugging features  
- **URL resolution**: Getting the base URL for fetching assets and making requests to the packager

The function is already used internally by React Native for:
- `symbolicateStackTrace.js` - Error stack symbolication
- `loadBundleFromServer.js` - Dynamic bundle loading
- `openFileInEditor.js` - Opening source files in editor
- React DevTools connection setup

## Changelog:

[GENERAL] [ADDED] - Export `getDevServer` function and `DevServerInfo` type from public API

## Test Plan

This is a straightforward export addition. The function already exists and is well-tested internally. Consumers can now import it directly:

```javascript
import { getDevServer } from 'react-native';

const { url, bundleLoadedFromServer } = getDevServer();
console.log('Dev server URL:', url);
```