### PR TITLE
Remove shouldUseLinkRoleForPressableText feature flag

### DIFF
--- a/packages/react-native/Libraries/Text/Text.js
+++ b/packages/react-native/Libraries/Text/Text.js
@@ -152,10 +152,7 @@ if (ReactNativeFeatureFlags.reduceDefaultPropsInText()) {
       _disabled !== true;
 
     const shouldUseLinkRole =
-      ReactNativeFeatureFlags.shouldUseLinkRoleForPressableText() &&
-      isPressable &&
-      accessibilityRole == null &&
-      role == null;
+      isPressable && accessibilityRole == null && role == null;
 
     const _accessibilityRole =
       accessibilityRole ?? (shouldUseLinkRole ? 'link' : undefined);
@@ -420,10 +417,7 @@ if (ReactNativeFeatureFlags.reduceDefaultPropsInText()) {
       _disabled !== true;
 
     const shouldUseLinkRole =
-      ReactNativeFeatureFlags.shouldUseLinkRoleForPressableText() &&
-      isPressable &&
-      accessibilityRole == null &&
-      role == null;
+      isPressable && accessibilityRole == null && role == null;
 
     const _accessibilityRole =
       accessibilityRole ?? (shouldUseLinkRole ? 'link' : undefined);

--- a/packages/react-native/Libraries/Text/__tests__/Text-test.js
+++ b/packages/react-native/Libraries/Text/__tests__/Text-test.js
@@ -12,7 +12,6 @@ import type {ReactTestRendererJSON} from '../../Utilities/ReactNativeTestTools';
 import type {ReactTestRenderer} from 'react-test-renderer';
 
 import {create} from '../../../jest/renderer';
-import * as ReactNativeFeatureFlags from '../../../src/private/featureflags/ReactNativeFeatureFlags';
 import flattenStyle from '../../StyleSheet/flattenStyle';
 import * as React from 'react';
 
@@ -76,252 +75,153 @@ describe('Text', () => {
   });
 
   describe('accessibilityRole with onPress/onLongPress', () => {
-    describe('when shouldUseLinkRoleForPressableText flag is OFF (default)', () => {
-      beforeEach(() => {
-        jest
-          .spyOn(ReactNativeFeatureFlags, 'shouldUseLinkRoleForPressableText')
-          .mockReturnValue(false);
-      });
+    it('automatically sets accessibilityRole="link" when onPress is provided', async () => {
+      const instance = await create(
+        <Text onPress={() => {}}>Clickable Text</Text>,
+      );
 
-      afterEach(() => {
-        jest.restoreAllMocks();
-      });
-
-      it('does not automatically set accessibilityRole when onPress is provided', async () => {
-        const instance = await create(
-          <Text onPress={() => {}}>Clickable Text</Text>,
-        );
-
-        expect(omitRefAndFlattenStyle(instance)).toMatchInlineSnapshot(`
-          <RCTText
-            accessible={true}
-            allowFontScaling={true}
-            ellipsizeMode="tail"
-            isHighlighted={false}
-            isPressable={true}
-          >
-            Clickable Text
-          </RCTText>
-        `);
-      });
-
-      it('does not automatically set accessibilityRole when onLongPress is provided', async () => {
-        const instance = await create(
-          <Text onLongPress={() => {}}>Long Press Text</Text>,
-        );
-
-        expect(omitRefAndFlattenStyle(instance)).toMatchInlineSnapshot(`
-          <RCTText
-            accessible={true}
-            allowFontScaling={true}
-            ellipsizeMode="tail"
-            isHighlighted={false}
-            isPressable={true}
-          >
-            Long Press Text
-          </RCTText>
-        `);
-      });
-
-      it('does not automatically set accessibilityRole when onStartShouldSetResponder is provided', async () => {
-        const instance = await create(
-          <Text onStartShouldSetResponder={() => true}>Responder Text</Text>,
-        );
-
-        expect(omitRefAndFlattenStyle(instance)).toMatchInlineSnapshot(`
-          <RCTText
-            accessible={true}
-            allowFontScaling={true}
-            ellipsizeMode="tail"
-            isHighlighted={false}
-            isPressable={true}
-          >
-            Responder Text
-          </RCTText>
-        `);
-      });
-
-      it('respects explicit accessibilityRole', async () => {
-        const instance = await create(
-          <Text accessibilityRole="button" onPress={() => {}}>
-            Explicit Button Role
-          </Text>,
-        );
-
-        expect(omitRefAndFlattenStyle(instance)).toMatchInlineSnapshot(`
-          <RCTText
-            accessibilityRole="button"
-            accessible={true}
-            allowFontScaling={true}
-            ellipsizeMode="tail"
-            isHighlighted={false}
-            isPressable={true}
-          >
-            Explicit Button Role
-          </RCTText>
-        `);
-      });
+      expect(omitRefAndFlattenStyle(instance)).toMatchInlineSnapshot(`
+        <RCTText
+          accessibilityRole="link"
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          isHighlighted={false}
+          isPressable={true}
+        >
+          Clickable Text
+        </RCTText>
+      `);
     });
 
-    describe('when shouldUseLinkRoleForPressableText flag is ON', () => {
-      beforeEach(() => {
-        jest
-          .spyOn(ReactNativeFeatureFlags, 'shouldUseLinkRoleForPressableText')
-          .mockReturnValue(true);
-      });
+    it('automatically sets accessibilityRole="link" when onLongPress is provided', async () => {
+      const instance = await create(
+        <Text onLongPress={() => {}}>Long Press Text</Text>,
+      );
 
-      afterEach(() => {
-        jest.restoreAllMocks();
-      });
+      expect(omitRefAndFlattenStyle(instance)).toMatchInlineSnapshot(`
+        <RCTText
+          accessibilityRole="link"
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          isHighlighted={false}
+          isPressable={true}
+        >
+          Long Press Text
+        </RCTText>
+      `);
+    });
 
-      it('automatically sets accessibilityRole="link" when onPress is provided', async () => {
-        const instance = await create(
-          <Text onPress={() => {}}>Clickable Text</Text>,
-        );
+    it('automatically sets accessibilityRole="link" when onStartShouldSetResponder is provided', async () => {
+      const instance = await create(
+        <Text onStartShouldSetResponder={() => true}>Responder Text</Text>,
+      );
 
-        expect(omitRefAndFlattenStyle(instance)).toMatchInlineSnapshot(`
-          <RCTText
-            accessibilityRole="link"
-            accessible={true}
-            allowFontScaling={true}
-            ellipsizeMode="tail"
-            isHighlighted={false}
-            isPressable={true}
-          >
-            Clickable Text
-          </RCTText>
-        `);
-      });
+      expect(omitRefAndFlattenStyle(instance)).toMatchInlineSnapshot(`
+        <RCTText
+          accessibilityRole="link"
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          isHighlighted={false}
+          isPressable={true}
+        >
+          Responder Text
+        </RCTText>
+      `);
+    });
 
-      it('automatically sets accessibilityRole="link" when onLongPress is provided', async () => {
-        const instance = await create(
-          <Text onLongPress={() => {}}>Long Press Text</Text>,
-        );
+    it('respects explicit accessibilityRole', async () => {
+      const instance = await create(
+        <Text accessibilityRole="button" onPress={() => {}}>
+          Explicit Button Role
+        </Text>,
+      );
 
-        expect(omitRefAndFlattenStyle(instance)).toMatchInlineSnapshot(`
-          <RCTText
-            accessibilityRole="link"
-            accessible={true}
-            allowFontScaling={true}
-            ellipsizeMode="tail"
-            isHighlighted={false}
-            isPressable={true}
-          >
-            Long Press Text
-          </RCTText>
-        `);
-      });
+      expect(omitRefAndFlattenStyle(instance)).toMatchInlineSnapshot(`
+        <RCTText
+          accessibilityRole="button"
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          isHighlighted={false}
+          isPressable={true}
+        >
+          Explicit Button Role
+        </RCTText>
+      `);
+    });
 
-      it('automatically sets accessibilityRole="link" when onStartShouldSetResponder is provided', async () => {
-        const instance = await create(
-          <Text onStartShouldSetResponder={() => true}>Responder Text</Text>,
-        );
+    it('respects explicit role prop', async () => {
+      // $FlowFixMe[prop-missing]
+      const instance = await create(
+        <Text onPress={() => {}} role="button">
+          Explicit Role Prop
+        </Text>,
+      );
 
-        expect(omitRefAndFlattenStyle(instance)).toMatchInlineSnapshot(`
-          <RCTText
-            accessibilityRole="link"
-            accessible={true}
-            allowFontScaling={true}
-            ellipsizeMode="tail"
-            isHighlighted={false}
-            isPressable={true}
-          >
-            Responder Text
-          </RCTText>
-        `);
-      });
+      expect(omitRefAndFlattenStyle(instance)).toMatchInlineSnapshot(`
+        <RCTText
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+          isHighlighted={false}
+          isPressable={true}
+          role="button"
+        >
+          Explicit Role Prop
+        </RCTText>
+      `);
+    });
 
-      it('respects explicit accessibilityRole', async () => {
-        const instance = await create(
-          <Text accessibilityRole="button" onPress={() => {}}>
-            Explicit Button Role
-          </Text>,
-        );
+    it('does not automatically set accessibilityRole when disabled', async () => {
+      const instance = await create(
+        <Text disabled onPress={() => {}}>
+          Disabled Pressable Text
+        </Text>,
+      );
 
-        expect(omitRefAndFlattenStyle(instance)).toMatchInlineSnapshot(`
-          <RCTText
-            accessibilityRole="button"
-            accessible={true}
-            allowFontScaling={true}
-            ellipsizeMode="tail"
-            isHighlighted={false}
-            isPressable={true}
-          >
-            Explicit Button Role
-          </RCTText>
-        `);
-      });
-
-      it('respects explicit role prop', async () => {
-        // $FlowFixMe[prop-missing]
-        const instance = await create(
-          <Text onPress={() => {}} role="button">
-            Explicit Role Prop
-          </Text>,
-        );
-
-        expect(omitRefAndFlattenStyle(instance)).toMatchInlineSnapshot(`
-          <RCTText
-            accessible={true}
-            allowFontScaling={true}
-            ellipsizeMode="tail"
-            isHighlighted={false}
-            isPressable={true}
-            role="button"
-          >
-            Explicit Role Prop
-          </RCTText>
-        `);
-      });
-
-      it('does not automatically set accessibilityRole when disabled', async () => {
-        const instance = await create(
-          <Text disabled onPress={() => {}}>
-            Disabled Pressable Text
-          </Text>,
-        );
-
-        expect(omitRefAndFlattenStyle(instance)).toMatchInlineSnapshot(`
-          <RCTText
-            accessibilityState={
-              Object {
-                "disabled": true,
-              }
+      expect(omitRefAndFlattenStyle(instance)).toMatchInlineSnapshot(`
+        <RCTText
+          accessibilityState={
+            Object {
+              "disabled": true,
             }
-            accessible={true}
-            allowFontScaling={true}
-            disabled={true}
-            ellipsizeMode="tail"
-          >
-            Disabled Pressable Text
-          </RCTText>
-        `);
-      });
+          }
+          accessible={true}
+          allowFontScaling={true}
+          disabled={true}
+          ellipsizeMode="tail"
+        >
+          Disabled Pressable Text
+        </RCTText>
+      `);
+    });
 
-      it('automatically sets accessibilityRole="link" for nested Text with onPress', async () => {
-        const instance = await create(
-          <Text>
-            Parent Text<Text onPress={() => {}}>Nested Clickable Link</Text>
-          </Text>,
-        );
+    it('automatically sets accessibilityRole="link" for nested Text with onPress', async () => {
+      const instance = await create(
+        <Text>
+          Parent Text<Text onPress={() => {}}>Nested Clickable Link</Text>
+        </Text>,
+      );
 
-        expect(omitRefAndFlattenStyle(instance)).toMatchInlineSnapshot(`
+      expect(omitRefAndFlattenStyle(instance)).toMatchInlineSnapshot(`
+        <RCTText
+          accessible={true}
+          allowFontScaling={true}
+          ellipsizeMode="tail"
+        >
+          Parent Text
           <RCTText
-            accessible={true}
-            allowFontScaling={true}
-            ellipsizeMode="tail"
+            accessibilityRole="link"
+            isHighlighted={false}
+            isPressable={true}
           >
-            Parent Text
-            <RCTText
-              accessibilityRole="link"
-              isHighlighted={false}
-              isPressable={true}
-            >
-              Nested Clickable Link
-            </RCTText>
+            Nested Clickable Link
           </RCTText>
-        `);
-      });
+        </RCTText>
+      `);
     });
 
     it('does not set accessibilityRole when no press handlers are provided', async () => {

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -980,16 +980,6 @@ const definitions: FeatureFlagDefinitions = {
       },
       ossReleaseStage: 'none',
     },
-    shouldUseLinkRoleForPressableText: {
-      defaultValue: true,
-      metadata: {
-        description:
-          'Set accessibilityRole to "link" for pressable Text components by default.',
-        expectedReleaseValue: true,
-        purpose: 'release',
-      },
-      ossReleaseStage: 'none',
-    },
     shouldUseRemoveClippedSubviewsAsDefaultOnIOS: {
       defaultValue: false,
       metadata: {

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<cc7c74d60512df0a15f85f61fb52b6fa>>
+ * @generated SignedSource<<0acb1755465fae151917d6043a737331>>
  * @flow strict
  * @noformat
  */
@@ -38,7 +38,6 @@ export type ReactNativeFeatureFlagsJsOnly = $ReadOnly<{
   reduceDefaultPropsInImage: Getter<boolean>,
   reduceDefaultPropsInText: Getter<boolean>,
   shouldUseAnimatedObjectForTransform: Getter<boolean>,
-  shouldUseLinkRoleForPressableText: Getter<boolean>,
   shouldUseRemoveClippedSubviewsAsDefaultOnIOS: Getter<boolean>,
   shouldUseSetNativePropsInFabric: Getter<boolean>,
 }>;
@@ -177,11 +176,6 @@ export const reduceDefaultPropsInText: Getter<boolean> = createJavaScriptFlagGet
  * Enables use of AnimatedObject for animating transform values.
  */
 export const shouldUseAnimatedObjectForTransform: Getter<boolean> = createJavaScriptFlagGetter('shouldUseAnimatedObjectForTransform', false);
-
-/**
- * Set accessibilityRole to "link" for pressable Text components by default.
- */
-export const shouldUseLinkRoleForPressableText: Getter<boolean> = createJavaScriptFlagGetter('shouldUseLinkRoleForPressableText', true);
 
 /**
  * removeClippedSubviews prop will be used as the default in FlatList on iOS to match Android


### PR DESCRIPTION
Summary:
Changelog: [Android][Fixed] - Set accessibilityRole to "link" for pressable Text components by default

 ---

This diff removes the `shouldUseLinkRoleForPressableText` feature flag since it has been tested in FB4A for a month with `defaultValue: true`.

The flag was introduced to automatically set `accessibilityRole="link"` for pressable Text components by default. This behavior is now the default.

Changes:
- Removed the flag definition from `ReactNativeFeatureFlags.config.js`
- Removed the conditional checks in `Text.js` (2 locations), now `shouldUseLinkRole` is computed directly without the feature flag
- Removed the override from `ReactNativeFeatureFlagsOverrides_Facebook.js`
- Updated tests in `Text-test.js` to remove flag mocking and only test the enabled behavior
- Regenerated all feature flag files via `js1 featureflags --update`

Reviewed By: javache

Differential Revision: D90385104
