### PR TITLE
Remove deprecated ImageManager and ContextContainer type aliases

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageManager.h
+++ b/packages/react-native/ReactCommon/react/renderer/imagemanager/ImageManager.h
@@ -17,10 +17,6 @@
 
 namespace facebook::react {
 
-class ImageManager;
-
-using SharedImageManager [[deprecated("Use std::shared_ptr<ImageManager> instead.")]] = std::shared_ptr<ImageManager>;
-
 /*
  * Cross platform facade for image management (e.g. iOS-specific
  * RCTImageManager)

--- a/packages/react-native/ReactCommon/react/utils/ContextContainer.h
+++ b/packages/react-native/ReactCommon/react/utils/ContextContainer.h
@@ -25,8 +25,6 @@ namespace facebook::react {
  */
 class ContextContainer final {
  public:
-  using Shared [[deprecated("Use std::shared_ptr<const ContextContainer> instead.")]] =
-      std::shared_ptr<const ContextContainer>;
   /*
    * Registers an instance of the particular type `T` in the container
    * using the provided `key`. Only one instance can be registered per key.


### PR DESCRIPTION
Summary:
Changelog:
[General] [Breaking]: Removing deprecated type aliases. Use the type directly.

Remove deprecated type aliases that are no longer used:
- `SharedImageManager` → use `std::shared_ptr<ImageManager>`
- `ContextContainer::Shared` → use `std::shared_ptr<const ContextContainer>`

Reviewed By: lenaic

Differential Revision: D90331219


