### PR TITLE
Yoga | dirty YGNode when removing it from parent

### DIFF
--- a/packages/react-native/ReactCommon/yoga/yoga/YGNode.cpp
+++ b/packages/react-native/ReactCommon/yoga/yoga/YGNode.cpp
@@ -177,6 +177,7 @@ void YGNodeRemoveChild(
     if (owner == childOwner) {
       excludedChild->setLayout({}); // layout is no longer valid
       excludedChild->setOwner(nullptr);
+      excludedChild->setDirty(true); // invalidate cache
     }
     owner->markDirtyAndPropagate();
   }
@@ -198,6 +199,7 @@ void YGNodeRemoveAllChildren(const YGNodeRef ownerRef) {
       yoga::Node* oldChild = owner->getChild(i);
       oldChild->setLayout({}); // layout is no longer valid
       oldChild->setOwner(nullptr);
+      oldChild->setDirty(true); // invalidate cache
     }
     owner->clearChildren();
     owner->markDirtyAndPropagate();


### PR DESCRIPTION
Summary:
## Context
When a child node is removed from its parent via YGNodeRemoveChild, the child's calculated layout is cleared (setLayout({})) but the child node is not marked dirty. This causes issues when the view is removed views and later reused with the same layout values. the layout values were cleared (resulting in NaN/0), but since the layout values are the same for the newly reattached node, it isn't dirtied. However, the user would expect it to be dirty, as:
a) a fully new node would be dirty by default.
b) They just set layout


**Example**:
- Node is removed from the view and it's layout is cleared.
- Node is reattatched and set with height/width that happens to be same as previous
- Checking if the view is dirty unexpectedly gives false, despite user setting a "new" value.
- Pulling height/width gives 0, as layout hasn't been recalculated yet



## This Diff
Marks the removed child node as dirty when clearing its layout in YGNodeRemoveChild, ensuring that subsequent layout calculations will properly recalculate the child's layout values

Reviewed By: NickGerleman

Differential Revision: D92280506


