### PR TITLE
Fix nightly builds by exposing `react_renderer_animationbackend` via prefab

### DIFF
--- a/packages/react-native/ReactAndroid/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/build.gradle.kts
@@ -270,6 +270,11 @@ val preparePrefab by
                       Pair("src/main/jni/first-party/yogajni/jni", ""),
                       // oscompat
                       Pair("../ReactCommon/oscompat/", "oscompat/"),
+                      // react_renderer_animationbackend
+                      Pair(
+                          "../ReactCommon/react/renderer/animationbackend/",
+                          "react/renderer/animationbackend/",
+                      ),
                   ),
               ),
               PrefabPreprocessingEntry(


### PR DESCRIPTION
Summary:
The nightlies of a couple of libraries started to fail because some headers
are now importing `AnimationChoreographer.h` from `react_renderer_animationbackend`
which is not exposed via prefab.

See https://github.com/react-native-community/nightly-tests/actions/runs/21197740502

This fixes it.

Changelog:
[Internal] [Changed] -

Differential Revision: D91118249


