### PR TITLE
Add host instance pointer and text node feature flags

### DIFF
--- a/private/react-native-fantom/runtime/mocks/ReactNativeInternalFeatureFlags.js
+++ b/private/react-native-fantom/runtime/mocks/ReactNativeInternalFeatureFlags.js
@@ -16,4 +16,6 @@ module.exports = {
   // See https://github.com/facebook/react/pull/33161 for details.
   enableEagerAlternateStateNodeCleanup: true,
   enableFragmentRefs: true,
+  enableFragmentRefsInstanceHandles: true,
+  enableFragmentRefsTextNodes: true,
 };


### PR DESCRIPTION
Summary:
- enableFragmentRefsInstanceHandles
  - Enables a pointer on each element back to the FragmentInstances that control it. Needed to implement the common IntersectionObserver pattern of reusing IntersectionObservers across multiple callbacks. See more in https://github.com/facebook/react/pull/34935
- enableFragmentRefsTextNodes
  - This should be a noop on RN as unlike dom, text nodes are considered host components and already handled. Text without a `<Text/>` wrapper throws an error.

Reviewed By: christophpurrer

Differential Revision: D93479122


