### PR TITLE
RN: Remove Special Case for "Warning: " Errors

### DIFF
--- a/packages/react-native/Libraries/LogBox/LogBox.js
+++ b/packages/react-native/Libraries/LogBox/LogBox.js
@@ -148,11 +148,7 @@ if (__DEV__) {
           let format = args[0];
           if (typeof format === 'string') {
             const filterResult =
-              require('../LogBox/Data/LogBoxData').checkWarningFilter(
-                // For legacy reasons, we strip the warning prefix from the message.
-                // Can remove this once we remove the warning module altogether.
-                format.replace(/^Warning: /, ''),
-              );
+              require('../LogBox/Data/LogBoxData').checkWarningFilter(format);
             if (filterResult.monitorEvent !== 'warning_unhandled') {
               if (filterResult.suppressCompletely) {
                 return;

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxMessage.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxMessage.js
@@ -101,7 +101,7 @@ function TappableLinks(props: {
 }
 
 const cleanContent = (content: string) =>
-  content.replace(/^(TransformError |Warning: (Warning: )?|Error: )/g, '');
+  content.replace(/^(TransformError |Error: )/g, '');
 
 function LogBoxMessage(props: Props): React.Node {
   const {content, substitutions}: Message = props.message;

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxMessage-test.js
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/LogBoxMessage-test.js
@@ -179,34 +179,6 @@ describe('LogBoxMessage', () => {
     expect(output).toMatchSnapshot();
   });
 
-  it('Should strip "Warning: " without breaking substitution', async () => {
-    const output = await render.create(
-      <LogBoxMessage
-        style={{}}
-        message={{
-          content: 'Warning: normal substitution normal',
-          substitutions: [{length: 12, offset: 16}],
-        }}
-      />,
-    );
-
-    expect(output).toMatchSnapshot();
-  });
-
-  it('Should strip "Warning: Warning: " without breaking substitution', async () => {
-    const output = await render.create(
-      <LogBoxMessage
-        style={{}}
-        message={{
-          content: 'Warning: Warning: normal substitution normal',
-          substitutions: [{length: 12, offset: 25}],
-        }}
-      />,
-    );
-
-    expect(output).toMatchSnapshot();
-  });
-
   it('Should make links tappable', async () => {
     const output = await render.create(
       <LogBoxMessage

--- a/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxMessage-test.js.snap
+++ b/packages/react-native/Libraries/LogBox/UI/__tests__/__snapshots__/LogBoxMessage-test.js.snap
@@ -77,38 +77,6 @@ Array [
 ]
 `;
 
-exports[`LogBoxMessage Should strip "Warning: " without breaking substitution 1`] = `
-Array [
-  <Text>
-    normal 
-  </Text>,
-  <Text
-    style={Object {}}
-  >
-    substitution
-  </Text>,
-  <Text>
-     normal
-  </Text>,
-]
-`;
-
-exports[`LogBoxMessage Should strip "Warning: Warning: " without breaking substitution 1`] = `
-Array [
-  <Text>
-    normal 
-  </Text>,
-  <Text
-    style={Object {}}
-  >
-    substitution
-  </Text>,
-  <Text>
-     normal
-  </Text>,
-]
-`;
-
 exports[`LogBoxMessage should render a plaintext message and clean the content 1`] = `
 <Text>
   This should not start with Error:

--- a/packages/react-native/Libraries/LogBox/__tests__/LogBox-test.js
+++ b/packages/react-native/Libraries/LogBox/__tests__/LogBox-test.js
@@ -18,7 +18,7 @@ declare var console: any;
 
 function mockFilterResult(returnValues: $FlowFixMe) {
   (LogBoxData.checkWarningFilter: any).mockReturnValue({
-    finalFormat: 'Warning: ...',
+    finalFormat: '...',
     forceDialogImmediately: false,
     suppressDialog_LEGACY: false,
     suppressCompletely: false,
@@ -124,17 +124,6 @@ describe('LogBox', () => {
     console.warn('...');
     expect(LogBoxData.addLog).not.toBeCalled();
     expect(LogBoxData.reportLogBoxError).toBeCalledWith(mockError);
-  });
-
-  it('only registers errors beginning with "Warning: "', () => {
-    jest.spyOn(LogBoxData, 'addLog');
-    jest.spyOn(LogBoxData, 'checkWarningFilter');
-
-    LogBox.install();
-
-    console.error('...');
-    expect(LogBoxData.addLog).not.toBeCalled();
-    expect(LogBoxData.checkWarningFilter).not.toBeCalled();
   });
 
   it('registers react errors with the formatting from filter', () => {
@@ -243,121 +232,6 @@ describe('LogBox', () => {
     expect(LogBoxData.addLog).toBeCalledWith(
       expect.objectContaining({level: 'fatal'}),
     );
-  });
-
-  it('registers warning module errors with the formatting from filter', () => {
-    jest.spyOn(LogBoxData, 'addLog');
-    jest.spyOn(LogBoxData, 'checkWarningFilter');
-
-    mockFilterResult({
-      finalFormat: 'Custom format',
-    });
-
-    ExceptionsManager.installConsoleErrorReporter();
-    LogBox.install();
-
-    console.error('Warning: ...');
-    expect(LogBoxData.addLog).toBeCalledWith(
-      expect.objectContaining({
-        message: {content: 'Custom format', substitutions: []},
-        category: 'Custom format',
-      }),
-    );
-    expect(LogBoxData.checkWarningFilter).toBeCalledWith('...');
-  });
-
-  it('registers warning module errors as errors by default', () => {
-    jest.spyOn(LogBoxData, 'addLog');
-    jest.spyOn(LogBoxData, 'checkWarningFilter');
-
-    mockFilterResult({});
-
-    ExceptionsManager.installConsoleErrorReporter();
-    LogBox.install();
-
-    console.error('Warning: ...');
-    expect(LogBoxData.addLog).toBeCalledWith(
-      expect.objectContaining({level: 'error'}),
-    );
-    expect(LogBoxData.checkWarningFilter).toBeCalledWith('...');
-  });
-
-  it('registers warning module errors with only legacy suppression as warning', () => {
-    jest.spyOn(LogBoxData, 'addLog');
-    jest.spyOn(LogBoxData, 'checkWarningFilter');
-
-    mockFilterResult({
-      suppressDialog_LEGACY: true,
-      monitorEvent: 'warning',
-    });
-
-    ExceptionsManager.installConsoleErrorReporter();
-    LogBox.install();
-
-    console.error('Warning: ...');
-    expect(LogBoxData.addLog).toBeCalledWith(
-      expect.objectContaining({level: 'warn'}),
-    );
-  });
-
-  it('registers warning module errors with a forced dialog as fatals', () => {
-    jest.spyOn(LogBoxData, 'addLog');
-    jest.spyOn(LogBoxData, 'checkWarningFilter');
-
-    mockFilterResult({
-      forceDialogImmediately: true,
-      monitorEvent: 'warning',
-    });
-
-    ExceptionsManager.installConsoleErrorReporter();
-    LogBox.install();
-
-    console.error('Warning: ...');
-    expect(LogBoxData.addLog).toBeCalledWith(
-      expect.objectContaining({level: 'fatal'}),
-    );
-  });
-
-  it('ignores warning module errors that are suppressed completely', () => {
-    jest.spyOn(LogBoxData, 'addLog');
-    jest.spyOn(LogBoxData, 'checkWarningFilter');
-
-    mockFilterResult({
-      suppressCompletely: true,
-      monitorEvent: 'warning',
-    });
-
-    ExceptionsManager.installConsoleErrorReporter();
-    LogBox.install();
-
-    console.error('Warning: ...');
-    expect(LogBoxData.addLog).not.toBeCalled();
-  });
-
-  it('ignores warning module errors that are pattern ignored', () => {
-    jest.spyOn(LogBoxData, 'checkWarningFilter');
-    jest.spyOn(LogBoxData, 'isMessageIgnored').mockReturnValue(true);
-    jest.spyOn(LogBoxData, 'addLog');
-
-    mockFilterResult({});
-
-    LogBox.install();
-
-    console.error('Warning: ...');
-    expect(LogBoxData.addLog).not.toBeCalled();
-  });
-
-  it('ignores warning module errors that are from LogBox itself', () => {
-    jest.spyOn(LogBoxData, 'checkWarningFilter');
-    jest.spyOn(LogBoxData, 'isLogBoxErrorMessage').mockReturnValue(true);
-    jest.spyOn(LogBoxData, 'addLog');
-
-    mockFilterResult({});
-
-    LogBox.install();
-
-    console.error('Warning: ...');
-    expect(LogBoxData.addLog).not.toBeCalled();
   });
 
   it('ignores logs that are pattern ignored"', () => {


### PR DESCRIPTION
Summary:
React no longer emits the "Warning: " prefix from error messages, so we no longer need special handling for error messages with this prefix.

If third party call sites are depending on `console.error('Warning: …')` being treated as a warning, they should be migrated to use `console.warn('…')`.

Changelog:
[General][Changed] - Logs created by `console.error` that begin with "Warning: " will no longer be treated as warnings. These call sites should migrate to using `console.warn` instead.

Differential Revision: D90795590


