### PR TITLE
Add selectNodeWithViewData to element inspector

### DIFF
--- a/packages/react-native/Libraries/Types/ReactDevToolsTypes.js
+++ b/packages/react-native/Libraries/Types/ReactDevToolsTypes.js
@@ -33,6 +33,7 @@ export type ReactDevToolsAgentEvents = {
 
 export type ReactDevToolsAgent = {
   selectNode(node: unknown): void,
+  selectNodeWithViewData(node: mixed): void,
   stopInspectingNative(value: boolean): void,
   addListener<Event: keyof ReactDevToolsAgentEvents>(
     event: Event,

--- a/packages/react-native/src/private/devsupport/devmenu/elementinspector/Inspector.js
+++ b/packages/react-native/src/private/devsupport/devmenu/elementinspector/Inspector.js
@@ -107,6 +107,11 @@ function Inspector({
         if (closestInstance != null) {
           reactDevToolsAgent.selectNode(closestInstance);
         }
+
+        // Attempt to send viewData to React DevTools.
+        if (reactDevToolsAgent.selectNodeWithViewData) {
+          reactDevToolsAgent.selectNodeWithViewData(viewData);
+        }
       }
 
       setPanelPosition(


### PR DESCRIPTION
Summary:
This allows us to leverage the element inspector as a component selector for react-native+livemate.

Changelog: [Internal]

Reviewed By: jorge-cab, shwanton

Differential Revision: D91229666


