### PR TITLE
Unfork Desktop TextNativeComponent

### DIFF
--- a/packages/react-native/Libraries/Text/TextNativeComponent.js
+++ b/packages/react-native/Libraries/Text/TextNativeComponent.js
@@ -47,6 +47,9 @@ const textViewConfig = {
     dataDetectorType: true,
     android_hyphenationFrequency: true,
     lineBreakStrategyIOS: true,
+    focusable: true,
+    tooltip: true,
+    href: true,
   },
   directEventTypes: {
     topTextLayout: {


### PR DESCRIPTION
Summary:
RN desktop seems to fork `TextNativeComponent` module, but not `Text`. This is to add more to ViewConfig. D92928315 updated both, and caused desktop version to be missing exports imported by `Text.js`.

Let's just add the desktop properties to the ViewConfig to avoid the forking.

Changelog: [Internal]

Differential Revision: D93687897


