### PR TITLE
Revert D91913117: Fix MissingSoLoaderLibrary lint warning

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactNativeJNISoLoader.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactNativeJNISoLoader.kt
@@ -9,10 +9,8 @@ package com.facebook.react.bridge
 
 import com.facebook.react.common.annotations.internal.InteropLegacyArchitecture
 import com.facebook.soloader.SoLoader
-import com.facebook.soloader.annotation.SoLoaderLibrary
 
 @InteropLegacyArchitecture
-@SoLoaderLibrary("reactnativejni")
 internal object ReactNativeJNISoLoader {
 
   @JvmStatic


### PR DESCRIPTION
Summary: Revert D91913117 which added SoLoaderLibrary("reactnativejni") annotation to ReactNativeJNISoLoader.kt and the corresponding soloader annotation dependency in BUCK.

Differential Revision: D92722377


