### PR TITLE
example(android): show default source image example

### DIFF
--- a/packages/rn-tester/js/examples/Image/ImageExample.js
+++ b/packages/rn-tester/js/examples/Image/ImageExample.js
@@ -18,7 +18,7 @@ import RNTesterText from '../../components/RNTesterText';
 import ImageCapInsetsExample from './ImageCapInsetsExample';
 import React from 'react';
 import {useEffect, useState} from 'react';
-import {Image, ImageBackground, StyleSheet, Text, View} from 'react-native';
+import {Image, ImageBackground, Platform, StyleSheet, Text, View} from 'react-native';
 
 const IMAGE1 =
   'https://www.facebook.com/assets/fb_lite_messaging/E2EE-settings@3x.png';
@@ -1040,7 +1040,13 @@ exports.examples = [
     render: function (): React.Node {
       return (
         <Image
-          defaultSource={require('../../assets/bunny.png')}
+          defaultSource={Platform.select({
+            ios: require('../../assets/bunny.png'),
+            // Android note:
+            // In development mode, require()'d images are not bundled into APK,
+            // so we use a different image that is known to be bundled.
+            android: __DEV__ ? { uri: "legacy_image" } : require('../../assets/alpha-hotdog.png'),
+          })}
           source={{
             // Note: Use a large image and bust cache so we can in fact
             // visualize the `defaultSource` image.
@@ -1050,7 +1056,6 @@ exports.examples = [
         />
       );
     },
-    platform: 'ios',
   },
   {
     title: 'Cache Policy',


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This enables the Image `defaultSource` prop example for android.

In debug builds we have to use a bundled image, as we just try to resolve it from the app's resources:

https://github.com/facebook/react-native/blob/c12806c4937ea76d65e89e6f0857e4c96e47c927/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.kt#L339-L340

The rational for this one is that i am experiencing a bug with `defaultSource` on android and this example is helping in the following PRs:

- https://github.com/facebook/react-native/pull/55210

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

[Internal] - RNTester app android enable Image `defaultSource` prop example

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[Internal] - RNTester app android enable Image `defaultSource` prop example

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Tested in tester app.

Debug:

https://github.com/user-attachments/assets/1a9ebba7-6b7b-4075-8422-803c35a8954c

Release:

https://github.com/user-attachments/assets/eb7f25c4-1d69-4ad5-a33b-663039781d1e


