### PR TITLE
Fix typos in feature flags utils comments

### DIFF
--- a/packages/react-native/scripts/featureflags/utils.js
+++ b/packages/react-native/scripts/featureflags/utils.js
@@ -34,7 +34,7 @@ export function getCxxValueFromDefaultValue(
     case 'number':
       const numericString = defaultValue.toString();
       // If the number is an integer, we need to append ".0" so that the result
-      // is interpeted as a double in C++.
+      // is interpreted as a double in C++.
       return numericString.includes('.') ? numericString : `${numericString}.0`;
     case 'string':
       return JSON.stringify(defaultValue);
@@ -97,7 +97,7 @@ export function getKotlinValueFromDefaultValue(
     case 'number':
       const numericString = defaultValue.toString();
       // If the number is an integer, we need to append ".0" so that the result
-      // is interpeted as a double in Kotlin.
+      // is interpreted as a double in Kotlin.
       return numericString.includes('.') ? numericString : `${numericString}.0`;
     case 'string':
       return JSON.stringify(defaultValue);


### PR DESCRIPTION
Summary:
Fixed spelling errors in code comments - "interpeted" → "interpreted" in two places.

---

Changelog:
[Internal]

Differential Revision: D93478901


