### PR TITLE
Remove NativeAnimatedModule.userDrivenScrollEnded

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -477,7 +477,6 @@ public final class com/facebook/react/animated/NativeAnimatedModule : com/facebo
 	public fun stopAnimation (D)V
 	public fun stopListeningToAnimatedNodeValue (D)V
 	public fun updateAnimatedNodeConfig (DLcom/facebook/react/bridge/ReadableMap;)V
-	public final fun userDrivenScrollEnded (I)V
 	public fun willDispatchViewUpdates (Lcom/facebook/react/bridge/UIManager;)V
 	public fun willMountItems (Lcom/facebook/react/bridge/UIManager;)V
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.kt
@@ -209,32 +209,6 @@ public class NativeAnimatedModule(reactContext: ReactApplicationContext) :
   private var numFabricAnimations = 0
   private var numNonFabricAnimations = 0
 
-  /**
-   * This method is used to notify the JS side that the user has stopped scrolling. With natively
-   * driven animation, we might have to force a resync between the Shadow Tree and the Native Tree.
-   * This is because with natively driven animation, the Shadow Tree is bypassed and it can have
-   * stale information on the layout of the native views. This method takes care of verifying if
-   * there are some views listening to the native driven animation and it triggers the resynch.
-   *
-   * @param viewTag The tag of the scroll view that has stopped scrolling
-   */
-  public fun userDrivenScrollEnded(viewTag: Int) {
-    // ask to the Node Manager for all the native nodes listening to OnScroll event
-    val nodeManager = nodesManagerRef.get() ?: return
-
-    val tags = nodeManager.getTagsOfConnectedNodes(viewTag, "topScrollEnded")
-
-    if (tags.isEmpty()) {
-      return
-    }
-
-    // emit the event to JS to resync the trees
-    val onAnimationEndedData = buildReadableMap { putArray("tags") { tags.forEach { add(it) } } }
-
-    val reactApplicationContext = reactApplicationContextIfActiveOrWarn
-    reactApplicationContext?.emitDeviceEvent("onUserDrivenAnimationEnded", onAnimationEndedData)
-  }
-
   override fun initialize() {
     super.initialize()
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -1204,8 +1204,6 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
                 if (mSendMomentumEvents) {
                   ReactScrollViewHelper.emitScrollMomentumEndEvent(ReactHorizontalScrollView.this);
                 }
-                ReactScrollViewHelper.notifyUserDrivenScrollEnded_internal(
-                    ReactHorizontalScrollView.this);
               } else {
                 if (mPagingEnabled && !mSnappingToPage) {
                   // If we have pagingEnabled and we have not snapped to the page

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactNestedScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactNestedScrollView.java
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<a79ecc0c8081ff170ad17a559095e1b1>>
+ * @generated SignedSource<<8bc2307ce295e1e0f3246dc185688ee8>>
  */
 
 /**
@@ -955,7 +955,6 @@ class ReactNestedScrollView extends NestedScrollView
                 if (mSendMomentumEvents) {
                   ReactScrollViewHelper.emitScrollMomentumEndEvent(ReactNestedScrollView.this);
                 }
-                ReactScrollViewHelper.notifyUserDrivenScrollEnded_internal(ReactNestedScrollView.this);
                 disableFpsListener();
               } else {
                 if (mPagingEnabled && !mSnappingToPage) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -947,7 +947,6 @@ public class ReactScrollView extends ScrollView
                 if (mSendMomentumEvents) {
                   ReactScrollViewHelper.emitScrollMomentumEndEvent(ReactScrollView.this);
                 }
-                ReactScrollViewHelper.notifyUserDrivenScrollEnded_internal(ReactScrollView.this);
                 disableFpsListener();
               } else {
                 if (mPagingEnabled && !mSnappingToPage) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
@@ -19,7 +19,6 @@ import androidx.annotation.RequiresApi
 import androidx.core.view.ViewCompat.FocusDirection
 import androidx.core.view.ViewCompat.FocusRealDirection
 import com.facebook.common.logging.FLog
-import com.facebook.react.animated.NativeAnimatedModule
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.WritableNativeMap
@@ -153,19 +152,6 @@ public object ReactScrollViewHelper {
       )
       if (scrollEventType == ScrollEventType.SCROLL) {
         scrollView.lastScrollDispatchTime = now
-      }
-    }
-  }
-
-  // TODO: Remove this once C++ animation driver is complete
-  @JvmStatic
-  @JvmName("notifyUserDrivenScrollEnded_internal")
-  internal fun notifyUserDrivenScrollEnded(scrollView: ViewGroup) {
-    val reactContext = scrollView.context as? ReactContext
-    if (reactContext != null) {
-      val nativeAnimated = reactContext.getNativeModule(NativeAnimatedModule::class.java)
-      if (nativeAnimated != null) {
-        nativeAnimated.userDrivenScrollEnded(scrollView.id)
       }
     }
   }
@@ -457,13 +443,11 @@ public object ReactScrollViewHelper {
 
               override fun onAnimationEnd(animator: Animator) {
                 scrollView.reactScrollViewScrollState.isFinished = true
-                notifyUserDrivenScrollEnded(scrollView)
                 updateFabricScrollState(scrollView)
               }
 
               override fun onAnimationCancel(animator: Animator) {
                 scrollView.reactScrollViewScrollState.isCanceled = true
-                notifyUserDrivenScrollEnded(scrollView)
               }
 
               override fun onAnimationRepeat(animator: Animator) = Unit


### PR DESCRIPTION
Summary:
## Changelog:

[Android] [Removed] - Remove NativeAnimatedModule.userDrivenScrollEnded

An alternative to keep supporting this backward is making `ReactScrollViewHelper.kt` import a NativeAnimatedModuleSpec, and add `userDrivenScrollEnded` to the spec, but that would be adding too much complexity to public API. `userDrivenScrollEnded` would not be needed when c++ animated is rolled out.

Differential Revision: D91472774


