### PR TITLE
Re-implement request body previews on Android

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/NetworkingModule.kt
@@ -610,12 +610,8 @@ public class NetworkingModule(
         request.url().toString(),
         request.method(),
         NetworkEventUtil.okHttpHeadersToMap(request.headers()),
-        if (ReactBuildConfig.DEBUG) {
-          // Debug build: Include request body for preview in DevTools
-          (request.body() as? ProgressRequestBody)?.getBodyPreview() ?: request.body()?.toString()
-        } else {
-          null
-        },
+        if (ReactBuildConfig.DEBUG) NetworkEventUtil.getRequestBodyPreview(request.body())
+        else null,
         request.body()?.contentLength() ?: 0,
     )
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/ProgressRequestBody.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/network/ProgressRequestBody.kt
@@ -50,6 +50,8 @@ internal class ProgressRequestBody(
     sinkWrapper.flush()
   }
 
+  fun innerBody(): RequestBody = requestBody
+
   private fun outputStreamSink(sink: BufferedSink): Sink {
     return Okio.sink(
         object : FilterOutputStream(sink.outputStream()) {
@@ -77,10 +79,5 @@ internal class ProgressRequestBody(
           }
         }
     )
-  }
-
-  fun getBodyPreview(): String {
-    // TODO: Safely implement request body previews
-    return "[Preview unavailable]"
   }
 }


### PR DESCRIPTION
Summary:
**Context**

Follow-up to https://github.com/facebook/react-native/pull/54917, which addressed a runtime Android crash with `FormData` uploads (https://github.com/facebook/react-native/issues/54881) but introduced a "[Preview unavailable]" fallback for the `ProgressRequestBody` case.

**This diff**

Reintroduce request body previews under this case.

Protects agains the original crash by:

- Checking `body.isOneShot()` to prevent disallowed double-reads of stream bodies.
- [Pre-existing] Preserves `BuildConfig.DEBUG` guard added in D89377163.

Changelog:
[Android][Added] - React Native DevTools: Restore request payload previews on Android

Differential Revision: D89381124


