### PR TITLE
Fix Double Fire of Pressable Text

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextView.kt
@@ -29,6 +29,7 @@ import com.facebook.react.uimanager.ReactCompoundView
 import com.facebook.react.uimanager.style.Overflow
 import com.facebook.react.views.text.internal.span.DrawCommandSpan
 import com.facebook.react.views.text.internal.span.ReactFragmentIndexSpan
+import com.facebook.react.views.text.internal.span.ReactLinkSpan
 import kotlin.collections.ArrayList
 import kotlin.math.roundToInt
 
@@ -204,7 +205,12 @@ internal class PreparedLayoutTextView(context: Context) : ViewGroup(context), Re
 
     if (action == MotionEvent.ACTION_UP) {
       clearSelection()
-      clickableSpan.onClick(this)
+
+      // This will already get triggered by reactTagForTouch() based hit testing if it is React
+      // managed clickable text. We still want to click any native ClickableSpan (e.g. for URIs).
+      if (clickableSpan !is ReactLinkSpan) {
+        clickableSpan.onClick(this)
+      }
     } else if (action == MotionEvent.ACTION_DOWN) {
       val layout = checkNotNull(preparedLayout).layout
       val start = (layout.text as Spanned).getSpanStart(clickableSpan)


### PR DESCRIPTION
Summary:
D86657563, which enabled `link` role by default in JS, exposed a bug in Facsimile, where we see hit testing, both against ClickableSpan, and normal React Tag based hit testing. We want the clickable spans for a11y/keyboarding, and can have non RN ClickableSpan that don't hit test via normal react mechanism.

Don't remember how we tricked ReactTextView to not run into this. joevilches might.

Differential Revision: D93589114


