### PR TITLE
Update View-itest.js for pointerEvents box-only unflattening behavior

### DIFF
--- a/packages/react-native/Libraries/Components/View/__tests__/View-itest.js
+++ b/packages/react-native/Libraries/Components/View/__tests__/View-itest.js
@@ -313,16 +313,8 @@ describe('<View>', () => {
           root.getRenderedOutput({props: ['pointerEvents']}).toJSX(),
         ).toEqual(null);
       });
-      it('box-only propagates to the mounting layer, does not unflatten', () => {
+      it('box-only propagates to the mounting layer, unflattens', () => {
         const root = Fantom.createRoot();
-
-        Fantom.runTask(() => {
-          root.render(<View collapsable={false} pointerEvents="box-only" />);
-        });
-
-        expect(
-          root.getRenderedOutput({props: ['pointerEvents']}).toJSX(),
-        ).toEqual(<rn-view pointerEvents="box-only" />);
 
         Fantom.runTask(() => {
           root.render(<View pointerEvents="box-only" />);
@@ -330,7 +322,7 @@ describe('<View>', () => {
 
         expect(
           root.getRenderedOutput({props: ['pointerEvents']}).toJSX(),
-        ).toEqual(null);
+        ).toEqual(<rn-view pointerEvents="box-only" />);
       });
       it('none propagates to the mounting layer, unflattens', () => {
         const root = Fantom.createRoot();


### PR DESCRIPTION
Summary:
D90772188 changed the behavior of views with `pointerEvents="box-only"` to prevent them from being collapsed/flattened. This is intentional because when `important_for_interaction` is applied on a view with `pointerEvents='box-only'`, the view must remain in the hierarchy to correctly signal to the gaze system that its children are not important for interaction.

The test expected the old behavior where `<View pointerEvents="box-only" />` would be collapsed and render `null`. After the C++ change, views with `pointerEvents="box-only"` now always form a stacking context and are not collapsed.

Updated the test to expect the new behavior where `pointerEvents="box-only"` causes views to unflatten, consistent with how `pointerEvents="none"` behaves.

Differential Revision: D90984297


