### PR TITLE
Enable Xlint:deprecation,unchecked for popup-menu-android

### DIFF
--- a/packages/react-native-popup-menu-android/android/build.gradle.kts
+++ b/packages/react-native-popup-menu-android/android/build.gradle.kts
@@ -29,6 +29,11 @@ kotlin {
   explicitApi()
 }
 
+tasks.withType<JavaCompile>().configureEach {
+  options.compilerArgs.add("-Xlint:deprecation,unchecked")
+  options.compilerArgs.add("-Werror")
+}
+
 dependencies {
   // Build React Native from source
   implementation(project(":packages:react-native:ReactAndroid"))


### PR DESCRIPTION
Summary:
Let's turn on those 2 compilation flags now that the warnigns have been suppressed.

Changelog:
[Internal] [Changed] -

Differential Revision: D92532099


