### PR TITLE
Fix `transparent` color on `Text` on android

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp
@@ -179,7 +179,7 @@ TextAttributes TextAttributes::defaultTextAttributes() {
     auto defaultAttrs = TextAttributes{};
     // Non-obvious (can be different among platforms) default text attributes.
     defaultAttrs.foregroundColor = blackColor();
-    defaultAttrs.backgroundColor = clearColor();
+    defaultAttrs.backgroundColor = SharedColor{};
     defaultAttrs.fontSize = 14.0;
     defaultAttrs.fontSizeMultiplier = 1.0;
     return defaultAttrs;

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/platform/android/react/renderer/components/androidtextinput/AndroidTextInputShadowNode.cpp
@@ -168,7 +168,7 @@ AttributedString AndroidTextInputShadowNode::getAttributedString(
   // Don't propagate the background color of the TextInput onto the attributed
   // string. Android tries to render shadow of the background alongside the
   // shadow of the text which results in weird artifacts.
-  childTextAttributes.backgroundColor = HostPlatformColor::UndefinedColor;
+  childTextAttributes.backgroundColor = SharedColor{};
 
   auto attributedString = AttributedString{};
   auto attachments = BaseTextShadowNode::Attachments{};

--- a/packages/react-native/ReactCommon/react/renderer/graphics/Color.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/Color.h
@@ -29,9 +29,9 @@ namespace facebook::react {
  */
 class SharedColor {
  public:
-  SharedColor() : color_(HostPlatformColor::UndefinedColor) {}
+  SharedColor() : color_{}, defined_(false) {}
 
-  SharedColor(Color color) : color_(color) {}
+  SharedColor(Color color) : color_(color), defined_(true) {}
 
   Color &operator*()
   {
@@ -45,23 +45,30 @@ class SharedColor {
 
   bool operator==(const SharedColor &otherColor) const
   {
+    if (defined_ != otherColor.defined_) {
+      return false;
+    }
+    if (!defined_) {
+      return true;
+    }
     return color_ == otherColor.color_;
   }
 
   bool operator!=(const SharedColor &otherColor) const
   {
-    return color_ != otherColor.color_;
+    return !(*this == otherColor);
   }
 
   operator bool() const
   {
-    return color_ != HostPlatformColor::UndefinedColor;
+    return defined_;
   }
 
   std::string toString() const noexcept;
 
  private:
   Color color_;
+  bool defined_;
 };
 
 bool isColorMeaningful(const SharedColor &color) noexcept;

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/HostPlatformColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/android/react/renderer/graphics/HostPlatformColor.h
@@ -14,10 +14,6 @@ namespace facebook::react {
 
 using Color = int32_t;
 
-namespace HostPlatformColor {
-constexpr facebook::react::Color UndefinedColor = 0;
-}
-
 inline Color hostPlatformColorFromRGBA(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
 {
   return (a & 0xff) << 24 | (r & 0xff) << 16 | (g & 0xff) << 8 | (b & 0xff);

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/cxx/react/renderer/graphics/HostPlatformColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/cxx/react/renderer/graphics/HostPlatformColor.h
@@ -15,10 +15,6 @@ namespace facebook::react {
 
 using Color = int32_t;
 
-namespace HostPlatformColor {
-constexpr facebook::react::Color UndefinedColor = 0;
-}
-
 inline Color hostPlatformColorFromRGBA(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
 {
   return (a & 0xff) << 24 | (r & 0xff) << 16 | (g & 0xff) << 8 | (b & 0xff);

--- a/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/HostPlatformColor.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/platform/ios/react/renderer/graphics/HostPlatformColor.h
@@ -60,17 +60,6 @@ struct Color {
   std::size_t uiColorHashValue_;
 };
 
-namespace HostPlatformColor {
-
-#if defined(__clang__)
-#define NO_DESTROY [[clang::no_destroy]]
-#else
-#define NO_DESTROY
-#endif
-
-NO_DESTROY static const facebook::react::Color UndefinedColor = Color();
-} // namespace HostPlatformColor
-
 inline Color hostPlatformColorFromRGBA(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
 {
   float ratio = 255;

--- a/packages/react-native/ReactCommon/react/renderer/graphics/tests/ColorTest.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/tests/ColorTest.cpp
@@ -36,3 +36,30 @@ TEST(ColorTest, testColorConversion) {
     EXPECT_EQ(std::round(colorComponents.blue * 10) / 10.f, 0);
   }
 }
+
+TEST(ColorTest, testTransparentColorIsNotUndefined) {
+  using namespace facebook::react;
+
+  // Default SharedColor should be falsy (undefined)
+  SharedColor undefinedColor;
+  EXPECT_FALSE(static_cast<bool>(undefinedColor));
+
+  // Transparent color should be truthy (defined)
+  auto transparentColor = colorFromRGBA(0, 0, 0, 0);
+  EXPECT_TRUE(static_cast<bool>(transparentColor));
+
+  // clearColor() should be truthy (it's an explicitly set transparent color)
+  auto clear = clearColor();
+  EXPECT_TRUE(static_cast<bool>(clear));
+
+  // Transparent color should not equal undefined color
+  EXPECT_NE(transparentColor, undefinedColor);
+
+  // Two undefined colors should be equal
+  SharedColor anotherUndefined;
+  EXPECT_EQ(undefinedColor, anotherUndefined);
+
+  // Two transparent colors should be equal
+  auto anotherTransparent = colorFromRGBA(0, 0, 0, 0);
+  EXPECT_EQ(transparentColor, anotherTransparent);
+}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Fixes - https://github.com/facebook/react-native/issues/53343. Passing `transparent` into text color renders black color text on android.

This broke with a fix implemented [here](https://github.com/facebook/react-native/pull/51379/files#diff-f6e7dcb5aa5a5207b399e2db2b94a589f2d102ecb9cc11e1b7f213307a81ad78R18). The issue is that if user passes `transparent` text color from JS, it gets converted to `0` value on platform. Currently, `0` is treated as [Undefined](https://github.com/facebook/react-native/blob/23ee291672ad153d77573ecfc57e2bdc395fedae/packages/react-native/ReactCommon/react/renderer/graphics/platform/cxx/react/renderer/graphics/HostPlatformColor.h#L19) on android, which causes [this](https://github.com/facebook/react-native/blob/646945c2f2e1fe226d3b093cc0e75102eadbdfa1/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp#L22) check to fail because `bool` override function returns [false](https://github.com/facebook/react-native/blob/23ee291672ad153d77573ecfc57e2bdc395fedae/packages/react-native/ReactCommon/react/renderer/graphics/Color.h#L58) thinking the passed color is `Undefined` 😅 .[ Default text attribute](https://github.com/facebook/react-native/blob/23ee291672ad153d77573ecfc57e2bdc395fedae/packages/react-native/ReactCommon/react/renderer/attributedstring/TextAttributes.cpp#L181) is black color so android keeps the black color instead of overriding it with `transparent`.

This PR fixes it by removing the concept of `Undefined` platform color and introducing a `defined` property to `SharedColor`. This will make it consistent on different platforms. If user does `SharedColor()`, they'll get an undefined color (in bool checks) and `SharedColor(red)` would give a defined shared color.



<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

[ANDROID] [FIXED] - Transparent text color renders black text.

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:


For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:
- Added testcase to check the behaviour of undefined/defined and transparent color in `ColorTest.cpp`
- Tested transparent/opaque color on Text on android and iOS. 

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
