### PR TITLE
Enable defaultTextToOverflowHidden by default

### DIFF
--- a/packages/react-native/Libraries/Components/Pressable/__tests__/Pressable-itest.js
+++ b/packages/react-native/Libraries/Components/Pressable/__tests__/Pressable-itest.js
@@ -150,7 +150,8 @@ describe('<Pressable>', () => {
               ellipsizeMode="tail"
               fontSize="NaN"
               fontSizeMultiplier="NaN"
-              foregroundColor="rgba(0, 0, 0, 0)">
+              foregroundColor="rgba(0, 0, 0, 0)"
+              overflow="hidden">
               the quick brown fox
             </rn-paragraph>
           </rn-view>,

--- a/packages/react-native/Libraries/Text/__tests__/Text-itest.js
+++ b/packages/react-native/Libraries/Text/__tests__/Text-itest.js
@@ -42,7 +42,8 @@ describe('<Text>', () => {
             ellipsizeMode="tail"
             fontSize="NaN"
             fontSizeMultiplier="NaN"
-            foregroundColor="rgba(0, 0, 0, 0)">
+            foregroundColor="rgba(0, 0, 0, 0)"
+            overflow="hidden">
             {TEST_TEXT}
           </rn-paragraph>,
         );

--- a/packages/react-native/Libraries/Text/__tests__/Text-test.js
+++ b/packages/react-native/Libraries/Text/__tests__/Text-test.js
@@ -66,6 +66,11 @@ describe('Text', () => {
         accessible={true}
         allowFontScaling={true}
         ellipsizeMode="tail"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
       />
     `);
   });
@@ -88,6 +93,11 @@ describe('Text', () => {
           ellipsizeMode="tail"
           isHighlighted={false}
           isPressable={true}
+          style={
+            Object {
+              "overflow": "hidden",
+            }
+          }
         >
           Clickable Text
         </RCTText>
@@ -107,6 +117,11 @@ describe('Text', () => {
           ellipsizeMode="tail"
           isHighlighted={false}
           isPressable={true}
+          style={
+            Object {
+              "overflow": "hidden",
+            }
+          }
         >
           Long Press Text
         </RCTText>
@@ -126,6 +141,11 @@ describe('Text', () => {
           ellipsizeMode="tail"
           isHighlighted={false}
           isPressable={true}
+          style={
+            Object {
+              "overflow": "hidden",
+            }
+          }
         >
           Responder Text
         </RCTText>
@@ -147,6 +167,11 @@ describe('Text', () => {
           ellipsizeMode="tail"
           isHighlighted={false}
           isPressable={true}
+          style={
+            Object {
+              "overflow": "hidden",
+            }
+          }
         >
           Explicit Button Role
         </RCTText>
@@ -169,6 +194,11 @@ describe('Text', () => {
           isHighlighted={false}
           isPressable={true}
           role="button"
+          style={
+            Object {
+              "overflow": "hidden",
+            }
+          }
         >
           Explicit Role Prop
         </RCTText>
@@ -193,6 +223,11 @@ describe('Text', () => {
           allowFontScaling={true}
           disabled={true}
           ellipsizeMode="tail"
+          style={
+            Object {
+              "overflow": "hidden",
+            }
+          }
         >
           Disabled Pressable Text
         </RCTText>
@@ -211,12 +246,22 @@ describe('Text', () => {
           accessible={true}
           allowFontScaling={true}
           ellipsizeMode="tail"
+          style={
+            Object {
+              "overflow": "hidden",
+            }
+          }
         >
           Parent Text
           <RCTText
             accessibilityRole="link"
             isHighlighted={false}
             isPressable={true}
+            style={
+              Object {
+                "overflow": "hidden",
+              }
+            }
           >
             Nested Clickable Link
           </RCTText>
@@ -232,6 +277,11 @@ describe('Text', () => {
           accessible={true}
           allowFontScaling={true}
           ellipsizeMode="tail"
+          style={
+            Object {
+              "overflow": "hidden",
+            }
+          }
         >
           Non-pressable Text
         </RCTText>
@@ -257,6 +307,11 @@ describe('Text compat with web', () => {
         allowFontScaling={true}
         ellipsizeMode="tail"
         nativeID="id"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
         tabIndex={0}
         testID="testID"
       />
@@ -374,6 +429,11 @@ describe('Text compat with web', () => {
         ellipsizeMode="tail"
         importantForAccessibility="no-hide-descendants"
         role="main"
+        style={
+          Object {
+            "overflow": "hidden",
+          }
+        }
       />
     `);
   });
@@ -404,6 +464,7 @@ describe('Text compat with web', () => {
             "display": "flex",
             "flex": 1,
             "marginInlineStart": 10,
+            "overflow": "hidden",
             "textAlignVertical": "center",
             "userSelect": undefined,
             "verticalAlign": undefined,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/internal/featureflags/ReactNativeFeatureFlagsDefaults.kt
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<9ae90142061f1ea0766058d9cf6f3dc6>>
+ * @generated SignedSource<<65cdfdcbe22ff163b75e0b067bd72693>>
  */
 
 /**
@@ -29,7 +29,7 @@ public open class ReactNativeFeatureFlagsDefaults : ReactNativeFeatureFlagsProvi
 
   override fun cxxNativeAnimatedEnabled(): Boolean = false
 
-  override fun defaultTextToOverflowHidden(): Boolean = false
+  override fun defaultTextToOverflowHidden(): Boolean = true
 
   override fun disableEarlyViewCommandExecution(): Boolean = false
 

--- a/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
+++ b/packages/react-native/ReactCommon/react/featureflags/ReactNativeFeatureFlagsDefaults.h
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<1926124626012fd9c635ccd00241f92a>>
+ * @generated SignedSource<<a0dcf7857ba3a41d1f39da63e1627335>>
  */
 
 /**
@@ -40,7 +40,7 @@ class ReactNativeFeatureFlagsDefaults : public ReactNativeFeatureFlagsProvider {
   }
 
   bool defaultTextToOverflowHidden() override {
-    return false;
+    return true;
   }
 
   bool disableEarlyViewCommandExecution() override {

--- a/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
+++ b/packages/react-native/scripts/featureflags/ReactNativeFeatureFlags.config.js
@@ -83,7 +83,7 @@ const definitions: FeatureFlagDefinitions = {
       ossReleaseStage: 'none',
     },
     defaultTextToOverflowHidden: {
-      defaultValue: false,
+      defaultValue: true,
       metadata: {
         dateAdded: '2026-02-13',
         description:

--- a/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
+++ b/packages/react-native/src/private/featureflags/ReactNativeFeatureFlags.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<c71f3d287866aa7b06479009e986a3e6>>
+ * @generated SignedSource<<97e082b7554dba5b4f387ef783d2d6e3>>
  * @flow strict
  * @noformat
  */
@@ -211,7 +211,7 @@ export const cxxNativeAnimatedEnabled: Getter<boolean> = createNativeFlagGetter(
 /**
  * When enabled, sets the default overflow style for Text components to hidden instead of visible.
  */
-export const defaultTextToOverflowHidden: Getter<boolean> = createNativeFlagGetter('defaultTextToOverflowHidden', false);
+export const defaultTextToOverflowHidden: Getter<boolean> = createNativeFlagGetter('defaultTextToOverflowHidden', true);
 /**
  * Dispatch view commands in mount item order.
  */


### PR DESCRIPTION
Summary:
Talking to mdvacca, we think this change should be pretty safe, so turning on by default. Changelog entry in last change.

Changelog: [Internal]

Reviewed By: mdvacca

Differential Revision: D93796779


