### PR TITLE
Fix `Image` Jest mock after extraction to separate package

### DIFF
--- a/packages/jest-preset/jest-preset.js
+++ b/packages/jest-preset/jest-preset.js
@@ -10,13 +10,15 @@
 
 'use strict';
 
+const path = require('path');
+
 module.exports = {
   haste: {
     defaultPlatform: 'ios',
     platforms: ['android', 'ios', 'native'],
   },
   moduleNameMapper: {
-    '^react-native($|/.*)': '<rootDir>/node_modules/react-native/$1',
+    '^react-native($|/.*)': `${path.dirname(require.resolve('react-native'))}/$1`,
   },
   resolver: require.resolve('./jest/resolver.js'),
   transform: {

--- a/private/helloworld/jest.config.js
+++ b/private/helloworld/jest.config.js
@@ -8,11 +8,6 @@
  * @format
  */
 
-const path = require('path');
-
 module.exports = {
   preset: 'react-native',
-  moduleNameMapper: {
-    '^react-native($|/.*)': `${path.dirname(require.resolve('react-native'))}/$1`,
-  },
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Transition to `@react-native/jest-preset` broke the `Image` mock, as it started to render unmocked `RCTImageView` instead of mocked `Image`. This is result of differences between node resolution that takes into account platform-specific imports (`Image.ios.js`) vs Jest mocking `Image.js`. This works fine in the files are in the same package, but broke when doing deep imports from separate package.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[INTERNAL] [FIXED] Fix `Image` Jest mock after extraction to `@react-native/jest-preset`

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Added automated tests to showcase the issue