### PR TITLE
Explicitely set REACT_NATIVE_DOWNLOADS_DIR to use predownloaded deps

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -50,6 +50,7 @@ jobs:
         ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
         ORG_GRADLE_PROJECT_SONATYPE_USERNAME: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_USERNAME }}
         ORG_GRADLE_PROJECT_SONATYPE_PASSWORD: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_PASSWORD }}
+        REACT_NATIVE_DOWNLOADS_DIR: /opt/react-native-downloads
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -78,6 +79,7 @@ jobs:
         LC_ALL: C.UTF8
         # By default we only build ARM64 to save time/resources. For release/nightlies, we override this value to build all archs.
         ORG_GRADLE_PROJECT_reactNativeArchitectures: "arm64-v8a"
+        REACT_NATIVE_DOWNLOADS_DIR: /opt/react-native-downloads
     env:
       GHA_NPM_TOKEN: ${{ secrets.GHA_NPM_TOKEN }}
       ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -69,6 +69,7 @@ jobs:
         GRADLE_OPTS: "-Dorg.gradle.daemon=false"
         # By default we only build ARM64 to save time/resources. For release/nightlies, we override this value to build all archs.
         ORG_GRADLE_PROJECT_reactNativeArchitectures: "arm64-v8a"
+        REACT_NATIVE_DOWNLOADS_DIR: /opt/react-native-downloads
     env:
       GHA_NPM_TOKEN: ${{ secrets.GHA_NPM_TOKEN }}
       ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}

--- a/.github/workflows/test-all.yml
+++ b/.github/workflows/test-all.yml
@@ -352,6 +352,7 @@ jobs:
         GRADLE_OPTS: "-Dorg.gradle.daemon=false"
         ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}
         ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
+        REACT_NATIVE_DOWNLOADS_DIR: /opt/react-native-downloads
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -377,6 +378,7 @@ jobs:
         GRADLE_OPTS: "-Dorg.gradle.daemon=false"
         ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}
         ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
+        REACT_NATIVE_DOWNLOADS_DIR: /opt/react-native-downloads
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -433,6 +435,7 @@ jobs:
         # via Gradle: https://github.com/gradle/gradle/issues/23391#issuecomment-1878979127
         LC_ALL: C.UTF8
         GRADLE_OPTS: "-Dorg.gradle.daemon=false"
+        REACT_NATIVE_DOWNLOADS_DIR: /opt/react-native-downloads
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -455,6 +458,7 @@ jobs:
       TERM: "dumb"
       GRADLE_OPTS: "-Dorg.gradle.daemon=false"
       TARGET_ARCHITECTURE: "arm64-v8a"
+      REACT_NATIVE_DOWNLOADS_DIR: /opt/react-native-downloads
     continue-on-error: true
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary:

This updates the CI to use `REACT_NATIVE_DOWNLOADS_DIR` so the directory where the C++ dependencies are consumed from is always the same.

This works in conjuction with:
- https://github.com/react-native-community/docker-android/pull/248

## Changelog:

[INTERNAL] -

## Test Plan:

CI