### PR TITLE
Remove build package.json dirty state check

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -29,9 +29,6 @@ runs:
     - name: Lint file structure
       shell: bash
       run: ./.github/workflow-scripts/lint_files.sh
-    - name: Verify not committing repo after running build
-      shell: bash
-      run: yarn run build --validate
     - name: Run flowcheck
       shell: bash
       run: yarn flow-check

--- a/scripts/run-ci-javascript-tests.js
+++ b/scripts/run-ci-javascript-tests.js
@@ -53,10 +53,9 @@ try {
 
   describe('Test: feature flags codegen');
   execAndLog(`${YARN_BINARY} run featureflags --verify-unchanged`);
+
   describe('Test: eslint');
   execAndLog(`${YARN_BINARY} run lint`);
-  describe('Test: No JS build artifacts');
-  execAndLog(`${YARN_BINARY} run build --validate`);
 
   describe('Test: Validate JS API snapshot');
   execAndLog(`${YARN_BINARY} run build-types --validate`);


### PR DESCRIPTION
Summary:
After https://github.com/facebook/react-native/pull/54857 (use of the "publishConfig" field), this check is no longer necessary, since `yarn build` will no longer make changes to any checked in files.

In the (expectedly) rare case that `yarn build --prepack` changes are committed (only intended for CI), Flow will also fail independently.

Changelog: [Internal]

Reviewed By: cipolleschi

Differential Revision: D92397786


