### PR TITLE
Introduce Scheduler briding logic for native Choreographer implementations

### DIFF
--- a/packages/react-native/React/Fabric/RCTScheduler.mm
+++ b/packages/react-native/React/Fabric/RCTScheduler.mm
@@ -78,6 +78,18 @@ class SchedulerDelegateProxy : public SchedulerDelegate {
     // This delegate method is not currently used on iOS.
   }
 
+  void schedulerShouldResumeAnimationBackend() override
+  {
+    // Does nothing.
+    // This delegate method is not currently used on iOS.
+  }
+
+  void schedulerShouldPauseAnimationBackend() override
+  {
+    // Does nothing.
+    // This delegate method is not currently used on iOS.
+  }
+
  private:
   void *scheduler_;
 };

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
@@ -764,6 +764,10 @@ void FabricUIManagerBinding::schedulerDidUpdateShadowTree(
   // no-op
 }
 
+void FabricUIManagerBinding::schedulerShouldResumeAnimationBackend() {}
+
+void FabricUIManagerBinding::schedulerShouldPauseAnimationBackend() {}
+
 void FabricUIManagerBinding::onAnimationStarted() {
   auto mountingManager = getMountingManager("onAnimationStarted");
   if (!mountingManager) {

--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.h
@@ -112,6 +112,10 @@ class FabricUIManagerBinding : public jni::HybridClass<FabricUIManagerBinding>,
 
   void schedulerDidUpdateShadowTree(const std::unordered_map<Tag, folly::dynamic> &tagToProps) override;
 
+  void schedulerShouldResumeAnimationBackend() override;
+
+  void schedulerShouldPauseAnimationBackend() override;
+
   void setPixelDensity(float pointScaleFactor);
 
   void driveCxxAnimations();

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerDelegate.h
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/SchedulerDelegate.h
@@ -60,6 +60,18 @@ class SchedulerDelegate {
 
   virtual void schedulerDidUpdateShadowTree(const std::unordered_map<Tag, folly::dynamic> &tagToProps) = 0;
 
+  /*
+   * Called when the animation backend should start receiving frame callbacks.
+   * This is used to control the platform-specific animation frame scheduling.
+   */
+  virtual void schedulerShouldResumeAnimationBackend() = 0;
+
+  /*
+   * Called when the animation backend should stop receiving frame callbacks.
+   * This is used to pause the platform-specific animation frame scheduling.
+   */
+  virtual void schedulerShouldPauseAnimationBackend() = 0;
+
   virtual ~SchedulerDelegate() noexcept = default;
 };
 

--- a/packages/react-native/ReactCxxPlatform/react/renderer/scheduler/SchedulerDelegateImpl.cpp
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/scheduler/SchedulerDelegateImpl.cpp
@@ -63,4 +63,12 @@ void SchedulerDelegateImpl::schedulerDidUpdateShadowTree(
   mountingManager_->onUpdateShadowTree(tagToProps);
 }
 
+void SchedulerDelegateImpl::schedulerShouldResumeAnimationBackend() {
+  // no-op for ReactCxxPlatform
+}
+
+void SchedulerDelegateImpl::schedulerShouldPauseAnimationBackend() {
+  // no-op for ReactCxxPlatform
+}
+
 } // namespace facebook::react

--- a/packages/react-native/ReactCxxPlatform/react/renderer/scheduler/SchedulerDelegateImpl.h
+++ b/packages/react-native/ReactCxxPlatform/react/renderer/scheduler/SchedulerDelegateImpl.h
@@ -47,6 +47,10 @@ class SchedulerDelegateImpl : public SchedulerDelegate {
 
   void schedulerDidUpdateShadowTree(const std::unordered_map<Tag, folly::dynamic> &tagToProps) override;
 
+  void schedulerShouldResumeAnimationBackend() override;
+
+  void schedulerShouldPauseAnimationBackend() override;
+
   std::shared_ptr<IMountingManager> mountingManager_;
 };
 


### PR DESCRIPTION
Summary:
This diff adds a scaffolding allowing for the Animation Backend to access platform-specific animation frame scheduling.

# Changelog
[General] [Added] - `schedulerShouldResumeAnimationFrameCallbacks` and `schedulerShouldPauseAnimationFrameCallbacks` methods to `SchedulerDelegate`

Differential Revision: D89663244


