### PR TITLE
Fix NonStaticNestedClass: Make inner class static

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -1012,18 +1012,18 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
    * especially helpful for views that are recycled so we can retain and restore the original
    * listener upon recycling (onDropViewInstance).
    */
-  private class BaseVMFocusChangeListener<V extends View> implements OnFocusChangeListener {
+  private static class BaseVMFocusChangeListener implements OnFocusChangeListener {
     private @Nullable OnFocusChangeListener mOriginalFocusChangeListener;
 
     public BaseVMFocusChangeListener(@Nullable OnFocusChangeListener originalFocusChangeListener) {
       mOriginalFocusChangeListener = originalFocusChangeListener;
     }
 
-    public void attach(T view) {
+    public void attach(View view) {
       view.setOnFocusChangeListener(this);
     }
 
-    public void detach(T view) {
+    public void detach(View view) {
       view.setOnFocusChangeListener(mOriginalFocusChangeListener);
     }
 


### PR DESCRIPTION
Summary:
The BaseVMFocusChangeListener inner class does not reference any members
of its outer class BaseViewManager. Making it static improves memory
efficiency by avoiding the implicit reference to the outer class instance.

Also removed the unused type parameter <V extends View> and changed the
method parameters from T to View since only View interface methods are used.

Reviewed By: cortinico

Differential Revision: D92020879


