### PR TITLE
Add Sonatype Central repository for users of nightly builds only

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -74,7 +74,7 @@ class ReactPlugin : Plugin<Project> {
         val hermesVersionPropertiesFile =
             File(reactNativeDir, "sdks/hermes-engine/version.properties")
         val versionAndGroupStrings =
-            readVersionAndGroupStrings(propertiesFile, hermesVersionPropertiesFile)
+            readVersionAndGroupStrings(project, propertiesFile, hermesVersionPropertiesFile)
         val hermesV1Enabled = rootExtension.hermesV1Enabled.get()
         configureDependencies(project, versionAndGroupStrings, hermesV1Enabled)
         configureRepositories(project, versionAndGroupStrings.isNightly)

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/DependencyUtils.kt
@@ -35,9 +35,10 @@ internal object DependencyUtils {
       val hermesV1VersionString: String,
       val reactGroupString: String = DEFAULT_INTERNAL_REACT_PUBLISHING_GROUP,
       val hermesGroupString: String = DEFAULT_INTERNAL_HERMES_PUBLISHING_GROUP,
+      private val isHermesNightly: Boolean = false,
   ) {
     val isNightly: Boolean
-      get() = versionString.isNightly()
+      get() = versionString.isNightly() || isHermesNightly
   }
 
   /**
@@ -209,7 +210,7 @@ internal object DependencyUtils {
     return dependencySubstitution
   }
 
-  fun readVersionAndGroupStrings(propertiesFile: File, hermesVersionFile: File): Coordinates {
+  fun readVersionAndGroupStrings(project: Project, propertiesFile: File, hermesVersionFile: File): Coordinates {
     val reactAndroidProperties = Properties()
     propertiesFile.inputStream().use { reactAndroidProperties.load(it) }
     val versionStringFromFile = (reactAndroidProperties[INTERNAL_VERSION_NAME] as? String).orEmpty()
@@ -242,6 +243,7 @@ internal object DependencyUtils {
 
     val hermesV1Version =
         (hermesVersionProperties[INTERNAL_HERMES_V1_VERSION_NAME] as? String).orEmpty()
+    val isHermesNightly = (project.findProperty(INTERNAL_USE_HERMES_NIGHTLY) as? String).toBoolean()
 
     return Coordinates(
         versionString,
@@ -249,6 +251,7 @@ internal object DependencyUtils {
         hermesV1Version,
         reactGroupString,
         hermesGroupString,
+        isHermesNightly,
     )
   }
 

--- a/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/DependencyUtilsTest.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/test/kotlin/com/facebook/react/utils/DependencyUtilsTest.kt
@@ -615,7 +615,8 @@ class DependencyUtilsTest {
           )
         }
 
-    val strings = readVersionAndGroupStrings(propertiesFile, hermesVersionFile)
+    val project = createProject()
+    val strings = readVersionAndGroupStrings(project, propertiesFile, hermesVersionFile)
     val versionString = strings.versionString
     val hermesVersionString = strings.hermesVersionString
     val hermesV1VersionString = strings.hermesV1VersionString
@@ -652,7 +653,8 @@ class DependencyUtilsTest {
           )
         }
 
-    val strings = readVersionAndGroupStrings(propertiesFile, hermesVersionFile)
+    val project = createProject()
+    val strings = readVersionAndGroupStrings(project, propertiesFile, hermesVersionFile)
     val versionString = strings.versionString
     val hermesVersionString = strings.hermesVersionString
     val hermesV1VersionString = strings.hermesV1VersionString
@@ -684,7 +686,8 @@ class DependencyUtilsTest {
           )
         }
 
-    val strings = readVersionAndGroupStrings(propertiesFile, hermesVersionFile)
+    val project = createProject()
+    val strings = readVersionAndGroupStrings(project, propertiesFile, hermesVersionFile)
     val versionString = strings.versionString
     val hermesVersionString = strings.hermesVersionString
     val hermesV1VersionString = strings.hermesV1VersionString
@@ -718,7 +721,8 @@ class DependencyUtilsTest {
           )
         }
 
-    val strings = readVersionAndGroupStrings(propertiesFile, hermesVersionFile)
+    val project = createProject()
+    val strings = readVersionAndGroupStrings(project, propertiesFile, hermesVersionFile)
     val versionString = strings.versionString
     val hermesVersionString = strings.hermesVersionString
     val hermesV1VersionString = strings.hermesV1VersionString
@@ -753,7 +757,8 @@ class DependencyUtilsTest {
           )
         }
 
-    val strings = readVersionAndGroupStrings(propertiesFile, hermesVersionFile)
+    val project = createProject()
+    val strings = readVersionAndGroupStrings(project, propertiesFile, hermesVersionFile)
     val reactGroupString = strings.reactGroupString
     val hermesGroupString = strings.hermesGroupString
 
@@ -785,7 +790,8 @@ class DependencyUtilsTest {
           )
         }
 
-    val strings = readVersionAndGroupStrings(propertiesFile, hermesVersionFile)
+    val project = createProject()
+    val strings = readVersionAndGroupStrings(project, propertiesFile, hermesVersionFile)
     val reactGroupString = strings.reactGroupString
     val hermesGroupString = strings.hermesGroupString
 


### PR DESCRIPTION
## Summary:

Even though Sonatype Central repository isn't used by an app, still the React Native Gradle plugin adds the Sonatype Central to repositories.
In some cases it leads to a considerable amount of failed requests on Gradle downloading dependencies.

<img width="1076" height="109" alt="858 failed requests out of 858 requests" src="https://github.com/user-attachments/assets/40d6aeb6-dcc4-4ebb-9f0b-742d26ba6e65" />


I'm introducing a change where Sonatype Central repository is included for users of nightly builds only.

## Changelog:

[ANDROID] [CHANGED] - Add Sonatype Central repository for users of nightly builds only

## Test Plan:

All of the tests in gradle plugin are green
```
$ ./gradlew test

BUILD SUCCESSFUL in 10s
20 actionable tasks: 20 executed
```
