### PR TITLE
Fix width/height not propagating to styles when uri is used

### DIFF
--- a/packages/react-native/Libraries/Image/ImageSourceUtils.js
+++ b/packages/react-native/Libraries/Image/ImageSourceUtils.js
@@ -23,11 +23,15 @@ export type ImageSourceHeaders = {
  * A function which returns the appropriate value for image source
  * by resolving the `source`, `src` and `srcSet` props.
  */
-export function getImageSourcesFromImageProps(
-  imageProps: ImageProps,
-):
+export function getImageSourcesFromImageProps(imageProps: ImageProps):
   | ?ResolvedAssetSource
-  | ReadonlyArray<{uri: string, headers: ImageSourceHeaders, ...}> {
+  | ReadonlyArray<{
+      +uri: string,
+      +headers: ImageSourceHeaders,
+      +width: ?number,
+      +height: ?number,
+      ...
+    }> {
   let source = resolveAssetSource(imageProps.source);
 
   let sources;

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -947,6 +947,16 @@ const definitions: FeatureFlagDefinitions = {
       },
       ossReleaseStage: 'none',
     },
+    fixImageSrcDimensionPropagation: {
+      defaultValue: false,
+      metadata: {
+        description:
+          'Fix image dimensions not being passed through when src is used',
+        expectedReleaseValue: true,
+        purpose: 'release',
+      },
+      ossReleaseStage: 'none',
+    },
     fixVirtualizeListCollapseWindowSize: {
       defaultValue: false,
       metadata: {

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<4680a90fe6a071f6352de95fc1ca01ba>>
+ * @generated SignedSource<<7d3f35de8808eb703debde85df332df8>>
  * @flow strict
  * @noformat
  */
@@ -34,6 +34,7 @@ export type ReactNativeFeatureFlagsJsOnly = $ReadOnly<{
   deferFlatListFocusChangeRenderUpdate: Getter<boolean>,
   disableMaintainVisibleContentPosition: Getter<boolean>,
   externalElementInspectionEnabled: Getter<boolean>,
+  fixImageSrcDimensionPropagation: Getter<boolean>,
   fixVirtualizeListCollapseWindowSize: Getter<boolean>,
   isLayoutAnimationEnabled: Getter<boolean>,
   shouldUseAnimatedObjectForTransform: Getter<boolean>,
@@ -156,6 +157,11 @@ export const disableMaintainVisibleContentPosition: Getter<boolean> = createJava
  * Enable the external inspection API for DevTools to communicate with the Inspector overlay.
  */
 export const externalElementInspectionEnabled: Getter<boolean> = createJavaScriptFlagGetter('externalElementInspectionEnabled', true);
+
+/**
+ * Fix image dimensions not being passed through when src is used
+ */
+export const fixImageSrcDimensionPropagation: Getter<boolean> = createJavaScriptFlagGetter('fixImageSrcDimensionPropagation', false);
 
 /**
  * Fixing an edge case where the current window size is not properly calculated with fast scrolling. Window size collapsed to 1 element even if windowSize more than the current amount of elements


### PR DESCRIPTION
Summary: Changelog: [General][Fixed] When using Image with a `uri`, `width` and `height` the default dimensions were being lost

Differential Revision: D92891095
