### PR TITLE
Transform $ReadOnly to Readonly 37/n

### DIFF
--- a/flow-typed/environment/node.js
+++ b/flow-typed/environment/node.js
@@ -199,7 +199,7 @@ declare module 'buffer' {
   declare var kMaxLength: number;
   declare var INSPECT_MAX_BYTES: number;
 
-  declare var constants: $ReadOnly<{
+  declare var constants: Readonly<{
     MAX_LENGTH: number,
     MAX_STRING_LENGTH: number,
   }>;
@@ -1467,7 +1467,7 @@ declare module 'fs' {
     path: string,
     options:
       | string
-      | $ReadOnly<{
+      | Readonly<{
           encoding?: string,
           recursive?: boolean,
           withFileTypes?: false,
@@ -1477,7 +1477,7 @@ declare module 'fs' {
   ): void;
   declare function readdir(
     path: string,
-    options: $ReadOnly<{
+    options: Readonly<{
       encoding?: string,
       recursive?: boolean,
       withFileTypes: true,
@@ -1493,7 +1493,7 @@ declare module 'fs' {
     path: string,
     options?:
       | string
-      | $ReadOnly<{
+      | Readonly<{
           encoding?: string,
           recursive?: boolean,
           withFileTypes?: false,
@@ -1503,7 +1503,7 @@ declare module 'fs' {
     path: string,
     options?:
       | string
-      | $ReadOnly<{
+      | Readonly<{
           encoding?: string,
           recursive?: boolean,
           withFileTypes: true,
@@ -1527,13 +1527,13 @@ declare module 'fs' {
   ): void;
   declare function openAsBlob(
     path: string | Buffer | URL,
-    options?: $ReadOnly<{
+    options?: Readonly<{
       type?: string, // Optional MIME type hint
     }>,
   ): Promise<Blob>;
   declare function opendir(
     path: string,
-    options?: $ReadOnly<{
+    options?: Readonly<{
       encoding?: string,
       bufferSize?: number,
       recursive?: boolean,
@@ -1542,7 +1542,7 @@ declare module 'fs' {
   ): void;
   declare function opendirSync(
     path: string,
-    options?: $ReadOnly<{
+    options?: Readonly<{
       encoding?: string,
       bufferSize?: number,
       recursive?: boolean,
@@ -1770,7 +1770,7 @@ declare module 'fs' {
   ): void;
   declare function watchFile(
     filename: string,
-    options?: $ReadOnly<{
+    options?: Readonly<{
       bigint?: boolean,
       persistent?: boolean,
       interval?: number,
@@ -1787,7 +1787,7 @@ declare module 'fs' {
   ): FSWatcher;
   declare function watch(
     filename: string,
-    options?: $ReadOnly<{
+    options?: Readonly<{
       persistent?: boolean,
       recursive?: boolean,
       encoding?: string,
@@ -1835,7 +1835,7 @@ declare module 'fs' {
   declare function cp(
     src: string | URL,
     dest: string | URL,
-    options: $ReadOnly<{
+    options: Readonly<{
       dereference?: boolean,
       errorOnExist?: boolean,
       filter?: (src: string, dest: string) => boolean | Promise<boolean>,
@@ -1855,7 +1855,7 @@ declare module 'fs' {
   declare function cpSync(
     src: string | URL,
     dest: string | URL,
-    options?: $ReadOnly<{
+    options?: Readonly<{
       dereference?: boolean,
       errorOnExist?: boolean,
       filter?: (src: string, dest: string) => boolean,
@@ -2022,7 +2022,7 @@ declare module 'fs' {
     chown(uid: number, guid: number): Promise<void>;
     close(): Promise<void>;
     createReadStream(
-      options?: $ReadOnly<{
+      options?: Readonly<{
         encoding?: string,
         autoClose?: boolean,
         emitClose?: boolean,
@@ -2033,7 +2033,7 @@ declare module 'fs' {
       }>,
     ): ReadStream;
     createWriteStream(
-      options?: $ReadOnly<{
+      options?: Readonly<{
         encoding?: string,
         autoClose?: boolean,
         emitClose?: boolean,
@@ -2055,12 +2055,12 @@ declare module 'fs' {
       ...
     }>;
     readableWebStream(
-      options?: $ReadOnly<{autoClose?: boolean}>,
+      options?: Readonly<{autoClose?: boolean}>,
     ): ReadableStream;
     readFile(options: EncodingFlag): Promise<Buffer>;
     readFile(options: string): Promise<string>;
     readLines(
-      options?: $ReadOnly<{
+      options?: Readonly<{
         encoding?: string,
         autoClose?: boolean,
         emitClose?: boolean,
@@ -2088,7 +2088,7 @@ declare module 'fs' {
     ): Promise<void>;
     write(
       buffer: Buffer | Uint8Array | DataView,
-      options?: $ReadOnly<{
+      options?: Readonly<{
         offset?: number,
         length?: number,
         position?: number,
@@ -2119,7 +2119,7 @@ declare module 'fs' {
     cp(
       src: string | URL,
       dest: string | URL,
-      options?: $ReadOnly<{
+      options?: Readonly<{
         dereference?: boolean,
         errorOnExist?: boolean,
         filter?: (src: string, dest: string) => boolean | Promise<boolean>,
@@ -2171,7 +2171,7 @@ declare module 'fs' {
     ): Promise<FileHandle>,
     opendir(
       path: string,
-      options?: $ReadOnly<{
+      options?: Readonly<{
         encoding?: string,
         bufferSize?: number,
         recursive?: boolean,
@@ -2192,7 +2192,7 @@ declare module 'fs' {
       path: FSPromisePath,
       options:
         | string
-        | $ReadOnly<{
+        | Readonly<{
             encoding?: string,
             recursive?: boolean,
             withFileTypes?: false,
@@ -2200,7 +2200,7 @@ declare module 'fs' {
     ) => Promise<Array<string>>) &
       ((
         path: FSPromisePath,
-        options: $ReadOnly<{
+        options: Readonly<{
           encoding?: string,
           recursive?: boolean,
           withFileTypes: true,
@@ -2249,7 +2249,7 @@ declare module 'fs' {
     ): Promise<void>,
     watch(
       filename: FSPromisePath,
-      options?: $ReadOnly<{
+      options?: Readonly<{
         persistent?: boolean,
         recursive?: boolean,
         encoding?: string,

--- a/flow-typed/npm/@octokit/rest_v22.x.x.js
+++ b/flow-typed/npm/@octokit/rest_v22.x.x.js
@@ -13,9 +13,9 @@ declare module '@octokit/rest' {
   declare class Octokit {
     constructor(options?: {auth?: string, ...}): this;
 
-    repos: $ReadOnly<{
+    repos: Readonly<{
       listReleaseAssets: (
-        params: $ReadOnly<{
+        params: Readonly<{
           owner: string,
           repo: string,
           release_id: string,
@@ -29,13 +29,13 @@ declare module '@octokit/rest' {
         ...
       }>,
       uploadReleaseAsset: (
-        params: $ReadOnly<{
+        params: Readonly<{
           owner: string,
           repo: string,
           release_id: string,
           name: string,
           data: Buffer,
-          headers: $ReadOnly<{
+          headers: Readonly<{
             'content-type': string,
             ...
           }>,

--- a/flow-typed/npm/babel-traverse_v7.x.x.js
+++ b/flow-typed/npm/babel-traverse_v7.x.x.js
@@ -97,7 +97,7 @@ declare module '@babel/traverse' {
     /** Traverse node with current scope and path. */
     traverse<S>(
       node: BabelNode | Array<BabelNode>,
-      opts: $ReadOnly<TraverseOptions<S>>,
+      opts: Readonly<TraverseOptions<S>>,
       state: S,
     ): void;
 
@@ -303,7 +303,7 @@ declare module '@babel/traverse' {
     shouldStop: boolean;
     removed: boolean;
     state: unknown;
-    +opts: $ReadOnly<TraverseOptions<unknown>> | null;
+    +opts: Readonly<TraverseOptions<unknown>> | null;
     skipKeys: null | {[key: string]: boolean};
     parentPath: ?NodePath<>;
     context: TraversalContext;
@@ -346,7 +346,7 @@ declare module '@babel/traverse' {
     ): TError;
 
     traverse<TState>(
-      visitor: $ReadOnly<TraverseOptions<TState>>,
+      visitor: Readonly<TraverseOptions<TState>>,
       state: TState,
     ): void;
 
@@ -1444,7 +1444,7 @@ declare module '@babel/traverse' {
     | VisitNodeFunction<TNode, TState>
     | VisitNodeObject<TNode, TState>;
 
-  declare export type Visitor<TState = void> = $ReadOnly<{
+  declare export type Visitor<TState = void> = Readonly<{
     enter?: VisitNodeFunction<BabelNode, TState>,
     exit?: VisitNodeFunction<BabelNode, TState>,
 
@@ -1872,7 +1872,7 @@ declare module '@babel/traverse' {
     explode<TState>(visitor: Visitor<TState>): Visitor<TState>,
     verify<TState>(visitor: Visitor<TState>): void,
     merge(
-      visitors: Array<$ReadOnly<Visitor<any>>>,
+      visitors: Array<Readonly<Visitor<any>>>,
       states: Array<any>,
       wrapper?: ?Function,
     ): Array<Visitor<any>>,
@@ -1891,7 +1891,7 @@ declare module '@babel/traverse' {
   declare export type Traverse = {
     <TState>(
       parent?: BabelNode | Array<BabelNode>,
-      opts?: $ReadOnly<TraverseOptions<TState>>,
+      opts?: Readonly<TraverseOptions<TState>>,
       scope?: ?Scope,
       state: TState,
       parentPath?: ?NodePath<BabelNode>,
@@ -1909,7 +1909,7 @@ declare module '@babel/traverse' {
 
     node<TState>(
       node: BabelNode,
-      opts: $ReadOnly<TraverseOptions<TState>>,
+      opts: Readonly<TraverseOptions<TState>>,
       scope: Scope,
       state: TState,
       parentPath: NodePath<>,

--- a/flow-typed/npm/babel_v7.x.x.js
+++ b/flow-typed/npm/babel_v7.x.x.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-type _BabelSourceMap = $ReadOnly<{
+type _BabelSourceMap = Readonly<{
   file?: string,
   mappings: string,
   names: Array<string>,
@@ -28,9 +28,9 @@ type _BabelSourceMapSegment = {
   ...
 };
 
-export type BabelSourceLocation = $ReadOnly<{
-  start: $ReadOnly<{line: number, column: number}>,
-  end: $ReadOnly<{line: number, column: number}>,
+export type BabelSourceLocation = Readonly<{
+  start: Readonly<{line: number, column: number}>,
+  end: Readonly<{line: number, column: number}>,
 }>;
 
 declare module '@babel/parser' {
@@ -330,7 +330,7 @@ declare module '@babel/core' {
 
     constructor(
       options: BabelCoreOptions,
-      input: $ReadOnly<{ast: BabelNode, code: string, inputMap: any}>,
+      input: Readonly<{ast: BabelNode, code: string, inputMap: any}>,
     ): File;
 
     getMetadata(): void;
@@ -1079,7 +1079,7 @@ declare module '@babel/core' {
   declare type ValidatedOptions = BabelCoreOptions;
 
   declare class PartialConfig {
-    +options: $ReadOnly<ValidatedOptions>;
+    +options: Readonly<ValidatedOptions>;
     +babelrc: string | void;
     +babelignore: string | void;
     +config: string | void;

--- a/flow-typed/npm/electron-packager_v18.x.x.js
+++ b/flow-typed/npm/electron-packager_v18.x.x.js
@@ -46,7 +46,7 @@ declare module '@electron/packager' {
 
   declare export type OsxUniversalOptions = $FlowFixMe;
 
-  declare export type Win32MetadataOptions = $ReadOnly<{
+  declare export type Win32MetadataOptions = Readonly<{
     CompanyName?: string,
     FileDescription?: string,
     OriginalFilename?: string,

--- a/flow-typed/npm/execa_v5.x.x.js
+++ b/flow-typed/npm/execa_v5.x.x.js
@@ -91,25 +91,25 @@ declare module 'execa' {
     (
       file: string,
       args?: $ReadOnlyArray<string>,
-      options?: $ReadOnly<Options>,
+      options?: Readonly<Options>,
     ): ExecaPromise;
-    (file: string, options?: $ReadOnly<Options>): ExecaPromise;
+    (file: string, options?: Readonly<Options>): ExecaPromise;
 
-    command(command: string, options?: $ReadOnly<Options>): ExecaPromise;
-    commandSync(command: string, options?: $ReadOnly<Options>): ExecaPromise;
+    command(command: string, options?: Readonly<Options>): ExecaPromise;
+    commandSync(command: string, options?: Readonly<Options>): ExecaPromise;
 
     node(
       path: string,
       args?: $ReadOnlyArray<string>,
-      options?: $ReadOnly<Options>,
+      options?: Readonly<Options>,
     ): void;
 
     sync(
       file: string,
       args?: $ReadOnlyArray<string>,
-      options?: $ReadOnly<SyncOptions>,
+      options?: Readonly<SyncOptions>,
     ): SyncResult;
-    sync(file: string, options?: $ReadOnly<SyncOptions>): SyncResult;
+    sync(file: string, options?: Readonly<SyncOptions>): SyncResult;
   }
 
   declare module.exports: Execa;

--- a/flow-typed/npm/jsonc-parser_v2.2.x.js
+++ b/flow-typed/npm/jsonc-parser_v2.2.x.js
@@ -22,7 +22,7 @@ declare module 'jsonc-parser' {
   /**
    * The scanner object, representing a JSON scanner at a position in the input string.
    */
-  export type JSONScanner = $ReadOnly<{
+  export type JSONScanner = Readonly<{
     /**
      * Sets the scan position to a new offset. A call to 'scan' is needed to get the first token.
      */
@@ -351,7 +351,7 @@ declare module 'jsonc-parser' {
   /**
    * Options used by {@linkcode format} when computing the formatting edit operations
    */
-  export type FormattingOptions = $ReadOnly<{
+  export type FormattingOptions = Readonly<{
     /**
      * If indentation is based on spaces (`insertSpaces` = true), the number of spaces that make an indent.
      */

--- a/flow-typed/npm/open_v7.x.x.js
+++ b/flow-typed/npm/open_v7.x.x.js
@@ -11,7 +11,7 @@
 declare module 'open' {
   import type {ChildProcess} from 'child_process';
 
-  declare export type Options = $ReadOnly<{
+  declare export type Options = Readonly<{
     wait?: boolean,
     background?: boolean,
     newInstance?: boolean,

--- a/flow-typed/npm/serve-static_v1.x.x.js
+++ b/flow-typed/npm/serve-static_v1.x.x.js
@@ -12,7 +12,7 @@ declare module 'serve-static' {
   import type {NextHandleFunction} from 'connect';
   import type http from 'http';
 
-  declare export type Options = $ReadOnly<{
+  declare export type Options = Readonly<{
     /**
      * Enable or disable accepting ranged requests, defaults to true. Disabling
      * this will not send `Accept-Ranges` and ignore the contents of the

--- a/flow-typed/npm/tinybench_v4.1.x.js
+++ b/flow-typed/npm/tinybench_v4.1.x.js
@@ -11,7 +11,7 @@
 declare module 'tinybench' {
   declare export class Task extends EventTarget {
     name: string;
-    result: void | $ReadOnly<TaskResult>;
+    result: void | Readonly<TaskResult>;
     runs: number;
 
     reset(): void;
@@ -108,13 +108,13 @@ declare module 'tinybench' {
   declare export class Bench extends EventTarget {
     concurrency: null | 'task' | 'bench';
     name?: string;
-    opts: $ReadOnly<BenchOptions>;
+    opts: Readonly<BenchOptions>;
     threshold: number;
 
     constructor(options?: BenchOptions): this;
 
     // $FlowExpectedError[unsafe-getters-setters]
-    get results(): Array<$ReadOnly<TaskResult>>;
+    get results(): Array<Readonly<TaskResult>>;
 
     // $FlowExpectedError[unsafe-getters-setters]
     get tasks(): Array<Task>;

--- a/flow-typed/npm/typescript_v5.x.x.js
+++ b/flow-typed/npm/typescript_v5.x.x.js
@@ -18,25 +18,25 @@ declare module 'typescript' {
     Bundler = 'Bundler',
   }
 
-  declare type SourceFile = $ReadOnly<{
+  declare type SourceFile = Readonly<{
     fileName: string,
     text: string,
     ...
   }>;
 
-  declare type Diagnostic = $ReadOnly<{
+  declare type Diagnostic = Readonly<{
     file?: SourceFile,
     start?: number,
     messageText: string,
     ...
   }>;
 
-  declare type EmitResult = $ReadOnly<{
+  declare type EmitResult = Readonly<{
     diagnostics: Array<Diagnostic>,
     ...
   }>;
 
-  declare type Program = $ReadOnly<{
+  declare type Program = Readonly<{
     emit: () => EmitResult,
     ...
   }>;
@@ -47,7 +47,7 @@ declare module 'typescript' {
     getLineAndCharacterOfPosition(
       file: SourceFile,
       start?: number,
-    ): $ReadOnly<{line: number, character: number}>,
+    ): Readonly<{line: number, character: number}>,
     convertCompilerOptionsFromJson(
       jsonOptions: any,
       basePath: string,

--- a/flow-typed/npm/undici_v5.x.x.js
+++ b/flow-typed/npm/undici_v5.x.x.js
@@ -15,7 +15,7 @@ declare interface undici$Agent$Options {
 }
 
 declare module 'undici' {
-  declare export type RequestOptions = $ReadOnly<{
+  declare export type RequestOptions = Readonly<{
     dispatcher?: Dispatcher,
     method?: string,
     headers?: HeadersInit,

--- a/packages/community-cli-plugin/src/commands/bundle/assetPathUtils.js
+++ b/packages/community-cli-plugin/src/commands/bundle/assetPathUtils.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-export type PackagerAsset = $ReadOnly<{
+export type PackagerAsset = Readonly<{
   httpServerLocation: string,
   name: string,
   type: string,

--- a/packages/community-cli-plugin/src/commands/start/OpenDebuggerKeyboardHandler.js
+++ b/packages/community-cli-plugin/src/commands/start/OpenDebuggerKeyboardHandler.js
@@ -12,7 +12,7 @@ import type {TerminalReporter} from 'metro';
 
 import {styleText} from 'util';
 
-type PageDescription = $ReadOnly<{
+type PageDescription = Readonly<{
   id: string,
   title: string,
   description: string,

--- a/packages/community-cli-plugin/src/commands/start/attachKeyHandlers.js
+++ b/packages/community-cli-plugin/src/commands/start/attachKeyHandlers.js
@@ -45,7 +45,7 @@ export default function attachKeyHandlers({
   reporter,
 }: {
   devServerUrl: string,
-  messageSocket: $ReadOnly<{
+  messageSocket: Readonly<{
     broadcast: (type: string, params?: Record<string, unknown> | null) => void,
     ...
   }>,

--- a/packages/community-cli-plugin/src/utils/createDevMiddlewareLogger.js
+++ b/packages/community-cli-plugin/src/utils/createDevMiddlewareLogger.js
@@ -18,7 +18,7 @@ type LoggerFn = (...message: $ReadOnlyArray<string>) => void;
  */
 export default function createDevMiddlewareLogger(
   reporter: TerminalReporter,
-): $ReadOnly<{
+): Readonly<{
   info: LoggerFn,
   error: LoggerFn,
   warn: LoggerFn,

--- a/packages/community-cli-plugin/src/utils/loadMetroConfig.js
+++ b/packages/community-cli-plugin/src/utils/loadMetroConfig.js
@@ -20,7 +20,7 @@ const debug = require('debug')('ReactNative:CommunityCliPlugin');
 
 export type {Config};
 
-export type ConfigLoadingContext = $ReadOnly<{
+export type ConfigLoadingContext = Readonly<{
   root: Config['root'],
   reactNativePath: Config['reactNativePath'],
   platforms: Config['platforms'],

--- a/packages/debugger-shell/src/electron/MainInstanceEntryPoint.js
+++ b/packages/debugger-shell/src/electron/MainInstanceEntryPoint.js
@@ -19,7 +19,7 @@ const {BrowserWindow, Menu, app, shell, ipcMain} = require('electron') as any;
 const appSettings = new SettingsStore();
 const windowMetadata = new WeakMap<
   typeof BrowserWindow,
-  $ReadOnly<{
+  Readonly<{
     windowKey: string,
   }>,
 >();

--- a/packages/debugger-shell/src/electron/SettingsStore.js
+++ b/packages/debugger-shell/src/electron/SettingsStore.js
@@ -14,7 +14,7 @@ const {app} = require('electron') as any;
 const fs = require('fs');
 const path = require('path');
 
-type Options = $ReadOnly<{
+type Options = Readonly<{
   name?: string,
   defaults?: Object,
 }>;

--- a/packages/debugger-shell/src/node/index.flow.js
+++ b/packages/debugger-shell/src/node/index.flow.js
@@ -31,7 +31,7 @@ async function unstable_spawnDebuggerShellWithArgs(
     mode = 'detached',
     flavor = process.env.RNDT_DEV === '1' ? 'dev' : 'prebuilt',
     prebuiltBinaryPath,
-  }: $ReadOnly<{
+  }: Readonly<{
     // In 'syncAndExit' mode, the current process will block until the spawned process exits, and then it will exit
     // with the same exit code as the spawned process.
     // In 'detached' mode, the spawned process will be detached from the current process and the current process will
@@ -97,7 +97,7 @@ async function unstable_spawnDebuggerShellWithArgs(
   });
 }
 
-export type DebuggerShellPreparationResult = $ReadOnly<{
+export type DebuggerShellPreparationResult = Readonly<{
   code:
     | 'success'
     | 'not_implemented'

--- a/packages/dev-middleware/src/__tests__/InspectorProtocolUtils.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProtocolUtils.js
@@ -21,18 +21,18 @@ import {createDebuggerMock} from './InspectorDebuggerUtils';
 import {createDeviceMock} from './InspectorDeviceUtils';
 import until from 'wait-for-expect';
 
-export type CdpMessageFromTarget = $ReadOnly<{
+export type CdpMessageFromTarget = Readonly<{
   method: string,
   id?: number,
   params?: JSONSerializable,
 }>;
 
-export type CdpResponseFromTarget = $ReadOnly<{
+export type CdpResponseFromTarget = Readonly<{
   id: number,
   result: JSONSerializable,
 }>;
 
-export type CdpMessageToTarget = $ReadOnly<{
+export type CdpMessageToTarget = Readonly<{
   method: string,
   id: number,
   params?: JSONSerializable,
@@ -108,7 +108,7 @@ export async function sendFromDebuggerToTarget<Message: CdpMessageToTarget>(
 }
 
 export async function createAndConnectTarget(
-  serverRef: $ReadOnly<{
+  serverRef: Readonly<{
     serverBaseUrl: string,
     serverBaseWsUrl: string,
     ...
@@ -119,7 +119,7 @@ export async function createAndConnectTarget(
     debuggerHostHeader = null,
     deviceId = null,
     deviceHostHeader = null,
-  }: $ReadOnly<{
+  }: Readonly<{
     debuggerHostHeader?: ?string,
     deviceId?: ?string,
     deviceHostHeader?: ?string,

--- a/packages/dev-middleware/src/__tests__/ResourceUtils.js
+++ b/packages/dev-middleware/src/__tests__/ResourceUtils.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-export function withAbortSignalForEachTest(): $ReadOnly<{signal: AbortSignal}> {
+export function withAbortSignalForEachTest(): Readonly<{signal: AbortSignal}> {
   const ref: {signal: AbortSignal} = {
     // $FlowFixMe[unsafe-getters-setters]
     get signal() {

--- a/packages/dev-middleware/src/__tests__/ServerUtils.js
+++ b/packages/dev-middleware/src/__tests__/ServerUtils.js
@@ -25,7 +25,7 @@ type CreateServerOptions = {
 };
 type ConnectApp = ReturnType<typeof connect>;
 
-export function withServerForEachTest(options: CreateServerOptions): $ReadOnly<{
+export function withServerForEachTest(options: CreateServerOptions): Readonly<{
   serverBaseUrl: string,
   serverBaseWsUrl: string,
   app: ConnectApp,

--- a/packages/dev-middleware/src/createDevMiddleware.js
+++ b/packages/dev-middleware/src/createDevMiddleware.js
@@ -23,7 +23,7 @@ import connect from 'connect';
 import path from 'path';
 import serveStaticMiddleware from 'serve-static';
 
-type Options = $ReadOnly<{
+type Options = Readonly<{
   /**
    * The base URL to the dev server, as reachable from the machine on which
    * dev-middleware is hosted. Typically `http://localhost:${metroPort}`.
@@ -70,7 +70,7 @@ type Options = $ReadOnly<{
   unstable_trackInspectorProxyEventLoopPerf?: boolean,
 }>;
 
-type DevMiddlewareAPI = $ReadOnly<{
+type DevMiddlewareAPI = Readonly<{
   middleware: NextHandleFunction,
   websocketEndpoints: {[path: string]: ws$WebSocketServer},
 }>;

--- a/packages/dev-middleware/src/inspector-proxy/CustomMessageHandler.js
+++ b/packages/dev-middleware/src/inspector-proxy/CustomMessageHandler.js
@@ -10,19 +10,19 @@
 
 import type {JSONSerializable, Page} from './types';
 
-type ExposedDevice = $ReadOnly<{
+type ExposedDevice = Readonly<{
   appId: string,
   id: string,
   name: string,
   sendMessage: (message: JSONSerializable) => void,
 }>;
 
-type ExposedDebugger = $ReadOnly<{
+type ExposedDebugger = Readonly<{
   userAgent: string | null,
   sendMessage: (message: JSONSerializable) => void,
 }>;
 
-export type CustomMessageHandlerConnection = $ReadOnly<{
+export type CustomMessageHandlerConnection = Readonly<{
   page: Page,
   device: ExposedDevice,
   debugger: ExposedDebugger,

--- a/packages/dev-middleware/src/inspector-proxy/Device.js
+++ b/packages/dev-middleware/src/inspector-proxy/Device.js
@@ -68,7 +68,7 @@ type DebuggerConnection = {
 
 const REACT_NATIVE_RELOADABLE_PAGE_ID = '-1';
 
-export type DeviceOptions = $ReadOnly<{
+export type DeviceOptions = Readonly<{
   id: string,
   name: string,
   app: string,
@@ -302,7 +302,7 @@ export default class Device {
     {
       debuggerRelativeBaseUrl,
       userAgent,
-    }: $ReadOnly<{
+    }: Readonly<{
       debuggerRelativeBaseUrl: URL,
       userAgent: string | null,
     }>,

--- a/packages/dev-middleware/src/inspector-proxy/DeviceEventReporter.js
+++ b/packages/dev-middleware/src/inspector-proxy/DeviceEventReporter.js
@@ -21,19 +21,19 @@ type PendingCommand = {
   metadata: RequestMetadata,
 };
 
-type DeviceMetadata = $ReadOnly<{
+type DeviceMetadata = Readonly<{
   appId: string,
   deviceId: string,
   deviceName: string,
 }>;
 
-type RequestMetadata = $ReadOnly<{
+type RequestMetadata = Readonly<{
   pageId: string | null,
   frontendUserAgent: string | null,
   prefersFuseboxFrontend: boolean | null,
 }>;
 
-type ResponseMetadata = $ReadOnly<{
+type ResponseMetadata = Readonly<{
   pageId: string | null,
   frontendUserAgent: string | null,
   prefersFuseboxFrontend: boolean | null,
@@ -68,7 +68,7 @@ class DeviceEventReporter {
   }
 
   logRequest(
-    req: $ReadOnly<{id: number, method: string, ...}>,
+    req: Readonly<{id: number, method: string, ...}>,
     origin: 'debugger' | 'proxy',
     metadata: RequestMetadata,
   ): void {
@@ -164,7 +164,7 @@ class DeviceEventReporter {
 
   logConnection(
     connectedEntity: 'debugger',
-    metadata: $ReadOnly<{
+    metadata: Readonly<{
       pageId: string,
       frontendUserAgent: string | null,
     }>,

--- a/packages/dev-middleware/src/inspector-proxy/types.js
+++ b/packages/dev-middleware/src/inspector-proxy/types.js
@@ -12,7 +12,7 @@
  * A capability flag disables a specific feature/hack in the InspectorProxy
  * layer by indicating that the target supports one or more modern CDP features.
  */
-export type TargetCapabilityFlags = $ReadOnly<{
+export type TargetCapabilityFlags = Readonly<{
   /**
    * The target supports a stable page representation across reloads.
    *
@@ -43,7 +43,7 @@ export type TargetCapabilityFlags = $ReadOnly<{
 // each new instance of VM and can appear when user reloads React Native
 // application.
 
-export type PageFromDevice = $ReadOnly<{
+export type PageFromDevice = Readonly<{
   id: string,
   title: string,
   /** Sent from modern targets only */
@@ -54,15 +54,15 @@ export type PageFromDevice = $ReadOnly<{
   capabilities?: TargetCapabilityFlags,
 }>;
 
-export type Page = $ReadOnly<{
+export type Page = Readonly<{
   ...PageFromDevice,
   capabilities: NonNullable<PageFromDevice['capabilities']>,
 }>;
 
 // Chrome Debugger Protocol message/event passed between device and debugger.
-export type WrappedEvent = $ReadOnly<{
+export type WrappedEvent = Readonly<{
   event: 'wrappedEvent',
-  payload: $ReadOnly<{
+  payload: Readonly<{
     pageId: string,
     wrappedEvent: string,
   }>,
@@ -70,16 +70,16 @@ export type WrappedEvent = $ReadOnly<{
 
 // Request sent from Inspector Proxy to Device when new debugger is connected
 // to particular page.
-export type ConnectRequest = $ReadOnly<{
+export type ConnectRequest = Readonly<{
   event: 'connect',
-  payload: $ReadOnly<{pageId: string}>,
+  payload: Readonly<{pageId: string}>,
 }>;
 
 // Request sent from Inspector Proxy to Device to notify that debugger is
 // disconnected.
-export type DisconnectRequest = $ReadOnly<{
+export type DisconnectRequest = Readonly<{
   event: 'disconnect',
-  payload: $ReadOnly<{pageId: string}>,
+  payload: Readonly<{pageId: string}>,
 }>;
 
 // Request sent from Inspector Proxy to Device to get a list of pages.
@@ -105,7 +105,7 @@ export type MessageToDevice =
   | DisconnectRequest;
 
 // Page description object that is sent in response to /json HTTP request from debugger.
-export type PageDescription = $ReadOnly<{
+export type PageDescription = Readonly<{
   id: string,
   title: string,
   appId: string,
@@ -121,7 +121,7 @@ export type PageDescription = $ReadOnly<{
   vm?: string,
 
   // React Native specific metadata
-  reactNative: $ReadOnly<{
+  reactNative: Readonly<{
     logicalDeviceId: string,
     capabilities: Page['capabilities'],
   }>,
@@ -131,7 +131,7 @@ export type JsonPagesListResponse = Array<PageDescription>;
 
 // Response to /json/version HTTP request from the debugger specifying browser type and
 // Chrome protocol version.
-export type JsonVersionResponse = $ReadOnly<{
+export type JsonVersionResponse = Readonly<{
   Browser: string,
   'Protocol-Version': string,
 }>;

--- a/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
+++ b/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
@@ -27,7 +27,7 @@ import url from 'url';
 const LEGACY_SYNTHETIC_PAGE_TITLE =
   'React Native Experimental (Improved Chrome Reloads)';
 
-type Options = $ReadOnly<{
+type Options = Readonly<{
   serverBaseUrl: string,
   logger?: Logger,
   browserLauncher: BrowserLauncher,

--- a/packages/dev-middleware/src/types/Experiments.js
+++ b/packages/dev-middleware/src/types/Experiments.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-export type Experiments = $ReadOnly<{
+export type Experiments = Readonly<{
   /**
    * Enables the handling of GET requests in the /open-debugger endpoint,
    * in addition to POST requests. GET requests respond by redirecting to

--- a/packages/dev-middleware/src/types/Logger.js
+++ b/packages/dev-middleware/src/types/Logger.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-export type Logger = $ReadOnly<{
+export type Logger = Readonly<{
   error: (...message: Array<string>) => void,
   info: (...message: Array<string>) => void,
   warn: (...message: Array<string>) => void,

--- a/packages/dev-middleware/src/utils/getDevToolsFrontendUrl.js
+++ b/packages/dev-middleware/src/utils/getDevToolsFrontendUrl.js
@@ -17,7 +17,7 @@ export default function getDevToolsFrontendUrl(
   experiments: Experiments,
   webSocketDebuggerUrl: string,
   devServerUrl: string,
-  options?: $ReadOnly<{
+  options?: Readonly<{
     relative?: boolean,
     launchId?: string,
     telemetryInfo?: string,
@@ -65,7 +65,7 @@ export default function getDevToolsFrontendUrl(
 function getWsParam({
   webSocketDebuggerUrl,
   devServerUrl,
-}: $ReadOnly<{
+}: Readonly<{
   webSocketDebuggerUrl: string,
   devServerUrl: string,
 }>): {

--- a/packages/metro-config/src/index.flow.js
+++ b/packages/metro-config/src/index.flow.js
@@ -64,7 +64,7 @@ export function getDefaultConfig(projectRoot: string): ConfigT {
         require.resolve('react-native/Libraries/Core/InitializeCore'),
       ],
       getPolyfills: () => require('@react-native/js-polyfills')(),
-      isThirdPartyModule({path: modulePath}: $ReadOnly<{path: string, ...}>) {
+      isThirdPartyModule({path: modulePath}: Readonly<{path: string, ...}>) {
         return (
           INTERNAL_CALLSITES_REGEX.test(modulePath) ||
           /(?:^|[/\\])node_modules[/\\]/.test(modulePath)
@@ -75,7 +75,7 @@ export function getDefaultConfig(projectRoot: string): ConfigT {
       port: Number(process.env.RCT_METRO_PORT) || 8081,
     },
     symbolicator: {
-      customizeFrame: (frame: $ReadOnly<{file: ?string, ...}>) => {
+      customizeFrame: (frame: Readonly<{file: ?string, ...}>) => {
         const collapse = Boolean(
           frame.file != null && INTERNAL_CALLSITES_REGEX.test(frame.file),
         );

--- a/packages/new-app-screen/src/NewAppScreen.js
+++ b/packages/new-app-screen/src/NewAppScreen.js
@@ -24,9 +24,9 @@ import {
 } from 'react-native';
 import openURLInBrowser from 'react-native/Libraries/Core/Devtools/openURLInBrowser';
 
-export type NewAppScreenProps = $ReadOnly<{
+export type NewAppScreenProps = Readonly<{
   templateFileName?: string,
-  safeAreaInsets?: $ReadOnly<{
+  safeAreaInsets?: Readonly<{
     top: number,
     bottom: number,
     left: number,

--- a/packages/react-native/Libraries/ActionSheetIOS/ActionSheetIOS.js
+++ b/packages/react-native/Libraries/ActionSheetIOS/ActionSheetIOS.js
@@ -16,7 +16,7 @@ import RCTActionSheetManager from './NativeActionSheetManager';
 const processColor = require('../StyleSheet/processColor').default;
 const invariant = require('invariant');
 
-export type ActionSheetIOSOptions = $ReadOnly<{
+export type ActionSheetIOSOptions = Readonly<{
   title?: ?string,
   message?: ?string,
   options: Array<string>,
@@ -30,7 +30,7 @@ export type ActionSheetIOSOptions = $ReadOnly<{
   disabledButtonIndices?: Array<number>,
 }>;
 
-export type ShareActionSheetIOSOptions = $ReadOnly<{
+export type ShareActionSheetIOSOptions = Readonly<{
   message?: ?string,
   url?: ?string,
   subject?: ?string,
@@ -42,7 +42,7 @@ export type ShareActionSheetIOSOptions = $ReadOnly<{
   userInterfaceStyle?: ?string,
 }>;
 
-export type ShareActionSheetError = $ReadOnly<{
+export type ShareActionSheetError = Readonly<{
   domain: string,
   code: string,
   userInfo?: ?Object,

--- a/packages/react-native/Libraries/Animated/AnimatedImplementation.js
+++ b/packages/react-native/Libraries/Animated/AnimatedImplementation.js
@@ -89,7 +89,7 @@ const diffClampImpl = function (
 
 const _combineCallbacks = function (
   callback: ?EndCallback,
-  config: $ReadOnly<{...AnimationConfig, ...}>,
+  config: Readonly<{...AnimationConfig, ...}>,
 ) {
   if (callback && config.onComplete) {
     return (...args: Array<EndResult>) => {

--- a/packages/react-native/Libraries/Animated/__tests__/Animated-itest.js
+++ b/packages/react-native/Libraries/Animated/__tests__/Animated-itest.js
@@ -581,7 +581,7 @@ test('AnimatedValue.interpolate', () => {
   let _interpolatedValueX;
   const viewRef = createRef<HostInstance>();
 
-  function MyApp({outputRangeX}: $ReadOnly<{outputRangeX: number}>) {
+  function MyApp({outputRangeX}: Readonly<{outputRangeX: number}>) {
     const valueX = useAnimatedValue(0.5, {useNativeDriver: true});
     _valueX = valueX;
     const offset = outputRangeX - 1;

--- a/packages/react-native/Libraries/Animated/animations/Animation.js
+++ b/packages/react-native/Libraries/Animated/animations/Animation.js
@@ -24,7 +24,7 @@ export type EndResult = {
 };
 export type EndCallback = (result: EndResult) => void;
 
-export type AnimationConfig = $ReadOnly<{
+export type AnimationConfig = Readonly<{
   isInteraction?: boolean,
   useNativeDriver: boolean,
   platformConfig?: PlatformConfig,
@@ -98,7 +98,7 @@ export default class Animation {
     this.__active = false;
   }
 
-  __getNativeAnimationConfig(): $ReadOnly<{
+  __getNativeAnimationConfig(): Readonly<{
     platformConfig: ?PlatformConfig,
     ...
   }> {

--- a/packages/react-native/Libraries/Animated/animations/DecayAnimation.js
+++ b/packages/react-native/Libraries/Animated/animations/DecayAnimation.js
@@ -14,11 +14,11 @@ import type {AnimationConfig, EndCallback} from './Animation';
 
 import Animation from './Animation';
 
-export type DecayAnimationConfig = $ReadOnly<{
+export type DecayAnimationConfig = Readonly<{
   ...AnimationConfig,
   velocity:
     | number
-    | $ReadOnly<{
+    | Readonly<{
         x: number,
         y: number,
         ...
@@ -27,7 +27,7 @@ export type DecayAnimationConfig = $ReadOnly<{
   ...
 }>;
 
-export type DecayAnimationConfigSingle = $ReadOnly<{
+export type DecayAnimationConfigSingle = Readonly<{
   ...AnimationConfig,
   velocity: number,
   deceleration?: number,
@@ -52,7 +52,7 @@ export default class DecayAnimation extends Animation {
     this._platformConfig = config.platformConfig;
   }
 
-  __getNativeAnimationConfig(): $ReadOnly<{
+  __getNativeAnimationConfig(): Readonly<{
     deceleration: number,
     iterations: number,
     platformConfig: ?PlatformConfig,

--- a/packages/react-native/Libraries/Animated/animations/SpringAnimation.js
+++ b/packages/react-native/Libraries/Animated/animations/SpringAnimation.js
@@ -19,7 +19,7 @@ import * as SpringConfig from '../SpringConfig';
 import Animation from './Animation';
 import invariant from 'invariant';
 
-export type SpringAnimationConfig = $ReadOnly<{
+export type SpringAnimationConfig = Readonly<{
   ...AnimationConfig,
   toValue:
     | number
@@ -44,7 +44,7 @@ export type SpringAnimationConfig = $ReadOnly<{
   restSpeedThreshold?: number,
   velocity?:
     | number
-    | $ReadOnly<{
+    | Readonly<{
         x: number,
         y: number,
         ...
@@ -60,7 +60,7 @@ export type SpringAnimationConfig = $ReadOnly<{
   ...
 }>;
 
-export type SpringAnimationConfigSingle = $ReadOnly<{
+export type SpringAnimationConfigSingle = Readonly<{
   ...AnimationConfig,
   toValue: number,
   overshootClamping?: boolean,
@@ -78,7 +78,7 @@ export type SpringAnimationConfigSingle = $ReadOnly<{
   ...
 }>;
 
-opaque type SpringAnimationInternalState = $ReadOnly<{
+opaque type SpringAnimationInternalState = Readonly<{
   lastPosition: number,
   lastVelocity: number,
   lastTime: number,
@@ -168,7 +168,7 @@ export default class SpringAnimation extends Animation {
     invariant(this._mass > 0, 'Mass value must be greater than 0');
   }
 
-  __getNativeAnimationConfig(): $ReadOnly<{
+  __getNativeAnimationConfig(): Readonly<{
     damping: number,
     initialVelocity: number,
     iterations: number,

--- a/packages/react-native/Libraries/Animated/animations/TimingAnimation.js
+++ b/packages/react-native/Libraries/Animated/animations/TimingAnimation.js
@@ -18,12 +18,12 @@ import type {AnimationConfig, EndCallback} from './Animation';
 import AnimatedColor from '../nodes/AnimatedColor';
 import Animation from './Animation';
 
-export type TimingAnimationConfig = $ReadOnly<{
+export type TimingAnimationConfig = Readonly<{
   ...AnimationConfig,
   toValue:
     | number
     | AnimatedValue
-    | $ReadOnly<{
+    | Readonly<{
         x: number,
         y: number,
         ...
@@ -38,7 +38,7 @@ export type TimingAnimationConfig = $ReadOnly<{
   ...
 }>;
 
-export type TimingAnimationConfigSingle = $ReadOnly<{
+export type TimingAnimationConfigSingle = Readonly<{
   ...AnimationConfig,
   toValue: number,
   easing?: (value: number) => number,
@@ -80,7 +80,7 @@ export default class TimingAnimation extends Animation {
     this._platformConfig = config.platformConfig;
   }
 
-  __getNativeAnimationConfig(): $ReadOnly<{
+  __getNativeAnimationConfig(): Readonly<{
     type: 'frames',
     frames: $ReadOnlyArray<number>,
     toValue: number,

--- a/packages/react-native/Libraries/Animated/createAnimatedComponent.js
+++ b/packages/react-native/Libraries/Animated/createAnimatedComponent.js
@@ -61,7 +61,7 @@ type NonAnimatedProps =
   | 'testID'
   | 'disabled'
   | 'accessibilityLabel';
-type PassThroughProps = $ReadOnly<{
+type PassThroughProps = Readonly<{
   passthroughAnimatedPropExplicitValues?: ViewProps | null,
 }>;
 
@@ -99,7 +99,7 @@ export default function createAnimatedComponent<
 >(
   Component: TInstance,
 ): AnimatedComponentType<
-  $ReadOnly<React.ElementConfig<TInstance>>,
+  Readonly<React.ElementConfig<TInstance>>,
   React.ElementRef<TInstance>,
 > {
   return unstable_createAnimatedComponentWithAllowlist(Component, null);

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedColor.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedColor.js
@@ -22,7 +22,7 @@ import {processColorObject} from '../../StyleSheet/PlatformColorValueTypes';
 import AnimatedValue, {flushValue} from './AnimatedValue';
 import AnimatedWithChildren from './AnimatedWithChildren';
 
-export type AnimatedColorConfig = $ReadOnly<{
+export type AnimatedColorConfig = Readonly<{
   ...AnimatedNodeConfig,
   useNativeDriver: boolean,
 }>;
@@ -112,7 +112,7 @@ function isRgbaAnimatedValue(value: any): boolean {
 
 export function getRgbaValueAndNativeColor(
   value: RgbaValue | ColorValue,
-): $ReadOnly<{
+): Readonly<{
   rgbaValue: RgbaValue,
   nativeColor?: NativeColorValue,
 }> {

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedInterpolation.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedInterpolation.js
@@ -34,7 +34,7 @@ export type InterpolationConfigSupportedOutputType =
 
 export type InterpolationConfigType<
   OutputT: InterpolationConfigSupportedOutputType,
-> = $ReadOnly<{
+> = Readonly<{
   ...AnimatedNodeConfig,
   inputRange: $ReadOnlyArray<number>,
   outputRange: $ReadOnlyArray<OutputT>,

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedNode.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedNode.js
@@ -15,7 +15,7 @@ import invariant from 'invariant';
 
 type ValueListenerCallback = (state: {value: number, ...}) => unknown;
 
-export type AnimatedNodeConfig = $ReadOnly<{
+export type AnimatedNodeConfig = Readonly<{
   debugID?: string,
   unstable_disableBatchingForNativeCreate?: boolean,
 }>;
@@ -34,7 +34,7 @@ export default class AnimatedNode {
   _platformConfig: ?PlatformConfig = undefined;
 
   constructor(
-    config?: ?$ReadOnly<{
+    config?: ?Readonly<{
       ...AnimatedNodeConfig,
       ...
     }>,

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedObject.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedObject.js
@@ -23,7 +23,7 @@ export function isPlainObject(
   value: unknown,
   /* $FlowFixMe[incompatible-type-guard] - Flow does not know that the prototype
      and ReactElement checks preserve the type refinement of `value`. */
-): value is $ReadOnly<{[string]: unknown}> {
+): value is Readonly<{[string]: unknown}> {
   const proto =
     value !== null && typeof value === 'object'
       ? Object.getPrototypeOf(value)

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js
@@ -24,7 +24,7 @@ import AnimatedObject from './AnimatedObject';
 import AnimatedStyle from './AnimatedStyle';
 import invariant from 'invariant';
 
-export type AnimatedPropsAllowlist = $ReadOnly<{
+export type AnimatedPropsAllowlist = Readonly<{
   style?: ?AnimatedStyleAllowlist,
   [key: string]: true | AnimatedStyleAllowlist,
 }>;
@@ -358,6 +358,6 @@ export default class AnimatedProps extends AnimatedNode {
 // this shim when they do.
 // $FlowFixMe[method-unbinding]
 const _hasOwnProp = Object.prototype.hasOwnProperty;
-const hasOwn: (obj: $ReadOnly<{...}>, prop: string) => boolean =
+const hasOwn: (obj: Readonly<{...}>, prop: string) => boolean =
   // $FlowFixMe[method-unbinding]
   Object.hasOwn ?? ((obj, prop) => _hasOwnProp.call(obj, prop));

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedStyle.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedStyle.js
@@ -19,7 +19,7 @@ import AnimatedObject from './AnimatedObject';
 import AnimatedTransform from './AnimatedTransform';
 import AnimatedWithChildren from './AnimatedWithChildren';
 
-export type AnimatedStyleAllowlist = $ReadOnly<{[string]: true}>;
+export type AnimatedStyleAllowlist = Readonly<{[string]: true}>;
 
 type FlatStyle = {[string]: unknown};
 type FlatStyleForWeb<TStyle: FlatStyle> = [unknown, TStyle];
@@ -253,6 +253,6 @@ export default class AnimatedStyle extends AnimatedWithChildren {
 // this shim when they do.
 // $FlowFixMe[method-unbinding]
 const _hasOwnProp = Object.prototype.hasOwnProperty;
-const hasOwn: (obj: $ReadOnly<{...}>, prop: string) => boolean =
+const hasOwn: (obj: Readonly<{...}>, prop: string) => boolean =
   // $FlowFixMe[method-unbinding]
   Object.hasOwn ?? ((obj, prop) => _hasOwnProp.call(obj, prop));

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedValue.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedValue.js
@@ -24,7 +24,7 @@ import NativeAnimatedHelper from '../../../src/private/animated/NativeAnimatedHe
 import AnimatedInterpolation from './AnimatedInterpolation';
 import AnimatedWithChildren from './AnimatedWithChildren';
 
-export type AnimatedValueConfig = $ReadOnly<{
+export type AnimatedValueConfig = Readonly<{
   ...AnimatedNodeConfig,
   useNativeDriver: boolean,
 }>;

--- a/packages/react-native/Libraries/Animated/nodes/AnimatedValueXY.js
+++ b/packages/react-native/Libraries/Animated/nodes/AnimatedValueXY.js
@@ -17,7 +17,7 @@ import AnimatedValue from './AnimatedValue';
 import AnimatedWithChildren from './AnimatedWithChildren';
 import invariant from 'invariant';
 
-export type AnimatedValueXYConfig = $ReadOnly<{
+export type AnimatedValueXYConfig = Readonly<{
   ...AnimatedNodeConfig,
   useNativeDriver: boolean,
 }>;

--- a/packages/react-native/Libraries/Components/ActivityIndicator/ActivityIndicator.js
+++ b/packages/react-native/Libraries/Components/ActivityIndicator/ActivityIndicator.js
@@ -26,7 +26,7 @@ const GRAY = '#999999';
 
 type IndicatorSize = number | 'small' | 'large';
 
-type ActivityIndicatorIOSProps = $ReadOnly<{
+type ActivityIndicatorIOSProps = Readonly<{
   /**
     Whether the indicator should hide when not animating.
 
@@ -34,7 +34,7 @@ type ActivityIndicatorIOSProps = $ReadOnly<{
   */
   hidesWhenStopped?: ?boolean,
 }>;
-export type ActivityIndicatorProps = $ReadOnly<{
+export type ActivityIndicatorProps = Readonly<{
   ...ViewProps,
   ...ActivityIndicatorIOSProps,
 

--- a/packages/react-native/Libraries/Components/Button.js
+++ b/packages/react-native/Libraries/Components/Button.js
@@ -27,7 +27,7 @@ import View from './View/View';
 import invariant from 'invariant';
 import * as React from 'react';
 
-export type ButtonProps = $ReadOnly<{
+export type ButtonProps = Readonly<{
   /**
     Text to display inside the button. On Android the given title will be
     converted to the uppercased form.

--- a/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroidTypes.js
+++ b/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroidTypes.js
@@ -22,12 +22,12 @@ import * as React from 'react';
 export type DrawerStates = 'Idle' | 'Dragging' | 'Settling';
 
 export type DrawerSlideEvent = NativeSyntheticEvent<
-  $ReadOnly<{
+  Readonly<{
     offset: number,
   }>,
 >;
 
-export type DrawerLayoutAndroidProps = $ReadOnly<{
+export type DrawerLayoutAndroidProps = Readonly<{
   ...ViewProps,
 
   /**

--- a/packages/react-native/Libraries/Components/Keyboard/Keyboard.js
+++ b/packages/react-native/Libraries/Components/Keyboard/Keyboard.js
@@ -25,7 +25,7 @@ export type KeyboardEventEasing =
   | 'linear'
   | 'keyboard';
 
-export type KeyboardMetrics = $ReadOnly<{
+export type KeyboardMetrics = Readonly<{
   screenX: number,
   screenY: number,
   width: number,
@@ -40,13 +40,13 @@ type BaseKeyboardEvent = {
   endCoordinates: KeyboardMetrics,
 };
 
-export type AndroidKeyboardEvent = $ReadOnly<{
+export type AndroidKeyboardEvent = Readonly<{
   ...BaseKeyboardEvent,
   duration: 0,
   easing: 'keyboard',
 }>;
 
-export type IOSKeyboardEvent = $ReadOnly<{
+export type IOSKeyboardEvent = Readonly<{
   ...BaseKeyboardEvent,
   startCoordinates: KeyboardMetrics,
   isEventFromThisApp: boolean,

--- a/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -26,7 +26,7 @@ import Keyboard from './Keyboard';
 import * as React from 'react';
 import {createRef} from 'react';
 
-export type KeyboardAvoidingViewProps = $ReadOnly<{
+export type KeyboardAvoidingViewProps = Readonly<{
   ...ViewProps,
 
   /**

--- a/packages/react-native/Libraries/Components/LayoutConformance/LayoutConformance.js
+++ b/packages/react-native/Libraries/Components/LayoutConformance/LayoutConformance.js
@@ -12,7 +12,7 @@ import StyleSheet from '../../StyleSheet/StyleSheet';
 import LayoutConformanceNativeComponent from './LayoutConformanceNativeComponent';
 import * as React from 'react';
 
-export type LayoutConformanceProps = $ReadOnly<{
+export type LayoutConformanceProps = Readonly<{
   /**
    * strict: Layout in accordance with W3C spec, even when breaking
    * compatibility: Layout with the same behavior as previous versions of React Native

--- a/packages/react-native/Libraries/Components/LayoutConformance/LayoutConformanceNativeComponent.js
+++ b/packages/react-native/Libraries/Components/LayoutConformance/LayoutConformanceNativeComponent.js
@@ -13,7 +13,7 @@ import type {ViewProps} from '../View/ViewPropTypes';
 
 import * as NativeComponentRegistry from '../../NativeComponent/NativeComponentRegistry';
 
-type Props = $ReadOnly<{
+type Props = Readonly<{
   mode: 'strict' | 'compatibility',
   ...ViewProps,
 }>;

--- a/packages/react-native/Libraries/Components/Pressable/Pressable.js
+++ b/packages/react-native/Libraries/Components/Pressable/Pressable.js
@@ -29,11 +29,11 @@ import {memo, useMemo, useRef, useState} from 'react';
 
 export type {PressableAndroidRippleConfig};
 
-export type PressableStateCallbackType = $ReadOnly<{
+export type PressableStateCallbackType = Readonly<{
   pressed: boolean,
 }>;
 
-type PressableBaseProps = $ReadOnly<{
+type PressableBaseProps = Readonly<{
   /**
    * Whether a press gesture can be interrupted by a parent gesture such as a
    * scroll event. Defaults to true.
@@ -156,7 +156,7 @@ type PressableBaseProps = $ReadOnly<{
   unstable_pressDelay?: ?number,
 }>;
 
-export type PressableProps = $ReadOnly<{
+export type PressableProps = Readonly<{
   // Pressability may override `onMouseEnter` and `onMouseLeave` to
   // implement `onHoverIn` and `onHoverOut` in a platform-agnostic way.
   // Hover events should be used instead of mouse events.

--- a/packages/react-native/Libraries/Components/Pressable/useAndroidRippleForView.js
+++ b/packages/react-native/Libraries/Components/Pressable/useAndroidRippleForView.js
@@ -19,7 +19,7 @@ import invariant from 'invariant';
 import * as React from 'react';
 import {useMemo} from 'react';
 
-type NativeBackgroundProp = $ReadOnly<{
+type NativeBackgroundProp = Readonly<{
   type: 'RippleAndroid',
   color: ?number,
   borderless: boolean,
@@ -40,13 +40,13 @@ export type PressableAndroidRippleConfig = {
 export default function useAndroidRippleForView(
   rippleConfig: ?PressableAndroidRippleConfig,
   viewRef: {current: null | React.ElementRef<typeof View>},
-): ?$ReadOnly<{
+): ?Readonly<{
   onPressIn: (event: GestureResponderEvent) => void,
   onPressMove: (event: GestureResponderEvent) => void,
   onPressOut: (event: GestureResponderEvent) => void,
   viewProps:
-    | $ReadOnly<{nativeBackgroundAndroid: NativeBackgroundProp}>
-    | $ReadOnly<{nativeForegroundAndroid: NativeBackgroundProp}>,
+    | Readonly<{nativeBackgroundAndroid: NativeBackgroundProp}>
+    | Readonly<{nativeForegroundAndroid: NativeBackgroundProp}>,
 }> {
   const {color, borderless, radius, foreground} = rippleConfig ?? {};
 

--- a/packages/react-native/Libraries/Components/ProgressBarAndroid/ProgressBarAndroidTypes.js
+++ b/packages/react-native/Libraries/Components/ProgressBarAndroid/ProgressBarAndroidTypes.js
@@ -35,7 +35,7 @@ type IndeterminateProgressBarAndroidStyleAttrProp = {
   indeterminate: true,
 };
 
-type ProgressBarAndroidBaseProps = $ReadOnly<{
+type ProgressBarAndroidBaseProps = Readonly<{
   /**
    * Whether to show the ProgressBar (true, the default) or hide it (false).
    */
@@ -51,12 +51,12 @@ type ProgressBarAndroidBaseProps = $ReadOnly<{
 }>;
 
 export type ProgressBarAndroidProps =
-  | $ReadOnly<{
+  | Readonly<{
       ...ViewProps,
       ...ProgressBarAndroidBaseProps,
       ...DeterminateProgressBarAndroidStyleAttrProp,
     }>
-  | $ReadOnly<{
+  | Readonly<{
       ...ViewProps,
       ...ProgressBarAndroidBaseProps,
       ...IndeterminateProgressBarAndroidStyleAttrProp,

--- a/packages/react-native/Libraries/Components/RefreshControl/RefreshControl.js
+++ b/packages/react-native/Libraries/Components/RefreshControl/RefreshControl.js
@@ -21,7 +21,7 @@ import * as React from 'react';
 
 const Platform = require('../../Utilities/Platform').default;
 
-export type RefreshControlPropsIOS = $ReadOnly<{
+export type RefreshControlPropsIOS = Readonly<{
   /**
    * The color of the refresh indicator.
    */
@@ -36,7 +36,7 @@ export type RefreshControlPropsIOS = $ReadOnly<{
   title?: ?string,
 }>;
 
-export type RefreshControlPropsAndroid = $ReadOnly<{
+export type RefreshControlPropsAndroid = Readonly<{
   /**
    * Whether the pull to refresh functionality is enabled.
    */
@@ -55,7 +55,7 @@ export type RefreshControlPropsAndroid = $ReadOnly<{
   size?: ?('default' | 'large'),
 }>;
 
-type RefreshControlBaseProps = $ReadOnly<{
+type RefreshControlBaseProps = Readonly<{
   /**
    * Called when the view starts refreshing.
    */
@@ -72,7 +72,7 @@ type RefreshControlBaseProps = $ReadOnly<{
   progressViewOffset?: ?number,
 }>;
 
-export type RefreshControlProps = $ReadOnly<{
+export type RefreshControlProps = Readonly<{
   ...ViewProps,
   ...RefreshControlPropsIOS,
   ...RefreshControlPropsAndroid,

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
@@ -174,7 +174,7 @@ export interface PublicScrollViewInstance
 
 type InnerViewInstance = React.ElementRef<typeof View>;
 
-export type ScrollViewPropsIOS = $ReadOnly<{
+export type ScrollViewPropsIOS = Readonly<{
   /**
    * Controls whether iOS should automatically adjust the content inset
    * for scroll views that are placed behind a navigation bar or
@@ -330,7 +330,7 @@ export type ScrollViewPropsIOS = $ReadOnly<{
   ),
 }>;
 
-export type ScrollViewPropsAndroid = $ReadOnly<{
+export type ScrollViewPropsAndroid = Readonly<{
   /**
    * Enables nested scrolling for Android API level 21+.
    * Nested scrolling is supported by default on iOS
@@ -391,11 +391,11 @@ export type ScrollViewPropsAndroid = $ReadOnly<{
 }>;
 
 type StickyHeaderComponentType = component(
-  ref?: React.RefSetter<$ReadOnly<interface {setNextHeaderY: number => void}>>,
+  ref?: React.RefSetter<Readonly<interface {setNextHeaderY: number => void}>>,
   ...ScrollViewStickyHeaderProps
 );
 
-type ScrollViewBaseProps = $ReadOnly<{
+type ScrollViewBaseProps = Readonly<{
   /**
    * These styles will be applied to the scroll view content container which
    * wraps all of the child views. Example:
@@ -514,7 +514,7 @@ type ScrollViewBaseProps = $ReadOnly<{
    * whether content is "visible" or not.
    *
    */
-  maintainVisibleContentPosition?: ?$ReadOnly<{
+  maintainVisibleContentPosition?: ?Readonly<{
     minIndexForVisible: number,
     autoscrollToTopThreshold?: ?number,
   }>,
@@ -673,7 +673,7 @@ type ScrollViewBaseProps = $ReadOnly<{
   scrollViewRef?: React.RefSetter<PublicScrollViewInstance>,
 }>;
 
-export type ScrollViewProps = $ReadOnly<{
+export type ScrollViewProps = Readonly<{
   ...Omit<ViewProps, 'experimental_accessibilityOrder'>,
   ...ScrollViewPropsIOS,
   ...ScrollViewPropsAndroid,
@@ -686,7 +686,7 @@ type ScrollViewState = {
 
 const IS_ANIMATING_TOUCH_START_THRESHOLD_MS = 16;
 
-export type ScrollViewComponentStatics = $ReadOnly<{
+export type ScrollViewComponentStatics = Readonly<{
   Context: typeof ScrollViewContext,
 }>;
 

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollViewNativeComponentType.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollViewNativeComponentType.js
@@ -19,7 +19,7 @@ import type {
 } from '../../Types/CoreEventTypes';
 import type {ViewProps} from '../View/ViewPropTypes';
 
-export type ScrollViewNativeProps = $ReadOnly<{
+export type ScrollViewNativeProps = Readonly<{
   ...ViewProps,
   alwaysBounceHorizontal?: ?boolean,
   alwaysBounceVertical?: ?boolean,
@@ -46,7 +46,7 @@ export type ScrollViewNativeProps = $ReadOnly<{
   indicatorStyle?: ?('default' | 'black' | 'white'),
   isInvertedVirtualizedList?: ?boolean,
   keyboardDismissMode?: ?('none' | 'on-drag' | 'interactive'),
-  maintainVisibleContentPosition?: ?$ReadOnly<{
+  maintainVisibleContentPosition?: ?Readonly<{
     minIndexForVisible: number,
     autoscrollToTopThreshold?: ?number,
   }>,

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollViewStickyHeader.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollViewStickyHeader.js
@@ -25,7 +25,7 @@ import {
   useState,
 } from 'react';
 
-export type ScrollViewStickyHeaderProps = $ReadOnly<{
+export type ScrollViewStickyHeaderProps = Readonly<{
   children?: React.Node,
   nextHeaderLayoutY: ?number,
   onLayout: (event: LayoutChangeEvent) => void,

--- a/packages/react-native/Libraries/Components/StaticRenderer.js
+++ b/packages/react-native/Libraries/Components/StaticRenderer.js
@@ -12,7 +12,7 @@
 
 import * as React from 'react';
 
-type Props = $ReadOnly<{
+type Props = Readonly<{
   /**
    * Indicates whether the render function needs to be called again
    */

--- a/packages/react-native/Libraries/Components/StatusBar/StatusBar.js
+++ b/packages/react-native/Libraries/Components/StatusBar/StatusBar.js
@@ -55,7 +55,7 @@ export type StatusBarAnimation = $Keys<{
   ...
 }>;
 
-export type StatusBarPropsAndroid = $ReadOnly<{
+export type StatusBarPropsAndroid = Readonly<{
   /**
    * The background color of the status bar.
    *
@@ -76,7 +76,7 @@ export type StatusBarPropsAndroid = $ReadOnly<{
   translucent?: ?boolean,
 }>;
 
-export type StatusBarPropsIOS = $ReadOnly<{
+export type StatusBarPropsIOS = Readonly<{
   /**
    * If the network activity indicator should be visible.
    *
@@ -92,7 +92,7 @@ export type StatusBarPropsIOS = $ReadOnly<{
   showHideTransition?: ?('fade' | 'slide' | 'none'),
 }>;
 
-type StatusBarBaseProps = $ReadOnly<{
+type StatusBarBaseProps = Readonly<{
   /**
    * If the status bar is hidden.
    */
@@ -108,7 +108,7 @@ type StatusBarBaseProps = $ReadOnly<{
   barStyle?: ?('default' | 'light-content' | 'dark-content'),
 }>;
 
-export type StatusBarProps = $ReadOnly<{
+export type StatusBarProps = Readonly<{
   ...StatusBarPropsAndroid,
   ...StatusBarPropsIOS,
   ...StatusBarBaseProps,

--- a/packages/react-native/Libraries/Components/Switch/Switch.js
+++ b/packages/react-native/Libraries/Components/Switch/Switch.js
@@ -48,7 +48,7 @@ export type SwitchPropsIOS = {
   tintColor?: ?ColorValue,
 };
 
-type SwitchChangeEventData = $ReadOnly<{
+type SwitchChangeEventData = Readonly<{
   target: number,
   value: boolean,
 }>;
@@ -82,7 +82,7 @@ type SwitchPropsBase = {
       color of the background exposed by the shrunken track, use
        [`ios_backgroundColor`](https://reactnative.dev/docs/switch#ios_backgroundColor).
      */
-  trackColor?: ?$ReadOnly<{
+  trackColor?: ?Readonly<{
     false?: ?ColorValue,
     true?: ?ColorValue,
   }>,
@@ -109,7 +109,7 @@ type SwitchPropsBase = {
   onValueChange?: ?(value: boolean) => Promise<void> | void,
 };
 
-export type SwitchProps = $ReadOnly<{
+export type SwitchProps = Readonly<{
   ...ViewProps,
   ...SwitchPropsIOS,
   ...SwitchPropsBase,

--- a/packages/react-native/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
+++ b/packages/react-native/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
@@ -63,7 +63,7 @@ export type ReturnKeyType =
 
 export type SubmitBehavior = 'submit' | 'blurAndSubmit' | 'newline';
 
-export type AndroidTextInputNativeProps = $ReadOnly<{
+export type AndroidTextInputNativeProps = Readonly<{
   // This allows us to inherit everything from ViewProps except for style (see below)
   // This must be commented for Fabric codegen to work.
   ...Omit<ViewProps, 'style'>,
@@ -339,13 +339,13 @@ export type AndroidTextInputNativeProps = $ReadOnly<{
    * Callback that is called when the text input is blurred.
    * `target` is the reactTag of the element
    */
-  onBlur?: ?BubblingEventHandler<$ReadOnly<{target: Int32}>>,
+  onBlur?: ?BubblingEventHandler<Readonly<{target: Int32}>>,
 
   /**
    * Callback that is called when the text input is focused.
    * `target` is the reactTag of the element
    */
-  onFocus?: ?BubblingEventHandler<$ReadOnly<{target: Int32}>>,
+  onFocus?: ?BubblingEventHandler<Readonly<{target: Int32}>>,
 
   /**
    * Callback that is called when the text input's text changes.
@@ -353,7 +353,7 @@ export type AndroidTextInputNativeProps = $ReadOnly<{
    * TODO: differentiate between onChange and onChangeText
    */
   onChange?: ?BubblingEventHandler<
-    $ReadOnly<{target: Int32, eventCount: Int32, text: string}>,
+    Readonly<{target: Int32, eventCount: Int32, text: string}>,
   >,
 
   /**
@@ -362,7 +362,7 @@ export type AndroidTextInputNativeProps = $ReadOnly<{
    * TODO: differentiate between onChange and onChangeText
    */
   onChangeText?: ?BubblingEventHandler<
-    $ReadOnly<{target: Int32, eventCount: Int32, text: string}>,
+    Readonly<{target: Int32, eventCount: Int32, text: string}>,
   >,
 
   /**
@@ -373,18 +373,16 @@ export type AndroidTextInputNativeProps = $ReadOnly<{
    * Only called for multiline text inputs.
    */
   onContentSizeChange?: ?DirectEventHandler<
-    $ReadOnly<{
+    Readonly<{
       target: Int32,
-      contentSize: $ReadOnly<{width: Double, height: Double}>,
+      contentSize: Readonly<{width: Double, height: Double}>,
     }>,
   >,
 
   /**
    * Callback that is called when text input ends.
    */
-  onEndEditing?: ?BubblingEventHandler<
-    $ReadOnly<{target: Int32, text: string}>,
-  >,
+  onEndEditing?: ?BubblingEventHandler<Readonly<{target: Int32, text: string}>>,
 
   /**
    * Callback that is called when the text input selection is changed.
@@ -392,9 +390,9 @@ export type AndroidTextInputNativeProps = $ReadOnly<{
    * `{ nativeEvent: { selection: { start, end } } }`.
    */
   onSelectionChange?: ?DirectEventHandler<
-    $ReadOnly<{
+    Readonly<{
       target: Int32,
-      selection: $ReadOnly<{start: Double, end: Double}>,
+      selection: Readonly<{start: Double, end: Double}>,
     }>,
   >,
 
@@ -403,7 +401,7 @@ export type AndroidTextInputNativeProps = $ReadOnly<{
    * Invalid if `multiline={true}` is specified.
    */
   onSubmitEditing?: ?BubblingEventHandler<
-    $ReadOnly<{target: Int32, text: string}>,
+    Readonly<{target: Int32, text: string}>,
   >,
 
   /**
@@ -413,7 +411,7 @@ export type AndroidTextInputNativeProps = $ReadOnly<{
    * the typed-in character otherwise including `' '` for space.
    * Fires before `onChange` callbacks.
    */
-  onKeyPress?: ?BubblingEventHandler<$ReadOnly<{target: Int32, key: string}>>,
+  onKeyPress?: ?BubblingEventHandler<Readonly<{target: Int32, key: string}>>,
 
   /**
    * Invoked on content scroll with `{ nativeEvent: { contentOffset: { x, y } } }`.
@@ -421,28 +419,28 @@ export type AndroidTextInputNativeProps = $ReadOnly<{
    * is not provided for performance reasons.
    */
   onScroll?: ?DirectEventHandler<
-    $ReadOnly<{
+    Readonly<{
       target: Int32,
       responderIgnoreScroll: boolean,
-      contentInset: $ReadOnly<{
+      contentInset: Readonly<{
         top: Double, // always 0 on Android
         bottom: Double, // always 0 on Android
         left: Double, // always 0 on Android
         right: Double, // always 0 on Android
       }>,
-      contentOffset: $ReadOnly<{
+      contentOffset: Readonly<{
         x: Double,
         y: Double,
       }>,
-      contentSize: $ReadOnly<{
+      contentSize: Readonly<{
         width: Double, // always 0 on Android
         height: Double, // always 0 on Android
       }>,
-      layoutMeasurement: $ReadOnly<{
+      layoutMeasurement: Readonly<{
         width: Double,
         height: Double,
       }>,
-      velocity: $ReadOnly<{
+      velocity: Readonly<{
         x: Double, // always 0 on Android
         y: Double, // always 0 on Android
       }>,
@@ -479,7 +477,7 @@ export type AndroidTextInputNativeProps = $ReadOnly<{
    * The start and end of the text input's selection. Set start and end to
    * the same value to position the cursor.
    */
-  selection?: ?$ReadOnly<{
+  selection?: ?Readonly<{
     start: Int32,
     end?: ?Int32,
   }>,
@@ -582,7 +580,7 @@ export type AndroidTextInputNativeProps = $ReadOnly<{
   textShadowRadius?: ?Float,
   textDecorationLine?: ?string,
   fontStyle?: ?string,
-  textShadowOffset?: ?$ReadOnly<{width?: ?Double, height?: ?Double}>,
+  textShadowOffset?: ?Readonly<{width?: ?Double, height?: ?Double}>,
   lineHeight?: ?Float,
   textTransform?: ?string,
   color?: ?Int32,

--- a/packages/react-native/Libraries/Components/TextInput/InputAccessoryView.js
+++ b/packages/react-native/Libraries/Components/TextInput/InputAccessoryView.js
@@ -76,7 +76,7 @@ import * as React from 'react';
  * For an example, look at InputAccessoryViewExample.js in RNTester.
  */
 
-export type InputAccessoryViewProps = $ReadOnly<{
+export type InputAccessoryViewProps = Readonly<{
   +children: React.Node,
   /**
    * An ID which is used to associate this `InputAccessoryView` to

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
@@ -25,7 +25,7 @@ import * as React from 'react';
 /**
  * @see TextInputProps.onChange
  */
-type TextInputChangeEventData = $ReadOnly<{
+type TextInputChangeEventData = Readonly<{
   eventCount: number,
   target: number,
   text: string,
@@ -35,10 +35,10 @@ export type TextInputChangeEvent =
   NativeSyntheticEvent<TextInputChangeEventData>;
 
 export type TextInputEvent = NativeSyntheticEvent<
-  $ReadOnly<{
+  Readonly<{
     eventCount: number,
     previousText: string,
-    range: $ReadOnly<{
+    range: Readonly<{
       start: number,
       end: number,
     }>,
@@ -47,9 +47,9 @@ export type TextInputEvent = NativeSyntheticEvent<
   }>,
 >;
 
-type TextInputContentSizeChangeEventData = $ReadOnly<{
+type TextInputContentSizeChangeEventData = Readonly<{
   target: number,
-  contentSize: $ReadOnly<{
+  contentSize: Readonly<{
     width: number,
     height: number,
   }>,
@@ -73,17 +73,17 @@ export type TextInputBlurEvent = BlurEvent;
  */
 export type TextInputFocusEvent = FocusEvent;
 
-type TargetEvent = $ReadOnly<{
+type TargetEvent = Readonly<{
   target: number,
   ...
 }>;
 
-export type Selection = $ReadOnly<{
+export type Selection = Readonly<{
   start: number,
   end: number,
 }>;
 
-type TextInputSelectionChangeEventData = $ReadOnly<{
+type TextInputSelectionChangeEventData = Readonly<{
   ...TargetEvent,
   selection: Selection,
   ...
@@ -95,7 +95,7 @@ type TextInputSelectionChangeEventData = $ReadOnly<{
 export type TextInputSelectionChangeEvent =
   NativeSyntheticEvent<TextInputSelectionChangeEventData>;
 
-type TextInputKeyPressEventData = $ReadOnly<{
+type TextInputKeyPressEventData = Readonly<{
   ...TargetEvent,
   key: string,
   target?: ?number,
@@ -109,7 +109,7 @@ type TextInputKeyPressEventData = $ReadOnly<{
 export type TextInputKeyPressEvent =
   NativeSyntheticEvent<TextInputKeyPressEventData>;
 
-type TextInputEndEditingEventData = $ReadOnly<{
+type TextInputEndEditingEventData = Readonly<{
   ...TargetEvent,
   eventCount: number,
   text: string,
@@ -122,7 +122,7 @@ type TextInputEndEditingEventData = $ReadOnly<{
 export type TextInputEndEditingEvent =
   NativeSyntheticEvent<TextInputEndEditingEventData>;
 
-type TextInputSubmitEditingEventData = $ReadOnly<{
+type TextInputSubmitEditingEventData = Readonly<{
   ...TargetEvent,
   eventCount: number,
   text: string,
@@ -266,7 +266,7 @@ export type EnterKeyHintTypeOptions =
 
 type PasswordRules = string;
 
-export type TextInputIOSProps = $ReadOnly<{
+export type TextInputIOSProps = Readonly<{
   /**
    * If true, the keyboard shortcuts (undo/redo and copy buttons) are disabled. The default value is false.
    * @platform ios
@@ -403,7 +403,7 @@ export type TextInputIOSProps = $ReadOnly<{
   smartInsertDelete?: ?boolean,
 }>;
 
-export type TextInputAndroidProps = $ReadOnly<{
+export type TextInputAndroidProps = Readonly<{
   /**
    * When provided it will set the color of the cursor (or "caret") in the component.
    * Unlike the behavior of `selectionColor` the cursor color will be set independently
@@ -512,7 +512,7 @@ export type TextInputAndroidProps = $ReadOnly<{
   underlineColorAndroid?: ?ColorValue,
 }>;
 
-type TextInputBaseProps = $ReadOnly<{
+type TextInputBaseProps = Readonly<{
   /**
    * When provided, the text input will only accept drag and drop events for the specified
    * types. If null or not provided, the text input will accept all types of drag and drop events.
@@ -946,7 +946,7 @@ type TextInputBaseProps = $ReadOnly<{
    * The start and end of the text input's selection. Set start and end to
    * the same value to position the cursor.
    */
-  selection?: ?$ReadOnly<{
+  selection?: ?Readonly<{
     start: number,
     end?: ?number,
   }>,
@@ -1031,7 +1031,7 @@ type TextInputBaseProps = $ReadOnly<{
   textAlign?: ?('left' | 'center' | 'right'),
 }>;
 
-export type TextInputProps = $ReadOnly<{
+export type TextInputProps = Readonly<{
   ...Omit<ViewProps, 'style' | 'experimental_accessibilityOrder'>,
   ...TextInputIOSProps,
   ...TextInputAndroidProps,
@@ -1167,8 +1167,8 @@ type InternalTextInput = component(
   ...TextInputProps
 );
 
-export type TextInputComponentStatics = $ReadOnly<{
-  State: $ReadOnly<{
+export type TextInputComponentStatics = Readonly<{
+  State: Readonly<{
     currentlyFocusedInput: () => ?HostInstance,
     currentlyFocusedField: () => ?number,
     focusTextInput: (textField: ?HostInstance) => void,

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.js
@@ -120,7 +120,7 @@ export type {
   TextInputSubmitEditingEvent,
 };
 
-type TextInputStateType = $ReadOnly<{
+type TextInputStateType = Readonly<{
   /**
    * @deprecated Use currentlyFocusedInput
    * Returns the ID of the currently focused text field, if one exists
@@ -965,7 +965,7 @@ TextInput.State = {
   focusTextInput: TextInputState.focusTextInput,
 };
 
-export type TextInputComponentStatics = $ReadOnly<{
+export type TextInputComponentStatics = Readonly<{
   State: TextInputStateType,
 }>;
 

--- a/packages/react-native/Libraries/Components/Touchable/TouchableBounce.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableBounce.js
@@ -19,7 +19,7 @@ import {PressabilityDebugView} from '../../Pressability/PressabilityDebug';
 import Platform from '../../Utilities/Platform';
 import * as React from 'react';
 
-type TouchableBounceProps = $ReadOnly<{
+type TouchableBounceProps = Readonly<{
   ...React.ElementConfig<TouchableWithoutFeedback>,
 
   onPressAnimationComplete?: ?() => void,
@@ -31,7 +31,7 @@ type TouchableBounceProps = $ReadOnly<{
   hostRef: React.RefSetter<React.ElementRef<typeof Animated.View>>,
 }>;
 
-type TouchableBounceState = $ReadOnly<{
+type TouchableBounceState = Readonly<{
   pressability: Pressability,
   scale: Animated.Value,
 }>;
@@ -226,10 +226,10 @@ export default (function TouchableBounceWrapper({
   ...props
 }: {
   ref: React.RefSetter<unknown>,
-  ...$ReadOnly<Omit<TouchableBounceProps, 'hostRef'>>,
+  ...Readonly<Omit<TouchableBounceProps, 'hostRef'>>,
 }) {
   return <TouchableBounce {...props} hostRef={hostRef} />;
 } as component(
   ref?: React.RefSetter<unknown>,
-  ...props: $ReadOnly<Omit<TouchableBounceProps, 'hostRef'>>
+  ...props: Readonly<Omit<TouchableBounceProps, 'hostRef'>>
 ));

--- a/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
@@ -22,7 +22,7 @@ import Platform from '../../Utilities/Platform';
 import * as React from 'react';
 import {cloneElement} from 'react';
 
-type AndroidProps = $ReadOnly<{
+type AndroidProps = Readonly<{
   nextFocusDown?: ?number,
   nextFocusForward?: ?number,
   nextFocusLeft?: ?number,
@@ -30,14 +30,14 @@ type AndroidProps = $ReadOnly<{
   nextFocusUp?: ?number,
 }>;
 
-type IOSProps = $ReadOnly<{
+type IOSProps = Readonly<{
   /**
    * @deprecated Use `focusable` instead
    */
   hasTVPreferredFocus?: ?boolean,
 }>;
 
-type TouchableHighlightBaseProps = $ReadOnly<{
+type TouchableHighlightBaseProps = Readonly<{
   /**
    * Determines what the opacity of the wrapped view should be when touch is active.
    */
@@ -63,19 +63,19 @@ type TouchableHighlightBaseProps = $ReadOnly<{
   hostRef?: React.RefSetter<React.ElementRef<typeof View>>,
 }>;
 
-export type TouchableHighlightProps = $ReadOnly<{
+export type TouchableHighlightProps = Readonly<{
   ...TouchableWithoutFeedbackProps,
   ...AndroidProps,
   ...IOSProps,
   ...TouchableHighlightBaseProps,
 }>;
 
-type ExtraStyles = $ReadOnly<{
+type ExtraStyles = Readonly<{
   child: ViewStyleProp,
   underlay: ViewStyleProp,
 }>;
 
-type TouchableHighlightState = $ReadOnly<{
+type TouchableHighlightState = Readonly<{
   pressability: Pressability,
   extraStyles: ?ExtraStyles,
 }>;
@@ -412,13 +412,13 @@ class TouchableHighlightImpl extends React.Component<
 
 const TouchableHighlight: component(
   ref?: React.RefSetter<React.ElementRef<typeof View>>,
-  ...props: $ReadOnly<Omit<TouchableHighlightProps, 'hostRef'>>
+  ...props: Readonly<Omit<TouchableHighlightProps, 'hostRef'>>
 ) = ({
   ref: hostRef,
   ...props
 }: {
   ref?: React.RefSetter<React.ElementRef<typeof View>>,
-  ...$ReadOnly<Omit<TouchableHighlightProps, 'hostRef'>>,
+  ...Readonly<Omit<TouchableHighlightProps, 'hostRef'>>,
 }) => <TouchableHighlightImpl {...props} hostRef={hostRef} />;
 
 TouchableHighlight.displayName = 'TouchableHighlight';

--- a/packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js
@@ -69,7 +69,7 @@ type TouchableNativeFeedbackTVProps = {
   nextFocusUp?: ?number,
 };
 
-export type TouchableNativeFeedbackProps = $ReadOnly<{
+export type TouchableNativeFeedbackProps = Readonly<{
   ...TouchableWithoutFeedbackProps,
   ...TouchableNativeFeedbackTVProps,
   /**
@@ -87,14 +87,14 @@ export type TouchableNativeFeedbackProps = $ReadOnly<{
    *         type is available on Android API level 21+
    */
   background?: ?(
-    | $ReadOnly<{
+    | Readonly<{
         type: 'ThemeAttrAndroid',
         attribute:
           | 'selectableItemBackground'
           | 'selectableItemBackgroundBorderless',
         rippleRadius: ?number,
       }>
-    | $ReadOnly<{
+    | Readonly<{
         type: 'RippleAndroid',
         color: ?number,
         borderless: boolean,
@@ -114,7 +114,7 @@ export type TouchableNativeFeedbackProps = $ReadOnly<{
   useForeground?: ?boolean,
 }>;
 
-type TouchableNativeFeedbackState = $ReadOnly<{
+type TouchableNativeFeedbackState = Readonly<{
   pressability: Pressability,
 }>;
 
@@ -138,7 +138,7 @@ class TouchableNativeFeedback extends React.Component<
    *
    * @param rippleRadius The radius of ripple effect
    */
-  static SelectableBackground: (rippleRadius?: ?number) => $ReadOnly<{
+  static SelectableBackground: (rippleRadius?: ?number) => Readonly<{
     attribute: 'selectableItemBackground',
     type: 'ThemeAttrAndroid',
     rippleRadius: ?number,
@@ -155,7 +155,7 @@ class TouchableNativeFeedback extends React.Component<
    *
    * @param rippleRadius The radius of ripple effect
    */
-  static SelectableBackgroundBorderless: (rippleRadius?: ?number) => $ReadOnly<{
+  static SelectableBackgroundBorderless: (rippleRadius?: ?number) => Readonly<{
     attribute: 'selectableItemBackgroundBorderless',
     type: 'ThemeAttrAndroid',
     rippleRadius: ?number,
@@ -180,7 +180,7 @@ class TouchableNativeFeedback extends React.Component<
     color: string,
     borderless: boolean,
     rippleRadius?: ?number,
-  ) => $ReadOnly<{
+  ) => Readonly<{
     borderless: boolean,
     color: ?number,
     rippleRadius: ?number,

--- a/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
@@ -21,7 +21,7 @@ import flattenStyle from '../../StyleSheet/flattenStyle';
 import Platform from '../../Utilities/Platform';
 import * as React from 'react';
 
-export type TouchableOpacityTVProps = $ReadOnly<{
+export type TouchableOpacityTVProps = Readonly<{
   /**
    * *(Apple TV only)* TV preferred focus (see documentation for the View component).
    *
@@ -66,7 +66,7 @@ export type TouchableOpacityTVProps = $ReadOnly<{
   nextFocusUp?: ?number,
 }>;
 
-type TouchableOpacityBaseProps = $ReadOnly<{
+type TouchableOpacityBaseProps = Readonly<{
   /**
    * Determines what the opacity of the wrapped view should be when touch is active.
    * Defaults to 0.2
@@ -77,13 +77,13 @@ type TouchableOpacityBaseProps = $ReadOnly<{
   hostRef?: ?React.RefSetter<React.ElementRef<typeof Animated.View>>,
 }>;
 
-export type TouchableOpacityProps = $ReadOnly<{
+export type TouchableOpacityProps = Readonly<{
   ...TouchableWithoutFeedbackProps,
   ...TouchableOpacityTVProps,
   ...TouchableOpacityBaseProps,
 }>;
 
-type TouchableOpacityState = $ReadOnly<{
+type TouchableOpacityState = Readonly<{
   anim: Animated.Value,
   pressability: Pressability,
 }>;

--- a/packages/react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -36,7 +36,7 @@ export type TouchableWithoutFeedbackPropsAndroid = {
   touchSoundDisabled?: ?boolean,
 };
 
-export type TouchableWithoutFeedbackProps = $ReadOnly<
+export type TouchableWithoutFeedbackProps = Readonly<
   {
     children?: ?React.Node,
     /**

--- a/packages/react-native/Libraries/Components/UnimplementedViews/UnimplementedView.js
+++ b/packages/react-native/Libraries/Components/UnimplementedViews/UnimplementedView.js
@@ -14,7 +14,7 @@ import type {ViewStyleProp} from '../../StyleSheet/StyleSheet';
 import StyleSheet from '../../StyleSheet/StyleSheet';
 import * as React from 'react';
 
-type Props = $ReadOnly<{
+type Props = Readonly<{
   style?: ?ViewStyleProp,
   children?: React.Node,
   ...

--- a/packages/react-native/Libraries/Components/View/ViewAccessibility.js
+++ b/packages/react-native/Libraries/Components/View/ViewAccessibility.js
@@ -154,7 +154,7 @@ export type AccessibilityActionName =
   | 'escape';
 
 // the info associated with an accessibility action
-export type AccessibilityActionInfo = $ReadOnly<{
+export type AccessibilityActionInfo = Readonly<{
   name: AccessibilityActionName | string,
   label?: string,
   ...
@@ -162,7 +162,7 @@ export type AccessibilityActionInfo = $ReadOnly<{
 
 // The info included in the event sent to onAccessibilityAction
 export type AccessibilityActionEvent = NativeSyntheticEvent<
-  $ReadOnly<{actionName: string, ...}>,
+  Readonly<{actionName: string, ...}>,
 >;
 
 export type AccessibilityState = {
@@ -189,7 +189,7 @@ export type AccessibilityState = {
   ...
 };
 
-export type AccessibilityValue = $ReadOnly<{
+export type AccessibilityValue = Readonly<{
   /**
    * The minimum value of this component's range. (should be an integer)
    */
@@ -211,7 +211,7 @@ export type AccessibilityValue = $ReadOnly<{
   text?: Stringish,
 }>;
 
-export type AccessibilityPropsAndroid = $ReadOnly<{
+export type AccessibilityPropsAndroid = Readonly<{
   /**
    * Identifies the element that labels the element it is applied to. When the assistive technology focuses on the component with this props,
    * the text is read aloud. The value should should match the nativeID of the related element.
@@ -268,7 +268,7 @@ export type AccessibilityPropsAndroid = $ReadOnly<{
   screenReaderFocusable?: boolean,
 }>;
 
-export type AccessibilityPropsIOS = $ReadOnly<{
+export type AccessibilityPropsIOS = Readonly<{
   /**
    * Prevents view from being inverted if set to true and color inversion is turned on.
    *
@@ -338,7 +338,7 @@ export type AccessibilityPropsIOS = $ReadOnly<{
   accessibilityRespondsToUserInteraction?: ?boolean,
 }>;
 
-export type AccessibilityProps = $ReadOnly<{
+export type AccessibilityProps = Readonly<{
   ...AccessibilityPropsAndroid,
   ...AccessibilityPropsIOS,
   /**

--- a/packages/react-native/Libraries/Components/View/ViewPropTypes.js
+++ b/packages/react-native/Libraries/Components/View/ViewPropTypes.js
@@ -33,7 +33,7 @@ import * as React from 'react';
 export type ViewLayout = LayoutRectangle;
 export type ViewLayoutEvent = LayoutChangeEvent;
 
-type DirectEventProps = $ReadOnly<{
+type DirectEventProps = Readonly<{
   /**
    * When `accessible` is true, the system will try to invoke this function
    * when the user performs an accessibility custom action.
@@ -79,13 +79,13 @@ type DirectEventProps = $ReadOnly<{
   onAccessibilityEscape?: ?() => unknown,
 }>;
 
-type MouseEventProps = $ReadOnly<{
+type MouseEventProps = Readonly<{
   onMouseEnter?: ?(event: MouseEvent) => void,
   onMouseLeave?: ?(event: MouseEvent) => void,
 }>;
 
 // Experimental/Work in Progress Pointer Event Callbacks (not yet ready for use)
-type PointerEventProps = $ReadOnly<{
+type PointerEventProps = Readonly<{
   onClick?: ?(event: PointerEvent) => void,
   onClickCapture?: ?(event: PointerEvent) => void,
   onPointerEnter?: ?(event: PointerEvent) => void,
@@ -110,21 +110,21 @@ type PointerEventProps = $ReadOnly<{
   onLostPointerCaptureCapture?: ?(e: PointerEvent) => void,
 }>;
 
-type FocusEventProps = $ReadOnly<{
+type FocusEventProps = Readonly<{
   onBlur?: ?(event: BlurEvent) => void,
   onBlurCapture?: ?(event: BlurEvent) => void,
   onFocus?: ?(event: FocusEvent) => void,
   onFocusCapture?: ?(event: FocusEvent) => void,
 }>;
 
-type KeyEventProps = $ReadOnly<{
+type KeyEventProps = Readonly<{
   onKeyDown?: ?(event: KeyDownEvent) => void,
   onKeyDownCapture?: ?(event: KeyDownEvent) => void,
   onKeyUp?: ?(event: KeyUpEvent) => void,
   onKeyUpCapture?: ?(event: KeyUpEvent) => void,
 }>;
 
-type TouchEventProps = $ReadOnly<{
+type TouchEventProps = Readonly<{
   onTouchCancel?: ?(e: GestureResponderEvent) => void,
   onTouchCancelCapture?: ?(e: GestureResponderEvent) => void,
   onTouchEnd?: ?(e: GestureResponderEvent) => void,
@@ -140,7 +140,7 @@ type TouchEventProps = $ReadOnly<{
  * `TouchableHighlight` or `TouchableOpacity`. Check out `Touchable.js`,
  * `ScrollResponder.js` and `ResponderEventPlugin.js` for more discussion.
  */
-export type GestureResponderHandlers = $ReadOnly<{
+export type GestureResponderHandlers = Readonly<{
   /**
    * Does this view want to "claim" touch responsiveness? This is called for
    * every touch move on the `View` when it is not the responder.
@@ -257,12 +257,12 @@ export type GestureResponderHandlers = $ReadOnly<{
   onStartShouldSetResponderCapture?: ?(e: GestureResponderEvent) => boolean,
 }>;
 
-type AndroidDrawableThemeAttr = $ReadOnly<{
+type AndroidDrawableThemeAttr = Readonly<{
   type: 'ThemeAttrAndroid',
   attribute: string,
 }>;
 
-type AndroidDrawableRipple = $ReadOnly<{
+type AndroidDrawableRipple = Readonly<{
   type: 'RippleAndroid',
   color?: ?number,
   borderless?: ?boolean,
@@ -271,7 +271,7 @@ type AndroidDrawableRipple = $ReadOnly<{
 
 type AndroidDrawable = AndroidDrawableThemeAttr | AndroidDrawableRipple;
 
-export type ViewPropsAndroid = $ReadOnly<{
+export type ViewPropsAndroid = Readonly<{
   nativeBackgroundAndroid?: ?AndroidDrawable,
   nativeForegroundAndroid?: ?AndroidDrawable,
 
@@ -356,7 +356,7 @@ export type ViewPropsAndroid = $ReadOnly<{
   onClick?: ?(event: GestureResponderEvent) => unknown,
 }>;
 
-export type TVViewPropsIOS = $ReadOnly<{
+export type TVViewPropsIOS = Readonly<{
   /**
    * *(Apple TV only)* When set to true, this view will be focusable
    * and navigable using the Apple TV remote.
@@ -401,7 +401,7 @@ export type TVViewPropsIOS = $ReadOnly<{
   tvParallaxMagnification?: number,
 }>;
 
-export type ViewPropsIOS = $ReadOnly<{
+export type ViewPropsIOS = Readonly<{
   /**
    * Whether this `View` should be rendered as a bitmap before compositing.
    *
@@ -412,7 +412,7 @@ export type ViewPropsIOS = $ReadOnly<{
   shouldRasterizeIOS?: ?boolean,
 }>;
 
-type ViewBaseProps = $ReadOnly<{
+type ViewBaseProps = Readonly<{
   children?: React.Node,
   style?: ?ViewStyleProp,
 
@@ -508,7 +508,7 @@ type ViewBaseProps = $ReadOnly<{
   experimental_accessibilityOrder?: ?Array<string>,
 }>;
 
-export type ViewProps = $ReadOnly<{
+export type ViewProps = Readonly<{
   ...DirectEventProps,
   ...GestureResponderHandlers,
   ...MouseEventProps,

--- a/packages/react-native/Libraries/Core/Devtools/parseHermesStack.js
+++ b/packages/react-native/Libraries/Core/Devtools/parseHermesStack.js
@@ -10,25 +10,25 @@
 
 'use strict';
 
-type HermesStackLocationNative = $ReadOnly<{
+type HermesStackLocationNative = Readonly<{
   type: 'NATIVE',
 }>;
 
-type HermesStackLocationSource = $ReadOnly<{
+type HermesStackLocationSource = Readonly<{
   type: 'SOURCE',
   sourceUrl: string,
   line1Based: number,
   column1Based: number,
 }>;
 
-type HermesStackLocationInternalBytecode = $ReadOnly<{
+type HermesStackLocationInternalBytecode = Readonly<{
   type: 'INTERNAL_BYTECODE',
   sourceUrl: string,
   line1Based: number,
   virtualOffset0Based: number,
 }>;
 
-type HermesStackLocationBytecode = $ReadOnly<{
+type HermesStackLocationBytecode = Readonly<{
   type: 'BYTECODE',
   sourceUrl: string,
   line1Based: number,
@@ -41,20 +41,20 @@ type HermesStackLocation =
   | HermesStackLocationInternalBytecode
   | HermesStackLocationBytecode;
 
-type HermesStackEntryFrame = $ReadOnly<{
+type HermesStackEntryFrame = Readonly<{
   type: 'FRAME',
   location: HermesStackLocation,
   functionName: string,
 }>;
 
-type HermesStackEntrySkipped = $ReadOnly<{
+type HermesStackEntrySkipped = Readonly<{
   type: 'SKIPPED',
   count: number,
 }>;
 
 type HermesStackEntry = HermesStackEntryFrame | HermesStackEntrySkipped;
 
-export type HermesParsedStack = $ReadOnly<{
+export type HermesParsedStack = Readonly<{
   message: string,
   entries: $ReadOnlyArray<HermesStackEntry>,
 }>;

--- a/packages/react-native/Libraries/Core/Devtools/symbolicateStackTrace.js
+++ b/packages/react-native/Libraries/Core/Devtools/symbolicateStackTrace.js
@@ -14,7 +14,7 @@ import type {StackFrame} from '../NativeExceptionsManager';
 
 const getDevServer = require('./getDevServer').default;
 
-export type CodeFrame = $ReadOnly<{
+export type CodeFrame = Readonly<{
   content: string,
   location: ?{
     row: number,
@@ -24,7 +24,7 @@ export type CodeFrame = $ReadOnly<{
   fileName: string,
 }>;
 
-export type SymbolicatedStackTrace = $ReadOnly<{
+export type SymbolicatedStackTrace = Readonly<{
   stack: Array<StackFrame>,
   codeFrame: ?CodeFrame,
 }>;

--- a/packages/react-native/Libraries/Core/RawEventEmitter.js
+++ b/packages/react-native/Libraries/Core/RawEventEmitter.js
@@ -12,7 +12,7 @@ import type {IEventEmitter} from '../vendor/emitter/EventEmitter';
 
 import EventEmitter from '../vendor/emitter/EventEmitter';
 
-export type RawEventEmitterEvent = $ReadOnly<{
+export type RawEventEmitterEvent = Readonly<{
   eventName: string,
   // We expect, but do not/cannot require, that nativeEvent is an object
   // with the properties: key, elementType (string), type (string), tag (numeric),

--- a/packages/react-native/Libraries/Core/setUpSegmentFetcher.js
+++ b/packages/react-native/Libraries/Core/setUpSegmentFetcher.js
@@ -19,7 +19,7 @@ export type FetchSegmentFunction = typeof __fetchSegment;
 
 function __fetchSegment(
   segmentId: number,
-  options: $ReadOnly<{
+  options: Readonly<{
     otaBuildNumber: ?string,
     requestedModuleName: string,
     segmentHash: string,

--- a/packages/react-native/Libraries/EventEmitter/NativeEventEmitter.js
+++ b/packages/react-native/Libraries/EventEmitter/NativeEventEmitter.js
@@ -45,9 +45,9 @@ type UnsafeNativeEventObject = Object;
  * can theoretically listen to `RCTDeviceEventEmitter` (although discouraged).
  */
 export default class NativeEventEmitter<
-  TEventToArgsMap: $ReadOnly<
+  TEventToArgsMap: Readonly<
     Record<string, $ReadOnlyArray<UnsafeNativeEventObject>>,
-  > = $ReadOnly<Record<string, $ReadOnlyArray<UnsafeNativeEventObject>>>,
+  > = Readonly<Record<string, $ReadOnlyArray<UnsafeNativeEventObject>>>,
 > implements IEventEmitter<TEventToArgsMap>
 {
   _nativeModule: ?NativeModule;

--- a/packages/react-native/Libraries/EventEmitter/__mocks__/NativeEventEmitter.js
+++ b/packages/react-native/Libraries/EventEmitter/__mocks__/NativeEventEmitter.js
@@ -19,7 +19,7 @@ import RCTDeviceEventEmitter from '../RCTDeviceEventEmitter';
  * Mock `NativeEventEmitter` to ignore Native Modules.
  */
 export default class NativeEventEmitter<
-  TEventToArgsMap: $ReadOnly<Record<string, $ReadOnlyArray<unknown>>>,
+  TEventToArgsMap: Readonly<Record<string, $ReadOnlyArray<unknown>>>,
 > implements IEventEmitter<TEventToArgsMap>
 {
   addListener<TEvent: $Keys<TEventToArgsMap>>(

--- a/packages/react-native/Libraries/Image/AssetSourceResolver.js
+++ b/packages/react-native/Libraries/Image/AssetSourceResolver.js
@@ -22,7 +22,7 @@ export type ResolvedAssetSource = {
 type AssetDestPathResolver = 'android' | 'generic';
 
 // From @react-native/assets-registry
-type PackagerAsset = $ReadOnly<{
+type PackagerAsset = Readonly<{
   __packager_asset: boolean,
   fileSystemLocation: string,
   httpServerLocation: string,

--- a/packages/react-native/Libraries/Image/ImageProps.js
+++ b/packages/react-native/Libraries/Image/ImageProps.js
@@ -38,7 +38,7 @@ type ImageProgressEventDataIOS = {
  * @see ImagePropsIOS.onProgress
  */
 export type ImageProgressEventIOS = NativeSyntheticEvent<
-  $ReadOnly<ImageProgressEventDataIOS>,
+  Readonly<ImageProgressEventDataIOS>,
 >;
 
 type ImageErrorEventData = {
@@ -46,7 +46,7 @@ type ImageErrorEventData = {
 };
 
 export type ImageErrorEvent = NativeSyntheticEvent<
-  $ReadOnly<ImageErrorEventData>,
+  Readonly<ImageErrorEventData>,
 >;
 
 type ImageLoadEventData = {
@@ -57,11 +57,9 @@ type ImageLoadEventData = {
   },
 };
 
-export type ImageLoadEvent = NativeSyntheticEvent<
-  $ReadOnly<ImageLoadEventData>,
->;
+export type ImageLoadEvent = NativeSyntheticEvent<Readonly<ImageLoadEventData>>;
 
-export type ImagePropsIOS = $ReadOnly<{
+export type ImagePropsIOS = Readonly<{
   /**
    * A static image to display while loading the image source.
    *
@@ -82,13 +80,13 @@ export type ImagePropsIOS = $ReadOnly<{
   onProgress?: ?(event: ImageProgressEventIOS) => void,
 }>;
 
-export type ImagePropsAndroid = $ReadOnly<{
+export type ImagePropsAndroid = Readonly<{
   /**
    * similarly to `source`, this property represents the resource used to render
    * the loading indicator for the image, displayed until image is ready to be
    * displayed, typically after when it got downloaded from network.
    */
-  loadingIndicatorSource?: ?(number | $ReadOnly<ImageURISource>),
+  loadingIndicatorSource?: ?(number | Readonly<ImageURISource>),
   progressiveRenderingEnabled?: ?boolean,
   fadeDuration?: ?number,
 
@@ -127,7 +125,7 @@ export type ImagePropsAndroid = $ReadOnly<{
   resizeMultiplier?: ?number,
 }>;
 
-export type ImagePropsBase = $ReadOnly<{
+export type ImagePropsBase = Readonly<{
   ...Omit<ViewProps, 'style'>,
   /**
    * When true, indicates the image is an accessibility element.
@@ -333,7 +331,7 @@ export type ImagePropsBase = $ReadOnly<{
   children?: empty,
 }>;
 
-export type ImageProps = $ReadOnly<{
+export type ImageProps = Readonly<{
   ...ImagePropsIOS,
   ...ImagePropsAndroid,
   ...ImagePropsBase,
@@ -344,7 +342,7 @@ export type ImageProps = $ReadOnly<{
   style?: ?ImageStyleProp,
 }>;
 
-export type ImageBackgroundProps = $ReadOnly<{
+export type ImageBackgroundProps = Readonly<{
   ...ImageProps,
   children?: React.Node,
 

--- a/packages/react-native/Libraries/Image/ImageSource.js
+++ b/packages/react-native/Libraries/Image/ImageSource.js
@@ -104,7 +104,7 @@ type ImageSourceProperties = {
 
 export function getImageSourceProperties(
   imageSource: ImageURISource,
-): $ReadOnly<ImageSourceProperties> {
+): Readonly<ImageSourceProperties> {
   const object: ImageSourceProperties = {};
   if (imageSource.body != null) {
     object.body = imageSource.body;

--- a/packages/react-native/Libraries/Image/ImageTypes.flow.js
+++ b/packages/react-native/Libraries/Image/ImageTypes.flow.js
@@ -23,7 +23,7 @@ export type ImageSize = {
 
 export type ImageResolvedAssetSource = ResolvedAssetSource;
 
-type ImageComponentStaticsIOS = $ReadOnly<{
+type ImageComponentStaticsIOS = Readonly<{
   getSize(uri: string): Promise<ImageSize>,
   getSize(
     uri: string,
@@ -60,7 +60,7 @@ type ImageComponentStaticsIOS = $ReadOnly<{
   resolveAssetSource(source: ImageSource): ?ImageResolvedAssetSource,
 }>;
 
-type ImageComponentStaticsAndroid = $ReadOnly<{
+type ImageComponentStaticsAndroid = Readonly<{
   ...ImageComponentStaticsIOS,
   abortPrefetch(requestId: number): void,
 }>;

--- a/packages/react-native/Libraries/Image/ImageViewNativeComponent.js
+++ b/packages/react-native/Libraries/Image/ImageViewNativeComponent.js
@@ -26,7 +26,7 @@ import {ConditionallyIgnoredEventHandlers} from '../NativeComponent/ViewConfigIg
 import codegenNativeCommands from '../Utilities/codegenNativeCommands';
 import Platform from '../Utilities/Platform';
 
-type ImageHostComponentProps = $ReadOnly<{
+type ImageHostComponentProps = Readonly<{
   ...ImageProps,
   ...ViewProps,
 
@@ -37,9 +37,7 @@ type ImageHostComponentProps = $ReadOnly<{
 
   // Android native props
   shouldNotifyLoadEvents?: boolean,
-  src?:
-    | ?ResolvedAssetSource
-    | ?$ReadOnlyArray<?$ReadOnly<{uri?: ?string, ...}>>,
+  src?: ?ResolvedAssetSource | ?$ReadOnlyArray<?Readonly<{uri?: ?string, ...}>>,
   headers?: ?{[string]: string},
   defaultSource?: ?ImageSource | ?string,
   loadingIndicatorSrc?: ?string,

--- a/packages/react-native/Libraries/Image/TextInlineImageNativeComponent.js
+++ b/packages/react-native/Libraries/Image/TextInlineImageNativeComponent.js
@@ -18,10 +18,10 @@ import type {ImageResizeMode} from './ImageResizeMode';
 
 import * as NativeComponentRegistry from '../NativeComponent/NativeComponentRegistry';
 
-type RCTTextInlineImageNativeProps = $ReadOnly<{
+type RCTTextInlineImageNativeProps = Readonly<{
   ...ViewProps,
   resizeMode?: ?ImageResizeMode,
-  src?: ?$ReadOnlyArray<?$ReadOnly<{uri?: ?string, ...}>>,
+  src?: ?$ReadOnlyArray<?Readonly<{uri?: ?string, ...}>>,
   tintColor?: ?ColorValue,
   headers?: ?{[string]: string},
 }>;

--- a/packages/react-native/Libraries/Image/nativeImageSource.js
+++ b/packages/react-native/Libraries/Image/nativeImageSource.js
@@ -12,7 +12,7 @@ import type {ImageURISource} from './ImageSource';
 
 import Platform from '../Utilities/Platform';
 
-type NativeImageSourceSpec = $ReadOnly<{
+type NativeImageSourceSpec = Readonly<{
   android?: string,
   ios?: string,
   default?: string,

--- a/packages/react-native/Libraries/Interaction/PanResponder.js
+++ b/packages/react-native/Libraries/Interaction/PanResponder.js
@@ -204,7 +204,7 @@ export type GestureResponderHandlerMethods = {
   onStartShouldSetResponderCapture: (event: GestureResponderEvent) => boolean,
 };
 
-export type PanResponderCallbacks = $ReadOnly<{
+export type PanResponderCallbacks = Readonly<{
   onMoveShouldSetPanResponder?: ?ActiveCallback,
   onMoveShouldSetPanResponderCapture?: ?ActiveCallback,
   onStartShouldSetPanResponder?: ?ActiveCallback,

--- a/packages/react-native/Libraries/LayoutAnimation/LayoutAnimation.js
+++ b/packages/react-native/Libraries/LayoutAnimation/LayoutAnimation.js
@@ -31,11 +31,11 @@ export type {
 // Reexport type
 export type {LayoutAnimationConfig} from '../Renderer/shims/ReactNativeTypes';
 
-export type LayoutAnimationTypes = $ReadOnly<{
+export type LayoutAnimationTypes = Readonly<{
   [type in LayoutAnimationType]: type,
 }>;
 
-export type LayoutAnimationProperties = $ReadOnly<{
+export type LayoutAnimationProperties = Readonly<{
   [prop in LayoutAnimationProperty]: prop,
 }>;
 

--- a/packages/react-native/Libraries/Lists/FlatList.js
+++ b/packages/react-native/Libraries/Lists/FlatList.js
@@ -38,7 +38,7 @@ type RequiredFlatListProps<ItemT> = {
    * An array (or array-like list) of items to render. Other data types can be
    * used by targeting VirtualizedList directly.
    */
-  data: ?$ReadOnly<$ArrayLike<ItemT>>,
+  data: ?Readonly<$ArrayLike<ItemT>>,
 };
 type OptionalFlatListProps<ItemT> = {
   /**
@@ -93,7 +93,7 @@ type OptionalFlatListProps<ItemT> = {
    * specify `ItemSeparatorComponent`.
    */
   getItemLayout?: (
-    data: ?$ReadOnly<$ArrayLike<ItemT>>,
+    data: ?Readonly<$ArrayLike<ItemT>>,
     index: number,
   ) => {
     length: number,

--- a/packages/react-native/Libraries/Lists/SectionListModern.js
+++ b/packages/react-native/Libraries/Lists/SectionListModern.js
@@ -101,7 +101,7 @@ type OptionalProps<ItemT, SectionT = DefaultSectionT> = {
   removeClippedSubviews?: boolean,
 };
 
-export type Props<ItemT, SectionT = DefaultSectionT> = $ReadOnly<{
+export type Props<ItemT, SectionT = DefaultSectionT> = Readonly<{
   ...Omit<
     VirtualizedSectionListProps<ItemT, SectionT>,
     'getItem' | 'getItemCount' | 'renderItem' | 'keyExtractor',

--- a/packages/react-native/Libraries/Lists/__tests__/FlatList-itest.js
+++ b/packages/react-native/Libraries/Lists/__tests__/FlatList-itest.js
@@ -20,7 +20,7 @@ function testPropPropagatedToMountingLayer<TValue>({
   value,
   defaultValue,
   renderChildrenForValue,
-}: $ReadOnly<{
+}: Readonly<{
   propName: string,
   value: TValue,
   defaultValue: TValue,
@@ -29,7 +29,7 @@ function testPropPropagatedToMountingLayer<TValue>({
   describe(propName, () => {
     it('is propagated to the mounting layer', () => {
       const root = Fantom.createRoot();
-      const props: FlatListProps<$ReadOnly<{}>> = {
+      const props: FlatListProps<Readonly<{}>> = {
         // $FlowFixMe[incompatible-type]
         [propName]: value,
       };
@@ -53,7 +53,7 @@ function testPropPropagatedToMountingLayer<TValue>({
 
     it(`default value is ${JSON.stringify(defaultValue) ?? 'null'}`, () => {
       const root = Fantom.createRoot();
-      const props: FlatListProps<$ReadOnly<{}>> = {
+      const props: FlatListProps<Readonly<{}>> = {
         // $FlowFixMe[incompatible-type]
         [propName]: defaultValue,
       };

--- a/packages/react-native/Libraries/Lists/__tests__/FlatList-test.js
+++ b/packages/react-native/Libraries/Lists/__tests__/FlatList-test.js
@@ -36,7 +36,7 @@ describe('FlatList', () => {
     expect(component).toMatchSnapshot();
   });
   it('renders simple list using ListItemComponent', async () => {
-    function ListItemComponent({item}: $ReadOnly<{item: {key: string}}>) {
+    function ListItemComponent({item}: Readonly<{item: {key: string}}>) {
       return <item value={item.key} />;
     }
     const component = await create(
@@ -48,7 +48,7 @@ describe('FlatList', () => {
     expect(component).toMatchSnapshot();
   });
   it('renders simple list using ListItemComponent (multiple columns)', async () => {
-    function ListItemComponent({item}: $ReadOnly<{item: {key: string}}>) {
+    function ListItemComponent({item}: Readonly<{item: {key: string}}>) {
       return <item value={item.key} />;
     }
     const component = await create(
@@ -137,7 +137,7 @@ describe('FlatList', () => {
     jest.resetModules();
     jest.unmock('../../Components/ScrollView/ScrollView');
 
-    function ListItemComponent({item}: $ReadOnly<{item: {key: string}}>) {
+    function ListItemComponent({item}: Readonly<{item: {key: string}}>) {
       return <item value={item.key} />;
     }
     const listRef = createRef<React.ElementRef<typeof FlatList>>();

--- a/packages/react-native/Libraries/Lists/__tests__/SectionList-test.js
+++ b/packages/react-native/Libraries/Lists/__tests__/SectionList-test.js
@@ -99,7 +99,7 @@ describe('SectionList', () => {
   });
 });
 
-function propStr(props: $ReadOnly<{[string]: $FlowFixMe}>) {
+function propStr(props: Readonly<{[string]: $FlowFixMe}>) {
   return Object.keys(props)
     .map(k => {
       const propObj = props[k] || {};

--- a/packages/react-native/Libraries/LogBox/Data/LogBoxData.js
+++ b/packages/react-native/Libraries/LogBox/Data/LogBoxData.js
@@ -26,7 +26,7 @@ import {parseLogBoxException} from './parseLogBoxLog';
 import * as React from 'react';
 
 export type LogBoxLogs = Set<LogBoxLog>;
-export type LogData = $ReadOnly<{
+export type LogData = Readonly<{
   level: LogLevel,
   message: Message,
   category: Category,
@@ -36,7 +36,7 @@ export type LogData = $ReadOnly<{
 }>;
 
 export type Observer = (
-  $ReadOnly<{
+  Readonly<{
     logs: LogBoxLogs,
     isDisabled: boolean,
     selectedLogIndex: number,
@@ -45,7 +45,7 @@ export type Observer = (
 
 export type IgnorePattern = string | RegExp;
 
-export type Subscription = $ReadOnly<{
+export type Subscription = Readonly<{
   unsubscribe: () => void,
 }>;
 
@@ -61,7 +61,7 @@ export type WarningInfo = {
 
 export type WarningFilter = (format: string) => WarningInfo;
 
-type AppInfo = $ReadOnly<{
+type AppInfo = Readonly<{
   appVersion: string,
   engine: string,
   onPress?: ?() => void,
@@ -427,8 +427,8 @@ function observeNext(observer: Observer): Subscription {
   };
 }
 
-type LogBoxStateSubscriptionProps = $ReadOnly<{}>;
-type LogBoxStateSubscriptionState = $ReadOnly<{
+type LogBoxStateSubscriptionProps = Readonly<{}>;
+type LogBoxStateSubscriptionState = Readonly<{
   logs: LogBoxLogs,
   isDisabled: boolean,
   hasError: boolean,
@@ -436,7 +436,7 @@ type LogBoxStateSubscriptionState = $ReadOnly<{
 }>;
 
 type SubscribedComponent = React.ComponentType<
-  $ReadOnly<{
+  Readonly<{
     logs: $ReadOnlyArray<LogBoxLog>,
     isDisabled: boolean,
     selectedLogIndex: number,

--- a/packages/react-native/Libraries/LogBox/Data/LogBoxLog.js
+++ b/packages/react-native/Libraries/LogBox/Data/LogBoxLog.js
@@ -55,7 +55,7 @@ function convertStackToComponentStack(stack: Stack): ComponentStack {
   return componentStack;
 }
 
-export type LogBoxLogData = $ReadOnly<{
+export type LogBoxLogData = Readonly<{
   level: LogLevel,
   type?: ?string,
   message: Message,
@@ -83,23 +83,23 @@ class LogBoxLog {
   isComponentError: boolean;
   extraData: unknown | void;
   symbolicated:
-    | $ReadOnly<{error: null, stack: null, status: 'NONE'}>
-    | $ReadOnly<{error: null, stack: null, status: 'PENDING'}>
-    | $ReadOnly<{error: null, stack: Stack, status: 'COMPLETE'}>
-    | $ReadOnly<{error: Error, stack: null, status: 'FAILED'}> = {
+    | Readonly<{error: null, stack: null, status: 'NONE'}>
+    | Readonly<{error: null, stack: null, status: 'PENDING'}>
+    | Readonly<{error: null, stack: Stack, status: 'COMPLETE'}>
+    | Readonly<{error: Error, stack: null, status: 'FAILED'}> = {
     error: null,
     stack: null,
     status: 'NONE',
   };
   symbolicatedComponentStack:
-    | $ReadOnly<{error: null, componentStack: null, status: 'NONE'}>
-    | $ReadOnly<{error: null, componentStack: null, status: 'PENDING'}>
-    | $ReadOnly<{
+    | Readonly<{error: null, componentStack: null, status: 'NONE'}>
+    | Readonly<{error: null, componentStack: null, status: 'PENDING'}>
+    | Readonly<{
         error: null,
         componentStack: ComponentStack,
         status: 'COMPLETE',
       }>
-    | $ReadOnly<{error: Error, componentStack: null, status: 'FAILED'}> = {
+    | Readonly<{error: Error, componentStack: null, status: 'FAILED'}> = {
     error: null,
     componentStack: null,
     status: 'NONE',

--- a/packages/react-native/Libraries/LogBox/Data/__tests__/LogBoxLog-test.js
+++ b/packages/react-native/Libraries/LogBox/Data/__tests__/LogBoxLog-test.js
@@ -18,7 +18,7 @@ jest.mock('../LogBoxSymbolication', () => {
   return {__esModule: true, symbolicate: jest.fn(), deleteStack: jest.fn()};
 });
 
-type CodeCodeFrame = $ReadOnly<{
+type CodeCodeFrame = Readonly<{
   content: string,
   location: ?{
     row: number,

--- a/packages/react-native/Libraries/LogBox/Data/parseLogBoxLog.js
+++ b/packages/react-native/Libraries/LogBox/Data/parseLogBoxLog.js
@@ -107,7 +107,7 @@ export type ExtendedExceptionData = ExceptionData & {
   ...
 };
 export type Category = string;
-export type CodeFrame = $ReadOnly<{
+export type CodeFrame = Readonly<{
   content: string,
   location: ?{
     row: number,
@@ -121,10 +121,10 @@ export type CodeFrame = $ReadOnly<{
   // it is not integrated into the LogBox UI.
   collapse?: boolean,
 }>;
-export type Message = $ReadOnly<{
+export type Message = Readonly<{
   content: string,
   substitutions: $ReadOnlyArray<
-    $ReadOnly<{
+    Readonly<{
       length: number,
       offset: number,
     }>,
@@ -136,7 +136,7 @@ export type ComponentStackType = 'legacy' | 'stack';
 
 const SUBSTITUTION = UTFSequence.BOM + '%s';
 
-export function parseInterpolation(args: $ReadOnlyArray<unknown>): $ReadOnly<{
+export function parseInterpolation(args: $ReadOnlyArray<unknown>): Readonly<{
   category: Category,
   message: Message,
 }> {

--- a/packages/react-native/Libraries/LogBox/LogBoxInspectorContainer.js
+++ b/packages/react-native/Libraries/LogBox/LogBoxInspectorContainer.js
@@ -16,7 +16,7 @@ import * as LogBoxData from './Data/LogBoxData';
 import LogBoxInspector from './UI/LogBoxInspector';
 import * as React from 'react';
 
-type Props = $ReadOnly<{
+type Props = Readonly<{
   logs: $ReadOnlyArray<LogBoxLog>,
   selectedLogIndex: number,
   isDisabled?: ?boolean,

--- a/packages/react-native/Libraries/LogBox/LogBoxNotificationContainer.js
+++ b/packages/react-native/Libraries/LogBox/LogBoxNotificationContainer.js
@@ -16,7 +16,7 @@ import LogBoxLog from './Data/LogBoxLog';
 import LogBoxLogNotification from './UI/LogBoxNotification';
 import * as React from 'react';
 
-type Props = $ReadOnly<{
+type Props = Readonly<{
   logs: $ReadOnlyArray<LogBoxLog>,
   selectedLogIndex: number,
   isDisabled?: ?boolean,

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxButton.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxButton.js
@@ -19,9 +19,9 @@ import * as LogBoxStyle from './LogBoxStyle';
 import * as React from 'react';
 import {useState} from 'react';
 
-type Props = $ReadOnly<{
+type Props = Readonly<{
   id?: string,
-  backgroundColor: $ReadOnly<{
+  backgroundColor: Readonly<{
     default: string,
     pressed: string,
   }>,

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspector.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspector.js
@@ -20,7 +20,7 @@ import * as LogBoxStyle from './LogBoxStyle';
 import * as React from 'react';
 import {useEffect} from 'react';
 
-type Props = $ReadOnly<{
+type Props = Readonly<{
   onDismiss: () => void,
   onChangeSelectedIndex: (index: number) => void,
   onMinimize: () => void,

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorCodeFrame.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorCodeFrame.js
@@ -23,7 +23,7 @@ import LogBoxInspectorSection from './LogBoxInspectorSection';
 import * as LogBoxStyle from './LogBoxStyle';
 import * as React from 'react';
 
-type Props = $ReadOnly<{
+type Props = Readonly<{
   componentCodeFrame: ?CodeFrame,
   codeFrame: ?CodeFrame,
 }>;

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorFooter.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorFooter.js
@@ -17,7 +17,7 @@ import LogBoxInspectorFooterButton from './LogBoxInspectorFooterButton';
 import * as LogBoxStyle from './LogBoxStyle';
 import * as React from 'react';
 
-type Props = $ReadOnly<{
+type Props = Readonly<{
   onDismiss: () => void,
   onMinimize: () => void,
   level?: ?LogLevel,

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorFooterButton.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorFooterButton.js
@@ -16,7 +16,7 @@ import LogBoxButton from './LogBoxButton';
 import * as LogBoxStyle from './LogBoxStyle';
 import * as React from 'react';
 
-type ButtonProps = $ReadOnly<{
+type ButtonProps = Readonly<{
   id: string,
   onPress: () => void,
   text: string,

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorHeader.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorHeader.js
@@ -20,7 +20,7 @@ import LogBoxInspectorHeaderButton from './LogBoxInspectorHeaderButton';
 import * as LogBoxStyle from './LogBoxStyle';
 import * as React from 'react';
 
-type Props = $ReadOnly<{
+type Props = Readonly<{
   onSelectIndex: (selectedIndex: number) => void,
   selectedIndex: number,
   total: number,

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorHeaderButton.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorHeaderButton.js
@@ -38,7 +38,7 @@ const backgroundForLevel = (level: LogLevel) =>
   })[level];
 
 export default function LogBoxInspectorHeaderButton(
-  props: $ReadOnly<{
+  props: Readonly<{
     id: string,
     disabled: boolean,
     image: ImageSource,

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorMessageHeader.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorMessageHeader.js
@@ -18,7 +18,7 @@ import LogBoxMessage from './LogBoxMessage';
 import * as LogBoxStyle from './LogBoxStyle';
 import * as React from 'react';
 
-type Props = $ReadOnly<{
+type Props = Readonly<{
   collapsed: boolean,
   message: Message,
   level: LogLevel,

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorReactFrames.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorReactFrames.js
@@ -21,7 +21,7 @@ import * as LogBoxStyle from './LogBoxStyle';
 import * as React from 'react';
 import {useState} from 'react';
 
-type Props = $ReadOnly<{
+type Props = Readonly<{
   log: LogBoxLog,
 }>;
 

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorSection.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorSection.js
@@ -14,7 +14,7 @@ import Text from '../../Text/Text';
 import * as LogBoxStyle from './LogBoxStyle';
 import * as React from 'react';
 
-type Props = $ReadOnly<{
+type Props = Readonly<{
   heading: string,
   children: React.Node,
   action?: ?React.Node,

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorSourceMapStatus.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorSourceMapStatus.js
@@ -19,7 +19,7 @@ import * as LogBoxStyle from './LogBoxStyle';
 import * as React from 'react';
 import {useEffect, useState} from 'react';
 
-type Props = $ReadOnly<{
+type Props = Readonly<{
   onPress?: ?(event: GestureResponderEvent) => void,
   status: 'COMPLETE' | 'FAILED' | 'NONE' | 'PENDING',
 }>;

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorStackFrame.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorStackFrame.js
@@ -19,7 +19,7 @@ import LogBoxButton from './LogBoxButton';
 import * as LogBoxStyle from './LogBoxStyle';
 import * as React from 'react';
 
-type Props = $ReadOnly<{
+type Props = Readonly<{
   frame: StackFrame,
   onPress?: ?(event: GestureResponderEvent) => void,
 }>;

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorStackFrames.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorStackFrames.js
@@ -24,7 +24,7 @@ import * as LogBoxStyle from './LogBoxStyle';
 import * as React from 'react';
 import {useState} from 'react';
 
-type Props = $ReadOnly<{
+type Props = Readonly<{
   log: LogBoxLog,
   onRetry: () => void,
 }>;
@@ -139,7 +139,7 @@ function StackFrameList(props: {
 }
 
 function StackFrameFooter(
-  props: $ReadOnly<{message: string, onPress: () => void}>,
+  props: Readonly<{message: string, onPress: () => void}>,
 ) {
   return (
     <View style={stackStyles.collapseContainer}>

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxNotification.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxNotification.js
@@ -20,7 +20,7 @@ import * as LogBoxStyle from './LogBoxStyle';
 import * as React from 'react';
 import {useEffect} from 'react';
 
-type Props = $ReadOnly<{
+type Props = Readonly<{
   log: LogBoxLog,
   totalLogCount: number,
   level: 'warn' | 'error',

--- a/packages/react-native/Libraries/Modal/Modal.js
+++ b/packages/react-native/Libraries/Modal/Modal.js
@@ -59,7 +59,7 @@ const ModalEventEmitter =
 // destroyed before the callback is fired.
 let uniqueModalIdentifier = 0;
 
-type OrientationChangeEvent = $ReadOnly<{
+type OrientationChangeEvent = Readonly<{
   orientation: 'portrait' | 'landscape',
 }>;
 
@@ -383,7 +383,7 @@ const styles = StyleSheet.create({
   },
 });
 
-type ModalRefProps = $ReadOnly<{
+type ModalRefProps = Readonly<{
   ref?: React.RefSetter<PublicModalInstance>,
 }>;
 

--- a/packages/react-native/Libraries/Network/RCTNetworkingEventDefinitions.flow.js
+++ b/packages/react-native/Libraries/Network/RCTNetworkingEventDefinitions.flow.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-export type RCTNetworkingEventDefinitions = $ReadOnly<{
+export type RCTNetworkingEventDefinitions = Readonly<{
   didSendNetworkData: [
     [
       number, // requestId

--- a/packages/react-native/Libraries/PermissionsAndroid/PermissionsAndroid.js
+++ b/packages/react-native/Libraries/PermissionsAndroid/PermissionsAndroid.js
@@ -31,7 +31,7 @@ const PERMISSION_REQUEST_RESULT = Object.freeze({
   NEVER_ASK_AGAIN: 'never_ask_again',
 });
 
-type PermissionsType = $ReadOnly<{
+type PermissionsType = Readonly<{
   READ_CALENDAR: 'android.permission.READ_CALENDAR',
   WRITE_CALENDAR: 'android.permission.WRITE_CALENDAR',
   CAMERA: 'android.permission.CAMERA',
@@ -134,7 +134,7 @@ const PERMISSIONS = Object.freeze({
  */
 class PermissionsAndroidImpl {
   PERMISSIONS: PermissionsType = PERMISSIONS;
-  RESULTS: $ReadOnly<{
+  RESULTS: Readonly<{
     DENIED: 'denied',
     GRANTED: 'granted',
     NEVER_ASK_AGAIN: 'never_ask_again',

--- a/packages/react-native/Libraries/Pressability/Pressability.js
+++ b/packages/react-native/Libraries/Pressability/Pressability.js
@@ -27,7 +27,7 @@ import PressabilityPerformanceEventEmitter from './PressabilityPerformanceEventE
 import {type PressabilityTouchSignal as TouchSignal} from './PressabilityTypes.js';
 import invariant from 'invariant';
 
-export type PressabilityConfig = $ReadOnly<{
+export type PressabilityConfig = Readonly<{
   /**
    * Whether a press gesture can be interrupted by a parent gesture such as a
    * scroll event. Defaults to true.
@@ -137,7 +137,7 @@ export type PressabilityConfig = $ReadOnly<{
   blockNativeResponder?: ?boolean,
 }>;
 
-export type EventHandlers = $ReadOnly<{
+export type EventHandlers = Readonly<{
   onBlur: (event: BlurEvent) => void,
   onClick: (event: GestureResponderEvent) => void,
   onFocus: (event: FocusEvent) => void,
@@ -378,13 +378,13 @@ export default class Pressability {
   _pressDelayTimeout: ?TimeoutID = null;
   _pressOutDelayTimeout: ?TimeoutID = null;
   _responderID: ?number | HostInstance = null;
-  _responderRegion: ?$ReadOnly<{
+  _responderRegion: ?Readonly<{
     bottom: number,
     left: number,
     right: number,
     top: number,
   }> = null;
-  _touchActivatePosition: ?$ReadOnly<{
+  _touchActivatePosition: ?Readonly<{
     pageX: number,
     pageY: number,
   }>;
@@ -830,7 +830,7 @@ export default class Pressability {
 
   _isTouchWithinResponderRegion(
     touch: GestureResponderEvent['nativeEvent'],
-    responderRegion: $ReadOnly<{
+    responderRegion: Readonly<{
       bottom: number,
       left: number,
       right: number,

--- a/packages/react-native/Libraries/Pressability/PressabilityDebug.js
+++ b/packages/react-native/Libraries/Pressability/PressabilityDebug.js
@@ -15,7 +15,7 @@ import normalizeColor from '../StyleSheet/normalizeColor';
 import {type RectOrSize, normalizeRect} from '../StyleSheet/Rect';
 import * as React from 'react';
 
-type Props = $ReadOnly<{
+type Props = Readonly<{
   color: ColorValue,
   hitSlop: ?RectOrSize,
 }>;

--- a/packages/react-native/Libraries/Pressability/PressabilityPerformanceEventEmitter.js
+++ b/packages/react-native/Libraries/Pressability/PressabilityPerformanceEventEmitter.js
@@ -10,7 +10,7 @@
 
 import {type PressabilityTouchSignal as TouchSignal} from './PressabilityTypes.js';
 
-export type PressabilityPerformanceEvent = $ReadOnly<{
+export type PressabilityPerformanceEvent = Readonly<{
   signal: TouchSignal,
   nativeTimestamp: number,
 }>;

--- a/packages/react-native/Libraries/Pressability/__tests__/Pressability-test.js
+++ b/packages/react-native/Libraries/Pressability/__tests__/Pressability-test.js
@@ -170,7 +170,7 @@ const createMockMouseEvent = (registrationName: string) => {
 const createMockPressEvent = (
   nameOrOverrides:
     | string
-    | $ReadOnly<{
+    | Readonly<{
         registrationName: string,
         pageX: number,
         pageY: number,

--- a/packages/react-native/Libraries/ReactNative/AppContainer.js
+++ b/packages/react-native/Libraries/ReactNative/AppContainer.js
@@ -13,7 +13,7 @@ import type {RootTag} from './RootTag';
 
 import * as React from 'react';
 
-export type Props = $ReadOnly<{
+export type Props = Readonly<{
   children?: React.Node,
   fabric?: boolean,
   rootTag: number | RootTag,

--- a/packages/react-native/Libraries/ReactNative/AppRegistry.flow.js
+++ b/packages/react-native/Libraries/ReactNative/AppRegistry.flow.js
@@ -29,7 +29,7 @@ export type AppConfig = {
   ...
 };
 export type AppParameters = {
-  initialProps: $ReadOnly<{[string]: unknown, ...}>,
+  initialProps: Readonly<{[string]: unknown, ...}>,
   rootTag: RootTag,
   fabric?: boolean,
 };

--- a/packages/react-native/Libraries/StyleSheet/PointPropType.js
+++ b/packages/react-native/Libraries/StyleSheet/PointPropType.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-export type PointProp = $ReadOnly<{
+export type PointProp = Readonly<{
   x: number,
   y: number,
   ...

--- a/packages/react-native/Libraries/StyleSheet/Rect.js
+++ b/packages/react-native/Libraries/StyleSheet/Rect.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-export type Rect = $ReadOnly<{
+export type Rect = Readonly<{
   bottom?: ?number,
   left?: ?number,
   right?: ?number,

--- a/packages/react-native/Libraries/StyleSheet/StyleSheetExports.js
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetExports.js
@@ -188,7 +188,7 @@ export default {
    * An identity function for creating style sheets.
    */
   // $FlowFixMe[unsupported-variance-annotation]
-  create<+S: ____Styles_Internal>(obj: S): $ReadOnly<S> {
+  create<+S: ____Styles_Internal>(obj: S): Readonly<S> {
     // TODO: This should return S as the return type. But first,
     // we need to codemod all the callsites that are typing this
     // return value as a number (even though it was opaque).

--- a/packages/react-native/Libraries/StyleSheet/StyleSheetExports.js.flow
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetExports.js.flow
@@ -13,7 +13,7 @@ import type {____Styles_Internal} from './StyleSheetTypes';
 import composeStyles from '../../src/private/styles/composeStyles';
 import flattenStyle from './flattenStyle';
 
-type AbsoluteFillStyle = $ReadOnly<{
+type AbsoluteFillStyle = Readonly<{
   position: 'absolute',
   left: 0,
   right: 0,
@@ -102,4 +102,4 @@ declare export const setStyleAttributePreprocessor: (
 // $FlowFixMe[unsupported-variance-annotation]
 declare export const create: <+S: ____Styles_Internal>(
   obj: S & ____Styles_Internal,
-) => $ReadOnly<S>;
+) => Readonly<S>;

--- a/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
+++ b/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.js
@@ -55,7 +55,7 @@ export type CursorValue = 'auto' | 'pointer';
  * These properties are a subset of our styles that are consumed by the layout
  * algorithm and affect the positioning and sizing of views.
  */
-type ____LayoutStyle_Internal = $ReadOnly<{
+type ____LayoutStyle_Internal = Readonly<{
   /** `display` sets the display type of this component.
    *
    *  It works similarly to `display` in CSS, but only support 'flex' and 'none'.
@@ -675,7 +675,7 @@ type ____LayoutStyle_Internal = $ReadOnly<{
  * To add a drop shadow to a view use the [`elevation` property](docs/viewstyleproptypes.html#elevation) (Android 5.0+).
  * To customize the color use the [`shadowColor` property](docs/shadow-props.html#shadowColor) (Android 9.0+).
  */
-export type ____ShadowStyle_InternalCore = $ReadOnly<{
+export type ____ShadowStyle_InternalCore = Readonly<{
   /**
    * Sets the drop shadow color
    * @platform ios
@@ -685,7 +685,7 @@ export type ____ShadowStyle_InternalCore = $ReadOnly<{
    * Sets the drop shadow offset
    * @platform ios
    */
-  shadowOffset?: $ReadOnly<{
+  shadowOffset?: Readonly<{
     width?: number,
     height?: number,
   }>,
@@ -701,7 +701,7 @@ export type ____ShadowStyle_InternalCore = $ReadOnly<{
   shadowRadius?: number,
 }>;
 
-export type ____ShadowStyle_Internal = $ReadOnly<{
+export type ____ShadowStyle_Internal = Readonly<{
   ...____ShadowStyle_InternalCore,
   ...____ShadowStyle_InternalOverrides,
 }>;
@@ -843,7 +843,7 @@ type ____BlendMode_Internal =
   | 'color'
   | 'luminosity';
 
-export type ____ViewStyle_InternalBase = $ReadOnly<{
+export type ____ViewStyle_InternalBase = Readonly<{
   backfaceVisibility?: 'visible' | 'hidden',
   backgroundColor?: ____ColorValue_Internal,
   borderColor?: ____ColorValue_Internal,
@@ -900,14 +900,14 @@ export type ____ViewStyle_InternalBase = $ReadOnly<{
   isolation?: 'auto' | 'isolate',
 }>;
 
-export type ____ViewStyle_InternalCore = $ReadOnly<{
+export type ____ViewStyle_InternalCore = Readonly<{
   ...$Exact<____LayoutStyle_Internal>,
   ...$Exact<____ShadowStyle_Internal>,
   ...$Exact<____TransformStyle_Internal>,
   ...____ViewStyle_InternalBase,
 }>;
 
-export type ____ViewStyle_Internal = $ReadOnly<{
+export type ____ViewStyle_Internal = Readonly<{
   ...____ViewStyle_InternalCore,
   ...____ViewStyle_InternalOverrides,
 }>;
@@ -999,14 +999,14 @@ export type ____FontVariant_Internal =
 export type ____FontVariantArray_Internal =
   $ReadOnlyArray<____FontVariant_Internal>;
 
-type ____TextStyle_InternalBase = $ReadOnly<{
+type ____TextStyle_InternalBase = Readonly<{
   color?: ____ColorValue_Internal,
   fontFamily?: string,
   fontSize?: number,
   fontStyle?: 'normal' | 'italic',
   fontWeight?: ____FontWeight_Internal,
   fontVariant?: ____FontVariantArray_Internal | string,
-  textShadowOffset?: $ReadOnly<{
+  textShadowOffset?: Readonly<{
     width: number,
     height: number,
   }>,
@@ -1030,17 +1030,17 @@ type ____TextStyle_InternalBase = $ReadOnly<{
   writingDirection?: 'auto' | 'ltr' | 'rtl',
 }>;
 
-export type ____TextStyle_InternalCore = $ReadOnly<{
+export type ____TextStyle_InternalCore = Readonly<{
   ...$Exact<____ViewStyle_Internal>,
   ...____TextStyle_InternalBase,
 }>;
 
-export type ____TextStyle_Internal = $ReadOnly<{
+export type ____TextStyle_Internal = Readonly<{
   ...____TextStyle_InternalCore,
   ...____TextStyle_InternalOverrides,
 }>;
 
-export type ____ImageStyle_InternalCore = $ReadOnly<{
+export type ____ImageStyle_InternalCore = Readonly<{
   ...$Exact<____ViewStyle_Internal>,
   resizeMode?: ImageResizeMode,
   objectFit?: 'cover' | 'contain' | 'fill' | 'scale-down' | 'none',
@@ -1049,12 +1049,12 @@ export type ____ImageStyle_InternalCore = $ReadOnly<{
   overflow?: 'visible' | 'hidden',
 }>;
 
-export type ____ImageStyle_Internal = $ReadOnly<{
+export type ____ImageStyle_Internal = Readonly<{
   ...____ImageStyle_InternalCore,
   ...____ImageStyle_InternalOverrides,
 }>;
 
-export type ____DangerouslyImpreciseStyle_InternalCore = $ReadOnly<{
+export type ____DangerouslyImpreciseStyle_InternalCore = Readonly<{
   ...$Exact<____TextStyle_Internal>,
   resizeMode?: ImageResizeMode,
   objectFit?: 'cover' | 'contain' | 'fill' | 'scale-down' | 'none',
@@ -1062,7 +1062,7 @@ export type ____DangerouslyImpreciseStyle_InternalCore = $ReadOnly<{
   overlayColor?: ColorValue,
 }>;
 
-export type ____DangerouslyImpreciseStyle_Internal = $ReadOnly<{
+export type ____DangerouslyImpreciseStyle_Internal = Readonly<{
   ...____DangerouslyImpreciseStyle_InternalCore,
   ...____DangerouslyImpreciseStyle_InternalOverrides,
   ...
@@ -1084,13 +1084,13 @@ export type ____DangerouslyImpreciseAnimatedStyleProp_Internal =
   WithAnimatedValue<StyleProp<Partial<____DangerouslyImpreciseStyle_Internal>>>;
 
 export type ____ViewStyleProp_Internal = StyleProp<
-  $ReadOnly<Partial<____ViewStyle_Internal>>,
+  Readonly<Partial<____ViewStyle_Internal>>,
 >;
 export type ____TextStyleProp_Internal = StyleProp<
-  $ReadOnly<Partial<____TextStyle_Internal>>,
+  Readonly<Partial<____TextStyle_Internal>>,
 >;
 export type ____ImageStyleProp_Internal = StyleProp<
-  $ReadOnly<Partial<____ImageStyle_Internal>>,
+  Readonly<Partial<____ImageStyle_Internal>>,
 >;
 
 export type ____Styles_Internal = {

--- a/packages/react-native/Libraries/StyleSheet/private/_StyleSheetTypesOverrides.js
+++ b/packages/react-native/Libraries/StyleSheet/private/_StyleSheetTypesOverrides.js
@@ -8,8 +8,8 @@
  * @format
  */
 
-export type ____DangerouslyImpreciseStyle_InternalOverrides = $ReadOnly<{}>;
-export type ____ImageStyle_InternalOverrides = $ReadOnly<{}>;
-export type ____ShadowStyle_InternalOverrides = $ReadOnly<{}>;
-export type ____TextStyle_InternalOverrides = $ReadOnly<{}>;
-export type ____ViewStyle_InternalOverrides = $ReadOnly<{}>;
+export type ____DangerouslyImpreciseStyle_InternalOverrides = Readonly<{}>;
+export type ____ImageStyle_InternalOverrides = Readonly<{}>;
+export type ____ShadowStyle_InternalOverrides = Readonly<{}>;
+export type ____TextStyle_InternalOverrides = Readonly<{}>;
+export type ____ViewStyle_InternalOverrides = Readonly<{}>;

--- a/packages/react-native/Libraries/StyleSheet/private/_TransformStyle.js
+++ b/packages/react-native/Libraries/StyleSheet/private/_TransformStyle.js
@@ -29,7 +29,7 @@ type MaximumOneOf<T: {...}> = $Values<{
   }>,
 }>;
 
-export type ____TransformStyle_Internal = $ReadOnly<{
+export type ____TransformStyle_Internal = Readonly<{
   /**
    * `transform` accepts an array of transformation objects. Each object specifies
    * the property that will be transformed as the key, and the value to use in the
@@ -48,7 +48,7 @@ export type ____TransformStyle_Internal = $ReadOnly<{
    */
   transform?:
     | $ReadOnlyArray<
-        $ReadOnly<
+        Readonly<
           MaximumOneOf<
             MergeUnion<
               | {+perspective: number | AnimatedNode}

--- a/packages/react-native/Libraries/Text/Text.js
+++ b/packages/react-native/Libraries/Text/Text.js
@@ -667,7 +667,7 @@ const TextImpl: component(
 
 TextImpl.displayName = 'Text';
 
-type TextPressabilityProps = $ReadOnly<{
+type TextPressabilityProps = Readonly<{
   onLongPress?: ?(event: GestureResponderEvent) => unknown,
   onPress?: ?(event: GestureResponderEvent) => unknown,
   onPressIn?: ?(event: GestureResponderEvent) => unknown,
@@ -801,7 +801,7 @@ function useTextPressability({
   );
 }
 
-type NativePressableTextProps = $ReadOnly<{
+type NativePressableTextProps = Readonly<{
   textProps: NativeTextProps,
   textPressabilityProps: TextPressabilityProps,
 }>;

--- a/packages/react-native/Libraries/Text/TextNativeComponent.js
+++ b/packages/react-native/Libraries/Text/TextNativeComponent.js
@@ -17,7 +17,7 @@ import {createViewConfig} from '../NativeComponent/ViewConfig';
 import UIManager from '../ReactNative/UIManager';
 import createReactNativeComponentClass from '../Renderer/shims/createReactNativeComponentClass';
 
-export type NativeTextProps = $ReadOnly<{
+export type NativeTextProps = Readonly<{
   ...TextProps,
   isHighlighted?: ?boolean,
   selectionColor?: ?ProcessedColorValue,

--- a/packages/react-native/Libraries/Text/TextProps.js
+++ b/packages/react-native/Libraries/Text/TextProps.js
@@ -25,14 +25,14 @@ import type {
 
 import * as React from 'react';
 
-export type PressRetentionOffset = $ReadOnly<{
+export type PressRetentionOffset = Readonly<{
   top: number,
   left: number,
   bottom: number,
   right: number,
 }>;
 
-type TextPointerEventProps = $ReadOnly<{
+type TextPointerEventProps = Readonly<{
   onPointerEnter?: (event: PointerEvent) => void,
   onPointerLeave?: (event: PointerEvent) => void,
   onPointerMove?: (event: PointerEvent) => void,
@@ -121,7 +121,7 @@ export type TextPropsAndroid = {
   minimumFontScale?: ?number,
 };
 
-type TextBaseProps = $ReadOnly<{
+type TextBaseProps = Readonly<{
   onAccessibilityAction?: ?(event: AccessibilityActionEvent) => unknown,
 
   /**
@@ -268,7 +268,7 @@ type TextBaseProps = $ReadOnly<{
 /**
  * @see https://reactnative.dev/docs/text#reference
  */
-export type TextProps = $ReadOnly<{
+export type TextProps = Readonly<{
   ...TextPointerEventProps,
   ...TextPropsIOS,
   ...TextPropsAndroid,

--- a/packages/react-native/Libraries/Types/CoreEventTypes.js
+++ b/packages/react-native/Libraries/Types/CoreEventTypes.js
@@ -10,12 +10,12 @@
 
 import type {HostInstance} from '../../src/private/types/HostInstance';
 
-export type NativeSyntheticEvent<+T> = $ReadOnly<{
+export type NativeSyntheticEvent<+T> = Readonly<{
   bubbles: ?boolean,
   cancelable: ?boolean,
   currentTarget: number | HostInstance,
   defaultPrevented: ?boolean,
-  dispatchConfig: $ReadOnly<{
+  dispatchConfig: Readonly<{
     registrationName: string,
   }>,
   eventPhase: ?number,
@@ -31,14 +31,14 @@ export type NativeSyntheticEvent<+T> = $ReadOnly<{
   type: ?string,
 }>;
 
-export type ResponderSyntheticEvent<T> = $ReadOnly<{
+export type ResponderSyntheticEvent<T> = Readonly<{
   ...NativeSyntheticEvent<T>,
-  touchHistory: $ReadOnly<{
+  touchHistory: Readonly<{
     indexOfSingleActiveTouch: number,
     mostRecentTimeStamp: number,
     numberActiveTouches: number,
     touchBank: $ReadOnlyArray<
-      $ReadOnly<{
+      Readonly<{
         touchActive: boolean,
         startPageX: number,
         startPageY: number,
@@ -54,14 +54,14 @@ export type ResponderSyntheticEvent<T> = $ReadOnly<{
   }>,
 }>;
 
-export type LayoutRectangle = $ReadOnly<{
+export type LayoutRectangle = Readonly<{
   x: number,
   y: number,
   width: number,
   height: number,
 }>;
 
-export type TextLayoutLine = $ReadOnly<{
+export type TextLayoutLine = Readonly<{
   ...LayoutRectangle,
   ascender: number,
   capHeight: number,
@@ -71,12 +71,12 @@ export type TextLayoutLine = $ReadOnly<{
 }>;
 
 export type LayoutChangeEvent = NativeSyntheticEvent<
-  $ReadOnly<{
+  Readonly<{
     layout: LayoutRectangle,
   }>,
 >;
 
-type TextLayoutEventData = $ReadOnly<{
+type TextLayoutEventData = Readonly<{
   lines: Array<TextLayoutLine>,
 }>;
 
@@ -220,7 +220,7 @@ export interface NativePointerEvent extends NativeMouseEvent {
 
 export type PointerEvent = NativeSyntheticEvent<NativePointerEvent>;
 
-export type NativeTouchEvent = $ReadOnly<{
+export type NativeTouchEvent = Readonly<{
   /**
    * Array of all touch events that have changed since the last event
    */
@@ -266,29 +266,29 @@ export type NativeTouchEvent = $ReadOnly<{
 
 export type GestureResponderEvent = ResponderSyntheticEvent<NativeTouchEvent>;
 
-export type NativeScrollRectangle = $ReadOnly<{
+export type NativeScrollRectangle = Readonly<{
   bottom: number,
   left: number,
   right: number,
   top: number,
 }>;
 
-export type NativeScrollPoint = $ReadOnly<{
+export type NativeScrollPoint = Readonly<{
   y: number,
   x: number,
 }>;
 
-export type NativeScrollVelocity = $ReadOnly<{
+export type NativeScrollVelocity = Readonly<{
   y: number,
   x: number,
 }>;
 
-export type NativeScrollSize = $ReadOnly<{
+export type NativeScrollSize = Readonly<{
   height: number,
   width: number,
 }>;
 
-export type NativeScrollEvent = $ReadOnly<{
+export type NativeScrollEvent = Readonly<{
   contentInset: NativeScrollRectangle,
   contentOffset: NativeScrollPoint,
   contentSize: NativeScrollSize,
@@ -304,7 +304,7 @@ export type NativeScrollEvent = $ReadOnly<{
 
 export type ScrollEvent = NativeSyntheticEvent<NativeScrollEvent>;
 
-export type TargetedEvent = $ReadOnly<{
+export type TargetedEvent = Readonly<{
   target: number,
   ...
 }>;
@@ -314,7 +314,7 @@ export type BlurEvent = NativeSyntheticEvent<TargetedEvent>;
 export type FocusEvent = NativeSyntheticEvent<TargetedEvent>;
 
 export type MouseEvent = NativeSyntheticEvent<
-  $ReadOnly<{
+  Readonly<{
     clientX: number,
     clientY: number,
     pageX: number,
@@ -323,7 +323,7 @@ export type MouseEvent = NativeSyntheticEvent<
   }>,
 >;
 
-export type KeyEvent = $ReadOnly<{
+export type KeyEvent = Readonly<{
   /**
    * The actual key that was pressed. For example, F would be "f" or "F" depending on the shift key.
    * @see https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key

--- a/packages/react-native/Libraries/Utilities/Dimensions.js
+++ b/packages/react-native/Libraries/Utilities/Dimensions.js
@@ -60,7 +60,7 @@ class Dimensions {
    *
    * @param {DimensionsPayload} dims Simple string-keyed object of dimensions to set
    */
-  static set(dims: $ReadOnly<DimensionsPayload>): void {
+  static set(dims: Readonly<DimensionsPayload>): void {
     // We calculate the window dimensions in JS so that we don't encounter loss of
     // precision in transferring the dimensions (which could be non-integers) over
     // the bridge.

--- a/packages/react-native/Libraries/Utilities/IPerformanceLogger.js
+++ b/packages/react-native/Libraries/Utilities/IPerformanceLogger.js
@@ -34,10 +34,10 @@ export interface IPerformanceLogger {
   clearCompleted(): void;
   close(): void;
   currentTimestamp(): number;
-  getExtras(): $ReadOnly<{[key: string]: ?ExtraValue, ...}>;
-  getPoints(): $ReadOnly<{[key: string]: ?number, ...}>;
-  getPointExtras(): $ReadOnly<{[key: string]: ?Extras, ...}>;
-  getTimespans(): $ReadOnly<{[key: string]: ?Timespan, ...}>;
+  getExtras(): Readonly<{[key: string]: ?ExtraValue, ...}>;
+  getPoints(): Readonly<{[key: string]: ?number, ...}>;
+  getPointExtras(): Readonly<{[key: string]: ?Extras, ...}>;
+  getTimespans(): Readonly<{[key: string]: ?Timespan, ...}>;
   hasTimespan(key: string): boolean;
   isClosed(): boolean;
   logEverything(): void;

--- a/packages/react-native/Libraries/Utilities/__tests__/useMergeRefs-test.js
+++ b/packages/react-native/Libraries/Utilities/__tests__/useMergeRefs-test.js
@@ -37,7 +37,7 @@ class Screen {
 }
 
 function TestComponent(
-  props: $ReadOnly<{children: () => React.MixedElement}>,
+  props: Readonly<{children: () => React.MixedElement}>,
 ): React.Node {
   return props.children();
 }

--- a/packages/react-native/Libraries/Utilities/codegenNativeCommands.js
+++ b/packages/react-native/Libraries/Utilities/codegenNativeCommands.js
@@ -10,7 +10,7 @@
 
 const {dispatchCommand} = require('../ReactNative/RendererProxy');
 
-type NativeCommandsOptions<T = string> = $ReadOnly<{
+type NativeCommandsOptions<T = string> = Readonly<{
   supportedCommands: $ReadOnlyArray<T>,
 }>;
 

--- a/packages/react-native/Libraries/Utilities/codegenNativeComponent.js
+++ b/packages/react-native/Libraries/Utilities/codegenNativeComponent.js
@@ -16,7 +16,7 @@ import requireNativeComponent from '../../Libraries/ReactNative/requireNativeCom
 import UIManager from '../ReactNative/UIManager';
 
 // TODO: import from CodegenSchema once workspaces are enabled
-type NativeComponentOptions = $ReadOnly<{
+type NativeComponentOptions = Readonly<{
   interfaceOnly?: boolean,
   paperComponentName?: string,
   paperComponentNameDeprecated?: string,

--- a/packages/react-native/Libraries/vendor/emitter/EventEmitter.js
+++ b/packages/react-native/Libraries/vendor/emitter/EventEmitter.js
@@ -16,7 +16,7 @@ export interface EventSubscription {
 }
 
 export interface IEventEmitter<
-  TEventToArgsMap: $ReadOnly<Record<string, $ReadOnlyArray<UnsafeEventObject>>>,
+  TEventToArgsMap: Readonly<Record<string, $ReadOnlyArray<UnsafeEventObject>>>,
 > {
   addListener<TEvent: $Keys<TEventToArgsMap>>(
     eventType: TEvent,
@@ -41,7 +41,7 @@ interface Registration<TArgs> {
 }
 
 type Registry<
-  TEventToArgsMap: $ReadOnly<Record<string, $ReadOnlyArray<UnsafeEventObject>>>,
+  TEventToArgsMap: Readonly<Record<string, $ReadOnlyArray<UnsafeEventObject>>>,
 > = {
   [K in keyof TEventToArgsMap]: Set<Registration<TEventToArgsMap[K]>>,
 };
@@ -67,9 +67,9 @@ type Registry<
  *
  */
 export default class EventEmitter<
-  TEventToArgsMap: $ReadOnly<
+  TEventToArgsMap: Readonly<
     Record<string, $ReadOnlyArray<UnsafeEventObject>>,
-  > = $ReadOnly<Record<string, $ReadOnlyArray<UnsafeEventObject>>>,
+  > = Readonly<Record<string, $ReadOnlyArray<UnsafeEventObject>>>,
 > implements IEventEmitter<TEventToArgsMap>
 {
   #registry: Registry<TEventToArgsMap>;
@@ -157,7 +157,7 @@ export default class EventEmitter<
 }
 
 function allocate<
-  TEventToArgsMap: $ReadOnly<Record<string, $ReadOnlyArray<UnsafeEventObject>>>,
+  TEventToArgsMap: Readonly<Record<string, $ReadOnlyArray<UnsafeEventObject>>>,
   TEvent: $Keys<TEventToArgsMap>,
   TEventArgs: TEventToArgsMap[TEvent],
 >(

--- a/packages/react-native/flow/bom.js.flow
+++ b/packages/react-native/flow/bom.js.flow
@@ -47,8 +47,8 @@ declare var console: {
   // Printing
   table(
     tabularData:
-      | $ReadOnly<{[key: string]: unknown, ...}>
-      | $ReadOnlyArray<$ReadOnly<{[key: string]: unknown, ...}>>
+      | Readonly<{[key: string]: unknown, ...}>
+      | $ReadOnlyArray<Readonly<{[key: string]: unknown, ...}>>
       | $ReadOnlyArray<$ReadOnlyArray<unknown>>,
   ): void,
   dir(...data: $ReadOnlyArray<unknown>): void,

--- a/packages/react-native/jest/mockComponent.js
+++ b/packages/react-native/jest/mockComponent.js
@@ -11,7 +11,7 @@
 import * as React from 'react';
 import {createElement} from 'react';
 
-type Modulish<T> = T | $ReadOnly<{default: T}>;
+type Modulish<T> = T | Readonly<{default: T}>;
 type ModuleDefault<T> = T['default'];
 
 type TComponentType = React.ComponentType<{...}>;
@@ -27,9 +27,8 @@ export default function mockComponent<
   moduleName: string,
   instanceMethods: ?interface {},
   isESModule: TIsESModule,
-): TIsESModule extends true
-  ? // $FlowFixMe[incompatible-use]
-    ModuleDefault<TComponentModule & typeof instanceMethods>
+): TIsESModule extends true // $FlowFixMe[incompatible-use]
+  ? ModuleDefault<TComponentModule & typeof instanceMethods>
   : TComponentModule & typeof instanceMethods {
   const RealComponent: TComponentType = isESModule
     ? // $FlowFixMe[prop-missing]

--- a/packages/react-native/scripts/featureflags/print.js
+++ b/packages/react-native/scripts/featureflags/print.js
@@ -37,8 +37,8 @@ function getPurposeString(purpose: string): string {
 }
 
 function compareFeatureFlags(
-  [keyA, valueA]: $ReadOnly<[string, $ReadOnly<{Purpose: string, ...}>]>,
-  [keyB, valueB]: $ReadOnly<[string, $ReadOnly<{Purpose: string, ...}>]>,
+  [keyA, valueA]: Readonly<[string, Readonly<{Purpose: string, ...}>]>,
+  [keyB, valueB]: Readonly<[string, Readonly<{Purpose: string, ...}>]>,
 ): number {
   const purposeA = PURPOSE_ORDER.indexOf(valueA.Purpose);
   const purposeB = PURPOSE_ORDER.indexOf(valueB.Purpose);

--- a/packages/react-native/scripts/featureflags/types.js
+++ b/packages/react-native/scripts/featureflags/types.js
@@ -10,7 +10,7 @@
 
 export type FeatureFlagValue = boolean | number | string;
 
-export type FeatureFlagDefinitions = $ReadOnly<{
+export type FeatureFlagDefinitions = Readonly<{
   common: CommonFeatureFlagList,
   jsOnly: JsOnlyFeatureFlagList,
 }>;
@@ -30,7 +30,7 @@ export type OSSReleaseStageValue =
 
 export type CommonFeatureFlagConfig<
   TValue: FeatureFlagValue = FeatureFlagValue,
-> = $ReadOnly<{
+> = Readonly<{
   defaultValue: TValue,
   metadata: FeatureFlagMetadata<TValue>,
   ossReleaseStage: OSSReleaseStageValue,
@@ -39,24 +39,24 @@ export type CommonFeatureFlagConfig<
   skipNativeAPI?: true,
 }>;
 
-export type CommonFeatureFlagList = $ReadOnly<{
+export type CommonFeatureFlagList = Readonly<{
   [flagName: string]: CommonFeatureFlagConfig<>,
 }>;
 
 export type JsOnlyFeatureFlagConfig<
   TValue: FeatureFlagValue = FeatureFlagValue,
-> = $ReadOnly<{
+> = Readonly<{
   defaultValue: TValue,
   metadata: FeatureFlagMetadata<TValue>,
   ossReleaseStage: OSSReleaseStageValue,
 }>;
 
-export type JsOnlyFeatureFlagList = $ReadOnly<{
+export type JsOnlyFeatureFlagList = Readonly<{
   [flagName: string]: JsOnlyFeatureFlagConfig<>,
 }>;
 
 export type FeatureFlagMetadata<TValue: FeatureFlagValue = FeatureFlagValue> =
-  | $ReadOnly<{
+  | Readonly<{
       purpose: 'experimentation',
       /**
        * Approximate date when the flag was added.
@@ -66,13 +66,13 @@ export type FeatureFlagMetadata<TValue: FeatureFlagValue = FeatureFlagValue> =
       description: string,
       expectedReleaseValue: TValue,
     }>
-  | $ReadOnly<{
+  | Readonly<{
       purpose: 'operational' | 'release',
       description: string,
       expectedReleaseValue: TValue,
     }>;
 
-export type GeneratorConfig = $ReadOnly<{
+export type GeneratorConfig = Readonly<{
   featureFlagDefinitions: FeatureFlagDefinitions,
   jsPath: string,
   commonCxxPath: string,
@@ -81,10 +81,10 @@ export type GeneratorConfig = $ReadOnly<{
   androidJniPath: string,
 }>;
 
-export type GeneratorOptions = $ReadOnly<{
+export type GeneratorOptions = Readonly<{
   verifyUnchanged: boolean,
 }>;
 
-export type GeneratorResult = $ReadOnly<{
+export type GeneratorResult = Readonly<{
   [path: string]: string /* content */,
 }>;

--- a/packages/react-native/src/private/animated/NativeAnimatedHelper.js
+++ b/packages/react-native/src/private/animated/NativeAnimatedHelper.js
@@ -406,7 +406,7 @@ function assertNativeAnimatedModule(): void {
 let _warnedMissingNativeAnimated = false;
 
 function shouldUseNativeDriver(
-  config: $ReadOnly<{...AnimationConfig, ...}> | EventConfig<unknown>,
+  config: Readonly<{...AnimationConfig, ...}> | EventConfig<unknown>,
 ): boolean {
   if (config.useNativeDriver == null) {
     console.warn(

--- a/packages/react-native/src/private/animated/createAnimatedPropsMemoHook.js
+++ b/packages/react-native/src/private/animated/createAnimatedPropsMemoHook.js
@@ -25,31 +25,31 @@ type CompositeKey = {
     | CompositeKeyComponent
     | AnimatedEvent
     | $ReadOnlyArray<unknown>
-    | $ReadOnly<{[string]: unknown}>,
+    | Readonly<{[string]: unknown}>,
 };
 
 type CompositeKeyComponent =
   | AnimatedNode
   | $ReadOnlyArray<CompositeKeyComponent | null>
-  | $ReadOnly<{[string]: CompositeKeyComponent}>;
+  | Readonly<{[string]: CompositeKeyComponent}>;
 
-type $ReadOnlyCompositeKey = $ReadOnly<{
-  style?: $ReadOnly<{[string]: CompositeKeyComponent}>,
+type $ReadOnlyCompositeKey = Readonly<{
+  style?: Readonly<{[string]: CompositeKeyComponent}>,
   [string]:
     | $ReadOnlyCompositeKeyComponent
     | AnimatedEvent
     | $ReadOnlyArray<unknown>
-    | $ReadOnly<{[string]: unknown}>,
+    | Readonly<{[string]: unknown}>,
 }>;
 
 type $ReadOnlyCompositeKeyComponent =
   | AnimatedNode
   | $ReadOnlyArray<$ReadOnlyCompositeKeyComponent | null>
-  | $ReadOnly<{[string]: $ReadOnlyCompositeKeyComponent}>;
+  | Readonly<{[string]: $ReadOnlyCompositeKeyComponent}>;
 
 type AnimatedPropsMemoHook = (
   () => AnimatedProps,
-  props: $ReadOnly<{[string]: unknown}>,
+  props: Readonly<{[string]: unknown}>,
 ) => AnimatedProps;
 
 /**
@@ -62,14 +62,14 @@ export function createAnimatedPropsMemoHook(
 ): AnimatedPropsMemoHook {
   return function useAnimatedPropsMemo(
     create: () => AnimatedProps,
-    props: $ReadOnly<{[string]: unknown}>,
+    props: Readonly<{[string]: unknown}>,
   ): AnimatedProps {
     const compositeKey = useMemo(
       () => createCompositeKeyForProps(props, allowlist),
       [props],
     );
 
-    const prevRef = useRef<?$ReadOnly<{
+    const prevRef = useRef<?Readonly<{
       compositeKey: typeof compositeKey,
       node: AnimatedProps,
     }>>();
@@ -107,7 +107,7 @@ export function createAnimatedPropsMemoHook(
  * returns null.
  */
 export function createCompositeKeyForProps(
-  props: $ReadOnly<{[string]: unknown}>,
+  props: Readonly<{[string]: unknown}>,
   allowlist: ?AnimatedPropsAllowlist,
 ): $ReadOnlyCompositeKey | null {
   let compositeKey: CompositeKey | null = null;
@@ -200,9 +200,9 @@ function createCompositeKeyForArray(
  * If `object` contains no `AnimatedNode` instances, this returns null.
  */
 function createCompositeKeyForObject(
-  object: $ReadOnly<{[string]: unknown}>,
+  object: Readonly<{[string]: unknown}>,
   allowlist?: ?AnimatedStyleAllowlist,
-): $ReadOnly<{[string]: $ReadOnlyCompositeKeyComponent}> | null {
+): Readonly<{[string]: $ReadOnlyCompositeKeyComponent}> | null {
   let compositeKey: {[string]: $ReadOnlyCompositeKeyComponent} | null = null;
 
   const keys = Object.keys(object);
@@ -355,6 +355,6 @@ function areCompositeKeyComponentsEqual(
 // this shim when they do.
 // $FlowFixMe[method-unbinding]
 const _hasOwnProp = Object.prototype.hasOwnProperty;
-const hasOwn: (obj: $ReadOnly<{...}>, prop: string) => boolean =
+const hasOwn: (obj: Readonly<{...}>, prop: string) => boolean =
   // $FlowFixMe[method-unbinding]
   Object.hasOwn ?? ((obj, prop) => _hasOwnProp.call(obj, prop));

--- a/packages/react-native/src/private/components/virtualview/VirtualView.js
+++ b/packages/react-native/src/private/components/virtualview/VirtualView.js
@@ -37,14 +37,14 @@ export enum VirtualViewRenderState {
   None = 2,
 }
 
-export type Rect = $ReadOnly<{
+export type Rect = Readonly<{
   x: number,
   y: number,
   width: number,
   height: number,
 }>;
 
-export type ModeChangeEvent = $ReadOnly<{
+export type ModeChangeEvent = Readonly<{
   ...Omit<NativeModeChangeEvent, 'mode'>,
   renderState: VirtualViewRenderState,
   mode: VirtualViewMode,

--- a/packages/react-native/src/private/components/virtualview/VirtualViewExperimentalNativeComponent.js
+++ b/packages/react-native/src/private/components/virtualview/VirtualViewExperimentalNativeComponent.js
@@ -18,7 +18,7 @@ import type {HostComponent} from '../../types/HostComponent';
 
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
 
-export type NativeModeChangeEvent = $ReadOnly<{
+export type NativeModeChangeEvent = Readonly<{
   /**
    * Virtualization mode of the target view.
    *
@@ -34,7 +34,7 @@ export type NativeModeChangeEvent = $ReadOnly<{
   /**
    * Rect of the target view, relative to the nearest ancestor scroll container.
    */
-  targetRect: $ReadOnly<{
+  targetRect: Readonly<{
     x: Double,
     y: Double,
     width: Double,
@@ -51,7 +51,7 @@ export type NativeModeChangeEvent = $ReadOnly<{
    *
    * This can be used to determine whether and how much new content to render.
    */
-  thresholdRect: $ReadOnly<{
+  thresholdRect: Readonly<{
     x: Double,
     y: Double,
     width: Double,
@@ -59,7 +59,7 @@ export type NativeModeChangeEvent = $ReadOnly<{
   }>,
 }>;
 
-type VirtualViewExperimentalNativeProps = $ReadOnly<{
+type VirtualViewExperimentalNativeProps = Readonly<{
   ...ViewProps,
 
   /**

--- a/packages/react-native/src/private/components/virtualview/VirtualViewNativeComponent.js
+++ b/packages/react-native/src/private/components/virtualview/VirtualViewNativeComponent.js
@@ -18,7 +18,7 @@ import type {HostComponent} from '../../types/HostComponent';
 
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
 
-export type NativeModeChangeEvent = $ReadOnly<{
+export type NativeModeChangeEvent = Readonly<{
   /**
    * Virtualization mode of the target view.
    *
@@ -34,7 +34,7 @@ export type NativeModeChangeEvent = $ReadOnly<{
   /**
    * Rect of the target view, relative to the nearest ancestor scroll container.
    */
-  targetRect: $ReadOnly<{
+  targetRect: Readonly<{
     x: Double,
     y: Double,
     width: Double,
@@ -51,7 +51,7 @@ export type NativeModeChangeEvent = $ReadOnly<{
    *
    * This can be used to determine whether and how much new content to render.
    */
-  thresholdRect: $ReadOnly<{
+  thresholdRect: Readonly<{
     x: Double,
     y: Double,
     width: Double,
@@ -59,7 +59,7 @@ export type NativeModeChangeEvent = $ReadOnly<{
   }>,
 }>;
 
-type VirtualViewNativeProps = $ReadOnly<{
+type VirtualViewNativeProps = Readonly<{
   ...ViewProps,
 
   /**

--- a/packages/react-native/src/private/components/virtualview/__tests__/VirtualView-itest.js
+++ b/packages/react-native/src/private/components/virtualview/__tests__/VirtualView-itest.js
@@ -355,7 +355,7 @@ export function dispatchModeChangeEvent(
 /**
  * Helper to create a callback ref that records instances using WeakRefs.
  */
-function createWeakRefCallback<T: interface {} = interface {}>(): $ReadOnly<{
+function createWeakRefCallback<T: interface {} = interface {}>(): Readonly<{
   weakRefs: $ReadOnlyArray<WeakRef<T>>,
   callbackRef: React.RefSetter<T>,
 }> {

--- a/packages/react-native/src/private/devsupport/devmenu/elementinspector/BorderBox.js
+++ b/packages/react-native/src/private/devsupport/devmenu/elementinspector/BorderBox.js
@@ -16,9 +16,9 @@ import * as React from 'react';
 
 const View = require('../../../../../Libraries/Components/View/View').default;
 
-type Props = $ReadOnly<{
+type Props = Readonly<{
   children: React.Node,
-  box?: ?$ReadOnly<{
+  box?: ?Readonly<{
     top: number,
     right: number,
     bottom: number,

--- a/packages/react-native/src/private/devsupport/devmenu/elementinspector/BoxInspector.js
+++ b/packages/react-native/src/private/devsupport/devmenu/elementinspector/BoxInspector.js
@@ -31,7 +31,7 @@ const blank = {
   bottom: 0,
 };
 
-type BoxInspectorProps = $ReadOnly<{
+type BoxInspectorProps = Readonly<{
   style: ViewStyleProp,
   frame: ?InspectedElementFrame,
 }>;
@@ -57,10 +57,10 @@ function BoxInspector({style, frame}: BoxInspectorProps): React.Node {
   );
 }
 
-type BoxContainerProps = $ReadOnly<{
+type BoxContainerProps = Readonly<{
   title: string,
   titleStyle?: TextStyleProp,
-  box: $ReadOnly<{
+  box: Readonly<{
     top: number,
     left: number,
     right: number,

--- a/packages/react-native/src/private/devsupport/devmenu/elementinspector/ElementBox.js
+++ b/packages/react-native/src/private/devsupport/devmenu/elementinspector/ElementBox.js
@@ -25,15 +25,15 @@ const Dimensions =
 const BorderBox = require('./BorderBox').default;
 const resolveBoxStyle = require('./resolveBoxStyle').default;
 
-type Props = $ReadOnly<{
+type Props = Readonly<{
   frame: InspectedElementFrame,
   style?: ?ViewStyleProp,
 }>;
 
 function ElementBox({frame, style}: Props): React.Node {
   const flattenedStyle = flattenStyle(style) || {};
-  let margin: ?$ReadOnly<Style> = resolveBoxStyle('margin', flattenedStyle);
-  let padding: ?$ReadOnly<Style> = resolveBoxStyle('padding', flattenedStyle);
+  let margin: ?Readonly<Style> = resolveBoxStyle('margin', flattenedStyle);
+  let padding: ?Readonly<Style> = resolveBoxStyle('padding', flattenedStyle);
 
   const frameStyle = {...frame};
   const contentStyle: {width: number, height: number} = {
@@ -110,7 +110,7 @@ type Style = {
  * @param style the style to resolve
  * @return a modified copy
  */
-function resolveRelativeSizes(style: $ReadOnly<Style>): Style {
+function resolveRelativeSizes(style: Readonly<Style>): Style {
   let resolvedStyle = {...style};
   resolveSizeInPlace(resolvedStyle, 'top', 'height');
   resolveSizeInPlace(resolvedStyle, 'right', 'width');

--- a/packages/react-native/src/private/devsupport/devmenu/elementinspector/ElementProperties.js
+++ b/packages/react-native/src/private/devsupport/devmenu/elementinspector/ElementProperties.js
@@ -30,7 +30,7 @@ const mapWithSeparator =
 const BoxInspector = require('./BoxInspector').default;
 const StyleInspector = require('./StyleInspector').default;
 
-type Props = $ReadOnly<{
+type Props = Readonly<{
   hierarchy: ?InspectorData['hierarchy'],
   style?: ?ViewStyleProp,
   frame?: ?Object,

--- a/packages/react-native/src/private/devsupport/devmenu/elementinspector/Inspector.js
+++ b/packages/react-native/src/private/devsupport/devmenu/elementinspector/Inspector.js
@@ -41,7 +41,7 @@ const {useState} = React;
 type PanelPosition = 'top' | 'bottom';
 
 export type InspectedElementFrame = TouchedViewDataAtPoint['frame'];
-export type InspectedElement = $ReadOnly<{
+export type InspectedElement = Readonly<{
   frame: InspectedElementFrame,
   style?: ViewStyleProp,
 }>;

--- a/packages/react-native/src/private/devsupport/devmenu/elementinspector/InspectorOverlay.js
+++ b/packages/react-native/src/private/devsupport/devmenu/elementinspector/InspectorOverlay.js
@@ -20,7 +20,7 @@ const StyleSheet =
   require('../../../../../Libraries/StyleSheet/StyleSheet').default;
 const ElementBox = require('./ElementBox').default;
 
-type Props = $ReadOnly<{
+type Props = Readonly<{
   inspected?: ?InspectedElement,
   onTouchPoint: (locationX: number, locationY: number) => void,
 }>;

--- a/packages/react-native/src/private/devsupport/devmenu/elementinspector/InspectorPanel.js
+++ b/packages/react-native/src/private/devsupport/devmenu/elementinspector/InspectorPanel.js
@@ -25,7 +25,7 @@ const StyleSheet =
 const Text = require('../../../../../Libraries/Text/Text').default;
 const ElementProperties = require('./ElementProperties').default;
 
-type Props = $ReadOnly<{
+type Props = Readonly<{
   devtoolsIsOpen: boolean,
   inspecting: boolean,
   setInspecting: (val: boolean) => void,
@@ -84,7 +84,7 @@ class InspectorPanel extends React.Component<Props> {
   }
 }
 
-type InspectorPanelButtonProps = $ReadOnly<{
+type InspectorPanelButtonProps = Readonly<{
   onClick: (val: boolean) => void,
   pressed: boolean,
   title: string,

--- a/packages/react-native/src/private/devsupport/devmenu/elementinspector/StyleInspector.js
+++ b/packages/react-native/src/private/devsupport/devmenu/elementinspector/StyleInspector.js
@@ -20,7 +20,7 @@ const StyleSheet =
   require('../../../../../Libraries/StyleSheet/StyleSheet').default;
 const Text = require('../../../../../Libraries/Text/Text').default;
 
-type Props = $ReadOnly<{
+type Props = Readonly<{
   style?: ?____FlattenStyleProp_Internal<ViewStyleProp>,
 }>;
 

--- a/packages/react-native/src/private/devsupport/devmenu/elementinspector/resolveBoxStyle.js
+++ b/packages/react-native/src/private/devsupport/devmenu/elementinspector/resolveBoxStyle.js
@@ -26,7 +26,7 @@ const I18nManager =
 function resolveBoxStyle(
   prefix: string,
   style: Object,
-): ?$ReadOnly<{
+): ?Readonly<{
   bottom: number,
   left: number,
   right: number,

--- a/packages/react-native/src/private/specs_DEPRECATED/components/ActivityIndicatorViewNativeComponent.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/components/ActivityIndicatorViewNativeComponent.js
@@ -15,7 +15,7 @@ import type {HostComponent} from '../../types/HostComponent';
 
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
 
-type RCTActivityIndicatorViewNativeProps = $ReadOnly<{
+type RCTActivityIndicatorViewNativeProps = Readonly<{
   ...ViewProps,
 
   /**

--- a/packages/react-native/src/private/specs_DEPRECATED/components/AndroidDrawerLayoutNativeComponent.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/components/AndroidDrawerLayoutNativeComponent.js
@@ -22,15 +22,15 @@ import codegenNativeCommands from '../../../../Libraries/Utilities/codegenNative
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
 import * as React from 'react';
 
-type DrawerStateEvent = $ReadOnly<{
+type DrawerStateEvent = Readonly<{
   drawerState: Int32,
 }>;
 
-type DrawerSlideEvent = $ReadOnly<{
+type DrawerSlideEvent = Readonly<{
   offset: Float,
 }>;
 
-type AndroidDrawerLayoutNativeProps = $ReadOnly<{
+type AndroidDrawerLayoutNativeProps = Readonly<{
   ...ViewProps,
   /**
    * Determines whether the keyboard gets dismissed in response to a drag.

--- a/packages/react-native/src/private/specs_DEPRECATED/components/AndroidHorizontalScrollContentViewNativeComponent.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/components/AndroidHorizontalScrollContentViewNativeComponent.js
@@ -13,7 +13,7 @@ import type {HostComponent} from '../../types/HostComponent';
 
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
 
-type AndroidHorizontalScrollContentViewNativeProps = $ReadOnly<{
+type AndroidHorizontalScrollContentViewNativeProps = Readonly<{
   ...ViewProps,
 
   removeClippedSubviews?: ?boolean,

--- a/packages/react-native/src/private/specs_DEPRECATED/components/AndroidSwipeRefreshLayoutNativeComponent.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/components/AndroidSwipeRefreshLayoutNativeComponent.js
@@ -21,7 +21,7 @@ import codegenNativeCommands from '../../../../Libraries/Utilities/codegenNative
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
 import * as React from 'react';
 
-type AndroidSwipeRefreshLayoutNativeProps = $ReadOnly<{
+type AndroidSwipeRefreshLayoutNativeProps = Readonly<{
   ...ViewProps,
 
   /**

--- a/packages/react-native/src/private/specs_DEPRECATED/components/AndroidSwitchNativeComponent.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/components/AndroidSwitchNativeComponent.js
@@ -21,12 +21,12 @@ import codegenNativeCommands from '../../../../Libraries/Utilities/codegenNative
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
 import * as React from 'react';
 
-type AndroidSwitchChangeEvent = $ReadOnly<{
+type AndroidSwitchChangeEvent = Readonly<{
   value: boolean,
   target: Int32,
 }>;
 
-type AndroidSwitchNativeProps = $ReadOnly<{
+type AndroidSwitchNativeProps = Readonly<{
   ...ViewProps,
 
   // Props

--- a/packages/react-native/src/private/specs_DEPRECATED/components/DebuggingOverlayNativeComponent.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/components/DebuggingOverlayNativeComponent.js
@@ -16,7 +16,7 @@ import codegenNativeCommands from '../../../../Libraries/Utilities/codegenNative
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
 import * as React from 'react';
 
-type DebuggingOverlayNativeProps = $ReadOnly<{
+type DebuggingOverlayNativeProps = Readonly<{
   ...ViewProps,
 }>;
 export type DebuggingOverlayNativeComponentType =

--- a/packages/react-native/src/private/specs_DEPRECATED/components/ProgressBarAndroidNativeComponent.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/components/ProgressBarAndroidNativeComponent.js
@@ -18,7 +18,7 @@ import type {HostComponent} from '../../types/HostComponent';
 
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
 
-type AndroidProgressBarNativeProps = $ReadOnly<{
+type AndroidProgressBarNativeProps = Readonly<{
   ...ViewProps,
 
   //Props

--- a/packages/react-native/src/private/specs_DEPRECATED/components/PullToRefreshViewNativeComponent.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/components/PullToRefreshViewNativeComponent.js
@@ -21,7 +21,7 @@ import codegenNativeCommands from '../../../../Libraries/Utilities/codegenNative
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
 import * as React from 'react';
 
-type PullToRefreshNativeProps = $ReadOnly<{
+type PullToRefreshNativeProps = Readonly<{
   ...ViewProps,
 
   /**

--- a/packages/react-native/src/private/specs_DEPRECATED/components/RCTInputAccessoryViewNativeComponent.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/components/RCTInputAccessoryViewNativeComponent.js
@@ -14,7 +14,7 @@ import type {HostComponent} from '../../types/HostComponent';
 
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
 
-type InputAccessoryNativeProps = $ReadOnly<{
+type InputAccessoryNativeProps = Readonly<{
   ...ViewProps,
   backgroundColor?: ?ColorValue,
 }>;

--- a/packages/react-native/src/private/specs_DEPRECATED/components/RCTModalHostViewNativeComponent.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/components/RCTModalHostViewNativeComponent.js
@@ -18,11 +18,11 @@ import type {HostComponent} from '../../types/HostComponent';
 
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
 
-type OrientationChangeEvent = $ReadOnly<{
+type OrientationChangeEvent = Readonly<{
   orientation: 'portrait' | 'landscape',
 }>;
 
-type RCTModalHostViewNativeProps = $ReadOnly<{
+type RCTModalHostViewNativeProps = Readonly<{
   ...ViewProps,
 
   /**

--- a/packages/react-native/src/private/specs_DEPRECATED/components/RCTSafeAreaViewNativeComponent.js
+++ b/packages/react-native/src/private/specs_DEPRECATED/components/RCTSafeAreaViewNativeComponent.js
@@ -13,7 +13,7 @@ import type {HostComponent} from '../../types/HostComponent';
 
 import codegenNativeComponent from '../../../../Libraries/Utilities/codegenNativeComponent';
 
-type RCTSafeAreaViewNativeProps = $ReadOnly<{
+type RCTSafeAreaViewNativeProps = Readonly<{
   ...ViewProps,
 
   // No props


### PR DESCRIPTION
Summary:
We are transforming the following utility types to be more consistent with typescript and better AI integration:

* `$NonMaybeType` -> `NonNullable`
* `$ReadOnly` -> `Readonly`
* `$ReadOnlyArray` -> `ReadonlyArray`
* `$ReadOnlyMap` -> `ReadonlyMap`
* `$ReadOnlySet` -> `ReadonlySet`
* `$Keys` -> `keyof`
* `$Values` -> `Values`
* `mixed` -> `unknown`

See details in https://fb.workplace.com/groups/flowlang/permalink/1837907750148213/.

drop-conflicts

Command:

`js1 flow-runner codemod flow/transformUtilityType --legacy-type='$ReadOnly'`

Differential Revision: D90146145
