### PR TITLE
Added missing tests for onHoverOut in Pressability

### DIFF
--- a/packages/react-native/Libraries/Pressability/__tests__/Pressability-test.js
+++ b/packages/react-native/Libraries/Pressability/__tests__/Pressability-test.js
@@ -349,7 +349,109 @@ describe('Pressability', () => {
     });
   });
 
-  // TODO: onHoverOut tests
+  describe('onHoverOut', () => {
+    let originalPlatform;
+
+    beforeEach(() => {
+      originalPlatform = Platform.OS;
+      /* $FlowFixMe[incompatible-type] Error found due to incomplete typing of
+       * Platform.flow.js */
+      Platform.OS = 'web';
+      // $FlowExpectedError[prop-missing]
+      HoverState.isHoverEnabled.mockReturnValue(true);
+    });
+
+    afterEach(() => {
+      /* $FlowFixMe[incompatible-type] Error found due to incomplete typing of
+       * Platform.flow.js */
+      Platform.OS = originalPlatform;
+    });
+
+    it('is ignored on unsupported platforms`', () => {
+      /* $FlowFixMe[incompatible-type] Error found due to incomplete typing of
+       * Platform.flow.js */
+      Platform.OS = 'ios';
+      const {handlers} = createMockPressability();
+      expect(handlers.onMouseLeave).toBeUndefined();
+    });
+
+    it('is called after `onMouseLeave`, and after onHoverIn', () => {
+      const {config, handlers} = createMockPressability();
+      invariant(
+        typeof handlers.onMouseEnter === 'function',
+        'Expected to find "onMouseEnter" function',
+      );
+      // $FlowExpectedError[not-a-function]
+      handlers.onMouseEnter(createMockMouseEvent('onMouseEnter'));
+      invariant(
+        typeof handlers.onMouseLeave === 'function',
+        'Expected to find "onMouseLeave" function',
+      );
+      // $FlowExpectedError[not-a-function]
+      handlers.onMouseLeave(createMockMouseEvent('onMouseLeave'));
+      expect(config.onHoverOut).toBeCalled();
+    });
+
+    it('is called with no delay by default', () => {
+      const {config, handlers} = createMockPressability({
+        delayHoverOut: null,
+      });
+      invariant(
+        typeof handlers.onMouseEnter === 'function',
+        'Expected to find "onMouseEnter" function',
+      );
+      // $FlowExpectedError[not-a-function]
+      handlers.onMouseEnter(createMockMouseEvent('onMouseEnter'));
+      invariant(
+        typeof handlers.onMouseLeave === 'function',
+        'Expected to find "onMouseLeave" function',
+      );
+      // $FlowExpectedError[not-a-function]
+      handlers.onMouseLeave(createMockMouseEvent('onMouseLeave'));
+      expect(config.onHoverOut).toBeCalled();
+    });
+
+    it('is called after a configured delay', () => {
+      const {config, handlers} = createMockPressability({
+        delayHoverOut: 500,
+      });
+      invariant(
+        typeof handlers.onMouseEnter === 'function',
+        'Expected to find "onMouseEnter" function',
+      );
+      // $FlowExpectedError[not-a-function]
+      handlers.onMouseEnter(createMockMouseEvent('onMouseEnter'));
+      invariant(
+        typeof handlers.onMouseLeave === 'function',
+        'Expected to find "onMouseLeave" function',
+      );
+      // $FlowExpectedError[not-a-function]
+      handlers.onMouseLeave(createMockMouseEvent('onMouseLeave'));
+      jest.advanceTimersByTime(499);
+      expect(config.onHoverOut).not.toBeCalled();
+      jest.advanceTimersByTime(1);
+      expect(config.onHoverOut).toBeCalled();
+    });
+
+    it('is called synchronously if delay is 0ms', () => {
+      const {config, handlers} = createMockPressability({
+        delayHoverOut: 0,
+      });
+      invariant(
+        typeof handlers.onMouseEnter === 'function',
+        'Expected to find "onMouseEnter" function',
+      );
+      // $FlowExpectedError[not-a-function]
+      handlers.onMouseEnter(createMockMouseEvent('onMouseEnter'));
+      invariant(
+        typeof handlers.onMouseLeave === 'function',
+        'Expected to find "onMouseLeave" function',
+      );
+      // $FlowExpectedError[not-a-function]
+      handlers.onMouseLeave(createMockMouseEvent('onMouseLeave'));
+      expect(config.onHoverOut).toBeCalled();
+    });
+  });
 
   describe('onLongPress', () => {
     it('is called if pressed for 500ms', () => {


### PR DESCRIPTION
## Summary:

This PR adds the missing tests for the `Pressability` class, specifically for the `onHoverOut` property.  
The tests simulate interactions similar to the existing `onHoverIn` tests, triggering `onMouseEnter` followed by `onMouseLeave` to verify that `onHoverOut` is called correctly.

## Changelog:

[General] [Added] - Added tests for `Pressability` `onHoverOut` property

## Test Plan:

- Ran the full React Native test suite to ensure all tests pass.  
- Verified that the tests fail if the production code for `onHoverOut` is removed, confirming their effectiveness.