### PR TITLE
Fix KotlinGenericsCast lint warning in getNativeModule

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactInstance.kt
@@ -7,6 +7,7 @@
 
 package com.facebook.react.runtime
 
+import android.annotation.SuppressLint
 import android.content.res.AssetManager
 import android.view.View
 import com.facebook.common.logging.FLog
@@ -359,6 +360,7 @@ internal class ReactInstance(
     return null
   }
 
+  @SuppressLint("KotlinGenericsCast")
   fun <T : NativeModule> getNativeModule(nativeModuleName: String): T? {
     synchronized(turboModuleManager) {
       @Suppress("UNCHECKED_CAST")


### PR DESCRIPTION
Summary:
**Lint Issue:** ANDROIDLINT KotlinGenericsCast warning on line 361.

The `getNativeModule` function casts `turboModuleManager.getModule(nativeModuleName)` to generic type `T?`. The lint warns that casts to erased Kotlin generic type references are only checked at compile time, and at runtime, casts to type arguments of a generic function are unchecked due to type erasure.

**Fix:** Added `SuppressLint("KotlinGenericsCast")` annotation to the function. The existing `Suppress("UNCHECKED_CAST")` only suppresses the Kotlin compiler warning, not the AndroidLint warning. This cast is intentional and unavoidable given the API design where callers specify the expected return type.



changelog: [internal] internal

Reviewed By: alanleedev

Differential Revision: D91709481


