### PR TITLE
Add @DoNotStripAny to AnimationBackendChoreographer

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/AnimationBackendChoreographer.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/AnimationBackendChoreographer.kt
@@ -7,6 +7,7 @@
 
 package com.facebook.react.fabric
 
+import com.facebook.proguard.annotations.DoNotStripAny
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.modules.core.ReactChoreographer
 import com.facebook.react.uimanager.GuardedFrameCallback
@@ -17,6 +18,7 @@ internal fun interface AnimationFrameCallback {
   fun onAnimationFrame(frameTimeMs: Double)
 }
 
+@DoNotStripAny
 internal class AnimationBackendChoreographer(
     reactApplicationContext: ReactApplicationContext,
 ) {


### PR DESCRIPTION
Summary:
- AnimationBackendChoreographer.resume() and pause() are called from C++ via
  JNI reflection in JAnimationBackendChoreographer.cpp, but the class had no
  ProGuard/R8 protection annotation
- R8 renames the methods during minification, causing NoSuchMethodError at
  runtime when JNI looks up "resume" by name
- Every other JNI-accessed class in the fabric package (FabricUIManager,
  ComponentFactory, StateWrapperImpl, EventEmitterWrapper, EventBeatManager,
  MountItem) already uses DoNotStripAny — this was the only one missing

changelog: [internal] internal

Reviewed By: fkgozali

Differential Revision: D92628923


