### PR TITLE
Simplify hasNativeModule boolean ternary

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
@@ -416,9 +416,8 @@ public class CatalystInstanceImpl implements CatalystInstance {
   @Override
   public <T extends NativeModule> boolean hasNativeModule(Class<T> nativeModuleInterface) {
     String moduleName = getNameFromAnnotation(nativeModuleInterface);
-    return getTurboModuleRegistry() != null && getTurboModuleRegistry().hasModule(moduleName)
-        ? true
-        : mNativeModuleRegistry.hasModule(moduleName);
+    return (getTurboModuleRegistry() != null && getTurboModuleRegistry().hasModule(moduleName))
+        || mNativeModuleRegistry.hasModule(moduleName);
   }
 
   @Override


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Simplified a redundant boolean ternary expression in CatalystInstanceImpl.hasNativeModule().

The expression `condition ? true : fallback` is equivalent to `condition || fallback`. This change improves code readability without changing behavior.

Reviewed By: cortinico

Differential Revision: D92836584


