### PR TITLE
Fix Hermes opt mode for local mac runs

### DIFF
--- a/private/react-native-fantom/runner/utils.js
+++ b/private/react-native-fantom/runner/utils.js
@@ -54,8 +54,12 @@ export function getHermesCompilerTarget(variant: HermesVariant): string {
 export function getBuckModesForPlatform(
   enableRelease: boolean = false,
 ): $ReadOnlyArray<string> {
-  let mode = enableRelease ? 'opt' : 'dev';
+  let modes = ['@//xplat/mode/react-native/granite'];
+  if (enableRelease) {
+    modes.push('@//xplat/mode/hermes/opt');
+  }
 
+  let mode = enableRelease ? 'opt' : 'dev';
   if (enableRelease) {
     if (EnvironmentOptions.enableASAN || EnvironmentOptions.enableTSAN) {
       printConsoleLog({
@@ -101,7 +105,8 @@ export function getBuckModesForPlatform(
       throw new Error(`Unsupported platform: ${os.platform()}`);
   }
 
-  return ['@//xplat/mode/react-native/granite', osPlatform];
+  modes.push(osPlatform);
+  return modes;
 }
 
 // TODO: T240293839 Remove when we get rid of RN_USE_ANIMATION_BACKEND preprocessor flag


### PR DESCRIPTION
Summary:
Some tests were failing locally on Mac, since //arvr/mode/mac-arm/opt doesn't correctly undefine REACT_NATIVE_DEBUG. Use `//xplat/mode/hermes/opt` as a short-cut since that directly defines rn_build_mode.

Changelog: [Internal]

Differential Revision: D90536112


