### PR TITLE
Fix unused exception parameter compile error in RCTUIManager catch block

### DIFF
--- a/packages/react-native/React/Modules/RCTUIManager.mm
+++ b/packages/react-native/React/Modules/RCTUIManager.mm
@@ -1248,7 +1248,7 @@ RCT_EXPORT_METHOD(
             [[RCTComposedViewRegistry alloc] initWithUIManager:strongSelf andRegistry:strongSelf->_viewRegistry];
         block(strongSelf, composedViewRegistry);
       }
-    } @catch (NSException *exception) {
+    } @catch (NSException *__unused exception) {
       RCTLogError(@"Exception thrown while executing UI block: %@", exception);
     }
   };


### PR DESCRIPTION
Summary:
In some configurations the errors might be stripped out and leading toward those kind of issues:

```
stderr:

xplat/js/react-native-github/packages/react-native/React/Modules/RCTUIManager.mm:1251:28: error: unused exception parameter 'exception' [-Werror,-Wunused-exception-parameter]

 1251 |     } catch (NSException \*exception) {

      |                            ^\~\~\~\~\~\~\~\~

1 error generated.
```

So marking the param as potentially unused.

Reviewed By: lodhaayush

Differential Revision: D90192993


