### PR TITLE
Add multi-session support to InspectorPackagerConnection

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnectionImpl.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/InspectorPackagerConnectionImpl.h
@@ -39,7 +39,6 @@ class InspectorPackagerConnection::Impl : public IWebSocketDelegate,
   void connect();
   void closeQuietly();
   void sendEventToAllConnections(const std::string &event);
-  std::unique_ptr<ILocalConnection> removeConnectionForPage(const std::string &pageId);
 
   /**
    * Send a message to the packager as soon as possible. This method is safe
@@ -47,14 +46,21 @@ class InspectorPackagerConnection::Impl : public IWebSocketDelegate,
    * is sent, in which case the message will be dropped. The message is also
    * dropped if the session is no longer valid.
    */
-  void scheduleSendToPackager(folly::dynamic message, SessionId sourceSessionId, const std::string &sourcePageId);
+  void scheduleSendToPackager(
+      folly::dynamic message,
+      SessionId sourceSessionId,
+      const std::string &sourcePageId,
+      const std::string &sourceProxySessionId);
 
  private:
   struct Session {
     std::unique_ptr<ILocalConnection> localConnection;
     SessionId sessionId;
+    std::string proxySessionId; // Session ID assigned by the proxy
   };
   class RemoteConnection;
+  using PageSessions = std::unordered_map<std::string /* proxySessionId */, Session>;
+  using InspectorSessionsByPage = std::unordered_map<std::string /* pageId */, PageSessions>;
 
   Impl(
       std::string url,
@@ -68,6 +74,31 @@ class InspectorPackagerConnection::Impl : public IWebSocketDelegate,
   void handleConnect(const folly::const_dynamic_view &payload);
   void handleWrappedEvent(const folly::const_dynamic_view &payload);
   void handleProxyMessage(const folly::const_dynamic_view &message);
+
+  /**
+   * Finds the page and session and referenced by the given message payload.
+   * Returns a pair of valid (dereferenceable) iterators if found, or nullopt otherwise.
+   * Supports both legacy single-session mode (proxySessionId == missing or empty) and multi-session mode
+   * (proxySessionId == some unique identifier assigned by the proxy).
+   */
+  std::optional<std::pair<InspectorSessionsByPage::iterator, PageSessions::iterator>> findPageAndSession(
+      const folly::const_dynamic_view &payload,
+      std::string_view caller);
+
+  /**
+   * Given a pair of (dereferenceable) iterators as returned by findPageAndSession, disconnects the
+   * given session. Invalidates the session iterator and may invalidate the page iterator. Returns
+   * the page iterator if still valid, or the corresponding end() iterator otherwise - this is
+   * useful when disconnecting multiple sessions in a loop.
+   */
+  InspectorSessionsByPage::iterator disconnectSession(
+      std::pair<InspectorSessionsByPage::iterator, PageSessions::iterator> sessionIterators);
+
+  /**
+   * Switch to legacy single-session mode.
+   */
+  void disconnectNonLegacySessions(const std::string &pageId);
+
   folly::dynamic pages();
   void reconnect();
   void closeAllConnections();
@@ -90,7 +121,9 @@ class InspectorPackagerConnection::Impl : public IWebSocketDelegate,
   const std::string appName_;
   const std::unique_ptr<InspectorPackagerConnectionDelegate> delegate_;
 
-  std::unordered_map<std::string, Session> inspectorSessions_;
+  // Nested map: pageId → (proxySessionId → Session)
+  // Supports multiple concurrent debugger sessions per page
+  InspectorSessionsByPage inspectorSessionsByPage_;
   std::unique_ptr<IWebSocket> webSocket_;
   bool connected_{false};
   bool closed_{false};
@@ -107,7 +140,8 @@ class InspectorPackagerConnection::Impl::RemoteConnection : public IRemoteConnec
   RemoteConnection(
       std::weak_ptr<InspectorPackagerConnection::Impl> owningPackagerConnection,
       std::string pageId,
-      SessionId sessionId);
+      SessionId sessionId,
+      std::string proxySessionId);
 
   // IRemoteConnection methods
   void onMessage(std::string message) override;
@@ -117,6 +151,7 @@ class InspectorPackagerConnection::Impl::RemoteConnection : public IRemoteConnec
   const std::weak_ptr<InspectorPackagerConnection::Impl> owningPackagerConnection_;
   const std::string pageId_;
   const SessionId sessionId_;
+  const std::string proxySessionId_;
 };
 
 } // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/__docs__/InspectorPackagerConnection.md
+++ b/packages/react-native/ReactCommon/jsinspector-modern/__docs__/InspectorPackagerConnection.md
@@ -1,0 +1,70 @@
+# InspectorPackagerConnection
+
+[🏠 Home](../../../../../__docs__/README.md)
+
+`InspectorPackagerConnection` is the shared C++ implementation of the
+device-side inspector-proxy protocol, located in
+`ReactCommon/jsinspector-modern/`.
+
+## 🚀 Usage
+
+This class handles:
+
+1. **WebSocket connection** to the inspector proxy at `/inspector/device`
+2. **Protocol message handling**: `getPages`, `connect`, `disconnect`,
+   `wrappedEvent`
+3. **Session management**: Routing CDP messages between the proxy and inspector
+   targets
+
+### Multi-Debugger Support
+
+The implementation supports multiple concurrent debugger sessions per page via
+`sessionId` routing:
+
+- **Incoming `connect`**: Creates a new session keyed by `pageId` + `sessionId`
+- **Incoming `wrappedEvent`**: Routes to the specific session by `sessionId`
+- **Outgoing `wrappedEvent`**: Includes `sessionId` for proxy routing
+- **Capability reporting**: Reports `supportsMultipleDebuggers: true` in page
+  capabilities
+
+## 📐 Design
+
+For canonical protocol documentation, see:
+**[Inspector Proxy Protocol](../../../../dev-middleware/src/inspector-proxy/__docs__/README.md)**
+
+### Session Data Structure
+
+Sessions are stored in a nested map for efficient page-level operations:
+
+```cpp
+std::unordered_map<std::string, std::unordered_map<std::string, Session>> inspectorSessions_;
+// pageId → (sessionId → Session)
+```
+
+### Compatibility with Legacy Proxies
+
+When connected to a legacy proxy that doesn't send `sessionId`:
+
+- Device treats the connection as a single-session legacy connection
+- Device generates an internal session ID for routing
+- Device includes `sessionId` in outgoing messages (legacy proxies ignore it)
+
+## 🔗 Relationship with other systems
+
+### Part of
+
+- React Native jsinspector-modern
+
+### Uses this
+
+- **Inspector Proxy** (`dev-middleware/src/inspector-proxy/`) - The Node.js
+  proxy that this connects to
+- **Platform delegates** - iOS (`RCTInspectorDevServerHelper.mm`), Android
+  (`DevServerHelper.kt`), ReactCxxPlatform (`Inspector.cpp`) provide WebSocket
+  I/O
+
+### Used by this
+
+- **IInspector** - The inspector instance for page registration and connection
+- **HostTarget / InstanceTarget / RuntimeTarget** - The CDP targets that handle
+  debugger sessions

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorPackagerConnectionMultiSessionTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorPackagerConnectionMultiSessionTest.cpp
@@ -1,0 +1,692 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <fmt/format.h>
+#include <folly/json.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "FollyDynamicMatchers.h"
+#include "InspectorPackagerConnectionTest.h"
+
+/**
+ * Tests for multi-session support in InspectorPackagerConnection.
+ *
+ * These tests verify that multiple debugger sessions can connect to
+ * the same page simultaneously using session IDs.
+ */
+
+using namespace ::testing;
+using namespace std::literals::chrono_literals;
+using namespace std::literals::string_literals;
+using folly::toJson;
+
+namespace facebook::react::jsinspector_modern {
+
+using InspectorPackagerConnectionMultiSessionTest =
+    InspectorPackagerConnectionTest;
+
+TEST_F(
+    InspectorPackagerConnectionMultiSessionTest,
+    TestReportsMultiDebuggerCapability) {
+  InSequence mockCallsMustBeInSequence;
+
+  packagerConnection_->connect();
+
+  auto pageId = getInspectorInstance().addPage(
+      "mock-description",
+      "mock-vm",
+      localConnections_
+          .lazily_make_unique<std::unique_ptr<IRemoteConnection>>());
+
+  // getPages should report supportsMultipleDebuggers: true
+  EXPECT_CALL(
+      *webSockets_[0],
+      send(JsonParsed(AllOf(
+          AtJsonPtr("/event", Eq("getPages")),
+          AtJsonPtr(
+              "/payload",
+              Contains(AllOf(
+                  AtJsonPtr("/id", Eq(std::to_string(pageId))),
+                  AtJsonPtr(
+                      "/capabilities/supportsMultipleDebuggers",
+                      Eq(true)))))))))
+      .RetiresOnSaturation();
+  webSockets_[0]->getDelegate().didReceiveMessage(R"({
+      "event": "getPages"
+    })");
+
+  getInspectorInstance().removePage(pageId);
+}
+
+TEST_F(
+    InspectorPackagerConnectionMultiSessionTest,
+    TestMultipleSessionsConnectToSamePage) {
+  auto mockCallsMustBeInSequence = std::make_optional<InSequence>();
+
+  packagerConnection_->connect();
+
+  auto pageId = getInspectorInstance().addPage(
+      "mock-description",
+      "mock-vm",
+      localConnections_
+          .lazily_make_unique<std::unique_ptr<IRemoteConnection>>());
+
+  // Connect first session with sessionId
+  webSockets_[0]->getDelegate().didReceiveMessage(
+      fmt::format(
+          R"({{
+          "event": "connect",
+          "payload": {{
+            "pageId": {0},
+            "sessionId": "session-1"
+          }}
+        }})",
+          toJson(std::to_string(pageId))));
+  ASSERT_TRUE(localConnections_[0]);
+
+  // Connect second session with different sessionId
+  webSockets_[0]->getDelegate().didReceiveMessage(
+      fmt::format(
+          R"({{
+          "event": "connect",
+          "payload": {{
+            "pageId": {0},
+            "sessionId": "session-2"
+          }}
+        }})",
+          toJson(std::to_string(pageId))));
+  ASSERT_TRUE(localConnections_[1]);
+
+  // Both connections should still be active
+  EXPECT_TRUE(localConnections_[0]);
+  EXPECT_TRUE(localConnections_[1]);
+
+  // The `disconnect` calls are not guaranteed to happen in order, so tear down
+  // our InSequence guard before cleaning up.
+  mockCallsMustBeInSequence.reset();
+  EXPECT_CALL(*localConnections_[0], disconnect()).RetiresOnSaturation();
+  EXPECT_CALL(*localConnections_[1], disconnect()).RetiresOnSaturation();
+  getInspectorInstance().removePage(pageId);
+}
+
+TEST_F(
+    InspectorPackagerConnectionMultiSessionTest,
+    TestWrappedEventRoutedBySessionId) {
+  auto mockCallsMustBeInSequence = std::make_optional<InSequence>();
+
+  packagerConnection_->connect();
+
+  auto pageId = getInspectorInstance().addPage(
+      "mock-description",
+      "mock-vm",
+      localConnections_
+          .lazily_make_unique<std::unique_ptr<IRemoteConnection>>());
+
+  // Connect two sessions
+  webSockets_[0]->getDelegate().didReceiveMessage(
+      fmt::format(
+          R"({{
+          "event": "connect",
+          "payload": {{
+            "pageId": {0},
+            "sessionId": "session-1"
+          }}
+        }})",
+          toJson(std::to_string(pageId))));
+  ASSERT_TRUE(localConnections_[0]);
+
+  webSockets_[0]->getDelegate().didReceiveMessage(
+      fmt::format(
+          R"({{
+          "event": "connect",
+          "payload": {{
+            "pageId": {0},
+            "sessionId": "session-2"
+          }}
+        }})",
+          toJson(std::to_string(pageId))));
+  ASSERT_TRUE(localConnections_[1]);
+
+  // Send a message to session-1 only
+  EXPECT_CALL(
+      *localConnections_[0],
+      sendMessage(JsonParsed(AtJsonPtr("/method", Eq("FakeDomain.method1")))))
+      .RetiresOnSaturation();
+  webSockets_[0]->getDelegate().didReceiveMessage(
+      fmt::format(
+          R"({{
+          "event": "wrappedEvent",
+          "payload": {{
+            "pageId": {0},
+            "sessionId": "session-1",
+            "wrappedEvent": {1}
+          }}
+        }})",
+          toJson(std::to_string(pageId)),
+          toJson(R"({"method": "FakeDomain.method1"})")));
+
+  // Send a message to session-2 only
+  EXPECT_CALL(
+      *localConnections_[1],
+      sendMessage(JsonParsed(AtJsonPtr("/method", Eq("FakeDomain.method2")))))
+      .RetiresOnSaturation();
+  webSockets_[0]->getDelegate().didReceiveMessage(
+      fmt::format(
+          R"({{
+          "event": "wrappedEvent",
+          "payload": {{
+            "pageId": {0},
+            "sessionId": "session-2",
+            "wrappedEvent": {1}
+          }}
+        }})",
+          toJson(std::to_string(pageId)),
+          toJson(R"({"method": "FakeDomain.method2"})")));
+
+  // The `disconnect` calls are not guaranteed to happen in order, so tear down
+  // our InSequence guard before cleaning up.
+  mockCallsMustBeInSequence.reset();
+  EXPECT_CALL(*localConnections_[0], disconnect()).RetiresOnSaturation();
+  EXPECT_CALL(*localConnections_[1], disconnect()).RetiresOnSaturation();
+  getInspectorInstance().removePage(pageId);
+}
+
+TEST_F(InspectorPackagerConnectionMultiSessionTest, TestDisconnectBySessionId) {
+  InSequence mockCallsMustBeInSequence;
+
+  packagerConnection_->connect();
+
+  auto pageId = getInspectorInstance().addPage(
+      "mock-description",
+      "mock-vm",
+      localConnections_
+          .lazily_make_unique<std::unique_ptr<IRemoteConnection>>());
+
+  // Connect two sessions
+  webSockets_[0]->getDelegate().didReceiveMessage(
+      fmt::format(
+          R"({{
+          "event": "connect",
+          "payload": {{
+            "pageId": {0},
+            "sessionId": "session-1"
+          }}
+        }})",
+          toJson(std::to_string(pageId))));
+  ASSERT_TRUE(localConnections_[0]);
+
+  webSockets_[0]->getDelegate().didReceiveMessage(
+      fmt::format(
+          R"({{
+          "event": "connect",
+          "payload": {{
+            "pageId": {0},
+            "sessionId": "session-2"
+          }}
+        }})",
+          toJson(std::to_string(pageId))));
+  ASSERT_TRUE(localConnections_[1]);
+
+  // Disconnect session-1 only
+  EXPECT_CALL(*localConnections_[0], disconnect()).RetiresOnSaturation();
+  webSockets_[0]->getDelegate().didReceiveMessage(
+      fmt::format(
+          R"({{
+          "event": "disconnect",
+          "payload": {{
+            "pageId": {0},
+            "sessionId": "session-1"
+          }}
+        }})",
+          toJson(std::to_string(pageId))));
+  EXPECT_FALSE(localConnections_[0]);
+
+  // Session-2 should still be active
+  EXPECT_TRUE(localConnections_[1]);
+
+  // Can still send messages to session-2
+  EXPECT_CALL(
+      *localConnections_[1],
+      sendMessage(JsonParsed(AtJsonPtr("/method", Eq("FakeDomain.method")))))
+      .RetiresOnSaturation();
+  webSockets_[0]->getDelegate().didReceiveMessage(
+      fmt::format(
+          R"({{
+          "event": "wrappedEvent",
+          "payload": {{
+            "pageId": {0},
+            "sessionId": "session-2",
+            "wrappedEvent": {1}
+          }}
+        }})",
+          toJson(std::to_string(pageId)),
+          toJson(R"({"method": "FakeDomain.method"})")));
+
+  // Clean up
+  EXPECT_CALL(*localConnections_[1], disconnect()).RetiresOnSaturation();
+  getInspectorInstance().removePage(pageId);
+}
+
+TEST_F(
+    InspectorPackagerConnectionMultiSessionTest,
+    TestOutgoingMessagesIncludeSessionId) {
+  InSequence mockCallsMustBeInSequence;
+
+  packagerConnection_->connect();
+
+  auto pageId = getInspectorInstance().addPage(
+      "mock-description",
+      "mock-vm",
+      localConnections_
+          .lazily_make_unique<std::unique_ptr<IRemoteConnection>>());
+
+  // Connect with a sessionId
+  webSockets_[0]->getDelegate().didReceiveMessage(
+      fmt::format(
+          R"({{
+          "event": "connect",
+          "payload": {{
+            "pageId": {0},
+            "sessionId": "my-session"
+          }}
+        }})",
+          toJson(std::to_string(pageId))));
+  ASSERT_TRUE(localConnections_[0]);
+
+  // When the local connection sends a message, it should include the sessionId
+  EXPECT_CALL(
+      *webSockets_[0],
+      send(JsonParsed(AllOf(
+          AtJsonPtr("/event", Eq("wrappedEvent")),
+          AtJsonPtr("/payload/pageId", Eq(std::to_string(pageId))),
+          AtJsonPtr("/payload/sessionId", Eq("my-session")),
+          AtJsonPtr(
+              "/payload/wrappedEvent",
+              JsonParsed(AtJsonPtr("/method", Eq("FakeDomain.event"))))))))
+      .RetiresOnSaturation();
+  localConnections_[0]->getRemoteConnection().onMessage(
+      R"({"method": "FakeDomain.event"})");
+
+  // When the local connection disconnects, it should include the sessionId
+  EXPECT_CALL(
+      *webSockets_[0],
+      send(JsonParsed(AllOf(
+          AtJsonPtr("/event", Eq("disconnect")),
+          AtJsonPtr("/payload/pageId", Eq(std::to_string(pageId))),
+          AtJsonPtr("/payload/sessionId", Eq("my-session"))))))
+      .RetiresOnSaturation();
+  localConnections_[0]->getRemoteConnection().onDisconnect();
+
+  EXPECT_CALL(*localConnections_[0], disconnect()).RetiresOnSaturation();
+  getInspectorInstance().removePage(pageId);
+}
+
+TEST_F(
+    InspectorPackagerConnectionTest,
+    TestLegacyConnectionWithEmptySessionId) {
+  InSequence mockCallsMustBeInSequence;
+
+  packagerConnection_->connect();
+
+  auto pageId = getInspectorInstance().addPage(
+      "mock-description",
+      "mock-vm",
+      localConnections_
+          .lazily_make_unique<std::unique_ptr<IRemoteConnection>>());
+
+  // Connect without sessionId (legacy proxy). This is treated as an empty
+  // string sessionId.
+  webSockets_[0]->getDelegate().didReceiveMessage(
+      fmt::format(
+          R"({{
+          "event": "connect",
+          "payload": {{
+            "pageId": {0}
+          }}
+        }})",
+          toJson(std::to_string(pageId))));
+  ASSERT_TRUE(localConnections_[0]);
+
+  // Incoming messages are routed correctly when sessionId is omitted
+  EXPECT_CALL(
+      *localConnections_[0],
+      sendMessage(JsonParsed(AtJsonPtr("/method", Eq("FakeDomain.method")))))
+      .RetiresOnSaturation();
+  webSockets_[0]->getDelegate().didReceiveMessage(
+      fmt::format(
+          R"({{
+          "event": "wrappedEvent",
+          "payload": {{
+            "pageId": {0},
+            "wrappedEvent": {1}
+          }}
+        }})",
+          toJson(std::to_string(pageId)),
+          toJson(R"({"method": "FakeDomain.method"})")));
+
+  // Outgoing messages include the empty string sessionId
+  EXPECT_CALL(
+      *webSockets_[0],
+      send(JsonParsed(AllOf(
+          AtJsonPtr("/event", Eq("wrappedEvent")),
+          AtJsonPtr("/payload/pageId", Eq(std::to_string(pageId))),
+          AtJsonPtr("/payload/sessionId", Eq("")),
+          AtJsonPtr(
+              "/payload/wrappedEvent",
+              JsonParsed(AtJsonPtr("/method", Eq("FakeDomain.event"))))))))
+      .RetiresOnSaturation();
+  localConnections_[0]->getRemoteConnection().onMessage(
+      R"({"method": "FakeDomain.event"})");
+
+  // Disconnect when sessionId is omitted
+  EXPECT_CALL(*localConnections_[0], disconnect()).RetiresOnSaturation();
+  webSockets_[0]->getDelegate().didReceiveMessage(
+      fmt::format(
+          R"({{
+          "event": "disconnect",
+          "payload": {{
+            "pageId": {0}
+          }}
+        }})",
+          toJson(std::to_string(pageId))));
+  EXPECT_FALSE(localConnections_[0]);
+}
+
+TEST_F(
+    InspectorPackagerConnectionTest,
+    TestDuplicateSessionIdDisconnectsExisting) {
+  // NOTE: See TestConnectWhileAlreadyConnectedCausesDisconnection for the
+  // equivalent legacy (empty session ID) case.
+  InSequence mockCallsMustBeInSequence;
+
+  packagerConnection_->connect();
+
+  auto pageId = getInspectorInstance().addPage(
+      "mock-description",
+      "mock-vm",
+      localConnections_
+          .lazily_make_unique<std::unique_ptr<IRemoteConnection>>());
+
+  // Connect with sessionId
+  webSockets_[0]->getDelegate().didReceiveMessage(
+      fmt::format(
+          R"({{
+          "event": "connect",
+          "payload": {{
+            "pageId": {0},
+            "sessionId": "session-1"
+          }}
+        }})",
+          toJson(std::to_string(pageId))));
+  ASSERT_TRUE(localConnections_[0]);
+
+  // Try to connect again with the same sessionId - should disconnect existing
+  EXPECT_CALL(*localConnections_[0], disconnect()).RetiresOnSaturation();
+  webSockets_[0]->getDelegate().didReceiveMessage(
+      fmt::format(
+          R"({{
+          "event": "connect",
+          "payload": {{
+            "pageId": {0},
+            "sessionId": "session-1"
+          }}
+        }})",
+          toJson(std::to_string(pageId))));
+
+  // Original connection was disconnected, no new connection created
+  EXPECT_FALSE(localConnections_[0]);
+  EXPECT_EQ(localConnections_.objectsVended(), 1);
+}
+
+TEST_F(
+    InspectorPackagerConnectionMultiSessionTest,
+    TestPageRemovalDisconnectsAllSessions) {
+  auto mockCallsMustBeInSequence = std::make_optional<InSequence>();
+
+  packagerConnection_->connect();
+
+  auto pageId = getInspectorInstance().addPage(
+      "mock-description",
+      "mock-vm",
+      localConnections_
+          .lazily_make_unique<std::unique_ptr<IRemoteConnection>>());
+
+  // Connect multiple sessions
+  webSockets_[0]->getDelegate().didReceiveMessage(
+      fmt::format(
+          R"({{
+            "event": "connect",
+            "payload": {{
+              "pageId": {0},
+              "sessionId": "session-1"
+            }}
+          }})",
+          toJson(std::to_string(pageId))));
+  ASSERT_TRUE(localConnections_[0]);
+
+  webSockets_[0]->getDelegate().didReceiveMessage(
+      fmt::format(
+          R"({{
+            "event": "connect",
+            "payload": {{
+              "pageId": {0},
+              "sessionId": "session-2"
+            }}
+          }})",
+          toJson(std::to_string(pageId))));
+  ASSERT_TRUE(localConnections_[1]);
+
+  webSockets_[0]->getDelegate().didReceiveMessage(
+      fmt::format(
+          R"({{
+            "event": "connect",
+            "payload": {{
+              "pageId": {0},
+              "sessionId": "session-3"
+            }}
+          }})",
+          toJson(std::to_string(pageId))));
+  ASSERT_TRUE(localConnections_[2]);
+
+  // Remove the page - all sessions should be disconnected.
+  // This is not guaranteed to be in order, so tear down our InSequence guard.
+  mockCallsMustBeInSequence.reset();
+
+  EXPECT_CALL(*localConnections_[0], disconnect());
+  EXPECT_CALL(*localConnections_[1], disconnect());
+  EXPECT_CALL(*localConnections_[2], disconnect());
+  getInspectorInstance().removePage(pageId);
+
+  EXPECT_FALSE(localConnections_[0]);
+  EXPECT_FALSE(localConnections_[1]);
+  EXPECT_FALSE(localConnections_[2]);
+}
+
+TEST_F(
+    InspectorPackagerConnectionTest,
+    TestLegacyConnectThenMultiSessionConnect) {
+  // Tests the edge case where a peer starts in legacy mode (empty sessionId)
+  // and later sends a connect with a non-empty sessionId.
+  auto mockCallsMustBeInSequence = std::make_optional<InSequence>();
+
+  packagerConnection_->connect();
+
+  auto pageId = getInspectorInstance().addPage(
+      "mock-description",
+      "mock-vm",
+      localConnections_
+          .lazily_make_unique<std::unique_ptr<IRemoteConnection>>());
+
+  // First connect in legacy mode (no sessionId)
+  webSockets_[0]->getDelegate().didReceiveMessage(
+      fmt::format(
+          R"({{
+            "event": "connect",
+            "payload": {{
+              "pageId": {0}
+            }}
+          }})",
+          toJson(std::to_string(pageId))));
+  ASSERT_TRUE(localConnections_[0]);
+
+  // Second connect with a sessionId - this is a different session,
+  // so both should coexist (legacy session uses empty string as key)
+  webSockets_[0]->getDelegate().didReceiveMessage(
+      fmt::format(
+          R"({{
+            "event": "connect",
+            "payload": {{
+              "pageId": {0},
+              "sessionId": "session-1"
+            }}
+          }})",
+          toJson(std::to_string(pageId))));
+  ASSERT_TRUE(localConnections_[1]);
+
+  // Both connections should be active
+  EXPECT_TRUE(localConnections_[0]);
+  EXPECT_TRUE(localConnections_[1]);
+
+  // Messages to the multi-session connection should work
+  EXPECT_CALL(
+      *localConnections_[1],
+      sendMessage(JsonParsed(AtJsonPtr("/method", Eq("FakeDomain.method1")))))
+      .RetiresOnSaturation();
+  webSockets_[0]->getDelegate().didReceiveMessage(
+      fmt::format(
+          R"({{
+            "event": "wrappedEvent",
+            "payload": {{
+              "pageId": {0},
+              "sessionId": "session-1",
+              "wrappedEvent": {1}
+            }}
+          }})",
+          toJson(std::to_string(pageId)),
+          toJson(R"({"method": "FakeDomain.method1"})")));
+
+  // Messages to the legacy connection should also work
+  EXPECT_CALL(
+      *localConnections_[0],
+      sendMessage(JsonParsed(AtJsonPtr("/method", Eq("FakeDomain.method2")))))
+      .RetiresOnSaturation();
+  webSockets_[0]->getDelegate().didReceiveMessage(
+      fmt::format(
+          R"({{
+            "event": "wrappedEvent",
+            "payload": {{
+              "pageId": {0},
+              "wrappedEvent": {1}
+            }}
+          }})",
+          toJson(std::to_string(pageId)),
+          toJson(R"({"method": "FakeDomain.method2"})")));
+
+  // Remove the page - all sessions should be disconnected.
+  // This is not guaranteed to be in order, so tear down our InSequence guard.
+  mockCallsMustBeInSequence.reset();
+  EXPECT_CALL(*localConnections_[0], disconnect()).RetiresOnSaturation();
+  EXPECT_CALL(*localConnections_[1], disconnect()).RetiresOnSaturation();
+  getInspectorInstance().removePage(pageId);
+}
+
+TEST_F(
+    InspectorPackagerConnectionTest,
+    TestMultiSessionConnectThenLegacyConnect) {
+  // Tests the edge case where a peer starts in multi-session mode
+  // and later sends a connect in legacy mode (empty sessionId).
+  // When switching to legacy mode, all non-legacy sessions should be
+  // disconnected first, as it implies the peer won't handle concurrent sessions
+  // correctly.
+  auto mockCallsMustBeInSequence = std::make_optional<InSequence>();
+
+  packagerConnection_->connect();
+
+  auto pageId = getInspectorInstance().addPage(
+      "mock-description",
+      "mock-vm",
+      localConnections_
+          .lazily_make_unique<std::unique_ptr<IRemoteConnection>>());
+
+  // First connect with a sessionId (multi-session mode)
+  webSockets_[0]->getDelegate().didReceiveMessage(
+      fmt::format(
+          R"({{
+            "event": "connect",
+            "payload": {{
+              "pageId": {0},
+              "sessionId": "session-1"
+            }}
+          }})",
+          toJson(std::to_string(pageId))));
+  ASSERT_TRUE(localConnections_[0]);
+
+  // Connect another multi-session connection
+  webSockets_[0]->getDelegate().didReceiveMessage(
+      fmt::format(
+          R"({{
+            "event": "connect",
+            "payload": {{
+              "pageId": {0},
+              "sessionId": "session-2"
+            }}
+          }})",
+          toJson(std::to_string(pageId))));
+  ASSERT_TRUE(localConnections_[1]);
+
+  // Both connections should be active
+  EXPECT_TRUE(localConnections_[0]);
+  EXPECT_TRUE(localConnections_[1]);
+
+  // When we switch to legacy mode, all non-legacy sessions should be
+  // disconnected (not guaranteed to be in order)
+  mockCallsMustBeInSequence.reset();
+  EXPECT_CALL(*localConnections_[0], disconnect()).RetiresOnSaturation();
+  EXPECT_CALL(*localConnections_[1], disconnect()).RetiresOnSaturation();
+  mockCallsMustBeInSequence.emplace();
+
+  // Now connect in legacy mode (no sessionId)
+  webSockets_[0]->getDelegate().didReceiveMessage(
+      fmt::format(
+          R"({{
+            "event": "connect",
+            "payload": {{
+              "pageId": {0}
+            }}
+          }})",
+          toJson(std::to_string(pageId))));
+  ASSERT_TRUE(localConnections_[2]);
+
+  // Only the legacy connection should be active now
+  EXPECT_FALSE(localConnections_[0]);
+  EXPECT_FALSE(localConnections_[1]);
+  EXPECT_TRUE(localConnections_[2]);
+
+  // Messages to the legacy connection should work
+  EXPECT_CALL(
+      *localConnections_[2],
+      sendMessage(JsonParsed(AtJsonPtr("/method", Eq("FakeDomain.method")))))
+      .RetiresOnSaturation();
+  webSockets_[0]->getDelegate().didReceiveMessage(
+      fmt::format(
+          R"({{
+            "event": "wrappedEvent",
+            "payload": {{
+              "pageId": {0},
+              "wrappedEvent": {1}
+            }}
+          }})",
+          toJson(std::to_string(pageId)),
+          toJson(R"({"method": "FakeDomain.method"})")));
+
+  // Clean up
+  EXPECT_CALL(*localConnections_[2], disconnect()).RetiresOnSaturation();
+  getInspectorInstance().removePage(pageId);
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorPackagerConnectionTest.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/tests/InspectorPackagerConnectionTest.cpp
@@ -119,8 +119,10 @@ TEST_F(InspectorPackagerConnectionTest, TestGetPages) {
                        AtJsonPtr("/app", Eq("my-app")),
                        AtJsonPtr("/capabilities/nativePageReloads", Eq(true)),
                        AtJsonPtr(
-                           "/capabilities/nativeSourceCodeFetching",
-                           Eq(false))),
+                           "/capabilities/nativeSourceCodeFetching", Eq(false)),
+                       AtJsonPtr(
+                           "/capabilities/supportsMultipleDebuggers",
+                           Eq(true))),
                    AllOf(
                        AtJsonPtr("/id", Eq(std::to_string(pageId2))),
                        AtJsonPtr("/title", Eq("my-app (my-device)")),
@@ -130,8 +132,10 @@ TEST_F(InspectorPackagerConnectionTest, TestGetPages) {
                        AtJsonPtr("/app", Eq("my-app")),
                        AtJsonPtr("/capabilities/nativePageReloads", Eq(true)),
                        AtJsonPtr(
-                           "/capabilities/nativeSourceCodeFetching",
-                           Eq(false)))}))))))
+                           "/capabilities/nativeSourceCodeFetching", Eq(false)),
+                       AtJsonPtr(
+                           "/capabilities/supportsMultipleDebuggers",
+                           Eq(true)))}))))))
       .RetiresOnSaturation();
   webSockets_[0]->getDelegate().didReceiveMessage(R"({
       "event": "getPages"
@@ -544,6 +548,7 @@ TEST_F(
         }})",
           toJson(std::to_string(pageId))));
   EXPECT_FALSE(localConnections_[0]);
+  EXPECT_EQ(localConnections_.objectsVended(), 1);
 }
 
 TEST_F(InspectorPackagerConnectionTest, TestMultipleDisconnect) {


### PR DESCRIPTION
Summary:
Adds multi-session support to the inspector-proxy protocol, specifically to the C++ `InspectorPackagerConnection` class that implements the "device" side of the protocol.

Changelog: [General][Added] Support multiple CDP connections to one React Native Host (diff 1 of 2)

Differential Revision: D90174642
