### PR TITLE
Remove const qualifier from side-effectful methods of Agents and Targets

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.cpp
@@ -385,8 +385,7 @@ class HostAgent::Impl final {
     return fuseboxClientType_ == FuseboxClientType::Fusebox;
   }
 
-  void emitExternalTracingProfile(
-      tracing::HostTracingProfile tracingProfile) const {
+  void emitExternalTracingProfile(tracing::HostTracingProfile tracingProfile) {
     assert(
         hasFuseboxClientConnected() &&
         "Attempted to emit a trace recording to a non-Fusebox client");
@@ -543,11 +542,11 @@ bool HostAgent::hasFuseboxClientConnected() const {
 }
 
 void HostAgent::emitExternalTracingProfile(
-    tracing::HostTracingProfile tracingProfile) const {
+    tracing::HostTracingProfile tracingProfile) {
   impl_->emitExternalTracingProfile(std::move(tracingProfile));
 }
 
-void HostAgent::emitSystemStateChanged(bool isSingleHost) const {
+void HostAgent::emitSystemStateChanged(bool isSingleHost) {
   impl_->emitSystemStateChanged(isSingleHost);
 }
 

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostAgent.h
@@ -77,13 +77,13 @@ class HostAgent final {
    * Emits the HostTracingProfile that was captured externally, not via the
    * CDP-initiated request.
    */
-  void emitExternalTracingProfile(tracing::HostTracingProfile tracingProfile) const;
+  void emitExternalTracingProfile(tracing::HostTracingProfile tracingProfile);
 
   /**
    * Emits a system state changed event when the number of ReactHost instances
    * changes.
    */
-  void emitSystemStateChanged(bool isSingleHost) const;
+  void emitSystemStateChanged(bool isSingleHost);
 
  private:
   // We use the private implementation idiom to ensure this class has the same

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.cpp
@@ -111,8 +111,7 @@ class HostTargetSession {
     return hostAgent_.hasFuseboxClientConnected();
   }
 
-  void emitHostTracingProfile(
-      tracing::HostTracingProfile tracingProfile) const {
+  void emitHostTracingProfile(tracing::HostTracingProfile tracingProfile) {
     hostAgent_.emitExternalTracingProfile(std::move(tracingProfile));
   }
 
@@ -384,7 +383,7 @@ bool HostTarget::hasActiveSessionWithFuseboxClient() const {
 }
 
 void HostTarget::emitTracingProfileForFirstFuseboxClient(
-    tracing::HostTracingProfile tracingProfile) const {
+    tracing::HostTracingProfile tracingProfile) {
   bool emitted = false;
   sessions_.forEach([&](HostTargetSession& session) {
     if (emitted) {

--- a/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/HostTarget.h
@@ -363,7 +363,7 @@ class JSINSPECTOR_EXPORT HostTarget : public EnableExecutorFromThis<HostTarget> 
    *
    * @see \c hasActiveFrontendSession
    */
-  void emitTracingProfileForFirstFuseboxClient(tracing::HostTracingProfile tracingProfile) const;
+  void emitTracingProfileForFirstFuseboxClient(tracing::HostTracingProfile tracingProfile);
 
   /**
    * An endpoint for the Host to report frame timings that will be recorded if and only if there is currently an active

--- a/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.cpp
@@ -120,14 +120,14 @@ bool TracingAgent::handleRequest(const cdp::PreparsedRequest& req) {
 }
 
 void TracingAgent::emitExternalHostTracingProfile(
-    tracing::HostTracingProfile tracingProfile) const {
+    tracing::HostTracingProfile tracingProfile) {
   frontendChannel_(
       cdp::jsonNotification("ReactNativeApplication.traceRequested"));
   emitHostTracingProfile(std::move(tracingProfile));
 }
 
 void TracingAgent::emitHostTracingProfile(
-    tracing::HostTracingProfile tracingProfile) const {
+    tracing::HostTracingProfile tracingProfile) {
   auto dataCollectedCallback = [this](folly::dynamic&& eventsChunk) {
     frontendChannel_(
         cdp::jsonNotification(

--- a/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/TracingAgent.h
@@ -44,7 +44,7 @@ class TracingAgent {
   /**
    * Emits the HostTracingProfile that was stashed externally by the HostTarget.
    */
-  void emitExternalHostTracingProfile(tracing::HostTracingProfile tracingProfile) const;
+  void emitExternalHostTracingProfile(tracing::HostTracingProfile tracingProfile);
 
  private:
   /**
@@ -60,7 +60,7 @@ class TracingAgent {
    * Emits captured HostTracingProfile in a series of
    * Tracing.dataCollected events, followed by a Tracing.tracingComplete event.
    */
-  void emitHostTracingProfile(tracing::HostTracingProfile tracingProfile) const;
+  void emitHostTracingProfile(tracing::HostTracingProfile tracingProfile);
 };
 
 } // namespace facebook::react::jsinspector_modern


### PR DESCRIPTION
Summary:
TSIA - minor refactor for correctness and clarity before making changes to some of these methods up the stack.

Changelog: [Internal]

Reviewed By: hoxyq

Differential Revision: D91140491


