### PR TITLE
Fix IMPORTANT_FOR_INTERACTION_EXCLUDE_DESCENDANTS value to match HorizonOS API

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ImportantForInteractionHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ImportantForInteractionHelper.kt
@@ -29,7 +29,7 @@ internal object ImportantForInteractionHelper {
   const val IMPORTANT_FOR_INTERACTION_NO: Int = 0x2
 
   /** Descendants of this view should be excluded from interaction handling. */
-  const val IMPORTANT_FOR_INTERACTION_EXCLUDE_DESCENDANTS: Int = 0x8
+  const val IMPORTANT_FOR_INTERACTION_EXCLUDE_DESCENDANTS: Int = 0x4
 
   /**
    * Sets the important_for_interaction tag on a view based on the given [PointerEvents] value.


### PR DESCRIPTION
Summary:
Changelog: [Internal]

The `IMPORTANT_FOR_INTERACTION_EXCLUDE_DESCENDANTS` constant was incorrectly set to `0x8`. This value was sourced from the "UI Understanding APIs TDD" design document, which had an outdated/incorrect value.

The correct value is `0x4`, as defined in the official HorizonOS API at `horizonos.view.ViewExt.IMPORTANT_FOR_INTERACTION_EXCLUDE_DESCENDANTS`.

References:
- Incorrect source (TDD doc): https://docs.google.com/document/d/1YQ5rel1bvZboTfs1-8uPWJnOAyfl_fSm9oILjU-2lbg/edit?tab=t.0
- Correct source (ViewExt.java): https://www.internalfb.com/code/aosp-vendor-meta-coresdk/[oculus-14.0]/api-src/volumetricwindow/java/horizonos/view/ViewExt.java?lines=50

Reviewed By: twasilczyk

Differential Revision: D91500494


