### PR TITLE
Support Android predictive back animation when exiting app

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
@@ -182,4 +182,8 @@ public abstract class ReactActivity extends AppCompatActivity
   protected final void loadApp(String appKey) {
     mDelegate.loadApp(appKey);
   }
+
+  protected OnBackPressedCallback getBackPressedCallback() {
+    return mBackPressedCallback;
+  }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
@@ -122,11 +122,12 @@ public abstract class ReactActivity extends AppCompatActivity
   public void invokeDefaultOnBackPressed() {
     // Disabling callback so the fallback logic (finish activity) can run
     // as super.onBackPressed() will call all enabled callbacks in the dispatcher.
+    boolean enabled = mBackPressedCallback.isEnabled();
     mBackPressedCallback.setEnabled(false);
     super.onBackPressed();
     // Re-enable callback to ensure custom back handling works after activity resume
     // Without this, the callback remains disabled when the app returns from background
-    mBackPressedCallback.setEnabled(true);
+    mBackPressedCallback.setEnabled(enabled);
   }
 
   @Override


### PR DESCRIPTION
## Summary:

When [onBackPressed was migrated to OnBackPressedCallback](https://github.com/facebook/react-native/pull/51096) react native lost the predictive back animation when exiting an app. This PR aims to restore the predictive back animation for apps that support predictive back (it's not reasonable to try and bring this back for all apps). Apps that support predictive back, for example, those [that use the Navigation router](https://grahammendick.github.io/navigation/native/), can disable the callback in their Activity.

```java
getBackPressedCallback().setEnabled(false);
```

### Expected behavior (and before the migration)

https://github.com/user-attachments/assets/0f9fd77a-46ec-4a4f-9a20-859df899c902

### Current behavior

https://github.com/user-attachments/assets/fdcdc001-4894-474e-b130-6c5526247e39

## Changelog:

[ANDROID] [FIXED] - Support predictive back animation when exiting app

## Test Plan:

Here is the [the Navigation router sample](https://github.com/grahammendick/navigation/tree/master/NavigationReactNative/sample/fabric) running with the callback disabled

https://github.com/user-attachments/assets/847144f6-b4c5-4594-ac3e-ccf2ec2cc20c

