### PR TITLE
Deprecate ReactZIndexedViewGroup and remove customDrawOrder logic from ReactViewGroup

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -6598,7 +6598,6 @@ public class com/facebook/react/views/view/ReactViewGroup : android/view/ViewGro
 	protected fun drawChild (Landroid/graphics/Canvas;Landroid/view/View;J)Z
 	public fun endViewTransition (Landroid/view/View;)V
 	public final fun getAxOrderList ()Ljava/util/List;
-	protected fun getChildDrawingOrder (II)I
 	public fun getClippingRect (Landroid/graphics/Rect;)V
 	public fun getHitSlopRect ()Landroid/graphics/Rect;
 	public fun getOverflow ()Ljava/lang/String;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactZIndexedViewGroup.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactZIndexedViewGroup.kt
@@ -7,7 +7,17 @@
 
 package com.facebook.react.uimanager
 
-/** ViewGroup that supports z-index. */
+import com.facebook.react.common.annotations.internal.LegacyArchitecture
+
+/**
+ * ViewGroup that supports z-index.
+ *
+ * This interface is part of the legacy architecture. CustomDrawOrder is no longer used when Fabric
+ * is enabled, which is now everywhere. Z-order is managed at the C++ layer, and no re-ordering is
+ * needed in the Android View layer. This interface is kept for backward compatibility but should
+ * not be used in new code.
+ */
+@LegacyArchitecture
 public interface ReactZIndexedViewGroup {
   /**
    * Determine the index of a child view at [index] considering z-index.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/TouchTargetHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/TouchTargetHelper.kt
@@ -214,11 +214,8 @@ public object TouchTargetHelper {
       }
 
       val childrenCount = viewGroup.childCount
-      // Consider z-index when determining the touch target.
-      val zIndexedViewGroup = viewGroup as? ReactZIndexedViewGroup
       for (i in childrenCount - 1 downTo 0) {
-        val childIndex = zIndexedViewGroup?.getZIndexMappedChildIndex(i) ?: i
-        val child = viewGroup.getChildAt(childIndex)
+        val child = viewGroup.getChildAt(i)
         val childPoint = tempPoint
         getChildPoint(eventCoords[0], eventCoords[1], viewGroup, child, childPoint)
         // The childPoint value will contain the view coordinates relative to the child.

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupDrawingOrderHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ViewGroupDrawingOrderHelper.kt
@@ -11,8 +11,10 @@ import android.view.View
 import android.view.ViewGroup
 import com.facebook.common.logging.FLog
 import com.facebook.react.common.ReactConstants
+import com.facebook.react.common.annotations.internal.LegacyArchitecture
 
 /** Helper to handle implementing ViewGroups with custom drawing order based on z-index. */
+@LegacyArchitecture
 public class ViewGroupDrawingOrderHelper(private val viewGroup: ViewGroup) {
   private var numberOfChildrenWithZIndex = 0
   private var drawingOrderIndices: IntArray? = null


### PR DESCRIPTION
Summary:
In the new architecture, z-index manipulation is done in the cross-platform Fabric layer, and we no longer need to use Android's isChildrenDrawingOrderEnabled.
 
Changelog: [Android][Removed] Removed support for ReactZIndexedViewGroup

Differential Revision: D91121582


