### PR TITLE
Fix expo-image-manipulator cropped image orientation

### DIFF
--- a/packages/react-native/Libraries/Image/RCTImageUtils.mm
+++ b/packages/react-native/Libraries/Image/RCTImageUtils.mm
@@ -55,6 +55,30 @@ static CGImagePropertyOrientation CGImagePropertyOrientationFromUIImageOrientati
   }
 }
 
+static UIImageOrientation UIImageOrientationFromCGImagePropertyOrientation(CGImagePropertyOrientation imageOrientation)
+{
+  switch (imageOrientation) {
+    case kCGImagePropertyOrientationUp:
+      return UIImageOrientationUp;
+    case kCGImagePropertyOrientationDown:
+      return UIImageOrientationDown;
+    case kCGImagePropertyOrientationLeft:
+      return UIImageOrientationLeft;
+    case kCGImagePropertyOrientationRight:
+      return UIImageOrientationRight;
+    case kCGImagePropertyOrientationUpMirrored:
+      return UIImageOrientationUpMirrored;
+    case kCGImagePropertyOrientationDownMirrored:
+      return UIImageOrientationDownMirrored;
+    case kCGImagePropertyOrientationLeftMirrored:
+      return UIImageOrientationLeftMirrored;
+    case kCGImagePropertyOrientationRightMirrored:
+      return UIImageOrientationRightMirrored;
+    default:
+      return UIImageOrientationUp;
+  }
+}
+
 CGRect RCTTargetRect(CGSize sourceSize, CGSize destSize, CGFloat destScale, RCTResizeMode resizeMode)
 {
   if (CGSizeEqualToSize(destSize, CGSizeZero)) {
@@ -269,6 +293,7 @@ UIImage *__nullable RCTDecodeImageWithData(NSData *data, CGSize destSize, CGFloa
   }
   NSNumber *width = (NSNumber *)CFDictionaryGetValue(imageProperties, kCGImagePropertyPixelWidth);
   NSNumber *height = (NSNumber *)CFDictionaryGetValue(imageProperties, kCGImagePropertyPixelHeight);
+  NSNumber *orientationNum = (NSNumber *)CFDictionaryGetValue(imageProperties, kCGImagePropertyOrientation);
   CGSize sourceSize = {width.doubleValue, height.doubleValue};
   CFRelease(imageProperties);
 
@@ -293,12 +318,15 @@ UIImage *__nullable RCTDecodeImageWithData(NSData *data, CGSize destSize, CGFloa
   CGImageRef imageRef;
   BOOL createThumbnail = targetPixelSize.width != 0 && targetPixelSize.height != 0 &&
       (sourceSize.width > targetPixelSize.width || sourceSize.height > targetPixelSize.height);
+  UIImageOrientation orientation = UIImageOrientationUp;
 
   if (createThumbnail) {
     CGFloat maxPixelSize = fmax(targetPixelSize.width, targetPixelSize.height);
 
     // Get a thumbnail of the source image. This is usually slower than creating a full-sized image,
     // but takes up less memory once it's done.
+    // It rotates the image according to the orientation from metadata, so we'll pass `UIImageOrientationUp`
+    // to the `UIImage` initializer
     imageRef = CGImageSourceCreateThumbnailAtIndex(
         sourceRef, 0, (__bridge CFDictionaryRef) @{
           (id)kCGImageSourceShouldAllowFloat : @YES,
@@ -313,6 +341,13 @@ UIImage *__nullable RCTDecodeImageWithData(NSData *data, CGSize destSize, CGFloa
         sourceRef, 0, (__bridge CFDictionaryRef) @{
           (id)kCGImageSourceShouldAllowFloat : @YES,
         });
+
+    // Unlike `CGImageSourceCreateThumbnailAtIndex` (with `kCGImageSourceCreateThumbnailWithTransform` set to YES),
+    // `CGImageSourceCreateImageAtIndex` doesn't rotate the image to keep the orientation, so we'll need to pass
+    // the actual orientation (if present) to the `UIImage` initializer
+    if (orientationNum) {
+      orientation = UIImageOrientationFromCGImagePropertyOrientation((CGImagePropertyOrientation)[orientationNum unsignedIntValue]);
+    }
   }
 
   CFRelease(sourceRef);
@@ -321,7 +356,7 @@ UIImage *__nullable RCTDecodeImageWithData(NSData *data, CGSize destSize, CGFloa
   }
 
   // Return image
-  UIImage *image = [UIImage imageWithCGImage:imageRef scale:destScale orientation:UIImageOrientationUp];
+  UIImage *image = [UIImage imageWithCGImage:imageRef scale:destScale orientation:orientation];
   CGImageRelease(imageRef);
   return image;
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
https://github.com/facebook/react-native/pull/54184 introduced a change that uses `CGImageSourceCreateImageAtIndex` instead of `CGImageSourceCreateThumbnailAtIndex` to decode full-sized images. However, unlike `CGImageSourceCreateThumbnailAtIndex` which rotates the image according to the orientation in the image's metadata, `CGImageSourceCreateThumbnailAtIndex` doesn't do that. Since the UIImage initializer is always passed `UIImageOrientationUp` for orientation, this results in the returned `UIImage` having wrong orientation.

This can be reproduced for example if you take a photo with `react-native-vision-camera` in an orientation different from "up" (e.g. taking a photo on an iPhone SE 2020 in a vertical position results in a photo with "landscape-right" orientation), then use PhotoManipulator.crop() to crop the image, then show the resulted image URI in an Image component - the image is shown in a wrong orientation.

This change fixes that by making sure the UIImage is passed the correct image orientation when `CGImageSourceCreateImageAtIndex` is used.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->
[IOS] [FIXED] - Fix expo-image-manipulator cropped image orientation

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

### 0.82.1

https://github.com/mlazari/RNImageRepro/tree/rn-0.82.1

https://github.com/user-attachments/assets/297f6419-980b-49b5-873c-46c43bcc0fd6


### 0.83.1

https://github.com/mlazari/RNImageRepro/tree/0.83.1

https://github.com/user-attachments/assets/286144e7-2196-49cb-b151-26f1a6ff274d


### 0.83.1 + patch with the changes in this PR

https://github.com/mlazari/RNImageRepro/tree/0.83.1-with-patch

https://github.com/user-attachments/assets/72ed6e74-a2cd-4b0d-b529-d91d0fdb3d52

