### PR TITLE
Transform $ReadOnlyArray to ReadonlyArray 17/n

### DIFF
--- a/flow-typed/environment/node.js
+++ b/flow-typed/environment/node.js
@@ -1887,7 +1887,7 @@ declare module 'fs' {
      */
     exclude?:
       | ((fileName: Node$Conditional<WithFileTypes, Dirent, string>) => boolean)
-      | $ReadOnlyArray<string>,
+      | ReadonlyArray<string>,
     ...
   }>;
 
@@ -1905,12 +1905,12 @@ declare module 'fs' {
    * @since v22.0.0
    */
   declare function glob(
-    pattern: string | $ReadOnlyArray<string>,
+    pattern: string | ReadonlyArray<string>,
     callback: (err: ?ErrnoError, matches: Array<string>) => void,
   ): void;
 
   declare function glob<WithFileTypes: boolean = false>(
-    pattern: string | $ReadOnlyArray<string>,
+    pattern: string | ReadonlyArray<string>,
     options: GlobOptions<WithFileTypes>,
     callback: (
       err: ?ErrnoError,
@@ -1928,7 +1928,7 @@ declare module 'fs' {
    * @returns paths of files that match the pattern.
    */
   declare function globSync<WithFileTypes: boolean = false>(
-    pattern: string | $ReadOnlyArray<string>,
+    pattern: string | ReadonlyArray<string>,
     options?: GlobOptions<WithFileTypes>,
   ): Node$Conditional<WithFileTypes, Array<Dirent>, Array<string>>;
 
@@ -2142,7 +2142,7 @@ declare module 'fs' {
       mtime: number | string | Date,
     ): Promise<void>,
     glob<WithFileTypes: boolean = false>(
-      pattern: string | $ReadOnlyArray<string>,
+      pattern: string | ReadonlyArray<string>,
       options?: GlobOptions<WithFileTypes>,
     ): Node$Conditional<
       WithFileTypes,
@@ -2292,7 +2292,7 @@ declare class http$Agent<+SocketT = net$Socket> {
   constructor(options: http$agentOptions): void;
   destroy(): void;
   // $FlowFixMe[incompatible-variance]
-  freeSockets: {[name: string]: $ReadOnlyArray<SocketT>, ...};
+  freeSockets: {[name: string]: ReadonlyArray<SocketT>, ...};
   getName(options: {
     host: string,
     port: number,
@@ -2302,9 +2302,9 @@ declare class http$Agent<+SocketT = net$Socket> {
   maxFreeSockets: number;
   maxSockets: number;
   // $FlowFixMe[incompatible-variance]
-  requests: {[name: string]: $ReadOnlyArray<http$ClientRequest<SocketT>>, ...};
+  requests: {[name: string]: ReadonlyArray<http$ClientRequest<SocketT>>, ...};
   // $FlowFixMe[incompatible-variance]
-  sockets: {[name: string]: $ReadOnlyArray<SocketT>, ...};
+  sockets: {[name: string]: ReadonlyArray<SocketT>, ...};
 }
 
 declare class http$IncomingMessage<SocketT = net$Socket>
@@ -2968,11 +2968,11 @@ declare module 'perf_hooks' {
   ) => void;
 
   declare export class PerformanceObserver {
-    static supportedEntryTypes: $ReadOnlyArray<EntryType>;
+    static supportedEntryTypes: ReadonlyArray<EntryType>;
     constructor(callback: PerformanceObserverCallback): this;
     observe(
       options: Readonly<{
-        entryTypes?: $ReadOnlyArray<EntryType>,
+        entryTypes?: ReadonlyArray<EntryType>,
         type?: EntryType,
         buffered?: boolean,
       }>,
@@ -3461,7 +3461,7 @@ declare module 'stream' {
       options?: StreamPipelineOptions,
     ): Promise<void>,
     pipeline(
-      streams: $ReadOnlyArray<stream$Stream>,
+      streams: ReadonlyArray<stream$Stream>,
       options?: StreamPipelineOptions,
     ): Promise<void>,
     ...
@@ -3900,7 +3900,7 @@ declare module 'url' {
   };
 
   declare type url$URLPatternResult = {
-    inputs: $ReadOnlyArray<string | url$URLPatternInit>,
+    inputs: ReadonlyArray<string | url$URLPatternInit>,
     protocol: url$URLPatternComponentResult,
     username: url$URLPatternComponentResult,
     password: url$URLPatternComponentResult,
@@ -4104,8 +4104,8 @@ declare module 'util' {
 
   declare type util$DiffEntry = [operation: -1 | 0 | 1, value: string];
   declare function diff(
-    actual: string | $ReadOnlyArray<string>,
-    expected: string | $ReadOnlyArray<string>,
+    actual: string | ReadonlyArray<string>,
+    expected: string | ReadonlyArray<string>,
   ): Array<util$DiffEntry>;
 
   declare function getSystemErrorMessage(err: number): string;
@@ -4224,7 +4224,7 @@ declare module 'util' {
       | ForegroundColors
       | BackgroundColors
       | Modifiers
-      | $ReadOnlyArray<ForegroundColors | BackgroundColors | Modifiers>,
+      | ReadonlyArray<ForegroundColors | BackgroundColors | Modifiers>,
     text: string,
     options?: Readonly<{
       stream?: ?stream$Stream,

--- a/flow-typed/npm/@expo/spawn-async_v1.x.x.js
+++ b/flow-typed/npm/@expo/spawn-async_v1.x.x.js
@@ -38,7 +38,7 @@ declare module '@expo/spawn-async' {
 
   declare function spawnAsync(
     command: string,
-    args?: $ReadOnlyArray<string>,
+    args?: ReadonlyArray<string>,
     options?: SpawnOptions,
   ): SpawnPromise<SpawnResult>;
 

--- a/flow-typed/npm/@react-native-community/cli-server-api_v19.x.x.js
+++ b/flow-typed/npm/@react-native-community/cli-server-api_v19.x.x.js
@@ -13,7 +13,7 @@ declare module '@react-native-community/cli-server-api' {
 
   declare type MiddlewareOptions = {
     host?: string,
-    watchFolders: $ReadOnlyArray<string>,
+    watchFolders: ReadonlyArray<string>,
     port: number,
   };
 

--- a/flow-typed/npm/babel-traverse_v7.x.x.js
+++ b/flow-typed/npm/babel-traverse_v7.x.x.js
@@ -390,9 +390,7 @@ declare module '@babel/traverse' {
      * Earliest is defined as being "before" all the other nodes in terms of list container
      * position and visiting key.
      */
-    getEarliestCommonAncestorFrom(
-      paths: $ReadOnlyArray<NodePath<>>,
-    ): NodePath<>;
+    getEarliestCommonAncestorFrom(paths: ReadonlyArray<NodePath<>>): NodePath<>;
 
     /**
      * Get the earliest path in the tree where the provided `paths` intersect.
@@ -400,7 +398,7 @@ declare module '@babel/traverse' {
      * TODO: Possible optimisation target.
      */
     getDeepestCommonAncestorFrom(
-      paths: $ReadOnlyArray<NodePath<>>,
+      paths: ReadonlyArray<NodePath<>>,
       filter?: (
         lastCommon: BabelNode,
         lastCommonIndex: number,

--- a/flow-typed/npm/babel_v7.x.x.js
+++ b/flow-typed/npm/babel_v7.x.x.js
@@ -1027,7 +1027,7 @@ declare module '@babel/core' {
   declare export var template: Template;
   declare export var traverse: Traverse;
   declare export var types: Types;
-  declare export var DEFAULT_EXTENSIONS: $ReadOnlyArray<string>;
+  declare export var DEFAULT_EXTENSIONS: ReadonlyArray<string>;
 
   declare export function buildExternalHelpers(
     whitelist?: Array<string>,

--- a/flow-typed/npm/execa_v5.x.x.js
+++ b/flow-typed/npm/execa_v5.x.x.js
@@ -37,7 +37,7 @@ declare module 'execa' {
     shell?: boolean | string,
     stderr?: ?StdIoOption,
     stdin?: ?StdIoOption,
-    stdio?: 'pipe' | 'ignore' | 'inherit' | $ReadOnlyArray<?StdIoOption>,
+    stdio?: 'pipe' | 'ignore' | 'inherit' | ReadonlyArray<?StdIoOption>,
     stdout?: ?StdIoOption,
     stripEof?: boolean,
     timeout?: number,
@@ -90,7 +90,7 @@ declare module 'execa' {
   declare interface Execa {
     (
       file: string,
-      args?: $ReadOnlyArray<string>,
+      args?: ReadonlyArray<string>,
       options?: Readonly<Options>,
     ): ExecaPromise;
     (file: string, options?: Readonly<Options>): ExecaPromise;
@@ -100,13 +100,13 @@ declare module 'execa' {
 
     node(
       path: string,
-      args?: $ReadOnlyArray<string>,
+      args?: ReadonlyArray<string>,
       options?: Readonly<Options>,
     ): void;
 
     sync(
       file: string,
-      args?: $ReadOnlyArray<string>,
+      args?: ReadonlyArray<string>,
       options?: Readonly<SyncOptions>,
     ): SyncResult;
     sync(file: string, options?: Readonly<SyncOptions>): SyncResult;

--- a/flow-typed/npm/jest.js
+++ b/flow-typed/npm/jest.js
@@ -13,7 +13,7 @@
 
 // MODIFIED: Added ESLint suppression comment - no-unused-vars doesn't understand declaration files
 
-type JestMockFn<TArguments: $ReadOnlyArray<unknown>, TReturn> = {
+type JestMockFn<TArguments: ReadonlyArray<unknown>, TReturn> = {
   (...args: TArguments): TReturn,
   /**
    * An object for introspecting mock calls
@@ -768,7 +768,7 @@ interface JestExpectType {
   /**
    *
    */
-  toHaveProperty(propPath: string | $ReadOnlyArray<string>, value?: any): void;
+  toHaveProperty(propPath: string | ReadonlyArray<string>, value?: any): void;
   /**
    * Use .toMatch to check that a string matches a regular expression or string.
    */
@@ -881,7 +881,7 @@ type JestObjectType = {
    * implementation.
    */
   // MODIFIED: Added defaults to type arguments.
-  fn<TArguments: $ReadOnlyArray<unknown> = $ReadOnlyArray<any>, TReturn = any>(
+  fn<TArguments: ReadonlyArray<unknown> = ReadonlyArray<any>, TReturn = any>(
     implementation?: (...args: TArguments) => TReturn,
   ): JestMockFn<TArguments, TReturn>,
   /**
@@ -1045,11 +1045,11 @@ declare var describe: {
    */
   each(
     ...table:
-      | $ReadOnlyArray<$ReadOnlyArray<unknown> | unknown>
-      | [$ReadOnlyArray<string>, string]
+      | ReadonlyArray<ReadonlyArray<unknown> | unknown>
+      | [ReadonlyArray<string>, string]
   ): (
     name: JestTestName,
-    fn?: (...args: $ReadOnlyArray<any>) => ?Promise<unknown>,
+    fn?: (...args: ReadonlyArray<any>) => ?Promise<unknown>,
     timeout?: number,
   ) => void,
   ...
@@ -1136,8 +1136,8 @@ declare var it: {
    */
   each(
     ...table:
-      | $ReadOnlyArray<$ReadOnlyArray<unknown> | unknown>
-      | [$ReadOnlyArray<string>, string]
+      | ReadonlyArray<ReadonlyArray<unknown> | unknown>
+      | [ReadonlyArray<string>, string]
   ): (
     name: JestTestName,
     fn?: (...args: Array<any>) => ?Promise<unknown>,
@@ -1252,13 +1252,13 @@ declare var expect: {
   any(value: unknown): JestAsymmetricEqualityType,
   anything(): any,
   // MODIFIED: Array -> $ReadOnlyArray
-  arrayContaining(value: $ReadOnlyArray<unknown>): Array<unknown>,
+  arrayContaining(value: ReadonlyArray<unknown>): Array<unknown>,
   objectContaining(value: Object): Object,
   /** Matches any received string that contains the exact expected string. */
   stringContaining(value: string): string,
   stringMatching(value: string | RegExp): string,
   not: {
-    arrayContaining: (value: $ReadOnlyArray<unknown>) => Array<unknown>,
+    arrayContaining: (value: ReadonlyArray<unknown>) => Array<unknown>,
     objectContaining: (value: {...}) => Object,
     stringContaining: (value: string) => string,
     stringMatching: (value: string | RegExp) => string,

--- a/flow-typed/npm/listr2_v8.x.x.js
+++ b/flow-typed/npm/listr2_v8.x.x.js
@@ -55,7 +55,7 @@ declare module 'listr2' {
       options?: Options,
     ): void;
     add<ReturnT>(task: TaskSpec<ContextT, ReturnT>): this;
-    add<ReturnT>(tasks: $ReadOnlyArray<TaskSpec<ContextT, ReturnT>>): this;
+    add<ReturnT>(tasks: ReadonlyArray<TaskSpec<ContextT, ReturnT>>): this;
     run(ctx?: ContextT): Promise<ContextT>;
   }
 }

--- a/flow-typed/npm/listr_v14.x.x.js
+++ b/flow-typed/npm/listr_v14.x.x.js
@@ -55,7 +55,7 @@ declare module 'listr' {
       options?: Options,
     ): void;
     add<ReturnT>(task: TaskSpec<ContextT, ReturnT>): this;
-    add<ReturnT>(tasks: $ReadOnlyArray<TaskSpec<ContextT, ReturnT>>): this;
+    add<ReturnT>(tasks: ReadonlyArray<TaskSpec<ContextT, ReturnT>>): this;
     run(ctx?: ContextT): Promise<ContextT>;
   }
 }

--- a/packages/community-cli-plugin/src/commands/bundle/assetCatalogIOS.js
+++ b/packages/community-cli-plugin/src/commands/bundle/assetCatalogIOS.js
@@ -31,7 +31,7 @@ type ImageSet = {
 export function getImageSet(
   catalogDir: string,
   asset: AssetData,
-  scales: $ReadOnlyArray<number>,
+  scales: ReadonlyArray<number>,
 ): ImageSet {
   const fileName = assetPathUtils.getResourceIdentifier(asset);
   return {

--- a/packages/community-cli-plugin/src/commands/bundle/createKeepFileAsync.js
+++ b/packages/community-cli-plugin/src/commands/bundle/createKeepFileAsync.js
@@ -15,7 +15,7 @@ import fs from 'fs';
 import path from 'path';
 
 async function createKeepFileAsync(
-  assets: $ReadOnlyArray<AssetData>,
+  assets: ReadonlyArray<AssetData>,
   outputDirectory: string,
 ): Promise<void> {
   if (!assets.length) {

--- a/packages/community-cli-plugin/src/commands/bundle/filterPlatformAssetScales.js
+++ b/packages/community-cli-plugin/src/commands/bundle/filterPlatformAssetScales.js
@@ -14,8 +14,8 @@ const ALLOWED_SCALES: {[key: string]: number[]} = {
 
 function filterPlatformAssetScales(
   platform: string,
-  scales: $ReadOnlyArray<number>,
-): $ReadOnlyArray<number> {
+  scales: ReadonlyArray<number>,
+): ReadonlyArray<number> {
   const whitelist: number[] = ALLOWED_SCALES[platform];
   if (!whitelist) {
     return scales;

--- a/packages/community-cli-plugin/src/commands/bundle/saveAssets.js
+++ b/packages/community-cli-plugin/src/commands/bundle/saveAssets.js
@@ -29,7 +29,7 @@ type CopiedFiles = {
 };
 
 async function saveAssets(
-  assets: $ReadOnlyArray<AssetData>,
+  assets: ReadonlyArray<AssetData>,
   platform: string,
   assetsDest?: string,
   assetCatalogDest?: string,

--- a/packages/community-cli-plugin/src/commands/start/OpenDebuggerKeyboardHandler.js
+++ b/packages/community-cli-plugin/src/commands/start/OpenDebuggerKeyboardHandler.js
@@ -22,7 +22,7 @@ type PageDescription = Readonly<{
 export default class OpenDebuggerKeyboardHandler {
   #devServerUrl: string;
   #reporter: TerminalReporter;
-  #targetsShownForSelection: ?$ReadOnlyArray<PageDescription> = null;
+  #targetsShownForSelection: ?ReadonlyArray<PageDescription> = null;
 
   constructor({
     devServerUrl,
@@ -82,7 +82,7 @@ export default class OpenDebuggerKeyboardHandler {
       if (res.status !== 200) {
         throw new Error(`Unexpected status code: ${res.status}`);
       }
-      const targets = (await res.json()) as $ReadOnlyArray<PageDescription>;
+      const targets = (await res.json()) as ReadonlyArray<PageDescription>;
       if (!Array.isArray(targets)) {
         throw new Error('Expected array.');
       }

--- a/packages/community-cli-plugin/src/commands/start/middleware.js
+++ b/packages/community-cli-plugin/src/commands/start/middleware.js
@@ -43,7 +43,7 @@ const communityMiddlewareFallback = {
   createDevServerMiddleware: (params: {
     host?: string,
     port: number,
-    watchFolders: $ReadOnlyArray<string>,
+    watchFolders: ReadonlyArray<string>,
   }): MiddlewareReturn => ({
     // FIXME: Several features will break without community middleware and
     // should be migrated into core.

--- a/packages/community-cli-plugin/src/utils/createDevMiddlewareLogger.js
+++ b/packages/community-cli-plugin/src/utils/createDevMiddlewareLogger.js
@@ -10,7 +10,7 @@
 
 import type {TerminalReporter} from 'metro';
 
-type LoggerFn = (...message: $ReadOnlyArray<string>) => void;
+type LoggerFn = (...message: ReadonlyArray<string>) => void;
 
 /**
  * Create a dev-middleware logger object that will emit logs via Metro's

--- a/packages/community-cli-plugin/src/utils/parseKeyValueParamArray.js
+++ b/packages/community-cli-plugin/src/utils/parseKeyValueParamArray.js
@@ -9,7 +9,7 @@
  */
 
 export default function parseKeyValueParamArray(
-  keyValueArray: $ReadOnlyArray<string>,
+  keyValueArray: ReadonlyArray<string>,
 ): Record<string, string> {
   const result = {};
 

--- a/packages/core-cli-utils/src/private/android.js
+++ b/packages/core-cli-utils/src/private/android.js
@@ -17,7 +17,7 @@ import execa from 'execa';
 type AndroidBuildMode = 'Debug' | 'Release';
 
 type Path = string;
-type Args = $ReadOnlyArray<string>;
+type Args = ReadonlyArray<string>;
 
 type Config = {
   cwd: Path,

--- a/packages/core-cli-utils/src/private/app.js
+++ b/packages/core-cli-utils/src/private/app.js
@@ -75,16 +75,13 @@ function getNodePackagePath(packageName: string): string {
   return require.resolve(packageName, {cwd: [process.cwd(), ...module.paths]});
 }
 
-function metro(...args: $ReadOnlyArray<string>): ExecaPromise {
+function metro(...args: ReadonlyArray<string>): ExecaPromise {
   log(`🚇 metro ${args.join(' ')} `);
   return execa('npx', ['--offline', 'metro', ...args]);
 }
 
 export const tasks = {
-  bundle: (
-    options: BundlerOptions,
-    ...args: $ReadOnlyArray<string>
-  ): Bundle => {
+  bundle: (options: BundlerOptions, ...args: ReadonlyArray<string>): Bundle => {
     const steps: Bundle = {
       /* eslint-disable sort-keys */
       validate: task(FIRST, 'Check if Metro is available', () => {
@@ -117,7 +114,7 @@ type Bundle = {
 
 const bundleApp = (
   options: BundlerOptions,
-  ...metroArgs: $ReadOnlyArray<string>
+  ...metroArgs: ReadonlyArray<string>
 ) => {
   if (options.outputJsBundle === options.outputBundle) {
     throw new Error('outputJsBundle and outputBundle cannot be the same.');

--- a/packages/core-cli-utils/src/private/apple.js
+++ b/packages/core-cli-utils/src/private/apple.js
@@ -144,7 +144,7 @@ export const tasks = {
   // 2. Build the iOS app using a setup environment
   build: (
     options: AppleBuildOptions,
-    ...args: $ReadOnlyArray<string>
+    ...args: ReadonlyArray<string>
   ): {
     validate: Task<void>,
     hasPodsInstalled: Task<void>,

--- a/packages/core-cli-utils/src/private/utils.js
+++ b/packages/core-cli-utils/src/private/utils.js
@@ -55,7 +55,7 @@ export function isOnPath(dep: string, description: string): PathCheckResult {
 }
 
 export function assertDependencies(
-  ...deps: $ReadOnlyArray<ReturnType<typeof isOnPath>>
+  ...deps: ReadonlyArray<ReturnType<typeof isOnPath>>
 ) {
   for (const {found, dep, description} of deps) {
     if (!found) {

--- a/packages/dev-middleware/src/inspector-proxy/CdpDebugLogging.js
+++ b/packages/dev-middleware/src/inspector-proxy/CdpDebugLogging.js
@@ -95,7 +95,7 @@ export default class CdpDebugLogging {
           );
         }
         if (timeout == null) {
-          timeout = setTimeout<$ReadOnlyArray<CDPMessageDestination>>(() => {
+          timeout = setTimeout<ReadonlyArray<CDPMessageDestination>>(() => {
             debug(
               '%s %s CDP messages of size %s MB %s in the last %ss.',
               getCDPLogPrefix(destination),

--- a/packages/dev-middleware/src/inspector-proxy/Device.js
+++ b/packages/dev-middleware/src/inspector-proxy/Device.js
@@ -282,7 +282,7 @@ export default class Device {
     return this.#app;
   }
 
-  getPagesList(): $ReadOnlyArray<Page> {
+  getPagesList(): ReadonlyArray<Page> {
     if (this.#lastConnectedLegacyReactNativePage) {
       return [...this.#pages.values(), this.#createSyntheticPage()];
     } else {

--- a/packages/dev-middleware/src/inspector-proxy/types.js
+++ b/packages/dev-middleware/src/inspector-proxy/types.js
@@ -88,7 +88,7 @@ export type GetPagesRequest = {event: 'getPages'};
 // Response to GetPagesRequest containing a list of page infos.
 export type GetPagesResponse = {
   event: 'getPages',
-  payload: $ReadOnlyArray<PageFromDevice>,
+  payload: ReadonlyArray<PageFromDevice>,
 };
 
 // Union type for all possible messages sent from device to Inspector Proxy.
@@ -141,12 +141,12 @@ export type JSONSerializable =
   | number
   | string
   | null
-  | $ReadOnlyArray<JSONSerializable>
+  | ReadonlyArray<JSONSerializable>
   | {+[string]: JSONSerializable};
 
 export type DeepReadOnly<T> =
-  T extends $ReadOnlyArray<infer V>
-    ? $ReadOnlyArray<DeepReadOnly<V>>
+  T extends ReadonlyArray<infer V>
+    ? ReadonlyArray<DeepReadOnly<V>>
     : T extends {...}
       ? {+[K in keyof T]: DeepReadOnly<T[K]>}
       : T;

--- a/packages/polyfills/error-guard.js
+++ b/packages/polyfills/error-guard.js
@@ -52,7 +52,7 @@ const ErrorUtils = {
      * Condition roll out. See https://fburl.com/workplace/1v97vimq. */
     _globalHandler && _globalHandler(error, true);
   },
-  applyWithGuard<TArgs: $ReadOnlyArray<unknown>, TOut>(
+  applyWithGuard<TArgs: ReadonlyArray<unknown>, TOut>(
     fun: Fn<TArgs, TOut>,
     context?: ?unknown,
     args?: ?TArgs,
@@ -75,7 +75,7 @@ const ErrorUtils = {
     }
     return null;
   },
-  applyWithGuardIfNeeded<TArgs: $ReadOnlyArray<unknown>, TOut>(
+  applyWithGuardIfNeeded<TArgs: ReadonlyArray<unknown>, TOut>(
     fun: Fn<TArgs, TOut>,
     context?: ?unknown,
     args?: ?TArgs,
@@ -94,7 +94,7 @@ const ErrorUtils = {
   inGuard(): boolean {
     return !!_inGuard;
   },
-  guard<TArgs: $ReadOnlyArray<unknown>, TOut>(
+  guard<TArgs: ReadonlyArray<unknown>, TOut>(
     fun: Fn<TArgs, TOut>,
     name?: ?string,
     context?: ?unknown,

--- a/packages/react-native-babel-preset/src/__mocks__/test-helpers.js
+++ b/packages/react-native-babel-preset/src/__mocks__/test-helpers.js
@@ -18,7 +18,7 @@ const t = require('@babel/types');
 const nullthrows = require('nullthrows');
 
 function makeTransformOptions<OptionsT: ?EntryOptions>(
-  plugins: $ReadOnlyArray<PluginEntry>,
+  plugins: ReadonlyArray<PluginEntry>,
   options: OptionsT,
 ): BabelCoreOptions {
   return {
@@ -53,7 +53,7 @@ function validateOutputAst(ast: BabelNode) {
 }
 
 function transformToAst<T: ?EntryOptions>(
-  plugins: $ReadOnlyArray<PluginEntry>,
+  plugins: ReadonlyArray<PluginEntry>,
   code: string,
   options: T,
 ): BabelNodeFile {
@@ -68,7 +68,7 @@ function transformToAst<T: ?EntryOptions>(
 
 function transform(
   code: string,
-  plugins: $ReadOnlyArray<PluginEntry>,
+  plugins: ReadonlyArray<PluginEntry>,
   options: ?EntryOptions,
 ): string {
   return generate(transformToAst(plugins, code, options)).code;

--- a/packages/react-native-codegen/src/CodegenSchema.js
+++ b/packages/react-native-codegen/src/CodegenSchema.js
@@ -70,14 +70,14 @@ export type VoidTypeAnnotation = Readonly<{
 
 export type ObjectTypeAnnotation<+T> = Readonly<{
   type: 'ObjectTypeAnnotation',
-  properties: $ReadOnlyArray<NamedShape<T>>,
+  properties: ReadonlyArray<NamedShape<T>>,
   // metadata for objects that generated from interfaces
-  baseTypes?: $ReadOnlyArray<string>,
+  baseTypes?: ReadonlyArray<string>,
 }>;
 
 export type UnionTypeAnnotation<+T> = Readonly<{
   type: 'UnionTypeAnnotation',
-  types: $ReadOnlyArray<T>,
+  types: ReadonlyArray<T>,
 }>;
 
 export type MixedTypeAnnotation = Readonly<{
@@ -91,7 +91,7 @@ export type EventEmitterTypeAnnotation = Readonly<{
 
 type FunctionTypeAnnotation<+P, +R> = Readonly<{
   type: 'FunctionTypeAnnotation',
-  params: $ReadOnlyArray<NamedShape<P>>,
+  params: ReadonlyArray<NamedShape<P>>,
   returnTypeAnnotation: R,
 }>;
 
@@ -110,10 +110,10 @@ export type ComponentSchema = Readonly<{
 
 export type ComponentShape = Readonly<{
   ...OptionsShape,
-  extendsProps: $ReadOnlyArray<ExtendsPropsShape>,
-  events: $ReadOnlyArray<EventTypeShape>,
-  props: $ReadOnlyArray<NamedShape<PropTypeAnnotation>>,
-  commands: $ReadOnlyArray<NamedShape<CommandTypeAnnotation>>,
+  extendsProps: ReadonlyArray<ExtendsPropsShape>,
+  events: ReadonlyArray<EventTypeShape>,
+  props: ReadonlyArray<NamedShape<PropTypeAnnotation>>,
+  commands: ReadonlyArray<NamedShape<CommandTypeAnnotation>>,
 }>;
 
 export type OptionsShape = Readonly<{
@@ -124,7 +124,7 @@ export type OptionsShape = Readonly<{
   // Does not check for new name
   paperComponentName?: string,
   // Use for components that are not used on other platforms.
-  excludedPlatforms?: $ReadOnlyArray<PlatformType>,
+  excludedPlatforms?: ReadonlyArray<PlatformType>,
   // Use for components currently being renamed in paper
   // Will use new name if it is available and fallback to this name
   paperComponentNameDeprecated?: string,
@@ -171,7 +171,7 @@ export type ComponentArrayTypeAnnotation = ArrayTypeAnnotation<
   | Readonly<{
       type: 'StringEnumTypeAnnotation',
       default: string,
-      options: $ReadOnlyArray<string>,
+      options: ReadonlyArray<string>,
     }>
   | ObjectTypeAnnotation<PropTypeAnnotation>
   | ReservedPropTypeAnnotation
@@ -220,12 +220,12 @@ export type PropTypeAnnotation =
   | Readonly<{
       type: 'StringEnumTypeAnnotation',
       default: string,
-      options: $ReadOnlyArray<string>,
+      options: ReadonlyArray<string>,
     }>
   | Readonly<{
       type: 'Int32EnumTypeAnnotation',
       default: number,
-      options: $ReadOnlyArray<number>,
+      options: ReadonlyArray<number>,
     }>
   | ReservedPropTypeAnnotation
   | ObjectTypeAnnotation<PropTypeAnnotation>
@@ -283,12 +283,12 @@ export type NativeModuleSchema = Readonly<{
   // Use for modules that are not used on other platforms.
   // TODO: It's clearer to define `restrictedToPlatforms` instead, but
   // `excludedPlatforms` is used here to be consistent with ComponentSchema.
-  excludedPlatforms?: $ReadOnlyArray<PlatformType>,
+  excludedPlatforms?: ReadonlyArray<PlatformType>,
 }>;
 
 type NativeModuleSpec = Readonly<{
-  eventEmitters: $ReadOnlyArray<NativeModuleEventEmitterShape>,
-  methods: $ReadOnlyArray<NativeModulePropertyShape>,
+  eventEmitters: ReadonlyArray<NativeModuleEventEmitterShape>,
+  methods: ReadonlyArray<NativeModulePropertyShape>,
 }>;
 
 export type NativeModuleEventEmitterShape =
@@ -353,7 +353,7 @@ export type NativeModuleEnumDeclarationWithMembers = {
   name: string,
   type: 'EnumDeclarationWithMembers',
   memberType: NativeModuleEnumMemberType,
-  members: $ReadOnlyArray<NativeModuleEnumMember>,
+  members: ReadonlyArray<NativeModuleEnumMember>,
 };
 
 export type NativeModuleGenericObjectTypeAnnotation = Readonly<{

--- a/packages/react-native-codegen/src/SchemaValidator.js
+++ b/packages/react-native-codegen/src/SchemaValidator.js
@@ -14,7 +14,7 @@ import type {SchemaType} from './CodegenSchema';
 
 const nullthrows = require('nullthrows');
 
-function getErrors(schema: SchemaType): $ReadOnlyArray<string> {
+function getErrors(schema: SchemaType): ReadonlyArray<string> {
   const errors = new Set<string>();
 
   // Map of component name -> Array of module names

--- a/packages/react-native-codegen/src/generators/Utils.js
+++ b/packages/react-native-codegen/src/generators/Utils.js
@@ -67,7 +67,7 @@ class HeterogeneousUnionError extends Error {
 function parseValidUnionType(
   annotation: NativeModuleUnionTypeAnnotation,
 ): ValidUnionType {
-  const isUnionOfType = (types: $ReadOnlyArray<string>): boolean => {
+  const isUnionOfType = (types: ReadonlyArray<string>): boolean => {
     return annotation.types.every(memberTypeAnnotation =>
       types.includes(memberTypeAnnotation.type),
     );

--- a/packages/react-native-codegen/src/generators/components/ComponentsGeneratorUtils.js
+++ b/packages/react-native-codegen/src/generators/components/ComponentsGeneratorUtils.js
@@ -46,7 +46,7 @@ function getNativeTypeFromAnnotation(
           | ReservedPropTypeAnnotation
           | {
               +default: string,
-              +options: $ReadOnlyArray<string>,
+              +options: ReadonlyArray<string>,
               +type: 'StringEnumTypeAnnotation',
             }
           | {
@@ -54,7 +54,7 @@ function getNativeTypeFromAnnotation(
               +type: 'ArrayTypeAnnotation',
             },
       },
-  nameParts: $ReadOnlyArray<string>,
+  nameParts: ReadonlyArray<string>,
 ): string {
   const typeAnnotation = prop.typeAnnotation;
 
@@ -214,7 +214,7 @@ const convertVarValueToPointer = (type: string, value: string): string => {
 };
 
 function getLocalImports(
-  properties: $ReadOnlyArray<NamedShape<PropTypeAnnotation>>,
+  properties: ReadonlyArray<NamedShape<PropTypeAnnotation>>,
 ): Set<string> {
   const imports: Set<string> = new Set();
 

--- a/packages/react-native-codegen/src/generators/components/CppHelpers.js
+++ b/packages/react-native-codegen/src/generators/components/CppHelpers.js
@@ -120,8 +120,8 @@ function getCppArrayTypeForAnnotation(
 
 function getImports(
   properties:
-    | $ReadOnlyArray<NamedShape<PropTypeAnnotation>>
-    | $ReadOnlyArray<NamedShape<EventTypeAnnotation>>,
+    | ReadonlyArray<NamedShape<PropTypeAnnotation>>
+    | ReadonlyArray<NamedShape<EventTypeAnnotation>>,
 ): Set<string> {
   const imports: Set<string> = new Set();
 
@@ -183,13 +183,13 @@ function getImports(
   return imports;
 }
 
-function generateEventStructName(parts: $ReadOnlyArray<string> = []): string {
+function generateEventStructName(parts: ReadonlyArray<string> = []): string {
   return parts.map(toSafeCppString).join('');
 }
 
 function generateStructName(
   componentName: string,
-  parts: $ReadOnlyArray<string> = [],
+  parts: ReadonlyArray<string> = [],
 ): string {
   const additional = parts.map(toSafeCppString).join('');
   return `${componentName}${additional}Struct`;

--- a/packages/react-native-codegen/src/generators/components/GenerateEventEmitterCpp.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateEventEmitterCpp.js
@@ -99,7 +99,7 @@ void ${className}EventEmitter::${eventName}() const {
 function generateSetter(
   variableName: string,
   propertyName: string,
-  propertyParts: $ReadOnlyArray<string>,
+  propertyParts: ReadonlyArray<string>,
   usingEvent: boolean,
   valueMapper: string => string = value => value,
 ) {
@@ -114,7 +114,7 @@ function generateSetter(
 function generateObjectSetter(
   variableName: string,
   propertyName: string,
-  propertyParts: $ReadOnlyArray<string>,
+  propertyParts: ReadonlyArray<string>,
   typeAnnotation: ObjectTypeAnnotation<EventTypeAnnotation>,
   extraIncludes: Set<string>,
   usingEvent: boolean,
@@ -151,7 +151,7 @@ function setValueAtIndex(
 function generateArraySetter(
   variableName: string,
   propertyName: string,
-  propertyParts: $ReadOnlyArray<string>,
+  propertyParts: ReadonlyArray<string>,
   elementType: EventTypeAnnotation,
   extraIncludes: Set<string>,
   usingEvent: boolean,
@@ -184,7 +184,7 @@ function handleArrayElementType(
   propertyName: string,
   indexVariable: string,
   loopLocalVariable: string,
-  propertyParts: $ReadOnlyArray<string>,
+  propertyParts: ReadonlyArray<string>,
   extraIncludes: Set<string>,
   usingEvent: boolean,
 ): string {
@@ -249,7 +249,7 @@ function convertObjectTypeArray(
   propertyName: string,
   indexVariable: string,
   loopLocalVariable: string,
-  propertyParts: $ReadOnlyArray<string>,
+  propertyParts: ReadonlyArray<string>,
   objectTypeAnnotation: ObjectTypeAnnotation<EventTypeAnnotation>,
   extraIncludes: Set<string>,
 ): string {
@@ -268,7 +268,7 @@ function convertArrayTypeArray(
   propertyName: string,
   indexVariable: string,
   loopLocalVariable: string,
-  propertyParts: $ReadOnlyArray<string>,
+  propertyParts: ReadonlyArray<string>,
   eventTypeAnnotation: EventTypeAnnotation,
   extraIncludes: Set<string>,
   usingEvent: boolean,
@@ -296,8 +296,8 @@ function convertArrayTypeArray(
 
 function generateSetters(
   parentPropertyName: string,
-  properties: $ReadOnlyArray<NamedShape<EventTypeAnnotation>>,
-  propertyParts: $ReadOnlyArray<string>,
+  properties: ReadonlyArray<NamedShape<EventTypeAnnotation>>,
+  propertyParts: ReadonlyArray<string>,
   extraIncludes: Set<string>,
   usingEvent: boolean = true,
 ): string {

--- a/packages/react-native-codegen/src/generators/components/GenerateEventEmitterH.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateEventEmitterH.js
@@ -117,7 +117,7 @@ static char const *toString(const ${enumName} value) {
 function getNativeTypeFromAnnotation(
   componentName: string,
   eventProperty: NamedShape<EventTypeAnnotation>,
-  nameParts: $ReadOnlyArray<string>,
+  nameParts: ReadonlyArray<string>,
 ): string {
   const {typeAnnotation} = eventProperty;
   switch (typeAnnotation.type) {
@@ -156,7 +156,7 @@ function getNativeTypeFromAnnotation(
 }
 function generateEnum(
   structs: StructsMap,
-  options: $ReadOnlyArray<string>,
+  options: ReadonlyArray<string>,
   nameParts: Array<string>,
 ) {
   const structName = generateEventStructName(nameParts);
@@ -186,7 +186,7 @@ function handleGenerateStructForArray(
   name: string,
   componentName: string,
   elementType: EventTypeAnnotation,
-  nameParts: $ReadOnlyArray<string>,
+  nameParts: ReadonlyArray<string>,
 ): void {
   if (elementType.type === 'ObjectTypeAnnotation') {
     generateStruct(
@@ -219,8 +219,8 @@ function handleGenerateStructForArray(
 function generateStruct(
   structs: StructsMap,
   componentName: string,
-  nameParts: $ReadOnlyArray<string>,
-  properties: $ReadOnlyArray<NamedShape<EventTypeAnnotation>>,
+  nameParts: ReadonlyArray<string>,
+  properties: ReadonlyArray<NamedShape<EventTypeAnnotation>>,
 ): void {
   const structNameParts = nameParts;
   const structName = generateEventStructName(structNameParts);

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsH.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsH.js
@@ -351,7 +351,7 @@ function convertValueToEnumOption(value: string): string {
 function generateArrayEnumString(
   componentName: string,
   name: string,
-  options: $ReadOnlyArray<string>,
+  options: ReadonlyArray<string>,
 ): string {
   const enumName = getEnumName(componentName, name);
 
@@ -393,7 +393,7 @@ function generateStringEnum(
 ) {
   const typeAnnotation = prop.typeAnnotation;
   if (typeAnnotation.type === 'StringEnumTypeAnnotation') {
-    const values: $ReadOnlyArray<string> = typeAnnotation.options;
+    const values: ReadonlyArray<string> = typeAnnotation.options;
     const enumName = getEnumName(componentName, prop.name);
 
     const fromCases = values
@@ -431,7 +431,7 @@ function generateIntEnum(
 ) {
   const typeAnnotation = prop.typeAnnotation;
   if (typeAnnotation.type === 'Int32EnumTypeAnnotation') {
-    const values: $ReadOnlyArray<number> = typeAnnotation.options;
+    const values: ReadonlyArray<number> = typeAnnotation.options;
     const enumName = getEnumName(componentName, prop.name);
 
     const fromCases = values
@@ -527,8 +527,8 @@ function generateEnumString(
 
 function generatePropsString(
   componentName: string,
-  props: $ReadOnlyArray<NamedShape<PropTypeAnnotation>>,
-  nameParts: $ReadOnlyArray<string>,
+  props: ReadonlyArray<NamedShape<PropTypeAnnotation>>,
+  nameParts: ReadonlyArray<string>,
   generateOptionalProperties?: boolean = false,
 ) {
   return props
@@ -557,7 +557,7 @@ function generatePropsString(
 }
 
 function getExtendsImports(
-  extendsProps: $ReadOnlyArray<ExtendsPropsShape>,
+  extendsProps: ReadonlyArray<ExtendsPropsShape>,
 ): Set<string> {
   const imports: Set<string> = new Set();
 
@@ -605,7 +605,7 @@ function generateStructsForComponent(
 
 function generateStructs(
   componentName: string,
-  properties: $ReadOnlyArray<NamedShape<PropTypeAnnotation>>,
+  properties: ReadonlyArray<NamedShape<PropTypeAnnotation>>,
   nameParts: Array<string>,
   generateOptionalObjectProperties?: boolean = false,
 ): StructsMap {
@@ -726,8 +726,8 @@ function generateStructs(
 function generateStruct(
   structs: StructsMap,
   componentName: string,
-  nameParts: $ReadOnlyArray<string>,
-  properties: $ReadOnlyArray<NamedShape<PropTypeAnnotation>>,
+  nameParts: ReadonlyArray<string>,
+  properties: ReadonlyArray<NamedShape<PropTypeAnnotation>>,
   generateOptionalObjectProperties?: boolean = false,
 ): void {
   const structNameParts = nameParts;

--- a/packages/react-native-codegen/src/generators/components/GeneratePropsJavaPojo/PojoCollector.js
+++ b/packages/react-native-codegen/src/generators/components/GeneratePropsJavaPojo/PojoCollector.js
@@ -29,7 +29,7 @@ const {capitalize} = require('../../Utils');
 export type Pojo = {
   name: string,
   namespace: string,
-  properties: $ReadOnlyArray<PojoProperty>,
+  properties: ReadonlyArray<PojoProperty>,
 };
 
 export type PojoProperty = NamedShape<PojoTypeAnnotation>;
@@ -63,12 +63,12 @@ export type PojoTypeAnnotation =
   | Readonly<{
       type: 'StringEnumTypeAnnotation',
       default: string,
-      options: $ReadOnlyArray<string>,
+      options: ReadonlyArray<string>,
     }>
   | Readonly<{
       type: 'Int32EnumTypeAnnotation',
       default: number,
-      options: $ReadOnlyArray<number>,
+      options: ReadonlyArray<number>,
     }>
   | ReservedPropTypeAnnotation
   | PojoTypeAliasAnnotation
@@ -84,7 +84,7 @@ export type PojoTypeAnnotation =
         | Readonly<{
             type: 'StringEnumTypeAnnotation',
             default: string,
-            options: $ReadOnlyArray<string>,
+            options: ReadonlyArray<string>,
           }>
         | PojoTypeAliasAnnotation
         | ReservedPropTypeAnnotation
@@ -182,7 +182,7 @@ class PojoCollector {
     });
   }
 
-  getAllPojos(): $ReadOnlyArray<Pojo> {
+  getAllPojos(): ReadonlyArray<Pojo> {
     return [...this._pojos.values()];
   }
 }

--- a/packages/react-native-codegen/src/generators/components/GenerateViewConfigJs.js
+++ b/packages/react-native-codegen/src/generators/components/GenerateViewConfigJs.js
@@ -184,7 +184,7 @@ function normalizeInputEventName(name: string) {
 
 // Replicates the behavior of viewConfig in RCTComponentData.m
 function getValidAttributesForEvents(
-  events: $ReadOnlyArray<EventTypeShape>,
+  events: ReadonlyArray<EventTypeShape>,
   imports: Set<string>,
 ) {
   imports.add(

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleH.js
@@ -170,7 +170,7 @@ const ModuleSpecClassDeclarationTemplate = ({
   enums: string,
   moduleEventEmitters: EventEmitterCpp[],
   moduleFunctions: string[],
-  methods: $ReadOnlyArray<Readonly<{methodName: string, paramCount: number}>>,
+  methods: ReadonlyArray<Readonly<{methodName: string, paramCount: number}>>,
 }>) => {
   return `${enums}${structs}
 template <typename T>
@@ -504,7 +504,7 @@ function getMemberValueAppearance(member: NativeModuleEnumMember['value']) {
 function generateEnum(
   hasteModuleName: string,
   origEnumName: string,
-  members: $ReadOnlyArray<NativeModuleEnumMember>,
+  members: ReadonlyArray<NativeModuleEnumMember>,
   memberType: NativeModuleEnumMemberType,
 ): string {
   const enumName = getEnumName(hasteModuleName, origEnumName);

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleJniCpp.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleJniCpp.js
@@ -60,8 +60,8 @@ const ModuleClassConstructorTemplate = ({
   methods,
 }: Readonly<{
   hasteModuleName: string,
-  eventEmitters: $ReadOnlyArray<NativeModuleEventEmitterShape>,
-  methods: $ReadOnlyArray<{
+  eventEmitters: ReadonlyArray<NativeModuleEventEmitterShape>,
+  methods: ReadonlyArray<{
     propertyName: string,
     argCount: number,
   }>,
@@ -109,7 +109,7 @@ const FileTemplate = ({
   libraryName: string,
   include: string,
   modules: string,
-  moduleLookups: $ReadOnlyArray<{
+  moduleLookups: ReadonlyArray<{
     hasteModuleName: string,
     moduleName: string,
   }>,
@@ -527,7 +527,7 @@ module.exports = {
       })
       .join('\n');
 
-    const moduleLookups: $ReadOnlyArray<{
+    const moduleLookups: ReadonlyArray<{
       hasteModuleName: string,
       moduleName: string,
     }> = Object.keys(nativeModules)

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/StructCollector.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/StructCollector.js
@@ -47,13 +47,13 @@ type StructContext = 'CONSTANTS' | 'REGULAR';
 export type RegularStruct = Readonly<{
   context: 'REGULAR',
   name: string,
-  properties: $ReadOnlyArray<StructProperty>,
+  properties: ReadonlyArray<StructProperty>,
 }>;
 
 export type ConstantsStruct = Readonly<{
   context: 'CONSTANTS',
   name: string,
-  properties: $ReadOnlyArray<StructProperty>,
+  properties: ReadonlyArray<StructProperty>,
 }>;
 
 export type Struct = RegularStruct | ConstantsStruct;
@@ -240,7 +240,7 @@ class StructCollector {
     }
   }
 
-  getAllStructs(): $ReadOnlyArray<Struct> {
+  getAllStructs(): ReadonlyArray<Struct> {
     return [...this._structs.values()];
   }
 

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/serializeMethod.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/serializeMethod.js
@@ -57,7 +57,7 @@ export type MethodSerializationOutput = Readonly<{
   methodName: string,
   protocolMethod: string,
   selector: string,
-  structParamRecords: $ReadOnlyArray<StructParameterRecord>,
+  structParamRecords: ReadonlyArray<StructParameterRecord>,
   returnJSType: ReturnJSType,
   argCount: number,
 }>;
@@ -67,7 +67,7 @@ function serializeMethod(
   property: NativeModulePropertyShape,
   structCollector: StructCollector,
   resolveAlias: AliasResolver,
-): $ReadOnlyArray<MethodSerializationOutput> {
+): ReadonlyArray<MethodSerializationOutput> {
   const {name: methodName, typeAnnotation: nullableTypeAnnotation} = property;
   const [propertyTypeAnnotation] = unwrapNullable(nullableTypeAnnotation);
   const {params} = propertyTypeAnnotation;
@@ -472,7 +472,7 @@ function serializeConstantsProtocolMethods(
   property: NativeModulePropertyShape,
   structCollector: StructCollector,
   resolveAlias: AliasResolver,
-): $ReadOnlyArray<MethodSerializationOutput> {
+): ReadonlyArray<MethodSerializationOutput> {
   const [propertyTypeAnnotation] = unwrapNullable(property.typeAnnotation);
   if (propertyTypeAnnotation.params.length !== 0) {
     throw new Error(

--- a/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/source/serializeModule.js
+++ b/packages/react-native-codegen/src/generators/modules/GenerateModuleObjCpp/source/serializeModule.js
@@ -29,10 +29,10 @@ const ModuleTemplate = ({
   methodSerializationOutputs,
 }: Readonly<{
   hasteModuleName: string,
-  structs: $ReadOnlyArray<Struct>,
+  structs: ReadonlyArray<Struct>,
   moduleName: string,
-  eventEmitters: $ReadOnlyArray<NativeModuleEventEmitterShape>,
-  methodSerializationOutputs: $ReadOnlyArray<MethodSerializationOutput>,
+  eventEmitters: ReadonlyArray<NativeModuleEventEmitterShape>,
+  methodSerializationOutputs: ReadonlyArray<MethodSerializationOutput>,
 }>) => `
 @implementation ${hasteModuleName}SpecBase
 ${eventEmitters
@@ -129,7 +129,7 @@ const MethodMapEntryTemplate = ({
 }: Readonly<{
   hasteModuleName: string,
   methodName: string,
-  structParamRecords: $ReadOnlyArray<StructParameterRecord>,
+  structParamRecords: ReadonlyArray<StructParameterRecord>,
   argCount: number,
 }>) => `
         methodMap_["${methodName}"] = MethodMetadata {${argCount}, __hostFunction_${hasteModuleName}SpecJSI_${methodName}};
@@ -141,10 +141,10 @@ const MethodMapEntryTemplate = ({
 
 function serializeModuleSource(
   hasteModuleName: string,
-  structs: $ReadOnlyArray<Struct>,
+  structs: ReadonlyArray<Struct>,
   moduleName: string,
-  eventEmitters: $ReadOnlyArray<NativeModuleEventEmitterShape>,
-  methodSerializationOutputs: $ReadOnlyArray<MethodSerializationOutput>,
+  eventEmitters: ReadonlyArray<NativeModuleEventEmitterShape>,
+  methodSerializationOutputs: ReadonlyArray<MethodSerializationOutput>,
 ): string {
   return ModuleTemplate({
     hasteModuleName,

--- a/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
+++ b/packages/react-native-codegen/src/parsers/__tests__/error-utils-test.js
@@ -635,7 +635,7 @@ describe('throwIfModuleTypeIsUnsupported', () => {
 describe('throwIfMoreThanOneModuleInterfaceParserError', () => {
   it("don't throw error if module specs length is <= 1", () => {
     const nativeModuleName = 'moduleName';
-    const moduleSpecs: $ReadOnlyArray<$FlowFixMe> = [];
+    const moduleSpecs: ReadonlyArray<$FlowFixMe> = [];
     const parserType = 'Flow';
 
     expect(() => {

--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -239,7 +239,7 @@ function throwIfPropertyValueTypeIsUnsupported(
 
 function throwIfMoreThanOneModuleInterfaceParserError(
   nativeModuleName: string,
-  moduleSpecs: $ReadOnlyArray<$FlowFixMe>,
+  moduleSpecs: ReadonlyArray<$FlowFixMe>,
   parserType: ParserType,
 ) {
   if (moduleSpecs.length > 1) {
@@ -333,7 +333,7 @@ function throwIfPartialWithMoreParameter(typeAnnotation: $FlowFixMe) {
 }
 
 function throwIfMoreThanOneCodegenNativecommands(
-  commandsTypeNames: $ReadOnlyArray<$FlowFixMe>,
+  commandsTypeNames: ReadonlyArray<$FlowFixMe>,
 ) {
   if (commandsTypeNames.length > 1) {
     throw new Error('codegenNativeCommands may only be called once in a file');
@@ -375,9 +375,9 @@ function throwIfBubblingTypeIsNull(
 }
 
 function throwIfArgumentPropsAreNull(
-  argumentProps: ?$ReadOnlyArray<$FlowFixMe>,
+  argumentProps: ?ReadonlyArray<$FlowFixMe>,
   eventName: string,
-): $ReadOnlyArray<$FlowFixMe> {
+): ReadonlyArray<$FlowFixMe> {
   if (!argumentProps) {
     throw new Error(`Unable to determine event arguments for "${eventName}"`);
   }

--- a/packages/react-native-codegen/src/parsers/errors.js
+++ b/packages/react-native-codegen/src/parsers/errors.js
@@ -15,7 +15,7 @@ import type {Parser} from './parser';
 export type ParserType = 'Flow' | 'TypeScript';
 
 class ParserError extends Error {
-  nodes: $ReadOnlyArray<$FlowFixMe>;
+  nodes: ReadonlyArray<$FlowFixMe>;
   constructor(
     nativeModuleName: string,
     astNodeOrNodes: $FlowFixMe,
@@ -57,8 +57,8 @@ class ModuleInterfaceNotFoundParserError extends ParserError {
 class MoreThanOneModuleInterfaceParserError extends ParserError {
   constructor(
     nativeModuleName: string,
-    flowModuleInterfaces: $ReadOnlyArray<$FlowFixMe>,
-    names: $ReadOnlyArray<string>,
+    flowModuleInterfaces: ReadonlyArray<$FlowFixMe>,
+    names: ReadonlyArray<string>,
     language: ParserType,
   ) {
     const finalName = names[names.length - 1];

--- a/packages/react-native-codegen/src/parsers/flow/components/commands.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/commands.js
@@ -33,7 +33,7 @@ function buildCommandSchema(
   optional: boolean,
   typeAnnotation: {
     type: 'FunctionTypeAnnotation',
-    params: $ReadOnlyArray<{
+    params: ReadonlyArray<{
       name: string,
       optional: boolean,
       typeAnnotation: CommandParamTypeAnnotation,
@@ -224,10 +224,10 @@ function getCommandArrayElementTypeType(
 }
 
 function getCommands(
-  commandTypeAST: $ReadOnlyArray<EventTypeAST>,
+  commandTypeAST: ReadonlyArray<EventTypeAST>,
   types: TypeDeclarationMap,
   parser: Parser,
-): $ReadOnlyArray<NamedShape<CommandTypeAnnotation>> {
+): ReadonlyArray<NamedShape<CommandTypeAnnotation>> {
   return commandTypeAST
     .filter(property => property.type === 'ObjectTypeProperty')
     .map(property => buildCommandSchema(property, types, parser))

--- a/packages/react-native-codegen/src/parsers/flow/components/componentsUtils.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/componentsUtils.js
@@ -187,10 +187,10 @@ function getTypeAnnotationForArray<+T>(
 }
 
 function flattenProperties(
-  typeDefinition: $ReadOnlyArray<PropAST>,
+  typeDefinition: ReadonlyArray<PropAST>,
   types: TypeDeclarationMap,
   parser: Parser,
-): $ReadOnlyArray<PropAST> {
+): ReadonlyArray<PropAST> {
   return typeDefinition
     .map(property => {
       if (property.type === 'ObjectTypeProperty') {

--- a/packages/react-native-codegen/src/parsers/flow/components/events.js
+++ b/packages/react-native-codegen/src/parsers/flow/components/events.js
@@ -275,10 +275,10 @@ type TypeMap = {
 };
 
 function getEvents(
-  eventTypeAST: $ReadOnlyArray<EventTypeAST>,
+  eventTypeAST: ReadonlyArray<EventTypeAST>,
   types: TypeMap,
   parser: Parser,
-): $ReadOnlyArray<EventTypeShape> {
+): ReadonlyArray<EventTypeShape> {
   return eventTypeAST
     .filter(property => property.type === 'ObjectTypeProperty')
     .map(property => buildEventSchema(types, property, parser))

--- a/packages/react-native-codegen/src/parsers/flow/modules/__tests__/module-parser-e2e-test.js
+++ b/packages/react-native-codegen/src/parsers/flow/modules/__tests__/module-parser-e2e-test.js
@@ -35,7 +35,7 @@ type PrimitiveTypeAnnotationType =
   | 'FloatTypeAnnotation'
   | 'BooleanTypeAnnotation';
 
-const PRIMITIVES: $ReadOnlyArray<[string, PrimitiveTypeAnnotationType]> = [
+const PRIMITIVES: ReadonlyArray<[string, PrimitiveTypeAnnotationType]> = [
   ['string', 'StringTypeAnnotation'],
   ['number', 'NumberTypeAnnotation'],
   ['Int32', 'Int32TypeAnnotation'],
@@ -44,9 +44,7 @@ const PRIMITIVES: $ReadOnlyArray<[string, PrimitiveTypeAnnotationType]> = [
   ['boolean', 'BooleanTypeAnnotation'],
 ];
 
-const RESERVED_FUNCTION_VALUE_TYPE_NAME: $ReadOnlyArray<'RootTag'> = [
-  'RootTag',
-];
+const RESERVED_FUNCTION_VALUE_TYPE_NAME: ReadonlyArray<'RootTag'> = ['RootTag'];
 
 const MODULE_NAME = 'NativeFoo';
 

--- a/packages/react-native-codegen/src/parsers/flow/parser.js
+++ b/packages/react-native-codegen/src/parsers/flow/parser.js
@@ -152,7 +152,7 @@ class FlowParser implements Parser {
 
   getFunctionTypeAnnotationParameters(
     functionTypeAnnotation: $FlowFixMe,
-  ): $ReadOnlyArray<$FlowFixMe> {
+  ): ReadonlyArray<$FlowFixMe> {
     return functionTypeAnnotation.params;
   }
 
@@ -227,7 +227,7 @@ class FlowParser implements Parser {
 
   parseEnumMembers(
     typeAnnotation: $FlowFixMe,
-  ): $ReadOnlyArray<NativeModuleEnumMember> {
+  ): ReadonlyArray<NativeModuleEnumMember> {
     return typeAnnotation.members.map(member => {
       const value =
         typeof member.init?.value === 'number'
@@ -371,7 +371,7 @@ class FlowParser implements Parser {
     return annotatedElement.right.properties;
   }
 
-  bodyProperties(typeAlias: $FlowFixMe): $ReadOnlyArray<$FlowFixMe> {
+  bodyProperties(typeAlias: $FlowFixMe): ReadonlyArray<$FlowFixMe> {
     return typeAlias.body.properties;
   }
 
@@ -489,9 +489,9 @@ class FlowParser implements Parser {
   }
 
   removeKnownExtends(
-    typeDefinition: $ReadOnlyArray<PropAST>,
+    typeDefinition: ReadonlyArray<PropAST>,
     types: TypeDeclarationMap,
-  ): $ReadOnlyArray<PropAST> {
+  ): ReadonlyArray<PropAST> {
     return typeDefinition.filter(
       prop =>
         prop.type !== 'ObjectTypeSpreadProperty' ||
@@ -500,9 +500,9 @@ class FlowParser implements Parser {
   }
 
   getExtendsProps(
-    typeDefinition: $ReadOnlyArray<PropAST>,
+    typeDefinition: ReadonlyArray<PropAST>,
     types: TypeDeclarationMap,
-  ): $ReadOnlyArray<ExtendsPropsShape> {
+  ): ReadonlyArray<ExtendsPropsShape> {
     return typeDefinition
       .filter(prop => prop.type === 'ObjectTypeSpreadProperty')
       .map(prop => this.extendsForProp(prop, types, this))
@@ -510,11 +510,11 @@ class FlowParser implements Parser {
   }
 
   getProps(
-    typeDefinition: $ReadOnlyArray<PropAST>,
+    typeDefinition: ReadonlyArray<PropAST>,
     types: TypeDeclarationMap,
   ): {
-    props: $ReadOnlyArray<NamedShape<PropTypeAnnotation>>,
-    extendsProps: $ReadOnlyArray<ExtendsPropsShape>,
+    props: ReadonlyArray<NamedShape<PropTypeAnnotation>>,
+    extendsProps: ReadonlyArray<ExtendsPropsShape>,
   } {
     const nonExtendsProps = this.removeKnownExtends(typeDefinition, types);
     const props = flattenProperties(nonExtendsProps, types, this)

--- a/packages/react-native-codegen/src/parsers/parser.js
+++ b/packages/react-native-codegen/src/parsers/parser.js
@@ -183,7 +183,7 @@ export interface Parser {
    */
   getFunctionTypeAnnotationParameters(
     functionTypeAnnotation: $FlowFixMe,
-  ): $ReadOnlyArray<$FlowFixMe>;
+  ): ReadonlyArray<$FlowFixMe>;
 
   /**
    * Given a parameter, it returns the function name of the parameter.
@@ -235,7 +235,7 @@ export interface Parser {
    */
   parseEnumMembers(
     typeAnnotation: $FlowFixMe,
-  ): $ReadOnlyArray<NativeModuleEnumMember>;
+  ): ReadonlyArray<NativeModuleEnumMember>;
 
   /**
    * Given a node, it returns true if it is a module interface
@@ -328,7 +328,7 @@ export interface Parser {
    * @parameter typeAlias: the type alias.
    * @returns: an array of properties.
    */
-  bodyProperties(typeAlias: $FlowFixMe): $ReadOnlyArray<$FlowFixMe>;
+  bodyProperties(typeAlias: $FlowFixMe): ReadonlyArray<$FlowFixMe>;
 
   /**
    * Given a keyword convert it to TypeAnnotation.
@@ -382,11 +382,11 @@ export interface Parser {
   getResolveTypeAnnotationFN(): ResolveTypeAnnotationFN;
 
   getProps(
-    typeDefinition: $ReadOnlyArray<PropAST>,
+    typeDefinition: ReadonlyArray<PropAST>,
     types: TypeDeclarationMap,
   ): {
-    props: $ReadOnlyArray<NamedShape<PropTypeAnnotation>>,
-    extendsProps: $ReadOnlyArray<ExtendsPropsShape>,
+    props: ReadonlyArray<NamedShape<PropTypeAnnotation>>,
+    extendsProps: ReadonlyArray<ExtendsPropsShape>,
   };
 
   getProperties(typeName: string, types: TypeDeclarationMap): $FlowFixMe;

--- a/packages/react-native-codegen/src/parsers/parserMock.js
+++ b/packages/react-native-codegen/src/parsers/parserMock.js
@@ -133,7 +133,7 @@ export class MockedParser implements Parser {
 
   getFunctionTypeAnnotationParameters(
     functionTypeAnnotation: $FlowFixMe,
-  ): $ReadOnlyArray<$FlowFixMe> {
+  ): ReadonlyArray<$FlowFixMe> {
     return functionTypeAnnotation.params;
   }
 
@@ -170,7 +170,7 @@ export class MockedParser implements Parser {
 
   parseEnumMembers(
     typeAnnotation: $FlowFixMe,
-  ): $ReadOnlyArray<NativeModuleEnumMember> {
+  ): ReadonlyArray<NativeModuleEnumMember> {
     return typeAnnotation.type === 'StringTypeAnnotation'
       ? [
           {
@@ -279,7 +279,7 @@ export class MockedParser implements Parser {
     return annotatedElement.right.properties;
   }
 
-  bodyProperties(typeAlias: $FlowFixMe): $ReadOnlyArray<$FlowFixMe> {
+  bodyProperties(typeAlias: $FlowFixMe): ReadonlyArray<$FlowFixMe> {
     return typeAlias.body.properties;
   }
 
@@ -401,9 +401,9 @@ export class MockedParser implements Parser {
   }
 
   getExtendsProps(
-    typeDefinition: $ReadOnlyArray<PropAST>,
+    typeDefinition: ReadonlyArray<PropAST>,
     types: TypeDeclarationMap,
-  ): $ReadOnlyArray<ExtendsPropsShape> {
+  ): ReadonlyArray<ExtendsPropsShape> {
     return typeDefinition
       .filter(prop => prop.type === 'ObjectTypeSpreadProperty')
       .map(prop => this.extendsForProp(prop, types, this))
@@ -439,9 +439,9 @@ export class MockedParser implements Parser {
   }
 
   removeKnownExtends(
-    typeDefinition: $ReadOnlyArray<PropAST>,
+    typeDefinition: ReadonlyArray<PropAST>,
     types: TypeDeclarationMap,
-  ): $ReadOnlyArray<PropAST> {
+  ): ReadonlyArray<PropAST> {
     return typeDefinition.filter(
       prop =>
         prop.type !== 'ObjectTypeSpreadProperty' ||
@@ -450,11 +450,11 @@ export class MockedParser implements Parser {
   }
 
   getProps(
-    typeDefinition: $ReadOnlyArray<PropAST>,
+    typeDefinition: ReadonlyArray<PropAST>,
     types: TypeDeclarationMap,
   ): {
-    props: $ReadOnlyArray<NamedShape<PropTypeAnnotation>>,
-    extendsProps: $ReadOnlyArray<ExtendsPropsShape>,
+    props: ReadonlyArray<NamedShape<PropTypeAnnotation>>,
+    extendsProps: ReadonlyArray<ExtendsPropsShape>,
   } {
     const nonExtendsProps = this.removeKnownExtends(typeDefinition, types);
     const props = flattenProperties(nonExtendsProps, types, this)

--- a/packages/react-native-codegen/src/parsers/parsers-commons.js
+++ b/packages/react-native-codegen/src/parsers/parsers-commons.js
@@ -78,7 +78,7 @@ const {
 const invariant = require('invariant');
 
 export type CommandOptions = Readonly<{
-  supportedCommands: $ReadOnlyArray<string>,
+  supportedCommands: ReadonlyArray<string>,
 }>;
 
 // $FlowFixMe[unclear-type] TODO(T108222691): Use flow-types for @babel/parser
@@ -90,7 +90,7 @@ type ExtendedPropResult = {
 } | null;
 
 export type EventArgumentReturnType = {
-  argumentProps: ?$ReadOnlyArray<$FlowFixMe>,
+  argumentProps: ?ReadonlyArray<$FlowFixMe>,
   paperTopLevelNameDeprecated: ?$FlowFixMe,
   bubblingType: ?'direct' | 'bubble',
 };
@@ -751,7 +751,7 @@ const buildModuleSchema = (
 ): NativeModuleSchema => {
   const language = parser.language();
   const types = parser.getTypes(ast);
-  const moduleSpecs = (Object.values(types): $ReadOnlyArray<$FlowFixMe>).filter(
+  const moduleSpecs = (Object.values(types): ReadonlyArray<$FlowFixMe>).filter(
     t => parser.isModuleInterface(t),
   );
 
@@ -793,7 +793,7 @@ const buildModuleSchema = (
         parser,
       )
     : {};
-  const properties: $ReadOnlyArray<$FlowFixMe> =
+  const properties: ReadonlyArray<$FlowFixMe> =
     language === 'Flow' ? moduleSpec.body.properties : moduleSpec.body.body;
 
   type PropertyShape =
@@ -1043,8 +1043,8 @@ function getCommandTypeNameAndOptionsExpression(
 }
 
 function propertyNames(
-  properties: $ReadOnlyArray<$FlowFixMe>,
-): $ReadOnlyArray<$FlowFixMe> {
+  properties: ReadonlyArray<$FlowFixMe>,
+): ReadonlyArray<$FlowFixMe> {
   return properties
     .map(property => property && property.key && property.key.name)
     .filter(Boolean);
@@ -1293,7 +1293,7 @@ function buildPropertiesForEvent(
 }
 
 function verifyPropNotAlreadyDefined(
-  props: $ReadOnlyArray<PropAST>,
+  props: ReadonlyArray<PropAST>,
   needleProp: PropAST,
 ) {
   const propName = needleProp.key.name;


### PR DESCRIPTION
Summary:
We are transforming the following utility types to be more consistent with typescript and better AI integration:

* `$NonMaybeType` -> `NonNullable`
* `$ReadOnly` -> `Readonly`
* `$ReadOnlyArray` -> `ReadonlyArray`
* `$ReadOnlyMap` -> `ReadonlyMap`
* `$ReadOnlySet` -> `ReadonlySet`
* `$Keys` -> `keyof`
* `$Values` -> `Values`
* `mixed` -> `unknown`

See details in https://fb.workplace.com/groups/flowlang/permalink/1837907750148213/.

drop-conflicts

Command:

`js1 flow-runner codemod flow/transformUtilityType --legacy-type='$ReadOnlyArray'`

Reviewed By: SamChou19815

Differential Revision: D90402950
