### PR TITLE
Fix diff-js-api-changes to compare PR head vs merge base

### DIFF
--- a/.github/actions/diff-js-api-changes/action.yml
+++ b/.github/actions/diff-js-api-changes/action.yml
@@ -3,22 +3,28 @@ description: Check for breaking changes in the public React Native JS API
 runs:
   using: composite
   steps:
-    - name: Compute merge base with main
+    - name: Fetch PR and main, compute merge base
       id: merge_base
       shell: bash
+      env:
+        PR_SHA: ${{ github.event.pull_request.head.sha }}
       run: |
         git fetch origin main
-        git fetch --deepen=500
-        echo "merge_base=$(git merge-base HEAD origin/main)" >> $GITHUB_OUTPUT
+        git fetch origin "$PR_SHA" --depth=500
+        echo "merge_base=$(git merge-base "$PR_SHA" origin/main)" >> $GITHUB_OUTPUT
 
-    - name: Output snapshot before state for comparison
+    - name: Extract before and after API snapshots
       shell: bash
       env:
         SCRATCH_DIR: ${{ runner.temp }}/diff-js-api-changes
+        MERGE_BASE: ${{ steps.merge_base.outputs.merge_base }}
+        PR_SHA: ${{ github.event.pull_request.head.sha }}
       run: |
         mkdir -p $SCRATCH_DIR
-        git show ${{ steps.merge_base.outputs.merge_base }}:packages/react-native/ReactNativeApi.d.ts > $SCRATCH_DIR/ReactNativeApi-before.d.ts \
+        git show "$MERGE_BASE":packages/react-native/ReactNativeApi.d.ts > $SCRATCH_DIR/ReactNativeApi-before.d.ts \
           || echo "" > $SCRATCH_DIR/ReactNativeApi-before.d.ts
+        git show "$PR_SHA":packages/react-native/ReactNativeApi.d.ts > $SCRATCH_DIR/ReactNativeApi-after.d.ts \
+          || echo "" > $SCRATCH_DIR/ReactNativeApi-after.d.ts
 
     - name: Run breaking change detection
       shell: bash
@@ -27,5 +33,5 @@ runs:
       run: |
         node ./scripts/js-api/diff-api-snapshot \
           $SCRATCH_DIR/ReactNativeApi-before.d.ts \
-          ./packages/react-native/ReactNativeApi.d.ts \
+          $SCRATCH_DIR/ReactNativeApi-after.d.ts \
           > $SCRATCH_DIR/output.json

--- a/.github/workflows/danger-pr.yml
+++ b/.github/workflows/danger-pr.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'facebook/react-native'
     steps:
-      - name: Check out PR branch
+      - name: Check out main branch
         uses: actions/checkout@v6
       - name: Setup Node.js
         uses: ./.github/actions/setup-node


### PR DESCRIPTION
Summary:
[INTERNAL] [FIXED] - Fix diff-js-api-changes workflow to correctly compare PR head vs merge base

The `diff-js-api-changes` action was comparing main to main instead of comparing the PR head to the point of main it branched from.

The workflow now:
1. Checks out main in `danger-pr.yml` to get the trusted scripts
2. Fetches the PR head commit and computes the merge base (the point it branched from main)
3. Extracts the API snapshots from both refs using `git show` to read-only temp files
4. Runs main's diff script to compare the two snapshots

**Security notes:** 
- `git fetch` only downloads git objects, it does not modify the working directory
- `git show <sha>:path` extracts a file as read-only data, not executable code
- All executed scripts come from main (trusted), PR content is only used as data
- The PR's `.d.ts` file is written to a temp directory and passed as input to main's diff script

Differential Revision: D90978905


