### PR TITLE
fix(typo): Update JDK string version from 11 to 17

### DIFF
--- a/.github/actions/maestro-ios/action.yml
+++ b/.github/actions/maestro-ios/action.yml
@@ -30,7 +30,7 @@ runs:
       run: |
         brew tap facebook/fb
         brew install facebook/fb/idb-companion
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v5
       with:
         java-version: '17'


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Fixes a typo on the step name of `maestro-ios` gh action:

From `Set up JDK 11` -? `Set up JDK 17`

to match the actual version and be in sync with the rest of the other actions (e.g. maestro-android)

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[GENERAL] [FIXED] - typo on maestro ios gh action for jdk step

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

No testing required
