### PR TITLE
Apply custom headers in RCTMultipartDataTask

### DIFF
--- a/packages/react-native/React/Base/RCTDevSupportHttpHeaders.h
+++ b/packages/react-native/React/Base/RCTDevSupportHttpHeaders.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+/**
+ * Thread-safe singleton that holds custom HTTP headers to be applied
+ * to all devsupport network requests (bundle fetches, packager status
+ * checks, inspector and HMR WebSocket connections).
+ */
+@interface RCTDevSupportHttpHeaders : NSObject
+
++ (instancetype)sharedInstance;
+
+- (void)addRequestHeader:(NSString *)name value:(NSString *)value;
+- (void)removeRequestHeader:(NSString *)name;
+- (NSDictionary<NSString *, NSString *> *)allHeaders;
+- (void)applyHeadersToRequest:(NSMutableURLRequest *)request;
+
+@end

--- a/packages/react-native/React/Base/RCTDevSupportHttpHeaders.m
+++ b/packages/react-native/React/Base/RCTDevSupportHttpHeaders.m
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTDevSupportHttpHeaders.h"
+
+@implementation RCTDevSupportHttpHeaders {
+  NSMutableDictionary<NSString *, NSString *> *_headers;
+  dispatch_queue_t _queue;
+}
+
++ (instancetype)sharedInstance
+{
+  static RCTDevSupportHttpHeaders *sharedInstance;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    sharedInstance = [[RCTDevSupportHttpHeaders alloc] init];
+  });
+  return sharedInstance;
+}
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    _headers = [NSMutableDictionary new];
+    _queue = dispatch_queue_create("com.facebook.react.RCTDevSupportHttpHeaders", DISPATCH_QUEUE_CONCURRENT);
+  }
+  return self;
+}
+
+- (void)addRequestHeader:(NSString *)name value:(NSString *)value
+{
+  dispatch_barrier_async(_queue, ^{
+    self->_headers[name] = value;
+  });
+}
+
+- (void)removeRequestHeader:(NSString *)name
+{
+  dispatch_barrier_async(_queue, ^{
+    [self->_headers removeObjectForKey:name];
+  });
+}
+
+- (NSDictionary<NSString *, NSString *> *)allHeaders
+{
+  __block NSDictionary<NSString *, NSString *> *snapshot;
+  dispatch_sync(_queue, ^{
+    snapshot = [self->_headers copy];
+  });
+  return snapshot;
+}
+
+- (void)applyHeadersToRequest:(NSMutableURLRequest *)request
+{
+  NSDictionary<NSString *, NSString *> *headers = [self allHeaders];
+  for (NSString *name in headers) {
+    [request setValue:headers[name] forHTTPHeaderField:name];
+  }
+}
+
+@end

--- a/packages/react-native/React/Base/RCTMultipartDataTask.m
+++ b/packages/react-native/React/Base/RCTMultipartDataTask.m
@@ -7,6 +7,8 @@
 
 #import "RCTMultipartDataTask.h"
 
+#import "RCTDevSupportHttpHeaders.h"
+
 @interface RCTMultipartDataTask () <NSURLSessionDataDelegate, NSURLSessionDataDelegate>
 
 @end
@@ -40,6 +42,7 @@
                                                    delegateQueue:nil];
   NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:_url];
   [request addValue:@"multipart/mixed" forHTTPHeaderField:@"Accept"];
+  [[RCTDevSupportHttpHeaders sharedInstance] applyHeadersToRequest:request];
   NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request];
   [dataTask resume];
   [session finishTasksAndInvalidate];


### PR DESCRIPTION
Summary: Inject custom devsupport headers into bundle download requests. This ensures that multipart bundle fetches include any headers registered via `RCTDevSupportHttpHeaders`.

Differential Revision: D93490951


