### PR TITLE
Delete Theme style from devsupport

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/res/devsupport/values/styles.xml
+++ b/packages/react-native/ReactAndroid/src/main/res/devsupport/values/styles.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <style name="Theme" />
   <style name="Theme.Catalyst"/>
   <style name="Theme.Catalyst.RedBox">
     <item name="android:windowBackground">@color/catalyst_redbox_background</item>


### PR DESCRIPTION
Summary:
The definition of "Theme" style conflicts with apps that are already defining it. Given that devsupport uses Theme.Catalyst it should be safe to delete Theme

changelog: [internal] internal

Differential Revision: D90811304


