### PR TITLE
Add scrollsChildToFocus as a valid prop attribute

### DIFF
--- a/packages/react-native/Libraries/Components/ScrollView/AndroidHorizontalScrollViewNativeComponent.js
+++ b/packages/react-native/Libraries/Components/ScrollView/AndroidHorizontalScrollViewNativeComponent.js
@@ -59,6 +59,7 @@ export const __INTERNAL_VIEW_CONFIG: PartialViewConfig = {
       process: require('../../StyleSheet/processColor').default,
     },
     pointerEvents: true,
+    scrollsChildToFocus: true,
   },
 };
 


### PR DESCRIPTION
Summary:
An extension of https://github.com/facebook/react-native/pull/55143, adds `scrollsChildToFocus` as a valid attribute to the horizontal scroll view

Changelog: [Internal]

Differential Revision: D91485193


