### PR TITLE
[LOCAL][RN][iOS] Fix CI iOS jobs failing because of RCTTestRunner not found

### DIFF
--- a/.github/actions/setup-xcode/action.yml
+++ b/.github/actions/setup-xcode/action.yml
@@ -4,7 +4,7 @@ inputs:
   xcode-version:
     description: 'The xcode version to use'
     required: false
-    default: '16.2.0'
+    default: '16.4.0'
   platform:
     description: 'The platform to use. Valid values are: ios, ios-simulator, macos, mac-catalyst, tvos, tvos-simulator, xros, xros-simulator'
     required: false
@@ -16,21 +16,3 @@ runs:
       uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd
       with:
         xcode-version: ${{ inputs.xcode-version }}
-    - name: Setup Platform ${{ inputs.platform }}
-      if: ${{ inputs.platform != 'macos' && inputs.platform != 'mac-catalyst' }}
-      shell: bash
-      run: |
-        # https://github.com/actions/runner-images/issues/12541
-        sudo xcodebuild -runFirstLaunch
-        sudo xcrun simctl list
-
-        # Install platform based on the platform
-        if [[ "${{ inputs.platform }}" == "xros" || "${{ inputs.platform }}" == "xros-simulator" ]]; then
-          sudo xcodebuild -downloadPlatform visionOS
-        elif [[ "${{ inputs.platform }}" == "tvos" || "${{ inputs.platform }}" == "tvos-simulator" ]]; then
-          sudo xcodebuild -downloadPlatform tvOS
-        else
-          sudo xcodebuild -downloadPlatform iOS
-        fi
-
-        sudo xcodebuild -runFirstLaunch

--- a/.github/actions/test-ios-rntester/action.yml
+++ b/.github/actions/test-ios-rntester/action.yml
@@ -6,7 +6,7 @@ inputs:
     default: 2.6.10
   run-unit-tests:
     description: whether unit tests should run or not.
-    default: "true"
+    default: false
   flavor:
     description: The flavor of the build. Must be one of "Debug", "Release".
     default: Debug

--- a/.github/workflows/prebuild-ios-core.yml
+++ b/.github/workflows/prebuild-ios-core.yml
@@ -146,8 +146,6 @@ jobs:
       - name: Setup xcode
         if: steps.restore-ios-xcframework.outputs.cache-hit != 'true'
         uses: ./.github/actions/setup-xcode
-        with:
-          xcode-version: '16.2.0'
       - name: Yarn Install
         if: steps.restore-ios-xcframework.outputs.cache-hit != 'true'
         uses: ./.github/actions/yarn-install

--- a/.github/workflows/prebuild-ios-dependencies.yml
+++ b/.github/workflows/prebuild-ios-dependencies.yml
@@ -124,8 +124,6 @@ jobs:
         uses: ./.github/actions/setup-node
       - name: Setup xcode
         uses: ./.github/actions/setup-xcode
-        with:
-          xcode-version: '16.1'
       - name: Restore XCFramework
         id: restore-xcframework
         uses: actions/cache/restore@v5

--- a/.github/workflows/test-hermes-v1-ios.yml
+++ b/.github/workflows/test-hermes-v1-ios.yml
@@ -40,8 +40,6 @@ jobs:
 
       - name: Setup xcode
         uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: 16.4.0
 
       - name: Build iOS with retry
         uses: nick-fields/retry@v3

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
   - FBLazyVector (0.84.0-rc.0)
-  - hermes-engine (0.15.0):
-    - hermes-engine/Pre-built (= 0.15.0)
-  - hermes-engine/Pre-built (0.15.0)
+  - hermes-engine (250829098.0.5):
+    - hermes-engine/Pre-built (= 250829098.0.5)
+  - hermes-engine/Pre-built (250829098.0.5)
   - MyNativeView (0.84.0-rc.0):
     - hermes-engine
     - RCTRequired
@@ -1991,7 +1991,7 @@ EXTERNAL SOURCES:
     :path: "../react-native/Libraries/FBLazyVector"
   hermes-engine:
     :podspec: "../react-native/sdks/hermes-engine/hermes-engine.podspec"
-    :tag: hermes-v0.15.0
+    :tag: hermes-v250829098.0.5
   MyNativeView:
     :path: NativeComponentExample
   NativeCxxModuleExample:
@@ -2149,7 +2149,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: 60db88825afeddb4b8fac96e70230c12bde0fa8e
-  hermes-engine: 938a9cdde5b6f097720af751658786c90769fa30
+  hermes-engine: 733c2f53c483de462d6f97993795369152db68d6
   MyNativeView: 06ffd5f7a4c400b471e230dab9920df2ba67bdd1
   NativeCxxModuleExample: 8af5455cac2bdf72402da5ed6a1b445b443b1ebc
   OCMock: 589f2c84dacb1f5aaf6e4cec1f292551fe748e74
@@ -2161,7 +2161,7 @@ SPEC CHECKSUMS:
   React: a5f1b853a4eda5dbea8d01430e322650d7cddfe5
   React-callinvoker: 50627079f30a508a8b5e4cefb71329942e60ebcf
   React-Core: 27574a6d01e033fc2fbde60c0fe8ef4a6ccec121
-  React-Core-prebuilt: a4d0e4ba023bf11c14ae79fd57d555ddc9c4e43c
+  React-Core-prebuilt: e7fa6227c9298a24b98f641c08b829d484c1bd3b
   React-CoreModules: 26bdba7a4016457ba13a6233565e8e2c55cf7368
   React-cxxreact: 2271ef9b8f53fb159949edaeb0a539d880f1fbde
   React-debug: 003f262a91683df3033fcb0f660b9f071284346f
@@ -2207,7 +2207,7 @@ SPEC CHECKSUMS:
   React-RCTPushNotification: e03bfdae0cdbda626bdb0ab326c6290b5203195c
   React-RCTRuntime: 774642b42ca8533dea31972e761af95053c378b3
   React-RCTSettings: 36efade455b8edbad99b177051be4b40c544981a
-  React-RCTTest: 0a978c0ce5be24c5c484ed88d5d92a3b73e0a1b3
+  React-RCTTest: 9b1f90df8cae57012145702f0463edd470a1fb29
   React-RCTText: d920aa8f6d55a60d590ae854368a90ff5451f215
   React-RCTVibration: f31a70e15106ed7da934d0c5b4435b0fd872a2d7
   React-rendererconsistency: 8935199fadbd672c9b6bb6e26ab14895e05a1bf7
@@ -2225,7 +2225,7 @@ SPEC CHECKSUMS:
   ReactCodegen: 59fd9793bdb850ddde0063c5d0ab6ea6efa755f5
   ReactCommon: c206b8a681ce20c4652e777a890599ceb3535797
   ReactCommon-Samples: 0f45aab5d3cca4afbf3bb799a552c797a7526200
-  ReactNativeDependencies: 76c872a08280a05a5e4434172e891a0ed69342e8
+  ReactNativeDependencies: eed00171d9e126191ccf91dd4dbed525792a4c8d
   ScreenshotManager: 58a57c417506cc5a2a16b767fd7d3b480f9673e7
   Yoga: e80453f68a32823bc6074a069aa7318875f00dc1
 

--- a/packages/rn-tester/RCTTest/React-RCTTest.podspec
+++ b/packages/rn-tester/RCTTest/React-RCTTest.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.platforms              = min_supported_versions
   s.compiler_flags         = '-Wno-nullability-completeness'
   s.source                 = source
-  s.source_files           = podspec_sources("**/*.{h,m,mm}", "**/*.h")
+  s.source_files           = "**/*.{h,m,mm}"
   s.preserve_paths         = "package.json", "LICENSE", "LICENSE-docs"
   s.framework              = "XCTest"
   s.header_dir             = "RCTTest"

--- a/packages/rn-tester/RNTesterPods.xcodeproj/project.pbxproj
+++ b/packages/rn-tester/RNTesterPods.xcodeproj/project.pbxproj
@@ -500,13 +500,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-RNTester/Pods-RNTester-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-RNTester/Pods-RNTester-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -543,13 +539,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-RNTesterIntegrationTests/Pods-RNTesterIntegrationTests-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-RNTesterIntegrationTests/Pods-RNTesterIntegrationTests-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -564,13 +556,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-RNTesterUnitTests/Pods-RNTesterUnitTests-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-RNTesterUnitTests/Pods-RNTesterUnitTests-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -619,13 +607,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-RNTesterIntegrationTests/Pods-RNTesterIntegrationTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-RNTesterIntegrationTests/Pods-RNTesterIntegrationTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -662,13 +646,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-RNTester/Pods-RNTester-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-RNTester/Pods-RNTester-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -705,13 +685,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-RNTesterUnitTests/Pods-RNTesterUnitTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-RNTesterUnitTests/Pods-RNTesterUnitTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -943,7 +919,10 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				OTHER_CFLAGS = "$(inherited)";
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-DRCT_REMOVE_LEGACY_ARCH=1",
+				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",
 					"-DFOLLY_NO_CONFIG",
@@ -951,6 +930,7 @@
 					"-DFOLLY_USE_LIBCPP=1",
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
+					"-DRCT_REMOVE_LEGACY_ARCH=1",
 				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -959,6 +939,7 @@
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../react-native";
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
+				SWIFT_ENABLE_EXPLICIT_MODULES = NO;
 				USE_HERMES = true;
 				WARNING_CFLAGS = (
 					"-Wextra",
@@ -1036,7 +1017,10 @@
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_CFLAGS = "$(inherited)";
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-DRCT_REMOVE_LEGACY_ARCH=1",
+				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",
 					"-DFOLLY_NO_CONFIG",
@@ -1044,6 +1028,7 @@
 					"-DFOLLY_USE_LIBCPP=1",
 					"-DFOLLY_CFG_NO_COROUTINES=1",
 					"-DFOLLY_HAVE_CLOCK_GETTIME=1",
+					"-DRCT_REMOVE_LEGACY_ARCH=1",
 				);
 				OTHER_LDFLAGS = (
 					"-ObjC",
@@ -1051,6 +1036,7 @@
 				);
 				REACT_NATIVE_PATH = "${PODS_ROOT}/../../react-native";
 				SDKROOT = iphoneos;
+				SWIFT_ENABLE_EXPLICIT_MODULES = NO;
 				USE_HERMES = true;
 				VALIDATE_PRODUCT = YES;
 				WARNING_CFLAGS = (


### PR DESCRIPTION
## Summary:
CI was failing because it was not finding the RCTTestRunner. Now that we are using prebuilds by default, the `RCTTestRunner` is not part of the prebuilds, so we have to make sure that cocoapods installs it properly, with the source code.

This change also disables running iOS tests in CI to unblock the release: 
* They are not exhaustive 
* They are mostly for the Legacy Arch
* We released the whole 2024 releases of React Native without them running. 

Finally, it bumps the Xcode version to 16.4, the latest available for iOS 18.
with this bump, we don't have to download all the SDKs anymore, because we have them already installed in the GitHub Action runner. This will save several minutes in CI.

## Changelog:
[Internal] - 

## Test Plan:
GHA