### PR TITLE
enable -DRN_USE_ANIMATION_BACKEND by default for cxx animated + cxx platform and fantom

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/animated/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/animated/CMakeLists.txt
@@ -32,4 +32,3 @@ target_link_libraries(react_renderer_animated
 )
 target_compile_reactnative_options(react_renderer_animated PRIVATE)
 target_compile_options(react_renderer_animated PRIVATE -Wpedantic)
-target_compile_definitions(react_renderer_animated PRIVATE RN_USE_ANIMATION_BACKEND)

--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.cpp
@@ -514,11 +514,9 @@ void NativeAnimatedNodesManager::handleAnimatedEvent(
     // proactivelly trigger the animation loop to avoid showing stale
     // frames.
     if (ReactNativeFeatureFlags::useSharedAnimatedBackend()) {
-#ifdef RN_USE_ANIMATION_BACKEND
       if (auto animationBackend = animationBackend_.lock()) {
         animationBackend->trigger();
       }
-#endif
     } else {
       onRender();
     }
@@ -553,14 +551,12 @@ void NativeAnimatedNodesManager::startRenderCallbackIfNeeded(bool isAsync) {
   }
 
   if (ReactNativeFeatureFlags::useSharedAnimatedBackend()) {
-#ifdef RN_USE_ANIMATION_BACKEND
     if (auto animationBackend = animationBackend_.lock()) {
       animationBackendCallbackId_ =
           animationBackend->start([this](AnimationTimestamp timestamp) {
             return pullAnimationMutations(timestamp);
           });
     }
-#endif
 
     return;
   }
@@ -579,13 +575,11 @@ void NativeAnimatedNodesManager::stopRenderCallbackIfNeeded(
   auto isRenderCallbackStarted = isRenderCallbackStarted_.exchange(false);
 
   if (ReactNativeFeatureFlags::useSharedAnimatedBackend()) {
-#ifdef RN_USE_ANIMATION_BACKEND
     if (isRenderCallbackStarted) {
       if (auto animationBackend = animationBackend_.lock()) {
         animationBackend->stop(animationBackendCallbackId_);
       }
     }
-#endif
     return;
   }
 
@@ -947,8 +941,6 @@ void NativeAnimatedNodesManager::schedulePropsCommit(
   }
 }
 
-#ifdef RN_USE_ANIMATION_BACKEND
-
 void NativeAnimatedNodesManager::insertMutations(
     std::unordered_map<Tag, std::pair<ShadowNodeFamily::Weak, folly::dynamic>>&
         updates,
@@ -1089,7 +1081,6 @@ AnimationMutations NativeAnimatedNodesManager::pullAnimationMutations(
   shouldRequestAsyncFlush_.clear();
   return mutations;
 }
-#endif
 
 void NativeAnimatedNodesManager::onRender() {
   if (ReactNativeFeatureFlags::useSharedAnimatedBackend()) {

--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManager.h
@@ -17,10 +17,8 @@
 #include <react/debug/flags.h>
 #include <react/renderer/animated/EventEmitterListener.h>
 #include <react/renderer/animated/event_drivers/EventAnimationDriver.h>
-#ifdef RN_USE_ANIMATION_BACKEND
 #include <react/renderer/animationbackend/AnimatedPropsBuilder.h>
 #include <react/renderer/animationbackend/AnimationBackend.h>
-#endif
 #include <react/renderer/core/ReactPrimitives.h>
 #include <react/renderer/core/ShadowNode.h>
 #include <react/renderer/uimanager/UIManagerAnimationBackend.h>
@@ -121,7 +119,6 @@ class NativeAnimatedNodesManager {
 
   void setAnimatedNodeOffset(Tag tag, double offset);
 
-#ifdef RN_USE_ANIMATION_BACKEND
   void insertMutations(
       std::unordered_map<Tag, std::pair<ShadowNodeFamily::Weak, folly::dynamic>> &updates,
       AnimationMutations &mutations,
@@ -129,7 +126,6 @@ class NativeAnimatedNodesManager {
       bool hasLayoutUpdates = false);
   AnimationMutations onAnimationFrameForBackend(AnimatedPropsBuilder &propsBuilder, AnimationTimestamp timestamp);
   AnimationMutations pullAnimationMutations(AnimationTimestamp timestamp);
-#endif
 
 #pragma mark - Drivers
 
@@ -286,9 +282,7 @@ class NativeAnimatedNodesManager {
   bool warnedAboutGraphTraversal_ = false;
 #endif
 
-#ifdef RN_USE_ANIMATION_BACKEND
   CallbackId animationBackendCallbackId_{0};
-#endif
 
   friend class ColorAnimatedNode;
   friend class AnimationDriver;

--- a/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManagerProvider.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animated/NativeAnimatedNodesManagerProvider.cpp
@@ -11,10 +11,8 @@
 #include <react/featureflags/ReactNativeFeatureFlags.h>
 #include <react/renderer/animated/MergedValueDispatcher.h>
 #include <react/renderer/animated/internal/AnimatedMountingOverrideDelegate.h>
-#ifdef RN_USE_ANIMATION_BACKEND
-#include <react/renderer/animationbackend/AnimationBackend.h>
-#endif
 #include <react/renderer/animated/internal/primitives.h>
+#include <react/renderer/animationbackend/AnimationBackend.h>
 #include <react/renderer/components/view/conversions.h>
 #include <react/renderer/scheduler/Scheduler.h>
 #include <react/renderer/uimanager/UIManagerBinding.h>
@@ -87,7 +85,6 @@ NativeAnimatedNodesManagerProvider::getOrCreate(
     };
 
     if (ReactNativeFeatureFlags::useSharedAnimatedBackend()) {
-#ifdef RN_USE_ANIMATION_BACKEND
       auto animationBackend = uiManager->unstable_getAnimationBackend().lock();
       react_native_assert(
           animationBackend != nullptr && "animationBackend is nullptr");
@@ -95,7 +92,6 @@ NativeAnimatedNodesManagerProvider::getOrCreate(
 
       nativeAnimatedNodesManager_ =
           std::make_shared<NativeAnimatedNodesManager>(animationBackend);
-#endif
     } else {
       nativeAnimatedNodesManager_ =
           std::make_shared<NativeAnimatedNodesManager>(

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/CMakeLists.txt
@@ -37,4 +37,3 @@ target_link_libraries(react_renderer_scheduler
 )
 target_compile_reactnative_options(react_renderer_scheduler PRIVATE)
 target_compile_options(react_renderer_scheduler PRIVATE -Wpedantic)
-target_compile_definitions(react_renderer_scheduler PRIVATE RN_USE_ANIMATION_BACKEND)

--- a/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/scheduler/Scheduler.cpp
@@ -13,6 +13,7 @@
 #include <cxxreact/TraceSection.h>
 #include <react/debug/react_native_assert.h>
 #include <react/featureflags/ReactNativeFeatureFlags.h>
+#include <react/renderer/animationbackend/AnimationBackend.h>
 #include <react/renderer/componentregistry/ComponentDescriptorRegistry.h>
 #include <react/renderer/core/EventQueueProcessor.h>
 #include <react/renderer/core/LayoutContext.h>
@@ -21,9 +22,6 @@
 #include <react/renderer/runtimescheduler/RuntimeScheduler.h>
 #include <react/renderer/uimanager/UIManager.h>
 #include <react/renderer/uimanager/UIManagerBinding.h>
-#ifdef RN_USE_ANIMATION_BACKEND
-#include <react/renderer/animationbackend/AnimationBackend.h>
-#endif
 
 namespace facebook::react {
 
@@ -59,7 +57,6 @@ Scheduler::Scheduler(
       std::make_shared<UIManager>(runtimeExecutor_, contextContainer_);
 
   if (ReactNativeFeatureFlags::useSharedAnimatedBackend()) {
-#ifdef RN_USE_ANIMATION_BACKEND
     auto animationBackend = std::make_shared<AnimationBackend>(
         schedulerToolbox.animationChoreographer, uiManager);
 
@@ -67,7 +64,6 @@ Scheduler::Scheduler(
         animationBackend);
 
     uiManager->unstable_setAnimationBackend(animationBackend);
-#endif
   }
 
   auto eventOwnerBox = std::make_shared<EventBeat::OwnerBox>();

--- a/private/react-native-fantom/runner/executables/tester.js
+++ b/private/react-native-fantom/runner/executables/tester.js
@@ -15,7 +15,6 @@ import {NATIVE_BUILD_OUTPUT_PATH} from '../paths';
 import {
   getBuckModesForPlatform,
   getBuckOptionsForHermes,
-  getConfigForAnimationBackend,
   getDebugInfoFromCommandResult,
   runBuck2,
   runBuck2Sync,
@@ -55,7 +54,6 @@ export function build(options: TesterOptions): void {
       'build',
       ...getBuckModesForPlatform(options.isOptimizedMode),
       ...getBuckOptionsForHermes(options.hermesVariant),
-      ...getConfigForAnimationBackend(),
       FANTOM_TESTER_BUCK_TARGET,
       '--out',
       tmpPath,
@@ -96,7 +94,6 @@ export function run(
         'run',
         ...getBuckModesForPlatform(options.isOptimizedMode),
         ...getBuckOptionsForHermes(options.hermesVariant),
-        ...getConfigForAnimationBackend(),
         FANTOM_TESTER_BUCK_TARGET,
         '--',
         ...args,

--- a/private/react-native-fantom/runner/utils.js
+++ b/private/react-native-fantom/runner/utils.js
@@ -109,11 +109,6 @@ export function getBuckModesForPlatform(
   return modes;
 }
 
-// TODO: T240293839 Remove when we get rid of RN_USE_ANIMATION_BACKEND preprocessor flag
-export function getConfigForAnimationBackend(): ReadonlyArray<string> {
-  return ['-c rn.use_animationbackend=true'];
-}
-
 export type AsyncCommandResult = {
   originalCommand: string,
   childProcess: ReturnType<typeof spawn>,


### PR DESCRIPTION
Summary:
## Changelog:

[General] [Changed] - enable -DRN_USE_ANIMATION_BACKEND by default for cxx animated + cxx platform and fantom

Differential Revision: D91069652


