### PR TITLE
Move RCT_DEV_SETTINGS_ENABLE_PACKAGER_CONNECTION to its only consumer

### DIFF
--- a/packages/react-native/React/Base/RCTDefines.h
+++ b/packages/react-native/React/Base/RCTDefines.h
@@ -95,14 +95,6 @@
 #define RCT_DEV_MENU RCT_DEV
 #endif
 
-#ifndef RCT_DEV_SETTINGS_ENABLE_PACKAGER_CONNECTION
-#if RCT_DEV && (__has_include("RCTPackagerConnection.h") || __has_include(<React/RCTPackagerConnection.h>))
-#define RCT_DEV_SETTINGS_ENABLE_PACKAGER_CONNECTION 1
-#else
-#define RCT_DEV_SETTINGS_ENABLE_PACKAGER_CONNECTION 0
-#endif
-#endif
-
 #if RCT_DEV
 #define RCT_IF_DEV(...) __VA_ARGS__
 #else

--- a/packages/react-native/React/CoreModules/RCTDevSettings.mm
+++ b/packages/react-native/React/CoreModules/RCTDevSettings.mm
@@ -36,6 +36,14 @@ static NSString *const kRCTDevSettingsUserDefaultsKey = @"RCTDevMenu";
 #import <React/RCTPackagerConnection.h>
 #endif
 
+#ifndef RCT_DEV_SETTINGS_ENABLE_PACKAGER_CONNECTION
+#if RCT_DEV && (__has_include("RCTPackagerConnection.h") || __has_include(<React/RCTPackagerConnection.h>))
+#define RCT_DEV_SETTINGS_ENABLE_PACKAGER_CONNECTION 1
+#else
+#define RCT_DEV_SETTINGS_ENABLE_PACKAGER_CONNECTION 0
+#endif
+#endif
+
 #if RCT_DEV_SETTINGS_ENABLE_PACKAGER_CONNECTION
 #import <React/RCTPackagerClient.h>
 #endif


### PR DESCRIPTION
Summary:
Move the RCT_DEV_SETTINGS_ENABLE_PACKAGER_CONNECTION define from RCTDefines.h to RCTDevSettings.mm, which is its only consumer. This removes a __has_include dependency from the shared header, making RCTDefines.h more usable as a standalone lightweight target without pulling in RCTPackagerConnection.h.

Changelog: [Internal]

Differential Revision: D93018381


