### PR TITLE
iOS - Image Timeout Exception Issue Fix

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTSyncImageManager.mm
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTSyncImageManager.mm
@@ -90,7 +90,7 @@ using namespace facebook::react;
                                  partialLoadBlock:nil
                                   completionBlock:completionBlock];
 
-  auto result = dispatch_group_wait(imageWaitGroup, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC));
+  auto result = dispatch_group_wait(imageWaitGroup, dispatch_time(DISPATCH_TIME_NOW, 20 * NSEC_PER_SEC));
   if (result != 0) {
     RCTLogError(@"Image timed out in test environment for url: %@", loaderRequest.imageURL);
   }


### PR DESCRIPTION
Summary: The current 5-second timeout in RCTSyncImageManager seems insufficient for image loading operations in test environments, and it’s causing spurious timeout errors. Have tried to increase the timeout to 20 seconds to give more headroom for image loading operations to complete successfully.

Reviewed By: javache, sammy-SC

Differential Revision: D92504548


