### PR TITLE
ERROR: StaticViewConfigValidator: Invalid static view config for 'AndroidHorizontalScrollView'

### DIFF
--- a/packages/react-native/Libraries/Components/ScrollView/AndroidHorizontalScrollViewNativeComponent.js
+++ b/packages/react-native/Libraries/Components/ScrollView/AndroidHorizontalScrollViewNativeComponent.js
@@ -59,6 +59,7 @@ export const __INTERNAL_VIEW_CONFIG: PartialViewConfig = {
       process: require('../../StyleSheet/processColor').default,
     },
     pointerEvents: true,
+    scrollsChildToFocus: true,
   },
 };
 


### PR DESCRIPTION
Summary:
Add missing scrollsChildToFocus attribute to AndroidHorizontalScrollViewNativeComponent.js
validAttributes to fix StaticViewConfigValidator error.

The native Android side (ReactHorizontalScrollViewManager.kt) defines scrollsChildToFocus as a ReactProp, but the JavaScript static view config was missing this attribute.

This fixes the error:
ERROR StaticViewConfigValidator: Invalid static view config for 'AndroidHorizontalScrollView'. 'validAttributes.scrollsChildToFocus' is missing.


Changelog: [Internal]

Reviewed By: javache

Differential Revision: D91480519


