### PR TITLE
Migrate SectionList examples to Flow component syntax

### DIFF
--- a/packages/rn-tester/js/examples/SectionList/SectionList-contentInset.js
+++ b/packages/rn-tester/js/examples/SectionList/SectionList-contentInset.js
@@ -17,7 +17,7 @@ import * as React from 'react';
 import {useState} from 'react';
 import {StyleSheet, Text, View} from 'react-native';
 
-export function SectionList_contentInset(): React.Node {
+export component SectionList_contentInset() {
   const [initialContentInset, toggledContentInset] = [44, 88];
 
   const [output, setOutput] = useState(

--- a/packages/rn-tester/js/examples/SectionList/SectionList-inverted.js
+++ b/packages/rn-tester/js/examples/SectionList/SectionList-inverted.js
@@ -14,7 +14,7 @@ import SectionListBaseExample from './SectionListBaseExample';
 import * as React from 'react';
 import {useState} from 'react';
 
-export function SectionList_inverted(): React.Node {
+export component SectionList_inverted() {
   const [output, setOutput] = useState('inverted false');
   const [exampleProps, setExampleProps] = useState({
     inverted: false,

--- a/packages/rn-tester/js/examples/SectionList/SectionList-onEndReached.js
+++ b/packages/rn-tester/js/examples/SectionList/SectionList-onEndReached.js
@@ -12,7 +12,7 @@ import SectionListBaseExample from './SectionListBaseExample';
 import * as React from 'react';
 import {useRef, useState} from 'react';
 
-export function SectionList_onEndReached(): React.Node {
+export component SectionList_onEndReached() {
   const [output, setOutput] = useState('');
   const exampleProps = {
     onEndReached: (info: {distanceFromEnd: number, ...}) =>

--- a/packages/rn-tester/js/examples/SectionList/SectionList-scrollable.js
+++ b/packages/rn-tester/js/examples/SectionList/SectionList-scrollable.js
@@ -172,7 +172,7 @@ const SectionSeparatorComponent = info => (
   <CustomSeparatorComponent {...info} text="SECTION SEPARATOR" />
 );
 
-export function SectionList_scrollable(Props: {...}): React.MixedElement {
+export component SectionList_scrollable() {
   const scrollPos = new Animated.Value(0);
   const scrollSinkY = Animated.event(
     [{nativeEvent: {contentOffset: {y: scrollPos}}}],

--- a/packages/rn-tester/js/examples/SectionList/SectionList-stickyHeadersEnabled.js
+++ b/packages/rn-tester/js/examples/SectionList/SectionList-stickyHeadersEnabled.js
@@ -14,7 +14,7 @@ import SectionListBaseExample from './SectionListBaseExample';
 import * as React from 'react';
 import {useState} from 'react';
 
-export function SectionList_stickySectionHeadersEnabled(): React.Node {
+export component SectionList_stickySectionHeadersEnabled() {
   const [output, setOutput] = useState('stickySectionHeadersEnabled false');
   const [exampleProps, setExampleProps] = useState({
     stickySectionHeadersEnabled: false,

--- a/packages/rn-tester/js/examples/SectionList/SectionList-withSeparators.js
+++ b/packages/rn-tester/js/examples/SectionList/SectionList-withSeparators.js
@@ -33,7 +33,7 @@ const Separator =
     );
   };
 
-export function SectionList_withSeparators(): React.Node {
+export component SectionList_withSeparators() {
   const exampleProps = {
     ItemSeparatorComponent: Separator('lightgreen', 'green', false),
     SectionSeparatorComponent: Separator('lightblue', 'blue', true),


### PR DESCRIPTION
Summary:
Migrates React components in rn-tester SectionList examples from the legacy
function syntax to the modern Flow component syntax.

The Flow component syntax is the preferred pattern for writing React
components in Flow-typed codebases at Meta.

Files changed:
- SectionList-inverted.js
- SectionList-contentInset.js
- SectionList-onEndReached.js
- SectionList-scrollable.js
- SectionList-stickyHeadersEnabled.js
- SectionList-withSeparators.js

Changelog: [Internal]

Reviewed By: cortinico

Differential Revision: D93483461


