### PR TITLE
Add text fragment rect measurement APIs

### DIFF
--- a/packages/react-native/Package.swift
+++ b/packages/react-native/Package.swift
@@ -423,6 +423,10 @@ let reactCore = RNTarget(
 let reactFabric = RNTarget(
   name: .reactFabric,
   path: "ReactCommon/react/renderer",
+  searchPaths: [
+    "ReactCommon/react/renderer/components/text/platform/cxx", // For <react/renderer/components/text/ParagraphState.h>
+    "ReactCommon/react/renderer/textlayoutmanager/platform/ios", // For <react/renderer/textlayoutmanager/TextLayoutManager.h>
+  ],
   excludedPaths: [
     "animations/tests",
     "attributedstring/tests",
@@ -456,7 +460,7 @@ let reactFabric = RNTarget(
     "components/root/tests",
   ],
   dependencies: [.reactNativeDependencies, .reactJsiExecutor, .rctTypesafety, .reactTurboModuleCore, .jsi, .logger, .reactDebug, .reactFeatureFlags, .reactUtils, .reactRuntimeScheduler, .reactCxxReact, .reactRendererDebug, .reactGraphics, .yoga],
-  sources: ["animationbackend", "animations", "attributedstring", "core", "componentregistry", "componentregistry/native", "components/root", "components/view", "components/view/platform/cxx", "components/scrollview", "components/scrollview/platform/cxx", "components/legacyviewmanagerinterop", "dom", "scheduler", "mounting", "observers/events", "observers/intersection", "telemetry", "consistency", "leakchecker", "uimanager", "uimanager/consistency"]
+  sources: ["animationbackend", "animations", "attributedstring", "core", "componentregistry", "componentregistry/native", "components/root", "components/view", "components/view/platform/cxx", "components/scrollview", "components/scrollview/platform/cxx", "components/legacyviewmanagerinterop", "scheduler", "mounting", "observers/events", "observers/intersection", "telemetry", "consistency", "leakchecker", "uimanager", "uimanager/consistency"]
 )
 
 let reactFabricInputAccessory = RNTarget(
@@ -486,6 +490,13 @@ let reactFabricSafeAreaView = RNTarget(
   name: .reactFabricSafeAreaView,
   path: "ReactCommon/react/renderer/components/safeareaview",
   dependencies: [.reactNativeDependencies, .reactCore, .reactJsiExecutor, .reactTurboModuleCore, .jsi, .logger, .reactDebug, .reactFeatureFlags, .reactUtils, .reactRuntimeScheduler, .reactCxxReact, .yoga, .reactRendererDebug, .reactGraphics, .reactFabric, .reactTurboModuleBridging]
+)
+
+let reactFabricDOM = RNTarget(
+  name: .reactFabricDOM,
+  path: "ReactCommon/react/renderer/dom",
+  dependencies: [.reactNativeDependencies, .reactJsiExecutor, .reactTurboModuleCore, .jsi, .logger, .reactDebug, .reactFeatureFlags, .reactUtils, .reactRuntimeScheduler, .reactCxxReact, .yoga, .reactRendererDebug, .reactGraphics, .reactFabric, .reactFabricText],
+  sources: ["."]
 )
 
 let reactFabricTextLayoutManager = RNTarget(
@@ -656,6 +667,7 @@ let targets = [
   reactFabricImage,
   reactFabricInputAccessory,
   reactFabricModal,
+  reactFabricDOM,
   reactFabricSafeAreaView,
   reactFabricSwitch,
   reactFabricTextLayoutManager,
@@ -835,6 +847,7 @@ extension String {
   static let reactFabric = "React-Fabric"
   static let reactRCTFabric = "React-RCTFabric"
 
+  static let reactFabricDOM = "React-FabricDOM"
   static let reactFabricImage = "React-FabricImage"
   static let reactFabricInputAccessory = "React-FabricInputAccessory"
   static let reactFabricModal = "React-FabricModal"

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -706,6 +706,60 @@ public class FabricUIManager
   }
 
   /**
+   * Returns the bounding rectangles for all text fragments that belong to the specified react tag.
+   * This is useful for getting the visual boundaries of nested {@code <Text>} components within a
+   * paragraph.
+   *
+   * @param preparedLayout The prepared text layout containing the layout and react tags
+   * @param targetReactTag The react tag of the TextShadowNode to get rects for
+   * @return A FloatArray containing [x, y, width, height] for each fragment rect, or empty array if
+   *     no fragments match the tag
+   */
+  @AnyThread
+  @ThreadConfined(ANY)
+  @UnstableReactNativeAPI
+  public float[] getFragmentRectsForReactTag(PreparedLayout preparedLayout, int targetReactTag) {
+    return TextLayoutManager.getFragmentRectsForReactTag(preparedLayout, targetReactTag);
+  }
+
+  /**
+   * Returns the bounding rectangles for all text fragments that belong to the specified react tag
+   * by creating a layout on-demand from the AttributedString. This is used as a fallback when
+   * PreparedLayout is not available (e.g., when enablePreparedTextLayout feature flag is disabled).
+   *
+   * @param surfaceId The surface ID to get context from
+   * @param attributedString The attributed string containing the text fragments
+   * @param paragraphAttributes The paragraph attributes for layout
+   * @param width The layout width constraint
+   * @param height The layout height constraint
+   * @param targetReactTag The react tag of the TextShadowNode to get rects for
+   * @return A FloatArray containing [x, y, width, height] for each fragment rect, or empty array if
+   *     no fragments match the tag
+   */
+  @AnyThread
+  @ThreadConfined(ANY)
+  @UnstableReactNativeAPI
+  public float[] getFragmentRectsFromAttributedString(
+      int surfaceId,
+      ReadableMapBuffer attributedString,
+      ReadableMapBuffer paragraphAttributes,
+      float width,
+      float height,
+      int targetReactTag) {
+    SurfaceMountingManager surfaceMountingManager = mMountingManager.getSurfaceManager(surfaceId);
+    Context context = surfaceMountingManager != null ? surfaceMountingManager.getContext() : null;
+    if (context == null) {
+      FLog.w(
+          TAG,
+          "Couldn't get context for surfaceId %d in getFragmentRectsFromAttributedString",
+          surfaceId);
+      return new float[0];
+    }
+    return TextLayoutManager.getFragmentRectsFromAttributedString(
+        context, attributedString, paragraphAttributes, width, height, targetReactTag);
+  }
+
+  /**
    * @param surfaceId {@link int} surface ID
    * @param defaultTextInputPadding {@link float[]} output parameter will contain the default theme
    *     padding used by RN Android TextInput.

--- a/packages/react-native/ReactCommon/React-Fabric.podspec
+++ b/packages/react-native/ReactCommon/React-Fabric.podspec
@@ -55,24 +55,6 @@ Pod::Spec.new do |s|
   add_rn_third_party_dependencies(s)
   add_rncore_dependency(s)
 
-  s.subspec "animated" do |ss|
-    ss.dependency             "React-Fabric/animationbackend"
-    ss.source_files         = podspec_sources("react/renderer/animated/**/*.{m,mm,cpp,h}", "react/renderer/animated/**/*.{h}")
-    ss.exclude_files        = "react/renderer/animated/tests"
-    ss.header_dir           = "react/renderer/animated"
-  end
-
-  s.subspec "animations" do |ss|
-    ss.source_files         = podspec_sources("react/renderer/animations/**/*.{m,mm,cpp,h}", "react/renderer/animations/**/*.{h}")
-    ss.exclude_files        = "react/renderer/animations/tests"
-    ss.header_dir           = "react/renderer/animations"
-  end
-
-  s.subspec "animationbackend" do |ss|
-    ss.source_files         = podspec_sources("react/renderer/animationbackend/**/*.{m,mm,cpp,h}", "react/renderer/animationbackend/**/*.{h}")
-    ss.header_dir           = "react/renderer/animationbackend"
-  end
-
   s.subspec "attributedstring" do |ss|
     ss.source_files         = podspec_sources("react/renderer/attributedstring/**/*.{m,mm,cpp,h}", "react/renderer/attributedstring/**/*.{h}")
     ss.exclude_files        = "react/renderer/attributedstring/tests"
@@ -147,23 +129,6 @@ Pod::Spec.new do |s|
     end
   end
 
-  s.subspec "dom" do |ss|
-    ss.dependency             "React-graphics"
-    ss.source_files         = podspec_sources("react/renderer/dom/**/*.{m,mm,cpp,h}", "react/renderer/dom/**/*.{h}")
-    ss.exclude_files        = "react/renderer/dom/tests"
-    ss.header_dir           = "react/renderer/dom"
-  end
-
-  s.subspec "scheduler" do |ss|
-    ss.source_files         = podspec_sources("react/renderer/scheduler/**/*.{m,mm,cpp,h}", "react/renderer/scheduler/**/*.h")
-    ss.header_dir           = "react/renderer/scheduler"
-
-    ss.dependency             "React-Fabric/animationbackend"
-    ss.dependency             "React-performancecdpmetrics"
-    ss.dependency             "React-performancetimeline"
-    ss.dependency             "React-Fabric/observers/events"
-  end
-
   s.subspec "imagemanager" do |ss|
     ss.source_files         = podspec_sources("react/renderer/imagemanager/*.{m,mm,cpp,h}", "react/renderer/imagemanager/*.h")
     ss.header_dir           = "react/renderer/imagemanager"
@@ -173,20 +138,6 @@ Pod::Spec.new do |s|
     ss.source_files         = podspec_sources("react/renderer/mounting/**/*.{m,mm,cpp,h}", "react/renderer/mounting/**/*.h")
     ss.exclude_files        = "react/renderer/mounting/tests"
     ss.header_dir           = "react/renderer/mounting"
-  end
-
-  s.subspec "observers" do |ss|
-    ss.subspec "events" do |sss|
-      sss.source_files         = podspec_sources("react/renderer/observers/events/**/*.{m,mm,cpp,h}", "react/renderer/observers/events/**/*.h")
-      sss.exclude_files        = "react/renderer/observers/events/tests"
-      sss.header_dir           = "react/renderer/observers/events"
-    end
-
-    ss.subspec "intersection" do |sss|
-      sss.source_files         = podspec_sources("react/renderer/observers/intersection/**/*.{m,mm,cpp,h}", "react/renderer/observers/intersection/**/*.h")
-      sss.exclude_files        = "react/renderer/observers/intersection/tests"
-      sss.header_dir           = "react/renderer/observers/intersection"
-    end
   end
 
   s.subspec "telemetry" do |ss|
@@ -199,17 +150,6 @@ Pod::Spec.new do |s|
   s.subspec "consistency" do |ss|
     ss.source_files         = podspec_sources("react/renderer/consistency/**/*.{m,mm,cpp,h}", "react/renderer/consistency/**/*.h")
     ss.header_dir           = "react/renderer/consistency"
-  end
-
-  s.subspec "uimanager" do |ss|
-    ss.subspec "consistency" do |sss|
-      sss.source_files         = podspec_sources("react/renderer/uimanager/consistency/*.{m,mm,cpp,h}", "react/renderer/uimanager/consistency/*.h")
-      sss.header_dir           = "react/renderer/uimanager/consistency"
-    end
-
-    ss.dependency             "React-rendererconsistency"
-    ss.source_files         = podspec_sources("react/renderer/uimanager/*.{m,mm,cpp,h}", "react/renderer/uimanager/*.h")
-    ss.header_dir           = "react/renderer/uimanager"
   end
 
   s.subspec "leakchecker" do |ss|

--- a/packages/react-native/ReactCommon/React-FabricComponents.podspec
+++ b/packages/react-native/ReactCommon/React-FabricComponents.podspec
@@ -167,4 +167,77 @@ Pod::Spec.new do |s|
                               "react/renderer/textlayoutmanager/platform/cxx"
     ss.header_dir           = "react/renderer/textlayoutmanager"
   end
+
+  s.subspec "dom" do |ss|
+    ss.dependency             "React-Fabric"
+    ss.dependency             "React-FabricComponents/components/text"
+    ss.dependency             "React-graphics"
+    ss.source_files         = podspec_sources("react/renderer/dom/**/*.{m,mm,cpp,h}", "react/renderer/dom/**/*.{h}")
+    ss.exclude_files        = "react/renderer/dom/tests"
+    ss.header_dir           = "react/renderer/dom"
+  end
+
+  s.subspec "uimanager" do |ss|
+    ss.dependency             "React-Fabric"
+    ss.dependency             "React-FabricComponents/dom"
+    ss.dependency             "React-rendererconsistency"
+    ss.subspec "consistency" do |sss|
+      sss.source_files         = podspec_sources("react/renderer/uimanager/consistency/*.{m,mm,cpp,h}", "react/renderer/uimanager/consistency/*.h")
+      sss.header_dir           = "react/renderer/uimanager/consistency"
+    end
+    ss.source_files         = podspec_sources("react/renderer/uimanager/*.{m,mm,cpp,h}", "react/renderer/uimanager/*.h")
+    ss.header_dir           = "react/renderer/uimanager"
+  end
+
+  s.subspec "animationbackend" do |ss|
+    ss.dependency             "React-Fabric"
+    ss.dependency             "React-FabricComponents/uimanager"
+    ss.source_files         = podspec_sources("react/renderer/animationbackend/**/*.{m,mm,cpp,h}", "react/renderer/animationbackend/**/*.{h}")
+    ss.header_dir           = "react/renderer/animationbackend"
+  end
+
+  s.subspec "animated" do |ss|
+    ss.dependency             "React-Fabric"
+    ss.dependency             "React-FabricComponents/animationbackend"
+    ss.dependency             "React-FabricComponents/uimanager"
+    ss.source_files         = podspec_sources("react/renderer/animated/**/*.{m,mm,cpp,h}", "react/renderer/animated/**/*.{h}")
+    ss.exclude_files        = "react/renderer/animated/tests"
+    ss.header_dir           = "react/renderer/animated"
+  end
+
+  s.subspec "animations" do |ss|
+    ss.dependency             "React-Fabric"
+    ss.source_files         = podspec_sources("react/renderer/animations/**/*.{m,mm,cpp,h}", "react/renderer/animations/**/*.{h}")
+    ss.exclude_files        = "react/renderer/animations/tests"
+    ss.header_dir           = "react/renderer/animations"
+  end
+
+  s.subspec "observers" do |ss|
+    ss.dependency             "React-Fabric"
+    ss.dependency             "React-FabricComponents/uimanager"
+
+    ss.subspec "events" do |sss|
+      sss.dependency            "React-performancetimeline"
+      sss.source_files         = podspec_sources("react/renderer/observers/events/**/*.{m,mm,cpp,h}", "react/renderer/observers/events/**/*.h")
+      sss.exclude_files        = "react/renderer/observers/events/tests"
+      sss.header_dir           = "react/renderer/observers/events"
+    end
+
+    ss.subspec "intersection" do |sss|
+      sss.source_files         = podspec_sources("react/renderer/observers/intersection/**/*.{m,mm,cpp,h}", "react/renderer/observers/intersection/**/*.h")
+      sss.exclude_files        = "react/renderer/observers/intersection/tests"
+      sss.header_dir           = "react/renderer/observers/intersection"
+    end
+  end
+
+  s.subspec "scheduler" do |ss|
+    ss.dependency             "React-Fabric"
+    ss.dependency             "React-FabricComponents/uimanager"
+    ss.dependency             "React-FabricComponents/animationbackend"
+    ss.dependency             "React-FabricComponents/observers/events"
+    ss.dependency             "React-performancecdpmetrics"
+    ss.dependency             "React-performancetimeline"
+    ss.source_files         = podspec_sources("react/renderer/scheduler/**/*.{m,mm,cpp,h}", "react/renderer/scheduler/**/*.h")
+    ss.header_dir           = "react/renderer/scheduler"
+  end
 end

--- a/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/React-intersectionobservernativemodule.podspec
+++ b/packages/react-native/ReactCommon/react/nativemodule/intersectionobserver/React-intersectionobservernativemodule.podspec
@@ -58,6 +58,7 @@ Pod::Spec.new do |s|
 
   s.dependency "React-Fabric"
   s.dependency "React-Fabric/bridging"
+  s.dependency "React-FabricComponents"
   s.dependency "React-runtimescheduler"
   add_dependency(s, "React-RCTFBReactNativeSpec")
   add_dependency(s, "React-runtimeexecutor", :additional_framework_paths => ["platform/ios"])

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.h
@@ -91,6 +91,26 @@ class TextLayoutManager {
       const TextLayoutContext &layoutContext,
       const LayoutConstraints &layoutConstraints) const;
 
+  /**
+   * Get the bounding rects of all text fragments that belong to the given
+   * react tag within a PreparedLayout. This is useful for getting the visual
+   * boundaries of nested <Text> components within a text paragraph.
+   */
+  std::vector<Rect> getFragmentRectsForReactTag(const PreparedLayout &layout, Tag targetReactTag) const;
+
+  /**
+   * Get the bounding rects of all text fragments that belong to the given
+   * react tag by creating a layout on-demand from the AttributedString.
+   * This is used as a fallback when PreparedLayout is not available
+   * (e.g., when enablePreparedTextLayout feature flag is disabled).
+   */
+  std::vector<Rect> getFragmentRectsFromAttributedString(
+      Tag surfaceId,
+      const AttributedString &attributedString,
+      const ParagraphAttributes &paragraphAttributes,
+      const LayoutConstraints &layoutConstraints,
+      Tag targetReactTag) const;
+
  private:
   std::shared_ptr<const ContextContainer> contextContainer_;
   TextMeasureCache textMeasureCache_;

--- a/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeElement-itest.js
+++ b/packages/react-native/src/private/webapis/dom/nodes/__tests__/ReactNativeElement-itest.js
@@ -916,7 +916,7 @@ describe('ReactNativeElement', () => {
         expect(textBoundingRectAfterUnmount.height).toBe(0);
       });
 
-      it('returns a DOMRect for nested Text elements', () => {
+      it('returns a DOMRect for nested Text elements that matches parent Paragraph boundaries', () => {
         const outerTextRef = createRef<HostInstance>();
         const nestedTextRef = createRef<HostInstance>();
 
@@ -954,15 +954,16 @@ describe('ReactNativeElement', () => {
         expect(outerTextBoundingRect.width).toBe(100);
         expect(outerTextBoundingRect.height).toBe(50);
 
-        // Nested text (virtual text) returns a DOMRect with zero values
-        // since it doesn't have its own independent layout
+        // Nested text (virtual text) returns the parent paragraph's bounding
+        // rect, matching web behavior where inline elements return their
+        // container's rect
         const nestedTextBoundingRect =
           nestedTextElement.getBoundingClientRect();
         expect(nestedTextBoundingRect).toBeInstanceOf(DOMRect);
-        expect(nestedTextBoundingRect.x).toBe(0);
-        expect(nestedTextBoundingRect.y).toBe(0);
-        expect(nestedTextBoundingRect.width).toBe(0);
-        expect(nestedTextBoundingRect.height).toBe(0);
+        expect(nestedTextBoundingRect.x).toBe(10);
+        expect(nestedTextBoundingRect.y).toBe(20);
+        expect(nestedTextBoundingRect.width).toBe(100);
+        expect(nestedTextBoundingRect.height).toBe(50);
 
         // After unmounting, both should return empty DOMRects
         Fantom.runTask(() => {


### PR DESCRIPTION
Summary:
Adds Android-specific implementation for measuring bounding rectangles of
text fragments that belong to a specific React tag. This enables getting
the visual boundaries of nested `<Text>` components within a paragraph.

The implementation provides two methods:
1. `getFragmentRectsForReactTag` - Uses PreparedLayout for efficient measurement
   when the enablePreparedTextLayout feature flag is enabled
2. `getFragmentRectsFromAttributedString` - Fallback that creates a layout
   on-demand when PreparedLayout is not available

Key features:
- Handles multi-line text fragments by returning a rect for each line
- Correctly handles RTL text direction
- Converts coordinates between pixels and DIPs

These methods are used by the DOM getClientRects() API to provide accurate
text fragment boundaries for accessibility and layout inspection.

Differential Revision: D91087221


