### PR TITLE
fix(android): fix fadeDuration=0 not working w/ props 2.0 diffing

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h
@@ -37,7 +37,7 @@ class ImageProps final : public ViewProps {
   Float resizeMultiplier{1.f};
   bool shouldNotifyLoadEvents{};
   SharedColor overlayColor{};
-  Float fadeDuration{};
+  Float fadeDuration{-1.f};
   bool progressiveRenderingEnabled{};
 
 #ifdef RN_SERIALIZABLE_STATE


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

In our app we are using the props 2.0 diffing mechanism (ie `getDiffProps` in cpp).
I noticed that our `<Image source={...} fadeDuration={0} />` were still showing with the [default 300ms fade duration](https://reactnative.dev/docs/next/image#fadeduration-android).

The issue is that we instantiate the `fadeDuration` in cpp with a default value of `0`:

https://github.com/facebook/react-native/blob/4356259c79076fc816e516ca98678088a251bb8e/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.h#L40

and then in the props diff implementation when comparing our prop value of `0` against the default, it will not be added to the final props, thus never set in the native image view:

https://github.com/facebook/react-native/blob/4356259c79076fc816e516ca98678088a251bb8e/packages/react-native/ReactCommon/react/renderer/components/image/ImageProps.cpp#L273-L275

The native image view uses a default value of `-1` so i thought to use the same here:

https://github.com/facebook/react-native/blob/4356259c79076fc816e516ca98678088a251bb8e/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/image/ReactImageView.kt#L104

Another solution could be to type the `fadeDuration` as `std::optional`, let me know what you prefer

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] [FIXED] - Image fadeDuration=0 not working with props 2.0 enabled

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

You can enable the props 2.0 feature flags in the RNTesterApp and check the image example!
