### PR TITLE
Add support for `backfaceVisibility` and add `flex` to `AnimatedPropsBuilder`

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropSerializer.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropSerializer.cpp
@@ -462,9 +462,9 @@ void packBoxShadow(folly::dynamic& dyn, const AnimatedPropBase& animatedProp) {
 void packMixBlendMode(
     folly::dynamic& dyn,
     const AnimatedPropBase& animatedProp) {
-  const auto& blendMode = get<BlendMode>(animatedProp);
+  const auto& mixBlendMode = get<BlendMode>(animatedProp);
   std::string blendModeStr;
-  switch (blendMode) {
+  switch (mixBlendMode) {
     case BlendMode::Normal:
       blendModeStr = "normal";
       break;
@@ -517,6 +517,25 @@ void packMixBlendMode(
       throw std::runtime_error("Unknown blend mode");
   }
   dyn.insert("mixBlendMode", blendModeStr);
+}
+
+void packBackfaceVisibility(
+    folly::dynamic& dyn,
+    const AnimatedPropBase& animatedProp) {
+  const auto& backfaceVisibility = get<BackfaceVisibility>(animatedProp);
+  std::string visibilityStr;
+  switch (backfaceVisibility) {
+    case BackfaceVisibility::Auto:
+      visibilityStr = "auto";
+      break;
+    case BackfaceVisibility::Visible:
+      visibilityStr = "visible";
+      break;
+    case BackfaceVisibility::Hidden:
+      visibilityStr = "hidden";
+      break;
+  }
+  dyn.insert("backfaceVisibility", visibilityStr);
 }
 
 void packAnimatedProp(
@@ -605,6 +624,10 @@ void packAnimatedProp(
 
     case MIX_BLEND_MODE:
       packMixBlendMode(dyn, *animatedProp);
+      break;
+
+    case BACKFACE_VISIBILITY:
+      packBackfaceVisibility(dyn, *animatedProp);
       break;
 
     case WIDTH:

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedProps.h
@@ -62,7 +62,8 @@ enum PropName {
   ISOLATION,
   CURSOR,
   BOX_SHADOW,
-  MIX_BLEND_MODE
+  MIX_BLEND_MODE,
+  BACKFACE_VISIBILITY
 };
 
 struct AnimatedPropBase {
@@ -408,6 +409,10 @@ inline void cloneProp(BaseViewProps &viewProps, const AnimatedPropBase &animated
 
     case MIX_BLEND_MODE:
       viewProps.mixBlendMode = get<BlendMode>(animatedProp);
+      break;
+
+    case BACKFACE_VISIBILITY:
+      viewProps.backfaceVisibility = get<BackfaceVisibility>(animatedProp);
       break;
 
     default:

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropsBuilder.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropsBuilder.h
@@ -52,6 +52,10 @@ struct AnimatedPropsBuilder {
   {
     props.push_back(std::make_unique<AnimatedProp<CascadedRectangleEdges<yoga::StyleLength>>>(POSITION, value));
   }
+  void setFlex(yoga::FloatOptional value)
+  {
+    props.push_back(std::make_unique<AnimatedProp<yoga::FloatOptional>>(FLEX, value));
+  }
   void setTransform(Transform &t)
   {
     props.push_back(std::make_unique<AnimatedProp<Transform>>(TRANSFORM, std::move(t)));
@@ -211,6 +215,10 @@ struct AnimatedPropsBuilder {
   void setMixBlendMode(BlendMode value)
   {
     props.push_back(std::make_unique<AnimatedProp<BlendMode>>(MIX_BLEND_MODE, value));
+  }
+  void setBackfaceVisibility(BackfaceVisibility value)
+  {
+    props.push_back(std::make_unique<AnimatedProp<BackfaceVisibility>>(BACKFACE_VISIBILITY, value));
   }
   void storeDynamic(folly::dynamic &d)
   {

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropsRegistry.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropsRegistry.h
@@ -284,6 +284,10 @@ inline void updateProp(const PropName propName, BaseViewProps &viewProps, const 
     case MIX_BLEND_MODE:
       viewProps.mixBlendMode = snapshot.props.mixBlendMode;
       break;
+
+    case BACKFACE_VISIBILITY:
+      viewProps.backfaceVisibility = snapshot.props.backfaceVisibility;
+      break;
   }
 }
 


### PR DESCRIPTION
## Summary:

Add support for the `backfaceVisibility` and add missing `flex` style to the `AnimatedPropsBuilder`.

## Changelog:
[General][Added] - added support for `backfaceVisibility` prop and added missing `flex` style to the `AnimatedPropsBuilder`.

Differential Revision: D90671092


