### PR TITLE
Respect accessibilityElementsHidden in recursive label aggregation

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -1360,6 +1360,10 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
   // Result string is initialized lazily to prevent useless but costly allocations.
   NSMutableString *result = nil;
   for (UIView *subview in view.subviews) {
+    // Skip subviews that have accessibilityElementsHidden set to YES
+    if (subview.accessibilityElementsHidden) {
+      continue;
+    }
     NSString *label = subview.accessibilityLabel;
     if (!label) {
       label = RCTRecursiveAccessibilityLabel(subview);

--- a/packages/react-native/React/Views/RCTView.m
+++ b/packages/react-native/React/Views/RCTView.m
@@ -92,6 +92,10 @@ static NSString *RCTRecursiveAccessibilityLabel(UIView *view)
   // Result string is initialized lazily to prevent useless but costly allocations.
   NSMutableString *str = nil;
   for (UIView *subview in view.subviews) {
+    // Skip subviews that have accessibilityElementsHidden set to YES
+    if (subview.accessibilityElementsHidden) {
+      continue;
+    }
     NSString *label = subview.accessibilityLabel;
     if (!label) {
       label = RCTRecursiveAccessibilityLabel(subview);


### PR DESCRIPTION
Summary:
When a parent View has `accessible={true}` on iOS, React Native recursively aggregates the `accessibilityLabel` values from all descendant Text components (or accessible components) to construct the parent's accessibility label for VoiceOver. However, this aggregation was **not respecting** the `accessibilityElementsHidden` prop, so any child elements with accessibility labels (even Text components marked with accessible={false}) were still being read aloud by VoiceOver.

This diff fixes the `RCTRecursiveAccessibilityLabel` function to skip subviews that have `accessibilityElementsHidden=YES`, ensuring that:
- Views marked with `accessibilityElementsHidden={true}` are properly excluded from label aggregation
- The behavior aligns with developer expectations when using this accessibility prop, since it is [described](https://reactnative.dev/docs/accessibility#accessibilityelementshidden-ios) as "similar to the Android property importantForAccessibility="no-hide-descendants".

Reviewed By: joevilches

Differential Revision: D90420237


