### PR TITLE
Fix crash in `cloneMultiple` when families have no path to root

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackendCommitHook.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/animationbackend/AnimationBackendCommitHook.cpp
@@ -35,8 +35,8 @@ RootShadowNode::Unshared AnimationBackendCommitHook::shadowTreeWillCommit(
   if (surfaceFamilies.empty()) {
     return newRootShadowNode;
   }
-  return std::static_pointer_cast<RootShadowNode>(
-      newRootShadowNode->cloneMultiple(
+  auto clonedRootShadowNode =
+      std::static_pointer_cast<RootShadowNode>(newRootShadowNode->cloneMultiple(
           surfaceFamilies,
           [&surfaceFamilies, &updates](
               const ShadowNode& shadowNode,
@@ -73,6 +73,12 @@ RootShadowNode::Unshared AnimationBackendCommitHook::shadowTreeWillCommit(
                  .state = shadowNode.getState(),
                  .runtimeShadowNodeReference = true});
           }));
+
+  if (clonedRootShadowNode == nullptr) {
+    return newRootShadowNode;
+  }
+
+  return clonedRootShadowNode;
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.cpp
@@ -471,7 +471,7 @@ std::shared_ptr<ShadowNode> ShadowNode::cloneMultiple(
     }
   }
 
-  if (childrenCount.empty()) {
+  if (!childrenCount.contains(&this->getFamily())) {
     return nullptr;
   }
 


### PR DESCRIPTION
Summary:
Fixes crash in `ShadowNode::cloneMultipleRecursive` which tried to access a missing root's family from the `childrenCount` map. The main issue is that in some cases there is no path between the given families to update and the root shadow node. The solution is to check after building the `childrenCount` map if it contains the root family and return `nullptr` otherwise. This behavior is closer to the `getAncestors` method which returns an empty array if there is no ancestor-descendant relationship. Due to this change, an additional check in `AnimationBackendCommitHook` is also required.

## Changelog:
[General][Fixed] - Fixed crash in `cloneMultiple` when families have no path to root

Differential Revision: D92838809


