### PR TITLE
main - Correctly bump hermes-compiler to V1 version

### DIFF
--- a/packages/react-native/scripts/hermes/bump-hermes-version.js
+++ b/packages/react-native/scripts/hermes/bump-hermes-version.js
@@ -108,7 +108,7 @@ async function main() {
 
   await setHermesTag(hermesTag, hermesV1Tag);
 
-  await updateHermesCompilerVersionInDependencies(hermesVersion);
+  await updateHermesCompilerVersionInDependencies(hermesV1Version);
   await updateHermesRuntimeDependenciesVersions(hermesVersion, hermesV1Version);
 }
 


### PR DESCRIPTION
Summary:
This is a cherry pick of
https://github.com/facebook/react-native/commit/7d901032a0b6a92c52293650a3ada9e2f9b696c9
which is currently on the 0.84 release branch on main.

Changelog:
[Internal] [Changed] -

Reviewed By: cipolleschi

Differential Revision: D90674702


