### PR TITLE
Expose `oscompat` headers via prefab

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -268,6 +268,8 @@ val preparePrefab by
                       // yoga
                       Pair("../ReactCommon/yoga/", ""),
                       Pair("src/main/jni/first-party/yogajni/jni", ""),
+                      // oscompat
+                      Pair("../ReactCommon/oscompat/", "oscompat/"),
                   ),
               ),
               PrefabPreprocessingEntry(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This PR fixes the following build error while trying to build `react-native@0.83.1` app with `react-native-worklets@0.7.1` installed using react-native prebuilds (AAR) due to a missing `oscompat/OSCompat.h` file in `prefab/modules/` inside `react-android-0.83.1-debug.aar`.

```
In file included from /Users/war-in/WebstormProjects/react-native-live-markdown-fork/example/node_modules/react-native-worklets/android/build/prefab-headers/worklets/worklets/WorkletRuntime/WorkletRuntime.h:5:
In file included from /Users/war-in/WebstormProjects/react-native-live-markdown-fork/node_modules/react-native/ReactCommon/jsiexecutor/jsireact/JSIExecutor.h:11:
In file included from /Users/war-in/.gradle/caches/9.0.0/transforms/f97a0c8835e876dfb08e8efd6d33fd2f/transformed/react-android-0.83.1-debug/prefab/modules/reactnative/include/cxxreact/JSExecutor.h:16:
In file included from /Users/war-in/.gradle/caches/9.0.0/transforms/f97a0c8835e876dfb08e8efd6d33fd2f/transformed/react-android-0.83.1-debug/prefab/modules/reactnative/include/jsinspector-modern/ReactCdp.h:11:
In file included from /Users/war-in/.gradle/caches/9.0.0/transforms/f97a0c8835e876dfb08e8efd6d33fd2f/transformed/react-android-0.83.1-debug/prefab/modules/reactnative/include/jsinspector-modern/FallbackRuntimeTargetDelegate.h:11:
In file included from /Users/war-in/.gradle/caches/9.0.0/transforms/f97a0c8835e876dfb08e8efd6d33fd2f/transformed/react-android-0.83.1-debug/prefab/modules/reactnative/include/jsinspector-modern/RuntimeTarget.h:14:
In file included from /Users/war-in/.gradle/caches/9.0.0/transforms/f97a0c8835e876dfb08e8efd6d33fd2f/transformed/react-android-0.83.1-debug/prefab/modules/reactnative/include/jsinspector-modern/RuntimeAgent.h:16:
In file included from /Users/war-in/.gradle/caches/9.0.0/transforms/f97a0c8835e876dfb08e8efd6d33fd2f/transformed/react-android-0.83.1-debug/prefab/modules/reactnative/include/jsinspector-modern/tracing/TargetTracingAgent.h:10:
/Users/war-in/.gradle/caches/9.0.0/transforms/f97a0c8835e876dfb08e8efd6d33fd2f/transformed/react-android-0.83.1-debug/prefab/modules/reactnative/include/jsinspector-modern/tracing/TraceRecordingState.h:14:10: fatal error: 'oscompat/OSCompat.h' file not found
   14 | #include <oscompat/OSCompat.h>
      |          ^~~~~~~~~~~~~~~~~~~~~
```

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

\[ANDROID\] \[CHANGED\] - Expose `oscompat` headers via prefab

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->