### PR TITLE
Apply custom headers in RCTCxxInspectorWebSocketAdapter

### DIFF
--- a/packages/react-native/Libraries/WebSocket/RCTReconnectingWebSocket.m
+++ b/packages/react-native/Libraries/WebSocket/RCTReconnectingWebSocket.m
@@ -9,6 +9,7 @@
 
 #import <React/RCTConvert.h>
 #import <React/RCTDefines.h>
+#import <React/RCTDevSupportHttpHeaders.h>
 
 #import <SocketRocket/SRWebSocket.h>
 
@@ -46,7 +47,9 @@
 {
   [self stop];
   _stopped = NO;
-  _socket = [[SRWebSocket alloc] initWithURL:_url];
+  NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:_url];
+  [[RCTDevSupportHttpHeaders sharedInstance] applyHeadersToRequest:request];
+  _socket = [[SRWebSocket alloc] initWithURLRequest:request];
   _socket.delegate = self;
   [_socket setDelegateDispatchQueue:_delegateDispatchQueue];
   [_socket open];

--- a/packages/react-native/React/Base/RCTBundleURLProvider.mm
+++ b/packages/react-native/React/Base/RCTBundleURLProvider.mm
@@ -10,6 +10,7 @@
 #import "RCTConstants.h"
 #import "RCTConvert.h"
 #import "RCTDefines.h"
+#import "RCTDevSupportHttpHeaders.h"
 #import "RCTLog.h"
 
 #import <jsinspector-modern/InspectorFlags.h>
@@ -93,9 +94,10 @@ static NSURL *serverRootWithHostPort(NSString *hostPort, NSString *scheme)
   NSURL *url = [serverRootWithHostPort(hostPort, scheme) URLByAppendingPathComponent:@"status"];
 
   NSURLSession *session = [NSURLSession sharedSession];
-  NSURLRequest *request = [NSURLRequest requestWithURL:url
-                                           cachePolicy:NSURLRequestUseProtocolCachePolicy
-                                       timeoutInterval:10];
+  NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url
+                                                         cachePolicy:NSURLRequestUseProtocolCachePolicy
+                                                     timeoutInterval:10];
+  [[RCTDevSupportHttpHeaders sharedInstance] applyHeadersToRequest:request];
   __block NSURLResponse *response;
   __block NSData *data;
 

--- a/packages/react-native/React/Base/RCTDevSupportHttpHeaders.h
+++ b/packages/react-native/React/Base/RCTDevSupportHttpHeaders.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <Foundation/Foundation.h>
+
+/**
+ * Thread-safe singleton that holds custom HTTP headers to be applied
+ * to all devsupport network requests (bundle fetches, packager status
+ * checks, inspector and HMR WebSocket connections).
+ */
+@interface RCTDevSupportHttpHeaders : NSObject
+
++ (instancetype)sharedInstance;
+
+- (void)addRequestHeader:(NSString *)name value:(NSString *)value;
+- (void)removeRequestHeader:(NSString *)name;
+- (NSDictionary<NSString *, NSString *> *)allHeaders;
+- (void)applyHeadersToRequest:(NSMutableURLRequest *)request;
+
+@end

--- a/packages/react-native/React/Base/RCTDevSupportHttpHeaders.m
+++ b/packages/react-native/React/Base/RCTDevSupportHttpHeaders.m
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTDevSupportHttpHeaders.h"
+
+@implementation RCTDevSupportHttpHeaders {
+  NSMutableDictionary<NSString *, NSString *> *_headers;
+  dispatch_queue_t _queue;
+}
+
++ (instancetype)sharedInstance
+{
+  static RCTDevSupportHttpHeaders *sharedInstance;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    sharedInstance = [[RCTDevSupportHttpHeaders alloc] init];
+  });
+  return sharedInstance;
+}
+
+- (instancetype)init
+{
+  if (self = [super init]) {
+    _headers = [NSMutableDictionary new];
+    _queue = dispatch_queue_create("com.facebook.react.RCTDevSupportHttpHeaders", DISPATCH_QUEUE_CONCURRENT);
+  }
+  return self;
+}
+
+- (void)addRequestHeader:(NSString *)name value:(NSString *)value
+{
+  dispatch_barrier_async(_queue, ^{
+    self->_headers[name] = value;
+  });
+}
+
+- (void)removeRequestHeader:(NSString *)name
+{
+  dispatch_barrier_async(_queue, ^{
+    [self->_headers removeObjectForKey:name];
+  });
+}
+
+- (NSDictionary<NSString *, NSString *> *)allHeaders
+{
+  __block NSDictionary<NSString *, NSString *> *snapshot;
+  dispatch_sync(_queue, ^{
+    snapshot = [self->_headers copy];
+  });
+  return snapshot;
+}
+
+- (void)applyHeadersToRequest:(NSMutableURLRequest *)request
+{
+  NSDictionary<NSString *, NSString *> *headers = [self allHeaders];
+  for (NSString *name in headers) {
+    [request setValue:headers[name] forHTTPHeaderField:name];
+  }
+}
+
+@end

--- a/packages/react-native/React/Base/RCTMultipartDataTask.m
+++ b/packages/react-native/React/Base/RCTMultipartDataTask.m
@@ -7,6 +7,8 @@
 
 #import "RCTMultipartDataTask.h"
 
+#import "RCTDevSupportHttpHeaders.h"
+
 @interface RCTMultipartDataTask () <NSURLSessionDataDelegate, NSURLSessionDataDelegate>
 
 @end
@@ -40,6 +42,7 @@
                                                    delegateQueue:nil];
   NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:_url];
   [request addValue:@"multipart/mixed" forHTTPHeaderField:@"Accept"];
+  [[RCTDevSupportHttpHeaders sharedInstance] applyHeadersToRequest:request];
   NSURLSessionDataTask *dataTask = [session dataTaskWithRequest:request];
   [dataTask resume];
   [session finishTasksAndInvalidate];

--- a/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.mm
+++ b/packages/react-native/React/DevSupport/RCTInspectorDevServerHelper.mm
@@ -14,6 +14,7 @@
 
 #import <React/RCTCxxInspectorPackagerConnection.h>
 #import <React/RCTDefines.h>
+#import <React/RCTDevSupportHttpHeaders.h>
 
 #import <CommonCrypto/CommonCrypto.h>
 #import <jsinspector-modern/InspectorFlags.h>
@@ -154,6 +155,7 @@ static void sendEventToAllConnections(NSString *event)
                                                                escapedInspectorDeviceId]];
   NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
   [request setHTTPMethod:@"POST"];
+  [[RCTDevSupportHttpHeaders sharedInstance] applyHeadersToRequest:request];
 
   [[[NSURLSession sharedSession]
       dataTaskWithRequest:request

--- a/packages/react-native/React/DevSupport/RCTInspectorNetworkHelper.mm
+++ b/packages/react-native/React/DevSupport/RCTInspectorNetworkHelper.mm
@@ -6,6 +6,7 @@
  */
 
 #import "RCTInspectorNetworkHelper.h"
+#import <React/RCTDevSupportHttpHeaders.h>
 #import <React/RCTLog.h>
 
 using ListenerBlock = void (^)(RCTInspectorNetworkListener *);
@@ -47,6 +48,7 @@ using ListenerBlock = void (^)(RCTInspectorNetworkListener *);
 
   NSMutableURLRequest *urlRequest = [NSMutableURLRequest requestWithURL:url];
   [urlRequest setHTTPMethod:@"GET"];
+  [[RCTDevSupportHttpHeaders sharedInstance] applyHeadersToRequest:urlRequest];
   NSURLSessionDataTask *dataTask = [self.session dataTaskWithRequest:urlRequest];
   __weak NSURLSessionDataTask *weakDataTask = dataTask;
 

--- a/packages/react-native/React/Inspector/RCTCxxInspectorWebSocketAdapter.mm
+++ b/packages/react-native/React/Inspector/RCTCxxInspectorWebSocketAdapter.mm
@@ -10,6 +10,7 @@
 #if RCT_DEV || RCT_REMOTE_PROFILE
 
 #import <React/RCTAssert.h>
+#import <React/RCTDevSupportHttpHeaders.h>
 #import <React/RCTInspector.h>
 #import <React/RCTInspectorPackagerConnection.h>
 #import <React/RCTUtils.h>
@@ -40,7 +41,10 @@ NSString *NSStringFromUTF8StringView(std::string_view view)
 {
   if ((self = [super init]) != nullptr) {
     _delegate = delegate;
-    _webSocket = [[SRWebSocket alloc] initWithURL:[NSURL URLWithString:NSStringFromUTF8StringView(url)]];
+    NSMutableURLRequest *request =
+        [NSMutableURLRequest requestWithURL:[NSURL URLWithString:NSStringFromUTF8StringView(url)]];
+    [[RCTDevSupportHttpHeaders sharedInstance] applyHeadersToRequest:request];
+    _webSocket = [[SRWebSocket alloc] initWithURLRequest:request];
     _webSocket.delegate = self;
     [_webSocket open];
   }


### PR DESCRIPTION
Summary: Inject custom devsupport headers into the inspector CDP WebSocket connection. Changes from `initWithURL:` to `initWithURLRequest:` so headers can be set on the HTTP upgrade handshake.

Differential Revision: D93490949


