### PR TITLE
Fix ASAN crash in touch event handling due to uninitialized members

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseTouch.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseTouch.h
@@ -22,39 +22,39 @@ struct BaseTouch {
   /*
    * The coordinate of point relative to the root component in points.
    */
-  Point pagePoint;
+  Point pagePoint{};
 
   /*
    * The coordinate of point relative to the target component in points.
    */
-  Point offsetPoint;
+  Point offsetPoint{};
 
   /*
    * The coordinate of point relative to the screen component in points.
    */
-  Point screenPoint;
+  Point screenPoint{};
 
   /*
    * An identification number for each touch point.
    */
-  int identifier;
+  int identifier{0};
 
   /*
    * The tag of a component on which the touch point started when it was first
    * placed on the surface, even if the touch point has since moved outside the
    * interactive area of that element.
    */
-  Tag target;
+  Tag target{0};
 
   /*
    * The force of the touch.
    */
-  Float force;
+  Float force{0.0f};
 
   /*
    * The time in seconds when the touch occurred or when it was last mutated.
    */
-  Float timestamp;
+  Float timestamp{0.0f};
 
   /*
    * The particular implementation of `Hasher` and (especially) `Comparator`


### PR DESCRIPTION
Summary:
Uninitialized boolean and numeric fields in BaseTouch and HostPlatformTouch classes were causing UBSan implicit conversion errors when touch events were dispatched on macOS. The uninitialized values triggered undefined behavior when passed to jsi::Object::setProperty():

```
00007079 02-02 13:34:25:301.17 F [HorizonStandalone] Core: ASSERT: Exception: Abort called 0x0. - handleSignal arvr/projects/mhe/libraries/core/code/source/core/ExceptionHandler.cpp(472) [HsrAssert.cpp:367] 
Stack Trace:
:_ZN7horizon13AssertHandler12handleAssertEbPKciS2_S2_
:_ZN7horizon12_GLOBAL__N_112handleSignalEiP9__siginfoPv
:_sigtramp
:pthread_kill
:abort
:__sanitizer_sandbox_on_notify
:__sanitizer_on_print
:__ubsan_handle_implicit_conversion
:_ZNK8facebook3jsi6Object11setPropertyIRKbEEvRNS0_7RuntimeERKNS0_6StringEOT_
:_ZNK8facebook3jsi6Object11setPropertyIRKbEEvRNS0_7RuntimeEPKcOT_
:_ZN8facebook5reactL23setTouchPayloadOnObjectERNS_3jsi6ObjectERNS1_7RuntimeERKNS0_17HostPlatformTouchE
:_ZN8facebook5reactL14touchesPayloadERNS_3jsi7RuntimeERKNSt3__113unordered_setINS0_17HostPlatformTouchENS0_9BaseTouch6HasherENS7_10ComparatorENS4_9allocatorIS6_EEEE
:_ZN8facebook5reactL17touchEventPayloadERNS_3jsi7RuntimeERKNS0_10TouchEventE
:_ZNSt3__110__function6__funcIZNK8facebook5react17TouchEventEmitter11onTouchMoveENS3_10TouchEventEE3$_0NS_9allocatorIS6_EEFNS2_3jsi5ValueERNS9_7RuntimeEEEclESC_
:_ZNKSt3__110__function12__value_funcIFN8facebook3jsi5ValueERNS3_7RuntimeEEEclB8ne200100ES6_
:_ZNK8facebook5react24ValueFactoryEventPayload10asJSIValueERNS_3jsi7RuntimeE
:_ZNK8facebook5react16UIManagerBinding17dispatchEventToJSERNS_3jsi7RuntimeEPKNS0_11EventTargetERKNSt3__112basic_stringIcNS8_11char_traitsIcEENS8_9allocatorIcEEEENS0_18ReactEventPriorityERKNS0_12EventPayloadE
:_ZNK8facebook5react16UIManagerBinding13dispatchEventERNS_3jsi7RuntimeEPKNS0_11EventTargetERKNSt3__112basic_stringIcNS8_11char_traitsIcEENS8_9allocatorIcEEEENS0_18ReactEventPriorityERKNS0_12EventPayloadE
:_ZNSt3__110__function6__funcIZZN8facebook5react9SchedulerC1ERKNS3_16SchedulerToolboxEPNS3_26UIManagerAnimationDelegateEPNS3_17SchedulerDelegateEENK3$_0clERNS2_3jsi7RuntimeEPKNS3_11EventTargetERKNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEENS3_18ReactEventPriorityERKNS3_12EventPayloadEEUlRKNS3_16UIManagerBindingEE_NSM_ISY_EEFvSX_EEclESX_
:_ZNKSt3__110__function12__value_funcIFvRKN8facebook5react16UIManagerBindingEEEclB8ne200100ES6_
:_ZNK8facebook5react9UIManager12visitBindingERKNSt3__18functionIFvRKNS0_16UIManagerBindingEEEERNS_3jsi7RuntimeE
:_ZNSt3__110__function6__funcIZN8facebook5react9SchedulerC1ERKNS3_16SchedulerToolboxEPNS3_26UIManagerAnimationDelegateEPNS3_17SchedulerDelegateEE3$_0NS_9allocatorISC_EEFvRNS2_3jsi7RuntimeEPKNS3_11EventTargetERKNS_12basic_stringIcNS_11char_traitsIcEENSD_IcEEEENS3_18ReactEventPriorityERKNS3_12EventPayloadEEEclESH_OSK_SR_OSS_SV_
:_ZNKSt3__110__function12__value_funcIFvRN8facebook3jsi7RuntimeEPKNS2_5react11EventTargetERKNS_12basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEENS6_18ReactEventPriorityERKNS6_12EventPayloadEEEclB8ne200100ES5_OS9_SH_OSI_SL_
:_ZNK8facebook5react19EventQueueProcessor11flushEventsERNS_3jsi7RuntimeEONSt3__16vectorINS0_8RawEventENS5_9allocatorIS7_EEEE
:_ZNK8facebook5react10EventQueue11flushEventsERNS_3jsi7RuntimeE
:_ZNSt3__110__function6__funcIZN8facebook5react10EventQueueC1ENS3_19EventQueueProcessorENS_10unique_ptrINS3_9EventBeatENS_14default_deleteIS7_EEEEE3$_0NS_9allocatorISB_EEFvRNS2_3jsi7RuntimeEEEclESG_
:_ZNKSt3__110__function12__value_funcIFvRN8facebook3jsi7RuntimeEEEclB8ne200100ES5_
:_ZNSt3__110__function6__funcIZNK8facebook5react9EventBeat6induceEvE3$_0NS_9allocatorIS5_EEFvRNS2_3jsi7RuntimeEEEclESA_
:_ZNKSt3__110__function12__value_funcIFvRN8facebook3jsi7RuntimeEEEclB8ne200100ES5_
:_ZN8facebook5react4Task7executeERNS_3jsi7RuntimeEb
:_ZNK8facebook5react23RuntimeScheduler_Modern11executeTaskERNS_3jsi7RuntimeERNS0_4TaskEb
:_ZN8facebook5react23RuntimeScheduler_Modern16runEventLoopTickERNS_3jsi7RuntimeERNS0_4TaskE
:_ZN8facebook5react23RuntimeScheduler_Modern12runEventLoopERNS_3jsi7RuntimeE
:_ZNSt3__110__function6__funcIZN8facebook5react23RuntimeScheduler_Modern17scheduleEventLoopEvE3$_0NS_9allocatorIS5_EEFvRNS2_3jsi7RuntimeEEEclESA_
:_ZNKSt3__110__function12__value_funcIFvRN8facebook3jsi7RuntimeEEEclB8ne200100ES5_
:_ZNSt3__110__function6__funcIZZN8facebook5react13ReactInstanceC1ENS_10unique_ptrINS3_9JSRuntimeENS_14default_deleteIS6_EEEENS_10shared_ptrINS3_18MessageQueueThreadEEENSA_INS3_12TimerManagerEEENS_8functionIFvRNS2_3jsi7RuntimeERKNS3_14JsErrorHandler14ProcessedErrorEEEEPNS3_18jsinspector_modern10HostTargetEENK3$_0clINSF_IFvSI_EEEEEDaT_EUlvE_NS_9allocatorISX_EEFvvEEclEv
:_ZNKSt3__110__function12__value_funcIFvvEEclB8ne200100Ev
:_ZN8facebook5react17tryAndReturnErrorERKNSt3__18functionIFvvEEE
:_ZNSt3__110__function6__funcIZN8facebook5react16RCTMessageThread10runOnQueueEONS_8functionIFvvEEEE3$_0NS_9allocatorIS9_EES6_EclEv
:_ZNKSt3__110__function12__value_funcIFvvEEclB8ne200100Ev
:___ZN8facebook5react16RCTMessageThread8runAsyncENSt3__18functionIFvvEEE_block_invoke
:__CFRUNLOOP_IS_CALLING_OUT_TO_A_BLOCK__
:__CFRunLoopDoBlocks
:__CFRunLoopRun
:_CFRunLoopRunSpecificWithOptions
:+[RCTJSThreadManager runRunLoop]
:__NSThread__start__
:__sanitizer_weak_hook_memcmp
:_pthread_start
:Stack End
```

This was discovered via ASAN crash in MHS on macOS with the stack trace pointing to __ubsan_handle_implicit_conversion in setTouchPayloadOnObject.

Reviewed By: ivan-golubev

Differential Revision: D92049049


