### PR TITLE
Allow overriding dev server ip via property

### DIFF
--- a/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/AgpConfiguratorUtils.kt
+++ b/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/AgpConfiguratorUtils.kt
@@ -88,6 +88,8 @@ internal object AgpConfiguratorUtils {
   }
 
   fun configureDevServerLocation(project: Project) {
+    val devServerIp =
+        project.properties["reactNativeDevServerIp"]?.toString() ?: getHostIpAddress()
     val devServerPort =
         project.properties["reactNativeDevServerPort"]?.toString() ?: DEFAULT_DEV_SERVER_PORT
 
@@ -100,7 +102,7 @@ internal object AgpConfiguratorUtils {
                 ext.defaultConfig.resValue(
                     "string",
                     "react_native_dev_server_ip",
-                    getHostIpAddress(),
+                    devServerIp,
                 )
                 ext.defaultConfig.resValue("integer", "react_native_dev_server_port", devServerPort)
               }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Similiar to how a specific port can be set also allow for setting a specific ip for the dev server.

This allows for easy configuration to aid in generating [reproducible builds](https://izzyondroid.org/docs/reproducibleBuilds/).

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID] [ADDED] - Allow specifying dev server ip via gradle property

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] [ADDED] - Allow specifying dev server ip via gradle property

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
1) Add `reactNativeDevServerIp=localhost` to `gradle.properties`
2) Generate an APK
3) Analyze the APK and check that the value of the string resource type `react_native_dev_server_ip` matches the value set in `gradle.properties`.
