### PR TITLE
Explicitly enable debugger when building Hermes for Fantom

### DIFF
--- a/private/react-native-fantom/build.gradle.kts
+++ b/private/react-native-fantom/build.gradle.kts
@@ -159,8 +159,8 @@ val prepareHermesDependencies by
     tasks.registering {
       dependsOn(
           enableHermesBuild,
-          ":packages:react-native:ReactAndroid:hermes-engine:buildHermesLib",
-          ":packages:react-native:ReactAndroid:hermes-engine:prepareHeadersForPrefab",
+          ":packages:react-native:ReactAndroid:hermes-engine:buildHermesLibWithDebugger",
+          ":packages:react-native:ReactAndroid:hermes-engine:prepareHeadersForPrefabWithDebugger",
       )
     }
 


### PR DESCRIPTION
Summary:
Changelog: [Internal]

After changing Hermes V1 to be the default engine, Fantom tests started failing. This was due to a combination of changes, one of them being the change of default value for `HERMES_ENABLE_DEBUGGER`. In case of legacy Hermes it was enabled by default, while for Hermes V1 it's disabled by default.

Fantom didn't explicitly set this flag, but the debug build of RN (which Fantom performs) requires it to be enabled. This diff explicitly sets this flag to true for Fantom builds.

Differential Revision: D90849881


