### PR TITLE
Add shared DevSupportHttpClient singleton

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/inspector/DevSupportHttpClient.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/inspector/DevSupportHttpClient.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+@file:Suppress("DEPRECATION_ERROR") // Conflicting okhttp versions
+
+package com.facebook.react.devsupport.inspector
+
+import java.util.concurrent.TimeUnit
+import okhttp3.OkHttpClient
+
+/**
+ * Shared [OkHttpClient] instances for devsupport networking. Uses a single connection pool and
+ * dispatcher across all dev support HTTP and WebSocket usage.
+ */
+internal object DevSupportHttpClient {
+  /** Client for HTTP requests: connect=5s, write=disabled, read=disabled. */
+  val httpClient: OkHttpClient =
+      OkHttpClient.Builder()
+          .connectTimeout(5, TimeUnit.SECONDS)
+          .writeTimeout(0, TimeUnit.MILLISECONDS)
+          .readTimeout(0, TimeUnit.MINUTES)
+          .build()
+
+  /** Client for WebSocket connections: connect=10s, write=10s, read=disabled. */
+  val websocketClient: OkHttpClient =
+      httpClient
+          .newBuilder()
+          .connectTimeout(10, TimeUnit.SECONDS)
+          .writeTimeout(10, TimeUnit.SECONDS)
+          .build()
+}


### PR DESCRIPTION
Summary:
The devsupport package creates multiple OkHttpClient instances across different files, each with its own connection pool and thread pool. This is wasteful and introduces bugs (thread-safety race in InspectorNetworkHelper, per-tap allocation in RedBoxContentView).

This diff introduces DevSupportHttpClient, an internal object singleton with two shared clients derived from the same connection pool:
- httpClient: with connect=5s, write=disabled, read=disabled (for HTTP requests)
- websocketClient: derived via newBuilder() with connect=10s, write=10s, read=disabled (for WebSocket/inspector use)

Subsequent diffs in this stack migrate each consumer to use these shared clients.

Changelog: [Internal]

Differential Revision: D93480249


