### PR TITLE
fix(android): fix XMLHttpRequest timeout error trigger onerror instead of ontimeout

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkEventUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkEventUtil.kt
@@ -18,6 +18,7 @@ import com.facebook.react.bridge.buildReadableArray
 import com.facebook.react.common.build.ReactBuildConfig
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
 import java.io.InterruptedIOException
+import java.net.SocketTimeoutException
 import okhttp3.Headers
 import okhttp3.Protocol
 import okhttp3.Request
@@ -197,7 +198,7 @@ internal object NetworkEventUtil {
         buildReadableArray {
           add(requestId)
           add(error)
-          if (e?.javaClass == InterruptedIOException::class.java) {
+          if (e?.javaClass == SocketTimeoutException::class.java || e?.javaClass === InterruptedIOException::class.java) {
             add(true) // last argument is a time out boolean
           }
         },

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkEventUtil.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkEventUtil.kt
@@ -17,7 +17,7 @@ import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.buildReadableArray
 import com.facebook.react.common.build.ReactBuildConfig
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
-import java.net.SocketTimeoutException
+import java.io.InterruptedIOException
 import okhttp3.Headers
 import okhttp3.Protocol
 import okhttp3.Request
@@ -197,7 +197,7 @@ internal object NetworkEventUtil {
         buildReadableArray {
           add(requestId)
           add(error)
-          if (e?.javaClass == SocketTimeoutException::class.java) {
+          if (e?.javaClass == InterruptedIOException::class.java) {
             add(true) // last argument is a time out boolean
           }
         },


### PR DESCRIPTION
## Summary:

Fix Issue #55081

## Changelog:

[ANDROID] [FIXED] - Fix Android `XMLHttpRequest` timeout error by catching `InterruptedIOException` in addition to `SocketTimeoutException`

## Test Plan:

Copied over the code from the reproducer into the RNTesterPlayground.js from issue #55081 and confirmed that the ontimeout error is working properly now

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/fa33446f-1d0c-44b5-afd6-c4aec1a92836" /> | <video src="https://github.com/user-attachments/assets/8b617337-f5a6-4d3c-a201-9b29fcb4e7b7" /> |
