### PR TITLE
fix(react-native): add prefabPublishing to hermes-engine for build-from-source

### DIFF
--- a/packages/react-native/ReactAndroid/hermes-engine/build.gradle.kts
+++ b/packages/react-native/ReactAndroid/hermes-engine/build.gradle.kts
@@ -421,7 +421,10 @@ android {
     java.srcDirs("$hermesDir/lib/Platform/Intl/java", "$hermesDir/lib/Platform/Unicode/java")
   }
 
-  buildFeatures { prefab = true }
+  buildFeatures {
+    prefab = true
+    prefabPublishing = true
+  }
 
   dependencies {
     implementation(libs.fbjni)


### PR DESCRIPTION
## Summary

PR #54707 removed `prefabPublishing = true` from hermes-engine when switching to prebuilt Hermes by default. This broke build-from-source because AGP no longer generates the CMake config file needed by `find_package(hermes-engine)` in ReactAndroid's native build.

Adding `prefabPublishing = true` back restores the CMake config generation and proper Gradle task ordering.

The same PR also disables all hermes tasks when not building from source - which will make the CI work correctly - ie. not build hermes from source when not needed.

Closes #55290

## Changelog:

[ANDROID] [FIXED] - Re-added prefabPublishing=true to make Android build from source work again

## Test Plan:

- Build RN Tester and build from source, verify that Android builds correctly.
- Check CI and verify that Hermes is not built from source