### PR TITLE
decouple ReactScrollViewHelper from kt NativeAnimated

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -439,7 +439,7 @@ public abstract interface class com/facebook/react/animated/AnimatedNodeValueLis
 	public abstract fun onValueUpdate (DD)V
 }
 
-public final class com/facebook/react/animated/NativeAnimatedModule : com/facebook/fbreact/specs/NativeAnimatedModuleSpec, com/facebook/react/bridge/LifecycleEventListener, com/facebook/react/bridge/UIManagerListener {
+public final class com/facebook/react/animated/NativeAnimatedModule : com/facebook/fbreact/specs/NativeAnimatedModuleSpec, com/facebook/react/bridge/LifecycleEventListener, com/facebook/react/bridge/ScrollEndedListener, com/facebook/react/bridge/UIManagerListener {
 	public static final field ANIMATED_MODULE_DEBUG Z
 	public static final field Companion Lcom/facebook/react/animated/NativeAnimatedModule$Companion;
 	public static final field NAME Ljava/lang/String;
@@ -465,6 +465,7 @@ public final class com/facebook/react/animated/NativeAnimatedModule : com/facebo
 	public fun onHostDestroy ()V
 	public fun onHostPause ()V
 	public fun onHostResume ()V
+	public fun onScrollEnded (Landroid/view/ViewGroup;)V
 	public fun queueAndExecuteBatchedOperations (Lcom/facebook/react/bridge/ReadableArray;)V
 	public fun removeAnimatedEventFromView (DLjava/lang/String;D)V
 	public fun removeListeners (D)V
@@ -1018,6 +1019,7 @@ public abstract class com/facebook/react/bridge/ReactContext : android/content/C
 	public abstract fun getNativeModule (Ljava/lang/String;)Lcom/facebook/react/bridge/NativeModule;
 	public abstract fun getNativeModules ()Ljava/util/Collection;
 	public fun getNativeModulesMessageQueueThread ()Lcom/facebook/react/bridge/queue/MessageQueueThread;
+	public fun getScrollEndedListeners ()Lcom/facebook/react/bridge/ScrollEndedListeners;
 	public abstract fun getSourceURL ()Ljava/lang/String;
 	public fun getSystemService (Ljava/lang/String;)Ljava/lang/Object;
 	public fun getUiMessageQueueThread ()Lcom/facebook/react/bridge/queue/MessageQueueThread;
@@ -1373,6 +1375,17 @@ public final class com/facebook/react/bridge/RuntimeExecutor : com/facebook/jni/
 }
 
 public final class com/facebook/react/bridge/RuntimeScheduler : com/facebook/jni/HybridClassBase {
+}
+
+public abstract interface class com/facebook/react/bridge/ScrollEndedListener {
+	public abstract fun onScrollEnded (Landroid/view/ViewGroup;)V
+}
+
+public final class com/facebook/react/bridge/ScrollEndedListeners {
+	public fun <init> ()V
+	public final fun addListener (Lcom/facebook/react/bridge/ScrollEndedListener;)V
+	public final fun notifyScrollEnded (Landroid/view/ViewGroup;)V
+	public final fun removeListener (Lcom/facebook/react/bridge/ScrollEndedListener;)V
 }
 
 public abstract interface class com/facebook/react/bridge/UIManager : com/facebook/react/bridge/PerformanceCounter {
@@ -4208,6 +4221,7 @@ public final class com/facebook/react/uimanager/ThemedReactContext : com/faceboo
 	public fun getNativeModule (Ljava/lang/String;)Lcom/facebook/react/bridge/NativeModule;
 	public fun getNativeModules ()Ljava/util/Collection;
 	public final fun getReactApplicationContext ()Lcom/facebook/react/bridge/ReactApplicationContext;
+	public fun getScrollEndedListeners ()Lcom/facebook/react/bridge/ScrollEndedListeners;
 	public fun getSourceURL ()Ljava/lang/String;
 	public final fun getSurfaceID ()Ljava/lang/String;
 	public final fun getSurfaceId ()I

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.kt
@@ -17,6 +17,7 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactSoftExceptionLogger
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.bridge.ScrollEndedListener
 import com.facebook.react.bridge.UIManager
 import com.facebook.react.bridge.UIManagerListener
 import com.facebook.react.bridge.buildReadableMap
@@ -80,7 +81,10 @@ import kotlin.concurrent.Volatile
 @OptIn(UnstableReactNativeAPI::class)
 @ReactModule(name = NativeAnimatedModuleSpec.NAME)
 public class NativeAnimatedModule(reactContext: ReactApplicationContext) :
-    NativeAnimatedModuleSpec(reactContext), LifecycleEventListener, UIManagerListener {
+    NativeAnimatedModuleSpec(reactContext),
+    LifecycleEventListener,
+    UIManagerListener,
+    ScrollEndedListener {
 
   // For `queueAndExecuteBatchedOperations`
   private enum class BatchExecutionOpCodes(value: Int) {
@@ -239,6 +243,11 @@ public class NativeAnimatedModule(reactContext: ReactApplicationContext) :
     super.initialize()
 
     reactApplicationContext.addLifecycleEventListener(this)
+    reactApplicationContext.scrollEndedListeners.addListener(this)
+  }
+
+  override fun onScrollEnded(scrollView: android.view.ViewGroup) {
+    userDrivenScrollEnded(scrollView.id)
   }
 
   override fun onHostResume() {
@@ -913,6 +922,7 @@ public class NativeAnimatedModule(reactContext: ReactApplicationContext) :
   override fun invalidate() {
     super.invalidate()
 
+    reactApplicationContext.scrollEndedListeners.removeListener(this)
     reactApplicationContext.removeLifecycleEventListener(this)
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java
@@ -50,6 +50,7 @@ public abstract class ReactContext extends ContextWrapper {
       new CopyOnWriteArraySet<>();
   private final CopyOnWriteArraySet<WindowFocusChangeListener> mWindowFocusEventListeners =
       new CopyOnWriteArraySet<>();
+  private final ScrollEndedListeners mScrollEndedListeners = new ScrollEndedListeners();
 
   private LifecycleState mLifecycleState = LifecycleState.BEFORE_CREATE;
 
@@ -193,6 +194,15 @@ public abstract class ReactContext extends ContextWrapper {
 
   public LifecycleState getLifecycleState() {
     return mLifecycleState;
+  }
+
+  /**
+   * This allows scroll views to notify NativeAnimatedModule when user-driven scrolling ends.
+   *
+   * @return The ScrollEndedListeners instance
+   */
+  public ScrollEndedListeners getScrollEndedListeners() {
+    return mScrollEndedListeners;
   }
 
   public void addLifecycleEventListener(final LifecycleEventListener listener) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ScrollEndedListener.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ScrollEndedListener.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.bridge
+
+import android.view.ViewGroup
+import java.lang.ref.WeakReference
+import java.util.concurrent.CopyOnWriteArrayList
+
+/** Listener interface for scroll ended events. This is a native only event. */
+public interface ScrollEndedListener {
+  /**
+   * Called when user-driven scrolling ends.
+   *
+   * @param scrollView The scroll view that has stopped scrolling
+   */
+  public fun onScrollEnded(scrollView: ViewGroup)
+}
+
+/**
+ * Registry for managing ScrollEndedListener instances. This provides a decoupled mechanism for
+ * scroll views to notify interested parties (like NativeAnimatedModule) when user-driven scrolling
+ * ends, without creating circular dependencies between modules.
+ *
+ * This class is instantiated per ReactContext and can be accessed via
+ * [com.facebook.react.bridge.ReactContext.getScrollEndedListeners].
+ */
+public class ScrollEndedListeners {
+  private val listeners = CopyOnWriteArrayList<WeakReference<ScrollEndedListener>>()
+
+  /**
+   * Adds a scroll ended listener. This listener is called when user-driven scrolling ends.
+   *
+   * @param listener The listener to add
+   */
+  public fun addListener(listener: ScrollEndedListener) {
+    listeners.add(WeakReference(listener))
+  }
+
+  /**
+   * Removes a scroll ended listener.
+   *
+   * @param listener The listener to remove
+   */
+  public fun removeListener(listener: ScrollEndedListener) {
+    val toRemove = ArrayList<WeakReference<ScrollEndedListener>>()
+    for (ref in listeners) {
+      val target = ref.get()
+      if (target == null || target == listener) {
+        toRemove.add(ref)
+      }
+    }
+    listeners.removeAll(toRemove)
+  }
+
+  /**
+   * Notifies all registered listeners that user-driven scrolling has ended.
+   *
+   * @param scrollView The scroll view that has stopped scrolling
+   */
+  public fun notifyScrollEnded(scrollView: ViewGroup) {
+    for (listenerRef in listeners) {
+      listenerRef.get()?.onScrollEnded(scrollView)
+    }
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ThemedReactContext.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ThemedReactContext.kt
@@ -19,6 +19,7 @@ import com.facebook.react.bridge.LifecycleEventListener
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactContext
+import com.facebook.react.bridge.ScrollEndedListeners
 import com.facebook.react.bridge.UIManager
 import com.facebook.react.common.annotations.internal.LegacyArchitecture
 import com.facebook.react.turbomodule.core.interfaces.CallInvokerHolder
@@ -154,4 +155,7 @@ public class ThemedReactContext(
   override fun registerSegment(segmentId: Int, path: String?, callback: Callback?) {
     reactApplicationContext.registerSegment(segmentId, path, callback)
   }
+
+  override fun getScrollEndedListeners(): ScrollEndedListeners =
+      reactApplicationContext.scrollEndedListeners
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
@@ -19,7 +19,6 @@ import androidx.annotation.RequiresApi
 import androidx.core.view.ViewCompat.FocusDirection
 import androidx.core.view.ViewCompat.FocusRealDirection
 import com.facebook.common.logging.FLog
-import com.facebook.react.animated.NativeAnimatedModule
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.WritableNativeMap
@@ -157,17 +156,11 @@ public object ReactScrollViewHelper {
     }
   }
 
-  // TODO: Remove this once C++ animation driver is complete
   @JvmStatic
   @JvmName("notifyUserDrivenScrollEnded_internal")
   internal fun notifyUserDrivenScrollEnded(scrollView: ViewGroup) {
     val reactContext = scrollView.context as? ReactContext
-    if (reactContext != null) {
-      val nativeAnimated = reactContext.getNativeModule(NativeAnimatedModule::class.java)
-      if (nativeAnimated != null) {
-        nativeAnimated.userDrivenScrollEnded(scrollView.id)
-      }
-    }
+    reactContext?.scrollEndedListeners?.notifyScrollEnded(scrollView)
   }
 
   /** This is only for Java listeners. onLayout events emitted to JS are handled elsewhere. */


### PR DESCRIPTION
Summary:
## Changelog:

[Android] [Changed] - decouple ReactScrollViewHelper from kt NativeAnimated

This diff decouples ReactScrollViewHelper from directly depending on NativeAnimatedModule on Android, following the iOS pattern where native animation modules are notified of scroll end events via a listener mechanism rather than direct coupling.

## Problem
* Previously, ReactScrollViewHelper had a direct import and dependency on NativeAnimatedModule to call userDrivenScrollEnded() when user-driven scrolling ends. This created a circular dependency in the build system (scroll module → animated module), making it harder to maintain and test these modules independently.

## Solution
1. Introduced ScrollEndedListener interface and ScrollEndedListeners class in the uimanager/events package as a decoupled notification mechanism
2. ScrollEndedListeners is instantiated per-ReactContext and accessible via ReactContext.getScrollEndedListeners()
3. NativeAnimatedModule now implements ScrollEndedListener and registers/unregisters itself with the ReactContext's ScrollEndedListeners during initialize()/invalidate()
4. ReactScrollViewHelper now gets the ReactContext from the scrollView and notifies listeners through the registry instead of directly calling NativeAnimatedModule

Differential Revision: D91497003


