### PR TITLE
fix: inability to disable hermesV1 on Android

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/ReactPlugin.kt
@@ -55,8 +55,8 @@ class ReactPlugin : Plugin<Project> {
                 project,
             )
 
-    if (project.rootProject.isHermesV1Enabled) {
-      rootExtension.hermesV1Enabled.set(true)
+    if (!project.rootProject.isHermesV1Enabled) {
+      rootExtension.hermesV1Enabled.set(false)
     }
 
     // App Only Configuration


### PR DESCRIPTION
## Summary:

Changing the line in `ReactPlugin.kt` that always set `hermesV1Enabled` to `true` even if it was explicitly disabled, accidentally omitted in #54989.

In recent update of hermes V1 binary a file `RuntimeAdapter.h` was removed.

## Changelog:

[ANDROID] [FIXED] - ReactPlugin.kt always setting `hermesV1Enabled` to `true`

## Test Plan:

Build React Native from source on latest 0.84 RC, disable hermesV1 and see that it compiles now.
