### PR TITLE
Add `transformOrigin` prop support to the `AnimationBackend`.

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropSerializer.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropSerializer.cpp
@@ -74,6 +74,34 @@ void packTransform(folly::dynamic& dyn, const AnimatedPropBase& animatedProp) {
       folly::dynamic::array(folly::dynamic::object("matrix", matrixArray)));
 }
 
+std::string unitTypeToString(UnitType unit) {
+  switch (unit) {
+    case UnitType::Undefined:
+      return "undefined";
+    case UnitType::Point:
+      return "point";
+    case UnitType::Percent:
+      return "percent";
+    default:
+      throw std::runtime_error("Unknown unit type");
+  }
+}
+
+void packTransformOrigin(
+    folly::dynamic& dyn,
+    const AnimatedPropBase& animatedProp) {
+  const auto& transformOrigin = get<TransformOrigin>(animatedProp);
+  auto originArray = folly::dynamic::array();
+  for (const auto& xyValue : transformOrigin.xy) {
+    folly::dynamic valueObj = folly::dynamic::object();
+    valueObj["value"] = xyValue.value;
+    valueObj["unit"] = unitTypeToString(xyValue.unit);
+    originArray.push_back(valueObj);
+  }
+  originArray.push_back(transformOrigin.z);
+  dyn.insert("transformOrigin", originArray);
+}
+
 void packBackgroundColor(
     folly::dynamic& dyn,
     const AnimatedPropBase& animatedProp) {
@@ -548,6 +576,10 @@ void packAnimatedProp(
 
     case TRANSFORM:
       packTransform(dyn, *animatedProp);
+      break;
+
+    case TRANSFORM_ORIGIN:
+      packTransformOrigin(dyn, *animatedProp);
       break;
 
     case BACKGROUND_COLOR:

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedProps.h
@@ -24,6 +24,7 @@ enum PropName {
   POSITION,
   FLEX,
   TRANSFORM,
+  TRANSFORM_ORIGIN,
   BACKGROUND_COLOR,
   SHADOW_COLOR,
   SHADOW_OFFSET,
@@ -253,6 +254,10 @@ inline void cloneProp(BaseViewProps &viewProps, const AnimatedPropBase &animated
 
     case TRANSFORM:
       viewProps.transform = get<Transform>(animatedProp);
+      break;
+
+    case TRANSFORM_ORIGIN:
+      viewProps.transformOrigin = get<TransformOrigin>(animatedProp);
       break;
 
     case BACKGROUND_COLOR:

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropsBuilder.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropsBuilder.h
@@ -56,9 +56,13 @@ struct AnimatedPropsBuilder {
   {
     props.push_back(std::make_unique<AnimatedProp<yoga::FloatOptional>>(FLEX, value));
   }
-  void setTransform(Transform &t)
+  void setTransform(const Transform &t)
   {
-    props.push_back(std::make_unique<AnimatedProp<Transform>>(TRANSFORM, std::move(t)));
+    props.push_back(std::make_unique<AnimatedProp<Transform>>(TRANSFORM, t));
+  }
+  void setTransformOrigin(const TransformOrigin &value)
+  {
+    props.push_back(std::make_unique<AnimatedProp<TransformOrigin>>(TRANSFORM_ORIGIN, value));
   }
   void setBackgroundColor(SharedColor value)
   {

--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropsRegistry.h
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimatedPropsRegistry.h
@@ -68,6 +68,10 @@ inline void updateProp(const PropName propName, BaseViewProps &viewProps, const 
       viewProps.transform = snapshot.props.transform;
       break;
 
+    case TRANSFORM_ORIGIN:
+      viewProps.transformOrigin = snapshot.props.transformOrigin;
+      break;
+
     case BORDER_RADII:
       viewProps.borderRadii = snapshot.props.borderRadii;
       break;


### PR DESCRIPTION
## Summary:
Adds `transformOrigin` prop support to the `AnimationBackend`.

## Changelog:
[General][Added] - Added `transformOrigin` prop support to the `AnimationBackend`.

Differential Revision: D90851823


