### PR TITLE
Implement getClientRects for text fragment measurement

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -706,6 +706,60 @@ public class FabricUIManager
   }
 
   /**
+   * Returns the bounding rectangles for all text fragments that belong to the specified react tag.
+   * This is useful for getting the visual boundaries of nested {@code <Text>} components within a
+   * paragraph.
+   *
+   * @param preparedLayout The prepared text layout containing the layout and react tags
+   * @param targetReactTag The react tag of the TextShadowNode to get rects for
+   * @return A FloatArray containing [x, y, width, height] for each fragment rect, or empty array if
+   *     no fragments match the tag
+   */
+  @AnyThread
+  @ThreadConfined(ANY)
+  @UnstableReactNativeAPI
+  public float[] getFragmentRectsForReactTag(PreparedLayout preparedLayout, int targetReactTag) {
+    return TextLayoutManager.getFragmentRectsForReactTag(preparedLayout, targetReactTag);
+  }
+
+  /**
+   * Returns the bounding rectangles for all text fragments that belong to the specified react tag
+   * by creating a layout on-demand from the AttributedString. This is used as a fallback when
+   * PreparedLayout is not available (e.g., when enablePreparedTextLayout feature flag is disabled).
+   *
+   * @param surfaceId The surface ID to get context from
+   * @param attributedString The attributed string containing the text fragments
+   * @param paragraphAttributes The paragraph attributes for layout
+   * @param width The layout width constraint
+   * @param height The layout height constraint
+   * @param targetReactTag The react tag of the TextShadowNode to get rects for
+   * @return A FloatArray containing [x, y, width, height] for each fragment rect, or empty array if
+   *     no fragments match the tag
+   */
+  @AnyThread
+  @ThreadConfined(ANY)
+  @UnstableReactNativeAPI
+  public float[] getFragmentRectsFromAttributedString(
+      int surfaceId,
+      ReadableMapBuffer attributedString,
+      ReadableMapBuffer paragraphAttributes,
+      float width,
+      float height,
+      int targetReactTag) {
+    SurfaceMountingManager surfaceMountingManager = mMountingManager.getSurfaceManager(surfaceId);
+    Context context = surfaceMountingManager != null ? surfaceMountingManager.getContext() : null;
+    if (context == null) {
+      FLog.w(
+          TAG,
+          "Couldn't get context for surfaceId %d in getFragmentRectsFromAttributedString",
+          surfaceId);
+      return new float[0];
+    }
+    return TextLayoutManager.getFragmentRectsFromAttributedString(
+        context, attributedString, paragraphAttributes, width, height, targetReactTag);
+  }
+
+  /**
    * @param surfaceId {@link int} surface ID
    * @param defaultTextInputPadding {@link float[]} output parameter will contain the default theme
    *     padding used by RN Android TextInput.

--- a/packages/react-native/ReactCommon/react/renderer/dom/CMakeLists.txt
+++ b/packages/react-native/ReactCommon/react/renderer/dom/CMakeLists.txt
@@ -6,16 +6,34 @@
 cmake_minimum_required(VERSION 3.13)
 set(CMAKE_VERBOSE_MAKEFILE on)
 
+include(${REACT_COMMON_DIR}/cmake-utils/internal/react-native-platform-selector.cmake)
 include(${REACT_COMMON_DIR}/cmake-utils/react-native-flags.cmake)
 
-file(GLOB react_renderer_dom_SRC CONFIGURE_DEPENDS *.cpp)
+react_native_android_selector(platform_SRC
+        platform/android/react/renderer/dom/*.cpp
+        platform/cxx/react/renderer/dom/*.cpp
+)
+file(GLOB react_renderer_dom_SRC CONFIGURE_DEPENDS *.cpp ${platform_SRC})
+
 add_library(react_renderer_dom OBJECT ${react_renderer_dom_SRC})
 
-target_include_directories(react_renderer_dom PUBLIC ${REACT_COMMON_DIR})
+react_native_android_selector(platform_DIR
+        ${CMAKE_CURRENT_SOURCE_DIR}/platform/android/
+        ${CMAKE_CURRENT_SOURCE_DIR}/platform/cxx/)
+target_include_directories(react_renderer_dom PUBLIC
+        ${REACT_COMMON_DIR}
+        ${platform_DIR})
+
+react_native_android_selector(platform_DIR_PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/platform/android/react/renderer/dom/
+        ${CMAKE_CURRENT_SOURCE_DIR}/platform/cxx/react/renderer/dom/)
+target_include_directories(react_renderer_dom PRIVATE
+        ${platform_DIR_PRIVATE})
 
 target_link_libraries(react_renderer_dom
         react_renderer_core
         react_renderer_graphics
+        react_renderer_textlayoutmanager
         rrc_root
         rrc_text)
 target_compile_reactnative_options(react_renderer_dom PRIVATE)

--- a/packages/react-native/ReactCommon/react/renderer/dom/DOM.h
+++ b/packages/react-native/ReactCommon/react/renderer/dom/DOM.h
@@ -111,4 +111,11 @@ std::optional<DOMRect> measureLayout(
     const ShadowNode &shadowNode,
     const ShadowNode &relativeToShadowNode);
 
+// Returns the bounding rects of all text fragments that belong to the given
+// shadow node within its parent Paragraph component. This is useful for getting
+// the visual boundaries of nested <Text> components within a text paragraph.
+// Returns an empty vector if the node is not a Text node or if it's not part
+// of a Paragraph.
+std::vector<DOMRect> getClientRects(const RootShadowNode::Shared &currentRevision, const ShadowNode &shadowNode);
+
 } // namespace facebook::react::dom

--- a/packages/react-native/ReactCommon/react/renderer/dom/platform/android/react/renderer/dom/DOMPlatform.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/dom/platform/android/react/renderer/dom/DOMPlatform.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "DOMPlatform.h"
+#include <react/renderer/textlayoutmanager/TextLayoutManagerExtended.h>
+
+namespace facebook::react::dom {
+
+std::vector<DOMRect> getClientRectsForTextNode(
+    const ParagraphShadowNode& paragraphNode,
+    const LayoutMetrics& paragraphLayoutMetrics,
+    Tag targetTag,
+    SurfaceId surfaceId) {
+  std::vector<DOMRect> result;
+
+  const auto& state = paragraphNode.getStateData();
+  auto layoutManager = state.layoutManager.lock();
+  if (layoutManager == nullptr) {
+    return result;
+  }
+
+  if constexpr (TextLayoutManagerExtended::supportsPreparedLayout()) {
+    const auto& preparedLayout = state.measuredLayout.preparedLayout;
+    if (preparedLayout.get() != nullptr) {
+      auto fragmentRects =
+          layoutManager->getFragmentRectsForReactTag(preparedLayout, targetTag);
+      result.reserve(fragmentRects.size());
+      auto contentOriginX = paragraphLayoutMetrics.frame.origin.x +
+          paragraphLayoutMetrics.contentInsets.left;
+      auto contentOriginY = paragraphLayoutMetrics.frame.origin.y +
+          paragraphLayoutMetrics.contentInsets.top;
+      for (const auto& rect : fragmentRects) {
+        result.push_back(
+            DOMRect{
+                .x = contentOriginX + rect.origin.x,
+                .y = contentOriginY + rect.origin.y,
+                .width = rect.size.width,
+                .height = rect.size.height});
+      }
+      return result;
+    }
+  }
+
+  auto layoutConstraints = LayoutConstraints{
+      .minimumSize = {0, 0},
+      .maximumSize = paragraphLayoutMetrics.frame.size,
+      .layoutDirection = paragraphLayoutMetrics.layoutDirection};
+
+  auto fragmentRects = layoutManager->getFragmentRectsFromAttributedString(
+      surfaceId,
+      state.attributedString,
+      state.paragraphAttributes,
+      layoutConstraints,
+      targetTag);
+
+  result.reserve(fragmentRects.size());
+  auto originX = paragraphLayoutMetrics.frame.origin.x;
+  auto originY = paragraphLayoutMetrics.frame.origin.y;
+  for (const auto& rect : fragmentRects) {
+    result.push_back(
+        DOMRect{
+            .x = originX + rect.origin.x,
+            .y = originY + rect.origin.y,
+            .width = rect.size.width,
+            .height = rect.size.height});
+  }
+  return result;
+}
+
+} // namespace facebook::react::dom

--- a/packages/react-native/ReactCommon/react/renderer/dom/platform/android/react/renderer/dom/DOMPlatform.h
+++ b/packages/react-native/ReactCommon/react/renderer/dom/platform/android/react/renderer/dom/DOMPlatform.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/components/text/ParagraphShadowNode.h>
+#include <react/renderer/core/LayoutMetrics.h>
+#include <react/renderer/dom/DOM.h>
+#include <vector>
+
+namespace facebook::react::dom {
+
+std::vector<DOMRect> getClientRectsForTextNode(
+    const ParagraphShadowNode &paragraphNode,
+    const LayoutMetrics &paragraphLayoutMetrics,
+    Tag targetTag,
+    SurfaceId surfaceId);
+
+} // namespace facebook::react::dom

--- a/packages/react-native/ReactCommon/react/renderer/dom/platform/cxx/react/renderer/dom/DOMPlatform.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/dom/platform/cxx/react/renderer/dom/DOMPlatform.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "DOMPlatform.h"
+
+namespace facebook::react::dom {
+
+std::vector<DOMRect> getClientRectsForTextNode(
+    const ParagraphShadowNode& paragraphNode,
+    const LayoutMetrics& paragraphLayoutMetrics,
+    Tag targetTag,
+    SurfaceId /*surfaceId*/) {
+  std::vector<DOMRect> result;
+
+  const auto& state = paragraphNode.getStateData();
+  const auto& attributedString = state.attributedString;
+  const auto& fragments = attributedString.getFragments();
+  auto paragraphFrame = paragraphLayoutMetrics.frame;
+
+  for (const auto& fragment : fragments) {
+    if (fragment.parentShadowView.tag == targetTag &&
+        !fragment.isAttachment()) {
+      result.push_back(
+          DOMRect{
+              .x = paragraphFrame.origin.x,
+              .y = paragraphFrame.origin.y,
+              .width = paragraphFrame.size.width,
+              .height = paragraphFrame.size.height});
+    }
+  }
+  return result;
+}
+
+} // namespace facebook::react::dom

--- a/packages/react-native/ReactCommon/react/renderer/dom/platform/cxx/react/renderer/dom/DOMPlatform.h
+++ b/packages/react-native/ReactCommon/react/renderer/dom/platform/cxx/react/renderer/dom/DOMPlatform.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/components/text/ParagraphShadowNode.h>
+#include <react/renderer/core/LayoutMetrics.h>
+#include <react/renderer/dom/DOM.h>
+#include <vector>
+
+namespace facebook::react::dom {
+
+std::vector<DOMRect> getClientRectsForTextNode(
+    const ParagraphShadowNode &paragraphNode,
+    const LayoutMetrics &paragraphLayoutMetrics,
+    Tag targetTag,
+    SurfaceId surfaceId);
+
+} // namespace facebook::react::dom

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.h
@@ -91,6 +91,26 @@ class TextLayoutManager {
       const TextLayoutContext &layoutContext,
       const LayoutConstraints &layoutConstraints) const;
 
+  /**
+   * Get the bounding rects of all text fragments that belong to the given
+   * react tag within a PreparedLayout. This is useful for getting the visual
+   * boundaries of nested <Text> components within a text paragraph.
+   */
+  std::vector<Rect> getFragmentRectsForReactTag(const PreparedLayout &layout, Tag targetReactTag) const;
+
+  /**
+   * Get the bounding rects of all text fragments that belong to the given
+   * react tag by creating a layout on-demand from the AttributedString.
+   * This is used as a fallback when PreparedLayout is not available
+   * (e.g., when enablePreparedTextLayout feature flag is disabled).
+   */
+  std::vector<Rect> getFragmentRectsFromAttributedString(
+      Tag surfaceId,
+      const AttributedString &attributedString,
+      const ParagraphAttributes &paragraphAttributes,
+      const LayoutConstraints &layoutConstraints,
+      Tag targetReactTag) const;
+
  private:
   std::shared_ptr<const ContextContainer> contextContainer_;
   TextMeasureCache textMeasureCache_;


### PR DESCRIPTION
Summary:
Adds the core DOM implementation for `getClientRects()` which returns the
bounding rectangles of all text fragments belonging to a TextShadowNode
within its parent ParagraphShadowNode.

This is useful for:
- Getting the visual boundaries of nested `<Text>` components within a paragraph
- Accessibility tools that need per-line text boundaries
- Layout inspection for text that spans multiple lines

On Android, the implementation uses the platform's TextLayoutManager to get
accurate fragment rects. On other platforms, a simplified fallback returns
the paragraph's frame for each fragment.

Differential Revision: D91087222


