### PR TITLE
Avoid repeated allocations in getChildOffsetRelativeToRoot

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/JSPointerDispatcher.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/JSPointerDispatcher.java
@@ -55,8 +55,7 @@ public class JSPointerDispatcher {
   private final ViewGroup mRootViewGroup;
 
   private static final int[] sRootScreenCoords = {0, 0};
-
-  // Set globally for hover interactions, referenced for coalescing hover events
+  private static final Rect sChildCoords = new Rect(0, 0, 1, 1);
 
   public JSPointerDispatcher(ViewGroup viewGroup) {
     mRootViewGroup = viewGroup;
@@ -659,9 +658,9 @@ public class JSPointerDispatcher {
 
         // cancel events need to report client coordinates of (0, 0) and offset coordinates relative
         // to the root view
-        int[] childOffset = getChildOffsetRelativeToRoot(targetView);
+        Rect childOffset = getChildOffsetRelativeToRoot(targetView);
         PointerEventState normalizedEventState =
-            normalizeToRoot(eventState, childOffset[0], childOffset[1]);
+            normalizeToRoot(eventState, childOffset.top, childOffset.left);
         Assertions.assertNotNull(eventDispatcher)
             .dispatchEvent(
                 PointerEvent.obtain(
@@ -677,16 +676,16 @@ public class JSPointerDispatcher {
   }
 
   // returns child (0, 0) relative to root coordinate system
-  private int[] getChildOffsetRelativeToRoot(View childView) {
+  private Rect getChildOffsetRelativeToRoot(View childView) {
+    sChildCoords.set(0, 0, 1, 1);
     if (childView.getRootView() != mRootViewGroup.getRootView()) {
       // NOTE: if we are here it means the target view has been reparented, so we can't call
       // mRootViewGroup.offsetDescendantRectToMyCoords because an exception will be thrown.
       // We still return (0, 0) to ensure the cancel event is dispatched.
-      return new int[] {0, 0};
+      return sChildCoords;
     }
-    Rect childCoords = new Rect(0, 0, 1, 1);
-    mRootViewGroup.offsetDescendantRectToMyCoords(childView, childCoords);
-    return new int[] {childCoords.top, childCoords.left};
+    mRootViewGroup.offsetDescendantRectToMyCoords(childView, sChildCoords);
+    return sChildCoords;
   }
 
   // Returns a copy of `original` with coordinates zeroed relative to the provided root coordinates.


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Refactors `getChildOffsetRelativeToRoot()` to use a static `Rect` field instead of allocating a new `Rect` and `int[]` on every call. Since this is a private method, we can return the `Rect` directly to avoid the extra `int[]` allocation.

This addresses the code review feedback on D90988373.

Differential Revision: D91230611


