### PR TITLE
downgrade NativeViewHierarchyOptimizer deprecation from ERROR to WARNING to fix template app build

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyOptimizer.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/NativeViewHierarchyOptimizer.kt
@@ -13,6 +13,6 @@ import com.facebook.react.common.annotations.internal.LegacyArchitectureLogLevel
 @LegacyArchitecture(logLevel = LegacyArchitectureLogLevel.ERROR)
 @Deprecated(
     message = "This class is part of Legacy Architecture and will be removed in a future release",
-    level = DeprecationLevel.ERROR,
+    level = DeprecationLevel.WARNING,
 )
 public class NativeViewHierarchyOptimizer() {}


### PR DESCRIPTION
Summary:
Changelog: [internal] 

Downgrading from `ERROR` to `WARNING` allows existing references to compile while still signaling that the class is deprecated and should be migrated away from.

Differential Revision: D94095560


