### PR TITLE
Add multi-session support to Device.js

### DIFF
--- a/packages/dev-middleware/src/__tests__/InspectorDeviceUtils.js
+++ b/packages/dev-middleware/src/__tests__/InspectorDeviceUtils.js
@@ -16,7 +16,7 @@ import type {
   JSONSerializable,
   MessageFromDevice,
   MessageToDevice,
-  WrappedEvent,
+  WrappedEventToDevice,
 } from '../inspector-proxy/types';
 
 import nullthrows from 'nullthrows';
@@ -106,9 +106,14 @@ export class DeviceMock extends DeviceAgent {
     | Promise<GetPagesResponse['payload'] | void>
     | void,
   > = jest.fn();
-  +wrappedEvent: JestMockFn<[message: WrappedEvent], void> = jest.fn();
+  +wrappedEvent: JestMockFn<[message: WrappedEventToDevice], void> = jest.fn();
   +wrappedEventParsed: JestMockFn<
-    [payload: {...WrappedEvent['payload'], wrappedEvent: JSONSerializable}],
+    [
+      payload: {
+        ...WrappedEventToDevice['payload'],
+        wrappedEvent: JSONSerializable,
+      },
+    ],
     void,
   > = jest.fn();
 

--- a/packages/dev-middleware/src/__tests__/InspectorProxyCdpRewritingHacks-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyCdpRewritingHacks-test.js
@@ -566,7 +566,7 @@ describe.each(['HTTP', 'HTTPS'])(
 
       describe('Debugger.getScriptSource', () => {
         test('should forward request directly to device (does not read source from disk in proxy)', async () => {
-          const {device, debugger_} = await createAndConnectTarget(
+          const {device, debugger_, sessionId} = await createAndConnectTarget(
             serverRef,
             autoCleanup.signal,
             pageDescription,
@@ -579,10 +579,17 @@ describe.each(['HTTP', 'HTTPS'])(
                 scriptId: 'script1',
               },
             };
-            await sendFromDebuggerToTarget(debugger_, device, 'page1', message);
+            await sendFromDebuggerToTarget(
+              debugger_,
+              device,
+              'page1',
+              message,
+              {sessionId},
+            );
 
             expect(device.wrappedEventParsed).toBeCalledWith({
               pageId: 'page1',
+              sessionId,
               wrappedEvent: message,
             });
           } finally {
@@ -594,7 +601,7 @@ describe.each(['HTTP', 'HTTPS'])(
 
       describe('Network.loadNetworkResource', () => {
         test('should forward event directly to client (does not rewrite url host)', async () => {
-          const {device, debugger_} = await createAndConnectTarget(
+          const {device, debugger_, sessionId} = await createAndConnectTarget(
             serverRef,
             autoCleanup.signal,
             pageDescription,
@@ -607,11 +614,19 @@ describe.each(['HTTP', 'HTTPS'])(
                 url: `${protocol.toLowerCase()}://10.0.2.2:${serverRef.port}`,
               },
             };
-            await sendFromDebuggerToTarget(debugger_, device, 'page1', message);
-            expect(device.wrappedEventParsed).toBeCalledWith({
-              pageId: 'page1',
-              wrappedEvent: message,
-            });
+            await sendFromDebuggerToTarget(
+              debugger_,
+              device,
+              'page1',
+              message,
+              {sessionId},
+            );
+            expect(device.wrappedEventParsed).toBeCalledWith(
+              expect.objectContaining({
+                pageId: 'page1',
+                wrappedEvent: message,
+              }),
+            );
           } finally {
             device.close();
             debugger_.close();

--- a/packages/dev-middleware/src/__tests__/InspectorProxyConcurrentSessions-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyConcurrentSessions-test.js
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {JsonPagesListResponse} from '../inspector-proxy/types';
+
+import {fetchJson} from './FetchUtils';
+import {createDebuggerMock} from './InspectorDebuggerUtils';
+import {createDeviceMock} from './InspectorDeviceUtils';
+import {withAbortSignalForEachTest} from './ResourceUtils';
+import {createServer} from './ServerUtils';
+import until from 'wait-for-expect';
+
+// WebSocket is unreliable when using fake timers.
+jest.useRealTimers();
+
+jest.setTimeout(10000);
+
+describe('inspector proxy concurrent sessions', () => {
+  const autoCleanup = withAbortSignalForEachTest();
+
+  describe('enableStandaloneFuseboxShell experiment disabled', () => {
+    test('page reporting supportsMultipleDebuggers:true is treated as false', async () => {
+      // Create a server with the experiment disabled
+      const {server} = await createServer({
+        logger: undefined,
+        unstable_experiments: {
+          enableStandaloneFuseboxShell: false,
+        },
+      });
+      const serverBaseUrl = `http://localhost:${server.address().port}`;
+      const serverBaseWsUrl = `ws://localhost:${server.address().port}`;
+
+      let device, debugger1, debugger2;
+      try {
+        // Connect a device with a page that explicitly reports supportsMultipleDebuggers: true
+        device = await createDeviceMock(
+          `${serverBaseWsUrl}/inspector/device?device=device1&name=foo&app=bar`,
+          autoCleanup.signal,
+        );
+        device.getPages.mockImplementation(() => [
+          {
+            id: 'page1',
+            app: 'bar-app',
+            title: 'bar-title',
+            vm: 'bar-vm',
+            capabilities: {
+              supportsMultipleDebuggers: true,
+            },
+          },
+        ]);
+
+        // Wait for page to be listed
+        let pageList: JsonPagesListResponse = [];
+        await until(async () => {
+          pageList = (await fetchJson(
+            `${serverBaseUrl}/json`,
+            // $FlowFixMe[unclear-type]
+          ): any);
+          expect(pageList).toHaveLength(1);
+        });
+
+        // Verify the capability is reported as false in the page list
+        expect(
+          pageList[0].reactNative?.capabilities?.supportsMultipleDebuggers,
+        ).toBe(false);
+
+        const webSocketDebuggerUrl = pageList[0].webSocketDebuggerUrl;
+
+        // Connect first debugger
+        debugger1 = await createDebuggerMock(
+          webSocketDebuggerUrl,
+          autoCleanup.signal,
+        );
+        await until(() => expect(device.connect).toHaveBeenCalledTimes(1));
+
+        // Connect second debugger - this should disconnect the first one
+        // because multi-session is disabled
+        debugger2 = await createDebuggerMock(
+          webSocketDebuggerUrl,
+          autoCleanup.signal,
+        );
+
+        // First debugger should be disconnected
+        await until(() =>
+          expect([3, 4]).toContain(debugger1.socket.readyState),
+        );
+
+        // Second debugger should be open
+        expect(debugger2.socket.readyState).toBe(1); // OPEN
+
+        // Device should have received disconnect for first session and connect for second
+        await until(() => expect(device.disconnect).toHaveBeenCalledTimes(1));
+        await until(() => expect(device.connect).toHaveBeenCalledTimes(2));
+      } finally {
+        device?.close();
+        debugger1?.close();
+        debugger2?.close();
+        server.close();
+      }
+    });
+  });
+});

--- a/packages/dev-middleware/src/__tests__/InspectorProxyCustomMessageHandler-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyCustomMessageHandler-test.js
@@ -202,6 +202,7 @@ describe('inspector proxy device message middleware', () => {
           event: 'wrappedEvent',
           payload: {
             pageId: page.id,
+            sessionId: expect.any(String),
             wrappedEvent: JSON.stringify({id: 1}),
           },
         }),
@@ -361,7 +362,11 @@ describe('inspector proxy device message middleware', () => {
       await until(() =>
         expect(device.wrappedEvent).toBeCalledWith({
           event: 'wrappedEvent',
-          payload: {pageId: page.id, wrappedEvent: JSON.stringify({id: 1337})},
+          payload: {
+            pageId: page.id,
+            sessionId: expect.any(String),
+            wrappedEvent: JSON.stringify({id: 1337}),
+          },
         }),
       );
       // Ensure the first message was not received by the device

--- a/packages/dev-middleware/src/__tests__/InspectorProxyReactNativeReloads-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyReactNativeReloads-test.js
@@ -90,6 +90,7 @@ describe('inspector proxy React Native reloads', () => {
       await until(() =>
         expect(device1.wrappedEventParsed).toBeCalledWith({
           pageId: 'originalPage-initial',
+          sessionId: expect.any(String),
           wrappedEvent: {
             method: 'Console.enable',
             id: 0,
@@ -133,6 +134,7 @@ describe('inspector proxy React Native reloads', () => {
       await until(() =>
         expect(device1.wrappedEventParsed).toBeCalledWith({
           pageId: 'originalPage-updated',
+          sessionId: expect.any(String),
           wrappedEvent: {
             method: 'Console.disable',
             id: 1,
@@ -311,6 +313,7 @@ describe('inspector proxy React Native reloads', () => {
       await until(async () => {
         expect(device1.wrappedEventParsed).toBeCalledWith({
           pageId: 'originalPage-updated',
+          sessionId: expect.any(String),
           wrappedEvent: {
             method: 'Runtime.enable',
             id: expect.any(Number),
@@ -318,6 +321,7 @@ describe('inspector proxy React Native reloads', () => {
         });
         expect(device1.wrappedEventParsed).toBeCalledWith({
           pageId: 'originalPage-updated',
+          sessionId: expect.any(String),
           wrappedEvent: {
             method: 'Debugger.enable',
             id: expect.any(Number),
@@ -354,6 +358,7 @@ describe('inspector proxy React Native reloads', () => {
       await until(() => {
         expect(device1.wrappedEventParsed).toBeCalledWith({
           pageId: 'originalPage-updated',
+          sessionId: expect.any(String),
           wrappedEvent: expect.objectContaining({
             method: 'Debugger.resume',
             id: expect.any(Number),
@@ -367,7 +372,7 @@ describe('inspector proxy React Native reloads', () => {
   });
 
   test('device disconnect event results in a nonstandard "reload" message to the debugger', async () => {
-    const {device, debugger_} = await createAndConnectTarget(
+    const {device, debugger_, sessionId} = await createAndConnectTarget(
       serverRef,
       autoCleanup.signal,
       {
@@ -383,6 +388,7 @@ describe('inspector proxy React Native reloads', () => {
         event: 'disconnect',
         payload: {
           pageId: 'page1',
+          sessionId,
         },
       });
       await until(() =>

--- a/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
+++ b/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
@@ -92,7 +92,7 @@ export default class InspectorProxy implements InspectorProxyQueries {
 
   #eventReporter: ?EventReporter;
 
-  #experiments: Experiments;
+  +#experiments: Experiments;
 
   // custom message handler factory allowing implementers to handle unsupported CDP messages.
   #customMessageHandler: ?CreateCustomMessageHandlerFn;
@@ -360,6 +360,7 @@ export default class InspectorProxy implements InspectorProxyQueries {
           deviceRelativeBaseUrl,
           serverRelativeBaseUrl: this.#serverBaseUrl,
           isProfilingBuild,
+          experiments: this.#experiments,
         };
 
         if (oldDevice) {

--- a/packages/dev-middleware/src/types/Experiments.js
+++ b/packages/dev-middleware/src/types/Experiments.js
@@ -27,6 +27,10 @@ export type Experiments = Readonly<{
    * Launch the Fusebox frontend in a standalone shell instead of a browser.
    * When this is enabled, we will use the optional unstable_showFuseboxShell
    * method on the BrowserLauncher, or throw an error if the method is missing.
+   *
+   * NOTE: Disabling this also disables support for concurrent sessions in the
+   * inspector proxy. Without the standalone shell, the proxy remains responsible
+   * for keeping only one debugger frontend active at a time per page.
    */
   enableStandaloneFuseboxShell: boolean,
 }>;


### PR DESCRIPTION
Summary:
Adds multi-session support to the Node side of the inspector-proxy protocol implementation. The protocol now has an explicit `sessionId` property in all relevant messages.

Multi-session support is fully backwards compatible:

* An app that does not report itself as multi-session capable will get the old proxy behaviour.
* If the `enableStandaloneFuseboxShell` experiment flag is disabled by the integrator/framework, we automatically disable multi-session support, too. This is to guarantee that we continue to have at most one active RNDT window/tab open per app. (The standalone shell guarantees this independently of the proxy, while the old browser-based flow requires the proxy to keep enforcing the single-session UX.)

Changelog: [General][Added] Support multiple CDP connections to one React Native Host (diff 2 of 2)

Differential Revision: D90174643
