### PR TITLE
resolve or remove unneeded `unused-promise` Flow annotations

### DIFF
--- a/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
+++ b/packages/react-native/Libraries/Components/DrawerAndroid/DrawerLayoutAndroid.android.js
@@ -150,7 +150,6 @@ class DrawerLayoutAndroid
    * LTI update could not be added via codemod */
   _onDrawerSlide = event => {
     if (this.props.onDrawerSlide) {
-      // $FlowFixMe[unused-promise]
       this.props.onDrawerSlide(event);
     }
     if (this.props.keyboardDismissMode === 'on-drag') {

--- a/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
+++ b/packages/react-native/Libraries/Components/Keyboard/KeyboardAvoidingView.js
@@ -112,14 +112,12 @@ class KeyboardAvoidingView extends React.Component<
 
   _onKeyboardChange = (event: ?KeyboardEvent) => {
     this._keyboardEvent = event;
-    // $FlowFixMe[unused-promise]
-    this._updateBottomIfNecessary();
+    void this._updateBottomIfNecessary();
   };
 
   _onKeyboardHide = (event: ?KeyboardEvent) => {
     this._keyboardEvent = null;
-    // $FlowFixMe[unused-promise]
-    this._updateBottomIfNecessary();
+    void this._updateBottomIfNecessary();
   };
 
   _onLayout = async (event: ViewLayoutEvent) => {

--- a/packages/react-native/Libraries/Components/RefreshControl/RefreshControl.js
+++ b/packages/react-native/Libraries/Components/RefreshControl/RefreshControl.js
@@ -186,8 +186,7 @@ class RefreshControl extends React.Component<RefreshControlProps> {
   _onRefresh = () => {
     this._lastNativeRefreshing = true;
 
-    // $FlowFixMe[unused-promise]
-    this.props.onRefresh && this.props.onRefresh();
+    this.props.onRefresh && void this.props.onRefresh();
 
     // The native component will start refreshing so force an update to
     // make sure it stays in sync with the js component.

--- a/packages/react-native/Libraries/Components/Switch/Switch.js
+++ b/packages/react-native/Libraries/Components/Switch/Switch.js
@@ -199,10 +199,8 @@ const Switch: component(
   const [native, setNative] = useState({value: (null: ?boolean)});
 
   const handleChange = (event: SwitchChangeEvent) => {
-    // $FlowFixMe[unused-promise]
-    onChange?.(event);
-    // $FlowFixMe[unused-promise]
-    onValueChange?.(event.nativeEvent.value);
+    void onChange?.(event);
+    void onValueChange?.(event.nativeEvent.value);
     setNative({value: event.nativeEvent.value});
   };
 

--- a/packages/react-native/Libraries/Core/Devtools/openFileInEditor.js
+++ b/packages/react-native/Libraries/Core/Devtools/openFileInEditor.js
@@ -13,8 +13,7 @@
 const getDevServer = require('./getDevServer').default;
 
 export default function openFileInEditor(file: string, lineNumber: number) {
-  // $FlowFixMe[unused-promise]
-  fetch(getDevServer().url + 'open-stack-frame', {
+  void fetch(getDevServer().url + 'open-stack-frame', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/packages/react-native/Libraries/Core/Devtools/openURLInBrowser.js
+++ b/packages/react-native/Libraries/Core/Devtools/openURLInBrowser.js
@@ -13,8 +13,7 @@
 const getDevServer = require('./getDevServer').default;
 
 export default function openURLInBrowser(url: string) {
-  // $FlowFixMe[unused-promise]
-  fetch(getDevServer().url + 'open-url', {
+  void fetch(getDevServer().url + 'open-url', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/packages/react-native/Libraries/LogBox/Data/__tests__/LogBoxSymbolication-test.js
+++ b/packages/react-native/Libraries/LogBox/Data/__tests__/LogBoxSymbolication-test.js
@@ -40,20 +40,16 @@ describe('LogBoxSymbolication', () => {
   });
 
   it('symbolicates different stacks', () => {
-    // $FlowFixMe[unused-promise]
-    LogBoxSymbolication.symbolicate(createStack(['A', 'B', 'C']));
-    // $FlowFixMe[unused-promise]
-    LogBoxSymbolication.symbolicate(createStack(['D', 'E', 'F']));
+    void LogBoxSymbolication.symbolicate(createStack(['A', 'B', 'C']));
+    void LogBoxSymbolication.symbolicate(createStack(['D', 'E', 'F']));
 
     expect(symbolicateStackTrace.mock.calls.length).toBe(2);
   });
 
   it('batch symbolicates equivalent stacks', () => {
     const stack = createStack(['A', 'B', 'C']);
-    // $FlowFixMe[unused-promise]
-    LogBoxSymbolication.symbolicate(stack);
-    // $FlowFixMe[unused-promise]
-    LogBoxSymbolication.symbolicate(stack);
+    void LogBoxSymbolication.symbolicate(stack);
+    void LogBoxSymbolication.symbolicate(stack);
 
     expect(symbolicateStackTrace.mock.calls.length).toBe(1);
   });

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxMessage.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxMessage.js
@@ -76,8 +76,7 @@ function TappableLinks(props: {
     fragments.push(
       <Text
         onPress={() => {
-          // $FlowFixMe[unused-promise]
-          Linking.openURL(link);
+          void Linking.openURL(link);
         }}
         key={++indexCounter}
         style={styles.linkText}>

--- a/packages/react-native/Libraries/ReactNative/AppRegistryImpl.js
+++ b/packages/react-native/Libraries/ReactNative/AppRegistryImpl.js
@@ -281,8 +281,7 @@ export function startHeadlessTask(
         NativeHeadlessJsTaskSupport &&
         reason instanceof HeadlessJsTaskError
       ) {
-        // $FlowFixMe[unused-promise]
-        NativeHeadlessJsTaskSupport.notifyTaskRetry(taskId).then(
+        void NativeHeadlessJsTaskSupport.notifyTaskRetry(taskId).then(
           retryPosted => {
             if (!retryPosted) {
               NativeHeadlessJsTaskSupport.notifyTaskFinished(taskId);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Find all `unused-promise` Flow annotations in core package, look at code and typings, use `void` to allow calling Promises without follow up, or just remove the annotation if the code no longer uses Promise.

## Changelog:

[INTERNAL] [FIXED] - Resolve or remove unneeded `unused-promise` Flow annotations

## Test Plan:

Running `yarn flow-check` does not yield any errors.
