### PR TITLE
Fixing fb4a crashes due to null pointer exception

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
+++ b/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricUIManagerBinding.cpp
@@ -52,7 +52,13 @@ void FabricUIManagerBinding::setPixelDensity(float pointScaleFactor) {
 }
 
 void FabricUIManagerBinding::driveCxxAnimations() {
-  getScheduler()->animationTick();
+  auto scheduler = getScheduler();
+  if (!scheduler) {
+    LOG(ERROR)
+        << "FabricUIManagerBinding::driveCxxAnimations: scheduler disappeared";
+    return;
+  }
+  scheduler->animationTick();
 }
 
 void FabricUIManagerBinding::driveAnimationBackend(jdouble frameTimeMs) {


### PR DESCRIPTION
Summary:
Crash failures during e2e: https://www.internalfb.com/intern/test/562949977559616
logview: https://fburl.com/logview/65na7gyr

Reason: null dereference

Reviewed By: javache

Differential Revision: D92986523


