### PR TITLE
fix(ios): force zero width for empty Text component

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/ios/react/renderer/textlayoutmanager/TextLayoutManager.mm
@@ -37,7 +37,8 @@ TextMeasurement TextLayoutManager::measure(
 
   switch (attributedStringBox.getMode()) {
     case AttributedStringBox::Mode::Value: {
-      auto attributedString = ensurePlaceholderIfEmpty_DO_NOT_USE(attributedStringBox.getValue());
+      auto originalAtributedString = attributedStringBox.getValue();
+      auto attributedString = ensurePlaceholderIfEmpty_DO_NOT_USE(originalAtributedString);
 
       measurement = textMeasureCache_.get(
           {.attributedString = attributedString,
@@ -53,6 +54,10 @@ TextMeasurement TextLayoutManager::measure(
                                                       paragraphAttributes:paragraphAttributes
                                                             layoutContext:layoutContext
                                                         layoutConstraints:layoutConstraints];
+              
+              if (originalAtributedString.isEmpty()) {
+                  measurement.size.width = 0;
+              }
 
             if (telemetry) {
               telemetry->didMeasureText();


### PR DESCRIPTION
## Summary:

This PR fixes a layout regression in iO where empty <Text /> components render with a non-zero width.

The Motivation: In commit(https://github.com/facebook/react-native/commit/9fe20d4ea33532abb344383873b320cdb779f5c4), the logic to add a placeholder "I" to empty strings was moved from ShadowNode to the platform-specific TextLayoutManager.

While the "I" placeholder provides the correct height, the measurement result also includes the width of the "I" character. This causes empty components to take up horizontal space.

## Changelog:

[IOS] [FIXED] - Force zero width for empty Text components in Fabric to prevent ghost layout artifacts.

## Test Plan:

Render a component with an empty string and a background color:

```
<Text style={{ backgroundColor: 'red' }} />
```

Before: A small red vertical sliver (the width of "I") is visible.
After: The component is invisible (0 width)

## Related issue:

https://github.com/facebook/react-native/issues/55468