### PR TITLE
Remove RCTUIStatusBarManager usage from AppleTV

### DIFF
--- a/packages/react-native/React/CoreModules/RCTStatusBarManager.h
+++ b/packages/react-native/React/CoreModules/RCTStatusBarManager.h
@@ -10,12 +10,14 @@
 #import <React/RCTConvert.h>
 #import <React/RCTEventEmitter.h>
 
+#if !TARGET_OS_TV
 @interface RCTConvert (UIStatusBar)
 
 + (UIStatusBarStyle)UIStatusBarStyle:(id)json;
 + (UIStatusBarAnimation)UIStatusBarAnimation:(id)json;
 
 @end
+#endif
 
 @interface RCTStatusBarManager : RCTEventEmitter
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTFabricModalHostViewController.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTFabricModalHostViewController.mm
@@ -46,20 +46,22 @@
 #endif
 }
 
+#if !TARGET_OS_TV
 - (UIStatusBarStyle)preferredStatusBarStyle
 {
   return [RCTUIStatusBarManager() statusBarStyle];
 }
 
+- (BOOL)prefersStatusBarHidden
+{
+  return [RCTUIStatusBarManager() isStatusBarHidden];
+}
+#endif
+
 - (void)viewDidDisappear:(BOOL)animated
 {
   [super viewDidDisappear:animated];
   _lastViewBounds = CGRectZero;
-}
-
-- (BOOL)prefersStatusBarHidden
-{
-  return [RCTUIStatusBarManager() isStatusBarHidden];
 }
 
 #if RCT_DEV && TARGET_OS_IOS


### PR DESCRIPTION
Summary:
UIStatusBar APIs are not available on AppleTV, removing.

Changelog: [Internal]

Just excluding RCTStatusBarManager from the build using exclusion rules instead of adding more platform guards.

Reviewed By: cipolleschi, shwanton

Differential Revision: D90704876


