### PR TITLE
Replace deprecated url.parse in dev-middleware

### DIFF
--- a/packages/dev-middleware/src/__tests__/ServerUtils.js
+++ b/packages/dev-middleware/src/__tests__/ServerUtils.js
@@ -16,7 +16,6 @@ import connect from 'connect';
 import http from 'http';
 import https from 'https';
 import * as selfsigned from 'selfsigned';
-import url from 'url';
 
 type CreateDevMiddlewareOptions = Parameters<typeof createDevMiddleware>[0];
 type CreateServerOptions = {
@@ -109,7 +108,7 @@ export async function createServer(options: CreateServerOptions): Promise<{
       });
       app.use(middleware);
       httpServer.on('upgrade', (request, socket, head) => {
-        const {pathname} = url.parse(request.url);
+        const {pathname} = new URL(request.url, 'http://example.com');
         if (pathname != null && websocketEndpoints[pathname]) {
           websocketEndpoints[pathname].handleUpgrade(
             request,

--- a/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
+++ b/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
@@ -22,7 +22,6 @@ import type {IncomingMessage, ServerResponse} from 'http';
 
 import getDevToolsFrontendUrl from '../utils/getDevToolsFrontendUrl';
 import {createHash} from 'crypto';
-import url from 'url';
 
 const LEGACY_SYNTHETIC_PAGE_TITLE =
   'React Native Experimental (Improved Chrome Reloads)';
@@ -74,7 +73,7 @@ export default function openDebuggerMiddleware({
       req.method === 'POST' ||
       (experiments.enableOpenDebuggerRedirect && req.method === 'GET')
     ) {
-      const parsedUrl = url.parse(req.url, true);
+      const {searchParams} = new URL(req.url, 'http://example.com');
 
       const query: {
         /** @deprecated Will only match legacy Hermes targets */
@@ -86,7 +85,7 @@ export default function openDebuggerMiddleware({
         target?: string,
         panel?: string,
         ...
-      } = parsedUrl.query;
+      } = Object.fromEntries(searchParams);
 
       const targets = inspectorProxy
         .getPageDescriptions({requestorRelativeBaseUrl: new URL(serverBaseUrl)})


### PR DESCRIPTION
Summary:
Use of Node's `url.parse` is deprecated and emits a runtime warning (when used in 1P code) from Node 24.

This wouldn't directly affect RN users, but does create noise running from monorepo source.

Changelog: [Internal]

Differential Revision: D90992431


