### PR TITLE
Add AppleTV support to RNTester

### DIFF
--- a/packages/rn-tester/RNTester/AppDelegate.mm
+++ b/packages/rn-tester/RNTester/AppDelegate.mm
@@ -7,7 +7,9 @@
 
 #import "AppDelegate.h"
 
+#if !TARGET_OS_TV
 #import <UserNotifications/UserNotifications.h>
+#endif
 
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTDefines.h>
@@ -15,7 +17,9 @@
 #import <ReactCommon/RCTSampleTurboModule.h>
 #import <ReactCommon/RCTTurboModuleManager.h>
 
+#if !TARGET_OS_TV
 #import <React/RCTPushNotificationManager.h>
+#endif
 
 #import <NativeCxxModuleExample/NativeCxxModuleExample.h>
 #ifndef RN_DISABLE_OSS_PLUGIN_HEADER
@@ -35,8 +39,13 @@
 
 static NSString *kBundlePath = @"js/RNTesterApp.ios";
 
+#if !TARGET_OS_TV
 @interface AppDelegate () <UNUserNotificationCenterDelegate>
 @end
+#else
+@interface AppDelegate ()
+@end
+#endif
 
 @implementation AppDelegate
 
@@ -63,7 +72,9 @@ static NSString *kBundlePath = @"js/RNTesterApp.ios";
                                         initialProperties:[self prepareInitialProps]
                                             launchOptions:launchOptions];
 
+#if !TARGET_OS_TV
   [[UNUserNotificationCenter currentNotificationCenter] setDelegate:self];
+#endif
 
   return YES;
 }
@@ -102,6 +113,7 @@ static NSString *kBundlePath = @"js/RNTesterApp.ios";
   return [super getTurboModule:name jsInvoker:jsInvoker];
 }
 
+#if !TARGET_OS_TV
 // Required for the remoteNotificationsRegistered event.
 - (void)application:(__unused UIApplication *)application
     didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
@@ -145,6 +157,7 @@ static NSString *kBundlePath = @"js/RNTesterApp.ios";
   [RCTPushNotificationManager didReceiveNotification:notification];
   completionHandler();
 }
+#endif
 
 #pragma mark - New Arch Enabled settings
 


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Adds a new tvOS binary and platform for RNTester, as well as compile out some unsupported APIs in AppDelegate.

Reviewed By: shwanton

Differential Revision: D91059550


