### PR TITLE
PreparedLayoutTextView: Don't show a selection highlight when tapping on links (all pressable text)

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/PreparedLayoutTextView.kt
@@ -209,11 +209,6 @@ internal class PreparedLayoutTextView(context: Context) : ViewGroup(context), Re
       if (clickableSpan !is ReactLinkSpan) {
         clickableSpan.onClick(this)
       }
-    } else if (action == MotionEvent.ACTION_DOWN) {
-      val layout = checkNotNull(preparedLayout).layout
-      val start = (layout.text as Spanned).getSpanStart(clickableSpan)
-      val end = (layout.text as Spanned).getSpanEnd(clickableSpan)
-      setSelection(start, end)
     }
 
     return true


### PR DESCRIPTION
Summary:
With [origins](https://github.com/facebook/litho/blob/55e28e58930a53133620fd32406ec8c3a9116c0c/litho-rendercore-text/src/main/java/com/facebook/rendercore/text/RCTextView.java#L525) in Litho's RCTextView, tapping a link in a PreparedLayoutTextView will select the link (as if keyboarding to it), before activating click, then clearing selection.

D86657563 made all pressable text links, so now we show a new selection highlight in a lot of places.

That's a visual difference compared to before, that I am concerned might be breaking. Let's remove it.

Changelog: [Internal]

Differential Revision: D93820112
