### PR TITLE
fix(android): support `unstable_path` query param in asset URLs

### DIFF
--- a/packages/community-cli-plugin/src/commands/bundle/assetPathUtils.js
+++ b/packages/community-cli-plugin/src/commands/bundle/assetPathUtils.js
@@ -75,7 +75,7 @@ function getResourceIdentifier(asset: PackagerAsset): string {
     .toLowerCase()
     .replace(/\//g, '_') // Encode folder structure in file name
     .replace(/([^a-z0-9_])/g, '') // Remove illegal chars
-    .replace(/^assets_/, ''); // Remove "assets_" prefix
+    .replace(/^(?:assets|assetsunstable_path)_/, ''); // Remove "assets_" or "assetsunstable_path_" prefix
 }
 
 function getBasePath(asset: PackagerAsset): string {


### PR DESCRIPTION
## Summary:

Syncs `getAndroidResourceIdentifier` implementations between [`/community-cli-plugin/src/commands/bundle/assetPathUtils.js`](https://github.com/facebook/react-native/blob/main/packages/community-cli-plugin/src/commands/bundle/assetPathUtils.js#L72-L79) and [`/assets/path-support.js`](https://github.com/facebook/react-native/blob/main/packages/assets/path-support.js#L77-L85).

Ideally, the former should use `@react-native/assets-registry` directly so we don't need to sync.

## Changelog:

[ANDROID] [FIXED] - Handle `unstable_path` query param in asset URLs

## Test Plan:

n/a