### PR TITLE
Split definition to separate statements

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityPrimitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/AccessibilityPrimitives.h
@@ -66,7 +66,8 @@ struct AccessibilityState {
   bool selected{false};
   bool busy{false};
   std::optional<bool> expanded{std::nullopt};
-  enum CheckedState { Unchecked, Checked, Mixed, None } checked{None};
+  enum CheckedState { Unchecked, Checked, Mixed, None };
+  CheckedState checked{CheckedState::None};
 };
 
 constexpr bool operator==(const AccessibilityState &lhs, const AccessibilityState &rhs)


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Separates enum declaration and declaration of the field of that type.

Differential Revision: D93477888


