### PR TITLE
Fix memory leak in TextInput

### DIFF
--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputShadowNode.h
@@ -24,14 +24,15 @@
 #include <react/utils/ContextContainer.h>
 
 namespace facebook::react {
-  inline ShadowView shadowViewFromShadowNode(const ShadowNode& shadowNode) {
-    auto shadowView = ShadowView{shadowNode};
-    // Clearing `props` and `state` (which we don't use) allows avoiding retain
-    // cycles.
-    shadowView.props = nullptr;
-    shadowView.state = nullptr;
-    return shadowView;
-  }
+
+inline ShadowView shadowViewFromShadowNode(const ShadowNode& shadowNode) {
+  auto shadowView = ShadowView{shadowNode};
+  // Clearing `props` and `state` (which we don't use) allows avoiding retain
+  // cycles.
+  shadowView.props = nullptr;
+  shadowView.state = nullptr;
+  return shadowView;
+}
 
 /*
  * Base `ShadowNode` for <TextInput> component.

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputShadowNode.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/BaseTextInputShadowNode.h
@@ -24,6 +24,14 @@
 #include <react/utils/ContextContainer.h>
 
 namespace facebook::react {
+  inline ShadowView shadowViewFromShadowNode(const ShadowNode& shadowNode) {
+    auto shadowView = ShadowView{shadowNode};
+    // Clearing `props` and `state` (which we don't use) allows avoiding retain
+    // cycles.
+    shadowView.props = nullptr;
+    shadowView.state = nullptr;
+    return shadowView;
+  }
 
 /*
  * Base `ShadowNode` for <TextInput> component.
@@ -171,7 +179,7 @@ class BaseTextInputShadowNode
     AttributedString attributedString;
     attributedString.appendFragment(
         AttributedString::Fragment{
-            .string = props.text, .textAttributes = textAttributes, .parentShadowView = ShadowView(*this)});
+            .string = props.text, .textAttributes = textAttributes, .parentShadowView = shadowViewFromShadowNode(*this)});
 
     auto attachments = BaseTextShadowNode::Attachments{};
     BaseTextShadowNode::buildAttributedString(textAttributes, *this, attributedString, attachments);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

When implementing a local FPS monitor I noticed that `TextInput` leaked memory. @tomekzaw helped triage and confirm whether the leak was occurring in reanimated or react-native upstream. 

We collaborated on a fix for this and noticed that this was fixed 6 years ago in text [here](https://github.com/facebook/react-native/commit/490e33dd8852150380ee4017c4448b3d7b436f89)

We've ported the same fix to `BaseTextInputShadowNode.h`


## Changelog:

[General] [Fixed] - Fix memory leak in TextInput

## Test Plan:

https://snack.expo.dev/@mobinni/memory-leak-reproducer

- Run this with XCode instruments and see memory grow over time

<img width="1094" height="930" alt="image" src="https://github.com/user-attachments/assets/bc9abb5a-42ff-430c-8efb-a418ba65ddc2" />

