### PR TITLE
[RN][iOS] Use prebuilds in E2E tests

### DIFF
--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -195,7 +195,7 @@ jobs:
 
           export RCT_USE_LOCAL_RN_DEP=/tmp/third-party/ReactNativeDependencies${{ matrix.flavor }}.xcframework.tar.gz
           # Disable prebuilds for now, as they are causing issues with E2E tests for 0.82-stable branch
-          # export RCT_TESTONLY_RNCORE_TARBALL_PATH="/tmp/ReactCore/ReactCore${{ matrix.flavor }}.xcframework.tar.gz"
+          export RCT_TESTONLY_RNCORE_TARBALL_PATH="/tmp/ReactCore/ReactCore${{ matrix.flavor }}.xcframework.tar.gz"
           RCT_NEW_ARCH_ENABLED=$NEW_ARCH_ENABLED bundle exec pod install
 
           xcodebuild \


### PR DESCRIPTION
## Summary:
Now that we are using prebuilds by default in the release, we should also use prebuilds when running the E2E tests of the template app

## Changelog:
[Internal] - 

## Test Plan:
GHA
