### PR TITLE
Remove legacy debugger entry point selection

### DIFF
--- a/packages/dev-middleware/src/__tests__/InspectorProxyHttpApi-test.js
+++ b/packages/dev-middleware/src/__tests__/InspectorProxyHttpApi-test.js
@@ -27,6 +27,9 @@ jest.useFakeTimers();
 describe('inspector proxy HTTP API', () => {
   const serverRef = withServerForEachTest({
     logger: undefined,
+    unstable_experiments: {
+      enableStandaloneFuseboxShell: false,
+    },
   });
   const autoCleanup = withAbortSignalForEachTest();
   afterEach(() => {
@@ -189,7 +192,9 @@ describe('inspector proxy HTTP API', () => {
             devtoolsFrontendUrl: expect.any(String),
             id: 'device1-page1',
             reactNative: {
-              capabilities: {},
+              capabilities: {
+                supportsMultipleDebuggers: false,
+              },
               logicalDeviceId: 'device1',
             },
             title: 'bar-title',
@@ -204,7 +209,9 @@ describe('inspector proxy HTTP API', () => {
             devtoolsFrontendUrl: expect.any(String),
             id: 'device2-page1',
             reactNative: {
-              capabilities: {},
+              capabilities: {
+                supportsMultipleDebuggers: false,
+              },
               logicalDeviceId: 'device2',
             },
             title: 'bar-title',

--- a/packages/dev-middleware/src/__tests__/StandaloneFuseboxShell-test.js
+++ b/packages/dev-middleware/src/__tests__/StandaloneFuseboxShell-test.js
@@ -60,8 +60,6 @@ describe('enableStandaloneFuseboxShell experiment', () => {
           capabilities: {
             // Ensure the device target can be found when launching the debugger
             nativePageReloads: true,
-            // Mark as Fusebox
-            prefersFuseboxFrontend: true,
           },
         },
       ]);

--- a/packages/dev-middleware/src/__tests__/getDevToolsFrontendUrl-test.js
+++ b/packages/dev-middleware/src/__tests__/getDevToolsFrontendUrl-test.js
@@ -30,7 +30,7 @@ describe('getDevToolsFrontendUrl', () => {
       );
       const url = new URL(actual);
       expect(url.host).toBe('localhost:8081');
-      expect(url.pathname).toBe('/debugger-frontend/rn_inspector.html');
+      expect(url.pathname).toBe('/debugger-frontend/rn_fusebox.html');
       expect(url.searchParams.get('ws')).toBe(
         '/inspector/debug?device=1a9372c&page=-1',
       );
@@ -44,7 +44,7 @@ describe('getDevToolsFrontendUrl', () => {
       );
       const url = new URL(actual);
       expect(url.host).toBe('localhost:8081');
-      expect(url.pathname).toBe('/debugger-frontend/rn_inspector.html');
+      expect(url.pathname).toBe('/debugger-frontend/rn_fusebox.html');
       expect(url.searchParams.get('unstable_enableNetworkPanel')).toBe('true');
       expect(url.searchParams.get('ws')).toBe(
         '/inspector/debug?device=1a9372c&page=-1',
@@ -87,7 +87,7 @@ describe('getDevToolsFrontendUrl', () => {
         },
       );
       const url = assertValidRelativeURL(actual);
-      expect(url.pathname).toBe('/debugger-frontend/rn_inspector.html');
+      expect(url.pathname).toBe('/debugger-frontend/rn_fusebox.html');
       expect(url.searchParams.get('ws')).toBe(
         '/inspector/debug?device=1a9372c&page=-1',
       );
@@ -103,7 +103,7 @@ describe('getDevToolsFrontendUrl', () => {
         },
       );
       const url = assertValidRelativeURL(actual);
-      expect(url.pathname).toBe('/debugger-frontend/rn_inspector.html');
+      expect(url.pathname).toBe('/debugger-frontend/rn_fusebox.html');
       expect(url.searchParams.get('unstable_enableNetworkPanel')).toBe('true');
       expect(url.searchParams.get('ws')).toBe(
         '/inspector/debug?device=1a9372c&page=-1',
@@ -147,7 +147,7 @@ describe('getDevToolsFrontendUrl', () => {
         },
       );
       const url = new URL(actual);
-      expect(url.pathname).toBe('/debugger-frontend/rn_inspector.html');
+      expect(url.pathname).toBe('/debugger-frontend/rn_fusebox.html');
       expect(url.searchParams.get('ws')).toBe(
         '/inspector/debug?device=1a9372c&page=-1',
       );
@@ -168,7 +168,7 @@ describe('getDevToolsFrontendUrl', () => {
         },
       );
       const url = new URL(actual);
-      expect(url.pathname).toBe('/debugger-frontend/rn_inspector.html');
+      expect(url.pathname).toBe('/debugger-frontend/rn_fusebox.html');
       expect(url.searchParams.get('unstable_enableNetworkPanel')).toBe('true');
       expect(url.searchParams.get('ws')).toBe(
         '/inspector/debug?device=1a9372c&page=-1',
@@ -199,22 +199,6 @@ describe('getDevToolsFrontendUrl', () => {
       expect(JSON.parse(url.searchParams.get('telemetryInfo') || '{}')).toEqual(
         JSON.parse(telemetryInfo),
       );
-    });
-  });
-
-  describe('useFuseboxEntryPoint: true', () => {
-    test('should return rn_fusebox.html entry point', async () => {
-      const result = getDevToolsFrontendUrl(
-        experiments,
-        webSocketDebuggerUrl,
-        devServerUrl,
-        {
-          useFuseboxEntryPoint: true,
-        },
-      );
-      const url = new URL(result);
-
-      expect(url.pathname).toBe('/debugger-frontend/rn_fusebox.html');
     });
   });
 });

--- a/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
+++ b/packages/dev-middleware/src/inspector-proxy/InspectorProxy.js
@@ -258,7 +258,6 @@ export default class InspectorProxy implements InspectorProxyQueries {
       new URL(this.#serverBaseUrl),
       {
         relative: true,
-        useFuseboxEntryPoint: page.capabilities.prefersFuseboxFrontend,
       },
     );
 

--- a/packages/dev-middleware/src/inspector-proxy/__docs__/README.md
+++ b/packages/dev-middleware/src/inspector-proxy/__docs__/README.md
@@ -127,7 +127,6 @@ interface Page {
   capabilities?: {
     nativePageReloads?: boolean; // Target keeps the socket open across reloads
     nativeSourceCodeFetching?: boolean; // Target supports Network.loadNetworkResource
-    prefersFuseboxFrontend?: boolean; // Target is designed for React Native DevTools
     supportsMultipleDebuggers?: boolean; // Supports concurrent debugger sessions
   };
 }
@@ -248,7 +247,6 @@ interface PageDescription {
     logicalDeviceId: string; // Used for target matching
     capabilities: {
       nativePageReloads?: boolean; // Used for target filtering
-      prefersFuseboxFrontend?: boolean; // Used for frontend selection
     };
   };
 }

--- a/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
+++ b/packages/dev-middleware/src/middleware/openDebuggerMiddleware.js
@@ -39,9 +39,6 @@ type Options = Readonly<{
 /**
  * Open the debugger frontend for a given CDP target.
  *
- * Currently supports React Native DevTools (rn_fusebox.html) and legacy Hermes
- * (rn_inspector.html) targets.
- *
  * @see https://chromedevtools.github.io/devtools-protocol/
  */
 export default function openDebuggerMiddleware({
@@ -65,6 +62,7 @@ export default function openDebuggerMiddleware({
       return result;
     });
   }
+
   return async (
     req: IncomingMessage,
     res: ServerResponse,
@@ -156,9 +154,6 @@ export default function openDebuggerMiddleware({
         return;
       }
 
-      const useFuseboxEntryPoint =
-        target.reactNative.capabilities?.prefersFuseboxFrontend ?? false;
-
       try {
         switch (launchType) {
           case 'launch': {
@@ -170,12 +165,11 @@ export default function openDebuggerMiddleware({
                 launchId: query.launchId,
                 telemetryInfo: query.telemetryInfo,
                 appId: target.appId,
-                useFuseboxEntryPoint,
                 panel: query.panel,
               },
             );
             let shouldUseStandaloneFuseboxShell =
-              useFuseboxEntryPoint && experiments.enableStandaloneFuseboxShell;
+              experiments.enableStandaloneFuseboxShell;
             if (shouldUseStandaloneFuseboxShell) {
               const shellPreparationResult = await shellPreparationPromise;
               switch (shellPreparationResult.code) {
@@ -229,7 +223,6 @@ export default function openDebuggerMiddleware({
                   launchId: query.launchId,
                   telemetryInfo: query.telemetryInfo,
                   appId: target.appId,
-                  useFuseboxEntryPoint,
                 },
               ),
             });
@@ -247,7 +240,7 @@ export default function openDebuggerMiddleware({
           pageId: target.id,
           deviceName: target.deviceName,
           targetDescription: target.description,
-          prefersFuseboxFrontend: useFuseboxEntryPoint,
+          prefersFuseboxFrontend: true,
         });
         return;
       } catch (e) {
@@ -261,7 +254,6 @@ export default function openDebuggerMiddleware({
           launchType,
           status: 'error',
           error: e,
-          prefersFuseboxFrontend: useFuseboxEntryPoint,
         });
         return;
       }

--- a/packages/dev-middleware/src/types/Experiments.js
+++ b/packages/dev-middleware/src/types/Experiments.js
@@ -24,7 +24,7 @@ export type Experiments = Readonly<{
   enableNetworkInspector: boolean,
 
   /**
-   * Launch the Fusebox frontend in a standalone shell instead of a browser.
+   * Launch the debugger frontend in a standalone shell instead of a browser.
    * When this is enabled, we will use the optional unstable_showFuseboxShell
    * method on the BrowserLauncher, or throw an error if the method is missing.
    *

--- a/packages/dev-middleware/src/utils/getDevToolsFrontendUrl.js
+++ b/packages/dev-middleware/src/utils/getDevToolsFrontendUrl.js
@@ -22,8 +22,6 @@ export default function getDevToolsFrontendUrl(
     relative?: boolean,
     launchId?: string,
     telemetryInfo?: string,
-    /** Whether to use the modern `rn_fusebox.html` entry point. */
-    useFuseboxEntryPoint?: boolean,
     appId?: string,
     panel?: string,
   }>,
@@ -35,10 +33,7 @@ export default function getDevToolsFrontendUrl(
 
   const appUrl =
     (options?.relative === true ? '' : devServerUrl.origin) +
-    '/debugger-frontend/' +
-    (options?.useFuseboxEntryPoint === true
-      ? 'rn_fusebox.html'
-      : 'rn_inspector.html');
+    '/debugger-frontend/rn_fusebox.html';
 
   const searchParams = new URLSearchParams([
     [wsParam.key, wsParam.value],


### PR DESCRIPTION
Summary:
**Context**

Clean up the legacy `rn_inspector.html` entry point. React Native DevTools has been the default since 0.76, and we have now removed all internal dependencies at Meta.

We've verified that Reanimated (`react-native-worklets`) also do not depend on this workflow, and documents `chrome://inspect` instead.

**This diff**

- Launching the debugger will no longer check for the `prefersFuseboxFrontend` capability flag (internal contract with the debugger server).
- The modern `rn_fusebox.html` entry point will always be used.

Changelog: [Internal]

Differential Revision: D93247604


