### PR TITLE
stop standalone Devtools from starting in Fantom

### DIFF
--- a/private/react-native-fantom/runner/global-setup/globalSetup.js
+++ b/private/react-native-fantom/runner/global-setup/globalSetup.js
@@ -53,6 +53,11 @@ async function startMetroServer() {
     websocketEndpoints: debuggerWebsocketEndpoints,
   } = createDevMiddleware({
     serverBaseUrl: `http://localhost:${metroConfig.server.port}`,
+    // Disable standalone DevTools shell preparation to avoid launching the
+    // Electron app during tests. This prevents crashes.
+    unstable_experiments: {
+      enableStandaloneFuseboxShell: false,
+    },
   });
 
   const enhanceMiddleware: ConfigT['server']['enhanceMiddleware'] = (


### PR DESCRIPTION
Summary:
changelog: [internal]

when running Fantom on Mac, I frequently see this error. This is DevTools standalone app crashing. Let's disable DevTools standalone app, it is not needed with tests anyway.

 {F1985865132}

Reviewed By: huntie

Differential Revision: D94092247


