### PR TITLE
Fix DoNotStripAnnotationUsage: Replace @DoNotStrip with @DoNotStripAny

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManagerBinding.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManagerBinding.kt
@@ -9,14 +9,14 @@ package com.facebook.react.fabric
 
 import android.annotation.SuppressLint
 import com.facebook.jni.HybridClassBase
-import com.facebook.proguard.annotations.DoNotStrip
+import com.facebook.proguard.annotations.DoNotStripAny
 import com.facebook.react.bridge.NativeMap
 import com.facebook.react.bridge.RuntimeExecutor
 import com.facebook.react.bridge.RuntimeScheduler
 import com.facebook.react.fabric.events.EventBeatManager
 import com.facebook.react.uimanager.PixelUtil.getDisplayMetricDensity
 
-@DoNotStrip
+@DoNotStripAny
 @SuppressLint("MissingNativeLoadLibrary")
 internal class FabricUIManagerBinding : HybridClassBase() {
   init {


### PR DESCRIPTION
Summary:
Fixed DoNotStripAnnotationUsage lint error in FabricUIManagerBinding.kt.

The class has many members (external methods like initHybrid, installFabricUIManager, etc.)
that need to be kept, so DoNotStripAny is more appropriate than DoNotStrip which only
keeps the directly annotated element.

changelog: [internal] internal

Reviewed By: javache

Differential Revision: D91840163


