### PR TITLE
Add nested error formatting for all error types

### DIFF
--- a/packages/react-native-compatibility-check/src/ComparisonResult.js
+++ b/packages/react-native-compatibility-check/src/ComparisonResult.js
@@ -135,12 +135,36 @@ export type NullableComparisonResult = {
 export type ComparisonResult =
   | {status: 'matching'}
   | {status: 'skipped'}
-  | {status: 'nullableChange', nullableLog: NullableComparisonResult}
-  | {status: 'properties', propertyLog: PropertiesComparisonResult}
-  | {status: 'members', memberLog: MembersComparisonResult}
-  | {status: 'unionMembers', memberLog: UnionMembersComparisonResult}
-  | {status: 'functionChange', functionChangeLog: FunctionComparisonResult}
-  | {status: 'positionalTypeChange', changeLog: PositionalComparisonResult}
+  | {
+      status: 'nullableChange',
+      nullableLog: NullableComparisonResult,
+      errorLog?: TypeComparisonError,
+    }
+  | {
+      status: 'properties',
+      propertyLog: PropertiesComparisonResult,
+      errorLog?: TypeComparisonError,
+    }
+  | {
+      status: 'members',
+      memberLog: MembersComparisonResult,
+      errorLog?: TypeComparisonError,
+    }
+  | {
+      status: 'unionMembers',
+      memberLog: UnionMembersComparisonResult,
+      errorLog?: TypeComparisonError,
+    }
+  | {
+      status: 'functionChange',
+      functionChangeLog: FunctionComparisonResult,
+      errorLog?: TypeComparisonError,
+    }
+  | {
+      status: 'positionalTypeChange',
+      changeLog: PositionalComparisonResult,
+      errorLog?: TypeComparisonError,
+    }
   | {status: 'error', errorLog: TypeComparisonError};
 
 export function isPropertyLogEmpty(

--- a/packages/react-native-compatibility-check/src/TypeDiffing.js
+++ b/packages/react-native-compatibility-check/src/TypeDiffing.js
@@ -569,12 +569,22 @@ export function compareObjectTypes<T: CompleteTypeAnnotation>(
     return {
       status: 'properties',
       propertyLog: {missingProperties: sortedOlderTypes},
+      errorLog: typeAnnotationComparisonError(
+        'Object has property changes',
+        objectTypeAnnotation(newerPropertyTypes),
+        objectTypeAnnotation(olderPropertyTypes),
+      ),
     };
   }
   if (sortedOlderTypes.length === 0) {
     return {
       status: 'properties',
       propertyLog: {addedProperties: sortedNewerTypes},
+      errorLog: typeAnnotationComparisonError(
+        'Object has property changes',
+        objectTypeAnnotation(newerPropertyTypes),
+        objectTypeAnnotation(olderPropertyTypes),
+      ),
     };
   }
   const result = comparePropertyArrays(sortedNewerTypes, sortedOlderTypes);
@@ -602,14 +612,20 @@ export function compareObjectTypes<T: CompleteTypeAnnotation>(
     return makeError(
       typeAnnotationComparisonError(
         'Object types do not match.',
-        // $FlowFixMe[incompatible-type]
         objectTypeAnnotation(newerPropertyTypes),
-        // $FlowFixMe[incompatible-type]
         objectTypeAnnotation(olderPropertyTypes),
       ),
     );
   }
-  return {status: 'properties', propertyLog: result};
+  return {
+    status: 'properties',
+    propertyLog: result,
+    errorLog: typeAnnotationComparisonError(
+      'Object has property changes',
+      objectTypeAnnotation(newerPropertyTypes),
+      objectTypeAnnotation(olderPropertyTypes),
+    ),
+  };
 }
 
 function objectTypeAnnotation<T>(
@@ -856,7 +872,15 @@ export function compareEnumDeclarationWithMembers(
     );
   }
 
-  return {status: 'members', memberLog: result};
+  return {
+    status: 'members',
+    memberLog: result,
+    errorLog: typeAnnotationComparisonError(
+      'Enum has member changes',
+      newerDeclaration,
+      olderDeclaration,
+    ),
+  };
 }
 
 function compareNullableChange(
@@ -895,6 +919,11 @@ function compareNullableChange(
         newType: newerAnnotation,
         oldType: olderAnnotation,
       },
+      errorLog: typeAnnotationComparisonError(
+        'Nullable type has changes',
+        newerAnnotation,
+        olderAnnotation,
+      ),
     };
   }
   const interiorLog = compareTypeAnnotation(newVoidRemoved, oldVoidRemoved);
@@ -917,6 +946,11 @@ function compareNullableChange(
           newType: newerAnnotation,
           oldType: olderAnnotation,
         },
+        errorLog: typeAnnotationComparisonError(
+          'Nullable type has changes',
+          newerAnnotation,
+          olderAnnotation,
+        ),
       };
     default:
       return {
@@ -928,6 +962,12 @@ function compareNullableChange(
           newType: newerAnnotation,
           oldType: olderAnnotation,
         },
+        errorLog: typeAnnotationComparisonError(
+          'Nullable type has changes',
+          newerAnnotation,
+          olderAnnotation,
+          interiorLog.errorLog,
+        ),
       };
   }
 }
@@ -977,7 +1017,15 @@ export function compareUnionTypes(
     );
   }
 
-  return {status: 'unionMembers', memberLog: result};
+  return {
+    status: 'unionMembers',
+    memberLog: result,
+    errorLog: typeAnnotationComparisonError(
+      'Union has member changes',
+      newerType,
+      olderType,
+    ),
+  };
 }
 
 export function comparePromiseTypes(
@@ -1128,6 +1176,11 @@ export function compareStringLiteralUnionTypes(
       return {
         status: 'positionalTypeChange',
         changeLog,
+        errorLog: typeAnnotationComparisonError(
+          'String literal union has member changes',
+          newerType,
+          olderType,
+        ),
       };
     case 'matching':
       return {status: 'matching'};
@@ -1206,7 +1259,15 @@ export function compareFunctionTypes(
   if (isFunctionLogEmpty(functionChanges)) {
     return {status: 'matching'};
   }
-  return {status: 'functionChange', functionChangeLog: functionChanges};
+  return {
+    status: 'functionChange',
+    functionChangeLog: functionChanges,
+    errorLog: typeAnnotationComparisonError(
+      'Function has parameter or return type changes',
+      newerType,
+      olderType,
+    ),
+  };
 }
 
 type ArrayComparisonResult =

--- a/packages/react-native-compatibility-check/src/__tests__/TypeDiffing-test.js
+++ b/packages/react-native-compatibility-check/src/__tests__/TypeDiffing-test.js
@@ -242,17 +242,22 @@ describe('components', () => {
           {},
           {},
         ),
-      ).toEqual({
-        status: 'unionMembers',
-        memberLog: {
-          addedMembers: [
-            {
-              type: 'StringLiteralTypeAnnotation',
-              value: 'baz',
-            },
-          ],
-        },
-      });
+      ).toEqual(
+        expect.objectContaining({
+          status: 'unionMembers',
+          memberLog: {
+            addedMembers: [
+              {
+                type: 'StringLiteralTypeAnnotation',
+                value: 'baz',
+              },
+            ],
+          },
+          errorLog: expect.objectContaining({
+            type: 'TypeAnnotationComparisonError',
+          }),
+        }),
+      );
     });
 
     it('array of an object to an extra key not compatible', () => {
@@ -515,6 +520,9 @@ describe('compareTypes objects', () => {
         propertyLog: expect.objectContaining({
           addedProperties: expect.any(Object),
         }),
+        errorLog: expect.objectContaining({
+          type: 'TypeAnnotationComparisonError',
+        }),
       }),
     );
   });
@@ -532,6 +540,9 @@ describe('compareTypes objects', () => {
         status: 'properties',
         propertyLog: expect.objectContaining({
           missingProperties: expect.any(Object),
+        }),
+        errorLog: expect.objectContaining({
+          type: 'TypeAnnotationComparisonError',
         }),
       }),
     );
@@ -610,6 +621,9 @@ describe('compareTypes objects', () => {
         propertyLog: expect.objectContaining({
           madeStrict: expect.any(Object),
         }),
+        errorLog: expect.objectContaining({
+          type: 'TypeAnnotationComparisonError',
+        }),
       }),
     );
   });
@@ -627,6 +641,9 @@ describe('compareTypes objects', () => {
         status: 'properties',
         propertyLog: expect.objectContaining({
           madeOptional: expect.any(Object),
+        }),
+        errorLog: expect.objectContaining({
+          type: 'TypeAnnotationComparisonError',
         }),
       }),
     );
@@ -646,9 +663,17 @@ describe('compareTypes objects', () => {
         propertyLog: expect.objectContaining({
           madeStrict: expect.objectContaining({
             '0': expect.objectContaining({
-              furtherChange: expect.objectContaining({status: 'properties'}),
+              furtherChange: expect.objectContaining({
+                status: 'properties',
+                errorLog: expect.objectContaining({
+                  type: 'TypeAnnotationComparisonError',
+                }),
+              }),
             }),
           }),
+        }),
+        errorLog: expect.objectContaining({
+          type: 'TypeAnnotationComparisonError',
         }),
       }),
     );
@@ -668,9 +693,17 @@ describe('compareTypes objects', () => {
         propertyLog: expect.objectContaining({
           madeOptional: expect.objectContaining({
             '0': expect.objectContaining({
-              furtherChange: expect.objectContaining({status: 'properties'}),
+              furtherChange: expect.objectContaining({
+                status: 'properties',
+                errorLog: expect.objectContaining({
+                  type: 'TypeAnnotationComparisonError',
+                }),
+              }),
             }),
           }),
+        }),
+        errorLog: expect.objectContaining({
+          type: 'TypeAnnotationComparisonError',
         }),
       }),
     );
@@ -1015,6 +1048,9 @@ describe('compareTypes unions', () => {
         memberLog: expect.objectContaining({
           missingMembers: expect.any(Array),
         }),
+        errorLog: expect.objectContaining({
+          type: 'TypeAnnotationComparisonError',
+        }),
       }),
     );
   });
@@ -1162,6 +1198,7 @@ describe('compareTypes on generic types', () => {
         propertyLog: expect.objectContaining({
           missingProperties: expect.any(Object),
         }),
+        errorLog: expect.any(Object),
       }),
     );
   });
@@ -1198,17 +1235,22 @@ describe('compareTypes on string literal unions', () => {
         nativeTypeDiffingTypesAliases,
         nativeTypeDiffingTypesAliases,
       ),
-    ).toEqual({
-      status: 'unionMembers',
-      memberLog: {
-        missingMembers: [
-          {
-            type: 'StringLiteralTypeAnnotation',
-            value: 'd',
-          },
-        ],
-      },
-    });
+    ).toEqual(
+      expect.objectContaining({
+        status: 'unionMembers',
+        memberLog: {
+          missingMembers: [
+            {
+              type: 'StringLiteralTypeAnnotation',
+              value: 'd',
+            },
+          ],
+        },
+        errorLog: expect.objectContaining({
+          type: 'TypeAnnotationComparisonError',
+        }),
+      }),
+    );
   });
 
   it('fails on unions with differing elements', () => {
@@ -1219,23 +1261,28 @@ describe('compareTypes on string literal unions', () => {
         nativeTypeDiffingTypesAliases,
         nativeTypeDiffingTypesAliases,
       ),
-    ).toEqual({
-      status: 'unionMembers',
-      memberLog: {
-        addedMembers: [
-          {
-            type: 'StringLiteralTypeAnnotation',
-            value: 'b',
-          },
-        ],
-        missingMembers: [
-          {
-            type: 'StringLiteralTypeAnnotation',
-            value: 'x',
-          },
-        ],
-      },
-    });
+    ).toEqual(
+      expect.objectContaining({
+        status: 'unionMembers',
+        memberLog: {
+          addedMembers: [
+            {
+              type: 'StringLiteralTypeAnnotation',
+              value: 'b',
+            },
+          ],
+          missingMembers: [
+            {
+              type: 'StringLiteralTypeAnnotation',
+              value: 'x',
+            },
+          ],
+        },
+        errorLog: expect.objectContaining({
+          type: 'TypeAnnotationComparisonError',
+        }),
+      }),
+    );
   });
 });
 
@@ -1266,6 +1313,9 @@ describe('compareTypes on nullables', () => {
           optionsReduced: true,
           interiorLog: expect.objectContaining({status: 'matching'}),
         }),
+        errorLog: expect.objectContaining({
+          type: 'TypeAnnotationComparisonError',
+        }),
       }),
     );
   });
@@ -1285,6 +1335,9 @@ describe('compareTypes on nullables', () => {
           optionsReduced: false,
           interiorLog: expect.objectContaining({status: 'matching'}),
         }),
+        errorLog: expect.objectContaining({
+          type: 'TypeAnnotationComparisonError',
+        }),
       }),
     );
   });
@@ -1302,7 +1355,15 @@ describe('compareTypes on nullables', () => {
         status: 'nullableChange',
         nullableLog: expect.objectContaining({
           optionsReduced: true,
-          interiorLog: expect.objectContaining({status: 'properties'}),
+          interiorLog: expect.objectContaining({
+            status: 'properties',
+            errorLog: expect.objectContaining({
+              type: 'TypeAnnotationComparisonError',
+            }),
+          }),
+        }),
+        errorLog: expect.objectContaining({
+          type: 'TypeAnnotationComparisonError',
         }),
       }),
     );
@@ -1386,6 +1447,9 @@ describe('compareTypes on enums', () => {
             }),
           ]),
         }),
+        errorLog: expect.objectContaining({
+          type: 'TypeAnnotationComparisonError',
+        }),
       }),
     );
   });
@@ -1412,6 +1476,9 @@ describe('compareTypes on enums', () => {
               }),
             }),
           ]),
+        }),
+        errorLog: expect.objectContaining({
+          type: 'TypeAnnotationComparisonError',
         }),
       }),
     );

--- a/packages/react-native-compatibility-check/src/__tests__/VersionDiffing-test.js
+++ b/packages/react-native-compatibility-check/src/__tests__/VersionDiffing-test.js
@@ -294,13 +294,24 @@ describe('buildSchemaDiff', () => {
           incompatibleSpecs: expect.arrayContaining([
             expect.objectContaining({
               changeInformation: expect.objectContaining({
-                incompatibleChanges: expect.objectContaining({
-                  '0': expect.objectContaining({
+                incompatibleChanges: expect.arrayContaining([
+                  expect.objectContaining({
+                    errorCode: 'removedProps',
                     errorInformation: expect.objectContaining({
-                      message: removedPropertiesMessage,
+                      mismatchedProperties: expect.arrayContaining([
+                        expect.objectContaining({
+                          fault: expect.objectContaining({
+                            previousError: expect.objectContaining({
+                              previousError: expect.objectContaining({
+                                message: removedPropertiesMessage,
+                              }),
+                            }),
+                          }),
+                        }),
+                      ]),
                     }),
                   }),
-                }),
+                ]),
               }),
             }),
           ]),
@@ -322,13 +333,24 @@ describe('buildSchemaDiff', () => {
           incompatibleSpecs: expect.arrayContaining([
             expect.objectContaining({
               changeInformation: expect.objectContaining({
-                incompatibleChanges: expect.objectContaining({
-                  '0': expect.objectContaining({
+                incompatibleChanges: expect.arrayContaining([
+                  expect.objectContaining({
+                    errorCode: 'optionalProps',
                     errorInformation: expect.objectContaining({
-                      message: tooOptionalPropertiesMessage,
+                      mismatchedProperties: expect.arrayContaining([
+                        expect.objectContaining({
+                          fault: expect.objectContaining({
+                            previousError: expect.objectContaining({
+                              previousError: expect.objectContaining({
+                                message: tooOptionalPropertiesMessage,
+                              }),
+                            }),
+                          }),
+                        }),
+                      ]),
                     }),
                   }),
-                }),
+                ]),
               }),
             }),
           ]),
@@ -353,13 +375,24 @@ describe('buildSchemaDiff', () => {
           incompatibleSpecs: expect.arrayContaining([
             expect.objectContaining({
               changeInformation: expect.objectContaining({
-                incompatibleChanges: expect.objectContaining({
-                  '0': expect.objectContaining({
+                incompatibleChanges: expect.arrayContaining([
+                  expect.objectContaining({
+                    errorCode: 'nullableOfNonNull',
                     errorInformation: expect.objectContaining({
-                      message: typeNullableChangeMessage,
+                      mismatchedProperties: expect.arrayContaining([
+                        expect.objectContaining({
+                          fault: expect.objectContaining({
+                            previousError: expect.objectContaining({
+                              previousError: expect.objectContaining({
+                                message: typeNullableChangeMessage,
+                              }),
+                            }),
+                          }),
+                        }),
+                      ]),
                     }),
                   }),
-                }),
+                ]),
               }),
             }),
           ]),
@@ -381,13 +414,24 @@ describe('buildSchemaDiff', () => {
           incompatibleSpecs: expect.arrayContaining([
             expect.objectContaining({
               changeInformation: expect.objectContaining({
-                incompatibleChanges: expect.objectContaining({
-                  '0': expect.objectContaining({
+                incompatibleChanges: expect.arrayContaining([
+                  expect.objectContaining({
+                    errorCode: 'optionalProps',
                     errorInformation: expect.objectContaining({
-                      message: tooOptionalPropertiesMessage,
+                      mismatchedProperties: expect.arrayContaining([
+                        expect.objectContaining({
+                          fault: expect.objectContaining({
+                            previousError: expect.objectContaining({
+                              previousError: expect.objectContaining({
+                                message: tooOptionalPropertiesMessage,
+                              }),
+                            }),
+                          }),
+                        }),
+                      ]),
                     }),
                   }),
-                }),
+                ]),
               }),
             }),
           ]),
@@ -449,7 +493,17 @@ describe('buildSchemaDiff', () => {
                       expect.objectContaining({
                         errorCode: 'addedEnumCases',
                         errorInformation: expect.objectContaining({
-                          message: addedEnumMessage,
+                          mismatchedProperties: expect.arrayContaining([
+                            expect.objectContaining({
+                              fault: expect.objectContaining({
+                                previousError: expect.objectContaining({
+                                  previousError: expect.objectContaining({
+                                    message: addedEnumMessage,
+                                  }),
+                                }),
+                              }),
+                            }),
+                          ]),
                         }),
                       }),
                     ]),
@@ -577,7 +631,23 @@ describe('buildSchemaDiff', () => {
                       expect.objectContaining({
                         errorCode: 'removedEnumCases',
                         errorInformation: expect.objectContaining({
-                          message: removedEnumMessage,
+                          mismatchedProperties: expect.arrayContaining([
+                            expect.objectContaining({
+                              fault: expect.objectContaining({
+                                previousError: expect.objectContaining({
+                                  mismatchedProperties: expect.arrayContaining([
+                                    expect.objectContaining({
+                                      fault: expect.objectContaining({
+                                        previousError: expect.objectContaining({
+                                          message: removedEnumMessage,
+                                        }),
+                                      }),
+                                    }),
+                                  ]),
+                                }),
+                              }),
+                            }),
+                          ]),
                         }),
                       }),
                     ]),
@@ -1607,8 +1677,17 @@ describe('RN NativeModule getConstants type diffing', () => {
               changeInformation: expect.objectContaining({
                 incompatibleChanges: expect.arrayContaining([
                   expect.objectContaining({
+                    errorCode: 'addedProps',
                     errorInformation: expect.objectContaining({
-                      message: addedPropertiesMessage,
+                      mismatchedProperties: expect.arrayContaining([
+                        expect.objectContaining({
+                          fault: expect.objectContaining({
+                            previousError: expect.objectContaining({
+                              message: addedPropertiesMessage,
+                            }),
+                          }),
+                        }),
+                      ]),
                     }),
                   }),
                 ]),

--- a/packages/react-native-compatibility-check/src/__tests__/__snapshots__/ErrorFormatting-test.js.snap
+++ b/packages/react-native-compatibility-check/src/__tests__/__snapshots__/ErrorFormatting-test.js.snap
@@ -195,8 +195,12 @@ Object {
       "incompatibleSpecs": Array [
         Object {
           "errorCode": "addedUnionCases",
-          "message": "NativeComponent.sizes: Union added items, but native will not expect/support them
-  -- Member \\"huge\\"",
+          "message": "NativeComponent: Object contained a property with a type mismatch
+  -- sizes: has conflicting type changes
+      --new: (small | large | huge)
+      --old: (small | large)
+      Union added items, but native will not expect/support them
+          -- Member \\"huge\\"",
         },
       ],
     },
@@ -236,8 +240,12 @@ Object {
       "incompatibleSpecs": Array [
         Object {
           "errorCode": "addedUnionCases",
-          "message": "NativeComponent.size: Union added items, but native will not expect/support them
-  -- Member \\"huge\\"",
+          "message": "NativeComponent: Object contained a property with a type mismatch
+  -- size: has conflicting type changes
+      --new: (small | huge | large)
+      --old: (small | large)
+      Union added items, but native will not expect/support them
+          -- Member \\"huge\\"",
         },
       ],
     },
@@ -344,8 +352,18 @@ Object {
       "incompatibleSpecs": Array [
         Object {
           "errorCode": "optionalProps",
-          "message": "NativeModuleTest.exampleFunction parameter 0: Property made optional, but native requires it
-  -- a2",
+          "message": "NativeModuleTest: Object contained a property with a type mismatch
+  -- exampleFunction: has conflicting type changes
+      --new: (a: {a1: string, a2?: number, a3: string}, b: number)=>void
+      --old: (a: {a1: string, a2: number}, b: number)=>void
+      Parameter at index 0 did not match
+          --new: {a1: string, a2?: number, a3: string}
+          --old: {a1: string, a2: number}
+          Object has property changes
+              --new: {a1: string, a2?: number, a3: string}
+              --old: {a1: string, a2: number}
+              Property made optional, but native requires it
+              -- a2",
         },
       ],
     },
@@ -391,8 +409,18 @@ Object {
       "incompatibleSpecs": Array [
         Object {
           "errorCode": "removedProps",
-          "message": "NativeModuleTest.exampleFunction parameter 0: Object removed required properties expected by native
-  -- a3",
+          "message": "NativeModuleTest: Object contained a property with a type mismatch
+  -- exampleFunction: has conflicting type changes
+      --new: (a: {a1: string, a2: number}, b: number)=>void
+      --old: (a: {a1: string, a2: number, a3: string}, b: number)=>void
+      Parameter at index 0 did not match
+          --new: {a1: string, a2: number}
+          --old: {a1: string, a2: number, a3: string}
+          Object has property changes
+              --new: {a1: string, a2: number}
+              --old: {a1: string, a2: number, a3: string}
+              Object removed required properties expected by native
+              -- a3",
         },
       ],
     },
@@ -409,8 +437,18 @@ Object {
       "incompatibleSpecs": Array [
         Object {
           "errorCode": "optionalProps",
-          "message": "NativeModuleTest.exampleFunction parameter 0: Property made optional, but native requires it
-  -- a2",
+          "message": "NativeModuleTest: Object contained a property with a type mismatch
+  -- exampleFunction: has conflicting type changes
+      --new: (a: {a1: string, a2?: number, a3: string}, b: number)=>void
+      --old: (a: {a1: string, a2: number, a3: string}, b: number)=>void
+      Parameter at index 0 did not match
+          --new: {a1: string, a2?: number, a3: string}
+          --old: {a1: string, a2: number, a3: string}
+          Object has property changes
+              --new: {a1: string, a2?: number, a3: string}
+              --old: {a1: string, a2: number, a3: string}
+              Property made optional, but native requires it
+              -- a2",
         },
       ],
     },
@@ -427,9 +465,16 @@ Object {
       "incompatibleSpecs": Array [
         Object {
           "errorCode": "nullableOfNonNull",
-          "message": "NativeModuleTest.exampleFunction parameter 0: Type made nullable, but native requires it
-  --new: ?{a1: string, a2?: number, a3: string}
-  --old: {a1: string, a2?: number, a3: string}",
+          "message": "NativeModuleTest: Object contained a property with a type mismatch
+  -- exampleFunction: has conflicting type changes
+      --new: (a: ?{a1: string, a2?: number, a3: string}, b: number)=>void
+      --old: (a: {a1: string, a2?: number, a3: string}, b: number)=>void
+      Parameter at index 0 did not match
+          --new: ?{a1: string, a2?: number, a3: string}
+          --old: {a1: string, a2?: number, a3: string}
+          Type made nullable, but native requires it
+              --new: ?{a1: string, a2?: number, a3: string}
+              --old: {a1: string, a2?: number, a3: string}",
         },
       ],
     },
@@ -472,8 +517,15 @@ Object {
       "incompatibleSpecs": Array [
         Object {
           "errorCode": "addedEnumCases",
-          "message": "NativeModuleTest.exampleFunction parameter 0: Enum added items, but native will not expect/support them
-  -- Member D",
+          "message": "NativeModuleTest: Object contained a property with a type mismatch
+  -- exampleFunction: has conflicting type changes
+      --new: (a: Enum<number>, b: number)=>void
+      --old: (a: Enum<number>, b: number)=>void
+      Parameter at index 0 did not match
+          --new: Enum<number> {A = 1, B = 2, C = 3, D = 4}
+          --old: Enum<number> {A = 1, B = 2, C = 3}
+          Enum added items, but native will not expect/support them
+              -- Member D",
         },
       ],
     },
@@ -490,8 +542,16 @@ Object {
       "incompatibleSpecs": Array [
         Object {
           "errorCode": "removedEnumCases",
-          "message": "NativeModuleTest.getConstants.exampleConstant: Enum removed items, but native may still provide them
-  -- Member D",
+          "message": "NativeModuleTest: Object contained a property with a type mismatch
+  -- getConstants: has conflicting type changes
+      --new: ()=>{exampleConstant: Enum<number>}
+      --old: ()=>{exampleConstant: Enum<number>}
+      Object contained a property with a type mismatch
+          -- exampleConstant: has conflicting type changes
+              --new: Enum<number> {A = 1, B = 2, C = 3}
+              --old: Enum<number> {A = 1, B = 2, C = 3, D = 4}
+              Enum removed items, but native may still provide them
+                  -- Member D",
         },
       ],
     },
@@ -710,8 +770,15 @@ Object {
       "incompatibleSpecs": Array [
         Object {
           "errorCode": "addedUnionCases",
-          "message": "NativeModuleTest.exampleFunction parameter 0: Union added items, but native will not expect/support them
-  -- Member \\"d\\"",
+          "message": "NativeModuleTest: Object contained a property with a type mismatch
+  -- exampleFunction: has conflicting type changes
+      --new: (a: (a | b | c | d), b: number)=>void
+      --old: (a: (a | b | c), b: number)=>void
+      Parameter at index 0 did not match
+          --new: (a | b | c | d)
+          --old: (a | b | c)
+          Union added items, but native will not expect/support them
+              -- Member \\"d\\"",
         },
       ],
     },
@@ -754,9 +821,16 @@ Object {
       "incompatibleSpecs": Array [
         Object {
           "errorCode": "addedUnionCases",
-          "message": "NativeModuleTest.exampleFunction parameter 0: Union added items, but native will not expect/support them
-  -- Member \\"b\\"
-  -- Member \\"c\\"",
+          "message": "NativeModuleTest: Object contained a property with a type mismatch
+  -- exampleFunction: has conflicting type changes
+      --new: (a: (a | b | c), b: number)=>void
+      --old: (a: (a | '0' | '1' | 'a long string'), b: number)=>void
+      Parameter at index 0 did not match
+          --new: (a | b | c)
+          --old: (a | '0' | '1' | 'a long string')
+          Union added items, but native will not expect/support them
+              -- Member \\"b\\"
+              -- Member \\"c\\"",
         },
       ],
     },
@@ -773,8 +847,16 @@ Object {
       "incompatibleSpecs": Array [
         Object {
           "errorCode": "removedUnionCases",
-          "message": "NativeModuleTest.getConstants.exampleConstant: Union removed items, but native may still provide them
-  -- Member \\"d\\"",
+          "message": "NativeModuleTest: Object contained a property with a type mismatch
+  -- getConstants: has conflicting type changes
+      --new: ()=>{exampleConstant: (a | b | c)}
+      --old: ()=>{exampleConstant: (a | b | c | d)}
+      Object contained a property with a type mismatch
+          -- exampleConstant: has conflicting type changes
+              --new: (a | b | c)
+              --old: (a | b | c | d)
+              Union removed items, but native may still provide them
+                  -- Member \\"d\\"",
         },
       ],
     },
@@ -817,8 +899,15 @@ Object {
       "incompatibleSpecs": Array [
         Object {
           "errorCode": "addedUnionCases",
-          "message": "NativeModuleTest.exampleFunction parameter 0: Union added items, but native will not expect/support them
-  -- Member TypeAliasTypeAnnotation",
+          "message": "NativeModuleTest: Object contained a property with a type mismatch
+  -- exampleFunction: has conflicting type changes
+      --new: (a: Union<mixed>, b: number)=>void
+      --old: (a: Union<mixed>, b: number)=>void
+      Parameter at index 0 did not match
+          --new: Union<mixed>
+          --old: Union<mixed>
+          Union added items, but native will not expect/support them
+              -- Member TypeAliasTypeAnnotation",
         },
       ],
     },


### PR DESCRIPTION
Summary:
Reviewer, read `ErrorFormatting-test.snap.js` first, to see the impact of this change.

Previously, only `incompatibleTypes` errors showed hierarchical nesting with full path context. Other error types (addedEnumCases, removedUnionCases, addedProps, etc.) displayed flat messages that made it difficult to trace where in the type hierarchy an issue occurred.

This change enriches ComparisonResult types with an optional `errorLog` field that carries path context from TypeDiffing through VersionDiffing to ErrorFormatting. Now all error types display with the same recursive nesting format, making it easier for developers to understand exactly where compatibility issues occur in deeply nested structures.

Changelog: [Internal]

Reviewed By: makovkastar

Differential Revision: D91251882


