### PR TITLE
Remove deprecated ShadowNode type aliases

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/core/ShadowNode.h
@@ -30,18 +30,6 @@ struct ShadowNodeWrapper;
 
 class ShadowNode : public Sealable, public DebugStringConvertible, public jsi::NativeState {
  public:
-  // TODO(T223558094): delete this in the next version.
-  using Shared [[deprecated("Use std::shared_ptr<const ShadowNode> instead")]] = std::shared_ptr<const ShadowNode>;
-  // TODO(T223558094): delete this in the next version.
-  using Weak [[deprecated("Use std::weak_ptr<const ShadowNode> instead")]] = std::weak_ptr<const ShadowNode>;
-  // TODO(T223558094): delete this in the next version.
-  using Unshared [[deprecated("Use std::shared_ptr<ShadowNode> instead")]] = std::shared_ptr<ShadowNode>;
-  // TODO(T223558094): delete this in the next version.
-  using ListOfShared [[deprecated("Use std::vector<std::shared_ptr<const ShadowNode>> instead")]] =
-      std::vector<std::shared_ptr<const ShadowNode>>;
-  // TODO(T223558094): delete this in the next version.
-  using ListOfWeak [[deprecated("Use std::vector<std::weak_ptr<const ShadowNode>> instead")]] =
-      std::vector<std::weak_ptr<const ShadowNode>>;
   using SharedListOfShared = std::shared_ptr<const std::vector<std::shared_ptr<const ShadowNode>>>;
   using UnsharedListOfShared = std::shared_ptr<std::vector<std::shared_ptr<const ShadowNode>>>;
   using UnsharedListOfWeak = std::shared_ptr<std::vector<std::weak_ptr<const ShadowNode>>>;

--- a/packages/react-native/ReactCommon/react/test_utils/shadowTreeGeneration.h
+++ b/packages/react-native/ReactCommon/react/test_utils/shadowTreeGeneration.h
@@ -89,9 +89,10 @@ static ShadowTreeEdge findRandomShadowNode(
   return findShadowNodeWithIndex(rootShadowNode, entropy.random<int>(1 /* Excluding a root node */, count - 1));
 }
 
-static ShadowNode::ListOfShared cloneSharedShadowNodeList(const ShadowNode::ListOfShared &list)
+static std::vector<std::shared_ptr<const ShadowNode>> cloneSharedShadowNodeList(
+    const std::vector<std::shared_ptr<const ShadowNode>> &list)
 {
-  auto result = ShadowNode::ListOfShared{};
+  auto result = std::vector<std::shared_ptr<const ShadowNode>>{};
   result.reserve(list.size());
   for (const auto &shadowNode : list) {
     result.push_back(shadowNode->clone({}));
@@ -105,7 +106,8 @@ static inline std::shared_ptr<ShadowNode> messWithChildren(const Entropy &entrop
   children = cloneSharedShadowNodeList(children);
   entropy.shuffle(children);
   return shadowNode.clone(
-      {ShadowNodeFragment::propsPlaceholder(), std::make_shared<const ShadowNode::ListOfShared>(children)});
+      {ShadowNodeFragment::propsPlaceholder(),
+       std::make_shared<const std::vector<std::shared_ptr<const ShadowNode>>>(children)});
 }
 
 static inline std::shared_ptr<ShadowNode> messWithLayoutableOnlyFlag(
@@ -280,7 +282,7 @@ static inline std::shared_ptr<const ShadowNode> generateShadowNodeTree(
   auto items = std::vector<int>(size);
   std::fill(items.begin(), items.end(), 1);
   auto chunks = entropy.distribute(items, deviation);
-  auto children = ShadowNode::ListOfShared{};
+  auto children = std::vector<std::shared_ptr<const ShadowNode>>{};
 
   for (const auto &chunk : chunks) {
     children.push_back(generateShadowNodeTree(entropy, componentDescriptor, chunk.size()));
@@ -289,7 +291,8 @@ static inline std::shared_ptr<const ShadowNode> generateShadowNodeTree(
   auto family = componentDescriptor.createFamily({generateReactTag(), SurfaceId(1), nullptr});
   return componentDescriptor.createShadowNode(
       ShadowNodeFragment{
-          generateDefaultProps(componentDescriptor), std::make_shared<const ShadowNode::ListOfShared>(children)},
+          generateDefaultProps(componentDescriptor),
+          std::make_shared<const std::vector<std::shared_ptr<const ShadowNode>>>(children)},
       family);
 }
 


### PR DESCRIPTION
Summary:
## Changelog:
[General] [Breaking]: Removing deprecated type aliases. Use the type directly.

Remove deprecated type aliases from ShadowNode that were scheduled for deletion in 0.84:
- `ShadowNode::Shared` → use `std::shared_ptr<const ShadowNode>`
- `ShadowNode::Weak` → use `std::weak_ptr<const ShadowNode>`
- `ShadowNode::Unshared` → use `std::shared_ptr<ShadowNode>`
- `ShadowNode::ListOfShared` → use `std::vector<std::shared_ptr<const ShadowNode>>`
- `ShadowNode::ListOfWeak` → use `std::vector<std::weak_ptr<const ShadowNode>>`

Reviewed By: lenaic

Differential Revision: D90331085


