### PR TITLE
Fix bump of Podfile.lock after release

### DIFF
--- a/.github/workflows/bump-podfile-lock.yml
+++ b/.github/workflows/bump-podfile-lock.yml
@@ -35,8 +35,9 @@ jobs:
       - name: Bump podfile.lock
         run: |
           cd packages/rn-tester
+          rm Podfile.lock
           bundle install
-          bundle exec pod update hermes-engine --no-repo-update
+          bundle exec pod install
       - name: Commit changes
         run: |
           git add packages/rn-tester/Podfile.lock


### PR DESCRIPTION
Summary:
Changelog: [Internal]

As suggested by cipolleschi, this is a more stable solution given that the workflow has been consistently failing for the past couple of RCs.

Differential Revision: D90992194


