### PR TITLE
Make AbortSignal abort and timeout correctly static, add AbortSignal.any

### DIFF
--- a/packages/react-native/flow/bom.js.flow
+++ b/packages/react-native/flow/bom.js.flow
@@ -609,12 +609,13 @@ declare class AbortController {
 }
 
 declare class AbortSignal extends EventTarget {
-  abort(reason?: $FlowFixMe): AbortSignal;
+  static abort(reason?: $FlowFixMe): AbortSignal;
+  static any(signals: Iterable<AbortSignal>): AbortSignal;
   +aborted: boolean;
   onabort: (event: Event) => unknown;
   +reason: $FlowFixMe;
   throwIfAborted(): void;
-  timeout(time: number): AbortSignal;
+  static timeout(time: number): AbortSignal;
 }
 
 declare function fetch(


### PR DESCRIPTION
Summary:
`AbortSignal` `abort` and `timeout` are incorrectly typed as instance methods - they should be static methods.

Also add the static `any()`, which returns a signal composed of other signals.

MDN:
 - [`AbortSignal.any(signals: Iterable<AbortSignal>)`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/any_static)
 - [`AbortSignal.abort(reason?: any)`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/abort_static)
 - [`AbortSignal.timeout(time: number)`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/timeout_static)

Changelog: [Internal]

Differential Revision: D91904485


