### PR TITLE
Add failing tests for union object type addition

### DIFF
--- a/packages/react-native-compatibility-check/src/__tests__/ErrorFormattingTests.js
+++ b/packages/react-native-compatibility-check/src/__tests__/ErrorFormattingTests.js
@@ -33,6 +33,10 @@ export const okayChanges = [
     'native-component-with-props/NativeComponent',
     'native-component-with-props-default-change/NativeComponent',
   ],
+  [
+    'native-module-with-union-object/NativeModule',
+    'native-module-with-union-object-added/NativeModule',
+  ],
 ];
 
 export const incompatibleChanges = [
@@ -129,6 +133,10 @@ export const incompatibleChanges = [
   [
     'native-module-with-union-object/NativeModule',
     'native-module-with-union-object-changes/NativeModule',
+  ],
+  [
+    'native-module-with-union-object-added/NativeModule',
+    'native-module-with-union-object/NativeModule',
   ],
   [
     'native-component-with-command/NativeComponent',

--- a/packages/react-native-compatibility-check/src/__tests__/VersionDiffing-test.js
+++ b/packages/react-native-compatibility-check/src/__tests__/VersionDiffing-test.js
@@ -118,6 +118,12 @@ const schemaWithUnionFromNative = makeRN(
 const schemaWithUnionFromNativeChanges = makeRN(
   'native-module-with-union-from-native-changes/NativeModule',
 );
+const schemaWithUnionObject = makeRN(
+  'native-module-with-union-object/NativeModule',
+);
+const schemaWithUnionObjectAdded = makeRN(
+  'native-module-with-union-object-added/NativeModule',
+);
 
 const schemaWithRNNativeComponent = makeRN('native-component/NativeComponent');
 const schemaNativeComponentWithCommand = makeRN(
@@ -1190,6 +1196,79 @@ describe('buildSchemaDiff', () => {
         }),
       }),
     );
+  });
+
+  it('RN with union object types, and addition', () => {
+    const schemaDiff = buildSchemaDiff(
+      schemaWithUnionObjectAdded, // new: ObjectA | ObjectB | ObjectC
+      schemaWithUnionObject, // old: ObjectA | ObjectB
+    );
+
+    expect(summarizeDiffSet(schemaDiff).status).toBe('incompatible');
+    expect(schemaDiffExporter(Array.from(schemaDiff)[0])).toEqual(
+      expect.objectContaining({
+        framework: 'ReactNative',
+        name: 'NativeModule',
+        status: expect.objectContaining({
+          incompatibleSpecs: expect.arrayContaining([
+            expect.objectContaining({
+              changeInformation: expect.objectContaining({
+                incompatibleChanges: expect.arrayContaining([
+                  expect.objectContaining({
+                    errorCode: 'addedMemberCases',
+                  }),
+                ]),
+                objectTypeChanges: expect.arrayContaining([
+                  expect.objectContaining({
+                    propertyChange: expect.objectContaining({
+                      nestedPropertyChanges: expect.arrayContaining([
+                        [
+                          'exampleFunction',
+                          expect.objectContaining({
+                            status: 'functionChange',
+                            functionChangeLog: expect.objectContaining({
+                              parameterTypes: expect.objectContaining({
+                                nestedChanges: expect.arrayContaining([
+                                  [
+                                    0,
+                                    0,
+                                    expect.objectContaining({
+                                      status: 'members',
+                                      memberLog: expect.objectContaining({
+                                        memberKind: 'union',
+                                        addedMembers: expect.arrayContaining([
+                                          expect.objectContaining({
+                                            type: 'TypeAliasTypeAnnotation',
+                                            name: 'ObjectC',
+                                          }),
+                                        ]),
+                                      }),
+                                    }),
+                                  ],
+                                ]),
+                              }),
+                            }),
+                          }),
+                        ],
+                      ]),
+                    }),
+                  }),
+                ]),
+              }),
+            }),
+          ]),
+        }),
+      }),
+    );
+  });
+
+  it('RN with union object types, removal is ok', () => {
+    const schemaDiff = buildSchemaDiff(
+      schemaWithUnionObject, // new: ObjectA | ObjectB
+      schemaWithUnionObjectAdded, // old: ObjectA | ObjectB | ObjectC
+    );
+
+    expect(summarizeDiffSet(schemaDiff).status).toBe('ok');
   });
 
   describe('NativeComponent', () => {

--- a/packages/react-native-compatibility-check/src/__tests__/__fixtures__/native-module-with-union-object-added/NativeModule.js.flow
+++ b/packages/react-native-compatibility-check/src/__tests__/__fixtures__/native-module-with-union-object-added/NativeModule.js.flow
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
+
+import * as TurboModuleRegistry from 'react-native/Libraries/TurboModule/TurboModuleRegistry';
+
+type ObjectA = {|
+  kind: 'a',
+  value: number,
+|};
+
+type ObjectB = {|
+  kind: 'b',
+  name: string,
+|};
+
+type ObjectC = {|
+  kind: 'c',
+  flag: boolean,
+|};
+
+type ObjectUnion = ObjectA | ObjectB | ObjectC;
+
+export interface Spec extends TurboModule {
+  +exampleFunction: (a: ObjectUnion, b: number) => void;
+  +getConstants: () => {
+    +exampleConstant: number,
+  };
+}
+
+export default (TurboModuleRegistry.getEnforcing<Spec>(
+  'NativeModuleTest',
+): Spec);

--- a/packages/react-native-compatibility-check/src/__tests__/__snapshots__/ErrorFormatting-test.js.snap
+++ b/packages/react-native-compatibility-check/src/__tests__/__snapshots__/ErrorFormatting-test.js.snap
@@ -42,6 +42,13 @@ Object {
 }
 `;
 
+exports[`codegen formattedSummarizeDiffSet allows a diff from native-module-with-union-object-added/NativeModule to native-module-with-union-object/NativeModule 1`] = `
+Object {
+  "incompatibilityReport": Object {},
+  "status": "ok",
+}
+`;
+
 exports[`codegen formattedSummarizeDiffSet reports a diff from native-component-with-command/NativeComponent to native-component-with-command-extra-arg/NativeComponent 1`] = `
 Object {
   "incompatibilityReport": Object {
@@ -883,6 +890,53 @@ Object {
           Union types do not match.
               --new: (1 | 2 | 3)
               --old: (4 | 5 | 6)",
+        },
+      ],
+    },
+  },
+  "status": "incompatible",
+}
+`;
+
+exports[`codegen formattedSummarizeDiffSet reports a diff from native-module-with-union-object/NativeModule to native-module-with-union-object-added/NativeModule 1`] = `
+Object {
+  "incompatibilityReport": Object {
+    "NativeModule": Object {
+      "framework": "ReactNative",
+      "incompatibleSpecs": Array [
+        Object {
+          "errorCode": "incompatibleTypes",
+          "message": "NativeModuleTest: Object contained a property with a type mismatch
+  -- exampleFunction: has conflicting type changes
+      --new: (a: Union<mixed>, b: number)=>void
+      --old: (a: Union<mixed>, b: number)=>void
+      Parameter at index 0 did not match
+          --new: (a: Union<mixed>, b: number)=>void
+          --old: (a: Union<mixed>, b: number)=>void
+          Union types do not match
+              --new: Union<mixed>
+              --old: Union<mixed>
+              Union contained members with type mismatches
+                  -- Member TypeAliasTypeAnnotation: has conflicting changes
+                      --new: ObjectB
+                      --old: ObjectA
+                      Object contained a property with a type mismatch
+                          -- kind: has conflicting type changes
+                              --new: b
+                              --old: a
+                              String literals are not equal
+                                  --new: b
+                                  --old: a
+                  -- Member TypeAliasTypeAnnotation: has conflicting changes
+                      --new: ObjectC
+                      --old: ObjectB
+                      Object contained a property with a type mismatch
+                          -- kind: has conflicting type changes
+                              --new: c
+                              --old: b
+                              String literals are not equal
+                                  --new: c
+                                  --old: b",
         },
       ],
     },


### PR DESCRIPTION
Summary:
The compat check v2 does not correctly detect when a new object type is added to a union used in a function parameter flowing to native. This adds test fixtures and test cases that reproduce this bug: adding ObjectC to an ObjectA | ObjectB union should be flagged as incompatible (native won't expect the new type), and removing ObjectC should be flagged as ok (native can handle fewer types). Currently the tests fail because the sorting logic treats all TypeAliasTypeAnnotation members as equal, causing the merge-comparison to misidentify added/removed members as type mismatches.

Changelog: [Internal]

Differential Revision: D93262587


