### PR TITLE
Remove Surface Handlers for AppleTV

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/InputAccessory/RCTInputAccessoryComponentView.mm
@@ -43,7 +43,9 @@ static UIView<RCTBackedTextInputViewProtocol> *_Nullable RCTFindTextInputWithNat
 @implementation RCTInputAccessoryComponentView {
   InputAccessoryShadowNode::ConcreteState::Shared _state;
   RCTInputAccessoryContentView *_contentView;
+#if !TARGET_OS_TV
   RCTSurfaceTouchHandler *_touchHandler;
+#endif
   UIView<RCTBackedTextInputViewProtocol> __weak *_textInput;
 }
 
@@ -52,8 +54,10 @@ static UIView<RCTBackedTextInputViewProtocol> *_Nullable RCTFindTextInputWithNat
   if (self = [super initWithFrame:frame]) {
     _props = InputAccessoryShadowNode::defaultSharedProps();
     _contentView = [RCTInputAccessoryContentView new];
+#if !TARGET_OS_TV
     _touchHandler = [RCTSurfaceTouchHandler new];
     [_touchHandler attachToView:_contentView];
+#endif
   }
 
   return self;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTFabricModalHostViewController.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTFabricModalHostViewController.mm
@@ -12,7 +12,9 @@
 
 @implementation RCTFabricModalHostViewController {
   CGRect _lastViewBounds;
+#if !TARGET_OS_TV
   RCTSurfaceTouchHandler *_touchHandler;
+#endif
 }
 
 - (instancetype)init
@@ -20,7 +22,9 @@
   if ((self = [super init]) == nullptr) {
     return nil;
   }
+#if !TARGET_OS_TV
   _touchHandler = [RCTSurfaceTouchHandler new];
+#endif
 
   return self;
 }
@@ -37,7 +41,9 @@
 - (void)loadView
 {
   self.view = [UIView new];
+#if !TARGET_OS_TV
   [_touchHandler attachToView:self.view];
+#endif
 }
 
 - (UIStatusBarStyle)preferredStatusBarStyle

--- a/packages/react-native/React/Fabric/RCTSurfacePointerHandler.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePointerHandler.mm
@@ -15,6 +15,8 @@
 #import "RCTConversions.h"
 #import "RCTTouchableComponentViewProtocol.h"
 
+#if !TARGET_OS_TV
+
 using namespace facebook::react;
 
 typedef NS_ENUM(NSInteger, RCTPointerEventType) {
@@ -771,3 +773,5 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
 }
 
 @end
+
+#endif // !TARGET_OS_TV

--- a/packages/react-native/React/Fabric/RCTSurfaceTouchHandler.mm
+++ b/packages/react-native/React/Fabric/RCTSurfaceTouchHandler.mm
@@ -15,6 +15,8 @@
 #import "RCTSurfacePointerHandler.h"
 #import "RCTTouchableComponentViewProtocol.h"
 
+#if !TARGET_OS_TV
+
 using namespace facebook::react;
 
 typedef NS_ENUM(NSInteger, RCTTouchEventType) {
@@ -414,3 +416,5 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)act
 }
 
 @end
+
+#endif // !TARGET_OS_TV

--- a/packages/react-native/React/Fabric/Surface/RCTFabricSurface.mm
+++ b/packages/react-native/React/Fabric/Surface/RCTFabricSurface.mm
@@ -45,7 +45,9 @@ using namespace facebook::react;
 
   // Can be accessed from the main thread only.
   RCTSurfaceView *_Nullable _view;
+#if !TARGET_OS_TV
   RCTSurfaceTouchHandler *_Nullable _touchHandler;
+#endif
 }
 
 @synthesize delegate = _delegate;
@@ -144,8 +146,10 @@ using namespace facebook::react;
   if (!_view) {
     _view = [[RCTSurfaceView alloc] initWithSurface:self];
     [self _updateLayoutContext];
+#if !TARGET_OS_TV
     _touchHandler = [RCTSurfaceTouchHandler new];
     [_touchHandler attachToView:_view];
+#endif
   }
 
   return _view;


### PR DESCRIPTION
Summary:
SurfaceTouch and SurfacePointer handlers use a lot of unsupported UIKit APIs. Instead of granuarly wrapping the UIKit usage, this minimally removes the handlers from AppleTV all-together, as they no-op anyways (there is no click-through support on simulator.)

Changelog: [Internal]

Reviewed By: Abbondanzo

Differential Revision: D90704270


