### PR TITLE
Fix ReflectionMethodUse: Remove reflection in AnimationDriver error message

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/AnimationDriver.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/animated/AnimationDriver.kt
@@ -34,8 +34,6 @@ internal abstract class AnimationDriver {
    * start animating with the new properties (different destination or spring settings)
    */
   open fun resetConfig(config: ReadableMap) {
-    throw JSApplicationCausedNativeException(
-        "Animation config for ${javaClass.simpleName} cannot be reset"
-    )
+    throw JSApplicationCausedNativeException("Animation config for AnimationDriver cannot be reset")
   }
 }


### PR DESCRIPTION
Summary:
Fixed ReflectionMethodUse lint error in AnimationDriver.kt.

Replaced `javaClass.simpleName` with a hardcoded string to avoid reflection
which can cause issues with Redex obfuscation in production builds.

changelog: [internal] internal

Differential Revision: D91736698


