### PR TITLE
Compile out UIView mulitpleTouchEnabled for AppleTV

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -67,7 +67,9 @@ const CGFloat BACKGROUND_COLOR_ZPOSITION = -1024.0f;
   if (self = [super initWithFrame:frame]) {
     _props = ViewShadowNode::defaultSharedProps();
     _reactSubviews = [NSMutableArray new];
+#if !TARGET_OS_TV
     self.multipleTouchEnabled = YES;
+#endif
     _useCustomContainerView = NO;
     _removeClippedSubviews = NO;
   }

--- a/packages/react-native/React/Views/RCTComponentData.mm
+++ b/packages/react-native/React/Views/RCTComponentData.mm
@@ -88,7 +88,9 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
   UIView *view = [self.manager view];
   view.reactTag = tag;
   view.rootTag = rootTag;
+#if !TARGET_OS_TV
   view.multipleTouchEnabled = YES;
+#endif
   view.userInteractionEnabled = YES; // required for touch handling
   view.layer.allowsGroupOpacity = YES; // required for touch handling
   return view;


### PR DESCRIPTION
Summary:
`multipleTouchEnabled` is not available for UIViews for AppleTV, compiling them out.

Changelog: [internal]

Differential Revision: D90513833


