### PR TITLE
Future proof for unknown type annotation node

### DIFF
--- a/packages/react-native-codegen/src/parsers/parsers-primitives.js
+++ b/packages/react-native-codegen/src/parsers/parsers-primitives.js
@@ -665,6 +665,7 @@ function emitCommonTypes(
     MixedTypeAnnotation: cxxOnly ? emitMixed : emitGenericObject,
     UnsafeMixed: cxxOnly ? emitMixed : emitGenericObject,
     unknown: cxxOnly ? emitMixed : emitGenericObject,
+    UnknownTypeAnnotation: cxxOnly ? emitMixed : emitGenericObject,
   };
 
   const typeAnnotationName = parser.convertKeywordToTypeAnnotation(


### PR DESCRIPTION
Summary:
In the future this will parse as `UnknownTypeAnnotation` - future proof.

Changelog: [Internal]

Reviewed By: marcoww6

Differential Revision: D90226759


