### PR TITLE
Cleanup PreparedLayoutTextView Recycling

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextView.kt
@@ -85,21 +85,17 @@ internal class PreparedLayoutTextView(context: Context) : ViewGroup(context), Re
     @DoNotStrip get() = preparedLayout?.layout?.text
 
   init {
-    initView()
     // ViewGroup by default says only its children will draw
     setWillNotDraw(false)
   }
 
-  private fun initView() {
-    clickableSpans = emptyList()
-    selection = null
-    preparedLayout = null
-  }
-
   fun recycleView(): Unit {
-    initView()
     BackgroundStyleApplicator.reset(this)
     overflow = Overflow.HIDDEN
+    clickableSpans = emptyList()
+    selection = null
+    selectionColor = null
+    preparedLayout = null
   }
 
   override fun onDraw(canvas: Canvas) {


### PR DESCRIPTION
Summary:
Everything in `initView` is already initialized implicitly, so should only be called during recycling, where we are also missing `selectionColor`.

Changelog: [internal]

Differential Revision: D93327082


