### PR TITLE
Transform mixed to unknown

### DIFF
--- a/flow-typed/environment/node.js
+++ b/flow-typed/environment/node.js
@@ -618,7 +618,7 @@ declare class crypto$Hash extends stream$Duplex {
     data: string | Buffer,
     input_encoding?: 'utf8' | 'ascii' | 'latin1' | 'binary',
   ): crypto$Hash;
-  copy(options?: mixed): crypto$Hash;
+  copy(options?: unknown): crypto$Hash;
 }
 
 declare class crypto$Hmac extends stream$Duplex {
@@ -703,7 +703,7 @@ declare class crypto$KeyObject {
       format: 'der',
     }>,
   ): Buffer;
-  export(options: Readonly<{format: 'jwk'}>): mixed;
+  export(options: Readonly<{format: 'jwk'}>): unknown;
   equals(otherKeyObject: crypto$KeyObject): boolean;
 }
 
@@ -739,7 +739,7 @@ declare class crypto$X509Certificate {
   checkIssued(otherCert: crypto$X509Certificate): boolean;
   checkPrivateKey(privateKey: crypto$KeyObject): boolean;
   toJSON(): string;
-  toLegacyObject(): mixed;
+  toLegacyObject(): unknown;
   toString(): string;
   verify(publicKey: crypto$KeyObject): boolean;
 }
@@ -930,10 +930,10 @@ declare module 'crypto' {
     encoding: buffer$Encoding,
   ): crypto$KeyObject;
   declare function createPublicKey(
-    key: string | Buffer | crypto$KeyObject | mixed,
+    key: string | Buffer | crypto$KeyObject | unknown,
   ): crypto$KeyObject;
   declare function createPrivateKey(
-    key: string | Buffer | mixed,
+    key: string | Buffer | unknown,
   ): crypto$KeyObject;
   declare function generateKeyPair(
     type:
@@ -945,7 +945,7 @@ declare module 'crypto' {
       | 'ed448'
       | 'x25519'
       | 'x448',
-    options: mixed,
+    options: unknown,
     callback: (
       err: ?Error,
       publicKey: crypto$KeyObject,
@@ -962,7 +962,7 @@ declare module 'crypto' {
       | 'ed448'
       | 'x25519'
       | 'x448',
-    options: mixed,
+    options: unknown,
   ): {publicKey: crypto$KeyObject, privateKey: crypto$KeyObject, ...};
   declare function generateKey(
     type: 'hmac' | 'aes',
@@ -2011,8 +2011,8 @@ declare module 'fs' {
       | Buffer
       | Uint8Array
       | DataView
-      | AsyncIterable<mixed>
-      | Iterable<mixed>
+      | AsyncIterable<unknown>
+      | Iterable<unknown>
       | stream$Readable,
     options: WriteOptions | string,
   ) => Promise<void>;
@@ -2908,17 +2908,19 @@ declare module 'perf_hooks' {
     +entryType: EntryType;
     +name: string;
     +startTime: number;
-    +detail?: mixed;
-    toJSON(): mixed;
+    +detail?: unknown;
+    toJSON(): unknown;
   }
 
-  declare export class PerformanceMark<T = mixed> extends PerformanceEntry {
+  declare export class PerformanceMark<T = unknown> extends PerformanceEntry {
     +entryType: 'mark';
     +duration: 0;
     +detail?: T;
   }
 
-  declare export class PerformanceMeasure<T = mixed> extends PerformanceEntry {
+  declare export class PerformanceMeasure<T = unknown>
+    extends PerformanceEntry
+  {
     +entryType: 'measure';
     +detail?: T;
   }
@@ -2987,12 +2989,12 @@ declare module 'perf_hooks' {
     +active: number,
   };
 
-  declare export type PerformanceMarkOptions<T = mixed> = Readonly<{
+  declare export type PerformanceMarkOptions<T = unknown> = Readonly<{
     detail?: T,
     startTime?: number,
   }>;
 
-  declare export type PerformanceMeasureOptions<T = mixed> = Readonly<{
+  declare export type PerformanceMeasureOptions<T = unknown> = Readonly<{
     detail?: T,
     duration?: number,
     end?: number | string,
@@ -3023,11 +3025,11 @@ declare module 'perf_hooks' {
     now(): number;
     setResourceTimingBufferSize(maxSize: number): void;
     +timeOrigin: number;
-    timerify<TArgs: Iterable<mixed>, TReturn>(
+    timerify<TArgs: Iterable<unknown>, TReturn>(
       fn: (...TArgs) => TReturn,
       options?: Readonly<{histogram?: RecordableHistogram}>,
     ): (...TArgs) => TReturn;
-    toJSON(): mixed;
+    toJSON(): unknown;
   }
 
   declare export var performance: Performance;
@@ -3720,20 +3722,20 @@ declare module 'timers' {
     // [key: $SymbolDispose]: () => void;
   }
 
-  declare export function setTimeout<TArgs: Iterable<mixed>>(
-    callback: (...args: TArgs) => mixed,
+  declare export function setTimeout<TArgs: Iterable<unknown>>(
+    callback: (...args: TArgs) => unknown,
     delay?: number,
     ...args: TArgs
   ): Timeout;
 
-  declare export function setInterval<TArgs: Iterable<mixed>>(
-    callback: (...args: TArgs) => mixed,
+  declare export function setInterval<TArgs: Iterable<unknown>>(
+    callback: (...args: TArgs) => unknown,
     delay?: number,
     ...args: TArgs
   ): Timeout;
 
-  declare export function setImmediate<TArgs: Iterable<mixed>>(
-    callback: (...args: TArgs) => mixed,
+  declare export function setImmediate<TArgs: Iterable<unknown>>(
+    callback: (...args: TArgs) => unknown,
     ...args: TArgs
   ): Immediate;
 


### PR DESCRIPTION
Summary:
We are transforming the following utility types to be more consistent with typescript and better AI integration:

* `$NonMaybeType` -> `NonNullable`
* `$ReadOnly` -> `Readonly`
* `$ReadOnlyArray` -> `ReadonlyArray`
* `$ReadOnlyMap` -> `ReadonlyMap`
* `$ReadOnlySet` -> `ReadonlySet`
* `$Keys` -> `keyof`
* `$Values` -> `Values`
* `mixed` -> `unknown`

See details in https://fb.workplace.com/groups/flowlang/permalink/1837907750148213/.

drop-conflicts


Command:

`js1 flow-runner codemod flow/transformUtilityType --format-files=false --legacy-type='$ReadOnlyArray'`

Reviewed By: SamChou19815

Differential Revision: D90728808


