### PR TITLE
Include manufacturer in deviceName metadata

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoHelpers.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/AndroidInfoHelpers.kt
@@ -77,7 +77,7 @@ public object AndroidInfoHelpers {
         "appDisplayName" to appDisplayName,
         "appIdentifier" to appIdentifier,
         "platform" to "android",
-        "deviceName" to Build.MODEL,
+        "deviceName" to "${Build.MANUFACTURER} ${Build.MODEL}",
         "reactNativeVersion" to getReactNativeVersionString(),
     )
   }


### PR DESCRIPTION
Summary:
Helps with devices that have obscure model names, and aligns with presentation in Android Studio (e.g. Logcat device selection).

Changelog:
[Android][Changed] - CDP:  The`deviceName` field in app metadata is now prefixed with the manufacturer

Differential Revision: D94082955


