### PR TITLE
Fix TypeError in LogBoxInspectorReactFrames on Windows/macOS

### DIFF
--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorReactFrames.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorReactFrames.js
@@ -164,14 +164,24 @@ const componentStyles = StyleSheet.create({
     paddingRight: 10,
   },
   frameName: {
-    fontFamily: Platform.select({android: 'monospace', ios: 'Menlo'}),
+    fontFamily: Platform.select({
+      android: 'monospace',
+      ios: 'Menlo',
+      macos: 'Menlo',
+      windows: 'Consolas',
+    }),
     color: LogBoxStyle.getTextColor(1),
     fontSize: 14,
     includeFontPadding: false,
     lineHeight: 18,
   },
   bracket: {
-    fontFamily: Platform.select({android: 'monospace', ios: 'Menlo'}),
+    fontFamily: Platform.select({
+      android: 'monospace',
+      ios: 'Menlo',
+      macos: 'Menlo',
+      windows: 'Consolas',
+    }),
     color: LogBoxStyle.getTextColor(0.4),
     fontSize: 14,
     fontWeight: '500',

--- a/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorStackFrame.js
+++ b/packages/react-native/Libraries/LogBox/UI/LogBoxInspectorStackFrame.js
@@ -90,7 +90,12 @@ const styles = StyleSheet.create({
     includeFontPadding: false,
     lineHeight: 18,
     fontWeight: '400',
-    fontFamily: Platform.select({android: 'monospace', ios: 'Menlo'}),
+    fontFamily: Platform.select({
+      android: 'monospace',
+      ios: 'Menlo',
+      macos: 'Menlo',
+      windows: 'Consolas',
+    }),
   },
   location: {
     color: LogBoxStyle.getTextColor(0.8),


### PR DESCRIPTION
Summary:
Syncs the Windows and macOS platform variants of LogBoxInspectorReactFrames
with the upstream base file. The platform-specific .windows.js and .macos.js
files were using stale StackFrame property names (frame.fileName, frame.content,
frame.location) that no longer exist. The upstream type now uses frame.file,
frame.methodName, and frame.lineNumber.

This caused TypeError: Cannot read property startsWith of undefined when
the LogBox inspector attempted to render component stack frames, since
frame.fileName is undefined. The error cascaded into a secondary LogBox crash.

Changes:
- frame.fileName to frame.file with null guard
- frame.content to frame.methodName
- frame.location.row to frame.lineNumber
- props.log.componentStack to props.log.getAvailableComponentStack()
  (uses symbolicated stack when available)

 {F1985363726} 
 {F1985363658} 

```
00005041 02-09 14:15:09:664.59 E [HorizonStandalone] React: { [Error: error generating skybox: It seems like I can't do generations right now, please try again later.]
  componentStack: '\n    at SelectableSlot (http://localhost:8081/xplat/js/RKJSModules/EntryPoints/Desktop/HorizonEditorBundle.bundle//&platform=windows&dev=true&hot=true&inlineSourceMap=false&excludeSource=true&sourcePaths=url-server&app=com.meta.editor&unstable_transformProfile=hermes-stable&lazy=true:477566:15)\n    at Suspense (<anonymous>)\nTypeError: Class constructor invoked without new\n    at RCTView (<anonymous>)\n    at View (http://localhost:8081/xplat/js/RKJSModules/EntryPoints/Desktop/HorizonEditorBundle.bundle//&platform=windows&dev=true&hot=true&inlineSourceMap=false&excludeSource=true&sourcePaths=url-server&app=com.meta.editor&unstable_transformProfile=hermes-stable&lazy=true:38045:23)\n    at LumaView (http://localhost:8081/xplat/js/RKJSModules/EntryPoints/Desktop/HorizonEditorBundle.bundle//&platform=windows&dev=true&hot=true&inlineSourceMap=false&excludeSource=true&sourcePaths=url-server&app=com.meta.editor&unstable_transformProfile=hermes-stable&lazy=true:110275:15)\n    at RCTScrollContentView (<anonymous>)\n    at RCTScrollView (<anonymous>)\nTypeError: Class constructor invoked without new\n    at ScrollView (http://localhost:8081/xplat/js/RKJSModules/EntryPoints/Desktop/HorizonEditorBundle.bundle//&platform=windows&dev=true&hot=true&inlineSourceMap=false&excludeSource=true&sourcePaths=url-server&app=com.meta.editor&unstable_transformProfile=hermes-stable&lazy=true:40707:39)\n    at LumaDesktopScrollView (http://localhost:8081/xplat/js/RKJSModules/EntryPoints/Desktop/HorizonEditorBundle.bundle//&platform=windows&dev=true&hot=true&inlineSourceMap=false&excludeSource=true&sourcePaths=url-server&app=com.meta.editor&unstable_transformProfile=hermes-stable&lazy=true:110496:15)\n    at LumaGridLayout (http://localhost:8081/xplat/js/RKJSModules/EntryPoints/Desktop/HorizonEditorBundle.bundle//&platform=windows&dev=true&hot=true&inlineSourceMap=false&excludeSource=true&sourcePaths=url-server&app=com.meta.editor&unstable_transformProfile=hermes-stable&lazy=true:378654:15)\n    at SelectionGrid (http://localhost:8081/xplat/js/RKJSModules/EntryPoints/Desktop/HorizonEditorBundle.bundle//&platform=windows&dev=true&hot=true&inlineSourceMap=false&excludeSource=true&sourcePaths=url-server&app=com.meta.editor&unstable_transformProfile=hermes-stable&lazy=true:477466:15)\n    at RCTView (<anonymous>)\n    at View (http://localhost:8081/xplat/js/RKJSModules/EntryPoints/Desktop/HorizonEditorBundle.bundle//&platform=windows&dev=true&hot=true&inlineSourceMap=false&excludeSource=true&sourcePaths=url-server&app=com.meta.editor&unstable_transformProfile=hermes-stable&lazy=true:38045:23)\n    at LumaView (http://localhost:8081/xplat/js/RKJSModules/EntryPoints/Desktop/HorizonEditorBundle.bundle//&platform=windows&dev=true&hot=true&inlineSourceMap=false&excludeSource=true&sourcePaths=url-server&app=com.meta.editor&unstable_transformProfile=hermes-stable&lazy=true:110275:15)\n    at LumaDisabledContextProvider (http://localhost:8081/xplat/js/RKJSModules/EntryPoints/Desktop/HorizonEditorBundle.bundle//&platform=windows&dev=true&hot=true&inlineSourceMap=false&excludeSource=true&sourcePaths=url-server&app=com.meta.editor&unstable_transformProfile=hermes-stable&lazy=true:106556:15)\n    at HSRGenAIAssistantSelectionMessage (http://localhost:8081/xplat/js/RKJSModules/EntryPoints/Desktop/HorizonEditorBundle.bundle//&platform=windows&dev=true&hot=true&inlineSourceMap=false&excludeSource=true&sourcePaths=url-server&app=com.meta.editor&unstable_transformProfile=hermes-stable&lazy=true:477281:15)\n    at RCTView (<anonymous>)\n    at View (http://localhost:8081/xplat/js/RKJSModules/EntryPoints/Desktop/HorizonEditorBundle.bundle//&platform=windows&dev=true&hot=true&inlineSourceMap=false&excludeSource=true&sourcePaths=url-server&app=com.meta.editor&unstable_transformProfile=hermes-stable&lazy=true:38045:23)\n    at LumaView (http://localhost:8081/xplat/js/RKJSModule00005042 02-09 14:15:09:930.73 E [HorizonStandalone] React: { [TypeError: Cannot read property 'startsWith' of undefined]
  componentStack: '\n    at LogBoxInspectorReactFrames (http://localhost:8081/xplat/js/RKJSModules/EntryPoints/Desktop/HorizonEditorBundle.bundle//&platform=windows&dev=true&hot=true&inlineSourceMap=false&excludeSource=true&sourcePaths=url-server&app=com.meta.editor&unstable_transformProfile=hermes-stable&lazy=true:59150:41)\n    at RCTScrollContentView (<anonymous>)\n    at RCTScrollView (<anonymous>)\nTypeError: Class constructor invoked without new\n    at ScrollView (http://localhost:8081/xplat/js/RKJSModules/EntryPoints/Desktop/HorizonEditorBundle.bundle//&platform=windows&dev=true&hot=true&inlineSourceMap=false&excludeSource=true&sourcePaths=url-server&app=com.meta.editor&unstable_transformProfile=hermes-stable&lazy=true:40707:39)\n    at LogBoxInspectorBody (http://localhost:8081/xplat/js/RKJSModules/EntryPoints/Desktop/HorizonEditorBundle.bundle//&platform=windows&dev=true&hot=true&inlineSourceMap=false&excludeSource=true&sourcePaths=url-server&app=com.meta.editor&unstable_transformProfile=hermes-stable&lazy=true:58116:29)\n    at RCTView (<anonymous>)\n    at View (http://localhost:8081/xplat/js/RKJSModules/EntryPoints/Desktop/HorizonEditorBundle.bundle//&platform=windows&dev=true&hot=true&inlineSourceMap=false&excludeSource=true&sourcePaths=url-server&app=com.meta.editor&unstable_transformProfile=hermes-stable&lazy=true:38045:23)\n    at LogBoxInspector (http://localhost:8081/xplat/js/RKJSModules/EntryPoints/Desktop/HorizonEditorBundle.bundle//&platform=windows&dev=true&hot=true&inlineSourceMap=false&excludeSource=true&sourcePaths=url-server&app=com.meta.editor&unstable_transformProfile=hermes-stable&lazy=true:57815:21)\n    at RCTView (<anonymous>)\n    at View (http://localhost:8081/xplat/js/RKJSModules/EntryPoints/Desktop/HorizonEditorBundle.bundle//&platform=windows&dev=true&hot=true&inlineSourceMap=false&excludeSource=true&sourcePaths=url-server&app=com.meta.editor&unstable_transformProfile=hermes-stable&lazy=true:38045:23)\nTypeError: Class constructor invoked without new\nTypeError: Class constructor invoked without new\n    at RCTView (<anonymous>)\n    at View (http://localhost:8081/xplat/js/RKJSModules/EntryPoints/Desktop/HorizonEditorBundle.bundle//&platform=windows&dev=true&hot=true&inlineSourceMap=false&excludeSource=true&sourcePaths=url-server&app=com.meta.editor&unstable_transformProfile=hermes-stable&lazy=true:38045:23)\n    at RCTView (<anonymous>)\n    at View (http://localhost:8081/xplat/js/RKJSModules/EntryPoints/Desktop/HorizonEditorBundle.bundle//&platform=windows&dev=true&hot=true&inlineSourceMap=false&excludeSource=true&sourcePaths=url-server&app=com.meta.editor&unstable_transformProfile=hermes-stable&lazy=true:38045:23)\n    at AppContainer (http://localhost:8081/xplat/js/RKJSModules/EntryPoints/Desktop/HorizonEditorBundle.bundle//&platform=windows&dev=true&hot=true&inlineSourceMap=false&excludeSource=true&sourcePaths=url-server&app=com.meta.editor&unstable_transformProfile=hermes-stable&lazy=true:37633:39)\n    at LogBox(RootComponent) (http://localhost:8081/xplat/js/RKJSModules/EntryPoints/Desktop/HorizonEditorBundle.bundle//&platform=windows&dev=true&hot=true&inlineSourceMap=false&excludeSource=true&sourcePaths=url-server&app=com.meta.editor&unstable_transformProfile=hermes-stable&lazy=true:57654:34)',
  isComponentError: true } [ReactNativeHostHolder-win.cpp:86]
00005043 02-09 14:15:09:937.02 E [HorizonStandalone] React: { [TypeError: An error was thrown when attempting to render log messages via LogBox.

Cannot read property 'startsWith' of undefined]
  componentStack: '\n    at LogBoxInspectorReactFrames (http://localhost:8081/xplat/js/RKJSModules/EntryPoints/Desktop/HorizonEditorBundle.bundle//&platform=windows&dev=true&hot=true&inlineSourceMap=false&excludeSource=true&sourcePaths=url-server&app=com.meta.editor&unstable_transformProfile=hermes-stable&lazy=true:59150:41)\n    at RCTScrollContentView (<anonymous>)\n    at RCTScrollView (<anonymous>)\nTypeError: Class constructor invoked without new\n    at ScrollView (http://localhost:8081/xplat/js/RKJSModules/EntryPoints/Desktop/HorizonEditorBundle.bundle//&platform=windows&dev=true&hot=true&inlineSourceMap=false&excludeSource=true&sourcePaths=url-server&app=com.meta.editor&unstable_transformProfile=hermes-stable&lazy=true:40707:39)\n    at LogBoxInspectorBody (http://localhost:8081/xplat/js/RKJSModules/EntryPoints/Desktop/HorizonEditorBundle.bundle//&platform=windows&dev=true&hot=true&inlineSourceMap=false&excludeSource=true&sourcePaths=url-server&app=com.meta.editor&unstable_transformProfile=hermes-stable&lazy=true:58116:29)\n    at RCTView (<anonymous>)\n    at View (http://localhost:8081/xplat/js/RKJSModules/EntryPoints/Desktop/HorizonEditorBundle.bundle//&platform=windows&dev=true&hot=true&inlineSourceMap=false&excludeSource=true&sourcePaths=url-server&app=com.meta.editor&unstable_transformProfile=hermes-stable&lazy=true:38045:23)\n    at LogBoxInspector (http://localhost:8081/xplat/js/RKJSModules/EntryPoints/Desktop/HorizonEditorBundle.bundle//&platform=windows&dev=true&hot=true&inlineSourceMap=false&excludeSource=true&sourcePaths=url-server&app=com.meta.editor&unstable_transformProfile=hermes-stable&lazy=true:57815:21)\n    at RCTView (<anonymous>)\n    at View (http://localhost:8081/xplat/js/RKJSModules/EntryPoints/Desktop/HorizonEditorBundle.bundle//&platform=windows&dev=true&hot=true&inlineSourceMap=false&excludeSource=true&sourcePaths=url-server&app=com.meta.editor&unstable_transformProfile=hermes-stable&lazy=true:38045:23)\nTypeError: Class constructor invoked without new\nTypeError: Class constructor invoked without new\n    at RCTView (<anonymous>)\n    at View (http://localhost:8081/xplat/js/RKJSModules/EntryPoints/Desktop/HorizonEditorBundle.bundle//&platform=windows&dev=true&hot=true&inlineSourceMap=false&excludeSource=true&sourcePaths=url-server&app=com.meta.editor&unstable_transformProfile=hermes-stable&lazy=true:38045:23)\n    at RCTView (<anonymous>)\n    at View (http://localhost:8081/xplat/js/RKJSModules/EntryPoints/Desktop/HorizonEditorBundle.bundle//&platform=windows&dev=true&hot=true&inlineSourceMap=false&excludeSource=true&sourcePaths=url-server&app=com.meta.editor&unstable_transformProfile=hermes-stable&lazy=true:38045:23)\n    at AppContainer (http://localhost:8081/xplat/js/RKJSModules/EntryPoints/Desktop/HorizonEditorBundle.bundle//&platform=windows&dev=true&hot=true&inlineSourceMap=false&excludeSource=true&sourcePaths=url-server&app=com.meta.editor&unstable_transformProfile=hermes-stable&lazy=true:37633:39)\n    at LogBox(RootComponent) (http://localhost:8081/xplat/js/RKJSModules/EntryPoints/Desktop/HorizonEditorBundle.bundle//&platform=windows&dev=true&hot=true&inlineSourceMap=false&excludeSource=true&sourcePaths=url-server&app=com.meta.editor&unstable_transformProfile=hermes-stable&lazy=true:57654:34)',
  isComponentError: true } [ReactNativeHostHolder-win.cpp:86]
```

Reviewed By: rickhanlonii

Differential Revision: D92736205


