### PR TITLE
Fix infinite recursion in ReactPropAnnotationSetterSpecTest

### DIFF
--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropAnnotationSetterSpecTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/uimanager/ReactPropAnnotationSetterSpecTest.kt
@@ -22,12 +22,11 @@ class ReactPropAnnotationSetterSpecTest {
   private abstract inner class BaseViewManager : ViewManager<View, ReactShadowNode<*>>() {
     override fun getName(): String = "IgnoredName"
 
-    override fun createShadowNodeInstance(): ReactShadowNode<*> = createShadowNodeInstance()
+    override fun createShadowNodeInstance(): ReactShadowNode<*> = ReactShadowNodeImpl()
 
     override fun getShadowNodeClass(): Class<out ReactShadowNode<*>> = ReactShadowNode::class.java
 
-    override fun createViewInstance(reactContext: ThemedReactContext): View =
-        createViewInstance(reactContext)
+    override fun createViewInstance(reactContext: ThemedReactContext): View = View(reactContext)
 
     override fun prepareToRecycleView(reactContext: ThemedReactContext, view: View): View? = null
 


### PR DESCRIPTION
Summary:
Fix infinite recursion bugs in `ReactPropAnnotationSetterSpecTest.kt`:

- `createShadowNodeInstance()` (line 25): Method calls itself recursively instead of creating a shadow node instance. Fixed to return `ReactShadowNodeImpl()`, which is the concrete implementation of `ReactShadowNode`.
- `createViewInstance(reactContext)` (line 30): Method calls itself recursively instead of creating a view instance. Fixed to return `View(reactContext)`, which creates a basic Android View.

Both methods are in an abstract inner `BaseViewManager` test class used to satisfy the `ViewManager` abstract contract. The test class is only used to verify `ReactProp` annotation validation, so these methods just need to return valid instances.

Detected by InfiniteRecursion lint detector (D93897169).

Differential Revision: D93927939


