### PR TITLE
Fix updating peerDependencies for releases

### DIFF
--- a/scripts/shared/monorepoUtils.js
+++ b/scripts/shared/monorepoUtils.js
@@ -22,6 +22,7 @@ export type PackageJson = {
   private?: boolean,
   dependencies?: Record<string, string>,
   devDependencies?: Record<string, string>,
+  peerDependencies?: Record<string, string>,
   main?: string,
   ...
 };
@@ -145,6 +146,7 @@ async function updatePackageJson(
   for (const dependencyField of [
     'dependencies',
     'devDependencies',
+    'peerDependencies',
   ] /*:: as const */) {
     const deps = packageJson[dependencyField];
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Recently added `@react-native/jest-preset` package is an optional peer dep to the main `react-native` package. However, it's version dep is not updated correctly for nightly builds. 

Peer dep version for [latest nightly](https://www.npmjs.com/package/react-native/v/0.85.0-nightly-20260219-44901aaf9?activeTab=code) is :
```
"peerDependencies": {
    "@eact-native/jest-preset": "0.84.0-main",
    // ....
  },
```

From my analysis this is because publishing scripts only update `deps` and `devDeps` but not `peerDeps`. Proposed change adds `peerDeps` to the list of potential deps locations to update

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[INTERNAL] [FIXED] - Fix peer deps version to `@react-native/jest-preset`.

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
