### PR TITLE
feat: [TypeScript] Add missing `onPressMove` prop to `<Pressable />`

### DIFF
--- a/packages/react-native/Libraries/Components/Pressable/Pressable.d.ts
+++ b/packages/react-native/Libraries/Components/Pressable/Pressable.d.ts
@@ -56,6 +56,11 @@ export interface PressableProps
   onPressIn?: null | ((event: GestureResponderEvent) => void) | undefined;
 
   /**
+   * Called when the press location moves.
+   */
+  onPressMove?: null | ((event: GestureResponderEvent) => void) | undefined;
+
+  /**
    * Called when a touch is released before `onPress`.
    */
   onPressOut?: null | ((event: GestureResponderEvent) => void) | undefined;


### PR DESCRIPTION
## Summary:

I worked on a bug that require to cancel my animation on TapDown+Drag event, so to do that I need to subscribe to move event

and `onPressMove` exist on JS side but not in the `.d.ts` 

## Changelog:

[GENERAL] [ADDED] - [TypeScript] Add missing `onPressMove` prop to `<Pressable />`

## Test Plan:


```tsx
<Pressable onPressMove={fn} /> // no TS error
```
