### PR TITLE
fix(android): fix crash with props 2.0 diffing when setting text props to null

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.cpp
@@ -380,19 +380,19 @@ void BaseTextProps::appendTextAttributesProps(
   if (textAttributes.fontWeight != oldProps->textAttributes.fontWeight) {
     result["fontWeight"] = textAttributes.fontWeight.has_value()
         ? toString(textAttributes.fontWeight.value())
-        : nullptr;
+        : folly::dynamic(nullptr);
   }
 
   if (textAttributes.fontStyle != oldProps->textAttributes.fontStyle) {
     result["fontStyle"] = textAttributes.fontStyle.has_value()
         ? toString(textAttributes.fontStyle.value())
-        : nullptr;
+        : folly::dynamic(nullptr);
   }
 
   if (textAttributes.fontVariant != oldProps->textAttributes.fontVariant) {
     result["fontVariant"] = textAttributes.fontVariant.has_value()
         ? toString(textAttributes.fontVariant.value())
-        : nullptr;
+        : folly::dynamic(nullptr);
   }
 
   if (textAttributes.allowFontScaling !=
@@ -412,7 +412,7 @@ void BaseTextProps::appendTextAttributesProps(
       oldProps->textAttributes.dynamicTypeRamp) {
     result["dynamicTypeRamp"] = textAttributes.dynamicTypeRamp.has_value()
         ? toString(textAttributes.dynamicTypeRamp.value())
-        : nullptr;
+        : folly::dynamic(nullptr);
   }
 
   if (!floatEquality(
@@ -424,7 +424,7 @@ void BaseTextProps::appendTextAttributesProps(
   if (textAttributes.textTransform != oldProps->textAttributes.textTransform) {
     result["textTransform"] = textAttributes.textTransform.has_value()
         ? toString(textAttributes.textTransform.value())
-        : nullptr;
+        : folly::dynamic(nullptr);
   }
 
   if (!floatEquality(
@@ -435,7 +435,7 @@ void BaseTextProps::appendTextAttributesProps(
   if (textAttributes.alignment != oldProps->textAttributes.alignment) {
     result["textAlign"] = textAttributes.alignment.has_value()
         ? toString(textAttributes.alignment.value())
-        : nullptr;
+        : folly::dynamic(nullptr);
   }
 
   if (textAttributes.baseWritingDirection !=
@@ -443,7 +443,7 @@ void BaseTextProps::appendTextAttributesProps(
     result["baseWritingDirection"] =
         textAttributes.baseWritingDirection.has_value()
         ? toString(textAttributes.baseWritingDirection.value())
-        : nullptr;
+        : folly::dynamic(nullptr);
   }
 
   if (textAttributes.lineBreakStrategy !=
@@ -451,13 +451,13 @@ void BaseTextProps::appendTextAttributesProps(
     result["lineBreakStrategyIOS"] =
         textAttributes.lineBreakStrategy.has_value()
         ? toString(textAttributes.lineBreakStrategy.value())
-        : nullptr;
+        : folly::dynamic(nullptr);
   }
 
   if (textAttributes.lineBreakMode != oldProps->textAttributes.lineBreakMode) {
     result["lineBreakModeIOS"] = textAttributes.lineBreakMode.has_value()
         ? toString(textAttributes.lineBreakMode.value())
-        : nullptr;
+        : folly::dynamic(nullptr);
   }
 
   if (textAttributes.textDecorationColor !=
@@ -470,7 +470,7 @@ void BaseTextProps::appendTextAttributesProps(
     result["textDecorationLine"] =
         textAttributes.textDecorationLineType.has_value()
         ? toString(textAttributes.textDecorationLineType.value())
-        : nullptr;
+        : folly::dynamic(nullptr);
   }
 
   if (textAttributes.textDecorationStyle !=
@@ -478,14 +478,14 @@ void BaseTextProps::appendTextAttributesProps(
     result["textDecorationStyle"] =
         textAttributes.textDecorationStyle.has_value()
         ? toString(textAttributes.textDecorationStyle.value())
-        : nullptr;
+        : folly::dynamic(nullptr);
   }
 
   if (textAttributes.textShadowOffset !=
       oldProps->textAttributes.textShadowOffset) {
     result["textShadowOffset"] = textAttributes.textShadowOffset.has_value()
         ? toDynamic(textAttributes.textShadowOffset.value())
-        : nullptr;
+        : folly::dynamic(nullptr);
   }
 
   if (!floatEquality(
@@ -515,13 +515,13 @@ void BaseTextProps::appendTextAttributesProps(
       oldProps->textAttributes.accessibilityRole) {
     result["accessibilityRole"] = textAttributes.accessibilityRole.has_value()
         ? toString(textAttributes.accessibilityRole.value())
-        : nullptr;
+        : folly::dynamic(nullptr);
   }
 
   if (textAttributes.role != oldProps->textAttributes.role) {
     result["role"] = textAttributes.role.has_value()
         ? toString(textAttributes.role.value())
-        : nullptr;
+        : folly::dynamic(nullptr);
   }
 
   if (!floatEquality(

--- a/packages/react-native/ReactCommon/react/renderer/components/text/platform/android/react/renderer/components/text/HostPlatformParagraphProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/platform/android/react/renderer/components/text/HostPlatformParagraphProps.cpp
@@ -160,7 +160,7 @@ folly::dynamic HostPlatformParagraphProps::getDiffProps(
     result["textAlignVertical"] =
         paragraphAttributes.textAlignVertical.has_value()
         ? toString(paragraphAttributes.textAlignVertical.value())
-        : nullptr;
+        : folly::dynamic(nullptr);;
   }
 
   if (isSelectable != oldProps->isSelectable) {


### PR DESCRIPTION
## Summary:

When enabling props 2.0 diffing mechanism I noticed crashes happening when setting certain props back to `undefined` for `<Text>` components, as reported here:

- https://github.com/facebook/react-native/issues/55264

The reason seems to be with how we use ternaries/conditional operator in `BaseTextProps.cpp`:

https://github.com/facebook/react-native/blob/b4da323c8ec5ab7fe0171196dbe8ea50db49b96e/packages/react-native/ReactCommon/react/renderer/components/text/BaseTextProps.cpp#L386-L390

The problem being that c++ tries to evaluate our expression to a common type, which here is `std::string`/`const char*`, so when we return nullptr it tries to implicitly convert to it in the folly::dynamic() constructor, which leads to the crash.

The fix is to explicitly use `folly::dynamic(nullptr)`

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] [FIXED] - Fix crash with setting certain `<Text>` props back to `undefined` when using `enablePropsUpdateReconciliationAndroid` feature flag

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Run reproduction code provided in issue and verify its not crashing any longer:


https://github.com/user-attachments/assets/c2096c01-14a6-451a-8fc6-fe53d746e5b3


