### PR TITLE
Fix TypeError when serializing arbitrary transform operation

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/graphics/TransformUtils.h
+++ b/packages/react-native/ReactCommon/react/renderer/graphics/TransformUtils.h
@@ -76,8 +76,9 @@ inline void updateTransformProps(
       serializeTransformAxis(operation, "perspective", 0, resultTranslateArray);
       return;
     case TransformOperationType::Arbitrary: {
-      operationName = "matrix";
-      resultTranslateArray[operationName] = transform;
+      folly::dynamic result = folly::dynamic::object();
+      result["matrix"] = transform;
+      resultTranslateArray.push_back(std::move(result));
       return;
     }
     case TransformOperationType::Identity:


### PR DESCRIPTION
Summary:
The `TransformOperationType::Arbitrary` case was incorrectly using the `[]` operator with a string key on a `folly::dynamic` array (`resultTranslateArray`). This throws a `TypeError` at runtime because `folly::dynamic` arrays only support numeric index access - string key access is only valid for objects.

The fix creates a `folly::dynamic::object()`, sets the "matrix" key on it, and then pushes the object to the array using `push_back()`. This follows the same pattern already used by `serializeTransformOperationValue()` and other serialization helpers in this file.

## Changelog:
[General][Fixed] - fixed TypeError when serializing arbitrary transform operation

Differential Revision: D92499621


