### PR TITLE
feat: Add `StateWrapper` to fbjni typings

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/StateWrapperImpl.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/StateWrapperImpl.h
@@ -11,12 +11,13 @@
 #include <react/common/mapbuffer/JReadableMapBuffer.h>
 #include <react/jni/ReadableNativeMap.h>
 #include <react/renderer/core/State.h>
+#include <react/uimanager/StateWrapper.h>
 
 namespace facebook::react {
 
 class Instance;
 
-class StateWrapperImpl : public jni::HybridClass<StateWrapperImpl> {
+class StateWrapperImpl : public jni::HybridClass<StateWrapperImpl, StateWrapper> {
  public:
   constexpr static const char *const kJavaDescriptor = "Lcom/facebook/react/fabric/StateWrapperImpl;";
   constexpr static auto StateWrapperImplJavaDescriptor = "com/facebook/react/fabric/StateWrapperImpl";

--- a/packages/react-native/ReactAndroid/src/main/jni/react/uimanager/StateWrapper.h
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/uimanager/StateWrapper.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <fbjni/fbjni.h>
+
+namespace facebook::react {
+
+class StateWrapper : public jni::HybridClass<StateWrapper> {
+ public:
+  constexpr static const char *const kJavaDescriptor = "Lcom/facebook/react/uimanager/StateWrapper;";
+};
+
+} // namespace facebook::react


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

In [Nitro](https://nitro.margelo.com), we support creating views using Fabric's view system.

We use `StateWrapper` (and `StateWrapperImpl`) from C++. While we can use `react::StateWrapperImpl` from C++, we had to define `StateWrapper` ourselves ([see `JStateWrapper.hpp`](https://github.com/mrousavy/nitro/blob/main/packages/react-native-nitro-modules/android/src/main/cpp/views/JStateWrapper.hpp))

`StateWrapperImpl` inherits from `StateWrapper` in Kotlin, but the same inheritance is not reflected in C++ via fbjni.

To fix this, we did some dirty static downcasting, which is not safe to do but worked.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[ANDROID] [ADDED] - Add `StateWrapper` to C++ fbjni types

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

When you have a `StateWrapperImpl` in Kotlin, pass that to C++ via fbjni using the `jni::alias_ref<react::StateWrapper>` type. (Example; `SimpleViewManager.updateState(...)` gives you a `StateWrapper`)

Then try downcasting via `jni::dynamic_ref_cast<react::StateWrapperImpl>(...)`.

If both works, this PR works.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
