### PR TITLE
Fix FieldsBelowInit lint warning for eventDispatcher property

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.kt
@@ -108,6 +108,10 @@ internal class ReactInstance(
   val nativeModules: Collection<NativeModule>
     get() = turboModuleManager.modules
 
+  val eventDispatcher: EventDispatcher
+    /** @return The [EventDispatcher] used by [FabricUIManager] to emit UI events to JS. */
+    get() = fabricUIManager.eventDispatcher
+
   init {
     Systrace.beginSection(Systrace.TRACE_TAG_REACT, "ReactInstance.initialize")
 
@@ -476,10 +480,6 @@ internal class ReactInstance(
       )
     }
   }
-
-  val eventDispatcher: EventDispatcher
-    /** @return The [EventDispatcher] used by [FabricUIManager] to emit UI events to JS. */
-    get() = fabricUIManager.eventDispatcher
 
   fun registerSegment(segmentId: Int, path: String) {
     registerSegmentNative(segmentId, path)


### PR DESCRIPTION
Summary:
**Lint Issue:** ANDROIDLINT FieldsBelowInit warning on line 480.

The `eventDispatcher` property was declared below the init block. The lint warns that fields declared after init blocks can lead to initialization order issues in Kotlin, where the field might not be available during the init block execution.

**Fix:** Moved the `eventDispatcher` computed property declaration to before the init block, alongside other property declarations. Since this is a computed property (getter only) that returns `fabricUIManager.eventDispatcher`, there's no actual initialization order issue, but placing it before the init block follows Kotlin best practices and avoids confusion.



changelog: [internal] internal

Reviewed By: alanleedev

Differential Revision: D91709482


