### PR TITLE
PreparedLayout -> PreparedTextLayout

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.cpp
@@ -144,7 +144,7 @@ void ParagraphShadowNode::setTextLayoutManager(
 template <typename ParagraphStateT>
 void ParagraphShadowNode::updateStateIfNeeded(
     const Content& content,
-    const MeasuredPreparedLayout& layout) {
+    const MeasuredPreparedTextLayout& layout) {
   ensureUnsealed();
 
   auto& state = static_cast<const ParagraphStateT&>(getStateData());
@@ -182,10 +182,10 @@ void ParagraphShadowNode::updateStateIfNeeded(const Content& content) {
           textLayoutManager_});
 }
 
-MeasuredPreparedLayout* ParagraphShadowNode::findUsableLayout() {
-  MeasuredPreparedLayout* ret = nullptr;
+MeasuredPreparedTextLayout* ParagraphShadowNode::findUsableLayout() {
+  MeasuredPreparedTextLayout* ret = nullptr;
 
-  if constexpr (TextLayoutManagerExtended::supportsPreparedLayout()) {
+  if constexpr (TextLayoutManagerExtended::supportsPreparedTextLayout()) {
     // We consider the layout to be reusable, if our content measurement,
     // combined with padding/border (not snapped) exactly corresponds to the
     // measurement of the node, before layout rounding. We may not find a
@@ -222,7 +222,7 @@ Size ParagraphShadowNode::rawContentSize() {
 Size ParagraphShadowNode::measureContent(
     const LayoutContext& layoutContext,
     const LayoutConstraints& layoutConstraints) const {
-  if constexpr (TextLayoutManagerExtended::supportsPreparedLayout()) {
+  if constexpr (TextLayoutManagerExtended::supportsPreparedTextLayout()) {
     for (const auto& layout : measuredLayouts_) {
       if (layout.layoutConstraints == layoutConstraints) {
         return layout.measurement.size;
@@ -238,7 +238,7 @@ Size ParagraphShadowNode::measureContent(
       .surfaceId = getSurfaceId(),
   };
 
-  if constexpr (TextLayoutManagerExtended::supportsPreparedLayout()) {
+  if constexpr (TextLayoutManagerExtended::supportsPreparedTextLayout()) {
     if (ReactNativeFeatureFlags::enablePreparedTextLayout()) {
       TextLayoutManagerExtended tme(*textLayoutManager_);
 
@@ -251,12 +251,12 @@ Size ParagraphShadowNode::measureContent(
           preparedLayout, textLayoutContext, layoutConstraints);
 
       measuredLayouts_.push_back(
-          MeasuredPreparedLayout{
+          MeasuredPreparedTextLayout{
               .layoutConstraints = layoutConstraints,
               .measurement = measurement,
-              // PreparedLayout is not trivially copyable on all platforms
+              // PreparedTextLayout is not trivially copyable on all platforms
               // NOLINTNEXTLINE(performance-move-const-arg)
-              .preparedLayout = std::move(preparedLayout)});
+              .preparedTextLayout = std::move(preparedLayout)});
       assert_valid_size(measurement.size, layoutConstraints);
       return measurement.size;
     }
@@ -316,7 +316,7 @@ void ParagraphShadowNode::layout(LayoutContext layoutContext) {
   auto measuredLayout = findUsableLayout();
 
   if constexpr (
-      TextLayoutManagerExtended::supportsPreparedLayout() &&
+      TextLayoutManagerExtended::supportsPreparedTextLayout() &&
       std::is_constructible_v<
           ParagraphState,
           decltype(content.attributedString),

--- a/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/ParagraphShadowNode.h
@@ -106,7 +106,7 @@ class ParagraphShadowNode final
    * `TextLayoutManager`) if needed.
    */
   template <typename ParagraphStateT>
-  void updateStateIfNeeded(const Content &content, const MeasuredPreparedLayout &layout);
+  void updateStateIfNeeded(const Content &content, const MeasuredPreparedTextLayout &layout);
 
   /*
    * Creates a `State` object (with `AttributedText` and
@@ -118,7 +118,7 @@ class ParagraphShadowNode final
    * Returns any previously prepared layout, generated for measurement, which
    * may be used, given the currently assigned layout to the ShadowNode
    */
-  MeasuredPreparedLayout *findUsableLayout();
+  MeasuredPreparedTextLayout *findUsableLayout();
 
   /**
    * Returns the final measure of the content frame, before layout rounding
@@ -136,7 +136,7 @@ class ParagraphShadowNode final
    * Intermediate layout results generated during measurement, that may be
    * reused by the platform.
    */
-  mutable std::vector<MeasuredPreparedLayout> measuredLayouts_;
+  mutable std::vector<MeasuredPreparedTextLayout> measuredLayouts_;
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/platform/android/react/renderer/components/text/ParagraphState.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/platform/android/react/renderer/components/text/ParagraphState.cpp
@@ -25,7 +25,7 @@ MapBuffer ParagraphState::getMapBuffer() const {
 }
 
 jni::local_ref<jobject> ParagraphState::getJNIReference() const {
-  return jni::make_local(measuredLayout.preparedLayout.get());
+  return jni::make_local(measuredLayout.preparedTextLayout.get());
 }
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/components/text/platform/android/react/renderer/components/text/ParagraphState.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/text/platform/android/react/renderer/components/text/ParagraphState.h
@@ -55,13 +55,13 @@ class ParagraphState final {
   /**
    * A fully prepared representation of a text layout to mount
    */
-  MeasuredPreparedLayout measuredLayout;
+  MeasuredPreparedTextLayout measuredLayout;
 
   ParagraphState(
       AttributedString attributedString,
       ParagraphAttributes paragraphAttributes,
       std::weak_ptr<const TextLayoutManager> layoutManager,
-      MeasuredPreparedLayout measuredLayout)
+      MeasuredPreparedTextLayout measuredLayout)
       : attributedString(std::move(attributedString)),
         paragraphAttributes(std::move(paragraphAttributes)),
         layoutManager(std::move(layoutManager)),

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextLayoutManagerExtended.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/TextLayoutManagerExtended.h
@@ -19,31 +19,31 @@
 namespace facebook::react {
 
 template <typename TextLayoutManagerT>
-concept TextLayoutManagerWithPreparedLayout = requires(
+concept TextLayoutManagerWithPreparedTextLayout = requires(
     TextLayoutManagerT textLayoutManager,
     AttributedString attributedString,
     ParagraphAttributes paragraphAttributes,
     TextLayoutContext layoutContext,
     LayoutConstraints layoutConstraints,
-    typename TextLayoutManagerT::PreparedLayout preparedLayout) {
-  sizeof(typename TextLayoutManagerT::PreparedLayout);
+    typename TextLayoutManagerT::PreparedTextLayout preparedTextLayout) {
+  sizeof(typename TextLayoutManagerT::PreparedTextLayout);
   {
     textLayoutManager.prepareLayout(attributedString, paragraphAttributes, layoutContext, layoutConstraints)
-  } -> std::same_as<typename TextLayoutManagerT::PreparedLayout>;
+  } -> std::same_as<typename TextLayoutManagerT::PreparedTextLayout>;
   {
-    textLayoutManager.measurePreparedLayout(preparedLayout, layoutContext, layoutConstraints)
+    textLayoutManager.measurePreparedLayout(preparedTextLayout, layoutContext, layoutConstraints)
   } -> std::same_as<TextMeasurement>;
 };
 
 namespace detail {
 template <typename T>
-struct PreparedLayoutT {
+struct PreparedTextLayoutT {
   using type = std::nullptr_t;
 };
 
-template <TextLayoutManagerWithPreparedLayout T>
-struct PreparedLayoutT<T> {
-  using type = typename T::PreparedLayout;
+template <TextLayoutManagerWithPreparedTextLayout T>
+struct PreparedTextLayoutT<T> {
+  using type = typename T::PreparedTextLayout;
 };
 
 /**
@@ -64,12 +64,12 @@ class TextLayoutManagerExtended {
     };
   }
 
-  static constexpr bool supportsPreparedLayout()
+  static constexpr bool supportsPreparedTextLayout()
   {
-    return TextLayoutManagerWithPreparedLayout<TextLayoutManagerT>;
+    return TextLayoutManagerWithPreparedTextLayout<TextLayoutManagerT>;
   }
 
-  using PreparedLayout = typename PreparedLayoutT<TextLayoutManagerT>::type;
+  using PreparedTextLayout = typename PreparedTextLayoutT<TextLayoutManagerT>::type;
 
   TextLayoutManagerExtended(const TextLayoutManagerT &textLayoutManager) : textLayoutManager_(textLayoutManager) {}
 
@@ -84,24 +84,24 @@ class TextLayoutManagerExtended {
     LOG(FATAL) << "Platform TextLayoutManager does not support measureLines";
   }
 
-  PreparedLayout prepareLayout(
+  PreparedTextLayout prepareLayout(
       const AttributedString &attributedString,
       const ParagraphAttributes &paragraphAttributes,
       const TextLayoutContext &layoutContext,
       const LayoutConstraints &layoutConstraints) const
   {
-    if constexpr (supportsPreparedLayout()) {
+    if constexpr (supportsPreparedTextLayout()) {
       return textLayoutManager_.prepareLayout(attributedString, paragraphAttributes, layoutContext, layoutConstraints);
     }
     LOG(FATAL) << "Platform TextLayoutManager does not support prepareLayout";
   }
 
   TextMeasurement measurePreparedLayout(
-      const PreparedLayout &layout,
+      const PreparedTextLayout &layout,
       const TextLayoutContext &layoutContext,
       const LayoutConstraints &layoutConstraints) const
   {
-    if constexpr (supportsPreparedLayout()) {
+    if constexpr (supportsPreparedTextLayout()) {
       return textLayoutManager_.measurePreparedLayout(layout, layoutContext, layoutConstraints);
     }
     LOG(FATAL) << "Platform TextLayoutManager does not support measurePreparedLayout";
@@ -114,10 +114,10 @@ class TextLayoutManagerExtended {
 
 using TextLayoutManagerExtended = detail::TextLayoutManagerExtended<TextLayoutManager>;
 
-struct MeasuredPreparedLayout {
+struct MeasuredPreparedTextLayout {
   LayoutConstraints layoutConstraints;
   TextMeasurement measurement;
-  TextLayoutManagerExtended::PreparedLayout preparedLayout{};
+  TextLayoutManagerExtended::PreparedTextLayout preparedTextLayout{};
 };
 
 } // namespace facebook::react

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.cpp
@@ -23,7 +23,7 @@
 namespace facebook::react {
 
 static_assert(TextLayoutManagerExtended::supportsLineMeasurement());
-static_assert(TextLayoutManagerExtended::supportsPreparedLayout());
+static_assert(TextLayoutManagerExtended::supportsPreparedTextLayout());
 
 namespace {
 
@@ -296,7 +296,7 @@ LinesMeasurements TextLayoutManager::measureLines(
             std::move(doMeasureLines));
 }
 
-TextLayoutManager::PreparedLayout TextLayoutManager::prepareLayout(
+TextLayoutManager::PreparedTextLayout TextLayoutManager::prepareLayout(
     const AttributedString& attributedString,
     const ParagraphAttributes& paragraphAttributes,
     const TextLayoutContext& layoutContext,
@@ -333,7 +333,7 @@ TextLayoutManager::PreparedLayout TextLayoutManager::prepareLayout(
         auto minimumSize = layoutConstraints.minimumSize;
         auto maximumSize = layoutConstraints.maximumSize;
 
-        return PreparedLayout{jni::make_global(prepareTextLayout(
+        return PreparedTextLayout{jni::make_global(prepareTextLayout(
             fabricUIManager,
             layoutContext.surfaceId,
             attributedStringMB.get(),
@@ -371,15 +371,16 @@ TextLayoutManager::PreparedLayout TextLayoutManager::prepareLayout(
 
     const auto& fabricUIManager =
         contextContainer_->at<jni::global_ref<jobject>>("FabricUIManager");
-    return PreparedLayout{jni::make_global(reusePreparedLayoutWithNewReactTags(
-        fabricUIManager, preparedText->get(), javaReactTags.get()))};
+    return PreparedTextLayout{
+        jni::make_global(reusePreparedLayoutWithNewReactTags(
+            fabricUIManager, preparedText->get(), javaReactTags.get()))};
   } else {
-    return PreparedLayout{*preparedText};
+    return PreparedTextLayout{*preparedText};
   }
 }
 
 TextMeasurement TextLayoutManager::measurePreparedLayout(
-    const PreparedLayout& preparedLayout,
+    const PreparedTextLayout& preparedLayout,
     const TextLayoutContext& /*layoutContext*/,
     const LayoutConstraints& layoutConstraints) const {
   const auto& fabricUIManager =

--- a/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/textlayoutmanager/platform/android/react/renderer/textlayoutmanager/TextLayoutManager.h
@@ -29,7 +29,7 @@ class TextLayoutManager;
  */
 class TextLayoutManager {
  public:
-  using PreparedLayout = SafeReleaseJniRef<jni::global_ref<JPreparedLayout>>;
+  using PreparedTextLayout = SafeReleaseJniRef<jni::global_ref<JPreparedLayout>>;
 
   TextLayoutManager(const std::shared_ptr<const ContextContainer> &contextContainer);
 
@@ -77,17 +77,17 @@ class TextLayoutManager {
    * Create a platform representation of fully laid out text, to later be
    * reused.
    */
-  PreparedLayout prepareLayout(
+  PreparedTextLayout prepareLayout(
       const AttributedString &attributedString,
       const ParagraphAttributes &paragraphAttributes,
       const TextLayoutContext &layoutContext,
       const LayoutConstraints &layoutConstraints) const;
 
   /**
-   * Derive text and attachment measurements from a PreparedLayout.
+   * Derive text and attachment measurements from a PreparedTextLayout.
    */
   TextMeasurement measurePreparedLayout(
-      const PreparedLayout &layout,
+      const PreparedTextLayout &layout,
       const TextLayoutContext &layoutContext,
       const LayoutConstraints &layoutConstraints) const;
 
@@ -95,7 +95,7 @@ class TextLayoutManager {
   std::shared_ptr<const ContextContainer> contextContainer_;
   TextMeasureCache textMeasureCache_;
   LineMeasureCache lineMeasureCache_;
-  SimpleThreadSafeCache<PreparedTextCacheKey, PreparedLayout, -1 /* Set dynamically*/> preparedTextCache_;
+  SimpleThreadSafeCache<PreparedTextCacheKey, PreparedTextLayout, -1 /* Set dynamically*/> preparedTextCache_;
 };
 
 } // namespace facebook::react


### PR DESCRIPTION
Summary:
`PreparedLayout`, in the Android context, refers to an `android.text.Layout`, but is ambiguous, outside of areas which are not clearly namespaced. Lets rename these instances to `PreparedTextLayout`, which also better matches the feature flag name, `enablePreparedTextLayout`, and the Android view `PreparedLayoutTextView`.

Changelog: [Internal]

Differential Revision: D93381797


