### PR TITLE
Include final (redirected to) URL in response object.  Fixes #55248.

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.kt
@@ -644,7 +644,7 @@ public class NetworkingModule(
                     reactApplicationContext,
                     requestId,
                     devToolsRequestId,
-                    url,
+                    response.request().url().toString(),
                     response,
                 )
 


### PR DESCRIPTION
## Summary:

This fixes a regression introduced by b18cd587dcb5adb065e2c199131854233fb0288c  by including the final, redirected to URL in the response object.

## Changelog:

ANDROID FIXED - fetch() response URL is incorrect after redirect (#55248)

## Test Plan:

Testing using the reproducer from issue #55248.
