### PR TITLE
Add isBinary parameter to ws$MessageListener type

### DIFF
--- a/flow-typed/npm/ws_v7.x.x.js
+++ b/flow-typed/npm/ws_v7.x.x.js
@@ -134,6 +134,7 @@ declare type ws$CloseListener = (code: number, reason: string) => unknown;
 declare type ws$ErrorListener = (error: Error) => unknown;
 declare type ws$MessageListener = (
   data: string | Buffer | ArrayBuffer | Array<Buffer>,
+  isBinary: boolean,
 ) => unknown;
 declare type ws$OpenListener = () => unknown;
 declare type ws$PingListener = (Buffer) => unknown;


### PR DESCRIPTION
Summary:
The `ws` library's `message` event passes `(data, isBinary)` to callbacks, but the flow-typed definition only included `data`. This caused Flow errors when correctly using `isBinary` to detect binary messages.

This fix adds the missing `isBinary: boolean` parameter to `ws$MessageListener` in both flow-typed locations to keep them synchronized:
- `xplat/js/tools/metro/flow-typed/npm/ws_v7.x.x.js`
- `xplat/js/react-native-github/flow-typed/npm/ws_v7.x.x.js`

This is backwards compatible - existing code that doesn't use `isBinary` will continue to work since for flow a function with fewer parameters is a subtype for callbacks. websocket was always sending both parameters and the javascript just ignored the second one.

https://github.com/websockets/ws/blob/master/doc/ws.md#event-message

Reviewed By: huntie

Differential Revision: D90507002


