### PR TITLE
getDirectManipulationAllowlist should return by const reference to avoid per-frame copies

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/animated/internal/NativeAnimatedAllowlist.h
+++ b/packages/react-native/ReactCommon/react/renderer/animated/internal/NativeAnimatedAllowlist.h
@@ -12,14 +12,14 @@
 
 namespace facebook::react {
 
-inline static std::unordered_set<std::string> getDirectManipulationAllowlist()
+inline const std::unordered_set<std::string> &getDirectManipulationAllowlist()
 {
   /**
    * Direct manipulation eligible styles allowed by the NativeAnimated JS
    * implementation. Keep in sync with
    * packages/react-native/Libraries/Animated/NativeAnimatedAllowlist.js
    */
-  static std::unordered_set<std::string> DIRECT_MANIPULATION_STYLES{
+  static const std::unordered_set<std::string> DIRECT_MANIPULATION_STYLES{
       /* SUPPORTED_COLOR_STYLES */
       "backgroundColor",
       "borderBottomColor",


### PR DESCRIPTION
Summary:
Fix a memory allocation hotspot with getDirectManipulationAllowlist(). Function was returning a static std::unordered_set<std::string> by value instead of by const reference, causing the set to be copied each call.

The fix changes the return type from std::unordered_set<std::string> to const std::unordered_set<std::string>&, eliminating the per-frame copy overhead entirely.

Changelog: [Internal]

Reviewed By: javache, rozele

Differential Revision: D91475194


