### PR TITLE
fix(iOS): Add null check for fontName in RCTGetFontWeight to prevent crash

### DIFF
--- a/packages/react-native/React/Views/RCTFont.mm
+++ b/packages/react-native/React/Views/RCTFont.mm
@@ -54,14 +54,16 @@ RCTFontWeight RCTGetFontWeight(UIFont *font)
   });
 
   NSString *fontName = font.fontName;
-  NSInteger i = 0;
-  for (NSString *suffix in weightSuffixes) {
-    // CFStringFind is much faster than any variant of rangeOfString: because it does not use a locale.
-    auto options = kCFCompareCaseInsensitive | kCFCompareAnchored | kCFCompareBackwards;
-    if (CFStringFind((CFStringRef)fontName, (CFStringRef)suffix, options).location != kCFNotFound) {
-      return (RCTFontWeight)fontWeights[i].doubleValue;
+  if (fontName) {
+    NSInteger i = 0;
+    for (NSString *suffix in weightSuffixes) {
+      // CFStringFind is much faster than any variant of rangeOfString: because it does not use a locale.
+      auto options = kCFCompareCaseInsensitive | kCFCompareAnchored | kCFCompareBackwards;
+      if (CFStringFind((CFStringRef)fontName, (CFStringRef)suffix, options).location != kCFNotFound) {
+        return (RCTFontWeight)fontWeights[i].doubleValue;
+      }
+      i++;
     }
-    i++;
   }
 
   auto traits = (__bridge_transfer NSDictionary *)CTFontCopyTraits((CTFontRef)font);

--- a/packages/react-native/React/Views/RCTFont.mm
+++ b/packages/react-native/React/Views/RCTFont.mm
@@ -15,6 +15,10 @@
 
 RCTFontWeight RCTGetFontWeight(UIFont *font)
 {
+  if (!font) {
+    return UIFontWeightRegular;
+  }
+
   static NSArray<NSString *> *weightSuffixes;
   static NSArray<NSNumber *> *fontWeights;
   static dispatch_once_t onceToken;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Adds defensive null check for `fontName` in `RCTGetFontWeight` before passing it  to `CFStringFind()`, preventing `EXC_BAD_ACCESS` crash.

## Problem 

`RCTGetFontWeight` passes `font.fontName` directly to `CFStringFind()` without checking if the result is nil. Unlike Objective-C methods, Core Foundation functions like `CFStringFind` do not gracefully handle NULL pointers and will 
crash with `EXC_BAD_ACCESS`.

While standard React Native apps typically register fonts at compile time. There are legitimate scenarios where fonts may not be immediately available. eg.
Brownfield applications - runtime font registration using `CTFontManagerRegisterGraphicsFont`, this causes RN to crash


## Changelog:

[IOS][FIXED] - Added null check for fontName in RCTGetFontWeight to prevent crash

## Test Plan:
When calling `RCTGetFontWeight` with nil UIFont (either empty string or unregistered font), no crash observed.