### PR TITLE
Remove enableClipChildrenForOverflowHidden logic

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
@@ -819,9 +819,6 @@ public open class ReactViewGroup public constructor(context: Context?) :
           } else {
             Overflow.fromString(overflow)
           }
-      if (ReactNativeFeatureFlags.enableClipChildrenForOverflowHidden()) {
-        clipChildren = (_overflow == Overflow.HIDDEN)
-      }
       invalidate()
     }
 


### PR DESCRIPTION
Summary:
Changelog: [Internal]

It looks like we have completely misunderstood the semantic of `clipChildren`.

Looking at the Android [source code](https://cs.android.com/android/platform/superproject/+/android-latest-release:frameworks/base/core/java/android/view/ViewGroup.java;l=4607?q=setClipToPadding&ss=android%2Fplatform%2Fsuperproject&fbclid=IwY2xjawP8LExleHRuA2FlbQIxMQBzcnRjBmFwcF9pZAEwAAEeQkZx96WcTaA0mIUVGXeFAxH_aLVBMR0an0N8jeKCYX4E-j9HW0eLnzZcSJI_aem__yWzHP0_x-bPxCQS1nN19w), it seems that `setClipChildren(true)` on a ViewGroup X means clipping **each child** to the **child's own bounds**, not the parent's bound.

Which means also [this](https://www.internalfb.com/code/aosp-vendor-meta-coresdk/[oculus-14.0%3Af0b9166acbb68da2e1e9f7622ba1b7fcee672ebc]/api-src/volumetricwindow/java/horizonos/view/interaction/providers/ViewInteractionNodeProvider.java?lines=502) line in HzOS is based on the same incorrect assumption.

Ultimately, RN should not be populating `clipChildren` when `overflow: hidden` is set.

Differential Revision: D93237429


