### PR TITLE
Log error when unsupported type is passed to interpolation outputRange

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/InterpolationAnimatedNode.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/InterpolationAnimatedNode.kt
@@ -8,6 +8,7 @@
 package com.facebook.react.animated
 
 import androidx.core.graphics.ColorUtils
+import com.facebook.common.logging.FLog
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
@@ -44,6 +45,15 @@ internal class InterpolationAnimatedNode(config: ReadableMap) : ValueAnimatedNod
       outputType = OutputType.String
       outputRange = fromStringPattern(output)
       pattern = output.getString(0)
+    } else if (output != null && output.size() > 0 && output.getType(0) != ReadableType.Number) {
+      FLog.e(
+          TAG,
+          "Unsupported value type in interpolation outputRange: expected Number but got " +
+              "${output.getType(0)}. This may indicate PlatformColor or other unsupported " +
+              "values are being used. Interpolation will not work correctly.",
+      )
+      outputType = OutputType.Number
+      outputRange = DoubleArray(output.size())
     } else {
       outputType = OutputType.Number
       outputRange = fromDoubleArray(output)
@@ -101,6 +111,8 @@ internal class InterpolationAnimatedNode(config: ReadableMap) : ValueAnimatedNod
       "InterpolationAnimatedNode[$tag] super: ${super.prettyPrint()}"
 
   companion object {
+    private const val TAG = "InterpolationAnimatedNode"
+
     const val EXTRAPOLATE_TYPE_IDENTITY: String = "identity"
     const val EXTRAPOLATE_TYPE_CLAMP: String = "clamp"
     const val EXTRAPOLATE_TYPE_EXTEND: String = "extend"


### PR DESCRIPTION
Summary:
## Changelog:

[Android] [Changed] - Log error when unsupported type is passed to interpolation outputRange

Add error logging when unsupported value types (like PlatformColor) are passed to interpolation outputRange. This prevents a ClassCastException crash by detecting non-Number types and logging an error instead.

Differential Revision: D90863942


