### PR TITLE
Refactor usage of custom global variables to use value imported from module

### DIFF
--- a/packages/react-native/Libraries/Animated/shouldUseTurboAnimatedModule.js
+++ b/packages/react-native/Libraries/Animated/shouldUseTurboAnimatedModule.js
@@ -9,13 +9,14 @@
  */
 
 import * as ReactNativeFeatureFlags from '../../src/private/featureflags/ReactNativeFeatureFlags';
+import {isBridgeless} from '../../src/private/runtime/ReactNativeRuntimeGlobals';
 import Platform from '../Utilities/Platform';
 
 function shouldUseTurboAnimatedModule(): boolean {
   if (ReactNativeFeatureFlags.cxxNativeAnimatedEnabled()) {
     return false;
   } else {
-    return Platform.OS === 'ios' && global.RN$Bridgeless === true;
+    return Platform.OS === 'ios' && isBridgeless;
   }
 }
 

--- a/packages/react-native/Libraries/BatchedBridge/NativeModules.js
+++ b/packages/react-native/Libraries/BatchedBridge/NativeModules.js
@@ -10,18 +10,18 @@
 
 'use strict';
 
+import type {ModuleConfig} from '../../src/private/runtime/ReactNativeRuntimeGlobals';
 import type {ExtendedError} from '../Core/ExtendedError';
 
+const {
+  batchedBridgeConfig,
+  nativeModuleProxy,
+  nativeRequireModuleConfig,
+} = require('../../src/private/runtime/ReactNativeRuntimeGlobals');
 const BatchedBridge = require('./BatchedBridge').default;
 const invariant = require('invariant');
 
-export type ModuleConfig = [
-  string /* name */,
-  ?{...} /* constants */,
-  ?ReadonlyArray<string> /* functions */,
-  ?ReadonlyArray<number> /* promise method IDs */,
-  ?ReadonlyArray<number> /* sync method IDs */,
-];
+export type {ModuleConfig} from '../../src/private/runtime/ReactNativeRuntimeGlobals';
 
 export type MethodType = 'async' | 'promise' | 'sync';
 
@@ -88,10 +88,10 @@ global.__fbGenNativeModule = genModule;
 
 function loadModule(name: string, moduleID: number): ?{...} {
   invariant(
-    global.nativeRequireModuleConfig,
+    nativeRequireModuleConfig,
     "Can't lazily create module without nativeRequireModuleConfig",
   );
-  const config = global.nativeRequireModuleConfig(name);
+  const config = nativeRequireModuleConfig(name);
   const info = genModule(config, moduleID);
   return info && info.module;
 }
@@ -182,18 +182,17 @@ function updateErrorWithErrorData(
 
 /* $FlowFixMe[unclear-type] unclear type of NativeModules */
 let NativeModules: {[moduleName: string]: any, ...} = {};
-if (global.nativeModuleProxy) {
-  NativeModules = global.nativeModuleProxy;
+if (nativeModuleProxy) {
+  NativeModules = nativeModuleProxy;
 } else {
-  const bridgeConfig = global.__fbBatchedBridgeConfig;
   invariant(
-    bridgeConfig,
+    batchedBridgeConfig,
     '__fbBatchedBridgeConfig is not set, cannot invoke native modules',
   );
 
   const defineLazyObjectProperty =
     require('../Utilities/defineLazyObjectProperty').default;
-  (bridgeConfig.remoteModuleConfig || []).forEach(
+  (batchedBridgeConfig.remoteModuleConfig || []).forEach(
     (config: ModuleConfig, moduleID: number) => {
       // Initially this config will only contain the module name when running in JSC. The actual
       // configuration of the module will be lazily loaded.

--- a/packages/react-native/Libraries/BatchedBridge/__tests__/NativeModules-test.js
+++ b/packages/react-native/Libraries/BatchedBridge/__tests__/NativeModules-test.js
@@ -205,24 +205,32 @@ describe('MessageQueue', function () {
   });
 
   describe('sync methods', () => {
-    afterEach(function () {
-      delete global.nativeCallSyncHook;
-    });
-
     it('throwing an exception', function () {
-      global.nativeCallSyncHook = jest.fn(() => {
+      const mockNativeCallSyncHook = jest.fn(() => {
         throw new Error('firstFailure');
       });
+
+      jest.resetModules();
+      jest.doMock(
+        '../../../src/private/runtime/ReactNativeRuntimeGlobals',
+        () => ({
+          ...jest.requireActual(
+            '../../../src/private/runtime/ReactNativeRuntimeGlobals',
+          ),
+          nativeCallSyncHook: mockNativeCallSyncHook,
+        }),
+      );
+      NativeModules = require('../NativeModules').default;
 
       let error;
       try {
         NativeModules.RemoteModule1.syncMethod('paloAlto', 'menloPark');
-      } catch (e) {
+      } catch (e: mixed) {
         error = e;
       }
 
-      expect(global.nativeCallSyncHook).toBeCalledTimes(1);
-      expect(global.nativeCallSyncHook).toBeCalledWith(
+      expect(mockNativeCallSyncHook).toHaveBeenCalledTimes(1);
+      expect(mockNativeCallSyncHook).toHaveBeenCalledWith(
         0, // `RemoteModule1`
         3, // `syncMethod`
         ['paloAlto', 'menloPark'],
@@ -234,14 +242,26 @@ describe('MessageQueue', function () {
     });
 
     it('returning a value', function () {
-      global.nativeCallSyncHook = jest.fn(() => {
+      const mockNativeCallSyncHook = jest.fn(() => {
         return 'secondSucc';
       });
 
+      jest.resetModules();
+      jest.doMock(
+        '../../../src/private/runtime/ReactNativeRuntimeGlobals',
+        () => ({
+          ...jest.requireActual(
+            '../../../src/private/runtime/ReactNativeRuntimeGlobals',
+          ),
+          nativeCallSyncHook: mockNativeCallSyncHook,
+        }),
+      );
+      NativeModules = require('../NativeModules').default;
+
       const result = NativeModules.RemoteModule2.syncMethod('mac', 'windows');
 
-      expect(global.nativeCallSyncHook).toBeCalledTimes(1);
-      expect(global.nativeCallSyncHook).toBeCalledWith(
+      expect(mockNativeCallSyncHook).toHaveBeenCalledTimes(1);
+      expect(mockNativeCallSyncHook).toHaveBeenCalledWith(
         1, // `RemoteModule2`
         3, // `syncMethod`
         ['mac', 'windows'],

--- a/packages/react-native/Libraries/Blob/BlobManager.js
+++ b/packages/react-native/Libraries/Blob/BlobManager.js
@@ -11,6 +11,7 @@
 import typeof BlobT from './Blob';
 import type {BlobCollector, BlobData, BlobOptions} from './BlobTypes';
 
+import {blobCollectorProvider} from '../../src/private/runtime/ReactNativeRuntimeGlobals';
 import NativeBlobModule from './NativeBlobModule';
 import invariant from 'invariant';
 
@@ -40,10 +41,10 @@ function uuidv4(): string {
 // that the current bridge infra doesn't allow to track js objects
 // deallocation. Ideally the whole Blob object should be a jsi::HostObject.
 function createBlobCollector(blobId: string): BlobCollector | null {
-  if (global.__blobCollectorProvider == null) {
+  if (blobCollectorProvider == null) {
     return null;
   } else {
-    return global.__blobCollectorProvider(blobId);
+    return blobCollectorProvider(blobId) ?? null;
   }
 }
 

--- a/packages/react-native/Libraries/Core/registerCallableModule.js
+++ b/packages/react-native/Libraries/Core/registerCallableModule.js
@@ -10,6 +10,11 @@
 
 'use strict';
 
+import {
+  isBridgeless,
+  registerCallableModule as nativeRegisterCallableModule,
+} from '../../src/private/runtime/ReactNativeRuntimeGlobals';
+
 type Module = {...};
 type RegisterCallableModule = (
   name: string,
@@ -17,14 +22,14 @@ type RegisterCallableModule = (
 ) => void;
 
 const registerCallableModule: RegisterCallableModule = (function () {
-  if (global.RN$Bridgeless === true) {
+  if (isBridgeless) {
     return (name, moduleOrFactory) => {
       if (typeof moduleOrFactory === 'function') {
-        global.RN$registerCallableModule(name, moduleOrFactory);
+        nativeRegisterCallableModule?.(name, moduleOrFactory);
         return;
       }
 
-      global.RN$registerCallableModule(name, () => moduleOrFactory);
+      nativeRegisterCallableModule?.(name, () => moduleOrFactory);
     };
   }
 

--- a/packages/react-native/Libraries/Core/setUpBatchedBridge.js
+++ b/packages/react-native/Libraries/Core/setUpBatchedBridge.js
@@ -10,10 +10,11 @@
 
 'use strict';
 
+import {isBridgeless} from '../../src/private/runtime/ReactNativeRuntimeGlobals';
 import registerModule from './registerCallableModule';
 
 registerModule('Systrace', () => require('../Performance/Systrace'));
-if (!(global.RN$Bridgeless === true)) {
+if (!isBridgeless) {
   registerModule('JSTimers', () => require('./Timers/JSTimers').default);
 }
 registerModule('RCTLog', () => require('../Utilities/RCTLog').default);

--- a/packages/react-native/Libraries/Core/setUpErrorHandling.js
+++ b/packages/react-native/Libraries/Core/setUpErrorHandling.js
@@ -10,7 +10,12 @@
 
 'use strict';
 
-if (global.RN$useAlwaysAvailableJSErrorHandling !== true) {
+import {
+  disableExceptionsManager,
+  useAlwaysAvailableJSErrorHandling,
+} from '../../src/private/runtime/ReactNativeRuntimeGlobals';
+
+if (!useAlwaysAvailableJSErrorHandling) {
   /**
    * Sets up the console and exception handling (redbox) for React Native.
    * You can use this module directly, or just require InitializeCore.
@@ -20,7 +25,7 @@ if (global.RN$useAlwaysAvailableJSErrorHandling !== true) {
   ExceptionsManager.installConsoleErrorReporter();
 
   // Set up error handler
-  if (!global.__fbDisableExceptionsManager) {
+  if (!disableExceptionsManager) {
     const handleError = (e: unknown, isFatal: boolean) => {
       try {
         ExceptionsManager.handleException(e, isFatal);

--- a/packages/react-native/Libraries/Core/setUpPerformance.js
+++ b/packages/react-native/Libraries/Core/setUpPerformance.js
@@ -8,6 +8,7 @@
  * @format
  */
 
+import {nativePerformanceNow} from '../../src/private/runtime/ReactNativeRuntimeGlobals';
 import setUpPerformanceModern from '../../src/private/setup/setUpPerformanceModern';
 import NativePerformance from '../../src/private/webapis/performance/specs/NativePerformance';
 
@@ -24,7 +25,7 @@ if (NativePerformance) {
       measure: () => {},
       clearMeasures: () => {},
       now: () => {
-        const performanceNow = global.nativePerformanceNow || Date.now;
+        const performanceNow = nativePerformanceNow || Date.now;
         return performanceNow();
       },
     };

--- a/packages/react-native/Libraries/Core/setUpReactDevTools.js
+++ b/packages/react-native/Libraries/Core/setUpReactDevTools.js
@@ -14,7 +14,7 @@ import type {Domain} from '../../src/private/devsupport/rndevtools/setUpFuseboxR
 import type {Spec as NativeReactDevToolsRuntimeSettingsModuleSpec} from '../../src/private/devsupport/rndevtools/specs/NativeReactDevToolsRuntimeSettingsModule';
 
 if (__DEV__) {
-  if (typeof global.queueMicrotask !== 'function') {
+  if (typeof queueMicrotask !== 'function') {
     console.error(
       'queueMicrotask should exist before setting up React DevTools.',
     );

--- a/packages/react-native/Libraries/Core/setUpTimers.js
+++ b/packages/react-native/Libraries/Core/setUpTimers.js
@@ -10,16 +10,18 @@
 
 'use strict';
 
+import {isBridgeless} from '../../src/private/runtime/ReactNativeRuntimeGlobals';
+
 const {polyfillGlobal} = require('../Utilities/PolyfillFunctions');
 
 if (__DEV__) {
-  if (typeof global.Promise !== 'function') {
+  if (typeof Promise === 'undefined') {
     console.error('Promise should exist before setting up timers.');
   }
 }
 
 // In bridgeless mode, timers are host functions installed from cpp.
-if (global.RN$Bridgeless === true) {
+if (isBridgeless) {
   // This is the flag that tells React to use `queueMicrotask` to batch state
   // updates, instead of using the scheduler to schedule a regular task.
   // We use a global variable because we don't currently have any other

--- a/packages/react-native/Libraries/LogBox/LogBox.js
+++ b/packages/react-native/Libraries/LogBox/LogBox.js
@@ -11,6 +11,10 @@
 import type {IgnorePattern, LogData} from './Data/LogBoxData';
 import type {ExtendedExceptionData} from './Data/parseLogBoxLog';
 
+import {
+  isRuntimeReady,
+  registerExceptionListener,
+} from '../../src/private/runtime/ReactNativeRuntimeGlobals';
 import toExtendedError from '../../src/private/utilities/toExtendedError';
 import Platform from '../Utilities/Platform';
 import RCTLog from '../Utilities/RCTLog';
@@ -55,10 +59,10 @@ if (__DEV__) {
 
       isLogBoxInstalled = true;
 
-      if (global.RN$registerExceptionListener != null) {
-        global.RN$registerExceptionListener(
+      if (registerExceptionListener != null) {
+        registerExceptionListener(
           (error: ExtendedExceptionData & {preventDefault: () => unknown}) => {
-            if (global.RN$isRuntimeReady?.() || !error.isFatal) {
+            if (isRuntimeReady?.() || !error.isFatal) {
               error.preventDefault();
               addException(error);
             }

--- a/packages/react-native/Libraries/NativeComponent/NativeComponentRegistry.js
+++ b/packages/react-native/Libraries/NativeComponent/NativeComponentRegistry.js
@@ -14,6 +14,7 @@ import type {
   ViewConfig,
 } from '../Renderer/shims/ReactNativeTypes';
 
+import {isBridgeless} from '../../src/private/runtime/ReactNativeRuntimeGlobals';
 import getNativeComponentAttributes from '../ReactNative/getNativeComponentAttributes';
 import UIManager from '../ReactNative/UIManager';
 import * as ReactNativeViewConfigRegistry from '../Renderer/shims/ReactNativeViewConfigRegistry';
@@ -54,7 +55,7 @@ export function get<Config: {...}>(
 ): HostComponent<Config> {
   ReactNativeViewConfigRegistry.register(name, () => {
     const {native, verify} = getRuntimeConfig?.(name) ?? {
-      native: !global.RN$Bridgeless,
+      native: !isBridgeless,
       verify: false,
     };
 

--- a/packages/react-native/Libraries/NativeComponent/NativeComponentRegistryUnstable.js
+++ b/packages/react-native/Libraries/NativeComponent/NativeComponentRegistryUnstable.js
@@ -8,6 +8,8 @@
  * @format
  */
 
+import {nativeComponentRegistryHasComponent} from '../../src/private/runtime/ReactNativeRuntimeGlobals';
+
 let componentNameToExists: Map<string, boolean> = new Map();
 
 /**
@@ -17,16 +19,16 @@ let componentNameToExists: Map<string, boolean> = new Map();
  * is registered in the native platform.
  */
 export function unstable_hasComponent(name: string): boolean {
-  let hasNativeComponent = componentNameToExists.get(name);
-  if (hasNativeComponent == null) {
-    if (global.__nativeComponentRegistry__hasComponent) {
-      hasNativeComponent = global.__nativeComponentRegistry__hasComponent(name);
-      componentNameToExists.set(name, hasNativeComponent);
+  let hasComponent = componentNameToExists.get(name);
+  if (hasComponent == null) {
+    if (nativeComponentRegistryHasComponent != null) {
+      hasComponent = nativeComponentRegistryHasComponent(name);
+      componentNameToExists.set(name, hasComponent);
     } else {
       throw new Error(
         `unstable_hasComponent('${name}'): Global function is not registered`,
       );
     }
   }
-  return hasNativeComponent;
+  return hasComponent;
 }

--- a/packages/react-native/Libraries/Performance/Systrace.js
+++ b/packages/react-native/Libraries/Performance/Systrace.js
@@ -10,6 +10,16 @@
 
 import typeof * as SystraceModule from './Systrace';
 
+import {
+  isProfilingEnabled,
+  nativeTraceBeginAsyncSection,
+  nativeTraceBeginSection,
+  nativeTraceCounter,
+  nativeTraceEndAsyncSection,
+  nativeTraceEndSection,
+  nativeTraceIsTracing,
+} from '../../src/private/runtime/ReactNativeRuntimeGlobals';
+
 const TRACE_TAG_REACT = 1 << 13; // eslint-disable-line no-bitwise
 
 let _asyncCookie = 0;
@@ -31,9 +41,9 @@ type EventArgs = ?{[string]: string};
  * }
  */
 export function isEnabled(): boolean {
-  return global.nativeTraceIsTracing
-    ? global.nativeTraceIsTracing(TRACE_TAG_REACT)
-    : Boolean(global.__RCTProfileIsProfiling);
+  return nativeTraceIsTracing != null
+    ? nativeTraceIsTracing(TRACE_TAG_REACT)
+    : isProfilingEnabled;
 }
 
 /**
@@ -52,7 +62,7 @@ export function beginEvent(eventName: EventName, args?: EventArgs): void {
   if (isEnabled()) {
     const eventNameString =
       typeof eventName === 'function' ? eventName() : eventName;
-    global.nativeTraceBeginSection(TRACE_TAG_REACT, eventNameString, args);
+    nativeTraceBeginSection?.(TRACE_TAG_REACT, eventNameString, args);
   }
 }
 
@@ -61,7 +71,7 @@ export function beginEvent(eventName: EventName, args?: EventArgs): void {
  */
 export function endEvent(args?: EventArgs): void {
   if (isEnabled()) {
-    global.nativeTraceEndSection(TRACE_TAG_REACT, args);
+    nativeTraceEndSection?.(TRACE_TAG_REACT, args);
   }
 }
 
@@ -79,7 +89,7 @@ export function beginAsyncEvent(
     _asyncCookie++;
     const eventNameString =
       typeof eventName === 'function' ? eventName() : eventName;
-    global.nativeTraceBeginAsyncSection(
+    nativeTraceBeginAsyncSection?.(
       TRACE_TAG_REACT,
       eventNameString,
       cookie,
@@ -101,7 +111,7 @@ export function endAsyncEvent(
   if (isEnabled()) {
     const eventNameString =
       typeof eventName === 'function' ? eventName() : eventName;
-    global.nativeTraceEndAsyncSection(
+    nativeTraceEndAsyncSection?.(
       TRACE_TAG_REACT,
       eventNameString,
       cookie,
@@ -117,8 +127,7 @@ export function counterEvent(eventName: EventName, value: number): void {
   if (isEnabled()) {
     const eventNameString =
       typeof eventName === 'function' ? eventName() : eventName;
-    global.nativeTraceCounter &&
-      global.nativeTraceCounter(TRACE_TAG_REACT, eventNameString, value);
+    nativeTraceCounter?.(TRACE_TAG_REACT, eventNameString, value);
   }
 }
 

--- a/packages/react-native/Libraries/ReactNative/BridgelessUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/BridgelessUIManager.js
@@ -13,6 +13,11 @@
 import type {RootTag} from '../Types/RootTagTypes';
 import type {UIManagerJSInterface} from '../Types/UIManagerJSInterface';
 
+import {
+  UIManager_getConstants,
+  UIManager_getConstantsForViewManager,
+  UIManager_getDefaultEventTypes,
+} from '../../src/private/runtime/ReactNativeRuntimeGlobals';
 import {unstable_hasComponent} from '../NativeComponent/NativeComponentRegistryUnstable';
 import defineLazyObjectProperty from '../Utilities/defineLazyObjectProperty';
 import Platform from '../Utilities/Platform';
@@ -26,33 +31,24 @@ function raiseSoftError(methodName: string, details?: string): void {
   );
 }
 
-const getUIManagerConstants: ?() => {[viewManagerName: string]: Object} =
-  global.RN$LegacyInterop_UIManager_getConstants;
-
 const getUIManagerConstantsCached = (function () {
   let wasCalledOnce = false;
   let result: {[viewManagerName: string]: Object} = {};
   return (): {[viewManagerName: string]: Object} => {
     if (!wasCalledOnce) {
-      result = nullthrows(getUIManagerConstants)();
+      result = nullthrows(UIManager_getConstants)();
       wasCalledOnce = true;
     }
     return result;
   };
 })();
 
-const getConstantsForViewManager: ?(viewManagerName: string) => ?Object =
-  global.RN$LegacyInterop_UIManager_getConstantsForViewManager;
-
-const getDefaultEventTypes: ?() => Object =
-  global.RN$LegacyInterop_UIManager_getDefaultEventTypes;
-
 const getDefaultEventTypesCached = (function () {
   let wasCalledOnce = false;
   let result = null;
   return (): Object => {
     if (!wasCalledOnce) {
-      result = nullthrows(getDefaultEventTypes)();
+      result = nullthrows(UIManager_getDefaultEventTypes)();
       wasCalledOnce = true;
     }
     return result;
@@ -166,15 +162,15 @@ const UIManagerJSDeprecatedPlatformAPIs = Platform.select({
 const UIManagerJSPlatformAPIs = Platform.select({
   android: {
     getConstantsForViewManager: (viewManagerName: string): ?Object => {
-      if (getConstantsForViewManager) {
-        return getConstantsForViewManager(viewManagerName);
+      if (UIManager_getConstantsForViewManager) {
+        return UIManager_getConstantsForViewManager(viewManagerName);
       }
 
       raiseSoftError('getConstantsForViewManager');
       return {};
     },
     getDefaultEventTypes: (): Array<string> => {
-      if (getDefaultEventTypes) {
+      if (UIManager_getDefaultEventTypes) {
         return getDefaultEventTypesCached();
       }
 
@@ -266,7 +262,7 @@ const UIManagerJS: UIManagerJSInterface & {[string]: any} = {
   ...UIManagerJSPlatformAPIs,
   ...UIManagerJSUnusedInNewArchAPIs,
   getViewManagerConfig: (viewManagerName: string): unknown => {
-    if (getUIManagerConstants) {
+    if (UIManager_getConstants) {
       const constants = getUIManagerConstantsCached();
       if (
         !constants[viewManagerName] &&
@@ -288,7 +284,7 @@ const UIManagerJS: UIManagerJSInterface & {[string]: any} = {
     return unstable_hasComponent(viewManagerName);
   },
   getConstants: (): Object => {
-    if (getUIManagerConstants) {
+    if (UIManager_getConstants) {
       return getUIManagerConstantsCached();
     } else {
       raiseSoftError('getConstants');
@@ -396,7 +392,7 @@ const UIManagerJS: UIManagerJSInterface & {[string]: any} = {
   },
 };
 
-if (getUIManagerConstants) {
+if (UIManager_getConstants) {
   Object.keys(getUIManagerConstantsCached()).forEach(viewConfigName => {
     UIManagerJS[viewConfigName] = getUIManagerConstantsCached()[viewConfigName];
   });

--- a/packages/react-native/Libraries/ReactNative/PaperUIManager.js
+++ b/packages/react-native/Libraries/ReactNative/PaperUIManager.js
@@ -11,6 +11,7 @@
 import type {RootTag} from '../Types/RootTagTypes';
 import type {UIManagerJSInterface} from '../Types/UIManagerJSInterface';
 
+import {nativeCallSyncHook} from '../../src/private/runtime/ReactNativeRuntimeGlobals';
 import NativeUIManager from './NativeUIManager';
 import nullthrows from 'nullthrows';
 
@@ -60,7 +61,7 @@ function getViewManagerConfig(viewManagerName: string): any {
 
   // If we're in the Chrome Debugger, let's not even try calling the sync
   // method.
-  if (!global.nativeCallSyncHook) {
+  if (!nativeCallSyncHook) {
     return config;
   }
 
@@ -168,7 +169,7 @@ if (Platform.OS === 'ios') {
   });
 }
 
-if (!global.nativeCallSyncHook) {
+if (!nativeCallSyncHook) {
   Object.keys(getConstants()).forEach(viewManagerName => {
     if (!UIManagerProperties.includes(viewManagerName)) {
       if (!viewManagerConfigs[viewManagerName]) {

--- a/packages/react-native/Libraries/ReactNative/ReactNativeRuntimeDiagnostics.js
+++ b/packages/react-native/Libraries/ReactNative/ReactNativeRuntimeDiagnostics.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import {diagnosticFlags} from '../../src/private/runtime/ReactNativeRuntimeGlobals';
+
 /**
  * Perform a set of runtime diagnostics, usually useful for test purpose.
  * This is only meaningful for __DEV__ mode.
@@ -33,8 +35,8 @@ let isEnabled = false;
 let shouldEnableAll = false;
 
 if (__DEV__) {
-  if (typeof global.RN$DiagnosticFlags === 'string') {
-    global.RN$DiagnosticFlags.split(',').forEach(flag => {
+  if (typeof diagnosticFlags === 'string') {
+    diagnosticFlags.split(',').forEach(flag => {
       switch (flag) {
         case 'early_js_errors':
         case 'all':

--- a/packages/react-native/Libraries/ReactNative/RendererImplementation.js
+++ b/packages/react-native/Libraries/ReactNative/RendererImplementation.js
@@ -18,6 +18,7 @@ import {
   onRecoverableError,
   onUncaughtError,
 } from '../../src/private/renderer/errorhandling/ErrorHandlers';
+import {isBridgeless} from '../../src/private/runtime/ReactNativeRuntimeGlobals';
 import * as React from 'react';
 
 let cachedFabricRenderer;
@@ -116,7 +117,7 @@ export function dispatchCommand(
   command: string,
   args: Array<unknown>,
 ): void {
-  if (global.RN$Bridgeless === true) {
+  if (isBridgeless) {
     // Note: this function has the same implementation in the legacy and new renderer.
     // However, evaluating the old renderer comes with some side effects.
     if (cachedFabricDispatchCommand == null) {

--- a/packages/react-native/Libraries/ReactNative/UIManager.js
+++ b/packages/react-native/Libraries/ReactNative/UIManager.js
@@ -10,6 +10,7 @@
 
 import type {UIManagerJSInterface} from '../Types/UIManagerJSInterface';
 
+import {isBridgeless} from '../../src/private/runtime/ReactNativeRuntimeGlobals';
 import {getFabricUIManager} from './FabricUIManager';
 import nullthrows from 'nullthrows';
 
@@ -18,10 +19,9 @@ function isFabricReactTag(reactTag: number): boolean {
   return reactTag % 2 === 0;
 }
 
-const UIManagerImpl: UIManagerJSInterface =
-  global.RN$Bridgeless === true
-    ? require('./BridgelessUIManager').default
-    : require('./PaperUIManager').default;
+const UIManagerImpl: UIManagerJSInterface = isBridgeless
+  ? require('./BridgelessUIManager').default
+  : require('./PaperUIManager').default;
 
 // $FlowFixMe[cannot-spread-interface]
 const UIManager: UIManagerJSInterface = {

--- a/packages/react-native/Libraries/Text/TextNativeComponent.js
+++ b/packages/react-native/Libraries/Text/TextNativeComponent.js
@@ -13,6 +13,7 @@ import type {ProcessedColorValue} from '../StyleSheet/processColor';
 import type {GestureResponderEvent} from '../Types/CoreEventTypes';
 import type {TextProps} from './TextProps';
 
+import {isBridgeless} from '../../src/private/runtime/ReactNativeRuntimeGlobals';
 import {createViewConfig} from '../NativeComponent/ViewConfig';
 import UIManager from '../ReactNative/UIManager';
 import createReactNativeComponentClass from '../Renderer/shims/createReactNativeComponentClass';
@@ -83,7 +84,7 @@ export const NativeText: HostComponent<NativeTextProps> =
   ): any);
 
 export const NativeVirtualText: HostComponent<NativeTextProps> =
-  !global.RN$Bridgeless && !UIManager.hasViewManagerConfig('RCTVirtualText')
+  !isBridgeless && !UIManager.hasViewManagerConfig('RCTVirtualText')
     ? NativeText
     : (createReactNativeComponentClass('RCTVirtualText', () =>
         /* $FlowFixMe[incompatible-type] Natural Inference rollout. See

--- a/packages/react-native/Libraries/TurboModule/TurboModuleRegistry.js
+++ b/packages/react-native/Libraries/TurboModule/TurboModuleRegistry.js
@@ -10,11 +10,10 @@
 
 import type {TurboModule} from './RCTExport';
 
+import {turboModuleProxy} from '../../src/private/runtime/ReactNativeRuntimeGlobals';
 import invariant from 'invariant';
 
 const NativeModules = require('../BatchedBridge/NativeModules').default;
-
-const turboModuleProxy = global.__turboModuleProxy;
 
 function requireModule<T: TurboModule>(name: string): ?T {
   if (turboModuleProxy != null) {

--- a/packages/react-native/Libraries/Utilities/RCTLog.js
+++ b/packages/react-native/Libraries/Utilities/RCTLog.js
@@ -10,7 +10,8 @@
 
 'use strict';
 
-const invariant = require('invariant');
+import {nativeLoggingHook} from '../../src/private/runtime/ReactNativeRuntimeGlobals';
+import invariant from 'invariant';
 
 const levelsMap = {
   log: 'log',
@@ -26,7 +27,7 @@ const RCTLog = {
   // level one of log, info, warn, error, mustfix
   logIfNoNativeHook(level: string, ...args: Array<unknown>): void {
     // We already printed in the native console, so only log here if using a js debugger
-    if (typeof global.nativeLoggingHook === 'undefined') {
+    if (nativeLoggingHook == null) {
       RCTLog.logToConsole(level, ...args);
     } else {
       // Report native warnings to LogBox

--- a/packages/react-native/Libraries/Utilities/codegenNativeComponent.js
+++ b/packages/react-native/Libraries/Utilities/codegenNativeComponent.js
@@ -13,6 +13,7 @@
 import type {HostComponent} from '../../src/private/types/HostComponent';
 
 import requireNativeComponent from '../../Libraries/ReactNative/requireNativeComponent';
+import {isBridgeless} from '../../src/private/runtime/ReactNativeRuntimeGlobals';
 import UIManager from '../ReactNative/UIManager';
 
 // TODO: import from CodegenSchema once workspaces are enabled
@@ -35,7 +36,7 @@ function codegenNativeComponent<Props: {...}>(
   componentName: string,
   options?: NativeComponentOptions,
 ): NativeComponentType<Props> {
-  if (global.RN$Bridgeless === true && __DEV__) {
+  if (isBridgeless && __DEV__) {
     console.warn(
       `Codegen didn't run for ${componentName}. This will be an error in the future. Make sure you are using @react-native/babel-preset when building your JavaScript code.`,
     );

--- a/packages/react-native/flow/global.js
+++ b/packages/react-native/flow/global.js
@@ -77,7 +77,6 @@ declare var global: {
 
   // Internal-specific
   +__DEV__?: boolean,
-  +RN$Bridgeless?: boolean,
 
   // setupDOM
   +DOMRect: typeof DOMRect,

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlagsBase.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlagsBase.js
@@ -13,6 +13,10 @@ import type {
   ReactNativeFeatureFlagsJsOnlyOverrides,
 } from './ReactNativeFeatureFlags';
 
+import {
+  isBridgeless,
+  turboModuleProxy,
+} from '../runtime/ReactNativeRuntimeGlobals';
 import NativeReactNativeFeatureFlags from './specs/NativeReactNativeFeatureFlags';
 
 const accessedFeatureFlags: Set<string> = new Set();
@@ -106,8 +110,7 @@ export function setOverrides(
 }
 
 const reportedConfigNames: Set<string> = new Set();
-const hasTurboModules =
-  global.RN$Bridgeless === true || global.__turboModuleProxy != null;
+const hasTurboModules = isBridgeless || turboModuleProxy != null;
 
 function maybeLogUnavailableNativeModuleError(configName: string): void {
   if (

--- a/packages/react-native/src/private/runtime/ReactNativeRuntimeGlobals.js
+++ b/packages/react-native/src/private/runtime/ReactNativeRuntimeGlobals.js
@@ -1,0 +1,356 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ */
+
+/**
+ * This module exports global variables that are defined by the native runtime.
+ * These are NOT assigned in JS files but are set directly by the native code.
+ */
+
+'use strict';
+
+import type {BlobCollector} from '../../../Libraries/Blob/BlobTypes';
+import type {ExtendedExceptionData} from '../../../Libraries/LogBox/Data/parseLogBoxLog';
+
+// =============================================================================
+// Bridgeless Mode
+// =============================================================================
+
+/**
+ * Indicates if the app is running in bridgeless mode (new architecture).
+ * When true, communication with native happens through JSI directly
+ * rather than through the bridge.
+ * Set by the native runtime.
+ */
+export const isBridgeless: boolean = global.RN$Bridgeless === true;
+
+// =============================================================================
+// Runtime Diagnostics
+// =============================================================================
+
+/**
+ * Diagnostic flags for the React Native runtime.
+ * Can include flags like 'early_js_errors', 'all', etc.
+ * Set by the native runtime.
+ */
+export const diagnosticFlags: ?string = global.RN$DiagnosticFlags;
+
+// =============================================================================
+// Error Handling
+// =============================================================================
+
+/**
+ * Flag indicating whether to use always-available JS error handling.
+ * When true, error handling is enabled even in bridgeless mode.
+ * Set by the native runtime.
+ */
+export const useAlwaysAvailableJSErrorHandling: boolean =
+  global.RN$useAlwaysAvailableJSErrorHandling === true;
+
+/**
+ * Flag to disable the exceptions manager (redbox).
+ * Set by the native runtime.
+ */
+export const disableExceptionsManager: boolean = Boolean(
+  global.__fbDisableExceptionsManager,
+);
+
+/**
+ * Handles exceptions in bridgeless mode.
+ * Returns true if the exception was handled and should not be propagated.
+ * Set by the native JSI runtime.
+ */
+export const handleException: ?(
+  error: mixed,
+  isFatal: boolean,
+  reportToConsole: boolean,
+) => boolean = global.RN$handleException;
+
+/**
+ * Checks if the runtime is currently inside an exception handler.
+ * Only available in bridgeless mode.
+ * Set by the native JSI runtime.
+ */
+export const inExceptionHandler: ?() => boolean = global.RN$inExceptionHandler;
+
+/**
+ * Checks if a fatal exception has already been handled.
+ * Only available in bridgeless mode.
+ * Set by the native JSI runtime.
+ */
+export const hasHandledFatalException: ?() => boolean =
+  global.RN$hasHandledFatalException;
+
+/**
+ * Notifies the runtime that a fatal exception has occurred.
+ * Only available in bridgeless mode.
+ * Set by the native JSI runtime.
+ */
+export const notifyOfFatalException: ?() => void =
+  global.RN$notifyOfFatalException;
+
+// =============================================================================
+// Callable Modules
+// =============================================================================
+
+/**
+ * Registers a JavaScript module that can be called from native code.
+ * Only available in bridgeless mode.
+ * Set by the native JSI runtime.
+ */
+export const registerCallableModule: ?(
+  name: string,
+  moduleOrFactory: {...} | (() => {...}),
+) => void = global.RN$registerCallableModule;
+
+// =============================================================================
+// UIManager (Bridgeless Mode)
+// =============================================================================
+
+/**
+ * Gets UIManager constants in bridgeless mode.
+ * Set by the native JSI runtime.
+ */
+export const UIManager_getConstants: ?() => {[viewManagerName: string]: {...}} =
+  global.RN$LegacyInterop_UIManager_getConstants;
+
+/**
+ * Gets constants for a specific view manager in bridgeless mode.
+ * Set by the native JSI runtime.
+ */
+export const UIManager_getConstantsForViewManager: ?(
+  viewManagerName: string,
+) => ?{...} = global.RN$LegacyInterop_UIManager_getConstantsForViewManager;
+
+/**
+ * Gets default event types in bridgeless mode.
+ * Set by the native JSI runtime.
+ */
+export const UIManager_getDefaultEventTypes: ?() => {...} =
+  global.RN$LegacyInterop_UIManager_getDefaultEventTypes;
+
+// =============================================================================
+// Native Component Registry
+// =============================================================================
+
+/**
+ * Checks if a native component is registered.
+ * Set by the native JSI runtime.
+ */
+export const nativeComponentRegistryHasComponent: ?(name: string) => boolean =
+  global.__nativeComponentRegistry__hasComponent;
+
+// =============================================================================
+// Performance Tracing (Systrace)
+// =============================================================================
+
+/**
+ * Checks if profiling/tracing is currently enabled.
+ * Set by the native JSI runtime.
+ */
+export const nativeTraceIsTracing: ?(tag: number) => boolean =
+  global.nativeTraceIsTracing;
+
+/**
+ * Flag indicating if profiling is currently active.
+ * Set by the native runtime.
+ */
+export const isProfilingEnabled: boolean = Boolean(
+  global.__RCTProfileIsProfiling,
+);
+
+/**
+ * Marks the beginning of a synchronous trace section.
+ * Set by the native JSI runtime.
+ */
+export const nativeTraceBeginSection: ?(
+  tag: number,
+  sectionName: string,
+  args?: ?{[string]: string},
+) => void = global.nativeTraceBeginSection;
+
+/**
+ * Marks the end of a synchronous trace section.
+ * Set by the native JSI runtime.
+ */
+export const nativeTraceEndSection: ?(
+  tag: number,
+  args?: ?{[string]: string},
+) => void = global.nativeTraceEndSection;
+
+/**
+ * Marks the beginning of an asynchronous trace section.
+ * Set by the native JSI runtime.
+ */
+export const nativeTraceBeginAsyncSection: ?(
+  tag: number,
+  sectionName: string,
+  cookie: number,
+  args?: ?{[string]: string},
+) => void = global.nativeTraceBeginAsyncSection;
+
+/**
+ * Marks the end of an asynchronous trace section.
+ * Set by the native JSI runtime.
+ */
+export const nativeTraceEndAsyncSection: ?(
+  tag: number,
+  sectionName: string,
+  cookie: number,
+  args?: ?{[string]: string},
+) => void = global.nativeTraceEndAsyncSection;
+
+/**
+ * Marks the beginning of an async flow for tracing.
+ * Set by the native JSI runtime.
+ */
+export const nativeTraceBeginAsyncFlow: ?(
+  tag: number,
+  sectionName: string,
+  cookie: number,
+) => void = global.nativeTraceBeginAsyncFlow;
+
+/**
+ * Records a trace counter event.
+ * Set by the native JSI runtime.
+ */
+export const nativeTraceCounter: ?(
+  tag: number,
+  sectionName: string,
+  value: number,
+) => void = global.nativeTraceCounter;
+
+// =============================================================================
+// Native Module Bridge (MessageQueue)
+// =============================================================================
+
+/**
+ * Synchronous hook for calling native modules.
+ * Not available when running in Chrome debugger.
+ * Set by the native JSI runtime.
+ */
+export const nativeCallSyncHook: ?(
+  moduleID: number,
+  methodID: number,
+  params: $ReadOnlyArray<mixed>,
+) => mixed = global.nativeCallSyncHook;
+
+/**
+ * Function to immediately flush the native call queue.
+ * Set by the native JSI runtime.
+ */
+export const nativeFlushQueueImmediate: ?(
+  queue: [Array<number>, Array<number>, Array<mixed>, number],
+) => void = global.nativeFlushQueueImmediate;
+
+// =============================================================================
+// Native Modules
+// =============================================================================
+
+/**
+ * Configuration for a native module.
+ * Tuple containing module name, constants, functions, promise method IDs, and sync method IDs.
+ */
+export type ModuleConfig = [
+  string /* name */,
+  ?{...} /* constants */,
+  ?ReadonlyArray<string> /* functions */,
+  ?ReadonlyArray<number> /* promise method IDs */,
+  ?ReadonlyArray<number> /* sync method IDs */,
+];
+
+/**
+ * The native module proxy for bridgeless mode.
+ * Provides access to native modules without the bridge.
+ * Set by the native JSI runtime.
+ */
+export const nativeModuleProxy: ?{[moduleName: string]: {...}, ...} =
+  global.nativeModuleProxy;
+
+/**
+ * Configuration for the batched bridge, containing module definitions.
+ * Used to lazily initialize native modules.
+ * Set by the native runtime.
+ */
+export const batchedBridgeConfig: ?{
+  remoteModuleConfig?: $ReadOnlyArray<ModuleConfig>,
+  ...
+} = global.__fbBatchedBridgeConfig;
+
+/**
+ * Function to lazily require native module configuration.
+ * Set by the native JSI runtime.
+ */
+export const nativeRequireModuleConfig: ?(moduleName: string) => ModuleConfig =
+  global.nativeRequireModuleConfig;
+
+// =============================================================================
+// Performance
+// =============================================================================
+
+/**
+ * High-resolution performance timestamp function.
+ * Falls back to Date.now if not available.
+ * Set by the native JSI runtime.
+ */
+export const nativePerformanceNow: ?() => number = global.nativePerformanceNow;
+
+// =============================================================================
+// TurboModules
+// =============================================================================
+
+/**
+ * The TurboModule proxy function for accessing TurboModules.
+ * This is the main entry point for the new native modules architecture.
+ * Set by the native runtime.
+ */
+export const turboModuleProxy: ?<T>(name: string) => ?T =
+  global.__turboModuleProxy;
+
+// =============================================================================
+// Logging
+// =============================================================================
+
+/**
+ * Native logging hook for sending console messages to native.
+ * Set by the native JSI runtime.
+ */
+export const nativeLoggingHook: ?(message: string, level: number) => void =
+  global.nativeLoggingHook;
+
+// =============================================================================
+// Blob Management
+// =============================================================================
+
+/**
+ * Provider function for creating blob collectors.
+ * Set by the native JSI runtime.
+ */
+export const blobCollectorProvider: ?(blobId: string) => ?BlobCollector =
+  global.__blobCollectorProvider;
+
+// =============================================================================
+// LogBox and Exception Handling
+// =============================================================================
+
+/**
+ * Registers an exception listener that can handle and prevent exceptions.
+ * Set by the native JSI runtime.
+ */
+export const registerExceptionListener: ?(
+  listener: (
+    error: ExtendedExceptionData & {preventDefault: () => unknown},
+  ) => void,
+) => void = global.RN$registerExceptionListener;
+
+/**
+ * Checks if the runtime is ready.
+ * Set by the native JSI runtime.
+ */
+export const isRuntimeReady: ?() => boolean = global.RN$isRuntimeReady;

--- a/packages/react-native/src/private/webapis/performance/internals/Utilities.js
+++ b/packages/react-native/src/private/webapis/performance/internals/Utilities.js
@@ -9,6 +9,7 @@
  */
 
 import warnOnce from '../../../../../Libraries/Utilities/warnOnce';
+import {nativePerformanceNow} from '../../../runtime/ReactNativeRuntimeGlobals';
 import NativePerformance from '../specs/NativePerformance';
 
 export function warnNoNativePerformance() {
@@ -18,10 +19,5 @@ export function warnNoNativePerformance() {
   );
 }
 
-declare var global: {
-  // This value is defined directly via JSI, if available.
-  +nativePerformanceNow?: ?() => number,
-};
-
 export const getCurrentTimeStamp: () => DOMHighResTimeStamp =
-  NativePerformance?.now ?? global.nativePerformanceNow ?? (() => Date.now());
+  NativePerformance?.now ?? nativePerformanceNow ?? (() => Date.now());


### PR DESCRIPTION
Summary:
Changelog: [internal]

This moves all references to global variables within the `react-native` package to consume them from a new module with typed exports instead.

This will improve the type safety of globals, by providing accurate types and by easily detecting when a global variable has been removed/changed.

Additionally, this is a good way to document all the globals we have, and possibly clean up some of them soon.

Differential Revision: D90588265


