### PR TITLE
Add NativeViewHierarchyOptimizer parameter to ReactShadowNode methods

### DIFF
--- a/packages/react-native/ReactAndroid/api/ReactAndroid.api
+++ b/packages/react-native/ReactAndroid/api/ReactAndroid.api
@@ -3539,6 +3539,10 @@ public class com/facebook/react/uimanager/NativeViewHierarchyManager {
 	public fun updateViewExtraData (ILjava/lang/Object;)V
 }
 
+public final class com/facebook/react/uimanager/NativeViewHierarchyOptimizer {
+	public fun <init> ()V
+}
+
 public final class com/facebook/react/uimanager/OnLayoutEvent : com/facebook/react/uimanager/events/Event {
 	public static final field Companion Lcom/facebook/react/uimanager/OnLayoutEvent$Companion;
 	public fun getEventName ()Ljava/lang/String;
@@ -3839,7 +3843,7 @@ public abstract interface class com/facebook/react/uimanager/ReactShadowNode {
 	public abstract fun calculateLayout (FF)V
 	public abstract fun calculateLayoutOnChildren ()Ljava/lang/Iterable;
 	public abstract fun dirty ()V
-	public abstract fun dispatchUpdates (FFLcom/facebook/react/uimanager/UIViewOperationQueue;)V
+	public abstract fun dispatchUpdates (FFLcom/facebook/react/uimanager/UIViewOperationQueue;Lcom/facebook/react/uimanager/NativeViewHierarchyOptimizer;)V
 	public abstract fun dispatchUpdatesWillChangeLayout (FF)Z
 	public abstract fun dispose ()V
 	public abstract fun getChildAt (I)Lcom/facebook/react/uimanager/ReactShadowNode;
@@ -3888,7 +3892,7 @@ public abstract interface class com/facebook/react/uimanager/ReactShadowNode {
 	public abstract fun markUpdateSeen ()V
 	public abstract fun markUpdated ()V
 	public abstract fun onAfterUpdateTransaction ()V
-	public abstract fun onBeforeLayout ()V
+	public abstract fun onBeforeLayout (Lcom/facebook/react/uimanager/NativeViewHierarchyOptimizer;)V
 	public abstract fun onCollectExtraUpdates (Lcom/facebook/react/uimanager/UIViewOperationQueue;)V
 	public abstract fun removeAllNativeChildren ()V
 	public abstract fun removeAndDisposeAllChildren ()V
@@ -3965,7 +3969,7 @@ public class com/facebook/react/uimanager/ReactShadowNodeImpl : com/facebook/rea
 	public fun calculateLayout (FF)V
 	public fun calculateLayoutOnChildren ()Ljava/lang/Iterable;
 	public fun dirty ()V
-	public fun dispatchUpdates (FFLcom/facebook/react/uimanager/UIViewOperationQueue;)V
+	public fun dispatchUpdates (FFLcom/facebook/react/uimanager/UIViewOperationQueue;Lcom/facebook/react/uimanager/NativeViewHierarchyOptimizer;)V
 	public fun dispatchUpdatesWillChangeLayout (FF)Z
 	public fun dispose ()V
 	public synthetic fun getChildAt (I)Lcom/facebook/react/uimanager/ReactShadowNode;
@@ -4022,7 +4026,7 @@ public class com/facebook/react/uimanager/ReactShadowNodeImpl : com/facebook/rea
 	public final fun markUpdateSeen ()V
 	public fun markUpdated ()V
 	public fun onAfterUpdateTransaction ()V
-	public fun onBeforeLayout ()V
+	public fun onBeforeLayout (Lcom/facebook/react/uimanager/NativeViewHierarchyOptimizer;)V
 	public fun onCollectExtraUpdates (Lcom/facebook/react/uimanager/UIViewOperationQueue;)V
 	public final fun removeAllNativeChildren ()V
 	public fun removeAndDisposeAllChildren ()V

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyOptimizer.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyOptimizer.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package com.facebook.react.uimanager
+
+import com.facebook.react.common.annotations.internal.LegacyArchitecture
+import com.facebook.react.common.annotations.internal.LegacyArchitectureLogLevel
+
+@LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
+@Deprecated(
+    message = "This class is part of Legacy Architecture and will be removed in a future release",
+    level = DeprecationLevel.ERROR,
+)
+public class NativeViewHierarchyOptimizer() {}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactShadowNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactShadowNode.java
@@ -111,7 +111,7 @@ public interface ReactShadowNode<T extends ReactShadowNode> {
    * layout. Will be only called for nodes that are marked as updated with {@link #markUpdated()} or
    * require layouting (marked with {@link #dirty()}).
    */
-  void onBeforeLayout();
+  void onBeforeLayout(NativeViewHierarchyOptimizer nativeViewHierarchyOptimizer);
 
   void updateProperties(ReactStylesDiffMap props);
 
@@ -129,7 +129,10 @@ public interface ReactShadowNode<T extends ReactShadowNode> {
   /* package */ boolean dispatchUpdatesWillChangeLayout(float absoluteX, float absoluteY);
 
   /* package */ void dispatchUpdates(
-      float absoluteX, float absoluteY, UIViewOperationQueue uiViewOperationQueue);
+      float absoluteX,
+      float absoluteY,
+      UIViewOperationQueue uiViewOperationQueue,
+      NativeViewHierarchyOptimizer nativeViewHierarchyOptimizer);
 
   int getReactTag();
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactShadowNodeImpl.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/ReactShadowNodeImpl.java
@@ -318,7 +318,7 @@ public class ReactShadowNodeImpl implements ReactShadowNode<ReactShadowNodeImpl>
    * require layouting (marked with {@link #dirty()}).
    */
   @Override
-  public void onBeforeLayout() {}
+  public void onBeforeLayout(NativeViewHierarchyOptimizer nativeViewHierarchyOptimizer) {}
 
   @Override
   public final void updateProperties(ReactStylesDiffMap props) {
@@ -367,7 +367,10 @@ public class ReactShadowNodeImpl implements ReactShadowNode<ReactShadowNodeImpl>
 
   @Override
   public void dispatchUpdates(
-      float absoluteX, float absoluteY, UIViewOperationQueue uiViewOperationQueue) {
+      float absoluteX,
+      float absoluteY,
+      UIViewOperationQueue uiViewOperationQueue,
+      @Nullable NativeViewHierarchyOptimizer nativeViewHierarchyOptimizer) {
     if (mNodeUpdated) {
       onCollectExtraUpdates(uiViewOperationQueue);
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIImplementation.java
@@ -849,7 +849,7 @@ public class UIImplementation {
     for (int i = 0; i < cssNode.getChildCount(); i++) {
       notifyOnBeforeLayoutRecursive(cssNode.getChildAt(i));
     }
-    cssNode.onBeforeLayout();
+    cssNode.onBeforeLayout(null);
   }
 
   protected void calculateRootLayout(ReactShadowNode cssRoot) {
@@ -897,7 +897,7 @@ public class UIImplementation {
       }
     }
 
-    cssNode.dispatchUpdates(absoluteX, absoluteY, mOperationsQueue);
+    cssNode.dispatchUpdates(absoluteX, absoluteY, mOperationsQueue, null);
 
     cssNode.markUpdateSeen();
   }


### PR DESCRIPTION
Summary:
Add a `NativeViewHierarchyOptimizer` parameter to `onBeforeLayout()` and `dispatchUpdates()` methods in `ReactShadowNode` and `ReactShadowNodeImpl`. This introduces a deprecated stub class `NativeViewHierarchyOptimizer.kt` annotated with `LegacyArchitecture` to support downstream callers that still reference this type, while signaling that it is part of the legacy architecture and will be removed in the future.

Callers in `UIImplementation` pass `null` for now since the optimizer is not actively used in this code path.

Changelog: [Android][Deprecated] - Deprecate NativeViewHierarchyOptimizer as part of Legacy Architecture cleanup

Differential Revision: D93935604


