### PR TITLE
Fix pointer cancel event coordinates in JSPointerDispatcher

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/JSPointerDispatcher.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/JSPointerDispatcher.java
@@ -660,7 +660,7 @@ public class JSPointerDispatcher {
         // to the root view
         Rect childOffset = getChildOffsetRelativeToRoot(targetView);
         PointerEventState normalizedEventState =
-            normalizeToRoot(eventState, childOffset.top, childOffset.left);
+            normalizeToRoot(eventState, childOffset.left, childOffset.top);
         Assertions.assertNotNull(eventDispatcher)
             .dispatchEvent(
                 PointerEvent.obtain(


### PR DESCRIPTION
Summary:
Changelog: [Internal]

The `normalizeToRoot` call in the pointer cancel handling code was passing coordinates in the wrong order - `(top, left)` instead of `(left, top)`. This would cause incorrect coordinate normalization for pointer cancel events, potentially leading to mispositioned cancel events being dispatched.

This fix swaps the argument order to correctly pass `(left, top)` which follows the standard (X, Y) coordinate convention expected by `normalizeToRoot`.

Differential Revision: D91703223


