### PR TITLE
fix rctimage observer crash when unloading with events in-flight

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Image/RCTImageComponentView.mm
@@ -21,7 +21,7 @@ using namespace facebook::react;
 
 @implementation RCTImageComponentView {
   ImageShadowNode::ConcreteState::Shared _state;
-  RCTImageResponseObserverProxy _imageResponseObserverProxy;
+  std::shared_ptr<RCTImageResponseObserverProxy> _imageResponseObserverProxy;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -36,7 +36,7 @@ using namespace facebook::react;
     _imageView.layer.minificationFilter = kCAFilterTrilinear;
     _imageView.layer.magnificationFilter = kCAFilterTrilinear;
 
-    _imageResponseObserverProxy = RCTImageResponseObserverProxy(self);
+    _imageResponseObserverProxy = std::make_shared<RCTImageResponseObserverProxy>(self);
 
     self.contentView = _imageView;
   }

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponseObserverCoordinator.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageResponseObserverCoordinator.h
@@ -11,6 +11,7 @@
 #include <react/renderer/imagemanager/ImageResponseObserver.h>
 #include <react/utils/SharedFunction.h>
 
+#include <memory>
 #include <mutex>
 #include <vector>
 
@@ -31,12 +32,12 @@ class ImageResponseObserverCoordinator {
    * If the current image request status is not equal to `Loading`, the observer
    * will be called immediately.
    */
-  void addObserver(const ImageResponseObserver &observer) const;
+  void addObserver(std::shared_ptr<const ImageResponseObserver> observer) const;
 
   /*
    * Interested parties may stop observing the image response.
    */
-  void removeObserver(const ImageResponseObserver &observer) const;
+  void removeObserver(const std::shared_ptr<const ImageResponseObserver> &observer) const;
 
   /*
    * Platform-specific image loader will call this method with progress updates.
@@ -65,7 +66,7 @@ class ImageResponseObserverCoordinator {
    * List of observers.
    * Mutable: protected by mutex_.
    */
-  mutable std::vector<const ImageResponseObserver *> observers_;
+  mutable std::vector<std::shared_ptr<const ImageResponseObserver>> observers_;
 
   /*
    * Current status of image loading.


### PR DESCRIPTION
Summary:
Resolves a rare native iOS ImageResponseObserverCoordinator crash that would result from a use-after-free in the observer.

## Original Error
EXC_BAD_ACCESS / KERN_INVALID_ADDRESS in ImageResponseObserverCoordinator::nativeImageResponseProgress

Differential Revision: D90552795


