### PR TITLE
Fix crash in async void TurboModule methods when NSException is thrown

### DIFF
--- a/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
+++ b/packages/react-native/ReactCommon/react/nativemodule/core/platform/ios/ReactCommon/RCTTurboModule.mm
@@ -461,7 +461,13 @@ void ObjCTurboModule::performVoidMethodInvocation(
     @try {
       [inv invokeWithTarget:strongModule];
     } @catch (NSException *exception) {
-      throw convertNSExceptionToJSError(runtime, exception, std::string{moduleName}, methodNameStr);
+      // Cannot rethrow C++ exceptions from async dispatch - nothing can catch them.
+      // Log the error for debugging purposes instead of crashing.
+      RCTLogError(
+          @"Exception thrown while invoking async method %s.%s: %@",
+          moduleName,
+          methodNameStr.c_str(),
+          exception);
     } @finally {
       [retainedObjectsForInvocation removeAllObjects];
     }


### PR DESCRIPTION
## Summary

Fixes uncaught C++ exception crash in `performVoidMethodInvocation` when async void TurboModule methods throw `NSException` during app termination or rapid UI transitions.

## Problem

In `RCTTurboModule.mm`, when an async void TurboModule method throws an `NSException`, the exception is caught and converted to a `JSError` which is then rethrown:

```objc
@catch (NSException *exception) {
  throw convertNSExceptionToJSError(runtime, exception, ...);
}
```

Since this code executes inside an async dispatch block via `invokeAsync()`, **nothing in the call stack can catch the C++ exception**, causing immediate app termination with `SIGABRT` / `EXC_BAD_ACCESS`.

## How to Reproduce

1. Navigate between screens rapidly while closing the app
2. Focus a text input (triggering keyboard), then quickly close the app
3. Any scenario where native modules are deallocated while async void methods are still executing

Common culprits include search/Spotlight indexing modules, analytics modules, and keyboard-related modules that fire async void methods during app lifecycle transitions.

## Solution

Replace the `throw` with `RCTLogError` to log the error instead of crashing:

```objc
@catch (NSException *exception) {
  // Cannot rethrow C++ exceptions from async dispatch - nothing can catch them.
  // Log the error for debugging purposes instead of crashing.
  RCTLogError(
      @"Exception thrown while invoking async method %s.%s: %@",
      moduleName,
      methodNameStr.c_str(),
      exception);
}
```

## Why This Fix is Safe

1. **Void methods have no return value** - the caller doesn't expect a result
2. **Async dispatch** - the original JS call has already returned; there's no Promise to reject
3. **Logging preserves visibility** - developers can still debug issues via `RCTLogError`
4. **Consistent with existing patterns** - `performMethodInvocation` already has special handling for async exceptions (re-throws `NSException` instead of converting to `JSError`)

## Related Issues

- Relates to the discussion at https://github.com/reactwg/react-native-new-architecture/discussions/276#discussioncomment-12567155 where similar handling was added for `performMethodInvocation`, but `performVoidMethodInvocation` was not addressed

## Changelog

[IOS] [FIXED] - Fix crash when async void TurboModule methods throw NSException


## Test Plan

1. Create a TurboModule with an async void method that throws (e.g., `voidFuncThrows` in `RCTSampleTurboModule.mm`)
2. Call the method and quickly terminate/background the app
3. Verify app does NOT crash
4. Verify error appears in console logs
