### PR TITLE
feat: enable reading fonts registered via addCustomFont

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/assets/ReactFontManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/common/assets/ReactFontManager.kt
@@ -33,6 +33,10 @@ public class ReactFontManager {
   private val fontCache: MutableMap<String, AssetFontFamily> = mutableMapOf()
   private val customTypefaceCache: MutableMap<String, Typeface> = mutableMapOf()
 
+  /** The set of font family names that have been registered via [addCustomFont]. */
+  public val customFontFamilies: Set<String>
+    get() = customTypefaceCache.keys.toSet()
+
   public fun getTypeface(
       fontFamilyName: String,
       style: Int,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

`ReactFontManager` has a write-only API for custom fonts — you can register fonts but there's no way to query what's been registered. This asymmetry means a library that needs to know about font availability needs to use reflection on the private `customTypefaceCache` map, or maintain a custom registry that can easily go out of sync.

This becomes a problem when multiple libraries need to cooperate around fonts. Today when a library registers a font,  there's no clean way for another library to discover what the first one registered.

This adds a `customFontFamilies` property that returns the set of font family names currently in the custom typeface cache.

Only `customTypefaceCache` is exposed in this PR because it contains fonts explicitly registered by library code  via `addCustomFont()`, whereas `fontCache` is lazily populated as a side effect of `getTypeface()` calls  and its contents depend on what has been requested so far rather than what is available.

Asset-based fonts (in `assets/fonts/`) already have a discoverable source of truth - the filesystem.

## Changelog:

[ANDROID] [ADDED] - `ReactFontManager.customFontFamilies` property to query registered custom font family names


## Test Plan:

- tested ok by adding
```kt
    val customFonts = ReactFontManager.getInstance().customFontFamilies
    Log.d("RNTesterApplication", "customFontFamilies: $customFonts")
```

prints: `customFontFamilies: [Rubik, FiraCode]`

[here](https://github.com/facebook/react-native/blob/9353eb55b877e6e51c35c6041eebd72971c6b9a5/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.kt#L123) 
