### PR TITLE
Remove "JavaScript logs have moved!" notice

### DIFF
--- a/packages/dev-middleware/src/createDevMiddleware.js
+++ b/packages/dev-middleware/src/createDevMiddleware.js
@@ -160,17 +160,6 @@ function createWrappedEventReporter(
             event.appId ?? 'unknown',
           );
           break;
-        case 'fusebox_console_notice':
-          logger?.info(
-            '\u001B[1m\u001B[7m💡 JavaScript logs have moved!\u001B[22m They can now be ' +
-              'viewed in React Native DevTools. Tip: Type \u001B[1mj\u001B[22m in ' +
-              'the terminal to open' +
-              (experiments.enableStandaloneFuseboxShell
-                ? ''
-                : ' (requires Google Chrome or Microsoft Edge)') +
-              '.\u001B[27m',
-          );
-          break;
         case 'fusebox_shell_preparation_attempt':
           switch (event.result.code) {
             case 'success':

--- a/packages/dev-middleware/src/inspector-proxy/Device.js
+++ b/packages/dev-middleware/src/inspector-proxy/Device.js
@@ -54,8 +54,6 @@ export const WS_CLOSE_REASON = {
 // more details.
 const FILE_PREFIX = 'file://';
 
-let fuseboxConsoleNoticeLogged = false;
-
 type DebuggerConnection = {
   // Debugger web socket connection
   socket: WS,
@@ -542,7 +540,6 @@ export default class Device {
       // created instead of manually checking this on every getPages result.
       for (const page of this.#pages.values()) {
         if (this.#pageHasCapability(page, 'nativePageReloads')) {
-          this.#logFuseboxConsoleNotice();
           continue;
         }
 
@@ -1091,15 +1088,5 @@ export default class Device {
 
   dangerouslyGetSocket(): WS {
     return this.#deviceSocket;
-  }
-
-  // TODO(T214991636): Remove notice
-  #logFuseboxConsoleNotice() {
-    if (fuseboxConsoleNoticeLogged) {
-      return;
-    }
-
-    this.#deviceEventReporter?.logFuseboxConsoleNotice();
-    fuseboxConsoleNoticeLogged = true;
   }
 }

--- a/packages/dev-middleware/src/inspector-proxy/DeviceEventReporter.js
+++ b/packages/dev-middleware/src/inspector-proxy/DeviceEventReporter.js
@@ -231,12 +231,6 @@ class DeviceEventReporter {
     });
   }
 
-  logFuseboxConsoleNotice(): void {
-    this.#eventReporter.logEvent({
-      type: 'fusebox_console_notice',
-    });
-  }
-
   #logExpiredCommand(pendingCommand: PendingCommand): void {
     this.#eventReporter.logEvent({
       type: 'debugger_command',

--- a/packages/dev-middleware/src/types/EventReporter.js
+++ b/packages/dev-middleware/src/types/EventReporter.js
@@ -89,9 +89,6 @@ export type ReportableEvent =
       ...DebuggerSessionIDs,
     }
   | {
-      type: 'fusebox_console_notice',
-    }
-  | {
       type: 'no_debug_pages_for_device',
       ...DebuggerSessionIDs,
     }


### PR DESCRIPTION
Summary:
It's been >1y since we introduced this notice (and introduced the `--client-logs` flag) — clean up.

Changelog:
[General][Changed] - Remove "JavaScript logs have moved!" notice from dev server CLI

Reviewed By: hoxyq

Differential Revision: D90247471


