### PR TITLE
Fix hermes-engine Podfile.lock checksum inconsistency across developers

### DIFF
--- a/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
+++ b/packages/react-native/sdks/hermes-engine/hermes-engine.podspec
@@ -4,6 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 require "json"
+require "pathname"
 require_relative "./hermes-utils.rb"
 
 begin
@@ -92,8 +93,13 @@ Pod::Spec.new do |spec|
         "require.resolve(\"hermes-compiler\", {paths: [\"#{react_native_path}\"]})", __dir__]).strip
       )
 
+      # Compute a relative path from PODS_ROOT to avoid absolute paths with usernames that cause different checksums across developers,
+      # and works regardless of project structure.
+      hermesc_path = "#{hermes_compiler_path}/hermesc/osx-bin/hermesc"
+      relative_hermesc_path = Pathname.new(hermesc_path).relative_path_from(Pod::Config.instance.sandbox_root)
+
       spec.user_target_xcconfig = {
-        'HERMES_CLI_PATH' => "#{hermes_compiler_path}/hermesc/osx-bin/hermesc"
+        'HERMES_CLI_PATH' => "${PODS_ROOT}/#{relative_hermesc_path}"
       }
     end
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fixed an issue where developers with identical development environments get different checksums for hermes-engine in Podfile.lock, causing unnecessary git conflicts.

The root cause was that hermes-engine.podspec used require.resolve() to get the absolute path to hermes-compiler, which included usernames. This caused the generated hermes-engine.podspec.json to differ across developers, resulting in different checksums.

See Issue: https://github.com/facebook/react-native/issues/54891

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[IOS] [FIXED] - Fix hermes-engine Podfile.lock checksum inconsistency across developers

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- Created a test project with local React Native changes
- Ran `pod install` and verified `hermes-engine.podspec.json` contains 
  `${PODS_ROOT}/../../node_modules/hermes-compiler` path
- Verified app builds and runs successfully with Hermes enabled
- Verified that `rn-tester` app builds and runs successfully
- Confirmed hermesc binary resolves correctly at build time
