### PR TITLE
Added missing tests for Standalone fusebox shell

### DIFF
--- a/packages/dev-middleware/src/__tests__/StandaloneFuseboxShell-test.js
+++ b/packages/dev-middleware/src/__tests__/StandaloneFuseboxShell-test.js
@@ -9,7 +9,10 @@
  */
 
 import type {JsonPagesListResponse} from '../inspector-proxy/types';
-import type {DebuggerShellPreparationResult, DevToolLauncher} from '../types/DevToolLauncher';
+import type {
+  DebuggerShellPreparationResult,
+  DevToolLauncher,
+} from '../types/DevToolLauncher';
 
 import {fetchJson, requestLocal} from './FetchUtils';
 import {createDeviceMock} from './InspectorDeviceUtils';
@@ -45,22 +48,26 @@ async function setupDevice(
   return device;
 }
 
-function setupToolLauncherWithFuseboxShell(prepareDebuggerShell: () => Promise<DebuggerShellPreparationResult>) {
-    const ToolLauncherWithFuseboxShell: DevToolLauncher = {
-      launchDebuggerAppWindow: async (url: string) => {},
-      launchDebuggerShell: () => {
-        throw new Error('Not implemented');
-      },
-      prepareDebuggerShell,
-    };
+function setupToolLauncherWithFuseboxShell(
+  prepareDebuggerShell: () => Promise<DebuggerShellPreparationResult>,
+) {
+  const ToolLauncherWithFuseboxShell: DevToolLauncher = {
+    launchDebuggerAppWindow: async (url: string) => {},
+    launchDebuggerShell: () => {
+      throw new Error('Not implemented');
+    },
+    prepareDebuggerShell,
+  };
 
-    const prepareDebuggerShellSpy = jest
-          .spyOn(ToolLauncherWithFuseboxShell, 'prepareDebuggerShell');
+  const prepareDebuggerShellSpy = jest.spyOn(
+    ToolLauncherWithFuseboxShell,
+    'prepareDebuggerShell',
+  );
 
-    return {
-      ToolLauncherWithFuseboxShell,
-      prepareDebuggerShellSpy,
-    };
+  return {
+    ToolLauncherWithFuseboxShell,
+    prepareDebuggerShellSpy,
+  };
 }
 
 describe('enableStandaloneFuseboxShell experiment', () => {
@@ -72,7 +79,10 @@ describe('enableStandaloneFuseboxShell experiment', () => {
 
   describe('/open-debugger endpoint', () => {
     describe('success', () => {
-      const {ToolLauncherWithFuseboxShell, prepareDebuggerShellSpy} = setupToolLauncherWithFuseboxShell(() => Promise.resolve({code: 'success'}));
+      const {ToolLauncherWithFuseboxShell, prepareDebuggerShellSpy} =
+        setupToolLauncherWithFuseboxShell(() =>
+          Promise.resolve({code: 'success'}),
+        );
       const server = withServerForEachTest({
         logger: undefined,
         unstable_toolLauncher: ToolLauncherWithFuseboxShell,
@@ -102,10 +112,7 @@ describe('enableStandaloneFuseboxShell experiment', () => {
           const firstPage = pageListResponse[0];
 
           // Build the URL for the debugger
-          const openUrl = new URL(
-            '/open-debugger',
-            server.serverBaseUrl,
-          );
+          const openUrl = new URL('/open-debugger', server.serverBaseUrl);
           openUrl.searchParams.set('launchId', 'launch1');
           openUrl.searchParams.set(
             'device',
@@ -162,7 +169,10 @@ describe('enableStandaloneFuseboxShell experiment', () => {
     });
 
     describe('prepareDebuggerShell failures', () => {
-      const {ToolLauncherWithFuseboxShell, prepareDebuggerShellSpy} = setupToolLauncherWithFuseboxShell(() => Promise.resolve({code: 'platform_not_supported'}));
+      const {ToolLauncherWithFuseboxShell, prepareDebuggerShellSpy} =
+        setupToolLauncherWithFuseboxShell(() =>
+          Promise.resolve({code: 'platform_not_supported'}),
+        );
       const server = withServerForEachTest({
         logger: undefined,
         unstable_toolLauncher: ToolLauncherWithFuseboxShell,
@@ -192,10 +202,7 @@ describe('enableStandaloneFuseboxShell experiment', () => {
           const firstPage = pageListResponse[0];
 
           // Build the URL for the debugger
-          const openUrl = new URL(
-            '/open-debugger',
-            server.serverBaseUrl,
-          );
+          const openUrl = new URL('/open-debugger', server.serverBaseUrl);
           openUrl.searchParams.set('launchId', 'launch1');
           openUrl.searchParams.set(
             'device',


### PR DESCRIPTION
## Summary:
This PR adds the missing test coverage for the standalone Fusebox debugger shell in `StandaloneFuseboxShell-test`.
First, I added some missing expectation for the success case (`enableStandaloneFuseboxShell=true` and no errors) already present:

- the assertion that `unstable_prepareFuseboxShell` is called just one time during middleware initialization
- the assertion that `launchDebuggerAppWindow` is never called when the standalone shell is available

Then, I added the missing test for the case when `unstable_prepareFuseboxShell` returns one of the error code like eg. `platform_not_supported` (as reported also in the TODO that I removed). 
In this way now the test is verifying the full behaviour for the new standalone mode for debugger/dev tools.

## Changelog:

[GENERAL] [CHANGED] - Added missing tests for Standalone fusebox shell

## Test Plan:

- Ran `StandaloneFuseboxShell-test` and verify all tests cases passed
- Ran the full React Native test suite to ensure all tests pass.
- Verified test correctness by intentionally breaking production code:
  - removing the calls to the `DefaultBrowserLauncher` in `openDebuggerMiddleware` to verify that the tests were correctly failing
