### PR TITLE
Update prettier-plugin-hermes-parser in xplat to 0.34.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "node-fetch": "^2.2.0",
     "nullthrows": "^1.1.1",
     "prettier": "3.6.2",
-    "prettier-plugin-hermes-parser": "0.33.2",
+    "prettier-plugin-hermes-parser": "0.34.0",
     "react": "19.2.3",
     "react-test-renderer": "19.2.3",
     "rimraf": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8180,10 +8180,10 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prettier-plugin-hermes-parser@0.33.2:
-  version "0.33.2"
-  resolved "https://registry.yarnpkg.com/prettier-plugin-hermes-parser/-/prettier-plugin-hermes-parser-0.33.2.tgz#abc853c0907fdce5f42457a09221c464c9e3e59e"
-  integrity sha512-YS9F5VhgDIJ+FyIMrwOSQjg5lYkMt4/csljG5E74FbhHAg4u9G0RHx7FImSd77qXDpxQMNW2QhZiWSUzWvegbQ==
+prettier-plugin-hermes-parser@0.34.0:
+  version "0.34.0"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-hermes-parser/-/prettier-plugin-hermes-parser-0.34.0.tgz#15ddb3fd0f31c61050a158ae29ccffe4d2a231f2"
+  integrity sha512-XhB4RQVA0Oo3YRtwshrU6D8jyXz0m6oQqVodH3LxInPObUk4uZwKkAwC2/AlYJPSaQVuJAu98zILIhBJxQM9KQ==
 
 prettier@3.6.2:
   version "3.6.2"


### PR DESCRIPTION
Summary:
Bump prettier-plugin-hermes-parser to 0.34.0.

Changelog: [internal]

Differential Revision: D92112954


