### PR TITLE
Support using the Network domain in multiple concurrent sessions

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/NetworkIOAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/NetworkIOAgent.h
@@ -211,6 +211,13 @@ class NetworkIOAgent {
   {
   }
 
+  ~NetworkIOAgent();
+
+  NetworkIOAgent(const NetworkIOAgent &) = delete;
+  NetworkIOAgent &operator=(const NetworkIOAgent &) = delete;
+  NetworkIOAgent(NetworkIOAgent &&) = delete;
+  NetworkIOAgent &operator=(NetworkIOAgent &&) = delete;
+
   /**
    * Handle a CDP request. The response will be sent over the provided
    * \c FrontendChannel synchronously or asynchronously.
@@ -246,6 +253,12 @@ class NetworkIOAgent {
    * NewtworkIOAgent instance. This stores the next one to use.
    */
   unsigned long nextStreamId_{0};
+
+  /**
+   * If non-nullopt, indicates that this agent has enabled the Network domain
+   * via NetworkHandler, storing the agent ID for cleanup.
+   */
+  std::optional<size_t> networkAgentId_;
 
   /**
    * Begin loading an HTTP resource, delegating platform-specific

--- a/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkHandler.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/network/NetworkHandler.cpp
@@ -37,28 +37,31 @@ NetworkHandler& NetworkHandler::getInstance() {
   return instance;
 }
 
-void NetworkHandler::setFrontendChannel(FrontendChannel frontendChannel) {
-  frontendChannel_ = std::move(frontendChannel);
-}
-
-bool NetworkHandler::enable() {
-  if (enabled_.load(std::memory_order_acquire)) {
-    return false;
-  }
-
+size_t NetworkHandler::enableAgent(FrontendChannel frontendChannel) {
+  std::lock_guard<std::mutex> lock(agentsMutex_);
+  size_t id = nextAgentId_++;
+  agents_.push_back({id, std::move(frontendChannel)});
   enabled_.store(true, std::memory_order_release);
-  return true;
+  return id;
 }
 
-bool NetworkHandler::disable() {
-  if (!enabled_.load(std::memory_order_acquire)) {
-    return false;
-  }
+void NetworkHandler::disableAgent(size_t agentId) {
+  std::lock_guard<std::mutex> lock(agentsMutex_);
+  agents_.remove_if(
+      [agentId](const AgentRecord& r) { return r.id == agentId; });
+  if (agents_.empty()) {
+    enabled_.store(false, std::memory_order_release);
 
-  enabled_.store(false, std::memory_order_release);
-  std::lock_guard<std::mutex> lock(requestBodyMutex_);
-  responseBodyBuffer_.clear();
-  return true;
+    std::lock_guard<std::mutex> lock2(requestBodyMutex_);
+    responseBodyBuffer_.clear();
+  }
+}
+
+void NetworkHandler::sendToAllAgents(std::string_view message) {
+  std::lock_guard<std::mutex> lock(agentsMutex_);
+  for (auto& agent : agents_) {
+    agent.channel(message);
+  }
 }
 
 void NetworkHandler::onRequestWillBeSent(
@@ -89,7 +92,7 @@ void NetworkHandler::onRequestWillBeSent(
       .redirectResponse = redirectResponse,
   };
 
-  frontendChannel_(
+  sendToAllAgents(
       cdp::jsonNotification("Network.requestWillBeSent", params.toDynamic()));
 }
 
@@ -106,7 +109,7 @@ void NetworkHandler::onRequestWillBeSentExtraInfo(
       .connectTiming = {.requestTime = getCurrentUnixTimestampSeconds()},
   };
 
-  frontendChannel_(
+  sendToAllAgents(
       cdp::jsonNotification(
           "Network.requestWillBeSentExtraInfo", params.toDynamic()));
 }
@@ -133,7 +136,7 @@ void NetworkHandler::onResponseReceived(
       .hasExtraInfo = false,
   };
 
-  frontendChannel_(
+  sendToAllAgents(
       cdp::jsonNotification("Network.responseReceived", params.toDynamic()));
 }
 
@@ -152,7 +155,7 @@ void NetworkHandler::onDataReceived(
       .encodedDataLength = encodedDataLength,
   };
 
-  frontendChannel_(
+  sendToAllAgents(
       cdp::jsonNotification("Network.dataReceived", params.toDynamic()));
 }
 
@@ -169,7 +172,7 @@ void NetworkHandler::onLoadingFinished(
       .encodedDataLength = encodedDataLength,
   };
 
-  frontendChannel_(
+  sendToAllAgents(
       cdp::jsonNotification("Network.loadingFinished", params.toDynamic()));
 }
 
@@ -192,7 +195,7 @@ void NetworkHandler::onLoadingFailed(
         .canceled = cancelled,
     };
 
-    frontendChannel_(
+    sendToAllAgents(
         cdp::jsonNotification("Network.loadingFailed", params.toDynamic()));
   }
 }


### PR DESCRIPTION
Summary: Changelog: [General][Fixed] Send network events to all CDP clients with the Network domain enabled

Differential Revision: D90888854
