### PR TITLE
Add @SuppressWarnings("deprecation") on `AndroidPopupMenuManagerDelegate`

### DIFF
--- a/packages/react-native-popup-menu-android/android/src/main/java/com/facebook/react/viewmanagers/AndroidPopupMenuManagerDelegate.java
+++ b/packages/react-native-popup-menu-android/android/src/main/java/com/facebook/react/viewmanagers/AndroidPopupMenuManagerDelegate.java
@@ -16,6 +16,7 @@ import com.facebook.react.uimanager.BaseViewManagerDelegate;
 import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.LayoutShadowNode;
 
+@SuppressWarnings("deprecation")
 public class AndroidPopupMenuManagerDelegate<T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & AndroidPopupMenuManagerInterface<T>> extends BaseViewManagerDelegate<T, U> {
   public AndroidPopupMenuManagerDelegate(U viewManager) {
     super(viewManager);


### PR DESCRIPTION
Summary:
This matches the same layout we have for codegen:
https://www.internalfb.com/code/fbsource/[c31aba8cd6c1aca236c066fa57054edd4fe2864b]/xplat/js/react-native-github/packages/react-native-codegen/src/generators/components/GeneratePropsJavaDelegate.js?lines=59

Created from CodeHub with https://fburl.com/edit-in-codehub

Differential Revision: D92530233


