### PR TITLE
Suppress LogBox during performance tracing

### DIFF
--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeAgent.cpp
@@ -155,9 +155,15 @@ RuntimeTracingAgent::RuntimeTracingAgent(
   if (state.enabledCategories.contains(tracing::Category::JavaScriptSampling)) {
     targetController_.enableSamplingProfiler();
   }
+  if (state.mode == tracing::Mode::CDP) {
+    targetController_.emitTracingStateChange(true);
+  }
 }
 
 RuntimeTracingAgent::~RuntimeTracingAgent() {
+  if (state_.mode == tracing::Mode::CDP) {
+    targetController_.emitTracingStateChange(false);
+  }
   if (state_.enabledCategories.contains(
           tracing::Category::JavaScriptSampling)) {
     targetController_.disableSamplingProfiler();

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTarget.h
@@ -21,6 +21,7 @@
 #include <jsinspector-modern/tracing/TraceRecordingState.h>
 
 #include <memory>
+#include <optional>
 #include <utility>
 
 #ifndef JSINSPECTOR_EXPORT
@@ -147,6 +148,11 @@ class RuntimeTargetController {
    */
   tracing::RuntimeSamplingProfile collectSamplingProfile();
 
+  /**
+   * Emits a tracing state change to JavaScript via the tracing state observer.
+   */
+  void emitTracingStateChange(bool isTracing);
+
  private:
   RuntimeTarget &target_;
 };
@@ -262,6 +268,7 @@ class JSINSPECTOR_EXPORT RuntimeTarget : public EnableExecutorFromThis<RuntimeTa
    * session - HostTargetTraceRecording.
    */
   std::weak_ptr<RuntimeTracingAgent> tracingAgent_;
+
   /**
    * Start sampling profiler for a particular JavaScript runtime.
    */
@@ -305,6 +312,13 @@ class JSINSPECTOR_EXPORT RuntimeTarget : public EnableExecutorFromThis<RuntimeTa
   void installDebuggerSessionObserver();
 
   /**
+   * Installs __TRACING_STATE_OBSERVER__ object on the JavaScript's global
+   * object, which can be referenced from JavaScript side for determining the
+   * status of performance tracing.
+   */
+  void installTracingStateObserver();
+
+  /**
    * Installs the private __NETWORK_REPORTER__ object on the Runtime's
    * global object.
    */
@@ -321,6 +335,11 @@ class JSINSPECTOR_EXPORT RuntimeTarget : public EnableExecutorFromThis<RuntimeTa
    * onStatusChange on __DEBUGGER_SESSION_OBSERVER__.
    */
   void emitDebuggerSessionDestroyed();
+
+  /**
+   * Emits a tracing state change to JavaScript via the tracing state observer.
+   */
+  void emitTracingStateChange(bool isTracing);
 
   /**
    * \returns a globally unique ID for a network request.

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTargetTracingStateObserver.cpp
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTargetTracingStateObserver.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "RuntimeTargetTracingStateObserver.h"
+
+#include <jsinspector-modern/RuntimeTargetGlobalStateObserver.h>
+
+namespace facebook::react::jsinspector_modern {
+
+void installTracingStateObserver(jsi::Runtime& runtime) {
+  installGlobalStateObserver(
+      runtime,
+      "__TRACING_STATE_OBSERVER__",
+      "isTracing",
+      "onTracingStateChange");
+}
+
+void emitTracingStateObserverChange(jsi::Runtime& runtime, bool isTracing) {
+  emitGlobalStateObserverChange(
+      runtime, "__TRACING_STATE_OBSERVER__", "onTracingStateChange", isTracing);
+}
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTargetTracingStateObserver.h
+++ b/packages/react-native/ReactCommon/jsinspector-modern/RuntimeTargetTracingStateObserver.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <jsi/jsi.h>
+
+namespace facebook::react::jsinspector_modern {
+
+/**
+ * Installs __TRACING_STATE_OBSERVER__ object on the JavaScript's global
+ * object, which can be referenced from JavaScript side for determining the
+ * status of performance tracing.
+ */
+void installTracingStateObserver(jsi::Runtime &runtime);
+
+/**
+ * Emits the tracing state change to JavaScript by calling onTracingStateChange
+ * on __TRACING_STATE_OBSERVER__.
+ */
+void emitTracingStateObserverChange(jsi::Runtime &runtime, bool isTracing);
+
+} // namespace facebook::react::jsinspector_modern

--- a/packages/react-native/src/private/devsupport/rndevtools/GlobalStateObserver.js
+++ b/packages/react-native/src/private/devsupport/rndevtools/GlobalStateObserver.js
@@ -21,18 +21,20 @@
  * This class provides a JS-friendly API over that global object.
  */
 class GlobalStateObserver {
-  #hasNativeSupport: boolean;
   #globalName: string;
   #statusProperty: string;
 
   constructor(globalName: string, statusProperty: string) {
     this.#globalName = globalName;
     this.#statusProperty = statusProperty;
-    this.#hasNativeSupport = global.hasOwnProperty(globalName);
+  }
+
+  #hasNativeSupport(): boolean {
+    return global.hasOwnProperty(this.#globalName);
   }
 
   getStatus(): boolean {
-    if (!this.#hasNativeSupport) {
+    if (!this.#hasNativeSupport()) {
       return false;
     }
 
@@ -40,7 +42,7 @@ class GlobalStateObserver {
   }
 
   subscribe(callback: (status: boolean) => void): () => void {
-    if (!this.#hasNativeSupport) {
+    if (!this.#hasNativeSupport()) {
       return () => {};
     }
 

--- a/packages/react-native/src/private/devsupport/rndevtools/TracingStateObserver.js
+++ b/packages/react-native/src/private/devsupport/rndevtools/TracingStateObserver.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict
+ * @format
+ */
+
+import GlobalStateObserver from './GlobalStateObserver';
+
+const observer = new GlobalStateObserver(
+  '__TRACING_STATE_OBSERVER__',
+  'isTracing',
+);
+
+const TracingStateObserver = {
+  isTracing(): boolean {
+    return observer.getStatus();
+  },
+
+  subscribe(callback: (isTracing: boolean) => void): () => void {
+    return observer.subscribe(callback);
+  },
+};
+
+export default TracingStateObserver;

--- a/packages/react-native/src/private/devsupport/rndevtools/__tests__/TracingStateObserver-test.js
+++ b/packages/react-native/src/private/devsupport/rndevtools/__tests__/TracingStateObserver-test.js
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+'use strict';
+
+describe('TracingStateObserver', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    delete global.__TRACING_STATE_OBSERVER__;
+  });
+
+  describe('without native support', () => {
+    it('isTracing returns false when native observer is not available', () => {
+      const TracingStateObserver = require('../TracingStateObserver').default;
+      expect(TracingStateObserver.isTracing()).toBe(false);
+    });
+
+    it('subscribe returns a no-op unsubscribe when native observer is not available', () => {
+      const TracingStateObserver = require('../TracingStateObserver').default;
+      const callback = jest.fn();
+      const unsubscribe = TracingStateObserver.subscribe(callback);
+
+      expect(typeof unsubscribe).toBe('function');
+
+      expect(() => unsubscribe()).not.toThrow();
+    });
+  });
+
+  describe('with native support', () => {
+    beforeEach(() => {
+      const mockSubscribers = new Set<(isTracing: boolean) => void>();
+      global.__TRACING_STATE_OBSERVER__ = {
+        isTracing: false,
+        subscribers: mockSubscribers,
+        onTracingStateChange: (isTracing: boolean) => {
+          global.__TRACING_STATE_OBSERVER__.isTracing = isTracing;
+          mockSubscribers.forEach(callback => callback(isTracing));
+        },
+      };
+    });
+
+    it('isTracing returns current tracing state', () => {
+      const TracingStateObserver = require('../TracingStateObserver').default;
+
+      expect(TracingStateObserver.isTracing()).toBe(false);
+
+      global.__TRACING_STATE_OBSERVER__.onTracingStateChange(true);
+      expect(TracingStateObserver.isTracing()).toBe(true);
+
+      global.__TRACING_STATE_OBSERVER__.onTracingStateChange(false);
+      expect(TracingStateObserver.isTracing()).toBe(false);
+    });
+
+    it('subscribe adds callback to subscribers and returns unsubscribe function', () => {
+      const TracingStateObserver = require('../TracingStateObserver').default;
+      const callback = jest.fn();
+
+      const unsubscribe = TracingStateObserver.subscribe(callback);
+
+      expect(global.__TRACING_STATE_OBSERVER__.subscribers.has(callback)).toBe(
+        true,
+      );
+
+      global.__TRACING_STATE_OBSERVER__.onTracingStateChange(true);
+      expect(callback).toHaveBeenCalledWith(true);
+
+      unsubscribe();
+      expect(global.__TRACING_STATE_OBSERVER__.subscribers.has(callback)).toBe(
+        false,
+      );
+
+      callback.mockClear();
+      global.__TRACING_STATE_OBSERVER__.onTracingStateChange(false);
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('multiple subscribers receive state changes', () => {
+      const TracingStateObserver = require('../TracingStateObserver').default;
+      const callback1 = jest.fn();
+      const callback2 = jest.fn();
+
+      TracingStateObserver.subscribe(callback1);
+      TracingStateObserver.subscribe(callback2);
+
+      global.__TRACING_STATE_OBSERVER__.onTracingStateChange(true);
+
+      expect(callback1).toHaveBeenCalledWith(true);
+      expect(callback2).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('with late native support installation', () => {
+    it('detects native global installed after module load', () => {
+      const TracingStateObserver = require('../TracingStateObserver').default;
+      expect(TracingStateObserver.isTracing()).toBe(false);
+
+      const mockSubscribers = new Set<(isTracing: boolean) => void>();
+      global.__TRACING_STATE_OBSERVER__ = {
+        isTracing: true,
+        subscribers: mockSubscribers,
+        onTracingStateChange: (isTracing: boolean) => {
+          global.__TRACING_STATE_OBSERVER__.isTracing = isTracing;
+          mockSubscribers.forEach(cb => cb(isTracing));
+        },
+      };
+
+      expect(TracingStateObserver.isTracing()).toBe(true);
+    });
+
+    it('subscribes when native global is installed after module load', () => {
+      const TracingStateObserver = require('../TracingStateObserver').default;
+
+      const mockSubscribers = new Set<(isTracing: boolean) => void>();
+      global.__TRACING_STATE_OBSERVER__ = {
+        isTracing: false,
+        subscribers: mockSubscribers,
+        onTracingStateChange: (isTracing: boolean) => {
+          global.__TRACING_STATE_OBSERVER__.isTracing = isTracing;
+          mockSubscribers.forEach(cb => cb(isTracing));
+        },
+      };
+
+      const callback = jest.fn();
+      TracingStateObserver.subscribe(callback);
+
+      expect(mockSubscribers.has(callback)).toBe(true);
+
+      global.__TRACING_STATE_OBSERVER__.onTracingStateChange(true);
+      expect(callback).toHaveBeenCalledWith(true);
+    });
+  });
+});


### PR DESCRIPTION
Summary:
LogBox errors and warnings can affect performance trace measurements by triggering UI updates during profiling. This change adds a mechanism to suppress LogBox messages when performance tracing is active.

The implementation consists of:

1. **Native observer infrastructure** (`RuntimeTargetPerformanceTracerObserver.cpp/h`): Installs a `__PERFORMANCE_TRACER_OBSERVER__` object on the JavaScript global, which tracks tracing state and notifies subscribers when tracing starts/stops via `onTracingStateChange`.

2. **JavaScript observer** (`PerformanceTracerObserver.js`): Provides a clean API to check tracing status (`isTracing()`) and subscribe to state changes. Gracefully handles environments where native support isn't available.

3. **LogBox integration** (`LogBoxData.js`): Subscribes to the performance tracer observer and:
   - Clears all LogBox messages when tracing starts
   - Skips logging new errors and exceptions while tracing is active

This ensures trace measurements are not impacted by LogBox UI rendering during profiling sessions.

Changelog: [GENERAL] [ADDED] - Suppress LogBox warnings and errors during performance tracing

Differential Revision: D92527815


