### PR TITLE
fix(react-native): resolve included-build gradle.properties from parent build in monorepos

### DIFF
--- a/packages/react-native/settings.gradle.kts
+++ b/packages/react-native/settings.gradle.kts
@@ -46,6 +46,15 @@ project(":packages:react-native").projectDir = file("/tmp")
 buildscript {
   val properties = java.util.Properties()
   val propertiesToInherit = listOf("hermesV1Enabled", "react.hermesV1Enabled")
+
+  // We cannot assume that the node_modules are next to the android project, for example
+  // in monorepos, they might get hoisted.
+  // In a composite build, this included build can access the invoking (consumer) build
+  // via `gradle.parent`. We use its StartParameter to locate the app's `gradle.properties`:
+  // - `projectDir/gradle.properties` when Gradle is run with `-p <androidDir>`
+  // - `currentDir/gradle.properties` when run from the app android folder
+  // If neither exists, we keep the legacy RN fallback path below.
+
   val parentGradle = gradle.parent
   val parentProjectDir = parentGradle?.startParameter?.projectDir
   val parentCurrentDir = parentGradle?.startParameter?.currentDir


### PR DESCRIPTION
_Disclaimer: The code was generated using GPT-5.3 Codex. I have read it, and it looks fine, but I'm no android expert. I made sure with logging that everything worked._
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

React Native’s included build was reading only ../../android/gradle.properties, which breaks in monorepos where Android apps live under packages/*/android. This updates settings.gradle.kts to resolve gradle.properties from the parent Gradle start parameters (projectDir/currentDir) first, with the old relative path kept as a backward-compatible fallback. This ensures hermesV1Enabled and react.hermesV1Enabled are propagated reliably across composite builds.

## Changelog:

[ANDROID] [FIXED] Fix included-build `gradle.properties` resolution for monorepos by reading from parent Gradle start parameters (`projectDir`/`currentDir`) before falling back to `../../android/gradle.properties`, so `hermesV1Enabled` can be inherited correctly.

## Test Plan:

I've tested manually with expo sdk 55 in our monorepo.


Ideally we'll want this in 83, so that expo 55 can use hermes V1 in monorepos