### PR TITLE
fix(android): make `ReactStylesDiffMap` not throw on missing key

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactStylesDiffMap.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactStylesDiffMap.kt
@@ -40,21 +40,21 @@ public class ReactStylesDiffMap(props: ReadableMap) {
 
   public fun toMap(): Map<String, Any?> = backingMap.toHashMap()
 
-  public fun hasKey(name: String): Boolean = backingMap.hasKey(name)
+public fun hasKey(name: String): Boolean = backingMap.hasKey(name)
 
   public fun isNull(name: String): Boolean = backingMap.isNull(name)
 
   public fun getBoolean(name: String, default: Boolean): Boolean =
-      if (backingMap.isNull(name)) default else backingMap.getBoolean(name)
+      if (!backingMap.hasKey(name) || backingMap.isNull(name)) default else backingMap.getBoolean(name)
 
   public fun getDouble(name: String, default: Double): Double =
-      if (backingMap.isNull(name)) default else backingMap.getDouble(name)
+      if (!backingMap.hasKey(name) || backingMap.isNull(name)) default else backingMap.getDouble(name)
 
   public fun getFloat(name: String, default: Float): Float =
-      if (backingMap.isNull(name)) default else backingMap.getDouble(name).toFloat()
+      if (!backingMap.hasKey(name) || backingMap.isNull(name)) default else backingMap.getDouble(name).toFloat()
 
   public fun getInt(name: String, default: Int): Int =
-      if (backingMap.isNull(name)) default else backingMap.getInt(name)
+      if (!backingMap.hasKey(name) || backingMap.isNull(name)) default else backingMap.getInt(name)
 
   public fun getString(name: String): String? = backingMap.getString(name)
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

When using `ReactStylesDiffMap.getBoolean(key, defaultFallback)` and the key is not present in the map it will throw. To me, this is unexpected as I am providing a fallback.

The stack here shows that the `isNull` will throw if the key is missing (which makes sense):

```
com.facebook.react.bridge.NoSuchKeyException: horizontal
	at com.facebook.react.bridge.ReadableNativeMap.isNull(ReadableNativeMap.kt:59)
	at com.facebook.react.uimanager.ReactStylesDiffMap.getBoolean(ReactStylesDiffMap.kt:48)
	at com.discord.fastest_list.react.FastestListViewManager.createViewInstance(FastestListViewManager.kt:59)
```

Partially a response to: 
- https://github.com/facebook/react-native/issues/55249

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

[ANDROID] [FIXED] - make `ReactStylesDiffMap` methods with fallbacks not throw on missing key

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] [FIXED] - make `ReactStylesDiffMap` methods with fallbacks not throw on missing key

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
