### PR TITLE
Add Android container to E2E test jobs

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -217,6 +217,11 @@ jobs:
   test_e2e_android_templateapp:
     runs-on: 4-core-ubuntu
     needs: build_npm_package
+    container:
+      image: reactnativecommunity/react-native-android:latest
+      env:
+        TERM: "dumb"
+        GRADLE_OPTS: "-Dorg.gradle.daemon=false"
     strategy:
       fail-fast: false
       matrix:
@@ -323,6 +328,11 @@ jobs:
   test_e2e_android_rntester:
     runs-on: 4-core-ubuntu
     needs: [build_android]
+    container:
+      image: reactnativecommunity/react-native-android:latest
+      env:
+        TERM: "dumb"
+        GRADLE_OPTS: "-Dorg.gradle.daemon=false"
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Summary:
The `test_e2e_android_templateapp` and `test_e2e_android_rntester` jobs were
running without the `reactnativecommunity/react-native-android:latest` container
that other Android jobs use.

This results in those jobs running on bare metal and re-downloading CMake and other
custom dependencies we already have in the containers.

Differential Revision: D90246606


