### PR TITLE
Sanitize module name to prevent Java code injection

### DIFF
--- a/packages/react-native-codegen/src/parsers/error-utils.js
+++ b/packages/react-native-codegen/src/parsers/error-utils.js
@@ -17,6 +17,7 @@ import type {Parser} from './parser';
 
 const {
   IncorrectModuleRegistryCallArgumentTypeParserError,
+  IncorrectModuleRegistryCallArgumentValueParserError,
   IncorrectModuleRegistryCallArityParserError,
   IncorrectModuleRegistryCallTypeParameterParserError,
   MisnamedModuleInterfaceParserError,
@@ -307,6 +308,16 @@ function throwIfIncorrectModuleRegistryCallArgument(
       callExpressionArg,
       methodName,
       type,
+    );
+  }
+
+  const value = callExpressionArg.value;
+  if (typeof value !== 'string' || !/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(value)) {
+    throw new IncorrectModuleRegistryCallArgumentValueParserError(
+      nativeModuleName,
+      callExpressionArg,
+      methodName,
+      String(value),
     );
   }
 }

--- a/packages/react-native-codegen/src/parsers/errors.js
+++ b/packages/react-native-codegen/src/parsers/errors.js
@@ -425,6 +425,21 @@ class IncorrectModuleRegistryCallArgumentTypeParserError extends ParserError {
   }
 }
 
+class IncorrectModuleRegistryCallArgumentValueParserError extends ParserError {
+  constructor(
+    nativeModuleName: string,
+    flowArgument: $FlowFixMe,
+    methodName: string,
+    value: string,
+  ) {
+    super(
+      nativeModuleName,
+      flowArgument,
+      `Please call TurboModuleRegistry.${methodName}<Spec>() with a safe module name. Module names must only contain alphanumeric characters and underscores (matching /^[a-zA-Z_][a-zA-Z0-9_]*$/). Got '${value.replace(/[^\x20-\x7e]/g, '?')}'`,
+    );
+  }
+}
+
 module.exports = {
   ParserError,
   MissingTypeParameterGenericParserError,
@@ -452,4 +467,5 @@ module.exports = {
   IncorrectModuleRegistryCallTypeParameterParserError,
   IncorrectModuleRegistryCallArityParserError,
   IncorrectModuleRegistryCallArgumentTypeParserError,
+  IncorrectModuleRegistryCallArgumentValueParserError,
 };


### PR DESCRIPTION
Summary:
This change adds content validation to ensure module names only contain safe identifier characters (alphanumeric and underscores, matching `^[a-zA-Z_][a-zA-Z0-9_]*$`). A new error class `IncorrectModuleRegistryCallArgumentValueParserError` provides a clear error message when an unsafe module name is detected.

Changelog: [Android][Fixed] - Validate module names in codegen

Reviewed By: CalixTang

Differential Revision: D92736956


