### PR TITLE
Fix MapBuffer OOB read vulnerability in release builds

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBuffer.h
+++ b/packages/react-native/ReactCommon/react/renderer/mapbuffer/MapBuffer.h
@@ -149,6 +149,8 @@ class MapBuffer {
 
   int32_t getKeyBucket(MapBuffer::Key key) const;
 
+  inline int32_t getIntAtBucket(int32_t bucketIndex) const;
+
   friend JReadableMapBuffer;
 };
 


### PR DESCRIPTION
Summary:
## Changelog:

[Internal] [Fixed] - Fix MapBuffer OOB read vulnerability in release builds

This fixes a security vulnerability where MapBuffer accessors could leak memory or crash when handling missing keys in release builds.

**Problem:**
The `react_native_assert` macro is defined as `((void)0)` when `REACT_NATIVE_DEBUG` is not defined (production builds). This means the assertions in `getInt`, `getLong`, and `getDouble` are completely stripped out in release builds. When `getKeyBucket` returns -1 (key not found), the code proceeds to read from an invalid offset, causing:
- Out-of-bounds memory reads
- Information disclosure (leaking sensitive data)
- Potential crashes

**Solution:**
Added runtime checks that work in release builds (debug build will abort at react_native_assert). This approach will not trigger more crash in release build.

**Affected methods:**
- `MapBuffer::getInt()`
- `MapBuffer::getLong()`
- `MapBuffer::getDouble()`

Note: `getBool()` and `getString()` are protected because they call `getInt()` internally.

[Session trajectory link](https://www.internalfb.com/intern/devai/devmate/inspector/?id=T247828667-0acc36ee-5abf-4f89-a444-3f8e1c959b51)

Differential Revision: D91478548


