### PR TITLE
Propagate Hermes V1 opt-in to Fantom

### DIFF
--- a/private/react-native-fantom/build.gradle.kts
+++ b/private/react-native-fantom/build.gradle.kts
@@ -6,6 +6,7 @@
  */
 
 import com.android.build.gradle.internal.tasks.factory.dependsOn
+import com.facebook.react.internal.PrivateReactExtension
 import com.facebook.react.tasks.internal.*
 import com.facebook.react.tasks.internal.utils.*
 import de.undercouch.gradle.tasks.download.Download
@@ -14,6 +15,9 @@ plugins {
   id("com.facebook.react")
   alias(libs.plugins.download)
 }
+
+val hermesV1Enabled =
+    rootProject.extensions.getByType(PrivateReactExtension::class.java).hermesV1Enabled.get()
 
 // This is the version of CMake we're requesting to the Android SDK to use.
 // If missing it will be downloaded automatically. Only CMake versions shipped with the
@@ -203,6 +207,11 @@ val configureFantomTester by
               "-DREACT_THIRD_PARTY_NDK_DIR=$reactAndroidBuildDir/third-party-ndk",
               "-DRN_ENABLE_DEBUG_STRING_CONVERTIBLE=ON",
           )
+
+      if (hermesV1Enabled) {
+        cmdArgs.add("-DHERMES_V1_ENABLED=1")
+      }
+
       commandLine(cmdArgs)
       standardOutputFile.set(project.file("$buildDir/reports/configure-fantom_tester.log"))
       errorOutputFile.set(project.file("$buildDir/reports/configure-fantom_tester.error.log"))


### PR DESCRIPTION
Summary:
Changelog: [Internal]

At the moment, Fantom doesn't propagate the Hermes V1 opt-in to the React Native build, which causes the code that should be gated by compile-time flags to be compiled. Since Hermes V1 differs in some cases, the headers there are missing.

This diff adds the opt-in propagation, so the code can be correctly compiled out.

Differential Revision: D90674696


