### PR TITLE
Fix codegen for projects in hidden folders

### DIFF
--- a/packages/react-native/scripts/codegen/generate-artifacts-executor/generateRCTThirdPartyComponents.js
+++ b/packages/react-native/scripts/codegen/generate-artifacts-executor/generateRCTThirdPartyComponents.js
@@ -169,11 +169,10 @@ function findFilesWithExtension(
       return null;
     }
 
-    // Skip hidden folders, that starts with `.` but allow `.pnpm`
-    if (
-      absolutePath.includes(`${path.sep}.`) &&
-      !absolutePath.includes(`${path.sep}.pnpm`)
-    ) {
+    // Skip hidden files/folders (starting with `.`) but allow `.pnpm`
+    // Note: Only check the filename, not the entire path, to avoid false positives
+    // when the workspace itself is under a hidden folder (e.g., ~/.jenkins/)
+    if (file.startsWith('.') && file !== '.pnpm') {
       return null;
     }
 
@@ -226,5 +225,6 @@ function findRCTComponentViewProtocolClass(filepath /*: string */) {
 }
 
 module.exports = {
+  findFilesWithExtension,
   generateRCTThirdPartyComponents,
 };


### PR DESCRIPTION
## Summary:

Fixes #55243

Fixes an issue where iOS codegen fails when the React Native project is located inside a hidden folder (a folder starting with `.`, such as `~/.jenkins/workspace/` or `/.buildkite/builds/`).

The issue was reported for React Native 0.79.4, but the bug affects all subsequent versions including the current main branch.

The `findFilesWithExtension` function was checking if the entire absolute path contained `/.` to skip hidden folders. This caused false positives when the project workspace itself was under a hidden folder, resulting in all files being incorrectly filtered out and codegen producing empty results.

The fix changes the check to only look at the current filename being iterated (`file.startsWith('.')`) rather than the full path, while preserving the existing `.pnpm` exception.

## Changelog:

[iOS] [Fixed] - Fix codegen failing when project is inside a hidden folder


## Test Plan:

Added unit tests for `findFilesWithExtension` that verify: 
 - Hidden files/folders are still correctly skipped
 - The `.pnpm` folder exception still works
 - Projects under hidden folders (e.g., `/.jenkins/workspace/`) now work correctly

Run tests with:
```bash
yarn jest packages/react-native/scripts/codegen/__tests__/generate-artifacts-executor-test.js --testNamePattern="findFilesWithExtension"
```

All 3 tests pass. The critical test `works when project is under a hidden folder` fails without the fix (returns empty array) and passes with the fix.


### Example of the codegen failing on a dotted path 🔴 
<img width="970" height="609" alt="Screenshot 2026-01-21 at 09 54 21" src="https://github.com/user-attachments/assets/247576c4-ce06-4656-93d7-06e880e779e3" />

- [`pod install` logs on Github Actions](https://github.com/dinisnunes1/.react-native-codegen-dotted-paths/actions/runs/21204831248/job/60998728238)
- [example based on the Reproducer repo](https://github.com/dinisnunes1/.react-native-codegen-dotted-paths/compare/main...test-dotted-path-codegen)

### Example of the codegen crawling working on a dotted path - with the fix ✅  
<img width="938" height="700" alt="Screenshot 2026-01-21 at 10 15 56" src="https://github.com/user-attachments/assets/f36ef04d-e5ca-454e-907f-9af1fcd0a6d9" />

- [`pod install` logs on Github Actions](https://github.com/dinisnunes1/.react-native-codegen-dotted-paths/actions/runs/21205599303/job/61001213856)
- [example based on the Reproducer repo - branch with RN `0.83.1` patched](https://github.com/dinisnunes1/.react-native-codegen-dotted-paths/compare/main...test-codegen-fix) 

