### PR TITLE
Bump Electron to 39.0.0

### DIFF
--- a/packages/debugger-shell/package.json
+++ b/packages/debugger-shell/package.json
@@ -46,7 +46,7 @@
     "fb-dotslash": "0.5.8"
   },
   "devDependencies": {
-    "electron": "37.2.6",
+    "electron": "39.0.0",
     "semver": "^7.1.3"
   },
   "files": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -4083,10 +4083,10 @@ electron-to-chromium@^1.5.73:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.113.tgz#1175b8ba4170541e44e9afa8b992e5bbfff0d150"
   integrity sha512-wjT2O4hX+wdWPJ76gWSkMhcHAV2PTMX+QetUCPYEdCIe+cxmgzzSSiGRCKW8nuh4mwKZlpv0xvoW7OF2X+wmHg==
 
-electron@37.2.6:
-  version "37.2.6"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-37.2.6.tgz#bc299eb21daf5bd8242f9b3a6119e19b4ef226cd"
-  integrity sha512-Ns6xyxE+hIK5UlujtRlw7w4e2Ju/ImCWXf1Q/PoOhc0N3/6SN6YW7+ujCarsHbxWnolbW+1RlkHtdklUJpjbPA==
+electron@39.0.0:
+  version "39.0.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-39.0.0.tgz#6906720c5bd3c40f98f6e01802fdc301654c4550"
+  integrity sha512-UejnuOK4jpRZUq7MkEAnR/szsRWLKBJAdvn6j3xdQLT57fVv13VSNdaUHHjSheaqGzNhCGIdkPsPJnGJVh5kiA==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^22.7.7"


### PR DESCRIPTION
Summary:
Upgrade from Electron 37.x → 39.x , which includes compiling for macOS 26.

Changelog: [Internal]

**Breaking changes from Electron 37.2.6 → 39.0.0:**

**Electron 38.0.0**
- Removed `ELECTRON_OZONE_PLATFORM_HINT` env var
- Removed `ORIGINAL_XDG_CURRENT_DESKTOP` env var  
- Removed macOS 11 support (minimum now macOS 12)
- Removed `plugin-crashed` event from webContents
- Deprecated `webFrame.routingId` (use `frameToken`)
- Deprecated `webFrame.findFrameByRoutingId()` (use `findFrameByToken()`)
- Linux now defaults to Wayland (force X11 with `--ozone-platform=x11`)

**Electron 39.0.0**
- Deprecated `--host-rules` flag (use `--host-resolver-rules`)
- `window.open` popups now always resizable (WHATWG spec)
- Shared texture OSR `paint` event structure changed

Reviewed By: motiz88

Differential Revision: D92154326


