### PR TITLE
add copyright header to Package.swift.template

### DIFF
--- a/packages/react-native/scripts/codegen/templates/Package.swift.template
+++ b/packages/react-native/scripts/codegen/templates/Package.swift.template
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 // swift-tools-version: 6.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 


### PR DESCRIPTION
Summary:
Changelog: [Internal]

Add the standard Meta copyright header to Package.swift.template, which was missing it. All other templates in the same directory already have the header.

Differential Revision: D93555928


