### PR TITLE
fix(debugger-shell): add missing `debug` dependency

### DIFF
--- a/packages/debugger-shell/package.json
+++ b/packages/debugger-shell/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "cross-spawn": "^7.0.6",
+    "debug": "^4.4.0",
     "fb-dotslash": "0.5.8"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary:

Use of `debug` was added in #54978 but never declared. This causes `react-native config` to fail in pnpm setups.

## Changelog:

[GENERAL] [FIXED] - Fixed missing dependency breaking `react-native config` in pnpm setups

## Test Plan:

n/a