### PR TITLE
RN: Verify Debugger Connection Origins

### DIFF
--- a/packages/dev-middleware/src/__tests__/InspectorDebuggerUtils.js
+++ b/packages/dev-middleware/src/__tests__/InspectorDebuggerUtils.js
@@ -22,11 +22,17 @@ export class DebuggerAgent {
   #ws: ?WebSocket;
   #readyPromise: Promise<void>;
 
-  constructor(url: string, signal?: AbortSignal, hostHeader?: ?string) {
+  constructor(
+    url: string,
+    signal?: AbortSignal,
+    headers?: ?{[string]: unknown},
+  ) {
     const ws = new WebSocket(url, {
       // The mock server uses a self-signed certificate.
       rejectUnauthorized: false,
-      ...(hostHeader != null ? {headers: {Host: hostHeader}} : {}),
+      ...(headers != null
+        ? {headers}
+        : {headers: {Origin: 'http://localhost:8081'}}),
     });
     this.#ws = ws;
     ws.on('message', data => {
@@ -116,9 +122,9 @@ export class DebuggerMock extends DebuggerAgent {
 export async function createDebuggerMock(
   url: string,
   signal: AbortSignal,
-  hostHeader?: ?string,
+  headers?: ?{[string]: unknown},
 ): Promise<DebuggerMock> {
-  const debuggerMock = new DebuggerMock(url, signal, hostHeader);
+  const debuggerMock = new DebuggerMock(url, signal, headers);
   await debuggerMock.ready();
   return debuggerMock;
 }

--- a/packages/dev-middleware/src/__tests__/InspectorProtocolUtils.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProtocolUtils.js
@@ -116,11 +116,12 @@ export async function createAndConnectTarget(
   signal: AbortSignal,
   page: PageFromDevice,
   {
-    debuggerHostHeader = null,
+    debuggerHeaders = null,
     deviceId = null,
     deviceHostHeader = null,
   }: Readonly<{
-    debuggerHostHeader?: ?string,
+    debuggerHeaders?: ?{[string]: unknown},
+    debuggerOriginHeader?: ?string,
     deviceId?: ?string,
     deviceHostHeader?: ?string,
   }> = {},
@@ -151,7 +152,7 @@ export async function createAndConnectTarget(
     debugger_ = await createDebuggerMock(
       webSocketDebuggerUrl,
       signal,
-      debuggerHostHeader,
+      debuggerHeaders,
     );
     await until(() => expect(device.connect).toBeCalled());
   } catch (e) {

--- a/packages/dev-middleware/src/__tests__/InspectorProxyCdpRewritingHacks-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyCdpRewritingHacks-test.js
@@ -273,7 +273,10 @@ describe.each(['HTTP', 'HTTPS'])(
               vm: 'bar-vm',
             },
             {
-              debuggerHostHeader: 'localhost:' + serverRef.port,
+              debuggerHeaders: {
+                Host: 'localhost:' + serverRef.port,
+                Origin: 'http://localhost:8081',
+              },
               deviceHostHeader: sourceHost,
             },
           );


### PR DESCRIPTION
Summary:
Introduces origin verification for requests to establish debugger connections.

Changelog:
[General][Fixed] - Changed debugger proxy to only permit connections from localhost.

Differential Revision: D90348550


