### PR TITLE
Enable nested scrolling for swipe refresh layouts

### DIFF
--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
@@ -1850,6 +1850,8 @@ class ScrollView extends React.Component<ScrollViewProps, ScrollViewState> {
           {style: StyleSheet.compose(baseStyle, outer)},
           <NativeScrollView
             {...props}
+            // Nested scroll should always be enabled to allow the child scroll view to handle events before passing them to the refresh control parent
+            nestedScrollEnabled={props.nestedScrollEnabled ?? true}
             style={StyleSheet.compose(baseStyle, inner)}
             // $FlowFixMe[incompatible-type] - Flow only knows element refs.
             ref={scrollViewRef}>


### PR DESCRIPTION
Summary:
If nested scrolling is not enabled by default for ScrollView that define a `RefreshControl`, the wrapping Android view `ReactSwipeRefreshLayout` will swallow and discard non-touch scroll actions, like joystick movements. This change updates the default to be true, a more-sane default, which aligns with the existing touch actions that are always allowed. This does not impact touch-based behavior at all.

Changelog: [Android][Changed] Updated the `nestedScrollEnabled` prop to default to true if the ScrollView defines a `refreshControl`

Differential Revision: D90778643


