### PR TITLE
Update ReactNativeVersion.h not to rely on an anonymous struct

### DIFF
--- a/packages/react-native/ReactCommon/cxxreact/ReactNativeVersion.h
+++ b/packages/react-native/ReactCommon/cxxreact/ReactNativeVersion.h
@@ -18,11 +18,13 @@
 
 namespace facebook::react {
 
-constexpr struct {
+struct ReactNativeVersionType {
   int32_t Major = 1000;
   int32_t Minor = 0;
   int32_t Patch = 0;
   std::string_view Prerelease = "";
-} ReactNativeVersion;
+};
+
+constexpr ReactNativeVersionType ReactNativeVersion;
 
 } // namespace facebook::react

--- a/scripts/releases/__tests__/__snapshots__/set-rn-artifacts-version-test.js.snap
+++ b/scripts/releases/__tests__/__snapshots__/set-rn-artifacts-version-test.js.snap
@@ -138,12 +138,14 @@ exports[`updateReactNativeArtifacts should set nightly version: packages/react-n
 
 namespace facebook::react {
 
-constexpr struct {
+struct ReactNativeVersionType {
   int32_t Major = 0;
   int32_t Minor = 81;
   int32_t Patch = 0;
   std::string_view Prerelease = \\"nightly-29282302-abcd1234\\";
-} ReactNativeVersion;
+};
+
+constexpr ReactNativeVersionType ReactNativeVersion;
 
 } // namespace facebook::react
 "
@@ -293,12 +295,14 @@ exports[`updateReactNativeArtifacts should set release version: packages/react-n
 
 namespace facebook::react {
 
-constexpr struct {
+struct ReactNativeVersionType {
   int32_t Major = 0;
   int32_t Minor = 81;
   int32_t Patch = 0;
   std::string_view Prerelease = \\"\\";
-} ReactNativeVersion;
+};
+
+constexpr ReactNativeVersionType ReactNativeVersion;
 
 } // namespace facebook::react
 "

--- a/scripts/releases/templates/ReactNativeVersion.h-template.js
+++ b/scripts/releases/templates/ReactNativeVersion.h-template.js
@@ -32,14 +32,16 @@ module.exports = ({version} /*: {version: Version} */) /*: string */ => `/**
 
 namespace facebook::react {
 
-constexpr struct {
+struct ReactNativeVersionType {
   int32_t Major = ${version.major};
   int32_t Minor = ${version.minor};
   int32_t Patch = ${version.patch};
   std::string_view Prerelease = ${
     version.prerelease != null ? `"${version.prerelease}"` : '""'
   };
-} ReactNativeVersion;
+};
+
+constexpr ReactNativeVersionType ReactNativeVersion;
 
 } // namespace facebook::react
 `;


### PR DESCRIPTION
Summary:
Changelog: [Internal]

During research for the Stable C++ Api project, I've noticed that doxygen isn't able to handle anonymous structs, producing weird results.

The only occurence of this pattern in the codebase was in the `ReactNativeVersion.h` file. This diff updates this file not to use that pattern.

Differential Revision: D91220998


