### PR TITLE
Wire native CSS parsing for aspectRatio

### DIFF
--- a/packages/react-native/Libraries/Components/View/ReactNativeStyleAttributes.js
+++ b/packages/react-native/Libraries/Components/View/ReactNativeStyleAttributes.js
@@ -67,6 +67,10 @@ export const transformOriginAttribute: AnyAttributeType = nativeCSSParsing
   ? true
   : {process: processTransformOrigin};
 
+export const aspectRatioAttribute: AnyAttributeType = nativeCSSParsing
+  ? true
+  : {process: processAspectRatio};
+
 const ReactNativeStyleAttributes: {[string]: AnyAttributeType, ...} = {
   /**
    * Layout
@@ -74,7 +78,7 @@ const ReactNativeStyleAttributes: {[string]: AnyAttributeType, ...} = {
   alignContent: true,
   alignItems: true,
   alignSelf: true,
-  aspectRatio: {process: processAspectRatio},
+  aspectRatio: aspectRatioAttribute,
   borderBottomWidth: true,
   borderEndWidth: true,
   borderLeftWidth: true,

--- a/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/YogaStylableProps.cpp
@@ -147,35 +147,40 @@ void YogaStylableProps::setProp(
     REBUILD_FIELD_SWITCH_CASE_YSP(flexBasis, setFlexBasis);
     REBUILD_FIELD_SWITCH_CASE2(positionType, setPositionType, "position");
     REBUILD_FIELD_YG_GUTTER(gap, setGap, "rowGap", "columnGap", "gap");
-    REBUILD_FIELD_SWITCH_CASE_YSP(aspectRatio, setAspectRatio);
-    REBUILD_FIELD_SWITCH_CASE_YSP(boxSizing, setBoxSizing);
-    REBUILD_FIELD_YG_DIMENSION(dimension, setDimension, "width", "height");
-    REBUILD_FIELD_YG_DIMENSION(
-        minDimension, setMinDimension, "minWidth", "minHeight");
-    REBUILD_FIELD_YG_DIMENSION(
-        maxDimension, setMaxDimension, "maxWidth", "maxHeight");
-    REBUILD_FIELD_YG_EDGES_POSITION();
-    REBUILD_FIELD_YG_EDGES(margin, setMargin, "margin", "");
-    REBUILD_FIELD_YG_EDGES(padding, setPadding, "padding", "");
-    REBUILD_FIELD_YG_EDGES(border, setBorder, "border", "Width");
+    case CONSTEXPR_RAW_PROPS_KEY_HASH("aspectRatio"): {
+      yogaStyle.setAspectRatio(
+          value.hasValue() ? convertAspectRatio(context, value)
+                           : ygDefaults.aspectRatio());
+      return;
+    }
+      REBUILD_FIELD_SWITCH_CASE_YSP(boxSizing, setBoxSizing);
+      REBUILD_FIELD_YG_DIMENSION(dimension, setDimension, "width", "height");
+      REBUILD_FIELD_YG_DIMENSION(
+          minDimension, setMinDimension, "minWidth", "minHeight");
+      REBUILD_FIELD_YG_DIMENSION(
+          maxDimension, setMaxDimension, "maxWidth", "maxHeight");
+      REBUILD_FIELD_YG_EDGES_POSITION();
+      REBUILD_FIELD_YG_EDGES(margin, setMargin, "margin", "");
+      REBUILD_FIELD_YG_EDGES(padding, setPadding, "padding", "");
+      REBUILD_FIELD_YG_EDGES(border, setBorder, "border", "Width");
 
-    // Aliases
-    RAW_SET_PROP_SWITCH_CASE(insetBlockEnd, "insetBlockEnd");
-    RAW_SET_PROP_SWITCH_CASE(insetBlockStart, "insetBlockStart");
-    RAW_SET_PROP_SWITCH_CASE(insetInlineEnd, "insetInlineEnd");
-    RAW_SET_PROP_SWITCH_CASE(insetInlineStart, "insetInlineStart");
-    RAW_SET_PROP_SWITCH_CASE(marginInline, "marginInline");
-    RAW_SET_PROP_SWITCH_CASE(marginInlineStart, "marginInlineStart");
-    RAW_SET_PROP_SWITCH_CASE(marginInlineEnd, "marginInlineEnd");
-    RAW_SET_PROP_SWITCH_CASE(marginBlock, "marginBlock");
-    RAW_SET_PROP_SWITCH_CASE(marginBlockStart, "marginBlockStart");
-    RAW_SET_PROP_SWITCH_CASE(marginBlockEnd, "marginBlockEnd");
-    RAW_SET_PROP_SWITCH_CASE(paddingInline, "paddingInline");
-    RAW_SET_PROP_SWITCH_CASE(paddingInlineStart, "paddingInlineStart");
-    RAW_SET_PROP_SWITCH_CASE(paddingInlineEnd, "paddingInlineEnd");
-    RAW_SET_PROP_SWITCH_CASE(paddingBlock, "paddingBlock");
-    RAW_SET_PROP_SWITCH_CASE(paddingBlockStart, "paddingBlockStart");
-    RAW_SET_PROP_SWITCH_CASE(paddingBlockEnd, "paddingBlockEnd");
+      // Aliases
+      RAW_SET_PROP_SWITCH_CASE(insetBlockEnd, "insetBlockEnd");
+      RAW_SET_PROP_SWITCH_CASE(insetBlockStart, "insetBlockStart");
+      RAW_SET_PROP_SWITCH_CASE(insetInlineEnd, "insetInlineEnd");
+      RAW_SET_PROP_SWITCH_CASE(insetInlineStart, "insetInlineStart");
+      RAW_SET_PROP_SWITCH_CASE(marginInline, "marginInline");
+      RAW_SET_PROP_SWITCH_CASE(marginInlineStart, "marginInlineStart");
+      RAW_SET_PROP_SWITCH_CASE(marginInlineEnd, "marginInlineEnd");
+      RAW_SET_PROP_SWITCH_CASE(marginBlock, "marginBlock");
+      RAW_SET_PROP_SWITCH_CASE(marginBlockStart, "marginBlockStart");
+      RAW_SET_PROP_SWITCH_CASE(marginBlockEnd, "marginBlockEnd");
+      RAW_SET_PROP_SWITCH_CASE(paddingInline, "paddingInline");
+      RAW_SET_PROP_SWITCH_CASE(paddingInlineStart, "paddingInlineStart");
+      RAW_SET_PROP_SWITCH_CASE(paddingInlineEnd, "paddingInlineEnd");
+      RAW_SET_PROP_SWITCH_CASE(paddingBlock, "paddingBlock");
+      RAW_SET_PROP_SWITCH_CASE(paddingBlockStart, "paddingBlockStart");
+      RAW_SET_PROP_SWITCH_CASE(paddingBlockEnd, "paddingBlockEnd");
   }
 }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/conversions.h
@@ -498,6 +498,23 @@ inline void fromRawValue(const PropsParserContext &context, const RawValue &valu
   result = value.hasType<float>() ? yoga::FloatOptional((float)value) : yoga::FloatOptional();
 }
 
+inline yoga::FloatOptional convertAspectRatio(const PropsParserContext &context, const RawValue &value)
+{
+  if (value.hasType<float>()) {
+    return yoga::FloatOptional((float)value);
+  }
+  if (ReactNativeFeatureFlags::enableNativeCSSParsing() && value.hasType<std::string>()) {
+    auto ratio = parseCSSProperty<CSSRatio>((std::string)value);
+    if (std::holds_alternative<CSSRatio>(ratio)) {
+      auto r = std::get<CSSRatio>(ratio);
+      if (!r.isDegenerate()) {
+        return yoga::FloatOptional(r.numerator / r.denominator);
+      }
+    }
+  }
+  return yoga::FloatOptional();
+}
+
 inline std::optional<Float> toRadians(const RawValue &value)
 {
   if (value.hasType<Float>()) {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/propsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/propsConversions.h
@@ -356,8 +356,12 @@ convertRawProp(const PropsParserContext &context, const RawProps &rawProps, cons
       yoga::Dimension::Height,
       convertRawProp(context, rawProps, "maxHeight", sourceValue.maxDimension(yoga::Dimension::Height), {}));
 
-  yogaStyle.setAspectRatio(
-      convertRawProp(context, rawProps, "aspectRatio", sourceValue.aspectRatio(), yogaStyle.aspectRatio()));
+  {
+    const auto *rawValue = rawProps.at("aspectRatio", nullptr, nullptr);
+    if (rawValue != nullptr) {
+      yogaStyle.setAspectRatio(rawValue->hasValue() ? convertAspectRatio(context, *rawValue) : yogaStyle.aspectRatio());
+    }
+  }
 
   yogaStyle.setBoxSizing(
       convertRawProp(context, rawProps, "boxSizing", sourceValue.boxSizing(), yogaStyle.boxSizing()));


### PR DESCRIPTION
Summary:
Gate `processAspectRatio` behind `enableNativeCSSParsing()`. When the flag is on, CSS ratio strings like `"16/9"` and number strings are parsed natively using the existing CSS ratio parser instead of being preprocessed in JS. The parsing is done in `fromRawValue(... FloatOptional &)` — string values are only sent for aspectRatio; other FloatOptional yoga props never receive strings from JS.

Changelog: [Internal]

Differential Revision: D94052732


