### PR TITLE
[RN][CI] Bump Xcode to 16.4 and stop downloading Apple SDKs

### DIFF
--- a/.github/actions/setup-xcode/action.yml
+++ b/.github/actions/setup-xcode/action.yml
@@ -4,11 +4,7 @@ inputs:
   xcode-version:
     description: 'The xcode version to use'
     required: false
-    default: '16.2.0'
-  platform:
-    description: 'The platform to use. Valid values are: ios, ios-simulator, macos, mac-catalyst, tvos, tvos-simulator, xros, xros-simulator'
-    required: false
-    default: 'macos'
+    default: '16.4.0'
 runs:
   using: "composite"
   steps:
@@ -16,21 +12,3 @@ runs:
       uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd
       with:
         xcode-version: ${{ inputs.xcode-version }}
-    - name: Setup Platform ${{ inputs.platform }}
-      if: ${{ inputs.platform != 'macos' && inputs.platform != 'mac-catalyst' }}
-      shell: bash
-      run: |
-        # https://github.com/actions/runner-images/issues/12541
-        sudo xcodebuild -runFirstLaunch
-        sudo xcrun simctl list
-
-        # Install platform based on the platform
-        if [[ "${{ inputs.platform }}" == "xros" || "${{ inputs.platform }}" == "xros-simulator" ]]; then
-          sudo xcodebuild -downloadPlatform visionOS
-        elif [[ "${{ inputs.platform }}" == "tvos" || "${{ inputs.platform }}" == "tvos-simulator" ]]; then
-          sudo xcodebuild -downloadPlatform tvOS
-        else
-          sudo xcodebuild -downloadPlatform iOS
-        fi
-
-        sudo xcodebuild -runFirstLaunch

--- a/.github/actions/test-ios-helloworld/action.yml
+++ b/.github/actions/test-ios-helloworld/action.yml
@@ -15,8 +15,6 @@ runs:
   steps:
     - name: Setup xcode
       uses: ./.github/actions/setup-xcode
-      with:
-        platform: ios
     - name: Setup node.js
       uses: ./.github/actions/setup-node
     - name: Run yarn install

--- a/.github/actions/test-ios-rntester/action.yml
+++ b/.github/actions/test-ios-rntester/action.yml
@@ -6,7 +6,7 @@ inputs:
     default: 2.6.10
   run-unit-tests:
     description: whether unit tests should run or not.
-    default: "true"
+    default: false
   flavor:
     description: The flavor of the build. Must be one of "Debug", "Release".
     default: Debug
@@ -24,8 +24,6 @@ runs:
   steps:
     - name: Setup xcode
       uses: ./.github/actions/setup-xcode
-      with:
-        platform: ios
     - name: Setup node.js
       uses: ./.github/actions/setup-node
     - name: Run yarn

--- a/.github/workflows/bump-podfile-lock.yml
+++ b/.github/workflows/bump-podfile-lock.yml
@@ -21,8 +21,6 @@ jobs:
           git config --local user.name "React Native Bot"
       - name: Setup xcode
         uses: ./.github/actions/setup-xcode
-        with:
-          platform: 'ios'
       - name: Extract branch name
         run: |
           TAG="${{ github.ref_name }}";

--- a/.github/workflows/prebuild-ios-core.yml
+++ b/.github/workflows/prebuild-ios-core.yml
@@ -41,8 +41,6 @@ jobs:
       - name: Setup xcode
         if: steps.restore-ios-slice.outputs.cache-hit != 'true'
         uses: ./.github/actions/setup-xcode
-        with:
-          platform: ${{ matrix.slice }}
       - name: Yarn Install
         if: steps.restore-ios-slice.outputs.cache-hit != 'true'
         uses: ./.github/actions/yarn-install
@@ -146,8 +144,6 @@ jobs:
       - name: Setup xcode
         if: steps.restore-ios-xcframework.outputs.cache-hit != 'true'
         uses: ./.github/actions/setup-xcode
-        with:
-          xcode-version: '16.2.0'
       - name: Yarn Install
         if: steps.restore-ios-xcframework.outputs.cache-hit != 'true'
         uses: ./.github/actions/yarn-install

--- a/.github/workflows/prebuild-ios-dependencies.yml
+++ b/.github/workflows/prebuild-ios-dependencies.yml
@@ -74,8 +74,6 @@ jobs:
       - name: Setup xcode
         if: steps.restore-slice-folder.outputs.cache-hit != 'true'
         uses: ./.github/actions/setup-xcode
-        with:
-          platform: ${{ matrix.slice }}
       - name: Yarn Install
         if: steps.restore-slice-folder.outputs.cache-hit != 'true'
         uses: ./.github/actions/yarn-install
@@ -124,8 +122,6 @@ jobs:
         uses: ./.github/actions/setup-node
       - name: Setup xcode
         uses: ./.github/actions/setup-xcode
-        with:
-          xcode-version: '16.1'
       - name: Restore XCFramework
         id: restore-xcframework
         uses: actions/cache/restore@v5

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -115,8 +115,6 @@ jobs:
         run: ls -lR /tmp/RNTesterBuild
       - name: Setup xcode
         uses: ./.github/actions/setup-xcode
-        with:
-          platform: ios
       - name: Run E2E Tests
         uses: ./.github/actions/maestro-ios
         with:
@@ -137,8 +135,6 @@ jobs:
         uses: actions/checkout@v6
       - name: Setup xcode
         uses: ./.github/actions/setup-xcode
-        with:
-          platform: ios
       - name: Setup node.js
         uses: ./.github/actions/setup-node
       - name: Run yarn

--- a/.github/workflows/test-hermes-v1-ios.yml
+++ b/.github/workflows/test-hermes-v1-ios.yml
@@ -40,8 +40,6 @@ jobs:
 
       - name: Setup xcode
         uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: 16.4.0
 
       - name: Build iOS with retry
         uses: nick-fields/retry@v3


### PR DESCRIPTION
## Summary:

When setting up Xcode, we also download the SDKs that is needed.
There might be cases where we can save money and time and skip the download

## Changelog:
[Internal] - 

## Test Plan:
GHA
