### PR TITLE
Fix MissingSoLoaderLibrary: Add @SoLoaderLibrary to JSTimerExecutor

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/hermes/instrumentation/HermesSamplingProfiler.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/hermes/instrumentation/HermesSamplingProfiler.kt
@@ -8,8 +8,10 @@
 package com.facebook.hermes.instrumentation
 
 import com.facebook.soloader.SoLoader
+import com.facebook.soloader.annotation.SoLoaderLibrary
 
 /** Hermes sampling profiler static JSI API. */
+@SoLoaderLibrary("jsijniprofiler")
 public object HermesSamplingProfiler {
   init {
     SoLoader.loadLibrary("jsijniprofiler")

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -13,6 +13,7 @@ import static com.facebook.react.uimanager.common.UIManagerType.FABRIC;
 import static com.facebook.react.uimanager.common.UIManagerType.LEGACY;
 import static com.facebook.systrace.Systrace.TRACE_TAG_REACT;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.BlendMode;
 import android.graphics.Canvas;
@@ -857,6 +858,9 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
     }
   }
 
+  @SuppressLint("ClassImplementsFinalize") // Used for memory leak detection during development.
+  // The finalize method only performs an assertion check and doesn't do cleanup,
+  // so the typical finalize() risks (performance, deadlocks) don't apply here.
   @Override
   protected void finalize() throws Throwable {
     super.finalize();

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/CatalystInstanceImpl.java
@@ -10,6 +10,7 @@ package com.facebook.react.bridge;
 import static com.facebook.infer.annotation.ThreadConfined.UI;
 import static com.facebook.systrace.Systrace.TRACE_TAG_REACT;
 
+import android.annotation.SuppressLint;
 import android.content.res.AssetManager;
 import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
@@ -318,6 +319,7 @@ public class CatalystInstanceImpl implements CatalystInstance {
     jniCallJSCallback(callbackID, (NativeArray) arguments);
   }
 
+  @SuppressLint("NotInvokedPrivateMethod") // Called from C++ via JNI
   private native void unregisterFromInspector();
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/FabricUIManager.java
@@ -841,6 +841,7 @@ public class FabricUIManager
             isLayoutable));
   }
 
+  @SuppressLint("NotInvokedPrivateMethod") // Called from C++ via JNI
   @SuppressWarnings("unused")
   @AnyThread
   @ThreadConfined(ANY)
@@ -874,6 +875,7 @@ public class FabricUIManager
    * to enforce execution order using {@link ReactChoreographer.CallbackType}. This method should
    * only be called as the result of a new tree being committed.
    */
+  @SuppressLint("NotInvokedPrivateMethod") // Called from C++ via JNI (Binding.cpp)
   @SuppressWarnings("unused")
   @AnyThread
   @ThreadConfined(ANY)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/JSRuntimeFactory.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/JSRuntimeFactory.kt
@@ -10,7 +10,9 @@ package com.facebook.react.runtime
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
 import com.facebook.soloader.SoLoader
+import com.facebook.soloader.annotation.SoLoaderLibrary
 
+@SoLoaderLibrary("rninstance")
 public abstract class JSRuntimeFactory(
     @Suppress("unused", "NoHungarianNotation", "NotAccessedPrivateField")
     @DoNotStrip

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/JSTimerExecutor.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/JSTimerExecutor.kt
@@ -13,8 +13,10 @@ import com.facebook.react.bridge.WritableArray
 import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.modules.core.JavaScriptTimerExecutor
 import com.facebook.soloader.SoLoader
+import com.facebook.soloader.annotation.SoLoaderLibrary
 
 @DoNotStrip
+@SoLoaderLibrary("rninstance")
 internal class JSTimerExecutor() : HybridClassBase(), JavaScriptTimerExecutor {
   init {
     initHybrid()

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostInspectorTarget.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/runtime/ReactHostInspectorTarget.kt
@@ -18,6 +18,7 @@ import com.facebook.react.devsupport.inspector.TracingStateListener
 import com.facebook.react.devsupport.perfmonitor.PerfMonitorInspectorTarget
 import com.facebook.react.devsupport.perfmonitor.PerfMonitorUpdateListener
 import com.facebook.soloader.SoLoader
+import com.facebook.soloader.annotation.SoLoaderLibrary
 import java.io.Closeable
 import java.util.concurrent.Executor
 
@@ -82,6 +83,7 @@ internal class ReactHostInspectorTarget(reactHostImpl: ReactHostImpl) :
     return mHybridData.isValid()
   }
 
+  @SoLoaderLibrary("rninstance")
   private companion object {
     init {
       SoLoader.loadLibrary("rninstance")

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManager.java
@@ -1012,18 +1012,18 @@ public abstract class BaseViewManager<T extends View, C extends LayoutShadowNode
    * especially helpful for views that are recycled so we can retain and restore the original
    * listener upon recycling (onDropViewInstance).
    */
-  private class BaseVMFocusChangeListener<V extends View> implements OnFocusChangeListener {
+  private static class BaseVMFocusChangeListener implements OnFocusChangeListener {
     private @Nullable OnFocusChangeListener mOriginalFocusChangeListener;
 
     public BaseVMFocusChangeListener(@Nullable OnFocusChangeListener originalFocusChangeListener) {
       mOriginalFocusChangeListener = originalFocusChangeListener;
     }
 
-    public void attach(T view) {
+    public void attach(View view) {
       view.setOnFocusChangeListener(this);
     }
 
-    public void detach(T view) {
+    public void detach(View view) {
       view.setOnFocusChangeListener(mOriginalFocusChangeListener);
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BlendModeHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BlendModeHelper.kt
@@ -7,10 +7,10 @@
 
 package com.facebook.react.uimanager
 
-import android.annotation.TargetApi
 import android.graphics.BlendMode
 import android.os.Build
 import android.view.ViewGroup
+import androidx.annotation.RequiresApi
 import androidx.core.view.children
 import com.facebook.react.R
 
@@ -20,7 +20,7 @@ import com.facebook.react.R
  * This object provides utilities to convert CSS mix-blend-mode string values into Android's
  * [BlendMode] enumeration and to determine when views need isolated layers for proper blending.
  */
-@TargetApi(29)
+@RequiresApi(29)
 internal object BlendModeHelper {
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/JSPointerDispatcher.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/JSPointerDispatcher.java
@@ -263,10 +263,10 @@ public class JSPointerDispatcher {
   }
 
   private PointerEventState createEventState(int activePointerId, MotionEvent motionEvent) {
-    Map<Integer, float[]> offsetByPointerId = new HashMap<Integer, float[]>();
-    Map<Integer, List<ViewTarget>> hitPathByPointerId = new HashMap<Integer, List<ViewTarget>>();
-    Map<Integer, float[]> eventCoordinatesByPointerId = new HashMap<Integer, float[]>();
-    Map<Integer, float[]> screenCoordinatesByPointerId = new HashMap<Integer, float[]>();
+    Map<Integer, float[]> offsetByPointerId = new HashMap<>();
+    Map<Integer, List<ViewTarget>> hitPathByPointerId = new HashMap<>();
+    Map<Integer, float[]> eventCoordinatesByPointerId = new HashMap<>();
+    Map<Integer, float[]> screenCoordinatesByPointerId = new HashMap<>();
     for (int index = 0; index < motionEvent.getPointerCount(); index++) {
       float[] offsetCoordinates = new float[2];
       float[] eventCoordinates = new float[] {motionEvent.getX(index), motionEvent.getY(index)};
@@ -549,7 +549,7 @@ public class JSPointerDispatcher {
       incrementCoalescingKey();
 
       // Out, Leave events
-      if (lastHitPath.size() > 0) {
+      if (!lastHitPath.isEmpty()) {
         int lastTargetTag = lastHitPath.get(0).getViewId();
         boolean listeningForOut =
             isAnyoneListeningForBubblingEvent(lastHitPath, EVENT.OUT, EVENT.OUT_CAPTURE);
@@ -566,7 +566,7 @@ public class JSPointerDispatcher {
                 EVENT.LEAVE,
                 EVENT.LEAVE_CAPTURE,
                 nonDivergentListeningToLeave);
-        if (leaveViewTargets.size() > 0) {
+        if (!leaveViewTargets.isEmpty()) {
           // We want to dispatch from target -> root, so no need to reverse
           dispatchEventForViewTargets(
               PointerEventHelper.POINTER_LEAVE,
@@ -593,7 +593,7 @@ public class JSPointerDispatcher {
               EVENT.ENTER_CAPTURE,
               nonDivergentListeningToEnter);
 
-      if (enterViewTargets.size() > 0) {
+      if (!enterViewTargets.isEmpty()) {
         // We want to iterate these from root -> target so we need to reverse
         Collections.reverse(enterViewTargets);
         dispatchEventForViewTargets(
@@ -723,14 +723,5 @@ public class JSPointerDispatcher {
         newEventCoords,
         newScreenCoords,
         new HashSet<>(original.getHoveringPointerIds()));
-  }
-
-  private static void debugPrintHitPath(List<ViewTarget> hitPath) {
-    StringBuilder builder = new StringBuilder("hitPath: ");
-    for (ViewTarget viewTarget : hitPath) {
-      builder.append(String.format("%d, ", viewTarget.getViewId()));
-    }
-
-    FLog.d(TAG, builder.toString());
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LayoutShadowNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/LayoutShadowNode.java
@@ -230,6 +230,7 @@ public class LayoutShadowNode extends ReactShadowNodeImpl {
     maxHeight.recycle();
   }
 
+  @Override
   @ReactProp(name = ViewProps.FLEX, defaultFloat = 0f)
   public void setFlex(float flex) {
     if (isVirtual()) {
@@ -238,6 +239,7 @@ public class LayoutShadowNode extends ReactShadowNodeImpl {
     super.setFlex(flex);
   }
 
+  @Override
   @ReactProp(name = ViewProps.FLEX_GROW, defaultFloat = 0f)
   public void setFlexGrow(float flexGrow) {
     if (isVirtual()) {
@@ -309,6 +311,7 @@ public class LayoutShadowNode extends ReactShadowNodeImpl {
     gap.recycle();
   }
 
+  @Override
   @ReactProp(name = ViewProps.FLEX_SHRINK, defaultFloat = 0f)
   public void setFlexShrink(float flexShrink) {
     if (isVirtual()) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyManager.java
@@ -7,6 +7,7 @@
 
 package com.facebook.react.uimanager;
 
+import android.annotation.SuppressLint;
 import android.graphics.Matrix;
 import android.graphics.Rect;
 import android.graphics.RectF;
@@ -76,6 +77,8 @@ public class NativeViewHierarchyManager {
   }
 
   private static final String TAG = NativeViewHierarchyManager.class.getSimpleName();
+  // Debug mode is intentionally disabled (false). To enable, change to just ReactBuildConfig.DEBUG
+  @SuppressLint("ClownyBooleanExpression")
   private final boolean DEBUG_MODE = ReactBuildConfig.DEBUG && false;
 
   private final SparseArray<View> mTagsToViews;
@@ -248,7 +251,6 @@ public class NativeViewHierarchyManager {
     viewToUpdate.setTag(R.id.view_tag_instance_handle, instanceHandle);
   }
 
-  @Nullable
   public synchronized long getInstanceHandle(int reactTag) {
     View view = mTagsToViews.get(reactTag);
     if (view == null) {
@@ -521,18 +523,6 @@ public class NativeViewHierarchyManager {
     if (pendingDeletionTags.isEmpty()) {
       mPendingDeletionsForTag.remove(tag);
     }
-  }
-
-  private boolean arrayContains(@Nullable int[] array, int ele) {
-    if (array == null) {
-      return false;
-    }
-    for (int curEle : array) {
-      if (curEle == ele) {
-        return true;
-      }
-    }
-    return false;
   }
 
   /**
@@ -849,18 +839,6 @@ public class NativeViewHierarchyManager {
     }
     ViewManager viewManager = resolveViewManager(reactTag);
     viewManager.receiveCommand(view, commandId, args);
-  }
-
-  /**
-   * @return Themed React context for view with a given {@param reactTag} - it gets the context
-   *     directly from the view using {@link View#getContext}.
-   */
-  private ThemedReactContext getReactContextForView(int reactTag) {
-    View view = mTagsToViews.get(reactTag);
-    if (view == null) {
-      throw new JSApplicationIllegalArgumentException("Could not find view with tag " + reactTag);
-    }
-    return (ThemedReactContext) view.getContext();
   }
 
   public synchronized void sendAccessibilityEvent(int tag, int eventType) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyOptimizer.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyOptimizer.java
@@ -231,12 +231,6 @@ public class NativeViewHierarchyOptimizer {
     mTagsWithLayoutVisited.clear();
   }
 
-  private NodeIndexPair walkUpUntilNativeKindIsParent(
-      ReactShadowNode node, int indexInNativeChildren) {
-    // Logic removed due to NativeKind removal
-    return new NodeIndexPair(node, indexInNativeChildren);
-  }
-
   private void addNodeToNode(ReactShadowNode parent, ReactShadowNode child, int index) {
     // Logic removed due to NativeKind removal
   }
@@ -288,8 +282,6 @@ public class NativeViewHierarchyOptimizer {
       return;
     }
     mTagsWithLayoutVisited.put(tag, true);
-
-    ReactShadowNode parent = node.getParent();
 
     // We use screenX/screenY (which round to integer pixels) at each node in the hierarchy to
     // emulate what the layout would look like if it were actually built with native views which

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -240,6 +240,7 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
     }
   }
 
+  @Override
   public boolean getScrollEnabled() {
     return mScrollEnabled;
   }
@@ -578,7 +579,7 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
   public void addFocusables(ArrayList<View> views, int direction, int focusableMode) {
     if (mPagingEnabled && !mPagedArrowScrolling) {
       // Only add elements within the current page to list of focusables
-      ArrayList<View> candidateViews = new ArrayList<View>();
+      ArrayList<View> candidateViews = new ArrayList<>();
       super.addFocusables(candidateViews, direction, focusableMode);
       for (View candidate : candidateViews) {
         // We must also include the currently focused in the focusables list or focus search will
@@ -1586,24 +1587,25 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
   }
 
   /**
-   * Calls `smoothScrollTo` and updates state.
+   * Calls {@code smoothScrollTo} and updates state.
    *
-   * <p>`smoothScrollTo` changes `contentOffset` and we need to keep `contentOffset` in sync between
-   * scroll view and state. Calling raw `smoothScrollTo` doesn't update state.
+   * <p>{@code smoothScrollTo} changes {@code contentOffset} and we need to keep {@code contentOffset} in sync between
+   * scroll view and state. Calling raw {@code smoothScrollTo} doesn't update state.
    */
+  @Override
   public void reactSmoothScrollTo(int x, int y) {
     ReactScrollViewHelper.smoothScrollTo(this, x, y);
     setPendingContentOffsets(x, y);
   }
 
   /**
-   * Calls `super.scrollTo` and updates state.
+   * Calls {@code super.scrollTo} and updates state.
    *
-   * <p>`super.scrollTo` changes `contentOffset` and we need to keep `contentOffset` in sync between
+   * <p>{@code super.scrollTo} changes {@code contentOffset} and we need to keep {@code contentOffset} in sync between
    * scroll view and state.
    *
-   * <p>Note that while we can override scrollTo, we *cannot* override `smoothScrollTo` because it
-   * is final. See `reactSmoothScrollTo`.
+   * <p>Note that while we can override scrollTo, we *cannot* override {@code smoothScrollTo} because it
+   * is final. See {@code reactSmoothScrollTo}.
    */
   @Override
   public void scrollTo(int x, int y) {
@@ -1630,7 +1632,7 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
 
   /**
    * If contentOffset is set before the View has been laid out, store the values and set them when
-   * `onLayout` is called.
+   * {@code onLayout} is called.
    *
    * @param x
    * @param y
@@ -1679,7 +1681,7 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
 
   /**
    * If we are in the middle of a fling animation from the user removing their finger (OverScroller
-   * is in `FLING_MODE`), recreate the existing fling animation since it was calculated against
+   * is in {@code FLING_MODE}), recreate the existing fling animation since it was calculated against
    * outdated scroll offsets.
    */
   private void recreateFlingAnimation(int scrollX, int maxX) {
@@ -1734,6 +1736,7 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
   }
 
   @Nullable
+  @Override
   public StateWrapper getStateWrapper() {
     return mStateWrapper;
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactNestedScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactNestedScrollView.java
@@ -300,6 +300,7 @@ class ReactNestedScrollView extends NestedScrollView
     mScrollEnabled = scrollEnabled;
   }
 
+  @Override
   public boolean getScrollEnabled() {
     return mScrollEnabled;
   }
@@ -880,6 +881,7 @@ class ReactNestedScrollView extends NestedScrollView
   }
 
   @Nullable
+  @Override
   public StateWrapper getStateWrapper() {
     return mStateWrapper;
   }
@@ -1368,7 +1370,7 @@ class ReactNestedScrollView extends NestedScrollView
 
   /**
    * If we are in the middle of a fling animation from the user removing their finger (OverScroller
-   * is in `FLING_MODE`), recreate the existing fling animation since it was calculated against
+   * is in {@code FLING_MODE}), recreate the existing fling animation since it was calculated against
    * outdated scroll offsets.
    */
   private void recreateFlingAnimation(int scrollY) {
@@ -1420,7 +1422,7 @@ class ReactNestedScrollView extends NestedScrollView
 
   /**
    * If contentOffset is set before the View has been laid out, store the values and set them when
-   * `onLayout` is called.
+   * {@code onLayout} is called.
    *
    * @param x
    * @param y
@@ -1513,8 +1515,8 @@ class ReactNestedScrollView extends NestedScrollView
    * View-flattened away. However, it is possible to pass custom styles into that View.
    *
    * <p>If you are using this feature it is assumed that you have full control over this NestedScrollView
-   * and that you are **not** overriding the NestedScrollView content view to pass in a `translateY`
-   * style. `translateY` must never be set from ReactJS while using this feature!
+   * and that you are **not** overriding the NestedScrollView content view to pass in a {@code translateY}
+   * style. {@code translateY} must never be set from ReactJS while using this feature!
    */
   public void setScrollAwayTopPaddingEnabledUnstable(int topPadding) {
     setScrollAwayTopPaddingEnabledUnstable(topPadding, true);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -292,6 +292,7 @@ public class ReactScrollView extends ScrollView
     mScrollEnabled = scrollEnabled;
   }
 
+  @Override
   public boolean getScrollEnabled() {
     return mScrollEnabled;
   }
@@ -872,6 +873,7 @@ public class ReactScrollView extends ScrollView
   }
 
   @Nullable
+  @Override
   public StateWrapper getStateWrapper() {
     return mStateWrapper;
   }
@@ -1360,7 +1362,7 @@ public class ReactScrollView extends ScrollView
 
   /**
    * If we are in the middle of a fling animation from the user removing their finger (OverScroller
-   * is in `FLING_MODE`), recreate the existing fling animation since it was calculated against
+   * is in {@code FLING_MODE}), recreate the existing fling animation since it was calculated against
    * outdated scroll offsets.
    */
   private void recreateFlingAnimation(int scrollY) {
@@ -1412,7 +1414,7 @@ public class ReactScrollView extends ScrollView
 
   /**
    * If contentOffset is set before the View has been laid out, store the values and set them when
-   * `onLayout` is called.
+   * {@code onLayout} is called.
    *
    * @param x
    * @param y
@@ -1505,8 +1507,8 @@ public class ReactScrollView extends ScrollView
    * View-flattened away. However, it is possible to pass custom styles into that View.
    *
    * <p>If you are using this feature it is assumed that you have full control over this ScrollView
-   * and that you are **not** overriding the ScrollView content view to pass in a `translateY`
-   * style. `translateY` must never be set from ReactJS while using this feature!
+   * and that you are **not** overriding the ScrollView content view to pass in a {@code translateY}
+   * style. {@code translateY} must never be set from ReactJS while using this feature!
    */
   public void setScrollAwayTopPaddingEnabledUnstable(int topPadding) {
     setScrollAwayTopPaddingEnabledUnstable(topPadding, true);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -157,26 +157,6 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
     updateView(); // call after changing ellipsizeLocation in particular
   }
 
-  private static WritableMap inlineViewJson(
-      int visibility, int index, int left, int top, int right, int bottom) {
-    WritableMap json = Arguments.createMap();
-    if (visibility == View.GONE) {
-      json.putString("visibility", "gone");
-      json.putInt("index", index);
-    } else if (visibility == View.VISIBLE) {
-      json.putString("visibility", "visible");
-      json.putInt("index", index);
-      json.putDouble("left", PixelUtil.toDIPFromPixel(left));
-      json.putDouble("top", PixelUtil.toDIPFromPixel(top));
-      json.putDouble("right", PixelUtil.toDIPFromPixel(right));
-      json.putDouble("bottom", PixelUtil.toDIPFromPixel(bottom));
-    } else {
-      json.putString("visibility", "unknown");
-      json.putInt("index", index);
-    }
-    return json;
-  }
-
   private ReactContext getReactContext() {
     Context context = getContext();
     return (context instanceof TintContextWrapper)
@@ -554,6 +534,7 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
     mShouldAdjustSpannableFontSize = true;
   }
 
+  @Override
   public void setLetterSpacing(float letterSpacing) {
     if (Float.isNaN(letterSpacing)) {
       return;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTypefaceUtils.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTypefaceUtils.kt
@@ -9,7 +9,6 @@ package com.facebook.react.views.text
 
 import android.content.res.AssetManager
 import android.graphics.Typeface
-import android.text.TextUtils
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.common.ReactConstants
 import com.facebook.react.common.assets.ReactFontManager
@@ -93,7 +92,7 @@ public object ReactTypefaceUtils {
         "stylistic-twenty" -> features.add("'ss20'")
       }
     }
-    return TextUtils.join(", ", features)
+    return features.joinToString(", ")
   }
 
   @JvmStatic

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextAttributeProps.kt
@@ -9,7 +9,6 @@ package com.facebook.react.views.text
 
 import android.os.Build
 import android.text.Layout
-import android.text.TextUtils
 import android.text.TextUtils.TruncateAt
 import android.util.LayoutDirection
 import android.view.Gravity
@@ -238,7 +237,7 @@ public class TextAttributeProps private constructor() {
         }
       }
     }
-    fontFeatureSettings = TextUtils.join(", ", features)
+    fontFeatureSettings = features.joinToString(", ")
   }
 
   private fun setFontWeight(fontWeightString: String?) {


### PR DESCRIPTION
Summary:
Fixed MissingSoLoaderLibrary lint error in JSTimerExecutor.kt.

Added `SoLoaderLibrary("rninstance")` annotation to document that this class loads
the "rninstance" native library via SoLoader.

changelog: [internal] internal

Reviewed By: alanleedev

Differential Revision: D92023704


