### PR TITLE
Add missing include for animated backend

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.h
@@ -18,6 +18,7 @@
 #include <react/renderer/animated/EventEmitterListener.h>
 #include <react/renderer/animated/event_drivers/EventAnimationDriver.h>
 #ifdef RN_USE_ANIMATION_BACKEND
+#include <react/renderer/animationbackend/AnimatedPropsBuilder.h>
 #include <react/renderer/animationbackend/AnimationBackend.h>
 #endif
 #include <react/renderer/core/ReactPrimitives.h>


### PR DESCRIPTION
Summary:
Changelog: [internal]

Fantom tests are currently failing because the binary is failing to compile because `AnimatedPropsBuilder` isn't defined in `NativeAnimatedNodesManager`. This fixes that.

Differential Revision: D90762526


