### PR TITLE
[0.84] Correctly bump hermes-compiler to V1 version

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -175,7 +175,7 @@
     "base64-js": "^1.5.1",
     "commander": "^12.0.0",
     "flow-enums-runtime": "^0.0.6",
-    "hermes-compiler": "0.15.0",
+    "hermes-compiler": "250829098.0.5",
     "invariant": "^2.2.4",
     "jest-environment-node": "^29.7.0",
     "memoize-one": "^5.0.0",

--- a/packages/react-native/scripts/hermes/bump-hermes-version.js
+++ b/packages/react-native/scripts/hermes/bump-hermes-version.js
@@ -108,7 +108,7 @@ async function main() {
 
   await setHermesTag(hermesTag, hermesV1Tag);
 
-  await updateHermesCompilerVersionInDependencies(hermesVersion);
+  await updateHermesCompilerVersionInDependencies(hermesV1Version);
   await updateHermesRuntimeDependenciesVersions(hermesVersion, hermesV1Version);
 }
 


### PR DESCRIPTION
## Summary:

This updates the `bump-hermes-version.js` script so that it bumps the `hermes-compiler` version to the v1 version.

On Android the app was instacrashing on release due to a mismatch on the Hermes bytecode version, so I'm also bumping the version to fix it.

## Changelog:

[INTERNAL] - 

## Test Plan:

CI