### PR TITLE
Fix FieldsBelowInit lint warning for nativeModules property

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.kt
@@ -105,6 +105,9 @@ internal class ReactInstance(
   val fabricUIManager: FabricUIManager
   val javaScriptContextHolder: JavaScriptContextHolder
 
+  val nativeModules: Collection<NativeModule>
+    get() = turboModuleManager.modules
+
   init {
     Systrace.beginSection(Systrace.TRACE_TAG_REACT, "ReactInstance.initialize")
 
@@ -343,9 +346,6 @@ internal class ReactInstance(
     }
     return false
   }
-
-  val nativeModules: Collection<NativeModule>
-    get() = turboModuleManager.modules
 
   fun <T : NativeModule> getNativeModule(nativeModuleInterface: Class<T>): T? {
     val annotation = nativeModuleInterface.getAnnotation(ReactModule::class.java)


### PR DESCRIPTION
Summary:
**Lint Issue:** ANDROIDLINT FieldsBelowInit warning on line 347.

The `nativeModules` property was declared below the init block. The lint warns that fields declared after init blocks can lead to initialization order issues in Kotlin, where the field might not be available during the init block execution.

**Fix:** Moved the `nativeModules` computed property declaration to before the init block, alongside other property declarations. Since this is a computed property (getter only), there's no actual initialization order issue, but placing it before the init block follows Kotlin best practices and avoids confusion.


changelog: [internal] internal

Reviewed By: alanleedev

Differential Revision: D91709480


