### PR TITLE
Fix crash in RawPropsKeyMap::at() for out-of-bounds prop name lengths

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsKey.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsKey.cpp
@@ -11,7 +11,6 @@
 #include <cassert>
 #include <cstring>
 
-#include <react/debug/react_native_assert.h>
 #include <react/renderer/core/RawPropsPrimitives.h>
 
 namespace facebook::react {
@@ -20,34 +19,29 @@ void RawPropsKey::render(char* buffer, RawPropsPropNameLength* length)
     const noexcept {
   *length = 0;
 
-  // Prefix
+  constexpr size_t maxLength = kPropNameLengthHardCap - 1;
+
+  auto appendSegment = [&](const char* segment) {
+    auto copyLen = std::min(std::strlen(segment), maxLength - *length);
+    std::memcpy(buffer + *length, segment, copyLen);
+    *length += static_cast<RawPropsPropNameLength>(copyLen);
+  };
+
   if (prefix != nullptr) {
-    auto prefixLength =
-        static_cast<RawPropsPropNameLength>(std::strlen(prefix));
-    std::memcpy(buffer, prefix, prefixLength);
-    *length = prefixLength;
+    appendSegment(prefix);
   }
 
-  // Name
-  auto nameLength = static_cast<RawPropsPropNameLength>(std::strlen(name));
-  std::memcpy(buffer + *length, name, nameLength);
-  *length += nameLength;
+  appendSegment(name);
 
-  // Suffix
   if (suffix != nullptr) {
-    auto suffixLength =
-        static_cast<RawPropsPropNameLength>(std::strlen(suffix));
-    std::memcpy(buffer + *length, suffix, suffixLength);
-    *length += suffixLength;
+    appendSegment(suffix);
   }
-  react_native_assert(*length < kPropNameLengthHardCap);
 }
 
 RawPropsKey::operator std::string() const noexcept {
   auto buffer = std::array<char, kPropNameLengthHardCap>();
   RawPropsPropNameLength length = 0;
   render(buffer.data(), &length);
-  react_native_assert(length < kPropNameLengthHardCap);
   return std::string{buffer.data(), length};
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/core/RawPropsKeyMap.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/core/RawPropsKeyMap.cpp
@@ -75,7 +75,7 @@ void RawPropsKeyMap::reindex() noexcept {
 
   buckets_.resize(kPropNameLengthHardCap);
 
-  auto length = RawPropsPropNameLength{0};
+  RawPropsPropNameLength length = 0;
   for (size_t i = 0; i < items_.size(); i++) {
     auto& item = items_[i];
     if (item.length != length) {
@@ -96,6 +96,9 @@ RawPropsValueIndex RawPropsKeyMap::at(
     RawPropsPropNameLength length) noexcept {
   react_native_assert(length > 0);
   react_native_assert(length < kPropNameLengthHardCap);
+  if (length == 0 || length >= kPropNameLengthHardCap) [[unlikely]] {
+    return kRawPropsValueIndexEmpty;
+  }
   // 1. Find the bucket.
   auto lower = int{buckets_[length - 1]};
   auto upper = int{buckets_[length]} - 1;


### PR DESCRIPTION
Summary:
Replace react_native_assert calls with real bounds checks in RawPropsKeyMap::at() and RawPropsKey::render() to prevent SIGILL/SIGTRAP crashes. In at(), an invalid length now returns kRawPropsValueIndexEmpty instead of trapping. In render(), an overlong prop name is clamped to kPropNameLengthHardCap - 1 instead of asserting.

Changelog: [Internal]

Differential Revision: D93094839


