### PR TITLE
[ios] Fix regression stopping `--project-directory` from working

### DIFF
--- a/packages/react-native/scripts/react_native_pods.rb
+++ b/packages/react-native/scripts/react_native_pods.rb
@@ -106,7 +106,7 @@ def use_react_native! (
   # that has invoked the `use_react_native!` function.
   ReactNativePodsUtils.detect_use_frameworks(current_target_definition)
 
-  CodegenUtils.clean_up_build_folder(path, $CODEGEN_OUTPUT_DIR)
+  CodegenUtils.clean_up_build_folder(react_native_path, $CODEGEN_OUTPUT_DIR)
 
   # We are relying on this flag also in third parties libraries to proper install dependencies.
   # Better to rely and enable this environment flag if the new architecture is turned on using flags.


### PR DESCRIPTION
## Summary:

This is a fix for a regression in #54948 found by @Kudo. Passing an absolute path for `react_native_path` was non-functional before and the change was meant to fix this.

This however used `Pathname.pwd.join(path)` since I assumed that'd be the intention for a relative path. However, my assumption was that `pod install` would only ever be run in the installation root and hence be equivalent to `Pod::Config.instance.installation_root` most of the time.

This broke: `pod install --project-directory ios` (and the likes), since I wasn't aware of the `--project-directory` argument before.

To fix this, we should construct the absolute path and join from `Pod::Config.instance.installation_root` as well.

**Note to self:** Needs a pick into `0.84.0` due to being a regression (will file a pick request after this is merged)

## Changelog:

[IOS] [FIXED] Regression from #54948 preventing `pod install --project-directory` from working properly

## Test Plan:

- Run `pod install` in `rn-tester` to validate
