### PR TITLE
Fix URL constructor type to accept URL as first argument

### DIFF
--- a/packages/react-native/flow/dom.js.flow
+++ b/packages/react-native/flow/dom.js.flow
@@ -5948,12 +5948,19 @@ declare class Comment extends CharacterData {
   text: string;
 }
 
+interface StringLike {
+  toString(): string;
+}
+
 declare class URL {
   static canParse(url: string, base?: string): boolean;
   static createObjectURL(blob: Blob): string;
   static createObjectURL(mediaSource: MediaSource): string;
   static revokeObjectURL(url: string): void;
-  constructor(url: string, base?: string | URL): void;
+  constructor(
+    url: string | URL | StringLike,
+    base?: string | URL | StringLike,
+  ): void;
   hash: string;
   host: string;
   hostname: string;


### PR DESCRIPTION
Summary:
According to the URL API specification, the first parameter is a USVString, which accepts anything stringifiable. Since URL objects are stringifiable, they should be accepted.

This change mirrors what we already do for the `base` parameter, which accepts `string | URL` and the spec also expects USVString.

## Changelog:
[GENERAL] [Changed] - Changed Flow type for `URL` constructor to accept `URL` as first argument, matching the second argument type

https://url.spec.whatwg.org/#dom-url-url

Differential Revision: D92271127


