### PR TITLE
Add KDoc documentation to UIManagerType.kt

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/common/UIManagerType.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/common/UIManagerType.kt
@@ -9,16 +9,38 @@ package com.facebook.react.uimanager.common
 
 import androidx.annotation.IntDef
 
+/**
+ * Annotation class that defines the type of UIManager being used in React Native.
+ *
+ * This annotation is used to distinguish between the legacy UIManager implementation and the newer
+ * Fabric renderer. It helps ensure type safety when working with UIManager-related code by
+ * restricting values to the defined constants.
+ *
+ * @see UIManagerType.LEGACY for legacy (Paper) UIManager
+ * @see UIManagerType.FABRIC for Fabric renderer
+ */
 @Retention(AnnotationRetention.SOURCE)
 @Suppress("DEPRECATION")
 @IntDef(UIManagerType.DEFAULT, UIManagerType.LEGACY, UIManagerType.FABRIC)
 public annotation class UIManagerType {
   public companion object {
+    /**
+     * Default UIManager type. Equivalent to [LEGACY].
+     *
+     * @deprecated Use [LEGACY] instead.
+     */
     @Deprecated(
         "UIManagerType.DEFAULT will be deleted in the next release of React Native. Use [LEGACY] instead."
     )
     public const val DEFAULT: Int = 1
+
+    /** Represents the legacy (Paper) UIManager implementation. */
     public const val LEGACY: Int = 1
+
+    /**
+     * Represents the Fabric renderer, React Native's new rendering system that provides improved
+     * performance and better integration with the host platform.
+     */
     public const val FABRIC: Int = 2
   }
 }


### PR DESCRIPTION
Summary:
Added comprehensive KDoc documentation to the UIManagerType annotation class and its companion object constants. This improves code readability and provides better IDE support for developers working with UIManager types.

The documentation explains:
- The purpose of the annotation (distinguishing between legacy and Fabric UIManager)
- Each constant (DEFAULT, LEGACY, FABRIC) and their use cases
- Deprecation notes for the DEFAULT constant

changelog: [internal] internal

Reviewed By: cortinico

Differential Revision: D91553347


