### PR TITLE
fix(android): Image `defaultSource` & `loadingIndicatorSrc` broken with props 2.0

### DIFF
--- a/packages/react-native/Libraries/Image/Image.android.js
+++ b/packages/react-native/Libraries/Image/Image.android.js
@@ -424,8 +424,6 @@ if (ReactNativeFeatureFlags.reduceDefaultPropsInImage()) {
 
     const actualRef = useWrapRefWithImageAttachedCallbacks(forwardedRef);
 
-    console.log('Image props=', nativeProps);
-
     return (
       <ImageAnalyticsTagContext.Consumer>
         {analyticTag => {

--- a/packages/react-native/Libraries/Image/Image.android.js
+++ b/packages/react-native/Libraries/Image/Image.android.js
@@ -256,14 +256,14 @@ if (ReactNativeFeatureFlags.reduceDefaultPropsInImage()) {
     }
 
     if (defaultSource_ != null && defaultSource_.uri != null) {
-      nativeProps.defaultSource = defaultSource_.uri;
+      nativeProps.defaultSource = defaultSource_;
     }
 
     if (
       loadingIndicatorSource_ != null &&
       loadingIndicatorSource_.uri != null
     ) {
-      nativeProps.loadingIndicatorSrc = loadingIndicatorSource_.uri;
+      nativeProps.loadingIndicatorSrc = loadingIndicatorSource_;
     }
 
     if (ariaLabel != null) {
@@ -395,9 +395,9 @@ if (ReactNativeFeatureFlags.reduceDefaultPropsInImage()) {
       /* $FlowFixMe[prop-missing](>=0.78.0 site=react_native_android_fb) This issue was found
        * when making Flow check .android.js files. */
       headers: (source?.[0]?.headers || source?.headers: ?{[string]: string}),
-      defaultSource: defaultSource ? defaultSource.uri : null,
+      defaultSource: defaultSource ? defaultSource : null,
       loadingIndicatorSrc: loadingIndicatorSource
-        ? loadingIndicatorSource.uri
+        ? loadingIndicatorSource
         : null,
       accessibilityLabel:
         props['aria-label'] ?? props.accessibilityLabel ?? props.alt,
@@ -423,6 +423,8 @@ if (ReactNativeFeatureFlags.reduceDefaultPropsInImage()) {
       objectFit || props.resizeMode || flattenedStyle?.resizeMode || 'cover';
 
     const actualRef = useWrapRefWithImageAttachedCallbacks(forwardedRef);
+
+    console.log('Image props=', nativeProps);
 
     return (
       <ImageAnalyticsTagContext.Consumer>

--- a/packages/react-native/Libraries/Image/ImageViewNativeComponent.js
+++ b/packages/react-native/Libraries/Image/ImageViewNativeComponent.js
@@ -40,7 +40,7 @@ type ImageHostComponentProps = Readonly<{
   src?: ?ResolvedAssetSource | ?ReadonlyArray<?Readonly<{uri?: ?string, ...}>>,
   headers?: ?{[string]: string},
   defaultSource?: ?ImageSource | ?string,
-  loadingIndicatorSrc?: ?string,
+  loadingIndicatorSrc?: ?ImageSource | ?string,
 }>;
 
 interface NativeCommands {

--- a/packages/react-native/Libraries/Image/__tests__/Image-itest.js
+++ b/packages/react-native/Libraries/Image/__tests__/Image-itest.js
@@ -162,7 +162,9 @@ describe('<Image>', () => {
           root.getRenderedOutput({props: ['defaultSource']}).toJSX(),
         ).toEqual(
           <rn-image
-            defaultSource-type="remote"
+            defaultSource-type="local"
+            defaultSource-scale="1"
+            defaultSource-size="{1, 1}"
             defaultSource-uri="file://drawable-mdpi/packages_reactnative_libraries_image___tests___img_img1.png"
           />,
         );

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.kt
@@ -12,11 +12,8 @@ import android.graphics.PorterDuff
 import com.facebook.common.logging.FLog
 import com.facebook.drawee.backends.pipeline.Fresco
 import com.facebook.drawee.controller.AbstractDraweeControllerBuilder
-import com.facebook.react.BuildConfig
-import com.facebook.react.bridge.ReactNoCrashSoftException
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
-import com.facebook.react.bridge.SoftAssertions
 import com.facebook.react.common.ReactConstants
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.BackgroundStyleApplicator
@@ -137,31 +134,13 @@ public constructor(
 
   @ReactProp(name = "defaultSource")
   public fun setDefaultSource(view: ReactImageView, source: ReadableMap?) {
-    if (source == null) {
-      view.setDefaultSource(null)
-      return
-    }
-    val imageSource = view.readableMapToImageSource(source, false)
-    SoftAssertions.assertCondition(
-      !BuildConfig.DEBUG && !imageSource.isResource,
-      "ReactImageView: Only local resources can be used as default image. Uri: ${imageSource.uri}")
-
-    view.setDefaultSource(imageSource.source)
+    view.setDefaultSource(source)
   }
 
   // In JS this is Image.props.loadingIndicatorSource.uri
   @ReactProp(name = "loadingIndicatorSrc")
   public fun setLoadingIndicatorSource(view: ReactImageView, source: ReadableMap?) {
-    if (source == null) {
-      view.setLoadingIndicatorSource(null)
-      return
-    }
-    val imageSource = view.readableMapToImageSource(source, false)
-    SoftAssertions.assertCondition(
-      !BuildConfig.DEBUG && !imageSource.isResource,
-      "ReactImageView: Only local resources can be used as loading indicator image. Uri: ${imageSource.uri}")
-
-    view.setLoadingIndicatorSource(imageSource.uri.toString())
+    view.setLoadingIndicatorSource(source)
   }
 
   @ReactProp(name = "borderColor", customType = "Color")

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.kt
@@ -142,13 +142,11 @@ public constructor(
       return
     }
     val imageSource = view.readableMapToImageSource(source, false)
-    if (!BuildConfig.DEBUG && !imageSource.isResource) {
-      throw ReactNoCrashSoftException(
-          "ReactImageView: Only local resources can be used as default image. Uri: ${imageSource.uri}",
-      )
-    }
+    SoftAssertions.assertCondition(
+      !BuildConfig.DEBUG && !imageSource.isResource,
+      "ReactImageView: Only local resources can be used as default image. Uri: ${imageSource.uri}")
 
-    view.setDefaultSource(imageSource.uri.toString())
+    view.setDefaultSource(imageSource.source)
   }
 
   // In JS this is Image.props.loadingIndicatorSource.uri
@@ -159,11 +157,10 @@ public constructor(
       return
     }
     val imageSource = view.readableMapToImageSource(source, false)
-    if (!BuildConfig.DEBUG && !imageSource.isResource) {
-      throw ReactNoCrashSoftException(
-          "ReactImageView: Only local resources can be used as loading indicator image. Uri: ${imageSource.uri}",
-      )
-    }
+    SoftAssertions.assertCondition(
+      !BuildConfig.DEBUG && !imageSource.isResource,
+      "ReactImageView: Only local resources can be used as loading indicator image. Uri: ${imageSource.uri}")
+
     view.setLoadingIndicatorSource(imageSource.uri.toString())
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageManager.kt
@@ -12,8 +12,11 @@ import android.graphics.PorterDuff
 import com.facebook.common.logging.FLog
 import com.facebook.drawee.backends.pipeline.Fresco
 import com.facebook.drawee.controller.AbstractDraweeControllerBuilder
+import com.facebook.react.BuildConfig
+import com.facebook.react.bridge.ReactNoCrashSoftException
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.SoftAssertions
 import com.facebook.react.common.ReactConstants
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.BackgroundStyleApplicator
@@ -133,14 +136,35 @@ public constructor(
   }
 
   @ReactProp(name = "defaultSource")
-  public fun setDefaultSource(view: ReactImageView, source: String?) {
-    view.setDefaultSource(source)
+  public fun setDefaultSource(view: ReactImageView, source: ReadableMap?) {
+    if (source == null) {
+      view.setDefaultSource(null)
+      return
+    }
+    val imageSource = view.readableMapToImageSource(source, false)
+    if (!BuildConfig.DEBUG && !imageSource.isResource) {
+      throw ReactNoCrashSoftException(
+          "ReactImageView: Only local resources can be used as default image. Uri: ${imageSource.uri}",
+      )
+    }
+
+    view.setDefaultSource(imageSource.uri.toString())
   }
 
   // In JS this is Image.props.loadingIndicatorSource.uri
   @ReactProp(name = "loadingIndicatorSrc")
-  public fun setLoadingIndicatorSource(view: ReactImageView, source: String?) {
-    view.setLoadingIndicatorSource(source)
+  public fun setLoadingIndicatorSource(view: ReactImageView, source: ReadableMap?) {
+    if (source == null) {
+      view.setLoadingIndicatorSource(null)
+      return
+    }
+    val imageSource = view.readableMapToImageSource(source, false)
+    if (!BuildConfig.DEBUG && !imageSource.isResource) {
+      throw ReactNoCrashSoftException(
+          "ReactImageView: Only local resources can be used as loading indicator image. Uri: ${imageSource.uri}",
+      )
+    }
+    view.setLoadingIndicatorSource(imageSource.uri.toString())
   }
 
   @ReactProp(name = "borderColor", customType = "Color")

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.kt
@@ -44,9 +44,11 @@ import com.facebook.imagepipeline.request.ImageRequest
 import com.facebook.imagepipeline.request.ImageRequest.RequestLevel
 import com.facebook.imagepipeline.request.ImageRequestBuilder
 import com.facebook.imagepipeline.request.Postprocessor
+import com.facebook.react.BuildConfig
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.SoftAssertions
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.common.annotations.VisibleForTesting
 import com.facebook.react.common.build.ReactBuildConfig
@@ -273,30 +275,6 @@ public class ReactImageView(
     }
   }
 
-  // todo: this must live elsewhere i think
-  public fun readableMapToImageSource(source: ReadableMap, includeSize: Boolean = false): ImageSource {
-    val cacheControl = computeCacheControl(source.getString("cache"))
-    val uri = source.getString("uri")
-    var imageSource = if (includeSize) {
-      ImageSource(
-        context,
-        uri,
-        source.getDouble("width"),
-        source.getDouble("height"),
-        cacheControl,
-      )
-    } else {
-      ImageSource(context, uri, cacheControl = cacheControl)
-    }
-
-    if (Uri.EMPTY == imageSource.uri) {
-      warnImageSource(uri)
-      imageSource = getTransparentBitmapImageSource(context)
-    }
-
-    return imageSource
-  }
-
   public fun setSource(sources: ReadableArray?) {
     val tmpSources = mutableListOf<ImageSource>()
 
@@ -343,16 +321,36 @@ public class ReactImageView(
     }
   }
 
-  public fun setDefaultSource(name: String?) {
-    val newDefaultDrawable = ResourceDrawableIdHelper.getResourceDrawable(context, name)
+  public fun setDefaultSource(source: ReadableMap?) {
+    var newDefaultDrawable: Drawable? = null
+    if (source != null) {
+      val imageSource = readableMapToImageSource(source, false)
+      SoftAssertions.assertCondition(
+        !BuildConfig.DEBUG && !imageSource.isResource,
+        "ReactImageView: Only local resources can be used as default image. Uri: ${imageSource.uri}"
+      )
+
+      newDefaultDrawable = ResourceDrawableIdHelper.getResourceDrawable(context, imageSource.source)
+    }
+
     if (defaultImageDrawable != newDefaultDrawable) {
       defaultImageDrawable = newDefaultDrawable
       isDirty = true
     }
   }
 
-  public fun setLoadingIndicatorSource(name: String?) {
-    val drawable = ResourceDrawableIdHelper.getResourceDrawable(context, name)
+  public fun setLoadingIndicatorSource(source: ReadableMap?) {
+    var drawable: Drawable? = null
+    if (source != null) {
+      val imageSource = readableMapToImageSource(source, false)
+      SoftAssertions.assertCondition(
+        !BuildConfig.DEBUG && !imageSource.isResource,
+        "ReactImageView: Only local resources can be used as default image. Uri: ${imageSource.uri}"
+      )
+
+      drawable = ResourceDrawableIdHelper.getResourceDrawable(context, imageSource.source)
+    }
+
     val newLoadingIndicatorSource = drawable?.let { AutoRotateDrawable(it, 1000) }
     if (loadingImageDrawable != newLoadingIndicatorSource) {
       loadingImageDrawable = newLoadingIndicatorSource
@@ -561,6 +559,29 @@ public class ReactImageView(
 
   private val isTiled: Boolean
     get() = tileMode != TileMode.CLAMP
+
+  private fun readableMapToImageSource(source: ReadableMap, includeSize: Boolean = false): ImageSource {
+    val cacheControl = computeCacheControl(source.getString("cache"))
+    val uri = source.getString("uri")
+    var imageSource = if (includeSize) {
+      ImageSource(
+        context,
+        uri,
+        source.getDouble("width"),
+        source.getDouble("height"),
+        cacheControl,
+      )
+    } else {
+      ImageSource(context, uri, cacheControl = cacheControl)
+    }
+
+    if (Uri.EMPTY == imageSource.uri) {
+      warnImageSource(uri)
+      imageSource = getTransparentBitmapImageSource(context)
+    }
+
+    return imageSource
+  }
 
   private fun setSourceImage() {
     imageSource = null

--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/primitives.h
@@ -66,9 +66,8 @@ class ImageSource {
     imageSourceResult["scale"] = scale;
 
     folly::dynamic sizeResult = folly::dynamic::object();
-    sizeResult["width"] = size.width;
-    sizeResult["height"] = size.height;
-    imageSourceResult["size"] = sizeResult;
+    imageSourceResult["width"] = size.width;
+    imageSourceResult["height"] = size.height;
 
     imageSourceResult["body"] = body;
     imageSourceResult["method"] = method;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fixes crashes using <Image> component on android with props 2.0 enabled using feature flag:

```
enablePropsUpdateReconciliationAndroid
```

<details>
<summary>Crash stack</summary>

```
Error while updating prop source
java.lang.reflect.InvocationTargetException
	at java.lang.reflect.Method.invoke(Native Method)
	at G0.a.q(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:89)
	at com.facebook.react.uimanager.ViewManager.updateProperties(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:33)
	at com.facebook.react.uimanager.ViewManager.createViewInstance(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:12)
	at com.facebook.react.uimanager.ViewManager.createView(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:1)
	at q1.h.b(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:62)
	at r1.g.execute(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:67)
	at q1.b.d(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:71)
	at q1.b.c(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:64)
	at m1.j.a(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:100)
	at com.facebook.react.uimanager.d.doFrame(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:1)
	at E1.o.doFrame(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:98)
	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:2457)
	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:2468)
	at android.view.Choreographer.doCallbacks(Choreographer.java:1693)
	at android.view.Choreographer.doAnimationLoad(Choreographer.java:1523)
	at android.view.Choreographer.doFrame(Choreographer.java:1438)
	at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:2284)
	at android.os.Handler.handleCallback(Handler.java:1014)
	at android.os.Handler.dispatchMessage(Handler.java:102)
	at android.os.Looper.loopOnce(Looper.java:250)
	at android.os.Looper.loop(Looper.java:340)
	at android.app.ActivityThread.main(ActivityThread.java:9911)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:621)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:957)
Caused by: com.facebook.react.bridge.NoSuchKeyException: width
	at com.facebook.react.bridge.ReadableNativeMap.getValue(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:3)
	at com.facebook.react.bridge.ReadableNativeMap.getDouble(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:6)
	at r2.l.setSource(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:143)
	at com.facebook.react.views.image.ReactImageManager.setSource(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:6)
	at java.lang.reflect.Method.invoke(Native Method) 
	at G0.a.q(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:89) 
	at com.facebook.react.uimanager.ViewManager.updateProperties(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:33) 
	at com.facebook.react.uimanager.ViewManager.createViewInstance(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:12) 
	at com.facebook.react.uimanager.ViewManager.createView(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:1) 
	at q1.h.b(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:62) 
	at r1.g.execute(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:67) 
	at q1.b.d(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:71) 
	at q1.b.c(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:64) 
	at m1.j.a(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:100) 
	at com.facebook.react.uimanager.d.doFrame(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:1) 
	at E1.o.doFrame(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:98) 
	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:2457) 
	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:2468) 
	at android.view.Choreographer.doCallbacks(Choreographer.java:1693) 
	at android.view.Choreographer.doAnimationLoad(Choreographer.java:1523) 
	at android.view.Choreographer.doFrame(Choreographer.java:1438) 
	at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:2284) 
	at android.os.Handler.handleCallback(Handler.java:1014) 
	at android.os.Handler.dispatchMessage(Handler.java:102) 
	at android.os.Looper.loopOnce(Looper.java:250) 
	at android.os.Looper.loop(Looper.java:340) 
	at android.app.ActivityThread.main(ActivityThread.java:9911) 
	at java.lang.reflect.Method.invoke(Native Method) 
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:621) 
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:957) 
Exception thrown when executing UIFrameGuarded
com.facebook.react.bridge.JSApplicationIllegalArgumentException: Error while updating property 'source' of a view managed by: RCTImageView
	at G0.a.q(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:144)
	at com.facebook.react.uimanager.ViewManager.updateProperties(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:33)
	at com.facebook.react.uimanager.ViewManager.createViewInstance(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:12)
	at com.facebook.react.uimanager.ViewManager.createView(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:1)
	at q1.h.b(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:62)
	at r1.g.execute(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:67)
	at q1.b.d(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:71)
	at q1.b.c(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:64)
	at m1.j.a(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:100)
	at com.facebook.react.uimanager.d.doFrame(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:1)
	at E1.o.doFrame(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:98)
	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:2457)
	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:2468)
	at android.view.Choreographer.doCallbacks(Choreographer.java:1693)
	at android.view.Choreographer.doAnimationLoad(Choreographer.java:1523)
	at android.view.Choreographer.doFrame(Choreographer.java:1438)
	at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:2284)
	at android.os.Handler.handleCallback(Handler.java:1014)
	at android.os.Handler.dispatchMessage(Handler.java:102)
	at android.os.Looper.loopOnce(Looper.java:250)
	at android.os.Looper.loop(Looper.java:340)
	at android.app.ActivityThread.main(ActivityThread.java:9911)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:621)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:957)
Caused by: java.lang.reflect.InvocationTargetException
	at java.lang.reflect.Method.invoke(Native Method)
	at G0.a.q(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:89)
	at com.facebook.react.uimanager.ViewManager.updateProperties(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:33) 
	at com.facebook.react.uimanager.ViewManager.createViewInstance(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:12) 
	at com.facebook.react.uimanager.ViewManager.createView(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:1) 
	at q1.h.b(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:62) 
	at r1.g.execute(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:67) 
	at q1.b.d(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:71) 
	at q1.b.c(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:64) 
	at m1.j.a(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:100) 
	at com.facebook.react.uimanager.d.doFrame(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:1) 
	at E1.o.doFrame(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:98) 
	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:2457) 
	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:2468) 
	at android.view.Choreographer.doCallbacks(Choreographer.java:1693) 
	at android.view.Choreographer.doAnimationLoad(Choreographer.java:1523) 
	at android.view.Choreographer.doFrame(Choreographer.java:1438) 
	at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:2284) 
	at android.os.Handler.handleCallback(Handler.java:1014) 
	at android.os.Handler.dispatchMessage(Handler.java:102) 
	at android.os.Looper.loopOnce(Looper.java:250) 
	at android.os.Looper.loop(Looper.java:340) 
	at android.app.ActivityThread.main(ActivityThread.java:9911) 
	at java.lang.reflect.Method.invoke(Native Method) 
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:621) 
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:957) 
Caused by: com.facebook.react.bridge.NoSuchKeyException: width
	at com.facebook.react.bridge.ReadableNativeMap.getValue(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:3)
	at com.facebook.react.bridge.ReadableNativeMap.getDouble(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:6)
	at r2.l.setSource(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:143)
	at com.facebook.react.views.image.ReactImageManager.setSource(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:6)
	at java.lang.reflect.Method.invoke(Native Method) 
	at G0.a.q(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:89) 
	at com.facebook.react.uimanager.ViewManager.updateProperties(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:33) 
	at com.facebook.react.uimanager.ViewManager.createViewInstance(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:12) 
	at com.facebook.react.uimanager.ViewManager.createView(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:1) 
	at q1.h.b(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:62) 
	at r1.g.execute(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:67) 
	at q1.b.d(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:71) 
	at q1.b.c(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:64) 
	at m1.j.a(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:100) 
	at com.facebook.react.uimanager.d.doFrame(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:1) 
	at E1.o.doFrame(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:98) 
	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:2457) 
	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:2468) 
	at android.view.Choreographer.doCallbacks(Choreographer.java:1693) 
	at android.view.Choreographer.doAnimationLoad(Choreographer.java:1523) 
	at android.view.Choreographer.doFrame(Choreographer.java:1438) 
	at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:2284) 
	at android.os.Handler.handleCallback(Handler.java:1014) 
	at android.os.Handler.dispatchMessage(Handler.java:102) 
	at android.os.Looper.loopOnce(Looper.java:250) 
	at android.os.Looper.loop(Looper.java:340) 
	at android.app.ActivityThread.main(ActivityThread.java:9911) 
	at java.lang.reflect.Method.invoke(Native Method) 
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:621) 
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:957) 
ReactHost{0}.handleHostException(message = "Error while updating property 'source' of a view managed by: RCTImageView")
Shutting down VM
FATAL EXCEPTION: main
Process: com.facebook.react.uiapp, PID: 23676
com.facebook.react.bridge.JSApplicationIllegalArgumentException: Error while updating property 'source' of a view managed by: RCTImageView
	at G0.a.q(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:144)
	at com.facebook.react.uimanager.ViewManager.updateProperties(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:33)
	at com.facebook.react.uimanager.ViewManager.createViewInstance(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:12)
	at com.facebook.react.uimanager.ViewManager.createView(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:1)
	at q1.h.b(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:62)
	at r1.g.execute(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:67)
	at q1.b.d(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:71)
	at q1.b.c(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:64)
	at m1.j.a(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:100)
	at com.facebook.react.uimanager.d.doFrame(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:1)
	at E1.o.doFrame(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:98)
	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:2457)
	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:2468)
	at android.view.Choreographer.doCallbacks(Choreographer.java:1693)
	at android.view.Choreographer.doAnimationLoad(Choreographer.java:1523)
	at android.view.Choreographer.doFrame(Choreographer.java:1438)
	at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:2284)
	at android.os.Handler.handleCallback(Handler.java:1014)
	at android.os.Handler.dispatchMessage(Handler.java:102)
	at android.os.Looper.loopOnce(Looper.java:250)
	at android.os.Looper.loop(Looper.java:340)
	at android.app.ActivityThread.main(ActivityThread.java:9911)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:621)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:957)
Caused by: java.lang.reflect.InvocationTargetException
	at java.lang.reflect.Method.invoke(Native Method)
	at G0.a.q(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:89)
	at com.facebook.react.uimanager.ViewManager.updateProperties(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:33) 
	at com.facebook.react.uimanager.ViewManager.createViewInstance(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:12) 
	at com.facebook.react.uimanager.ViewManager.createView(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:1) 
	at q1.h.b(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:62) 
	at r1.g.execute(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:67) 
	at q1.b.d(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:71) 
	at q1.b.c(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:64) 
	at m1.j.a(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:100) 
	at com.facebook.react.uimanager.d.doFrame(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:1) 
	at E1.o.doFrame(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:98) 
	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:2457) 
	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:2468) 
	at android.view.Choreographer.doCallbacks(Choreographer.java:1693) 
	at android.view.Choreographer.doAnimationLoad(Choreographer.java:1523) 
	at android.view.Choreographer.doFrame(Choreographer.java:1438) 
	at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:2284) 
	at android.os.Handler.handleCallback(Handler.java:1014) 
	at android.os.Handler.dispatchMessage(Handler.java:102) 
	at android.os.Looper.loopOnce(Looper.java:250) 
	at android.os.Looper.loop(Looper.java:340) 
	at android.app.ActivityThread.main(ActivityThread.java:9911) 
	at java.lang.reflect.Method.invoke(Native Method) 
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:621) 
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:957) 
Caused by: com.facebook.react.bridge.NoSuchKeyException: width
	at com.facebook.react.bridge.ReadableNativeMap.getValue(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:3)
	at com.facebook.react.bridge.ReadableNativeMap.getDouble(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:6)
	at r2.l.setSource(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:143)
	at com.facebook.react.views.image.ReactImageManager.setSource(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:6)
	at java.lang.reflect.Method.invoke(Native Method) 
	at G0.a.q(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:89) 
	at com.facebook.react.uimanager.ViewManager.updateProperties(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:33) 
	at com.facebook.react.uimanager.ViewManager.createViewInstance(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:12) 
	at com.facebook.react.uimanager.ViewManager.createView(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:1) 
	at q1.h.b(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:62) 
	at r1.g.execute(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:67) 
	at q1.b.d(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:71) 
	at q1.b.c(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:64) 
	at m1.j.a(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:100) 
	at com.facebook.react.uimanager.d.doFrame(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:1) 
	at E1.o.doFrame(r8-map-id-1a92cc952529f7daea85f71c4ad30656f52b60c3e338ced74ff1293d461ae7b1:98) 
	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:2457) 
	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:2468) 
	at android.view.Choreographer.doCallbacks(Choreographer.java:1693) 
	at android.view.Choreographer.doAnimationLoad(Choreographer.java:1523) 
	at android.view.Choreographer.doFrame(Choreographer.java:1438) 
	at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:2284) 
	at android.os.Handler.handleCallback(Handler.java:1014) 
	at android.os.Handler.dispatchMessage(Handler.java:102) 
	at android.os.Looper.loopOnce(Looper.java:250) 
	at android.os.Looper.loop(Looper.java:340) 
	at android.app.ActivityThread.main(ActivityThread.java:9911) 
	at java.lang.reflect.Method.invoke(Native Method) 
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:621) 
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:957) 

```
</details>

On android we pass the `defaultSource` and `loadingIndicatorSrc` as strings. however, when enabling prop diffing this causes crashes, as the prop diff mechanism is parsing them to `ImageSource` as defined in `ImageProps.h`.

W/o props 2.0 diffing we simply return the props as we receive them from JS (with those sources as string):

https://github.com/facebook/react-native/blob/c12806c4937ea76d65e89e6f0857e4c96e47c927/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp#L341

With props diffing …

https://github.com/facebook/react-native/blob/c12806c4937ea76d65e89e6f0857e4c96e47c927/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp#L309

… We actually transform them to the c++ object:

https://github.com/facebook/react-native/blob/c12806c4937ea76d65e89e6f0857e4c96e47c927/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp#L210-L215

https://github.com/facebook/react-native/blob/c12806c4937ea76d65e89e6f0857e4c96e47c927/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h#L29-L30

https://github.com/facebook/react-native/blob/c12806c4937ea76d65e89e6f0857e4c96e47c927/packages/react-native/ReactCommon/react/renderer/imagemanager/primitives.h#L47-L74

This throws errors and crashes the app:


https://github.com/user-attachments/assets/04d20369-f49a-4170-8747-643766fba971



I think the proper solution here is to pass the full objects down, with or without props 2.0 diffing and handle the objects in native code correctly. This way android aligns with the iOS implementation too.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] [FIXED] - fixed `defaultSource` and `loadingIndicatorSrc` causing a crash when `enablePropsUpdateReconciliationAndroid` is enabled
[ANDROID] [BREAKING] - Changed `ReactImageView#setDefaultSource(String?)` to  `ReactImageView#setDefaultSource(ReadableMap?)`
[ANDROID] [BREAKING] - Changed `ReactImageView#setLoadingIndicatorSource(String?)` to  `ReactImageView#setLoadingIndicatorSource(ReadableMap?)`

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

1. Test that the defaultProp example in RNTester is working
2. Enable props 2.0 diffing mechanism:
```diff
diff --git a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android.kt b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android.kt
index bb0a6b525da..04fcbf4ba8f 100644
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android.kt
@@ -11,4 +11,8 @@ public class ReactNativeFeatureFlagsOverrides_RNOSS_Stable_Android() :
     ReactNativeNewArchitectureFeatureFlagsDefaults() {
 
   override fun useFabricInterop(): Boolean = true
+
+  override fun enableAccumulatedUpdatesInRawPropsAndroid(): Boolean = true
+  override fun enablePropsUpdateReconciliationAndroid(): Boolean = true
+  override fun enableExclusivePropsUpdateAndroid(): Boolean = true
 }
```

3. Test all image examples:
    - Verify there is no crash
    - Verify defaultSource example is working

Recordings:

| Debug | Release |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/df5d75e7-4666-4201-81e7-39271c54fe0b" /> | <video src="https://github.com/user-attachments/assets/d64fcefd-6d1f-4d84-8581-363ff572a721" /> | 

Note: this uses the example setup from this PR in the recordings:
- https://github.com/facebook/react-native/pull/55234
