### PR TITLE
Fix js sync on animation end in Animation Backend

### DIFF
--- a/private/react-native-fantom/tester/src/TesterAnimationChoreographer.cpp
+++ b/private/react-native-fantom/tester/src/TesterAnimationChoreographer.cpp
@@ -7,6 +7,7 @@
 
 #include "TesterAnimationChoreographer.h"
 #include <react/renderer/core/ReactPrimitives.h>
+#include <react/renderer/core/ShadowNode.h>
 #include <react/runtime/ReactInstanceConfig.h>
 
 namespace facebook::react {
@@ -20,7 +21,9 @@ void TesterAnimationChoreographer::pause() {
 
 void TesterAnimationChoreographer::runUITick(AnimationTimestamp timestamp) {
   if (!isPaused_) {
+    ShadowNode::setUseRuntimeShadowNodeReferenceUpdateOnThread(false);
     onAnimationFrame(timestamp);
+    ShadowNode::setUseRuntimeShadowNodeReferenceUpdateOnThread(true);
   }
 }
 


### PR DESCRIPTION
Summary:
In Animation Backend, we allow animation frameowrks to request a js-thread sync of the current animation state. It is used by c++ Animated, and is meant to serve as a way to push animation changes to react through RSNRU, after the animation finsishes. This way we ensure that subsequent rerenders of the component don't bring back the old style value.

This approach is currently broken when the animation performs any main-thread commits, as in this case the `runtimeShadowNodeReference_` is not copied to new node revisions, so the js-thread sync commit cannot use RSNRU properly. The bug was not visible, because we don't clean up the registry in that case, we only do it for react commits.

This PR fixes the issue for the case when `updateRuntimeShadowNodeReferencesOnCommitThread` is enabled, as this fixes the RSNRU propagation, so we can clean-up the registry. If the flag is disabled, we don't cleanup the registry, as we want the next react commit to make sure the animation state is not overwritten.

# Changelog

[General][Added] - test for the Animation Backend js sync
[General][Changed] - TesterAnimationChoreographer changes the thread_local RSNRU flag when running animation update, to better simulate the real application use-case
[General][Changed] - AnimationBackend now cleans-up the AnimatedPropsRegistry after the js sync when `updateRuntimeShadowNodeReferencesOnCommitThread` is enabled

Differential Revision: D93414839


