### PR TITLE
Fix importantForInteraction mapping for AUTO and BOX_ONLY pointer events

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ImportantForInteractionHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ImportantForInteractionHelper.kt
@@ -34,12 +34,17 @@ internal object ImportantForInteractionHelper {
   /**
    * Sets the important_for_interaction tag on a view based on the given [PointerEvents] value.
    *
+   * Note: The pointer events value alone does not determine if a view is important for interaction.
+   * A view with pointerEvents=auto or pointerEvents=box-only is only important for interaction if
+   * it is also clickable. Therefore, for these cases we let the view's own state determine whether
+   * it's important for interaction rather than setting the tag.
+   *
    * The mapping is as follows:
-   * - [PointerEvents.AUTO] -> [IMPORTANT_FOR_INTERACTION_YES]
+   * - [PointerEvents.AUTO] -> No tag set (i.e. the view's own state determines importance)
    * - [PointerEvents.NONE] -> [IMPORTANT_FOR_INTERACTION_NO] |
    *   [IMPORTANT_FOR_INTERACTION_EXCLUDE_DESCENDANTS]
-   * - [PointerEvents.BOX_ONLY] -> [IMPORTANT_FOR_INTERACTION_YES] |
-   *   [IMPORTANT_FOR_INTERACTION_EXCLUDE_DESCENDANTS]
+   * - [PointerEvents.BOX_ONLY] -> [IMPORTANT_FOR_INTERACTION_EXCLUDE_DESCENDANTS] (i.e. the view's
+   *   own state determines importance but its descendants are excluded)
    * - [PointerEvents.BOX_NONE] -> [IMPORTANT_FOR_INTERACTION_NO]
    *
    * @param view The view to set the tag on
@@ -49,11 +54,10 @@ internal object ImportantForInteractionHelper {
   fun setImportantForInteraction(view: View, pointerEvents: PointerEvents) {
     val value =
         when (pointerEvents) {
-          PointerEvents.AUTO -> IMPORTANT_FOR_INTERACTION_YES
+          PointerEvents.AUTO -> return
           PointerEvents.NONE ->
               IMPORTANT_FOR_INTERACTION_NO or IMPORTANT_FOR_INTERACTION_EXCLUDE_DESCENDANTS
-          PointerEvents.BOX_ONLY ->
-              IMPORTANT_FOR_INTERACTION_YES or IMPORTANT_FOR_INTERACTION_EXCLUDE_DESCENDANTS
+          PointerEvents.BOX_ONLY -> IMPORTANT_FOR_INTERACTION_EXCLUDE_DESCENDANTS
           PointerEvents.BOX_NONE -> IMPORTANT_FOR_INTERACTION_NO
         }
     view.setTag(R.id.important_for_interaction, value)


### PR DESCRIPTION
Summary:
Changelog: [Internal]

The previous mapping was conceptually incorrect:
- `pointerEvents=auto -> importantForInteraction=yes` was wrong because a view with `pointerEvents=auto` that is not clickable shouldn't have `importantForInteraction=yes`
- `pointerEvents=box-only -> importantForInteraction=yes | excludeDescendants` was also wrong for the same reason - the view itself being important for interaction depends on whether it's clickable, not just on pointer events

The fix:
- For `AUTO`: Skip setting the tag entirely and let the view's own state (e.g., isClickable) determine whether it's important for interaction
- For `BOX_ONLY`: Only set `excludeDescendants` to indicate descendants are not important, but let the view's own state determine if the view itself is important for interaction

This ensures that views are only marked as important for interaction when they are actually interactive (clickable), rather than incorrectly assuming importance based solely on pointer events.

Reviewed By: twasilczyk

Differential Revision: D91606360


