### PR TITLE
fix: add missing jest-preset.js export

### DIFF
--- a/packages/jest-preset/package.json
+++ b/packages/jest-preset/package.json
@@ -19,6 +19,7 @@
   "main": "./jest-preset.js",
   "files": [
     "jest",
+    "jest-preset.js",
     "index.js",
     "README.md",
     "!**/__docs__/**",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

The new `@react-native/jest-preset` package did not include critical `jest-present.js` file in the exported version: https://www.npmjs.com/package/@react-native/jest-preset?activeTab=code
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Without this the new preset is not usable, and the old preset is no longer available (in nightly versions)

Changelog: [Internal]

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
