### PR TITLE
Make ImportantForInteractionHelper internal and move to views.view package

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3359,14 +3359,6 @@ public class com/facebook/react/uimanager/IllegalViewOperationException : com/fa
 	public final fun getView ()Landroid/view/View;
 }
 
-public final class com/facebook/react/uimanager/ImportantForInteractionHelper {
-	public static final field IMPORTANT_FOR_INTERACTION_EXCLUDE_DESCENDANTS I
-	public static final field IMPORTANT_FOR_INTERACTION_NO I
-	public static final field IMPORTANT_FOR_INTERACTION_YES I
-	public static final field INSTANCE Lcom/facebook/react/uimanager/ImportantForInteractionHelper;
-	public static final fun setImportantForInteraction (Landroid/view/View;Lcom/facebook/react/uimanager/PointerEvents;)V
-}
-
 public class com/facebook/react/uimanager/JSPointerDispatcher {
 	public fun <init> (Landroid/view/ViewGroup;)V
 	public fun handleMotionEvent (Landroid/view/MotionEvent;Lcom/facebook/react/uimanager/events/EventDispatcher;Z)V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ImportantForInteractionHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ImportantForInteractionHelper.kt
@@ -5,10 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.react.uimanager
+package com.facebook.react.views.view
 
 import android.view.View
 import com.facebook.react.R
+import com.facebook.react.uimanager.PointerEvents
 
 /**
  * Helper class for managing the important_for_interaction view tag. This tag determines how a view
@@ -20,15 +21,15 @@ import com.facebook.react.R
  * - [IMPORTANT_FOR_INTERACTION_EXCLUDE_DESCENDANTS]: Descendants should be excluded from
  *   interaction
  */
-public object ImportantForInteractionHelper {
+internal object ImportantForInteractionHelper {
   /** The view is important for interaction. */
-  public const val IMPORTANT_FOR_INTERACTION_YES: Int = 0x1
+  const val IMPORTANT_FOR_INTERACTION_YES: Int = 0x1
 
   /** The view is not important for interaction. */
-  public const val IMPORTANT_FOR_INTERACTION_NO: Int = 0x2
+  const val IMPORTANT_FOR_INTERACTION_NO: Int = 0x2
 
   /** Descendants of this view should be excluded from interaction handling. */
-  public const val IMPORTANT_FOR_INTERACTION_EXCLUDE_DESCENDANTS: Int = 0x8
+  const val IMPORTANT_FOR_INTERACTION_EXCLUDE_DESCENDANTS: Int = 0x8
 
   /**
    * Sets the important_for_interaction tag on a view based on the given [PointerEvents] value.
@@ -45,7 +46,7 @@ public object ImportantForInteractionHelper {
    * @param pointerEvents The pointer events value to convert and set
    */
   @JvmStatic
-  public fun setImportantForInteraction(view: View, pointerEvents: PointerEvents) {
+  fun setImportantForInteraction(view: View, pointerEvents: PointerEvents) {
     val value =
         when (pointerEvents) {
           PointerEvents.AUTO -> IMPORTANT_FOR_INTERACTION_YES

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
@@ -44,7 +44,6 @@ import com.facebook.react.uimanager.BackgroundStyleApplicator.setBorderStyle
 import com.facebook.react.uimanager.BackgroundStyleApplicator.setBorderWidth
 import com.facebook.react.uimanager.BackgroundStyleApplicator.setFeedbackUnderlay
 import com.facebook.react.uimanager.BlendModeHelper.needsIsolatedLayer
-import com.facebook.react.uimanager.ImportantForInteractionHelper
 import com.facebook.react.uimanager.LengthPercentage
 import com.facebook.react.uimanager.LengthPercentageType
 import com.facebook.react.uimanager.MeasureSpecAssertions.assertExplicitMeasureSpec

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.kt
@@ -21,7 +21,6 @@ import com.facebook.react.common.ReactConstants
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.BackgroundStyleApplicator
-import com.facebook.react.uimanager.ImportantForInteractionHelper
 import com.facebook.react.uimanager.LengthPercentage
 import com.facebook.react.uimanager.LengthPercentageType
 import com.facebook.react.uimanager.PixelUtil.dpToPx


### PR DESCRIPTION
Summary:
This change makes `ImportantForInteractionHelper` internal to avoid exposing it as part of the public API. The class is moved from `com.facebook.react.uimanager` to `com.facebook.react.views.view` package since it's only used by `ReactViewGroup` and `ReactViewManager` within that package.

This reduces the public API surface of ReactAndroid and keeps implementation details private.

Differential Revision: D90767295
