### PR TITLE
Remove the remaining templateprocessor subspec from React-Fabric.podspec

### DIFF
--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -187,12 +187,6 @@ Pod::Spec.new do |s|
     end
   end
 
-  s.subspec "templateprocessor" do |ss|
-    ss.source_files         = podspec_sources("react/renderer/templateprocessor/**/*.{m,mm,cpp,h}", "react/renderer/templateprocessor/**/*.h")
-    ss.exclude_files        = "react/renderer/templateprocessor/tests"
-    ss.header_dir           = "react/renderer/templateprocessor"
-  end
-
   s.subspec "telemetry" do |ss|
     ss.source_files         = podspec_sources("react/renderer/telemetry/**/*.{m,mm,cpp,h}", "react/renderer/telemetry/**/*.h")
     ss.exclude_files        = "react/renderer/telemetry/tests"


### PR DESCRIPTION
## Summary:

A few years ago, the source files of the **templateprocessor module** were removed from the React Native codebase. Based on the linked pull request, these files were no longer used. However, based on my investigation, the subspec of this module was missed and is still defined in _packages/react-native/ReactCommon/React-Fabric.podspec_.

https://github.com/facebook/react-native/pull/39487

During an open-source scan, the `templateprocessor` module was detected, but its source code could not be found. After further investigation, I found that this module is no longer in use.

## Changelog:

[Internal] [Removed] – Remove the remaining templateprocessor subspec from React-Fabric.podspec
