### PR TITLE
feat:- fix compilation issue with objcxx interop

### DIFF
--- a/packages/react-native/scripts/ios-configure-glog.sh
+++ b/packages/react-native/scripts/ios-configure-glog.sh
@@ -102,3 +102,21 @@ cp -f src/glog/logging.h "$EXPORTED_INCLUDE_DIR/"
 cp -f src/glog/raw_logging.h "$EXPORTED_INCLUDE_DIR/"
 cp -f src/glog/stl_logging.h "$EXPORTED_INCLUDE_DIR/"
 cp -f src/glog/vlog_is_on.h "$EXPORTED_INCLUDE_DIR/"
+
+
+# Create a custom module.modulemap that works with Swift C++ interop
+# The issue is that glog headers include other headers inside namespace blocks
+# which Clang treats as module imports inside namespaces (which is illegal)
+# Solution: Use textual headers to prevent submodule creation
+cat > src/glog/module.modulemap << 'MODULEMAP'
+module glog {
+     // Use textual headers to avoid submodule generation
+     // This prevents the "import within namespace" error with Swift C++ interop
+     textual header "log_severity.h"
+     textual header "logging.h"
+     textual header "raw_logging.h"
+     textual header "stl_logging.h"
+     textual header "vlog_is_on.h"
+     export *
+}
+MODULEMAP

--- a/packages/react-native/third-party-podspecs/glog.podspec
+++ b/packages/react-native/third-party-podspecs/glog.podspec
@@ -33,6 +33,7 @@ Pod::Spec.new do |spec|
   spec.exclude_files       = "src/windows/**/*"
   spec.compiler_flags      = '-Wno-shorten-64-to-32'
   spec.resource_bundles = {'glog_privacy' => 'glog/PrivacyInfo.xcprivacy'}
+  spec.module_map = 'src/glog/module.modulemap'
 
   spec.pod_target_xcconfig = {
     "USE_HEADERMAP" => "NO",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:
So currently RN app is broken with following error if the `SWIFT_OBJC_INTEROP_MODE` is changed to `objcxx`.
<img width="567" height="112" alt="image" src="https://github.com/user-attachments/assets/7a8e8cf4-a8a3-42d3-a65f-9943cbf296f2" />

### Why do we need this interop ?
So currently any pod that uses `objcxx` as interop (For example Any library created with Nitro modules) cannot be  imported into App directly .
<img width="548" height="59" alt="image" src="https://github.com/user-attachments/assets/b6d9fb7a-00df-4bf2-aa0c-c61fb3a6538f" />

We are using this in nitro-ota where we override bundle url . And nitro-player for jellify app where we create a new scene for carplay . Currently we are using hacky stuffs like creating two pods to address this but the solution is messy.
### RCA for failing 
<img width="633" height="155" alt="image" src="https://github.com/user-attachments/assets/7eb811cc-d1ba-410d-902c-4217bfc47b40" />

Currently glog imports some things inside namespace which is not allowed.

### Fix 
This patches creates a module map that uses textual headers to prevent submodule creation. We can still keep using the old interop by default . Users who need to do this can change the interop themselves

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS][FIXED] - Fix glog namespace issue to allow using interop mode of objcxx

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
To test this I forked Nightly repo and ran against all the libraries and nothing seems to fail
With objcxx interop :- https://github.com/riteshshukla04/nightly-tests/actions/runs/20908210967
with Objc interop :- https://github.com/riteshshukla04/nightly-tests/actions/runs/20902452877


