### PR TITLE
fix: Add nkf and base64 to Gemfile for Ruby 3.4 compatibility

### DIFF
--- a/packages/rn-tester/Gemfile
+++ b/packages/rn-tester/Gemfile
@@ -16,3 +16,6 @@ gem 'bigdecimal'
 gem 'logger'
 gem 'benchmark'
 gem 'mutex_m'
+gem 'nkf'
+gem 'base64'
+

--- a/private/helloworld/Gemfile
+++ b/private/helloworld/Gemfile
@@ -12,5 +12,8 @@ gem 'bigdecimal'
 gem 'logger'
 gem 'benchmark'
 gem 'mutex_m'
+gem 'nkf'
+gem 'base64'
+
 gem 'ffi',  '>= 1.17.2'
 gem 'rexml', '>= 3.3.9'


### PR DESCRIPTION
Ruby 3.4 removed 'kconv' (which requires 'nkf') and 'base64' from the standard library. This commit adds them to the Gemfiles to fix 'pod install' failures on Ruby 3.4 environments.
